### PR TITLE
Don't catch TypeError when calling tools (we now handle this in other ways)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Eliminate log spam from spurious grpc fork message.
 - Fix issue with hf_dataset shuffle=True not actually shuffling.
 - Improved error handling when loading invalid setuptools entrypoints.
+- Don't catch TypeError when calling tools (we now handle this in other ways)
 
 ## v0.3.30 (18 September 2024)
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -166,18 +166,14 @@ async def call_tool(tools: list[ToolDef], call: ToolCall) -> Any:
     if validation_errors:
         raise ToolParsingError(validation_errors)
 
+    # get arguments (with creation of dataclasses, pydantic objects, etc.)
+    arguments = tool_params(call.arguments, tool_def.tool)
+
     # call the tool
-    try:
-        # get arguments (with creation of dataclasses, pydantic objects, etc.)
-        arguments = tool_params(call.arguments, tool_def.tool)
+    result = await tool_def.tool(**arguments)
 
-        # call the tool
-        result = await tool_def.tool(**arguments)
-
-        # return result + events
-        return result
-    except TypeError as ex:
-        raise ToolParsingError(exception_message(ex))
+    # return result + events
+    return result
 
 
 def tools_info(tools: list[Tool] | list[ToolInfo]) -> list[ToolInfo]:

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -18,7 +18,6 @@ from jsonschema import Draft7Validator
 from pydantic import BaseModel
 
 from inspect_ai._util.content import Content, ContentImage, ContentText
-from inspect_ai._util.error import exception_message
 from inspect_ai._util.registry import registry_info
 from inspect_ai.tool import Tool, ToolCall, ToolError, ToolInfo
 from inspect_ai.tool._tool import TOOL_PROMPT, ToolParsingError


### PR DESCRIPTION
No longer required since we added automatic coercion of str to first arg and full JSON schema validation (w/ error reporting to the model) prior to tool calls.