### PR TITLE
load extension entrypoints per-package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Display images created by tool calls in the Viewer.
 - Fix duplicated tool call output display in Viewer for Gemini and Llama models.
 - Require a `max_messages` for use of `basic_agent()` (as without it, the agent could end up in an infinite loop).
+- Load extension entrypoints per-package (prevent unnecessary imports from packages not being referenced).
 - Track sample task state in solver decorator rather than solver transcript.
 - Display solver input parameters for forked subtasks.
 - Improvements to docker compose down cleanup: timeout, survive missing compose files.

--- a/src/inspect_ai/_util/entrypoints.py
+++ b/src/inspect_ai/_util/entrypoints.py
@@ -1,23 +1,49 @@
-from importlib.metadata import EntryPoints, entry_points
+from importlib.metadata import entry_points
 from logging import getLogger
 
 logger = getLogger(__name__)
 
 
-def ensure_entry_points() -> None:
-    # ensure that inspect model provider extensions are loaded if
-    # they haven't been already
-    global _inspect_ai_eps
-    if not _inspect_ai_eps:
-        _inspect_ai_eps = entry_points(group="inspect_ai")
-        for ep in _inspect_ai_eps:
-            try:
+def ensure_entry_points(package: str | None = None) -> None:
+    # have we already loaded all entry points?
+    global _inspect_ai_eps_loaded_all
+    if _inspect_ai_eps_loaded_all:
+        return None
+
+    # have we already loaded entry points for this package?
+    if package in _inspect_ai_eps_loaded:
+        return None
+
+    # inspect_evals is special b/c it's in _this_ package,
+    # load it manually
+    if package == "inspect_evals":
+        from inspect_evals import _registry  # noqa: F401
+
+        _inspect_ai_eps_loaded.append(package)
+        return None
+
+    # enumerate entry points
+    eps = entry_points(group="inspect_ai")
+    for ep in eps:
+        try:
+            # if there is a package filter then condition on that
+            if package is not None:
+                if ep.dist and ep.dist.name == package:
+                    ep.load()
+                    _inspect_ai_eps_loaded.append(package)
+
+            # if there is no package filter then load unconditionally
+            # and mark us as fully loaded
+            else:
                 ep.load()
-            except Exception as ex:
-                logger.warning(
-                    f"Unexpected exception loading entrypoints from '{ep.value}': {ex}"
-                )
+                _inspect_ai_eps_loaded_all = True
+
+        except Exception as ex:
+            logger.warning(
+                f"Unexpected exception loading entrypoints from '{ep.value}': {ex}"
+            )
 
 
 # inspect extension entry points
-_inspect_ai_eps: EntryPoints | None = None
+_inspect_ai_eps_loaded: list[str] = []
+_inspect_ai_eps_loaded_all: bool = False

--- a/src/inspect_ai/_util/registry.py
+++ b/src/inspect_ai/_util/registry.py
@@ -149,12 +149,10 @@ def registry_lookup(type: RegistryType, name: str) -> object | None:
 
     # try to recover
     if o is None:
-        # load entry points as required
+        # load entry points for this package as required
         if name.find("/") != -1 and name.find(".") == -1:
-            ensure_entry_points()
-        # if this is a request for inspect_evals/ import its registry
-        if name.startswith("inspect_evals/"):
-            import inspect_evals._registry  # noqa: F401
+            package = name.split("/")[0]
+            ensure_entry_points(package)
 
         return _lookup()
     else:

--- a/tests/test_package/inspect_package/_registry.py
+++ b/tests/test_package/inspect_package/_registry.py
@@ -5,7 +5,7 @@ from .solvers.cot import cot  # noqa: F401
 
 # delayed import for the model and sandbox allows us to only resolve the imports
 # when they are actually requeasted (so that we don't end up requiring all
-# of their dependencies whenever inspect is loaded)
+# of their dependencies when this package's entry points are loaded)
 
 
 @modelapi(name="custom")

--- a/tests/test_package/pyproject.toml
+++ b/tests/test_package/pyproject.toml
@@ -17,5 +17,5 @@ requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
 [project.entry-points.inspect_ai]
-inspect_package = "inspect_package.inspect_extensions"
+inspect_package = "inspect_package._registry"
 


### PR DESCRIPTION
This will prevent prevent unnecessary imports from packages not being referenced.
