### PR TITLE
enhance python logger messages

### DIFF
--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -1353,8 +1353,21 @@
       ],
       "additionalProperties": false
     },
+    "JsonValue": {},
     "LoggingMessage": {
       "properties": {
+        "name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Name"
+        },
         "level": {
           "enum": [
             "debug",
@@ -1375,9 +1388,41 @@
         "created": {
           "title": "Created",
           "type": "number"
+        },
+        "filename": {
+          "default": "unknown",
+          "title": "Filename",
+          "type": "string"
+        },
+        "module": {
+          "default": "unknown",
+          "title": "Module",
+          "type": "string"
+        },
+        "lineno": {
+          "default": 0,
+          "title": "Lineno",
+          "type": "integer"
+        },
+        "args": {
+          "allOf": [
+            {
+              "$ref": "#/$defs/JsonValue"
+            }
+          ],
+          "default": null
         }
       },
-      "required": ["level", "message", "created"],
+      "required": [
+        "name",
+        "level",
+        "message",
+        "created",
+        "filename",
+        "module",
+        "lineno",
+        "args"
+      ],
       "title": "LoggingMessage",
       "type": "object",
       "additionalProperties": false

--- a/src/inspect_ai/_view/www/log.d.ts
+++ b/src/inspect_ai/_view/www/log.d.ts
@@ -158,6 +158,7 @@ export type Value1 =
 export type Answer = string | null;
 export type Explanation = string | null;
 export type Metadata4 = {} | null;
+export type Name4 = string | null;
 export type Level =
   | "debug"
   | "http"
@@ -168,6 +169,9 @@ export type Level =
   | "critical";
 export type Message2 = string;
 export type Created1 = number;
+export type Filename = string;
+export type Module = string;
+export type Lineno = number;
 export type Logging = LoggingMessage[];
 
 export interface EvalLog {
@@ -413,7 +417,12 @@ export interface Score {
 }
 export interface Metadata5 {}
 export interface LoggingMessage {
+  name: Name4;
   level: Level;
   message: Message2;
   created: Created1;
+  filename: Filename;
+  module: Module;
+  lineno: Lineno;
+  args: unknown;
 }

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -418,7 +418,9 @@ class LoggingMessage(BaseModel):
         return LoggingMessage(
             # don't include full file paths (as the filename is also below),
             # we just want to use this to capture e.g. 'httpx', 'openai', etc.
-            name=record.name if re.match(r"^[\w_]+$", record.name) is not None else None,
+            name=record.name
+            if re.match(r"^[\w_]+$", record.name) is not None
+            else None,
             level=cast(LoggingLevel, record.levelname.lower()),
             message=record.getMessage(),
             created=record.created * 1000,
@@ -426,7 +428,9 @@ class LoggingMessage(BaseModel):
             module=record.module,
             lineno=record.lineno,
             # serialize anything we can from the additional arguments
-            args=to_jsonable_python(record.args, fallback=lambda _x: None) if record.args else None,
+            args=to_jsonable_python(record.args, fallback=lambda _x: None)
+            if record.args
+            else None,
         )
 
     @model_validator(mode="before")

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import logging
 import os
+import re
 import sys
 import traceback
 from logging import LogRecord
@@ -10,7 +11,8 @@ from typing import Any, Literal, Type, cast
 
 import click
 import tenacity
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+from pydantic_core import to_jsonable_python
 from rich.console import Console, RenderableType
 from rich.traceback import Traceback
 
@@ -378,6 +380,9 @@ LoggingLevel = Literal[
 
 
 class LoggingMessage(BaseModel):
+    name: str | None = Field(default=None)
+    """Logger name (e.g. 'httpx')"""
+
     level: LoggingLevel
     """Logging level."""
 
@@ -386,6 +391,18 @@ class LoggingMessage(BaseModel):
 
     created: float
     """Message created time."""
+
+    filename: str = Field(default="unknown")
+    """Logged from filename."""
+
+    module: str = Field(default="unknown")
+    """Logged from module."""
+
+    lineno: int = Field(default=0)
+    """Logged from line number."""
+
+    args: JsonValue = Field(default=None)
+    """Extra arguments passed to log function."""
 
     @staticmethod
     def from_log_record(record: LogRecord) -> "LoggingMessage":
@@ -399,9 +416,17 @@ class LoggingMessage(BaseModel):
 
         """
         return LoggingMessage(
+            # don't include full file paths (as the filename is also below),
+            # we just want to use this to capture e.g. 'httpx', 'openai', etc.
+            name=record.name if re.match(r"^[\w_]+$", record.name) is not None else None,
             level=cast(LoggingLevel, record.levelname.lower()),
             message=record.getMessage(),
             created=record.created * 1000,
+            filename=record.filename,
+            module=record.module,
+            lineno=record.lineno,
+            # serialize anything we can from the additional arguments
+            args=to_jsonable_python(record.args, fallback=lambda _x: None) if record.args else None,
         )
 
     @model_validator(mode="before")


### PR DESCRIPTION
## This PR contains:
- [x] New features

Enhance the `LoggingMessage` class to include the subsystem name (e.g. "httpx"),  filename, module, line number, and additional args passed to the logging function.

All of these values have defaults so that old logs without these fields are still readable (i.e. they validate on the log file schema).
