### PR TITLE
Added the answer to be logged during evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Warn when using the `name` parameter with task created from `@task` decorated function.
 - Make sample `metadata` available in prompt, grading, and self-criqique templates.
 - Retry on several additional OpenAI errors (APIConnectionError | APITimeoutError | InternalServerError)
+- Fix a regression which would cause the 'answer' to be improperly recorded when scoring a sample.
 
 ## v0.3.20 (03 August 2024)
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -386,6 +386,7 @@ async def task_run_sample(
                 if score_result is not None:
                     sample_score = SampleScore(
                         value=score_result.value,
+                        answer=score_result.answer,
                         explanation=score_result.explanation,
                         metadata=score_result.metadata,
                         sample_id=sample.id,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
During an eval, the answer field of scores was not being logged. It looks like this was first introduced in the[ Feature / epoch reducer pr: ](https://github.com/UKGovernmentBEIS/inspect_ai/commit/a9ba06eb7419ba4e3d2916123fef799668747398)

Should fix https://github.com/UKGovernmentBEIS/inspect_ai/issues/208

### What is the new behavior?
Starts logging this again

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Shouldn't do

### Other information:
