### PR TITLE
Preserve first score data when reducing scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Provide unique tool id when parsing tool calls for models that don't support native tool usage.
 - Fix bug that prevented `epoch_reducer` from being used in eval-retry.
 - Fix bug that prevented eval() level `epoch` from overriding task level `epoch`. 
+- Ensure that Scores produced after being reduced still retain `answer`, `explanation`, and `metadata`.
 
 ## v0.3.28 (14 September 2024)
 

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -568,6 +568,12 @@ Inspect includes several built in reducers which are summarised below.
 : {tbl-colwidths="\[40,60\]"}
 
 
+:::{.callout-note}
+
+The built in reducers will compute a reduced `value` for the score and populate the remaining fields (`answer`, `explanation`, and `metadata` using the values from the first score that is being reduced)
+
+:::
+
 
 ## Workflow {#sec-scorer-workflow}
 

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -155,6 +155,7 @@ async def task_score(task: Task, log: EvalLog) -> EvalLog:
                     value=score.value,
                     answer=score.answer,
                     explanation=score.explanation,
+                    metadata=score.metadata,
                 )
                 for score_key, score in sample.scores.items()
             }
@@ -188,6 +189,7 @@ async def run_score_task(
             value=result.value,
             answer=result.answer,
             explanation=result.explanation,
+            metadata=result.metadata,
         )
 
     progress()

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -292,6 +292,7 @@ def reduce_scores(
             SampleScore(
                 sample_id=scores[0].sample_id,
                 value=reduced.value,
+                answer=reduced.answer,
                 explanation=reduced.explanation,
                 metadata=reduced.metadata,
             )

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -355,10 +355,11 @@ async def task_run_sample(
             if previous_sample.scores:
                 return {
                     key: SampleScore(
+                        sample_id=previous_sample.id,
                         value=score.value,
                         answer=score.answer,
                         explanation=score.explanation,
-                        sample_id=previous_sample.id,
+                        metadata=score.metadata,
                     )
                     for key, score in previous_sample.scores.items()
                 }
@@ -455,11 +456,11 @@ async def task_run_sample(
                     )
                     if score_result is not None:
                         sample_score = SampleScore(
+                            sample_id=sample.id,
                             value=score_result.value,
                             answer=score_result.answer,
                             explanation=score_result.explanation,
                             metadata=score_result.metadata,
-                            sample_id=sample.id,
                         )
                         transcript()._event(ScoreEvent(score=score_result))
                         results[scorer_name] = sample_score

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -144,7 +144,7 @@ def max_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
                     key=value_to_float,  # type: ignore
                 )
                 dict_result[key] = max_value
-            return _reduced_score(dict_result)
+            return _reduced_score(dict_result, scores)
         elif isinstance(scores[0].value, list):
             list_result: list[str | int | float | bool] = []
             list_size = len(scores[0].value)  # type: ignore
@@ -159,10 +159,10 @@ def max_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
                     )
                 else:
                     list_result.append(max_value)
-            return _reduced_score(list_result)
+            return _reduced_score(list_result, scores)
         else:
             max_score = max(scores, key=lambda score: value_to_float(score.value))
-            return _reduced_score(max_score.value)
+            return _reduced_score(max_score.value, scores)
 
     return reduce
 
@@ -178,7 +178,7 @@ def _count_scalar(
         counter_fn: a function which returns a scalar value based upon the counter
     """
     counts = Counter([score._as_scalar() for score in scores])
-    return _reduced_score(counter_fn(counts))
+    return _reduced_score(counter_fn(counts), scores)
 
 
 def _count_dict(
@@ -202,7 +202,7 @@ def _count_dict(
         )
         dict_result[key] = counter_fn(counts)
     return _reduced_score(
-        cast(dict[str, str | int | float | bool | None], dict_result),
+        cast(dict[str, str | int | float | bool | None], dict_result), scores
     )
 
 
@@ -226,9 +226,7 @@ def _count_list(
             [score.value[i] for score in scores]  # type:ignore
         )
         list_result.append(counter_fn(counts))
-    return _reduced_score(
-        list_result,
-    )
+    return _reduced_score(list_result, scores)
 
 
 def _compute_dict_stat(
@@ -250,9 +248,7 @@ def _compute_dict_stat(
     for key in scores[0].value.keys():  # type: ignore
         values = [value_to_float(score.value[key]) for score in scores]  # type: ignore
         dict_result[key] = statistic(values)
-    return _reduced_score(
-        dict_result,
-    )
+    return _reduced_score(dict_result, scores)
 
 
 def _compute_list_stat(
@@ -275,9 +271,7 @@ def _compute_list_stat(
     for i in range(list_size):
         values = [value_to_float(score.value[i]) for score in scores]  # type: ignore
         list_result.append(statistic(values))
-    return _reduced_score(
-        list_result,
-    )
+    return _reduced_score(list_result, scores)
 
 
 def _compute_scalar_stat(
@@ -294,9 +288,7 @@ def _compute_scalar_stat(
     """
     values = [value_to_float(score.value) for score in scores]
     result = statistic(values)
-    return _reduced_score(
-        result,
-    )
+    return _reduced_score(result, scores)
 
 
 def _check_value_dict(scores: list[Score]) -> None:
@@ -323,14 +315,16 @@ def _check_value_list(scores: list[Score]) -> None:
             raise ValueError("Attempting to reduce a list score for a non-list value")
 
 
-def _reduced_score(value: Value) -> Score:
+def _reduced_score(value: Value, scores: list[Score]) -> Score:
     r"""Create a Score based upon a single Value and list of Scores that produced it
 
     Args:
         value: the reduced Value
-        scores: a list of Scores.
-        explanation: the score explanation
+        scores: ths list of scores being reduced
     """
     return Score(
         value=value,
+        answer=scores[0].answer,
+        explanation=scores[0].explanation,
+        metadata=scores[0].metadata,
     )

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -77,6 +77,39 @@ def test_dict_reducers() -> None:
     assert at_least_5_reducer(dict_scores).value == {"coolness": 0, "spiciness": 0}
 
 
+def test_reducer_preserve_metadata() -> None:
+    simple_scores = [
+        Score(
+            value=1, answer="1", explanation="An explanation", metadata={"foo": "bar"}
+        ),
+        Score(value=2),
+        Score(value=3),
+        Score(value=4),
+        Score(value=5),
+        Score(value=6),
+    ]
+
+    reducers = [
+        avg_reducer,
+        median_reducer,
+        mode_reducer,
+        max_reducer,
+        at_least_3_reducer,
+    ]
+
+    # verify that metadata is preserved
+    for reducer in reducers:
+        assert reducer(simple_scores).answer is not None
+        assert reducer(simple_scores).explanation is not None
+        assert reducer(simple_scores).metadata is not None
+
+    # verify that metadata is preserved for a single epoch
+    for reducer in reducers:
+        assert reducer([simple_scores[0]]).answer is not None
+        assert reducer([simple_scores[0]]).explanation is not None
+        assert reducer([simple_scores[0]]).metadata is not None
+
+
 @score_reducer(name="add_em_up")
 def sum(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
     def sum(scores: list[Score]) -> Score:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

We incorrectly may drop non-value score values when running the reducer. 

### What is the new behavior?

We don't drop the values -  we instead select the values from the first score in the reduced set. fixes #400 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
