### PR TITLE
Bugfix: Gemini tool call error: parameters properties should be non-empty for OBJECT type

### DIFF
--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -412,6 +412,10 @@ def schema_from_param(param: ToolParam | ToolParams) -> Schema:
             type=param.type, properties=param.properties, required=param.required
         )
 
+    empty_object_placeholder = {
+        "placeholder": ToolParam(type="string", description="empty object placeholder")
+    }
+
     if param.type == "number":
         return Schema(type=Type.NUMBER, description=param.description)
     elif param.type == "integer":
@@ -427,12 +431,12 @@ def schema_from_param(param: ToolParam | ToolParams) -> Schema:
             items=schema_from_param(param.items) if param.items else None,
         )
     elif param.type == "object":
+        if not param.properties:
+            param.properties = empty_object_placeholder
         return Schema(
             type=Type.OBJECT,
             description=param.description,
-            properties={k: schema_from_param(v) for k, v in param.properties.items()}
-            if param.properties is not None
-            else None,
+            properties={k: schema_from_param(v) for k, v in param.properties.items()},
             required=param.required,
         )
     else:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When running evaluations against Gemini models, if a tool doesn't take any input parameters, then we would see the following error: `InvalidArgument: 400 * GenerateContentRequest.tools[0].function_declarations[0].parameters.properties: should be non-empty for OBJECT type`.

For example, `web_browser_forward`, `web_browser_back`, and `web_browser_refresh` would trigger this error for any tasks that uses `web_browser` tool. We observed the same error when running AgentHarm, which was triggered by various custom tools that had no input parameters.

The root cause of this error is from formatting inspect tools to gemini format. When a tool takes no input parameters, its parameter property would be an empty `OBJECT`.
### What is the new behavior?
Replacing empty `OBJECT` with a placeholder eliminates the 400 error when using the aforementioned tools.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Other information:
N/A