### PR TITLE
show sample id and model at the top of sample transcript view

### DIFF
--- a/src/inspect_ai/_display/textual/app.py
+++ b/src/inspect_ai/_display/textual/app.py
@@ -141,11 +141,6 @@ class TaskScreenApp(App[TR]):
         tasks_view = self.query_one(TasksView)
         tasks_view.init_tasks(tasks)
 
-        # dynamic tab caption for task(s)
-        tabs = self.query_one(TabbedContent)
-        tasks_tab = tabs.get_tab("tasks")
-        tasks_tab.label = Text.from_markup("Tasks" if self._total_tasks > 1 else "Task")
-
         # update display
         self.update_display()
 
@@ -184,7 +179,7 @@ class TaskScreenApp(App[TR]):
         with TabbedContent(id="tabs", initial="tasks"):
             with TabPane("Tasks", id="tasks"):
                 yield TasksView()
-            with TabPane("Samples", id="samples"):
+            with TabPane("Running Samples", id="samples"):
                 yield SamplesView()
             with TabPane("Console", id="console"):
                 yield ConsoleView()

--- a/src/inspect_ai/_display/textual/widgets/samples.py
+++ b/src/inspect_ai/_display/textual/widgets/samples.py
@@ -25,7 +25,7 @@ class SamplesView(Widget):
         layout: grid;
         grid-size: 2 3;
         grid-rows: auto 1fr auto;
-        grid-columns: 30 1fr;
+        grid-columns: 32 1fr;
         grid-gutter: 1;
     }
     """
@@ -147,14 +147,14 @@ class SamplesList(OptionList):
             return None
 
 
-class SampleInfo(Widget):
+class SampleInfo(Horizontal):
     DEFAULT_CSS = """
     SampleInfo {
         color: $text-muted;
         layout: grid;
         grid-size: 2 1;
         grid-rows: auto 1fr;
-        width: 1fr;
+        width: 100%;
     }
     #sample-info-model {
         text-align: right;
@@ -171,7 +171,7 @@ class SampleInfo(Widget):
         if sample is not None:
             self.display = True
             id = Text.from_markup(
-                f"[bold]{sample.task}[/bold]  id: {sample.sample.id} (epoch {sample.epoch})"
+                f"[bold]{registry_unqualified_name(sample.task)}[/bold] - id: {sample.sample.id} (epoch {sample.epoch})"
             )
             info_id.update(id)
             model = Text.from_markup(sample.model)

--- a/src/inspect_ai/_display/textual/widgets/samples.py
+++ b/src/inspect_ai/_display/textual/widgets/samples.py
@@ -11,7 +11,7 @@ from textual.widgets.option_list import Option, Separator
 from inspect_ai._util.registry import registry_unqualified_name
 from inspect_ai.log._samples import ActiveSample
 
-from ...core.progress import progress_time
+from ...core.progress import MAX_MODEL_NAME_WIDTH, progress_time
 from .clock import Clock
 from .transcript import TranscriptView
 
@@ -23,29 +23,10 @@ class SamplesView(Widget):
         height: 1fr;
         padding: 0 1 0 1;
         layout: grid;
-        grid-size: 2 2;
-        grid-rows: 1fr auto;
+        grid-size: 2 3;
+        grid-rows: auto 1fr auto;
         grid-columns: 30 1fr;
         grid-gutter: 1;
-    }
-    SamplesView OptionList {
-        height: 100%;
-        scrollbar-size-vertical: 1;
-        margin-bottom: 1;
-        row-span: 2;
-        background: transparent;
-    }
-    SamplesView OptionList:focus > .option-list--option-highlighted {
-        background: $primary 40%;
-    }
-
-    SamplesView OptionList > .option-list--option-highlighted {
-        background: $primary 40%;
-    }
-
-    SamplesView TranscriptView {
-        scrollbar-size-vertical: 1;
-        scrollbar-gutter: stable;
     }
     """
 
@@ -54,22 +35,58 @@ class SamplesView(Widget):
         self.samples: list[ActiveSample] = []
 
     def compose(self) -> ComposeResult:
-        yield OptionList()
+        yield SamplesList()
+        yield SampleInfo()
         yield TranscriptView()
         yield SampleToolbar()
 
     def on_mount(self) -> None:
-        self.watch(self.query_one(OptionList), "highlighted", self.set_highlighted)
+        self.watch(
+            self.query_one(SamplesList), "highlighted", self.set_highlighted_sample
+        )
 
     async def notify_active(self, active: bool) -> None:
         await self.query_one(TranscriptView).notify_active(active)
 
     def set_samples(self, samples: list[ActiveSample]) -> None:
+        self.query_one(SamplesList).set_samples(samples)
+
+    async def set_highlighted_sample(self, highlighted: int | None) -> None:
+        if highlighted is not None:
+            sample = self.query_one(SamplesList).sample_for_highlighted(highlighted)
+            if sample is not None:
+                await self.query_one(SampleInfo).sync_sample(sample)
+                await self.query_one(TranscriptView).sync_sample(sample)
+                await self.query_one(SampleToolbar).sync_sample(sample)
+
+
+class SamplesList(OptionList):
+    DEFAULT_CSS = """
+    SamplesList {
+        height: 100%;
+        scrollbar-size-vertical: 1;
+        margin-bottom: 1;
+        row-span: 3;
+        background: transparent;
+    }
+    SamplesList:focus > .option-list--option-highlighted {
+        background: $primary 40%;
+    }
+
+    SamplesList  > .option-list--option-highlighted {
+        background: $primary 40%;
+    }
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.samples: list[ActiveSample] = []
+
+    def set_samples(self, samples: list[ActiveSample]) -> None:
         # check for a highlighted sample (make sure we don't remove it)
