### PR TITLE
Increase sandbox `exec()` output limit from 1 MiB to 10 MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Improve path handling when using `inspect log convert` to convert a single log file.
 - Web browser tool: Subtasks now each have independent web browser sessions.
 - Anthropic: Ensure that assistant messages created in generate never have empty content lists.
+- Increase sandbox `exec()` output limit from 1 MiB to 10 MiB.
 
 ## v0.3.45 (11 November 2024)
 

--- a/src/inspect_ai/util/_sandbox/limits.py
+++ b/src/inspect_ai/util/_sandbox/limits.py
@@ -7,8 +7,8 @@ from inspect_ai.util._subprocess import ExecResult
 class SandboxEnvironmentLimits:
     """Encapsulates limits for sandbox environments."""
 
-    MAX_EXEC_OUTPUT_SIZE = 1024**2
-    MAX_EXEC_OUTPUT_SIZE_STR = "1 MiB"
+    MAX_EXEC_OUTPUT_SIZE = 10 * 1024**2
+    MAX_EXEC_OUTPUT_SIZE_STR = "10 MiB"
 
     MAX_READ_FILE_SIZE = 100 * 1024**2
     MAX_READ_FILE_SIZE_STR = "100 MiB"

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -294,7 +294,7 @@ async def test_cwd_absolute(sandbox_env: SandboxEnvironment) -> None:
 
 
 async def test_exec_stdout_is_limited(sandbox_env: SandboxEnvironment) -> None:
-    output_size = 1024**2 + 1024  # 1 MiB + 1 KiB
+    output_size = 10 * 1024**2 + 1024  # 10 MiB + 1 KiB
     with pytest.raises(OutputLimitExceededError) as e_info:
         await sandbox_env.exec(["sh", "-c", f"yes | head -c {output_size}"])
     assert "limit of 1 MiB was exceeded" in str(e_info.value)
@@ -304,7 +304,7 @@ async def test_exec_stdout_is_limited(sandbox_env: SandboxEnvironment) -> None:
 
 
 async def test_exec_stderr_is_limited(sandbox_env: SandboxEnvironment) -> None:
-    output_size = 1024**2 + 1024  # 1 MiB + 1 KiB
+    output_size = 10 * 1024**2 + 1024  # 10 MiB + 1 KiB
     with pytest.raises(OutputLimitExceededError) as e_info:
         await sandbox_env.exec(["sh", "-c", f"yes | head -c {output_size} 1>&2"])
     assert "limit of 1 MiB was exceeded" in str(e_info.value)


### PR DESCRIPTION
@craigwalton-dsit We have already seen scorers exceeding the 1 MiB limit (e.g. in SWE bench capturing all of the test results, etc.). I think we can afford to take this higher without risking a run on memory (given that even if _every_ `exec()` call was simultaneously at the limit it would at most require `max_subprocesses * 10mb` of memory). LMK what you think! 