### PR TITLE
Clarify scorer can access sandbox.

### DIFF
--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -355,6 +355,8 @@ The following instance methods are available to tools that need to interact with
 
 {{< include _sandboxenv-interface.md >}}
 
+The sandbox is also available to custom [scorers](#sec-sandbox-access).
+
 ### Environment Binding
 
 There are two sandbox environments built in to Inspect:
@@ -364,7 +366,7 @@ There are two sandbox environments built in to Inspect:
 | `local` | Run `sandbox()` methods in the same file system as the running evaluation (should *only be used* if you are already running your evaluation in another sandbox). |
 | `docker` | Run `sandbox()` methods within a Docker container (see the [Docker Configuration](#sec-docker-configuration) section below for additional details). |
 
-Sandbox environments can be bound at the `Sample`, `Task`, or `eval()` level. Binding precedence goes from `eval()`, to `Task` to `Sample`, however sandbox config files defined on the `Sample` always take precedence when the sandbox type for the `Sample` is the same as the enclosing `Task` or `eval()`.
+Sandbox environment definitions can be bound at the `Sample`, `Task`, or `eval()` level. Binding precedence goes from `eval()`, to `Task` to `Sample`, however sandbox config files defined on the `Sample` always take precedence when the sandbox type for the `Sample` is the same as the enclosing `Task` or `eval()`.
 
 Here is a `Task` that defines a `sandbox` and corresponding sandbox config file:
 
@@ -392,7 +394,7 @@ The `Sample` class includes `sandbox`, `files` and `setup` fields that are used 
 
 #### Sandbox {#sec-per-sample-sandbox}
 
-You can either define a default `sandbox` for an entire `Task` as illustrated abvove, or alternatively define a per-sample `sandbox`. For example, you might want to do this if each sample has its own Dockerfile and/or custom compose configuration file.
+You can either define a default `sandbox` for an entire `Task` as illustrated abvove, or alternatively define a per-sample `sandbox`. For example, you might want to do this if each sample has its own Dockerfile and/or custom compose configuration file. (Note, each sample gets its own sandbox *instance*, even if the sandbox is defined at Task level. So samples do not interfere with each other's sandboxes.)
 
 The `sandbox` can be specified as a string (e.g. `"docker`") or a list of sandbox type and config file (e.g. `["docker", "compose.yaml"]`).
 

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -404,6 +404,60 @@ multi_scorer(
 Use of `multi_scorer()` requires both a list of scorers as well as a *reducer* which determines how a list of scores will be turned into a single score. In this case we use the "mode" reducer which returns the score that appeared most frequently in the answers.
 
 
+### Sandbox access
+
+If your Solver is an [agent](agents) with tool use, you might want to inspect the contents of the tool sandbox to score the task.
+
+The contents of the sandbox for the Sample are available to the scorer; simply call `await sandbox().read_file()` (or `.exec()`).
+
+For example:
+
+
+```python
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import Score, Target, accuracy, scorer
+from inspect_ai.solver import Plan, TaskState, generate, use_tools
+from inspect_ai.tool import bash
+from inspect_ai.util import sandbox
+
+
+@scorer(metrics=[accuracy()])
+def check_file_exists():
+    async def score(state: TaskState, target: Target):
+        try:
+            _ = await sandbox().read_file(target.text)
+            exists = True
+        except FileNotFoundError:
+            exists = False
+        return Score(value=1 if exists else 0)
+
+    return score
+
+
+@task
+def challenge() -> Task:
+    return Task(
+        dataset=[
+            Sample(
+                input="Create a file called hello-world.txt",
+                target="hello-world.txt",
+            )
+        ],
+        plan=Plan(
+            [
+                use_tools([bash()]),
+                generate(),
+            ]
+        ),
+        sandbox="local",
+        scorer=check_file_exists(),
+    )
+
+```
+
+
+
 ## Scoring Metrics
 
 Each scorer provides one or more built-in metrics (typically `accuracy` and `stderr`) corresponding to the most typically useful metrics for that scorer.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

There were multiple enquires about how to access the sandbox from a scorer. It's trivial, but undocumented.

### What is the new behavior?

Now documented.

I also found the docs a bit ambiguous about the sandbox lifecycle so I tried to clarify it.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

I am not convinced I've got the correct qmd syntax for links in this PR