### PR TITLE
Preserve reduced score data only if equal across all epochs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Track sample task state in solver decorator rather than solver transcript.
 - Display solver input parameters for forked subtasks.
 - Improvements to docker compose down cleanup: timeout, survive missing compose files.
+- Scores produced after being reduced retain `answer`, `explanation`, and `metadata` only if equal across all epochs.
 
 ## v0.3.32 (25 September 2024)
 

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -565,9 +565,31 @@ Inspect includes several built in reducers which are summarised below.
 
 :::{.callout-note}
 
-The built in reducers will compute a reduced `value` for the score and populate the remaining fields (`answer`, `explanation`, and `metadata` using the values from the first score that is being reduced)
+The built in reducers will compute a reduced `value` for the score and populate the remaining fields (`answer`, `explanation`, and `metadata`) only if equal across all epochs. If your custom metrics function relies on these fields, you should also implement your own custom reducer and merge or preserve these fields in some way.
 
 :::
+
+### Custom Reducers
+
+You can also add your own reducer with `@score_reducer` decorated functions. Here’s a somewhat simplified version of the code for the `mean` reducer:
+
+``` python
+import statistics
+
+from inspect_ai.scorer import Score, ScoreReducer, score_reducer
+
+@score_reducer(name="mean")
+def mean_score() -> ScoreReducer:
+    def reduce(scores: list[Score]) -> Score:
+        """Compute a mean value of all scores."""
+
+        values = [float(score.value) for score in scores]
+        mean_value = statistics.mean(values)
+
+        return Score(value=mean_value)
+
+    return reduce
+```
 
 
 ## Workflow {#sec-scorer-workflow}

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -324,7 +324,15 @@ def _reduced_score(value: Value, scores: list[Score]) -> Score:
     """
     return Score(
         value=value,
-        answer=scores[0].answer,
-        explanation=scores[0].explanation,
-        metadata=scores[0].metadata,
+        # retain remaining fields only if equal across all Scores
+        answer=scores[0].answer
+        if len(set(score.answer for score in scores)) == 1
+        else None,
+        explanation=scores[0].explanation
+        if len(set(score.explanation for score in scores)) == 1
+        else None,
+        metadata=scores[0].metadata
+        if len(set(tuple(score.metadata.items()) for score in scores if score.metadata))
+        == 1
+        else None,
     )


### PR DESCRIPTION
* Extended `test_reducer_preserve_metadata` to check for new behavior.

* Added changelog entry and adjusted existing note in documentation, mentioning the possibility of having a custom reducer.

* Added a new documentation section for custom reducers.

## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [X] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Reduced scores retain `explanation`, `answer`, and `metadata` fields from the first score, which may not be the best choice in all cases.

### What is the new behavior?
`Score` fields `explanation`, `answer`, and `metadata` are retained only if equal across all epochs. Based on discussion in #426 (after it was merged).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Technically, it does, since as of #426 the additional fields were always retained from the first score, but this behavior is only two weeks old. Before that, these additional fields weren't retained at all.

### Other information:
Since the doc note added in #426 now mentions the possibility of having a custom reducer in case the custom metrics function relies on these additional fields, have also added a new doc section for custom reducers.