### PR TITLE
Make anthropic tool reminder injection optional

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -315,6 +315,14 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         envvar="INSPECT_EVAL_MAX_TOOL_OUTPUT",
     )
     @click.option(
+        "--anthropic-tool-reminder-injection/--no-anthropic-tool-reminder-injection",
+        type=bool,
+        is_flag=True,
+        default=True,
+        help="Whether to inject the reminder 'Before answering, explain your reasoning step-by-step in tags.' at the end of the system prompt when calling Anthropic models with tools. Defaults to True.",
+        envvar="ANTHROPIC_TOOL_REMINDER_INJECTION",
+    )
+    @click.option(
         "--cache-prompt",
         type=click.Choice(["auto", "true", "false"]),
         help='Cache prompt prefix (Anthropic only). Defaults to "auto", which will enable caching for requests with tools.',

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -69,6 +69,9 @@ class GenerateConfigArgs(TypedDict, total=False):
     max_tool_output: int | None
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
+    anthropic_tool_reminder_injection: bool | None
+    """Whether to inject the reminder 'Before answering, explain your reasoning step-by-step in tags.' at the end of the system prompt when calling Anthropic models with tools. Defaults to True."""
+
     cache_prompt: Literal["auto"] | bool | None
     """Whether to cache the prompt prefix. Defaults to "auto", which will enable caching for requests with tools. Anthropic only."""
 
@@ -135,6 +138,9 @@ class GenerateConfig(BaseModel):
 
     max_tool_output: int | None = Field(default=None)
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
+
+    anthropic_tool_reminder_injection: bool | None = Field(default=None)
+    """Whether to inject the reminder 'Before answering, explain your reasoning step-by-step in tags.' at the end of the system prompt when calling Anthropic models with tools. Defaults to True."""
 
     cache_prompt: Literal["auto"] | bool | None = Field(default=None)
     """Whether to cache the prompt prefix. Defaults to "auto", which will enable caching for requests with tools. Anthropic only."""

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -265,15 +265,15 @@ async def resolve_chat_input(
     # extract system message
     system_messages, messages = split_system_messages(input, config)
 
-    # some special handling for tools
-    if len(tools) > 0:
-        # encourage claude to show its thinking, see
-        # https://docs.anthropic.com/claude/docs/tool-use#chain-of-thought-tool-use
-        system_messages.append(
-            ChatMessageSystem(
-                content="Before answering, explain your reasoning step-by-step in tags."
+    if config.anthropic_tool_reminder_injection:
+        if len(tools) > 0:
+            # encourage claude to show its thinking, see
+            # https://docs.anthropic.com/claude/docs/tool-use#chain-of-thought-tool-use
+            system_messages.append(
+                ChatMessageSystem(
+                    content="Before answering, explain your reasoning step-by-step in tags."
+                )
             )
-        )
 
     # messages
     message_params = [(await message_param(message)) for message in messages]


### PR DESCRIPTION
Only one of this PR and https://github.com/UKGovernmentBEIS/inspect_ai/pull/700 should be merged. These two PRs are two variants of a fix.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently, whenever we call an Anthropic model with tool calls enabled, a system message "Before answering, explain your reasoning step-by-step in tags." is forcibly injected at the end of the existing system message.

This injection cannot be turned off and is very difficult to detect in the log viewer -- you can see it in the json details of the transcript log which logs raw model requests but not the main Messages view.

### What is the new behavior?
The existing behavior is maintained but can now be turned off by setting the anthropic_tool_reminder_injection flag in GenerateConfig. This flag can also be adjusted using the environment variable ANTHROPIC_TOOL_REMINDER_INJECTION and the CLI flag --anthropic-tool-reminder-injection or --no-anthropic-tool-reminder-injection.

An alternate solution is to remove this behavior entirely and give no option for turning it back on (unless the user hardcodes it in at some higher layer of the stack). https://github.com/UKGovernmentBEIS/inspect_ai/pull/700 implements the complete removal change.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.