### PR TITLE
eliminate need to use chdir=False for task parallelism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Raise error when a Solver does not return a TaskState.
 - Only run tests that use model APIs when the `--runapi` flag is passed to `pytest` (prevents unintended token usage)
 - Remove `chdir` option from `@tasks` (tasks now always chdir during execution).
+- Do not process `.env` files in task directories (all required vars should be specified in the global `.env`).
 - Added [CommonsenseQA](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/benchmarks/commonsense_qa) benchmark.
 
 ## v0.3.25 (25 August 2024)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Treat `cwd` that are relative paths as relative to sample working directry.
 - Raise error when a Solver does not return a TaskState.
 - Only run tests that use model APIs when the `--runapi` flag is passed to `pytest` (prevents unintended token usage)
+- Remove `chdir` option from `@tasks` (tasks now always chdir during execution).
 - Added [CommonsenseQA](https://github.com/UKGovernmentBEIS/inspect_ai/tree/main/benchmarks/commonsense_qa) benchmark.
 
 ## v0.3.25 (25 August 2024)

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -81,13 +81,9 @@ INSPECT_EVAL_MODEL=openai/gpt-4-turbo,google/gemini-1.5-pro
 
 ## Multiple Tasks {#sec-multiple-tasks}
 
-By default, Inspect runs a single task at a time. This is because most tasks consist of 10 or more samples, which generally means that sample parallelism is enough to make full use of the `max_connections` defined for the active model. If however, the number samples per task is substantially lower than `max_connections` then you might benefit from running multiple tasks in parallel.
+By default, Inspect runs a single task at a time. This is because most tasks consist of 10 or more samples, which generally means that sample parallelism is enough to make full use of the `max_connections` defined for the active model. 
 
-There is one important constraint on task parallelism to note: by default, all of the tasks *must share a working directory* (as Inspect switches to the working directory of tasks when executing them). This constraint can be relaxed using the `chdir=False` option on the `@task` decorator (see the discussion in [Working Directory](#working-directory) below for details).
-
-### Max Tasks Option
-
-Run multiple tasks in parallel using the `--max-tasks` CLI option or `max_tasks` parameter to the `eval()` function. For example, here we run all of the tasks in the current working directory with up 5 tasks run in parallel:
+If however, the number samples per task is substantially lower than `max_connections` then you might benefit from running multiple tasks in parallel You can do this via the `--max-tasks` CLI option or `max_tasks` parameter to the `eval()` function. For example, here we run all of the tasks in the current working directory with up 5 tasks run in parallel:
 
 ``` bash
 $ inspect eval . --max-tasks=5 
@@ -123,19 +119,6 @@ eval(
 
 This code will evaluate a total of 12 tasks (6 temperature variations against 2 models each) with up to 5 tasks run in parallel.
 
-### Working Directory {#working-directory}
-
-By default, inspect both *loads* and *executes* tasks within the directory that contains the task source file. This is done so that relative references to Python modules, datasets, prompt templates, and other resources are resolved correctly.
-
-Since task parallelism requires that tasks are executed from within the same working directory, you may want to change this default behaviour. You can do this using the `chdir` option of the `@task` decorator. For example:
-
-``` python
-@task(chdir=False)
-def my_task():
-  ...
-```
-
-Note that this only affects where tasks are *executed*. Even with `chdir=False` task files are still *loaded* within their parent directory (so Python modules, datasets, prompts, etc. will still resolve correctly with relative references). If however you are making reference to external files at *runtime* (e.g. within the `solve()` or `score()` method of a `Sovler` or `Scorer`) you'll need to be sure to not rely on relative path resolution when `chdir=False`.
 
 ## Sandbox Environments {#sec-parallel-tool-environments}
 

--- a/docs/workflow.qmd
+++ b/docs/workflow.qmd
@@ -99,7 +99,7 @@ $ inspect eval theory.py --temperature 0 --seed 42
 
 ## Configuration {#sec-workflow-configuration}
 
-As you can see, there is often a lot of configuration required for calling `inspect eval`. While we can include it all on the command line, it's generally easier to use environment variables. To facilitate this, the `inspect` CLI will automatically read and process `.env` files located in both the working directory and the directory where the task source file is located (this is done using the [python-dotenv](https://pypi.org/project/python-dotenv/) package).
+As you can see, there is often a lot of configuration required for calling `inspect eval`. While we can include it all on the command line, it's generally easier to use environment variables. To facilitate this, the `inspect` CLI will automatically read and process `.env` files located in the current working directory (also searching in parent directories if a `.env` file is not found in the working directory). This is done using the [python-dotenv](https://pypi.org/project/python-dotenv/) package).
 
 For example, here's a `.env` file that makes available API keys for several providers and sets a bunch of defaults for a working session:
 

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -10,7 +10,6 @@ from types import ModuleType
 from typing import Any, Callable, cast
 
 from inspect_ai._eval.task.util import task_file, task_run_dir
-from inspect_ai._util.dotenv import dotenv_environ
 from inspect_ai._util.path import chdir_python
 from inspect_ai._util.registry import (
     RegistryInfo,
@@ -246,7 +245,7 @@ def create_tasks(
 
 
 def load_file_tasks(file: Path) -> list[RegistryInfo]:
-    with chdir_python(file.parent.as_posix()), dotenv_environ():
+    with chdir_python(file.parent.as_posix()):
         return _load_task_specs(file)
 
 
@@ -256,7 +255,7 @@ def create_file_tasks(
     task_specs: list[str] | list[RegistryInfo] | None = None,
     task_args: dict[str, Any] = {},
 ) -> list[Task]:
-    with chdir_python(file.parent.as_posix()), dotenv_environ():
+    with chdir_python(file.parent.as_posix()):
         # if we don't have task specs then go get them (also,
         # turn them into plain names)
         if task_specs is None:

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -8,7 +8,6 @@ from typing_extensions import Unpack
 
 from inspect_ai._display import display
 from inspect_ai._display._display import clear_task_screen, init_task_screen
-from inspect_ai._util.dotenv import dotenv_environ
 from inspect_ai._util.error import exception_message
 from inspect_ai._util.path import chdir
 from inspect_ai.log import EvalConfig, EvalLog
@@ -283,7 +282,7 @@ async def startup_sandbox_environments(
 
         # run startup
         task_init = cast(TaskInit, getattr(sandboxenv_type, "task_init"))
-        with chdir(sandboxenv[2]), dotenv_environ():
+        with chdir(sandboxenv[2]):
             await task_init("startup", sandboxenv[1])
 
         # append cleanup method
@@ -295,7 +294,7 @@ async def startup_sandbox_environments(
         for cleanup_jobs in cleanups:
             try:
                 cleanup_fn, config, task_run_dir = cleanup_jobs
-                with chdir(task_run_dir), dotenv_environ():
+                with chdir(task_run_dir):
                     await cleanup_fn("shutdown", config, cleanup)
             except BaseException as ex:
                 log.warning(

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -8,10 +8,9 @@ from typing_extensions import Unpack
 
 from inspect_ai._display import display
 from inspect_ai._display._display import clear_task_screen, init_task_screen
-from inspect_ai._eval.task.sandbox import resolve_sandbox
 from inspect_ai._util.dotenv import dotenv_environ
 from inspect_ai._util.error import exception_message
-from inspect_ai._util.path import chdir_python
+from inspect_ai._util.path import chdir
 from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._log import Recorder
 from inspect_ai.model import GenerateConfig, GenerateConfigArgs
@@ -23,6 +22,8 @@ from inspect_ai.util._sandbox.registry import registry_find_sandboxenv
 from .loader import ResolvedTask
 from .task.log import TaskLogger
 from .task.run import TaskRunOptions, create_sample_semaphore, task_run
+from .task.rundir import task_run_dir_switching
+from .task.sandbox import resolve_sandbox_for_task
 from .task.util import task_run_dir
 
 log = logging.getLogger(__name__)
@@ -40,11 +41,9 @@ async def eval_run(
     score: bool = True,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> list[EvalLog]:
-    # we rely on the run_dir being the same across all tasks
-    # alias and then confirm that the rest of the tasks conform
+    # see if we need to use run_dir switching
     run_dir = task_run_dir(tasks[0].task)
-    if any([task_run_dir(task.task) != run_dir for task in tasks]):
-        raise RuntimeError("Parallel tasks must have the same working directory.")
+    multiple_run_dirs = any([task_run_dir(task.task) != run_dir for task in tasks])
     has_sandbox = next((task.has_sandbox for task in tasks), None)
 
     # if we have a sandbox then we need to enforce sample concurrency at
@@ -58,20 +57,19 @@ async def eval_run(
     # get cwd before switching to task dir
     eval_wd = os.getcwd()
 
-    # switch to task directory context
-    with chdir_python(run_dir), dotenv_environ():
-        # run startup pass for the sandbox environment
-        shutdown_sandbox_environments: Callable[[], Awaitable[None]] | None = None
-        if has_sandbox:
-            cleanup = eval_config.sandbox_cleanup is not False
-            shutdown_sandbox_environments = await startup_sandbox_environments(
-                tasks, cleanup
-            )
+    # run startup pass for the sandbox environments
+    shutdown_sandbox_environments: Callable[[], Awaitable[None]] | None = None
+    if has_sandbox:
+        cleanup = eval_config.sandbox_cleanup is not False
+        shutdown_sandbox_environments = await startup_sandbox_environments(
+            tasks, cleanup
+        )
 
-        try:
-            # create run tasks
-            task_run_options: list[TaskRunOptions] = []
-            for resolved_task in tasks:
+    try:
+        # create run tasks
+        task_run_options: list[TaskRunOptions] = []
+        for resolved_task in tasks:
+            with chdir(task_run_dir(resolved_task.task)):
                 # tasks can provide their own epochs and max_messages
                 task = resolved_task.task
                 task_eval_config = eval_config.model_copy()
@@ -129,26 +127,31 @@ async def eval_run(
                     )
                 )
 
-            # multiple mode is for running/displaying multiple
-            # task definitions, which requires some smart scheduling
-            # to ensure that we spread work among models
-            if parallel > 1:
+        # multiple mode is for running/displaying multiple
+        # task definitions, which requires some smart scheduling
+        # to ensure that we spread work among models
+        if parallel > 1:
+            if multiple_run_dirs:
+                with task_run_dir_switching():
+                    return await run_multiple(task_run_options, parallel)
+            else:
                 return await run_multiple(task_run_options, parallel)
 
-            # single mode is for a single task definitions (which
-            # could in turn be executed for multiple models)
-            else:
+        # single mode is for a single task definitions (which
+        # could in turn be executed for multiple models)
+        else:
+            with chdir(run_dir):
                 return await run_single(task_run_options)
 
-        finally:
-            # shutdown sandbox environments
-            if shutdown_sandbox_environments:
-                try:
-                    await shutdown_sandbox_environments()
-                except BaseException as ex:
-                    log.warning(
-                        f"Error occurred shutting down sandbox environments: {exception_message(ex)}"
-                    )
+    finally:
+        # shutdown sandbox environments
+        if shutdown_sandbox_environments:
+            try:
+                await shutdown_sandbox_environments()
+            except BaseException as ex:
+                log.warning(
+                    f"Error occurred shutting down sandbox environments: {exception_message(ex)}"
+                )
 
 
 # single mode -- run a single logical task (could consist of multiple
@@ -264,34 +267,36 @@ async def startup_sandbox_environments(
     tasks: list[ResolvedTask], cleanup: bool
 ) -> Callable[[], Awaitable[None]]:
     # find unique sandboxenvs
-    sandboxenvs: Set[tuple[str, str | None]] = set()
+    sandboxenvs: Set[tuple[str, str | None, str]] = set()
     for task in tasks:
         # resolve each sample and add to sandboxenvs
         for sample in task.task.dataset:
-            sandbox = resolve_sandbox(task.sandbox, sample)
+            sandbox = resolve_sandbox_for_task(task.task, sample)
             if sandbox is not None and sandbox not in sandboxenvs:
                 sandboxenvs.add(sandbox)
 
     # initialiase sandboxenvs (track cleanups)
-    cleanups: list[tuple[TaskCleanup, str | None]] = []
+    cleanups: list[tuple[TaskCleanup, str | None, str]] = []
     for sandboxenv in sandboxenvs:
         # find type
         sandboxenv_type = registry_find_sandboxenv(sandboxenv[0])
 
         # run startup
         task_init = cast(TaskInit, getattr(sandboxenv_type, "task_init"))
-        await task_init("startup", sandboxenv[1])
+        with chdir(sandboxenv[2]), dotenv_environ():
+            await task_init("startup", sandboxenv[1])
 
         # append cleanup method
         task_cleanup = cast(TaskCleanup, getattr(sandboxenv_type, "task_cleanup"))
-        cleanups.append((task_cleanup, sandboxenv[1]))
+        cleanups.append((task_cleanup, sandboxenv[1], sandboxenv[2]))
 
     # return shutdown method
     async def shutdown() -> None:
         for cleanup_jobs in cleanups:
             try:
-                cleanup_fn, config = cleanup_jobs
-                await cleanup_fn("shutdown", config, cleanup)
+                cleanup_fn, config, task_run_dir = cleanup_jobs
+                with chdir(task_run_dir), dotenv_environ():
+                    await cleanup_fn("shutdown", config, cleanup)
             except BaseException as ex:
                 log.warning(
                     f"Error occurred shutting down sandbox environments: {exception_message(ex)}"

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -3,7 +3,6 @@ from copy import deepcopy
 from typing import Callable, cast
 
 from inspect_ai._display import display
-from inspect_ai._util.dotenv import dotenv_environ
 from inspect_ai._util.path import chdir_python
 from inspect_ai._util.platform import platform_init
 from inspect_ai._util.registry import registry_create
@@ -131,7 +130,7 @@ async def score_async(
 
 
 async def task_score(task: Task, log: EvalLog) -> EvalLog:
-    with chdir_python(task_run_dir(task)), dotenv_environ():
+    with chdir_python(task_run_dir(task)):
         # confirm we have a scorer
         if task.scorer is None:
             raise ValueError("You must specify a scorer for evals to be scored.")

--- a/src/inspect_ai/_eval/task/constants.py
+++ b/src/inspect_ai/_eval/task/constants.py
@@ -1,3 +1,2 @@
 TASK_FILE_ATTR = "__task_file__"
 TASK_RUN_DIR_ATTR = "__task_run_dir__"
-TASK_SRC_DIR_ATTR = "__task_src_dir__"

--- a/src/inspect_ai/_eval/task/rundir.py
+++ b/src/inspect_ai/_eval/task/rundir.py
@@ -1,0 +1,71 @@
+import asyncio
+import os
+import sys
+from contextlib import contextmanager
+from contextvars import ContextVar
+from functools import wraps
+from typing import Any, Callable, Iterator, TypeVar
+
+TASK_DIRECTORY_ATTRIB = "task_directory"
+
+_task_run_dir = ContextVar[str]("task_run_dir")
+
+T = TypeVar("T", bound="asyncio.BaseEventLoop")
+
+
+@contextmanager
+def task_run_dir_switching() -> Iterator[None]:
+    # get the beginning working dir
+    cwd = os.getcwd()
+
+    # get the class for the current event loop instance
+    loop = asyncio.get_event_loop()
+    if not isinstance(loop, asyncio.BaseEventLoop):
+        raise ValueError(
+            "Can't run tasks in multiple directories with loop of type %s" % type(loop)
+        )
+    cls: type[asyncio.BaseEventLoop] = loop.__class__
+
+    # patch call_soon with directory switching version
+    original_call_soon = cls.call_soon
+
+    def patched_call_soon(
+        self: T, callback: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> asyncio.Handle:
+        wrapped_callback = _wrap_callback(callback)
+        return original_call_soon(self, wrapped_callback, *args, **kwargs)
+
+    cls.call_soon = patched_call_soon  # type: ignore
+
+    # execute and restore original call_soon at the end
+    try:
+        yield
+    finally:
+        cls.call_soon = original_call_soon  # type: ignore
+        os.chdir(cwd)
+
+
+@contextmanager
+def set_task_run_dir(run_dir: str) -> Iterator[None]:
+    token = _task_run_dir.set(run_dir)
+    try:
+        yield
+    finally:
+        _task_run_dir.reset(token)
+
+
+if sys.platform == "win32":
+    BaseEventLoop = asyncio.ProactorEventLoop
+else:
+    BaseEventLoop = asyncio.SelectorEventLoop
+
+
+def _wrap_callback(callback: Callable[..., Any]) -> Callable[..., Any]:
+    @wraps(callback)
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        run_dir = _task_run_dir.get(None)
+        if run_dir is not None and run_dir != os.getcwd():
+            os.chdir(run_dir)
+        return callback(*args, **kwargs)
+
+    return wrapper

--- a/src/inspect_ai/_eval/task/sandbox.py
+++ b/src/inspect_ai/_eval/task/sandbox.py
@@ -2,6 +2,8 @@ import base64
 import contextlib
 from typing import AsyncGenerator
 
+from inspect_ai._eval.task.task import Task
+from inspect_ai._eval.task.util import task_run_dir
 from inspect_ai._util.file import file, filesystem
 from inspect_ai._util.url import data_uri_to_base64, is_data_uri
 from inspect_ai.dataset import Sample
@@ -89,6 +91,17 @@ def read_sandboxenv_file(contents: str) -> bytes:
             file_bytes = contents.encode("utf-8")
 
     return file_bytes
+
+
+def resolve_sandbox_for_task(
+    task: Task,
+    sample: Sample,
+) -> tuple[str, str | None, str] | None:
+    sandbox = resolve_sandbox(task.sandbox, sample)
+    if sandbox is not None:
+        return sandbox + (task_run_dir(task),)
+    else:
+        return None
 
 
 def resolve_sandbox(

--- a/src/inspect_ai/_eval/task/util.py
+++ b/src/inspect_ai/_eval/task/util.py
@@ -7,7 +7,7 @@ from inspect_ai.dataset import Sample
 from inspect_ai.model import ChatMessage, ChatMessageUser
 
 from ..task import Task
-from .constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR, TASK_SRC_DIR_ATTR
+from .constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
 
 
 def sample_messages(sample: Sample) -> list[ChatMessage]:
@@ -22,10 +22,6 @@ def sample_messages(sample: Sample) -> list[ChatMessage]:
 
 def task_run_dir(task: Task) -> str:
     return getattr(task, TASK_RUN_DIR_ATTR, os.getcwd())
-
-
-def task_src_dir(task: Task) -> str:
-    return getattr(task, TASK_SRC_DIR_ATTR, os.getcwd())
 
 
 def task_file(task: Task, relative: bool = False) -> str | None:

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -44,7 +44,7 @@ async def self_check(sandbox_env: SandboxEnvironment) -> dict[str, bool | str]:
 
 
 async def _cleanup_file(sandbox_env: SandboxEnvironment, filename: str) -> None:
-    res = await sandbox_env.exec(["/usr/bin/rm", filename])
+    res = await sandbox_env.exec(["rm", filename])
     assert res.success
 
 
@@ -172,14 +172,14 @@ async def test_exec_timeout(sandbox_env: SandboxEnvironment) -> None:
 async def test_cwd_unspecified(sandbox_env: SandboxEnvironment) -> None:
     file_name = "test_cwd_unspecified.file"
     await sandbox_env.write_file(file_name, "ls me plz")
-    current_dir_contents = (await sandbox_env.exec(["/usr/bin/ls", "-1"])).stdout
+    current_dir_contents = (await sandbox_env.exec(["ls", "-1"])).stdout
     assert file_name in current_dir_contents
     await _cleanup_file(sandbox_env, file_name)
 
 
 async def test_cwd_custom(sandbox_env: SandboxEnvironment) -> None:
-    current_dir_contents = (await sandbox_env.exec(["/usr/bin/ls"], cwd="/etc")).stdout
-    assert "passwd" in current_dir_contents
+    current_dir_contents = (await sandbox_env.exec(["ls"], cwd="/usr/bin")).stdout
+    assert "man" in current_dir_contents
 
 
 async def test_cwd_relative(sandbox_env: SandboxEnvironment) -> None:
@@ -188,9 +188,7 @@ async def test_cwd_relative(sandbox_env: SandboxEnvironment) -> None:
     file_name = "test_cwd_relative.file"
     file_path = cwd_subdirectory + "/" + file_name
     await sandbox_env.write_file(file_path, "ls me plz")
-    current_dir_contents = (
-        await sandbox_env.exec(["/usr/bin/ls"], cwd=cwd_subdirectory)
-    ).stdout
+    current_dir_contents = (await sandbox_env.exec(["ls"], cwd=cwd_subdirectory)).stdout
     assert (
         file_name in current_dir_contents
     ), f"{file_name} not found in {current_dir_contents}"
@@ -202,9 +200,7 @@ async def test_cwd_absolute(sandbox_env: SandboxEnvironment) -> None:
     await sandbox_env.exec(["mkdir", cwd_directory])
     file_name = "/tmp/test_cwd_absolute/test_cwd_absolute.file"
     await sandbox_env.write_file(file_name, "ls me plz")
-    current_dir_contents = (
-        await sandbox_env.exec(["/usr/bin/ls"], cwd=cwd_directory)
-    ).stdout
+    current_dir_contents = (await sandbox_env.exec(["ls"], cwd=cwd_directory)).stdout
     assert "test_cwd_absolute.file" in current_dir_contents
     await _cleanup_file(sandbox_env, file_name)
 

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -1,12 +1,13 @@
 import importlib.util
 import os
 import subprocess
+from pathlib import Path
 
 import pytest
 
 from inspect_ai import eval
 from inspect_ai.model import ChatMessage, ModelName, ModelOutput
-from inspect_ai.solver import TaskState
+from inspect_ai.solver import Generate, TaskState, solver
 
 
 def skip_if_env_var(var: str, exists=True):
@@ -124,3 +125,14 @@ def simple_task_state(
         output=ModelOutput.from_content(model="model", content=model_output),
         sample_id=0,
     )
+
+
+@solver
+def file_check(file: str):
+    async def solve(state: TaskState, generate: Generate):
+        if not Path(file).exists():
+            raise ValueError(f"File {file} does not exist.")
+
+        return state
+
+    return solve

--- a/tests/test_run_dir.py
+++ b/tests/test_run_dir.py
@@ -1,0 +1,19 @@
+import os
+from pathlib import Path
+
+from inspect_ai import eval
+
+TEST_RUN_DIR_PATH = Path("tests/test_run_dir")
+
+
+def test_run_dir():
+    cwd = os.getcwd()
+
+    logs = eval(
+        [(TEST_RUN_DIR_PATH / task).as_posix() for task in ["task1", "task2"]],
+        model="mockllm/model",
+        max_tasks=2,
+    )
+    assert all([log.status == "success" for log in logs])
+
+    assert cwd == os.getcwd()

--- a/tests/test_run_dir/task1/task1.py
+++ b/tests/test_run_dir/task1/task1.py
@@ -1,0 +1,15 @@
+from test_helpers.utils import file_check
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate
+
+
+@task
+def task1():
+    return Task(
+        dataset=[Sample(input="What is 1+1?", target="2")],
+        plan=[file_check("task1.py"), generate()],
+        scorer=includes(),
+    )

--- a/tests/test_run_dir/task2/task2.py
+++ b/tests/test_run_dir/task2/task2.py
@@ -1,0 +1,15 @@
+from test_helpers.utils import file_check
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate
+
+
+@task
+def task2():
+    return Task(
+        dataset=[Sample(input="What is 1+1?", target="2")] * 10,
+        plan=[file_check("task2.py"), generate()],
+        scorer=includes(),
+    )

--- a/tests/tools/test_sandbox_docker_and_local.py
+++ b/tests/tools/test_sandbox_docker_and_local.py
@@ -1,10 +1,15 @@
 from pathlib import Path
 
+import pytest
+from test_helpers.utils import skip_if_no_docker
+
 from inspect_ai.util._sandbox.docker.docker import DockerSandboxEnvironment
 from inspect_ai.util._sandbox.local import LocalSandboxEnvironment
 from inspect_ai.util._sandbox.self_check import self_check
 
 
+@skip_if_no_docker
+@pytest.mark.slow
 async def test_self_check_local(request) -> None:
     task_name = f"{__name__}_{request.node.name}_local"
 
@@ -16,6 +21,8 @@ async def test_self_check_local(request) -> None:
     return await check_results_of_self_check(task_name, envs_dict)
 
 
+@skip_if_no_docker
+@pytest.mark.slow
 async def test_self_check_docker_custom_nonroot(request) -> None:
     task_name = f"{__name__}_{request.node.name}_docker_nonroot"
 
@@ -32,6 +39,8 @@ async def test_self_check_docker_custom_nonroot(request) -> None:
     return await check_results_of_self_check(task_name, envs_dict)
 
 
+@skip_if_no_docker
+@pytest.mark.slow
 async def test_self_check_docker_default_root(request) -> None:
     task_name = f"{__name__}_{request.node.name}_docker_root"
 


### PR DESCRIPTION
This PR makes task parallelism work for tasks that live in different directories. Note that this was previously possible using `@task(chdir=False)`, however the updated implementation handles changing directories when required via patching the event loop's dispatching function (`call_soon()`). 

We have chosen to eliminate the `chdir` option entirely so that there are consistent directory semantics no matter how a task is run. The `chdir` option should therefore be removed from any tasks that use it (a warning is emitted if it is encountered).

