### PR TITLE
Properly render complex scores in transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Grok](https://docs.x.ai/) model provider.
 - Extensions: correctly load extensions in packages where package name differs from dist name.
 - Added `--model-config`, `--task-config`, and `--solver-config` CLI arguments for specifying model, task, and solver args using a JSON or YAML config file.
+- View: properly render complex score objects in transcript.
 - Write custom tool call views into transcript for use by Inspect View.
 - Use `casefold()` for case-insensitive compare in `includes()`, `match()`, `exact()`, and `f1()` scorers.
 - OpenAI: eliminate use of `strict` tool calling (sporadically supported across models and we already interally validate).

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -19171,7 +19171,7 @@ const ScoreEventView = ({ id, event, style }) => {
       <div><${MarkdownDiv} markdown=${event.score.explanation}/></div>
       <div style=${{ gridColumn: "1 / -1", borderBottom: "solid 1px var(--bs-light-border-subtle" }}></div>
       <div style=${{ ...TextStyle.label }}>Score</div>  
-      <div>${event.score.value}</div>
+      <div>${renderScore(event.score.value)}</div>
       <div style=${{ gridColumn: "1 / -1", borderBottom: "solid 1px var(--bs-light-border-subtle" }}></div>
     </div>
     ${event.score.metadata ? m$1`<div name="Metadata">
@@ -19181,9 +19181,16 @@ const ScoreEventView = ({ id, event, style }) => {
               style=${{ margin: "0.5em 0" }}
             />
           </div>` : void 0}
-
-
   </${EventPanel}>`;
+};
+const renderScore = (value) => {
+  if (Array.isArray(value)) {
+    return m$1`<${MetaDataGrid} entries=${value} />`;
+  } else if (typeof value === "object") {
+    return m$1`<${MetaDataGrid} entries=${value} />`;
+  } else {
+    return value;
+  }
 };
 const ApprovalEventView = ({ id, event, style }) => {
   return m$1`

--- a/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
@@ -5,9 +5,9 @@ import { TranscriptView } from "./transcript/TranscriptView.mjs";
 /**
  * Renders the SampleTranscript component.
  *
- * @param {Object} params - The parameters for the component.
- * @param {string} params.id - The id of this component
- * @param {import("../types/log").Events} params.evalEvents - The transcript to display.
+ * @param {Object} props - The parameters for the component.
+ * @param {string} props.id - The id of this component
+ * @param {import("../types/log").Events} props.evalEvents - The transcript to display.
  * @returns {import("preact").JSX.Element} The SampleTranscript component.
  */
 export const SampleTranscript = ({ id, evalEvents }) => {

--- a/src/inspect_ai/_view/www/src/samples/transcript/ScoreEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ScoreEventView.mjs
@@ -49,7 +49,7 @@ export const ScoreEventView = ({ id, event, style }) => {
       <div><${MarkdownDiv} markdown=${event.score.explanation}/></div>
       <div style=${{ gridColumn: "1 / -1", borderBottom: "solid 1px var(--bs-light-border-subtle" }}></div>
       <div style=${{ ...TextStyle.label }}>Score</div>  
-      <div>${event.score.value}</div>
+      <div>${renderScore(event.score.value)}</div>
       <div style=${{ gridColumn: "1 / -1", borderBottom: "solid 1px var(--bs-light-border-subtle" }}></div>
     </div>
     ${
@@ -63,7 +63,15 @@ export const ScoreEventView = ({ id, event, style }) => {
           </div>`
         : undefined
     }
-
-
   </${EventPanel}>`;
+};
+
+const renderScore = (value) => {
+  if (Array.isArray(value)) {
+    return html`<${MetaDataGrid} entries=${value} />`;
+  } else if (typeof value === "object") {
+    return html`<${MetaDataGrid} entries=${value} />`;
+  } else {
+    return value;
+  }
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -18,12 +18,10 @@ import { EventNode } from "./Types.mjs";
 /**
  * Renders the TranscriptView component.
  *
- * @param {Object} params - The parameters for the component.
- * @param {string} params.id - The identifier for this view
- * @param {import("../../types/log").Events} params.events - The transcript events to display.
- * @param {import("./Types.mjs").StateManager} params.stateManager - A function that updates the state with a new state object.
- * @param {import("./Types.mjs").StateManager} params.storeManager - A function that updates the state with a new state object.
- * @param {number} params.depth - The base depth for this transcript view
+ * @param {Object} props - The parameters for the component.
+ * @param {string} props.id - The identifier for this view
+ * @param {import("../../types/log").Events} props.events - The transcript events to display.
+ * @param {number} props.depth - The base depth for this transcript view
  * @returns {import("preact").JSX.Element} The TranscriptView component.
  */
 export const TranscriptView = ({ id, events, depth = 0 }) => {
@@ -36,10 +34,10 @@ export const TranscriptView = ({ id, events, depth = 0 }) => {
 /**
  * Renders the Transcript component.
  *
- * @param {Object} params - The parameters for the component.
- * @param {string} params.id - The identifier for this view
- * @param {EventNode[]} params.eventNodes - The transcript events nodes to display.
- * @param {Object} params.style - The transcript style to display.
+ * @param {Object} props - The parameters for the component.
+ * @param {string} props.id - The identifier for this view
+ * @param {EventNode[]} props.eventNodes - The transcript events nodes to display.
+ * @param {Object} props.style - The transcript style to display.
  * @returns {import("preact").JSX.Element} The TranscriptView component.
  */
 export const TranscriptComponent = ({ id, eventNodes, style }) => {


### PR DESCRIPTION
We were simply displaying score values in transcripts, but the score value could be a complex object. This would result in the object participating in the preact render lifecycle and gaining additional properties (making it circular). When it was then stringified to JSON, the circularity was an issue. 

This fixes the rendering properly render records and arrays which removes the circularity.


## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Error rendering logs which contains scorers that produce arrays or records.

### What is the new behavior?

No error.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:
