### PR TITLE
Support custom incorrect messages in basic_agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Ensure that the scorer is only run once for basic_agent with max_attempts = 1.
+- Support custom incorrect messages in basic_agent
 
 ## v0.3.46 (12 November 2024) 
 

--- a/tests/solver/test_basic_agent.py
+++ b/tests/solver/test_basic_agent.py
@@ -1,9 +1,9 @@
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
 from inspect_ai.log import EvalLog
-from inspect_ai.model import ModelOutput, get_model
-from inspect_ai.scorer import includes
-from inspect_ai.solver import Solver, basic_agent, solver, system_message
+from inspect_ai.model import ChatMessageUser, ModelOutput, get_model
+from inspect_ai.scorer import Score, Target, accuracy, includes, scorer
+from inspect_ai.solver import Solver, TaskState, basic_agent, solver, system_message
 from inspect_ai.tool import Tool, tool
 
 
@@ -67,6 +67,20 @@ def run_basic_agent(
     return eval(task, model=model)[0]
 
 
+def mockllm_model(answers: list[str]):
+    return get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": answer},
+            )
+            for answer in answers
+        ],
+    )
+
+
 def test_basic_agent_solver():
     @solver
     def addition_tool() -> Solver:
@@ -108,19 +122,6 @@ def test_basic_agent_retries():
             scorer=includes(),
         )
 
-    def mockllm_model(answers: list[str]):
-        return get_model(
-            "mockllm/model",
-            custom_outputs=[
-                ModelOutput.for_tool_call(
-                    model="mockllm/model",
-                    tool_name="submit",
-                    tool_arguments={"answer": answer},
-                )
-                for answer in answers
-            ],
-        )
-
     # incorrect answer with no retries
     log = eval(addition_task(1), mockllm_model(["5"]))[0]
     assert log.results.scores[0].metrics["accuracy"].value == 0
@@ -132,3 +133,51 @@ def test_basic_agent_retries():
         1 for event in log.samples[0].transcript.events if event.event == "model"
     )
     assert model_events == 3
+
+
+def test_basic_agent_retries_with_custom_incorrect_message():
+    @scorer(metrics=[accuracy()])
+    def compare_quantities():
+        async def score(state: TaskState, target: Target) -> Score:
+            answer = float(state.output.completion)
+            target_value = float(target.text)
+            if answer == target_value:
+                return Score(value=1.0, answer=state.output.completion)
+            elif answer > target_value:
+                return Score(
+                    value=0.0,
+                    answer=state.output.completion,
+                    explanation="Answer is too high",
+                )
+            else:
+                return Score(
+                    value=0.0,
+                    answer=state.output.completion,
+                    explanation="Answer is too low",
+                )
+
+        return score
+
+    def custom_incorrect_message(state: TaskState, score: Score):
+        return f"Your response to the input '{state.input}' was incorrect: {score.explanation}"
+
+    addition_task = Task(
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+        solver=basic_agent(
+            tools=[addition()],
+            max_attempts=3,
+            message_limit=30,
+            incorrect_message=custom_incorrect_message,
+        ),
+        scorer=compare_quantities(),
+    )
+    log = eval(addition_task, mockllm_model(["5", "1", "2"]))[0]
+    assert log.results.scores[0].metrics["accuracy"].value == 1
+    user_msgs = [
+        m.content for m in log.samples[0].messages if isinstance(m, ChatMessageUser)
+    ]
+    assert user_msgs == [
+        "What is 1 + 1?",
+        "Your response to the input 'What is 1 + 1?' was incorrect: Answer is too high",
+        "Your response to the input 'What is 1 + 1?' was incorrect: Answer is too low",
+    ]


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When using the `basic_agent` solver, if the model submits an incorrect answer, the user can only return a pre-defined static string (such as `Your answer was incorrect.`)

### What is the new behavior?

When using the `basic_agent` solver, if the model submits an incorrect answer, the user can return a custom string based on the `TaskState` and `Score`. This allows the user to incorporate a Score's explanation, or other state information, into feedback for the model. One use case for this: if the model writes some code, and the scorer executes that code and finds that it raises an exception, the exception message can be passed back to the model.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

See conversation on Slack here: https://inspectcommunity.slack.com/archives/C080K7SQ4SG/p1731605753325889
