### PR TITLE
Make bash a login shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `EvalLog` now includes a [location](https://github.com/UKGovernmentBEIS/inspect_ai/pull/872) property indicating where it was read from.
 - Use [tool views](https://inspect.ai-safety-institute.org.uk/approval.html#tool-views) when rendering tool calls in Insepct View.
 - Consistent behavior for `max_samples` across sandbox and non-sandbox evals (both now apply `max_samples` per task, formerly evals with sandboxes applied `max_samples` globally).
+- Bash tool: add `--login` option so that e.g. .bashrc is read before executing the command.
 - Log viewer: display sample ids rather than indexes.
 - Log viewer: add timestamps to transcript events.
 - Log viewer: metadata which contains images will now render the images.

--- a/src/inspect_ai/tool/_tools/_execute.py
+++ b/src/inspect_ai/tool/_tools/_execute.py
@@ -45,7 +45,7 @@ def bash(timeout: int | None = None, user: str | None = None) -> Tool:
         """
         # execute the command
         result = await sandbox().exec(
-            cmd=["bash", "-c", cmd], timeout=timeout, user=user
+            cmd=["bash", "--login", "-c", cmd], timeout=timeout, user=user
         )
         # return output (including stderr if any)
         output = ""

--- a/tests/tools/test_bash_tool.py
+++ b/tests/tools/test_bash_tool.py
@@ -3,8 +3,11 @@ from test_helpers.tasks import minimal_task_for_tool_use
 from test_helpers.tool_call_utils import get_tool_call, get_tool_response
 from test_helpers.utils import skip_if_no_docker
 
-from inspect_ai import eval
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
 from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, use_tools
 from inspect_ai.tool import bash
 
 
@@ -32,3 +35,45 @@ def test_bash_simple_echo() -> None:
     tool_call_response = get_tool_response(messages, tool_call)
     assert tool_call_response is not None
     assert tool_call_response.content == "testing bash tool\n"
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_bash_profile() -> None:
+    tool_task = Task(
+        dataset=[
+            Sample(
+                input="Please use the tool",
+                target="n/a",
+                files={
+                    "/etc/profile.d/test_bash_profile.sh": "export ENV_VAR=custom_value\n"
+                },
+            )
+        ],
+        solver=[use_tools(bash()), generate()],
+        scorer=includes(),
+        metadata={"task_idx": 1},
+        message_limit=3,
+        sandbox="docker",
+    )
+    result = eval(
+        tool_task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name=bash.__name__,
+                    tool_arguments={"cmd": "echo $ENV_VAR"},
+                ),
+            ],
+        ),
+        sandbox_cleanup=False,
+    )[0]
+    assert result.samples
+    messages = result.samples[0].messages
+    tool_call = get_tool_call(messages, bash.__name__)
+    assert tool_call is not None
+    tool_call_response = get_tool_response(messages, tool_call)
+    assert tool_call_response is not None
+    assert tool_call_response.content == "custom_value\n"


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

In for example SWE-Bench, the Docker container setup adds things to `.bashrc` (etc), as part of Conda.
But if you run the inspect bash tool, it doesn't include these modifications, so it's very unusual for a AI agent to get the Python environment into the correct state before attempting the task.

See for example here https://github.com/princeton-nlp/SWE-bench/blob/main/swebench/harness/dockerfiles.py#L29

### What is the new behavior?

The bash tool uses a login shell so it sources the expected files

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

It's possible this could break things if any existing evals relied on bash not having a login shell

### Other information:
