### PR TITLE
Change Field to field in ToolCall

### DIFF
--- a/src/inspect_ai/tool/_tool_call.py
+++ b/src/inspect_ai/tool/_tool_call.py
@@ -48,7 +48,7 @@ class ToolCall:
     parse_error: str | None = field(default=None)
     """Error which occurred parsing tool call."""
 
-    view: ToolCallContent | None = Field(default=None)
+    view: ToolCallContent | None = field(default=None)
     """Custom view of tool call input."""
 
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The current behavior is that we are using the pydantic `Field` function on a python dataclass object. I believe this is a typo and leads to the warning
```
pydantic/main.py:390: UserWarning: Pydantic serializer warnings:
  Expected `ToolCallContent` but got `FieldInfo` with value `FieldInfo(annotation=Unio...red=False, default=None)` - serialized value may not be as expected
  return self.__pydantic_serializer__.to_python(
```

Unfortunately I do not have a minimal reproduction of the above warning.

### What is the new behavior?
We switch to using the `dataclasses.field` function and the warning no longer appears.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No