### PR TITLE
docker sandbox: give an informative error message if version cmd fails

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/prereqs.py
+++ b/src/inspect_ai/util/_sandbox/docker/prereqs.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 from logging import getLogger
 from typing import Callable
 
@@ -88,6 +89,13 @@ async def validate_version(
         raise PrerequisiteError(
             "ERROR: Docker sandbox environments require Docker Engine\n\n"
             + "Install: https://docs.docker.com/engine/install/"
+        )
+
+    if not result.success:
+        raise PrerequisiteError(
+            "ERROR: Docker sandbox environments require a working Docker Engine\n\n"
+            + f"{cmd[0]} exited with return code {result.returncode} when executing: {shlex.join(cmd)}\n"
+            + result.stderr
         )
 
     # validate version


### PR DESCRIPTION
This happens when we get an error such as "Cannot connect to the Docker daemon ..."
