### PR TITLE
Logging: Only call CreateBucket on Amazon S3 when the bucket does not already exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Logging: Only call CreateBucket on Amazon S3 when the bucket does not already exist.
 - Improve cancellation feedback and prevent multiple cancellations when using fullscreen display.
 
 ## v0.3.48 (01 December 2024) 


### PR DESCRIPTION
This PR changes our directory creation behavior for S3 filesystems as follows:

1) Rather than calling the the fsspec [makedirs](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.makedirs) function w/ `create_parents=True` (which in turn [calls create_bucket](https://github.com/fsspec/s3fs/blob/b6a00957d77c83df11a1680a0590bdfd06d6ddc6/s3fs/core.py#L905) for S3FS), we start off by calling [mkdir](https://filesystem-spec.readthedocs.io/en/latest/api.html#fsspec.spec.AbstractFileSystem.mkdir) with `create_parents=False`.

2. If this fails due to `FileNotFoundError` then we go ahead and call `makedirs` to cause the bucket to be created.

This avoids calling S3 CreateBucket unless absolutely required, which in turn makes it play better with prvillieges that allow for writing to exiting buckets but not creating new ones.