### PR TITLE
Bugfix: Properly setting base_url for mistral provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Write custom tool call views into transcript for use by Inspect View.
 - Use `casefold()` for case-insensitive compare in `includes()`, `match()`, `exact()`, and `f1()` scorers.
 - OpenAI: eliminate use of `strict` tool calling (sporadically supported across models and we already interally validate).
+- Mistral: fix bug where base_url was not respected when passing both an api_key and base_url.
 - Don't include package scope for task name part of log files.
 - Improve performance of write_file for Docker sandboxes.
 - Use user_data_dir rather than user_runtime_dir for view notifications.

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -78,8 +78,6 @@ class MistralAPI(ModelAPI):
             self.api_key = os.environ.get(MISTRAL_API_KEY, None)
             if self.api_key:
                 base_url = model_base_url(base_url, "MISTRAL_BASE_URL")
-                if base_url:
-                    model_args["server_url"] = base_url
             else:
                 self.api_key = os.environ.get(
                     AZUREAI_MISTRAL_API_KEY, os.environ.get(AZURE_MISTRAL_API_KEY, None)
@@ -94,7 +92,9 @@ class MistralAPI(ModelAPI):
                         "You must provide a base URL when using Mistral on Azure. Use the AZUREAI_MISTRAL_BASE_URL "
                         + " environment variable or the --model-base-url CLI flag to set the base URL."
                     )
-                model_args["server_url"] = base_url
+
+        if base_url:
+            model_args["server_url"] = base_url
 
         # create client
         self.client = Mistral(


### PR DESCRIPTION
Bug: When passing both an api_key and base_url to MistralAPI.init, the base_url gets ignored.

Fix: Always set the base_url if available.