### PR TITLE
revert change to score reducers to address regression in what types are supported in scorer metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Catch o1-preview "invalid_prompt" exception and convert to normal content_filter refusal.
+- Revert change to score reducers to address regression in what types are supported in scorer metadata.
 
 ## v0.3.34 (30 September 2024)
 

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -1,6 +1,6 @@
 import statistics
 from collections import Counter
-from typing import Any, Callable, cast
+from typing import Callable, cast
 
 import numpy as np
 
@@ -332,32 +332,7 @@ def _reduced_score(value: Value, scores: list[Score]) -> Score:
         if len(set(score.explanation for score in scores)) == 1
         else None,
         metadata=scores[0].metadata
-        if len(
-            set(
-                tuple(
-                    (key, _make_hashable(value))
-                    for key, value in score.metadata.items()
-                )
-                for score in scores
-                if score.metadata
-            )
-        )
+        if len(set(tuple(score.metadata.items()) for score in scores if score.metadata))
         == 1
         else None,
     )
-
-
-def _make_hashable(item: Any) -> Any:
-    r"""Recursively convert dictionaries to tuples of tuples to make them hashable.
-
-    Args:
-        item: a dictionary or list of dictionaries
-    """
-    if isinstance(item, dict):
-        return tuple(
-            (key, _make_hashable(value)) for key, value in sorted(item.items())
-        )
-    elif isinstance(item, list):
-        return tuple(_make_hashable(x) for x in item)
-    else:
-        return item


### PR DESCRIPTION
Addresses: https://github.com/UKGovernmentBEIS/inspect_ai/issues/587

Regression introduced in: https://github.com/UKGovernmentBEIS/inspect_ai/pull/577

@tflesch I think we need to find a way to accomplish this without the type coercion. Since metadata often has unexpected types, I wonder if the merging could ignore metadata (and perhaps just take the first value for that).