### PR TITLE
various improvements to tool error handling

### DIFF
--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -93,11 +93,11 @@ The default tool use loop demonstrated above will work fine for some tasks, but 
 
 When you call the `generate()` function from a solver, use the `tool_calls` parameter to customise how tool calls made by the model are handled:
 
-|  |  |
+|          |                                                                                                                                                         |
 |------------------------------------|------------------------------------|
-| `loop` | Resolve tools calls and then invoke `generate()`, proceeding in a loop which terminates when there are no more tool calls or `max_messages` is reached. |
-| `single` | Resolve at most a single set of tool calls and then return. |
-| `none` | Do not resolve tool calls at all (in this case you will need to invoke `call_tools()` directly). |
+| `loop`   | Resolve tools calls and then invoke `generate()`, proceeding in a loop which terminates when there are no more tool calls or `max_messages` is reached. |
+| `single` | Resolve at most a single set of tool calls and then return.                                                                                             |
+| `none`   | Do not resolve tool calls at all (in this case you will need to invoke `call_tools()` directly).                                                        |
 
 : {tbl-colwidths=\[20,80\]}
 
@@ -131,6 +131,8 @@ You can imagine several ways you might want to customise this loop:
 3.  Examining and possibly filtering the tool calls before invoking `call_tools()`
 4.  Adding a critique / reflection step between tool calling and generate.
 5.  Deep copying the `TaskState` and exploring several trajectories.
+
+Note that by default *expected* errors (e.g. file not found, insufficient, permission , timeouts, etc.) are forwarded to the model for possible recovery. If you would like to intervene in the default error handling then rather than immediately appending the list of assistant messages returned from `call_tools()` to `state.messages`(as shown above), check the `error` property of these messages (which will be `None` in the case of no error) and proceed accordingly.
 
 ### Tool Filtering
 
@@ -295,7 +297,7 @@ def wikipedia() -> Task:
 
 The full source code for this example can be found in the Inspect GitHub repo at [examples/agents/langchain](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/examples/agents/langchain).
 
-## Sandbox Environments {#sec-sandbox-environments}
+## Sandboxing {#sec-sandbox-environments}
 
 The examples shown above execute tool code within the main process running the evaluation task. In some cases however, you may require the provisioning of dedicated environments for running tool code. This might be the case if:
 
@@ -380,10 +382,10 @@ The following instance methods are available to tools that need to interact with
 
 There are two sandbox environments built in to Inspect:
 
