### PR TITLE
improved tool error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Show task/display progress immediately (rather than waiting for connections to fill).
 - Reduce foreground task contention for Inspect View history loading.
 - Ability to host standalone version of Inspect View to view single log files.
+- Throw `TimeoutError` if a call to `subprocess()` or `tool_environment().exec()` times out (formerly a textual error was returned along with a non-zero exit code).
 
 
 ## v0.3.18 (14 July 2024)

--- a/docs/_toolenv-interface.md
+++ b/docs/_toolenv-interface.md
@@ -1,0 +1,49 @@
+
+``` python
+class ToolEnvironment:
+   
+    async def exec(
+        self,
+        cmd: list[str],
+        input: str | bytes | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] = {},
+        timeout: int | None = None,
+    ) -> ExecResult[str]:
+        """
+        Raises:
+          FileNotFoundError: If the file does not exist.
+          UnicodeDecodeError: If an error occurs while
+            decoding the command output.
+          PermissionError: If the user does not have
+            permission to execute the command.
+        """
+        ...
+
+    async def write_file(
+        self, file: str, contents: str | bytes
+    ) -> None:
+        """
+        Raises:
+          PermissionError: If the user does not have
+            permission to write to the specified path.
+        """
+        ...
+
+    async def read_file(
+        self, file: str, text: bool = True
+    ) -> Union[str | bytes]:
+        """
+        Raises:
+          FileNotFoundError: If the file does not exist.
+          UnicodeDecodeError: If an encoding error occurs 
+            while reading the file.
+          PermissionError: If the user does not have
+            permission to read from the specified path.
+        """
+        ...
+```
+
+Note that `write_file()` automatically creates parent directories as required if they don't exist.
+
+For each method there is a documented set of errors that are raised: these are _expected_ errors and can either be caught by tools or allowed to propagate in which case they will be reported to the model for potential recovery. In addition, _unexpected_ errors may occur (e.g. a networking error connecting to a remote container): these errors are not reported to the model and fail the `Sample` with an error state. 

--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -79,7 +79,7 @@ Take special note of the `CMD_TIMEOUT` and `MAX_MESSAGES` constants. These put b
 
 The full source code for this example can be found in the Inspect GitHub repo at [examples/agents/intercode-ctf](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/examples/agents/intercode-ctf).
 
-## Custom Scaffolding
+## Custom Scaffolding {#sec-custom-scaffolding}
 
 The default tool use loop demonstrated above will work fine for some tasks, but in other cases you may need to provide more custom logic. For example, you might want to:
 
@@ -370,33 +370,9 @@ Note that `files` are specified as part of the `Sample`. Files can be specified 
 
 ### Environment Interface
 
-The following methods are available for all tool environments:
+The following instance methods are available to tools that need to interact with a `ToolEnvironment`:
 
-``` python
-class ToolEnvironment:
-   
-    async def exec(
-        self,
-        cmd: list[str],
-        input: str | bytes | None = None,
-        cwd: str | None = None,
-        env: dict[str, str] = {},
-        timeout: int | None = None,
-    ) -> ExecResult[str]:
-        ...
-
-    async def write_file(
-        self, file: str, contents: str | bytes
-    ) -> None:
-        ...
-
-    async def read_file(
-        self, file: str, text: bool = True
-    ) -> Union[str | bytes]:
-        ...
-```
-
-Note that `read_file()` will raise a `FileNotFoundError` if the specified `file` does not exist in the tool environment. Tools calling `read_file()` will often want to catch the `FileNotFoundError` and re-throw a `ToolError` (since models will often attempt to read files that do not exist).
+{{< include _toolenv-interface.md >}}
 
 ### Environment Binding
 

--- a/docs/extensions.qmd
+++ b/docs/extensions.qmd
@@ -96,7 +96,9 @@ eval(math, model = "custom/my-model")
 | `local`          | Run `tool_environment()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
 | `docker`         | Run `tool_environment()` methods within a Docker container                                                                                                                |
 
-To create a custom tool environment, derive a class from `ToolEnvironment`, implement the required static and instance methods, and add the `@toolenv` decorator to it. For example:
+To create a custom tool environment, derive a class from `ToolEnvironment`, implement the required static and instance methods, and add the `@toolenv` decorator to it. 
+
+The static class methods control the lifecycle of containers and other computing resources associated with the `ToolEnvironment`:
 
 ``` python
 @toolenv(name="podman")
@@ -137,37 +139,7 @@ class PodmanToolEnvironment(ToolEnvironment):
     async def cli_cleanup(cls, id: str | None) -> None:
         ...
 
-    async def exec(
-        self,
-        cmd: list[str],
-        input: str | bytes | None = None,
-        cwd: str | None = None,
-        env: dict[str, str] = {},
-        timeout: int | None = None,
-    ) -> ExecResult[str]:
-        ...
-
-    async def write_file(
-        self, file: str, contents: str | bytes
-    ) -> None:
-        ...
-
-    @overload
-    async def read_file(
-        self, file: str, text: Literal[True] = True
-    ) -> str: 
-        ...
-      
-    @overload
-    async def read_file(
-        self, file: str, text: Literal[False]
-    ) -> bytes: 
-        ...
-      
-    async def read_file(
-        self, file: str, text: bool = True
-    ) -> Union[str | bytes]:
-        ...
+    # (instance methods shown below)
 ```
 
 The class methods take care of various stages of initialisation, setup, and teardown:
@@ -198,11 +170,10 @@ The `cli_cleanup()` function is a global cleanup handler that should be able to 
 
 The `task_cleanup()` function will typically print out the information required to invoke `cli_cleanup()` when it is invoked with `cleanup = False`. Try invoking the `DockerToolEnvironmet` with `--no-toolenv-cleanup` to see an example.
 
-The `ToolEnvironment` instance methods provide access to process execution and file input/output within the environment. A few notes on implementing these methods:
+The `ToolEnvironment` instance methods provide access to process execution and file input/output within the environment.
 
-1.  The `exec()` method currently only handles text output. If a call results in binary output then a `UnicodeDecodeError` will be raised. Tool environments should catch this and raise a `ToolError`.
+{{< include _toolenv-interface.md >}}
 
-2.  The `read_file()` method raise a `FileNotFoundError` if the specified `file` does not exist in the tool environment, as tools calling `read_file()` will often want to catch the `FileNotFoundError` and re-throw a `ToolError` (since models will frequently attempt to read files that do not exist).
 
 The best way to learn about writing tool environments is to look at the source code for the built in environments, [LocalToolEnvironment](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/tool/_environment/local.py) and [DockerToolEnvironment](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/tool/_environment/docker/docker.py).
 

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -305,7 +305,10 @@ Note that if you need to execute computationally expensive code in an eval, you 
 If you need to ensure that your subprocess runs for no longer than a specified interval, you can use the `timeout` option. For example:
 
 ``` python
-result = await subprocess(["ls", dir], timeout = 30)
+try:
+  result = await subprocess(["ls", dir], timeout = 30)
+except TimeoutError:
+  ...
 ```
 
-If a timeout occurs, then the `result.status` will be `False` and a timeout error message will be included in `result.stderr`.
+If a timeout occurs, then a `TimeoutError` will be thrown (which your code should generally handle in whatever manner is appropriate).

--- a/docs/tools.qmd
+++ b/docs/tools.qmd
@@ -61,28 +61,73 @@ Note that when using tools with models, the models do not call the Python functi
 
 ## Tool Errors
 
-If an exception occurs during tool execution, it will by default result in a runtime error that exits the evaluation task. This is often the correct behaviour (as a malfunctioning tool invalidates the assumptions of the eval), however sometimes there are "expected" errors. For example, if you give the model a tool to execute bash or python code, it may submit invalid code. In this case you want to report the error to the model and have it adapt.
+Various errors can occur during tool execution, especially when interacting with the file system or network or when using [Tool Environments](#sec-tool-environments) to execute code in a container sandbox. As a tool writer you need to decide how you'd like to handle error conditions. A number of approaches are possible:
 
-You can report errors to the model from tools by raising a `ToolError` exception. These exceptions will not terminate the eval, but rather will report back to the model and that an error has occurred and allow it to recover. For example, here is the code for the built in `bash()` tool:
+1.  Notify the model that an error occurred to see whether it can recover.
+
+2.  Catch and handle the error internally (trying another code path, etc.).
+
+3.  Allow the error to propagate, resulting in the current `Sample` failing with an error state.
+
+There are no universally correct approaches as tool usage and semantics can vary widely—some rough guidelines are provided below.
+
+### Default Handling {#default-handling}
+
+If you do not explicitly handle errors, then Inspect provides some default error handling behaviour. Specifically, if any of the following errors are raised they will be handled and reported to the model:
+
+-   `TimeoutError` — Occurs when a call to `subprocess()` or `tool_environment().exec()` times out.
+
+-   `PermissionError` — Occurs when there are inadequate permissions to read or write a file.
+
+-   `UnicodeDecodeError` — Occurs when the output from executing a process or reading a file is binary rather than text.
+
+-   `ToolError` — Special error thrown by tools to indicate they'd like to report an error to the model.
+
+These are all errors that are *expected* (in fact the `ToolEnvironemnt` interface documents them as such) and possibly recoverable by the model (try a different command, read a different file, etc.). Unexpected errors (e.g. a network error communicating with a remote service or container runtime) on the other hand are not automatically handled and result in the `Sample` failing with an error.
+
+Many tools can simply rely on the default handling to provide reasonable behaviour around both expected and unexpected errors.
+
+::: {.callout-note appearance="simple"}
+When we say that the errors are reported directly to the model, this refers to the behaviour when using the default `generate()`. If on the other hand, you are have created [custom scaffolding](#sec-custom-scaffolding) for an agent, you can intercept tool errors and apply additional filtering and logic.
+:::
+
+### Explicit Handling
+
+In some cases a tool can implement a recovery strategy for error conditions. For example, an HTTP request might fail due to transient network issues, and retrying the request (perhaps after a delay) may resolve the problem. Explicit error handling strategies are generally applied when there are *expected* errors that are not already handled by Inspect's [Default Handling](#default-handling).
+
+Another type of explicit handling is re-raising an error to bypass Inspect's default handling. For example, here we catch at re-raise `TimeoutError` so that it fails the `Sample`:
 
 ``` python
-@tool(prompt="Use the bash tool for shell commands.")
-def bash(timeout: int | None = None) -> Tool:
-   
-    async def execute(cmd: str) -> str:
-        """
-        Execute a bash command.
+try:
+  result = await tool_environment().exec(
+    cmd=["decode", file], 
+    timeout=timeout
+  )
+except TimeoutError:
+  raise RuntimeError("Decode operation timed out.")
+  
+```
+
+## Tool Environments
+
+Tools may have a need to interact with a sandboxed environment (e.g. to provide models with the ability to execute arbitrary bash or python commands). The active tool environment can be obtained via the `tool_environment()` function. For example:
+
+
+``` python
+from inspect_ai.tool import ToolError, tool, tool_environment
+
+@tool(prompt="Use the list_files function to enumerate files.")
+def list_files():
+    async def execute(dir: str):
+        """List the files in a directory.
 
         Args:
-          cmd (str): The bash command to execute.
+            dir (str): Directory
 
         Returns:
