### PR TITLE
Improve robustness of copy button

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -23760,12 +23760,18 @@ const CopyButton = ({ value }) => {
   }}
     data-clipboard-text=${value}
     onclick=${(e2) => {
-    const iEl = e2.target;
+    let iEl = e2.target;
+    if (iEl.tagName === "BUTTON") {
+      iEl = iEl.firstChild;
+    }
+    console.log({ iEl });
     if (iEl) {
-      iEl.className = `${ApplicationIcons.confirm} primary`;
-      setTimeout(() => {
-        iEl.className = ApplicationIcons.copy;
-      }, 1250);
+      if (iEl) {
+        iEl.className = `${ApplicationIcons.confirm} primary`;
+        setTimeout(() => {
+          iEl.className = ApplicationIcons.copy;
+        }, 1250);
+      }
     }
     return false;
   }}

--- a/src/inspect_ai/_view/www/src/components/CopyButton.mjs
+++ b/src/inspect_ai/_view/www/src/components/CopyButton.mjs
@@ -23,12 +23,23 @@ export const CopyButton = ({ value }) => {
     }}
     data-clipboard-text=${value}
     onclick=${(e) => {
-      const iEl = e.target;
+      let iEl = e.target;
+      // I haven't yet been able to consistently cause this, but
+      // this issue https://github.com/UKGovernmentBEIS/inspect_ai/issues/717
+      // does sometimes happen and when it does, the target element is the BUTTON
+      // not the I. Since I can't reliably determine the cause, for now just band-aid
+      // by getting the child in this case.
+      if (iEl.tagName === "BUTTON") {
+        iEl = iEl.firstChild;
+      }
+      console.log({ iEl });
       if (iEl) {
-        iEl.className = `${ApplicationIcons.confirm} primary`;
-        setTimeout(() => {
-          iEl.className = ApplicationIcons.copy;
-        }, 1250);
+        if (iEl) {
+          iEl.className = `${ApplicationIcons.confirm} primary`;
+          setTimeout(() => {
+            iEl.className = ApplicationIcons.copy;
+          }, 1250);
+        }
       }
       return false;
     }}


### PR DESCRIPTION
I haven't yet been able to consistently cause this, but this issue (#717) does sometimes happen and when it does, the target element is the BUTTON not the I. Since I can't reliably determine the cause, for now just band-aid by getting the child in this case.

Fixes #717

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
