### PR TITLE
remove api_key from model_args

### DIFF
--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -66,6 +66,11 @@ class TaskLogger:
         )
         packages = {PKG_NAME: importlib_metadata.version(PKG_NAME)}
 
+        # remove api_key from model_args
+        model_args = model_args.copy()
+        if "api_key" in model_args:
+            del model_args["api_key"]
+
         # create eval spec
         self.eval = EvalSpec(
             run_id=run_id,


### PR DESCRIPTION
Note that this will mean that eval-retry won't work for these logs (eval-set can be used instead)