### PR TITLE
Improve conversion path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [eval](https://inspect.ai-safety-institute.org.uk/eval-logs.html#sec-log-format) is now the default log format (use `--log-format=json` to use old format).
 - Base 64 images are now logged by default for all log formats (disable with `--no-log-images`).
 - The log viewer now properly displays sample errors in the sample list for `eval` format log files.
+- Improve path handling when using `inspect log convert` to convert a single log file.
 
 ## v0.3.45 (11 November 2024)
 

--- a/src/inspect_ai/log/_convert.py
+++ b/src/inspect_ai/log/_convert.py
@@ -44,16 +44,23 @@ def convert_eval_logs(
         # compute input and ensure output dir exists
         input_name, _ = os.path.splitext(input_file)
         input_dir = os.path.dirname(input_name.replace("\\", "/"))
-        target_dir = f"{output_dir}{fs.sep}{input_dir}"
+
+        # Compute paths, handling directories being converted
+        # and files being converted specially
+        path_is_dir = fs.info(path).type == "directory"
+        if path_is_dir:
+            target_dir = f"{output_dir}{fs.sep}{input_dir}"
+            input_file = f"{path}{fs.sep}{input_file}"
+            output_file_basename = input_name
+        else:
+            target_dir = output_dir
+            output_file_basename = os.path.basename(input_name)
+
         output_fs = filesystem(target_dir)
         output_fs.mkdir(target_dir, exist_ok=True)
 
-        # compute file input file based on path
-        if fs.info(path).type == "directory":
-            input_file = f"{path}{fs.sep}{input_file}"
-
         # compute full output file and enforce overwrite
-        output_file = f"{output_dir}{fs.sep}{input_name}.{to}"
+        output_file = f"{output_dir}{fs.sep}{output_file_basename}.{to}"
         if exists(output_file) and not overwrite:
             raise FileExistsError(
                 "Output file {output_file} already exists (use --overwrite to overwrite existing files)"


### PR DESCRIPTION
Preserve existing behavior for converting folders. For files, no longer use the original file name subdirectories - just place the converted file in the folder provided by the `—output-dir` arg.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

