### PR TITLE
Fix scoring behaviour in basic agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Ensure that the scorer is only run once for basic_agent with max_attempts = 1.
+
 ## v0.3.46 (12 November 2024) 
 
 - [eval](https://inspect.ai-safety-institute.org.uk/eval-logs.html#sec-log-format) is now the default log format (use `--log-format=json` to use old format).

--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -194,7 +194,7 @@ def basic_agent(
                         attempts += 1
                         if attempts >= max_attempts:
                             break
-                        
+
                         # exit if the submission is successful
                         answer_scores = await score(state)
                         if score_value_fn(answer_scores[0].value) == 1.0:

--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -190,15 +190,16 @@ def basic_agent(
                         # set the output to the answer for scoring
                         state.output.completion = answer
 
-                        # score it
-                        answer_scores = await score(state)
-                        if score_value_fn(answer_scores[0].value) == 1.0:
-                            break
-
                         # exit if we are at max_attempts
                         attempts += 1
                         if attempts >= max_attempts:
                             break
+                        
+                        # exit if the submission is successful
+                        answer_scores = await score(state)
+                        if score_value_fn(answer_scores[0].value) == 1.0:
+                            break
+
                         # otherwise notify the model that it was incorrect and continue
                         else:
                             state.messages.append(


### PR DESCRIPTION
Inspect's basic agent will, by default, run the scorer at least twice.

It will run it at least once when checking the score, and then once for the actual scoring.

As I understand it, this is to enable retrying based whether your submission is correct. But the issue is - this means the scorer runs twice! If your scorer makes mutations to some state (e.g. in the sandbox environment), this can cause problems with scoring correctness.

This came up in the context of an evaluation where the scorer runs some script on the disk which checks if a marker file exists, does nothing if it does, and writes this marker file at exit. This ensures the script runs once and only once on the machine. 

But, since our scorer runs twice, and the score that actually gets reported is from the second time it runs, we were seeing this script do nothing (since the marker file already existed), and report the wrong score for some reason we couldn't figure out. 

I think the fix is fairly simple - just don't run the scorer if max attempts == 1, since we will be breaking either way.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
see above

### What is the new behavior?
see above

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
no

### Other information:
