### PR TITLE
Revert "Better support string values for scores (#785)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,6 @@
 - Implement `read_eval_log_sample()` for JSON log files.
 - Log the list of dataset sample IDs.
 - Limit `SandboxEnvironment.exec()` output streams to 1 MiB. Limit `SandboxEnvironment.read_file()` to 100 MiB.
-- Fix an issue which forced all values passed to a custom metric to a float value (#775)
 - Add `INSPECT_DISABLE_MODEL_API` environment variable for disabling all Model APIs save for mockllm.
 - Add optional `tool_call_id` param to `ModelOutput.for_tool_call()`.
 

--- a/src/inspect_ai/_view/www/.gitignore
+++ b/src/inspect_ai/_view/www/.gitignore
@@ -2,4 +2,3 @@ node_modules/
 .env
 __pycache__/
 dist/assets/*.js.map
-logs/

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -46,8 +46,6 @@ def mean_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
             return _compute_dict_stat(scores, value_to_float, statistics.mean)
         elif isinstance(scores[0].value, list):
             return _compute_list_stat(scores, value_to_float, statistics.mean)
-        elif isinstance(scores[0].value, str):
-            return mode_score()(scores)
         else:
             return _compute_scalar_stat(scores, value_to_float, statistics.mean)
 

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -211,50 +211,6 @@ def test_complex_metrics() -> None:
     check_log(log)
 
 
-@metric
-def is_string() -> Metric:
-    """Demonstrates that a string arrives on the scene."""
-
-    def metric(scores: list[Score]) -> float:
-        string_count = 0
-        for s in scores:
-            if isinstance(s.value, str):
-                string_count = string_count + 1
-        return string_count / len(scores)
-
-    return metric
-
-
-@scorer(metrics=[is_string()])
-def string_scorer() -> Scorer:
-    async def score(state: TaskState, target: Target) -> Score:
-        return Score(value="e")
-
-    return score
-
-
-def test_string_score_metric() -> None:
-    def check_log(log):
-        assert (
-            log.results
-            and (list(log.results.scores[0].metrics.keys()) == ["is_string"])
-            and (log.results.scores[0].metrics["is_string"].value == 1.0)
-        )
-
-    task = Task(
-        dataset=[
-            Sample(
-                input="What is the fifth letter of the US alphabet?", target=["e", "E"]
-            )
-        ],
-        scorer=string_scorer(),
-    )
-
-    # normal eval
-    log = eval(tasks=task, model="mockllm/model")[0]
-    check_log(log)
-
-
 def registry_assert(metric: Metric | Callable[..., Metric], name: str) -> None:
     info = registry_info(metric)
     assert info.name == name

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -251,3 +251,14 @@ def test_score_reducer():
 
     log = score(eval_with_reducer(), match(), [mode_score(), mean_score()])
     assert log.eval.config.epochs_reducer == ["mode", "mean"]
+
+
+def test_main_reducer():
+    str_scores = [
+        Score(value="I"),
+        Score(value="I"),
+        Score(value="I"),
+        Score(value="C"),
+        Score(value="C"),
+    ]
+    assert mean_score()(str_scores).value == 0.4


### PR DESCRIPTION
This reverts commit 79f1d7e730195303e283aed4b7ac6329da3be291.

Fixes #796

# Conflicts:
#	CHANGELOG.md

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
