### PR TITLE
do not skip `test_docker_sandbox_setup`

### DIFF
--- a/tests/util/sandbox/test_sandbox_setup.py
+++ b/tests/util/sandbox/test_sandbox_setup.py
@@ -33,7 +33,6 @@ def check_foo() -> Solver:
 
 
 @skip_if_no_docker
-@pytest.mark.slow
 def test_docker_sandbox_setup():
     def sample(file: str, target: str, setup: str) -> Sample:
         return Sample(


### PR DESCRIPTION
By default, pytest skips tests marked with @pytest.mark.slow.


## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