-        option_list = self.query_one(OptionList)
         highlighted_id = (
-            option_list.get_option_at_index(option_list.highlighted).id
-            if option_list.highlighted is not None
+            self.get_option_at_index(self.highlighted).id
+            if self.highlighted is not None
             else None
         )
         highlighted_sample = (
@@ -89,7 +106,7 @@ class SamplesView(Widget):
         self.samples.sort(key=lambda sample: sample.execution_time, reverse=True)
 
         # rebuild the list
-        option_list.clear_options()
+        self.clear_options()
         options: list[Option | Separator] = []
         for sample in self.samples:
             table = Table.grid(expand=True)
@@ -111,7 +128,7 @@ class SamplesView(Widget):
             options.append(Option(table, id=sample.id))
             options.append(Separator())
 
-        option_list.add_options(options)
+        self.add_options(options)
 
         # select sample (re-select the highlighted sample if there is one)
         if len(self.samples) > 0:
@@ -119,24 +136,49 @@ class SamplesView(Widget):
                 index = sample_index_for_id(self.samples, highlighted_id)
             else:
                 index = 0
-            option_list.highlighted = index
-            option_list.scroll_to_highlight()
+            self.highlighted = index
+            self.scroll_to_highlight()
 
-    async def set_highlighted(self, highlighted: int | None) -> None:
-        # alias widgets
-        option_list = self.query_one(OptionList)
-        transcript_view = self.query_one(TranscriptView)
-        sample_toolbar = self.query_one(SampleToolbar)
+    def sample_for_highlighted(self, highlighted: int) -> ActiveSample | None:
+        highlighted_id = self.get_option_at_index(highlighted).id
+        if highlighted_id is not None:
+            return sample_for_id(self.samples, highlighted_id)
+        else:
+            return None
 
-        # look for a highlighted sample to sync
-        if highlighted is not None:
-            highlighted_id = option_list.get_option_at_index(highlighted).id
-            if highlighted_id is not None:
-                sample = sample_for_id(self.samples, highlighted_id)
-                if sample:
-                    await sample_toolbar.sync_sample(sample)
-                    await transcript_view.sync_sample(sample)
-                    return
+
+class SampleInfo(Widget):
+    DEFAULT_CSS = """
+    SampleInfo {
+        color: $text-muted;
+        layout: grid;
+        grid-size: 2 1;
+        grid-rows: auto 1fr;
+        width: 1fr;
+    }
+    #sample-info-model {
+        text-align: right;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        yield Static(id="sample-info-id")
+        yield Static(id="sample-info-model")
+
+    async def sync_sample(self, sample: ActiveSample | None) -> None:
+        info_id = cast(Static, self.query_one("#sample-info-id"))
+        info_model = cast(Static, self.query_one("#sample-info-model"))
+        if sample is not None:
+            self.display = True
+            id = Text.from_markup(
+                f"[bold]{sample.task}[/bold]  id: {sample.sample.id} (epoch {sample.epoch})"
+            )
+            info_id.update(id)
+            model = Text.from_markup(sample.model)
+            model.truncate(MAX_MODEL_NAME_WIDTH, overflow="ellipsis")
+            info_model.update(sample.model)
+        else:
+            self.display = False
 
 
 class SampleToolbar(Horizontal):

--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -39,6 +39,13 @@ from inspect_ai.tool._tool import ToolResult
 
 
 class TranscriptView(ScrollableContainer):
+    DEFAULT_CSS = """
+    TranscriptView {
+        scrollbar-size-vertical: 1;
+        scrollbar-gutter: stable;
+    }
+    """
+
     def __init__(self) -> None:
         super().__init__()
         self._sample_id: str | None = None


### PR DESCRIPTION
Also rename the tab "Running Samples" so its more clear that its not all samples but just currently executing ones that are displayed:



