### PR TITLE
Perform secondary sort by epoch after id

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -23830,25 +23830,48 @@ const byEpoch = (sort) => {
 const bySample = (sort) => {
   return sort === kSampleAscVal || sort === kSampleDescVal;
 };
+const sortId = (a2, b2) => {
+  if (isNumeric(a2.id) && isNumeric(b2.id)) {
+    return Number(a2.id) - Number(b2.id);
+  } else {
+    return String(a2.id).localeCompare(String(b2.id));
+  }
+};
 const sortSamples = (sort, samples, samplesDescriptor) => {
   const sortedSamples = samples.sort((a2, b2) => {
     switch (sort) {
-      case kSampleAscVal:
-        if (isNumeric(a2.id) && isNumeric(b2.id)) {
-          return Number(a2.id) - Number(b2.id);
+      case kSampleAscVal: {
+        const result = sortId(a2, b2);
+        if (result !== 0) {
+          return result;
         } else {
-          return String(a2.id).localeCompare(String(b2.id));
+          return a2.epoch - b2.epoch;
         }
-      case kSampleDescVal:
-        if (isNumeric(a2.id) && isNumeric(b2.id)) {
-          return Number(b2.id) - Number(a2.id);
+      }
+      case kSampleDescVal: {
+        const result = sortId(b2, a2);
+        if (result !== 0) {
+          return result;
         } else {
-          return String(b2.id).localeCompare(String(a2.id));
+          return a2.epoch - b2.epoch;
         }
-      case kEpochAscVal:
-        return a2.epoch - b2.epoch;
-      case kEpochDescVal:
-        return b2.epoch - a2.epoch;
+      }
+      case kEpochAscVal: {
+        const result = a2.epoch - b2.epoch;
+        if (result !== 0) {
+          return result;
+        } else {
+          return sortId(a2, b2);
+        }
+      }
+      case kEpochDescVal: {
+        const result = b2.epoch - a2.epoch;
+        if (result !== 0) {
+          return result;
+        } else {
+          return sortId(a2, b2);
+        }
+      }
       case kScoreAscVal:
         return samplesDescriptor.scoreDescriptor.compare(
           samplesDescriptor.selectedScore(a2).value,

--- a/src/inspect_ai/_view/www/src/samples/tools/SortFilter.mjs
+++ b/src/inspect_ai/_view/www/src/samples/tools/SortFilter.mjs
@@ -74,6 +74,17 @@ export const bySample = (sort) => {
   return sort === kSampleAscVal || sort === kSampleDescVal;
 };
 
+const sortId = (a, b) => {
+  if (isNumeric(a.id) && isNumeric(b.id)) {
+    return Number(a.id) - Number(b.id);
+  } else {
+    // Note that if there are mixed types of ids (e.g. a string
+    // and a number), we need to be sure we're working with strings
+    // to performan the comparison
+    return String(a.id).localeCompare(String(b.id));
+  }
+};
+
 /**
  * Sorts a list of samples
  *
@@ -85,28 +96,39 @@ export const bySample = (sort) => {
 export const sortSamples = (sort, samples, samplesDescriptor) => {
   const sortedSamples = samples.sort((a, b) => {
     switch (sort) {
-      case kSampleAscVal:
-        if (isNumeric(a.id) && isNumeric(b.id)) {
-          return Number(a.id) - Number(b.id);
+      case kSampleAscVal: {
+        const result = sortId(a, b);
+        if (result !== 0) {
+          return result;
         } else {
-          // Note that if there are mixed types of ids (e.g. a string
-          // and a number), we need to be sure we're working with strings
-          // to performan the comparison
-          return String(a.id).localeCompare(String(b.id));
+          return a.epoch - b.epoch;
         }
-      case kSampleDescVal:
-        if (isNumeric(a.id) && isNumeric(b.id)) {
-          return Number(b.id) - Number(a.id);
+      }
+      case kSampleDescVal: {
+        const result = sortId(b, a);
+        if (result !== 0) {
+          return result;
         } else {
-          // Note that if there are mixed types of ids (e.g. a string
-          // and a number), we need to be sure we're working with strings
-          // to perform the comparison
-          return String(b.id).localeCompare(String(a.id));
+          return a.epoch - b.epoch;
         }
-      case kEpochAscVal:
-        return a.epoch - b.epoch;
-      case kEpochDescVal:
-        return b.epoch - a.epoch;
+      }
+      case kEpochAscVal: {
+        const result = a.epoch - b.epoch;
+        if (result !== 0) {
+          return result;
+        } else {
+          return sortId(a, b);
+        }
+      }
+      case kEpochDescVal: {
+        const result = b.epoch - a.epoch;
+        if (result !== 0) {
+          return result;
+        } else {
+          return sortId(a, b);
+        }
+      }
+
       case kScoreAscVal:
         return samplesDescriptor.scoreDescriptor.compare(
           samplesDescriptor.selectedScore(a).value,


### PR DESCRIPTION
We were previously relying upon natural order, but we need to explicitly sort since samples may not be written in epoch order.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

