### PR TITLE
show eval dir relative log file paths in task output

### DIFF
--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -1,5 +1,6 @@
 import asyncio
 import logging
+import os
 from typing import Any, Awaitable, Callable, Set, cast
 
 from shortuuid import uuid
@@ -51,6 +52,9 @@ async def eval_run(
         if sandbox
         else None
     )
+
+    # get cwd before switching to task dir
+    eval_wd = os.getcwd()
 
     # switch to task directory context
     with chdir_python(run_dir), dotenv_environ():
@@ -108,6 +112,7 @@ async def eval_run(
                         model=resolved_task.model,
                         sandbox=resolved_task.sandbox,
                         logger=logger,
+                        eval_wd=eval_wd,
                         config=task_eval_config,
                         plan=plan,
                         score=score,

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -5,6 +5,7 @@ import sys
 from copy import deepcopy
 from dataclasses import dataclass, field
 from logging import getLogger
+from pathlib import PurePath
 from typing import AsyncGenerator, Callable, Literal
 
 from typing_extensions import Unpack
@@ -76,6 +77,7 @@ class TaskRunOptions:
     model: Model
     sandbox: tuple[str, str | None] | None
     logger: TaskLogger
+    eval_wd: str
     config: EvalConfig = field(default_factory=EvalConfig)
     plan: Plan | Solver | list[Solver] | None = field(default=None)
     score: bool = field(default=True)
@@ -90,6 +92,7 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
     model = options.model
     sandbox = options.sandbox
     logger = options.logger
+    eval_wd = options.eval_wd
     config = options.config
     plan = options.plan
     score = options.score
@@ -144,6 +147,12 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
         len(plan.steps) + (1 if plan.finish else 0) + (1)  # scorer
     )
 
+    # compute an eval directory relative log location if we can
+    if PurePath(logger.location).is_relative_to(PurePath(eval_wd)):
+        log_location = PurePath(logger.location).relative_to(eval_wd).as_posix()
+    else:
+        log_location = logger.location
+
     # create task profile for display
     profile = TaskProfile(
         name=task.name,
@@ -155,7 +164,7 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
         eval_config=config,
         task_args=logger.eval.task_args,
         generate_config=generate_config,
-        log_location=logger.location,
+        log_location=log_location,
     )
 
     with display().task(profile) as td:


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

The work on parallel disks changed the directory from which we computed relative log locations, which in turn resulted in either absolute paths or task dir relative paths in the task display. This PR correctly offsets these paths from the eval working dir before printing them.
