### PR TITLE
Provide a default value if an add operation is missing a value

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -18430,11 +18430,17 @@ const initStateManager = () => {
     applyChanges: (changes) => {
       state = applyPatch(
         structuredClone(state),
-        structuredClone(changes),
+        structuredClone(changes).map(ensureValidChange),
         true
       ).newDocument;
     }
   };
+};
+const ensureValidChange = (change) => {
+  if (change.op === "add" && !change.value) {
+    change.value = null;
+  }
+  return change;
 };
 const TranscriptView = ({ id, events, stateManager, depth = 0 }) => {
   const resolvedEvents = fixupEventStream(events);
@@ -18566,7 +18572,6 @@ const RenderedEventNode = ({ id, node, style, stateManager }) => {
       return m$1`<${ErrorEventView}
         id=${id}
         event=${node.event}
-        stateManager=${stateManager}
         style=${style}
       />`;
     default:

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptState.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptState.mjs
@@ -33,9 +33,23 @@ export const initStateManager = () => {
     applyChanges: (changes) => {
       state = applyPatch(
         structuredClone(state),
-        structuredClone(changes),
+        structuredClone(changes).map(ensureValidChange),
         true,
       ).newDocument;
     },
   };
+};
+
+/**
+ * Ensures that the change is valid (provides default values)
+ * If the operation is "add" and `value` is not present, it assigns `null` to `value`.
+ *
+ * @param { import("../../types/log").JsonChange } change - The change object containing the operation and value.
+ * @returns {Object} The modified change object with a guaranteed `value` property.
+ */
+const ensureValidChange = (change) => {
+  if (change.op === "add" && !change.value) {
+    change.value = null;
+  }
+  return change;
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -189,7 +189,6 @@ export const RenderedEventNode = ({ id, node, style, stateManager }) => {
       return html`<${ErrorEventView}
         id=${id}
         event=${node.event}
-        stateManager=${stateManager}
         style=${style}
       />`;
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

I suspect that this is caused by a state change with `None` for a value. This results in JsonChange which has no value, which isn't value. Provide a a `null` default value in this case.