### PR TITLE
add 'transient` option for input_screen()

### DIFF
--- a/docs/interactivity.qmd
+++ b/docs/interactivity.qmd
@@ -50,18 +50,32 @@ with input_screen() as console:
 
 The `Prompt` class is designed to be subclassed for more specialized inputs. The `IntPrompt` and `FloatPrompt` classes are built-in, but you can also create your own more customised prompts (the `Confirm` class is another example of this). See the [prompt.py](https://github.com/Textualize/rich/blob/master/rich/prompt.py) source code for additional details.
 
+## Progress
+
+Evaluations with user input alternate between asking for input and displaying task progress. By default, the normal task status display is shown when a user input screen is not active.
+
+However, if your evaluation is dominated by user input with very short model interactions in between, the task display flashing on and off might prove distracting. For these cases, you can specify the `transient=False` option, to indicate that the input screen should be shown at all times. For example:
+
+``` python
+with input_screen(transient=False) as console:
+    console.print("Some preamble text")
+    input = console.input("Please enter your name: ")
+```
+
+This will result in the input screen staying active throughout the evaluation. A small progress indicator will be shown whenever user input isn't being requested so that the user knows that the evaluation is still running.
+
 ## Header
 
 You can add a header to your console input via the `header` parameter. For example:
 
 ``` python
-with input_screen("Input Request") as console:
+with input_screen(header="Input Request") as console:
     input = console.input("Please enter your name: ")
 ```
 
 The `header` option is a useful way to delineate user input requests (especially when switching between input display and the normal task display). You might also prefer to create your own heading treatments--under the hood, the `header` option calls `console.rule()` with a blue bold treatment:
 
-```python
+``` python
 console.rule(f"[blue bold]{header}[/blue bold]", style="blue bold")
 ```
 

--- a/src/inspect_ai/_display/_display.py
+++ b/src/inspect_ai/_display/_display.py
@@ -58,10 +58,12 @@ class TaskSuccess:
 TaskResult = Union[TaskError, TaskCancelled, TaskSuccess]
 
 
-class TaskScreen(abc.ABC):
+class TaskScreen(contextlib.AbstractContextManager["TaskScreen"]):
     @abc.abstractmethod
     @contextlib.contextmanager
-    def input_screen(self, header: str | None = None) -> Iterator[Console]: ...
+    def input_screen(
+        self, header: str | None = None, transient: bool = True
+    ) -> Iterator[Console]: ...
 
 
 class TaskDisplay(abc.ABC):

--- a/src/inspect_ai/util/_console.py
+++ b/src/inspect_ai/util/_console.py
@@ -6,20 +6,24 @@ from rich.console import Console
 
 
 @contextmanager
-def input_screen(header: str | None = None) -> Iterator[Console]:
+def input_screen(
+    header: str | None = None, transient: bool = True
+) -> Iterator[Console]:
     """Input screen for receiving user input.
 
     Context manager that clears the task display and provides a
     screen for receiving console input.
 
     Args:
-       header (str | None): Header line to print above console
-         content (defaults to printing no header)
+      header (str | None): Header line to print above console
+        content (defaults to printing no header)
+      transient (bool): Return to task progress display after
+        the user completes input (defaults to `True`).
 
     Returns:
        Console to use for input.
     """
     from inspect_ai._display._display import task_screen
 
-    with task_screen().input_screen(header=header) as console:
+    with task_screen().input_screen(header=header, transient=transient) as console:
         yield console


### PR DESCRIPTION
This PR introduces a new `transient` option for the `input_screen()` context manager. Evaluations with user input alternate between asking for input and displaying task progress. By default, the normal task status display is shown when a user input screen is not active.

However, if your evaluation is dominated by user input with very short model interactions in between, the task display flashing on and off might prove distracting. For these cases, you can now specify the `transient=False` option, to indicate that the input screen should be shown at all times. For example:

``` python
with input_screen(transient=False) as console:
    console.print("Some preamble text")
    input = console.input("Please enter your name: ")
```

This will result in the input screen staying active throughout the evaluation. A small progress indicator will be shown whenever user input isn't being requested so that the user knows that the evaluation is still running.