### PR TITLE
Replace `bootstrap_std` with `stderr` as default metric

### DIFF
--- a/benchmarks/mathematics.py
+++ b/benchmarks/mathematics.py
@@ -20,8 +20,8 @@ from inspect_ai.scorer import (
     Score,
     Target,
     accuracy,
-    bootstrap_std,
     scorer,
+    stderr,
 )
 from inspect_ai.solver import TaskState, generate, prompt_template
 
@@ -52,7 +52,7 @@ def math(shuffle=True):
     )
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def expression_equivalance():
     async def score(state: TaskState, target: Target):
         # extract answer

--- a/docs/_examples/mathematics.qmd
+++ b/docs/_examples/mathematics.qmd
@@ -41,7 +41,7 @@ from inspect_ai.scorer import (
     Score,
     Target,
     accuracy,
-    bootstrap_std,
+    stderr,
     scorer,
 )
 from inspect_ai.solver import TaskState, generate, prompt_template
@@ -88,7 +88,7 @@ def math(shuffle=True):
 The heart of this eval isn't in the task definition though, rather it's in how we grade the output. Math expressions can be logically equivalent but not literally the same. Consequently, we'll use a model to assess whether the output and the target are logically equivalent. the `expression_equivalence()` custom scorer implements this:
 
 ```{python}
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def expression_equivalence():
     async def score(state: TaskState, target: Target):
         # extract answer

--- a/docs/examples.qmd
+++ b/docs/examples.qmd
@@ -266,7 +266,7 @@ from inspect_ai.scorer import (
     Score,
     Target,
     accuracy,
-    bootstrap_std,
+    stderr,
     scorer,
 )
 from inspect_ai.solver import TaskState, generate, prompt_template
@@ -313,7 +313,7 @@ def math(shuffle=True):
 The heart of this eval isn't in the task definition though, rather it's in how we grade the output. Math expressions can be logically equivalent but not literally the same. Consequently, we'll use a model to assess whether the output and the target are logically equivalent. the `expression_equivalence()` custom scorer implements this:
 
 ```{python}
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def expression_equivalence():
     async def score(state: TaskState, target: Target):
         # extract answer

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -46,7 +46,7 @@ Inspect includes some simple text matching scorers as well as a couple of model 
 
     Have another model assess whether the model output contains a fact that is set out in `target`. This is a more narrow assessment than `model_graded_qa()`, and is used when model output is too complex to be assessed using a simple `match()` or `pattern()` scorer.
 
-Scorers provide one or more built-in metrics (each of the scorers above provides `accuracy` as a metric). You can also provide your own custom metrics in `Task` definitions. For example:
+Scorers provide one or more built-in metrics (each of the scorers above provides `accuracy` and `stderr` as a metric). You can also provide your own custom metrics in `Task` definitions. For example:
 
 ``` python
 Task(
@@ -60,6 +60,13 @@ Task(
 )
 ```
 
+:::{.callout-note}
+
+Inspect's latest update replaced the `bootstrap_std` metric with `stderr`, a calulation of the standard error of the means using the Central Limit Theorem. We are able to compute the error directly using `stderr` (rather than using bootstrapping to estimate it) since the evaluation scores are means of numbers having finite variance. 
+
+:::
+
+
 ## Model Graded
 
 Model graded scorers are well suited to assessing open ended answers as well as factual answers that are embedded in a longer narrative. The built-in model graded scorers can be customised in several ways—you can also create entirely new model scorers (see the model graded example below for a starting point).
@@ -67,7 +74,7 @@ Model graded scorers are well suited to assessing open ended answers as well as 
 Here is the declaration for the `model_graded_qa()` function:
 
 ``` python
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def model_graded_qa(
     template: str | None = None,
     instructions: str | None = None,
@@ -171,7 +178,7 @@ Next, we'll take a look at the source code for a couple of the built in scorers 
 Here is the source code for the built-in `includes()` scorer:
 
 ``` python
-@scorer(metrics=[accuracy(), bootstrap_std()])   # <1>
+@scorer(metrics=[accuracy(), stderr()])   # <1>
 def includes(ignore_case: bool = True):
 
     async def score(state: TaskState, target: Target):   # <2>
@@ -196,7 +203,7 @@ def includes(ignore_case: bool = True):
 1.  The function applies the `@scorer` decorator and registers two metrics for use with the scorer.
 2.  The `score()` function is declared as `async`. This is so that it can participate in Inspect's optimised scheduling for expensive model generation calls (this scorer doesn't call a model but others will).
 3.  We make use of the `text` property on the `Target`. This is a convenience property to get a simple text value out of the `Target` (as targets can technically be a list of strings).
