### PR TITLE
Display a message index in messages tab

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -13569,7 +13569,7 @@ const ChatView = ({ id, messages, style }) => {
         marginTop: "0.1em"
       }}
             >
-              ${index + 1})
+              ${index + 1}
             </div>
             <${ChatMessage}
               id=${`${id}-chat-messages`}
@@ -21977,7 +21977,7 @@ const WorkSpace = (props) => {
         if (!((_d2 = workspaceLog.contents) == null ? void 0 : _d2.samples) && ((_g = (_f2 = (_e2 = workspaceLog.contents) == null ? void 0 : _e2.eval) == null ? void 0 : _f2.dataset) == null ? void 0 : _g.samples) > 0 && ((_h = workspaceLog.contents) == null ? void 0 : _h.status) !== "error") {
           warnings.push(
             m$1`<${WarningBand}
-              message="This evaluation log is too large display samples."
+              message="This evaluation log is too large to display samples."
             />`
           );
         }

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -7791,7 +7791,8 @@ const ApplicationIcons = {
     user: "bi bi-person",
     system: "bi bi-cpu",
     assistant: "bi bi-robot",
-    tool: "bi bi-tools"
+    tool: "bi bi-tools",
+    unknown: "bi bi-patch-question"
   },
   running: "bi bi-stars",
   sample: "bi bi-database",
@@ -13552,12 +13553,37 @@ const ChatView = ({ id, messages, style }) => {
   }
   const result = m$1`
     <div style=${style}>
-      ${collapsedMessages.map((msg) => {
-    return m$1`<${ChatMessage}
-          id=${`${id}-chat-messages`}
-          message=${msg}
-          toolMessages=${toolMessages}
-        />`;
+      ${collapsedMessages.map((msg, index) => {
+    if (collapsedMessages.length > 1) {
+      return m$1` <div
+            style=${{
+        display: "grid",
+        gridTemplateColumns: "max-content auto",
+        columnGap: "0.7em"
+      }}
+          >
+            <div
+              style=${{
+        fontSize: FontSize.smaller,
+        ...TextStyle.secondary,
+        marginTop: "0.1em"
+      }}
+            >
+              ${index + 1})
+            </div>
+            <${ChatMessage}
+              id=${`${id}-chat-messages`}
+              message=${msg}
+              toolMessages=${toolMessages}
+            />
+          </div>`;
+    } else {
+      return m$1` <${ChatMessage}
+            id=${`${id}-chat-messages`}
+            message=${msg}
+            toolMessages=${toolMessages}
+          />`;
+    }
   })}
     </div>
   `;
@@ -13574,54 +13600,38 @@ const normalizeContent = (content) => {
   }
 };
 const ChatMessage = ({ id, message, toolMessages }) => {
-  const iconCls = iconForMsg(message);
-  const icon = iconCls ? m$1`<i class="${iconCls}"></i>` : "";
   const collapse = message.role === "system";
   return m$1`
     <div
-      class="container-fluid ${message.role}"
+      class="${message.role}"
       style=${{
     fontSize: FontSize.base,
     fontWeight: "300",
     paddingBottom: ".5em",
-    justifyContent: "flex-start",
     marginLeft: "0",
     marginRight: "0",
     opacity: message.role === "system" ? "0.7" : "1",
     whiteSpace: "normal"
   }}
     >
-      <div class="row row-cols-2">
-        <div
-          class="col"
-          style=${{
-    flex: "0 1 1em",
-    paddingLeft: "0",
-    paddingRight: "0.5em",
-    marginLeft: "0",
-    fontWeight: "500"
-  }}
-        >
-          ${icon}
-        </div>
-        <div
-          class="col"
-          style=${{
-    flex: "1 0 auto",
-    marginLeft: ".3rem",
-    paddingLeft: "0"
-  }}
-        >
-          <div style=${{ fontWeight: "500", ...TextStyle.label }}>${message.role}</div>
-          <${ExpandablePanel} collapse=${collapse}>
-            <${MessageContents}
-              key=${`${id}-contents`}
-              message=${message}
-              toolMessages=${toolMessages}
-            />
-          </${ExpandablePanel}>
-        </div>
+      <div style=${{
+    display: "grid",
+    gridTemplateColumns: "max-content auto",
+    columnGap: "0.3em",
+    fontWeight: "500",
+    marginBottom: "0.5em",
+    ...TextStyle.label
+  }}>
+        <i class="${iconForMsg(message)}"></i>
+        ${message.role}
       </div>
+      <${ExpandablePanel} collapse=${collapse}>
+        <${MessageContents}
+          key=${`${id}-contents`}
+          message=${message}
+          toolMessages=${toolMessages}
+        />
+      </${ExpandablePanel}>
     </div>
   `;
 };
