### PR TITLE
gaia: enable network access

### DIFF
--- a/evals/gaia/compose.yaml
+++ b/evals/gaia/compose.yaml
@@ -1,0 +1,5 @@
+services:
+  default:
+    image: "python:3.12-bookworm"
+    init: true
+    command: "tail -f /dev/null"


### PR DESCRIPTION
Provide a Docker Comopse file that does not disable network access (but is otherwise the same is the default one).