-4.  We use the special constants `CORRECT` and `INCORRECT` for the score value (as the `accuracy()` and `bootstrap_std()` metrics know how to convert these special constants to float values (1.0 and 0.0 respectively).
+4.  We use the special constants `CORRECT` and `INCORRECT` for the score value (as the `accuracy()`, `stderr()`, and `bootstrap_std()` metrics know how to convert these special constants to float values (1.0 and 0.0 respectively).
 5.  We provide the full model completion as the answer for the score (`answer` is optional, but highly recommended as it is often useful to refer to during evaluation development).
 
 ### Example: Model Grading
@@ -205,7 +212,7 @@ Here's a somewhat simplified version of the code for the `model_graded_qa()` sco
 
 ``` python
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def model_graded_qa(
     template: str = DEFAULT_MODEL_GRADED_QA_TEMPLATE,
     instructions: str = DEFAULT_MODEL_GRADED_QA_INSTRUCTIONS,
@@ -299,8 +306,8 @@ You may also create a scorer which yields multiple scores. This is useful when t
 ``` python
 @scorer(
     metrics={  # <1>
-        "a_count": [mean(), bootstrap_std()],  # <1>
-        "e_count": [mean(), bootstrap_std()]   # <1>
+        "a_count": [mean(), stderr()],  # <1>
+        "e_count": [mean(), stderr()]   # <1>
     } # <1>
 )
 def letter_count():
@@ -324,7 +331,7 @@ task = Task(
 1.  The metrics for this scorer are a dictionary—this defines metrics to be applied to scores (by name).
 2.  The score value itself is a dictionary—the keys corresponding to the keys defined in the metrics on the `@scorer` decorator.
 
-The above example will produce two scores, `a_count` and `e_count`, each of which will have metrics for `mean` and `bootstrap_std`.
+The above example will produce two scores, `a_count` and `e_count`, each of which will have metrics for `mean` and `stderr`.
 
 ### Reducing Multiple Scores
 
@@ -366,7 +373,7 @@ def multi_model_graded(models)
 
 ## Metrics
 
-Each scorer provides one or more built-in metrics (typically `accuracy` and `bootstrap_std`). In addition, you can specify other metrics (either built-in or custom) to compute when defining a `Task`:
+Each scorer provides one or more built-in metrics (typically `accuracy` and `stderr`). In addition, you can specify other metrics (either built-in or custom) to compute when defining a `Task`:
 
 ``` python
 Task(
@@ -395,6 +402,14 @@ Inspect includes some simple built in metrics for calculating accuracy, mean, et
 -   `var()`
 
     Variance over all scores.
+
+-   `std()`
+
+    Sample standard deviation of all scores.
+
+-   `stderr()`
+
+    Standard error of the mean.
 
 -   `bootstrap_std()`
 

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -15,7 +15,7 @@ from ._metric import (
 )
 from ._metrics.accuracy import accuracy
 from ._metrics.mean import mean
-from ._metrics.std import bootstrap_std
+from ._metrics.std import bootstrap_std, std, stderr
 from ._model import model_graded_fact, model_graded_qa
 from ._multi import ScoreReducer, majority_vote, multi_scorer
 from ._pattern import pattern
@@ -36,6 +36,8 @@ __all__ = [
     "scorer",
     "accuracy",
     "bootstrap_std",
+    "std",
+    "stderr",
     "mean",
     "Metric",
     "metric",

--- a/src/inspect_ai/scorer/_answer.py
+++ b/src/inspect_ai/scorer/_answer.py
@@ -7,7 +7,7 @@ from inspect_ai._util.pattern import (
     ANSWER_PATTERN_WORD,
 )
 
-from ._metrics import accuracy, bootstrap_std
+from ._metrics import accuracy, stderr
 from ._pattern import pattern
 from ._scorer import Scorer, scorer
 
@@ -32,7 +32,7 @@ class AnswerPattern(str, Enum):
     """
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def answer(type: Literal["letter", "word", "line"]) -> Scorer:
     """Scorer for model output that preceded answers with ANSWER:.
 

--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -7,7 +7,7 @@ from inspect_ai.solver._multiple_choice import (
 )
 
 from ._metric import CORRECT, INCORRECT, Score
-from ._metrics import accuracy, bootstrap_std
+from ._metrics import accuracy, stderr
 from ._scorer import Scorer, scorer
 from ._target import Target
 
@@ -38,7 +38,7 @@ def _shuffled_explanation(choices: Choices) -> str:
     return f"Choices were shuffled before generating a response, the following was sent to the model:\n\n{answer_options(choices)}\nShuffled answer:\nANSWER: {', '.join(generated_answers)}"
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def choice() -> Scorer:
     """
     Scorer for multiple choice answers, required by the `multiple_choice` solver.

--- a/src/inspect_ai/scorer/_match.py
+++ b/src/inspect_ai/scorer/_match.py
@@ -1,11 +1,11 @@
 from typing import Literal
 
 from ._common import match_str, str_match_scorer
-from ._metrics import accuracy, bootstrap_std
+from ._metrics import accuracy, stderr
 from ._scorer import Scorer, scorer
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def match(
     location: Literal["begin", "end", "any", "exact"] = "end",
     *,
@@ -37,7 +37,7 @@ def match(
     return str_match_scorer(check)
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def includes(ignore_case: bool = True) -> Scorer:
     """Check whether the specified text is included in the model output.
 

--- a/src/inspect_ai/scorer/_metrics/__init__.py
+++ b/src/inspect_ai/scorer/_metrics/__init__.py
@@ -1,5 +1,12 @@
 from .accuracy import accuracy
 from .mean import mean, var
-from .std import bootstrap_std
+from .std import bootstrap_std, std, stderr
 
-__all__ = ["accuracy", "mean", "var", "bootstrap_std"]
+__all__ = [
+    "accuracy",
+    "mean",
+    "var",
+    "bootstrap_std",
+    "std",
+    "stderr",
+]

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -45,3 +45,74 @@ def bootstrap_std(
         return cast(float, std.item())
 
     return metric
+
+
+@metric
+def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
+    """Standard error of the mean using Central Limit Theorem.
+
+    Args:
+        to_float (ValueToFloat): Function for mapping
+            Value to float for computing metrics. The default
+            `value_to_float()` maps CORRECT ("C") to 1.0,
+            INCORRECT ("I") to 0, PARTIAL ("P") to 0.5, and
+            NOANSWER ("N") to 0, casts numeric values to
+            float directly, and prints a warning and returns
+            0 if the Value is a complex object (list or dict).
+
+    Returns:
+        stderr metric
+    """
+
+    def metric(scores: list[Score]) -> float:
+        values = [to_float(score.value) for score in scores]
+        n = len(values)
+
+        # standard deviation is calculated by dividing by n-ddof so ensure
+        # that we won't divide by zero
+        if (n - 1) < 1:
+            return 0
+
+        # Calculate the sample standard deviation
+        sample_std = np.std(values, ddof=1)
+
+        # Calculate the standard error of the mean
+        standard_error = sample_std / np.sqrt(n)
+
+        return cast(float, standard_error)
+
+    return metric
+
+
+@metric
+def std(to_float: ValueToFloat = value_to_float()) -> Metric:
+    """Calculates the sample standard deviation of a list of scores.
+
+    Args:
+        to_float (ValueToFloat): Function for mapping
+            Value to float for computing metrics. The default
+            `value_to_float()` maps CORRECT ("C") to 1.0,
+            INCORRECT ("I") to 0, PARTIAL ("P") to 0.5, and
+            NOANSWER ("N") to 0, casts numeric values to
+            float directly, and prints a warning and returns
+            0 if the Value is a complex object (list or dict).
+
+    Returns:
+        std metric
+    """
+
+    def metric(scores: list[Score]) -> float:
+        values = [to_float(score.value) for score in scores]
+        n = len(values)
+
+        # standard deviation is calculated by dividing by n-ddof so ensure
+        # that we won't divide by zero
+        if (n - 1) < 1:
+            return 0
+
+        # Calculate the sample standard deviation
+        sample_std = np.std(values, ddof=1)
+
+        return cast(float, sample_std)
+
+    return metric

--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -6,13 +6,13 @@ from inspect_ai.solver import TaskState
 from inspect_ai.util import resource
 
 from ._metric import INCORRECT, Score
-from ._metrics import accuracy, bootstrap_std
+from ._metrics import accuracy, stderr
 from ._multi import majority_vote, multi_scorer
 from ._scorer import Scorer, scorer
 from ._target import Target
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def model_graded_fact(
     template: str | None = None,
     instructions: str | None = None,
@@ -52,7 +52,7 @@ def model_graded_fact(
     )
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def model_graded_qa(
     template: str | None = None,
     instructions: str | None = None,
@@ -97,7 +97,7 @@ def model_graded_qa(
     return multi_scorer(scorers, majority_vote)
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def _model_graded_qa_single(
     template: str | None = None,
     instructions: str | None = None,

--- a/src/inspect_ai/scorer/_pattern.py
+++ b/src/inspect_ai/scorer/_pattern.py
@@ -4,7 +4,7 @@ from typing import Any
 from inspect_ai.solver import TaskState
 
 from ._metric import CORRECT, INCORRECT, Score
-from ._metrics import accuracy, bootstrap_std
+from ._metrics import accuracy, stderr
 from ._scorer import Scorer, scorer
 from ._target import Target
 
@@ -43,7 +43,7 @@ def match_all_groups(
     return target.text
 
 
-@scorer(metrics=[accuracy(), bootstrap_std()])
+@scorer(metrics=[accuracy(), stderr()])
 def pattern(pattern: str, ignore_case: bool = True, match_all: bool = False) -> Scorer:
     """Scorer which extracts the model answer using a regex.
 

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -6,6 +6,7 @@ from inspect_ai._util.registry import registry_info
 from inspect_ai.dataset import Sample
 from inspect_ai.scorer import Metric, Score, accuracy, includes, match, metric
 from inspect_ai.scorer._metric import MetricType, metric_create
+from inspect_ai.scorer._metrics import std
 
 # declare some metrics using the various forms supported (function,
 # function returning Metric, class deriving from Metric) as well
@@ -76,19 +77,20 @@ def test_extra_metrics() -> None:
     # check that we get the extra metrics and de-duping works
     def check_log(log):
         assert log.results and (
-            list(log.results.metrics.keys())
+            list(log.results.scores[0].metrics.keys())
             == [
                 "accuracy",
-                "bootstrap_std",
+                "stderr",
                 "accuracy1",
                 "Accuracy3",
+                "std",
             ]
         )
 
     task = Task(
         dataset=[Sample(input="What is 1 + 1?", target=["2", "2.0", "Two"])],
         scorer=match(),
-        metrics=[accuracy(), accuracy1(), Accuracy3()],
+        metrics=[accuracy(), accuracy1(), Accuracy3(), std()],
     )
 
     # normal eval

--- a/tests/scorer/test_multiscorer.py
+++ b/tests/scorer/test_multiscorer.py
@@ -2,11 +2,11 @@ import random
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
-from inspect_ai.scorer import Score, Target, bootstrap_std, mean, scorer
+from inspect_ai.scorer import Score, Target, mean, scorer, stderr
 from inspect_ai.solver import TaskState
 
 
-@scorer(metrics=[mean(), bootstrap_std()])
+@scorer(metrics=[mean(), stderr()])
 def rand_score():
     async def score(state: TaskState, target: Target):
         answer = state.output.completion
@@ -15,7 +15,7 @@ def rand_score():
     return score
 
 
-@scorer(metrics=[mean(), bootstrap_std()])
+@scorer(metrics=[mean(), stderr()])
 def another_rand_score():
     async def score(state: TaskState, target: Target):
         answer = state.output.completion
@@ -24,9 +24,7 @@ def another_rand_score():
     return score
 
 
-@scorer(
-    metrics={"a_count": [mean(), bootstrap_std()], "e_count": [mean(), bootstrap_std()]}
-)
+@scorer(metrics={"a_count": [mean(), stderr()], "e_count": [mean(), stderr()]})
 def letter_count():
     async def score(state: TaskState, target: Target):
         answer = state.output.completion
@@ -64,7 +62,7 @@ def test_single_scorer() -> None:
 
     # normal eval
     log = eval(tasks=task, model="mockllm/model")[0]
-    check_log(log, ["rand_score"], ["mean", "bootstrap_std"])
+    check_log(log, ["rand_score"], ["mean", "stderr"])
 
 
 # test two scorers
@@ -76,7 +74,7 @@ def test_multi_scorer() -> None:
 
     # normal eval
     log = eval(tasks=task, model="mockllm/model")[0]
-    check_log(log, ["rand_score", "another_rand_score"], ["mean", "bootstrap_std"])
+    check_log(log, ["rand_score", "another_rand_score"], ["mean", "stderr"])
 
 
 # test dictionary scorer
@@ -88,7 +86,7 @@ def test_dict_scorer() -> None:
 
     # normal eval
     log = eval(tasks=task, model="mockllm/model")[0]
-    check_log(log, ["a_count", "e_count"], ["mean", "bootstrap_std"])
+    check_log(log, ["a_count", "e_count"], ["mean", "stderr"])
 
 
 # test blend of dictionary and simple scorers
@@ -100,4 +98,4 @@ def test_blend_scorer() -> None:
 
     # normal eval
     log = eval(tasks=task, model="mockllm/model")[0]
-    check_log(log, ["a_count", "e_count", "rand_score"], ["mean", "bootstrap_std"])
+    check_log(log, ["a_count", "e_count", "rand_score"], ["mean", "stderr"])


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

We currently compute `bootstrap_std` for our scorers. 

### What is the new behavior?

We now compute `stderr` instead as a replacement for `bootstrap_std`. `boostrap_std` is still a supported metric when explicitly specified for a scorer. Added `std` metric as well.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Kind of? Users may be expecting to see `bootstrap_std` in their results (either JSON or viewer) and it will now be replaced by `stderr`, which we believe is a better measure.

### Other information:

We are able to compute the error directly using `stderr` (rather than using bootstrapping to estimate it) since the evaluation scores are means of numbers having finite variance. Using bootstrapping isn't really necessary since we can just compute it directly.
