### PR TITLE
Increase density of title block, add min-width

### DIFF
--- a/src/inspect_ai/_view/www/App.css
+++ b/src/inspect_ai/_view/www/App.css
@@ -228,13 +228,26 @@ body {
 
 .navbar-title-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(350px, 1fr) 1fr;
   width: 100%;
 }
 
-@media (min-width: 575px) {
+@media (max-width: 575px) {
+  .navbar .vertical-metric-label {
+    font-size: 0.7rem !important;
+  }  
+}
+
+@media (max-width: 575px) {
+  .navbar .vertical-metric-value {
+    margin-top: 0.2rem !important;
+    font-size: 0.9rem !important;
+  }
+}
+
+@media (max-width: 575px) {
   .navbar-title-grid {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr auto-fill;
   }
 }
 

--- a/src/inspect_ai/_view/www/App.css
+++ b/src/inspect_ai/_view/www/App.css
@@ -239,6 +239,12 @@ body {
 }
 
 @media (max-width: 575px) {
+  .tab-tools  select { 
+    width: 50px;
+  }
+}
+
+@media (max-width: 575px) {
   .navbar .vertical-metric-value {
     margin-top: 0.2rem !important;
     font-size: 0.9rem !important;

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -361,6 +361,12 @@ body {
 }
 
 @media (max-width: 575px) {
+  .tab-tools  select { 
+    width: 50px;
+  }
+}
+
+@media (max-width: 575px) {
   .navbar .vertical-metric-value {
     margin-top: 0.2rem !important;
     font-size: 0.9rem !important;

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -350,13 +350,26 @@ body {
 
 .navbar-title-grid {
   display: grid;
-  grid-template-columns: 1fr;
+  grid-template-columns: minmax(350px, 1fr) 1fr;
   width: 100%;
 }
 
-@media (min-width: 575px) {
+@media (max-width: 575px) {
+  .navbar .vertical-metric-label {
+    font-size: 0.7rem !important;
+  }  
+}
+
+@media (max-width: 575px) {
+  .navbar .vertical-metric-value {
+    margin-top: 0.2rem !important;
+    font-size: 0.9rem !important;
+  }
+}
+
+@media (max-width: 575px) {
   .navbar-title-grid {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr auto-fill;
   }
 }
 

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -6730,6 +6730,7 @@ const VerticalMetric = ({ metric, isFirst }) => {
       </div>` : "";
   return m$1`<div style=${{ paddingLeft: isFirst ? "0" : "1em" }}>
     <div
+      class="vertical-metric-label"
       style=${{
     fontSize: "0.8rem",
     fontWeight: "200",
@@ -6744,8 +6745,9 @@ const VerticalMetric = ({ metric, isFirst }) => {
     </div>
     ${reducer_component}
     <div
+      class="vertical-metric-value"
       style=${{
-    fontSize: "1.5rem",
+    fontSize: "1.1rem",
     fontWeight: "500",
     textAlign: "center"
   }}
@@ -8661,7 +8663,7 @@ const Tab2 = ({ type, tab, index, style }) => {
     ...style
   };
   return m$1`
-    <li class="nav-item" role="presentation">
+    <li class="nav-item" role="presentation" style=${{ alignSelf: "end" }}>
       <button
         id="${tabId}"
         style=${type === "tabs" ? tabStyle : pillStyle}

--- a/src/inspect_ai/_view/www/dist/index.html
+++ b/src/inspect_ai/_view/www/dist/index.html
@@ -22,7 +22,7 @@
     <link rel="stylesheet" crossorigin href="/assets/index.css">
   </head>
 
-  <body>
+  <body style="min-width: 450px;">
     <div id="app"></div>
   </body>
 </html>

--- a/src/inspect_ai/_view/www/index.html
+++ b/src/inspect_ai/_view/www/index.html
@@ -28,7 +28,7 @@
     </script>
   </head>
 
-  <body>
+  <body style="min-width: 450px;">
     <div id="app"></div>
     <script type="module" src="./src/index.js"></script>
   </body>

--- a/src/inspect_ai/_view/www/src/components/TabSet.mjs
+++ b/src/inspect_ai/_view/www/src/components/TabSet.mjs
@@ -82,7 +82,7 @@ const Tab = ({ type, tab, index, style }) => {
     ...style,
   };
   return html`
-    <li class="nav-item" role="presentation">
+    <li class="nav-item" role="presentation" style=${{ alignSelf: "end" }}>
       <button
         id="${tabId}"
         style=${type === "tabs" ? tabStyle : pillStyle}

--- a/src/inspect_ai/_view/www/src/navbar/Navbar.mjs
+++ b/src/inspect_ai/_view/www/src/navbar/Navbar.mjs
@@ -244,6 +244,7 @@ const VerticalMetric = ({ metric, isFirst }) => {
 
   return html`<div style=${{ paddingLeft: isFirst ? "0" : "1em" }}>
     <div
+      class="vertical-metric-label"
       style=${{
         fontSize: "0.8rem",
         fontWeight: "200",
@@ -258,8 +259,9 @@ const VerticalMetric = ({ metric, isFirst }) => {
     </div>
     ${reducer_component}
     <div
+      class="vertical-metric-value"
       style=${{
-        fontSize: "1.5rem",
+        fontSize: "1.1rem",
         fontWeight: "500",
         textAlign: "center",
       }}


### PR DESCRIPTION
This improves the appearance of the log viewer at very narrow widths

Appearance at 500px wide:

<img width="500" alt="Screenshot 2024-08-12 at 9 38 18 AM" src="https://github.com/user-attachments/assets/bec4b4c2-dc0d-43b9-b121-50611b4852d3">

<img width="492" alt="Screenshot 2024-08-12 at 9 44 24 AM" src="https://github.com/user-attachments/assets/da4e9a27-2e20-413b-94df-4c9297b69394">
