### PR TITLE
MMLU-Pro benchmark

### DIFF
--- a/benchmarks/mmlu_pro/README.md
+++ b/benchmarks/mmlu_pro/README.md
@@ -1,0 +1,27 @@
+# MMLU-Pro: A More Robust and Challenging Multi-Task Language Understanding Benchmark
+
+[MMLU-Pro](https://arxiv.org/pdf/2406.01574) is a more robust and challenging massive multi-task understanding dataset tailored to more rigorously benchmark large language models' capabilities. This dataset contains 12K complex questions across 14 disciplines (including 'Other'). There are three major differences compared to original MMLU:
+1. MMLU-Pro increases the number of options from 4 to 10, making the evaluation more realistic and challenging.
+2. In this dataset, the creators increase the problem difficulty and integrate more reasoning-focused problems.
+3. The benchmark is made more robust by increasing the number of distractor options.
+
+## Execution
+Here is an example from the dataset:
+```python
+Question: Approximately how far away is the Andromeda Galaxy?
+Options:
+A) 5 million light years
+B) 2.5 million light years
+C) 2.1 million light years
+D) 1.9 million light years
+E) 3.2 million light years
+F) 4 million light years
+G) 1.7 million light years
+H) 3.5 million light years
+I) 1.2 million light years
+J) 2.8 million light years
+```
+The model is tasked to answer the question and choose the appropriate option.
+
+## Evaluation
+The prompts are based on EleutherAI's [lm-evaluation-harness](https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/mmlu_pro) and the [SINGLE_ANSWER_TEMPLATE](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_multiple_choice.py#L14). The in-built `choice` scorer is used for evaluation.

--- a/benchmarks/mmlu_pro/mmlu_pro.py
+++ b/benchmarks/mmlu_pro/mmlu_pro.py
@@ -1,0 +1,190 @@
+"""MMLU-Pro: A More Robust and Challenging Multi-Task Language Understanding Benchmark
+
+Yubo Wang, Xueguang Ma, Ge Zhang, Yuansheng Ni, Abhranil Chandra, Shiguang Guo,
+Weiming Ren, Aaran Arulraj, Xuan He, Ziyan Jiang, Tianle Li, Max Ku, Kai Wang,
+Alex Zhuang, Rongqi Fan, Xiang Yue, Wenhu Chen
+https://arxiv.org/pdf/2406.01574
+
+Based on: https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/mmlu_pro
+
+# run with zero-shot (default)
+inspect eval mmlu_pro/mmlu_pro.py
+
+# run with fewshot samples
+inspect eval mmlu_pro/mmlu_pro.py -T fewshot=5
+
+# run for specific subjects
+inspect eval mmlu_pro/mmlu_pro.py -T subjects=math,physics
+"""
+
+from typing import Dict
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Dataset, Sample, hf_dataset
+from inspect_ai.model import ChatMessageSystem
+from inspect_ai.scorer import choice
+from inspect_ai.solver import (
+    Generate,
+    Solver,
+    TaskState,
+    multiple_choice,
+    solver,
+)
+from inspect_ai.solver._util import append_system_message
+from inspect_ai.util import resource
+
+# Based on the prompt provided here:
+# https://github.com/EleutherAI/lm-evaluation-harness/tree/main/lm_eval/tasks/mmlu_pro
+SYSTEM_W_EXAMPLES_PROMPT_TEMPLATE = """
+The following are multiple choice questions (with answers) about {subject}. Think step by step and then finish your answer with 'ANSWER: $LETTER' (without quotes) where LETTER is the correct letter choice.
+
+{examples}
+""".strip()
+# Based on the SINGLE_ANSWER_TEMPLATE provided in the multiple choice solver:
+# https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_multiple_choice.py#L14
+USER_PROMPT_TEMPLATE = """Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: $LETTER' (without quotes) where LETTER is one of {letters}. Think step by step before answering.
+
+Question:
+{question}
+Options:
+{choices}
+""".strip()
+
+
+@task
+def mmlu_pro(
+    subjects: list = [],
+    fewshot: int = 0,
+):
+    """Inspect task implementing the MMLU-Pro benchmark.
+
+    Args:
+        subjects (List): List of subjects to evaluate on.
+        fewshot (int): Number of few shot examples to use.
+    """
+    dataset = hf_dataset(
+        "TIGER-Lab/MMLU-Pro",
+        split="test",
+        trust=True,
+        sample_fields=record_to_sample,
+        shuffle=True,
+    )
+    # Subset the data based on subject
+    subjects = subjects if isinstance(subjects, list) else [subjects]
+    dataset = filter_dataset(dataset=dataset, subjects=subjects)
+
+    return Task(
+        dataset=dataset,
+        plan=build_plan(fewshot=fewshot),
+        scorer=choice(),
+    )
+
+
+@solver
+def mmlu_pro_system_message(dataset: Dataset, fewshot: int) -> Solver:
+    """Solver which inserts a system message for MMLU-Pro based on sample into the conversation.
+
+    The new message will go after other system messages (if there
+    are none it will be inserted at the beginning of the conversation).
+
+    Args:
+       dataset (Dataset): Dataset consisting of fewshot samples.
+       fewshot (int): Number of few shot examples to use.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        # Subset the data based on subject
+        subject = state.metadata["subject"]
+        fewshot_samples = filter_dataset(dataset=dataset, subjects=[subject])
+
+        # Select fewshot samples
+        assert (
+            len(fewshot_samples) >= fewshot
+        ), f"""The dataset ({len(fewshot_samples)}) does not have the requested number of fewshot samples ({fewshot}), reduce 'fewshot'."""
+        if fewshot < len(fewshot_samples):
+            fewshot_samples = fewshot_samples[:fewshot]
+
+        message = SYSTEM_W_EXAMPLES_PROMPT_TEMPLATE.format(
+            subject=subject,
+            examples="\n\n".join(
+                [sample_to_fewshot(sample=sample) for sample in fewshot_samples]
+            ),
+        )
+        content = resource(message)
+        append_system_message(state.messages, ChatMessageSystem(content=content))
+
+        return state
+
+    return solve
+
+
+def filter_dataset(dataset: Dataset, subjects: list) -> Dataset:
+    """Filters the MMLU-Pro dataset by subjects.
+
+    Args:
+        dataset (Dataset): Dataset object to be filtered.
+        subjects (List): List of subjects to filter on.
+    """
+    # Filter dataset by subjects, if required
+    if len(subjects) > 0:
+        dataset = dataset.filter(
+            name=f"{dataset.name}_subject-{'-'.join(subjects)}",
+            predicate=lambda sample: sample.metadata["subject"] in subjects
+            if sample.metadata is not None
+            else False,
+        )
+
+    return dataset
+
+
+def build_plan(
+    fewshot: int,
+) -> list:
+    plan = [multiple_choice(template=USER_PROMPT_TEMPLATE, shuffle=False)]
+
+    if fewshot:
+        fewshot_samples = hf_dataset(
+            "TIGER-Lab/MMLU-Pro",
+            split="validation",
+            trust=True,
+            sample_fields=record_to_sample,
+        )
+        plan.insert(
+            0,
+            mmlu_pro_system_message(
+                dataset=fewshot_samples,
+                fewshot=fewshot,
+            ),
+        )
+
+    return plan
+
+
+def record_to_sample(record: Dict) -> Sample:
+    return Sample(
+        input=record["question"],
+        choices=record["options"],
+        target=record["answer"],
+        id=record["question_id"],
+        metadata={
+            "cot_content": record["cot_content"],
+            "subject": record["category"].lower(),
+        },
+    )
+
+
+def sample_to_fewshot(sample: Sample) -> str:
+    q_str = f"""Question:\n{str(sample.input)}"""
+    options = sample.choices if sample.choices is not None else []
+    opt_str_list = []
+    for i, opt in enumerate(options):
+        opt_str_list.append(f"""{chr(65 + i)}) {opt}""")
+    opt_str = "\n".join(opt_str_list)
+    opt_str = f"""Options:\n{opt_str}"""
+    ans_str = sample.metadata["cot_content"] if sample.metadata is not None else ""
+    ans_str = ans_str.replace("The answer is", "ANSWER:")
+    ans_opt = ans_str.split("ANSWER:")[-1].split(".")[0].strip().strip("(").strip(")")
+    ans_str = ans_str.replace(f"ANSWER: ({ans_opt})", f"ANSWER: {ans_opt}")
+    final_str = "\n".join([q_str, opt_str, ans_str])
+
+    return final_str


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The package currently does not support the [MMLU-Pro](https://arxiv.org/pdf/2406.01574) benchmark.

### What is the new behavior?
Implementation of the [MMLU-Pro](https://arxiv.org/pdf/2406.01574) benchmark.

The benchmark can be run using the following command:
```python
cd benchmarks
inspect eval mmlu_pro/mmlu_pro.py  --model openai/gpt-4o
``` 

This implementation has been validated against the results for `Llama-3.1-8B-Instruct` reported in the paper [here](https://ai.meta.com/research/publications/the-llama-3-herd-of-models/) (Table 2). The following generations parameters were passed to reproduce the results: `--max-tokens 1024 --temperature 0 --seed 42 --stop-seqs '<|eot_id|>' -T fewshot=5` following [this](https://huggingface.co/datasets/meta-llama/Meta-Llama-3.1-8B-Instruct-evals/viewer/Meta-Llama-3.1-8B-Instruct-evals__mmlu_pro__details).
| acc | mean | std |
|--------|--------|--------|
| Llama-3 paper | 48.30 | - |
| Inspect | 45.15 | 0.45 | 

**Note-1:** The mean accuracy computed from the released [evals dataset](https://huggingface.co/datasets/meta-llama/Meta-Llama-3.1-8B-Instruct-evals/viewer/Meta-Llama-3.1-8B-Instruct-evals__mmlu_pro__details) is **47.02**, which is slightly lower than that reported in the paper.
**[IMP] Note-2:** The accuracy reported on HF's [Open LLM Leaderboard](https://huggingface.co/spaces/open-llm-leaderboard/open_llm_leaderboard) is just **30.68**, **much lower** than that reported in the paper. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking changes. The PR is a self-contained implementation of the benchmark.