### PR TITLE
Fix to allow repeat evals on azureai

### DIFF
--- a/tests/model/providers/test_azureai.py
+++ b/tests/model/providers/test_azureai.py
@@ -1,0 +1,34 @@
+import pytest
+from test_helpers.utils import skip_if_no_azureai
+from test_helpers.tasks import minimal_task
+from inspect_ai import eval_async
+from inspect_ai.model import GenerateConfig, get_model
+
+model = get_model(
+    model="azureai/Meta-Llama-3-1-405B-Instruct-twe",
+    azure=True,
+    config=GenerateConfig(
+        frequency_penalty=0.0,
+        stop_seqs=None,
+        max_tokens=2,
+        presence_penalty=0.0,
+        seed=None,
+        temperature=0.0,
+        top_p=1.0,
+    ),
+)
+
+message = "This is a test string. What are you?"
+
+@pytest.mark.asyncio
+@skip_if_no_azureai
+async def test_azureai_api() -> None:
+    response = await model.generate(input=message)
+    assert len(response.completion) >= 1
+
+@pytest.mark.asyncio
+@skip_if_no_azureai
+async def test_azureai_api_repeat_eval() -> None:
+    _ = await eval_async(tasks=minimal_task, model=model)
+    eval_log = await eval_async(tasks=minimal_task, model=model)
+    assert eval_log[0].error is None, "Error on running consecutive evaluations"

--- a/tests/test_helpers/tasks.py
+++ b/tests/test_helpers/tasks.py
@@ -1,6 +1,19 @@
 from inspect_ai import Task, task
 
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate
 
 @task
 def empty_task() -> Task:
     return Task()
+
+@task
+def minimal_task() -> Task:
+    return Task(
+        dataset=[Sample(input="What is 1+1?", target="2")],
+        solver=[generate()],
+        scorer=includes(),
+        metadata={"task_idx": 1},
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Repeated calls to azureai models leads to an async error, which stems from the AzureAI `ChatCompletionsClient` needing to be manually closed

### What is the new behavior?
Creates the client in the generate block, and closes it at the end of the generation.
Also added a regression test.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
