### PR TITLE
Add InternalServerError to rate_limit / retry errors for OpenAI

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -8,8 +8,8 @@ from openai import (
     APITimeoutError,
     AsyncAzureOpenAI,
     AsyncOpenAI,
+    InternalServerError,
     RateLimitError,
-    InternalServerError
 )
 from openai._types import NOT_GIVEN
 from openai.types.chat import (
@@ -200,7 +200,9 @@ class OpenAIAPI(ModelAPI):
                 and "You exceeded your current quota" not in ex.message
             ):
                 return True
-        elif isinstance(ex, (APIConnectionError | APITimeoutError | InternalServerError)):
+        elif isinstance(
+            ex, (APIConnectionError | APITimeoutError | InternalServerError)
+        ):
             return True
         return False
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -9,6 +9,7 @@ from openai import (
     AsyncAzureOpenAI,
     AsyncOpenAI,
     RateLimitError,
+    InternalServerError
 )
 from openai._types import NOT_GIVEN
 from openai.types.chat import (
@@ -199,7 +200,7 @@ class OpenAIAPI(ModelAPI):
                 and "You exceeded your current quota" not in ex.message
             ):
                 return True
-        elif isinstance(ex, (APIConnectionError | APITimeoutError)):
+        elif isinstance(ex, (APIConnectionError | APITimeoutError | InternalServerError)):
             return True
         return False
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
We don't catch and retry Openai's internal server errors afaict

### What is the new behavior?
now we do catch and retry them, as recommended by [OpenAI docs](https://platform.openai.com/docs/guides/error-codes/python-library-error-types) (ctrl-f InternalServerError)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
no

### Other information:
