### PR TITLE
Option to disable ANSI terminal output with `--no-ansi` or `INSPECT_NO_ANSI`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Option to disable ANSI terminal output with `--no-ansi` or `INSPECT_NO_ANSI`
+
 ## v0.3.32 (25 September 2024)
 
 - Fix issue w/ subtasks not getting a fresh store() (regression from introduction of `fork()` in v0.3.30)

--- a/src/inspect_ai/_cli/common.py
+++ b/src/inspect_ai/_cli/common.py
@@ -1,4 +1,5 @@
 import functools
+import os
 from typing import Any, Callable, Tuple, cast
 
 import click
@@ -10,6 +11,7 @@ from inspect_ai._util.constants import ALL_LOG_LEVELS, DEFAULT_LOG_LEVEL
 class CommonOptions(TypedDict):
     log_level: str
     log_dir: str
+    no_ansi: bool | None
     debug: bool
     debug_port: int
     debug_errors: bool
@@ -43,6 +45,13 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         help="Directory for log files.",
     )
     @click.option(
+        "--no-ansi",
+        type=bool,
+        is_flag=True,
+        help="Do not print ANSI control characters.",
+        envvar="INSPECT_NO_ANSI",
+    )
+    @click.option(
         "--debug", is_flag=True, envvar="INSPECT_DEBUG", help="Wait to attach debugger"
     )
     @click.option(
@@ -66,6 +75,10 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 
 
 def resolve_common_options(options: CommonOptions) -> Tuple[str, str]:
+    # disable ansi if requested
+    if options["no_ansi"]:
+        os.environ["INSPECT_NO_ANSI"] = "1"
+
     # attach debugger if requested
     if options["debug"]:
         import debugpy  # type: ignore

--- a/src/inspect_ai/_display/rich.py
+++ b/src/inspect_ai/_display/rich.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import datetime
+import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Callable, Iterator, Set
@@ -85,10 +86,6 @@ class RichDisplay(Display):
     @override
     @contextlib.contextmanager
     def task_screen(self, total_tasks: int, parallel: bool) -> Iterator[TaskScreen]:
-        # reconfigure the default global console
-        use_color = is_running_in_vscode() and not is_running_in_jupyterlab()
-        rich.reconfigure(no_color=not use_color)
-
         self.total_tasks = total_tasks
         self.tasks = []
         self.progress_ui = rich_progress()
@@ -132,6 +129,11 @@ class RichDisplay(Display):
     @override
     @contextlib.contextmanager
     def task(self, profile: TaskProfile) -> Iterator[TaskDisplay]:
+        # if there is no ansi display than all of the below will
+        # be a no-op, so we print a simple text message for the task
+        if rich_no_ansi():
+            rich_console().print(task_no_ansi(profile))
+
         # for typechekcer
         if self.tasks is None:
             self.tasks = []
@@ -498,6 +500,14 @@ def task_targets(profile: TaskProfile) -> str:
     return "   " + "\n   ".join(targets)
 
 
+def task_no_ansi(profile: TaskProfile) -> str:
+    message = f"Running task {task_title(profile, True)}"
+    config = task_config(profile)
+    if config:
+        message = f"{message} (config: {config})"
+    return f"{message}..."
+
+
 def task_config(profile: TaskProfile, generate_config: bool = True) -> str:
     # merge config
     theme = rich_theme()
@@ -664,6 +674,23 @@ def task_dict(d: dict[str, str], bold_value: bool = False) -> str:
 
 def is_vscode_notebook(console: Console) -> bool:
     return console.is_jupyter and is_running_in_vscode()
+
+
+def rich_no_ansi() -> bool:
+    return os.environ.get("INSPECT_NO_ANSI", None) is not None
+
+
+def rich_initialise() -> None:
+    use_color = is_running_in_vscode() and not is_running_in_jupyterlab()
+    no_color = rich_no_ansi() or not use_color
+    if no_color:
+        rich.reconfigure(no_color=True)
+
+    if rich_no_ansi():
+        rich.reconfigure(
+            force_terminal=False,
+            force_interactive=False,
+        )
 
 
 def rich_theme() -> Theme:

--- a/src/inspect_ai/_util/platform.py
+++ b/src/inspect_ai/_util/platform.py
@@ -18,6 +18,11 @@ def running_in_notebook() -> bool:
 
 
 def platform_init() -> None:
+    # initialise rich
+    from inspect_ai._display.rich import rich_initialise
+
+    rich_initialise()
+
     # set exception hook if we haven't already
     set_exception_hook()
 


### PR DESCRIPTION
Addresses https://github.com/UKGovernmentBEIS/inspect_ai/issues/496