### PR TITLE
Add vLLM provider support

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -66,6 +66,13 @@ $ export HF_TOKEN=your-hf-token
 $ inspect eval arc.py --model hf/meta-llama/Llama-2-7b-chat-hf
 ```
 
+#### vLLM
+
+``` bash
+$ pip install vllm
+$ inspect eval arc.py --model vllm/meta-llama/Llama-2-7b-chat-hf
+```
+
 #### Together
 
 ``` bash

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -11,6 +11,7 @@ Inspect has built in support for a variety of language model API providers and c
 | Google       | `pip install google-generativeai` | `GOOGLE_API_KEY`                                                       |
 | Mistral      | `pip install mistralai`           | `MISTRAL_API_KEY`                                                      |
 | Hugging Face | `pip install transformers`        | `HF_TOKEN`                                                             |
+| vLLM         | `pip install vllm`                | None required                                                          |
 | Ollama       | `pip install openai`              | None required                                                          |
 | TogetherAI   | `pip install openai`              | `TOGETHER_API_KEY`                                                     |
 | AWS Bedrock  | `pip install boto3`               | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_DEFAULT_REGION` |
@@ -34,6 +35,7 @@ To select a model for use in an evaluation task you specify it using a *model na
 | Google       | `google/gemini-1.0-pro`           | [Google Models](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/models)             |
 | Mistral      | `mistral/mistral-large-latest`    | [Mistral Models](https://docs.mistral.ai/platform/endpoints/)                                   |
 | Hugging Face | `hf/openai-community/gpt2`        | [Hugging Face Models](https://huggingface.co/models?pipeline_tag=text-generation&sort=trending) |
+| vLLM         | `vllm/openai-community/gpt2`      | [vLLM Models](https://docs.vllm.ai/en/latest/models/supported_models.html)                      |
 | Ollama       | `ollama/llama3`                   | [Ollama Models](https://ollama.com/library)                                                     |
 | TogetherAI   | `together/lmsys/vicuna-13b-v1.5`  | [TogetherAI Models](https://docs.together.ai/docs/inference-models#chat-models)                 |
 | AWS Bedrock  | `bedrock/meta.llama2-70b-chat-v1` | [AWS Bedrock Models](https://aws.amazon.com/bedrock/)                                           |
@@ -145,7 +147,7 @@ def popularity(model):
 
 ## Provider Notes
 
-This section provides additional documentation on using the Azure AI, AWS Bedrock, and Hugging Face providers.
+This section provides additional documentation on using the Azure AI, AWS Bedrock, Hugging Face, and vLLM providers.
 
 ### Azure AI {#azure-ai}
 
@@ -260,6 +262,37 @@ Or in a call to `get_model()`
 model = get_model("hf/local", model_path="./my-model")
 ```
 
