### PR TITLE
anthropic: ensure that there is always content when is_error is true

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -288,6 +288,13 @@ async def message_param(message: ChatMessage) -> MessageParam:
             content: str | list[TextBlockParam | ImageBlockParam] = (
                 message.error.message
             )
+            # anthropic requires that content be populated when
+            # is_error is true (throws bad_request_error when not)
+            # so make sure this precondition is met
+            if not content:
+                content = message.text
+            if not content:
+                content = "error"
         elif isinstance(message.content, str):
             content = [TextBlockParam(type="text", text=message.content)]
         else:

--- a/src/inspect_ai/tool/_tools/_execute.py
+++ b/src/inspect_ai/tool/_tools/_execute.py
@@ -30,7 +30,9 @@ def bash(timeout: int | None = None) -> Tool:
         if result.success:
             return result.stdout
         else:
-            raise ToolError(result.stderr)
+            raise ToolError(
+                result.stderr if result.stderr else "error executing command"
+            )
 
     return execute
 
@@ -62,6 +64,6 @@ def python(timeout: int | None = None) -> Tool:
         if result.success:
             return result.stdout
         else:
-            raise ToolError(result.stderr)
+            raise ToolError(result.stderr if result.stderr else "error executing code")
 
     return execute


### PR DESCRIPTION
anthropic requires that content be populated when is_error is true (throws bad_request_error when not) so make sure this precondition is always met. there are two parts to this:

1) The original culprit was sandbox().exec() returning error statuses for bash/python commands with no stderr (which is entirely within expectation). This code was modified to always output a simple error message (e.g. "error executing code") in that case.

2) There is a failsafe in the anthropic handler to minimally output "error" in the case that there is no error message and no other content.
