### PR TITLE
Add dataset support for `.tsv` files

### DIFF
--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -1,7 +1,7 @@
 import csv
 from io import TextIOWrapper
 from pathlib import Path
-from typing import Any
+from typing import Any, List
 
 from inspect_ai._util.file import file
 from inspect_ai.dataset._sources.util import resolve_sample_files
@@ -27,13 +27,14 @@ def csv_dataset(
     encoding: str = "utf-8",
     name: str | None = None,
     fs_options: dict[str, Any] = {},
+    fieldnames: list[str] | None = None,
 ) -> Dataset:
     r"""Read dataset from CSV file.
 
     Args:
-        csv_file (str): Path to CSV file. Can be a local filesystem path or
-            a path to an S3 bucket (e.g. "s3://my-bucket"). Use `fs_options`
-            to pass arguments through to the `S3FileSystem` constructor.
+        csv_file (str): Path to CSV file. Can be a local filesystem path,
+            a path to an S3 bucket (e.g. "s3://my-bucket"), or an HTTPS URL.
+            Use `fs_options` to pass arguments through to the `S3FileSystem` constructor.
         sample_fields (FieldSpec | RecordToSample): Method of mapping underlying
             fields in the data source to Sample objects. Pass `None` if the data is already
             stored in `Sample` form (i.e. has "input" and "target" columns.); Pass a
@@ -43,13 +44,16 @@ def csv_dataset(
         shuffle (bool): Randomly shuffle the dataset order.
         seed: (int | None): Seed used for random shuffle.
         limit (int | None): Limit the number of records to read.
-        dialect (str): CSV dialect ("unix" or "excel", defaults to "unix").
+        dialect (str): CSV dialect ("unix", "excel" or"excel-tab"). Defaults to "unix". See https://docs.python.org/3/library/csv.html#dialects-and-formatting-parameters for more details
         encoding (str): Text encoding for file (defaults to "utf-8").
         name (str): Optional name for dataset (for logging). If not specified,
             defaults to the stem of the filename
         fs_options (dict[str, Any]): Optional. Additional arguments to pass through
             to the filesystem provider (e.g. `S3FileSystem`). Use `{"anon": True }`
             if you are accessing a public S3 bucket with no credentials.
+        fieldnames (list[str] | None): Optional. A list of fieldnames to use for the CSV.
+            If None, the values in the first row of file f will be used as the fieldnames.
+            Useful for files without a header.
 
     Returns:
         Dataset read from CSV file.
@@ -62,7 +66,7 @@ def csv_dataset(
         # filter out rows with empty values
         valid_data = [
             data
-            for data in csv_dataset_reader(f, dialect)
+            for data in csv_dataset_reader(f, dialect, fieldnames)
             if data and any(value.strip() for value in data.values())
         ]
         name = name if name else Path(csv_file).stem
@@ -86,5 +90,7 @@ def csv_dataset(
         return dataset
 
 
-def csv_dataset_reader(file: TextIOWrapper, dialect: str = "unix") -> DatasetReader:
-    return csv.DictReader(file, dialect=dialect)
+def csv_dataset_reader(
+    file: TextIOWrapper, dialect: str = "unix", fieldnames: List[str] | None = None
+) -> DatasetReader:
+    return csv.DictReader(file, dialect=dialect, fieldnames=fieldnames)


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

1. It is not possible to load `.tsv` files properly
2. It is not possible to load `.csv` and `.tsv` files without a header

MGSM dataset uses tab-separated file format without a header.
See [simple-evals/mgsm_eval.py](https://github.com/openai/simple-evals/blob/main/mgsm_eval.py)

This functionality would help add MGSM to `inspect_eval` (see https://github.com/UKGovernmentBEIS/inspect_evals/issues/3 )

### What is the new behavior?

1. New parameter `fieldnames` is added to `csv_dataset`. By default it is None, which preserves backward compatibility. This parameter is passed directly into csv.
2. Docstring is updated.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking changes.

### Other information:

This is how I currently use `csv_dataset`:

```python
  mgsm_dataset = csv_dataset(
      tsv_file_path, fieldnames=["input", "target"], dialect="excel-tab"
  )
```

I am not very familiar with the codebase. Tests are passing, but not 100% that this will not break anything.