### PR TITLE
docker init for faster shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Specify `init` value in default Docker compose file so that exit signals are handled correctly (substantially improves container shutdown performance).
+
 ## v0.3.24 (18 August 2024)
 
 - Support for tool calling for Llama 3.1 models on Bedrock.

--- a/src/inspect_ai/util/_sandbox/docker/config.py
+++ b/src/inspect_ai/util/_sandbox/docker/config.py
@@ -74,6 +74,7 @@ services:
   default:
     image: "python:3.12-bookworm"
     command: "tail -f /dev/null"
+    init: true
     network_mode: none
     stop_grace_period: 1s
 """
@@ -84,6 +85,7 @@ services:
     build:
       context: "."
     command: "tail -f /dev/null"
+    init: true
     network_mode: none
     stop_grace_period: 1s
 """


### PR DESCRIPTION
Specify `init` value in default Docker compose file so that exit signals are handled correctly (substantially improves container shutdown performance)