### PR TITLE
OpenAI: eliminate use of `strict` tool calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - New binary [log format](https://inspect.ai-safety-institute.org.uk/eval-logs.html#sec-log-format) which yields substantial size and speed improvements (JSON format log files are still fully supported and utilities for converting between the formats are provided).
 - Extensions: correctly load extensions in packages where package name differs from dist name.
 - Use `casefold()` for case-insensitive compare in `includes()`, `match()`, `exact()`, and `f1()` scorers.
+- OpenAI: eliminate use of `strict` tool calling (sporadically supported across models and we already interally validate).
 
 ## v0.3.42 (23 October 2024)
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -344,9 +344,6 @@ def chat_tool_param(tool: ToolInfo) -> ChatCompletionToolParam:
         name=tool.name,
         description=tool.description,
         parameters=tool.parameters.model_dump(exclude_none=True),
-        # use strict tool calling if all params are required (OpenAI
-        # will reject strict mode if there are optional params)
-        strict=len(tool.parameters.properties) == len(tool.parameters.required),
     )
     return ChatCompletionToolParam(type="function", function=function)
 


### PR DESCRIPTION
Sporadically supported across models and we already internally validate and report errors to the model

