### PR TITLE
use user_data_dir rather than user_runtime_dir for view notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Use `casefold()` for case-insensitive compare in `includes()`, `match()`, `exact()`, and `f1()` scorers.
 - OpenAI: eliminate use of `strict` tool calling (sporadically supported across models and we already interally validate).
 - Don't include package scope for task name part of log files.
+- Use user_data_dir rather than user_runtime_dir for view notifications.
 
 ## v0.3.42 (23 October 2024)
 

--- a/src/inspect_ai/_util/appdirs.py
+++ b/src/inspect_ai/_util/appdirs.py
@@ -1,16 +1,16 @@
 from pathlib import Path
 
-from platformdirs import user_cache_path, user_runtime_path
+from platformdirs import user_cache_path, user_data_path
 
 from inspect_ai._util.constants import PKG_NAME
 
 
-def inspect_runtime_dir(subdir: str | None) -> Path:
-    runtime_dir = user_runtime_path(PKG_NAME)
+def inspect_data_dir(subdir: str | None) -> Path:
+    data_dir = user_data_path(PKG_NAME)
     if subdir:
-        runtime_dir = runtime_dir / subdir
-    runtime_dir.mkdir(parents=True, exist_ok=True)
-    return runtime_dir
+        data_dir = data_dir / subdir
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return data_dir
 
 
 def inspect_cache_dir(subdir: str | None) -> Path:

--- a/src/inspect_ai/_view/notify.py
+++ b/src/inspect_ai/_view/notify.py
@@ -3,7 +3,7 @@ import os
 from pathlib import Path
 from urllib.parse import urlparse
 
-from inspect_ai._util.appdirs import inspect_runtime_dir
+from inspect_ai._util.appdirs import inspect_data_dir
 
 # lightweight tracking of when the last eval task completed
 # this enables the view client to poll for changes frequently
@@ -41,9 +41,9 @@ def view_last_eval_time() -> int:
         return 0
 
 
-def view_runtime_dir() -> Path:
-    return inspect_runtime_dir("view")
+def view_data_dir() -> Path:
+    return inspect_data_dir("view")
 
 
 def view_last_eval_file() -> Path:
-    return view_runtime_dir() / "last-eval-result"
+    return view_data_dir() / "last-eval-result"

--- a/src/inspect_ai/_view/view.py
+++ b/src/inspect_ai/_view/view.py
@@ -16,7 +16,7 @@ from inspect_ai._util.dotenv import init_dotenv
 from inspect_ai._util.error import exception_message
 from inspect_ai._view.server import view_server
 
-from .notify import view_runtime_dir
+from .notify import view_data_dir
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,7 @@ def view(
 
 
 def view_port_pid_file(port: int) -> Path:
-    ports_dir = view_runtime_dir() / "ports"
+    ports_dir = view_data_dir() / "ports"
     ports_dir.mkdir(parents=True, exist_ok=True)
     return ports_dir / str(port)
 

--- a/tools/vscode/src/inspect/props.ts
+++ b/tools/vscode/src/inspect/props.ts
@@ -6,7 +6,7 @@ import { AbsolutePath, toAbsolutePath } from "../core/path";
 import { Disposable } from "vscode";
 import { runProcess } from "../core/process";
 import { join } from "path";
-import { userRuntimeDir } from "../core/appdirs";
+import { userDataDir, userRuntimeDir } from "../core/appdirs";
 import { kInspectChangeEvalSignalVersion } from "../providers/inspect/inspect-constants";
 import { existsSync } from "fs";
 
@@ -182,18 +182,16 @@ export function inspectBinPath(): AbsolutePath | null {
   }
 }
 
