### PR TITLE
Fix Docstring has no attribute description error

### DIFF
--- a/src/inspect_ai/tool/_tool_info.py
+++ b/src/inspect_ai/tool/_tool_info.py
@@ -119,9 +119,7 @@ def parse_tool_info(func: Callable[..., Any]) -> ToolInfo:
 
     # Add function description if available
     if parsed_docstring:
-        if parsed_docstring.description:
-            info.description = parsed_docstring.description.strip()
-        elif parsed_docstring.long_description:
+        if parsed_docstring.long_description:
             info.description = parsed_docstring.long_description.strip()
         elif parsed_docstring.short_description:
             info.description = parsed_docstring.short_description.strip()


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When running end-to-end tests of an Inspect-native evaluation I built, I get the following issue:

![image](https://github.com/user-attachments/assets/1ed7e06d-a6b4-4fef-90db-e12ce613a2d6)

Examining the code, I notice that this error is correct, and the Docstring object has no description parameter. Thus, it should never be checked, so I removed those lines. (Note: This may not be intended, and Docstring may be supposed to have a description parameter - if so, I am open to another fix. This isn't urgent since I can change my library copy accordingly)

### What is the new behavior?

When making this change in my library copy of Inspect, the tests now pass correctly, and the error does not happen.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:
