### PR TITLE
don't raise error for missing answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Handle sorting sample ids of different types in Inspect View.
 - Correctly resolve default model based on CLI --model argument.
 - Add `setup` field to `Sample` for providing a per-sample setup script.
+- Score multiple choice question with parseable answers as incorrect (rather than being an error).
 - Read JSON encoded `metadata` field from samples.
 - Reduce foreground task contention for Inspect View history loading.
 - Ability to host standalone version of Inspect View to view single log files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 - Correctly resolve default model based on CLI --model argument.
 - Add `azure` model arg for OpenAI provider to force binding (or not binding) to the Azure OpenAI back-end.
 - Add `setup` field to `Sample` for providing a per-sample setup script.
-- Score multiple choice question with parseable answers as incorrect (rather than being an error).
+- Score multiple choice questions without parsed answers as incorrect (rather than being an error). Llama 3 and 3.1 models especially often fail to yield an answer.
 - Read JSON encoded `metadata` field from samples.
 - Reduce foreground task contention for Inspect View history loading.
 - Ability to host standalone version of Inspect View to view single log files.

--- a/src/inspect_ai/scorer/_choice.py
+++ b/src/inspect_ai/scorer/_choice.py
@@ -68,15 +68,6 @@ def choice() -> Scorer:
         else:
             explanation = state.output.completion
 
-        unanswered_choices = [
-            choice.value for choice in choices if choice.correct is None
-        ]
-
-        if any(unanswered_choices):
-            raise ValueError(
-                f"Cannot score choice, missing generated answers for: {','.join(unanswered_choices)}"
-            )
-
         target_positions, answers = _score_target(target, choices)
 
         generated_selected_choices = [

--- a/tests/scorer/test_choice.py
+++ b/tests/scorer/test_choice.py
@@ -111,23 +111,6 @@ async def test_correct_single_answer():
 
 
 @pytest.mark.asyncio
-async def test_state_not_had_answers_generated():
-    scorer = choice()
-    state = simple_task_state(
-        model_output="ANSWERS: A",
-        choices=["choice 1", "choice 2"],
-    )
-
-    state.choices.mark_choice(0, True)
-    # We've never set the second choice (for whatever reason)
-
-    with pytest.raises(
-        ValueError, match="Cannot score choice, missing generated answers for: choice 2"
-    ):
-        await scorer(state, Target("A"))
-
-
-@pytest.mark.asyncio
 async def test_correct_multiple_answers_one_incorrect():
     scorer = choice()
     state = simple_task_state(model_output="ANSWERS: ", choices=["A"])


### PR DESCRIPTION
When scoring using the choice scorer, the current implementation will raise an error when scoring if the answer isn’t present (which blows up the eval). This error condition occurred frequently when testing Llama 3 and 3.1 models.

Failing to throw will result in the sample being scored as `incorrect`, which seems like the correct behavior.

