### PR TITLE
tools: improved typing/schema support (unions, optional params, enums)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Tools: Improved typing/schema support (unions, optional params, enums)
 - Docker sandbox: Streamed reads of stderr/stdout (enabling us to enforce output limits for read_file and exec at the source).
 - Add `time` field to `ModelOutput` that records total time spent within call to ModelAPI `generate()`. 
 

--- a/src/inspect_ai/tool/_tool_def.py
+++ b/src/inspect_ai/tool/_tool_def.py
@@ -190,8 +190,8 @@ def tool_def_fields(tool: Tool) -> ToolDefFields:
                 f"{context} not provided for parameter '{param_name}' of tool function '{name}'."
             )
 
-        if param.type == "null":
-            raise_not_provided_error("Type annotation")
+        if param.type is None and not param.anyOf and not param.enum:
+            raise_not_provided_error("Unsupported type or type annotation")
         elif not param.description:
             raise_not_provided_error("Description")
 

--- a/src/inspect_ai/tool/_tool_params.py
+++ b/src/inspect_ai/tool/_tool_params.py
@@ -13,9 +13,10 @@ JSONType = Literal["string", "integer", "number", "boolean", "array", "object", 
 class ToolParam(BaseModel):
     """Description of tool parameter in JSON Schema format."""
 
-    type: JSONType = Field(default="null")
+    type: JSONType | None = Field(default=None)
     description: str | None = Field(default=None)
     default: Any = Field(default=None)
+    enum: list[Any] | None = Field(default=None)
     items: Optional["ToolParam"] = Field(default=None)
     properties: dict[str, "ToolParam"] | None = Field(default=None)
     additionalProperties: Optional["ToolParam"] | bool | None = Field(default=None)

--- a/tests/tools/test_tool_parse.py
+++ b/tests/tools/test_tool_parse.py
@@ -26,7 +26,7 @@ def test_parse_type():
         type="object", additionalProperties=ToolParam(type="integer")
     )
     assert parse_type(Optional[str]) == ToolParam(
-        anyOf=[ToolParam(type="string"), ToolParam()]
+        anyOf=[ToolParam(type="string"), ToolParam(type="null")]
     )
     assert parse_type(Union[int, str]) == ToolParam(
         anyOf=[ToolParam(type="integer"), ToolParam(type="string")]


### PR DESCRIPTION
The PR enhances our support for generating JSON schemas for tools from Python types. We now support the following additional typing constructs:

- Unions (e.g. `str | list[str]`)
- Optional parameters (e.g. `str | None`)
- Default parameters (e.g. `str | None = None`)
- Enum/literal parameters (e.g. `Literal[1,2,3]`)

These in addition to existing support for `TypedDict`, `@dataclass`, and Pydantic `BaseModel` should mean that we can parse just about any type definition. In the case where we can't discover a type definition we've also clarified the error message to indicate that the type is unsupported (previously the error indicated that there was no annotation, which wasn't actually correct in the case of unsupported type annotations).