### PR TITLE
Task metadata

### DIFF
--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -141,6 +141,7 @@ async def eval_run(
                     model_args=model_args,
                     eval_config=task_eval_config,
                     recorder=recorder,
+                    metadata=task.metadata,
                 )
 
                 # append task

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -56,6 +56,7 @@ class TaskLogger:
         model_args: dict[str, Any],
         eval_config: EvalConfig,
         recorder: Recorder,
+        metadata: dict[str, Any],
     ) -> None:
         # determine versions
         git = git_context()
@@ -96,6 +97,7 @@ class TaskLogger:
             config=eval_config,
             revision=revision,
             packages=packages,
+            metadata=metadata,
         )
 
         # stack recorder and location

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -56,7 +56,7 @@ class TaskLogger:
         model_args: dict[str, Any],
         eval_config: EvalConfig,
         recorder: Recorder,
-        metadata: dict[str, Any],
+        metadata: dict[str, Any] | None,
     ) -> None:
         # determine versions
         git = git_context()

--- a/src/inspect_ai/_eval/task/task.py
+++ b/src/inspect_ai/_eval/task/task.py
@@ -54,6 +54,7 @@ class Task:
           eval() directly)
         version: (int): Version of task (to distinguish evolutions
           of the task spec or breaking changes to it)
+        metadata: (dict[str, Any] | None): Additional metadata to associate with the task.
     """
 
     def __init__(
@@ -69,6 +70,7 @@ class Task:
         max_messages: int | None = None,
         name: str | None = None,
         version: int = 0,
+        metadata: dict[str, Any] | None = None,
         **kwargs: Unpack[TaskDeprecatedArgs],
     ) -> None:
         # handle deprecated args
@@ -118,6 +120,7 @@ class Task:
         self.max_messages = max_messages
         self.version = version
         self._name = name
+        self.metadata = metadata
 
     @property
     def name(self) -> str:

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -62,7 +62,8 @@ def test_fail_version():
 
 
 def test_valid_log_header():
-    read_eval_log(log_path("log_valid"), header_only=True)
+    log = read_eval_log(log_path("log_valid"), header_only=True)
+    assert log.eval.metadata["meaning_of_life"] == 42
 
 
 def test_migrate_length_stop_reason():

--- a/tests/log/test_eval_log/log_valid.txt
+++ b/tests/log/test_eval_log/log_valid.txt
@@ -18,6 +18,9 @@
         "model_args": {},
         "config": {
             "limit": 20
+        },
+        "metadata": {
+            "meaning_of_life": 42
         }
     },
     "plan": {

--- a/tests/test_log_dir/example_task/example_task.py
+++ b/tests/test_log_dir/example_task/example_task.py
@@ -8,5 +8,6 @@ def example_task() -> Task:
     task = Task(
         dataset=[Sample(input="Say Hello", target="Hello")],
         scorer=match(),
+        metadata={"meaning_of_life": 42},
     )
     return task

--- a/tests/test_log_dir/test_log_dir.py
+++ b/tests/test_log_dir/test_log_dir.py
@@ -4,6 +4,7 @@ import shutil
 import pytest
 
 from inspect_ai import eval_async
+from inspect_ai.log import read_eval_log
 
 
 @pytest.fixture(scope="session")
@@ -26,3 +27,11 @@ async def test_log_dir(log_dir, base_tmp_dir):
     assert (
         len(os.listdir(log_dir)) >= 1
     )  # as currently a empty dir is created before cwd to task dir is called.
+
+    # Check that metadata is being logged correctly
+    for filename in os.listdir(log_dir):
+        if filename.endswith(".json"):
+            file_path = os.path.join(log_dir, filename)
+            log = read_eval_log(file_path)
+            assert log.eval.metadata["meaning_of_life"] == 42
+            break

--- a/tests/test_run_dir.py
+++ b/tests/test_run_dir.py
@@ -9,11 +9,14 @@ TEST_RUN_DIR_PATH = Path("tests/test_run_dir")
 def test_run_dir():
     cwd = os.getcwd()
 
-    logs = eval(
+    log1, log2 = eval(
         [(TEST_RUN_DIR_PATH / task).as_posix() for task in ["task1", "task2"]],
         model="mockllm/model",
         max_tasks=2,
     )
-    assert all([log.status == "success" for log in logs])
+    assert all([log.status == "success" for log in [log1, log2]])
+
+    assert log1.eval.metadata["task_idx"] == 1
+    assert log2.eval.metadata["task_idx"] == 2
 
     assert cwd == os.getcwd()

--- a/tests/test_run_dir/task1/task1.py
+++ b/tests/test_run_dir/task1/task1.py
@@ -12,4 +12,5 @@ def task1():
         dataset=[Sample(input="What is 1+1?", target="2")],
         solver=[file_check("task1.py"), generate()],
         scorer=includes(),
+        metadata={"task_idx": 1},
     )

--- a/tests/test_run_dir/task2/task2.py
+++ b/tests/test_run_dir/task2/task2.py
@@ -12,4 +12,5 @@ def task2():
         dataset=[Sample(input="What is 1+1?", target="2")] * 10,
         solver=[file_check("task2.py"), generate()],
         scorer=includes(),
+        metadata={"task_idx": 2},
     )


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Task does not support a `metadata` argument despite EvalSpec supporting one.

### What is the new behavior?
You can optionally pass an arbitrary `metadata: dict[str, Any]` argument into the `Task` constructor. This metadata will get logged to the inspect log file, and will also be read by `read_eval_log`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Implements the feature requested in https://github.com/UKGovernmentBEIS/inspect_ai/issues/655 and https://github.com/UKGovernmentBEIS/inspect_ai/issues/50#issuecomment-2175918773.
