### PR TITLE
Add option for ignoring HTTPS errors in web browser tooling

### DIFF
--- a/src/inspect_ai/tool/_tools/_web_browser/_resources/playwright_crawler.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_resources/playwright_crawler.py
@@ -9,6 +9,7 @@ import enum
 import logging
 import re
 import time
+from os import getenv
 from typing import Any, Literal
 
 import accessibility_node as at
@@ -78,6 +79,7 @@ class PlaywrightCrawler:
             permissions=["geolocation"],
             timezone_id="Europe/London",
             viewport={"width": self.WIDTH, "height": self.HEIGHT},
+            ignore_https_errors=getenv("IGNORE_HTTPS_ERRORS", "") != "",
         )
 
         self._page = self._context.new_page()


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Any HTTPS errors (such as from self-signed certs) will result in empty responses.

https://github.com/UKGovernmentBEIS/inspect_ai/issues/772

### What is the new behavior?

Page content is now returned when HTTPS errors occur if the developer uses a custom image and specifies any non-empty value of IGNORE_HTTPS_ERRORS for the web browser server.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Tested when forking the browser code. Also not sure how to rebuild the official image after this change to get these to take effect.

See the issue - I also explored other options, but I think this is the fastest way to unblock workflows with self-signed certs.
