### PR TITLE
preserve tool_error text for anthropic tool call responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Throw `TimeoutError` if a call to `subprocess()` or `sandbox().exec()` times out (formerly a textual error was returned along with a non-zero exit code).
 - Validate name passed to `example_dataset()` (and print available example dataset names).
 - Resolve relative image paths within Dataset samples against the directory containing the dataset.
+- Preserve `tool_error` text for Anthropic tool call responses.
 
 
 ## v0.3.18 (14 July 2024)

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -291,7 +291,7 @@ async def message_param(message: ChatMessage) -> MessageParam:
     elif message.role == "tool":
         if message.tool_error is not None:
             content: str | list[TextBlockParam | ImageBlockParam] = message.tool_error
-        if isinstance(message.content, str):
+        elif isinstance(message.content, str):
             content = [TextBlockParam(type="text", text=message.content)]
         else:
             content = [


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

