### PR TITLE
Fix multi-epoch reducer score display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improve recording of `@task` arguments so that dynamically created tasks can be retried.
 - Only print `eval-retry` message to terminal for filesystem based tasks.
 - Enhance Python logger messages to capture more context from the log record.
+- Fix an issue that could result in duplicate display of scorers in log view when using multiple epoch reducers.
 
 ## v0.3.19 (02 August 2024)
 

--- a/src/inspect_ai/_view/www/src/sidebar/Sidebar.mjs
+++ b/src/inspect_ai/_view/www/src/sidebar/Sidebar.mjs
@@ -72,11 +72,13 @@ export const Sidebar = ({
 
           const model = logHeader?.eval?.model;
           const dataset = logHeader?.eval?.dataset;
-          const scorer = logHeader?.results?.scores
-            ?.map((scorer) => {
-              return scorer.name;
-            })
-            .join(",");
+
+          const uniqScorers = new Set();
+          logHeader?.results?.scores?.forEach((scorer) => {
+            uniqScorers.add(scorer.name);
+          });
+          const scorer = Array.from(uniqScorers).join(",");
+
           const scorerLabel =
             Object.keys(logHeader?.results?.scores || {}).length === 1
               ? "scorer"

--- a/src/inspect_ai/_view/www/src/title/TitleBlock.mjs
+++ b/src/inspect_ai/_view/www/src/title/TitleBlock.mjs
@@ -96,15 +96,12 @@ const ScorerSummary = ({ scorers }) => {
     return "";
   }
 
-  const summary = [];
-  summary.push(
-    scorers
-      .map((scorer) => {
-        return scorer.name;
-      })
-      .join(", "),
-  );
-  return summary;
+  const uniqScorers = new Set();
+  scorers.forEach((scorer) => {
+    uniqScorers.add(scorer.name);
+  });
+
+  return Array.from(uniqScorers).join(", ");
 };
 
 const ParamSummary = ({ params }) => {

--- a/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
+++ b/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
@@ -90,14 +90,23 @@ export const WorkSpace = (props) => {
           scorer: workspaceLog.contents.results.scores[0].scorer,
         }
       : undefined;
-    const scorers = (workspaceLog.contents?.results?.scores || []).map(
-      (score) => {
+    const scorers = (workspaceLog.contents?.results?.scores || [])
+      .map((score) => {
         return {
           name: score.name,
           scorer: score.scorer,
         };
-      },
-    );
+      })
+      .reduce((accum, scorer) => {
+        if (
+          !accum.find((sc) => {
+            return scorer.scorer === sc.scorer && scorer.name === sc.name;
+          })
+        ) {
+          accum.push(scorer);
+        }
+        return accum;
+      }, []);
 
     // Reset state
     setScores(scorers);


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When there were multiple epoch reducers, scores could be be duplicated in the display.

### What is the new behavior?

Don't duplicate.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
