### PR TITLE
more targeted escaping for transcript markdown

### DIFF
--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -249,10 +249,12 @@ def render_score_event(event: ScoreEvent) -> EventDisplay:
     table.add_column("", justify="left")
     table.add_row("Target", str(event.target).strip())
     if event.score.answer:
-        table.add_row("Answer", transcript_markdown(event.score.answer))
+        table.add_row("Answer", transcript_markdown(event.score.answer, escape=True))
     table.add_row("Score", str(event.score.value).strip())
     if event.score.explanation:
-        table.add_row("Explanation", transcript_markdown(event.score.explanation))
+        table.add_row(
+            "Explanation", transcript_markdown(event.score.explanation, escape=True)
+        )
 
     return EventDisplay("score", table)
 
@@ -329,7 +331,7 @@ def render_message(
     ]
     text = text or message.text
     if text:
-        content.extend([transcript_markdown(text.strip())])
+        content.extend([transcript_markdown(text.strip(), escape=True)])
     return content
 
 

--- a/src/inspect_ai/_util/transcript.py
+++ b/src/inspect_ai/_util/transcript.py
@@ -13,10 +13,10 @@ def transcript_code_theme() -> str:
     return "github-dark"
 
 
-def transcript_markdown(content: str) -> Markdown:
+def transcript_markdown(content: str, *, escape: bool = False) -> Markdown:
     code_theme = transcript_code_theme()
     return Markdown(
-        html.escape(content),
+        html.escape(content) if escape else content,
         code_theme=code_theme,
         inline_code_lexer="python",
         inline_code_theme=code_theme,

--- a/src/inspect_ai/model/_trace.py
+++ b/src/inspect_ai/model/_trace.py
@@ -31,12 +31,12 @@ def trace_assistant_message(
         for m in messages_preceding_assistant(input):
             trace_panel(
                 title=m.role.capitalize(),
-                content=transcript_markdown(m.text),
+                content=transcript_markdown(m.text, escape=True),
             )
 
         # start with assistant content
         content: list[RenderableType] = (
-            [transcript_markdown(message.text)] if message.text else []
+            [transcript_markdown(message.text, escape=True)] if message.text else []
         )
 
         # print tool calls


### PR DESCRIPTION
In order to facilitate printing of `<thinking>` and other model injected tags we recently added escaping to output of transcript markdown. However, this ended up escaping Python and Bash code making it much less legible. This PR makes escaping opt-in and much better targeted to only free form message content not tool calls.
