### PR TITLE
Add healthchecks to services in GDM CTFs

### DIFF
--- a/evals/gdm_capabilities/in_house_ctf/data/cmd_injection/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/cmd_injection/compose.yaml
@@ -6,6 +6,11 @@ services:
       - cmd_injection_network
     expose:
       - 8080
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:8080/ || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/db_3/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/db_3/compose.yaml
@@ -6,6 +6,11 @@ services:
       - db_3_network
     expose:
       - 5432
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U admin" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/grafana/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/grafana/compose.yaml
@@ -6,6 +6,12 @@ services:
       - grafana_network
     expose:
       - 3000
+    healthcheck:
+      # curl is not installed in the grafana image, so use wget
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:3000/api/health || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/idor/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/idor/compose.yaml
@@ -6,6 +6,11 @@ services:
       - idor_network
     expose:
       - 8081
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:8081/ || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/pw_reuse/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/pw_reuse/compose.yaml
@@ -6,12 +6,22 @@ services:
       - pw_reuse_network
     expose:
       - 22
+    healthcheck:
+      test: [ "CMD-SHELL", "nc -z localhost 22 || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   pw_reuse_db:
     image: marshw/pw_reuse_db
     init: true
     networks:
       - pw_reuse_network
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U admin" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/spray/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/spray/compose.yaml
@@ -6,6 +6,11 @@ services:
       - spray_network
     expose:
       - 8082
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:8082/ || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/sqli/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/sqli/compose.yaml
@@ -6,6 +6,11 @@ services:
       - sqli_network
     expose:
       - 80
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://0.0.0.0:80/users || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/ssh/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/ssh/compose.yaml
@@ -6,6 +6,11 @@ services:
       - ssh_network
     expose:
       - 22
+    healthcheck:
+      test: [ "CMD-SHELL", "nc -z localhost 22 || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker

--- a/evals/gdm_capabilities/in_house_ctf/data/webmin/compose.yaml
+++ b/evals/gdm_capabilities/in_house_ctf/data/webmin/compose.yaml
@@ -6,6 +6,11 @@ services:
       - webmin_network
     expose:
       - 10000
+    healthcheck:
+      test: [ "CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:10000 || exit 1" ]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   attacker:
     image: marshw/attacker


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Compose projects are marked as ready and the eval starts before some of the infrastructure has properly started.

See #449 

### What is the new behavior?
The healthchecks must succeed before `docker compose up --wait` returns. If the healthcheck never succeeds (indicating something has gone horribly wrong), the eval fails.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Whilst these healthchecks could be baked into the docker images instead of specified in `compose.yaml`, I think this approach will be more compatible with our k8s work. K8s ignores healthchecks in docker images, so we'll have to define `readinessProbe`s.

I've run this eval suite with `--max-messages=1` just to confirm that all compose projects do correctly start.

These healthchecks are actually quite a good basic sanity check that ports are configured properly etc.