### PR TITLE
lighten dev dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - [Transcript](https://inspect.ai-safety-institute.org.uk/agents-api.html#transcripts) for detailed sample level tracking of model and tool calls, state changes, logging, etc.
 - [Subtasks](https://inspect.ai-safety-institute.org.uk/agents-api.html#sec-subtasks) for delegating work to helper models, sub-agents, etc.
 - Integration with Anthropic [prompt caching](https://inspect.ai-safety-institute.org.uk/caching.html#sec-provider-caching).
-- [fail_on_error](errors-and-limits.qmd#failure-threshold) option to tolerate some threshold of sample failures without failing the evaluation.
+- [fail_on_error](https://inspect.ai-safety-institute.org.uk/errors-and-limits.html#failure-threshold) option to tolerate some threshold of sample failures without failing the evaluation.
 - Specify `init` value in default Docker compose file so that exit signals are handled correctly (substantially improves container shutdown performance).
 - Add `function` field to `ChatMessageTool` to indicate the name of the function called.
 - Added [RACE](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/benchmarks/race-h/) benchmark.

--- a/examples/agents/langchain/inspect_langchain.py
+++ b/examples/agents/langchain/inspect_langchain.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import json
 from typing import Any, Dict, Protocol, cast, runtime_checkable
 

--- a/examples/agents/langchain/wikipedia.py
+++ b/examples/agents/langchain/wikipedia.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 from typing import Any, cast
 
 from inspect_langchain import langchain_solver

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ norecursedirs = [
 log_level = "warning"
 
 [tool.mypy]
+exclude = "examples/agents/"
 warn_unused_ignores = true
 no_implicit_reexport = true
 strict_equality = true
@@ -98,7 +99,17 @@ Documentation = "https://inspect.ai-safety-institute.org.uk/"
 inspect = "inspect_ai._cli.main:main"
 
 [project.optional-dependencies]
+models = [
+    "anthropic", 
+    "boto3", 
+    "google-cloud-aiplatform",
+    "google-generativeai", 
+    "groq", 
+    "mistralai",
+    "openai"
+]
 dev = [
+    "inspect_ai[models]",
     "ipython",
     "mypy",
     "nbformat",
@@ -119,15 +130,6 @@ dev = [
     "types-protobuf",
     "types-psutil",
     "types-python-dateutil"
-]
-models = [
-    "anthropic", 
-    "boto3", 
-    "google-cloud-aiplatform",
-    "google-generativeai", 
-    "groq", 
-    "mistralai",
-    "openai"
 ]
 doc = ["quarto-cli", "jupyter"]
 dist = ["twine", "build"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,20 +99,17 @@ Documentation = "https://inspect.ai-safety-institute.org.uk/"
 inspect = "inspect_ai._cli.main:main"
 
 [project.optional-dependencies]
-models = [
+dev = [
     "anthropic", 
     "boto3", 
     "google-cloud-aiplatform",
     "google-generativeai", 
     "groq", 
-    "mistralai",
-    "openai"
-]
-dev = [
-    "inspect_ai[models]",
     "ipython",
+    "mistralai",
     "mypy",
     "nbformat",
+    "openai",
     "pre-commit",
     "pytest",
     "pytest-asyncio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,6 @@ disallow_untyped_decorators = true
 extra_checks = true
 disable_error_code = "unused-ignore"
 
-[[tool.mypy.overrides]]
-module = "pandas-stubs.*"
-ignore_errors = true
-
-
 [project]
 name = "inspect_ai"
 description = "Framework for large language model evaluations"
@@ -104,21 +99,9 @@ inspect = "inspect_ai._cli.main:main"
 
 [project.optional-dependencies]
 dev = [
-    "accelerate",
-    "anthropic",
-    "boto3",
-    "datasets",
-    "google-cloud-aiplatform",
-    "google-generativeai",
     "ipython",
-    "ipywidgets",
-    "langchain",
-    "langchainhub",
-    "mistralai",
     "mypy",
     "nbformat",
-    "openai",
-    "pandas-stubs",
     "pre-commit",
     "pytest",
     "pytest-asyncio",
@@ -126,8 +109,6 @@ dev = [
     "pytest-dotenv",
     "pytest-xdist",
     "ruff",
-    "torch",
-    "transformers",
     "types-PyYAML",
     "types-aiofiles",
     "types-beautifulsoup4",
@@ -137,10 +118,16 @@ dev = [
     "types-jsonschema",
     "types-protobuf",
     "types-psutil",
-    "types-python-dateutil",
-    "wikipedia",
-    "groq",
-    "wikipedia",
+    "types-python-dateutil"
+]
+models = [
+    "anthropic", 
+    "boto3", 
+    "google-cloud-aiplatform",
+    "google-generativeai", 
+    "groq", 
+    "mistralai",
+    "openai"
 ]
 doc = ["quarto-cli", "jupyter"]
 dist = ["twine", "build"]

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -7,8 +7,8 @@ from threading import Thread
 from typing import Any, Literal, Protocol, cast
 
 import numpy as np
-import torch
-from torch import Tensor
+import torch  # type: ignore
+from torch import Tensor  # type: ignore
 from transformers import (  # type: ignore
     AutoModelForCausalLM,
     AutoTokenizer,

--- a/tests/model/providers/test_hf.py
+++ b/tests/model/providers/test_hf.py
@@ -1,6 +1,9 @@
 import pytest
-from test_helpers.utils import skip_if_github_action, skip_if_no_transformers
-from transformers import PreTrainedModel  # type: ignore
+from test_helpers.utils import (
+    skip_if_github_action,
+    skip_if_no_accelerate,
+    skip_if_no_transformers,
+)
 
 from inspect_ai.model import (
     ChatMessageUser,
@@ -10,7 +13,7 @@ from inspect_ai.model import (
 
 
 @pytest.fixture
-def model() -> PreTrainedModel:
+def model():
     return get_model(
         "hf/EleutherAI/pythia-70m",
         config=GenerateConfig(
@@ -26,7 +29,8 @@ def model() -> PreTrainedModel:
 @pytest.mark.asyncio
 @skip_if_github_action
 @skip_if_no_transformers
-async def test_hf_api(model: PreTrainedModel) -> None:
+@skip_if_no_accelerate
+async def test_hf_api(model) -> None:
     message = ChatMessageUser(content="Lorem ipsum dolor")
     response = await model.generate(input=[message])
     assert len(response.completion) >= 1
@@ -35,7 +39,7 @@ async def test_hf_api(model: PreTrainedModel) -> None:
 @pytest.mark.asyncio
 @skip_if_github_action
 @skip_if_no_transformers
-async def test_hf_api_fails(model: PreTrainedModel) -> None:
+async def test_hf_api_fails(model) -> None:
     temp_before = model.config.temperature
     try:
         model.config.temperature = 0.0

--- a/tests/model/test_logprobs.py
+++ b/tests/model/test_logprobs.py
@@ -1,8 +1,10 @@
 import pytest
 from test_helpers.utils import (
     skip_if_github_action,
+    skip_if_no_accelerate,
     skip_if_no_openai,
     skip_if_no_together,
+    skip_if_no_transformers,
     skip_if_no_vllm,
 )
 
@@ -44,6 +46,8 @@ async def test_together_logprobs() -> None:
 
 @pytest.mark.asyncio
 @skip_if_github_action
+@skip_if_no_transformers
+@skip_if_no_accelerate
 async def test_hf_logprobs() -> None:
     response = await generate_with_logprobs(
         "hf/EleutherAI/pythia-70m",

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -35,6 +35,10 @@ def skip_if_no_transformers(func):
     return skip_if_no_package("transformers")(func)
 
 
+def skip_if_no_accelerate(func):
+    return skip_if_no_package("accelerate")(func)
+
+
 def skip_if_no_openai(func):
     return skip_if_env_var("OPENAI_API_KEY", exists=False)(func)
 


### PR DESCRIPTION
Remove packages used in examples as well as transformers/accelerate from dev dependencies (these can be installed piecemeal as required). 