### PR TITLE
eval_set does not support zero retries

### DIFF
--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -366,7 +366,7 @@ def eval_set(
         retry=retry_if_not_result(all_evals_succeeded),
         retry_error_callback=return_last_value,
         reraise=True,
-        stop=stop_after_attempt(retry_attempts or 10),
+        stop=stop_after_attempt(10 if retry_attempts is None else retry_attempts),
         wait=wait_exponential(retry_wait or 30, max=(60 * 60)),
         before_sleep=before_sleep,
         before=before,

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -3,7 +3,7 @@ import tempfile
 from copy import deepcopy
 from pathlib import Path
 
-from test_helpers.utils import failing_solver, failing_task
+from test_helpers.utils import failing_solver, failing_task, failing_task_det
 
 from inspect_ai import Task, task
 from inspect_ai._eval.evalset import (
@@ -219,3 +219,16 @@ def test_eval_set_s3(mock_s3) -> None:
     )
     assert success
     assert logs[0].status == "success"
+
+
+def test_eval_zero_retries() -> None:
+    with tempfile.TemporaryDirectory() as log_dir:
+        success, logs = eval_set(
+            tasks=failing_task_det([False, True]),
+            log_dir=log_dir,
+            retry_attempts=0,
+            retry_wait=0.1,
+            model="mockllm/model",
+        )
+        assert not success
+        assert logs[0].status == "error"

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -3,7 +3,7 @@ import tempfile
 from copy import deepcopy
 from pathlib import Path
 
-from test_helpers.utils import failing_solver, failing_task, failing_task_det
+from test_helpers.utils import failing_solver, failing_task, failing_task_deterministic
 
 from inspect_ai import Task, task
 from inspect_ai._eval.evalset import (
@@ -224,11 +224,10 @@ def test_eval_set_s3(mock_s3) -> None:
 def test_eval_zero_retries() -> None:
     with tempfile.TemporaryDirectory() as log_dir:
         success, logs = eval_set(
-            tasks=failing_task_det([False, True]),
+            tasks=failing_task_deterministic([True, False]),
             log_dir=log_dir,
             retry_attempts=0,
             retry_wait=0.1,
             model="mockllm/model",
         )
         assert not success
-        assert logs[0].status == "error"

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 from pathlib import Path
 from random import random
+from typing import Sequence
 
 import pytest
 
@@ -165,6 +166,26 @@ def failing_task(rate=0.5, samples=1) -> Task:
         scorer=match(),
     )
 
+@solver
+def failing_solver_det(yay_or_nay: Sequence[bool]):
+    it = iter(yay_or_nay)
+    async def solve(state: TaskState, generate: Generate):
+        if it.__next__():
+            raise ValueError("Eval failed!")
+        return state
+
+    return solve
+
+@task
+def failing_task_det(yay_or_nay: Sequence[bool]) -> Task:
+    dataset: list[Sample] = []
+    for _ in range(0, len(yay_or_nay)):
+        dataset.append(Sample(input="Say hello", target="hello"))
+    return Task(
+        dataset=dataset,
+        plan=[failing_solver_det(yay_or_nay), generate()],
+        scorer=match(),
+    )
 
 def ensure_test_package_installed():
     try:

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -166,26 +166,31 @@ def failing_task(rate=0.5, samples=1) -> Task:
         scorer=match(),
     )
 
+
 @solver
-def failing_solver_det(yay_or_nay: Sequence[bool]):
-    it = iter(yay_or_nay)
+def failing_solver_deterministic(should_fail: Sequence[bool]):
+    it = iter(should_fail)
+
     async def solve(state: TaskState, generate: Generate):
-        if it.__next__():
+        should_fail_this_time = it.__next__()
+        if should_fail_this_time:
             raise ValueError("Eval failed!")
         return state
 
     return solve
 
+
 @task
-def failing_task_det(yay_or_nay: Sequence[bool]) -> Task:
+def failing_task_deterministic(should_fail: Sequence[bool]) -> Task:
     dataset: list[Sample] = []
-    for _ in range(0, len(yay_or_nay)):
+    for _ in range(0, len(should_fail)):
         dataset.append(Sample(input="Say hello", target="hello"))
     return Task(
         dataset=dataset,
-        plan=[failing_solver_det(yay_or_nay), generate()],
+        plan=[failing_solver_deterministic(should_fail), generate()],
         scorer=match(),
     )
+
 
 def ensure_test_package_installed():
     try:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

You get ten retries if you pass a retry count of zero

### What is the new behavior?

You get zero retries

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
