### PR TITLE
Impove Sample Tab Selection

### DIFF
--- a/src/inspect_ai/_view/www/src/components/LargeModal.mjs
+++ b/src/inspect_ai/_view/www/src/components/LargeModal.mjs
@@ -3,7 +3,17 @@ import { html } from "htm/preact";
 import { FontSize } from "../appearance/Fonts.mjs";
 
 export const LargeModal = (props) => {
-  const { id, title, detail, detailTools, footer, onkeyup, children } = props;
+  const {
+    id,
+    title,
+    detail,
+    detailTools,
+    footer,
+    onkeyup,
+    visible,
+    onHide,
+    children,
+  } = props;
 
   // The footer
   const modalFooter = footer
@@ -61,7 +71,9 @@ export const LargeModal = (props) => {
   headerEls.push(html`<button
       type="button"
       class="btn btn-close-large-dialog"
-      data-bs-dismiss="modal"
+      onclick=${() => {
+        onHide();
+      }}
       aria-label="Close"
       style=${{
         borderWidth: "0px",
@@ -81,7 +93,11 @@ export const LargeModal = (props) => {
     tabindex="0"
     role="dialog"
     onkeyup=${onkeyup}
-    style=${{ borderRadius: "var(--bs-border-radius)" }}
+    style=${{
+      borderRadius: "var(--bs-border-radius)",
+      display: visible ? "block" : "none",
+    }}
+    tabindex=${visible ? 0 : undefined}
   >
     <div
       class="modal-dialog modal-dialog-scrollable"

--- a/src/inspect_ai/_view/www/src/samples/SampleDialog.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDialog.mjs
@@ -16,13 +16,15 @@ export const SampleDialog = (props) => {
     sampleDescriptor,
     nextSample,
     prevSample,
+    sampleDialogVisible,
+    hideSample,
     context,
   } = props;
 
   // If there is no sample, just show an empty panel
   // This should never happen
   if (!sample) {
-    return html`<${LargeModal} id=${id} title="No Sample"><${EmptyPanel}>No Sample Selected</${EmptyPanel}></${LargeModal}>`;
+    return html`<${LargeModal} visible=${sampleDialogVisible} onHide=${hideSample} id=${id} title="No Sample"><${EmptyPanel}>No Sample Selected</${EmptyPanel}></${LargeModal}>`;
   }
 
   const tools = useMemo(() => {
@@ -59,6 +61,9 @@ export const SampleDialog = (props) => {
             prevSample();
           }
           break;
+        case "Escape":
+          hideSample();
+          break;
       }
     },
     [prevSample, nextSample],
@@ -71,12 +76,15 @@ export const SampleDialog = (props) => {
       detail=${title}
       detailTools=${tools}
       onkeyup=${handleKeyUp}   
+      visible=${sampleDialogVisible}
+      onHide=${hideSample}
     >
     <${SampleDisplay}
       index=${index}
       id=${id}
       sample=${sample}
       sampleDescriptor=${sampleDescriptor}
+      visible=${sampleDialogVisible}
       context=${context}/>
     </${LargeModal}>`;
 };

--- a/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
@@ -42,24 +42,31 @@ export const InlineSampleDisplay = ({
   </div>`;
 };
 
-export const SampleDisplay = ({ index, sample, sampleDescriptor, context }) => {
+export const SampleDisplay = ({
+  sample,
+  sampleDescriptor,
+  visible,
+  context,
+}) => {
   // Tab ids
-  const baseId = `sample-${index}`;
+  const baseId = `sample-dialog`;
   const msgTabId = `${baseId}-messages`;
   const transcriptTabId = `${baseId}-transcript`;
   const scoringTabId = `${baseId}-scoring`;
   const metdataTabId = `${baseId}-metadata`;
   const errorTabId = `${baseId}-error`;
 
-  // Upon sample update
+  // Upon new dialog
   useEffect(() => {
-    // reset tabs when sample changes
-    if (sample.transcript && sample.transcript.events.length > 0) {
-      setSelectedTab(transcriptTabId);
-    } else {
-      setSelectedTab(msgTabId);
+    // reset tabs when the dialog loads
+    if (!visible) {
+      const defaultTab =
+        sample.transcript && sample.transcript.events.length
+          ? transcriptTabId
+          : msgTabId;
+      setSelectedTab(defaultTab);
     }
-  }, [sample]);
+  }, [visible]);
 
   // Tab selection
   const [selectedTab, setSelectedTab] = useState(undefined);

--- a/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
@@ -1,4 +1,3 @@
-import { Modal } from "bootstrap";
 import { html } from "htm/preact";
 import { useCallback, useEffect, useRef, useState } from "preact/hooks";
 
@@ -27,6 +26,7 @@ export const SamplesTab = (props) => {
 
   const sampleListRef = useRef(/** @type {HTMLElement|null} */ (null));
   const sampleDialogRef = useRef(/** @type {HTMLElement|null} */ (null));
+  const [sampleDialogVisible, setSampleDialogVisible] = useState(false);
 
   // Re-filter the samples
   useEffect(() => {
@@ -50,36 +50,19 @@ export const SamplesTab = (props) => {
 
   // Shows the sample dialog
   const showSample = useCallback(() => {
-    const dialogEl = sampleDialogRef.current;
-    if (dialogEl) {
-      const modal = new Modal(dialogEl.base);
-      modal.show();
-    }
-  }, [sampleDialogRef]);
+    setSampleDialogVisible(true);
+    setTimeout(() => {
+      sampleDialogRef.current.base.focus();
+    }, 0);
+  }, [setSampleDialogVisible, sampleDialogRef]);
 
   const hideSample = useCallback(() => {
-    const dialogEl = sampleDialogRef.current;
-    if (dialogEl && dialogEl.base) {
-      const modal = Modal.getInstance(dialogEl.base);
-      if (modal) {
-        modal.hide();
-      }
+    setSampleDialogVisible(false);
+    const listEl = sampleListRef.current;
+    if (listEl && listEl.base) {
+      listEl.base.focus();
     }
-  }, [sampleDialogRef]);
-
-  // When the sample dialog is dismissed, move the focus to the
-  // to the list itself
-  useEffect(() => {
-    const dialogEl = sampleDialogRef.current;
-    if (dialogEl) {
-      dialogEl.base.addEventListener("hidden.bs.modal", () => {
-        const listEl = sampleListRef.current;
-        if (listEl) {
-          listEl.base.focus();
-        }
-      });
-    }
-  }, [sampleDialogRef, sampleListRef]);
+  }, [setSampleDialogVisible]);
 
   useEffect(() => {
     // Sort the samples
@@ -191,6 +174,8 @@ export const SamplesTab = (props) => {
       sampleDescriptor=${sampleDescriptor}
       nextSample=${nextSample}
       prevSample=${previousSample}
+      sampleDialogVisible=${sampleDialogVisible}
+      hideSample=${hideSample}
       context=${context}
     />
   `);


### PR DESCRIPTION
Previously, when moving between samples using `next` and `previous`, the tab would reset. This is annoying- the tab should only reset when the dialog is dismissed and re-opened.

This required converting from using bootstrap + javascript to manage the modal to using preact state to manage the modal.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

