### PR TITLE
Correct eval_log_headers implementation

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -22084,10 +22084,20 @@ function simpleHttpAPI(logInfo) {
       cache.set(response.parsed);
       return response;
     },
-    eval_log_headers: async () => {
+    eval_log_headers: async (files) => {
       const headers = await fetchLogHeaders(log_dir);
       if (headers) {
-        return Object.values(headers.parsed);
+        const keys = Object.keys(headers.parsed);
+        const result = [];
+        files.forEach((file) => {
+          const fileKey = keys.find((key2) => {
+            return file.endsWith(key2);
+          });
+          if (fileKey) {
+            result.push(headers.parsed[fileKey]);
+          }
+        });
+        return result;
       } else if (log_file) {
         let evalLog = cache.get();
         if (!evalLog) {

--- a/src/inspect_ai/_view/www/src/api/api-http.mjs
+++ b/src/inspect_ai/_view/www/src/api/api-http.mjs
@@ -88,10 +88,20 @@ function simpleHttpAPI(logInfo) {
       cache.set(response.parsed);
       return response;
     },
-    eval_log_headers: async () => {
+    eval_log_headers: async (files) => {
       const headers = await fetchLogHeaders(log_dir);
       if (headers) {
-        return Object.values(headers.parsed);
+        const keys = Object.keys(headers.parsed);
+        const result = [];
+        files.forEach((file) => {
+          const fileKey = keys.find((key) => {
+            return file.endsWith(key);
+          });
+          if (fileKey) {
+            result.push(headers.parsed[fileKey]);
+          }
+        });
+        return result;
       } else if (log_file) {
         // Check the cache
         let evalLog = cache.get();


### PR DESCRIPTION
It needs to only return the requested files.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
