### PR TITLE
multiple choice fixes/cleanup

### DIFF
--- a/benchmarks/gpqa.py
+++ b/benchmarks/gpqa.py
@@ -44,14 +44,14 @@ def record_to_sample(record):
 
 
 @task
-def gpqa_diamond(cot=True):
+def gpqa_diamond():
     return Task(
         dataset=csv_dataset(
             csv_file="https://openaipublic.blob.core.windows.net/simple-evals/gpqa_diamond.csv",
             sample_fields=record_to_sample,
         ),
         plan=[
-            multiple_choice(cot=cot, shuffle=True),
+            multiple_choice(shuffle=True),
         ],
         scorer=choice(),
         config=GenerateConfig(temperature=0.5),

--- a/src/inspect_ai/util/_resource.py
+++ b/src/inspect_ai/util/_resource.py
@@ -61,7 +61,7 @@ def resource(
         # parse the url
         try:
             parsed = urlparse(resource)
-        except (OSError, ValueError):
+        except (ValueError, OSError):
             return resource
 
         # if it has a scheme then its likely a file

--- a/src/inspect_ai/util/_resource.py
+++ b/src/inspect_ai/util/_resource.py
@@ -61,7 +61,7 @@ def resource(
         # parse the url
         try:
             parsed = urlparse(resource)
-        except OSError:
+        except (OSError, ValueError):
             return resource
 
         # if it has a scheme then its likely a file
@@ -81,7 +81,7 @@ def resource(
             # extract the path
             try:
                 path = url2pathname(parsed.path)
-            except OSError:
+            except (ValueError, OSError):
                 return resource
 
             # return it if it exists (otherwise return the str)


### PR DESCRIPTION
- Remove unsupported `cot` argument from gpqa benchmark
- Catch `ValueError` in `resource()` function when probing to determine if the argument is a string a file path.
