### PR TITLE
Bugfix for metric aggregation

### DIFF
--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -182,7 +182,7 @@ def scorer_for_metrics(
         # in the dictionary into a result
         if isinstance(metric_value, dict):
             for metric_key, value in metric_value.items():
-                if value:
+                if value is not None:
                     name = metrics_unique_key(metric_key, list(list_metrics.keys()))
                     list_metrics[name] = EvalMetric(
                         name=name,
@@ -193,7 +193,7 @@ def scorer_for_metrics(
         # into a result
         elif isinstance(metric_value, list):
             for index, value in enumerate(metric_value):
-                if value:
+                if value is not None:
                     count = str(index + 1)
                     name = metrics_unique_key(
                         with_suffix(key, count), list(list_metrics.keys())
@@ -292,7 +292,6 @@ def reduce_scores(
             SampleScore(
                 sample_id=scores[0].sample_id,
                 value=reduced.value,
-                answer=reduced.answer,
                 explanation=reduced.explanation,
                 metadata=reduced.metadata,
             )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
If a metric returns 0.0 or some other falsey score across all samples, this `if value:` check can cause no metrics to be reported for an eval. 

### What is the new behavior?
We explicitly check if the value is None to avoid the above. Now even if all samples score a falsey score, the metrics will be reported in the logs. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
no

### Other information:
