### PR TITLE
improve recording of @task args

### DIFF
--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -15,6 +15,7 @@ from inspect_ai._util.registry import (
     is_registry_object,
     registry_info,
     registry_lookup,
+    registry_params,
 )
 from inspect_ai.model import Model, ModelName
 from inspect_ai.util import SandboxEnvironmentSpec
@@ -48,7 +49,7 @@ def resolve_tasks(
         return [
             ResolvedTask(
                 task=task,
-                task_args=task_args,
+                task_args=resolve_task_args(task),
                 task_file=task_file(task, relative=True),
                 model=model,
                 sandbox=(
@@ -119,6 +120,19 @@ def resolve_tasks(
     return as_resolved_tasks(
         load_tasks(cast(list[str] | None, tasks), model, task_args)
     )
+
+
+def resolve_task_args(task: Task) -> dict[str, Any]:
+    # was the task instantiated via the registry or a decorator?
+    # if so then we can get the task_args from the registry.
+    try:
+        return registry_params(task)
+
+    # if it wasn't instantiated via the registry or a decorator
+    # then it will not be in the registy and not have formal
+    # task args (as it was simply synthesized via ad-hoc code)
+    except ValueError:
+        return {}
 
 
 def load_tasks(

--- a/src/inspect_ai/_util/registry.py
+++ b/src/inspect_ai/_util/registry.py
@@ -194,7 +194,7 @@ def registry_params(o: object) -> dict[str, Any]:
     Returns:
         Dictionary of parameters used to instantiate object.
     """
-    params = getattr(o, REGISTRY_PARAMS)
+    params = getattr(o, REGISTRY_PARAMS, None)
     if params is not None:
         return cast(dict[str, Any], params)
     else:


### PR DESCRIPTION
Any Task created via an `@task` decorated function now has its parameters recorded (and is thus retryable). Formerly, parameterised tasks were only retryable if they had explicit task args (e.g. via `-T` or `task_args=`). 

Minimal retry example:

```python
from inspect_ai import Task, eval, eval_retry, task
from inspect_ai.dataset import example_dataset
from inspect_ai.scorer import model_graded_fact
from inspect_ai.solver import generate

@task
def security_guide(grader_model="openai/gpt-4o"):
    return Task(
        dataset=example_dataset("security_guide"),
        plan=[generate()],
        scorer=model_graded_fact(grader_model),
    )

if __name__ == "__main__":
    logs = eval(security_guide(grader_model="claude-3-5-sonnet-20240620"))
    logs = eval_retry(logs)
```

Note that an important restriction on retryable task args remains that they must be seriasable (e.g. they cannot be fully instantiated models) since they need to be recorded in the eval log JSON for replay during the retry attempt.