### PR TITLE
`write_log_dir_manifest()` to write log header manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Eval Sets](https://inspect.ai-safety-institute.org.uk/eval-sets.html) for running groups of tasks with automatic retries.
 - [Per-sample](https://inspect.ai-safety-institute.org.uk/agents.html#sec-per-sample-sandbox) Sandbox environments can now be specified (e.g. allowing for a distinct Dockerfile or Docker compose file for each sample).
 - [input_screen()](https://inspect.ai-safety-institute.org.uk/interactivity.html) context manager to temporarily clear task display for user input.
+- `write_log_dir_manifest()` to write a log header manifest for a log directory
 - Add optional user parameter to SandboxEnvironment.exec for specifying the user. Currently only DockerSandboxEnvironment is supported.
 - Fix issue with resolving Docker configuration files when not running from the task directory.
 - Treat Sancbox exec `cwd` that are relative paths as relative to sample working directry.

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from copy import deepcopy
 from typing import Any, Callable, NamedTuple, Set, cast
 
@@ -15,7 +14,7 @@ from tenacity import (
 from typing_extensions import Unpack
 
 from inspect_ai._util.error import PrerequisiteError
-from inspect_ai._util.file import filesystem
+from inspect_ai._util.file import basename, filesystem
 from inspect_ai._util.registry import is_registry_object
 from inspect_ai.log import EvalLog
 from inspect_ai.log._file import (
@@ -23,6 +22,7 @@ from inspect_ai.log._file import (
     list_eval_logs,
     read_eval_log,
     read_eval_log_headers,
+    write_log_dir_manifest,
 )
 from inspect_ai.model import (
     GenerateConfigArgs,
@@ -251,10 +251,14 @@ def eval_set(
     #   - tasks with a successful log (they'll just be returned)
     #   - tasks with failed logs (they'll be retried)
     def try_eval() -> list[EvalLog]:
+        # list all logs currently in the log directory (update manifest if there are some)
+        all_logs = list_all_eval_logs(log_dir)
+        if len(all_logs) > 0:
+            write_log_dir_manifest(log_dir)
+
         # see which tasks are yet to run (to complete successfully we need
         # a successful eval for every [task_file/]task_name/model combination)
         # for those that haven't run, schedule them into models => tasks groups
-        all_logs = list_all_eval_logs(log_dir)
         log_task_identifers = [log.task_identifier for log in all_logs]
         all_tasks = [(task_identifer(task), task) for task in resolved_tasks]
         pending_tasks = [
@@ -364,6 +368,9 @@ def eval_set(
     else:
         msg = status_msg(f"Did not successfully complete all tasks in '{log_dir}'.")
     console.print(f"{msg}")
+
+    # update manifest
+    write_log_dir_manifest(log_dir)
 
     # return status + results
     return success, results
@@ -484,7 +491,7 @@ def validate_eval_set_prerequisites(
     for log in all_logs:
         if log.task_identifier not in task_identifiers:
             raise PrerequisiteError(
-                f"[bold]ERROR[/bold]: Existing log file '{os.path.basename(log.info.name)}' in log_dir is not "
+                f"[bold]ERROR[/bold]: Existing log file '{basename(log.info.name)}' in log_dir is not "
                 + "associated with a task passed to eval_set (you must run eval_set "
                 + "in a fresh log directory)"
             )

--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -8,6 +8,8 @@ from typing import Any, BinaryIO, Iterator, Literal, cast, overload
 from urllib.parse import urlparse
 
 import fsspec  # type: ignore
+from fsspec.core import split_protocol  # type: ignore
+from fsspec.implementations.local import make_path_posix  # type: ignore
 from pydantic import BaseModel
 
 # https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/spec.html#AbstractFileSystem
@@ -75,6 +77,23 @@ def file(
             yield f
         finally:
             f.close()
+
+
+def basename(file: str) -> str:
+    """Get the base name of the file.
+
+    Works for all variations of fsspec providers, posix/windows/etc.
+
+    Args:
+       file (str): File name
+
+    Returns:
+       Base name for file
+    """
+    normalized_path = make_path_posix(file)
+    _, path_without_protocol = split_protocol(normalized_path)
+    name: str = path_without_protocol.rstrip("/").split("/")[-1]
+    return name
 
 
 class FileInfo(BaseModel):

--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -90,6 +90,9 @@ def basename(file: str) -> str:
     Returns:
        Base name for file
     """
+    # windows paths aren't natively handled on posix so flip backslashes
+    if os.sep == "/":
+        file = file.replace("\\", "/")
     normalized_path = make_path_posix(file)
     _, path_without_protocol = split_protocol(normalized_path)
     name: str = path_without_protocol.rstrip("/").split("/")[-1]

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -5,6 +5,7 @@ from ._file import (
     list_eval_logs,
     read_eval_log,
     write_eval_log,
+    write_log_dir_manifest,
 )
 from ._log import (
     EvalConfig,
@@ -43,5 +44,6 @@ __all__ = [
     "list_eval_logs",
     "read_eval_log",
     "write_eval_log",
+    "write_log_dir_manifest",
     "retryable_eval_logs",
 ]

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -104,7 +104,7 @@ def write_eval_log(log: EvalLog, log_file: str | FileInfo) -> None:
 def write_log_dir_manifest(
     log_dir: str,
     *,
-    filename: str = "manifest.json",
+    filename: str = "logs.json",
     output_dir: str | None = None,
     fs_options: dict[str, Any] = {},
 ) -> None:
@@ -115,7 +115,7 @@ def write_log_dir_manifest(
 
     Args:
       log_dir (str): Log directory to write manifest for.
-      filename (str): Manifest filename (defaults to "manifest.json")
+      filename (str): Manifest filename (defaults to "logs.json")
       output_dir (str | None): Output directory for manifest (defaults to log_dir)
       fs_options (dict[str,Any]): Optional. Additional arguments to pass through
         to the filesystem provider (e.g. `S3FileSystem`).

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -118,8 +118,7 @@ def write_log_dir_manifest(
       filename (str): Manifest filename (defaults to "manifest.json")
       output_dir (str | None): Output directory for manifest (defaults to log_dir)
       fs_options (dict[str,Any]): Optional. Additional arguments to pass through
-        to the filesystem provider (e.g. `S3FileSystem`). Use `{"anon": True }`
-        if you are accessing a public S3 bucket with no credentials.
+        to the filesystem provider (e.g. `S3FileSystem`).
     """
     # resolve dir to list of eval logs
     logs = list_eval_logs(log_dir)

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -13,7 +13,13 @@ from inspect_ai._util.constants import (
     DEFAULT_LOG_BUFFER_REMOTE,
 )
 from inspect_ai._util.error import EvalError
-from inspect_ai._util.file import FileInfo, absolute_file_path, file, filesystem
+from inspect_ai._util.file import (
+    FileInfo,
+    absolute_file_path,
+    basename,
+    file,
+    filesystem,
+)
 
 from ._log import (
     EvalLog,
@@ -93,6 +99,45 @@ def write_eval_log(log: EvalLog, log_file: str | FileInfo) -> None:
     log_file = log_file if isinstance(log_file, str) else log_file.name
     with file(log_file, "w") as f:
         f.write(eval_log_json(log))
+
+
+def write_log_dir_manifest(
+    log_dir: str,
+    *,
+    filename: str = "manifest.json",
+    output_dir: str | None = None,
+    fs_options: dict[str, Any] = {},
+) -> None:
+    """Write a manifest for a log directory.
+
+    A log directory manifest is a dictionary of EvalLog headers (EvalLog w/o samples)
+    keyed by log file names (names are relative to the log directory)
+
+    Args:
+      log_dir (str): Log directory to write manifest for.
+      filename (str): Manifest filename (defaults to "manifest.json")
+      output_dir (str | None): Output directory for manifest (defaults to log_dir)
+      fs_options (dict[str,Any]): Optional. Additional arguments to pass through
+        to the filesystem provider (e.g. `S3FileSystem`). Use `{"anon": True }`
+        if you are accessing a public S3 bucket with no credentials.
+    """
+    # resolve dir to list of eval logs
+    logs = list_eval_logs(log_dir)
+
+    # resolve to manifest
+    names = [basename(log_name(log)) for log in logs]
+    headers = read_eval_log_headers(logs)
+    manifest_logs = dict(zip(names, headers))
+
+    # form target path and write
+    output_dir = output_dir or log_dir
+    fs = filesystem(output_dir)
+    manifest = f"{output_dir}{fs.sep}{filename}"
+    manifest_json = to_json(
+        value=manifest_logs, indent=2, exclude_none=True, fallback=lambda _x: None
+    )
+    with file(manifest, mode="wb", fs_options=fs_options) as f:
+        f.write(manifest_json)
 
 
 def eval_log_json(log: EvalLog) -> str:
@@ -189,6 +234,13 @@ def read_eval_log_headers(
     log_files: list[str] | list[FileInfo] | list[EvalLogInfo],
 ) -> list[EvalLog]:
     return [read_eval_log(log_file, header_only=True) for log_file in log_files]
+
+
+def log_name(log: str | FileInfo | EvalLogInfo) -> str:
+    if isinstance(log, str):
+        return log
+    else:
+        return log.name
 
 
 class FileRecorder(Recorder):

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -1,0 +1,16 @@
+from inspect_ai._util.file import basename
+
+
+def test_basename():
+    MYFILE = "myfile.log"
+    assert basename(f"s3://my-bucket/{MYFILE}") == MYFILE
+    assert basename(f"/opt/files/{MYFILE}") == MYFILE
+    assert basename(f"C:\\Documents\\{MYFILE}") == MYFILE
+
+    MYDIR = "mydir"
+    assert basename(f"s3://my-bucket/{MYDIR}") == MYDIR
+    assert basename(f"s3://my-bucket/{MYDIR}/") == MYDIR
+    assert basename(f"/opt/files/{MYDIR}") == MYDIR
+    assert basename(f"/opt/files/{MYDIR}/") == MYDIR
+    assert basename(f"C:\\Documents\\{MYDIR}") == MYDIR
+    assert basename(f"C:\\Documents\\{MYDIR}/") == MYDIR


### PR DESCRIPTION
This PR introduces a new `write_log_dir_manifest()` function, which will write a `manifest.json` file into a log directory (which in turn is a dictionary of relative log file name => log file header).

The `eval_set()` function now automatically calls this after each pass of work.