+### vLLM {#sec-vllm}
+
+The vLLM provider also implements support for local models using the [vllm](https://github.com/vllm-project/vllm/) package. You can use any vLLM model by specifying it with the `vllm/` prefix. For example:
+
+``` bash
+$ inspect eval popularity --model vllm/openai-community/gpt2
+```
+
+vLLM is generally much faster than the Hugging Face provider as the library is designed entirely for inference speed whereas the Hugging Face library is more general purpose.
+
+#### Device
+
+The `device` option is also available for vLLM models, and you can use it to specify the device(s) to run the model on. For example:
+
+``` bash
+$ inspect eval popularity --model vllm/meta-llama/Meta-Llama-3-8B-Instruct -M device='0,1,2,3'
+```
+
+#### Batching
+
+vLLM automatically handles batching, so you generally don't have to worry about selecting the optimal batch size. However, you can still use the `max_connections` option to control the number of concurrent requests which defaults to 32.
+
+#### Local Models
+
+Similar to the Hugging Face provider, you can also use local models with the vLLM provider. Use `vllm/local` along with the `model_path`, and (optionally) `tokenizer_path` arguments to select a local model. For example, from the command line, use the `-M` flag to pass the model arguments:
+
+``` bash
+$ inspect eval popularity --model vllm/local -M model_path=./my-model
+```
+
+
 ## Helper Models
 
 Often you'll want to use language models in the implementation of [Solvers](#sec-solvers) and [Scorers](#sec-scorers). Inspect includes some critique solvers and model graded scorers that do this, and you'll often want to do the same in your own.
@@ -317,6 +350,7 @@ The additional `model_args` are forwarded as follows for the various providers:
 | Google       | `genai.configure`                      |
 | Mistral      | `MistralAsyncClient`                   |
 | Hugging Face | `AutoModelForCausalLM.from_pretrained` |
+| vLLM         | `SamplingParams`                       |
 | Ollama       | `AsyncOpenAI`                          |
 | TogetherAI   | `AsyncOpenAI`                          |
 | AzureAI      | Chat HTTP Post Body                    |
@@ -324,7 +358,7 @@ The additional `model_args` are forwarded as follows for the various providers:
 
 : {tbl-colwidths="\[30,70\]"}
 
-See the OpenAI, Anthropic, Google, Mistral, Hugging Face, Ollama, TogetherAI, Azure AI, and Cloudflare provider documentation for more information on the additional options available.
+See the OpenAI, Anthropic, Google, Mistral, Hugging Face, vLLM, Ollama, TogetherAI, Azure AI, and Cloudflare provider documentation for more information on the additional options available.
 
 ## Custom Models
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,13 @@ src = ["src"]
 
 [tool.ruff.lint]
 select = [
-    "E",      # pycodestyle errors
-    "W",      # pycodestyle warnings
-    "F",      # flake8
-    "D",      # pydocstyle
-    "I",      # isort
+    "E", # pycodestyle errors
+    "W", # pycodestyle warnings
+    "F", # flake8
+    "D", # pydocstyle
+    "I", # isort
     "SIM101", # duplicate isinstance
-    "UP038",  # non-pep604-isinstance
+    "UP038", # non-pep604-isinstance
     # "RET", # flake8-return
     # "RUF", # ruff rules
 ]
@@ -134,7 +134,8 @@ dev = [
     "types-protobuf",
     "types-psutil",
     "types-python-dateutil",
-    "wikipedia",
+    "vllm",
+    "wikipedia"
 ]
 doc = ["quarto-cli"]
 dist = ["twine", "build"]

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -91,37 +91,37 @@ class GenerateConfig(BaseModel):
     """Sequences where the API will stop generating further tokens. The returned text will not contain the stop sequence."""
 
     best_of: int | None = Field(default=None)
-    """Generates best_of completions server-side and returns the 'best' (the one with the highest log probability per token). OpenAI only."""
+    """Generates best_of completions server-side and returns the 'best' (the one with the highest log probability per token). OpenAI and vLLM only."""
 
     frequency_penalty: float | None = Field(default=None)
-    """Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. OpenAI only."""
+    """Number between -2.0 and 2.0. Positive values penalize new tokens based on their existing frequency in the text so far, decreasing the model's likelihood to repeat the same line verbatim. OpenAI and vLLM only."""
 
     presence_penalty: float | None = Field(default=None)
-    """Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. OpenAI only."""
+    """Number between -2.0 and 2.0. Positive values penalize new tokens based on whether they appear in the text so far, increasing the model's likelihood to talk about new topics. OpenAI and vLLM only."""
 
     logit_bias: dict[int, float] | None = Field(default=None)
     """Map token Ids to an associated bias value from -100 to 100 (e.g. "42=10,43=-10"). OpenAI only."""
 
     seed: int | None = Field(default=None)
-    """Random seed. OpenAI and Mistral only."""
+    """Random seed. OpenAI, Mistral, HuggingFace, and vLLM only."""
 
     suffix: str | None = Field(default=None)
     """The suffix that comes after a completion of inserted text. OpenAI only."""
 
     top_k: int | None = Field(default=None)
-    """Randomly sample the next word from the top_k most likely next words. Anthropic, Google, and HuggingFace only."""
+    """Randomly sample the next word from the top_k most likely next words. Anthropic, Google, HuggingFace, and vLLM only."""
 
     num_choices: int | None = Field(default=None)
-    """How many chat completion choices to generate for each input message. OpenAI, Google, and TogetherAI only."""
+    """How many chat completion choices to generate for each input message. OpenAI, Google, TogetherAI, and vLLM only."""
 
     logprobs: bool | None = Field(default=None)
-    """Return log probabilities of the output tokens. OpenAI, TogetherAI, and Huggingface only."""
+    """Return log probabilities of the output tokens. OpenAI, TogetherAI, Huggingface, and vLLM only."""
 
     top_logprobs: int | None = Field(default=None)
-    """Number of most likely tokens (0-20) to return at each token position, each with an associated log probability. OpenAI and Huggingface only."""
+    """Number of most likely tokens (0-20) to return at each token position, each with an associated log probability. OpenAI, Huggingface, and vLLM only."""
 
     def merge(
-        self, other: Union["GenerateConfig", GenerateConfigArgs]
+            self, other: Union["GenerateConfig", GenerateConfigArgs]
     ) -> "GenerateConfig":
         """Merge another model configuration into this one.
 

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -121,7 +121,7 @@ class GenerateConfig(BaseModel):
     """Number of most likely tokens (0-20) to return at each token position, each with an associated log probability. OpenAI, Huggingface, and vLLM only."""
 
     def merge(
-            self, other: Union["GenerateConfig", GenerateConfigArgs]
+        self, other: Union["GenerateConfig", GenerateConfigArgs]
     ) -> "GenerateConfig":
         """Merge another model configuration into this one.
 

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -130,7 +130,7 @@ class HuggingFaceAPI(ModelAPI):
         if config.top_k is not None:
             kwargs["top_k"] = config.top_k
         if config.logprobs is not None:
-            kwargs["output_logits"] = True
+            kwargs["output_logits"] = config.logprobs
         if "return_dict_in_generate" in kwargs:
             assert kwargs["return_dict_in_generate"]
         kwargs["return_dict_in_generate"] = True

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -4,7 +4,6 @@ from inspect_ai._util.version import verify_required_version
 from .._model import ModelAPI
 from .._registry import modelapi
 
-
 # Defer importing model api classes until they are actually used
 # (this allows the package to load without the optional deps)
 # Note that some api providers (e.g. Cloudflare, AzureAI) don't
@@ -81,9 +80,7 @@ def vllm() -> type[ModelAPI]:
     try:
         from .vllm import VLLMAPI
     except ImportError:
-        raise pip_dependency_error(
-            "vLLM Models", ["vllm"]
-        )
+        raise pip_dependency_error("vLLM Models", ["vllm"])
 
     return VLLMAPI
 

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -4,6 +4,7 @@ from inspect_ai._util.version import verify_required_version
 from .._model import ModelAPI
 from .._registry import modelapi
 
+
 # Defer importing model api classes until they are actually used
 # (this allows the package to load without the optional deps)
 # Note that some api providers (e.g. Cloudflare, AzureAI) don't
@@ -73,6 +74,18 @@ def hf() -> type[ModelAPI]:
         )
 
     return HuggingFaceAPI
