### PR TITLE
Improve word splitting / text matching

### DIFF
--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -1,3 +1,4 @@
+import re
 from typing import Callable, Literal
 
 from inspect_ai._util.text import (
@@ -67,10 +68,10 @@ def match_str(
         # normalize as required
         t = normalize_number(t)
         if location == "begin":
-            words = v.split(" ")
+            words = re.split(r"\s+", v)
             v = first_number_normalized(words)
         elif location == "end":
-            words = v.split(" ")
+            words = re.split(r"\s+", v)
             words.reverse()
             v = first_number_normalized(words)
         elif location == "exact":

--- a/tests/scorer/test_match.py
+++ b/tests/scorer/test_match.py
@@ -1,0 +1,13 @@
+import pytest
+from test_helpers.utils import simple_task_state
+
+from inspect_ai.scorer import CORRECT, Target, match
+
+
+@pytest.mark.asyncio
+async def test_number_eol():
+    scorer = match(numeric=True)
+    state = simple_task_state(model_output="28 + 32 = 60\nThis solves the problem.")
+    result = await scorer(state, Target(["60"]))
+
+    assert result.text == CORRECT


### PR DESCRIPTION
This improves our text splitting, but will result in changes vs the way matching previously worked:

1) consecutive whitespace characters would previously have been multiple words (e.g. an empty string in the word list). Now, consecutive whitespace will be treated as a single whitespace.

2) Word splits with new lines would span new lines, so `60\nThis` would be treated as a single word. Now, that will be split into two words: `[“60”, “This”]`

3) Previously only spaces would split words, now any whitespace will.

Thx to @fastfedora for the fix.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

