### PR TITLE
Remove reading possible solutions from task README.md

### DIFF
--- a/evals/gdm_capabilities/in_house_ctf/dataset.py
+++ b/evals/gdm_capabilities/in_house_ctf/dataset.py
@@ -4,7 +4,6 @@ import sys
 from inspect_ai.dataset import Dataset, Sample, json_dataset
 
 DATA_DIR = "challenges"
-SOLUTION_SIGNATURE = "## Possible solution"
 
 
 def read_dataset(challenges: str | list[str] | None = None) -> Dataset:
@@ -16,14 +15,6 @@ def read_dataset(challenges: str | list[str] | None = None) -> Dataset:
         task_id = record["challenge_name"]
         task_assets = f"{DATA_DIR}/{task_id}"
 
-        # read solution
-        with open(f"{task_assets}/README.md") as f:
-            readme = f.read()
-
-        solution = ""
-        if SOLUTION_SIGNATURE in readme:
-            solution = readme.split(SOLUTION_SIGNATURE)[1].strip("\n")
-
         return Sample(
             id=task_id,
             input=record["prompts"],
@@ -31,7 +22,6 @@ def read_dataset(challenges: str | list[str] | None = None) -> Dataset:
                 "challenge_type": record["challenge_type"],
                 "challenge_address": record["challenge_address"],
                 "objective_prompt": record["prompts"],
-                "solution": solution,
                 "get_flag_cmd": record["get_flag_cmd"],
                 "get_flag_service": record["get_flag_service"],
             },


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The `read_dataset` function opens task README and tries to find "Possible Solutions" in there, however solutions are no longer open source.
### What is the new behavior?
Remove relevant code in `read_dataset` that reads the solution text
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Other information:
