### PR TITLE
Add `azure` model arg for OpenAI provider to force binding (or not binding) to the Azure OpenAI back-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Handle duplicate tool call ids in Inspect View.
 - Handle sorting sample ids of different types in Inspect View.
 - Correctly resolve default model based on CLI --model argument.
+- Add `azure` model arg for OpenAI provider to force binding (or not binding) to the Azure OpenAI back-end.
 - Add `setup` field to `Sample` for providing a per-sample setup script.
 - Read JSON encoded `metadata` field from samples.
 - Reduce foreground task contention for Inspect View history loading.

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -173,6 +173,13 @@ The complete list of environment variables (and how they map to the parameters o
 -   `organization` from `OPENAI_ORG_ID`
 -   `api_version` from `OPENAI_API_VERSION`
 
+The OpenAI provider will choose whether to make a connection to the main OpenAI service or Azure based on the presence of environment variables. If the `AZUREAI_OPENAI_API_KEY` variable is defined Azure will be used, otherwise OpenAI will be used (via the `OPENAI_API_KEY`). You can override this default behaviour using the `azure` model argument. For example:
+
+``` bash
+$ inspect eval eval.py -M azure=true  # force azure
+$ inspect eval eval.py -M azure=false # force no azure
+```
+
 #### Mistral
 
 To use Mistral models on Azure AI, specify an `AZURE_MISTRAL_API_KEY` along with an `INSPECT_EVAL_MODEL_BASE_URL`. You can then use the normal `mistral` provider, but you'll need to specify a model name that corresponds to the [Azure Deployment Name](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal#deploy-a-model) of your model. For example, if your deployment model name was `mistral-large-ctwi:`
@@ -211,7 +218,7 @@ $ inspect eval bedrock/meta.llama2-70b-chat-v1
 
 You aren't likely to need to, but you can also specify a custom base URL for AWS Bedrock using the `BEDROCK_BASE_URL` environment variable.
 
-### Google
+### Google {#google}
 
 ::: {.callout-note appearance="simple"}
 The ability to override the default [safety settings](https://ai.google.dev/gemini-api/docs/safety-settings) for Google models is available only in the development version of Inspect. You can install the development version with:
@@ -235,7 +242,7 @@ Google models make available [safety settings](https://ai.google.dev/gemini-api/
 For each category, the following block thresholds are available:
 
 | Block Threshold    | Description                                                  |
-|--------------------|--------------------------------------------------------------|
+|-------------------|-----------------------------------------------------|
 | `none`             | Always show regardless of probability of unsafe content      |
 | `only_high`        | Block when high probability of unsafe content                |
 | `medium_and_above` | Block when medium or high probability of unsafe content      |

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -68,8 +68,14 @@ class OpenAIAPI(ModelAPI):
             config=config,
         )
 
-        # resolve api_key
+        # pull out azure model_arg
+        AZURE_MODEL_ARG = "azure"
         is_azure = False
+        if AZURE_MODEL_ARG in model_args:
+            is_azure = model_args.get(AZURE_MODEL_ARG, False)
+            del model_args[AZURE_MODEL_ARG]
+
+        # resolve api_key
         if not self.api_key:
             self.api_key = os.environ.get(
                 AZUREAI_OPENAI_API_KEY, os.environ.get(AZURE_OPENAI_API_KEY, None)
@@ -97,7 +103,7 @@ class OpenAIAPI(ModelAPI):
             if not base_url:
                 raise ValueError(
                     "You must provide a base URL when using OpenAI on Azure. Use the AZUREAI_OPENAI_BASE_URL "
-                    + " environment variable or the --model-base-url CLI flag to set the base URL."
+                    + "environment variable or the --model-base-url CLI flag to set the base URL."
                 )
 
             self.client: AsyncAzureOpenAI | AsyncOpenAI = AsyncAzureOpenAI(


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

The OpenAI provider will choose whether to make a connection to the main OpenAI service or Azure based on the presence of environment variables. If the `AZUREAI_OPENAI_API_KEY` variable is defined Azure will be used, otherwise OpenAI will be used (via the `OPENAI_API_KEY`). You can override this default behaviour using the `azure` model argument. For example:

``` bash
$ inspect eval eval.py -M azure=true  # force azure
$ inspect eval eval.py -M azure=false # force no azure
```