### PR TITLE
Make html fixups backward compatible

### DIFF
--- a/tools/vscode/CHANGELOG.md
+++ b/tools/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.27
+
+- Minor fix to view rendering across differing versions of Inspect.
+
 ## 0.3.26
 
 - Properly preserve focus When showing the log viewer upon task completion.

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "UK AI Safety Institute"
   },
-  "version": "0.3.26",
+  "version": "0.3.27",
   "license": "MIT",
   "homepage": "https://inspect.ai-safety-institute.org.uk/",
   "repository": {

--- a/tools/vscode/src/providers/logview/logview-webview.ts
+++ b/tools/vscode/src/providers/logview/logview-webview.ts
@@ -294,21 +294,54 @@ class InspectLogviewWebview extends InspectWebview<LogviewState> {
           .asWebviewUri(Uri.joinPath(viewDirUri, path))
           .toString();
 
-      // fixup css references
-      indexHtml = indexHtml.replace(/href="([^"]+)"/g, (_, p1: string) => {
-        return `href="${resourceUri(p1)}"`;
-      });
-
-      // fixup js references
-      indexHtml = indexHtml.replace(/src="([^"]+)"/g, (_, p1: string) => {
-        return `src="${resourceUri(p1)}"`;
-      });
-
       // nonces for scripts
       indexHtml = indexHtml.replace(
         /<script([ >])/g,
         `<script nonce="${nonce}"$1`
       );
+
+      // Determine whether this is the old index.html format (before bundling),
+      // or the newer one. Fix up the html properly in each case
+
+      if (indexHtml.match(/"\.(\/App\.mjs)"/g)) {
+        // Old unbundle html
+        // fixup css references
+        indexHtml = indexHtml.replace(/href="\.([^"]+)"/g, (_, p1: string) => {
+          return `href="${resourceUri(p1)}"`;
+        });
+
+        // fixup js references
+        indexHtml = indexHtml.replace(/src="\.([^"]+)"/g, (_, p1: string) => {
+          return `src="${resourceUri(p1)}"`;
+        });
+
+        // fixup import maps
+        indexHtml = indexHtml.replace(
+          /": "\.([^?"]+)(["?])/g,
+          (_, p1: string, p2: string) => {
+            return `": "${resourceUri(p1)}${p2}`;
+          }
+        );
+
+        // fixup App.mjs
+        indexHtml = indexHtml.replace(/"\.(\/App\.mjs)"/g, (_, p1: string) => {
+          return `"${resourceUri(p1)}"`;
+        });
+
+      } else {
+        // New bundled html
+        // fixup css references
+        indexHtml = indexHtml.replace(/href="([^"]+)"/g, (_, p1: string) => {
+          return `href="${resourceUri(p1)}"`;
+        });
+
+        // fixup js references
+        indexHtml = indexHtml.replace(/src="([^"]+)"/g, (_, p1: string) => {
+          return `src="${resourceUri(p1)}"`;
+        });
+
+
+      }
 
       return indexHtml;
     } else {


### PR DESCRIPTION
This was fixed to support the latest bundling of inspect-ai, but I didn’t implement in a way that was compatible with older installations of inspect. this fixes that, performing in a backward compatible way by applying fixups specifically based upon what is present in the html.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
