### PR TITLE
Correct o1 tool calling when empty arguments passed

### DIFF
--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -266,7 +266,7 @@ def chat_completion_choice(
 ) -> ChatCompletionChoice:
     content = choice["message"]["content"]
     return ChatCompletionChoice(
-        message=handler.parse_assistent_response(content, tools),
+        message=handler.parse_assistant_response(content, tools),
         stop_reason=choice_stop_reason(choice),
     )
 

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -298,7 +298,7 @@ class MistralChatHandler(BedrockChatHandler):
     ) -> ChatCompletionChoice:
         outputs: list[dict[str, str]] = response.get("outputs", [])
         return ChatCompletionChoice(
-            message=handler.parse_assistent_response(
+            message=handler.parse_assistant_response(
                 response="\n".join([output.get("text", "") for output in outputs]),
                 tools=tools,
             ),
@@ -335,7 +335,7 @@ class BaseLlamaChatHandler(BedrockChatHandler):
         self, response: dict[str, Any], tools: list[ToolInfo], handler: ChatAPIHandler
     ) -> ChatCompletionChoice:
         return ChatCompletionChoice(
-            message=handler.parse_assistent_response(
+            message=handler.parse_assistant_response(
                 response.get("generation", ""), tools
             ),
             stop_reason=as_stop_reason(response.get("stop_reason")),

--- a/src/inspect_ai/model/_providers/cloudflare.py
+++ b/src/inspect_ai/model/_providers/cloudflare.py
@@ -90,7 +90,7 @@ class CloudFlareAPI(ModelAPI):
                 model=self.model_name,
                 choices=[
                     ChatCompletionChoice(
-                        message=self.chat_api_handler().parse_assistent_response(
+                        message=self.chat_api_handler().parse_assistant_response(
                             content, tools
                         ),
                         stop_reason="stop",

--- a/src/inspect_ai/model/_providers/openai_o1.py
+++ b/src/inspect_ai/model/_providers/openai_o1.py
@@ -131,7 +131,7 @@ def chat_choices_from_response(
         # the assistant message might include a tool call so we call the
         # ChatAPIHandler to parse it and sort this out
         ChatCompletionChoice(
-            message=handler.parse_assistent_response(
+            message=handler.parse_assistant_response(
                 choice.message.content or "", tools
             ),
             stop_reason=as_stop_reason(choice.finish_reason),
@@ -189,7 +189,7 @@ class O1PreviewChatAPIHandler(ChatAPIHandler):
         return [ChatMessageUser(content=tool_prompt)] + input
 
     @override
-    def parse_assistent_response(
+    def parse_assistant_response(
         self, response: str, tools: list[ToolInfo]
     ) -> ChatMessageAssistant:
         """Parse content and tool calls from a model response.
@@ -294,9 +294,9 @@ def parse_tool_call_content(content: str, tools: list[ToolInfo]) -> ToolCall:
         # see if we can get the fields (if not report error)
         name = tool_call_data.get("name", None)
         arguments = tool_call_data.get("arguments", None)
-        if not name or not arguments:
+        if (not name) or (arguments is None):
             raise ValueError(
-                "Required 'name' and 'arguments' not provided in JSON dictionary."
+                "Required 'name' and/or 'arguments' not provided in JSON dictionary."
             )
 
         # now perform the parse (we need to call thi function because it includes

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -253,7 +253,7 @@ def together_chat_message(
     message: dict[str, str], tools: list[ToolInfo], handler: ChatAPIHandler
 ) -> ChatMessageAssistant:
     content: str = message.get("content", "")
-    return handler.parse_assistent_response(content, tools)
+    return handler.parse_assistant_response(content, tools)
 
 
 def together_stop_reason(reason: str) -> StopReason:

--- a/src/inspect_ai/model/_providers/util/chatapi.py
+++ b/src/inspect_ai/model/_providers/util/chatapi.py
@@ -30,7 +30,7 @@ class ChatAPIHandler:
     ) -> list[ChatMessage]:
         return input
 
-    def parse_assistent_response(
+    def parse_assistant_response(
         self, response: str, tools: list[ToolInfo]
     ) -> ChatMessageAssistant:
         return ChatMessageAssistant(content=response)

--- a/src/inspect_ai/model/_providers/util/llama31.py
+++ b/src/inspect_ai/model/_providers/util/llama31.py
@@ -70,7 +70,7 @@ class Llama31Handler(ChatAPIHandler):
         return [ChatMessageSystem(content=tool_prompt)] + input
 
     @override
-    def parse_assistent_response(
+    def parse_assistant_response(
         self, response: str, tools: list[ToolInfo]
     ) -> ChatMessageAssistant:
         """Parse content and tool calls from a model response.

--- a/tests/model/providers/test_openai_o1.py
+++ b/tests/model/providers/test_openai_o1.py
@@ -1,0 +1,57 @@
+from inspect_ai.model import ChatMessageAssistant
+from inspect_ai.model._providers.openai_o1 import O1PreviewChatAPIHandler
+
+
+def test_openai_o1_tool_call_parsing() -> None:
+    handler = O1PreviewChatAPIHandler()
+
+    resp: ChatMessageAssistant = handler.parse_assistant_response(
+        response="""I will enter the search term into the search box and submit the search.
+
+<tool_call>{"name": "web_browser_type_submit", "arguments": {"element_id": 11399, "text": "hilarious cat videos"}}</tool_call>""",
+        tools=[],
+    )
+
+    assert resp.tool_calls is not None
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].function == "web_browser_type_submit"
+    assert resp.tool_calls[0].arguments == {
+        "element_id": 11399,
+        "text": "hilarious cat videos",
+    }
+
+
+def test_openai_o1_tool_call_parsing_empty_arguments() -> None:
+    handler = O1PreviewChatAPIHandler()
+
+    resp: ChatMessageAssistant = handler.parse_assistant_response(
+        response="""I need to return to the search results to explore other potential sources for the answer.
+
+<tool_call>
+{"name": "web_browser_back", "arguments": {}}
+</tool_call>""",
+        tools=[],
+    )
+
+    assert resp.tool_calls is not None
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].function == "web_browser_back"
+    assert resp.tool_calls[0].arguments == {}
+
+
+def test_openai_o1_tool_call_parsing_no_arguments() -> None:
+    handler = O1PreviewChatAPIHandler()
+
+    resp: ChatMessageAssistant = handler.parse_assistant_response(
+        response="""I need to return to the search results to explore other potential sources for the answer.
+
+<tool_call>
+{"name": "web_browser_back"}
+</tool_call>""",
+        tools=[],
+    )
+
+    assert resp.tool_calls is not None
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].function == "unknown"
+    assert resp.tool_calls[0].parse_error is not None


### PR DESCRIPTION
Also fix typo in our function name

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The o1 tool call parsing is overly strict. The following valid tool call fails validation because arguments is empty:

```
<tool_call>
{"name": "web_browser_back", "arguments": {}}
</tool_call>
```

This results in poor elicitation with the new browser tool

### What is the new behavior?

This case is handled correctly

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Any model providers using `parse_assistent_response` will need to use the updated spelling `parse_assistant_response`

### Other information:
