### PR TITLE
parallel tasks w/ multiple toolenvs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [vLLM](https://inspect.ai-safety-institute.org.uk/models.html#sec-vllm) model provider.
 - [Groq](https://groq.com/) model provider.
 - Replace the use of the `bootstrap_std` metric with `stderr` for built in scorers (see [rationale](https://inspect.ai-safety-institute.org.uk/scorers.html#stderr-note) for details).
+- Enable parallel execution of tasks that share a working directory.
 - Gracefully handle tool calls that include only a single value (rather than a named dict of parameters).
 - Support `tool_choice="any"` for OpenAI models (requires >= 1.24.0 of openai package).
 - Add `cwd` argument to `ToolEnvironment.exec()`.

--- a/docs/_sample-preservation.md
+++ b/docs/_sample-preservation.md
@@ -18,4 +18,3 @@ Another consideration is `max_samples`, which is the maximum number of samples t
 
 By default, Inspect sets the value of `max_samples` to `max_connections + 1`, ensuring that the model API is always fully saturated (note that it would rarely make sense to set it _lower_ than `max_connections`). The default `max_connections` is 10, which will typically result in samples being written to the log frequently. On the other hand, setting a very large `max_connections` (e.g. 100 `max_connections` for a dataset with 100 samples) may result in very few recoverable samples in the case of an interruption. 
 
-Note also that when using [Tool Environments](#sec-tool-environments), the tool environment provider may place an additional cap on the default `max_samples` (for example, the Docker provider limits the default `max_samples` to no more than 25).

--- a/docs/extensions.qmd
+++ b/docs/extensions.qmd
@@ -91,10 +91,10 @@ eval(math, model = "custom/my-model")
 
 [Tool Environments](#sec-tool-environments) provide a mechanism for sandboxing execution of tool code as well as providing more sophisticated infrastructure (e.g. creating network hosts for a cybersecurity eval). Inspect comes with two tool environments built in:
 
-| Environment Type | Description |
+| Environment Type | Description                                                                                                                                                               |
 |----------------------------|--------------------------------------------|
-| `local` | Run `tool_environment()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
-| `docker` | Run `tool_environment()` methods within a Docker container |
+| `local`          | Run `tool_environment()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
+| `docker`         | Run `tool_environment()` methods within a Docker container                                                                                                                |
 
 To create a custom tool environment, derive a class from `ToolEnvironment`, implement the required static and instance methods, and add the `@toolenv` decorator to it. For example:
 
@@ -172,16 +172,16 @@ class PodmanToolEnvironment(ToolEnvironment):
 
 The class methods take care of various stages of initialisation, setup, and teardown:
 
-| Method | Lifecycle | Purpose |
+| Method             | Lifecycle                                                                                          | Purpose                                                                                               |
 |-------------------|-------------------|----------------------------------|
-| `task_init()` | Called at the beginning of each `Task`. | Expensive initialisation operations (e.g. pulling or building images) |
-| `sample_init()` | Called at the beginning of each `Sample`. | Create `ToolEnvironment` instances for the sample. |
-| `sample_cleanup()` | Called at the end of each `Sample` | Cleanup `ToolEnvironment` instances for the sample. |
-| `task_cleanup()` | Called at the end of each `Task`. | Last chance handler for any resources not yet cleaned up (see also discussion below). |
-| `cli_cleanup()` | Called via `inspect toolenv cleanup` | CLI invoked manual cleanup of resources created by this `ToolEnvironment`. |
-| `max_samples()` | Called at startup | Provide a default `max_samples` (used to cap the default, explicit `max_samples` will override this). |
+| `task_init()`      | Called once for each unique tool environment config before executing the tasks in an `eval()` run. | Expensive initialisation operations (e.g. pulling or building images)                                 |
+| `sample_init()`    | Called at the beginning of each `Sample`.                                                          | Create `ToolEnvironment` instances for the sample.                                                    |
+| `sample_cleanup()` | Called at the end of each `Sample`                                                                 | Cleanup `ToolEnvironment` instances for the sample.                                                   |
+| `task_cleanup()`   | Called once for each unique tool environment config after executing the tasks in an `eval()` run.  | Last chance handler for any resources not yet cleaned up (see also discussion below).                 |
+| `cli_cleanup()`    | Called via `inspect toolenv cleanup`                                                               | CLI invoked manual cleanup of resources created by this `ToolEnvironment`.                            |
+| `max_samples()`    | Called at startup                                                                                  | Provide a default `max_samples` (used to cap the default, explicit `max_samples` will override this). |
 
-In the case of parallel execution of a group of tasks that share a working directory and tool environment, the `task_init()` and `task_cleanup()` functions may be called once for the entire group as a performance optimisation.
+In the case of parallel execution of a group of tasks within the same working directory, the `task_init()` and `task_cleanup()` functions will be called once for each unique tool environment configuration (e.g. Docker Compose file). This is a performance optimisation derived from the fact that initialisation and cleanup are shared for tasks with identical configurations.
 
 The `task_cleanup()` has a number of important functions:
 

--- a/docs/extensions.qmd
+++ b/docs/extensions.qmd
@@ -172,14 +172,13 @@ class PodmanToolEnvironment(ToolEnvironment):
 
 The class methods take care of various stages of initialisation, setup, and teardown:
 
-| Method             | Lifecycle                                                                                          | Purpose                                                                                               |
+| Method             | Lifecycle                                                                                          | Purpose                                                                               |
 |-------------------|-------------------|----------------------------------|
-| `task_init()`      | Called once for each unique tool environment config before executing the tasks in an `eval()` run. | Expensive initialisation operations (e.g. pulling or building images)                                 |
-| `sample_init()`    | Called at the beginning of each `Sample`.                                                          | Create `ToolEnvironment` instances for the sample.                                                    |
-| `sample_cleanup()` | Called at the end of each `Sample`                                                                 | Cleanup `ToolEnvironment` instances for the sample.                                                   |
-| `task_cleanup()`   | Called once for each unique tool environment config after executing the tasks in an `eval()` run.  | Last chance handler for any resources not yet cleaned up (see also discussion below).                 |
-| `cli_cleanup()`    | Called via `inspect toolenv cleanup`                                                               | CLI invoked manual cleanup of resources created by this `ToolEnvironment`.                            |
-| `max_samples()`    | Called at startup                                                                                  | Provide a default `max_samples` (used to cap the default, explicit `max_samples` will override this). |
+| `task_init()`      | Called once for each unique tool environment config before executing the tasks in an `eval()` run. | Expensive initialisation operations (e.g. pulling or building images)                 |
+| `sample_init()`    | Called at the beginning of each `Sample`.                                                          | Create `ToolEnvironment` instances for the sample.                                    |
+| `sample_cleanup()` | Called at the end of each `Sample`                                                                 | Cleanup `ToolEnvironment` instances for the sample.                                   |
+| `task_cleanup()`   | Called once for each unique tool environment config after executing the tasks in an `eval()` run.  | Last chance handler for any resources not yet cleaned up (see also discussion below). |
+| `cli_cleanup()`    | Called via `inspect toolenv cleanup`                                                               | CLI invoked manual cleanup of resources created by this `ToolEnvironment`.            |
 
 In the case of parallel execution of a group of tasks within the same working directory, the `task_init()` and `task_cleanup()` functions will be called once for each unique tool environment configuration (e.g. Docker Compose file). This is a performance optimisation derived from the fact that initialisation and cleanup are shared for tasks with identical configurations.
 

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -92,7 +92,7 @@ async def eval_run(
                     TaskRunOptions(
                         task=task,
                         model=resolved_task.model,
-                        toolenv=toolenv,
+                        toolenv=resolved_task.toolenv,
                         logger=logger,
                         config=task_eval_config,
                         plan=plan,

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -222,7 +222,7 @@ async def startup_tool_environments(
 
         # run startup
         task_init = cast(TaskInit, getattr(toolenv_type, "task_init"))
-        await task_init("init", toolenv[1])
+        await task_init("startup", toolenv[1])
 
         # append cleanup method
         task_cleanup = cast(TaskCleanup, getattr(toolenv_type, "task_cleanup"))
@@ -233,7 +233,7 @@ async def startup_tool_environments(
         for cleanup_jobs in cleanups:
             try:
                 cleanup_fn, config = cleanup_jobs
-                await cleanup_fn("cleanup", config, cleanup)
+                await cleanup_fn("shutdown", config, cleanup)
             except BaseException as ex:
                 log.warning(
                     f"Error occurred shutting down tool environments: {exception_message(ex)}"

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -1,6 +1,6 @@
 import asyncio
 import logging
-from typing import Any, Awaitable, Callable, Set
+from typing import Any, Awaitable, Callable, Set, cast
 
 from shortuuid import uuid
 from typing_extensions import Unpack
@@ -13,7 +13,8 @@ from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._log import Recorder
 from inspect_ai.model import GenerateConfig, GenerateConfigArgs
 from inspect_ai.solver import Plan, Solver
-from inspect_ai.tool._environment.context import startup_tool_environments
+from inspect_ai.tool._environment.environment import TaskCleanup, TaskInit
+from inspect_ai.tool._environment.registry import registry_find_toolenv
 
 from .loader import ResolvedTask
 from .task.log import TaskLogger
@@ -40,13 +41,11 @@ async def eval_run(
     if any([task_run_dir(task.task) != run_dir for task in tasks]):
         raise RuntimeError("Parallel tasks must have the same working directory.")
     toolenv = next((task.toolenv for task in tasks if task.toolenv is not None), None)
-    if any([task.toolenv is not None and task.toolenv != toolenv for task in tasks]):
-        raise RuntimeError("Parallel tasks must have the same tool environment.")
 
     # if we have a toolenv then we need to enforce sample concurrency at
     # this level of the eval (so we don't explode the # of toolenvs)
     sample_semaphore: asyncio.Semaphore | None = (
-        create_sample_semaphore(eval_config, GenerateConfig(**kwargs), toolenv)
+        create_sample_semaphore(eval_config, GenerateConfig(**kwargs))
         if toolenv
         else None
     )
@@ -57,9 +56,7 @@ async def eval_run(
         shutdown_tool_environments: Callable[[], Awaitable[None]] | None = None
         if toolenv:
             cleanup = eval_config.toolenv_cleanup is not False
-            shutdown_tool_environments = await startup_tool_environments(
-                "startup", toolenv, cleanup
-            )
+            shutdown_tool_environments = await startup_tool_environments(tasks, cleanup)
 
         try:
             # create run tasks
@@ -206,3 +203,40 @@ async def run_multiple(tasks: list[TaskRunOptions], parallel: int) -> list[EvalL
             w.cancel()
 
         return results
+
+
+async def startup_tool_environments(
+    tasks: list[ResolvedTask], cleanup: bool
+) -> Callable[[], Awaitable[None]]:
+    # find unique toolenvs
+    toolenvs: Set[tuple[str, str | None]] = set()
+    for task in tasks:
+        if task.toolenv is not None and task.toolenv not in toolenvs:
+            toolenvs.add(task.toolenv)
+
+    # initialiase toolenvs (track cleanups)
+    cleanups: list[tuple[TaskCleanup, str | None]] = []
+    for toolenv in toolenvs:
+        # find type
+        toolenv_type = registry_find_toolenv(toolenv[0])
+
+        # run startup
+        task_init = cast(TaskInit, getattr(toolenv_type, "task_init"))
+        await task_init("init", toolenv[1])
+
+        # append cleanup method
+        task_cleanup = cast(TaskCleanup, getattr(toolenv_type, "task_cleanup"))
+        cleanups.append((task_cleanup, toolenv[1]))
+
+    # return shutdown method
+    async def shutdown() -> None:
+        for cleanup_jobs in cleanups:
+            try:
+                cleanup_fn, config = cleanup_jobs
+                await cleanup_fn("cleanup", config, cleanup)
+            except BaseException as ex:
+                log.warning(
+                    f"Error occurred shutting down tool environments: {exception_message(ex)}"
+                )
+
+    return shutdown

--- a/src/inspect_ai/tool/_environment/docker/docker.py
+++ b/src/inspect_ai/tool/_environment/docker/docker.py
@@ -165,10 +165,6 @@ class DockerToolEnvironment(ToolEnvironment):
         self._service = service
         self._project = project
 
-    @classmethod
-    def max_samples(cls) -> int | None:
-        return 25
-
     @override
     async def exec(
         self,

--- a/src/inspect_ai/tool/_environment/docker/util.py
+++ b/src/inspect_ai/tool/_environment/docker/util.py
@@ -1,6 +1,7 @@
 import re
 from dataclasses import dataclass
 from logging import getLogger
+from pathlib import Path
 
 from shortuuid import uuid
 
@@ -27,7 +28,7 @@ class ComposeProject:
         working_dir: str = "/",
     ) -> "ComposeProject":
         # ensure we have an auto-compose file if we need one
-        config = config if config else await auto_compose()
+        config = Path(config).resolve().as_posix() if config else await auto_compose()
         await ensure_auto_compose_file(config)
 
         # return project

--- a/src/inspect_ai/tool/_environment/environment.py
+++ b/src/inspect_ai/tool/_environment/environment.py
@@ -90,10 +90,6 @@ class ToolEnvironment(abc.ABC):
         """
         pass
 
-    @classmethod
-    def max_samples(cls) -> int | None:
-        return None
-
     @abc.abstractmethod
     async def exec(
         self,


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

This PR relaxes the constraint around tool environments for parallel tasks. Previously, all tasks in a parallel run needed to not only have the same working directory but also have the same tool environment. With this PR, unique tool environments are pulled out of the list of tasks and initialised and shutdown as required.

There are still a couple of issues I am running down w/ Ctrl+C cancellation, so the PR is still in draft status.