### PR TITLE
Max/expading yaml errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To get started with Inspect, please see the documentation at <https://inspect.ai
 
 ***
 
-#### Development
+
 
 To work on development of Inspect, clone the repository and install with the `-e` flag and `[dev]` optional dependencies:
 

--- a/src/inspect_ai/model/_providers/util.py
+++ b/src/inspect_ai/model/_providers/util.py
@@ -73,7 +73,7 @@ def parse_tool_call(
             try:
                 value = yaml.safe_load(arguments)
                 arguments_dict[tool_info.params[0].name] = value
-            except yaml.parser.ParserError as ex:
+            except yaml.error.YAMLError as ex:
                 report_parse_error(ex)
 
     # return ToolCall with error payload

--- a/src/inspect_ai/model/_providers/util.py
+++ b/src/inspect_ai/model/_providers/util.py
@@ -77,10 +77,9 @@ def parse_tool_call(
             try:
                 value = yaml.safe_load(arguments)
                 arguments_dict[potential_params[0]] = value
-            except yaml.parser.ParserError as ex:
+            except yaml.error.YAMLError as ex:
                 # If the yaml parser fails, we treat it as a string argument.
                 arguments_dict[potential_params[0]] = arguments
-                report_parse_error(ex)
 
     # return ToolCall with error payload
     return ToolCall(

--- a/src/inspect_ai/model/_providers/util.py
+++ b/src/inspect_ai/model/_providers/util.py
@@ -62,18 +62,24 @@ def parse_tool_call(
         except json.JSONDecodeError as ex:
             report_parse_error(ex)
 
-    # otherwise parse it as yaml (which will pickup unquoted strings, numbers, and true/false)
-    # and then create a dict that maps it to the first function argument
+    # if the model hasn't returned a dictionary, we assume that the model's output corresponds to the first-non-default parameter of the tool.
+    # we do this by parsing it as a YAML, which will handle unquoted strings, numbers, and true/false.
     else:
         tool_info = next(
             (tool for tool in tools if tool.name == function and len(tool.params) > 0),
             None,
         )
         if tool_info:
+            all_params = [param.name for param in tool_info.params]
+            non_optional_parameters = [param.name for param in tool_info.params if not param.optional]
+            potential_params = non_optional_parameters if len(non_optional_parameters) > 0 else all_params
+
             try:
                 value = yaml.safe_load(arguments)
-                arguments_dict[tool_info.params[0].name] = value
-            except yaml.error.YAMLError as ex:
+                arguments_dict[potential_params[0]] = value
+            except yaml.parser.ParserError as ex:
+                # If the yaml parser fails, we treat it as a string argument.
+                arguments_dict[potential_params[0]] = arguments
                 report_parse_error(ex)
 
     # return ToolCall with error payload

--- a/tests/model/test_parse_tool_call.py
+++ b/tests/model/test_parse_tool_call.py
@@ -1,0 +1,35 @@
+from inspect_ai.model._providers.util import parse_tool_call
+from inspect_ai.tool import ToolInfo, ToolParam
+
+testing_tool = ToolInfo(name="testing_tool", description="This is a testing tool.", params=[ToolParam(name="param1", type="str", description="This is parameter1", optional=False)])
+testing_tool_bool = ToolInfo(name="testing_tool", description="This is a testing tool, with a boolean parameter.", params=[ToolParam(name="param1", type="bool", description="This is parameter1", optional=False)])
+
+def test_parse_tool_call_with_a_dict():
+   tool_call = parse_tool_call("id", "testing_tool", '{"param1": "I am a dictionary!"}', [testing_tool])
+
+   assert "param1" in tool_call.arguments
+   assert tool_call.arguments["param1"] == "I am a dictionary!"
+
+def test_parse_string_tool_call_without_a_dict():
+
+   tool_call = parse_tool_call("id", "testing_tool", "I am not a dictionary!", [testing_tool])
+
+   assert "param1" in tool_call.arguments
+   # When passed a non-dictonary input, for tools with a single argument, the tool should try to set that argument to the value of the input string.
+   assert tool_call.arguments["param1"] == "I am not a dictionary!"
+
+def test_parse_bool_tool_call_without_a_dict():
+    # Tests if the parser correctly handles boolean values.
+   
+    tool_call = parse_tool_call("id", "testing_tool", "True", [testing_tool_bool])
+    
+    assert "param1" in tool_call.arguments
+    assert tool_call.arguments["param1"] == True
+
+def test_parse_single_quotes_in_string_tool_call_without_a_dict():
+    # Tests if the parser correctly handles a string with a single quote, when they haven't been given as part of a JSON.
+   
+    tool_call = parse_tool_call("id", "testing_tool", "'", [testing_tool])
+
+    assert "param1" in tool_call.arguments
+    assert tool_call.arguments["param1"] == "'"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently, when models output a non-Json string for their tool call arguments, the inspect tool_call parser tries to read these arguments as a YAML. This is a problem when models output illegal YAML (such as any text with single quotes), which happens quite often. For example, in [this run](https://beisgov-my.sharepoint.com/:u:/g/personal/maximillian_kaufmann_dsit_gov_uk/Ef-mVXqBTJVKrIAF391D4xwBSfR2I9WM66HU5aSmYV1JZA?e=pUCNgJ) (link only available within AISI), 30% of failures are due to a YAML parsing error, as the model is putting out bash code which the YAML parser attempts to read.

This PR makes some changes to this default behaviour:
 1) We catch a wider set of YAML errors (this is important as YAML can output several different errors, which were previously crashing the run - see linked runs).
 2) We pass the YAML-parsed arguments to the first non-default option of the function (instead of the first argument of the function - this makes things more deterministic).
 3) When we catch a YAML error, instead of treating it as a parsing error we simply treat the input as a string.

1) and 2) feel correct to me, but 3) Is a little sad, since its inspect "messing with model outputs", and can perhaps be quite confusing to models and higher level users. I'm not sure what the best approach here is given how much its affecting performance - perhaps the agent_code should catch relevant parsing errors and prompt the model to put out correct JSON?

I recommend looking at the 'test_parse_single_quotes_in_string_tool_call_without_a_dict():' in test_parse_tool_call to see something which fails before the change, and passes after. Interested in peoples thoughts!
### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
