### PR TITLE
Don’t use scorer qualified name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Provide unique tool id when parsing tool calls for models that don't support native tool usage.
 - Fix bug that prevented `epoch_reducer` from being used in eval-retry.
 - Fix bug that prevented eval() level `epoch` from overriding task level `epoch`. 
+- Improve scorer names imported from modules by not including the the module names.
 
 ## v0.3.28 (14 September 2024)
 

--- a/src/inspect_ai/scorer/_scorer.py
+++ b/src/inspect_ai/scorer/_scorer.py
@@ -16,6 +16,7 @@ from inspect_ai._util.registry import (
     registry_log_name,
     registry_name,
     registry_tag,
+    registry_unqualified_name,
 )
 from inspect_ai.solver._task_state import TaskState
 
@@ -158,11 +159,11 @@ def scorer_metrics(
 
 
 def unique_scorer_name(scorer: Scorer, already_used_names: list[str]) -> str:
-    base_name = registry_log_name(scorer)
+    base_name = registry_unqualified_name(scorer)
     scorer_name = base_name
     count = 1
     while scorer_name in already_used_names:
-        scorer_name = f"{scorer_name}{count}"
+        scorer_name = f"{base_name}{count}"
         count = count + 1
     return scorer_name
 

--- a/src/inspect_ai/scorer/_scorer.py
+++ b/src/inspect_ai/scorer/_scorer.py
@@ -13,7 +13,6 @@ from inspect_ai._util.registry import (
     registry_add,
     registry_create,
     registry_info,
-    registry_log_name,
     registry_name,
     registry_tag,
     registry_unqualified_name,

--- a/tests/scorer/test_scorer.py
+++ b/tests/scorer/test_scorer.py
@@ -1,5 +1,5 @@
 import pytest
-from test_helpers.utils import run_example
+from test_helpers.utils import ensure_test_package_installed, run_example
 
 from inspect_ai import Task, eval, score
 from inspect_ai.dataset import Sample
@@ -72,3 +72,30 @@ def test_score_function():
     log = run_example("popularity.py", "mockllm/model")
     log = score(log[0], includes())
     assert log.samples[0].score.value
+
+
+def test_score_package_name():
+    ensure_test_package_installed()
+    from inspect_package import simple_score  # type: ignore
+
+    task = Task(
+        dataset=[Sample(input="What is the capital of Kansas?", target=["Topeka"])],
+        scorer=simple_score(),
+    )
+    eval_log = eval(tasks=task, model="mockllm/model")[0]
+    assert eval_log.results.scores[0].name == "simple_score"
+
+
+def test_score_unique():
+    ensure_test_package_installed()
+    from inspect_package import simple_score  # type: ignore
+
+    task = Task(
+        dataset=[Sample(input="What is the capital of Kansas?", target=["Topeka"])],
+        scorer=[simple_score(), simple_score(), simple_score()],
+    )
+    eval_log = eval(tasks=task, model="mockllm/model")[0]
+
+    assert eval_log.results.scores[0].name == "simple_score"
+    assert eval_log.results.scores[1].name == "simple_score1"
+    assert eval_log.results.scores[2].name == "simple_score2"

--- a/tests/test_package/inspect_package/__init__.py
+++ b/tests/test_package/inspect_package/__init__.py
@@ -1,0 +1,3 @@
+from .score.scorer import simple_score  # noqa: F401
+
+__all__ = ["simple_score"]

--- a/tests/test_package/inspect_package/score/scorer.py
+++ b/tests/test_package/inspect_package/score/scorer.py
@@ -1,0 +1,27 @@
+from inspect_ai.scorer import (
+    CORRECT,
+    INCORRECT,
+    Score,
+    Target,
+    accuracy,
+    scorer,
+    stderr,
+)
+from inspect_ai.solver import TaskState
+
+
+@scorer(metrics=[accuracy(), stderr()])
+def simple_score(ignore_case: bool = True):
+    async def score(state: TaskState, target: Target):
+        # check for correct
+        answer = state.output.completion
+        text = target.text
+        if ignore_case:
+            correct = answer.lower().rfind(text.lower()) != -1
+        else:
+            correct = answer.rfind(text) != -1
+
+        # return score
+        return Score(value=CORRECT if correct else INCORRECT, answer=answer)
+
+    return score


### PR DESCRIPTION
We already have logic to ensure scorer names are unique, so just drop the package qualification

fixes #383

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
