### PR TITLE
Skip reducing scores if only one epoch

### DIFF
--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -155,6 +155,7 @@ async def task_score(task: Task, log: EvalLog) -> EvalLog:
                     value=score.value,
                     answer=score.answer,
                     explanation=score.explanation,
+                    metadata=score.metadata,
                 )
                 for score_key, score in sample.scores.items()
             }
@@ -188,6 +189,7 @@ async def run_score_task(
             value=result.value,
             answer=result.answer,
             explanation=result.explanation,
+            metadata=result.metadata,
         )
 
     progress()

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -284,7 +284,14 @@ def reduce_scores(
         if sample_score.sample_id is not None:
             grouped_scores[str(sample_score.sample_id)].append(sample_score)
 
-    # reduce the scores
+    # count epochs to be reduced
+    epochs = len(next(iter(grouped_scores.values()), []))
+
+    # if only one epoch, no need to reduce, also avoids losing score attributes
+    if epochs == 1:
+        return scores, epochs
+
+    # more than one epoch, need to reduce the scores
     reduced_scores: list[SampleScore] = []
     for scores in grouped_scores.values():
         reduced = reducer(cast(list[Score], scores))
@@ -292,13 +299,12 @@ def reduce_scores(
             SampleScore(
                 sample_id=scores[0].sample_id,
                 value=reduced.value,
+                answer=reduced.answer,
                 explanation=reduced.explanation,
                 metadata=reduced.metadata,
             )
         )
 
-    # count epochs reduced
-    epochs = len(next(iter(grouped_scores.values()), []))
     return reduced_scores, epochs
 
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -359,6 +359,7 @@ async def task_run_sample(
                         value=score.value,
                         answer=score.answer,
                         explanation=score.explanation,
+                        metadata=score.metadata,
                         sample_id=previous_sample.id,
                     )
                     for key, score in previous_sample.scores.items()


### PR DESCRIPTION
Also add missing attributes when creating `SampleScore`'s.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Custom metrics can't access any other `Score` attribute except `value` (issue #400) 

### What is the new behavior?
Score reducer isn't executed if there is only one epoch and all `Score` attributes are referenced when creating `SampleScore` objects throughout the codebase.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Haven't used Inspect before PR #148 that introduced score reducers for epochs so don't know how it worked before, but I'd say this PR is trying to fix a regression.

### Other information:
