### PR TITLE
Export `SandboxEnvironmentLimits` (for 3rd party sandbox providers)

### DIFF
--- a/src/inspect_ai/util/__init__.py
+++ b/src/inspect_ai/util/__init__.py
@@ -4,6 +4,7 @@ from ._resource import resource
 from ._sandbox import (
     OutputLimitExceededError,
     SandboxEnvironment,
+    SandboxEnvironmentLimits,
     SandboxEnvironments,
     SandboxEnvironmentSpec,
     SandboxEnvironmentType,
@@ -27,6 +28,7 @@ __all__ = [
     "resource",
     "subprocess",
     "SandboxEnvironment",
+    "SandboxEnvironmentLimits",
     "SandboxEnvironments",
     "SandboxEnvironmentSpec",
     "SandboxEnvironmentType",

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -6,8 +6,8 @@ import pytest
 from inspect_ai.util import (
     OutputLimitExceededError,
     SandboxEnvironment,
+    SandboxEnvironmentLimits,
 )
-from inspect_ai.util._sandbox import SandboxEnvironmentLimits
 
 
 async def check_test_fn(


### PR DESCRIPTION
This exports `SandboxEnvironmentLimits` so that non-inspect `SandboxEnvironment` providers can access them (e.g. k8s in the works).