### PR TITLE
Add optional content parameter to ModelOutput.for_tool_call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add support for reading CSV files of dialect 'excel-tab'.
 - Improve prompting for Python tool to emphasise the need to print output.
 - For `basic_agent()`, defer to task `max_messages` if none is specified for the agent (default to 50 is the task does not specify `max_messages`).
+- Add optional `content` parameter to `ModelOutput.for_tool_call()`.
 
 ## v0.3.39 (3 October 2024)
 

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -158,7 +158,10 @@ class ModelOutput(BaseModel):
 
     @staticmethod
     def for_tool_call(
-        model: str, tool_name: str, tool_arguments: dict[str, Any]
+        model: str,
+        tool_name: str,
+        tool_arguments: dict[str, Any],
+        content: str | None = None,
     ) -> "ModelOutput":
         """
         Returns a ModelOutput for requesting a tool call.
@@ -167,16 +170,20 @@ class ModelOutput(BaseModel):
             model: model name
             tool_name: The name of the tool.
             tool_arguments: The arguments passed to the tool.
+            content: Optional content to include in the message. Defaults to "tool call for tool {tool_name}".
 
         Returns:
             A ModelOutput corresponding to the tool call
         """
+        if content is None:
+            content = f"tool call for tool {tool_name}"
+
         return ModelOutput(
             model=model,
             choices=[
                 ChatCompletionChoice(
                     message=ChatMessageAssistant(
-                        content=f"tool call for tool {tool_name}",
+                        content=content,
                         source="generate",
                         tool_calls=[
                             ToolCall(


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
* When calling `ModelOutput.for_tool_call()`, the `content` of the model output is `"tool call for {tool_name}"`

### What is the new behavior?
* The `content` of the model output defaults to the same, but can be customised via an optional parameter

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. it's optional and the default doesn't change
