### PR TITLE
improvements to docker compose down cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Allow Docker sandboxes configured with `x-default` to be referred to by their declared service name.
 - Track sample task state in solver decorator rather than solver transcript.
 - Display solver input parameters for forked subtasks.
+- Improvements to docker compose down cleanup: timeout, survive missing compose files.
 
 ## v0.3.32 (25 September 2024)
 

--- a/src/inspect_ai/util/_sandbox/docker/config.py
+++ b/src/inspect_ai/util/_sandbox/docker/config.py
@@ -15,7 +15,7 @@ CONFIG_FILES = [
 ]
 
 
-async def resolve_compose_file(parent: str = "") -> str | None:
+async def resolve_compose_file(parent: str = "") -> str:
     # existing compose file provides all the config we need
     compose = find_compose_file(parent)
     if compose is not None:


### PR DESCRIPTION
- 60 second timeout (and warn if we hit it)
- Print complete error message for failures
- Survive docker compose files that no longer exist
