### PR TITLE
Fix Azure bug

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -107,7 +107,7 @@ class OpenAIAPI(ModelAPI):
                 )
 
             self.client: AsyncAzureOpenAI | AsyncOpenAI = AsyncAzureOpenAI(
-                api_key=api_key,
+                api_key=self.api_key,
                 azure_endpoint=base_url,
                 azure_deployment=model_name,
                 max_retries=(
@@ -117,7 +117,7 @@ class OpenAIAPI(ModelAPI):
             )
         else:
             self.client = AsyncOpenAI(
-                api_key=api_key,
+                api_key=self.api_key,
                 base_url=model_base_url(base_url, "OPENAI_BASE_URL"),
                 max_retries=(
                     config.max_retries if config.max_retries else DEFAULT_MAX_RETRIES


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
If you try to run an eval with an Azure OpenAI model using a command like:
```
inspect eval benchmarks/gpqa.py@gpqa_diamond --model openai/azr-gpt-4o-latest
```
with an .env file that has the following contents
```
AZUREAI_OPENAI_BASE_URL=https://???.openai.azure.com
AZUREAI_OPENAI_API_KEY=???
OPENAI_API_VERSION=2024-02-15-preview
```
you will get the following error:
```
  File "/home/ubuntu/repos/tonys-evals/inspect_ai/src/inspect_ai/model/_model.py", line 488, in get_model
    modelapi_instance = modelapi_type(
                        ^^^^^^^^^^^^^^
  File "/home/ubuntu/repos/tonys-evals/inspect_ai/src/inspect_ai/model/_registry.py", line 56, in model_wrapper
    model = model_type(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/repos/tonys-evals/inspect_ai/src/inspect_ai/model/_providers/openai.py", line 109, in __init__
    self.client: AsyncAzureOpenAI | AsyncOpenAI = AsyncAzureOpenAI(
                                                  ^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/repos/tonys-evals/.venv/lib/python3.12/site-packages/openai/lib/azure.py", line 413, in __init__
    raise OpenAIError(
openai.OpenAIError: Missing credentials. Please pass one of `api_key`, `azure_ad_token`, `azure_ad_token_provider`, or the `AZURE_OPENAI_API_KEY` or `AZURE_OPENAI_AD_TOKEN` environment variables.
```

### What is the new behavior?
You can now successfully run an Azure OpenAI model with the following command:
```
inspect eval benchmarks/gpqa.py@gpqa_diamond --model openai/azr-gpt-4o-latest
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
I don't believe so.

### Other information:
My first inspect PR!