-| Environment Type | Description |
-|------------------------------------|-----------------------------------------------------------------|
-| `local` | Run `sandbox()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
-| `docker` | Run `sandbox()` methods within a Docker container (see the [Docker Configuration](#sec-docker-configuration) section below for additional details). |
+| Environment Type | Description                                                                                                                                                      |
+|--------------------------|----------------------------------------------|
+| `local`          | Run `sandbox()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
+| `docker`         | Run `sandbox()` methods within a Docker container (see the [Docker Configuration](#sec-docker-configuration) section below for additional details).              |
 
 Sandbox environments can be bound at the `Task` level or at the `eval()` level (where `eval()` takes precedence). To bind a sandbox environment to a `Task`, use the `sandbox` option:
 
@@ -435,11 +437,11 @@ You can use the Docker sandbox enviornment without any special configuration, ho
 
 Here is how Docker sandbox environments are created based on the presence of `Dockerfile` and/or `compose.yml` in the task directory:
 
-| Config Files | Behavior |
-|--------------------------|---------------------------------------------|
-| None | Creates a sandbox environment based on the official [python:3.12-bookworm](https://hub.docker.com/_/python) image. |
-| `Dockerfile` | Creates a sandbox environment by building the image. |
-| `compose.yaml` | Creates sandbox environment(s) based on `compose.yaml`. |
+| Config Files   | Behavior                                                                                                           |
+|---------------------------|---------------------------------------------|
+| None           | Creates a sandbox environment based on the official [python:3.12-bookworm](https://hub.docker.com/_/python) image. |
+| `Dockerfile`   | Creates a sandbox environment by building the image.                                                               |
+| `compose.yaml` | Creates sandbox environment(s) based on `compose.yaml`.                                                            |
 
 Providing a `compose.yaml` is not strictly required, as Inspect will automatically generate one as needed. Note that the automatically generated compose file will restrict internet access by default, so if your evaluations require this you'll need to provide your own `compose.yaml` file.
 
@@ -541,7 +543,7 @@ See the documentation on [Docker Compose](https://docs.docker.com/compose/compos
 
 #### Sample Metadata
 
-You might want to interpolate Sample metadata into your Docker compose files. You can do this using the standard clmpose environment variable syntax, where any metadata in the Sample is made available with a `SAMPLE_METADATA_` prefix. For example, you might have a per-sample memory limit (with a default value of 0.5gb if unspecified):
+You might want to interpolate Sample metadata into your Docker compose files. You can do this using the standard compose environment variable syntax, where any metadata in the Sample is made available with a `SAMPLE_METADATA_` prefix. For example, you might have a per-sample memory limit (with a default value of 0.5gb if unspecified):
 
 ``` yaml
 services:

--- a/examples/tool_use.py
+++ b/examples/tool_use.py
@@ -107,10 +107,7 @@ def read_file():
         Returns:
             File contents
         """
-        try:
-            return await sandbox().read_file(file)
-        except FileNotFoundError:
-            raise ToolError(f"File {file} not found.")
+        return await sandbox().read_file(file)
 
     return execute
 
@@ -134,10 +131,7 @@ def write_file():
             file (str): File to write
             contents (str): Contents of file
         """
-        try:
-            return await sandbox().write_file(file, contents)
-        except FileNotFoundError:
-            raise ToolError(f"File {file} not found.")
+        return await sandbox().write_file(file, contents)
 
     return execute
 

--- a/src/inspect_ai/_view/schema.py
+++ b/src/inspect_ai/_view/schema.py
@@ -29,6 +29,7 @@ def sync_view_schema() -> None:
         # generate types w/ json-schema-to-typescript
         subprocess.run(
             [
+                "yarn",
                 "json2ts",
                 "--input",
                 schema_path,
@@ -36,8 +37,10 @@ def sync_view_schema() -> None:
                 types_path,
                 "--additionalProperties",
                 "false",
-            ]
+            ],
+            cwd=WWW_DIR,
         )
+        subprocess.run(["yarn", "prettier:write"])
 
 
 def schema_to_strict(schema: dict[str, Any]) -> dict[str, Any]:

--- a/src/inspect_ai/_view/schema.py
+++ b/src/inspect_ai/_view/schema.py
@@ -29,7 +29,6 @@ def sync_view_schema() -> None:
         # generate types w/ json-schema-to-typescript
         subprocess.run(
             [
-                "yarn",
                 "json2ts",
                 "--input",
                 schema_path,
@@ -40,7 +39,7 @@ def sync_view_schema() -> None:
             ],
             cwd=WWW_DIR,
         )
-        subprocess.run(["yarn", "prettier:write"])
+        subprocess.run(["yarn", "prettier:write"], cwd=WWW_DIR)
 
 
 def schema_to_strict(schema: dict[str, Any]) -> dict[str, Any]:

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -67,9 +67,7 @@
         "role": {
           "const": "assistant",
           "default": "assistant",
-          "enum": ["assistant"],
-          "title": "Role",
-          "type": "string"
+          "title": "Role"
         },
         "tool_calls": {
           "anyOf": [
@@ -131,9 +129,7 @@
         "role": {
           "const": "system",
           "default": "system",
-          "enum": ["system"],
-          "title": "Role",
-          "type": "string"
+          "title": "Role"
         },
         "tool": {
           "anyOf": [
@@ -192,9 +188,7 @@
         "role": {
           "const": "tool",
           "default": "tool",
-          "enum": ["tool"],
-          "title": "Role",
-          "type": "string"
+          "title": "Role"
         },
         "tool_call_id": {
           "anyOf": [
@@ -264,9 +258,7 @@
         "role": {
           "const": "user",
           "default": "user",
-          "enum": ["user"],
-          "title": "Role",
-          "type": "string"
+          "title": "Role"
         }
       },
       "required": ["content", "source", "role"],
@@ -279,9 +271,7 @@
         "type": {
           "const": "image",
           "default": "image",
-          "enum": ["image"],
-          "title": "Type",
-          "type": "string"
+          "title": "Type"
         },
         "image": {
           "title": "Image",
@@ -304,9 +294,7 @@
         "type": {
           "const": "text",
           "default": "text",
-          "enum": ["text"],
-          "title": "Type",
-          "type": "string"
+          "title": "Type"
         },
         "text": {
           "title": "Text",
@@ -695,9 +683,7 @@
       "properties": {
         "type": {
           "const": "git",
-          "enum": ["git"],
-          "title": "Type",
-          "type": "string"
+          "title": "Type"
         },
         "origin": {
           "title": "Origin",
@@ -1608,9 +1594,7 @@
         },
         "type": {
           "const": "function",
-          "enum": ["function"],
-          "title": "Type",
-          "type": "string"
+          "title": "Type"
         },
         "parse_error": {
           "anyOf": [

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -67,7 +67,9 @@
         "role": {
           "const": "assistant",
           "default": "assistant",
-          "title": "Role"
+          "enum": ["assistant"],
+          "title": "Role",
+          "type": "string"
         },
         "tool_calls": {
           "anyOf": [
@@ -129,7 +131,9 @@
         "role": {
           "const": "system",
           "default": "system",
-          "title": "Role"
+          "enum": ["system"],
+          "title": "Role",
+          "type": "string"
         },
         "tool": {
           "anyOf": [
@@ -188,7 +192,9 @@
         "role": {
           "const": "tool",
           "default": "tool",
-          "title": "Role"
+          "enum": ["tool"],
+          "title": "Role",
+          "type": "string"
         },
         "tool_call_id": {
           "anyOf": [
@@ -202,20 +208,19 @@
           "default": null,
           "title": "Tool Call Id"
         },
-        "tool_error": {
+        "error": {
           "anyOf": [
             {
-              "type": "string"
+              "$ref": "#/$defs/ToolCallError"
             },
             {
               "type": "null"
             }
           ],
-          "default": null,
-          "title": "Tool Error"
+          "default": null
         }
       },
-      "required": ["content", "source", "role", "tool_call_id", "tool_error"],
+      "required": ["content", "source", "role", "tool_call_id", "error"],
       "title": "ChatMessageTool",
       "type": "object",
       "additionalProperties": false
@@ -259,7 +264,9 @@
         "role": {
           "const": "user",
           "default": "user",
-          "title": "Role"
+          "enum": ["user"],
+          "title": "Role",
+          "type": "string"
         }
       },
       "required": ["content", "source", "role"],
@@ -272,7 +279,9 @@
         "type": {
           "const": "image",
           "default": "image",
-          "title": "Type"
+          "enum": ["image"],
+          "title": "Type",
+          "type": "string"
         },
         "image": {
           "title": "Image",
@@ -295,7 +304,9 @@
         "type": {
           "const": "text",
           "default": "text",
-          "title": "Type"
+          "enum": ["text"],
+          "title": "Type",
+          "type": "string"
         },
         "text": {
           "title": "Text",
@@ -684,7 +695,9 @@
       "properties": {
         "type": {
           "const": "git",
-          "title": "Type"
+          "enum": ["git"],
+          "title": "Type",
+          "type": "string"
         },
         "origin": {
           "title": "Origin",
@@ -1595,7 +1608,9 @@
         },
         "type": {
           "const": "function",
-          "title": "Type"
+          "enum": ["function"],
+          "title": "Type",
+          "type": "string"
         },
         "parse_error": {
           "anyOf": [
@@ -1612,6 +1627,30 @@
       },
       "required": ["id", "function", "arguments", "type", "parse_error"],
       "title": "ToolCall",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ToolCallError": {
+      "properties": {
+        "type": {
+          "enum": [
+            "parsing",
+            "timeout",
+            "unicode_decode",
+            "permission",
+            "file_not_found",
+            "unknown"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "message": {
+          "title": "Message",
+          "type": "string"
+        }
+      },
+      "required": ["type", "message"],
+      "title": "ToolCallError",
       "type": "object",
       "additionalProperties": false
     },

--- a/src/inspect_ai/_view/www/log.d.ts
+++ b/src/inspect_ai/_view/www/log.d.ts
@@ -61,7 +61,7 @@ export type ParallelToolCalls = boolean | null;
 export type Name2 = string;
 export type Scorer = string;
 export type Name3 = string;
-export type Value = number | number;
+export type Value = number;
 export type Metadata1 = {} | null;
 export type Metadata2 = {} | null;
 export type Scores = EvalScore[];
@@ -109,7 +109,14 @@ export type Content3 = string | (ContentText | ContentImage)[];
 export type Source3 = ("input" | "generate" | "cache") | null;
 export type Role3 = "tool";
 export type ToolCallId = string | null;
-export type ToolError = string | null;
+export type Type4 =
+  | "parsing"
+  | "timeout"
+  | "unicode_decode"
+  | "permission"
+  | "file_not_found"
+  | "unknown";
+export type Message1 = string;
 export type Choices = string[] | null;
 export type Target = string | string[];
 export type Messages = (
@@ -141,11 +148,10 @@ export type Scores1 = {
 export type Value1 =
   | string
   | number
-  | number
   | boolean
-  | (string | number | number | boolean)[]
+  | (string | number | boolean)[]
   | {
-      [k: string]: string | number | number | boolean | null;
+      [k: string]: string | number | boolean | null;
     };
 export type Answer = string | null;
 export type Explanation = string | null;
@@ -158,7 +164,7 @@ export type Level =
   | "warning"
   | "error"
   | "critical";
-export type Message1 = string;
+export type Message2 = string;
 export type Created1 = number;
 export type Logging = LoggingMessage[];
 
@@ -346,7 +352,11 @@ export interface ChatMessageTool {
   source: Source3;
   role: Role3;
   tool_call_id: ToolCallId;
-  tool_error: ToolError;
+  error: ToolCallError | null;
+}
+export interface ToolCallError {
+  type: Type4;
+  message: Message1;
 }
 export interface ModelOutput {
   model: Model1;
@@ -400,6 +410,6 @@ export interface Score {
 export interface Metadata5 {}
 export interface LoggingMessage {
   level: Level;
-  message: Message1;
+  message: Message2;
   created: Created1;
 }

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -240,7 +240,8 @@ const resolveToolMessage = (toolMessage) => {
     return undefined;
   }
 
-  const content = toolMessage.tool_error || toolMessage.content;
+  const content =
+    toolMessage.error?.message || toolMessage.tool_error || toolMessage.content;
   if (typeof content === "string") {
     return [
       {

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -102,7 +102,7 @@ def read_messages(messages: list[dict[str, Any]]) -> list[ChatMessage]:
                         content=content,
                         source="input",
                         tool_call_id=message.get("tool_call_id", None),
-                        tool_error=message.get("tool_error", None),
+                        error=message.get("error", None),
                     )
                 )
             case _:

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -57,7 +57,7 @@ async def call_tools(
             except FileNotFoundError as ex:
                 tool_error = ToolCallError(
                     "file_not_found",
-                    f"File '{ex.filename}' was not found. {ex.strerror}.",
+                    f"File '{ex.filename}' was not found.",
                 )
             except ToolParsingError as ex:
                 tool_error = ToolCallError("parsing", ex.message)

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -14,7 +14,8 @@ from inspect_ai._util.error import exception_message
 from inspect_ai._util.json import python_type_to_json_type
 from inspect_ai._util.registry import registry_info
 from inspect_ai.tool import Tool, ToolCall, ToolError, ToolInfo, ToolParam
-from inspect_ai.tool._tool import TOOL_PROMPT
+from inspect_ai.tool._tool import TOOL_PROMPT, ToolParsingError
+from inspect_ai.tool._tool_call import ToolCallError
 
 from ._chat_message import ChatMessageAssistant, ChatMessageTool
 
@@ -35,33 +36,38 @@ async def call_tools(
         tdefs = tool_defs(tools)
 
         async def call_tool_task(call: ToolCall) -> ChatMessageTool:
-            tool_error: str | None = None
+            result = ""
+            tool_error: ToolCallError | None = None
             try:
                 result = await call_tool(tdefs, call)
             except TimeoutError:
-                result = ""
-                tool_error = "Command timed out before completing."
-            except UnicodeDecodeError:
-                result = ""
-                tool_error = "Unicode decoding error (file or command output is likely binary rather than text)"
-            except PermissionError:
-                # TODO: Crash the sample not the eval; error state for sample
-                # TODO: Ascertain PermissionError for docker read/write file
-                # TODO: Preflight check for sandbox environment for better errors
-                # TODO: Document the error requirements for sandboxenvs and tools
-
-                # TODO: Consider: Should there by typeinfo on error
-                # TODO: Consider: Raw mode with no fault barrier?
-                result = ""
-                tool_error = "The user does not have permission to write to the specified location."
+                tool_error = ToolCallError(
+                    "timeout", "Command timed out before completing."
+                )
+            except UnicodeDecodeError as ex:
+                tool_error = ToolCallError(
+                    "unicode_decode",
+                    f"Error decoding bytes to {ex.encoding}: {ex.reason}",
+                )
+            except PermissionError as ex:
+                message = f"Permission error: {ex.strerror}."
+                if isinstance(ex.filename, str):
+                    message = f"{message} Filename '{ex.filename}'."
+                tool_error = ToolCallError("permission", message)
+            except FileNotFoundError as ex:
+                tool_error = ToolCallError(
+                    "file_not_found",
+                    f"File '{ex.filename}' was not found. {ex.strerror}.",
+                )
+            except ToolParsingError as ex:
+                tool_error = ToolCallError("parsing", ex.message)
             except ToolError as ex:
-                result = ""
-                tool_error = ex.message
+                tool_error = ToolCallError("unknown", ex.message)
 
             return ChatMessageTool(
                 content=result if isinstance(result, list) else str(result),
-                tool_error=tool_error,
                 tool_call_id=call.id,
+                error=tool_error,
             )
 
         tasks = [call_tool_task(call) for call in message.tool_calls]
@@ -92,18 +98,18 @@ class ToolDef:
 async def call_tool(tools: list[ToolDef], call: ToolCall) -> Any:
     # if there was an error parsing the ToolCall, raise that
     if call.parse_error:
-        raise ToolError(call.parse_error)
+        raise ToolParsingError(call.parse_error)
 
     # find the tool
     tool_def = next((tool for tool in tools if tool.name == call.function), None)
     if tool_def is None:
-        raise ToolError(f"Tool {call.function} not found")
+        raise ToolParsingError(f"Tool {call.function} not found")
 
     # call the tool
     try:
         return await tool_def.tool(**call.arguments)
     except TypeError as ex:
-        raise ToolError(exception_message(ex))
+        raise ToolParsingError(exception_message(ex))
 
 
 def tools_info(tools: list[Tool] | list[ToolInfo]) -> list[ToolInfo]:

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -50,7 +50,7 @@ async def call_tools(
                     f"Error decoding bytes to {ex.encoding}: {ex.reason}",
                 )
             except PermissionError as ex:
-                message = f"Permission error: {ex.strerror}."
+                message = f"{ex.strerror}."
                 if isinstance(ex.filename, str):
                     message = f"{message} Filename '{ex.filename}'."
                 tool_error = ToolCallError("permission", message)

--- a/src/inspect_ai/model/_chat_message.py
+++ b/src/inspect_ai/model/_chat_message.py
@@ -4,6 +4,7 @@ from pydantic import BaseModel, Field
 
 from inspect_ai._util.content import Content, ContentText
 from inspect_ai.tool import ToolCall
+from inspect_ai.tool._tool_call import ToolCallError
 
 
 class ChatMessageBase(BaseModel):
@@ -89,8 +90,8 @@ class ChatMessageTool(ChatMessageBase):
     tool_call_id: str | None = Field(default=None)
     """ID of tool call."""
 
-    tool_error: str | None = Field(default=None)
-    """Error calling tool."""
+    error: ToolCallError | None = Field(default=None)
+    """Error which occurred during tool call."""
 
 
 ChatMessage = Union[

--- a/src/inspect_ai/model/_chat_message.py
+++ b/src/inspect_ai/model/_chat_message.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 from typing import Literal, Union
 
 from pydantic import BaseModel, Field
@@ -5,6 +6,8 @@ from pydantic import BaseModel, Field
 from inspect_ai._util.content import Content, ContentText
 from inspect_ai.tool import ToolCall
 from inspect_ai.tool._tool_call import ToolCallError
+
+logger = getLogger(__name__)
 
 
 class ChatMessageBase(BaseModel):
@@ -92,6 +95,17 @@ class ChatMessageTool(ChatMessageBase):
 
     error: ToolCallError | None = Field(default=None)
     """Error which occurred during tool call."""
+
+    @property
+    def tool_error(self) -> str | None:
+        """Tool error (deprecated)."""
+        logger.warning(
+            "The 'tool_error' field is deprecated. Access error information via 'error' instead."
+        )
+        if self.error:
+            return self.error.message
+        else:
+            return None
 
 
 ChatMessage = Union[

--- a/src/inspect_ai/model/_chat_message.py
+++ b/src/inspect_ai/model/_chat_message.py
@@ -1,7 +1,7 @@
 from logging import getLogger
-from typing import Literal, Union
+from typing import Any, Literal, Type, Union
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from inspect_ai._util.content import Content, ContentText
 from inspect_ai.tool import ToolCall
@@ -106,6 +106,16 @@ class ChatMessageTool(ChatMessageBase):
             return self.error.message
         else:
             return None
+
+    @model_validator(mode="before")
+    @classmethod
+    def convert_tool_error_to_error(
+        cls: Type["ChatMessageTool"], values: dict[str, Any]
+    ) -> dict[str, Any]:
+        tool_error = values.get("tool_error", None)
+        if tool_error:
+            values["error"] = ToolCallError("unknown", tool_error)
+        return values
 
 
 ChatMessage = Union[

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -289,8 +289,10 @@ async def message_param(message: ChatMessage) -> MessageParam:
 
     # "tool" means serving a tool call result back to claude
     elif message.role == "tool":
-        if message.tool_error is not None:
-            content: str | list[TextBlockParam | ImageBlockParam] = message.tool_error
+        if message.error is not None:
+            content: str | list[TextBlockParam | ImageBlockParam] = (
+                message.error.message
+            )
         if isinstance(message.content, str):
             content = [TextBlockParam(type="text", text=message.content)]
         else:
@@ -305,7 +307,7 @@ async def message_param(message: ChatMessage) -> MessageParam:
                     tool_use_id=str(message.tool_call_id),
                     type="tool_result",
                     content=content,
-                    is_error=message.tool_error is not None,
+                    is_error=message.error is not None,
                 )
             ],
         )

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -212,8 +212,8 @@ async def content_dict(
             response=ParseDict(
                 js_dict={
                     "content": (
-                        message.tool_error
-                        if message.tool_error is not None
+                        message.error.message
+                        if message.error is not None
                         else message.text
                     )
                 },

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -182,7 +182,7 @@ def mistral_chat_message(message: ChatMessage) -> MistralChatMessage:
             role=message.role,
             name=message.tool_call_id,
             content=(
-                f"Error: {message.tool_error}" if message.tool_error else message.text
+                f"Error: {message.error.message}" if message.error else message.text
             ),
         )
     else:

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -279,7 +279,7 @@ async def openai_chat_message(message: ChatMessage) -> ChatCompletionMessagePara
         return ChatCompletionToolMessageParam(
             role=message.role,
             content=(
-                f"Error: {message.tool_error}" if message.tool_error else message.text
+                f"Error: {message.error.message}" if message.error else message.text
             ),
             tool_call_id=str(message.tool_call_id),
         )

--- a/src/inspect_ai/tool/_tool.py
+++ b/src/inspect_ai/tool/_tool.py
@@ -26,6 +26,11 @@ class ToolError(Exception):
         self.message = message
 
 
+class ToolParsingError(ToolError):
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
 @runtime_checkable
 class Tool(Protocol):
     async def __call__(

--- a/src/inspect_ai/tool/_tool_call.py
+++ b/src/inspect_ai/tool/_tool_call.py
@@ -18,3 +18,17 @@ class ToolCall:
 
     parse_error: str | None = field(default=None)
     """Error which occurred parsing tool call."""
+
+
+@dataclass
+class ToolCallError:
+    type: Literal[
+        "parsing",
+        "timeout",
+        "unicode_decode",
+        "permission",
+        "file_not_found",
+        "unknown",
+    ]
+
+    message: str


### PR DESCRIPTION
A few improvements to make error handling from tool calls more deterministic and diagnostic rich:

- Extract error conditions from stderr of Docker Compose commands and convert to requisite Python types
- Exception barrier after tool call that catches and appropriately formats error messages for consumption by the model.
- Provide error type information on `ChatMessageTool` for custom tool use loops that want to dispatch on specific error conditions.
