### PR TITLE
Properly resolve was region for Bedrock Anthropic

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -78,11 +78,18 @@ class AnthropicAPI(ModelAPI):
                 base_url, ["ANTHROPIC_BEDROCK_BASE_URL", "BEDROCK_ANTHROPIC_BASE_URL"]
             )
 
+            # resolve the default region
+            aws_region = None
+            base_region = os.environ.get("AWS_REGION", None)
+            if base_region is None:
+                aws_region = os.environ.get("AWS_DEFAULT_REGION", None)
+
             self.client: AsyncAnthropic | AsyncAnthropicBedrock = AsyncAnthropicBedrock(
                 base_url=base_url,
                 max_retries=(
                     config.max_retries if config.max_retries else DEFAULT_MAX_RETRIES
                 ),
+                aws_region=aws_region,
                 **model_args,
             )
         else:


### PR DESCRIPTION
Internally, Anthropic’s SDK is using `AWS_REGION` if the region isn’t explicitly passed.

- First, see if that value is set and if it is, don’t set the region (just let Anthropic do what it does).

- If that value isn’t set, see if our documented ‘AWS_DEFAULT_REGION’ is set (this is what boto3 uses and what we documented). If that is set, pass it explicitly.

- Otherwise, just use the default, which is currently `us-east-1`. Since this is the default chosen by Anthropic, I don’t think we should override it- but, just in case we think otherwise, only the Claude3 Opus model isn’t available in us-east (all others are).

