### PR TITLE
docs: Fix typo, and minor phrasing simplification on parallelism

### DIFF
--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -193,7 +193,7 @@ graders = [model.generate(prompt) for model in models]
 grader_outputs = await asyncio.gather(*graders)
 ```
 
-Note that we don't await the call to `model.generate()` when building our list of graders. Rather the call to `asyncio.gather()` will await each of these requests and return when they have all completed. Inspect's internal handling of `max_connections` for model APIs will apply to these requests, so you need now worry about how many you put in flight, they will be throttled as appropriate.
+Note that we don't await the call to `model.generate()` when building our list of graders. Rather the call to `asyncio.gather()` will await each of these requests and return when they have all completed. Inspect's internal handling of `max_connections` for model APIs will throttle these requests, so don't need to worry about how many you put in flight.
 
 #### Web Requests
 

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -193,7 +193,7 @@ graders = [model.generate(prompt) for model in models]
 grader_outputs = await asyncio.gather(*graders)
 ```
 
-Note that we don't await the call to `model.generate()` when building our list of graders. Rather the call to `asyncio.gather()` will await each of these requests and return when they have all completed. Inspect's internal handling of `max_connections` for model APIs will throttle these requests, so don't need to worry about how many you put in flight.
+Note that we don't await the call to `model.generate()` when building our list of graders. Rather the call to `asyncio.gather()` will await each of these requests and return when they have all completed. Inspect's internal handling of `max_connections` for model APIs will throttle these requests, so there is no need to worry about how many you put in flight.
 
 #### Web Requests
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### Explanation

> you need now worry about how many you put in flight

I think this meant to be:

> you need *not* worry about how many you put in flight

This sentence is quite long too, so I've simplified it a bit by bringing forward the note on throttling.

### Other information:

I realise I'm submitting a lot of these! I'm not sure how useful you're finding it - do let me know if you'd rather not receieve all these tiny nit-picky PRs.