### PR TITLE
Fix eval sets on S3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ dev = [
     "groq", 
     "ipython",
     "mistralai",
+    "moto[server]",
     "mypy",
     "nbformat",
     "openai",

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -452,7 +452,9 @@ def latest_completed_task_eval_logs(
         id_logs = [id_log for id_log in id_logs if id_log[1].status != "started"]
 
         # sort by last file write time
-        id_logs.sort(key=lambda id_log: id_log[0].mtime, reverse=True)
+        id_logs.sort(
+            key=lambda id_log: (id_log[0].mtime if id_log[0].mtime else 0), reverse=True
+        )
 
         # take the most recent
         latest_completed_logs.append(id_logs[0])

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -293,7 +293,9 @@ def log_files_from_ls(
 ) -> list[EvalLogInfo]:
     return [
         log_file_info(file)
-        for file in sorted(ls, key=lambda file: file.mtime, reverse=descending)
+        for file in sorted(
+            ls, key=lambda file: (file.mtime if file.mtime else 0), reverse=descending
+        )
         if file.type == "file" and is_log_file(file.name, extensions)
     ]
 

--- a/src/inspect_ai/log/_retry.py
+++ b/src/inspect_ai/log/_retry.py
@@ -45,7 +45,11 @@ def retryable_eval_logs(logs: list[EvalLogInfo]) -> list[EvalLogInfo]:
             if log_header.eval.task_id not in completed_task_ids:
                 existing_log = retryable_logs.get(log_header.eval.task_id, None)
                 if existing_log:
-                    if log.mtime > existing_log.mtime:
+                    if (
+                        existing_log.mtime is not None
+                        and log.mtime is not None
+                        and log.mtime > existing_log.mtime
+                    ):
                         retryable_logs[log_header.eval.task_id] = log
                 else:
                     retryable_logs[log_header.eval.task_id] = log

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -182,15 +182,22 @@ def mock_s3():
     # Give the server a moment to start up
     time.sleep(1)
 
-    existing_endpoint = os.environ.get("AWS_ENDPOINT_URL", None)
+    existing_env = {
+        key: os.environ.get(key, None)
+        for key in ["AWS_ENDPOINT_URL", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+    }
+
     os.environ["AWS_ENDPOINT_URL"] = "http://127.0.0.1:19100"
+    os.environ["AWS_ACCESS_KEY_ID"] = "unused_id_mock_s3"
+    os.environ["AWS_SECRET_ACCESS_KEY"] = "unused_key_mock_s3"
 
     yield
 
-    if existing_endpoint is None:
-        del os.environ["AWS_ENDPOINT_URL"]
-    else:
-        os.environ["AWS_ENDPOINT_URL"] = existing_endpoint
+    for key, value in existing_env.items():
+        if value is None:
+            del os.environ[key]
+        else:
+            os.environ[key] = value
 
     server.stop()
 

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -176,29 +176,24 @@ def test_latest_completed_task_eval_logs() -> None:
 
 @pytest.fixture(scope="module")
 def mock_s3():
-    temp_dir = tempfile.mkdtemp()
-
     server = ThreadedMotoServer(port=19100)
     server.start()
 
     # Give the server a moment to start up
     time.sleep(1)
 
-    # Set environment variables for the client, preserving existing values if set:
-    existing_env = {
-        key: os.environ.get(key, None)
-        for key in ["AWS_ENDPOINT_URL"]
-    }
-
+    existing_endpoint = os.environ.get("AWS_ENDPOINT_URL", None)
     os.environ["AWS_ENDPOINT_URL"] = "http://127.0.0.1:19100"
 
     yield
 
-    os.environ.update(existing_env)
+    if existing_endpoint is None:
+        del os.environ["AWS_ENDPOINT_URL"]
+    else:
+        os.environ["AWS_ENDPOINT_URL"] = existing_endpoint
 
-    # Teardown: stop the server and remove the temporary directory
     server.stop()
-    os.system(f"rm -r {temp_dir}")
+
 
 def test_eval_set_s3(mock_s3) -> None:
     succces, logs = eval_set(

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -29,26 +29,26 @@ from inspect_ai.solver._solver import generate
 def test_eval_set() -> None:
     # run eval with a solver that fails 20% of the time
     with tempfile.TemporaryDirectory() as log_dir:
-        succces, logs = eval_set(
+        success, logs = eval_set(
             tasks=failing_task(rate=0.2, samples=10),
             log_dir=log_dir,
             retry_attempts=100,
             retry_wait=1,
             model="mockllm/model",
         )
-        assert succces
+        assert success
         assert logs[0].status == "success"
 
     # run eval that is guaranteed to fail
     with tempfile.TemporaryDirectory() as log_dir:
-        succces, logs = eval_set(
+        success, logs = eval_set(
             tasks=failing_task(rate=1, samples=10),
             log_dir=log_dir,
             retry_attempts=1,
             retry_wait=1,
             model="mockllm/model",
         )
-        assert not succces
+        assert not success
         assert logs[0].status == "error"
 
 
@@ -203,12 +203,12 @@ def mock_s3():
 
 
 def test_eval_set_s3(mock_s3) -> None:
-    succces, logs = eval_set(
+    success, logs = eval_set(
         tasks=failing_task(rate=0, samples=1),
         log_dir="s3://test-bucket",
         retry_attempts=1,
         retry_wait=1,
         model="mockllm/model",
     )
-    assert succces
+    assert success
     assert logs[0].status == "success"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The attempt to write the manifest `logs.json` fails on S3 [here](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/_util/file.py#L176) because `timestamp` is not implemented for s3fs.

### What is the new behavior?

The code no longer attempts to retrieve the mtime for a directory file.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

`FileInfo` changes `mtime` from `float` to `float | None` which might break some people's types.

### Other information:

I added a mock S3 server, this should probably be documented and encouraged, since I couldn't find any other tests that use S3.