### PR TITLE
Use tee for Docker implementation of write_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Gracefully handle tool calls that include only a single value (rather than a named dict of parameters).
 - Support `tool_choice="any"` for OpenAI models (requires >= 1.24.0 of openai package).
 - Add `cwd` argument to `ToolEnvironment.exec()`.
+- Use `tee` rather than `docker cp` for Docker tool environment implementation of `write_file()`.
 - Handle duplicate tool call ids in Inspect View.
 - Handle sorting sample ids of different types in Inspect View.
 - Correctly resolve default model based on CLI --model argument.

--- a/examples/tool_use.py
+++ b/examples/tool_use.py
@@ -122,3 +122,33 @@ def read():
         scorer=match(),
         tool_environment="local",
     )
+
+
+@tool(prompt="If you need to write a text file, use the write_file tool.")
+def write_file():
+    async def execute(file: str, contents: str):
+        """Write a file
+
+        Args:
+            file (str): File to write
+            contents (str): Contents of file
+        """
+        try:
+            return await tool_environment().write_file(file, contents)
+        except FileNotFoundError:
+            raise ToolError(f"File {file} not found.")
+
+    return execute
+
+
+@task
+def write():
+    return Task(
+        dataset=[Sample(input="Please write 'bar' to a file named 'foo.txt'.")],
+        plan=[
+            use_tools([write_file()]),
+            generate(),
+        ],
+        scorer=match(),
+        tool_environment="local",
+    )

--- a/src/inspect_ai/tool/_environment/docker/docker.py
+++ b/src/inspect_ai/tool/_environment/docker/docker.py
@@ -218,7 +218,7 @@ class DockerToolEnvironment(ToolEnvironment):
                 raise RuntimeError(msg)
 
         # write the file
-        result = await self.exec(["tee", file], input=contents)
+        result = await self.exec(["tee", "--", file], input=contents)
         if not result.success:
             msg = f"Failed to write file '{file}' into container: {result.stderr}"
             raise RuntimeError(msg)

--- a/src/inspect_ai/tool/_environment/docker/docker.py
+++ b/src/inspect_ai/tool/_environment/docker/docker.py
@@ -206,34 +206,22 @@ class DockerToolEnvironment(ToolEnvironment):
     async def write_file(self, file: str, contents: str | bytes) -> None:
         tools_log(f"write_file: {file}")
 
-        # Write the contents to a temp file
-        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
-            src_file = os.path.join(temp_dir, os.path.basename(file))
-            if isinstance(contents, str):
-                async with aiofiles.open(src_file, "w", encoding="utf-8") as f:
-                    await f.write(contents)
-            else:
-                async with aiofiles.open(src_file, "wb") as f:
-                    await f.write(contents)
+        # resolve relative file paths
+        file = container_file(self._project, file)
 
-            # resolve relative file paths
-            file = container_file(self._project, file)
+        # ensure that the directory exists
+        parent = Path(file).parent.as_posix()
+        if parent != ".":
+            result = await self.exec(["mkdir", "-p", parent])
+            if not result.success:
+                msg = f"Failed to create container directory {parent}: {result.stderr}"
+                raise RuntimeError(msg)
 
-            # ensure that the directory exists
-            parent = Path(file).parent.as_posix()
-            if parent != ".":
-                result = await self.exec(["mkdir", "-p", parent])
-                if not result.success:
-                    msg = f"Failed to create container directory {parent}: {result.stderr}"
-                    raise RuntimeError(msg)
-
-            # use the cp command to copy the file
-            await compose_cp(
-                src=os.path.basename(src_file),
-                dest=f"{self._service}:{file}",
-                project=self._project,
-                cwd=os.path.dirname(src_file),
-            )
+        # write the file
+        result = await self.exec(["tee", file], input=contents)
+        if not result.success:
+            msg = f"Failed to write file '{file}' into container: {result.stderr}"
+            raise RuntimeError(msg)
 
     @overload
     async def read_file(self, file: str, text: Literal[True] = True) -> str: ...


### PR DESCRIPTION

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Previously we used `docker cp`, which in some cases refused to overwrite certain files (e.g. `/etc/hosts`). Using `tee` runs inside the container so has the correct privileges to write to any file in the container. 
