### PR TITLE
capture list and dict of registry objects when logging plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Requirements: require semver>=3.0.0
 - Added `delimiter` option to `csv_dataset()` (defaults to ",")
 - Open log files in binary mode when reading headers (fixes ijson deprecation warning).
+- Capture `list` and `dict` of registry objects when logging `plan`.
 - Add `model_usage` field to `EvalSample` to record token usage by model for each sample.
 - Correct directory handling for tasks that are imported as local (non-package) modules.
 - Call tools sequentially when they have opted out of parallel calling.

--- a/src/inspect_ai/_util/registry.py
+++ b/src/inspect_ai/_util/registry.py
@@ -82,9 +82,7 @@ def registry_tag(
 
     # serialise registry objects with RegistryDict
     for param in named_params.keys():
-        value = named_params[param]
-        if has_registry_params(value):
-            named_params[param] = registry_dict(value)
+        named_params[param] = registry_value(named_params[param])
 
     # callables are not serializable so use their names
     for param in named_params.keys():
@@ -377,10 +375,19 @@ def is_registry_dict(o: object) -> TypeGuard[RegistryDict]:
     return isinstance(o, dict) and "type" in o and "name" in o and "params" in o
 
 
-def registry_dict(o: object) -> RegistryDict:
-    return dict(
-        type=registry_info(o).type, name=registry_log_name(o), params=registry_params(o)
-    )
+def registry_value(o: object) -> Any:
+    if isinstance(o, list):
+        return [registry_value(x) for x in o]
+    elif isinstance(o, dict):
+        return {k: registry_value(v) for k, v in o.items()}
+    elif has_registry_params(o):
+        return dict(
+            type=registry_info(o).type,
+            name=registry_log_name(o),
+            params=registry_params(o),
+        )
+    else:
+        return o
 
 
 def registry_create_from_dict(d: RegistryDict) -> object:

--- a/tests/util/test_registry.py
+++ b/tests/util/test_registry.py
@@ -3,9 +3,9 @@ from typing import cast
 from inspect_ai._util.constants import PKG_NAME
 from inspect_ai._util.registry import (
     registry_create_from_dict,
-    registry_dict,
     registry_info,
     registry_lookup,
+    registry_value,
 )
 from inspect_ai.scorer import Metric, Score, metric
 from inspect_ai.solver import Plan, Solver, solver, use_tools
@@ -35,7 +35,7 @@ def test_registry_dict() -> None:
         return use_tools(tool)
 
     mysolver = create_solver(bash(timeout=10))
-    solver_dict = registry_dict(mysolver)
+    solver_dict = registry_value(mysolver)
     assert solver_dict["type"] == "solver"
     assert solver_dict["params"]["tool"]["type"] == "tool"
 


### PR DESCRIPTION
Previously lists of registry objects were not logged correctly in the `plan`. For example:

```json
{
  "solver": "use_tools",
  "params": {
      "tools": [
        "execute",
        "execute"
      ]
   }
},
```

With this PR this is now logged as:

```json
{
  "solver": "use_tools",
   "params": {
     "tools": [
       {
         "type": "tool",
         "name": "add",
         "params": {}
       },
       {
         "type": "tool",
         "name": "list_files",
         "params": {}
       }
     ]
  }
}
```
