### PR TITLE
track changes/transcript for tool calls

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15653,11 +15653,11 @@ const ToolEventView = ({ id, depth, stateManager, event }) => {
       />
   </div>
   ${event.events.length > 0 ? m$1`<${TranscriptView}
-        id="${id}-subtask"
-        name="Transcript"
-        events=${event.events}
-        stateManager=${stateManager}
-      />` : ""}
+          id="${id}-subtask"
+          name="Transcript"
+          events=${event.events}
+          stateManager=${stateManager}
+        />` : ""}
   </${EventPanel}>`;
 };
 const TranscriptView = ({ id, events, stateManager }) => {
@@ -15752,7 +15752,12 @@ const renderNode = (id, event, depth, stateManager) => {
         stateManager=${stateManager}
       />`;
     case "tool":
-      return m$1`<${ToolEventView} depth=${depth} id=${id} event=${event} stateManager=${stateManager} />`;
+      return m$1`<${ToolEventView}
+        depth=${depth}
+        id=${id}
+        event=${event}
+        stateManager=${stateManager}
+      />`;
     default:
       return m$1``;
   }
@@ -16459,21 +16464,12 @@ const SampleTranscript = ({ id, evalEvents }) => {
   />`;
 };
 const resolveEventContent = (evalEvents) => {
-  return evalEvents.events.map((e2) => {
-    if (e2.event === "model") {
-      e2.input = resolveValue(e2.input, evalEvents);
-      e2.call = resolveValue(e2.call, evalEvents);
-      e2.output = resolveValue(e2.output, evalEvents);
-    } else if (e2.event === "state") {
-      e2.changes = e2.changes.map((change) => {
-        change.value = resolveValue(change.value, evalEvents);
-        return change;
-      });
-    } else if (e2.event === "sample_init") {
-      e2.state["messages"] = resolveValue(e2.state["messages"], evalEvents);
-    }
-    return e2;
-  });
+  return (
+    /** @type {import("../types/log").Events} */
+    evalEvents.events.map((e2) => {
+      return resolveValue(e2, evalEvents);
+    })
+  );
 };
 const resolveValue = (value, evalEvents) => {
   if (Array.isArray(value)) {

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15377,10 +15377,10 @@ const SubtaskEventView = ({ id, depth, event, stateManager }) => {
   return m$1`
     <${EventPanel} id=${id} depth=${depth} title="Subtask: ${event.name}" icon=${ApplicationIcons.subtask}>
       <${SubtaskSummary} name="Summary"  input=${event.input} result=${event.result}/>
-      ${event.events.events.length > 0 ? m$1`<${TranscriptView}
+      ${event.events.length > 0 ? m$1`<${TranscriptView}
               id="${id}-subtask"
               name="Transcript"
-              evalEvents=${event.events}
+              events=${event.events}
               stateManager=${stateManager}
             />` : ""}
     </${EventPanel}>`;
@@ -15630,7 +15630,7 @@ const ScoreEventView = ({ id, depth, event }) => {
 
   </${EventPanel}>`;
 };
-const ToolEventView = ({ id, depth, event }) => {
+const ToolEventView = ({ id, depth, stateManager, event }) => {
   const { input, functionCall, inputType } = resolveToolInput(
     event.function,
     event.arguments
@@ -15652,12 +15652,16 @@ const ToolEventView = ({ id, depth, event }) => {
       mode="compact"
       />
   </div>
+  ${event.events.length > 0 ? m$1`<${TranscriptView}
+        id="${id}-subtask"
+        name="Transcript"
+        events=${event.events}
+        stateManager=${stateManager}
+      />` : ""}
   </${EventPanel}>`;
 };
-const kContentProtocol = "tc://";
-const TranscriptView = ({ id, evalEvents, stateManager }) => {
-  const denormalizedEvents = resolveEventContent(evalEvents);
-  const resolvedEvents = fixupEventStream(denormalizedEvents);
+const TranscriptView = ({ id, events, stateManager }) => {
+  const resolvedEvents = fixupEventStream(events);
   let depth = 0;
   const rows = resolvedEvents.map((event, index) => {
     const row = m$1`
@@ -15748,43 +15752,10 @@ const renderNode = (id, event, depth, stateManager) => {
         stateManager=${stateManager}
       />`;
     case "tool":
-      return m$1`<${ToolEventView} depth=${depth} id=${id} event=${event} />`;
+      return m$1`<${ToolEventView} depth=${depth} id=${id} event=${event} stateManager=${stateManager} />`;
     default:
       return m$1``;
   }
-};
-const resolveEventContent = (evalEvents) => {
-  return evalEvents.events.map((e2) => {
-    if (e2.event === "model") {
-      e2.input = resolveValue(e2.input, evalEvents);
-      e2.call = resolveValue(e2.call, evalEvents);
-      e2.output = resolveValue(e2.output, evalEvents);
-    } else if (e2.event === "state") {
-      e2.changes = e2.changes.map((change) => {
-        change.value = resolveValue(change.value, evalEvents);
-        return change;
-      });
-    } else if (e2.event === "sample_init") {
-      e2.state["messages"] = resolveValue(e2.state["messages"], evalEvents);
-    }
-    return e2;
-  });
-};
-const resolveValue = (value, evalEvents) => {
-  if (Array.isArray(value)) {
-    return value.map((v2) => resolveValue(v2, evalEvents));
-  } else if (value && typeof value === "object") {
-    const resolvedObject = {};
-    for (const key2 of Object.keys(value)) {
-      resolvedObject[key2] = resolveValue(value[key2], evalEvents);
-    }
-    return resolvedObject;
-  } else if (typeof value === "string") {
-    if (value.startsWith(kContentProtocol)) {
-      return evalEvents.content[value.replace(kContentProtocol, "")];
-    }
-  }
-  return value;
 };
 const fixupEventStream = (events) => {
   const initEventIndex = events.findIndex((e2) => {
@@ -16477,13 +16448,48 @@ const initStateManager = () => {
     }
   };
 };
+const kContentProtocol = "tc://";
 const SampleTranscript = ({ id, evalEvents }) => {
   const stateManager = initStateManager();
+  const denormalizedEvents = resolveEventContent(evalEvents);
   return m$1`<${TranscriptView}
     id=${id}
-    evalEvents=${evalEvents}
+    events=${denormalizedEvents}
     stateManager=${stateManager}
   />`;
+};
+const resolveEventContent = (evalEvents) => {
+  return evalEvents.events.map((e2) => {
+    if (e2.event === "model") {
+      e2.input = resolveValue(e2.input, evalEvents);
+      e2.call = resolveValue(e2.call, evalEvents);
+      e2.output = resolveValue(e2.output, evalEvents);
+    } else if (e2.event === "state") {
+      e2.changes = e2.changes.map((change) => {
+        change.value = resolveValue(change.value, evalEvents);
+        return change;
+      });
+    } else if (e2.event === "sample_init") {
+      e2.state["messages"] = resolveValue(e2.state["messages"], evalEvents);
+    }
+    return e2;
+  });
+};
+const resolveValue = (value, evalEvents) => {
+  if (Array.isArray(value)) {
+    return value.map((v2) => resolveValue(v2, evalEvents));
+  } else if (value && typeof value === "object") {
+    const resolvedObject = {};
+    for (const key2 of Object.keys(value)) {
+      resolvedObject[key2] = resolveValue(value[key2], evalEvents);
+    }
+    return resolvedObject;
+  } else if (typeof value === "string") {
+    if (value.startsWith(kContentProtocol)) {
+      return evalEvents.content[value.replace(kContentProtocol, "")];
+    }
+  }
+  return value;
 };
 const InlineSampleDisplay = ({
   index,

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15289,7 +15289,7 @@ const summarizeChanges = (changes) => {
 };
 const StepEventView = ({ depth, event }) => {
   const descriptor = stepDescriptor(event);
-  if (event.action === "end" || event.type === "generate_loop") {
+  if (event.action === "end") {
     if (descriptor.endSpace) {
       return m$1`<div style=${{ height: "1.5em" }}></div>`;
     } else {
@@ -15681,7 +15681,7 @@ const TranscriptView = ({ id, events, stateManager }) => {
         </div>
       </div>
     `;
-    if (event.event === "step" && event.type !== "generate_loop") {
+    if (event.event === "step") {
       if (event.action === "end") {
         depth = depth - 1;
       } else {

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -1735,14 +1735,6 @@
           "default": 0,
           "title": "Lineno",
           "type": "integer"
-        },
-        "args": {
-          "allOf": [
-            {
-              "$ref": "#/$defs/JsonValue"
-            }
-          ],
-          "default": null
         }
       },
       "required": [
@@ -1752,8 +1744,7 @@
         "created",
         "filename",
         "module",
-        "lineno",
-        "args"
+        "lineno"
       ],
       "title": "LoggingMessage",
       "type": "object",
@@ -2602,7 +2593,42 @@
           "title": "Result"
         },
         "events": {
-          "$ref": "#/$defs/EvalEvents"
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SampleInitEvent"
+              },
+              {
+                "$ref": "#/$defs/StateEvent"
+              },
+              {
+                "$ref": "#/$defs/StoreEvent"
+              },
+              {
+                "$ref": "#/$defs/ModelEvent"
+              },
+              {
+                "$ref": "#/$defs/ToolEvent"
+              },
+              {
+                "$ref": "#/$defs/ScoreEvent"
+              },
+              {
+                "$ref": "#/$defs/LoggerEvent"
+              },
+              {
+                "$ref": "#/$defs/InfoEvent"
+              },
+              {
+                "$ref": "#/$defs/StepEvent"
+              },
+              {
+                "$ref": "#/$defs/SubtaskEvent"
+              }
+            ]
+          },
+          "title": "Events",
+          "type": "array"
         }
       },
       "required": [
@@ -2760,6 +2786,55 @@
             }
           ],
           "title": "Result"
+        },
+        "error": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ToolCallError"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "events": {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/SampleInitEvent"
+              },
+              {
+                "$ref": "#/$defs/StateEvent"
+              },
+              {
+                "$ref": "#/$defs/StoreEvent"
+              },
+              {
+                "$ref": "#/$defs/ModelEvent"
+              },
+              {
+                "$ref": "#/$defs/ToolEvent"
+              },
+              {
+                "$ref": "#/$defs/ScoreEvent"
+              },
+              {
+                "$ref": "#/$defs/LoggerEvent"
+              },
+              {
+                "$ref": "#/$defs/InfoEvent"
+              },
+              {
+                "$ref": "#/$defs/StepEvent"
+              },
+              {
+                "$ref": "#/$defs/SubtaskEvent"
+              }
+            ]
+          },
+          "title": "Events",
+          "type": "array"
         }
       },
       "required": [
@@ -2769,7 +2844,9 @@
         "id",
         "function",
         "arguments",
-        "result"
+        "result",
+        "error",
+        "events"
       ],
       "title": "ToolEvent",
       "type": "object",
@@ -2987,6 +3064,7 @@
               "type": "null"
             }
           ],
+          "default": null,
           "title": "Bytes"
         }
       },

--- a/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
@@ -3,6 +3,8 @@ import { html } from "htm/preact";
 import { TranscriptView } from "./transcript/TranscriptView.mjs";
 import { initStateManager } from "./transcript/TranscriptState.mjs";
 
+const kContentProtocol = "tc://";
+
 /**
  * Renders the SampleTranscript component.
  *
@@ -14,9 +16,67 @@ import { initStateManager } from "./transcript/TranscriptState.mjs";
 export const SampleTranscript = ({ id, evalEvents }) => {
   const stateManager = initStateManager();
 
+  // Resolve content Uris (content may be stored separately to avoid
+  // repetition - it will be address with a uri)
+  const denormalizedEvents = resolveEventContent(evalEvents);
+
   return html`<${TranscriptView}
     id=${id}
-    evalEvents=${evalEvents}
+    events=${denormalizedEvents}
     stateManager=${stateManager}
   />`;
+};
+
+/**
+ * Resolves event content
+ *
+ * @param {import("../types/log").EvalEvents} evalEvents - The transcript events to display.
+ * @returns {import("../types/log").Events} Events with resolved content.
+ */
+const resolveEventContent = (evalEvents) => {
+  return evalEvents.events.map((e) => {
+    if (e.event === "model") {
+      //@ts-ignore
+      e.input = resolveValue(e.input, evalEvents);
+      //@ts-ignore
+      e.call = resolveValue(e.call, evalEvents);
+      //@ts-ignore
+      e.output = resolveValue(e.output, evalEvents);
+    } else if (e.event === "state") {
+      e.changes = e.changes.map((change) => {
+        change.value = resolveValue(change.value, evalEvents);
+        return change;
+      });
+    } else if (e.event === "sample_init") {
+      //@ts-ignore
+      e.state["messages"] = resolveValue(e.state["messages"], evalEvents);
+    }
+    return e;
+  });
+};
+
+/**
+ * Resolves individual value
+ *
+ * @param {unknown} value - The value to resolve.
+ * @param {import("../types/log").EvalEvents} evalEvents - The transcript events to display.
+ * @returns {unknown} Value with resolved content.
+ */
+const resolveValue = (value, evalEvents) => {
+  if (Array.isArray(value)) {
+    return value.map((v) => resolveValue(v, evalEvents));
+  } else if (value && typeof value === "object") {
+    /** @type {Record<string, unknown>} */
+    const resolvedObject = {};
+    for (const key of Object.keys(value)) {
+      //@ts-ignore
+      resolvedObject[key] = resolveValue(value[key], evalEvents);
+    }
+    return resolvedObject;
+  } else if (typeof value === "string") {
+    if (value.startsWith(kContentProtocol)) {
+      return evalEvents.content[value.replace(kContentProtocol, "")];
+    }
+  }
+  return value;
 };

