### PR TITLE
Hostable Viewer

### DIFF
--- a/docs/log-viewer.qmd
+++ b/docs/log-viewer.qmd
@@ -140,3 +140,15 @@ Note that you can also set the log level using the `INSPECT_LOG_LEVEL` environme
 The **Info** panel of the log viewer provides additional meta-information about evaluation tasks, including dataset, plan, and scorer details, git revision, and model token usage:
 
 ![](images/inspect-view-info.png){.border .lightbox fig-alt="The Info panel of the Inspect log viewer, displaying various details about the evaluation including dataset, plan, and scorer details, git revision, and model token usage."}
+
+## Viewer Embedding
+
+The log viewer can be published to a static web server and linked to or embedded in another page (for example, in an iframe). To embed the viewer:
+
+1.  Copy the contents of the [`www`](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/src/inspect_ai/_view/www) directory (`src/inspect_ai/_view/www`) to the folder you will be publishing.
+
+2.  Create a `logs` sub-directory within the folder into which you placed the contents of the `www` directory. Place any logs you'd like to display within this `logs` folder.
+
+3.  Link to the viewer with the query parameter `log_file` and the path to a log file. For example:
+
+    `https://<deployment url>/?log_file=logs/2024-07-18T09-00-04-04-00_bash_QuRMsu7hRUWrJjxe8xePLa.json`

--- a/src/inspect_ai/_view/www/App.mjs
+++ b/src/inspect_ai/_view/www/App.mjs
@@ -133,11 +133,17 @@ export function App() {
   // Keep a queue of loading operations that will be run
   // as needed
   const loadLogsImpl = useCallback(async () => {
-    const result = await api.eval_logs();
-    if (result) {
-      setLogs(result);
-    } else {
-      setLogs({ log_dir: "", files: [] });
+    try {
+      const result = await api.eval_logs();
+      if (result) {
+        setLogs(result);
+      } else {
+        setLogs({ log_dir: "", files: [] });
+      }
+    } catch (e) {
+      // Show an error
+      console.log(e);
+      setStatus({ loading: false, error: e });
     }
   }, []);
 

--- a/src/inspect_ai/_view/www/src/api/api-browser.mjs
+++ b/src/inspect_ai/_view/www/src/api/api-browser.mjs
@@ -1,4 +1,5 @@
 import { asyncJsonParse } from "../utils/Json.mjs";
+import { download_file } from "./api-shared.mjs";
 
 const loaded_time = Date.now();
 let last_eval_time = 0;
@@ -59,16 +60,6 @@ async function api(method, path, body) {
   } else {
     throw new Error(`${response.status} - ${response.statusText} `);
   }
-}
-
-async function download_file(_logfile, filename, filecontents) {
-  const blob = new Blob([filecontents], { type: "text/plain" });
-  const link = document.createElement("a");
-  link.href = URL.createObjectURL(blob);
-  link.download = filename;
-  document.body.appendChild(link);
-  link.click();
-  document.body.removeChild(link);
 }
 
 export default {

--- a/src/inspect_ai/_view/www/src/api/api-http.mjs
+++ b/src/inspect_ai/_view/www/src/api/api-http.mjs
@@ -1,0 +1,87 @@
+import { asyncJsonParse } from "../utils/Json.mjs";
+import { download_file } from "./api-shared.mjs";
+
+// This provides an API implementation that will serve a single
+// file using an http parameter, designed to be deployed
+// to a webserver without inspect or the ability to enumerate log
+// files
+export default function singleFileHttpApi() {
+  const urlParams = new URLSearchParams(window.location.search);
+  const fetchLogPath = urlParams.get("log_file");
+  if (fetchLogPath) {
+    const api = httpApiForFile(fetchLogPath);
+    return api;
+  }
+}
+
+function httpApiForFile(logFile) {
+  let contents;
+  const getContents = async () => {
+    if (contents) {
+      return contents;
+    } else {
+      const response = await fetch(`${logFile}`, { method: "GET" });
+      if (response.ok) {
+        const text = await response.text();
+
+        const log = await asyncJsonParse(text);
+        if (log.version === 1) {
+          // Update log structure to v2 format
+          if (log.results) {
+            log.results.scores = [];
+            log.results.scorer.scorer = log.results.scorer.name;
+            log.results.scores.push(log.results.scorer);
+            delete log.results.scorer;
+            log.results.scores[0].metrics = log.results.metrics;
+            delete log.results.metrics;
+
+            // migrate samples
+            const scorerName = log.results.scores[0].name;
+            log.samples.forEach((sample) => {
+              sample.scores = { [scorerName]: sample.score };
+              delete sample.score;
+            });
+          }
+        }
+
+        return {
+          parsed: log,
+          raw: text,
+        };
+      } else if (response.status !== 200) {
+        const message = (await response.text()) || response.statusText;
+        const error = new Error(`Error: ${response.status}: ${message})`);
+        throw error;
+      } else {
+        throw new Error(`${response.status} - ${response.statusText} `);
+      }
+    }
+  };
+
+  return {
+    client_events: async () => {
+      return Promise.resolve([]);
+    },
+    eval_logs: async () => {
+      const contents = await getContents();
+      const files = [
+        {
+          name: logFile,
+          task: contents.parsed.eval.task,
+          task_id: contents.parsed.eval.task_id,
+        },
+      ];
+      return Promise.resolve({
+        files,
+      });
+    },
+    eval_log: async () => {
+      return await getContents();
+    },
+    eval_log_headers: async () => {
+      const contents = await getContents();
+      return Promise.resolve([contents.parsed]);
+    },
+    download_file,
+  };
+}

--- a/src/inspect_ai/_view/www/src/api/api-shared.mjs
+++ b/src/inspect_ai/_view/www/src/api/api-shared.mjs
@@ -1,0 +1,10 @@
+// Function that uses the dom to download the contents provided in filecontents
+export async function download_file(_logfile, filename, filecontents) {
+  const blob = new Blob([filecontents], { type: "text/plain" });
+  const link = document.createElement("a");
+  link.href = URL.createObjectURL(blob);
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+}

--- a/src/inspect_ai/_view/www/src/api/index.mjs
+++ b/src/inspect_ai/_view/www/src/api/index.mjs
@@ -1,4 +1,7 @@
 import browserApi from "./api-browser.mjs";
 import vscodeApi from "./api-vscode.mjs";
+import singleFileHttpApi from "./api-http.mjs";
 
-export default window.acquireVsCodeApi ? vscodeApi : browserApi;
+export default window.acquireVsCodeApi
+  ? vscodeApi
+  : singleFileHttpApi() || browserApi;


### PR DESCRIPTION
The viewer may now be hosted alongside deployed log files, which will be loaded individually using:

`?log_file=<path>`

So, for example, you can serve the log viewer and then display a log file using:

`http://localhost:8000/?log_file=logs/2024-07-18T09-00-04-04-00_bash_QuRMsu7hRUWrJjxe8xePLa.json`

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Inspect view must be served from `inspect` or within vscode.

### What is the new behavior?

Inspect view may be served by http for a single file.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
