### PR TITLE
Open log files directly in the vscode log viewer

### DIFF
--- a/tools/vscode/CHANGELOG.md
+++ b/tools/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.43
+
+- Add support for links which open the log viewer directly in VSCode. You may copy links to remote log files from the logs panel of the Inspect Activity Panel.
+
 ## 0.3.42
 
 - Improve support for selecting text in the full screen terminal

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "UK AI Safety Institute"
   },
-  "version": "0.3.42",
+  "version": "0.3.43",
   "license": "MIT",
   "homepage": "https://inspect.ai-safety-institute.org.uk/",
   "repository": {

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -146,6 +146,11 @@
         "enablement": "workspaceFolderCount != 0"
       },
       {
+        "command": "inspect.logListingCopyEditorPath",
+        "title": "Copy Editor URL",
+        "enablement": "workspaceFolderCount != 0"
+      },      
+      {
         "command": "inspect.logListingReveal",
         "title": "Reveal Log Listing",
         "category": "Inspect",
@@ -368,8 +373,13 @@
         },
         {
           "command": "inspect.logListingCopyLogPath",
-          "group": "1_copycommands",
+          "group": "1_copycommands@1",
           "when": "view == inspect_ai.logs-view && inspect_ai.haveEvalLogFormat && viewItem =~ /file/"
+        },
+        {
+          "command": "inspect.logListingCopyEditorPath",
+          "group": "1_copycommands@2",
+          "when": "view == inspect_ai.logs-view && inspect_ai.haveEvalLogFormat && viewItem =~ /file\\+remote/"
         },
         {
           "command": "inspect.logListingDeleteLogFile",

--- a/tools/vscode/src/extension.ts
+++ b/tools/vscode/src/extension.ts
@@ -26,6 +26,7 @@ import { InspectViewServer } from "./providers/inspect/inspect-view-server";
 import { InspectLogsWatcher } from "./providers/inspect/inspect-logs-watcher";
 import { activateLogNotify } from "./providers/lognotify";
 import { activateOpenLog } from "./providers/openlog";
+import { activateProtocolHandler } from "./providers/protocol-handler";
 
 const kInspectMinimumVersion = "0.3.8";
 
@@ -64,6 +65,9 @@ export async function activate(context: ExtensionContext) {
 
   // Initial the workspace
   await initializeWorkspace(stateManager);
+
+  // Initialize the protocol handler
+  activateProtocolHandler(context);
 
   // Inspect Manager watches for changes to inspect binary
   const inspectManager = activateInspectManager(context);

--- a/tools/vscode/src/providers/activity-bar/log-listing/log-listing-provider.ts
+++ b/tools/vscode/src/providers/activity-bar/log-listing/log-listing-provider.ts
@@ -153,6 +153,15 @@ export async function activateLogListing(
     }
   }));
 
+  // Register copy editor command
+  disposables.push(vscode.commands.registerCommand('inspect.logListingCopyEditorPath', async (node: LogNode) => {
+    const logUri = treeDataProvider.getLogListing()?.uriForNode(node);
+    if (logUri) {
+      const url = `vscode://ukaisi.inspect-ai/open?log=${logUri.toString()}`;
+      await vscode.env.clipboard.writeText(url);
+    }
+  }));
+
   // refresh when a log in our directory changes
   disposables.push(logsWatcher.onInspectLogCreated((e) => {
     const treeLogDir = treeDataProvider.getLogListing()?.logDir();

--- a/tools/vscode/src/providers/protocol-handler.ts
+++ b/tools/vscode/src/providers/protocol-handler.ts
@@ -29,11 +29,7 @@ export class InspectProtocolHandler implements UriHandler {
           }
 
           // Execute the open command
-          await commands.executeCommand(
-            "vscode.openWith",
-            logUri,
-            "inspect-ai.log-editor"
-          );
+          await commands.executeCommand('inspect.openLogViewer', logUri);
         }
       }
     }

--- a/tools/vscode/src/providers/protocol-handler.ts
+++ b/tools/vscode/src/providers/protocol-handler.ts
@@ -1,0 +1,41 @@
+import { existsSync } from "fs";
+import { ExtensionContext, Uri, UriHandler, window, commands } from "vscode";
+import { showError } from "../components/error";
+
+export function activateProtocolHandler(context: ExtensionContext) {
+  const protocolHandler = new InspectProtocolHandler();
+  context.subscriptions.push(window.registerUriHandler(protocolHandler));
+}
+
+export class InspectProtocolHandler implements UriHandler {
+  public async handleUri(uri: Uri): Promise<void> {
+    // Read the command
+    const command = uri.path.replace(/^\//, "");
+    const queryParams = new URLSearchParams(uri.query);
+    switch (command) {
+      // The open command
+      case "open": {
+        // Get the log file
+        const logFile = queryParams.get("log");
+        if (logFile) {
+          const logUri = Uri.parse(logFile);
+
+          // For local file paths, make sure the file exists or show an error
+          if (logUri.scheme === "file") {
+            if (!existsSync(logUri.fsPath)) {
+              await showError(`The file ${logUri.fsPath} does exist.`);
+              return;
+            }
+          }
+
+          // Execute the open command
+          await commands.executeCommand(
+            "vscode.openWith",
+            logUri,
+            "inspect-ai.log-editor"
+          );
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Supports both json and eval files (both local and remote)
- Copy Editor Link command is available from the `logs` activity panel for remote files only