--- a/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
@@ -34,25 +34,11 @@ export const SampleTranscript = ({ id, evalEvents }) => {
  * @returns {import("../types/log").Events} Events with resolved content.
  */
 const resolveEventContent = (evalEvents) => {
-  return evalEvents.events.map((e) => {
-    if (e.event === "model") {
-      //@ts-ignore
-      e.input = resolveValue(e.input, evalEvents);
-      //@ts-ignore
-      e.call = resolveValue(e.call, evalEvents);
-      //@ts-ignore
-      e.output = resolveValue(e.output, evalEvents);
-    } else if (e.event === "state") {
-      e.changes = e.changes.map((change) => {
-        change.value = resolveValue(change.value, evalEvents);
-        return change;
-      });
-    } else if (e.event === "sample_init") {
-      //@ts-ignore
-      e.state["messages"] = resolveValue(e.state["messages"], evalEvents);
-    }
-    return e;
-  });
+  return /** @type {import("../types/log").Events} */ (
+    evalEvents.events.map((e) => {
+      return resolveValue(e, evalEvents);
+    })
+  );
 };
 
 /**

--- a/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
@@ -13,7 +13,7 @@ import { EventPanel } from "./EventPanel.mjs";
  */
 export const StepEventView = ({ depth, event }) => {
   const descriptor = stepDescriptor(event);
-  if (event.action === "end" || event.type === "generate_loop") {
+  if (event.action === "end") {
     // end events have no special implicit UI
     if (descriptor.endSpace) {
       return html`<div style=${{ height: "1.5em" }}></div>`;

--- a/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.mjs
@@ -21,11 +21,11 @@ export const SubtaskEventView = ({ id, depth, event, stateManager }) => {
     <${EventPanel} id=${id} depth=${depth} title="Subtask: ${event.name}" icon=${ApplicationIcons.subtask}>
       <${SubtaskSummary} name="Summary"  input=${event.input} result=${event.result}/>
       ${
-        event.events.events.length > 0
+        event.events.length > 0
           ? html`<${TranscriptView}
               id="${id}-subtask"
               name="Transcript"
-              evalEvents=${event.events}
+              events=${event.events}
               stateManager=${stateManager}
             />`
           : ""

--- a/src/inspect_ai/_view/www/src/samples/transcript/ToolEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ToolEventView.mjs
@@ -4,6 +4,7 @@ import { EventPanel } from "./EventPanel.mjs";
 import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { ExpandablePanel } from "../../components/ExpandablePanel.mjs";
 import { resolveToolInput, ToolCallView } from "../../components/Tools.mjs";
+import { TranscriptView } from "./TranscriptView.mjs";
 
 /**
  * Renders the InfoEventView component.
@@ -12,9 +13,10 @@ import { resolveToolInput, ToolCallView } from "../../components/Tools.mjs";
  * @param { string  } props.id - The id of this event.
  * @param { number } props.depth - The depth of this event.
  * @param {import("../../types/log").ToolEvent} props.event - The event object to display.
+ * @param {import("./TranscriptState.mjs").StateManager} props.stateManager - A function that updates the state with a new state object.
  * @returns {import("preact").JSX.Element} The component.
  */
-export const ToolEventView = ({ id, depth, event }) => {
+export const ToolEventView = ({ id, depth, stateManager, event }) => {
   // Extract tool input
   const { input, functionCall, inputType } = resolveToolInput(
     event.function,
@@ -38,5 +40,15 @@ export const ToolEventView = ({ id, depth, event }) => {
       mode="compact"
       />
   </div>
+  ${
+    event.events.length > 0
+      ? html`<${TranscriptView}
+          id="${id}-subtask"
+          name="Transcript"
+          events=${event.events}
+          stateManager=${stateManager}
+        />`
+      : ""
+  }
   </${EventPanel}>`;
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -44,7 +44,7 @@ export const TranscriptView = ({ id, events, stateManager }) => {
       </div>
     `;
 
-    if (event.event === "step" && event.type !== "generate_loop") {
+    if (event.event === "step") {
       if (event.action === "end") {
         depth = depth - 1;
       } else {

--- a/src/inspect_ai/_view/www/src/types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/types/log.d.ts
@@ -265,6 +265,30 @@ export type Name7 = string;
 export type Timestamp9 = string;
 export type Event9 = "subtask";
 export type Name8 = string;
+export type Events2 = (
+  | SampleInitEvent
+  | StateEvent
+  | StoreEvent
+  | ModelEvent
+  | ToolEvent
+  | ScoreEvent
+  | LoggerEvent
+  | InfoEvent
+  | StepEvent
+  | SubtaskEvent
+)[];
+export type Events1 = (
+  | SampleInitEvent
+  | StateEvent
+  | StoreEvent
+  | ModelEvent
+  | ToolEvent
+  | ScoreEvent
+  | LoggerEvent
+  | InfoEvent
+  | StepEvent
+  | SubtaskEvent
+)[];
 export type Events = (
   | SampleInitEvent
   | StateEvent
@@ -702,6 +726,8 @@ export interface ToolEvent {
   function: Function1;
   arguments: Arguments1;
   result: Result;
+  error: ToolCallError | null;
+  events: Events1;
 }
 export interface Arguments1 {
   [k: string]: JsonValue;
@@ -730,7 +756,6 @@ export interface LoggingMessage {
   filename: Filename;
   module: Module;
   lineno: Lineno;
-  args: unknown;
 }
 /**
  * Event with custom info/data.
@@ -759,7 +784,7 @@ export interface SubtaskEvent {
   name: Name8;
   input: Input3;
   result: Result1;
-  events: EvalEvents;
+  events: Events2;
 }
 export interface Input3 {}
 export interface Result1 {

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -32,6 +32,11 @@ from inspect_ai.tool._tool_with import tool_description
 
 from ._chat_message import ChatMessageAssistant, ChatMessageTool
 
+# TODO: do we need eval_events to do content per task/tool anymore?
+# TODO: should we put simple type coersion in front of full json validation
+# TODO: test json schema validation reporting (raise vs. return)
+# TODO: should tool calls also capture store change events as subtasks do?
+
 
 async def call_tools(
     message: ChatMessageAssistant, tools: list[Tool]
@@ -46,9 +51,20 @@ async def call_tools(
        List of tool calls
     """
     if message.tool_calls:
+        from inspect_ai.solver._subtask.transcript import (
+            ToolEvent,
+            Transcript,
+            eval_events,
+            init_transcript,
+            transcript,
+        )
+
         tdefs = tool_defs(tools)
 
-        async def call_tool_task(call: ToolCall) -> ChatMessageTool:
+        async def call_tool_task(call: ToolCall) -> tuple[ChatMessageTool, ToolEvent]:
+            # create a transript for this call
+            init_transcript(Transcript(name=call.function))
+
             result: Any = ""
             tool_error: ToolCallError | None = None
             try:
@@ -86,14 +102,33 @@ async def call_tools(
             else:
                 content = str(result)
 
+            # create event
+            event = ToolEvent(
+                id=call.id,
+                function=call.function,
+                arguments=call.arguments,
+                result=content,
+                error=tool_error,
+                events=eval_events(transcript().events),
+            )
+
+            # return message and event
             return ChatMessageTool(
                 content=content,
                 tool_call_id=call.id,
                 error=tool_error,
-            )
+            ), event
 
+        # call tools in parallel
         tasks = [call_tool_task(call) for call in message.tool_calls]
-        return await asyncio.gather(*tasks)
+        results = await asyncio.gather(*tasks)
+
+        # fire tool events for each result
+        for event in [result[1] for result in results]:
+            transcript()._event(event)
+
+        # return tool messages
+        return [result[0] for result in results]
 
     else:
         return []
@@ -127,29 +162,17 @@ async def call_tool(tools: list[ToolDef], call: ToolCall) -> Any:
     # validate the schema of the passed object
     validation_errors = validate_tool_input(call.arguments, tool_def.parameters)
     if validation_errors:
-        return ToolParsingError(validation_errors)
+        raise ToolParsingError(validation_errors)
 
     # call the tool
     try:
-        from inspect_ai.solver._subtask.transcript import ToolEvent, transcript
-
         # get arguments (with creation of dataclasses, pydantic objects, etc.)
         arguments = tool_params(call.arguments, tool_def.tool)
 
         # call the tool
         result = await tool_def.tool(**arguments)
 
-        # report via ToolEvent
-        transcript()._event(
-            ToolEvent(
-                id=call.id,
-                function=call.function,
-                arguments=call.arguments,
-                result=result,
-            )
-        )
-
-        # return result
+        # return result + events
         return result
     except TypeError as ex:
         raise ToolParsingError(exception_message(ex))

--- a/src/inspect_ai/solver/_subtask/subtask.py
+++ b/src/inspect_ai/solver/_subtask/subtask.py
@@ -18,7 +18,6 @@ from .store import Store, dict_jsonable, init_subtask_store
 from .transcript import (
     SubtaskEvent,
     Transcript,
-    eval_events,
     init_transcript,
     track_store_changes,
     transcript,
@@ -106,7 +105,7 @@ def subtask(name: str | Subtask) -> Callable[..., Subtask] | Subtask:
                     name=subtask_name,
                     input=input,
                     result=result,
-                    events=eval_events(transcript().events),
+                    events=transcript().events,
                 )
 
                 # return result and event

--- a/src/inspect_ai/solver/_subtask/transcript.py
+++ b/src/inspect_ai/solver/_subtask/transcript.py
@@ -43,14 +43,6 @@ class BaseEvent(BaseModel):
         return dt.astimezone().isoformat()
 
 
-class EvalEvents(BaseModel):
-    events: list["Event"] = Field(default_factory=list)
-    """List of events."""
-
-    content: dict[str, str] = Field(default_factory=dict)
-    """Content references."""
-
-
 class SampleInitEvent(BaseEvent):
     """Beginning of processing a Sample."""
 
@@ -136,7 +128,7 @@ class ToolEvent(BaseEvent):
     error: ToolCallError | None = Field(default=None)
     """Error that occurred during tool call."""
 
-    events: EvalEvents
+    events: list["Event"]
     """Transcript of events for tool."""
 
 
@@ -201,7 +193,7 @@ class SubtaskEvent(BaseEvent):
     result: Any
     """Subtask function result."""
 
-    events: EvalEvents
+    events: list["Event"]
     """Transcript of events for subtask."""
 
 
@@ -302,6 +294,14 @@ _transcript: ContextVar[Transcript] = ContextVar(
 CONTENT_PROTOCOL = "tc://"
 
 
+class EvalEvents(BaseModel):
+    events: list[Event] = Field(default_factory=list)
+    """List of events."""
+
+    content: dict[str, str] = Field(default_factory=dict)
+    """Content references."""
+
+
 def eval_events(events: list[Event]) -> EvalEvents:
     content: dict[str, str] = {}
 
@@ -335,12 +335,28 @@ def walk_events(events: list[Event], content_fn: Callable[[str], str]) -> list[E
 def walk_event(event: Event, content_fn: Callable[[str], str]) -> Event:
     if isinstance(event, SampleInitEvent):
         return walk_sample_init_event(event, content_fn)
-    if isinstance(event, ModelEvent):
+    elif isinstance(event, ModelEvent):
         return walk_model_event(event, content_fn)
     elif isinstance(event, StateEvent):
         return walk_state_event(event, content_fn)
+    elif isinstance(event, StoreEvent):
+        return walk_store_event(event, content_fn)
+    elif isinstance(event, SubtaskEvent):
+        return walk_subtask_event(event, content_fn)
+    elif isinstance(event, ToolEvent):
+        return walk_tool_event(event, content_fn)
     else:
         return event
+
+
+def walk_subtask_event(
+    event: SubtaskEvent, content_fn: Callable[[str], str]
+) -> SubtaskEvent:
+    return event.model_copy(update=dict(events=walk_events(event.events, content_fn)))
+
+
+def walk_tool_event(event: ToolEvent, content_fn: Callable[[str], str]) -> ToolEvent:
+    return event.model_copy(update=dict(events=walk_events(event.events, content_fn)))
 
 
 def walk_sample_init_event(
@@ -417,15 +433,23 @@ def walk_state_event(event: StateEvent, content_fn: Callable[[str], str]) -> Sta
     return event
 
 
+def walk_store_event(event: StoreEvent, content_fn: Callable[[str], str]) -> StoreEvent:
+    event = event.model_copy(
+        update=dict(
+            changes=[
+                walk_state_json_change(change, content_fn) for change in event.changes
+            ]
+        )
+    )
+    return event
+
+
 def walk_state_json_change(
     change: JsonChange, content_fn: Callable[[str], str]
 ) -> JsonChange:
-    if change.path.startswith("/messages") or change.path.startswith("/output"):
-        return change.model_copy(
-            update=dict(value=walk_json_value(change.value, content_fn))
-        )
-    else:
-        return change
+    return change.model_copy(
+        update=dict(value=walk_json_value(change.value, content_fn))
+    )
 
 
 def walk_json_value(value: JsonValue, content_fn: Callable[[str], str]) -> JsonValue:

--- a/src/inspect_ai/solver/_subtask/transcript.py
+++ b/src/inspect_ai/solver/_subtask/transcript.py
@@ -24,6 +24,7 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ModelCall, ModelOutput
 from inspect_ai.scorer._metric import Score
 from inspect_ai.tool._tool import ToolResult
+from inspect_ai.tool._tool_call import ToolCallError
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
 
@@ -40,6 +41,14 @@ class BaseEvent(BaseModel):
     @field_serializer("timestamp")
     def serialize_timestamp(self, dt: datetime) -> str:
         return dt.astimezone().isoformat()
+
+
+class EvalEvents(BaseModel):
+    events: list["Event"] = Field(default_factory=list)
+    """List of events."""
+
+    content: dict[str, str] = Field(default_factory=dict)
+    """Content references."""
 
 
 class SampleInitEvent(BaseEvent):
@@ -124,6 +133,12 @@ class ToolEvent(BaseEvent):
     result: ToolResult
     """Function return value."""
 
+    error: ToolCallError | None = Field(default=None)
+    """Error that occurred during tool call."""
+
+    events: EvalEvents
+    """Transcript of events for tool."""
+
 
 class LoggerEvent(BaseEvent):
     """Log message recorded with Python logger."""
@@ -169,14 +184,6 @@ class StepEvent(BaseEvent):
 
     name: str
     """Event name."""
-
-
-class EvalEvents(BaseModel):
-    events: list["Event"] = Field(default_factory=list)
-    """List of events."""
-
-    content: dict[str, str] = Field(default_factory=dict)
-    """Content references."""
 
 
 class SubtaskEvent(BaseEvent):


### PR DESCRIPTION
This PR adds treatment for the `ToolCall` event that parallels what we do for `SubtaskEvent`, specifically:

1) `ToolEvent` now carries an `events` field that has the transcript of events that occurred within the tool call.
2) `StoreEvent` is now emitted inside this event stream if the store is updated during the tool call.

Additionally, there are two content-aliasing related changes here:

1) All content aliasing is done at the root `Sample` (previously `SubtaskEvent` had its own content bucket, no longer).
2) When resolving content aliases all changes in `StateEvent` should be handled (previously we used this conditional: `if change.path.startswith("/messages") or change.path.startswith("/output"):`, no longer)

A related question, currently `StateEvent` can duplicate changes when there are nested steps / subtasks / tool calls. This is not incorrect as we do often want to see specifically which state changes occurred where. However, this does give us some motivation to eliminate spurious internal steps. One that note, are we making use of the "generate_loop" step and if not should we remove it?