### PR TITLE
Add api pytest mark and --runapi flag

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,17 +18,25 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runslow", action="store_true", default=False, help="run slow tests"
     )
+    parser.addoption(
+        "--runapi", action="store_true", default=False, help="run API tests"
+    )
 
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
+    config.addinivalue_line("markers", "api: mark test as requiring API access")
 
 
 def pytest_collection_modifyitems(config, items):
-    if config.getoption("--runslow"):
-        # --runslow given in cli: do not skip slow tests
-        return
-    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
-    for item in items:
-        if "slow" in item.keywords:
-            item.add_marker(skip_slow)
+    if not config.getoption("--runslow"):
+        skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+        for item in items:
+            if "slow" in item.keywords:
+                item.add_marker(skip_slow)
+
+    if not config.getoption("--runapi"):
+        skip_api = pytest.mark.skip(reason="need --runapi option to run")
+        for item in items:
+            if "api" in item.keywords:
+                item.add_marker(skip_api)

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -10,6 +10,12 @@ from inspect_ai.solver import TaskState
 
 
 def skip_if_env_var(var: str, exists=True):
+    """
+    Pytest mark to skip the test if the var environment variable is not defined.
+
+    Use in combination with `pytest.mark.api` if the environment variable in
+    question corresponds to a paid API. For example, see `skip_if_no_openai`.
+    """
     condition = (var in os.environ.keys()) if exists else (var not in os.environ.keys())
     return pytest.mark.skipif(
         condition,
@@ -41,19 +47,19 @@ def skip_if_no_accelerate(func):
 
 
 def skip_if_no_openai(func):
-    return skip_if_env_var("OPENAI_API_KEY", exists=False)(func)
+    return pytest.mark.api(skip_if_env_var("OPENAI_API_KEY", exists=False)(func))
 
 
 def skip_if_no_anthropic(func):
-    return skip_if_env_var("ANTHROPIC_API_KEY", exists=False)(func)
+    return pytest.mark.api(skip_if_env_var("ANTHROPIC_API_KEY", exists=False)(func))
 
 
 def skip_if_no_google(func):
-    return skip_if_env_var("GOOGLE_API_KEY", exists=False)(func)
+    return pytest.mark.api(skip_if_env_var("GOOGLE_API_KEY", exists=False)(func))
 
 
 def skip_if_no_mistral(func):
-    return skip_if_env_var("MISTRAL_API_KEY", exists=False)(func)
+    return pytest.mark.api(skip_if_env_var("MISTRAL_API_KEY", exists=False)(func))
 
 
 def skip_if_no_cloudflare(func):
@@ -61,15 +67,15 @@ def skip_if_no_cloudflare(func):
 
 
 def skip_if_no_together(func):
-    return skip_if_env_var("TOGETHER_API_KEY", exists=False)(func)
+    return pytest.mark.api(skip_if_env_var("TOGETHER_API_KEY", exists=False)(func))
 
 
 def skip_if_no_azureai(func):
-    return skip_if_env_var("AZURE_API_KEY", exists=False)(func)
+    return pytest.mark.api(skip_if_env_var("AZURE_API_KEY", exists=False)(func))
 
 
 def skip_if_no_vertex(func):
-    return skip_if_env_var("ENABLE_VERTEX_TESTS", exists=False)(func)
+    return pytest.mark.api(skip_if_env_var("ENABLE_VERTEX_TESTS", exists=False)(func))
 
 
 def skip_if_github_action(func):


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
#282 

### What is the new behavior?
* Add `api` pytest mark and `--runapi` flag
* Update the `skip_if_no_x` decorators to use the `api` mark where appropriate

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
* No

### Other information:
* I considered adding this directly to the `skip_if_no_env_var` function, but it seems that it's not required in all cases.  We could have added a flag, but it seems more explicit to just add it directly to the functions that need it
* I manually tested this by running various tests with/without the variables and the `--runapi` flag