### PR TITLE
Always preserve first metadata value when reducing scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Catch o1-preview "invalid_prompt" exception and convert to normal content_filter refusal.
 - Support 'anthropoic/bedrock/' service prefix for Anthropic models hosted on AWS Bedrock.
+- Change score reducer behavior to always reduce score metadata to the value of the `metadata` field in the first epoch
 
 ## v0.3.34 (30 September 2024)
 

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -565,7 +565,7 @@ Inspect includes several built in reducers which are summarised below.
 
 :::{.callout-note}
 
-The built in reducers will compute a reduced `value` for the score and populate the remaining fields (`answer`, `explanation`, and `metadata`) only if equal across all epochs. If your custom metrics function relies on these fields, you should also implement your own custom reducer and merge or preserve these fields in some way.
+The built in reducers will compute a reduced `value` for the score and populate the fields `answer` and `explanation` only if their value is equal across all epochs. The `metadata` field will always be reduced to the value of `metadata` in the first epoch. If your custom metrics function needs differing behavior for reducing fields, you should also implement your own custom reducer and merge or preserve fields in some way.
 
 :::
 

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -1,6 +1,6 @@
 import statistics
 from collections import Counter
-from typing import Any, Callable, cast
+from typing import Callable, cast
 
 import numpy as np
 
@@ -331,33 +331,5 @@ def _reduced_score(value: Value, scores: list[Score]) -> Score:
         explanation=scores[0].explanation
         if len(set(score.explanation for score in scores)) == 1
         else None,
-        metadata=scores[0].metadata
-        if len(
-            set(
-                tuple(
-                    (key, _make_hashable(value))
-                    for key, value in score.metadata.items()
-                )
-                for score in scores
-                if score.metadata
-            )
-        )
-        == 1
-        else None,
+        metadata=scores[0].metadata,
     )
-
-
-def _make_hashable(item: Any) -> Any:
-    r"""Recursively convert dictionaries to tuples of tuples to make them hashable.
-
-    Args:
-        item: a dictionary or list of dictionaries
-    """
-    if isinstance(item, dict):
-        return tuple(
-            (key, _make_hashable(value)) for key, value in sorted(item.items())
-        )
-    elif isinstance(item, list):
-        return tuple(_make_hashable(x) for x in item)
-    else:
-        return item

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -1,3 +1,7 @@
+from collections import namedtuple
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
 from functools import reduce
 
 from inspect_ai import Epochs, Task, eval
@@ -118,7 +122,7 @@ def test_reducer_preserve_metadata() -> None:
         reduced = reducer(simple_scores)
         assert reduced.answer is None
         assert reduced.explanation is None
-        assert reduced.metadata is None
+        assert reduced.metadata == simple_scores[0].metadata
         # reduce all scores _except_ the last one
         reduced = reducer(simple_scores[:-1])
         assert reduced.answer == simple_scores[0].answer
@@ -131,6 +135,85 @@ def test_reducer_preserve_metadata() -> None:
         assert reduced.answer == simple_scores[0].answer
         assert reduced.explanation == simple_scores[0].explanation
         assert reduced.metadata == simple_scores[0].metadata
+
+
+@dataclass
+class Foo:
+    foo: bool
+
+
+class DifficultyLevel(Enum):
+    EASY = 1
+    MEDIUM = 2
+    HARD = 3
+
+
+Point = namedtuple("Point", ["x", "y"])  # noqa: F821
+
+
+def test_complex_metadata_reduce():
+    list_scores = [
+        Score(
+            value=1,
+            answer="A",
+            explanation="It is A",
+            metadata={
+                "foo": Foo(foo=True),
+                "count": 5,
+                "probability": 0.75,
+                "tags": ["math", "algebra"],
+                "user": {"id": 123, "name": "John"},
+                "timestamp": datetime.now(),
+                "difficulty": DifficultyLevel.MEDIUM,
+                "optional_data": None,
+                "stats": {"attempts": 3, "success_rate": 0.67},
+                "frozen_set": frozenset([1, 2, 3]),
+                "point": Point(x=1, y=2),
+            },
+        ),
+        Score(
+            value=1,
+            answer="A",
+            explanation="It is A",
+            metadata={
+                "foo": Foo(foo=True),
+                "count": 5,
+                "probability": 0.75,
+                "tags": ["math", "algebra"],
+                "user": {"id": 123, "name": "John"},
+                "timestamp": datetime.now(),
+                "difficulty": DifficultyLevel.MEDIUM,
+                "optional_data": None,
+                "stats": {"attempts": 3, "success_rate": 0.67},
+                "frozen_set": frozenset([1, 2, 3]),
+                "point": Point(x=1, y=2),
+            },
+        ),
+        Score(
+            value=1,
+            answer="A",
+            explanation="It is A",
+            metadata={
+                "foo": Foo(foo=True),
+                "count": 5,
+                "probability": 0.75,
+                "tags": ["math", "algebra"],
+                "user": {"id": 123, "name": "John"},
+                "timestamp": datetime.now(),
+                "difficulty": DifficultyLevel.MEDIUM,
+                "optional_data": None,
+                "stats": {"attempts": 3, "success_rate": 0.67},
+                "frozen_set": frozenset([1, 2, 3]),
+                "point": Point(x=1, y=2),
+            },
+        ),
+    ]
+
+    reduced = avg_reducer(list_scores)
+    assert reduced.value == 1
+    assert reduced.answer == "A"
+    assert reduced.explanation == "It is A"
+    assert reduced.metadata == list_scores[0].metadata
 
 
 @score_reducer(name="add_em_up")


### PR DESCRIPTION
Fixes #587

See conversation on PR #591

The simplest approach which is deterministic is to simply preserve the first metadata value when reducing (without any comparison). This will avoid the complicated comparison of metadata objects which have all the various traps we're running into and keep metadata around for common cases.

The alternative would be to never preserve score metadata, but this would have the effect of clearing the metadata even when a single score is being ‘reduced’ since we run the reducer pass no matter the number of epochs being run.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Score metadata is compared for equality using hashing to determine whether the value should be retained when reducing.

### What is the new behavior?

The first score metadata value is always preserved when reducing scores.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

It could - if there is code depending upon the absence of score metadata when being reduced, this would cause differing behavior.

### Other information:
