### PR TITLE
sample setup script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Handle duplicate tool call ids in Inspect View.
 - Handle sorting sample ids of different types in Inspect View.
 - Correctly resolve default model based on CLI --model argument.
+- Add `setup` field to `Sample` for providing a per-sample setup script.
 - Read JSON encoded `metadata` field from samples.
 - Ability to host standalone version of Inspect View to view single log files.
 

--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -403,7 +403,7 @@ Note that `read_file()` will raise a `FileNotFoundError` if the specified `file`
 There are two tool environments built in to Inspect:
 
 | Environment Type | Description |
-|---------------------------|---------------------------------------------|
+|------------------------------------|-----------------------------------------------------------------|
 | `local` | Run `tool_environment()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
 | `docker` | Run `tool_environment()` methods within a Docker container (see the [Docker Configuration](#sec-docker-configuration) section below for additional details). |
 
@@ -427,6 +427,30 @@ For this example, if there is a `compose.yaml` file in the task directory it wil
 tool_environment=("docker","my-compose.yaml")
 ```
 
+### Per Sample Setup
+
+The `Sample` class includes `files` and `setup` fields that are used to specify per-sample file assets and setup logic.
+
+#### Files
+
+Sample `files` is a `dict[str,str]` that specifies files to copy into tool environments. The key of the `dict` specifies the name of the file to write. By default files are written into the default tool environment but they can optionally include a prefix indicating that they should be written into a specific tool environment (e.g. `"victim:flag.txt": "flag.txt"`).
+
+The value of the `dict` can be either the file contents, a file path, or a base64 encoded [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
+
+#### Script
+
+If there is a Sample `setup` script it will be executed within the default tool environment after any Sample `files` are copied into the environment. The `setup` field can be either the script contents, a file path containing the script, or a base64 encoded [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).
+
+The `setup` script is by default interpreted as a bash script, however you can have it executed by another interpreter using a shebang comment. For example, this will be executed as a Python script:
+
+``` bash
+#!/usr/bin/env python3
+
+print('hello from python')
+```
+
+#### 
+
 ### Docker Configuration {#sec-docker-configuration}
 
 Before using Docker tool environments, please be sure to install [Docker Engine](https://docs.docker.com/engine/install/) (version 24.0.7 or greater).
@@ -436,7 +460,7 @@ You can use the Docker tool enviornment without any special configuration, howev
 Here is how Docker tool environments are created based on the presence of `Dockerfile` and/or `compose.yml` in the task directory:
 
 | Config Files | Behavior |
-|--------------------------|----------------------------------------------|
+|--------------------------|---------------------------------------------|
 | None | Creates a tool environment based on the official [python:3.12-bookworm](https://hub.docker.com/_/python) image. |
 | `Dockerfile` | Creates a tool environment by building the image. |
 | `compose.yaml` | Creates tool environment(s) based on `compose.yaml`. |
@@ -515,10 +539,6 @@ tool_environment("victim")  # named tool environment
 ::: {.callout-note apperance="simple"}
 If you define multiple tool environments you are *required* to name one of them "default" so that Inspect knows which environment to copy samples files to and resolve for calls to `tool_environment()` without an argument.
 :::
-
-#### Files
-
-Sample `files` will be copied into the default tool environment unless their name contains a prefix mapping them into another environment (e.g. `"victim:flag.txt": "flag.txt"`).
 
 #### Infrastructure
 

--- a/docs/datasets.qmd
+++ b/docs/datasets.qmd
@@ -20,22 +20,23 @@ The core data type underlying the use of datasets with Inspect is the `Sample`, 
 
 **Class** `inspect_ai.dataset.Sample`
 
-| Field      | Type                      | Description                                                                                           |
+| Field | Type | Description |
 |-------------------|---------------------|--------------------------------|
-| `input`    | `str | list[ChatMessage]` | The input to be submitted to the model.                                                               |
-| `choices`  | `list[str] | None`        | Optional. Multiple choice answer list.                                                                |
-| `target`   | `str | list[str] | None`  | Optional. Ideal target output. May be a literal value or narrative text to be used by a model grader. |
-| `id`       | `str | None`              | Optional. Unique identifier for sample.                                                               |
-| `metadata` | `dict[str | Any] | None`  | Optional. Arbitrary metadata associated with the sample.                                              |
-| `files`    | `dict[str | str] | None`  | Optional. Files that go along with the sample (copied to tool environments).                          |
+| `input` | `str | list[ChatMessage]` | The input to be submitted to the model. |
+| `choices` | `list[str] | None` | Optional. Multiple choice answer list. |
+| `target` | `str | list[str] | None` | Optional. Ideal target output. May be a literal value or narrative text to be used by a model grader. |
+| `id` | `str | None` | Optional. Unique identifier for sample. |
+| `metadata` | `dict[str | Any] | None` | Optional. Arbitrary metadata associated with the sample. |
+| `files` | `dict[str | str] | None` | Optional. Files that go along with the sample (copied to tool environments). |
+| `setup` | `str | None` | Optional. Setup script to run for sample (executed within default tool environment). |
 
 : {tbl-colwidths="\[20,40,40\]"}
 
 So a CSV dataset with the following structure:
 
-| input                                                                        | target                                                    |
+| input | target |
 |-----------------------------------------|-------------------------------|
-| What cookie attributes should I use for strong security?                     | secure samesite and httponly                              |
+| What cookie attributes should I use for strong security? | secure samesite and httponly |
 | How should I store passwords securely for an authentication system database? | strong hashing algorithms with salt like Argon2 or bcrypt |
 
 Can be read directly with:
@@ -165,10 +166,10 @@ The most important data structure within `Sample` is the `ChatMessage`. Note tha
 
 **Class** `inspect_ai.model.ChatMessage`
 
-| Field     | Type                                       | Description                                                                                                |
+| Field | Type | Description |
 |-------------------|---------------------|--------------------------------|
-| `role`    | `"system" | "user" | "assistant" | "tool"` | Role of this chat message.                                                                                 |
-| `content` | `str | list[ChatContent]`                  | The content of the message. Can be a simple string or a list of content parts intermixing text and images. |
+| `role` | `"system" | "user" | "assistant" | "tool"` | Role of this chat message. |
+| `content` | `str | list[ChatContent]` | The content of the message. Can be a simple string or a list of content parts intermixing text and images. |
 
 : {tbl-colwidths="\[10,35,55\]"}
 

--- a/examples/agents/intercode-ctf/dataset.py
+++ b/examples/agents/intercode-ctf/dataset.py
@@ -36,19 +36,20 @@ def read_dataset(shuffle=False, force_download=False):
             input=record["query"],
             target=record["gold"],
             metadata={
-                "setup": record.get("setup", None),
-                "files": list(files.keys()),
                 "source": record["source"],
                 "tags": record["tags"],
                 "solution": solution,
             },
             files=files,
+            setup=record.get("setup", None),
         )
 
     # read dataset. we filter out samples that required internet access, as
     # is also done in the GDM paper (https://arxiv.org/pdf/2403.13793)
     excluded = [
+        1,
         9,
+        14,
         16,
         20,
         28,

--- a/examples/agents/intercode-ctf/task.py
+++ b/examples/agents/intercode-ctf/task.py
@@ -3,16 +3,12 @@ from dataset import read_dataset
 from inspect_ai import Task, task
 from inspect_ai.scorer import includes
 from inspect_ai.solver import (
-    Generate,
-    TaskState,
     bash,
     generate,
     python,
-    solver,
     system_message,
     use_tools,
 )
-from inspect_ai.tool import tool_environment
 
 # maximum chat messages before giving up
 MAX_MESSAGES = 30
@@ -28,32 +24,9 @@ def intercode_ctf(shuffle=False):
         plan=[
             system_message("system.txt"),
             use_tools([bash(timeout=CMD_TIMEOUT), python(timeout=CMD_TIMEOUT)]),
-            sample_init(),
             generate(),
         ],
         scorer=includes(),
         max_messages=MAX_MESSAGES,
         tool_environment="docker",
     )
-
-
-@solver
-def sample_init():
-    async def solve(state: TaskState, generate: Generate):
-        # run setup code if provided
-        if state.metadata.get("setup") is not None:
-            await tool_environment().exec(["bash", "-c", state.metadata["setup"]])
-
-        # add available files (if any) to prompt
-        files = state.metadata["files"]
-        if len(files) > 0:
-            state.user_prompt.text = (
-                "The following files are located in the working directory: "
-                + f"{' '.join(files)}\n\n"
-                + f"{state.user_prompt.text}"
-            )
-
-        # return state
-        return state
-
-    return solve

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -538,24 +538,16 @@ async def toolenv_context(
     files: dict[str, bytes] = {}
     if sample.files:
         for path, contents in sample.files.items():
-            if is_data_uri(contents):
-                contents_base64 = data_uri_to_base64(contents)
-                file_bytes = base64.b64decode(contents_base64)
-            else:
-                # try to read as a file (if it doesn't exist or has a path not cool w/
-                # the fileystem then we fall back to contents)
-                try:
-                    fs = filesystem(contents)
-                    if fs.exists(contents):
-                        with file(contents, "rb") as f:
-                            file_bytes = f.read()
-                    else:
-                        file_bytes = contents.encode("utf-8")
-                except Exception:
-                    file_bytes = contents.encode("utf-8")
+            files[path] = read_toolenv_file(contents)
 
-            # record resolved bytes
-            files[path] = file_bytes
+    # read setup script from sample (add bash shebang if necessary)
+    setup: bytes | None = None
+    if sample.setup:
+        setup = read_toolenv_file(sample.setup)
+        setup_str = setup.decode(encoding="utf-8")
+        if not setup_str.strip().startswith("#!"):
+            setup_str = f"#!/usr/bin/env bash\n\n{setup_str}"
+            setup = setup_str.encode(encoding="utf-8")
 
     interrupted = False
     environments: dict[str, ToolEnvironment] | None = None
@@ -566,6 +558,7 @@ async def toolenv_context(
             task_name=task_name,
             config=tool_environment[1],
             files=files,
+            setup=setup,
             metadata=sample.metadata if sample.metadata else {},
         )
 
@@ -586,3 +579,23 @@ async def toolenv_context(
                 environments=environments,
                 interrupted=interrupted,
             )
+
+
+def read_toolenv_file(contents: str) -> bytes:
+    if is_data_uri(contents):
+        contents_base64 = data_uri_to_base64(contents)
+        file_bytes = base64.b64decode(contents_base64)
+    else:
+        # try to read as a file (if it doesn't exist or has a path not cool w/
+        # the fileystem then we fall back to contents)
+        try:
+            fs = filesystem(contents)
+            if fs.exists(contents):
+                with file(contents, "rb") as f:
+                    file_bytes = f.read()
+            else:
+                file_bytes = contents.encode("utf-8")
+        except Exception:
+            file_bytes = contents.encode("utf-8")
+
+    return file_bytes

--- a/src/inspect_ai/dataset/_dataset.py
+++ b/src/inspect_ai/dataset/_dataset.py
@@ -31,9 +31,10 @@ class Sample(BaseModel):
             or narrative text to be used by a model grader.
         id (int | str | None): Optional. Unique identifier for sample.
         metadata (dict[str,Any] | None): Optional. Arbitrary metadata associated with the sample.
-        files (dict[str, str]): Optional. Files that go along with the sample (copied to
+        files (dict[str, str] | None): Optional. Files that go along with the sample (copied to
           ToolEnvironment). Files can be paths, inline text, or inline binary (base64 encoded data URL).
-
+        setup: (str | None): Optional. Setup script to run for sample (run
+          within default ToolEnvironment).
     """
 
     input: str | list[ChatMessage]
@@ -53,6 +54,9 @@ class Sample(BaseModel):
 
     files: dict[str, str] | None = Field(default=None)
     """Files that go along with the sample (copied to ToolEnvironment)"""
+
+    setup: str | None = Field(default=None)
+    """Setup script to run for sample (run within default ToolEnvironment)."""
 
 
 def sample_input_len(sample: Sample) -> int:
@@ -172,6 +176,9 @@ class FieldSpec(BaseModel):
 
     files: str = Field(default="files")
     """Files that go along wtih the sample."""
+
+    setup: str = Field(default="setup")
+    """Setup script to run for sample (run within default ToolEnvironment)."""
 
 
 RecordToSample = Callable[[DatasetRecord], Sample]

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -1,4 +1,5 @@
-from typing import Any
+import json
+from typing import Any, cast
 
 from inspect_ai.model import (
     ChatMessage,
@@ -42,6 +43,8 @@ def record_to_sample_fn(
                 choices=read_choices(record.get(sample_fields.choices)),
                 id=record.get(sample_fields.id, None),
                 metadata=metadata,
+                files=read_files(record.get(sample_fields.files)),
+                setup=read_setup(record.get(sample_fields.setup)),
             )
 
     else:
@@ -116,5 +119,26 @@ def read_choices(obj: Any | None) -> list[str] | None:
             return [choice.strip() for choice in choices]
         else:
             return [str(obj)]
+    else:
+        return None
+
+
+def read_setup(setup: Any | None) -> str | None:
+    if setup is not None:
+        return str(setup)
+    else:
+        return None
+
+
+def read_files(files: Any | None) -> dict[str, str] | None:
+    if files is not None:
+        if isinstance(files, str):
+            files = json.loads(files)
+        if isinstance(files, dict):
+            if all(isinstance(v, str) for v in files.values()):
+                return cast(dict[str, str], files)
+
+        # didn't find the right type
+        raise ValueError(f"Unexpected type for 'files' field: {type(files)}")
     else:
         return None


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

This PR introduces support for a new `setup` field for `Sample` objects. The `setup` field specifies a script to execute within the default tool environment after any Sample `files` are copied into the environment. The `setup` field can be either the script contents, a file path containing the script, or a base64 encoded [Data URL](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/Data_URLs).

The `setup` script is by default interpreted as a bash script, however you can have it executed by another interpreter using a shebang comment. For example, this will be executed as a Python script:

``` bash
#!/usr/bin/env python3

print('hello from python')
```

The Intercode-CTF example is also updated to use the `setup` field (previously it had done its own `setup` handling using a `metadata` field and custom solver).