### PR TITLE
Display user messages prior to the model call

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -12138,8 +12138,6 @@ const ChatView = ({ id, messages, style, indented }) => {
       if (resolvedMessages.length > 0) {
         const msg = resolvedMessages[resolvedMessages.length - 1];
         msg.toolOutput = message;
-      } else {
-        console.warn("Received a tool message without a preceding message.");
       }
     } else {
       resolvedMessages.push({ message });

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -16269,7 +16269,24 @@ const ModelEventView = ({ id, event, style }) => {
     alignSelf: "start",
     justifySelf: "start"
   };
+  const userMessages = [];
+  for (const msg of event.input.reverse()) {
+    if (msg.role === "user") {
+      userMessages.push(msg);
+    } else {
+      break;
+    }
+  }
+  const userMsg = userMessages.length > 0 ? m$1`
+  <${EventPanel} id=${id} title="Message" icon=${ApplicationIcons.input} style=${style}>
+    <${ChatView}
+      id="${id}-model-output"
+      messages=${[...userMessages || []]}
+      style=${{ paddingTop: "1em" }}
+      />
+  </${EventPanel}>` : "";
   return m$1`
+  ${userMsg}
   <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}" icon=${ApplicationIcons.model} style=${style}>
   
     <div name="Completion" style=${{ margin: "0.5em 0" }}>

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -16275,22 +16275,13 @@ const ModelEventView = ({ id, event, style }) => {
       break;
     }
   }
-  const userMsg = userMessages.length > 0 ? m$1`
-  <${EventPanel} id=${id} title="Message" icon=${ApplicationIcons.input} style=${style}>
-    <${ChatView}
-      id="${id}-model-output"
-      messages=${[...userMessages || []]}
-      style=${{ paddingTop: "1em" }}
-      />
-  </${EventPanel}>` : "";
   return m$1`
-  ${userMsg}
   <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}" icon=${ApplicationIcons.model} style=${style}>
   
     <div name="Completion" style=${{ margin: "0.5em 0" }}>
     <${ChatView}
       id="${id}-model-output"
-      messages=${[...outputMessages || []]}
+      messages=${[...userMessages, ...outputMessages || []]}
       style=${{ paddingTop: "1em" }}
       />
     </div>

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -32,8 +32,6 @@ export const ChatView = ({ id, messages, style, indented }) => {
       if (resolvedMessages.length > 0) {
         const msg = resolvedMessages[resolvedMessages.length - 1];
         msg.toolOutput = message;
-      } else {
-        console.warn("Received a tool message without a preceding message.");
       }
     } else {
       resolvedMessages.push({ message });

--- a/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
@@ -46,7 +46,30 @@ export const ModelEventView = ({ id, event, style }) => {
     justifySelf: "start",
   };
 
+  // For any user messages which immediately preceded this model call, including a
+  // panel and display those user messages
+  const userMessages = [];
+  for (const msg of event.input.reverse()) {
+    if (msg.role === "user") {
+      userMessages.push(msg);
+    } else {
+      break;
+    }
+  }
+  const userMsg =
+    userMessages.length > 0
+      ? html`
+  <${EventPanel} id=${id} title="Message" icon=${ApplicationIcons.input} style=${style}>
+    <${ChatView}
+      id="${id}-model-output"
+      messages=${[...(userMessages || [])]}
+      style=${{ paddingTop: "1em" }}
+      />
+  </${EventPanel}>`
+      : "";
+
   return html`
+  ${userMsg}
   <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}" icon=${ApplicationIcons.model} style=${style}>
   
     <div name="Completion" style=${{ margin: "0.5em 0" }}>

--- a/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
@@ -56,26 +56,14 @@ export const ModelEventView = ({ id, event, style }) => {
       break;
     }
   }
-  const userMsg =
-    userMessages.length > 0
-      ? html`
-  <${EventPanel} id=${id} title="Message" icon=${ApplicationIcons.input} style=${style}>
-    <${ChatView}
-      id="${id}-model-output"
-      messages=${[...(userMessages || [])]}
-      style=${{ paddingTop: "1em" }}
-      />
-  </${EventPanel}>`
-      : "";
 
   return html`
-  ${userMsg}
   <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}" icon=${ApplicationIcons.model} style=${style}>
   
     <div name="Completion" style=${{ margin: "0.5em 0" }}>
     <${ChatView}
       id="${id}-model-output"
-      messages=${[...(outputMessages || [])]}
+      messages=${[...userMessages, ...(outputMessages || [])]}
       style=${{ paddingTop: "1em" }}
       />
     </div>


### PR DESCRIPTION
When we display a model call, we will no display any user message that immediately preceded it, making it easier to understand the context of the model call (and to be aware that this user message exists!).

<img width="969" alt="Screenshot 2024-09-29 at 7 59 58 PM" src="https://github.com/user-attachments/assets/70eb3687-7b6b-4ce0-ac6a-bfa9da7bef90">

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor


