### PR TITLE
Fix bug that sets all temperatures to 0.02 or less for vLLM

### DIFF
--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -161,7 +161,7 @@ class VLLMAPI(ModelAPI):
 
         if config.temperature is not None:
             # for some reason vllm doesn't generate anything for 0 < temperature < 0.02
-            if 0 < config.temperature > 0.02:
+            if 0 < config.temperature < 0.02:
                 config.temperature = 0.02
             kwargs["temperature"] = config.temperature
         if config.top_p is not None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor


----

```python
# for some reason vllm doesn't generate anything for 0 < temperature < 0.02
if 0 < config.temperature > 0.02:
    config.temperature = 0.02
kwargs["temperature"] = config.temperature
```

Notice the `config.temperature > 0.02` in the code. This condition sets temperature to 0.02 for any temperature greater than 0.02!

----

To reproduce an end-to-end example, place breakpoint or print statement inside the `LLM` class of vLLM:

```python
# vllm/entrypoints/llm.py
class LLM:
    def generate(
        self,
        ...
    ) -> List[RequestOutput]:
        print("generating with temperature", sampling_params.temperature)
```

Then run this minimal example with a temperature of 5:

```python
from inspect_ai import Task, task, eval
from inspect_ai.dataset import Sample, hf_dataset
from inspect_ai.model import GenerateConfig
from inspect_ai.scorer import match
from inspect_ai.solver import generate


def record_to_sample(record):
    DELIM = "####"
    input = record["question"]
    answer = record["answer"].split(DELIM)
    target = answer.pop().strip()
    return Sample(input=input, target=target)


@task
def gsm8k():
    plan = [generate()]
    return Task(
        dataset=hf_dataset(
            path="openai/gsm8k",
            data_dir="main",
            split="test",
            sample_fields=record_to_sample,
            limit=1,
        ),
        plan=plan,
        scorer=match(numeric=True),
        config=GenerateConfig(
            temperature=5,
        )
    )


eval(gsm8k(), model="vllm/TinyLlama/TinyLlama-1.1B-Chat-v1.0", max_connections=1)
```

This prints:
```
generating with temperature 0.02
```