### PR TITLE
MMMU: Resize images to be <= 1024 pixels per side

### DIFF
--- a/evals/mmmu/utils.py
+++ b/evals/mmmu/utils.py
@@ -23,6 +23,7 @@ def save_image(record, image_number, subject_dir, question_number):
         image_filename = f"question_{question_number}_image_{image_number}.png"
         image_path = os.path.join(subject_dir, image_filename)
         image = record[f"image_{image_number}"]
+        image.thumbnail((1024, 1024))
         image.save(image_path, format="PNG")
         return image_path
     return None


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

MMMU images are embedded at their native size. This causes failures with some API endpoints which have limits in terms of both pixels and bytes.

### What is the new behavior?

Use [Image.thumbnail](https://pillow.readthedocs.io/en/stable/reference/Image.html#PIL.Image.Image.thumbnail) to reduce the size of images to be at most 1024 pixels on a dimension. Images which are already less than 1024 pixels on each side will not be resized.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

