### PR TITLE
more flexible external specifications of plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #.idea/
 *.*workspace
 data/datasets/*/hidden
-logs/
+logs*/
 
 # thumbnails
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -162,7 +162,7 @@ cython_debug/
 #.idea/
 *.*workspace
 data/datasets/*/hidden
-logs*/
+logs/
 
 # thumbnails
 .DS_Store

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ norecursedirs = [
     "tests/test_task_list",
 ]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 log_level = "warning"
 
 [tool.mypy]

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -73,7 +73,7 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
     )
     @click.option(
         "--plan",
-        type="str",
+        type=str,
         envvar="INSPECT_EVAL_PLAN",
         help="Plan to execute (overrides task default plan)",
     )

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -18,6 +18,7 @@ from inspect_ai._util.samples import parse_samples_limit
 from inspect_ai.log._file import log_file_info
 from inspect_ai.model import GenerateConfigArgs
 from inspect_ai.scorer._reducer import create_reducers
+from inspect_ai.solver._plan import PlanSpec
 
 from .common import CommonOptions, common_options, resolve_common_options
 from .util import parse_cli_args, parse_sandbox
@@ -60,7 +61,7 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         "-M",
         multiple=True,
         type=str,
-        envvar=["INSPECT_EVAL_MODEL_ARGS"],
+        envvar="INSPECT_EVAL_MODEL_ARGS",
         help="One or more native model arguments (e.g. -M arg=value)",
     )
     @click.option(
@@ -69,6 +70,19 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         type=str,
         envvar="INSPECT_EVAL_TASK_ARGS",
         help="One or more task arguments (e.g. -T arg=value)",
+    )
+    @click.option(
+        "--plan",
+        type="str",
+        envvar="INSPECT_EVAL_PLAN",
+        help="Plan to execute (overrides task default plan)",
+    )
+    @click.option(
+        "-P",
+        multiple=True,
+        type=str,
+        envvar="INSPECT_EVAL_PLAN_ARGS",
+        help="One or more plan arguments (e.g. -P arg=value)",
     )
     @click.option(
         "--sandbox",
@@ -292,10 +306,12 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 @eval_options
 def eval_command(
     tasks: tuple[str] | None,
+    plan: str | None,
     model: str,
     model_base_url: str | None,
     m: tuple[str] | None,
     t: tuple[str] | None,
+    p: tuple[str] | None,
     sandbox: str | None,
     no_sandbox_cleanup: bool | None,
     epochs: int | None,
@@ -343,12 +359,14 @@ def eval_command(
     # exec eval
     eval_exec(
         tasks=tasks,
+        plan=plan,
         log_level=log_level,
         log_dir=log_dir,
         model=model,
         model_base_url=model_base_url,
         m=m,
         t=t,
+        p=p,
         sandbox=sandbox,
         no_sandbox_cleanup=no_sandbox_cleanup,
         epochs=epochs,
@@ -420,10 +438,12 @@ def eval_set_command(
     retry_wait: int | None,
     retry_connections: float | None,
     no_retry_cleanup: bool | None,
+    plan: str | None,
     model: str,
     model_base_url: str | None,
     m: tuple[str] | None,
     t: tuple[str] | None,
+    p: tuple[str] | None,
     sandbox: str | None,
     no_sandbox_cleanup: bool | None,
     epochs: int | None,
@@ -473,12 +493,14 @@ def eval_set_command(
     # exec eval
     success = eval_exec(
         tasks=tasks,
+        plan=plan,
         log_level=log_level,
         log_dir=log_dir,
         model=model,
         model_base_url=model_base_url,
         m=m,
         t=t,
+        p=p,
         sandbox=sandbox,
         no_sandbox_cleanup=no_sandbox_cleanup,
         epochs=epochs,
@@ -511,12 +533,14 @@ def eval_set_command(
 
 def eval_exec(
     tasks: tuple[str] | None,
+    plan: str | None,
     log_level: str,
     log_dir: str,
     model: str,
     model_base_url: str | None,
     m: tuple[str] | None,
     t: tuple[str] | None,
+    p: tuple[str] | None,
     sandbox: str | None,
     no_sandbox_cleanup: bool | None,
     epochs: int | None,
@@ -542,8 +566,9 @@ def eval_exec(
     bundle_overwrite: bool = False,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> bool:
-    # parse params and model args
+    # parse task, plan, and model args
     task_args = parse_cli_args(t)
+    plan_args = parse_cli_args(p)
     model_args = parse_cli_args(m)
 
     # resolve epochs
@@ -576,6 +601,7 @@ def eval_exec(
             model_base_url=model_base_url,
             model_args=model_args,
             task_args=task_args,
+            plan=PlanSpec(plan, plan_args) if plan else None,
             sandbox=parse_sandbox(sandbox),
             sandbox_cleanup=sandbox_cleanup,
             log_level=log_level,

--- a/src/inspect_ai/_display/rich.py
+++ b/src/inspect_ai/_display/rich.py
@@ -25,6 +25,7 @@ from inspect_ai._util.constants import CONSOLE_DISPLAY_WIDTH
 from inspect_ai._util.logger import http_rate_limit_count
 from inspect_ai._util.path import cwd_relative_path
 from inspect_ai._util.platform import is_running_in_jupyterlab, is_running_in_vscode
+from inspect_ai._util.registry import is_registry_dict
 from inspect_ai._util.throttle import throttle
 from inspect_ai.log import EvalStats
 from inspect_ai.log._log import rich_traceback
@@ -504,8 +505,8 @@ def task_config(profile: TaskProfile, generate_config: bool = True) -> str:
     task_args = dict(profile.task_args)
     for key in task_args.keys():
         value = task_args[key]
-        if isinstance(value, dict) and "plan" in value and "params" in value:
-            task_args[key] = value["plan"]
+        if is_registry_dict(value):
+            task_args[key] = value["name"]
     config = task_args | dict(profile.eval_config.model_dump(exclude_none=True))
     if generate_config:
         config = config | dict(profile.generate_config.model_dump(exclude_none=True))

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -31,7 +31,7 @@ from inspect_ai.model import (
     Model,
 )
 from inspect_ai.model._generate_config import GenerateConfig
-from inspect_ai.solver import Plan, Solver
+from inspect_ai.solver import Plan, PlanSpec
 from inspect_ai.util import SandboxEnvironmentSpec
 
 from .eval import eval, eval_init
@@ -55,7 +55,7 @@ def eval_set(
     task_args: dict[str, Any] = dict(),
     sandbox: SandboxEnvironmentSpec | None = None,
     sandbox_cleanup: bool | None = None,
-    plan: Plan | Solver | list[Solver] | None = None,
+    plan: Plan | PlanSpec | None = None,
     score: bool = True,
     log_level: str | None = None,
     limit: int | tuple[int, int] | None = None,
@@ -100,8 +100,8 @@ def eval_set(
            environment type (or optionally a tuple with type and config file)
         sandbox_cleanup (bool | None): Cleanup sandbox environments after task completes
           (defaults to True)
-        plan (Plan | Solver | list[Solver] | None): Alternative plan
-           for evaluating task(s). Optional (uses task plan by default).
+        plan (Plan | PlanSpec | None): Alternative plan for evaluating task(s).
+          Optional (uses task plan by default).
         score (bool): Score output (defaults to True)
         log_level (str | None): "debug", "http", "sandbox", "info", "warning", "error",
            or "critical" (defaults to "info")

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -36,6 +36,7 @@ from inspect_ai.model._model import model_usage
 from inspect_ai.scorer import Score
 from inspect_ai.scorer._metric import SampleScore
 from inspect_ai.solver import Plan, Solver, TaskState
+from inspect_ai.solver._plan import PlanSpec
 
 
 class TaskLogger:
@@ -46,6 +47,7 @@ class TaskLogger:
         task_file: str | None,
         task_id: str | None,
         run_id: str,
+        plan: PlanSpec | None,
         model: Model,
         dataset: Dataset,
         sandbox: tuple[str, str | None] | None,
@@ -66,12 +68,16 @@ class TaskLogger:
 
         # create eval spec
         self.eval = EvalSpec(
-            task=f"{task_name}",
-            task_version=task_version,
-            task_file=task_file,
-            task_id=task_id if task_id else uuid(),
             run_id=run_id,
             created=iso_now(),
+            task=f"{task_name}",
+            task_id=task_id if task_id else uuid(),
+            task_version=task_version,
+            task_file=task_file,
+            task_attribs=task_attribs,
+            task_args=task_args,
+            plan=plan.plan if plan else None,
+            plan_args=plan.args if plan else None,
             model=str(ModelName(model)),
             model_base_url=model.api.base_url,
             dataset=EvalDataset(
@@ -81,8 +87,6 @@ class TaskLogger:
                 shuffled=dataset.shuffled,
             ),
             sandbox=sandbox,
-            task_attribs=task_attribs,
-            task_args=task_args,
             model_args=model_args,
             config=eval_config,
             revision=revision,

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -58,7 +58,7 @@ from inspect_ai.scorer import Scorer, Target
 from inspect_ai.scorer._metric import SampleScore
 from inspect_ai.scorer._score import init_scoring_context
 from inspect_ai.scorer._scorer import unique_scorer_name
-from inspect_ai.solver import Generate, Plan, Solver, TaskState
+from inspect_ai.solver import Generate, Plan, TaskState
 from inspect_ai.solver._task_state import state_jsonable
 from inspect_ai.util._subtask import init_subtask
 
@@ -88,7 +88,7 @@ class TaskRunOptions:
     logger: TaskLogger
     eval_wd: str
     config: EvalConfig = field(default_factory=EvalConfig)
-    plan: Plan | Solver | list[Solver] | None = field(default=None)
+    plan: Plan | None = field(default=None)
     score: bool = field(default=True)
     debug_errors: bool = field(default=False)
     sample_source: EvalSampleSource | None = field(default=None)
@@ -146,13 +146,7 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
         )
 
         # resolve the plan and scorer
-        plan = (
-            plan
-            if isinstance(plan, Plan)
-            else Plan(plan)
-            if plan is not None
-            else task.plan
-        )
+        plan = plan if plan else task.plan
         score = score and task.scorer is not None
         scorers: list[Scorer] | None = task.scorer if (score and task.scorer) else None
         scorer_profiles = (

--- a/src/inspect_ai/_util/registry.py
+++ b/src/inspect_ai/_util/registry.py
@@ -6,9 +6,8 @@ from typing import Any, Callable, Literal, TypedDict, TypeGuard, cast
 from pydantic import BaseModel, Field
 from pydantic_core import to_jsonable_python
 
-from .entrypoints import ensure_entry_points
-
 from .constants import PKG_NAME
+from .entrypoints import ensure_entry_points
 
 obj_type = type
 

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -1275,8 +1275,22 @@
     },
     "EvalSpec": {
       "properties": {
+        "run_id": {
+          "default": "",
+          "title": "Run Id",
+          "type": "string"
+        },
+        "created": {
+          "title": "Created",
+          "type": "string"
+        },
         "task": {
           "title": "Task",
+          "type": "string"
+        },
+        "task_id": {
+          "default": "",
+          "title": "Task Id",
           "type": "string"
         },
         "task_version": {
@@ -1296,19 +1310,39 @@
           "default": null,
           "title": "Task File"
         },
-        "task_id": {
-          "default": "",
-          "title": "Task Id",
-          "type": "string"
+        "task_attribs": {
+          "default": {},
+          "title": "Task Attribs",
+          "type": "object"
         },
-        "run_id": {
-          "default": "",
-          "title": "Run Id",
-          "type": "string"
+        "task_args": {
+          "default": {},
+          "title": "Task Args",
+          "type": "object"
         },
-        "created": {
-          "title": "Created",
-          "type": "string"
+        "plan": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Plan"
+        },
+        "plan_args": {
+          "anyOf": [
+            {
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Plan Args"
         },
         "dataset": {
           "$ref": "#/$defs/EvalDataset"
@@ -1358,16 +1392,6 @@
           "default": null,
           "title": "Model Base Url"
         },
-        "task_attribs": {
-          "default": {},
-          "title": "Task Attribs",
-          "type": "object"
-        },
-        "task_args": {
-          "default": {},
-          "title": "Task Args",
-          "type": "object"
-        },
         "model_args": {
           "default": {},
           "title": "Model Args",
@@ -1409,18 +1433,20 @@
         }
       },
       "required": [
-        "task",
-        "task_version",
-        "task_file",
-        "task_id",
         "run_id",
         "created",
+        "task",
+        "task_id",
+        "task_version",
+        "task_file",
+        "task_attribs",
+        "task_args",
+        "plan",
+        "plan_args",
         "dataset",
         "sandbox",
         "model",
         "model_base_url",
-        "task_attribs",
-        "task_args",
         "model_args",
         "config",
         "revision",

--- a/src/inspect_ai/_view/www/src/types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/types/log.d.ts
@@ -7,12 +7,14 @@
 
 export type Version = number;
 export type Status = "started" | "success" | "cancelled" | "error";
-export type Task = string;
-export type TaskVersion = number;
-export type TaskFile = string | null;
-export type TaskId = string;
 export type RunId = string;
 export type Created = string;
+export type Task = string;
+export type TaskId = string;
+export type TaskVersion = number;
+export type TaskFile = string | null;
+export type Plan = string | null;
+export type PlanArgs = {} | null;
 export type Name = string | null;
 export type Location = string | null;
 export type Samples = number | null;
@@ -339,32 +341,34 @@ export interface EvalLog {
   samples?: Samples2;
 }
 export interface EvalSpec {
-  task: Task;
-  task_version: TaskVersion;
-  task_file: TaskFile;
-  task_id: TaskId;
   run_id: RunId;
   created: Created;
+  task: Task;
+  task_id: TaskId;
+  task_version: TaskVersion;
+  task_file: TaskFile;
+  task_attribs: TaskAttribs;
+  task_args: TaskArgs;
+  plan: Plan;
+  plan_args: PlanArgs;
   dataset: EvalDataset;
   sandbox: Sandbox;
   model: Model;
   model_base_url: ModelBaseUrl;
-  task_attribs: TaskAttribs;
-  task_args: TaskArgs;
   model_args: ModelArgs;
   config: EvalConfig;
   revision: EvalRevision | null;
   packages: Packages;
   metadata: Metadata;
 }
+export interface TaskAttribs {}
+export interface TaskArgs {}
 export interface EvalDataset {
   name: Name;
   location: Location;
   samples: Samples;
   shuffled: Shuffled;
 }
-export interface TaskAttribs {}
-export interface TaskArgs {}
 export interface ModelArgs {}
 export interface EvalConfig {
   limit: Limit;

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -306,8 +306,17 @@ class EvalRevision(BaseModel):
 
 
 class EvalSpec(BaseModel):
+    run_id: str = Field(default="")
+    """Unique run id"""
+
+    created: str
+    """Time created."""
+
     task: str
     """Task name."""
+
+    task_id: str = Field(default="")
+    """Unique task id."""
 
     task_version: int = Field(default=0)
     """Task version."""
@@ -315,14 +324,17 @@ class EvalSpec(BaseModel):
     task_file: str | None = Field(default=None)
     """Task source file."""
 
-    task_id: str = Field(default="")
-    """Unique task id."""
+    task_attribs: dict[str, Any] = Field(default={})
+    """Attributes of the @task decorator."""
 
-    run_id: str = Field(default="")
-    """Unique run id"""
+    task_args: dict[str, Any] = Field(default={})
+    """Arguments used for invoking the task."""
 
-    created: str
-    """Time created."""
+    plan: str | None = Field(default=None)
+    """Plan name."""
+
+    plan_args: dict[str, Any] | None = Field(default=None)
+    """Arguments used for invoking the plan."""
 
     dataset: EvalDataset
     """Dataset used for eval."""
@@ -335,12 +347,6 @@ class EvalSpec(BaseModel):
 
     model_base_url: str | None = Field(default=None)
     """Optional override of model base url"""
-
-    task_attribs: dict[str, Any] = Field(default={})
-    """Attributes of the @task decorator."""
-
-    task_args: dict[str, Any] = Field(default={})
-    """Arguments used for invoking the task."""
 
     model_args: dict[str, Any] = Field(default={})
     """Model specific arguments."""

--- a/src/inspect_ai/scorer/_reducer/registry.py
+++ b/src/inspect_ai/scorer/_reducer/registry.py
@@ -1,7 +1,6 @@
 import re
 from typing import Any, Callable, TypeVar, cast, overload
 
-from inspect_ai._util.entrypoints import ensure_entry_points
 from inspect_ai._util.registry import (
     RegistryInfo,
     registry_add,
@@ -135,8 +134,6 @@ def create_reducers(reducers: None) -> None: ...
 def create_reducers(reducers: ScoreReducers | None) -> list[ScoreReducer] | None:
     if reducers is None:
         return None
-
-    ensure_entry_points()
 
     def create_reducer(name: str) -> ScoreReducer:
         # special case to get digit parameters

--- a/src/inspect_ai/solver/__init__.py
+++ b/src/inspect_ai/solver/__init__.py
@@ -3,7 +3,7 @@ from inspect_ai._util.deprecation import relocated_module_attribute
 from ._basic_agent import basic_agent
 from ._critique import self_critique
 from ._multiple_choice import multiple_choice
-from ._plan import Plan, plan
+from ._plan import Plan, PlanSpec, plan
 from ._prompt import (
     chain_of_thought,
     prompt_template,
@@ -24,6 +24,7 @@ __all__ = [
     "use_tools",
     "plan",
     "Plan",
+    "PlanSpec",
     "Solver",
     "solver",
     "Choice",

--- a/src/inspect_ai/solver/_plan.py
+++ b/src/inspect_ai/solver/_plan.py
@@ -1,4 +1,5 @@
 import inspect
+from dataclasses import dataclass, field
 from typing import Any, Awaitable, Callable, TypeVar, cast
 
 from inspect_ai._util.registry import (
@@ -78,6 +79,17 @@ class Plan:
 
 
 PlanType = TypeVar("PlanType", bound=Callable[..., Plan])
+
+
+@dataclass(frozen=True)
+class PlanSpec:
+    """Plan specification used to (re-)create plans."""
+
+    plan: str
+    """Plan name (simple name or file@name)."""
+
+    args: dict[str, Any] = field(default_factory=dict)
+    """Plan arguments."""
 
 
 def plan(*plan: PlanType | None, name: str | None = None, **attribs: Any) -> Any:

--- a/src/inspect_ai/util/_sandbox/registry.py
+++ b/src/inspect_ai/util/_sandbox/registry.py
@@ -1,6 +1,5 @@
 from typing import Callable, Type, TypeVar, cast
 
-from inspect_ai._util.entrypoints import ensure_entry_points
 from inspect_ai._util.registry import (
     RegistryInfo,
     registry_add,
@@ -43,9 +42,6 @@ def sandboxenv_register(sandboxenv_type: Type[T], name: str) -> Type[T]:
 
 
 def registry_find_sandboxenv(envtype: str) -> type[SandboxEnvironment]:
-    # ensure external packages are loaded
-    ensure_entry_points()
-
     # find a matching sandboxenv_type
     sanxboxenv_types = registry_find(registry_match_sandboxenv(envtype))
     if len(sanxboxenv_types) > 0:
@@ -56,9 +52,6 @@ def registry_find_sandboxenv(envtype: str) -> type[SandboxEnvironment]:
 
 
 def registry_has_sandboxenv(envtype: str) -> bool:
-    # ensure external packages are loaded
-    ensure_entry_points()
-
     # see if we have this type
     return len(registry_find(registry_match_sandboxenv(envtype))) > 0
 

--- a/tests/solver/test_plan.py
+++ b/tests/solver/test_plan.py
@@ -1,4 +1,5 @@
 from random import random
+
 import pytest
 
 from inspect_ai import Task, eval, eval_async, eval_retry, task

--- a/tests/solver/test_plan.py
+++ b/tests/solver/test_plan.py
@@ -2,6 +2,7 @@ import os
 from random import random
 
 import pytest
+from test_helpers.utils import ensure_test_package_installed
 
 from inspect_ai import Task, eval, eval_async, eval_retry, task
 from inspect_ai.dataset import Sample
@@ -76,12 +77,22 @@ def test_plan_spec():
         log = eval(
             f"{plan_file}@the_task",
             plan=PlanSpec(plan_spec, {"rate": 1.0}),
+            model="mockllm/model",
         )[0]
         check_plan(log, plan_spec)
 
     check_plan_spec("the_plan")
     check_plan_spec(plan_file)
     check_plan_spec(f"{plan_file}@the_plan")
+
+
+def test_plan_extension():
+    ensure_test_package_installed()
+    log = eval(the_task(), plan=PlanSpec("inspect_package/cot"), model="mockllm/model")[
+        0
+    ]
+    assert log.eval.plan == "inspect_package/cot"
+    assert log.plan.steps[0].solver == "chain_of_thought"
 
 
 def test_plan_retry():

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,11 +1,6 @@
-# type: ignore
-
-import subprocess
-import sys
-
 import pytest
 from test_helpers.tools import list_files
-from test_helpers.utils import skip_if_no_openai
+from test_helpers.utils import ensure_test_package_installed, skip_if_no_openai
 
 from inspect_ai import Task, eval_async
 from inspect_ai.dataset import Sample
@@ -17,7 +12,7 @@ from inspect_ai.solver import generate, use_tools
 @pytest.mark.asyncio
 async def test_extension_model():
     # ensure the package is installed
-    ensure_package_installed()
+    ensure_test_package_installed()
 
     # call the model
     mdl = get_model("custom/gpt7")
@@ -29,7 +24,7 @@ async def test_extension_model():
 @pytest.mark.asyncio
 async def test_extension_sandboxenv():
     # ensure the package is installed
-    ensure_package_installed()
+    ensure_test_package_installed()
 
     # run a task using the sandboxenv
     try:
@@ -46,12 +41,3 @@ async def test_extension_sandboxenv():
         await eval_async(task, model="openai/gpt-4")
     except Exception as ex:
         pytest.fail(f"Exception raised: {ex}")
-
-
-def ensure_package_installed():
-    try:
-        import inspect_package  # noqa: F401
-    except ImportError:
-        subprocess.check_call(
-            [sys.executable, "-m", "pip", "install", "--no-deps", "tests/test_package"]
-        )

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -1,6 +1,7 @@
 import importlib.util
 import os
 import subprocess
+import sys
 from pathlib import Path
 from random import random
 
@@ -163,3 +164,12 @@ def failing_task(rate=0.5, samples=1) -> Task:
         plan=[failing_solver(rate), generate()],
         scorer=match(),
     )
+
+
+def ensure_test_package_installed():
+    try:
+        import inspect_package  # type: ignore # noqa: F401
+    except ImportError:
+        subprocess.check_call(
+            [sys.executable, "-m", "pip", "install", "--no-deps", "tests/test_package"]
+        )

--- a/tests/test_package/inspect_package/inspect_extensions.py
+++ b/tests/test_package/inspect_package/inspect_extensions.py
@@ -1,5 +1,6 @@
 from inspect_ai.model import modelapi
 
+from .plans.cot import cot  # noqa: F401
 from .sandboxenv.podman import PodmanSandboxEnvironment  # noqa: F401
 
 

--- a/tests/test_package/inspect_package/plans/cot.py
+++ b/tests/test_package/inspect_package/plans/cot.py
@@ -1,0 +1,6 @@
+from inspect_ai.solver import Plan, chain_of_thought, generate, plan
+
+
+@plan
+def cot() -> Plan:
+    return Plan([chain_of_thought(), generate()])

--- a/tests/util/test_registry.py
+++ b/tests/util/test_registry.py
@@ -1,6 +1,15 @@
+from typing import cast
+
 from inspect_ai._util.constants import PKG_NAME
-from inspect_ai._util.registry import registry_info, registry_lookup
+from inspect_ai._util.registry import (
+    registry_create_from_dict,
+    registry_dict,
+    registry_info,
+    registry_lookup,
+)
 from inspect_ai.scorer import Metric, Score, metric
+from inspect_ai.solver import Plan, Solver, plan, solver, use_tools
+from inspect_ai.tool import Tool, bash
 
 
 def test_registry_namespaces() -> None:
@@ -18,3 +27,23 @@ def test_registry_namespaces() -> None:
     info = registry_info(registry_lookup("metric", f"{PKG_NAME}/accuracy"))
     assert info
     assert info.name == f"{PKG_NAME}/accuracy"
+
+
+def test_registry_dict() -> None:
+    @plan
+    def create_plan(solver: Solver) -> Plan:
+        return Plan(solver)
+
+    @solver
+    def create_solver(tool: Tool) -> Solver:
+        return use_tools(tool)
+
+    myplan = create_plan(create_solver(bash(timeout=10)))
+    plan_dict = registry_dict(myplan)
+    assert plan_dict["type"] == "plan"
+    assert plan_dict["params"]["solver"]["type"] == "solver"
+    assert plan_dict["params"]["solver"]["params"]["tool"]["type"] == "tool"
+
+    myplan2 = cast(Plan, registry_create_from_dict(plan_dict))
+    assert isinstance(myplan2, Plan)
+    assert isinstance(myplan2.steps[0], Solver)


### PR DESCRIPTION
Several improvements related to providing the `plan` externally (i.e. overriding a tasks default plan):

- Inspect `eval` and `eval-set` CLI arguments for plans (`--plan` and `-P` for plan args)
- `eval-retry` now works correctly with `eval()` invoked with a `plan` override.
- Recursively serialize all registry objects (plans, solvers, tools, etc.) when saving params (improves support for retry even with registry objects in function signatures)

Also made some improvements to test scaffolding (always fully uninstall the test "inspect_package" at the end of tests)