### PR TITLE
Only show no logs error once log_dir is initialized

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -7870,7 +7870,9 @@ const ErrorPanel = ({ id, classes, title, error }) => {
         <div>
           Error: ${message || ""}
           ${stack2 && m$1`
-            <pre style=${{ fontSize: FontSize.smaller, whiteSpace: "pre-wrap" }}>
+            <pre
+              style=${{ fontSize: FontSize.smaller, whiteSpace: "pre-wrap" }}
+            >
             <code>
               at ${stack2}
             </code>
@@ -22957,8 +22959,13 @@ function App({ api: api2, pollForLogs = true }) {
         console.log(e2);
         setStatus({ loading: false, error: e2 });
       }
-    } else if (logs.files.length === 0) {
-      setStatus({ loading: false, error: new Error(`No log files to display in the directory ${logs.log_dir}. Are you sure this is the correct log directory?`) });
+    } else if (logs.log_dir && logs.files.length === 0) {
+      setStatus({
+        loading: false,
+        error: new Error(
+          `No log files to display in the directory ${logs.log_dir}. Are you sure this is the correct log directory?`
+        )
+      });
     }
   }, [selected, logs, capabilities, currentLog, setCurrentLog, setStatus]);
   const loadLogs = async () => {

--- a/src/inspect_ai/_view/www/src/App.mjs
+++ b/src/inspect_ai/_view/www/src/App.mjs
@@ -114,7 +114,7 @@ export function App({ api, pollForLogs = true }) {
         console.log(e);
         setStatus({ loading: false, error: e });
       }
-    } else if (logs.files.length === 0) {
+    } else if (logs.log_dir && logs.files.length === 0) {
       setStatus({
         loading: false,
         error: new Error(


### PR DESCRIPTION
Don't flash the no logs error message when the viewer first loads.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
