### PR TITLE
Handle Mathvista PNG images with .jpg extension

### DIFF
--- a/evals/mathvista/mathvista.py
+++ b/evals/mathvista/mathvista.py
@@ -2,6 +2,7 @@ import re
 from pathlib import Path
 
 from inspect_ai import Task, task
+from inspect_ai._util.images import is_image_png
 from inspect_ai.dataset import Sample, hf_dataset
 from inspect_ai.model import ChatMessage, ChatMessageUser, ContentImage, ContentText
 from inspect_ai.scorer import (
@@ -115,11 +116,17 @@ def mathvista_solver() -> Solver:
 def record_to_sample(record: dict) -> Sample:
     # extract image
     image = Path(record["image"])
+
+    # images are a mix of jpg and png but all have a file extension of .jpg
+    image_bytes = record["decoded_image"]["bytes"]
+    if (is_image_png(image_bytes)):
+        image = image.with_suffix(".png")
+
     if not image.exists():
         print(f"Extracting {image}")
         image.parent.mkdir(exist_ok=True)
         with open(image, "wb") as file:
-            file.write(record["decoded_image"]["bytes"])
+            file.write(image_bytes)
 
     message: list[ChatMessage] = [
         ChatMessageUser(

--- a/src/inspect_ai/_util/images.py
+++ b/src/inspect_ai/_util/images.py
@@ -43,3 +43,7 @@ async def image_as_data_uri(image: str) -> str:
     base64_image = base64.b64encode(bytes).decode("utf-8")
     image = f"data:{mime_type};base64,{base64_image}"
     return image
+
+
+def is_image_png(image_bytes: bytes) -> bool:
+    return image_bytes[:8] == b"\x89\x50\x4E\x47\x0D\x0A\x1A\x0A"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
https://github.com/UKGovernmentBEIS/inspect_ai/issues/483

### What is the new behavior?
PNG images from Mathvista are now saved with the extension `.png` instead of `.jpg`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Hopefully none, though I am not certain.

### Other information:
I checked that this works by running sections of the code locally - if this needs proper tests, I may need someone to point me in the right direction.