### PR TITLE
support service prefixes for anthropic models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Catch o1-preview "invalid_prompt" exception and convert to normal content_filter refusal.
+- Support 'anthropoic/bedrock/' service prefix for Anthropic models hosted on AWS Bedrock.
 
 ## v0.3.34 (30 September 2024)
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -66,6 +66,14 @@ class AnthropicAPI(ModelAPI):
         bedrock: bool = False,
         **model_args: Any,
     ):
+        # extract any service prefix from model name
+        parts = model_name.split("/")
+        if len(parts) > 1:
+            service = parts[0]
+            bedrock = service == "bedrock"
+            model_name = "/".join(parts[1:])
+
+        # call super
         super().__init__(
             model_name=model_name,
             base_url=base_url,


### PR DESCRIPTION
For example, to use a bedrock model:

```bash
--model anthropic/bedrock/anthropic.claude-3-5-sonnet-20240620-v1:0
```
