### PR TITLE
revert change to single epoch reducer behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3.44 (04 November 2024)
+
+- Revert change to single epoch reducer behavior (regressed some scoring scenarios).
+
 ## v0.3.43 (04 November 2024)
 
 - New binary [log format](https://inspect.ai-safety-institute.org.uk/eval-logs.html#sec-log-format) which yields substantial size and speed improvements (JSON format log files are still fully supported and utilities for converting between the formats are provided).
@@ -20,8 +24,8 @@
 - Limit `SandboxEnvironment.exec()` output streams to 1 MiB. Limit `SandboxEnvironment.read_file()` to 100 MiB.
 - Add `INSPECT_DISABLE_MODEL_API` environment variable for disabling all Model APIs save for mockllm.
 - Add optional `tool_call_id` param to `ModelOutput.for_tool_call()`.
-- Don't apply a reducer if there is only a single epoch (previously the reducer would be run against the single epoch value, which had side effects on score values)
 - Support all JSON and CSV dataset arguments in `file_dataset()` function.
+
 
 ## v0.3.42 (23 October 2024)
 

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -286,31 +286,16 @@ def reduce_scores(
     # reduce the scores
     reduced_scores: list[SampleScore] = []
     for scores in grouped_scores.values():
-        if len(scores) > 1:
-            # There are multiple instances of this sample with scors
-            # run the reducer
-            reduced = reducer(cast(list[Score], scores))
-            reduced_scores.append(
-                SampleScore(
-                    sample_id=scores[0].sample_id,
-                    value=reduced.value,
-                    answer=reduced.answer,
-                    explanation=reduced.explanation,
-                    metadata=reduced.metadata,
-                )
+        reduced = reducer(cast(list[Score], scores))
+        reduced_scores.append(
+            SampleScore(
+                sample_id=scores[0].sample_id,
+                value=reduced.value,
+                answer=reduced.answer,
+                explanation=reduced.explanation,
+                metadata=reduced.metadata,
             )
-        else:
-            # There is only a single sample - don't run the reducer
-            # as there is nothing to reduce
-            reduced_scores.append(
-                SampleScore(
-                    sample_id=scores[0].sample_id,
-                    value=scores[0].value,
-                    answer=scores[0].answer,
-                    explanation=scores[0].explanation,
-                    metadata=scores[0].metadata,
-                )
-            )
+        )
 
     return reduced_scores
 


### PR DESCRIPTION
This change regressed some scoring scenarios. We will look for another fix for metrics that want access to raw string content.
