### PR TITLE
Display model time in model call events

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -19184,7 +19184,15 @@ const ModelUsagePanel = ({ usage }) => {
 const ModelEventView = ({ id, event, style }) => {
   var _a2, _b2;
   const totalUsage = (_a2 = event.output.usage) == null ? void 0 : _a2.total_tokens;
-  const subtitle = totalUsage ? `(${formatNumber(totalUsage)} tokens)` : "";
+  const callTime = event.output.time;
+  const subItems = [];
+  if (totalUsage) {
+    subItems.push(`${formatNumber(totalUsage)} tokens`);
+  }
+  if (callTime) {
+    subItems.push(`${formatPrettyDecimal(callTime)} sec`);
+  }
+  const subtitle = subItems.length > 0 ? `(${subItems.join(", ")})` : "";
   const outputMessages = (_b2 = event.output.choices) == null ? void 0 : _b2.map((choice) => {
     return choice.message;
   });

--- a/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/ModelEventView.mjs
@@ -14,7 +14,11 @@ import { ApplicationIcons } from "../../appearance/Icons.mjs";
 import { MetaDataGrid } from "../../components/MetaDataGrid.mjs";
 import { FontSize, TextStyle } from "../../appearance/Fonts.mjs";
 import { ModelUsagePanel } from "../../usage/UsageCard.mjs";
-import { formatDateTime, formatNumber } from "../../utils/Format.mjs";
+import {
+  formatDateTime,
+  formatNumber,
+  formatPrettyDecimal,
+} from "../../utils/Format.mjs";
 
 /**
  * Renders the StateEventView component.
@@ -28,7 +32,16 @@ import { formatDateTime, formatNumber } from "../../utils/Format.mjs";
  */
 export const ModelEventView = ({ id, event, style }) => {
   const totalUsage = event.output.usage?.total_tokens;
-  const subtitle = totalUsage ? `(${formatNumber(totalUsage)} tokens)` : "";
+  const callTime = event.output.time;
+
+  const subItems = [];
+  if (totalUsage) {
+    subItems.push(`${formatNumber(totalUsage)} tokens`);
+  }
+  if (callTime) {
+    subItems.push(`${formatPrettyDecimal(callTime)} sec`);
+  }
+  const subtitle = subItems.length > 0 ? `(${subItems.join(", ")})` : "";
 
   // Note: despite the type system saying otherwise, this has appeared empircally
   // to sometimes be undefined


### PR DESCRIPTION
<img width="784" alt="Screenshot 2024-12-03 at 9 47 12 AM" src="https://github.com/user-attachments/assets/d2f1655c-510a-4274-b98f-04e41eaf7185">

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor


