### PR TITLE
HumanEval: add sandbox parameter

### DIFF
--- a/evals/humaneval/humaneval.py
+++ b/evals/humaneval/humaneval.py
@@ -50,7 +50,7 @@ this function.\n
 
 
 @task
-def humaneval():
+def humaneval(sandbox="docker"):
     return Task(
         dataset=hf_dataset(
             path="openai_humaneval", split="test", sample_fields=record_to_sample
@@ -58,7 +58,7 @@ def humaneval():
         epochs=Epochs(NUM_EPOCHS, ["mean", "pass_at_1", "pass_at_2", "pass_at_5"]),
         solver=[generate()],
         scorer=verify(),
-        sandbox="docker",
+        sandbox=sandbox,
     )
 
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

HumanEval's `sandbox` property is not immediately configurable

### What is the new behavior?

Let callers to `humaneval` specify a `sandbox` argument

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
