### PR TITLE
Prune Sample Reductions

### DIFF
--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -264,7 +264,12 @@ def read_eval_log(log_file: str | FileInfo, header_only: bool = False) -> EvalLo
 
         # prune if header_only
         if header_only:
+            # exclude samples
             log.samples = None
+
+            # prune sample reductions
+            if log.results is not None:
+                log.results.sample_reductions = None
 
         # return log
         return log


### PR DESCRIPTION
When returning `header_only` we’re trying to provide macro level performance and metadata while omitting sample specific data which inflates the size the of the data. We are currently leaving `sample_reductions` when providing `header_only`, which can inflate the size of the headers file since it includes an entry for each sample (bad, for example, when model grading and each reduced sample carries an explanation from the model).

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor
