### PR TITLE
allow sandboxes to specified at the sample level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Sandbox environments can now be specified [per-sample](https://inspect.ai-safety-institute.org.uk/agents.html#sec-per-sample-sandbox) (e.g. allowing for a distinct Dockerfile or Docker compose file for each sample).
+
 ## v0.3.25 (25 August 2024)
 
 - [Store](https://inspect.ai-safety-institute.org.uk/agents-api.html#sharing-state) for manipulating arbitrary sample state from within solvers and tools.

--- a/docs/agents-api.qmd
+++ b/docs/agents-api.qmd
@@ -296,4 +296,4 @@ def list_files():
     return execute
 ```
 
-See the section on [Sandbox Environments](agents.qmd##sec-sandbox-environments) for further details on using sandboxes with Inspect.
+See the section on [Sandbox Environments](agents.qmd#sec-sandbox-environments) for further details on using sandboxes with Inspect.

--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -455,13 +455,14 @@ Here's an example of a `compose.yaml` file that sets container resource limits a
 services:
   default: 
     build: .
+    init: true
     command: tail -f /dev/null
     cpus: 1.0
     mem_limit: 0.5gb
     network_mode: none
 ```
 
-The `command` is provided to prevent the container from exiting.
+The `init: true` entry enables the container to respond to shutdown requests. The `command` is provided to prevent the container from exiting after it starts.
 
 Here is what a simple `compose.yaml` would look like for a local pre-built image named `ctf-agent-environment` (resource and network limits excluded for brevity):
 
@@ -470,6 +471,7 @@ services:
   default: 
     image: ctf-agent-environment
     x-local: true
+    init: true
     command: tail -f /dev/null
 ```
 
@@ -479,6 +481,7 @@ The `ctf-agent-environment` is not an image that exists on a remote registry, so
 services:
   default: 
     image: ctf-agent-environment:1.0.0
+    init: true
     command: tail -f /dev/null
 ```
 
@@ -488,6 +491,7 @@ If we are using an image from a remote registry we similarly don't need to inclu
 services:
   default:
     image: python:3.12-bookworm
+    init: true
     command: tail -f /dev/null
 ```
 
@@ -502,11 +506,13 @@ services:
   default:
     image: ctf-agent-environment
     x-local: true
+    init: true
     cpus: 1.0
     mem_limit: 0.5gb
   victim:
     image: ctf-victim-environment
     x-local: true
+    init: true
     cpus: 1.0
     mem_limit: 1gb
 ```
@@ -531,12 +537,14 @@ services:
   default: 
     image: ctf-agent-environment
     x-local: true
+    init: true
     volumes:
       - ctf-challenge-volume:/shared-data
     
   writer:
     image: ctf-challenge-writer
     x-local: true
+    init: true
     volumes:
       - ctf-challenge-volume:/shared-data
 volumes:
@@ -554,6 +562,7 @@ services:
   default:
     image: ctf-agent-environment
     x-local: true
+    init: true
     cpus: 1.0
     mem_limit: ${SAMPLE_METDATA_MEMORY_LIMIT-0.5gb}
 ```

--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -391,7 +391,9 @@ There are two sandbox environments built in to Inspect:
 | `local`          | Run `sandbox()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
 | `docker`         | Run `sandbox()` methods within a Docker container (see the [Docker Configuration](#sec-docker-configuration) section below for additional details).              |
 
-Sandbox environments can be bound at the `Task` level or at the `eval()` level (where `eval()` takes precedence). To bind a sandbox environment to a `Task`, use the `sandbox` option:
+Sandbox environments can be bound at the `Sample`, `Task`, or `eval()` level. Binding precedence goes from `eval()`, to `Task` to `Sample`, however sandbox config files defined on the `Sample` always take precedence when the sandbox type for the `Sample` is the same as the enclosing `Task` or `eval()`.
+
+Here is a `Task` that defines a `sandbox` and corresponding sandbox config file:
 
 ``` python
 Task(
@@ -401,19 +403,34 @@ Task(
         generate()
     ]),
     scorer=match(),
-    sandbox="docker"
+    sandbox=("docker", "compose.yaml")
 )
 ```
 
-For this example, if there is a `compose.yaml` file in the task directory it will be used to provision Docker services (if there is no `compose.yaml` then the Docker's default Python 3.12 image will be used). You can specify an alternate config file using a tuple:
+In this example there is a `compose.yaml` file in the task directory that will be used to provision Docker services (if there is no config file specified then the Docker default Python 3.12 image will be used). For example:
 
 ``` python
-sandbox=("docker","my-compose.yaml")
+sandbox="docker"
 ```
 
 ### Per Sample Setup
 
-The `Sample` class includes `files` and `setup` fields that are used to specify per-sample file assets and setup logic.
+The `Sample` class includes `sandbox`, `files` and `setup` fields that are used to specify per-sample sandbox config, file assets, and setup logic.
+
+#### Sandbox {#sec-per-sample-sandbox}
+
+::: {.callout-note appearance="simple"}
+Note that per-sample `sandbox` specification is available only in the development version of Inspect. You can install the development version with:
+
+```bash
+pip install git+https://github.com/ukgovernmentbeis/inspect_ai
+```
+:::
+
+You can either define a default `sandbox` for an entire `Task` as illustrated abvove, or alternatively define a per-sample `sandbox`. For example, you might want to do this if each sample has its own Dockerfile and/or custom compose configuration file.
+
+The `sandbox` can be specified as a string (e.g. `"docker`") or a list of sandbox type and config file (e.g. `["docker", "compose.yaml"]`).
+
 
 #### Files
 

--- a/docs/datasets.qmd
+++ b/docs/datasets.qmd
@@ -27,6 +27,7 @@ The core data type underlying the use of datasets with Inspect is the `Sample`, 
 | `target` | `str | list[str] | None` | Optional. Ideal target output. May be a literal value or narrative text to be used by a model grader. |
 | `id` | `str | None` | Optional. Unique identifier for sample. |
 | `metadata` | `dict[str | Any] | None` | Optional. Arbitrary metadata associated with the sample. |
+| `sandbox` | `str | tuple[str,str]` | Optional. Sandbox environment type (or optionally a tuple with type and config file) | 
 | `files` | `dict[str | str] | None` | Optional. Files that go along with the sample (copied to sandbox environments). |
 | `setup` | `str | None` | Optional. Setup script to run for sample (executed within default sandbox environment). |
 

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -38,6 +38,15 @@ class ResolvedTask:
     id: str | None = field(default=None)
     sample_source: EvalSampleSource | None = field(default=None)
 
+    @property
+    def has_sandbox(self) -> bool:
+        if self.sandbox:
+            return True
+        else:
+            return any(
+                [True if sample.sandbox else False for sample in self.task.dataset]
+            )
+
 
 def resolve_tasks(
     tasks: Tasks,

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -7,6 +7,7 @@ from shortuuid import uuid
 from typing_extensions import Unpack
 
 from inspect_ai._display import display
+from inspect_ai._eval.task.sandbox import resolve_sandbox
 from inspect_ai._util.dotenv import dotenv_environ
 from inspect_ai._util.error import exception_message
 from inspect_ai._util.path import chdir_python
@@ -255,8 +256,11 @@ async def startup_sandbox_environments(
     # find unique sandboxenvs
     sandboxenvs: Set[tuple[str, str | None]] = set()
     for task in tasks:
-        if task.sandbox is not None and task.sandbox not in sandboxenvs:
-            sandboxenvs.add(task.sandbox)
+        # resolve each sample and add to sandboxenvs
+        for sample in task.task.dataset:
+            sandbox = resolve_sandbox(task.sandbox, sample)
+            if sandbox is not None and sandbox not in sandboxenvs:
+                sandboxenvs.add(sandbox)
 
     # initialiase sandboxenvs (track cleanups)
     cleanups: list[tuple[TaskCleanup, str | None]] = []

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -137,6 +137,13 @@ class TaskLogger:
                 choices=sample.choices,
                 target=sample.target,
                 metadata=state.metadata if state.metadata else {},
+                sandbox=(
+                    (sample.sandbox, None)
+                    if isinstance(sample.sandbox, str)
+                    else sample.sandbox
+                ),
+                files=list(sample.files.keys()) if sample.files else None,
+                setup=sample.setup,
                 messages=state.messages,
                 output=state.output,
                 scores=cast(dict[str, Score], scores),

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1,12 +1,11 @@
 import asyncio
-import base64
 import contextlib
 import sys
 from copy import deepcopy
 from dataclasses import dataclass, field
 from logging import getLogger
 from pathlib import PurePath
-from typing import AsyncGenerator, Callable, Literal
+from typing import Callable, Literal
 
 from typing_extensions import Unpack
 
@@ -24,13 +23,11 @@ from inspect_ai._util.constants import (
 )
 from inspect_ai._util.datetime import iso_now
 from inspect_ai._util.error import exception_message
-from inspect_ai._util.file import file, filesystem
 from inspect_ai._util.hooks import send_telemetry
 from inspect_ai._util.registry import (
     is_registry_object,
     registry_log_name,
 )
-from inspect_ai._util.url import data_uri_to_base64, is_data_uri
 from inspect_ai._view.view import view_notify_eval
 from inspect_ai.dataset import Dataset, Sample
 from inspect_ai.log import (
@@ -63,11 +60,6 @@ from inspect_ai.solver._subtask.transcript import (
     transcript,
 )
 from inspect_ai.solver._task_state import state_jsonable
-from inspect_ai.util._sandbox.context import (
-    cleanup_sandbox_environments_sample,
-    init_sandbox_environments_sample,
-)
-from inspect_ai.util._sandbox.environment import SandboxEnvironment
 
 from ..context import init_task_context
 from ..task import Task
@@ -76,6 +68,7 @@ from .generate import task_generate
 from .images import samples_with_base64_images, states_with_base64_images
 from .log import TaskLogger, collect_eval_data, log_plan
 from .results import eval_results
+from .sandbox import sandboxenv_context
 from .transcript import solver_transcript
 from .util import sample_messages
 
@@ -361,10 +354,10 @@ async def task_run_sample(
     # initialise subtask
     init_subtask(SAMPLE_SUBTASK, state.store)
 
-    # use toolenv if provided
+    # use sandbox if provided
     sandboxenv_cm = (
         sandboxenv_context(task_name, sandbox, sandbox_cleanup, sample)
-        if sandbox
+        if sandbox or sample.sandbox is not None
         else contextlib.nullcontext()
     )
 
@@ -598,77 +591,3 @@ def create_sample_semaphore(
 
     # return the semaphore
     return asyncio.Semaphore(max_samples)
-
-
-@contextlib.asynccontextmanager
-async def sandboxenv_context(
-    task_name: str,
-    sandbox: tuple[str, str | None],
-    cleanup: bool,
-    sample: Sample,
-) -> AsyncGenerator[None, None]:
-    # read files from sample
-    files: dict[str, bytes] = {}
-    if sample.files:
-        for path, contents in sample.files.items():
-            files[path] = read_sandboxenv_file(contents)
-
-    # read setup script from sample (add bash shebang if necessary)
-    setup: bytes | None = None
-    if sample.setup:
-        setup = read_sandboxenv_file(sample.setup)
-        setup_str = setup.decode(encoding="utf-8")
-        if not setup_str.strip().startswith("#!"):
-            setup_str = f"#!/usr/bin/env bash\n\n{setup_str}"
-            setup = setup_str.encode(encoding="utf-8")
-
-    interrupted = False
-    environments: dict[str, SandboxEnvironment] | None = None
-    try:
-        # initialize sandbox environment,
-        environments = await init_sandbox_environments_sample(
-            type=sandbox[0],
-            task_name=task_name,
-            config=sandbox[1],
-            files=files,
-            setup=setup,
-            metadata=sample.metadata if sample.metadata else {},
-        )
-
-        # run sample
-        yield
-
-    except BaseException as ex:
-        interrupted = True
-        raise ex
-
-    finally:
-        # cleanup sandbox environment
-        if environments and cleanup:
-            await cleanup_sandbox_environments_sample(
-                type=sandbox[0],
-                task_name=task_name,
-                config=sandbox[1],
-                environments=environments,
-                interrupted=interrupted,
-            )
-
-
-def read_sandboxenv_file(contents: str) -> bytes:
-    if is_data_uri(contents):
-        contents_base64 = data_uri_to_base64(contents)
-        file_bytes = base64.b64decode(contents_base64)
-    else:
-        # try to read as a file (if it doesn't exist or has a path not cool w/
-        # the fileystem then we fall back to contents)
-        try:
-            fs = filesystem(contents)
-            if fs.exists(contents):
-                with file(contents, "rb") as f:
-                    file_bytes = f.read()
-            else:
-                file_bytes = contents.encode("utf-8")
-        except Exception:
-            file_bytes = contents.encode("utf-8")
-
-    return file_bytes

--- a/src/inspect_ai/_eval/task/sandbox.py
+++ b/src/inspect_ai/_eval/task/sandbox.py
@@ -1,0 +1,118 @@
+import base64
+import contextlib
+from typing import AsyncGenerator
+
+from inspect_ai._util.file import file, filesystem
+from inspect_ai._util.url import data_uri_to_base64, is_data_uri
+from inspect_ai.dataset import Sample
+from inspect_ai.util._sandbox.context import (
+    cleanup_sandbox_environments_sample,
+    init_sandbox_environments_sample,
+)
+from inspect_ai.util._sandbox.environment import SandboxEnvironment
+
+
+@contextlib.asynccontextmanager
+async def sandboxenv_context(
+    task_name: str,
+    sandbox: tuple[str, str | None] | None,
+    cleanup: bool,
+    sample: Sample,
+) -> AsyncGenerator[None, None]:
+    # resolve sandbox
+    sandbox = resolve_sandbox(sandbox, sample)
+    if not sandbox:
+        raise ValueError("sandboxenv_context called with no sandbox specified")
+
+    # read files from sample
+    files: dict[str, bytes] = {}
+    if sample.files:
+        for path, contents in sample.files.items():
+            files[path] = read_sandboxenv_file(contents)
+
+    # read setup script from sample (add bash shebang if necessary)
+    setup: bytes | None = None
+    if sample.setup:
+        setup = read_sandboxenv_file(sample.setup)
+        setup_str = setup.decode(encoding="utf-8")
+        if not setup_str.strip().startswith("#!"):
+            setup_str = f"#!/usr/bin/env bash\n\n{setup_str}"
+            setup = setup_str.encode(encoding="utf-8")
+
+    interrupted = False
+    environments: dict[str, SandboxEnvironment] | None = None
+    try:
+        # initialize sandbox environment,
+        environments = await init_sandbox_environments_sample(
+            type=sandbox[0],
+            task_name=task_name,
+            config=sandbox[1],
+            files=files,
+            setup=setup,
+            metadata=sample.metadata if sample.metadata else {},
+        )
+
+        # run sample
+        yield
+
+    except BaseException as ex:
+        interrupted = True
+        raise ex
+
+    finally:
+        # cleanup sandbox environment
+        if environments and cleanup:
+            await cleanup_sandbox_environments_sample(
+                type=sandbox[0],
+                task_name=task_name,
+                config=sandbox[1],
+                environments=environments,
+                interrupted=interrupted,
+            )
+
+
+def read_sandboxenv_file(contents: str) -> bytes:
+    if is_data_uri(contents):
+        contents_base64 = data_uri_to_base64(contents)
+        file_bytes = base64.b64decode(contents_base64)
+    else:
+        # try to read as a file (if it doesn't exist or has a path not cool w/
+        # the fileystem then we fall back to contents)
+        try:
+            fs = filesystem(contents)
+            if fs.exists(contents):
+                with file(contents, "rb") as f:
+                    file_bytes = f.read()
+            else:
+                file_bytes = contents.encode("utf-8")
+        except Exception:
+            file_bytes = contents.encode("utf-8")
+
+    return file_bytes
+
+
+def resolve_sandbox(
+    sandbox: tuple[str, str | None] | None,
+    sample: Sample,
+) -> tuple[str, str | None] | None:
+    # resolve sandbox (task type overrides sample type, but sample config
+    # file overrides task config file if they have the same type)
+    sample_sandbox = (
+        (sample.sandbox, None) if isinstance(sample.sandbox, str) else sample.sandbox
+    )
+    task_sandbox = sandbox
+    if task_sandbox is not None:
+        sandbox_type = task_sandbox[0]
+        if (
+            sample_sandbox
+            and sample_sandbox[0] == sandbox_type
+            and isinstance(sample_sandbox[1], str)
+        ):
+            sandbox_config: str | None = sample_sandbox[1]
+        else:
+            sandbox_config = task_sandbox[1]
+        return (sandbox_type, sandbox_config)
+    elif sample_sandbox is not None:
+        return sample_sandbox
+    else:
+        return None

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -1036,6 +1036,62 @@
           ],
           "title": "Target"
         },
+        "sandbox": {
+          "anyOf": [
+            {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sandbox"
+        },
+        "files": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Files"
+        },
+        "setup": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Setup"
+        },
         "messages": {
           "items": {
             "anyOf": [
@@ -1104,6 +1160,9 @@
         "input",
         "choices",
         "target",
+        "sandbox",
+        "files",
+        "setup",
         "messages",
         "output",
         "scores",
@@ -2153,7 +2212,7 @@
       "additionalProperties": false
     },
     "Sample": {
-      "description": "Sample to be used in an evaluation task.\n\nArgs:\n    input (str | list[ChatMessage]): The input to be submitted to the model.\n    choices (list[str] | None): Optional. List of available answer choices\n       (used only for multiple-choice evals).\n    target (str | list[str]): Optional. Ideal target output. May be a literal value\n        or narrative text to be used by a model grader.\n    id (int | str | None): Optional. Unique identifier for sample.\n    metadata (dict[str,Any] | None): Optional. Arbitrary metadata associated with the sample.\n    files (dict[str, str] | None): Optional. Files that go along with the sample (copied to\n      SandboxEnvironment). Files can be paths, inline text, or inline binary (base64 encoded data URL).\n    setup: (str | None): Optional. Setup script to run for sample (run\n      within default SandboxEnvironment).",
+      "description": "Sample to be used in an evaluation task.\n\nArgs:\n    input (str | list[ChatMessage]): The input to be submitted to the model.\n    choices (list[str] | None): Optional. List of available answer choices\n       (used only for multiple-choice evals).\n    target (str | list[str]): Optional. Ideal target output. May be a literal value\n        or narrative text to be used by a model grader.\n    id (int | str | None): Optional. Unique identifier for sample.\n    metadata (dict[str,Any] | None): Optional. Arbitrary metadata associated with the sample.\n    sandbox (SandboxEnvironmentSpec | None): Optional. Sandbox environment\n      type and optional config file.\n    files (dict[str, str] | None): Optional. Files that go along with the sample (copied to\n      SandboxEnvironment). Files can be paths, inline text, or inline binary (base64 encoded data URL).\n    setup (str | None): Optional. Setup script to run for sample (run\n      within default SandboxEnvironment).",
       "properties": {
         "input": {
           "anyOf": [
@@ -2239,6 +2298,38 @@
           "default": null,
           "title": "Metadata"
         },
+        "sandbox": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "null"
+                    }
+                  ]
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sandbox"
+        },
         "files": {
           "anyOf": [
             {
@@ -2273,6 +2364,7 @@
         "target",
         "id",
         "metadata",
+        "sandbox",
         "files",
         "setup"
       ],

--- a/src/inspect_ai/_view/www/src/types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/types/log.d.ts
@@ -143,6 +143,9 @@ export type Type4 =
 export type Message1 = string;
 export type Choices = string[] | null;
 export type Target = string | string[];
+export type Sandbox1 = [unknown, unknown] | null;
+export type Files = string[] | null;
+export type Setup = string | null;
 export type Messages = (
   | ChatMessageSystem
   | ChatMessageUser
@@ -194,10 +197,11 @@ export type Choices2 = string[] | null;
 export type Target1 = string | string[];
 export type Id2 = number | string | null;
 export type Metadata7 = {} | null;
-export type Files = {
+export type Sandbox2 = string | [unknown, unknown] | null;
+export type Files1 = {
   [k: string]: string;
 } | null;
-export type Setup = string | null;
+export type Setup1 = string | null;
 export type JsonValue = unknown;
 export type Timestamp1 = string;
 export type Event1 = "state";
@@ -482,6 +486,9 @@ export interface EvalSample {
   input: Input;
   choices: Choices;
   target: Target;
+  sandbox: Sandbox1;
+  files: Files;
+  setup: Setup;
   messages: Messages;
   output: ModelOutput;
   scores: Scores1;
@@ -610,9 +617,11 @@ export interface SampleInitEvent {
  *         or narrative text to be used by a model grader.
  *     id (int | str | None): Optional. Unique identifier for sample.
  *     metadata (dict[str,Any] | None): Optional. Arbitrary metadata associated with the sample.
+ *     sandbox (SandboxEnvironmentSpec | None): Optional. Sandbox environment
+ *       type and optional config file.
  *     files (dict[str, str] | None): Optional. Files that go along with the sample (copied to
  *       SandboxEnvironment). Files can be paths, inline text, or inline binary (base64 encoded data URL).
- *     setup: (str | None): Optional. Setup script to run for sample (run
+ *     setup (str | None): Optional. Setup script to run for sample (run
  *       within default SandboxEnvironment).
  */
 export interface Sample {
@@ -621,8 +630,9 @@ export interface Sample {
   target: Target1;
   id: Id2;
   metadata: Metadata7;
-  files: Files;
-  setup: Setup;
+  sandbox: Sandbox2;
+  files: Files1;
+  setup: Setup1;
 }
 /**
  * Change to the current `TaskState`

--- a/src/inspect_ai/dataset/_dataset.py
+++ b/src/inspect_ai/dataset/_dataset.py
@@ -165,7 +165,9 @@ class FieldSpec(BaseModel):
         choices (str): Optional. Name of field containing the list of answer choices.
         id (str): Optional. Unique identifier for the sample.
         metadata (list[str] | None): List of additional field names that should be read as metadata.
+        sandbox (str): Optional. Sandbox type along with optional config file
         files (str): Optional. Files that go along with the sample.
+        setup (str): Optional. Setup script to run for sample .
     """
 
     input: str = Field(default="input")
@@ -182,6 +184,9 @@ class FieldSpec(BaseModel):
 
     metadata: list[str] | None = Field(default=None)
     """List of additional field names that should be read as metadata."""
+
+    sandbox: str = Field(default="sandbox")
+    """Sandbox type along with optional config file."""
 
     files: str = Field(default="files")
     """Files that go along wtih the sample."""

--- a/src/inspect_ai/dataset/_dataset.py
+++ b/src/inspect_ai/dataset/_dataset.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from typing_extensions import override
 
 from inspect_ai.model import ChatMessage
+from inspect_ai.util import SandboxEnvironmentSpec
 
 if TYPE_CHECKING:
     from _typeshed import SupportsRichComparison
@@ -31,9 +32,11 @@ class Sample(BaseModel):
             or narrative text to be used by a model grader.
         id (int | str | None): Optional. Unique identifier for sample.
         metadata (dict[str,Any] | None): Optional. Arbitrary metadata associated with the sample.
+        sandbox (SandboxEnvironmentSpec | None): Optional. Sandbox environment
+          type and optional config file.
         files (dict[str, str] | None): Optional. Files that go along with the sample (copied to
           SandboxEnvironment). Files can be paths, inline text, or inline binary (base64 encoded data URL).
-        setup: (str | None): Optional. Setup script to run for sample (run
+        setup (str | None): Optional. Setup script to run for sample (run
           within default SandboxEnvironment).
     """
 
@@ -51,6 +54,9 @@ class Sample(BaseModel):
 
     metadata: dict[str, Any] | None = Field(default=None)
     """Arbitrary metadata associated with the sample."""
+
+    sandbox: SandboxEnvironmentSpec | None = Field(default=None)
+    """Sandbox environment type and optional config file."""
 
     files: dict[str, str] | None = Field(default=None)
     """Files that go along with the sample (copied to SandboxEnvironment)"""

--- a/src/inspect_ai/dataset/_sources/util.py
+++ b/src/inspect_ai/dataset/_sources/util.py
@@ -36,6 +36,10 @@ def resolve_sample_files(dataset: Dataset) -> None:
 
     # for each sample
     for sample in dataset:
+        # check for sandbox config file
+        if isinstance(sample.sandbox, tuple) and sample.sandbox[1] is not None:
+            sample.sandbox = (sample.sandbox[0], resolve_file(sample.sandbox[1]))
+
         # check for files
         if sample.files is not None:
             for path in sample.files.keys():

--- a/src/inspect_ai/dataset/_sources/util.py
+++ b/src/inspect_ai/dataset/_sources/util.py
@@ -25,10 +25,7 @@ def resolve_sample_files(dataset: Dataset) -> None:
         try:
             target_file = f"{parent_dir}{fs.sep}{file}"
             if fs.exists(target_file):
-                if fs.is_local():
-                    return Path(target_file).resolve().as_posix()
-                else:
-                    return target_file
+                return target_file
             else:
                 return file
         except OSError:

--- a/src/inspect_ai/dataset/_sources/util.py
+++ b/src/inspect_ai/dataset/_sources/util.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from typing import Callable
 
 from inspect_ai._util.content import Content, ContentImage

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -8,6 +8,7 @@ from inspect_ai.model import (
     ChatMessageTool,
     ChatMessageUser,
 )
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
 from ._dataset import (
     DatasetRecord,
@@ -53,6 +54,7 @@ def record_to_sample_fn(
                 choices=read_choices(record.get(sample_fields.choices)),
                 id=record.get(sample_fields.id, None),
                 metadata=metadata,
+                sandbox=read_sandbox(record.get(sample_fields.sandbox)),
                 files=read_files(record.get(sample_fields.files)),
                 setup=read_setup(record.get(sample_fields.setup)),
             )
@@ -137,6 +139,24 @@ def read_choices(obj: Any | None) -> list[str] | None:
 def read_setup(setup: Any | None) -> str | None:
     if setup is not None:
         return str(setup)
+    else:
+        return None
+
+
+def read_sandbox(sandbox: Any | None) -> SandboxEnvironmentSpec | None:
+    if sandbox is not None:
+        if isinstance(sandbox, str):
+            return (sandbox, None)
+        if isinstance(sandbox, list):
+            if len(sandbox) == 2:
+                return str(sandbox[0]), str(sandbox[1])
+            else:
+                raise ValueError(
+                    f"Invalid 'sandbox' value: '{str(sandbox)}'. Sandbox must be string or 2-item list"
+                )
+
+        # didn't find the right type
+        raise ValueError(f"Unexpected type for 'sandbox' field: {type(sandbox)}")
     else:
         return None
 

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -146,7 +146,11 @@ def read_setup(setup: Any | None) -> str | None:
 def read_sandbox(sandbox: Any | None) -> SandboxEnvironmentSpec | None:
     if sandbox is not None:
         if isinstance(sandbox, str):
-            return (sandbox, None)
+            if sandbox.strip().startswith("["):
+                sandbox = json.loads(sandbox)
+            else:
+                return (sandbox, None)
+
         if isinstance(sandbox, list):
             if len(sandbox) == 2:
                 return str(sandbox[0]), str(sandbox[1])

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -88,6 +88,15 @@ class EvalSample(BaseModel):
     target: str | list[str]
     """Sample target value(s)"""
 
+    sandbox: tuple[str, str | None] | None = Field(default=None)
+    """Sandbox environment type and optional config file."""
+
+    files: list[str] | None = Field(default=None)
+    """Files that go along with the sample (copied to SandboxEnvironment)"""
+
+    setup: str | None = Field(default=None)
+    """Setup script to run for sample (run within default SandboxEnvironment)."""
+
     messages: list[ChatMessage]
     """Chat conversation history for sample."""
 

--- a/src/inspect_ai/util/_sandbox/context.py
+++ b/src/inspect_ai/util/_sandbox/context.py
@@ -27,9 +27,8 @@ def sandbox(name: str = "default") -> SandboxEnvironment:
     environments = sandbox_environments_context_var.get(None)
     if not environments:
         raise RuntimeError(
-            "No sandbox environment has been provided for the current task. "
-            + "Please specify one using either the sandbox task/eval "
-            + "option, or the --sandbox CLI option."
+            "No sandbox environment has been provided for the current sample or task. "
+            + "Please specify a sandbox for the sample or a global default sandbox for the task"
         )
 
     # short circuit for 1 environment (allows single environment to not sweat 'default')

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -84,7 +84,6 @@ def test_dataset_image_paths() -> None:
     assert isinstance(sample.input[0], ChatMessageUser)
     assert isinstance(sample.input[0].content[1], ContentImage)
     image = Path(sample.input[0].content[1].image)
-    assert image.is_absolute()
     assert image.exists()
 
 

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -44,7 +44,8 @@ def test_dataset_fields(type: Type[T_ds], file: str) -> None:
         dataset_path(file), sample_fields=sample_field_spec
     )
     assert_sample(dataset[0])
-    assert dataset[0].sandbox == ("docker", "compose.yaml")
+    assert isinstance(dataset[0].sandbox, tuple)
+    assert dataset[0].sandbox[0] == "docker"
 
 
 # test reading a dataset with a custom data_to_sample function

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -44,6 +44,7 @@ def test_dataset_fields(type: Type[T_ds], file: str) -> None:
         dataset_path(file), sample_fields=sample_field_spec
     )
     assert_sample(dataset[0])
+    assert dataset[0].sandbox == ("docker", "compose.yaml")
 
 
 # test reading a dataset with a custom data_to_sample function

--- a/tests/dataset/test_dataset/samples.csv
+++ b/tests/dataset/test_dataset/samples.csv
@@ -1,2 +1,2 @@
-input,target,label,extra
-"Say 'Hello, World'","Hello, World","Hello, World","data"
+input,target,label,extra,sandbox
+"Say 'Hello, World'","Hello, World","Hello, World","data","[""docker"",""compose.yaml""]"

--- a/tests/dataset/test_dataset/samples.json
+++ b/tests/dataset/test_dataset/samples.json
@@ -3,6 +3,10 @@
     "input": "Say 'Hello, World'",
     "target": "Hello, World",
     "label": "Hello, World",
-    "extra": "data"
+    "extra": "data",
+    "sandbox": [
+      "docker",
+      "compose.yaml"
+    ]
   }
 ]

--- a/tests/dataset/test_dataset/samples.jsonl
+++ b/tests/dataset/test_dataset/samples.jsonl
@@ -1,1 +1,1 @@
-{ "input": "Say 'Hello, World'", "target": "Hello, World", "label": "Hello, World", "extra": "data", "sandbox": "[\"docker\",\"compose.yaml\"]"}
+{ "input": "Say 'Hello, World'", "target": "Hello, World", "label": "Hello, World", "extra": "data", "sandbox": "docker"}

--- a/tests/dataset/test_dataset/samples.jsonl
+++ b/tests/dataset/test_dataset/samples.jsonl
@@ -1,1 +1,1 @@
-{ "input": "Say 'Hello, World'", "target": "Hello, World", "label": "Hello, World", "extra": "data" }
+{ "input": "Say 'Hello, World'", "target": "Hello, World", "label": "Hello, World", "extra": "data", "sandbox": "[\"docker\",\"compose.yaml\"]"}


### PR DESCRIPTION
Sandbox environments can be now bound at the `Sample`, `Task`, or `eval()` level. Binding precedence goes from `eval()`, to `Task` to `Sample`, however sandbox config files defined on the `Sample` always take precedence when the sandbox type for the `Sample` is the same as the enclosing `Task` or `eval()`.

Here is a `Task` that defines a `sandbox` and corresponding sandbox config file:

``` python
Task(
    dataset=dataset,
    plan([
        use_tools([read_file(), list_files()])), 
        generate()
    ]),
    scorer=match(),
    sandbox=("docker", "compose.yaml")
)
```

Here is a `Sample` that specifies a custom sandbox:

```python
Sample(
    ...,
    sandbox=("docker", "compose42.yaml")
)
```

When specified in a dataset file you can specify either a plain string or an array of [sandbox_type,config]:

```
{
    ...,
    sandbox=["docker", "compose42.yaml"]
}
```

When inside a dataset file, the config file is resolved related to the location of the dataset. When in a dynamically constructed `Sample`, the config file is relative to the task directory (or must be absolute if `chdir=False` is specified for the task).
