### PR TITLE
[WIP] Parametrize sandbox environment tests

### DIFF
--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -1,9 +1,9 @@
-from typing import Any, Generic, Optional, Type, TypeVar
+from typing import Any, Callable, Coroutine, Generic, Optional, Type, TypeVar
 
 from inspect_ai.util import SandboxEnvironment
 
 
-def sandbox_test_functions():
+def sandbox_test_functions() -> list[Callable[..., Coroutine[Any, Any, None]]]:
     return [
         test_read_and_write_file_text,
         test_read_and_write_file_binary,

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -1,48 +1,28 @@
-from typing import Any, Callable, Coroutine, Generic, Optional, Type, TypeVar
+from typing import Any, Generic, Optional, Type, TypeVar
 
 from inspect_ai.util import SandboxEnvironment
 
 
-async def check_test_fn(
-    fn: Callable[[SandboxEnvironment], Coroutine[Any, Any, None]],
-    sandbox_env: SandboxEnvironment,
-) -> bool | str:
-    try:
-        await fn(sandbox_env)
-        return True
-    except AssertionError as e:
-        return f"FAILED: {str(e)}"
-    except Exception as e:
-        return f"ERROR: {str(e)}"
-
-
-async def self_check(
-    sandbox_env: SandboxEnvironment,
-    test_fn: Callable[[SandboxEnvironment], Coroutine[Any, Any, None]],
-) -> bool | str:
-    return await check_test_fn(test_fn, sandbox_env)
-
-
-def get_test_functions():
+def sandbox_test_functions():
     return [
         test_read_and_write_file_text,
-        # test_read_and_write_file_binary,
-        # test_read_and_write_file_including_directory_absolute,
-        # test_read_and_write_file_including_directory_relative,
-        # test_read_file_zero_length,
-        # test_read_file_not_found,
-        # test_read_file_not_allowed,
-        # test_read_file_is_directory,
-        # test_read_file_nonsense_name,
-        # test_write_file_zero_length,
-        # test_write_file_is_directory,
-        # test_write_file_without_permissions,
-        # test_exec_timeout,
-        # test_exec_permission_error,
-        # test_cwd_unspecified,
-        # test_cwd_custom,
-        # test_cwd_relative,
-        # test_cwd_absolute,
+        test_read_and_write_file_binary,
+        test_read_and_write_file_including_directory_absolute,
+        test_read_and_write_file_including_directory_relative,
+        test_read_file_zero_length,
+        test_read_file_not_found,
+        test_read_file_not_allowed,
+        test_read_file_is_directory,
+        test_read_file_nonsense_name,
+        test_write_file_zero_length,
+        test_write_file_is_directory,
+        test_write_file_without_permissions,
+        test_exec_timeout,
+        test_exec_permission_error,
+        test_cwd_unspecified,
+        test_cwd_custom,
+        test_cwd_relative,
+        test_cwd_absolute,
     ]
 
 

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -16,32 +16,34 @@ async def check_test_fn(
         return f"ERROR: {str(e)}"
 
 
-async def self_check(sandbox_env: SandboxEnvironment) -> dict[str, bool | str]:
-    results = {}
+async def self_check(
+    sandbox_env: SandboxEnvironment,
+    test_fn: Callable[[SandboxEnvironment], Coroutine[Any, Any, None]],
+) -> bool | str:
+    return await check_test_fn(test_fn, sandbox_env)
 
-    for fn in [
+
+def get_test_functions():
+    return [
         test_read_and_write_file_text,
-        test_read_and_write_file_binary,
-        test_read_and_write_file_including_directory_absolute,
-        test_read_and_write_file_including_directory_relative,
-        test_read_file_zero_length,
-        test_read_file_not_found,
-        test_read_file_not_allowed,
-        test_read_file_is_directory,
-        test_read_file_nonsense_name,
-        test_write_file_zero_length,
-        test_write_file_is_directory,
-        test_write_file_without_permissions,
-        test_exec_timeout,
-        test_exec_permission_error,
-        test_cwd_unspecified,
-        test_cwd_custom,
-        test_cwd_relative,
-        test_cwd_absolute,
-    ]:
-        results[fn.__name__] = await check_test_fn(fn, sandbox_env)
-
-    return results
+        # test_read_and_write_file_binary,
+        # test_read_and_write_file_including_directory_absolute,
+        # test_read_and_write_file_including_directory_relative,
+        # test_read_file_zero_length,
+        # test_read_file_not_found,
+        # test_read_file_not_allowed,
+        # test_read_file_is_directory,
+        # test_read_file_nonsense_name,
+        # test_write_file_zero_length,
+        # test_write_file_is_directory,
+        # test_write_file_without_permissions,
+        # test_exec_timeout,
+        # test_exec_permission_error,
+        # test_cwd_unspecified,
+        # test_cwd_custom,
+        # test_cwd_relative,
+        # test_cwd_absolute,
+    ]
 
 
 async def _cleanup_file(sandbox_env: SandboxEnvironment, filename: str) -> None:

--- a/tests/tools/test_sandbox_docker_and_local.py
+++ b/tests/tools/test_sandbox_docker_and_local.py
@@ -5,7 +5,7 @@ from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai.util._sandbox.docker.docker import DockerSandboxEnvironment
 from inspect_ai.util._sandbox.local import LocalSandboxEnvironment
-from inspect_ai.util._sandbox.self_check import get_test_functions, self_check
+from inspect_ai.util._sandbox.self_check import sandbox_test_functions
 
 
 @pytest.fixture(scope="module")
@@ -68,32 +68,20 @@ async def docker_root_sandbox(request):
 
 @skip_if_no_docker
 @pytest.mark.slow
-@pytest.mark.parametrize("test_fn", get_test_functions())
+@pytest.mark.parametrize("test_fn", sandbox_test_functions())
 async def test_local_sandbox(local_sandbox, test_fn):
-    result = await self_check(local_sandbox, test_fn)
-    assert result, f"Test {test_fn.__name__} failed in local sandbox: {result}"
+    await test_fn(local_sandbox)
 
 
 @skip_if_no_docker
 @pytest.mark.slow
-@pytest.mark.parametrize("test_fn", get_test_functions())
+@pytest.mark.parametrize("test_fn", sandbox_test_functions())
 async def test_docker_nonroot_sandbox(docker_nonroot_sandbox, test_fn):
-    result = await self_check(docker_nonroot_sandbox, test_fn)
-    assert (
-        result
-    ), f"Test {test_fn.__name__} failed in docker non-root sandbox: {result}"
+    await test_fn(docker_nonroot_sandbox)
 
 
 @skip_if_no_docker
 @pytest.mark.slow
-@pytest.mark.parametrize("test_fn", get_test_functions())
+@pytest.mark.parametrize("test_fn", sandbox_test_functions())
 async def test_docker_root_sandbox(docker_root_sandbox, test_fn):
-    result = await self_check(docker_root_sandbox, test_fn)
-    if test_fn.__name__ == "test_write_file_without_permissions":
-        assert (
-            result
-        ), f"Expected {test_fn.__name__} to fail in docker root sandbox, but it passed"
-    else:
-        assert (
-            result
-        ), f"Test {test_fn.__name__} failed in docker root sandbox: {result}"
+    await test_fn(docker_root_sandbox)

--- a/tests/tools/test_sandbox_docker_and_local.py
+++ b/tests/tools/test_sandbox_docker_and_local.py
@@ -1,81 +1,89 @@
 from pathlib import Path
+from typing import AsyncGenerator, Optional, Type
 
 import pytest
+from pytest import FixtureRequest
 from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai.util._sandbox.docker.docker import DockerSandboxEnvironment
+from inspect_ai.util._sandbox.environment import SandboxEnvironment
 from inspect_ai.util._sandbox.local import LocalSandboxEnvironment
 from inspect_ai.util._sandbox.self_check import sandbox_test_functions
 
 
-async def setup_and_teardown_sandbox(request, sandbox_class, sandbox_type, config=None):
+async def setup_and_teardown_sandbox(
+    request: FixtureRequest,
+    sandbox_class: Type[SandboxEnvironment],
+    sandbox_type: str,
+    config: Optional[str] = None,
+) -> AsyncGenerator[SandboxEnvironment, None]:
     task_name = f"{__name__}_{request.node.name}_{sandbox_type}"
 
-    if config and isinstance(config, str):
-        config_file = str(Path(__file__).parent / config)
-    else:
-        config_file = config
-
-    await sandbox_class.task_init(task_name=task_name, config=config_file)
+    await sandbox_class.task_init(task_name=task_name, config=config)
     envs_dict = await sandbox_class.sample_init(
-        task_name=task_name, config=config_file, metadata={}
+        task_name=task_name, config=config, metadata={}
     )
     yield envs_dict["default"]
     await envs_dict["default"].sample_cleanup(
         task_name=task_name,
-        config=config_file,
+        config=config,
         environments=envs_dict,
         interrupted=False,
     )
     await envs_dict["default"].task_cleanup(
-        task_name=task_name, config=config_file, cleanup=True
+        task_name=task_name, config=config, cleanup=True
     )
 
 
 @pytest.fixture(scope="module")
-async def local_sandbox(request):
+async def local_sandbox(
+    request: FixtureRequest,
+) -> AsyncGenerator[SandboxEnvironment, None]:
     async for sandbox in setup_and_teardown_sandbox(
         request, LocalSandboxEnvironment, "local"
     ):
         yield sandbox
 
 
+@skip_if_no_docker
+@pytest.mark.slow
+@pytest.mark.parametrize("test_fn", sandbox_test_functions())
+async def test_local_sandbox(local_sandbox: SandboxEnvironment, test_fn):
+    await test_fn(local_sandbox)
+
+
 @pytest.fixture(scope="module")
-async def docker_nonroot_sandbox(request):
+async def docker_nonroot_sandbox(
+    request: FixtureRequest,
+) -> AsyncGenerator[SandboxEnvironment, None]:
+    config_file = str(Path(__file__).parent / "test_sandbox_compose.yaml")
     async for sandbox in setup_and_teardown_sandbox(
-        request, DockerSandboxEnvironment, "docker_nonroot", "test_sandbox_compose.yaml"
+        request, DockerSandboxEnvironment, "docker_nonroot", config_file
     ):
         yield sandbox
 
 
+@skip_if_no_docker
+@pytest.mark.slow
+@pytest.mark.parametrize("test_fn", sandbox_test_functions())
+async def test_docker_nonroot_sandbox(
+    docker_nonroot_sandbox: SandboxEnvironment, test_fn
+):
+    await test_fn(docker_nonroot_sandbox)
+
+
 @pytest.fixture(scope="module")
-async def docker_root_sandbox(request):
+async def docker_root_sandbox(
+    request: FixtureRequest,
+) -> AsyncGenerator[SandboxEnvironment, None]:
     async for sandbox in setup_and_teardown_sandbox(
         request, DockerSandboxEnvironment, "docker_root"
     ):
         yield sandbox
 
 
-# The test functions remain unchanged
 @skip_if_no_docker
 @pytest.mark.slow
 @pytest.mark.parametrize("test_fn", sandbox_test_functions())
-async def test_local_sandbox(local_sandbox, test_fn):
-    await test_fn(local_sandbox)
-
-
-@skip_if_no_docker
-@pytest.mark.slow
-@pytest.mark.parametrize("test_fn", sandbox_test_functions())
-async def test_docker_nonroot_sandbox(docker_nonroot_sandbox, test_fn):
-    await test_fn(docker_nonroot_sandbox)
-
-
-@skip_if_no_docker
-@pytest.mark.slow
-@pytest.mark.parametrize("test_fn", sandbox_test_functions())
-async def test_docker_root_sandbox(docker_root_sandbox, test_fn):
-    if test_fn.__name__ == "test_write_file_without_permissions":
-        pytest.skip("Root user always has write permissions")
-
+async def test_docker_root_sandbox(docker_root_sandbox: SandboxEnvironment, test_fn):
     await test_fn(docker_root_sandbox)

--- a/tests/tools/test_sandbox_docker_and_local.py
+++ b/tests/tools/test_sandbox_docker_and_local.py
@@ -86,4 +86,7 @@ async def docker_root_sandbox(
 @pytest.mark.slow
 @pytest.mark.parametrize("test_fn", sandbox_test_functions())
 async def test_docker_root_sandbox(docker_root_sandbox: SandboxEnvironment, test_fn):
+    if test_fn.__name__ == "test_write_file_without_permissions":
+        pytest.skip("Root user always has write permissions.")
+
     await test_fn(docker_root_sandbox)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Sandbox tests are parametrized using a for loop rather than pytest native parametrization. This is suboptimal for a number of reasons:

#### 1. All test cases for a given sandbox are grouped together as a single "test" in the test output. 
```python
========================================== test session starts ===========================================
...

tests/tools/test_sandbox_docker_and_local.py::test_self_check_local PASSED                         [ 33%]
tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_custom_nonroot PASSED         [ 66%]
tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_default_root PASSED           [100%]

================================================= PASSES =================================================
```
#### 2. Individual test durations are very long.

This is a kind of frustrating dev experience as the test suite seems unresponsive and like it may be hanging. Plus you don't see test failures until the whole list of sandbox tests has run. 

```python
=========================================== slowest durations ============================================
19.57s call     tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_custom_nonroot
14.05s call     tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_default_root
1.11s call     tests/tools/test_sandbox_docker_and_local.py::test_self_check_local

(6 durations < 0.005s hidden.  Use -vv to show these durations.)
```

#### 3. Stack trace is hard to interpret on test failures
Example: forcing a test to fail:

<details> <summary> diff </summary>

```diff
diff --git a/src/inspect_ai/util/_sandbox/self_check.py b/src/inspect_ai/util/_sandbox/self_check.py
index 924e8b4..e89bf52 100644
--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -50,7 +50,7 @@ async def _cleanup_file(sandbox_env: SandboxEnvironment, filename: str) -> None:
 
 
 async def test_read_and_write_file_text(sandbox_env: SandboxEnvironment) -> None:
-    await sandbox_env.write_file("test_read_and_write_file_text.file", "gret #content")
+    await sandbox_env.write_file("test_read_and_write_file_text.file", "random string")
     written_file_string = await sandbox_env.read_file(
         "test_read_and_write_file_text.file", text=True
     )
```

</details>

In the stack trace below you don't see the actual assertion that fails, instead the assertion error shows up on `if failures: assert False`. And then right at the bottom in the summary you see ` AssertionError: Test test_read_and_write_file_text failed: FAILED: unexpected content: [gret #content]`

<details> <summary> Stack trace </summary>

```python
❯ pytest tests/tools/test_sandbox_docker_and_local.py  --runslow -v --durations=0
...
========================================== test session starts ===========================================
...

tests/tools/test_sandbox_docker_and_local.py::test_self_check_local FAILED                         [ 33%]
tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_custom_nonroot FAILED         [ 66%]
tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_default_root FAILED           [100%]

================================================ FAILURES ================================================
_________________________________________ test_self_check_local __________________________________________

request = <FixtureRequest for <Coroutine test_self_check_local>>

    @skip_if_no_docker
    @pytest.mark.slow
    async def test_self_check_local(request) -> None:
        task_name = f"{__name__}_{request.node.name}_local"

        await LocalSandboxEnvironment.task_init(task_name=task_name, config=None)
        envs_dict = await LocalSandboxEnvironment.sample_init(
            task_name=task_name, config=None, metadata={}
        )

>       return await check_results_of_self_check(task_name, envs_dict)

tests/tools/test_sandbox_docker_and_local.py:21:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

task_name = 'test_sandbox_docker_and_local_test_self_check_local_local'
envs_dict = {'default': <inspect_ai.util._sandbox.local.LocalSandboxEnvironment object at 0x107c37710>}
known_failures = []

    async def check_results_of_self_check(task_name, envs_dict, known_failures=[]):
        sandbox_env = envs_dict["default"]

        try:
            self_check_results = await self_check(sandbox_env)
            failures = []
            for test_name, result in self_check_results.items():
                if result is not True and test_name not in known_failures:
                    failures.append(f"Test {test_name} failed: {result}")
            if failures:
>               assert False, "\n".join(failures)
E               AssertionError: Test test_read_and_write_file_text failed: FAILED: unexpected content: [gret #content]
E               assert False

tests/tools/test_sandbox_docker_and_local.py:67: AssertionError
_________________________________ test_self_check_docker_custom_nonroot __________________________________
... same for other test cases
------------------------------------------ Captured stdout call ------------------------------------------

------------------------------------------ Captured stderr call ------------------------------------------
 default Skipped - Image is already present locally
=========================================== slowest durations ============================================
3.18s call     tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_custom_nonroot
2.55s call     tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_default_root

(7 durations < 0.005s hidden.  Use -vv to show these durations.)
======================================== short test summary info =========================================
FAILED tests/tools/test_sandbox_docker_and_local.py::test_self_check_local - AssertionError: Test test_read_and_write_file_text failed: FAILED: unexpected content: [gret #content]
FAILED tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_custom_nonroot - AssertionError: Test test_read_and_write_file_text failed: FAILED: unexpected content: [gret #content]
FAILED tests/tools/test_sandbox_docker_and_local.py::test_self_check_docker_default_root - AssertionError: Test test_read_and_write_file_text failed: FAILED: unexpected content: [gret #content]
=========================================== 3 failed in 6.34s ============================================
```

</details>

#### 4. Custom logic is required to loop over test cases, print out assertion failures etc. 

Specifically the functions `check_test_fn` and `check_results_of_self_check`. This is duplicating functionality that pytest provides.

#### 5. Selecting individual tests to run requires editing the code

#### 6. Forced to use every test in the suite
Skipping only possible via `known_failures`

### What is the new behavior?

I've updated the tests to use pytest parametrization. This seems much nicer from a dev workflow perspective because it solves most of the issues mentioned above.

#### 1. Each test case / environment pair has its own test case: 
```python
========================================== test session starts ===========================================
...


tests/tools/test_sandbox_docker_and_local.py::test_local_sandbox[test_read_and_write_file_text] PASSED [  1%]
tests/tools/test_sandbox_docker_and_local.py::test_local_sandbox[test_read_and_write_file_binary] PASSED [  3%]

...

tests/tools/test_sandbox_docker_and_local.py::test_docker_root_sandbox[test_cwd_absolute] PASSED   [100%]
tests/tools/test_sandbox_docker_and_local.py::test_docker_root_sandbox[test_cwd_absolute] ERROR    [100%]

...
```
#### 2. Individual test durations reduced by an order of magnitude at least

This improves dev experience, removes worry that tests are hanging, gives quicker feedback

```python
=========================================== slowest durations ============================================
3.12s setup    tests/tools/test_sandbox_docker_and_local.py::test_docker_root_sandbox[test_read_and_write_file_text]
1.99s setup    tests/tools/test_sandbox_docker_and_local.py::test_docker_nonroot_sandbox[test_read_and_write_file_text]
1.90s call     tests/tools/test_sandbox_docker_and_local.py::test_docker_nonroot_sandbox[test_write_file_without_permissions]

...

0.01s call     tests/tools/test_sandbox_docker_and_local.py::test_local_sandbox[test_exec_permission_error]
0.01s call     tests/tools/test_sandbox_docker_and_local.py::test_local_sandbox[test_read_file_not_allowed]

(117 durations < 0.005s hidden.  Use -vv to show these durations.)
```

#### 3. Stack trace tells you exactly which assertion failed.

<details> <summary> example stack trace </summary> 

```python
================================================ FAILURES ================================================
___________________________ test_local_sandbox[test_read_and_write_file_text] ____________________________

local_sandbox = <inspect_ai.util._sandbox.local.LocalSandboxEnvironment object at 0x11314cf20>
test_fn = <function test_read_and_write_file_text at 0x11316b920>

    @skip_if_no_docker
    @pytest.mark.slow
    @pytest.mark.parametrize("test_fn", sandbox_test_functions())
    async def test_local_sandbox(local_sandbox: SandboxEnvironment, test_fn):
>       await test_fn(local_sandbox)

tests/tools/test_sandbox_docker_and_local.py:52:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

sandbox_env = <inspect_ai.util._sandbox.local.LocalSandboxEnvironment object at 0x11314cf20>

    async def test_read_and_write_file_text(sandbox_env: SandboxEnvironment) -> None:
        await sandbox_env.write_file("test_read_and_write_file_text.file", "gret #content")
        written_file_string = await sandbox_env.read_file(
            "test_read_and_write_file_text.file", text=True
        )
        assert (
>           "random string" == written_file_string
        ), f"unexpected content: [{written_file_string}]"
E       AssertionError: unexpected content: ["random string"]

src/inspect_ai/util/_sandbox/self_check.py:40: AssertionError
```

</details>

#### 4. Test cases call the check functions directly, removing need for `check_test_fn` and `check_results_of_self_check`

#### 5. Individual test cases can be selected via `-k`
e.g. 
```python
pytest -k "test_local_sandbox[test_read_and_write_file_including_directory_relative]"
```

This is much nicer for development because when the tests are slow you can choose to run only the test which failed or which you are working on. 

#### 6. Test functions have much more control over which functions they skip
* You can choose to parametrise by a different set of tests
* You can explicitly call "pytest.skip" based on any criterion you can code, not just adding to "known_failures"

Example:
```python

@pytest.mark.parametrize("test_fn", sandbox_test_functions())
async def test_docker_root_sandbox(docker_root_sandbox: SandboxEnvironment, test_fn):
    if test_fn.__name__ == "test_write_file_without_permissions":
        pytest.skip("Root user always has write permissions.")

    await test_fn(docker_root_sandbox)
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Unfortunately it's not working yet! The problem is that when we try to clean up the tests we see an error `LookupError: <ContextVar name='docker_running_projects'`. 

<details> <summary> stack trace </summary>

```python
================================================= ERRORS =================================================
______________ ERROR at teardown of test_docker_root_sandbox[test_read_and_write_file_text] ______________
  + Exception Group Traceback (most recent call last):
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/runner.py", line 341, in from_call
  |     result: TResult | None = func()
  |                              ^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/runner.py", line 242, in <lambda>
  |     lambda: runtest_hook(item=item, **kwds), when=when, reraise=reraise
  |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_hooks.py", line 513, in __call__
  |     return self._hookexec(self.name, self._hookimpls.copy(), kwargs, firstresult)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_manager.py", line 120, in _hookexec
  |     return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
  |            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_callers.py", line 139, in _multicall
  |     raise exception.with_traceback(exception.__traceback__)
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/threadexception.py", line 97, in pytest_runtest_teardown
  |     yield from thread_exception_runtest_hook()
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/threadexception.py", line 68, in thread_exception_runtest_hook
  |     yield
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 100, in pytest_runtest_teardown
  |     yield from unraisable_exception_runtest_hook()
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/unraisableexception.py", line 70, in unraisable_exception_runtest_hook
  |     yield
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/logging.py", line 855, in pytest_runtest_teardown
  |     yield from self._runtest_for(item, "teardown")
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/logging.py", line 831, in _runtest_for
  |     yield
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_callers.py", line 122, in _multicall
  |     teardown.throw(exception)  # type: ignore[union-attr]
  |     ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/capture.py", line 884, in pytest_runtest_teardown
  |     return (yield)
  |             ^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pluggy/_callers.py", line 103, in _multicall
  |     res = hook_impl.function(*args)
  |           ^^^^^^^^^^^^^^^^^^^^^^^^^
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/runner.py", line 189, in pytest_runtest_teardown
  |     item.session._setupstate.teardown_exact(nextitem)
  |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/runner.py", line 557, in teardown_exact
  |     raise exceptions[0]
  | ExceptionGroup: errors while tearing down <Module test_sandbox_docker_and_local.py> (2 sub-exceptions)
  +-+---------------- 1 ----------------
    | Traceback (most recent call last):
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/runner.py", line 546, in teardown_exact
    |     fin()
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/fixtures.py", line 1031, in finish
    |     raise exceptions[0]
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/fixtures.py", line 1020, in finish
    |     fin()
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pytest_asyncio/plugin.py", line 341, in finalizer
    |     event_loop.run_until_complete(async_finalizer())
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    |     return future.result()
    |            ^^^^^^^^^^^^^^^
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pytest_asyncio/plugin.py", line 333, in async_finalizer
    |     await gen_obj.__anext__()  # type: ignore[union-attr]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/rusheb/pcode/inspect_ai/tests/tools/test_sandbox_docker_and_local.py", line 60, in docker_nonroot_sandbox
    |     async for sandbox in setup_and_teardown_sandbox(
    |   File "/Users/rusheb/pcode/inspect_ai/tests/tools/test_sandbox_docker_and_local.py", line 27, in setup_and_teardown_sandbox
    |     await envs_dict["default"].sample_cleanup(
    |   File "/Users/rusheb/pcode/inspect_ai/src/inspect_ai/util/_sandbox/docker/docker.py", line 165, in sample_cleanup
    |     await project_cleanup(project=project, quiet=True)
    |   File "/Users/rusheb/pcode/inspect_ai/src/inspect_ai/util/_sandbox/docker/cleanup.py", line 36, in project_cleanup
    |     if project in running_projects():
    |                   ^^^^^^^^^^^^^^^^^^
    |   File "/Users/rusheb/pcode/inspect_ai/src/inspect_ai/util/_sandbox/docker/cleanup.py", line 127, in running_projects
    |     return _running_projects.get()
    |            ^^^^^^^^^^^^^^^^^^^^^^^
    | LookupError: <ContextVar name='docker_running_projects' at 0x1054ead90>
    +---------------- 2 ----------------
    | Traceback (most recent call last):
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/runner.py", line 546, in teardown_exact
    |     fin()
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/fixtures.py", line 1031, in finish
    |     raise exceptions[0]
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/_pytest/fixtures.py", line 1020, in finish
    |     fin()
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pytest_asyncio/plugin.py", line 341, in finalizer
    |     event_loop.run_until_complete(async_finalizer())
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    |     return future.result()
    |            ^^^^^^^^^^^^^^^
    |   File "/Users/rusheb/miniconda3/envs/inspect/lib/python3.12/site-packages/pytest_asyncio/plugin.py", line 333, in async_finalizer
    |     await gen_obj.__anext__()  # type: ignore[union-attr]
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^
    |   File "/Users/rusheb/pcode/inspect_ai/tests/tools/test_sandbox_docker_and_local.py", line 79, in docker_root_sandbox
    |     async for sandbox in setup_and_teardown_sandbox(
    |   File "/Users/rusheb/pcode/inspect_ai/tests/tools/test_sandbox_docker_and_local.py", line 27, in setup_and_teardown_sandbox
    |     await envs_dict["default"].sample_cleanup(
    |   File "/Users/rusheb/pcode/inspect_ai/src/inspect_ai/util/_sandbox/docker/docker.py", line 165, in sample_cleanup
    |     await project_cleanup(project=project, quiet=True)
    |   File "/Users/rusheb/pcode/inspect_ai/src/inspect_ai/util/_sandbox/docker/cleanup.py", line 36, in project_cleanup
    |     if project in running_projects():
    |                   ^^^^^^^^^^^^^^^^^^
    |   File "/Users/rusheb/pcode/inspect_ai/src/inspect_ai/util/_sandbox/docker/cleanup.py", line 127, in running_projects
    |     return _running_projects.get()
    |            ^^^^^^^^^^^^^^^^^^^^^^^
    | LookupError: <ContextVar name='docker_running_projects' at 0x1054ead90>
    +------------------------------------
----------------------------------------- Captured stdout setup ------------------------------------------
```

</details>

My guess at what is happening is that the teardown is using a different async context to the actual tests and so the `running_projects` context var is not set. This also leads to the docker compose file that the tests generate failing to get deleted.

Unfortunately my async knowledge isn't good enough to resolve this myself, but if you think this would be a worthwhile improvement then I would be happy to collaborate to resolve it with someone with better async knowledge. 