### PR TITLE
Remove `SandboxEnvironment.exec()` claim (and associated test)

### DIFF
--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -111,8 +111,7 @@ class SandboxEnvironment(abc.ABC):
         filesystem context.
 
         Each output stream (stdout and stderr) is limited to 1 MiB. If exceeded, an
-        `OutputLimitExceededError` will be raised. This will not cause the command to be
-        terminated.
+        `OutputLimitExceededError` will be raised.
 
         Args:
           cmd (str | list[str]): Command or command and arguments to execute.


### PR DESCRIPTION
Unfortunately, the claim that I'd put in the `SandboxEnvironment.exec()` docstring as part of #781  is (technically true but) misleading wrt behaviour in k8s (and eventually docker if we move to streaming output)
>This will not cause the command to be terminated.

**Why?**
To avoid battering the Kubernetes API when an agent executes a command which results in a very large output, we want to stop the network traffic (by closing the websocket) once the limit is reached. Whilst this does not terminate the underlying sandboxed command, it will prevent stdout/stderr pipes from being consumed. Depending on the command being run, this can cause the remote sandboxed process to block when trying to write to stdout/stderr.

We _could_ continue streaming all the output from these commands but just discard the excess, but this would result in extremely wasteful network traffic.

We'd have a similar issue if we adapt our Docker sandbox environment to use `subprocess.communicate()`.