### PR TITLE
Clarify sandbox provider ordering requirement

### DIFF
--- a/docs/extensions.qmd
+++ b/docs/extensions.qmd
@@ -185,6 +185,10 @@ The class methods take care of various stages of initialisation, setup, and tear
 
 In the case of parallel execution of a group of tasks within the same working directory, the `task_init()` and `task_cleanup()` functions will be called once for each unique sandbox environment configuration (e.g. Docker Compose file). This is a performance optimisation derived from the fact that initialisation and cleanup are shared for tasks with identical configurations.
 
+::: {.callout-note appearance="simple"}
+The "default" `SandboxEnvironment` i.e. that named "default" or marked as default in some other provider-specific way, **must** be the first key/value in the dictionary returned from `sample_init()`.
+:::
+
 The `task_cleanup()` has a number of important functions:
 
 1.  There may be global resources that are not tied to samples that need to be cleaned up.

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -49,7 +49,9 @@ class SandboxEnvironment(abc.ABC):
           metadata (dict[str,str]): Sample `metadata` field
 
         Returns:
-          Dictionary of named sandbox environments.
+          Dictionary of named sandbox environments. The environment which represents
+          the default environment (resolved by `sandbox("default")` or `sandbox()`) must
+          be the first key/value pair in the dictionary.
         """
         return {}
 


### PR DESCRIPTION
If other sandbox providers (e.g. k8s) happen to provide the sandboxes in another order (e.g. alphabetically because that's how the API returns them) then even calling `sandbox("default")` would resolve the sandbox named `another` below:
```
service:
  default: ...
  another: ...
```
 
This PR aims to make Inspect's requirement clearer both in the docs and in the `SandboxEnvironment` interface inline docs.