### PR TITLE
Don’t steal focus

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -17710,10 +17710,6 @@ const SamplesTab = (props) => {
   }, [setSampleDialogVisible, sampleDialogRef]);
   const hideSample = q(() => {
     setSampleDialogVisible(false);
-    const listEl = sampleListRef.current;
-    if (listEl && listEl.base) {
-      listEl.base.focus();
-    }
   }, [setSampleDialogVisible]);
   y(() => {
     const { sorted, order: order2 } = sort(sort$1, filteredSamples, sampleDescriptor);

--- a/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
@@ -58,10 +58,6 @@ export const SamplesTab = (props) => {
 
   const hideSample = useCallback(() => {
     setSampleDialogVisible(false);
-    const listEl = sampleListRef.current;
-    if (listEl && listEl.base) {
-      listEl.base.focus();
-    }
   }, [setSampleDialogVisible]);
 
   useEffect(() => {


### PR DESCRIPTION
This steals focus when a view is loaded since it tries to dimsiss any visible sample dialog.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
