### PR TITLE
Properly Support Multi Tool Call Output

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15359,10 +15359,10 @@ const ChatView = ({
     if (message.role === "tool") {
       if (resolvedMessages.length > 0) {
         const msg = resolvedMessages[resolvedMessages.length - 1];
-        msg.toolOutput = message;
+        msg.toolMessages.push(message);
       }
     } else {
-      resolvedMessages.push({ message });
+      resolvedMessages.push({ message, toolMessages: [] });
     }
   }
   const systemMessages = [];
@@ -15410,7 +15410,7 @@ const ChatView = ({
             <${ChatMessage}
               id=${`${id}-chat-messages`}
               message=${msg.message}
-              toolMessage=${msg.toolOutput}
+              toolMessages=${msg.toolMessages}
               indented=${indented}
             />
           </div>`;
@@ -15418,7 +15418,7 @@ const ChatView = ({
       return m$1` <${ChatMessage}
             id=${`${id}-chat-messages`}
             message=${msg.message}
-            toolMessage=${msg.toolOutput}
+            toolMessages=${msg.toolMessages}
             indented=${indented}
           />`;
     }
@@ -15437,7 +15437,7 @@ const normalizeContent = (content) => {
     return content;
   }
 };
-const ChatMessage = ({ id, message, toolMessage, indented }) => {
+const ChatMessage = ({ id, message, toolMessages, indented }) => {
   const collapse = message.role === "system";
   return m$1`
     <div
@@ -15468,14 +15468,14 @@ const ChatMessage = ({ id, message, toolMessage, indented }) => {
         <${MessageContents}
           key=${`${id}-contents`}
           message=${message}
-          toolMessage=${toolMessage}
+          toolMessages=${toolMessages}
         />
       </${ExpandablePanel}>
       </div>
     </div>
   `;
 };
-const MessageContents = ({ message, toolMessage }) => {
+const MessageContents = ({ message, toolMessages }) => {
   if (message.role === "assistant" && message.tool_calls && message.tool_calls.length) {
     const result = [];
     if (message.content) {
@@ -15485,11 +15485,19 @@ const MessageContents = ({ message, toolMessage }) => {
         </div>`
       );
     }
-    const toolCalls = message.tool_calls.map((tool_call) => {
+    const toolCalls = message.tool_calls.map((tool_call, idx) => {
       const { input, functionCall, inputType } = resolveToolInput(
         tool_call.function,
         tool_call.arguments
       );
+      let toolMessage;
+      if (tool_call.id) {
+        toolMessage = toolMessages.find((msg) => {
+          return msg.tool_call_id === tool_call.id;
+        });
+      } else {
+        toolMessage = toolMessages[idx];
+      }
       const resolvedToolOutput = resolveToolMessage(toolMessage);
       return m$1`<${ToolCallView}
         functionCall=${functionCall}
@@ -15523,7 +15531,7 @@ const resolveToolMessage = (toolMessage) => {
   if (!toolMessage) {
     return void 0;
   }
-  const content = toolMessage.error !== null ? toolMessage.error.message : toolMessage.content;
+  const content = toolMessage.error !== null && toolMessage.error ? toolMessage.error.message : toolMessage.content;
   if (typeof content === "string") {
     return [
       {

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15476,7 +15476,7 @@ const ChatMessage = ({ id, message, toolMessage, indented }) => {
   `;
 };
 const MessageContents = ({ message, toolMessage }) => {
-  if (message.tool_calls && message.tool_calls.length) {
+  if (message.role === "assistant" && message.tool_calls && message.tool_calls.length) {
     const result = [];
     if (message.content) {
       result.push(
@@ -15520,11 +15520,10 @@ const iconForMsg = (msg) => {
   }
 };
 const resolveToolMessage = (toolMessage) => {
-  var _a2;
   if (!toolMessage) {
     return void 0;
   }
-  const content = ((_a2 = toolMessage.error) == null ? void 0 : _a2.message) || toolMessage.tool_error || toolMessage.content;
+  const content = toolMessage.error !== null ? toolMessage.error.message : toolMessage.content;
   if (typeof content === "string") {
     return [
       {

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -30,7 +30,7 @@ export const ChatView = ({
   // can use to lookup the tool responses
 
   /**
-   * @type {Array<{message: import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser, toolOutput?: import("../types/log").ChatMessageTool}>}
+   * @type {Array<{message: import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser, toolMessages?: import("../types/log").ChatMessageTool[]}>}
    */
   const resolvedMessages = [];
   for (const message of messages) {
@@ -38,10 +38,10 @@ export const ChatView = ({
       // Add this tool message onto the previous message
       if (resolvedMessages.length > 0) {
         const msg = resolvedMessages[resolvedMessages.length - 1];
-        msg.toolOutput = message;
+        msg.toolMessages.push(message);
       }
     } else {
-      resolvedMessages.push({ message });
+      resolvedMessages.push({ message, toolMessages: [] });
     }
   }
 
@@ -110,7 +110,7 @@ export const ChatView = ({
             <${ChatMessage}
               id=${`${id}-chat-messages`}
               message=${msg.message}
-              toolMessage=${msg.toolOutput}
+              toolMessages=${msg.toolMessages}
               indented=${indented}
             />
           </div>`;
@@ -118,7 +118,7 @@ export const ChatView = ({
           return html` <${ChatMessage}
             id=${`${id}-chat-messages`}
             message=${msg.message}
-            toolMessage=${msg.toolOutput}
+            toolMessages=${msg.toolMessages}
             indented=${indented}
           />`;
         }
@@ -151,11 +151,11 @@ const normalizeContent = (content) => {
  * @param {Object} props
  * @param {string} props.id - The ID for the chat view.
  * @param {import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser} props.message - The primary message
- * @param {import("../types/log").ChatMessageTool} props.toolMessage - The tool output message
+ * @param {import("../types/log").ChatMessageTool[]} props.toolMessages - The tool output message
  * @param {boolean} props.indented - Whether the chatview has indented messages
  * @returns {import("preact").JSX.Element} The component.
  */
-const ChatMessage = ({ id, message, toolMessage, indented }) => {
+const ChatMessage = ({ id, message, toolMessages, indented }) => {
   const collapse = message.role === "system";
   return html`
     <div
@@ -186,7 +186,7 @@ const ChatMessage = ({ id, message, toolMessage, indented }) => {
         <${MessageContents}
           key=${`${id}-contents`}
           message=${message}
-          toolMessage=${toolMessage}
+          toolMessages=${toolMessages}
         />
       </${ExpandablePanel}>
       </div>
@@ -198,10 +198,10 @@ const ChatMessage = ({ id, message, toolMessage, indented }) => {
  *
  * @param {Object} props
  * @param {import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser} props.message - The primary message
- * @param {import("../types/log").ChatMessageTool} props.toolMessage - The tool output message
+ * @param {import("../types/log").ChatMessageTool[]} props.toolMessages - The tool output message
  * @returns {import("preact").JSX.Element | import("preact").JSX.Element[]} The component.
  */
-const MessageContents = ({ message, toolMessage }) => {
+const MessageContents = ({ message, toolMessages }) => {
   if (
     message.role === "assistant" &&
     message.tool_calls &&
@@ -218,12 +218,21 @@ const MessageContents = ({ message, toolMessage }) => {
     }
 
     // Render the tool calls made by this message
-    const toolCalls = message.tool_calls.map((tool_call) => {
+    const toolCalls = message.tool_calls.map((tool_call, idx) => {
       // Extract tool input
       const { input, functionCall, inputType } = resolveToolInput(
         tool_call.function,
         tool_call.arguments,
       );
+
+      let toolMessage;
+      if (tool_call.id) {
+        toolMessage = toolMessages.find((msg) => {
+          return msg.tool_call_id === tool_call.id;
+        });
+      } else {
+        toolMessage = toolMessages[idx];
+      }
 
       // Resolve the tool output
       const resolvedToolOutput = resolveToolMessage(toolMessage);
@@ -269,7 +278,7 @@ const resolveToolMessage = (toolMessage) => {
   }
 
   const content =
-    toolMessage.error !== null
+    toolMessage.error !== null && toolMessage.error
       ? toolMessage.error.message
       : toolMessage.content;
   if (typeof content === "string") {

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -146,6 +146,15 @@ const normalizeContent = (content) => {
   }
 };
 
+/**
+ *
+ * @param {Object} props
+ * @param {string} props.id - The ID for the chat view.
+ * @param {import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser} props.message - The primary message
+ * @param {import("../types/log").ChatMessageTool} props.toolMessage - The tool output message
+ * @param {boolean} props.indented - Whether the chatview has indented messages
+ * @returns {import("preact").JSX.Element} The component.
+ */
 const ChatMessage = ({ id, message, toolMessage, indented }) => {
   const collapse = message.role === "system";
   return html`
@@ -185,10 +194,20 @@ const ChatMessage = ({ id, message, toolMessage, indented }) => {
   `;
 };
 
+/**
+ *
+ * @param {Object} props
+ * @param {import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser} props.message - The primary message
+ * @param {import("../types/log").ChatMessageTool} props.toolMessage - The tool output message
+ * @returns {import("preact").JSX.Element | import("preact").JSX.Element[]} The component.
+ */
 const MessageContents = ({ message, toolMessage }) => {
-  if (message.tool_calls && message.tool_calls.length) {
+  if (
+    message.role === "assistant" &&
+    message.tool_calls &&
+    message.tool_calls.length
+  ) {
     const result = [];
-
     // If the message contains content, render that.
     if (message.content) {
       result.push(
@@ -239,13 +258,20 @@ export const iconForMsg = (msg) => {
   }
 };
 
+/**
+ *
+ * @param {import("../types/log").ChatMessageTool} toolMessage - The tool output message
+ * @returns {Array<{type: string, content: import("../types/log").Content3}>|undefined} An array of formatted tool message objects, or undefined if toolMessage is falsy.
+ */
 const resolveToolMessage = (toolMessage) => {
   if (!toolMessage) {
     return undefined;
   }
 
   const content =
-    toolMessage.error?.message || toolMessage.tool_error || toolMessage.content;
+    toolMessage.error !== null
+      ? toolMessage.error.message
+      : toolMessage.content;
   if (typeof content === "string") {
     return [
       {

--- a/src/inspect_ai/_view/www/src/components/Tools.mjs
+++ b/src/inspect_ai/_view/www/src/components/Tools.mjs
@@ -22,7 +22,7 @@ import { FontSize } from "../appearance/Fonts.mjs";
 /**
  * Resolves the input and metadata for a given tool call.
  * @param { string } fn - The tool call function name
- * @param { Record<string, unknown> } toolArgs - The tool call arguments
+ * @param { import("../types/log").Arguments } toolArgs - The tool call arguments
  *
  * @returns {ToolCallResult}  An object containing the following properties:
  */


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

If the model makes more than one tool call in a single message, we previously would capture on the last tool output and display that for all tool calls. This allows the message to carry more than one tool output for display.
