### PR TITLE
remove file bodies from sample init event

### DIFF
--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -361,9 +361,14 @@ async def task_run_sample(
     # solver loop
     async with semaphore_cm, sandboxenv_cm:
         try:
-            # sample init event
+            # sample init event (remove file bodies as they have content or absolute paths)
+            event_sample = sample.model_copy(
+                update=dict(files={k: "" for k in sample.files.keys()})
+                if sample.files
+                else None
+            )
             transcript()._event(
-                SampleInitEvent(sample=sample, state=state_jsonable(state))
+                SampleInitEvent(sample=event_sample, state=state_jsonable(state))
             )
 
             # run plan steps (checking for early termination)

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15144,7 +15144,7 @@ const EventPanel = ({
                 onclick=${() => {
     setCollapsed(!collapsed);
   }}
-              />` : ""}
+              />` : m$1`<div></div>`}
           <div
             style=${{ ...TextStyle.label, ...TextStyle.secondary }}
             onclick=${() => {
@@ -15337,10 +15337,6 @@ const MetaDataGrid = ({
     ${entryEls}
   </div>`;
 };
-const isBase64 = (str) => {
-  const base64Pattern = /^(?:[A-Za-z0-9+/]{4})*?(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
-  return base64Pattern.test(str);
-};
 const EventSection = ({ title, style, children }) => {
   return m$1`<div
     style=${{
@@ -15366,12 +15362,10 @@ const SampleInitEventView = ({ id, depth, event, stateManager }) => {
   stateManager.setState(stateObj);
   const sections = [];
   if (event.sample.files && Object.keys(event.sample.files).length > 0) {
-    const filesTable = {};
-    Object.keys(event.sample.files).forEach((key2) => {
-      filesTable[key2] = isBase64(event.sample.files[key2]) ? `<Base64 string>` : event.sample.files[key2];
-    });
     sections.push(m$1`<${EventSection} title="Files">
-      <${MetaDataGrid} entries=${filesTable}/>
+      ${Object.keys(event.sample.files).map((file) => {
+      return m$1`<pre style=${{ marginBottom: "0" }}>${file}</pre>`;
+    })}
       </${EventSection}>
   `);
   }

--- a/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
@@ -68,7 +68,7 @@ export const EventPanel = ({
                   setCollapsed(!collapsed);
                 }}
               />`
-            : ""}
+            : html`<div></div>`}
           <div
             style=${{ ...TextStyle.label, ...TextStyle.secondary }}
             onclick=${() => {

--- a/src/inspect_ai/_view/www/src/samples/transcript/SampleInitEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/SampleInitEventView.mjs
@@ -3,7 +3,6 @@ import { html } from "htm/preact";
 import { EventPanel } from "./EventPanel.mjs";
 import { MetaDataGrid } from "../../components/MetaDataGrid.mjs";
 import { ChatView } from "../../components/ChatView.mjs";
-import { isBase64 } from "../../utils/Base64.mjs";
 import { EventSection } from "./EventSection.mjs";
 
 /**
@@ -30,15 +29,10 @@ export const SampleInitEventView = ({ id, depth, event, stateManager }) => {
   const sections = [];
 
   if (event.sample.files && Object.keys(event.sample.files).length > 0) {
-    const filesTable = {};
-    Object.keys(event.sample.files).forEach((key) => {
-      filesTable[key] = isBase64(event.sample.files[key])
-        ? `<Base64 string>`
-        : event.sample.files[key];
-    });
-
     sections.push(html`<${EventSection} title="Files">
-      <${MetaDataGrid} entries=${filesTable}/>
+      ${Object.keys(event.sample.files).map((file) => {
+        return html`<pre style=${{ marginBottom: "0" }}>${file}</pre>`;
+      })}
       </${EventSection}>
   `);
   }


### PR DESCRIPTION
File bodies are now just an empty string, so we should update the UI to show the files as a simple list of filenames.