### PR TITLE
Informative error message when directory is not writeable

### DIFF
--- a/src/inspect_ai/_util/appdirs.py
+++ b/src/inspect_ai/_util/appdirs.py
@@ -5,11 +5,21 @@ from platformdirs import user_cache_path, user_runtime_path
 from inspect_ai._util.constants import PKG_NAME
 
 
+def _xdg_error(dir_type: str, dir_name: str) -> str:
+    return f"""{dir_type} directory {dir_name} is not writeable.
+        This may be because you are running Inspect without a normal login session.
+        On Linux, try setting XDG_RUNTIME_DIR to somewhere writeable.
+        See also https://github.com/UKGovernmentBEIS/inspect_ai/issues/51."""
+
+
 def inspect_runtime_dir(subdir: str | None) -> Path:
     runtime_dir = user_runtime_path(PKG_NAME)
     if subdir:
         runtime_dir = runtime_dir / subdir
-    runtime_dir.mkdir(parents=True, exist_ok=True)
+    try:
+        runtime_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError as e:
+        raise Exception(_xdg_error("Runtime", runtime_dir)) from e
     return runtime_dir
 
 
@@ -17,5 +27,9 @@ def inspect_cache_dir(subdir: str | None) -> Path:
     cache_dir = user_cache_path(PKG_NAME)
     if subdir:
         cache_dir = cache_dir / subdir
-    cache_dir.mkdir(parents=True, exist_ok=True)
+    # catch this failure, suggest setting XDG_CACHE_HOME
+    try:
+        cache_dir.mkdir(parents=True, exist_ok=True)
+    except PermissionError as e:
+        raise Exception(_xdg_error("Cache", cache_dir)) from e
     return cache_dir

--- a/src/inspect_ai/_util/appdirs.py
+++ b/src/inspect_ai/_util/appdirs.py
@@ -5,8 +5,8 @@ from platformdirs import user_cache_path, user_runtime_path
 from inspect_ai._util.constants import PKG_NAME
 
 
-def _xdg_error(dir_type: str, dir_name: str) -> str:
-    return f"""{dir_type} directory {dir_name} is not writeable.
+def _xdg_error(dir_type: str, dir: Path) -> str:
+    return f"""{dir_type} directory {dir} is not writeable.
         This may be because you are running Inspect without a normal login session.
         On Linux, try setting XDG_RUNTIME_DIR to somewhere writeable.
         See also https://github.com/UKGovernmentBEIS/inspect_ai/issues/51."""

--- a/src/inspect_ai/_util/appdirs.py
+++ b/src/inspect_ai/_util/appdirs.py
@@ -1,3 +1,4 @@
+import textwrap
 from pathlib import Path
 
 from platformdirs import user_cache_path, user_runtime_path
@@ -6,10 +7,10 @@ from inspect_ai._util.constants import PKG_NAME
 
 
 def _xdg_error(dir_type: str, dir: Path) -> str:
-    return f"""{dir_type} directory {dir} is not writeable.
+    return textwrap.dedent(f"""{dir_type} directory {dir} is not writeable.
         This may be because you are running Inspect without a normal login session.
         On Linux, try setting XDG_RUNTIME_DIR to somewhere writeable.
-        See also https://github.com/UKGovernmentBEIS/inspect_ai/issues/51."""
+        See also https://github.com/UKGovernmentBEIS/inspect_ai/issues/51.""")
 
 
 def inspect_runtime_dir(subdir: str | None) -> Path:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

You get an obscure error message if you try to run inspect in a devcontainer or other CI context without a login session.

### What is the new behavior?

You get a better error message.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
