### PR TITLE
Replace `logging.warn()` (deprecated) -> `logging.warning()`

### DIFF
--- a/src/inspect_ai/_util/logger.py
+++ b/src/inspect_ai/_util/logger.py
@@ -32,7 +32,7 @@ def http_rate_limit_count() -> int:
 
 def warn_once(logger: Logger, message: str) -> None:
     if message not in _warned:
-        logger.warn(message)
+        logger.warning(message)
         _warned.append(message)
 
 

--- a/src/inspect_ai/tool/_tool.py
+++ b/src/inspect_ai/tool/_tool.py
@@ -118,7 +118,7 @@ def tool(
     """
     if prompt:
         print(prompt)
-        logger.warn(
+        logger.warning(
             "WARNING: The prompt parameter is deprecated (please relocate "
             + "to the tool function's description doc comment)"
         )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
(Ironically) when inspect tries to emit a warning, the following warning is emitted:
```
.venv/lib/python3.11/site-packages/inspect_ai/tool/_tool.py:121
  .venv/lib/python3.11/site-packages/inspect_ai/tool/_tool.py:121: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
    logger.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
```

### What is the new behavior?
No `logging` deprecation warning emitted.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
I believe this has been deprecated since Python 3.3 https://stackoverflow.com/a/15655674