### PR TITLE
correctly load extensions in packages where package name differs from dist name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - New binary [log format](https://inspect.ai-safety-institute.org.uk/eval-logs.html#sec-log-format) which yields substantial size and speed improvements (JSON format log files are still fully supported and utilities for converting between the formats are provided).
+- Extensions: correctly load extensions in packages where package name differs from dist name.
 
 ## v0.3.42 (23 October 2024)
 

--- a/src/inspect_ai/_util/entrypoints.py
+++ b/src/inspect_ai/_util/entrypoints.py
@@ -20,7 +20,7 @@ def ensure_entry_points(package: str | None = None) -> None:
         try:
             # if there is a package filter then condition on that
             if package is not None:
-                if ep.dist and ep.dist.name == package:
+                if ep.name and (ep.name == package):
                     ep.load()
                     _inspect_ai_eps_loaded.append(package)
 


### PR DESCRIPTION
Resolves https://github.com/UKGovernmentBEIS/inspect_ai/issues/747

Note that one other change to `pyproject.toml` is required for this all to work end to end:

```toml
[project.entry-points.inspect_ai]
el = "el.supervision.inspect_ai._registry"
```
