### PR TITLE
Improve HumanEval code parsing

### DIFF
--- a/evals/humaneval/humaneval.py
+++ b/evals/humaneval/humaneval.py
@@ -105,8 +105,9 @@ def verify() -> Scorer:
 
 # extract code from completion (removing markdown and/or signature)
 def find_code(completion: str) -> str:
-    pattern = re.compile(r"```python\n(.*?)```", re.DOTALL)
-    matches = pattern.findall(completion)
+    pattern_1 = re.compile(r"```python\n(.*?)```", re.DOTALL)
+    pattern_2 = re.compile(r"```\n(.*?)```", re.DOTALL)
+    matches = pattern_1.findall(completion) + pattern_2.findall(completion)
     extracted_answer = matches[0] if len(matches) >= 1 else completion
     # remove signature
     extracted_answer = extracted_answer[extracted_answer.find(":\n    ") + 2 :]


### PR DESCRIPTION
Correctly parse markdown code blocks which do not include the language after the backticks

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The HumanEval function `find_code` only matches code blocks that start with triple backticks followed by `python`. Code blocks with backticks only, without the string `python`, are not found.

As a result, all models that write code with backticks only score approximately 0%. See this example with Llama 3 8B Chat. [2024-09-30T16-02-46+01-00_bench-humaneval_FCpw3ESRoQmiy7WKtfUmxQ.json](https://github.com/user-attachments/files/17192249/2024-09-30T16-02-46%2B01-00_bench-humaneval_FCpw3ESRoQmiy7WKtfUmxQ.json)

### What is the new behavior?
Both types of code blocks are parsed correctly. Llama 3 8B Chat gets 58% on HumanEval, which is close to the [claims](https://ai.meta.com/blog/meta-llama-3/) made by Meta. See 
[2024-09-30T15-52-39+01-00_bench-humaneval_EhzkmRvn36i3UqKjVFxJ4z.json](https://github.com/user-attachments/files/17192300/2024-09-30T15-52-39%2B01-00_bench-humaneval_EhzkmRvn36i3UqKjVFxJ4z.json)


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
Normally, I would include a test with a PR. I didn't include one since the codebase so far contains no tests for benchmark implementations, so I didn't know where to put it.