@@ -13658,15 +13668,17 @@ const MessageContents = ({ message, toolMessages }) => {
   }
 };
 const iconForMsg = (msg) => {
-  let iconCls = ApplicationIcons.role.assistant;
   if (msg.role === "user") {
-    iconCls = ApplicationIcons.role.user;
+    return ApplicationIcons.role.user;
   } else if (msg.role === "system") {
-    iconCls = ApplicationIcons.role.system;
+    return ApplicationIcons.role.system;
   } else if (msg.role === "tool") {
-    iconCls = ApplicationIcons.role.tool;
+    return ApplicationIcons.role.tool;
+  } else if (msg.role === "assistant") {
+    return ApplicationIcons.role.assistant;
+  } else {
+    return ApplicationIcons.role.unknown;
   }
-  return iconCls;
 };
 const resolveToolMessage = (toolMessage) => {
   var _a;

--- a/src/inspect_ai/_view/www/src/appearance/Icons.mjs
+++ b/src/inspect_ai/_view/www/src/appearance/Icons.mjs
@@ -34,6 +34,7 @@
  * @property {string} system
  * @property {string} assistant
  * @property {string} tool
+ * @property {string} unknown
  */
 
 /**
@@ -173,6 +174,7 @@ export const ApplicationIcons = {
     system: "bi bi-cpu",
     assistant: "bi bi-robot",
     tool: "bi bi-tools",
+    unknown: "bi bi-patch-question",
   },
   running: "bi bi-stars",
   sample: "bi bi-database",

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -62,12 +62,37 @@ export const ChatView = ({ id, messages, style }) => {
 
   const result = html`
     <div style=${style}>
-      ${collapsedMessages.map((msg) => {
-        return html`<${ChatMessage}
-          id=${`${id}-chat-messages`}
-          message=${msg}
-          toolMessages=${toolMessages}
-        />`;
+      ${collapsedMessages.map((msg, index) => {
+        if (collapsedMessages.length > 1) {
+          return html` <div
+            style=${{
+              display: "grid",
+              gridTemplateColumns: "max-content auto",
+              columnGap: "0.7em",
+            }}
+          >
+            <div
+              style=${{
+                fontSize: FontSize.smaller,
+                ...TextStyle.secondary,
+                marginTop: "0.1em",
+              }}
+            >
+              ${index + 1})
+            </div>
+            <${ChatMessage}
+              id=${`${id}-chat-messages`}
+              message=${msg}
+              toolMessages=${toolMessages}
+            />
+          </div>`;
+        } else {
+          return html` <${ChatMessage}
+            id=${`${id}-chat-messages`}
+            message=${msg}
+            toolMessages=${toolMessages}
+          />`;
+        }
       })}
     </div>
   `;
@@ -87,54 +112,38 @@ const normalizeContent = (content) => {
 };
 
 const ChatMessage = ({ id, message, toolMessages }) => {
-  const iconCls = iconForMsg(message);
-  const icon = iconCls ? html`<i class="${iconCls}"></i>` : "";
   const collapse = message.role === "system";
   return html`
     <div
-      class="container-fluid ${message.role}"
+      class="${message.role}"
       style=${{
         fontSize: FontSize.base,
         fontWeight: "300",
         paddingBottom: ".5em",
-        justifyContent: "flex-start",
         marginLeft: "0",
         marginRight: "0",
         opacity: message.role === "system" ? "0.7" : "1",
         whiteSpace: "normal",
       }}
     >
-      <div class="row row-cols-2">
-        <div
-          class="col"
-          style=${{
-            flex: "0 1 1em",
-            paddingLeft: "0",
-            paddingRight: "0.5em",
-            marginLeft: "0",
-            fontWeight: "500",
-          }}
-        >
-          ${icon}
-        </div>
-        <div
-          class="col"
-          style=${{
-            flex: "1 0 auto",
-            marginLeft: ".3rem",
-            paddingLeft: "0",
-          }}
-        >
-          <div style=${{ fontWeight: "500", ...TextStyle.label }}>${message.role}</div>
-          <${ExpandablePanel} collapse=${collapse}>
-            <${MessageContents}
-              key=${`${id}-contents`}
-              message=${message}
-              toolMessages=${toolMessages}
-            />
-          </${ExpandablePanel}>
-        </div>
+      <div style=${{
+        display: "grid",
+        gridTemplateColumns: "max-content auto",
+        columnGap: "0.3em",
+        fontWeight: "500",
+        marginBottom: "0.5em",
+        ...TextStyle.label,
+      }}>
+        <i class="${iconForMsg(message)}"></i>
+        ${message.role}
       </div>
+      <${ExpandablePanel} collapse=${collapse}>
+        <${MessageContents}
+          key=${`${id}-contents`}
+          message=${message}
+          toolMessages=${toolMessages}
+        />
+      </${ExpandablePanel}>
     </div>
   `;
 };
@@ -183,15 +192,17 @@ const MessageContents = ({ message, toolMessages }) => {
 };
 
 export const iconForMsg = (msg) => {
-  let iconCls = ApplicationIcons.role.assistant;
   if (msg.role === "user") {
-    iconCls = ApplicationIcons.role.user;
+    return ApplicationIcons.role.user;
   } else if (msg.role === "system") {
-    iconCls = ApplicationIcons.role.system;
+    return ApplicationIcons.role.system;
   } else if (msg.role === "tool") {
-    iconCls = ApplicationIcons.role.tool;
+    return ApplicationIcons.role.tool;
+  } else if (msg.role === "assistant") {
+    return ApplicationIcons.role.assistant;
+  } else {
+    return ApplicationIcons.role.unknown;
   }
-  return iconCls;
 };
 
 const resolveToolMessage = (toolMessage) => {

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -78,7 +78,7 @@ export const ChatView = ({ id, messages, style }) => {
                 marginTop: "0.1em",
               }}
             >
-              ${index + 1})
+              ${index + 1}
             </div>
             <${ChatMessage}
               id=${`${id}-chat-messages`}

--- a/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
+++ b/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
@@ -234,7 +234,7 @@ export const WorkSpace = (props) => {
         ) {
           warnings.push(
             html`<${WarningBand}
-              message="This evaluation log is too large display samples."
+              message="This evaluation log is too large to display samples."
             />`,
           );
         }


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Shows the message number next to the message in the messages view:

<img width="671" alt="Screenshot 2024-09-04 at 3 12 11 PM" src="https://github.com/user-attachments/assets/935eeaa7-6f55-4ea7-84c5-a8486da66cf3">
