### PR TITLE
Include datetime and level in file logger.

### DIFF
--- a/src/inspect_ai/_display/logger.py
+++ b/src/inspect_ai/_display/logger.py
@@ -3,6 +3,7 @@ from logging import (
     INFO,
     WARNING,
     FileHandler,
+    Formatter,
     LogRecord,
     addLevelName,
     getLevelName,
@@ -36,6 +37,10 @@ class LogHandler(RichHandler):
         # log into an external file if requested via env var
         file_logger = os.environ.get("INSPECT_PY_LOGGER_FILE", None)
         self.file_logger = FileHandler(file_logger) if file_logger else None
+        if self.file_logger:
+            self.file_logger.setFormatter(
+                Formatter("%(asctime)s - %(levelname)s - %(message)s")
+            )
 
         # see if the user has a special log level for the file
         file_logger_level = os.environ.get("INSPECT_PY_LOGGER_LEVEL", "")

--- a/src/inspect_ai/_display/logger.py
+++ b/src/inspect_ai/_display/logger.py
@@ -85,7 +85,7 @@ class LogHandler(RichHandler):
 # initialize logging -- this function can be called multiple times
 # in the lifetime of the process (the levelno will update globally)
 def init_logger(log_level: str | None = None) -> None:
-    # backwards compatiblity for 'tools'
+    # backwards compatibility for 'tools'
     if log_level == "tools":
         log_level = "sandbox"
 
@@ -102,7 +102,7 @@ def init_logger(log_level: str | None = None) -> None:
     if log_level not in ALL_LOG_LEVELS:
         log_levels = ", ".join([level.lower() for level in ALL_LOG_LEVELS])
         raise RuntimeError(
-            f"Invald log level '{log_level.lower()}'. Log level must be one of {log_levels}"
+            f"Invalid log level '{log_level.lower()}'. Log level must be one of {log_levels}"
         )
 
     # convert to integer


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`INSPECT_PY_LOGGER_FILE` logs do not contain the log level or the time.

### What is the new behavior?
`INSPECT_PY_LOGGER_FILE` contain the same information as the logs shown in the console output.

The timestamp in particular will be very helpful for debugging long-running tasks like k8s eval sets.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Tried with the hello world example:
```
2024-10-07 10:30:18,071 - INFO - Received API key override for key: <redacted>
2024-10-07 10:30:18,089 - INFO - Found credentials from IAM Role: <redacted>
2024-10-07 10:30:18,872 - INFO - Overriding API key: <redacted>
2024-10-07 10:30:19,763 - INFO - Found credentials from IAM Role: <redacted>
```