### PR TITLE
Sanitize keys displayed in state/storage

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -18369,7 +18369,7 @@ function format(delta, left2) {
   return defaultInstance.format(delta, left2);
 }
 const StateDiffView = ({ before, after, style }) => {
-  const state_diff = diff(before, after);
+  const state_diff = diff(sanitizeKeys(before), sanitizeKeys(after));
   const html_result = format(state_diff) || "Unable to render differences";
   return m$1`<div
     dangerouslySetInnerHTML=${{ __html: unescapeNewlines(html_result) }}
@@ -18385,6 +18385,20 @@ function unescapeNewlines(obj) {
     }
   }
   return obj;
+}
+function sanitizeKeys(obj) {
+  if (typeof obj !== "object" || obj === null) {
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeKeys);
+  }
+  return Object.fromEntries(
+    Object.entries(obj).map(([key2, value]) => [
+      key2.replace(/</g, "&lt;").replace(/>/g, "&gt;"),
+      sanitizeKeys(value)
+    ])
+  );
 }
 const StateEventView = ({ id, event, style }) => {
   const summary = summarizeChanges(event.changes);

--- a/src/inspect_ai/_view/www/src/samples/transcript/state/StateDiffView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/state/StateDiffView.mjs
@@ -16,7 +16,8 @@ import { format } from "jsondiffpatch/formatters/html";
  */
 export const StateDiffView = ({ before, after, style }) => {
   // Diff the objects and render the diff
-  const state_diff = diff(before, after);
+  const state_diff = diff(sanitizeKeys(before), sanitizeKeys(after));
+
   const html_result = format(state_diff) || "Unable to render differences";
   return html`<div
     dangerouslySetInnerHTML=${{ __html: unescapeNewlines(html_result) }}
@@ -32,4 +33,21 @@ function unescapeNewlines(obj) {
     }
   }
   return obj;
+}
+
+function sanitizeKeys(obj) {
+  if (typeof obj !== "object" || obj === null) {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(sanitizeKeys);
+  }
+
+  return Object.fromEntries(
+    Object.entries(obj).map(([key, value]) => [
+      key.replace(/</g, "&lt;").replace(/>/g, "&gt;"),
+      sanitizeKeys(value),
+    ]),
+  );
 }


### PR DESCRIPTION
Currently keys with angle brackets ‘disappear’ when rendered in the state / store events of the transcript.

