### PR TITLE
Remove anthropic tool reminder injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Anthropic: remove stock tool use chain of thought prompt (many Anthropic models now do this internally, in other cases its better for this to be explicit rather than implicit).
 - Google: compatibility with google-generativeai v0.8.3
 - Open log files in binary mode when reading headers (fixes ijson deprecation warning).
 - Bugfix: strip protocol prefix when resolving eval event content

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -265,16 +265,6 @@ async def resolve_chat_input(
     # extract system message
     system_messages, messages = split_system_messages(input, config)
 
-    # some special handling for tools
-    if len(tools) > 0:
-        # encourage claude to show its thinking, see
-        # https://docs.anthropic.com/claude/docs/tool-use#chain-of-thought-tool-use
-        system_messages.append(
-            ChatMessageSystem(
-                content="Before answering, explain your reasoning step-by-step in tags."
-            )
-        )
-
     # messages
     message_params = [(await message_param(message)) for message in messages]
 


### PR DESCRIPTION
Only one of this PR and https://github.com/UKGovernmentBEIS/inspect_ai/pull/701 should be merged. These two PRs are two variants of a fix.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently, whenever we call an Anthropic model with tool calls enabled, a system message "Before answering, explain your reasoning step-by-step in tags." is forcibly injected at the end of the existing system message.

This injection cannot be turned off and is very difficult to detect in the log viewer -- you can see it in the json details of the transcript log which logs raw model requests but not the main Messages view.

### What is the new behavior?

The tool call injection is removed. I feel like it is somewhat of an anti-pattern to be injecting a prompt at this level of the abstraction hierarchy, so I opted to remove this injection instead of making it optional. 

If we were to make it optional, we could add some parameter in GenerateConfig to turn this option on and off. This is what is implemented by https://github.com/UKGovernmentBEIS/inspect_ai/pull/701.

@jjallaire curious on your thoughts on what to do here.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes. Agent scaffolds written for Anthropic models that relied on the behavior of this injection may not work the same. Also if queries are cached, this change would not trigger a cache miss and instead a version of the response with the tool reminder injection would be returned.
