### PR TITLE
Treat dictionary keys as globs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Scoring: When using a dictionary to map metrics to score value dictionaries, you may now use globs as keys. See our [scorer documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#sec-multiple-scorers) for more information.
+- Use [tool views](https://inspect.ai-safety-institute.org.uk/approval.html#tool-views) when rendering tool calls in Insepct View.
 
 ## v0.3.47 (18 November 2024) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Google: Combine consecutive tool messages into single content part; ensure no empty text content parts.
 - AzureAI: Create and close client with each call to generate (fixes issue w/ using azureai on multiple passes of eval).\
 - Bedrock: Migrate to the [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html), which supports many more features including tool calling and multimodal models.
+- Scoring: When using a dictionary to map metrics to score value dictionaries, you may now use globs as keys. See our [scorer documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#sec-multiple-scorers) for more information.
 
 ## v0.3.46 (12 November 2024) 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Scoring: When using a dictionary to map metrics to score value dictionaries, you may now use globs as keys. See our [scorer documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#sec-multiple-scorers) for more information.
+
 ## v0.3.47 (18 November 2024) 
 
 - Basic agent: Ensure that the scorer is only run once when max_attempts = 1.
@@ -8,7 +12,6 @@
 - Google: Combine consecutive tool messages into single content part; ensure no empty text content parts.
 - AzureAI: Create and close client with each call to generate (fixes issue w/ using azureai on multiple passes of eval).
 - Bedrock: Migrate to the [Converse API](https://docs.aws.amazon.com/bedrock/latest/userguide/conversation-inference-supported-models-features.html), which supports many more features including tool calling and multimodal models.
-- Scoring: When using a dictionary to map metrics to score value dictionaries, you may now use globs as keys. See our [scorer documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#sec-multiple-scorers) for more information.
 
 ## v0.3.46 (12 November 2024) 
 

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -338,6 +338,27 @@ task = Task(
 
 The above example will produce two scores, `a_count` and `e_count`, each of which will have metrics for `mean` and `stderr`.
 
+When working with complex score values and metrics, you may use globs as keys for mapping metrics to scores. For example, a more succinct way to write the previous example:
+
+``` python
+@scorer(
+    metrics={
+        "*": [mean(), stderr()], 
+    }
+)
+```
+
+Glob keys will each be resolved and a complete list of matching metrics will be applied to each score key. For example to compute `mean` for all score keys, and only compute `stderr` for `e_count` you could write:
+
+``` python
+@scorer(
+    metrics={
+        "*": [mean()], 
+        "e_count": [stderr()]
+    }
+)
+```
+
 ### Scorer with Complex Metrics 
 
 Sometime, it is useful for a scorer to compute multiple values (returning a dictionary as the score value) and to have metrics computed both for each key in the score dictionary, but also for the dictionary as a whole. For example:


### PR DESCRIPTION
When a score value returns a dictionary value, it is common to provide a dictionary of metrics to apply to the keys in the score value. For example:

```
@scorer(metrics={
	"basic": [mean(), stderr()],
	"fancy_1": [mean(), stderr()],
	"fancy_1": [mean(), stderr()]
})
	def complex_score():
	async def score(state: TaskState, target: Target):
		return Score(value={
			"basic": 1.0,
			"fancy_1": 0.9,
			"fancy_1": 0.1
			})
	return score
```

glob keys permit this (which is the equivalent of the above):

```
@scorer(metrics={
	"*": [mean(), stderr()],
})
	def complex_score():
	async def score(state: TaskState, target: Target):
		return Score(value={
			"basic": 1.0,
			"fancy_1": 0.9,
			"fancy_1": 0.1
			})
	return score
```

or this (which will apply mean, stderr to the base score and mean, stderr, and accuracy to the fancy scores):

```
@scorer(metrics={
	"*": [mean(), stderr()], "fancy_*": [accuracy()]
})
	def complex_score():
	async def score(state: TaskState, target: Target):
		return Score(value={
			"basic": 1.0,
			"fancy_1": 0.9,
			"fancy_1": 0.1
			})
	return score
```

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
