### PR TITLE
Google: compatibility with google-generativeai v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Google: compatibility with google-generativeai v0.8.3
 - Open log files in binary mode when reading headers (fixes ijson deprecation warning).
 
 ## v0.3.41 (11 October 2024)

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -354,7 +354,7 @@ def chat_tools(tools: list[ToolInfo]) -> list[Tool]:
         )
         for tool in tools
     ]
-    return [Tool(declarations)]
+    return [Tool(function_declarations=declarations)]
 
 
 # https://ai.google.dev/gemini-api/tutorials/extract_structured_data#define_the_schema

--- a/src/inspect_ai/model/_providers/vertex.py
+++ b/src/inspect_ai/model/_providers/vertex.py
@@ -299,7 +299,7 @@ def chat_tools(tools: list[ToolInfo]) -> list[Tool]:
         )
         for tool in tools
     ]
-    return [Tool(declarations)]
+    return [Tool(function_declarations=declarations)]
 
 
 def completion_choice_from_candidate(candidate: Candidate) -> ChatCompletionChoice:


### PR DESCRIPTION
Use named parameter for`Tool` instantiation for compatibility w/ recent updated to google-generativeai (0.8.3)

Fixes https://github.com/UKGovernmentBEIS/inspect_ai/issues/695
