### PR TITLE
Ensure non add/copy/move ops don’t throw

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15718,7 +15718,7 @@ const generatePreview = (changes, resolvedState) => {
     const requiredMatchCount = changeType.signature.remove.length + changeType.signature.replace.length + changeType.signature.add.length;
     let matchingOps = 0;
     for (const change of changes) {
-      if (changeType.signature[change.op].length > 0) {
+      if (changeType.signature[change.op] && changeType.signature[change.op].length > 0) {
         changeType.signature[change.op].forEach((signature) => {
           if (change.path.match(signature)) {
             matchingOps++;

--- a/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventView.mjs
@@ -64,13 +64,19 @@ export const StateEventView = ({ id, event, style, stateManager }) => {
 const generatePreview = (changes, resolvedState) => {
   const results = [];
   for (const changeType of RenderableChangeTypes) {
+    // Note that we currently only have renderers that depend upon
+    // add, remove, replace, but we should likely add
+    // move, copy, test
     const requiredMatchCount =
       changeType.signature.remove.length +
       changeType.signature.replace.length +
       changeType.signature.add.length;
     let matchingOps = 0;
     for (const change of changes) {
-      if (changeType.signature[change.op].length > 0) {
+      if (
+        changeType.signature[change.op] &&
+        changeType.signature[change.op].length > 0
+      ) {
         changeType.signature[change.op].forEach((signature) => {
           if (change.path.match(signature)) {
             matchingOps++;


### PR DESCRIPTION
Renderers currently on pay attention to 3 ops (add, remove, replace) when rendering previews. But we would incorrectly assume that an op that appeared in a patch would be supported on renderers, so move, copy, or test would cause an error.

fixes #455

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

