### PR TITLE
require a `max_messages` for use of `basic_agent()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Capture solver input params for subtasks created by `fork()`.
 - Option to disable ANSI terminal output with `--no-ansi` or `INSPECT_NO_ANSI`
 - Allow Docker sandboxes configured with `x-default` to be referred to by their declared service name.
+- Require a `max_messages` for use of `basic_agent()` (as without it, the agent could end up in an infinite loop).
 - Track sample task state in solver decorator rather than solver transcript.
 - Display solver input parameters for forked subtasks.
 - Improvements to docker compose down cleanup: timeout, survive missing compose files.

--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -132,6 +132,12 @@ def basic_agent(
     @solver
     def basic_agent_loop() -> Solver:
         async def solve(state: TaskState, generate: Generate) -> TaskState:
+            # validate that there is a max_messages
+            if state.max_messages is None:
+                raise RuntimeError(
+                    "max_messages must be set when using basic_agent (without max_messages providing a termination condition it's possible the agent could end up in an infinite loop)"
+                )
+
             # track attempts
             attempts = 0
 

--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -250,6 +250,11 @@ class TaskState:
             raise ValueError("user_prompt requested from TaskState but none available")
 
     @property
+    def max_messages(self) -> int | None:
+        """max_messages before task is marked completed."""
+        return self._max_messages
+
+    @property
     def completed(self) -> bool:
         """Is the task completed."""
         if self._completed:

--- a/tests/solver/test_basic_agent.py
+++ b/tests/solver/test_basic_agent.py
@@ -38,7 +38,9 @@ AGENT_SUBMIT_TOOL_NAME = "agent_submit"
 AGENT_SUBMIT_TOOL_DESCRIPTION = "Submit an answer."
 
 
-def run_basic_agent(tools: list[Tool] | Solver) -> EvalLog:
+def run_basic_agent(
+    tools: list[Tool] | Solver, max_messages: int | None = 30
+) -> EvalLog:
     task = Task(
         dataset=[Sample(input="What is 1 + 1?", target=["2", "2.0", "Two"])],
         solver=basic_agent(
@@ -48,6 +50,7 @@ def run_basic_agent(tools: list[Tool] | Solver) -> EvalLog:
             submit_description=AGENT_SUBMIT_TOOL_DESCRIPTION,
         ),
         scorer=includes(),
+        max_messages=max_messages,
     )
 
     model = get_model(
@@ -127,3 +130,11 @@ def test_basic_agent_retries():
         1 for event in log.samples[0].transcript.events if event.event == "model"
     )
     assert model_events == 3
+
+
+def test_basic_agent_requires_max_messages():
+    try:
+        run_basic_agent([addition()], max_messages=None)[0]
+        assert False
+    except Exception:
+        pass

--- a/tests/solver/test_basic_agent.py
+++ b/tests/solver/test_basic_agent.py
@@ -104,6 +104,7 @@ def test_basic_agent_retries():
             dataset=[Sample(input="What is 1 + 1?", target=["2", "2.0", "Two"])],
             solver=basic_agent(tools=[addition()], max_attempts=max_attempts),
             scorer=includes(),
+            max_messages=30,
         )
 
     def mockllm_model(answers: list[str]):


### PR DESCRIPTION
Require a `max_messages` for use of `basic_agent()` (as without it, the agent could end up in an infinite loop).