### PR TITLE
consistent behavior for `max_samples` across sandbox and non-sandbox evals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Consistent behavior for `max_samples` across sandbox and non-sandbox evals (both now apply `max_samples` per task, formerly evals with sandboxes applied `max_samples` globally).
+
 ## v0.3.47 (18 November 2024) 
 
 - Basic agent: Ensure that the scorer is only run once when max_attempts = 1.

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -12,7 +12,7 @@ from inspect_ai._util.error import exception_message
 from inspect_ai._util.path import chdir
 from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._recorders import Recorder
-from inspect_ai.model import GenerateConfig, GenerateConfigArgs
+from inspect_ai.model import GenerateConfigArgs
 from inspect_ai.scorer._reducer import ScoreReducer, reducer_log_names
 from inspect_ai.scorer._reducer.registry import validate_reducer
 from inspect_ai.solver._solver import Solver, SolverSpec
@@ -25,7 +25,7 @@ from .loader import (
     solver_from_spec,
 )
 from .task.log import TaskLogger
-from .task.run import TaskRunOptions, create_sample_semaphore, task_run
+from .task.run import TaskRunOptions, task_run
 from .task.rundir import task_run_dir_switching
 from .task.sandbox import TaskSandboxEnvironment, resolve_sandbox_for_task
 from .task.util import task_run_dir
@@ -51,14 +51,6 @@ async def eval_run(
     run_dir = task_run_dir(tasks[0].task)
     multiple_run_dirs = any([task_run_dir(task.task) != run_dir for task in tasks])
     has_sandbox = next((task.has_sandbox for task in tasks), None)
-
-    # if we have a sandbox then we need to enforce sample concurrency at
-    # this level of the eval (so we don't explode the # of sandboxes)
-    sample_semaphore: asyncio.Semaphore | None = (
-        create_sample_semaphore(eval_config, GenerateConfig(**kwargs))
-        if has_sandbox
-        else None
-    )
 
     # get cwd before switching to task dir
     eval_wd = os.getcwd()
@@ -178,7 +170,6 @@ async def eval_run(
                         score=score,
                         debug_errors=debug_errors,
                         sample_source=resolved_task.sample_source,
-                        sample_semaphore=sample_semaphore,
                         kwargs=kwargs,
                     )
                 )

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -104,7 +104,6 @@ class TaskRunOptions:
     score: bool = field(default=True)
     debug_errors: bool = field(default=False)
     sample_source: EvalSampleSource | None = field(default=None)
-    sample_semaphore: asyncio.Semaphore | None = field(default=None)
     kwargs: GenerateConfigArgs = field(default_factory=lambda: GenerateConfigArgs())
 
 
@@ -120,7 +119,6 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
     tags = options.tags
     score = options.score
     sample_source = options.sample_source
-    sample_semaphore = options.sample_semaphore
     kwargs = options.kwargs
 
     # resolve default generate_config for task
@@ -239,10 +237,8 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
                     set_task_generate(generate)
 
                     # semaphore to limit concurrency
-                    sample_semaphore = (
-                        sample_semaphore
-                        if sample_semaphore
-                        else create_sample_semaphore(config, generate_config, model.api)
+                    sample_semaphore = create_sample_semaphore(
+                        config, generate_config, model.api
                     )
 
                     # create sample coroutines


### PR DESCRIPTION
The normal behavior for `max_samples` is that it is is applied per task (i.e. total running samples is `max_tasks` * `max_samples`). However, we previously implemented special behavior for evals with sandboxes, enforcing this limit globally rather than per task This was in turn a result of the observation that Docker tended to get flakey at > 30 running containers (especially if they used networking) so we were trying to make it harder for users to unknowingly get into a situation where Docker was overloaded.

With this PR, `max_samples` are handled the same for all evals (sandbox or no sandbox). There are several benefits to this:

1. The previous inconsistent behavior is harder to reason about consistently (a simple answer to how `max_samples` is applied is better than one with qualifications).
2. The concern about users accidentally over-provisioning Docker is better mitigated by clear documentation and guidelines vs. hammering in an unexpected limit.
3. In a world where sandboxes aren't running locally (forthcoming k8s sandbox provider) it's entirely inappropriate to artificially cap running containers (since there is no overload problem). 
4. When running with sandboxes, the previous behavior caused all tasks to share a sample semaphore, which in evals with larger numbers of samples could often result in the first task grabbing all of the sample semaphores (reducing parallelism across tasks).

**IMPORTANT NOTE**: With this change you should review your job scripts to ensure you aren't creating more Docker containers (`max_samples` * `max_tasks`) than is ideal in your environment.
