### PR TITLE
Fix environment variable name

### DIFF
--- a/tools/vscode/src/providers/inspect/inspect-constants.ts
+++ b/tools/vscode/src/providers/inspect/inspect-constants.ts
@@ -6,7 +6,7 @@ export const kInspectEnvValues = {
   connections: "INSPECT_EVAL_MAX_CONNECTIONS",
   retries: "INSPECT_EVAL_MAX_RETRIES",
   timeout: "INSPECT_EVAL_TIMEOUT",
-  modelBaseUrl: "INSPECT_MODEL_BASE_URL",
+  modelBaseUrl: "INSPECT_EVAL_MODEL_BASE_URL",
 };
 
 export const kLogLevelEnv = "INSPECT_EVAL_MODEL";


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
#246 

### What is the new behavior?
The correct name should be INSPECT_EVAL_MODEL_BASE_URL, not INSPECT_MODEL_BASE_URL.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
