### PR TITLE
Invoke rate limit retry for OpenAI APITimeoutError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Gracefully handle tool calls that include only a single value (rather than a named dict of parameters).
 - Support `tool_choice="any"` for OpenAI models (requires >= 1.24.0 of openai package).
 - Make multiple tool calls in parallel. Parallel tool calls occur by default for OpenAI, Anthropic, Mistral, and Groq. You can disable this behavior for OpenAI and Groq with `--parallel-tool-calls false`.
+- Invoke rate limit retry for OpenAI APITimeoutError (which they have recently begun returning a lot of more of as a result of httpx.ConnectTimeout, which is only 5 seconds by default.).
 - Add `cwd` argument to `SandboxEnvironment.exec()`
 - Use `tee` rather than `docker cp` for Docker sandbox environment implementation of `write_file()`.
 - Handle duplicate tool call ids in Inspect View.

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -2,7 +2,13 @@ import json
 import os
 from typing import Any, cast
 
-from openai import APIStatusError, AsyncAzureOpenAI, AsyncOpenAI, RateLimitError
+from openai import (
+    APIStatusError,
+    APITimeoutError,
+    AsyncAzureOpenAI,
+    AsyncOpenAI,
+    RateLimitError,
+)
 from openai._types import NOT_GIVEN
 from openai.types.chat import (
     ChatCompletion,
@@ -193,6 +199,8 @@ class OpenAIAPI(ModelAPI):
                 and "You exceeded your current quota" not in ex.message
             ):
                 return True
+        elif isinstance(ex, APITimeoutError):
+            return True
         return False
 
     @override


### PR DESCRIPTION
We have recently observed OpenAI returning a lot of more of these errors with source error of httpx.ConnectTimeout (which is only 5 seconds by default in the OpenAI client). This PR will treat APITimeoutError as a rate limit error (and thus retry it).
