### PR TITLE
sample metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Handle duplicate tool call ids in Inspect View.
 - Handle sorting sample ids of different types in Inspect View.
 - Correctly resolve default model based on CLI --model argument.
+- Read JSON encoded `metadata` field from samples.
 - Ability to host standalone version of Inspect View to view single log files.
 
 ## v0.3.18 (14 July 2024)

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 from inspect_ai.model import (
@@ -34,6 +35,16 @@ def record_to_sample_fn(
                 metadata = {}
                 for name in sample_fields.metadata:
                     metadata[name] = record.get(name)
+            elif "metadata" in record:
+                metadata_field = record.get("metadata")
+                if isinstance(metadata_field, str):
+                    metadata = json.loads(metadata_field)
+                elif isinstance(metadata_field, dict):
+                    metadata = metadata_field
+                else:
+                    raise ValueError(
+                        f"Unexpected type for 'metadata' field: {type(metadata_field)}"
+                    )
 
             # return sample
             return Sample(

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -22,6 +22,10 @@ json = (json_dataset, "samples.json")
 jsonl = (file_dataset, "samples.jsonl")
 dataset_params = [csv, json, jsonl]
 
+dataset_md_params = [
+    (param[0], param[1].replace(".", "-md.")) for param in dataset_params
+]
+
 
 # test reading a dataset using default configuration
 @pytest.mark.parametrize("type,file", dataset_params)
@@ -47,6 +51,13 @@ def test_dataset_fields_fn(type: Type[T_ds], file: str) -> None:
         sample_fields=data_to_sample,
     )
     assert_sample(dataset[0])
+
+
+# test reading metadata field
+@pytest.mark.parametrize("type,file", dataset_md_params)
+def test_dataset_metadata(type: Type[T_ds], file: str) -> None:
+    dataset: Dataset = type.__call__(dataset_path(file))
+    assert dataset[0].metadata and dataset[0].metadata.get("foo") == "bar"
 
 
 @skip_if_github_action

--- a/tests/dataset/test_dataset/samples-md.csv
+++ b/tests/dataset/test_dataset/samples-md.csv
@@ -1,0 +1,2 @@
+input,target,label,metadata
+"Say 'Hello, World'","Hello, World","Hello, World","{""foo"": ""bar""}"

--- a/tests/dataset/test_dataset/samples-md.json
+++ b/tests/dataset/test_dataset/samples-md.json
@@ -1,0 +1,10 @@
+[
+  {
+    "input": "Say 'Hello, World'",
+    "target": "Hello, World",
+    "label": "Hello, World",
+    "metadata": {
+      "foo": "bar"
+    }
+  }
+]

--- a/tests/dataset/test_dataset/samples-md.jsonl
+++ b/tests/dataset/test_dataset/samples-md.jsonl
@@ -1,0 +1,1 @@
+{ "input": "Say 'Hello, World'", "target": "Hello, World", "label": "Hello, World", "metadata": "{\"foo\": \"bar\"}" }


### PR DESCRIPTION
If samples have a `metadata` field (i.e. they have been prepared specifically for Inspect) we now automatically read it (including parsing JSON if it is represented as a string). 

Resolves https://github.com/UKGovernmentBEIS/inspect_ai/issues/87