+
+
+@modelapi(name="vllm")
+def vllm() -> type[ModelAPI]:
+    try:
+        from .vllm import VLLMAPI
+    except ImportError:
+        raise pip_dependency_error(
+            "vLLM Models", ["vllm"]
+        )
+
+    return VLLMAPI
 
 
 @modelapi(name="cf")

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -301,8 +301,13 @@ def string_to_bytes(string: str) -> list[int]:
 def extract_logprobs(
     completion: CompletionOutput, num_top_logprobs: int | None
 ) -> Logprobs | None:
-    if completion.logprobs is None:
+    if completion.logprobs is None or not completion.logprobs:
         return None
+
+    # if config.logprobs = True, we want to get the selected tokens logprob
+    # but if config.top_logprobs is not set, we don't want to return the top logprobs
+    if num_top_logprobs is None:
+        num_top_logprobs = 0
 
     logprobs = []
     for token_id, logprob in zip(completion.token_ids, completion.logprobs):
@@ -319,9 +324,9 @@ def extract_logprobs(
         selected_token = logprob[token_id]
         logprobs.append(
             Logprob(
-                token=selected_token.decoded_token,
+                token=cast(str, selected_token.decoded_token),
                 logprob=selected_token.logprob,
-                bytes=string_to_bytes(selected_token.decoded_token),
+                bytes=string_to_bytes(cast(str, selected_token.decoded_token)),
                 top_logprobs=top_logprobs,
             )
         )

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -1,0 +1,395 @@
+import asyncio
+import functools
+import os
+from dataclasses import dataclass
+from queue import Empty, Queue
+from threading import Thread
+from typing import Any, cast
+
+from inspect_ai._util.constants import DEFAULT_MAX_TOKENS
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+from .._model import ModelAPI, simple_input_messages
+from .._generate_config import GenerateConfig
+from .._chat_message import ChatMessage, ChatMessageAssistant, ChatMessageUser
+from .._model_output import (
+    Logprob,
+    Logprobs,
+    ModelOutput,
+    ModelUsage,
+    TopLogprob,
+    ChatCompletionChoice,
+    ModelUsage
+)
+from .._util import chat_api_input
+from typing_extensions import override
+
+from vllm import LLM, SamplingParams
+
+DEFAULT_START_TOKEN = '<|im_start|>'
+DEFAULT_END_TOKEN = '<|im_end|>'
+
+HF_TOKEN = "HF_TOKEN"
+
+
+@dataclass
+class GenerateInput:
+    input: str
+    generator: Any
+    batch_size: int
+    num_logprobs: int = 0
+
+
+@dataclass
+class GenerateOutput:
+    output: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    stop_reason: str | None = None
+    logprobs: Logprobs | None = None
+
+
+class VLLMAPI(ModelAPI):
+    def __init__(
+            self,
+            model_name: str,
+            base_url: str | None = None,
+            api_key: str | None = None,
+            config: GenerateConfig = GenerateConfig(),
+            **model_args: Any,
+    ) -> None:
+
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            api_key_vars=[HF_TOKEN],
+            config=config,
+        )
+
+        self.seed = None
+        if config.seed is not None:
+            self.seed = config.seed
+
+        # collect known model_args (then delete them so we can pass the rest on)
+        def collect_model_arg(name: str) -> Any | None:
+            nonlocal model_args
+            value = model_args.get(name, None)
+            if value:
+                model_args.pop(name)
+            return value
+
+        device = collect_model_arg("device")
+        tokenizer = collect_model_arg("tokenizer")
+        model_path = collect_model_arg("model_path")
+        tokenizer_path = collect_model_arg("tokenizer_path")
+        self.batch_size = collect_model_arg("batch_size")
+        self.chat_template = collect_model_arg("chat_template")
+
+        # if user provides model_path, use that instead of model_name
+        if model_path:
+            model_name = model_path
+
+        # load tokenizer
+        if not tokenizer:
+            if tokenizer_path:
+                tokenizer = tokenizer_path
+            else:
+                tokenizer = model_name
+
+        # set which GPUs are available to use
+        if device is not None:
+            os.environ["CUDA_VISIBLE_DEVICES"] = str(device)
+
+        # tell vllm how many GPUs to use
+        if 'tensor_parallel_size' not in model_args:
+            devices = os.environ.get("CUDA_VISIBLE_DEVICES", "").split(",")
+            num_devices = len(devices)
+            if num_devices > 1:
+                model_args["tensor_parallel_size"] = num_devices
+            else:
+                model_args["tensor_parallel_size"] = 1
+
+        # https://github.com/vllm-project/vllm/pull/6051
+        # Gemma 2 models require FlashInfer backend for softcap logits
+        if 'google/gemma-2' in model_name:
+            os.environ['VLLM_ATTENTION_BACKEND'] = 'FLASHINFER'
+            try:
+                import flashinfer  # noqa: F401
+            except ImportError:
+                raise ImportError(
+                    "To use the 'google/gemma-2' model, you must install the 'flashinfer' package. "
+                    "See https://docs.flashinfer.ai/installation.html"
+                )
+
+        # load model
+        self.model = LLM(
+            model_name,
+            tokenizer=tokenizer,
+            **model_args
+        )
+
+        # we get the tokenizer so we can use it to apply the model's chat template later
+        self.tokenizer = self.model.get_tokenizer()
+
+    def apply_chat_template(self, messages: list[ChatMessage]) -> str:
+        # handle system message and consecutive user messages
+        messages = simple_input_messages(messages)
+        # convert to chat template input format
+        chat_messages = chat_api_input(messages)
+        # apply chat template
+        chat = self.tokenizer.apply_chat_template(
+            chat_messages,
+            add_generation_prompt=True,
+            tokenize=False,
+            chat_template=self.chat_template,
+        )
+        return cast(str, chat)
+
+    @override
+    def max_connections(self) -> int:
+        """Effectively the batch size."""
+        return 32
+
+    def get_sampling_params(self, config: GenerateConfig, chat: str) -> SamplingParams:
+        kwargs: dict[str, Any] = dict()
+        if config.max_tokens is not None:
+            kwargs["max_tokens"] = config.max_tokens
+        else:
+            kwargs["max_tokens"] = DEFAULT_MAX_TOKENS
+
+        if config.temperature is not None:
+            kwargs["temperature"] = config.temperature
+        if config.top_p is not None:
+            kwargs["top_p"] = config.top_p
+        if config.top_k is not None:
+            kwargs["top_k"] = config.top_k
+        # if config.min_p is not None:
+        #     kwargs["min_p"] = config.min_p
+        if config.seed is not None:
+            kwargs["seed"] = config.seed
+        elif self.seed is not None:
+            kwargs["seed"] = self.seed
+
+        if config.frequency_penalty is not None:
+            kwargs["frequency_penalty"] = config.frequency_penalty
+        if config.presence_penalty is not None:
+            kwargs["presence_penalty"] = config.presence_penalty
+
+        if config.num_choices is not None:
+            kwargs["n"] = config.num_choices
+        if config.best_of is not None:
+            kwargs["best_of"] = config.best_of
+
+        if config.logprobs is not None:
+            kwargs["logprobs"] = 0
+        if config.top_logprobs is not None:
+            kwargs["logprobs"] = config.top_logprobs
+
+        if config.stop_seqs is not None:
+            kwargs["stop"] = config.stop_seqs
+
+        # some models don't stop at <|im_end|> token
+        # perhaps there is a better solution than this (modify tokenizer?)
+        # TODO: what model needs this?
+        if chat.startswith(DEFAULT_START_TOKEN):
+            if "stop" not in kwargs:
+                kwargs["stop"] = [DEFAULT_END_TOKEN]
+            else:
+                kwargs["stop"].append(DEFAULT_END_TOKEN)
+
+        sampling_params = SamplingParams(
+            **kwargs,
+            stop_token_ids=self.tokenizer.all_special_ids,  # We default to stopping at all special tokens
+            include_stop_str_in_output=False
+        )
+        return sampling_params
+
+    async def generate(
+            self,
+            input: list[ChatMessage],
+            tools: list[ToolInfo] = None,
+            tool_choice: ToolChoice = None,
+            config: GenerateConfig = None,
+    ) -> ModelOutput:
+        if config is None:
+            config = GenerateConfig()
+
+        chat = self.apply_chat_template(input)
+
+        # prepare generator
+        sampling_params = self.get_sampling_params(config, chat)
+        generator = functools.partial(self.model.generate, sampling_params=sampling_params, use_tqdm=False)
+
+        # generate
+        responses = await batched_generate(
+            GenerateInput(
+                input=chat,
+                generator=generator,
+                batch_size=config.max_connections or self.max_connections(),
+                num_logprobs=config.top_logprobs,
+            )
+        )
+
+        return self.process_responses(responses)
+
+    def process_responses(self, responses: list[GenerateOutput]) -> ModelOutput:
+        choices = [
+            ChatCompletionChoice(
+                message=ChatMessageAssistant(
+                    content=response.output,
+                    source="generate",
+                ),
+                stop_reason=response.stop_reason,
+                logprobs=response.logprobs,
+            )
+            for response in responses
+        ]
+
+        # TODO: what's the best way to calculate token usage for num_choices > 1
+        input_tokens = responses[0].input_tokens
+        output_tokens = sum(response.output_tokens for response in responses)
+        total_tokens = input_tokens + output_tokens
+
+        return ModelOutput(
+            model=self.model_name,
+            choices=choices,
+            usage=ModelUsage(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                total_tokens=total_tokens,
+            ),
+        )
+
+
+@dataclass
+class _QueueItem:
+    input: GenerateInput
+    future: asyncio.Future[list[GenerateOutput]]
+    loop: asyncio.AbstractEventLoop
+
+
+batch_thread: Thread | None = None
+
+batch_queue: "Queue[_QueueItem]" = Queue()
+
+
+async def batched_generate(input: GenerateInput) -> list[GenerateOutput]:
+    # start the background thread if necessary
+    global batch_thread
+    if batch_thread is None:
+        batch_thread = Thread(target=process_batches, daemon=True)
+        batch_thread.start()
+
+    # enqueue the job
+    loop = asyncio.get_event_loop()
+    future: asyncio.Future[list[GenerateOutput]] = loop.create_future()
+    batch_queue.put(_QueueItem(input=input, future=future, loop=loop))
+
+    # await the job
+    await future
+
+    # return it
+    return future.result()
+
+
+def string_to_bytes(string: str) -> list[int]:
+    return list(map(ord, string))
+
+
+def extract_logprobs(completion, num_logprobs) -> Logprobs | None:
+    if completion.logprobs is None:
+        return None
+
+    logprobs = []
+    for token_id, logprob in zip(completion.token_ids, completion.logprobs):
+        top_logprobs = [
+            TopLogprob(
+                token=token.decoded_token,
+                logprob=token.logprob,
+                bytes=string_to_bytes(token.decoded_token)
+            )
+            # exclude the chosen token if it's not in the top logprobs
+            for token in logprob.values() if token.rank - 1 < num_logprobs
+        ]
+        selected_token = logprob[token_id]
+        logprobs.append(Logprob(
+            token=selected_token.decoded_token,
+            logprob=selected_token.logprob,
+            bytes=string_to_bytes(selected_token.decoded_token),
+            top_logprobs=top_logprobs
+        ))
+
+    return Logprobs(content=logprobs)
+
+
+def post_process_output(output, i, num_logprobs) -> GenerateOutput:
+    completion = output.outputs[i]
+    output_text: str = completion.text
+
+    # # remove end token if it's there (byproduct of default chat template)
+    # TODO: Remove
+    # if output_text.endswith(DEFAULT_END_TOKEN):
+    #     output_text = output_text[:len(DEFAULT_END_TOKEN)]
+
+    input_tokens = len(output.prompt_token_ids)
+    output_tokens = len(completion.token_ids)
+    total_tokens = input_tokens + output_tokens
+
+    return GenerateOutput(
+        output=output_text,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        stop_reason=completion.finish_reason,
+        logprobs=extract_logprobs(completion, num_logprobs)
+    )
+
+
+def post_process_outputs(output, num_logprobs) -> list[GenerateOutput]:
+    return [post_process_output(output, i, num_logprobs) for i in range(len(output.outputs))]
+
+
+def process_batches() -> None:
+    while True:
+        # drain the queue (wait until no new messages have shown up for 2 seconds)
+        inputs: list[tuple[GenerateInput, asyncio.Future[list[GenerateOutput]]]] = []
+        while True:
+            try:
+                input = batch_queue.get(timeout=2)  # wait 2 seconds max TODO: what's optimal wait time?
+                loop = input.loop
+                inputs.append((input.input, input.future))
+                if len(inputs) >= input.input.batch_size:
+                    # max batch size reached
+                    break
+            except Empty:
+                # we have exhausted the queue
+                break
+
+        # see if we have any work to do
+        if len(inputs) == 0:
+            continue
+
+        try:
+            first_input = inputs[0][0]
+            generator = first_input.generator
+            num_logprobs = first_input.num_logprobs
+
+            # generate
+            outputs = generator([input[0].input for input in inputs])
+
+            for i, output in enumerate(outputs):
+                future = inputs[i][1]
+
+                # asyncio futures are not thread safe, so we need to pass the event loop
+                # down to this point, so we can mark the future as done in a thread safe manner.
+                # see: https://docs.python.org/3/library/asyncio-dev.html#concurrency-and-multithreading
+                loop.call_soon_threadsafe(
+                    future.set_result,
+                    post_process_outputs(output, num_logprobs)
+                )
+
+        except Exception as e:
+            for _, future in inputs:
+                loop.call_soon_threadsafe(future.set_exception, e)

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -46,7 +46,7 @@ class GenerateOutput:
     input_tokens: int
     output_tokens: int
     total_tokens: int
