### PR TITLE
Move INSPECT_DISABLE_MODEL_API check

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -215,13 +215,6 @@ class Model:
         Returns:
            ModelOutput
         """
-        # verify that model apis are allowed
-        if (
-            os.getenv("INSPECT_DISABLE_MODEL_API", None) is not None
-            and ModelName(self).api != "mockllm"
-        ):
-            raise RuntimeError("Model APIs disabled by INSPECT_DISABLE_MODEL_API")
-
         # base config for this model
         base_config = self.config
 
@@ -345,6 +338,13 @@ class Model:
                         call=None,
                     )
                     return existing
+
+            # verify that model apis are allowed
+            if (
+                os.getenv("INSPECT_DISABLE_MODEL_API", None) is not None
+                and ModelName(self).api != "mockllm"
+            ):
+                raise RuntimeError("Model APIs disabled by INSPECT_DISABLE_MODEL_API")
 
             result = await self.api.generate(
                 input=input,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
If INSPECT_DISABLE_MODEL_API was set, an error would be thrown even if there would have been a cache hit

### What is the new behavior?
An error is only thrown if there is a cache miss and we are actually about to call a model for realsies

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
If someone was relying on the previous behaviour (excluding cache hits) then this would break, but I doubt that is the case