### PR TITLE
Feature/timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Scoring: When using a dictionary to map metrics to score value dictionaries, you may now use globs as keys. See our [scorer documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#sec-multiple-scorers) for more information.
 - Use [tool views](https://inspect.ai-safety-institute.org.uk/approval.html#tool-views) when rendering tool calls in Insepct View.
 - Consistent behavior for `max_samples` across sandbox and non-sandbox evals (both now apply `max_samples` per task, formerly evals with sandboxes applied `max_samples` globally).
+- Log viewer: add timestamps to transcript events.
 
 ## v0.3.47 (18 November 2024) 
 

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -7662,6 +7662,18 @@ function formatNumber(num) {
     maximumFractionDigits: 5
   });
 }
+function formatDateTime(date) {
+  const options = {
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true
+  };
+  return new Intl.DateTimeFormat(void 0, options).format(date);
+}
 const filename = (path) => {
   const pathparts = path.split("/");
   const basename = pathparts.slice(-1)[0];
@@ -7862,6 +7874,9 @@ const TextStyle = {
   },
   secondary: {
     color: "var(--bs-secondary)"
+  },
+  tertiary: {
+    color: "var(--bs-tertiary-color)"
   }
 };
 const ErrorPanel = ({ id, classes, title, error: error2 }) => {
@@ -16650,6 +16665,7 @@ const EventPanel = ({
   id,
   classes,
   title,
+  subTitle,
   text: text2,
   icon,
   titleColor,
@@ -16679,6 +16695,9 @@ const EventPanel = ({
     gridColumns2.push("max-content");
   }
   gridColumns2.push("minmax(0, max-content)");
+  if (subTitle) {
+    gridColumns2.push("minmax(0, max-content)");
+  }
   gridColumns2.push("auto");
   gridColumns2.push("minmax(0, max-content)");
   gridColumns2.push("minmax(0, max-content)");
@@ -16721,6 +16740,20 @@ const EventPanel = ({
           >
             ${title}
           </div>
+          ${subTitle ? m$1` <div
+                style=${{
+    marginLeft: "0.5em",
+    ...TextStyle.label,
+    ...TextStyle.tertiary,
+    ...titleStyle,
+    fontWeight: "400"
+  }}
+                onclick=${() => {
+    setCollapsed(!collapsed);
+  }}
+              >
+                ${subTitle}
+              </div>` : ""}
           <div
             onclick=${() => {
     setCollapsed(!collapsed);
@@ -16958,7 +16991,7 @@ const SampleInitEventView = ({ id, event, style }) => {
   `);
   }
   return m$1`
-  <${EventPanel} id=${id} style=${style} title="Sample" icon=${ApplicationIcons.sample}>
+  <${EventPanel} id=${id} style=${style} title="Sample" icon=${ApplicationIcons.sample} subTitle=${formatDateTime(new Date(event.timestamp))}>
     <div name="Sample" style=${{ margin: "1em 0em" }}>
       <${ChatView} messages=${stateObj["messages"]}/>
       <div>
@@ -18571,7 +18604,7 @@ const StateEventView = ({ id, event, style }) => {
   }
   const title = event.event === "state" ? "State Updated" : "Store Updated";
   return m$1`
-  <${EventPanel} id=${id} title="${title}" text=${tabs.length === 1 ? summary : void 0} collapse=${changePreview === void 0 ? true : void 0} style=${style}>
+  <${EventPanel} id=${id} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} text=${tabs.length === 1 ? summary : void 0} collapse=${changePreview === void 0 ? true : void 0} style=${style}>
     ${tabs}
   </${EventPanel}>`;
 };
@@ -18716,6 +18749,7 @@ const StepEventView = ({ event, children, style }) => {
     id=${`step-${event.name}`}
     classes="transcript-step"
     title="${title}"
+    subTitle=${formatDateTime(new Date(event.timestamp))}
     icon=${descriptor.icon}
     style=${{ ...descriptor.style, ...style }}
     titleStyle=${{ ...descriptor.titleStyle }}
@@ -18844,7 +18878,7 @@ const SubtaskEventView = ({ id, event, style, depth }) => {
         `;
   const type = event.type === "fork" ? "Fork" : "Subtask";
   return m$1`
-    <${EventPanel} id=${id} title="${type}: ${event.name}" style=${style} collapse=${false}>
+    <${EventPanel} id=${id} title="${type}: ${event.name}" subTitle=${formatDateTime(new Date(event.timestamp))} style=${style} collapse=${false}>
       ${body}
     </${EventPanel}>`;
 };
@@ -19096,7 +19130,7 @@ const ModelEventView = ({ id, event, style }) => {
     }
   }
   return m$1`
-  <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}" icon=${ApplicationIcons.model} style=${style}>
+  <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}"  subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.model} style=${style}>
   
     <div name="Summary" style=${{ margin: "0.5em 0" }}>
     <${ChatView}
@@ -19307,14 +19341,14 @@ const InfoEventView = ({ id, event, style }) => {
     );
   }
   return m$1`
-  <${EventPanel} id=${id} title="Info" icon=${ApplicationIcons.info} style=${style}>
+  <${EventPanel} id=${id} title="Info" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.info} style=${style}>
     ${panels}
   </${EventPanel}>`;
 };
 const ScoreEventView = ({ id, event, style }) => {
   const resolvedTarget = event.target ? Array.isArray(event.target) ? event.target.join("\n") : event.target : void 0;
   return m$1`
-  <${EventPanel} id=${id} title="Score" icon=${ApplicationIcons.scorer} style=${style}>
+  <${EventPanel} id=${id} title="Score" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.scorer} style=${style}>
   
     <div
       name="Explanation"
@@ -19410,7 +19444,7 @@ const ToolEventView = ({ id, event, style, depth }) => {
   });
   const title = `Tool: ${event.function}`;
   return m$1`
-  <${EventPanel} id=${id} title="${title}" icon=${ApplicationIcons.solvers.use_tools} style=${style}>  
+  <${EventPanel} id=${id} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.solvers.use_tools} style=${style}>  
   <div name="Summary" style=${{ margin: "0.5em 0" }}>
     <${ToolCallView}
       functionCall=${functionCall}
@@ -19436,13 +19470,13 @@ const ToolEventView = ({ id, event, style, depth }) => {
 };
 const ErrorEventView = ({ id, event, style }) => {
   return m$1`
-  <${EventPanel} id=${id} title="Error" icon=${ApplicationIcons.error} style=${style}>
+  <${EventPanel} id=${id} title="Error" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.error} style=${style}>
     <${ANSIDisplay} output=${event.error.traceback_ansi} style=${{ fontSize: "clamp(0.5rem, calc(0.25em + 1vw), 0.8rem)", margin: "0.5em 0" }}/>
   </${EventPanel}>`;
 };
 const InputEventView = ({ id, event, style }) => {
   return m$1`
-  <${EventPanel} id=${id} title="Input" icon=${ApplicationIcons.input} style=${style}>
+  <${EventPanel} id=${id} title="Input" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.input} style=${style}>
     <${ANSIDisplay} output=${event.input_ansi} style=${{ fontSize: "clamp(0.4rem, 1.15vw, 0.9rem)", ...style }}/>
   </${EventPanel}>`;
 };

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -16702,6 +16702,7 @@ const EventPanel = ({
   gridColumns2.push("minmax(0, max-content)");
   gridColumns2.push("minmax(0, max-content)");
   const titleEl = title || icon || filteredArrChildren.length > 1 ? m$1`<div
+          title=${subTitle}
           style=${{
     display: "grid",
     gridTemplateColumns: gridColumns2.join(" "),
@@ -16740,20 +16741,6 @@ const EventPanel = ({
           >
             ${title}
           </div>
-          ${subTitle ? m$1` <div
-                style=${{
-    marginLeft: "0.5em",
-    ...TextStyle.label,
-    ...TextStyle.tertiary,
-    ...titleStyle,
-    fontWeight: "400"
-  }}
-                onclick=${() => {
-    setCollapsed(!collapsed);
-  }}
-              >
-                ${subTitle}
-              </div>` : ""}
           <div
             onclick=${() => {
     setCollapsed(!collapsed);

--- a/src/inspect_ai/_view/www/src/appearance/Fonts.mjs
+++ b/src/inspect_ai/_view/www/src/appearance/Fonts.mjs
@@ -45,6 +45,8 @@ export const FontSize = {
  * @property {string} label.textTransform - The text transformation for label text.
  * @property {Object} secondary - The style for secondary text.
  * @property {string} secondary.color - The color for secondary text.
+ * @property {Object} tertiary - The style for secondary text.
+ * @property {string} tertiary.color - The color for secondary text.
  */
 
 /**
@@ -57,5 +59,8 @@ export const TextStyle = {
   },
   secondary: {
     color: "var(--bs-secondary)",
+  },
+  tertiary: {
+    color: "var(--bs-tertiary-color)",
   },
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/ErrorEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ErrorEventView.mjs
@@ -3,6 +3,7 @@ import { html } from "htm/preact";
 import { EventPanel } from "./EventPanel.mjs";
 import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { ANSIDisplay } from "../../components/AnsiDisplay.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the ErrorEventView component.
@@ -15,7 +16,7 @@ import { ANSIDisplay } from "../../components/AnsiDisplay.mjs";
  */
 export const ErrorEventView = ({ id, event, style }) => {
   return html`
-  <${EventPanel} id=${id} title="Error" icon=${ApplicationIcons.error} style=${style}>
+  <${EventPanel} id=${id} title="Error" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.error} style=${style}>
     <${ANSIDisplay} output=${event.error.traceback_ansi} style=${{ fontSize: "clamp(0.5rem, calc(0.25em + 1vw), 0.8rem)", margin: "0.5em 0" }}/>
   </${EventPanel}>`;
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
@@ -75,6 +75,7 @@ export const EventPanel = ({
   const titleEl =
     title || icon || filteredArrChildren.length > 1
       ? html`<div
+          title=${subTitle}
           style=${{
             display: "grid",
             gridTemplateColumns: gridColumns.join(" "),
@@ -119,22 +120,6 @@ export const EventPanel = ({
           >
             ${title}
           </div>
-          ${subTitle
-            ? html` <div
-                style=${{
-                  marginLeft: "0.5em",
-                  ...TextStyle.label,
-                  ...TextStyle.tertiary,
-                  ...titleStyle,
-                  fontWeight: "400",
-                }}
-                onclick=${() => {
-                  setCollapsed(!collapsed);
-                }}
-              >
-                ${subTitle}
-              </div>`
-            : ""}
           <div
             onclick=${() => {
               setCollapsed(!collapsed);

--- a/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
@@ -11,6 +11,7 @@ import { FontSize, TextStyle } from "../../appearance/Fonts.mjs";
  * @param {string} props.id - The id of the event
  * @param {string} props.classes - The classes for this element
  * @param {string | undefined} props.title - The name of the event
+ * @param {string} props.subTitle - The subtitle for the event
  * @param {string | undefined} props.text - Secondary text for the event
  * @param {string | undefined} props.icon - The icon of the event
  * @param {number | undefined} props.titleColor - The title color of this item
@@ -24,6 +25,7 @@ export const EventPanel = ({
   id,
   classes,
   title,
+  subTitle,
   text,
   icon,
   titleColor,
@@ -63,6 +65,9 @@ export const EventPanel = ({
     gridColumns.push("max-content");
   }
   gridColumns.push("minmax(0, max-content)");
+  if (subTitle) {
+    gridColumns.push("minmax(0, max-content)");
+  }
   gridColumns.push("auto");
   gridColumns.push("minmax(0, max-content)");
   gridColumns.push("minmax(0, max-content)");
@@ -114,6 +119,22 @@ export const EventPanel = ({
           >
             ${title}
           </div>
+          ${subTitle
+            ? html` <div
+                style=${{
+                  marginLeft: "0.5em",
+                  ...TextStyle.label,
+                  ...TextStyle.tertiary,
+                  ...titleStyle,
+                  fontWeight: "400",
+                }}
+                onclick=${() => {
+                  setCollapsed(!collapsed);
+                }}
+              >
+                ${subTitle}
+              </div>`
+            : ""}
           <div
             onclick=${() => {
               setCollapsed(!collapsed);

--- a/src/inspect_ai/_view/www/src/samples/transcript/InfoEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/InfoEventView.mjs
@@ -4,6 +4,7 @@ import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { EventPanel } from "./EventPanel.mjs";
 import { JSONPanel } from "../../components/JsonPanel.mjs";
 import { MarkdownDiv } from "../../components/MarkdownDiv.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the InfoEventView component.
@@ -30,7 +31,7 @@ export const InfoEventView = ({ id, event, style }) => {
   }
 
   return html`
-  <${EventPanel} id=${id} title="Info" icon=${ApplicationIcons.info} style=${style}>
+  <${EventPanel} id=${id} title="Info" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.info} style=${style}>
     ${panels}
   </${EventPanel}>`;
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/InputEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/InputEventView.mjs
@@ -3,6 +3,7 @@ import { html } from "htm/preact";
 import { EventPanel } from "./EventPanel.mjs";
 import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { ANSIDisplay } from "../../components/AnsiDisplay.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the ErrorEventView component.
@@ -15,7 +16,7 @@ import { ANSIDisplay } from "../../components/AnsiDisplay.mjs";
  */
 export const InputEventView = ({ id, event, style }) => {
   return html`
-  <${EventPanel} id=${id} title="Input" icon=${ApplicationIcons.input} style=${style}>
+  <${EventPanel} id=${id} title="Input" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.input} style=${style}>
     <${ANSIDisplay} output=${event.input_ansi} style=${{ fontSize: "clamp(0.4rem, 1.15vw, 0.9rem)", ...style }}/>
   </${EventPanel}>`;
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
@@ -14,7 +14,7 @@ import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { MetaDataGrid } from "../../components/MetaDataGrid.mjs";
 import { FontSize, TextStyle } from "../../appearance/Fonts.mjs";
 import { ModelUsagePanel } from "../../usage/UsageCard.mjs";
-import { formatNumber } from "../../utils/Format.mjs";
+import { formatDateTime, formatNumber } from "../../utils/Format.mjs";
 
 /**
  * Renders the StateEventView component.
@@ -58,7 +58,7 @@ export const ModelEventView = ({ id, event, style }) => {
   }
 
   return html`
-  <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}" icon=${ApplicationIcons.model} style=${style}>
+  <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}"  subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.model} style=${style}>
   
     <div name="Summary" style=${{ margin: "0.5em 0" }}>
     <${ChatView}

--- a/src/inspect_ai/_view/www/src/samples/transcript/SampleInitEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/SampleInitEventView.mjs
@@ -6,6 +6,7 @@ import { ChatView } from "../../components/ChatView.mjs";
 import { EventSection } from "./EventSection.mjs";
 import { toArray } from "../../utils/Type.mjs";
 import { ApplicationIcons } from "../../appearance/Icons.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the SampleInitEventView component.
@@ -42,7 +43,7 @@ export const SampleInitEventView = ({ id, event, style }) => {
   }
 
   return html`
-  <${EventPanel} id=${id} style=${style} title="Sample" icon=${ApplicationIcons.sample}>
+  <${EventPanel} id=${id} style=${style} title="Sample" icon=${ApplicationIcons.sample} subTitle=${formatDateTime(new Date(event.timestamp))}>
     <div name="Sample" style=${{ margin: "1em 0em" }}>
       <${ChatView} messages=${stateObj["messages"]}/>
       <div>

--- a/src/inspect_ai/_view/www/src/samples/transcript/ScoreEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ScoreEventView.mjs
@@ -5,6 +5,7 @@ import { MetaDataGrid } from "../../components/MetaDataGrid.mjs";
 import { EventPanel } from "./EventPanel.mjs";
 import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { TextStyle } from "../../appearance/Fonts.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the InfoEventView component.
@@ -23,7 +24,7 @@ export const ScoreEventView = ({ id, event, style }) => {
     : undefined;
 
   return html`
-  <${EventPanel} id=${id} title="Score" icon=${ApplicationIcons.scorer} style=${style}>
+  <${EventPanel} id=${id} title="Score" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.scorer} style=${style}>
   
     <div
       name="Explanation"

--- a/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
@@ -2,6 +2,7 @@
 import { html } from "htm/preact";
 import { EventPanel } from "./EventPanel.mjs";
 import { TranscriptComponent } from "./TranscriptView.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the StepEventView component.
@@ -23,6 +24,7 @@ export const StepEventView = ({ event, children, style }) => {
     id=${`step-${event.name}`}
     classes="transcript-step"
     title="${title}"
+    subTitle=${formatDateTime(new Date(event.timestamp))}
     icon=${descriptor.icon}
     style=${{ ...descriptor.style, ...style }}
     titleStyle=${{ ...descriptor.titleStyle }}

--- a/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.mjs
@@ -5,6 +5,7 @@ import { EventPanel } from "./EventPanel.mjs";
 import { MetaDataView } from "../../components/MetaDataView.mjs";
 import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { FontSize, TextStyle } from "../../appearance/Fonts.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the StateEventView component.
@@ -53,7 +54,7 @@ export const SubtaskEventView = ({ id, event, style, depth }) => {
   // Is this a traditional subtask or a fork?
   const type = event.type === "fork" ? "Fork" : "Subtask";
   return html`
-    <${EventPanel} id=${id} title="${type}: ${event.name}" style=${style} collapse=${false}>
+    <${EventPanel} id=${id} title="${type}: ${event.name}" subTitle=${formatDateTime(new Date(event.timestamp))} style=${style} collapse=${false}>
       ${body}
     </${EventPanel}>`;
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/ToolEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ToolEventView.mjs
@@ -5,6 +5,7 @@ import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { resolveToolInput, ToolCallView } from "../../components/Tools.mjs";
 import { TranscriptView } from "./TranscriptView.mjs";
 import { ApprovalEventView } from "./ApprovalEventView.mjs";
+import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
  * Renders the ToolEventView component.
@@ -30,7 +31,7 @@ export const ToolEventView = ({ id, event, style, depth }) => {
 
   const title = `Tool: ${event.function}`;
   return html`
-  <${EventPanel} id=${id} title="${title}" icon=${ApplicationIcons.solvers.use_tools} style=${style}>  
+  <${EventPanel} id=${id} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.solvers.use_tools} style=${style}>  
   <div name="Summary" style=${{ margin: "0.5em 0" }}>
     <${ToolCallView}
       functionCall=${functionCall}

--- a/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventView.mjs
@@ -4,6 +4,7 @@ import { html } from "htm/preact";
 import { EventPanel } from "../EventPanel.mjs";
 import { RenderableChangeTypes } from "./StateEventRenderers.mjs";
 import { StateDiffView } from "./StateDiffView.mjs";
+import { formatDateTime } from "../../../utils/Format.mjs";
 
 /**
  * Renders the StateEventView component.
@@ -44,7 +45,7 @@ export const StateEventView = ({ id, event, style }) => {
   const title = event.event === "state" ? "State Updated" : "Store Updated";
 
   return html`
-  <${EventPanel} id=${id} title="${title}" text=${tabs.length === 1 ? summary : undefined} collapse=${changePreview === undefined ? true : undefined} style=${style}>
+  <${EventPanel} id=${id} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} text=${tabs.length === 1 ? summary : undefined} collapse=${changePreview === undefined ? true : undefined} style=${style}>
     ${tabs}
   </${EventPanel}>`;
 };

--- a/src/inspect_ai/_view/www/src/utils/Format.mjs
+++ b/src/inspect_ai/_view/www/src/utils/Format.mjs
@@ -216,3 +216,25 @@ export function formatNumber(num) {
     maximumFractionDigits: 5,
   });
 }
+
+/**
+ * Formats a number to a string without trailing zeroes after the decimal point.
+ *
+ * @param {Date} date - The number to format.
+ * @returns {string} - The formatted number as a string
+ */
+export function formatDateTime(date) {
+  const options = {
+    year: "2-digit",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "numeric",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: true,
+  };
+
+  // Use the default system locale and timezone
+  // @ts-ignore
+  return new Intl.DateTimeFormat(undefined, options).format(date);
+}


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Add timestamps to event stream as tooltips. It is difficult to fit them in without being highly repetitive so lets start trying this to see how useable it is.

<img width="255" alt="Screenshot 2024-11-20 at 10 44 18 AM" src="https://github.com/user-attachments/assets/dfde6e89-a53b-4ddb-b44e-a9034588b858">
