### PR TITLE
Cleanup Docker Containers immediately for samples with errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Cleanup Docker Containers immediately for samples with errors.
 - Anthropic: remove stock tool use chain of thought prompt (many Anthropic models now do this internally, in other cases its better for this to be explicit rather than implicit).
 - Google: compatibility with google-generativeai v0.8.3
 - Open log files in binary mode when reading headers (fixes ijson deprecation warning).

--- a/src/inspect_ai/_eval/task/sandbox.py
+++ b/src/inspect_ai/_eval/task/sandbox.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import contextlib
 from typing import AsyncGenerator
@@ -57,7 +58,7 @@ async def sandboxenv_context(
         # run sample
         yield
 
-    except BaseException as ex:
+    except asyncio.CancelledError as ex:
         interrupted = True
         raise ex
 


### PR DESCRIPTION
For the Docker sandbox we have a deferred cleanup logic that allows users to see console progress for cleanup. This was initially put in because cleanup could be very long (in which case users might Ctrl+C, leaking containers). 

At the time there was no concept of multiple concurrent tasks and no concept of `fail_on_error`, which meant at a practical level "deferred" cleanup was really just deferring a few hundred milliseconds (because any error implied that the entire eval was ending). In the meantime, a number of things have changed:

(1) We have resolved the long cleanup issues w/ a combination of `init: true` and `stop_grace_period: 1s` (which means that containers terminate typically in 1 second or less)

(2) We have added two independent ways that evals can continue in the presence of errors: (a) `max_tasks > 1` means that one task can fail but others keep running; and (b) `fail_on_error` means that a sample can fail but the others keep running. 

The implication of (2) above means that our deferral can result in many containers hanging around far longer than they are needed (whereas before this could never happen b/c errors ended the entire eval). 

This change modifies our setting of the `interrupted` flag -- we now only set this for `asyncio.CancelledError` (which will deterministically end the entire eval). This means that when ordinary sample errors occur their container(s) will be cleaned up immediately.
