### PR TITLE
location property for eval logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Realtime display](https://github.com/UKGovernmentBEIS/inspect_ai/pull/865) of sample transcripts (including ability to cancel running samples).
 - Scoring: When using a dictionary to map metrics to score value dictionaries, you may now use globs as keys. See our [scorer documentation](https://inspect.ai-safety-institute.org.uk/scorers.html#sec-multiple-scorers) for more information.
+- `EvalLog` now includes a [location](https://github.com/UKGovernmentBEIS/inspect_ai/pull/872) property indicating where it was read from.
 - Use [tool views](https://inspect.ai-safety-institute.org.uk/approval.html#tool-views) when rendering tool calls in Insepct View.
 - Consistent behavior for `max_samples` across sandbox and non-sandbox evals (both now apply `max_samples` per task, formerly evals with sandboxes applied `max_samples` globally).
 - Log viewer: add timestamps to transcript events.

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -92,7 +92,7 @@ If you do need to interact with the underlying JSON (e.g., when reading logs fro
 
 By default, full base64 encoded copies of images are included in the log file. Image logging will not create performance problems when using `.eval` logs, however if you are using `.json` logs then large numbers of images could become unweildy (i.e. if your `.json` log file grows to 100mb or larger as a result).
 
- You can disable this using the `--no-log-images` flag. For example, here we enable the `.json` log format and disable image logging:
+You can disable this using the `--no-log-images` flag. For example, here we enable the `.json` log format and disable image logging:
 
 ``` bash
 inspect eval images.py --log-format=json --no-log-images
@@ -130,12 +130,53 @@ if log.status == "success":
 
 In the section below we'll talk more about how to deal with logs from failed evaluations (e.g. retrying the eval).
 
+### Location
+
+::: {.callout-note appearance="simple"}
+The `location` property described below is supported only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+The `EvalLog` object returned from `eval()` and `read_eval_log()` has a `location` property that indicates the storage location it was written to or read from.
+
+The `write_eval_log()` function will use this `location` if it isn't passed an explicit `location` to write to. This enables you to modify the contents of a log file return from `eval()` as follows:
+
+``` python
+log = eval(my_task())[0]
+# edit EvalLog as required
+write_eval_log(log)
+```
+
+Or alternatively for an `EvalLog` read from a filesystem:
+
+``` python
+log = read_eval_log(log_file_path)
+# edit EvalLog as required
+write_eval_log(log)
+```
+
+If you are working with the results of an [Eval Set](eval-sets.qmd), the returned logs are headers rather than the full log with all samples. If you want to edit logs returned from `eval_set` you should read them fully, edit them, and then write them. For example:
+
+``` python
+success, logs = eval_set(tasks)
+ 
+for log in logs:
+    log = read_eval_log(log.location)
+    # edit EvalLog as required
+    write_eval_log(log)
+```
+
+Note that the `EvalLog.location` is a URI rather than a traditional file path(e.g. it could be a `file://` URI, an `s3://` URI or any other URI supported by [fsspec](https://filesystem-spec.readthedocs.io/)).
+
 ### Functions
 
 You can enumerate, read, and write `EvalLog` objects using the following helper functions from the `inspect_ai.log` module:
 
 | Function | Description |
-|--------------------|----------------------------------------------------|
+|----------------------|--------------------------------------------------|
 | `list_eval_logs` | List all of the eval logs at a given location. |
 | `read_eval_log` | Read an `EvalLog` from a log file path (pass `header_only` to not read samples). |
 | `read_eval_log_sample` | Read a single `EvalSample` from a log file |
@@ -162,14 +203,15 @@ Note that `list_eval_logs()` lists log files recursively. Pass `recursive=False`
 
 If you are working with log files that are too large to comfortably fit in memory, we recommend the following options and workflow to stream them rather than loading them into memory all at once :
 
-1.  Use the `.eval` log file format which supports compression and incremental access to samples (see details on this in the [Log Format] section above). If you have existing `.json` files you can easily batch convert them to `.eval` using the [Log Commands](#converting-logs) described below.
+1.  Use the `.eval` log file format which supports compression and incremental access to samples (see details on this in the [Log Format](#sec-log-format) section above). If you have existing `.json` files you can easily batch convert them to `.eval` using the [Log Commands](#converting-logs) described below.
 
 2.  If you only need access to the "header" of the log file (which includes general eval metadata as well as the evaluation results) use the `header_only` option of `read_eval_log()`:
 
     ``` python
     log = read_eval_log(log_file, header_only = True)
     ```
-3. If you want to read individual samples, either read them selectively using `read_eval_log_sample()`, or read them iteratively using `read_eval_log_samples()` (which will ensure that only one sample at a time is read into memory):
+
+3.  If you want to read individual samples, either read them selectively using `read_eval_log_sample()`, or read them iteratively using `read_eval_log_samples()` (which will ensure that only one sample at a time is read into memory):
 
     ``` python
     # read a single sample
@@ -182,7 +224,7 @@ If you are working with log files that are too large to comfortably fit in memor
 
 Note that `read_eval_log_samples()` will raise an error if you pass it a log that does not have `status=="success"` (this is because it can't read all of the samples in an incomplete log). If you want to read the samples anyway, pass the `all_samples_required=False` option:
 
-```python
+``` python
 # will not raise an error if the log file has an "error" or "cancelled" status
 for sample in read_eval_log_samples(log_file, all_samples_required=False):
     ...
@@ -278,7 +320,7 @@ $ inspect log dump file:///home/user/log/logfile.json
 $ inspect log dump s3://my-evals-bucket/logfile.json
 ```
 
-### Converting Logs
+### Converting Logs {#converting-logs}
 
 You can convert between the two underlying [log formats](#sec-log-format) using the `inspect log convert` command. The convert command takes a source path (with either a log file or a directory of log files) along with two required arguments that specify the conversion (`--to` and `--output-dir`). For example:
 

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -149,25 +149,33 @@ async def list_eval_logs_async(
 
 def write_eval_log(
     log: EvalLog,
-    log_file: str | FileInfo,
+    location: str | FileInfo | None = None,
     format: Literal["eval", "json", "auto"] = "auto",
 ) -> None:
     """Write an evaluation log.
 
     Args:
        log (EvalLog): Evaluation log to write.
-       log_file (str | FileInfo): Location to write log to.
+       location (str | FileInfo): Location to write log to.
        format (Literal["eval", "json", "auto"]): Write to format
           (defaults to 'auto' based on `log_file` extension)
     """
-    log_file = log_file if isinstance(log_file, str) else log_file.name
+    # resolve location
+    if location is None:
+        if log.location:
+            location = log.location
+        else:
+            raise ValueError(
+                "EvalLog passe to write_eval_log does not have a location, so you must pass an explicit location"
+            )
+    location = location if isinstance(location, str) else location.name
 
     # get recorder type
     if format == "auto":
-        recorder_type = recorder_type_for_location(log_file)
+        recorder_type = recorder_type_for_location(location)
     else:
         recorder_type = recorder_type_for_format(format)
-    recorder_type.write_log(log_file, log)
+    recorder_type.write_log(location, log)
 
 
 def write_log_dir_manifest(

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -562,6 +562,9 @@ class EvalLog(BaseModel):
     reductions: list[EvalSampleReductions] | None = Field(default=None)
     """Reduced sample values"""
 
+    location: str = Field(default_factory=str, exclude=True)
+    """Location that the log file was read from."""
+
     @model_validator(mode="after")
     def populate_scorer_name_for_samples(self) -> "EvalLog":
         if self.samples and self.results and self.results.scores:

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -193,7 +193,7 @@ class EvalRecorder(FileRecorder):
     def read_log(cls, location: str, header_only: bool = False) -> EvalLog:
         with file(location, "rb") as z:
             with ZipFile(z, mode="r") as zip:
-                evalLog = _read_header(zip)
+                evalLog = _read_header(zip, location)
                 if REDUCTIONS_JSON in zip.namelist():
                     with zip.open(REDUCTIONS_JSON, "r") as f:
                         reductions = [
@@ -399,18 +399,18 @@ def _read_all_summaries(zip: ZipFile, count: int) -> list[SampleSummary]:
         return summaries
 
 
-def _read_header(zip: ZipFile) -> EvalLog:
+def _read_header(zip: ZipFile, location: str) -> EvalLog:
     # first see if the header is here
     if HEADER_JSON in zip.namelist():
         with zip.open(HEADER_JSON, "r") as f:
-            return EvalLog(**json.load(f))
+            log = EvalLog(**json.load(f))
+            log.location = location
+            return log
     else:
         with zip.open(_journal_path(START_JSON), "r") as f:
             start = LogStart(**json.load(f))
         return EvalLog(
-            version=start.version,
-            eval=start.eval,
-            plan=start.plan,
+            version=start.version, eval=start.eval, plan=start.plan, location=location
         )
 
 

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -105,6 +105,7 @@ class JSONRecorder(FileRecorder):
         if reductions:
             log.data.reductions = reductions
         self.write_log(log.file, log.data)
+        log.data.location = log.file
 
         # stop tracking this data
         del self.data[self._log_file_key(spec)]
@@ -142,6 +143,7 @@ class JSONRecorder(FileRecorder):
             # parse w/ pydantic
             raw_data = from_json(f.read())
             log = EvalLog(**raw_data)
+            log.location = location
 
             # fail for unknown version
             _validate_version(log.version)
@@ -238,4 +240,5 @@ def _read_header_streaming(log_file: str) -> EvalLog:
         status=status,
         version=version,
         error=error if has_error else None,
+        location=log_file,
     )

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic_core import PydanticSerializationError
 
 from inspect_ai import Task, eval
+from inspect_ai._util.file import filesystem
 from inspect_ai.dataset import Sample
 from inspect_ai.log import read_eval_log
 from inspect_ai.log._file import read_eval_log_sample, write_eval_log
@@ -90,6 +91,21 @@ def test_read_sample():
         write_eval_log(log, eval_log_path)
         sample = read_eval_log_sample(eval_log_path, 1, 1)
         assert sample.target == " Yes"
+
+
+def test_log_location():
+    json_log_file = os.path.join("tests", "log", "test_eval_log", "log_formats.json")
+    check_log_location(json_log_file)
+    eval_log_file = os.path.join("tests", "log", "test_eval_log", "log_streaming.eval")
+    check_log_location(eval_log_file)
+
+
+def check_log_location(log_file: str):
+    location = filesystem(log_file).info(log_file).name
+    log = read_eval_log(location)
+    assert log.location == location
+    log = read_eval_log(location, header_only=True)
+    assert log.location == location
 
 
 def check_log_raises(log_file):

--- a/tests/log/test_log_formats.py
+++ b/tests/log/test_log_formats.py
@@ -13,7 +13,9 @@ from inspect_ai.log import read_eval_log, write_eval_log
 def original_log():
     """Fixture to provide a starting log file."""
     log_file = os.path.join("tests", "log", "test_eval_log", "log_formats.json")
-    return read_eval_log(log_file)
+    log = read_eval_log(log_file)
+    log.location = None
+    return log
 
 
 @pytest.fixture
@@ -34,6 +36,7 @@ def test_log_format_round_trip_single(original_log, temp_dir):
 
         # Read the new log file
         new_log = read_eval_log(new_log_path, format=format)
+        new_log.location = None
 
         # Compare the logs
         assert original_log == new_log, f"Round-trip failed for {format} format"
@@ -47,6 +50,7 @@ def test_log_format_round_trip_cross(original_log, temp_dir):
 
     # Read the EVAL log
     eval_log = read_eval_log(eval_log_path, format="eval")
+    eval_log.location = None
 
     # Write it back to JSON
     new_json_log_path = (temp_dir / "cross_format.json").as_posix()
@@ -54,6 +58,7 @@ def test_log_format_round_trip_cross(original_log, temp_dir):
 
     # Read the new JSON log
     new_json_log = read_eval_log(new_json_log_path, format="json")
+    new_json_log.location = None
 
     # Compare the logs
     assert original_log == new_json_log, "Cross-format round-trip failed"
@@ -70,7 +75,9 @@ def test_log_format_equality(original_log, temp_dir):
 
     # Read both logs back
     json_log = read_eval_log(json_log_path, format="json")
+    json_log.location = None
     eval_log = read_eval_log(eval_log_path, format="eval")
+    eval_log.location = None
 
     # Compare the logs
     assert json_log == eval_log, "Logs in different formats are not identical"
@@ -87,7 +94,9 @@ def test_log_format_detection(original_log, temp_dir):
 
     # Read both logs back using auto format
     json_log = read_eval_log(json_log_path, format="auto")
+    json_log.location = None
     eval_log = read_eval_log(eval_log_path, format="auto")
+    eval_log.location = None
 
     # Compare the logs
     assert json_log == eval_log, "Auto format detection failed"
@@ -140,6 +149,7 @@ def test_log_format_eval_zip_roundtrip(original_log, temp_dir):
 
     # Read the new JSON log
     new_json_log = read_eval_log(new_json_log_path, format="json")
+    new_json_log.location = None
 
     # Compare the original and new JSON logs
     assert (

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -23,7 +23,7 @@ from inspect_ai._eval.evalset import (
 )
 from inspect_ai._eval.loader import ResolvedTask
 from inspect_ai.dataset import Sample
-from inspect_ai.log._file import list_eval_logs
+from inspect_ai.log._file import list_eval_logs, read_eval_log, write_eval_log
 from inspect_ai.model import Model, get_model
 from inspect_ai.scorer._match import includes
 from inspect_ai.solver import generate
@@ -41,6 +41,15 @@ def test_eval_set() -> None:
         )
         assert success
         assert logs[0].status == "success"
+
+        # read and write logs based on location
+        for log in logs:
+            log = read_eval_log(log.location)
+            log.eval.metadata = {"foo": "bar"}
+            write_eval_log(log)
+            log = read_eval_log(log.location)
+            assert log.eval.metadata
+            log.eval.metadata["foo"] = "bar"
 
     # run eval that is guaranteed to fail
     with tempfile.TemporaryDirectory() as log_dir:


### PR DESCRIPTION
The `EvalLog` object returned from `eval()` and `read_eval_log()` now has a `location` property that indicates the storage location it was written to or read from.

The `write_eval_log()` function will use this `location` if it isn't passed an explicit `location` to write to. This enables you to modify the contents of a log file return from `eval()` as follows:

``` python
log = eval(my_task())[0]
# edit EvalLog as required
write_eval_log(log)
```

Or alternatively for an `EvalLog` read from a filesystem:

``` python
log = read_eval_log(log_file_path)
# edit EvalLog as required
write_eval_log(log)
```

If you are working with the results of an [Eval Set](eval-sets.qmd), the returned logs are headers rather than the full log with all samples. If you want to edit logs returned from `eval_set` you should read them fully, edit them, and then write them. For example:

``` python
success, logs = eval_set(tasks)

for log in logs:
    log = read_eval_log(log.location)
    # edit EvalLog as required
    write_eval_log(log)
```

Note that the `EvalLog.location` is a URI rather than a traditional file path(e.g. it could be a `file://` URI, an `s3://` URI or any other URI supported by [fsspec](https://filesystem-spec.readthedocs.io/)).