### PR TITLE
docker/compose.py: `shlex.join` for more copy-pastable logs

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shlex
 from logging import getLogger
 from pathlib import Path
 from typing import Any, Literal, TypedDict, cast
@@ -265,7 +266,7 @@ async def compose_command(
     compose_command = compose_command + command
 
     # Execute the command
-    sandbox_log(f"compose command: {compose_command}")
+    sandbox_log(f"compose command: {shlex.join(compose_command)}")
     result = await subprocess(
         compose_command,
         input=input,


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [] Changes to dev-tools e.g. CI config / github tooling
- [] Docs
- [] Bug fixes
- [] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Logs like `SANDBOX  DOCKER: compose command: ['docker', 'compose', '--project-name', 'inspect-startup-ibbfditfgxpc4nsjex3wd2t', '-f', ...`

### What is the new behavior?

Logs like `SANDBOX  DOCKER: compose command: docker compose --project-name inspect-startup-ibbfditfgxpc4nsjex3wd2t -f ...`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Shouldn't

### Other information:
