### PR TITLE
bug fixes for epoch handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Don't log base64 images by default (re-enable logging with `--log-images`).
 - Provide unique tool id when parsing tool calls for models that don't support native tool usage.
 - Fix bug that prevented `epoch_reducer` from being used in eval-retry.
+- Fix bug that prevented eval() level `epoch` from overriding task level `epoch`. 
 
 ## v0.3.28 (14 September 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Improved support for eval retries when calling `eval()` or `eval_set()` with a `plan` argument.
 - Don't log base64 images by default (re-enable logging with `--log-images`).
 - Provide unique tool id when parsing tool calls for models that don't support native tool usage.
+- Fix bug that prevented `epoch_reducer` from being used in eval-retry.
 
 ## v0.3.28 (14 September 2024)
 

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -512,7 +512,11 @@ async def eval_retry_async(
         model_args = eval_log.eval.model_args
         task_args = eval_log.eval.task_args
         limit = eval_log.eval.config.limit
-        epochs = eval_log.eval.config.epochs
+        epochs = (
+            Epochs(eval_log.eval.config.epochs, eval_log.eval.config.epochs_reducer)
+            if eval_log.eval.config.epochs
+            else None
+        )
         fail_on_error = eval_log.eval.config.fail_on_error
         max_messages = eval_log.eval.config.max_messages
         max_samples = max_samples or eval_log.eval.config.max_samples


### PR DESCRIPTION
- Fix bug that prevented `epoch_reducer` from being used in eval-retry
- Fix bug that prevented eval() level `epoch` from overriding task level `epoch`
