### PR TITLE
fix issue w/ subtasks not getting a fresh store()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix issue w/ subtasks not getting a fresh store() (regression from introduction of `fork()` in v0.3.30)
+
 ## v0.3.31 (24 September 2024)
 
 - Deprecated `Plan` in favor of `Solver` (with `chain()` function to compose multiple solvers).

--- a/src/inspect_ai/util/_subtask.py
+++ b/src/inspect_ai/util/_subtask.py
@@ -96,10 +96,7 @@ def subtask(
             # create coroutine so we can provision a subtask contextvars
             async def run() -> tuple[RT, SubtaskEvent]:
                 # initialise subtask (provisions store and transcript)
-                nonlocal store
-                if store is None:
-                    store = Store()
-                init_subtask(subtask_name, store)
+                init_subtask(subtask_name, store if store else Store())
 
                 # run the subtask
                 with track_store_changes():  # type: ignore

--- a/tests/solver/test_subtask.py
+++ b/tests/solver/test_subtask.py
@@ -12,6 +12,7 @@ from inspect_ai.util._subtask import subtask
 
 @subtask
 async def times_two(input: int) -> int:
+    assert store().get("x", 0) == 0
     store().set("x", 84)
     return input * 2
 
@@ -21,6 +22,8 @@ def test_subtask():
     def subtask_solver():
         async def solve(state: TaskState, generate: Generate):
             state.store.set("x", 42)
+            # call twice so times_two can verify that state is reset
+            result = await times_two(int(state.input_text))
             result = await times_two(int(state.input_text))
             state.output = ModelOutput.from_content(state.model.name, str(result))
             return state


### PR DESCRIPTION
regression from introduction of `fork()` in v0.3.30
