### PR TITLE
Better support string values for scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Use user_data_dir rather than user_runtime_dir for view notifications.
 - Implement `read_eval_log_sample()` for JSON log files.
 - Log the list of dataset sample IDs.
+- Fix an issue which forced all values passed to a custom metric to a float value (https://github.com/UKGovernmentBEIS/inspect_ai/issues/775)
 
 ## v0.3.42 (23 October 2024)
 

--- a/src/inspect_ai/_view/www/.gitignore
+++ b/src/inspect_ai/_view/www/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 .env
 __pycache__/
 dist/assets/*.js.map
+logs/

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -46,6 +46,8 @@ def mean_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
             return _compute_dict_stat(scores, value_to_float, statistics.mean)
         elif isinstance(scores[0].value, list):
             return _compute_list_stat(scores, value_to_float, statistics.mean)
+        elif isinstance(scores[0].value, str):
+            return mode_score()(scores)
         else:
             return _compute_scalar_stat(scores, value_to_float, statistics.mean)
 

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -211,6 +211,50 @@ def test_complex_metrics() -> None:
     check_log(log)
 
 
+@metric
+def is_string() -> Metric:
+    """Demonstrates that a string arrives on the scene."""
+
+    def metric(scores: list[Score]) -> float:
+        string_count = 0
+        for s in scores:
+            if isinstance(s.value, str):
+                string_count = string_count + 1
+        return string_count / len(scores)
+
+    return metric
+
+
+@scorer(metrics=[is_string()])
+def string_scorer() -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value="e")
+
+    return score
+
+
+def test_string_score_metric() -> None:
+    def check_log(log):
+        assert (
+            log.results
+            and (list(log.results.scores[0].metrics.keys()) == ["is_string"])
+            and (log.results.scores[0].metrics["is_string"].value == 1.0)
+        )
+
+    task = Task(
+        dataset=[
+            Sample(
+                input="What is the fifth letter of the US alphabet?", target=["e", "E"]
+            )
+        ],
+        scorer=string_scorer(),
+    )
+
+    # normal eval
+    log = eval(tasks=task, model="mockllm/model")[0]
+    check_log(log)
+
+
 def registry_assert(metric: Metric | Callable[..., Metric], name: str) -> None:
     info = registry_info(metric)
     assert info.name == name


### PR DESCRIPTION
If a user produces a score whose value is a string, when that value is ‘reduced’ using the default mean reducer, it is coerced to a float. For strings thing means when the Score arrives at the custom metric, it will carry the reduced value which has been coerced to a float.

This fix is minimal - it implements support for string values in the mean reducer, providing the most common string value (or the first string value if non are most common).

Fixes #775

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Scorers that return string values run through the reduction process and the string values are reduced to a float by the mean reducer.

### What is the new behavior?

The mean reducer will reduce strings to the most common value, meaning that the string value is preserved across the mean reducer. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
