### PR TITLE
VSCode: 0.3.30 - Less restrictive `open with` command

### DIFF
--- a/tools/vscode/CHANGELOG.md
+++ b/tools/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.31
+
+- Don't restrict the availability of the `Open with Inspect View` command based upon the filename.
+
 ## 0.3.30
 
 - Further refinement to Inspect View behavior when a task is complete. We will now refresh the viewer without bringing it the foreground when it is already displaying and a task completes. This will ensure that focus is handled correctly in the editor. Use `cmd+shift+L` to bring the viewer to the foreground (or show it if it isn't showing).

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "UK AI Safety Institute"
   },
-  "version": "0.3.30",
+  "version": "0.3.31",
   "license": "MIT",
   "homepage": "https://inspect.ai-safety-institute.org.uk/",
   "repository": {

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -265,7 +265,7 @@
         {
           "command": "inspect.openInInspectView",
           "group": "navigation@100",
-          "when": "inspect_ai.enableOpenInView && resourceFilename =~ /^\\d{4}-\\d{2}-\\d{2}T\\d{2}[:-]\\d{2}[:-]\\d{2}.*\\.json/"
+          "when": "inspect_ai.enableOpenInView && resourceFilename =~ /^.*\\.json$/"
         }
       ],
       "view/item/context": [


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

The command will appear for any json file now. When the command is executed, we verify that the file appears to be a log file.