### PR TITLE
requirements: require semver >= 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Cleanup Docker Containers immediately for samples with errors.
 - Anthropic: remove stock tool use chain of thought prompt (many Anthropic models now do this internally, in other cases its better for this to be explicit rather than implicit).
 - Google: compatibility with google-generativeai v0.8.3
+- Requirements: require semver>=3.0.0
 - Open log files in binary mode when reading headers (fixes ijson deprecation warning).
 - Bugfix: strip protocol prefix when resolving eval event content
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ python-dotenv
 pyyaml
 rich
 s3fs>=2023
-semver
+semver>=3.0.0
 shortuuid
 tenacity
 typing_extensions>=4.9.0


### PR DESCRIPTION
Required for use of `semver.Version`: https://github.com/UKGovernmentBEIS/inspect_ai/blob/d52b1920391eabc69bb32f3ea83470f3ad2ec760/src/inspect_ai/_util/version.py#L19

Resolves https://github.com/UKGovernmentBEIS/inspect_ai/issues/705
