### PR TITLE
Fix circular error when rendering tool input

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15337,8 +15337,15 @@ const extractInput = (inputKey, args) => {
   };
   if (args) {
     if (Object.keys(args).length === 1) {
+      const inputRaw = args[Object.keys(args)[0]];
+      let input;
+      if (Array.isArray(inputRaw) || typeof inputRaw === "object") {
+        input = JSON.stringify(inputRaw, void 0, 2);
+      } else {
+        input = String(inputRaw);
+      }
       return {
-        input: args[Object.keys(args)[0]],
+        input,
         args: []
       };
     } else if (args[inputKey]) {

--- a/src/inspect_ai/_view/www/src/components/Tools.mjs
+++ b/src/inspect_ai/_view/www/src/components/Tools.mjs
@@ -269,18 +269,26 @@ const extractInputMetadata = (toolName) => {
 /**
  * @param {string} inputKey
  * @param {Object<string, any>} args
- * @returns {{ input: any, args: string[] }}
+ * @returns {{ input: string | undefined, args: string[] }}
  */
 const extractInput = (inputKey, args) => {
   const formatArg = (key, value) => {
     const quotedValue = typeof value === "string" ? `"${value}"` : value;
     return `${key}: ${quotedValue}`;
   };
-
   if (args) {
     if (Object.keys(args).length === 1) {
+      const inputRaw = args[Object.keys(args)[0]];
+
+      let input;
+      if (Array.isArray(inputRaw) || typeof inputRaw === "object") {
+        input = JSON.stringify(inputRaw, undefined, 2);
+      } else {
+        input = String(inputRaw);
+      }
+
       return {
-        input: args[Object.keys(args)[0]],
+        input: input,
         args: [],
       };
     } else if (args[inputKey]) {

--- a/src/inspect_ai/_view/www/src/utils/debugging.mjs
+++ b/src/inspect_ai/_view/www/src/utils/debugging.mjs
@@ -1,0 +1,23 @@
+export function printCircularReferences(obj) {
+  const seenObjects = new WeakMap();
+
+  function detect(value, path = "") {
+    if (typeof value === "object" && value !== null) {
+      if (seenObjects.has(value)) {
+        console.log(
+          `Circular reference detected at path: ${seenObjects.get(value)}`,
+        );
+        return;
+      }
+      seenObjects.set(value, path);
+
+      for (const key in value) {
+        if (Object.prototype.hasOwnProperty.call(value, key)) {
+          detect(value[key], `${path}.${key}`);
+        }
+      }
+    }
+  }
+
+  detect(obj, "root");
+}


### PR DESCRIPTION
Because an object was getting through the input parsing, it was ending up decorated with props and other reactive elements from preact. when it was then converted to json, there is circularity. The  `extractInput` should be returning a string always, so ensure this is true.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