-          The output of the command.
+            File listing of the directory
         """
-        result = await tool_environment().exec(
-            cmd=["bash", "-c", cmd], 
-            timeout=timeout
-        )
+        result = await tool_environment().exec(["ls", dir])
         if result.success:
             return result.stdout
         else:
@@ -91,7 +136,12 @@ def bash(timeout: int | None = None) -> Tool:
     return execute
 ```
 
-We *expect* that some bash commands will result in an error status, so we explicitly raise `ToolError` rather than a normal exception.
+
+The following instance methods are available to tools that need to interact with a `ToolEnvironment`:
+
+{{< include _toolenv-interface.md >}}
+
+See the documentation on [Tool Environments](#sec-tool-environments) for additional details.
 
 ## Tool Choice
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -38,6 +38,22 @@ async def call_tools(
             tool_error: str | None = None
             try:
                 result = await call_tool(tdefs, call)
+            except TimeoutError:
+                result = ""
+                tool_error = "Command timed out before completing."
+            except UnicodeDecodeError:
+                result = ""
+                tool_error = "Unicode decoding error (file or command output is likely binary rather than text)"
+            except PermissionError:
+                # TODO: Crash the sample not the eval; error state for sample
+                # TODO: Ascertain PermissionError for docker read/write file
+                # TODO: Preflight check for tool environment for better errors
+                # TODO: Document the error requirements for toolenvs and tools
+
+                # TODO: Consider: Should there by typeinfo on error
+                # TODO: Consider: Raw mode with no fault barrier?
+                result = ""
+                tool_error = "The user does not have permission to write to the specified location."
             except ToolError as ex:
                 result = ""
                 tool_error = ex.message

--- a/src/inspect_ai/tool/_environment/docker/docker.py
+++ b/src/inspect_ai/tool/_environment/docker/docker.py
@@ -189,18 +189,12 @@ class DockerToolEnvironment(ToolEnvironment):
                 args.append("--env")
                 args.append(f"{key}={value}")
 
-        try:
-            result = await compose_exec(
-                args + [self._service] + cmd,
-                project=self._project,
-                timeout=timeout,
-                input=input,
-            )
-        except UnicodeDecodeError:
-            raise ToolError(
-                "Unicode decoding error reading command output (it is likely binary rather than text)"
-            )
-        return result
+        return await compose_exec(
+            args + [self._service] + cmd,
+            project=self._project,
+            timeout=timeout,
+            input=input,
+        )
 
     @override
     async def write_file(self, file: str, contents: str | bytes) -> None:

--- a/src/inspect_ai/tool/_environment/docker/docker.py
+++ b/src/inspect_ai/tool/_environment/docker/docker.py
@@ -7,7 +7,6 @@ from typing import Literal, Union, cast, overload
 import aiofiles
 from typing_extensions import override
 
-from inspect_ai.tool._tool import ToolError
 from inspect_ai.util._subprocess import ExecResult
 
 from ..environment import ToolEnvironment

--- a/src/inspect_ai/tool/_environment/environment.py
+++ b/src/inspect_ai/tool/_environment/environment.py
@@ -113,6 +113,11 @@ class ToolEnvironment(abc.ABC):
 
         Returns:
           Execution result (status code, stderr/stdout, etc.)
+
+        Raises:
+          TimeoutError: If the specified `timeout` expires.
+          UnicodeDecodeError: If an encoding error occurs while
+            reading the command output.
         """
         ...
 
@@ -120,10 +125,17 @@ class ToolEnvironment(abc.ABC):
     async def write_file(self, file: str, contents: str | bytes) -> None:
         """Write a file into the tool environment.
 
+        If the parent directories of the file path do not exist they
+        should be automatically created.
+
         Args:
           file (str): Path to file (relative file paths will resolve to the
             per-sample working directory).
           contents (str | bytes): Text or binary file contents.
+
+        Raises:
+          PermissionErrror: If the current user does not have permission to
+            write to the specified path.
         """
         ...
 
@@ -144,6 +156,13 @@ class ToolEnvironment(abc.ABC):
 
         Returns:
           Contents of file (as str or bytes for binary files)
