### PR TITLE
Log View: Restore Scroll Position in VS Code

### DIFF
--- a/src/inspect_ai/_view/www/src/App.mjs
+++ b/src/inspect_ai/_view/www/src/App.mjs
@@ -102,6 +102,14 @@ export function App({
   const [selectedSampleTab, setSelectedSampleTab] = useState(
     initialState?.selectedSampleTab,
   );
+  const sampleScrollPosition = useRef(initialState?.sampleScrollPosition || 0);
+  const setSampleScrollPosition = useCallback((position) => {
+    sampleScrollPosition.current = position;
+    setUpdateState((prev) => {
+      return prev + 1;
+    });
+  }, []);
+  const [updateState, setUpdateState] = useState(0);
 
   const loadingSampleIndexRef = useRef(null);
 
@@ -201,6 +209,7 @@ export function App({
       filteredSamples,
       groupBy,
       groupByOrder,
+      sampleScrollPosition: sampleScrollPosition.current,
     };
     if (saveInitialState) {
       saveInitialState(state);
@@ -230,6 +239,7 @@ export function App({
     filteredSamples,
     groupBy,
     groupByOrder,
+    updateState,
   ]);
 
   const handleSampleShowingDialog = useCallback(
@@ -365,6 +375,7 @@ export function App({
           sample.events = resolveAttachments(sample.events, sample.attachments);
           sample.attachments = {};
 
+          setSampleScrollPosition(0);
           setSelectedSample(sample);
 
           refreshSampleTab(sample);
@@ -375,7 +386,10 @@ export function App({
         .catch((e) => {
           setSampleStatus("error");
           setSampleError(e);
+
+          setSampleScrollPosition(0);
           setSelectedSample(undefined);
+
           loadingSampleIndexRef.current = null;
         });
     }
@@ -852,6 +866,8 @@ export function App({
               setScore=${setScore}
               scores=${scores}
               renderContext=${context}
+              sampleScrollPosition=${sampleScrollPosition.current}
+              setSampleScrollPosition=${setSampleScrollPosition}
             />`
       }
     </div>

--- a/src/inspect_ai/_view/www/src/App.mjs
+++ b/src/inspect_ai/_view/www/src/App.mjs
@@ -112,6 +112,20 @@ export function App({
   );
   const loadingSampleIndexRef = useRef(null);
 
+  const workspaceTabScrollPosition = useRef(
+    initialState?.workspaceTabScrollPosition || {},
+  );
+  const setWorkspaceTabScrollPosition = useCallback(
+    debounce((tab, position) => {
+      workspaceTabScrollPosition.current = {
+        ...workspaceTabScrollPosition.current,
+        [tab]: position,
+      };
+      flushInitialState();
+    }, 250),
+    [],
+  );
+
   const [updateInitialState, setUpdateInitialState] = useState(0);
   const flushInitialState = useCallback(() => {
     setUpdateInitialState((prev) => {
@@ -216,6 +230,7 @@ export function App({
       groupBy,
       groupByOrder,
       sampleScrollPosition: sampleScrollPosition.current,
+      workspaceTabScrollPosition: workspaceTabScrollPosition.current,
     };
     if (saveInitialState) {
       saveInitialState(state);
@@ -496,6 +511,8 @@ export function App({
       } else {
         setSelectedSampleIndex(-1);
       }
+
+      workspaceTabScrollPosition.current = {};
     },
     [setSelectedWorkspaceTab],
   );
@@ -876,6 +893,8 @@ export function App({
               renderContext=${context}
               sampleScrollPosition=${sampleScrollPosition.current}
               setSampleScrollPosition=${setSampleScrollPosition}
+              workspaceTabScrollPosition=${workspaceTabScrollPosition.current}
+              setWorkspaceTabScrollPosition=${setWorkspaceTabScrollPosition}
             />`
       }
     </div>

--- a/src/inspect_ai/_view/www/src/components/LargeModal.mjs
+++ b/src/inspect_ai/_view/www/src/components/LargeModal.mjs
@@ -1,7 +1,9 @@
 import { html } from "htm/preact";
+import { useEffect, useRef } from "preact/hooks";
 
 import { FontSize } from "../appearance/Fonts.mjs";
 import { ProgressBar } from "./ProgressBar.mjs";
+import { throttle } from "../utils/sync.mjs";
 
 export const LargeModal = (props) => {
   const {
@@ -15,12 +17,26 @@ export const LargeModal = (props) => {
     onHide,
     showProgress,
     children,
+    initialScrollPosition,
+    setInitialScrollPosition,
   } = props;
 
   // The footer
   const modalFooter = footer
     ? html`<div class="modal-footer">${footer}</div>`
     : "";
+
+  const scrollRef = useRef();
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      setTimeout(() => {
+        if (scrollRef.current.scrollTop !== initialScrollPosition) {
+          scrollRef.current.scrollTop = initialScrollPosition;
+        }
+      }, 0);
+    }
+  }, [initialScrollPosition]);
 
   // Capture header elements
   const headerEls = [];
@@ -124,7 +140,20 @@ export const LargeModal = (props) => {
             backgroundColor: "var(--bs-body-bg)",
           }}
         />
-        <div class="modal-body">${children}</div>
+        <div
+          class="modal-body"
+          ref=${scrollRef}
+          onscroll=${() => {
+            if (scrollRef.current) {
+              throttle(
+                setInitialScrollPosition(scrollRef.current.scrollTop),
+                1000,
+              );
+            }
+          }}
+        >
+          ${children}
+        </div>
         ${modalFooter}
       </div>
     </div>

--- a/src/inspect_ai/_view/www/src/components/TabSet.mjs
+++ b/src/inspect_ai/_view/www/src/components/TabSet.mjs
@@ -1,5 +1,7 @@
 import { html } from "htm/preact";
 import { FontSize, TextStyle } from "../appearance/Fonts.mjs";
+import { useCallback, useEffect, useRef } from "preact/hooks";
+import { debounce } from "../utils/sync.mjs";
 
 // styles: { tabSet:{}, tabBody: {}}
 export const TabSet = ({ id, type, classes, tools, styles, children }) => {
@@ -38,12 +40,34 @@ export const TabPanel = ({
   style,
   scrollable,
   classes,
+  scrollPosition,
+  setScrollPosition,
   children,
 }) => {
   const tabContentsId = computeTabContentsId(id, index);
+  const tabContentsRef = useRef();
+  useEffect(() => {
+    setTimeout(() => {
+      if (
+        scrollPosition !== undefined &&
+        tabContentsRef.current &&
+        tabContentsRef.current.scrollTop !== scrollPosition
+      ) {
+        tabContentsRef.current.scrollTop = scrollPosition;
+      }
+    }, 0);
+  });
+
+  const onScroll = useCallback(
+    debounce((e) => {
+      setScrollPosition(e.srcElement.scrollTop);
+    }, 100),
+    [setScrollPosition],
+  );
 
   return html`<div
     id="${tabContentsId}"
+    ref=${tabContentsRef}
     class="tab-pane show${selected ? " active" : ""}${classes
       ? ` ${classes}`
       : ""}"
@@ -52,6 +76,7 @@ export const TabPanel = ({
       overflowY: scrollable === undefined || scrollable ? "auto" : "hidden",
       ...style,
     }}
+    onscroll=${onScroll}
   >
     ${children}
   </div>`;

--- a/src/inspect_ai/_view/www/src/samples/SampleDialog.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDialog.mjs
@@ -23,6 +23,8 @@ import { ErrorPanel } from "../components/ErrorPanel.mjs";
  * @param {(showing: boolean) => void} props.setShowingSampleDialog - function to set whether the dialog is showing
  * @param {() => void} [props.nextSample] - function to move to next sample
  * @param {() => void} [props.prevSample] - function to move to previous sample
+ * @param {number} props.sampleScrollPosition - the sample scroll position
+ * @param {(position: number) => void} props.setSampleScrollPosition - set the sample scroll position
  * @param {import("../Types.mjs").RenderContext} props.context - the app context
  * @returns {import("preact").JSX.Element} The TranscriptView component.
  */
@@ -39,6 +41,8 @@ export const SampleDialog = ({
   setShowingSampleDialog,
   selectedTab,
   setSelectedTab,
+  sampleScrollPosition,
+  setSampleScrollPosition,
   context,
 }) => {
   const tools = useMemo(() => {
@@ -95,6 +99,8 @@ export const SampleDialog = ({
         setShowingSampleDialog(false);
       }}
       showProgress=${sampleStatus === "loading"}
+      initialScrollPosition=${sampleScrollPosition}
+      setInitialScrollPosition=${setSampleScrollPosition}
     >
         ${
           sampleError

--- a/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
@@ -30,6 +30,8 @@ import { EmptyPanel } from "../components/EmptyPanel.mjs";
  * @param {(tab: string) => void} props.setSelectedSampleTab - function to select a tab
  * @param {string} props.epoch - the selected epoch
  * @param {import("../Types.mjs").ScoreFilter} props.filter - the selected filter
+ * @param {number} props.sampleScrollPosition - the sample scroll position
+ * @param {(position: number) => void} props.setSampleScrollPosition - sets the sample scroll position
  * @param {any} props.sort - the selected sort
  *
  * @returns {import("preact").JSX.Element[]} The TranscriptView component.
@@ -51,6 +53,8 @@ export const SamplesTab = ({
   setShowingSampleDialog,
   selectedSampleTab,
   setSelectedSampleTab,
+  sampleScrollPosition,
+  setSampleScrollPosition,
   context,
 }) => {
   const [items, setItems] = useState([]);
@@ -195,6 +199,8 @@ export const SamplesTab = ({
       nextSample=${nextSample}
       prevSample=${previousSample}
       context=${context}
+      sampleScrollPosition=${sampleScrollPosition}
+      setSampleScrollPosition=${setSampleScrollPosition}
     />
   `);
 

--- a/src/inspect_ai/_view/www/src/utils/sync.mjs
+++ b/src/inspect_ai/_view/www/src/utils/sync.mjs
@@ -45,10 +45,57 @@ export function throttle(func, wait, options) {
       }
       previous = now;
       result = func.apply(context, args);
+
       if (!timeout) context = args = null;
     } else if (!timeout && options.trailing !== false) {
       timeout = setTimeout(later, remaining);
     }
+    return result;
+  };
+}
+
+/**
+ * Creates a debounced version of a function that delays invoking the function
+ * until after `wait` milliseconds have passed since the last time it was invoked.
+ *
+ * @param {Function} func - The function to debounce.
+ * @param {number} wait - The number of milliseconds to delay.
+ * @param {Object} [options] - The options object.
+ * @param {boolean} [options.leading=false] - If `true`, the function will be invoked on the leading edge of the timeout.
+ * @param {boolean} [options.trailing=true] - If `false`, the function will not be invoked on the trailing edge.
+ * @returns {Function} - The debounced function.
+ */
+export function debounce(func, wait, options = {}) {
+  let timeout, context, args, result;
+  let lastCallTime = null;
+
+  const later = () => {
+    const last = Date.now() - lastCallTime;
+    if (last < wait && last >= 0) {
+      timeout = setTimeout(later, wait - last);
+    } else {
+      timeout = null;
+      if (!options.leading) {
+        result = func.apply(context, args);
+        if (!timeout) context = args = null;
+      }
+    }
+  };
+
+  return function () {
+    context = this;
+    args = arguments;
+    lastCallTime = Date.now();
+
+    const callNow = options.leading && !timeout;
+    if (!timeout) {
+      timeout = setTimeout(later, wait);
+    }
+    if (callNow) {
+      result = func.apply(context, args);
+      context = args = null;
+    }
+
     return result;
   };
 }

--- a/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
+++ b/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
@@ -68,6 +68,8 @@ import {
  * @param {(id: string) => void} props.setSelectedTab - function to update the selected tab
  * @param {number} props.sampleScrollPosition - The initial scroll position for the sample
  * @param {(position: number) => void} props.setSampleScrollPosition - Set the most recent scroll position for this element
+ * @param {number} props.workspaceTabScrollPosition - The initial scroll position for the workspace tabs
+ * @param {(tab: string, position: number) => void} props.setWorkspaceTabScrollPosition - The initial scroll position for the workspace tabs
  * @param {import("../Types.mjs").RenderContext} props.renderContext - is this off canvas
  * @returns {import("preact").JSX.Element | string} The Workspace component.
  */
@@ -114,6 +116,8 @@ export const WorkSpace = ({
   renderContext,
   sampleScrollPosition,
   setSampleScrollPosition,
+  workspaceTabScrollPosition,
+  setWorkspaceTabScrollPosition,
 }) => {
   const divRef = useRef(/** @type {HTMLElement|null} */ (null));
 
@@ -317,6 +321,8 @@ export const WorkSpace = ({
     showToggle=${showToggle}
     offcanvas=${offcanvas}
     setSelectedTab=${setSelectedTab}
+    workspaceTabScrollPosition=${workspaceTabScrollPosition}
+    setWorkspaceTabScrollPosition=${setWorkspaceTabScrollPosition}
   />`;
 };
 
@@ -333,6 +339,8 @@ const WorkspaceDisplay = ({
   setSelectedTab,
   divRef,
   offcanvas,
+  workspaceTabScrollPosition,
+  setWorkspaceTabScrollPosition,
 }) => {
   if (evalSpec === undefined) {
     return html`<${EmptyPanel} />`;
@@ -410,7 +418,12 @@ const WorkspaceDisplay = ({
                   setSelectedTab(id);
                 }}
                 selected=${selectedTab === tab.id}
-                scrollable=${!!tab.scrollable}>
+                scrollable=${!!tab.scrollable}
+                scrollPosition=${workspaceTabScrollPosition[tab.id]}
+                setScrollPosition=${(position) => {
+                  setWorkspaceTabScrollPosition(tab.id, position);
+                }}
+                >
                   ${tab.content()}
                 </${TabPanel}>`;
               })}

--- a/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
+++ b/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
@@ -66,6 +66,8 @@ import {
  * @param {boolean} props.offcanvas - is this off canvas
  * @param {string} props.selectedTab - The selected tab id
  * @param {(id: string) => void} props.setSelectedTab - function to update the selected tab
+ * @param {number} props.sampleScrollPosition - The initial scroll position for the sample
+ * @param {(position: number) => void} props.setSampleScrollPosition - Set the most recent scroll position for this element
  * @param {import("../Types.mjs").RenderContext} props.renderContext - is this off canvas
  * @returns {import("preact").JSX.Element | string} The Workspace component.
  */
@@ -110,6 +112,8 @@ export const WorkSpace = ({
   selectedTab,
   setSelectedTab,
   renderContext,
+  sampleScrollPosition,
+  setSampleScrollPosition,
 }) => {
   const divRef = useRef(/** @type {HTMLElement|null} */ (null));
 
@@ -158,6 +162,8 @@ export const WorkSpace = ({
           sort=${sort}
           epoch=${epoch}
           context=${renderContext}
+          sampleScrollPosition=${sampleScrollPosition}
+          setSampleScrollPosition=${setSampleScrollPosition}
         />`;
       },
       tools: () => {


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When a log viewer in vscode is sent to the background (e.g. you select another tab), the scroll position of the viewer is reset since we completely reload the viewer when restoring the tab.

### What is the new behavior?

When a log viewer in vscode is sent to the background (e.g. you select another tab), the scroll position of the viewer is preserved. We don't preserve other potentially useful things like expanded panels, selected sub tabs within transcripts, etc.. But the general scroll position will be preserved now.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
