### PR TITLE
Capture solver input params for subtasks created by `fork()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Option to disable ANSI terminal output with `--no-ansi` or `INSPECT_NO_ANSI`
 - Allow Docker sandboxes configured with `x-default` to be referred to by their declared service name.
 - Track sample task state in solver decorator rather than solver transcript.
+- Display solver input parameters for forked subtasks.
 
 ## v0.3.32 (25 September 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Capture solver input params for subtasks created by `fork()`.
+
 ## v0.3.32 (25 September 2024)
 
 - Fix issue w/ subtasks not getting a fresh store() (regression from introduction of `fork()` in v0.3.30)

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15893,18 +15893,35 @@ const SubtaskEventView = ({
   storeManager,
   depth
 }) => {
+  const transcript = event.events.length > 0 ? m$1`<${TranscriptView}
+          id="${id}-subtask"
+          name="Transcript"
+          events=${event.events}
+          stateManager=${stateManager}
+          storeManager=${storeManager}
+          depth=${depth + 1}
+        />` : "";
+  const body = event.type === "fork" ? m$1`
+          <div title="Summary" style=${{ width: "100%", margin: "0.5em 0em" }}>
+            <div style=${{ ...TextStyle.label }}>Inputs</div>
+            <div style=${{ marginBottom: "1em" }}>
+              <${Rendered} values=${event.input} />
+            </div>
+            <div style=${{ ...TextStyle.label }}>Transcript</div>
+            ${transcript}
+          </div>
+        ` : m$1`
+          <${SubtaskSummary}
+            name="Summary"
+            input=${event.input}
+            result=${event.result}
+          />
+          ${transcript}
+        `;
   const type = event.type === "fork" ? "Fork" : "Subtask";
   return m$1`
     <${EventPanel} id=${id} title="${type}: ${event.name}" style=${style} collapse=${false}>
-      ${event.type === "fork" ? "" : m$1`<${SubtaskSummary} name="Summary" input=${event.input} result=${event.result} />`}
-      ${event.events.length > 0 ? m$1`<${TranscriptView}
-              id="${id}-subtask"
-              name="Transcript"
-              events=${event.events}
-              stateManager=${stateManager}
-              storeManager=${storeManager}
-              depth=${depth + 1}
-            />` : ""}
+      ${body}
     </${EventPanel}>`;
 };
 const SubtaskSummary = ({ input, result }) => {

--- a/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.mjs
@@ -26,23 +26,46 @@ export const SubtaskEventView = ({
   storeManager,
   depth,
 }) => {
+  // Render Forks specially
+
+  const transcript =
+    event.events.length > 0
+      ? html`<${TranscriptView}
+          id="${id}-subtask"
+          name="Transcript"
+          events=${event.events}
+          stateManager=${stateManager}
+          storeManager=${storeManager}
+          depth=${depth + 1}
+        />`
+      : "";
+
+  const body =
+    event.type === "fork"
+      ? html`
+          <div title="Summary" style=${{ width: "100%", margin: "0.5em 0em" }}>
+            <div style=${{ ...TextStyle.label }}>Inputs</div>
+            <div style=${{ marginBottom: "1em" }}>
+              <${Rendered} values=${event.input} />
+            </div>
+            <div style=${{ ...TextStyle.label }}>Transcript</div>
+            ${transcript}
+          </div>
+        `
+      : html`
+          <${SubtaskSummary}
+            name="Summary"
+            input=${event.input}
+            result=${event.result}
+          />
+          ${transcript}
+        `;
+
   // Is this a traditional subtask or a fork?
   const type = event.type === "fork" ? "Fork" : "Subtask";
   return html`
     <${EventPanel} id=${id} title="${type}: ${event.name}" style=${style} collapse=${false}>
-      ${event.type === "fork" ? "" : html`<${SubtaskSummary} name="Summary" input=${event.input} result=${event.result} />`}
-      ${
-        event.events.length > 0
-          ? html`<${TranscriptView}
-              id="${id}-subtask"
-              name="Transcript"
-              events=${event.events}
-              stateManager=${stateManager}
-              storeManager=${storeManager}
-              depth=${depth + 1}
-            />`
-          : ""
-      }
+      ${body}
     </${EventPanel}>`;
 };
 


### PR DESCRIPTION
@dragonstyle This is the first part of addressing https://github.com/UKGovernmentBEIS/inspect_ai/issues/490. The solver params are now captured for forked subtasks -- could you add to this PR an update to the viewer that display the params?