### PR TITLE
Correctly URL encode copied URL

### DIFF
--- a/tools/vscode/CHANGELOG.md
+++ b/tools/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.44
+
+- Fix incorrect url encoding when copying links to remote log files.
+
 ## 0.3.43
 
 - Add support for links which open the log viewer directly in VSCode. You may copy links to remote log files from the logs panel of the Inspect Activity Panel.

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "UK AI Safety Institute"
   },
-  "version": "0.3.43",
+  "version": "0.3.44",
   "license": "MIT",
   "homepage": "https://inspect.ai-safety-institute.org.uk/",
   "repository": {

--- a/tools/vscode/src/providers/activity-bar/log-listing/log-listing-provider.ts
+++ b/tools/vscode/src/providers/activity-bar/log-listing/log-listing-provider.ts
@@ -157,7 +157,7 @@ export async function activateLogListing(
   disposables.push(vscode.commands.registerCommand('inspect.logListingCopyEditorPath', async (node: LogNode) => {
     const logUri = treeDataProvider.getLogListing()?.uriForNode(node);
     if (logUri) {
-      const url = `vscode://ukaisi.inspect-ai/open?log=${logUri.toString()}`;
+      const url = `vscode://ukaisi.inspect-ai/open?log=${encodeURIComponent(logUri.toString())}`;
       await vscode.env.clipboard.writeText(url);
     }
   }));


### PR DESCRIPTION
This correctly encodes the log file path, which can contain characters such as `+` which must be encoded.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

500 error when following URLs with incorrect encoding.

### What is the new behavior?

It works!

