### PR TITLE
add chdir option to @task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Groq](https://groq.com/) model provider.
 - Replace the use of the `bootstrap_std` metric with `stderr` for built in scorers (see [rationale](https://inspect.ai-safety-institute.org.uk/scorers.html#stderr-note) for details).
 - Enable parallel execution of tasks that share a working directory.
+- Add `chdir` option to `@task` to opt-out of changing the working directory during task execution.
 - Enable overriding of default safety settings for Google models.
 - Gracefully handle tool calls that include only a single value (rather than a named dict of parameters).
 - Support `tool_choice="any"` for OpenAI models (requires >= 1.24.0 of openai package).

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -92,13 +92,15 @@ INSPECT_EVAL_MODEL=openai/gpt-4-turbo,google/gemini-1.5-pro
 The multiple tasks feature described below is currently available only in the development version of Inspect. You can install the development version with:
 
 ``` bash
-$ pip install git+https://github.com/ukgovernmentbeis/inspect_ai.git
+$ pip install git+https://github.com/ukgovernmentbeis/inspect_ai
 ```
 :::
 
 By default, Inspect runs a single task at a time. This is because most tasks consist of 10 or more samples, which generally means that sample parallelism is enough to make full use of the `max_connections` defined for the active model. If however, the number samples per task is substantially lower than `max_connections` then you might benefit from running multiple tasks in parallel.
 
-There is one important constraint on task parallelism to note: all of the tasks *must share a working directory* (as Inspect switches to the working directory of tasks when executing them).
+There is one important constraint on task parallelism to note: by default, all of the tasks *must share a working directory* (as Inspect switches to the working directory of tasks when executing them). This constraint can be relaxed using the `chdir=False` option on the `@task` decorator (see the discussion in [Working Directory](#working-directory) below for details).
+
+### Max Tasks Option
 
 Run multiple tasks in parallel using the `--max-tasks` CLI option or `max_tasks` parameter to the `eval()` function. For example, here we run all of the tasks in the current working directory with up 5 tasks run in parallel:
 
@@ -135,6 +137,20 @@ eval(
 ```
 
 This code will evaluate a total of 12 tasks (6 temperature variations against 2 models each) with up to 5 tasks run in parallel.
+
+### Working Directory {#working-directory}
+
+By default, inspect both *loads* and *executes* tasks within the directory that contains the task source file. This is done so that relative references to Python modules, datasets, prompt templates, and other resources are resolved correctly.
+
+Since task parallelism requires that tasks are executed from within the same working directory, you may want to change this default behaviour. You can do this using the `chdir` option of the `@task` decorator. For example:
+
+``` python
+@task(chdir=False)
+def my_task():
+  ...
+```
+
+Note that this only affects where tasks are *executed*. Even with `chdir=False` task files are still *loaded* within their parent directory (so Python modules, datasets, prompts, etc. will still resolve correctly with relative references). If however you are making reference to external files at *runtime* (e.g. within the `solve()` or `score()` method of a `Sovler` or `Scorer`) you'll need to be sure to not rely on relative path resolution when `chdir=False`.
 
 ## Tool Environments {#sec-parallel-tool-environments}
 

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -208,7 +208,8 @@ def create_file_tasks(
             # (will be used later to ensure it runs in the directory)
             task = task_create(task_spec, model, **task_args)
             setattr(task, TASK_FILE_ATTR, file.as_posix())
-            setattr(task, TASK_RUN_DIR_ATTR, file.parent.as_posix())
+            if task.attribs.get("chdir", True):
+                setattr(task, TASK_RUN_DIR_ATTR, file.parent.as_posix())
             tasks.append(task)
         return tasks
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Add `chdir` option to `@task` to opt-out of changing the working directory during task execution.