### PR TITLE
Diffs don’t fail the viewer

### DIFF
--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptState.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptState.mjs
@@ -34,11 +34,23 @@ export const initStateManager = (scope) => {
      * @param {import("../../types/log").Changes} changes - The new state object to update with.
      */
     applyChanges: (changes) => {
-      state = applyPatch(
-        structuredClone(state),
-        structuredClone(changes).map(ensureValidChange),
-        true,
-      ).newDocument;
+      try {
+        state = applyPatch(
+          structuredClone(state),
+          structuredClone(changes).map(ensureValidChange),
+          true,
+        ).newDocument;
+      } catch (ex) {
+        const ops = changes.reduce((prev, change) => {
+          if (!Object.keys(prev).includes(change.op)) {
+            prev[change.op] = [];
+          }
+          prev[change.op].push(change.path);
+          return prev;
+        }, {});
+        const message = `${ex.name}\nFailed to apply patch:\n${JSON.stringify(ops, undefined, 2)}`;
+        console.error(message);
+      }
     },
   };
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/state/StateDiffView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/state/StateDiffView.mjs
@@ -16,7 +16,7 @@ import { format } from "jsondiffpatch/formatters/html";
  */
 export const StateDiffView = ({ starting, ending, style }) => {
   const changes = diff(starting, ending);
-  const html_result = format(changes);
+  const html_result = format(changes) || "Unable to render differences";
   return html`<div
     dangerouslySetInnerHTML=${{ __html: unescapeNewlines(html_result) }}
     style=${{ ...style }}


### PR DESCRIPTION
Make the viewer robust against failures to apply diffs properly. Instead, display an ‘Unable to render diff’ message and log some details in the console. This will prevent state bugs from blowing up the viewer.

For discussion and a working branch as I work on improving the robustness of our state diff rendering.