### PR TITLE
add missing metric decorator to docs

### DIFF
--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -505,6 +505,7 @@ import numpy as np
 
 from inspect_ai.scorer import Metric, Score, metric
 
+@metric
 def var() -> Metric:
     """Compute variance over all scores."""
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Missing metric decorator in the example [here](https://inspect.ai-safety-institute.org.uk/scorers.html#custom-metrics)

### What is the new behavior?
Added the missing decorator

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
I copied this example as a starting point for my custom metric and kept getting a registry error. It took me a little while to realize that the example I copied was missing the decorator.
