### PR TITLE
add `APIConnectionError` to rate limit errors for openai

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -3,6 +3,7 @@ import os
 from typing import Any, cast
 
 from openai import (
+    APIConnectionError,
     APIStatusError,
     APITimeoutError,
     AsyncAzureOpenAI,
@@ -198,7 +199,7 @@ class OpenAIAPI(ModelAPI):
                 and "You exceeded your current quota" not in ex.message
             ):
                 return True
-        elif isinstance(ex, APITimeoutError):
+        elif isinstance(ex, (APIConnectionError | APITimeoutError)):
             return True
         return False
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
we don't handle APIConnectionError error properly for openAI, if I'm not mistaken. In [anthropic.py](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/model/_providers/anthropic.py) an APIConnectionError is treated as a rate limit error and retried, but this is not the case in openai.py where we only retry on RateLimitError and APITimeoutError.  

### What is the new behavior?
now `is_rate_limit` returns true for APIConnectionErrors and they should be retried.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
no

### Other information:
