### PR TITLE
[DRAFT] Quac Benchmark - ASET

### DIFF
--- a/benchmarks/quac/README.md
+++ b/benchmarks/quac/README.md
@@ -27,11 +27,3 @@ The model is tasked to answer the questions by referring to the dialog history a
 ## Evaluation
 
 The evaluation is performed using word-level F1 score, implemented similarly to SQuAD. We are only evaluating on the last question instead of iterating over all questions in the text. 
-
-
-## TODOS:
-- I'm only evaluating on the last question instead of iterating over all questions in the text. 
-- Can we skip current state in a custom scorer easily? If not I need to create a workaround or implement that in the core library
-- I haven't implemented the Human Equivalence Score for questions (HEQ-Q) and for dialogs (HEQ-D) reported in the paper. However, it seems like other implementations don't have done that either ([GPT-3 Paper](https://paperswithcode.com/paper/language-models-are-few-shot-learners), and [LLama 3 Paper](https://paperswithcode.com/paper/the-llama-3-herd-of-models))
-- The paper introduces two new metrics: Human Equivalence Score for questions (HEQ-Q) and for dialogs (HEQ-D), which are not implemented here. 
-- I'm evaluating only on the last question of the full text (not the previous questions in the text)

--- a/benchmarks/quac/README.md
+++ b/benchmarks/quac/README.md
@@ -1,4 +1,4 @@
-# QuAC: Question Answering in Context
+# QuAC: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Dialogs
 
 [QuAC](https://arxiv.org/abs/1808.07036) is a large-scale dataset for Question Answering in Context that contains 14K information-seeking QA dialogs (100K total questions). The dialogs involve two crowd workers: a student who poses questions to learn about a hidden Wikipedia text, and a teacher who answers by providing short excerpts from the text.
 
@@ -27,3 +27,11 @@ The model is tasked to answer the questions by referring to the dialog history a
 ## Evaluation
 
 The evaluation is performed using word-level F1 score, implemented similarly to SQuAD. We are only evaluating on the last question instead of iterating over all questions in the text. 
+
+
+## TODOS:
+- I'm only evaluating on the last question instead of iterating over all questions in the text. 
+- Can we skip current state in a custom scorer easily? If not I need to create a workaround or implement that in the core library
+- I haven't implemented the Human Equivalence Score for questions (HEQ-Q) and for dialogs (HEQ-D) reported in the paper. However, it seems like other implementations don't have done that either ([GPT-3 Paper](https://paperswithcode.com/paper/language-models-are-few-shot-learners), and [LLama 3 Paper](https://paperswithcode.com/paper/the-llama-3-herd-of-models))
+- The paper introduces two new metrics: Human Equivalence Score for questions (HEQ-Q) and for dialogs (HEQ-D), which are not implemented here. 
+- I'm evaluating only on the last question of the full text (not the previous questions in the text)

--- a/benchmarks/quac/README.md
+++ b/benchmarks/quac/README.md
@@ -1,4 +1,4 @@
-# QuAC: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Dialogs
+# QuAC: Question Answering in Context
 
 [QuAC](https://arxiv.org/abs/1808.07036) is a large-scale dataset for Question Answering in Context that contains 14K information-seeking QA dialogs (100K total questions). The dialogs involve two crowd workers: a student who poses questions to learn about a hidden Wikipedia text, and a teacher who answers by providing short excerpts from the text.
 

--- a/benchmarks/quac/README.md
+++ b/benchmarks/quac/README.md
@@ -1,0 +1,29 @@
+# QuAC: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Dialogs
+
+[QuAC](https://arxiv.org/abs/1808.07036) is a large-scale dataset for Question Answering in Context that contains 14K information-seeking QA dialogs (100K total questions). The dialogs involve two crowd workers: a student who poses questions to learn about a hidden Wikipedia text, and a teacher who answers by providing short excerpts from the text.
+
+## Execution
+
+Here is an example from the dataset:
+
+```
+Section: Augusto Pinochet : Intellectual life...
+
+STUDENT: Was he known for being intelligent?
+TEACHER: ,→ No, Pinochet was publicly known as a man with a lack of culture.
+
+STUDENT: why did people feel that way?
+TEACHER: ,→ reinforced by the fact that he also portrayed himself as a common man
+
+STUDENT: did he have any hobbies?
+TEACHER: ,→ Yes, Before wresting power from Allende, Pinochet had written two books.
+
+STUDENT: what is the name of a book written by him?
+TEACHER: ,→ Geopolitica (1968) and Campana de Tarapaca (1972).
+```
+
+The model is tasked to answer the questions by referring to the dialog history and the hidden passage.
+
+## Evaluation
+
+The evaluation is performed using word-level F1 score, implemented similarly to SQuAD. We are only evaluating on the last question instead of iterating over all questions in the text. 

--- a/benchmarks/quac/f1.py
+++ b/benchmarks/quac/f1.py
@@ -1,9 +1,11 @@
-from statistics import mean
-from typing import List, Callable
-from collections import Counter
-import string
+import logging
 import re
+import string
 import nltk
+
+from collections import Counter
+from statistics import mean
+from typing import List
 from nltk.corpus import stopwords
 
 from inspect_ai.scorer import scorer, mean, stderr, Score, Target, CORRECT, INCORRECT
@@ -11,8 +13,12 @@ from inspect_ai.solver import (
     TaskState,
 )
 
-nltk.download('stopwords', quiet=True)
-STOP_WORDS = set(stopwords.words('english'))
+logger = logging.getLogger(__name__)
+nltk.download("stopwords", quiet=True)
+
+STOP_WORDS = set(stopwords.words("english"))
+MIN_HUMAN_F1 = 0.4  # 0.4 was used in the paper
+
 
 @scorer(metrics=[mean(), stderr()])
 def f1_scorer():
@@ -21,32 +27,46 @@ def f1_scorer():
 
         if prediction.upper() == "CANNOTANSWER":
             return Score(
-                value=CORRECT if any(t.upper() == "CANNOTANSWER" for t in targets) else INCORRECT,
-                answer="CANNOTANSWER"
+                value=CORRECT
+                if any(t.upper() == "CANNOTANSWER" for t in targets)
+                else INCORRECT,
+                answer="CANNOTANSWER",
             )
+        else:
+            human_f1 = calculate_human_f1(targets)
+            if human_f1 < MIN_HUMAN_F1:
+                logger.info(
+                    f"Human F1 score {human_f1} is below threshold {MIN_HUMAN_F1}. Skipping evaluation."
+                )
+                return Score(
+                    value=1,  # TODO: How can we skip current state instead of returning 1? If not we need to do some workaround...
+                    answer=prediction,
+                    explanation=f"Human F1 score {human_f1} below threshold {MIN_HUMAN_F1}. Evaluation skipped.",
+                    metadata={"human_f1": human_f1, "skipped": True},
+                )
 
-        f1_scores = []
-        for i in range(len(targets)):
-            current_reference = targets[i]
-            other_references = targets[:i] + targets[i+1:]
-            f1_with_current = f1_score(prediction, current_reference)
-            f1_with_others = max((f1_score(prediction, ref) for ref in other_references), default=0)
-            max_f1 = max(f1_with_current, f1_with_others)
-            f1_scores.append(max_f1)
+            if len(targets) == 1:
+                f1 = f1_score(prediction, targets[0])
+            else:
+                f1_scores = []
+                for i in range(len(targets)):
+                    other_references = targets[:i] + targets[i + 1 :]
+                    f1_with_others = max(
+                        f1_score(prediction, ref) for ref in other_references
+                    )
+                    f1_scores.append(f1_with_others)
+                f1 = sum(f1_scores) / len(f1_scores)
 
-        final_f1 = sum(f1_scores) / len(f1_scores)
+            return Score(value=f1, answer=prediction, explanation=f"F1 score: {f1}")
 
-        return Score(
-            value=final_f1,
-            answer=prediction,
-            explanation=f"F1 score: {final_f1}"
-        )
     return score
 
+
+# TODO: Can we use _f1 from the core library instead?
 def f1_score(prediction: str, ground_truth: str) -> float:
     prediction_tokens = normalize_answer(prediction)
     ground_truth_tokens = normalize_answer(ground_truth)
-    
+
     common = Counter(prediction_tokens) & Counter(ground_truth_tokens)
     num_same = sum(common.values())
     if num_same == 0:
@@ -56,19 +76,40 @@ def f1_score(prediction: str, ground_truth: str) -> float:
     f1 = (2 * precision * recall) / (precision + recall)
     return f1
 
+
 def normalize_answer(s: str) -> List[str]:
     """Lowercase, remove punctuation, articles, stopwords, and extra whitespace."""
+
     def remove_articles(text):
-        return re.sub(r'\b(a|an|the)\b', ' ', text)
+        return re.sub(r"\b(a|an|the)\b", " ", text)
+
     def white_space_fix(text):
-        return ' '.join(text.split())
+        return " ".join(text.split())
+
     def remove_punc(text):
         exclude = set(string.punctuation)
-        return ''.join(ch for ch in text if ch not in exclude)
+        return "".join(ch for ch in text if ch not in exclude)
+
     def lower(text):
         return text.lower()
+
+    # TODO: Can we use _normalize from the core library and also add the following after:
     def remove_stopwords(text):
         return [word for word in text.split() if word not in STOP_WORDS]
-    
+
     result = remove_stopwords(white_space_fix(remove_articles(remove_punc(lower(s)))))
     return result
+
+
+def calculate_human_f1(references: List[str]) -> float:
+    if len(references) <= 1:
+        return 1.0
+
+    # comparing each reference against the subset of other references
+    leave_one_out_f1s = []
+    for i, reference in enumerate(references):
+        other_references = references[:i] + references[i + 1 :]
+        f1_scores = [f1_score(reference, other) for other in other_references]
+        leave_one_out_f1s.append(max(f1_scores))
+
+    return sum(leave_one_out_f1s) / len(leave_one_out_f1s)

--- a/benchmarks/quac/f1.py
+++ b/benchmarks/quac/f1.py
@@ -2,7 +2,6 @@ import logging
 import re
 import string
 from collections import Counter
-from statistics import mean
 from typing import List
 
 import nltk

--- a/benchmarks/quac/f1.py
+++ b/benchmarks/quac/f1.py
@@ -10,6 +10,33 @@ from pprint import pp
 from typing import List, Tuple, Union
 from scipy.optimize import linear_sum_assignment  # type: ignore
 
+
+"""
+FROM PAPER:
+
+4.1 Evaluation Metrics
+Our core evaluation metric, word-level F1, is im- plemented similarly to SQuAD (Rajpurkar et al., 
+2016): precision and recall are computed by con- sidering the portion of words in the prediction 
+and references that overlap after removing stop- words.12 For no answer questions, we give the 
+system an F1 of one if it correctly predicts no answerandzerootherwise.13 Like 
+SQuAD,we compute the maximum F1 among all references; however, since many questions have 
+multiple valid answers, this metric varies significantly with
+
+the number of reference annotations. To make or- acle human and system performance comparable, 
+given n references, we report the average of the maximum F1 computed from each n − 1 
+subset with respect to the heldout reference.
+Additionally, since averaged F1 can be mislead- ing for 
+questions with multiple valid answers, we introduce the human equivalence score (HEQ)
+,a performance measure for judging whether a sys- tem’s output is as good as that of 
+an average hu- man.14 HEQmeasuresthepercentageofexamples for which system F1 exceeds 
+or matches human F1. We compute two variants: (1) the percentage of questions for 
+which this is true (HEQ-Q), and (2) the percentage of dialogs for which this is 
+true for every question in the dialog (HEQ-D). A sys- tem that achieves a value of
+100 on HEQ-D can by definition maintain average human quality output over full dialogs.
+For dialog acts, we report accuracy with respect to the majority annotation, breaking ties randomly.
+
+"""
+
 # !!!!
 # WIP
 # Taken from drop benchmark, need to refactor or add directly to inspect library as new f1 scorer

--- a/benchmarks/quac/f1.py
+++ b/benchmarks/quac/f1.py
@@ -1,0 +1,198 @@
+import re
+import numpy as np
+import string
+from inspect_ai.scorer import Score, Target, bootstrap_std, mean, scorer
+from inspect_ai.solver import (
+    TaskState,
+)
+
+from pprint import pp
+from typing import List, Tuple, Union
+from scipy.optimize import linear_sum_assignment  # type: ignore
+
+# !!!!
+# WIP
+# Taken from drop benchmark, need to refactor or add directly to inspect library as new f1 scorer
+@scorer(metrics=[mean(), bootstrap_std()])
+def f1_scorer():
+    async def score(state: TaskState, target: Target) -> Score:
+        # Get generated answer and extract relevant answer text
+        answer = state.output.completion
+        match = re.search(r"(?i)answer\s*:\s*([^\n]+)", answer)
+        answer = match.group(1) if match else answer
+
+        # Get target answers (convert str elm to tuple by splitting on "|")
+        ref_answers = [tuple(elm.split("|")) for elm in target.target]
+        
+        em_score, f1_score = await process_results(answer, ref_answers)
+
+        # F1 score reported as main aggregated metric, EM score added to metadata
+        return Score(
+            value=f1_score,
+            answer=answer,
+            metadata={
+                "metrics": {
+                    "f1_score": f1_score,
+                    "em_score": em_score,
+                },
+                "gold_answers": ref_answers,
+            },
+        )
+
+
+    return score
+
+async def process_results(
+    preds: Union[str, List[str]], golds: List
+) -> Tuple[float, float]:
+    max_em = 0.0
+    max_f1 = 0.0
+    for gold_answer in golds:
+        exact_match, f1_score = await get_metrics(preds, gold_answer)
+        if gold_answer[0].strip():
+            max_em = max(max_em, exact_match)
+            max_f1 = max(max_f1, f1_score)
+    return (max_em, max_f1)
+
+
+async def get_metrics(
+    predicted: Union[str, List[str]], gold: Union[str, List[str], Tuple[str]]
+) -> Tuple[float, float]:
+    """Takes a predicted answer and a gold answer (that are both either a string or a list of strings), and returns exact match and the DROP F1 metric for the prediction.
+
+    If you are writing a script for evaluating objects in memory (say, the output of predictions during
+    validation, or while training), this is the function you want to call, after using
+    :func:`answer_json_to_strings` when reading the gold answer from the released data file.
+    """
+    predicted_bags = await _answer_to_bags(predicted)
+    gold_bags = await _answer_to_bags(gold)
+
+    if set(predicted_bags[0]) == set(gold_bags[0]) and len(predicted_bags[0]) == len(
+        gold_bags[0]
+    ):
+        exact_match = 1.0
+    else:
+        exact_match = 0.0
+
+    f1_per_bag = await _align_bags(predicted_bags[1], gold_bags[1])
+    f1 = np.mean(f1_per_bag).item()
+    f1 = round(f1, 2)
+    return exact_match, f1
+
+
+async def _answer_to_bags(
+    answer: Union[str, List[str], Tuple[str]],
+) -> Tuple[list, list]:
+    if isinstance(answer, list | tuple):
+        raw_spans = answer
+    else:
+        raw_spans = [answer]
+    normalized_spans = []
+    token_bags = []
+    for raw_span in raw_spans:
+        normalized_span = await _normalize(raw_span)
+        normalized_spans.append(normalized_span)
+        token_bags.append(set(normalized_span.split()))
+    return normalized_spans, token_bags
+
+
+async def _align_bags(predicted: List[set], gold: List[set]) -> np.ndarray:
+    """Takes gold and predicted answer sets and first finds the optimal 1-1 alignment between them and gets maximum metric values over all the answers."""
+    scores = np.zeros([len(gold), len(predicted)])
+    for gold_index, gold_item in enumerate(gold):
+        for pred_index, pred_item in enumerate(predicted):
+            match_numbers = await _match_numbers_if_present(gold_item, pred_item)
+            if match_numbers:
+                scores[gold_index, pred_index] = await _compute_f1(pred_item, gold_item)
+    row_ind, col_ind = linear_sum_assignment(-scores)
+
+    max_scores = np.zeros([max(len(gold), len(predicted))])
+    for row, column in zip(row_ind, col_ind):
+        max_scores[row] = max(max_scores[row], scores[row, column])
+    return max_scores
+
+
+async def _compute_f1(predicted_bag: set, gold_bag: set) -> float:
+    intersection = len(gold_bag.intersection(predicted_bag))
+    if not predicted_bag:
+        precision = 1.0
+    else:
+        precision = intersection / float(len(predicted_bag))
+    if not gold_bag:
+        recall = 1.0
+    else:
+        recall = intersection / float(len(gold_bag))
+    f1 = (
+        (2 * precision * recall) / (precision + recall)
+        if not (precision == 0.0 and recall == 0.0)
+        else 0.0
+    )
+    return f1
+
+
+async def _match_numbers_if_present(gold_bag: set, predicted_bag: set) -> bool:
+    gold_numbers = set()
+    predicted_numbers = set()
+    for word in gold_bag:
+        is_number = await _is_number(word)
+        if is_number:
+            gold_numbers.add(word)
+    for word in predicted_bag:
+        is_number = await _is_number(word)
+        if is_number:
+            predicted_numbers.add(word)
+    if (not gold_numbers) or gold_numbers.intersection(predicted_numbers):
+        return True
+    return False
+
+
+async def _is_number(text: str) -> bool:
+    try:
+        float(text)
+        return True
+    except ValueError:
+        return False
+
+
+async def _remove_articles(text: str) -> str:
+    _ARTICLES = re.compile(r"\b(a|an|the)\b", re.UNICODE)
+    return _ARTICLES.sub(" ", text)
+
+
+async def _white_space_fix(text: str) -> str:
+    return " ".join(text.split())
+
+
+async def _remove_punc(text: str) -> str:
+    exclude = set(string.punctuation)
+    is_number = await _is_number(text)
+    if not is_number:
+        return "".join(ch for ch in text if ch not in exclude)
+    else:
+        return text
+
+
+async def _fix_number(text: str) -> str:
+    is_number = await _is_number(text)
+    if is_number:
+        return str(float(text))
+    else:
+        return text
+
+
+async def _tokenize(text: str) -> List[str]:
+    return re.split(" |-", text)
+
+
+async def _normalize(answer: str) -> str:
+    tokens = []
+    tokenized_answer = await _tokenize(answer)
+    for token in tokenized_answer:
+        token = await _remove_punc(token.lower())
+        token = await _fix_number(token)
+        token = await _remove_articles(token)
+        token = await _white_space_fix(token)
+        tokens.append(token)
+    tokens = [token for token in tokens if token.strip()]
+    normalized = " ".join(tokens).strip()
+    return normalized

--- a/benchmarks/quac/f1.py
+++ b/benchmarks/quac/f1.py
@@ -1,229 +1,74 @@
-import re
-import numpy as np
+from statistics import mean
+from typing import List, Callable
+from collections import Counter
 import string
-from inspect_ai.scorer import Score, Target, bootstrap_std, mean, scorer
+import re
+import nltk
+from nltk.corpus import stopwords
+
+from inspect_ai.scorer import scorer, mean, stderr, Score, Target, CORRECT, INCORRECT
 from inspect_ai.solver import (
     TaskState,
 )
 
-from pprint import pp
-from typing import List, Tuple, Union
-from scipy.optimize import linear_sum_assignment  # type: ignore
+nltk.download('stopwords', quiet=True)
+STOP_WORDS = set(stopwords.words('english'))
 
-
-"""
-FROM PAPER:
-
-4.1 Evaluation Metrics
-Our core evaluation metric, word-level F1, is im- plemented similarly to SQuAD (Rajpurkar et al., 
-2016): precision and recall are computed by con- sidering the portion of words in the prediction 
-and references that overlap after removing stop-words.12 For no answer questions, we give the 
-system an F1 of one if it correctly predicts no answerandzerootherwise.13 Like 
-SQuAD,we compute the maximum F1 among all references; however, since many questions have 
-multiple valid answers, this metric varies significantly with
-
-the number of reference annotations. To make or- acle human and system performance comparable, 
-given n references, we report the average of the maximum F1 computed from each n − 1 
-subset with respect to the heldout reference.
-Additionally, since averaged F1 can be mislead- ing for 
-questions with multiple valid answers, we introduce the human equivalence score (HEQ)
-,a performance measure for judging whether a sys- tem’s output is as good as that of 
-an average hu- man.14 HEQmeasuresthepercentageofexamples for which system F1 exceeds 
-or matches human F1. We compute two variants: (1) the percentage of questions for 
-which this is true (HEQ-Q), and (2) the percentage of dialogs for which this is 
-true for every question in the dialog (HEQ-D). A sys- tem that achieves a value of
-100 on HEQ-D can by definition maintain average human quality output over full dialogs.
-For dialog acts, we report accuracy with respect to the majority annotation, breaking ties randomly.
-
-"""
-
-# !!!!
-# WIP
-# Taken from drop benchmark, need to refactor or add directly to inspect library as new f1 scorer
-# Todos:
-# - Remove stop words
-# - Run some additional checks to see if it really works as expected
-# - Add HEQ metric from paper?
-@scorer(metrics=[mean(), bootstrap_std()])
+@scorer(metrics=[mean(), stderr()])
 def f1_scorer():
-    async def score(state: TaskState, target: Target) -> Score:
-        # Get generated answer and extract relevant answer text
-        answer = state.output.completion
-        match = re.search(r"(?i)answer\s*:\s*([^\n]+)", answer)
-        answer = match.group(1) if match else answer
+    async def score(state: TaskState, targets: Target) -> Score:
+        prediction = state.output.completion
 
-        # Get target answers (convert str elm to tuple by splitting on "|")
-        ref_answers = [tuple(elm.split("|")) for elm in target.target]
-        
-        em_score, f1_score = await process_results(answer, ref_answers)
+        if prediction.upper() == "CANNOTANSWER":
+            return Score(
+                value=CORRECT if any(t.upper() == "CANNOTANSWER" for t in targets) else INCORRECT,
+                answer="CANNOTANSWER"
+            )
 
-        # F1 score reported as main aggregated metric, EM score added to metadata
+        f1_scores = []
+        for i in range(len(targets)):
+            current_reference = targets[i]
+            other_references = targets[:i] + targets[i+1:]
+            f1_with_current = f1_score(prediction, current_reference)
+            f1_with_others = max((f1_score(prediction, ref) for ref in other_references), default=0)
+            max_f1 = max(f1_with_current, f1_with_others)
+            f1_scores.append(max_f1)
+
+        final_f1 = sum(f1_scores) / len(f1_scores)
+
         return Score(
-            value=f1_score,
-            answer=answer,
-            metadata={
-                "metrics": {
-                    "f1_score": f1_score,
-                    "em_score": em_score,
-                },
-                "gold_answers": ref_answers,
-            },
+            value=final_f1,
+            answer=prediction,
+            explanation=f"F1 score: {final_f1}"
         )
-
-
     return score
 
-async def process_results(
-    preds: Union[str, List[str]], golds: List
-) -> Tuple[float, float]:
-    max_em = 0.0
-    max_f1 = 0.0
-    for gold_answer in golds:
-        exact_match, f1_score = await get_metrics(preds, gold_answer)
-        if gold_answer[0].strip():
-            max_em = max(max_em, exact_match)
-            max_f1 = max(max_f1, f1_score)
-    return (max_em, max_f1)
-
-
-async def get_metrics(
-    predicted: Union[str, List[str]], gold: Union[str, List[str], Tuple[str]]
-) -> Tuple[float, float]:
-    """Takes a predicted answer and a gold answer (that are both either a string or a list of strings), and returns exact match and the DROP F1 metric for the prediction.
-
-    If you are writing a script for evaluating objects in memory (say, the output of predictions during
-    validation, or while training), this is the function you want to call, after using
-    :func:`answer_json_to_strings` when reading the gold answer from the released data file.
-    """
-    predicted_bags = await _answer_to_bags(predicted)
-    gold_bags = await _answer_to_bags(gold)
-
-    if set(predicted_bags[0]) == set(gold_bags[0]) and len(predicted_bags[0]) == len(
-        gold_bags[0]
-    ):
-        exact_match = 1.0
-    else:
-        exact_match = 0.0
-
-    f1_per_bag = await _align_bags(predicted_bags[1], gold_bags[1])
-    f1 = np.mean(f1_per_bag).item()
-    f1 = round(f1, 2)
-    return exact_match, f1
-
-
-async def _answer_to_bags(
-    answer: Union[str, List[str], Tuple[str]],
-) -> Tuple[list, list]:
-    if isinstance(answer, list | tuple):
-        raw_spans = answer
-    else:
-        raw_spans = [answer]
-    normalized_spans = []
-    token_bags = []
-    for raw_span in raw_spans:
-        normalized_span = await _normalize(raw_span)
-        normalized_spans.append(normalized_span)
-        token_bags.append(set(normalized_span.split()))
-    return normalized_spans, token_bags
-
-
-async def _align_bags(predicted: List[set], gold: List[set]) -> np.ndarray:
-    """Takes gold and predicted answer sets and first finds the optimal 1-1 alignment between them and gets maximum metric values over all the answers."""
-    scores = np.zeros([len(gold), len(predicted)])
-    for gold_index, gold_item in enumerate(gold):
-        for pred_index, pred_item in enumerate(predicted):
-            match_numbers = await _match_numbers_if_present(gold_item, pred_item)
-            if match_numbers:
-                scores[gold_index, pred_index] = await _compute_f1(pred_item, gold_item)
-    row_ind, col_ind = linear_sum_assignment(-scores)
-
-    max_scores = np.zeros([max(len(gold), len(predicted))])
-    for row, column in zip(row_ind, col_ind):
-        max_scores[row] = max(max_scores[row], scores[row, column])
-    return max_scores
-
-
-async def _compute_f1(predicted_bag: set, gold_bag: set) -> float:
-    intersection = len(gold_bag.intersection(predicted_bag))
-    if not predicted_bag:
-        precision = 1.0
-    else:
-        precision = intersection / float(len(predicted_bag))
-    if not gold_bag:
-        recall = 1.0
-    else:
-        recall = intersection / float(len(gold_bag))
-    f1 = (
-        (2 * precision * recall) / (precision + recall)
-        if not (precision == 0.0 and recall == 0.0)
-        else 0.0
-    )
+def f1_score(prediction: str, ground_truth: str) -> float:
+    prediction_tokens = normalize_answer(prediction)
+    ground_truth_tokens = normalize_answer(ground_truth)
+    
+    common = Counter(prediction_tokens) & Counter(ground_truth_tokens)
+    num_same = sum(common.values())
+    if num_same == 0:
+        return 0
+    precision = 1.0 * num_same / len(prediction_tokens)
+    recall = 1.0 * num_same / len(ground_truth_tokens)
+    f1 = (2 * precision * recall) / (precision + recall)
     return f1
 
-
-async def _match_numbers_if_present(gold_bag: set, predicted_bag: set) -> bool:
-    gold_numbers = set()
-    predicted_numbers = set()
-    for word in gold_bag:
-        is_number = await _is_number(word)
-        if is_number:
-            gold_numbers.add(word)
-    for word in predicted_bag:
-        is_number = await _is_number(word)
-        if is_number:
-            predicted_numbers.add(word)
-    if (not gold_numbers) or gold_numbers.intersection(predicted_numbers):
-        return True
-    return False
-
-
-async def _is_number(text: str) -> bool:
-    try:
-        float(text)
-        return True
-    except ValueError:
-        return False
-
-
-async def _remove_articles(text: str) -> str:
-    _ARTICLES = re.compile(r"\b(a|an|the)\b", re.UNICODE)
-    return _ARTICLES.sub(" ", text)
-
-
-async def _white_space_fix(text: str) -> str:
-    return " ".join(text.split())
-
-
-async def _remove_punc(text: str) -> str:
-    exclude = set(string.punctuation)
-    is_number = await _is_number(text)
-    if not is_number:
-        return "".join(ch for ch in text if ch not in exclude)
-    else:
-        return text
-
-
-async def _fix_number(text: str) -> str:
-    is_number = await _is_number(text)
-    if is_number:
-        return str(float(text))
-    else:
-        return text
-
-
-async def _tokenize(text: str) -> List[str]:
-    return re.split(" |-", text)
-
-
-async def _normalize(answer: str) -> str:
-    tokens = []
-    tokenized_answer = await _tokenize(answer)
-    for token in tokenized_answer:
-        token = await _remove_punc(token.lower())
-        token = await _fix_number(token)
-        token = await _remove_articles(token)
-        token = await _white_space_fix(token)
-        tokens.append(token)
-    tokens = [token for token in tokens if token.strip()]
-    normalized = " ".join(tokens).strip()
-    return normalized
+def normalize_answer(s: str) -> List[str]:
+    """Lowercase, remove punctuation, articles, stopwords, and extra whitespace."""
+    def remove_articles(text):
+        return re.sub(r'\b(a|an|the)\b', ' ', text)
+    def white_space_fix(text):
+        return ' '.join(text.split())
+    def remove_punc(text):
+        exclude = set(string.punctuation)
+        return ''.join(ch for ch in text if ch not in exclude)
+    def lower(text):
+        return text.lower()
+    def remove_stopwords(text):
+        return [word for word in text.split() if word not in STOP_WORDS]
+    
+    result = remove_stopwords(white_space_fix(remove_articles(remove_punc(lower(s)))))
+    return result

--- a/benchmarks/quac/f1.py
+++ b/benchmarks/quac/f1.py
@@ -1,14 +1,14 @@
 import logging
 import re
 import string
-import nltk
-
 from collections import Counter
 from statistics import mean
 from typing import List
+
+import nltk
 from nltk.corpus import stopwords
 
-from inspect_ai.scorer import scorer, mean, stderr, Score, Target, CORRECT, INCORRECT
+from inspect_ai.scorer import CORRECT, INCORRECT, Score, Target, mean, scorer, stderr
 from inspect_ai.solver import (
     TaskState,
 )

--- a/benchmarks/quac/f1.py
+++ b/benchmarks/quac/f1.py
@@ -17,7 +17,7 @@ FROM PAPER:
 4.1 Evaluation Metrics
 Our core evaluation metric, word-level F1, is im- plemented similarly to SQuAD (Rajpurkar et al., 
 2016): precision and recall are computed by con- sidering the portion of words in the prediction 
-and references that overlap after removing stop- words.12 For no answer questions, we give the 
+and references that overlap after removing stop-words.12 For no answer questions, we give the 
 system an F1 of one if it correctly predicts no answerandzerootherwise.13 Like 
 SQuAD,we compute the maximum F1 among all references; however, since many questions have 
 multiple valid answers, this metric varies significantly with
@@ -40,6 +40,10 @@ For dialog acts, we report accuracy with respect to the majority annotation, bre
 # !!!!
 # WIP
 # Taken from drop benchmark, need to refactor or add directly to inspect library as new f1 scorer
+# Todos:
+# - Remove stop words
+# - Run some additional checks to see if it really works as expected
+# - Add HEQ metric from paper?
 @scorer(metrics=[mean(), bootstrap_std()])
 def f1_scorer():
     async def score(state: TaskState, target: Target) -> Score:

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -1,0 +1,70 @@
+from typing import Dict, List
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.dataset._sources.hf import hf_dataset
+from inspect_ai.model import GenerateConfig
+from inspect_ai.scorer import choice
+
+MULTIPLE_CHOICE_TEMPLATE_COT = r"""
+Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: $LETTER' (without quotes) where LETTER is one of {letters}. Think step by step before answering.
+
+{question}
+
+{choices}
+""".strip()
+
+
+@task
+def quac():
+    dataset = hf_dataset(
+        path="allenai/quac",
+        sample_fields=record_to_sample,
+        split="validation",
+        shuffle=True,
+        trust=True
+    )
+    dataset = dataset[:100]
+    breakpoint()
+    
+    # TODO:
+    plan = None # TO IMPLEMENT
+    return Task(
+        dataset=dataset,
+        plan=plan, # What plan to use?
+        scorer=choice(),
+        config=GenerateConfig(temperature=0.5),
+    )
+    
+    
+def record_to_sample(record: Dict) -> Sample:
+    return Sample(
+        input=format_input(record),
+        target=format_target(record),
+        id=record["dialogue_id"],
+    )
+    
+def format_input(doc: Dict) -> str:
+    wikipedia_title = f"""wikipedia_page_title: {doc["wikipedia_page_title"]}"""
+    background = f"""background: {doc["background"]}"""
+    section_title = f"""section_title: {doc["section_title"]}"""
+    context = f"""context: {doc["context"]}"""
+    
+    questions = doc["questions"]
+    previous_questions_answers = []
+    for idx, question in enumerate(questions[:-1]):
+        answer = doc["answers"]["texts"][idx][0]
+        question = f"""question: {question}"""
+        answer = f"""answer: {answer}"""
+        previous_questions_answers.append(question)
+        previous_questions_answers.append(answer)
+        
+    current_question = questions[-1]
+    
+    input_str = "\n".join([wikipedia_title, background, section_title, context, "\n".join(previous_questions_answers), current_question, """answer:"""])
+    return input_str
+
+def format_target(doc: Dict) -> List[str]:
+    target = doc["answers"]["texts"][-1]
+    # Convert each tuple to str, since 'target' only accepts 'str' or 'List[str]'.
+    target = ["|".join(elm) for elm in target]
+    return target

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -1,10 +1,10 @@
-from pprint import pp
+
 from typing import Dict, List
+from f1 import f1_scorer
 from inspect_ai import Task, task
 from inspect_ai.dataset import Sample
 from inspect_ai.dataset._sources.hf import hf_dataset
-from inspect_ai.model import GenerateConfig
-from inspect_ai.scorer import choice
+from inspect_ai.model._generate_config import GenerateConfig
 
 
 @task
@@ -12,31 +12,26 @@ def quac():
     dataset = hf_dataset(
         path="allenai/quac",
         sample_fields=record_to_sample,
-        split="validation",
+        split="train",
         shuffle=True,
         trust=True
     )
-    dataset = dataset[:100]
-    breakpoint()
+    dataset = dataset[:10]
     
-    # TODO:
-    plan = None # TO IMPLEMENT
     return Task(
         dataset=dataset,
-        plan=plan, # What plan to use?
-        scorer=choice(),
+        scorer=f1_scorer(),
         config=GenerateConfig(temperature=0.5),
     )
     
-    
-def record_to_sample(record: Dict) -> Sample:
+def record_to_sample(record) -> Sample:
     return Sample(
         input=format_input(record),
         target=format_target(record),
         id=record["dialogue_id"],
     )
     
-def format_input(doc: Dict) -> str:
+def format_input(doc) -> str:
     wikipedia_title = f"""wikipedia_page_title: {doc["wikipedia_page_title"]}"""
     background = f"""background: {doc["background"]}"""
     section_title = f"""section_title: {doc["section_title"]}"""

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -1,4 +1,3 @@
-
 from typing import Dict, List
 from f1 import f1_scorer
 from inspect_ai import Task, task
@@ -14,30 +13,32 @@ def quac():
         sample_fields=record_to_sample,
         split="validation",
         shuffle=True,
-        trust=True
+        trust=True,
     )
     return Task(
         dataset=dataset,
         scorer=f1_scorer(),
         config=GenerateConfig(temperature=0.5),
     )
-    
+
+
 def record_to_sample(record) -> Sample:
     return Sample(
         input=format_input(record),
         target=format_target(record),
         id=record["dialogue_id"],
     )
-    
+
+
 def format_input(record) -> str:
     wikipedia_title = f"""Wikipedia Page Title: {record["wikipedia_page_title"]}"""
     background = f"""Background: {record["background"]}"""
     section_title = f"""Section Title: {record["section_title"]}"""
     context = f"""Context: {record["context"]}"""
-    
+
     questions = record["questions"]
     previous_questions_answers = []
-    
+
     # We just append everything but the last question for now
     for idx, question in enumerate(questions[:-1]):
         answer = record["answers"]["texts"][idx][0]
@@ -45,12 +46,23 @@ def format_input(record) -> str:
         answer = f"""answer: {answer}"""
         previous_questions_answers.append(question)
         previous_questions_answers.append(answer)
-        
-    # We use the last question as current question for now 
+
+    # We use the last question as current question for now
     current_question = questions[-1]
-    
-    input_str = "\n".join([wikipedia_title, background, section_title, context, "\n".join(previous_questions_answers), current_question, """answer:"""])
+
+    input_str = "\n".join(
+        [
+            wikipedia_title,
+            background,
+            section_title,
+            context,
+            "\n".join(previous_questions_answers),
+            current_question,
+            """answer:""",
+        ]
+    )
     return input_str
 
+
 def format_target(record):
-    return record["answers"]["texts"][-1] # get the answers for the last question only
+    return record["answers"]["texts"][-1]  # get the answers for the last question only

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -1,17 +1,10 @@
+from pprint import pp
 from typing import Dict, List
 from inspect_ai import Task, task
 from inspect_ai.dataset import Sample
 from inspect_ai.dataset._sources.hf import hf_dataset
 from inspect_ai.model import GenerateConfig
 from inspect_ai.scorer import choice
-
-MULTIPLE_CHOICE_TEMPLATE_COT = r"""
-Answer the following multiple choice question. The last line of your response should be of the following format: 'ANSWER: $LETTER' (without quotes) where LETTER is one of {letters}. Think step by step before answering.
-
-{question}
-
-{choices}
-""".strip()
 
 
 @task
@@ -67,7 +60,5 @@ def format_input(doc: Dict) -> str:
     return input_str
 
 def format_target(doc: Dict) -> List[str]:
-    target = doc["answers"]["texts"][-1]
-    # Convert each tuple to str, since 'target' only accepts 'str' or 'List[str]'.
-    target = ["|".join(elm) for elm in target]
+    target = " | ".join(doc["answers"]["texts"][-1])
     return target

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -1,3 +1,13 @@
+"""
+QuAC: A Reading Comprehension Benchmark Requiring Discrete Reasoning Over Dialogs
+
+Eunsol Choi, He He, Mohit Iyyer, Mark Yatskar, Wen-tau Yih†, Yejin Choi, Percy Liang, Luke Zettlemoyer
+https://arxiv.org/pdf/1808.07036
+
+# eval all subjects w/ 500 randomly selected samples
+inspect eval quac.py --limit 1000
+"""
+
 from f1 import f1_scorer
 
 from inspect_ai import Task, task

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -12,12 +12,10 @@ def quac():
     dataset = hf_dataset(
         path="allenai/quac",
         sample_fields=record_to_sample,
-        split="train",
+        split="validation",
         shuffle=True,
         trust=True
     )
-    dataset = dataset[:10]
-    
     return Task(
         dataset=dataset,
         scorer=f1_scorer(),
@@ -31,18 +29,18 @@ def record_to_sample(record) -> Sample:
         id=record["dialogue_id"],
     )
     
-def format_input(doc) -> str:
-    wikipedia_title = f"""wikipedia_page_title: {doc["wikipedia_page_title"]}"""
-    background = f"""background: {doc["background"]}"""
-    section_title = f"""section_title: {doc["section_title"]}"""
-    context = f"""context: {doc["context"]}"""
+def format_input(record) -> str:
+    wikipedia_title = f"""Wikipedia Page Title: {record["wikipedia_page_title"]}"""
+    background = f"""Background: {record["background"]}"""
+    section_title = f"""Section Title: {record["section_title"]}"""
+    context = f"""Context: {record["context"]}"""
     
-    questions = doc["questions"]
+    questions = record["questions"]
     previous_questions_answers = []
     
     # We just append everything but the last question for now
     for idx, question in enumerate(questions[:-1]):
-        answer = doc["answers"]["texts"][idx][0]
+        answer = record["answers"]["texts"][idx][0]
         question = f"""question: {question}"""
         answer = f"""answer: {answer}"""
         previous_questions_answers.append(question)
@@ -54,6 +52,5 @@ def format_input(doc) -> str:
     input_str = "\n".join([wikipedia_title, background, section_title, context, "\n".join(previous_questions_answers), current_question, """answer:"""])
     return input_str
 
-def format_target(doc: Dict) -> List[str]:
-    target = " | ".join(doc["answers"]["texts"][-1])
-    return target
+def format_target(record):
+    return record["answers"]["texts"][-1] # get the answers for the last question only

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -51,6 +51,8 @@ def format_input(doc: Dict) -> str:
     
     questions = doc["questions"]
     previous_questions_answers = []
+    
+    # We just append everything but the last question for now
     for idx, question in enumerate(questions[:-1]):
         answer = doc["answers"]["texts"][idx][0]
         question = f"""question: {question}"""
@@ -58,6 +60,7 @@ def format_input(doc: Dict) -> str:
         previous_questions_answers.append(question)
         previous_questions_answers.append(answer)
         
+    # We use the last question as current question for now 
     current_question = questions[-1]
     
     input_str = "\n".join([wikipedia_title, background, section_title, context, "\n".join(previous_questions_answers), current_question, """answer:"""])

--- a/benchmarks/quac/quac.py
+++ b/benchmarks/quac/quac.py
@@ -1,5 +1,5 @@
-from typing import Dict, List
 from f1 import f1_scorer
+
 from inspect_ai import Task, task
 from inspect_ai.dataset import Sample
 from inspect_ai.dataset._sources.hf import hf_dataset

--- a/benchmarks/quac/test_quac.py
+++ b/benchmarks/quac/test_quac.py
@@ -1,10 +1,11 @@
 import pytest
+from f1 import f1_scorer
+
+from inspect_ai.dataset import Sample
 from inspect_ai.model._model import ModelName
-from inspect_ai.scorer import Target, Score
+from inspect_ai.scorer import Target
 from inspect_ai.scorer._metric import CORRECT, INCORRECT
 from inspect_ai.solver import TaskState
-from inspect_ai.dataset import Sample
-from f1 import f1_scorer, normalize_answer
 
 
 # Helper function to create a TaskState

--- a/benchmarks/quac/test_quac.py
+++ b/benchmarks/quac/test_quac.py
@@ -1,0 +1,90 @@
+import pytest
+from inspect_ai.model._model import ModelName
+from inspect_ai.scorer import Target, Score
+from inspect_ai.scorer._metric import CORRECT, INCORRECT
+from inspect_ai.solver import TaskState
+from inspect_ai.dataset import Sample
+from f1 import f1_scorer, normalize_answer
+
+# Helper function to create a TaskState
+def create_task_state(completion: str) -> TaskState:
+    return TaskState(
+        model=ModelName('openai/gpt-4o-mini'),
+        sample_id='test_id',
+        epoch=0,
+        input=Sample(input='test input'),
+        messages=[],
+        output=type('obj', (object,), {'completion': completion})()
+    )
+
+@pytest.mark.asyncio
+async def test_perfect_match():
+    scorer = f1_scorer()
+    state = create_task_state('The cat sat on the mat.')
+    target = Target(['The cat sat on the mat.', 'banana'])
+    score = await scorer(state, target)
+    assert score.value == pytest.approx(1.0)
+    assert score.answer == 'The cat sat on the mat.'
+
+@pytest.mark.asyncio
+async def test_partial_match():
+    scorer = f1_scorer()
+    state = create_task_state('A cat sat on a mat.')
+    target = Target(['The cat sat on the television.'])
+    score = await scorer(state, target)
+    assert 0 < score.value < 1, f"score value: {score.value}"
+    assert score.answer == 'A cat sat on a mat.', f"score answer: {score.answer}"
+
+@pytest.mark.asyncio
+async def test_no_match():
+    scorer = f1_scorer()
+    state = create_task_state('The dog slept on the floor.')
+    target = Target(['The cat sat on the mat.'])
+    score = await scorer(state, target)
+    assert score.value == pytest.approx(0.0)
+    assert score.answer == 'The dog slept on the floor.'
+
+@pytest.mark.asyncio
+async def test_cannotanswer_correct():
+    scorer = f1_scorer()
+    state = create_task_state('CANNOTANSWER')
+    target = Target(['CANNOTANSWER'])
+    score = await scorer(state, target)
+    assert score.value == CORRECT, f"score value: {score.value}"
+    assert score.answer == 'CANNOTANSWER', f"score answer: {score.answer}"
+
+@pytest.mark.asyncio
+async def test_cannotanswer_incorrect():
+    scorer = f1_scorer()
+    state = create_task_state('CANNOTANSWER')
+    target = Target(['The cat sat on the mat.'])
+    score = await scorer(state, target)
+    assert score.value == INCORRECT, f"score value: {score.value}"
+    assert score.answer == 'CANNOTANSWER', f"score answer: {score.answer}"
+
+@pytest.mark.asyncio
+async def test_multiple_references():
+    scorer = f1_scorer()
+    state = create_task_state('A feline rested on the carpet.')
+    target = Target(['The cat sat on the mat.', 'A feline rested on the rug.', 'The kitten lounged on the carpet.'])
+    score = await scorer(state, target)
+    assert 0 < score.value < 1, f"score value: {score.value}"
+    assert score.answer == 'A feline rested on the carpet.', f"score answer: {score.answer}"
+
+@pytest.mark.asyncio
+async def test_empty_prediction():
+    scorer = f1_scorer()
+    state = create_task_state('')
+    target = Target(['The cat sat on the mat.'])
+    score = await scorer(state, target)
+    assert score.value == pytest.approx(0.0)
+    assert score.answer == ''
+
+@pytest.mark.asyncio
+async def test_empty_target():
+    scorer = f1_scorer()
+    state = create_task_state('The cat sat on the mat.')
+    target = Target([''])
+    score = await scorer(state, target)
+    assert score.value == pytest.approx(0.0)
+    assert score.answer == 'The cat sat on the mat.'

--- a/benchmarks/quac/test_quac.py
+++ b/benchmarks/quac/test_quac.py
@@ -6,85 +6,102 @@ from inspect_ai.solver import TaskState
 from inspect_ai.dataset import Sample
 from f1 import f1_scorer, normalize_answer
 
+
 # Helper function to create a TaskState
 def create_task_state(completion: str) -> TaskState:
     return TaskState(
-        model=ModelName('openai/gpt-4o-mini'),
-        sample_id='test_id',
+        model=ModelName("openai/gpt-4o-mini"),
+        sample_id="test_id",
         epoch=0,
-        input=Sample(input='test input'),
+        input=Sample(input="test input"),
         messages=[],
-        output=type('obj', (object,), {'completion': completion})()
+        output=type("obj", (object,), {"completion": completion})(),
     )
+
 
 @pytest.mark.asyncio
 async def test_perfect_match():
     scorer = f1_scorer()
-    state = create_task_state('The cat sat on the mat.')
-    target = Target(['The cat sat on the mat.', 'banana'])
+    state = create_task_state("The cat sat on the mat.")
+    target = Target(["The cat sat on the mat.", "banana"])
     score = await scorer(state, target)
     assert score.value == pytest.approx(1.0)
-    assert score.answer == 'The cat sat on the mat.'
+    assert score.answer == "The cat sat on the mat."
+
 
 @pytest.mark.asyncio
 async def test_partial_match():
     scorer = f1_scorer()
-    state = create_task_state('A cat sat on a mat.')
-    target = Target(['The cat sat on the television.'])
+    state = create_task_state("A cat sat on a mat.")
+    target = Target(["The cat sat on the television."])
     score = await scorer(state, target)
     assert 0 < score.value < 1, f"score value: {score.value}"
-    assert score.answer == 'A cat sat on a mat.', f"score answer: {score.answer}"
+    assert score.answer == "A cat sat on a mat.", f"score answer: {score.answer}"
+
 
 @pytest.mark.asyncio
 async def test_no_match():
     scorer = f1_scorer()
-    state = create_task_state('The dog slept on the floor.')
-    target = Target(['The cat sat on the mat.'])
+    state = create_task_state("The dog slept on the floor.")
+    target = Target(["The cat sat on the mat."])
     score = await scorer(state, target)
     assert score.value == pytest.approx(0.0)
-    assert score.answer == 'The dog slept on the floor.'
+    assert score.answer == "The dog slept on the floor."
+
 
 @pytest.mark.asyncio
 async def test_cannotanswer_correct():
     scorer = f1_scorer()
-    state = create_task_state('CANNOTANSWER')
-    target = Target(['CANNOTANSWER'])
+    state = create_task_state("CANNOTANSWER")
+    target = Target(["CANNOTANSWER"])
     score = await scorer(state, target)
     assert score.value == CORRECT, f"score value: {score.value}"
-    assert score.answer == 'CANNOTANSWER', f"score answer: {score.answer}"
+    assert score.answer == "CANNOTANSWER", f"score answer: {score.answer}"
+
 
 @pytest.mark.asyncio
 async def test_cannotanswer_incorrect():
     scorer = f1_scorer()
-    state = create_task_state('CANNOTANSWER')
-    target = Target(['The cat sat on the mat.'])
+    state = create_task_state("CANNOTANSWER")
+    target = Target(["The cat sat on the mat."])
     score = await scorer(state, target)
     assert score.value == INCORRECT, f"score value: {score.value}"
-    assert score.answer == 'CANNOTANSWER', f"score answer: {score.answer}"
+    assert score.answer == "CANNOTANSWER", f"score answer: {score.answer}"
+
 
 @pytest.mark.asyncio
 async def test_multiple_references():
     scorer = f1_scorer()
-    state = create_task_state('A feline rested on the carpet.')
-    target = Target(['The cat sat on the mat.', 'A feline rested on the rug.', 'The kitten lounged on the carpet.'])
+    state = create_task_state("A feline rested on the carpet.")
+    target = Target(
+        [
+            "The cat sat on the mat.",
+            "A feline rested on the rug.",
+            "The kitten lounged on the carpet.",
+        ]
+    )
     score = await scorer(state, target)
     assert 0 < score.value < 1, f"score value: {score.value}"
-    assert score.answer == 'A feline rested on the carpet.', f"score answer: {score.answer}"
+    assert (
+        score.answer == "A feline rested on the carpet."
+    ), f"score answer: {score.answer}"
+
 
 @pytest.mark.asyncio
 async def test_empty_prediction():
     scorer = f1_scorer()
-    state = create_task_state('')
-    target = Target(['The cat sat on the mat.'])
+    state = create_task_state("")
+    target = Target(["The cat sat on the mat."])
     score = await scorer(state, target)
     assert score.value == pytest.approx(0.0)
-    assert score.answer == ''
+    assert score.answer == ""
+
 
 @pytest.mark.asyncio
 async def test_empty_target():
     scorer = f1_scorer()
-    state = create_task_state('The cat sat on the mat.')
-    target = Target([''])
+    state = create_task_state("The cat sat on the mat.")
+    target = Target([""])
     score = await scorer(state, target)
     assert score.value == pytest.approx(0.0)
-    assert score.answer == 'The cat sat on the mat.'
+    assert score.answer == "The cat sat on the mat."

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ shortuuid
 tenacity
 typing_extensions>=4.9.0
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
+nltk==3.8.1


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Implementation of Quac Benchmark

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:

#### Questions and TODOS:
- Can we skip current state in a custom scorer easily? If not I need to create a workaround or implement that in the core library
- Evaluation of the full dataset is still missing because of the previous point
- Add benchmark to benchmarks/README.md

#### Development decisions:

- I'm only evaluating on the last question instead of iterating over all questions in the text. This is a simplification of course, but maybe enough (?) 
- I haven't implemented the Human Equivalence Score for questions (HEQ-Q) and for dialogs (HEQ-D) reported in the paper. **However**, it seems like other implementations don't have done that either ([GPT-3 Paper](https://paperswithcode.com/paper/language-models-are-few-shot-learners), and [LLama 3 Paper](https://paperswithcode.com/paper/the-llama-3-herd-of-models))
- I implemented my custom f1 scorer for now, since some custom code was needed (e.g. skipping of states in scorer, return f1 score of 1 for correctly returning "CANNOTANSWER"...). However, a few things can probably be reused and refactored.

