### PR TITLE
docs: Fix DEFAULT_PROMPT examples

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -110,7 +110,7 @@ from inspect_ai.solver import (
   prompt_template, generate, self_critique   
 )                                             
 
-DEFAULT_PROMPT="<prompt>"
+DEFAULT_PROMPT="{prompt}"
 
 @task
 def theory_of_mind():
@@ -187,7 +187,7 @@ from inspect_ai.solver import (
   chain, prompt_template, generate, self_critique   
 ) 
 
-DEFAULT_PROMPT="<prompt>"
+DEFAULT_PROMPT="{prompt}"
 
 from tree_of_thought imoprt TREE_PROMPT, generate_tree
 

--- a/docs/workflow.qmd
+++ b/docs/workflow.qmd
@@ -18,7 +18,7 @@ from inspect_ai.solver import (
   chain, prompt_template, generate, self_critique   
 ) 
 
-DEFAULT_PROMPT="<prompt>"
+DEFAULT_PROMPT="{prompt}"
 
 from tree_of_thought imoprt TREE_PROMPT, generate_tree
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### Description

As per [src/inspect_ai/solver/_prompt.py](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/solver/_prompt.py#L16), the prompt template is supposed to contain a `{prompt}` placeholder, not a `<prompt>` placeholder.

This is incorrect in the docs in places, which causes confusion when getting set up as to why the prompt template does not work.

This PR fixes the docs examples to correctly use `{prompt}` as a placeholder.