-export function inspectLastEvalPath(): AbsolutePath | null {
+export function inspectLastEvalPaths(): AbsolutePath[]  {
   const descriptor = inspectVersionDescriptor();
   const fileName =
     descriptor && descriptor.version.compare(kInspectChangeEvalSignalVersion) < 0
       ? "last-eval"
       : "last-eval-result";
-  const lastEvalFile = join(
-    userRuntimeDir(kPythonPackageName),
-    "view",
-    fileName
-  );
-  return toAbsolutePath(lastEvalFile);
+  
+  return [userRuntimeDir(kPythonPackageName), userDataDir(kPythonPackageName)]
+    .map(dir => join(dir, "view", fileName))
+    .map(toAbsolutePath);
 }
 
 function inspectFileName(): string {

--- a/tools/vscode/src/providers/inspect/inspect-logs-watcher.ts
+++ b/tools/vscode/src/providers/inspect/inspect-logs-watcher.ts
@@ -1,6 +1,6 @@
 import { Disposable, Event, EventEmitter, Uri } from "vscode";
 
-import { inspectLastEvalPath } from "../../inspect/props";
+import { inspectLastEvalPaths } from "../../inspect/props";
 import { existsSync, readFileSync, statSync } from "fs";
 import { log } from "../../core/log";
 import { WorkspaceStateManager } from "../workspace/workspace-state-provider";
@@ -20,51 +20,53 @@ export class InspectLogsWatcher implements Disposable {
     log.appendLine("Watching for evaluation logs");
     this.lastEval_ = Date.now();
 
-    const evalSignalFile = inspectLastEvalPath()?.path;
+    const evalSignalFiles = inspectLastEvalPaths().map(path => path.path);
 
     this.watchInterval_ = setInterval(() => {
-      if (evalSignalFile && existsSync(evalSignalFile)) {
-        const updated = statSync(evalSignalFile).mtime.getTime();
-        if (updated > this.lastEval_) {
-          this.lastEval_ = updated;
+      for (const evalSignalFile of evalSignalFiles) {
+        if (existsSync(evalSignalFile)) {
+          const updated = statSync(evalSignalFile).mtime.getTime();
+          if (updated > this.lastEval_) {
+            this.lastEval_ = updated;
 
-          let evalLogPath: string | undefined;
-          let workspaceId;
-          const contents = readFileSync(evalSignalFile, { encoding: "utf-8" });
+            let evalLogPath: string | undefined;
+            let workspaceId;
+            const contents = readFileSync(evalSignalFile, { encoding: "utf-8" });
 
-          // Parse the eval signal file result
-          withMinimumInspectVersion(
-            kInspectChangeEvalSignalVersion,
-            () => {
-              // 0.3.10- or later
-              const contentsObj = JSON.parse(contents) as {
-                location: string;
-                workspace_id?: string;
-              };
-              evalLogPath = contentsObj.location;
-              workspaceId = contentsObj.workspace_id;
-            },
-            () => {
-              // 0.3.8 or earlier
-              evalLogPath = contents;
+            // Parse the eval signal file result
+            withMinimumInspectVersion(
+              kInspectChangeEvalSignalVersion,
+              () => {
+                // 0.3.10- or later
+                const contentsObj = JSON.parse(contents) as {
+                  location: string;
+                  workspace_id?: string;
+                };
+                evalLogPath = contentsObj.location;
+                workspaceId = contentsObj.workspace_id;
+              },
+              () => {
+                // 0.3.8 or earlier
+                evalLogPath = contents;
+              }
+            );
+
+            if (evalLogPath !== undefined) {
+              // see if this is another instance of vscode
+              const externalWorkspace = !!workspaceId && workspaceId !== this.workspaceStateManager_.getWorkspaceInstance();
+
+              // log
+              log.appendLine(`New log: ${evalLogPath}`);
+
+              // fire event
+              try {
+                const logUri = resolveToUri(evalLogPath);
+                this.onInspectLogCreated_.fire({ log: logUri, externalWorkspace });
+              } catch (error) {
+                log.appendLine(`Unexpected error parsing URI ${evalLogPath}`);
+              }
+
             }
-          );
-
-          if (evalLogPath !== undefined) {
-            // see if this is another instance of vscode
-            const externalWorkspace = !!workspaceId && workspaceId !== this.workspaceStateManager_.getWorkspaceInstance();
-
-            // log
-            log.appendLine(`New log: ${evalLogPath}`);
-
-            // fire event
-            try {
-              const logUri = resolveToUri(evalLogPath);
-              this.onInspectLogCreated_.fire({ log: logUri, externalWorkspace });
-            } catch (error) {
-              log.appendLine(`Unexpected error parsing URI ${evalLogPath}`);
-            }
-
           }
         }
       }


### PR DESCRIPTION
Resolves https://github.com/UKGovernmentBEIS/inspect_ai/issues/665

It seems as if unlike other directories, user_runtime_dir does not have a fallback if the user don't have the requisite parent directories with permissions. This causes failure modes on devcontainers and other minimally configured systems.

The resolution is to use the user_data_dir instead, which has a `~/.local/share` fallback on Linux. VS Code extension is also updated to look for view notification files in both locations to support older and newer versions.
