### PR TITLE
Add a test for overwriting a file with write_file

### DIFF
--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -44,6 +44,7 @@ async def self_check(sandbox_env: SandboxEnvironment) -> dict[str, bool | str]:
         test_write_file_space,
         test_write_file_is_directory,
         test_write_file_without_permissions,
+        test_write_file_exists,
         test_exec_output,
         test_exec_timeout,
         test_exec_permission_error,
@@ -201,6 +202,16 @@ async def test_write_file_without_permissions(
     with Raises(PermissionError) as e_info:
         await sandbox_env.write_file(file_name, "this won't stick")
     assert file_name in str(e_info.value)
+
+
+async def test_write_file_exists(
+    sandbox_env: SandboxEnvironment,
+) -> None:
+    file_name = "file_exists.file"
+    await sandbox_env.write_file(file_name, "mundane content")
+    await sandbox_env.write_file(file_name, "altered content")
+    altered_content = await sandbox_env.read_file(file_name, text=True)
+    assert altered_content == "altered content"
 
 
 async def test_exec_output(sandbox_env: SandboxEnvironment) -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

It wasn't clear whether write_file should allow an existing file to be overwritten. 

### What is the new behavior?

It should be allowed, as long as the sandbox user would be allowed to. I've added a test to clarify.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

Original discussion https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1731645089944059