### PR TITLE
Add `init: true` to all services in GDM in-house CTF

### DIFF
--- a/evals/gdm_capabilities/in_house_ctf/data/cmd_injection/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/cmd_injection/compose.yaml
@@ -1,6 +1,7 @@
 services:
   cmd_injection:
     image: marshw/cmd_injection
+    init: true
     networks:
       - cmd_injection_network
     expose:

--- a/evals/gdm_capabilities/in_house_ctf/data/db_3/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/db_3/compose.yaml
@@ -1,6 +1,7 @@
 services:
   db_3:
     image: marshw/db_3
+    init: true
     networks:
       - db_3_network
     expose:

--- a/evals/gdm_capabilities/in_house_ctf/data/grafana/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/grafana/compose.yaml
@@ -1,6 +1,7 @@
 services:
   grafana:
     image: marshw/grafana
+    init: true
     networks:
       - grafana_network
     expose:

--- a/evals/gdm_capabilities/in_house_ctf/data/idor/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/idor/compose.yaml
@@ -1,6 +1,7 @@
 services:
   idor:
     image: marshw/idor
+    init: true
     networks:
       - idor_network
     expose:

--- a/evals/gdm_capabilities/in_house_ctf/data/pw_reuse/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/pw_reuse/compose.yaml
@@ -1,6 +1,7 @@
 services:
   pw_reuse:
     image: marshw/pw_reuse_ssh
+    init: true
     networks:
       - pw_reuse_network
     expose:
@@ -8,6 +9,7 @@ services:
 
   pw_reuse_db:
     image: marshw/pw_reuse_db
+    init: true
     networks:
       - pw_reuse_network
 

--- a/evals/gdm_capabilities/in_house_ctf/data/spray/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/spray/compose.yaml
@@ -1,6 +1,7 @@
 services:
   spray:
     image: marshw/spray
+    init: true
     networks:
       - spray_network
     expose:

--- a/evals/gdm_capabilities/in_house_ctf/data/sqli/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/sqli/compose.yaml
@@ -1,6 +1,7 @@
 services:
   sqli:
     image: marshw/sqli
+    init: true
     networks:
       - sqli_network
     expose:

--- a/evals/gdm_capabilities/in_house_ctf/data/ssh/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/ssh/compose.yaml
@@ -1,6 +1,7 @@
 services:
   ssh:
     image: marshw/ssh:latest
+    init: true
     networks:
       - ssh_network
     expose:

--- a/evals/gdm_capabilities/in_house_ctf/data/webmin/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/webmin/compose.yaml
@@ -1,6 +1,7 @@
 services:
   webmin:
     image: marshw/webmin
+    init: true
     networks:
       - webmin_network
     expose:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Some services don't have `init: true` specified.

### What is the new behavior?

All services don't have `init: true` specified. They will now respect signals e.g. SIGTERM/SIGINT and shutdown gracefully.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
