### PR TITLE
add option to choose delimiter for csv file

### DIFF
--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -28,6 +28,7 @@ def csv_dataset(
     name: str | None = None,
     fs_options: dict[str, Any] = {},
     fieldnames: list[str] | None = None,
+    delimiter: str = ",",
 ) -> Dataset:
     r"""Read dataset from CSV file.
 
@@ -54,6 +55,7 @@ def csv_dataset(
         fieldnames (list[str] | None): Optional. A list of fieldnames to use for the CSV.
             If None, the values in the first row of the file will be used as the fieldnames.
             Useful for files without a header.
+        delimiter (str): Optional. The delimiter to use when parsing the file. Defaults to ",".
 
     Returns:
         Dataset read from CSV file.
@@ -66,7 +68,7 @@ def csv_dataset(
         # filter out rows with empty values
         valid_data = [
             data
-            for data in csv_dataset_reader(f, dialect, fieldnames)
+            for data in csv_dataset_reader(f, dialect, fieldnames, delimiter)
             if data and any(value.strip() for value in data.values())
         ]
         name = name if name else Path(csv_file).stem
@@ -91,6 +93,9 @@ def csv_dataset(
 
 
 def csv_dataset_reader(
-    file: TextIOWrapper, dialect: str = "unix", fieldnames: list[str] | None = None
+    file: TextIOWrapper, 
+    dialect: str = "unix", 
+    fieldnames: list[str] | None = None, 
+    delimiter: str = ",",
 ) -> DatasetReader:
-    return csv.DictReader(file, dialect=dialect, fieldnames=fieldnames)
+    return csv.DictReader(file, dialect=dialect, fieldnames=fieldnames, delimiter=delimiter)


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently, the csv_dataset loader only supports comma-delimited csv files.
### What is the new behavior?
This PR adds an optional argument to choose the delimiter to parse the csv file.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Other information:
N/A