+
+        Raises:
+          FileNotFoundError: If the specified file does not exist.
+          UnicodeDecodeError: If an encoding error occurs while
+            reading the command output.
+          PermissionErrror: If the current user does not have
+            permission to read from the specified path.
         """
         ...
 

--- a/src/inspect_ai/tool/_environment/environment.py
+++ b/src/inspect_ai/tool/_environment/environment.py
@@ -134,7 +134,7 @@ class ToolEnvironment(abc.ABC):
           contents (str | bytes): Text or binary file contents.
 
         Raises:
-          PermissionErrror: If the current user does not have permission to
+          PermissionError: If the current user does not have permission to
             write to the specified path.
         """
         ...
@@ -160,8 +160,8 @@ class ToolEnvironment(abc.ABC):
         Raises:
           FileNotFoundError: If the specified file does not exist.
           UnicodeDecodeError: If an encoding error occurs while
-            reading the command output.
-          PermissionErrror: If the current user does not have
+            reading the file.
+          PermissionError: If the user does not have
             permission to read from the specified path.
         """
         ...

--- a/src/inspect_ai/tool/_environment/local.py
+++ b/src/inspect_ai/tool/_environment/local.py
@@ -46,18 +46,13 @@ class LocalToolEnvironment(ToolEnvironment):
         env: dict[str, str] = {},
         timeout: int | None = None,
     ) -> ExecResult[str]:
-        try:
-            return await subprocess(
-                args=cmd,
-                input=input,
-                cwd=cwd if cwd else self.directory.name,
-                env=env,
-                timeout=timeout,
-            )
-        except UnicodeDecodeError:
-            raise ToolError(
-                "Unicode decoding error reading command output (it is likely binary rather than text)"
-            )
+        return await subprocess(
+            args=cmd,
+            input=input,
+            cwd=cwd if cwd else self.directory.name,
+            env=env,
+            timeout=timeout,
+        )
 
     @override
     async def write_file(self, file: str, contents: str | bytes) -> None:

--- a/src/inspect_ai/tool/_environment/local.py
+++ b/src/inspect_ai/tool/_environment/local.py
@@ -7,7 +7,6 @@ from typing_extensions import override
 
 from inspect_ai.util import ExecResult, subprocess
 
-from .._tool import ToolError
 from .environment import ToolEnvironment
 from .registry import toolenv
 

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -76,10 +76,14 @@ async def subprocess(
        env (dict[str, str]): Additional environment variables.
        capture_output (bool): Capture stderr and stdout into ExecResult
          (if False, then output is redirected to parent stderr/stdout)
-       timeout (int | None): Timeout
+       timeout (int | None): Timeout. If the timeout expires then
+         a `TimeoutError` will be raised.
 
     Returns:
        Subprocess result (text or binary depending on `text` param)
+
+    Raises:
+       TimeoutError: If the specified `timeout` expires.
     """
     # resolve input
     input = input.encode() if isinstance(input, str) else input
@@ -135,7 +139,7 @@ async def subprocess(
                 else:
                     return await asyncio.wait_for(run_command(), timeout=timeout)
             except asyncio.exceptions.TimeoutError:
-                return ExecResult(False, 1, "", "Command timed out before completing")
+                raise TimeoutError
         else:
             return await run_command()
 

--- a/tests/util/test_subprocess.py
+++ b/tests/util/test_subprocess.py
@@ -60,5 +60,8 @@ async def test_subprocess_env():
 
 @pytest.mark.asyncio
 async def test_subprocess_timeout():
-    result = await subprocess(["sleep", "2"], timeout=1)
-    assert result.returncode == 1
+    try:
+        await subprocess(["sleep", "2"], timeout=1)
+        assert False
+    except TimeoutError:
+        pass


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

- No longer raise `ToolError` from tool environments
- Propagate `TimeoutError` up from `subprocess()` and `tool_environment().exec()`.
- Fault barrier on tool calls to catch expected exceptions (`TimeoutError`, `PermissionError`, `FileNotFoundError`, and `UnicodeDecodeErrors`).
- Improved documentation on the exception contract implemented by tool environments.
