### PR TITLE
Fix bug in match() scorer where float value would be ignored

### DIFF
--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -82,7 +82,7 @@ def match_str(
 
 
 def first_number_normalized(words: list[str]) -> str:
-    number = next((word for word in words if word.isnumeric()), words[0])
+    number = next((word for word in words if word.replace(".", "").isnumeric()), words[0])
     return normalize_number(number)
 
 


### PR DESCRIPTION
I found an issue with the `match()` scorer. When calling the `match_str()` function with the following inputs:
```python
target = "16"
value = "4 eggs. The answer is 16.00"
match_str(value=value, target=target, location="end", numeric=True)
```
I get `('4', False)` instead of `('16', True)`. The bug can be found in `first_number_normalized()` where any word representing a float with decimals is ignored. This function is called by `match_str()` which is called by the `match()` scorer.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`first_number_normalized(words)` ignores any string representing a float with a character "." in the `words` list. In the above example, the list is `words = ['16.00', 'is', 'answer', 'the', 'eggs', '4']`. This function returns `'4'` instead of `'16'`. 
### What is the new behavior?
`first_number_normalized(words)` returns the first number in the `words` list including one with floating point.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
