### PR TITLE
Properly display sample errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- The log viewer now properly displays sample errors in the sample list for `eval` format log files.
+
 ## v0.3.45 (11 November 2024)
 
 - [time_limit](https://inspect.ai-safety-institute.org.uk/errors_and_limits.html#sec-sample-limits) option for specifying a maximum execution time for samples.

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -19543,7 +19543,9 @@ const SampleError = ({ message, align, style }) => {
     height: FontSize.small
   }}
     />
-    <div>${errorType(message)}</div>
+    <div style=${{ maxWidth: "300px", ...ApplicationStyles.lineClamp(2) }}>
+      ${errorType(message)}
+    </div>
   </div>`;
 };
 const FlatSampleError = ({ message, style }) => {
@@ -20461,7 +20463,7 @@ const SampleRow = ({
     display: "flex"
   }}
       >
-        ${sample.error ? m$1`<${SampleError} message=${sample.error.message} />` : sampleDescriptor == null ? void 0 : sampleDescriptor.selectedScore(sample).render()}
+        ${sample.error ? m$1`<${SampleError} message=${sample.error} />` : sampleDescriptor == null ? void 0 : sampleDescriptor.selectedScore(sample).render()}
       </div>
     </div>
   `;
@@ -23207,13 +23209,15 @@ const clientApi = (api2) => {
     } else {
       const logContents = await get_log(log_file);
       const sampleSummaries = logContents.parsed.samples ? (_a2 = logContents.parsed.samples) == null ? void 0 : _a2.map((sample) => {
+        var _a3;
         return {
           id: sample.id,
           epoch: sample.epoch,
           input: sample.input,
           target: sample.target,
           scores: sample.scores,
-          metadata: sample.metadata
+          metadata: sample.metadata,
+          error: (_a3 = sample.error) == null ? void 0 : _a3.message
         };
       }) : [];
       const parsed = logContents.parsed;

--- a/src/inspect_ai/_view/www/src/api/client-api.mjs
+++ b/src/inspect_ai/_view/www/src/api/client-api.mjs
@@ -90,6 +90,7 @@ export const clientApi = (api) => {
               target: sample.target,
               scores: sample.scores,
               metadata: sample.metadata,
+              error: sample.error?.message,
             };
           })
         : [];

--- a/src/inspect_ai/_view/www/src/samples/SampleError.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleError.mjs
@@ -3,6 +3,7 @@ import { html } from "htm/preact";
 
 import { FontSize } from "../appearance/Fonts.mjs";
 import { ApplicationIcons } from "../appearance/Icons.mjs";
+import { ApplicationStyles } from "../appearance/Styles.mjs";
 
 /**
  * Component to display a styled error message.
@@ -34,7 +35,9 @@ export const SampleError = ({ message, align, style }) => {
         height: FontSize.small,
       }}
     />
-    <div>${errorType(message)}</div>
+    <div style=${{ maxWidth: "300px", ...ApplicationStyles.lineClamp(2) }}>
+      ${errorType(message)}
+    </div>
   </div>`;
 };
 

--- a/src/inspect_ai/_view/www/src/samples/SampleList.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleList.mjs
@@ -326,7 +326,7 @@ const SampleRow = ({
         }}
       >
         ${sample.error
-          ? html`<${SampleError} message=${sample.error.message} />`
+          ? html`<${SampleError} message=${sample.error} />`
           : sampleDescriptor?.selectedScore(sample).render()}
       </div>
     </div>

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -33,6 +33,7 @@ class SampleSummary(BaseModel):
     input: str | list[ChatMessage]
     target: str | list[str]
     scores: dict[str, Score] | None
+    error: str | None
 
 
 class LogStart(BaseModel):
@@ -266,6 +267,7 @@ class EvalRecorder(FileRecorder):
                     input=text_inputs(sample.input),
                     target=sample.target,
                     scores=sample.scores,
+                    error=sample.error.message if sample.error is not None else None,
                 )
             )
         log.samples.clear()


### PR DESCRIPTION
Sample summaries were not properly carrying error messages, so sample errors in .eval files are not currently displayed. This fixes that issue, and also preserves the display of errors in json formatted files.

Existing ‘eval’ formatted log files will not display errors (the error is missing from the file). They can be updated to properly display by round tripping them using `inspect log convert` and converting them to json and then back to eval format.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
