### PR TITLE
Exposing ToolCallError

### DIFF
--- a/src/inspect_ai/tool/__init__.py
+++ b/src/inspect_ai/tool/__init__.py
@@ -2,7 +2,7 @@ from inspect_ai._util.content import Content, ContentImage, ContentText
 from inspect_ai._util.deprecation import relocated_module_attribute
 
 from ._tool import Tool, ToolError, ToolResult, tool
-from ._tool_call import ToolCall
+from ._tool_call import ToolCall, ToolCallError
 from ._tool_choice import ToolChoice, ToolFunction
 from ._tool_info import ToolInfo, ToolParam, ToolParams
 from ._tool_with import tool_with
@@ -16,6 +16,7 @@ __all__ = [
     "tool",
     "tool_with",
     "Tool",
+    "ToolCallError",
     "ToolError",
     "ToolResult",
     "Content",


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

This PR includes a minor change to expose `ToolCallError` in `inspect_ai.tool`

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
