### PR TITLE
Making sure Score .to_float() can handle strings (in tasks that are scored by strings, e.g. GAIA)

### DIFF
--- a/src/inspect_ai/scorer/_metric.py
+++ b/src/inspect_ai/scorer/_metric.py
@@ -98,8 +98,10 @@ class Score(BaseModel):
             raise ValueError("This score is not a dictionary")
 
     def _as_scalar(self) -> str | int | float | bool:
-        if isinstance(self.value, str | int | float | bool):
+        if isinstance(self.value, int | float | bool):
             return self.value
+        elif isinstance(self.value, str):
+            return value_to_float()(self.value)
         else:
             raise ValueError("This score is not a scalar")
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently the to_float doesn't handle string inputs (not sure if this a was change!), leading to errors like:
```│ │ /home/ubuntu/src/agent_framework/.venv/lib/python3.12/site-packages/inspect_ai/scorer/_metrics/mean.py:15 in metric  │                                                                            │
│ │                                                                                                                      │                                                                            │
│ │ /home/ubuntu/src/agent_framework/.venv/lib/python3.12/site-packages/inspect_ai/scorer/_metric.py:87 in as_float      │                                                                            │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                                                                            │
│ ValueError: could not convert string to float: 'I' 
```

This would fix it for me. I suspect its a wrong/incorrecfix, value_to_float needs to be configurable with how you are mapping values to float - more opening for discussion, I suspect @jjallaire can rustle up a better fix quite quickly.
