### PR TITLE
Fix calculation of task duration in viewer

### DIFF
--- a/src/inspect_ai/_view/www/src/utils/Format.mjs
+++ b/src/inspect_ai/_view/www/src/utils/Format.mjs
@@ -151,7 +151,7 @@ export const formatTime = (seconds) => {
   } else if (seconds < 60 * 60) {
     return `${Math.floor(seconds / 60)} min ${seconds % 60} sec`;
   } else {
-    return `${Math.floor((seconds / 60) * 60 * 24)} days ${Math.floor(
+    return `${Math.floor(seconds / (60 * 60 * 24))} days ${Math.floor(
       seconds / 60,
     )} min ${seconds % 60} sec`;
   }


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

In viewer, when duration of eval exceeds one hour, the number of days is wrong:

![image](https://github.com/user-attachments/assets/9634a1b8-900f-4b7c-a6a4-0c63f2f51f7d)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:
