### PR TITLE
Make sandbox env use generic types

### DIFF
--- a/src/inspect_ai/util/_sandbox/registry.py
+++ b/src/inspect_ai/util/_sandbox/registry.py
@@ -1,4 +1,4 @@
-from typing import Callable, cast
+from typing import Callable, cast, Type, TypeVar
 
 from inspect_ai._util.entrypoints import ensure_entry_points
 from inspect_ai._util.registry import (
@@ -11,22 +11,19 @@ from inspect_ai._util.registry import (
 
 from .environment import SandboxEnvironment
 
+T = TypeVar('T', bound=SandboxEnvironment)
 
-def sandboxenv(name: str) -> Callable[..., type[SandboxEnvironment]]:
+def sandboxenv(name: str) -> Callable[[Type[T]], Type[T]]:
     r"""Decorator for registering sandbox environments.
 
     Args:
         name (str): Name of SandboxEnvironment type
     """
-
-    def wrapper(
-        sandboxenv_type: type[SandboxEnvironment]
-        | Callable[..., type[SandboxEnvironment]],
-    ) -> type[SandboxEnvironment]:
+    
+    def wrapper(sandboxenv_type: Type[T] | Callable[..., Type[T]]) -> Type[T]:
         # resolve if its a function
         if not isinstance(sandboxenv_type, type):
             sandboxenv_type = sandboxenv_type()
-
         # determine name
         sandboxenv_name = registry_name(sandboxenv_type, name)
 
@@ -37,8 +34,8 @@ def sandboxenv(name: str) -> Callable[..., type[SandboxEnvironment]]:
 
 
 def sandboxenv_register(
-    sandboxenv_type: type[SandboxEnvironment], name: str
-) -> type[SandboxEnvironment]:
+    sandboxenv_type: Type[T], name: str
+) -> Type[T]:
     registry_add(
         sandboxenv_type,
         RegistryInfo(type="sandboxenv", name=name),

--- a/src/inspect_ai/util/_sandbox/registry.py
+++ b/src/inspect_ai/util/_sandbox/registry.py
@@ -13,7 +13,7 @@ from .environment import SandboxEnvironment
 
 T = TypeVar('T', bound=SandboxEnvironment)
 
-def sandboxenv(name: str) -> Callable[[Type[T]], Type[T]]:
+def sandboxenv(name: str) -> Callable[..., Type[T]]:
     r"""Decorator for registering sandbox environments.
 
     Args:

--- a/src/inspect_ai/util/_sandbox/registry.py
+++ b/src/inspect_ai/util/_sandbox/registry.py
@@ -1,4 +1,4 @@
-from typing import Callable, cast, Type, TypeVar
+from typing import Callable, Type, TypeVar, cast
 
 from inspect_ai._util.entrypoints import ensure_entry_points
 from inspect_ai._util.registry import (
@@ -11,7 +11,8 @@ from inspect_ai._util.registry import (
 
 from .environment import SandboxEnvironment
 
-T = TypeVar('T', bound=SandboxEnvironment)
+T = TypeVar("T", bound=SandboxEnvironment)
+
 
 def sandboxenv(name: str) -> Callable[..., Type[T]]:
     r"""Decorator for registering sandbox environments.
@@ -19,7 +20,7 @@ def sandboxenv(name: str) -> Callable[..., Type[T]]:
     Args:
         name (str): Name of SandboxEnvironment type
     """
-    
+
     def wrapper(sandboxenv_type: Type[T] | Callable[..., Type[T]]) -> Type[T]:
         # resolve if its a function
         if not isinstance(sandboxenv_type, type):
@@ -33,9 +34,7 @@ def sandboxenv(name: str) -> Callable[..., Type[T]]:
     return wrapper
 
 
-def sandboxenv_register(
-    sandboxenv_type: Type[T], name: str
-) -> Type[T]:
+def sandboxenv_register(sandboxenv_type: Type[T], name: str) -> Type[T]:
     registry_add(
         sandboxenv_type,
         RegistryInfo(type="sandboxenv", name=name),


### PR DESCRIPTION
The `sandboxenv` decorator can mess with any classes that inherit from `SandboxEnvironment`, as it returns a `SandboxEnv` type rather than the same type that was passed in. Using generic types should fix this. 

Below is a minimal reproduction of the error (you'll need to do this in an environment with a linter or run mypy/pyright over the file):

```python
from inspect_ai.util._sandbox.environment import SandboxEnvironment
from inspect_ai.util._sandbox.registry import sandboxenv

@sandboxenv(name="mocksandbox")
class MockSandbox(SandboxEnvironment):
    def specific_method(self):
        pass

mock_sandbox: MockSandbox = MockSandbox()
# On main, you should see a type check error here, and `mock_sandbox` will be of type `SandboxEnvironment`
# With the fix, you should see that it's type `MockSandbox` and the error should be gone.
mock_sandbox.specific_method()  
```

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
see example above
### What is the new behavior?
see example above
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
no
### Other information:
