### PR TITLE
Allow HTML in markdown

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -14515,7 +14515,8 @@ const MarkdownDiv = (props) => {
   let renderedHtml = protectedText;
   try {
     const md = MarkdownIt({
-      breaks: true
+      breaks: true,
+      html: true
     });
     renderedHtml = md.render(protectedText);
   } catch (ex) {

--- a/src/inspect_ai/_view/www/src/components/MarkdownDiv.mjs
+++ b/src/inspect_ai/_view/www/src/components/MarkdownDiv.mjs
@@ -16,6 +16,7 @@ export const MarkdownDiv = (props) => {
   try {
     const md = markdownit({
       breaks: true,
+      html: true,
     });
     renderedHtml = md.render(protectedText);
   } catch (ex) {


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

We rely upon html tags occasionally when rendering markdown (for example, in multiple choice answers, we use paragraphs).