### PR TITLE
Fix S3 tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,7 +56,6 @@ def mock_s3():
             "AWS_ACCESS_KEY_ID",
             "AWS_SECRET_ACCESS_KEY",
             "AWS_DEFAULT_REGION",
-            "AWS_REGION",
         ]
     }
 
@@ -64,7 +63,6 @@ def mock_s3():
     os.environ["AWS_ACCESS_KEY_ID"] = "unused_id_mock_s3"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "unused_key_mock_s3"
     os.environ["AWS_DEFAULT_REGION"] = "us-west-1"
-    os.environ["AWS_REGION"] = "us-west-1"
 
     s3_client = boto3.client("s3")
     s3_client.create_bucket(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ import sys
 import time
 import warnings
 
+import boto3
 import pytest
 from moto.server import ThreadedMotoServer
 
@@ -40,7 +41,7 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_api)
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def mock_s3():
     server = ThreadedMotoServer(port=19100)
     server.start()
@@ -50,22 +51,49 @@ def mock_s3():
 
     existing_env = {
         key: os.environ.get(key, None)
-        for key in ["AWS_ENDPOINT_URL", "AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"]
+        for key in [
+            "AWS_ENDPOINT_URL",
+            "AWS_ACCESS_KEY_ID",
+            "AWS_SECRET_ACCESS_KEY",
+            "AWS_DEFAULT_REGION",
+            "AWS_REGION",
+        ]
     }
 
     os.environ["AWS_ENDPOINT_URL"] = "http://127.0.0.1:19100"
     os.environ["AWS_ACCESS_KEY_ID"] = "unused_id_mock_s3"
     os.environ["AWS_SECRET_ACCESS_KEY"] = "unused_key_mock_s3"
+    os.environ["AWS_DEFAULT_REGION"] = "us-west-1"
+    os.environ["AWS_REGION"] = "us-west-1"
+
+    s3_client = boto3.client("s3")
+    s3_client.create_bucket(
+        Bucket="test-bucket",
+        CreateBucketConfiguration={"LocationConstraint": "us-west-1"},
+    )
 
     yield
 
+    # Unfortunately, we can't just throw away moto,
+    # because there is caching of S3 bucket state (e.g. ownership)
+    # somewhere in s3fs or boto. So we have to go through
+    # the charade of emptying and deleting the mocked bucket.
+    s3 = boto3.resource("s3")
+    s3_bucket = s3.Bucket("test-bucket")
+    bucket_versioning = s3.BucketVersioning("test-bucket")
+    if bucket_versioning.status == "Enabled":
+        s3_bucket.object_versions.delete()
+    else:
+        s3_bucket.objects.all().delete()
+
+    s3_client.delete_bucket(Bucket="test-bucket")
+
+    server.stop()
     for key, value in existing_env.items():
         if value is None:
             del os.environ[key]
         else:
             os.environ[key] = value
-
-    server.stop()
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -41,7 +41,7 @@ def pytest_collection_modifyitems(config, items):
                 item.add_marker(skip_api)
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture(scope="module")
 def mock_s3():
     server = ThreadedMotoServer(port=19100)
     server.start()
@@ -72,7 +72,7 @@ def mock_s3():
 
     yield
 
-    # Unfortunately, we can't just throw away moto,
+    # Unfortunately, we can't just throw away moto after the test,
     # because there is caching of S3 bucket state (e.g. ownership)
     # somewhere in s3fs or boto. So we have to go through
     # the charade of emptying and deleting the mocked bucket.

--- a/tests/view/test_bundle.py
+++ b/tests/view/test_bundle.py
@@ -15,9 +15,6 @@ def test_s3_bundle(mock_s3) -> None:
     # run an eval to generate a log file to this directory
     s3_fs = filesystem("s3://test-bucket/")
 
-    # ensure log directory exists
-    s3_fs.mkdir("test_s3_bundle/logs")
-
     # target directories
     log_dir = "s3://test-bucket/test_s3_bundle/logs"
     output_dir = "s3://test-bucket/test_s3_bundle/view"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The s3-related tests were broken.

### What is the new behavior?

The s3 tests pass. (Note, having INSPECT_API_KEY_OVERRIDE or INSPECT_TELEMETRY will break them)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

I assume at no point should inspect be trying to create a bucket if it doesn't exist. The combination of s3fs+fsspec tries to do this sometimes (e.g. here https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/_util/file.py#L172)  which can cause confusion.