### PR TITLE
enable users to pass a function for include_history

### DIFF
--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -92,7 +92,7 @@ def model_graded_qa(
     template: str | None = None,
     instructions: str | None = None,
     grade_pattern: str | None = None,
-    include_history: bool = False,
+    include_history: bool | Callable[[TaskState], str] = False,
     partial_credit: bool = False,
     model: list[str | Model] | str | Model | None = None,
 ) -> Scorer:
@@ -102,7 +102,7 @@ def model_graded_qa(
 The default model graded QA scorer is tuned to grade answers to open ended questions. The default `template` and `instructions` ask the model to produce a grade in the format `GRADE: C` or `GRADE: I`, and this grade is extracted using the default `grade_pattern` regular expression. The grading is by default done with the model currently being evaluated. There are a few ways you can customise the default behaviour:
 
 1.  Provide alternate `instructions`—the default instructions ass the model to use chain of thought reasoning and provide grades in the format `GRADE: C` or `GRADE: I`. Note that if you provide instructions that ask the model to format grades in a different way, you will also want to customise the `grade_pattern`.
-2.  Specify `include_history = True` to include the full chat history in the presented question (by default only the original sample input is presented).
+2.  Specify `include_history = True` to include the full chat history in the presented question (by default only the original sample input is presented). You may optionally instead pass a function that enables customising the presentation of the chat history.
 3.  Specify `partial_credit = True` to prompt the model to assign partial credit to answers that are not entirely right but come close (metrics by default convert this to a value of 0.5). Note that this parameter is only valid when using the default `instructions`.
 4.  Specify an alternate `model` to perform the grading (e.g. a more powerful model or a model fine tuned for grading).
 5.  Specify a different `template`—note that templates are passed these variables: `question`, `criterion`, `answer`, and `instructions.`


### PR DESCRIPTION
Follow on to https://github.com/UKGovernmentBEIS/inspect_ai/pull/738 that enables customisation of the way the chat history is presented by passing a function rather than `True`.

