### PR TITLE
docker sandbox: streamed reads of stderr/stdout (enabling us to enforce output limits for read_file and exec at the source).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Improve cancellation feedback and prevent multiple cancellations when using fullscreen display.
+
 ## v0.3.48 (01 December 2024) 
 
 - [Realtime display](https://github.com/UKGovernmentBEIS/inspect_ai/pull/865) of sample transcripts (including ability to cancel running samples).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Improve cancellation feedback and prevent multiple cancellations when using fullscreen display.
+- Docker sandbox: Streamed reads of stderr/stdout (enabling us to enforce output limits for read_file and exec at the source).
 
 ## v0.3.48 (01 December 2024) 
 

--- a/src/inspect_ai/_display/textual/app.py
+++ b/src/inspect_ai/_display/textual/app.py
@@ -221,7 +221,9 @@ class TaskScreenApp(App[TR]):
     # update the header title
     def update_title(self) -> None:
         # determine title
-        if len(self._tasks) > 0:
+        if self._worker and self._worker.is_cancelled:
+            title = "eval interrupted (cancelling running samples...)"
+        elif len(self._tasks) > 0:
             if self._parallel:
                 completed = sum(1 for task in self._tasks if task.result is not None)
                 title = f"{tasks_title(completed, self._total_tasks)}"
@@ -302,8 +304,9 @@ class TaskScreenApp(App[TR]):
     # map ctrl+c to cancelling the worker
     @override
     async def action_quit(self) -> None:
-        if self._worker and self._worker.is_running:
+        if self._worker and self._worker.is_running and not self._worker.is_cancelled:
             self._worker.cancel()
+            self.update_title()
 
 
 class TextualTaskScreen(TaskScreen, Generic[TR]):

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -71,9 +71,15 @@ async def compose_down(project: ComposeProject, quiet: bool = True) -> None:
 
 
 async def compose_cp(
-    src: str, dest: str, project: ComposeProject, cwd: str | Path | None = None
+    src: str,
+    dest: str,
+    project: ComposeProject,
+    cwd: str | Path | None = None,
+    output_limit: int | None = None,
 ) -> None:
-    result = await compose_command(["cp", "--", src, dest], project=project, cwd=cwd)
+    result = await compose_command(
+        ["cp", "--", src, dest], project=project, cwd=cwd, output_limit=output_limit
+    )
     if not result.success:
         msg = f"Failed to copy file from '{src}' to '{dest}': {result.stderr}"
         raise RuntimeError(msg)
@@ -149,6 +155,7 @@ async def compose_exec(
     project: ComposeProject,
     timeout: int | None = None,
     input: str | bytes | None = None,
+    output_limit: int | None = None,
 ) -> ExecResult[str]:
     return await compose_command(
         ["exec"] + command,
@@ -156,6 +163,7 @@ async def compose_exec(
         timeout=timeout,
         input=input,
         forward_env=False,
+        output_limit=output_limit,
     )
 
 
@@ -241,6 +249,7 @@ async def compose_command(
     cwd: str | Path | None = None,
     forward_env: bool = True,
     capture_output: bool = True,
+    output_limit: int | None = None,
     ansi: Literal["never", "always", "auto"] | None = None,
 ) -> ExecResult[str]:
     # The base docker compose command
@@ -278,6 +287,7 @@ async def compose_command(
         env=env,
         timeout=timeout,
         capture_output=capture_output,
+        output_limit=output_limit,
     )
     sandbox_log(f"compose command completed: {shlex.join(compose_command)}")
     return result

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -15,7 +15,11 @@ from ..environment import (
     SandboxConnectionContainer,
     SandboxEnvironment,
 )
-from ..limits import verify_exec_result_size, verify_read_file_size
+from ..limits import (
+    SandboxEnvironmentLimits,
+    verify_exec_result_size,
+    verify_read_file_size,
+)
 from ..registry import sandboxenv
 from .cleanup import (
     cli_cleanup,
@@ -241,6 +245,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
             project=self._project,
             timeout=timeout,
             input=input,
+            output_limit=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
         )
         verify_exec_result_size(exec_result)
         if exec_result.returncode == 126 and "permission denied" in exec_result.stdout:
@@ -369,6 +374,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                     dest=os.path.basename(dest_file),
                     project=self._project,
                     cwd=os.path.dirname(dest_file),
+                    output_limit=SandboxEnvironmentLimits.MAX_READ_FILE_SIZE,
                 )
             except RuntimeError as ex:
                 # extract the message and normalise case

--- a/src/inspect_ai/util/_sandbox/local.py
+++ b/src/inspect_ai/util/_sandbox/local.py
@@ -8,7 +8,11 @@ from typing_extensions import override
 
 from .._subprocess import ExecResult, subprocess
 from .environment import SandboxConnection, SandboxConnectionLocal, SandboxEnvironment
-from .limits import verify_exec_result_size, verify_read_file_size
+from .limits import (
+    SandboxEnvironmentLimits,
+    verify_exec_result_size,
+    verify_read_file_size,
+)
 from .registry import sandboxenv
 
 
@@ -63,6 +67,7 @@ class LocalSandboxEnvironment(SandboxEnvironment):
             cwd=final_cwd,
             env=env,
             timeout=timeout,
+            output_limit=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
         )
         verify_exec_result_size(result)
         return result

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -151,6 +151,7 @@ async def subprocess(
 
                 # stop if we have a limit and we have exceeded it
                 if output_limit is not None and len(output) > output_limit:
+                    proc.kill()
                     break
 
             # return stream output

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -138,7 +138,7 @@ async def subprocess(
                 return bytes()
 
             # read 8k at a time
-            output = bytes()
+            output = bytearray()
             while True:
                 # read chunk and terminate if we are done
                 chunk = await stream.read(8192)
@@ -146,14 +146,14 @@ async def subprocess(
                     break
 
                 # append to output
-                output = output + chunk
+                output.extend(chunk)
 
                 # stop if we have a limit and we have exceeded it
                 if output_limit is not None and len(output) > output_limit:
                     break
 
             # return stream output
-            return output
+            return bytes(output)
 
         # wait for it to execute and yield result
         stdout, stderr = await asyncio.gather(

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -125,9 +125,10 @@ async def subprocess(
         yield proc
 
         # write stdin if specified
-        if input is not None and proc.stdin is not None:
-            proc.stdin.write(input)
-            await proc.stdin.drain()
+        if proc.stdin is not None:
+            if input is not None:
+                proc.stdin.write(input)
+                await proc.stdin.drain()
             proc.stdin.close()
             await proc.stdin.wait_closed()
 

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -39,6 +39,7 @@ async def subprocess(
     cwd: str | Path | None = None,
     env: dict[str, str] = {},
     capture_output: bool = True,
+    output_limit: int | None = None,
     timeout: int | None = None,
 ) -> ExecResult[str]: ...
 
@@ -51,6 +52,7 @@ async def subprocess(
     cwd: str | Path | None = None,
     env: dict[str, str] = {},
     capture_output: bool = True,
+    output_limit: int | None = None,
     timeout: int | None = None,
 ) -> ExecResult[bytes]: ...
 
@@ -62,6 +64,7 @@ async def subprocess(
     cwd: str | Path | None = None,
     env: dict[str, str] = {},
     capture_output: bool = True,
+    output_limit: int | None = None,
     timeout: int | None = None,
 ) -> Union[ExecResult[str], ExecResult[bytes]]:
     """Execute and wait for a subprocess.
@@ -80,6 +83,8 @@ async def subprocess(
        env (dict[str, str]): Additional environment variables.
        capture_output (bool): Capture stderr and stdout into ExecResult
          (if False, then output is redirected to parent stderr/stdout)
+       output_limit (int | None): Stop reading output if it exceeds
+         the specified limit (in bytes).
        timeout (int | None): Timeout. If the timeout expires then
          a `TimeoutError` will be raised.
 
@@ -119,10 +124,43 @@ async def subprocess(
         # yield the proc
         yield proc
 
+        # write stdin if specified
+        if input is not None and proc.stdin is not None:
+            proc.stdin.write(input)
+            await proc.stdin.drain()
+            proc.stdin.close()
+            await proc.stdin.wait_closed()
+
+        # read streams incrementally so we can check output limits
+        async def read_stream(stream: asyncio.StreamReader | None) -> bytes:
+            # return early for no stream
+            if stream is None:
+                return bytes()
+
+            # read 8k at a time
+            output = bytes()
+            while True:
+                # read chunk and terminate if we are done
+                chunk = await stream.read(8192)
+                if not chunk:
+                    break
+
+                # append to output
+                output = output + chunk
+
+                # stop if we have a limit and we have exceeded it
+                if output_limit is not None and len(output) > output_limit:
+                    break
+
+            # return stream output
+            return output
+
         # wait for it to execute and yield result
-        stdout, stderr = await proc.communicate(input=input)
-        success = proc.returncode == 0
-        returncode = proc.returncode if proc.returncode is not None else 1
+        stdout, stderr = await asyncio.gather(
+            read_stream(proc.stdout), read_stream(proc.stderr)
+        )
+        returncode = await proc.wait()
+        success = returncode == 0
         if text:
             yield ExecResult[str](
                 success=success,

--- a/tests/tools/test_max_exec_output.py
+++ b/tests/tools/test_max_exec_output.py
@@ -1,4 +1,3 @@
-
 from inspect_ai import Task, eval
 from inspect_ai.dataset._dataset import Sample
 from inspect_ai.model._generate_config import GenerateConfig
@@ -9,8 +8,11 @@ from inspect_ai.util import sandbox
 @solver
 def big_output_solver() -> Solver:
     async def solve(state: TaskState, generate: Generate):
-
-        await sandbox().exec(["python", "-c", """#!/usr/bin/env python
+        await sandbox().exec(
+            [
+                "python",
+                "-c",
+                """#!/usr/bin/env python
 import random
 import string
 
@@ -21,14 +23,16 @@ for _ in range(1000):
     print(foo)
     foo_big += foo
     print(len(foo_big))
-            """])
+            """,
+            ]
+        )
         state.completed = True
         return state
 
     return solve
 
-def test_max_exec_output():
 
+def test_max_exec_output():
     task = Task(
         dataset=[
             Sample(
@@ -42,4 +46,3 @@ def test_max_exec_output():
     log = eval(task, model="mockllm/model", sandbox="docker")[0]
 
     assert log.error
-

--- a/tests/tools/test_max_exec_output.py
+++ b/tests/tools/test_max_exec_output.py
@@ -1,3 +1,6 @@
+import pytest
+from test_helpers.utils import skip_if_no_docker
+
 from inspect_ai import Task, eval
 from inspect_ai.dataset._dataset import Sample
 from inspect_ai.model._generate_config import GenerateConfig
@@ -20,7 +23,11 @@ foo_big = ""
 
 for _ in range(1000):
     foo = ''.join(random.choices(string.ascii_letters + string.digits, k=1_000_000))
+
+    # stream out another 1MB of data
     print(foo)
+
+    # deliberately keep the big string in memory
     foo_big += foo
     print(len(foo_big))
             """,
@@ -32,6 +39,10 @@ for _ in range(1000):
     return solve
 
 
+# Run this test with a memory limit of around 200MB,
+# e.g. systemd-run --user --scope -p MemoryMax=200M pytest tests/tools/test_max_exec_output.py --capture=no --runslow
+@skip_if_no_docker
+@pytest.mark.slow
 def test_max_exec_output():
     task = Task(
         dataset=[


### PR DESCRIPTION
This PR makes a few changes aimed at enforcing sandbox output limits at the source (thereby never allowing larger than desired outputs into memory):

- Our `subprocess()` function now streams stderr and stdout rather than reading them in one shot. 
- The `subprocess()` function gains an `output_limit` argument which terminates the read loop if the total bytes read exceeds the `output_limit`.
- The Docker sandbox passes the requisite read_file and exec output limits into `subprocess()`
- Output limits are still enforced in the same place (they just will have less excess output in memory due to the truncation in `subprocess()`.

I have run the main test suite + run some agent evals (Intercode CTF, GDM In House CTF, and GAIA Level 1) to confirm that `subprocess()` is still working as expected.

I would also like to run the sandbox test suite but can't seem to get it to run properly. I am trying with e.g. `pytest -k self_check_docker_default_root --runslow` and while the test is correctly selected it just seems to hang (let it go for 10 minutes before interrupting in case it was just a particularly long running set of tests). @art-dsit  LMK what you think could be going on here.

Addresses https://github.com/UKGovernmentBEIS/inspect_ai/issues/836
