### PR TITLE
Track sample task state in solver decorator rather than solver transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Option to disable ANSI terminal output with `--no-ansi` or `INSPECT_NO_ANSI`
 - Allow Docker sandboxes configured with `x-default` to be referred to by their declared service name.
+- Track sample task state in solver decorator rather than solver transcript.
 
 ## v0.3.32 (25 September 2024)
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -62,7 +62,7 @@ from inspect_ai.solver import Generate, Plan, TaskState
 from inspect_ai.solver._chain import Chain, unroll
 from inspect_ai.solver._fork import set_task_generate
 from inspect_ai.solver._solver import Solver
-from inspect_ai.solver._task_state import state_jsonable
+from inspect_ai.solver._task_state import set_sample_state, state_jsonable
 from inspect_ai.util._subtask import init_subtask
 
 from ..context import init_task_context
@@ -385,6 +385,7 @@ async def task_run_sample(
     )
 
     # initialise subtask and scoring context
+    set_sample_state(state)
     init_subtask(SAMPLE_SUBTASK, state.store)
     if scorers:
         init_scoring_context(scorers, Target(sample.target))

--- a/src/inspect_ai/solver/_solver.py
+++ b/src/inspect_ai/solver/_solver.py
@@ -194,20 +194,22 @@ def solver(name: str | SolverType) -> Callable[..., SolverType] | SolverType:
                 raise TypeError(f"'{solver}' is not declared as an async callable.")
 
             @wraps(solver)
-            async def solver_wrapper(state: TaskState, generate: Generate) -> TaskState:
+            async def solver_with_state(
+                state: TaskState, generate: Generate
+            ) -> TaskState:
                 state = await solver(state, generate)
                 set_sample_state(state)
                 return state
 
             registry_tag(
                 solver_type,
-                solver_wrapper,
+                solver_with_state,
                 RegistryInfo(type="solver", name=solver_name),
                 *args,
                 **kwargs,
             )
 
-            return solver
+            return solver_with_state
 
         return solver_register(cast(SolverType, solver_wrapper), solver_name)
 

--- a/src/inspect_ai/solver/_solver.py
+++ b/src/inspect_ai/solver/_solver.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from functools import wraps
 from typing import (
     Any,
     Callable,
@@ -22,7 +23,7 @@ from inspect_ai._util.registry import (
 )
 from inspect_ai.model import CachePolicy, GenerateConfigArgs
 
-from ._task_state import TaskState
+from ._task_state import TaskState, set_sample_state
 
 
 @runtime_checkable
@@ -192,9 +193,15 @@ def solver(name: str | SolverType) -> Callable[..., SolverType] | SolverType:
             if not is_callable_coroutine(solver):
                 raise TypeError(f"'{solver}' is not declared as an async callable.")
 
+            @wraps(solver)
+            async def solver_wrapper(state: TaskState, generate: Generate) -> TaskState:
+                state = await solver(state, generate)
+                set_sample_state(state)
+                return state
+
             registry_tag(
                 solver_type,
-                solver,
+                solver_wrapper,
                 RegistryInfo(type="solver", name=solver_name),
                 *args,
                 **kwargs,

--- a/src/inspect_ai/solver/_transcript.py
+++ b/src/inspect_ai/solver/_transcript.py
@@ -5,7 +5,7 @@ from inspect_ai._util.json import json_changes
 from inspect_ai._util.registry import registry_log_name
 
 from ._solver import Solver
-from ._task_state import TaskState, set_sample_state, state_jsonable
+from ._task_state import TaskState, state_jsonable
 
 
 class SolverTranscript:
@@ -28,7 +28,6 @@ def solver_transcript(
 ) -> Iterator[SolverTranscript]:
     from inspect_ai.log._transcript import transcript
 
-    set_sample_state(state)
     name = registry_log_name(name or solver)
     with transcript().step(name=name, type="solver"):
         yield SolverTranscript(name, state)

--- a/tests/solver/test_solver_spec.py
+++ b/tests/solver/test_solver_spec.py
@@ -61,7 +61,7 @@ def test_solver_extension():
         the_task(), solver=SolverSpec("inspect_package/cot"), model="mockllm/model"
     )[0]
     assert log.eval.solver == "inspect_package/cot"
-    assert log.plan.steps[0].solver == "chain_of_thought"
+    assert log.plan.steps[0].solver == "inspect_package/cot"
 
 
 def test_solver_retry():


### PR DESCRIPTION
Sample task state is used for creating state change events for steps, as well as soon for approvals. Previously we set it along with the transcript, which caught it whenever we were explicitly executing the solver (e.g. the main task solver(s), chains, and fork) however would not catch user solver executions. Now, we add a wrapper function that sets the state within the solver decorator.