### PR TITLE
Allow sorting by ids of differing types

### DIFF
--- a/src/inspect_ai/_view/www/src/samples/tools/SortFilter.mjs
+++ b/src/inspect_ai/_view/www/src/samples/tools/SortFilter.mjs
@@ -74,13 +74,19 @@ export const sort = (sort, samples, sampleDescriptor) => {
         if (isNumeric(a.id) && isNumeric(b.id)) {
           return a.id - b.id;
         } else {
-          return a.id.localeCompare(b.id);
+          // Note that if there are mixed types of ids (e.g. a string
+          // and a number), we need to be sure we're working with strings
+          // to performan the comparison
+          return String(a.id).localeCompare(String(b.id));
         }
       case kSampleDescVal:
         if (isNumeric(a.id) && isNumeric(b.id)) {
           return b.id - a.id;
         } else {
-          return b.id.localeCompare(a.id);
+          // Note that if there are mixed types of ids (e.g. a string
+          // and a number), we need to be sure we're working with strings
+          // to performan the comparison
+          return String(b.id).localeCompare(String(a.id));
         }
       case kEpochAscVal:
         return a.epoch - b.epoch;


### PR DESCRIPTION
When the samples have differing types of id (e.g. some samples have a numeric id, others have a string id), we shouldn’t fail with an error.

The sorting behavior may be unintuitive in this case, but we shouldn’t be failing with an error.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The log viewer fails with an error when an evaluation contains samples with ids of different types (e.g. a numeric id and and string id).

### What is the new behavior?

The log viewer properly displays the log. Ensure we coerce both types to strings before sorting.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
