### PR TITLE
allow CI checks to be run manually with workflow_dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - main
       - "release/**"
+  workflow_dispatch:
 
 jobs:
   ruff:


### PR DESCRIPTION
Avoids opening a PR just to get the workflow to run on a new branch

## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor
