### PR TITLE
DROP: include passage_hash in sample metadata

### DIFF
--- a/evals/drop/drop.py
+++ b/evals/drop/drop.py
@@ -15,6 +15,7 @@ inspect eval drop/drop.py -T fewshot=5
 inspect eval drop/drop.py -T fewshot=false
 """
 
+import hashlib
 import re
 from typing import Dict, List
 
@@ -124,6 +125,7 @@ def record_to_sample(record: Dict) -> Sample:
         input=format_input(record),
         target=get_answers(record),
         id=record["query_id"],
+        metadata={"passage_hash": hashlib.md5(record["passage"].encode()).hexdigest()},
     )
 
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

DROP `Sample` objects do not include a passage identifier. This makes it difficult to perform analyses that specially treat questions which share a passage.

### What is the new behavior?

Include an MD5 hash of the passage in `Sample.metadata["passage_hash"]`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

Tested on a subset of the DROP dataset.