### PR TITLE
Fix tool_choice="any" for OpenAI

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -302,9 +302,9 @@ def chat_tool_choice(tool_choice: ToolChoice) -> ChatCompletionToolChoiceOptionP
         return ChatCompletionNamedToolChoiceParam(
             type="function", function=dict(name=tool_choice.name)
         )
-    # openai does not support 'any' so we force it to 'auto'
+    # openai supports 'any' via the 'required' keyword
     elif tool_choice == "any":
-        return "auto"
+        return "required"
     else:
         return tool_choice
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When setting tool_choice="any" and expecting tool choice to be enforced, it is only set to auto which may cause the tool call to fail.

### What is the new behavior?
Using the `"required"` option of the OpenAI API to enforce calling at least one tool as described for `"any"`.
See https://platform.openai.com/docs/api-reference/chat/create#chat-create-tool_choice for reference.
<img width="652" alt="image" src="https://github.com/user-attachments/assets/07224283-122e-4d82-867d-ea075e6268ae">


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
