### PR TITLE
Allow binary files in samples

### DIFF
--- a/src/inspect_ai/dataset/_dataset.py
+++ b/src/inspect_ai/dataset/_dataset.py
@@ -34,7 +34,7 @@ class Sample(BaseModel):
         metadata (dict[str,Any] | None): Optional. Arbitrary metadata associated with the sample.
         sandbox (SandboxEnvironmentSpec | None): Optional. Sandbox environment
           type and optional config file.
-        files (dict[str, str] | None): Optional. Files that go along with the sample (copied to
+        files (dict[str, str | bytes] | None): Optional. Files that go along with the sample (copied to
           SandboxEnvironment). Files can be paths, inline text, or inline binary (base64 encoded data URL).
         setup (str | None): Optional. Setup script to run for sample (run
           within default SandboxEnvironment).
@@ -58,7 +58,7 @@ class Sample(BaseModel):
     sandbox: SandboxEnvironmentSpec | None = Field(default=None)
     """Sandbox environment type and optional config file."""
 
-    files: dict[str, str] | None = Field(default=None)
+    files: dict[str, str | bytes] | None = Field(default=None)
     """Files that go along with the sample (copied to SandboxEnvironment)"""
 
     setup: str | None = Field(default=None)


### PR DESCRIPTION
Fixes #502

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

#502
```
 File "/Users/jason/Documents/GitHub/ai_scientist/.venv/bin/inspect", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_cli/main.py", line 52, in main
    inspect(auto_envvar_prefix="INSPECT")
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/click/core.py", line 1688, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_cli/common.py", line 31, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_cli/common.py", line 63, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_cli/eval.py", line 299, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_cli/eval.py", line 360, in eval_command
    eval_exec(
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_cli/eval.py", line 636, in eval_exec
    eval(**params)
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/eval.py", line 112, in eval
    return asyncio.run(
           ^^^^^^^^^^^^
  File "/Users/jason/.pyenv/versions/3.11.9/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/Users/jason/.pyenv/versions/3.11.9/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/.pyenv/versions/3.11.9/lib/python3.11/asyncio/base_events.py", line 654, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/eval.py", line 228, in eval_async
    model, resolved_tasks = eval_init(
                            ^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/eval.py", line 605, in eval_init
    resolved_tasks.extend(resolve_tasks(tasks, task_args, m, sandbox))
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 148, in resolve_tasks
    load_tasks(cast(list[str] | None, tasks), model, task_args)
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 219, in load_tasks
    return [
           ^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 222, in <listcomp>
    for spec in load_task_spec(task_spec, model_name, task_args)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 235, in load_task_spec
    return create_tasks([task_spec], model, task_args)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 267, in create_tasks
    tasks.extend(create_file_tasks(file, model, None, task_args))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 287, in create_file_tasks
    task_specs = _load_task_specs(file)
                 ^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 318, in _load_task_specs
    module = load_module(task_path, code_has_task)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/inspect_ai/_eval/loader.py", line 350, in load_module
    loader.exec_module(module)
  File "<frozen importlib._bootstrap_external>", line 940, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/jason/Documents/GitHub/ai_scientist/ai_scientist/eval_run/mech_interp_adversarial_examples/max_of_4.py", line 96, in <module>
    Sample(
  File "/Users/jason/Documents/GitHub/ai_scientist/.venv/lib/python3.11/site-packages/pydantic/main.py", line 193, in __init__
    self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for Sample
files.`assets/MaxOf4-123.pth`
  Input should be a valid string, unable to parse raw data as a unicode string [type=string_unicode, input_value=b'PK\x03\x04\x00\x00\x08\...008\x9b\x06\x00\x00\x00', input_type=bytes]
    For further information visit https://errors.pydantic.dev/2.8/v/string_unicode
```

### What is the new behavior?

No error

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Should not

### Other information:
