### PR TITLE
only run moto tests on linux

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ dev = [
     "groq", 
     "ipython",
     "mistralai",
-    "moto[server]",
+    'moto[server]; platform_system == "Linux"',
     "mypy",
     "nbformat",
     "openai",

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -6,8 +6,12 @@ from copy import deepcopy
 from pathlib import Path
 
 import pytest
-from moto.server import ThreadedMotoServer
-from test_helpers.utils import failing_solver, failing_task
+from test_helpers.utils import (
+    failing_solver,
+    failing_task,
+    skip_if_no_flask,
+    skip_if_no_moto,
+)
 
 from inspect_ai import Task
 from inspect_ai._eval.evalset import (
@@ -176,6 +180,8 @@ def test_latest_completed_task_eval_logs() -> None:
 
 @pytest.fixture(scope="module")
 def mock_s3():
+    from moto.server import ThreadedMotoServer
+
     server = ThreadedMotoServer(port=19100)
     server.start()
 
@@ -202,6 +208,8 @@ def mock_s3():
     server.stop()
 
 
+@skip_if_no_flask
+@skip_if_no_moto
 def test_eval_set_s3(mock_s3) -> None:
     success, logs = eval_set(
         tasks=failing_task(rate=0, samples=1),

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -46,6 +46,14 @@ def skip_if_no_transformers(func):
     return skip_if_no_package("transformers")(func)
 
 
+def skip_if_no_flask(func):
+    return skip_if_no_package("flask")(func)
+
+
+def skip_if_no_moto(func):
+    return skip_if_no_package("moto")(func)
+
+
 def skip_if_no_accelerate(func):
     return skip_if_no_package("accelerate")(func)
 


### PR DESCRIPTION
moto package is not available on macos so we carve it out of deps and skip tests that require it

strangely, the skip of moto was not enough for the eval_set_s3 test (also had to skip if no flask)