### PR TITLE
Add omitted render method for categorical scores

### DIFF
--- a/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
@@ -295,6 +295,9 @@ const scoreCategorizers = [
           compare: (a, b) => {
             return a.localeCompare(b);
           },
+          render: (score) => {
+            return score;
+          },
         };
       }
     },


### PR DESCRIPTION
This function should’ve been there!

fixes #175

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Categorical scores throw an error when rendering.

### What is the new behavior?

Categorical scores don't throw an error when rendering.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