-    stop_reason: str | None = None
+    stop_reason: StopReason
     logprobs: Logprobs | None = None
 
 
@@ -308,13 +308,13 @@ def extract_logprobs(
     for token_id, logprob in zip(completion.token_ids, completion.logprobs):
         top_logprobs = [
             TopLogprob(
-                token=token.decoded_token,
+                token=cast(str, token.decoded_token),
                 logprob=token.logprob,
-                bytes=string_to_bytes(token.decoded_token),
+                bytes=string_to_bytes(cast(str, token.decoded_token)),
             )
             # exclude the chosen token if it's not in the top logprobs
             for token in logprob.values()
-            if token.rank - 1 < num_top_logprobs
+            if cast(int, token.rank) - 1 < num_top_logprobs
         ]
         selected_token = logprob[token_id]
         logprobs.append(
@@ -329,12 +329,12 @@ def extract_logprobs(
     return Logprobs(content=logprobs)
 
 
-def get_stop_reason(completion: CompletionOutput) -> StopReason:
-    if completion.finish_reason == "stop":
+def get_stop_reason(finish_reason: str | None) -> StopReason:
+    if finish_reason == "stop":
         return "stop"
-    elif completion.finish_reason == "length":
+    elif finish_reason == "length":
         return "length"
-    elif completion.finish_reason == "abort":
+    elif finish_reason == "abort":
         return "unknown"
     else:
         return "unknown"

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -11,12 +11,11 @@ from inspect_ai.tool import ToolChoice, ToolInfo
 
 from .._model import ModelAPI, simple_input_messages
 from .._generate_config import GenerateConfig
-from .._chat_message import ChatMessage, ChatMessageAssistant, ChatMessageUser
+from .._chat_message import ChatMessage, ChatMessageAssistant
 from .._model_output import (
     Logprob,
     Logprobs,
     ModelOutput,
-    ModelUsage,
     TopLogprob,
     ChatCompletionChoice,
     ModelUsage
@@ -160,6 +159,9 @@ class VLLMAPI(ModelAPI):
             kwargs["max_tokens"] = DEFAULT_MAX_TOKENS
 
         if config.temperature is not None:
+            # for some reason vllm doesn't generate anything for 0 < temperature < 0.02
+            if 0 < config.temperature > 0.02:
+                config.temperature = 0.02
             kwargs["temperature"] = config.temperature
         if config.top_p is not None:
             kwargs["top_p"] = config.top_p

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -7,7 +7,7 @@ from threading import Thread
 from typing import Any, cast
 
 from typing_extensions import override
-from vllm import LLM, SamplingParams, CompletionOutput, RequestOutput
+from vllm import LLM, CompletionOutput, RequestOutput, SamplingParams
 
 from inspect_ai._util.constants import DEFAULT_MAX_TOKENS
 from inspect_ai.tool import ToolChoice, ToolInfo

--- a/src/inspect_ai/scorer/_metric.py
+++ b/src/inspect_ai/scorer/_metric.py
@@ -202,7 +202,6 @@ def metric(name: str) -> Callable[..., MetricType]: ...
 
 
 @overload
-# type: ignore
 def metric(name: Callable[..., Metric]) -> Callable[..., Metric]: ...
 
 

--- a/src/inspect_ai/solver/_solver.py
+++ b/src/inspect_ai/solver/_solver.py
@@ -126,7 +126,6 @@ def solver(name: str) -> Callable[..., SolverType]: ...
 
 
 @overload
-# type: ignore
 def solver(name: Callable[..., Solver]) -> Callable[..., Solver]: ...
 
 

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -27,7 +27,6 @@ class ExecResult(Generic[T]):
 
 
 @overload
-# type: ignore
 async def subprocess(
     args: str | list[str],
     text: Literal[True] = True,

--- a/tests/model/providers/test_vllm.py
+++ b/tests/model/providers/test_vllm.py
@@ -1,0 +1,55 @@
+import pytest
+from test_helpers.utils import skip_if_github_action
+
+from inspect_ai.model import (
+    ChatMessageUser,
+    GenerateConfig,
+    get_model,
+)
+
+
+@pytest.fixture
+def model():
+    return get_model(
+        "vllm/EleutherAI/pythia-70m",
+        config=GenerateConfig(
+            max_tokens=1,
+            seed=42,
+            temperature=0.7,  # for some reason vllm doesn't generate anything for 0 < temperature < 0.02
+            top_p=0.9,
+            top_k=None,
+            frequency_penalty=0.0,
+            presence_penalty=0.0,
+            best_of=None,
+            num_choices=2,
+            top_logprobs=3,
+        ),
+        device=7,
+        # this allows us to run base models with the chat message scaffolding:
+        chat_template="{% for message in messages %}{{ message.content }}{% endfor %}",
+    )
+
+
+@pytest.mark.asyncio
+@skip_if_github_action
+async def test_hf_api(model) -> None:
+    message = ChatMessageUser(content="Lorem ipsum dolor")
+    response = await model.generate(input=[message])
+    assert len(response.completion) >= 1
+    assert len(response.choices) == 2
+    assert len(response.choices[0].logprobs.content) == 1
+    assert len(response.choices[0].logprobs.content[0].top_logprobs) == 3
+
+
+@pytest.mark.asyncio
+@skip_if_github_action
+async def test_hf_api_fails(model) -> None:
+    temp_before = model.config.temperature
+    try:
+        model.config.temperature = 0.0
+
+        message = ChatMessageUser(content="Lorem ipsum dolor")
+        with pytest.raises(Exception):
+            await model.generate(input=[message])
+    finally:
+        model.config.temperature = temp_before

--- a/tests/model/providers/test_vllm.py
+++ b/tests/model/providers/test_vllm.py
@@ -8,48 +8,24 @@ from inspect_ai.model import (
 )
 
 
-@pytest.fixture
-def model():
-    return get_model(
+@pytest.mark.asyncio
+@skip_if_github_action
+async def test_hf_api() -> None:
+    model = get_model(
         "vllm/EleutherAI/pythia-70m",
         config=GenerateConfig(
             max_tokens=1,
             seed=42,
-            temperature=0.7,  # for some reason vllm doesn't generate anything for 0 < temperature < 0.02
+            temperature=0.7,
             top_p=0.9,
             top_k=None,
             frequency_penalty=0.0,
             presence_penalty=0.0,
-            best_of=None,
-            num_choices=2,
-            top_logprobs=3,
         ),
-        device=7,
+        device=0,
         # this allows us to run base models with the chat message scaffolding:
         chat_template="{% for message in messages %}{{ message.content }}{% endfor %}",
     )
-
-
-@pytest.mark.asyncio
-@skip_if_github_action
-async def test_hf_api(model) -> None:
     message = ChatMessageUser(content="Lorem ipsum dolor")
     response = await model.generate(input=[message])
     assert len(response.completion) >= 1
-    assert len(response.choices) == 2
-    assert len(response.choices[0].logprobs.content) == 1
-    assert len(response.choices[0].logprobs.content[0].top_logprobs) == 3
-
-
-@pytest.mark.asyncio
-@skip_if_github_action
-async def test_hf_api_fails(model) -> None:
-    temp_before = model.config.temperature
-    try:
-        model.config.temperature = 0.0
-
-        message = ChatMessageUser(content="Lorem ipsum dolor")
-        with pytest.raises(Exception):
-            await model.generate(input=[message])
-    finally:
-        model.config.temperature = temp_before

--- a/tests/model/test_logprobs.py
+++ b/tests/model/test_logprobs.py
@@ -53,3 +53,17 @@ async def test_hf_logprobs() -> None:
         and response.choices[0].logprobs.content[0].top_logprobs is not None
     )
     assert len(response.choices[0].logprobs.content[0].top_logprobs) == 2
+
+
+@pytest.mark.asyncio
+@skip_if_github_action
+async def test_vllm_logprobs() -> None:
+    response = await generate_with_logprobs(
+        "vllm/EleutherAI/pythia-70m",
+        chat_template="{% for message in messages %}{{ message.content }}{% endfor %}",
+    )
+    assert (
+        response.choices[0].logprobs
+        and response.choices[0].logprobs.content[0].top_logprobs is not None
+    )
+    assert len(response.choices[0].logprobs.content[0].top_logprobs) == 2

--- a/tests/model/test_num_choices.py
+++ b/tests/model/test_num_choices.py
@@ -1,5 +1,9 @@
 import pytest
-from test_helpers.utils import skip_if_no_openai, skip_if_no_together, skip_if_github_action
+from test_helpers.utils import (
+    skip_if_github_action,
+    skip_if_no_openai,
+    skip_if_no_together,
+)
 
 from inspect_ai.model import GenerateConfig, get_model
 

--- a/tests/model/test_num_choices.py
+++ b/tests/model/test_num_choices.py
@@ -1,5 +1,5 @@
 import pytest
-from test_helpers.utils import skip_if_no_openai, skip_if_no_together
+from test_helpers.utils import skip_if_no_openai, skip_if_no_together, skip_if_github_action
 
 from inspect_ai.model import GenerateConfig, get_model
 
@@ -27,6 +27,12 @@ async def test_openai_num_choices() -> None:
 @skip_if_no_together
 async def test_together_num_choices() -> None:
     await check_num_choices("together/google/gemma-2b-it")
+
+
+@pytest.mark.asyncio
+@skip_if_github_action
+async def test_vllm_num_choices() -> None:
+    await check_num_choices("vllm/EleutherAI/pythia-70m")
 
 
 # @pytest.mark.asyncio


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

This PR adds support for using vLLM to run local model inference as an alternative to the huggingface backend. The main benefit of vLLM is that it is much faster than huggingface and automatically manages GPU memory so you don't have to find the optimal batch size. Here is a small example where vLLM is 5x faster than huggingface on an A100 (for larger datasets I've found vLLM can be around 30x faster):

```bash
inspect eval examples/popularity.py --model hf/meta-llama/Meta-Llama-3-8B-Instruct -M device='cuda:0'
inspect eval examples/popularity.py --model vllm/meta-llama/Meta-Llama-3-8B-Instruct -M device=0
```

The other benefits is that it has support for some of the parameters in `GenerateConfig` that huggingface doesn't support such as `best_of`, `frequency_penalty`, `presence_penalty`, and `num_choices`.

Another thing to consider is that vLLM is in the process of implementing tool call/guided generation capabilities into the library so once that is released it will be very easy to add function-calling support for local models (I have my own personal implementation for local models, not included in this PR, but it relies on the model getting the syntax right which isn't always reliable).

Feedback is very appreciated!