### PR TITLE
properly process the header only parameter

### DIFF
--- a/src/inspect_ai/_view/view.py
+++ b/src/inspect_ai/_view/view.py
@@ -151,7 +151,7 @@ class ViewHTTPRequestHandler(InspectHTTPRequestHandler):
         # read query parameters from the URL
         query_params = parse_qs(parsed.query)
         header_param = query_params.get("header-only", None)
-        header_only = int(header_param[0]) if header_param is not None else 0
+        header_only = int(header_param[0]) if header_param is not None else sys.maxsize
 
         # reconstruct the path
         path = urlunparse(

--- a/src/inspect_ai/_view/view.py
+++ b/src/inspect_ai/_view/view.py
@@ -150,7 +150,8 @@ class ViewHTTPRequestHandler(InspectHTTPRequestHandler):
 
         # read query parameters from the URL
         query_params = parse_qs(parsed.query)
-        header_only = query_params.get("header-only", None) is not None
+        header_param = query_params.get("header-only", None)
+        header_only = int(header_param[0]) if header_param is not None else 0
 
         # reconstruct the path
         path = urlunparse(


### PR DESCRIPTION
The parameter is supposed to always be an int (older version of inspect do not pass it).

