### PR TITLE
Add MBPP benchmark

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -25,3 +25,5 @@ This directory contains evals for several benchmarks. Datasets for evals are not
 | SQuAD: A Reading Comprehension Benchmark requiring reasoning over Wikipedia articles | <https://arxiv.org/pdf/1806.03822>   |             [squad.py](squad/squad.py) | Hugging Face |
 | IFEval: Instruction-Following Evaluation for Large Language Models                 | <https://arxiv.org/pdf/2311.07911> |   [ifeval.py](ifeval/ifeval.py) | Hugging Face |
 | AGIEval: A Human-Centric Benchmark for Evaluating Foundation Models                 | <https://arxiv.org/pdf/2304.06364> |   [agieval_en.py](agieval/agieval_en.py) | Download |
+| MBPP: Mostly Basic Python Problems                                                              | <https://arxiv.org/abs/2108.07732>   |   [mbpp.py](mbpp/mbpp.py) | Hugging Face |
+

--- a/benchmarks/mbpp/README.md
+++ b/benchmarks/mbpp/README.md
@@ -14,3 +14,9 @@ The model is tasked to write Python code that will pass the assert statements in
 
 ## Evaluation
 The model is prompted to solve the problem, given its description and test cases to pass. Additionally, [few shot examples](https://github.com/google-research/google-research/tree/master/mbpp) can be included in the prompt, with prompts patterned after an [AgentCoder implementation](https://github.com/huangd1999/AgentCoder/blob/main/prompts/mbpp_prompt.txt) which topped the [leaderboard](https://paperswithcode.com/sota/code-generation-on-mbpp). 
+
+Evaluation metrics follow similar benchmarks such as HumanEval. The benchmark uses the $\text{pass}@k$ metric to measure functional correctness. In brief terms, this is the per-problem probability of at least 1 correct sample generation given $k$ generations. It is defined using the following expectation:
+
+$$ \text{pass@}k := \underset{\text{Problems}}{\mathbb{E}}\left[1-\frac{{n-c}\choose{k}}{{n}\choose{k}}\right]$$
+
+where we sample $n \geq k$ generations to reduce variance. Note that the default in this benchmark implementation is $n = 5$, and we evaluate $\text{pass}@k$ for $k \in \\{1, 2, 5\\}$.

--- a/benchmarks/mbpp/README.md
+++ b/benchmarks/mbpp/README.md
@@ -1,0 +1,16 @@
+# MBPP: Mostly Basic Python Problems
+
+[MBPP](https://arxiv.org/abs/2108.07732) is a dataset for evaluating the ability of models to synthesize short Python programs from natural language descriptions. It contains programming tasks that are designed to be solvable by entry-level programmers. We evaluate on the [sanitized test split](https://huggingface.co/datasets/google-research-datasets/mbpp/viewer/sanitized/test) of the dataset, which was hand-verified to remove samples that lacked detail or were ambiguous.
+
+## Execution
+Here is a sample from the dataset:
+```python
+task_id: 14
+prompt: Write a python function to find the volume of a triangular prism.
+test_list: [ "assert find_Volume(10,8,6) == 240", "assert find_Volume(3,2,2) == 6", "assert find_Volume(1,2,1) == 1" ]
+```
+
+The model is tasked to write Python code that will pass the assert statements in the `test_list`.
+
+## Evaluation
+The model is prompted to solve the problem, given its description and test cases to pass. Additionally, [few shot examples](https://github.com/google-research/google-research/tree/master/mbpp) can be included in the prompt, with prompts patterned after an [AgentCoder implementation](https://github.com/huangd1999/AgentCoder/blob/main/prompts/mbpp_prompt.txt) which topped the [leaderboard](https://paperswithcode.com/sota/code-generation-on-mbpp). 

--- a/benchmarks/mbpp/mbpp.py
+++ b/benchmarks/mbpp/mbpp.py
@@ -156,10 +156,9 @@ def mbpp(
     return Task(
         dataset=dataset,
         plan=[
-            prompt_template(template, ),
+            prompt_template(template),
             generate(),
         ],
         scorer=code_acceptance(),
         config=GenerateConfig(temperature=0.0),
-
     )

--- a/benchmarks/mbpp/mbpp.py
+++ b/benchmarks/mbpp/mbpp.py
@@ -101,8 +101,6 @@ def mbpp(
         split="test",
     )
 
-    dataset = dataset.filter(lambda x: x.id in [11, 14])
-
     return Task(
         dataset=dataset,
         epochs=Epochs(NUM_EPOCHS, ["mean", "pass_at_1", "pass_at_2", "pass_at_5"]),

--- a/benchmarks/mbpp/mbpp.py
+++ b/benchmarks/mbpp/mbpp.py
@@ -1,0 +1,167 @@
+"""
+MBPP: Mostly Basic Python Problems
+
+Jacob Austin, Augustus Odena, Maxwell Nye, Maarten Bosma, Henryk Michalewski,
+David Dohan, Ellen Jiang, Carrie Cai, Michael Terry, Quoc Le, Charles Sutton
+https://arxiv.org/pdf/2108.07732
+
+Based on: https://github.com/google-research/google-research/tree/master/mbpp
+
+# run the eval on the sanitized test split
+inspect eval benchmarks/mbpp/mbpp.py
+"""
+import math  # Used by some assert statements by MBPP.
+
+from datasets import load_dataset
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample, hf_dataset
+from inspect_ai.model import GenerateConfig
+from inspect_ai.scorer import (CORRECT, INCORRECT, Score, Target, accuracy,
+                               scorer, stderr)
+from inspect_ai.solver import TaskState, generate, prompt_template
+
+PROMPT_TEMPLATE = """
+You are an expert Python programmer. You will be given a task, and the tests that your code must pass.
+Write the Python function to solve the task. Do not give additional explanations, just output the
+Python function. Only use imports that are include in Python's standard library.
+"""
+
+
+def record_to_sample(record):
+    return Sample(
+        input=record["prompt"],
+        target=record["test_list"],
+        id=record["task_id"],
+        metadata={
+            "prompt": record["prompt"],
+            "test_list": record["test_list"],
+            "test_list_str": "\n".join(record["test_list"]),
+            "source_file": record["source_file"],
+            "code": record["code"],
+            "test_imports": record["test_imports"],
+            "task_id": record["task_id"],
+        }
+    )
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def code_acceptance():
+    async def score(state: TaskState, target: Target):
+
+        # It is assumed that generated output is of the form:
+        # ```python
+        # [code output]
+        # ```
+        raw_generated_code = state.output.completion
+        generated_code = raw_generated_code.replace("```python", "").replace("```", "")
+
+        explanation = ""
+        passed = True
+        try:
+            # Pass globals() as exec() may not work for functions that are recursive
+            # or use other functions that will still be defined afterwards.
+            exec(generated_code, globals())
+        except Exception as e:
+            explanation += f"Could not execute generated code. Error: {e}\n"
+            passed = False
+
+        if passed:
+            for i, test_case in enumerate(target.target):
+                try:
+                    exec(test_case, globals())
+                    print(f"Passed {i} case {test_case}")
+                except AssertionError:
+                    print(f"Failed {i} case {test_case}")
+                    passed = False
+                    explanation += f"Failed Test Case {i+1}: {test_case}. Assertion failed.\n"
+                except Exception as e:
+                    passed = False
+                    explanation += f"Failed Test Case {i+1}: {test_case}. Error: {e}\n"
+
+        if passed:
+            explanation += "All test cases passed.\n"
+
+        explanation += "The raw, generated output is shown below: \n"
+        explanation += raw_generated_code
+
+        return Score(
+            value=CORRECT if passed else INCORRECT,
+            answer=generated_code,
+            explanation=explanation
+        )
+
+    return score
+
+
+@task
+def mbpp(
+):
+    template = PROMPT_TEMPLATE
+    template += """
+# For example:"""
+
+    few_shot_dataset = load_dataset(
+        "google-research-datasets/mbpp",
+        "full",
+        split="prompt",
+    )
+    # Task IDs 2, 3, 4 are from
+    # https://github.com/google-research/google-research/tree/master/mbpp
+    few_shot_ids = [2, 3, 4]
+    few_shot_dataset = few_shot_dataset.filter(lambda row: row['task_id'] in few_shot_ids)
+
+    # Few shot prompts are based off
+    # https://github.com/huangd1999/AgentCoder/blob/main/prompts/mbpp_prompt.txt
+    for i, sample in enumerate(few_shot_dataset):
+        test_cases = "\n".join(sample["test_list"])
+        template += f"""
+
+## Prompt {i+1}:
+```python
+{sample['text']}
+```
+
+## Test Case {i+1}:
+```python
+{test_cases}
+```
+
+## Completion {i+1}:
+```python
+{sample['code']}
+```"""
+
+    template += """
+# Now, do it for the following task.
+
+## Prompt:
+```python
+{prompt}
+```
+
+## Test Case:
+```python
+{test_list_str}
+```
+
+## Completion:
+"""
+
+    dataset = hf_dataset(
+        "google-research-datasets/mbpp",
+        "sanitized",
+        sample_fields=record_to_sample,
+        split="test",
+    )
+
+    return Task(
+        dataset=dataset,
+        plan=[
+            prompt_template(template, ),
+            generate(),
+        ],
+        scorer=code_acceptance(),
+        config=GenerateConfig(temperature=0.0),
+
+    )

--- a/benchmarks/mbpp/mbpp.py
+++ b/benchmarks/mbpp/mbpp.py
@@ -70,9 +70,7 @@ def code_acceptance():
             for i, test_case in enumerate(target.target):
                 try:
                     exec(test_case, globals())
-                    print(f"Passed {i} case {test_case}")
                 except AssertionError:
-                    print(f"Failed {i} case {test_case}")
                     passed = False
                     explanation += f"Failed Test Case {i+1}: {test_case}. Assertion failed.\n"
                 except Exception as e:

--- a/benchmarks/mbpp/mbpp.py
+++ b/benchmarks/mbpp/mbpp.py
@@ -24,7 +24,7 @@ from inspect_ai.solver import TaskState, generate, prompt_template
 PROMPT_TEMPLATE = """
 You are an expert Python programmer. You will be given a task, and the tests that your code must pass.
 Write the Python function to solve the task. Do not give additional explanations, just output the
-Python function. Only use imports that are include in Python's standard library.
+Python function. Only use imports that are included in Python's standard library.
 """
 
 


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
No implementation for MBPP.

### What is the new behavior?
Adds implementation for [Mostly Basic Python Problems (MBPP)](https://arxiv.org/abs/2108.07732).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
This implementation is on the sanitized test split, with the same 3 few-shot examples ([task IDs 2-4](https://github.com/google-research/google-research/tree/master/mbpp)) in the prompt, and uses $k=1$ code completion.

For future PRs, here are some possible extensions:
- Include variable number of few-shot examples, though this may not matter as much ([Section 4.2](https://arxiv.org/abs/2108.07732))
- Include different subsets of few-shot examples. They mentioned 15 subsets (seeds) of few-shot prompts in Section 4.3, but did not detail which examples were used in each subset
- Consider multiple code completions for a problem, e.g., $k=80$ in Sections 3 & 4, though this may not be done by other implementations (e.g., the reference [AgentCoder implementation in the leaderboard](https://arxiv.org/abs/2312.13010v3) used $k=1$ (pass@1) in the results. Other models/APIs may not support multiple completions as well
- Explore alternatives to `exec()` for code execution that are more secure
- Alongside using `exec()`, possibly clean up the implementation so that the function names executed (from the generated code) are removed after going through the `assert` test cases

Other notes:
- Testing was mostly done on gemini-1.5-flash, as gemini-1.5-pro resulted to HTTP 500 internal errors, even after multiple retries
- Accuracy for gemini-1.5-flash was 74.3%
