### PR TITLE
Remove base64 data from images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 - Tools: Improved typing/schema support (unions, optional params, enums)
 - Docker sandbox: Streamed reads of stderr/stdout (enabling us to enforce output limits for read_file and exec at the source).
-- Add `time` field to `ModelOutput` that records total time spent within call to ModelAPI `generate()`. 
+- Add `time` field to `ModelOutput` that records total time spent within call to ModelAPI `generate()`.
+- Web browser: Remove base64 images from web page contents (prevent filling up model context with large images)
 
 ## v0.3.49 (03 December 2024)
 

--- a/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
@@ -373,6 +373,12 @@ async def web_browser_cmd(cmd: str, *args: str) -> str:
             web_at = (
                 str(response.get("web_at")) or "(no web accessiblity tree available)"
             )
+            # Remove base64 data from images.
+            web_at_lines = web_at.split("\n")
+            web_at_lines = [
+                line.partition("data:image/png;base64")[0] for line in web_at_lines
+            ]
+            web_at = "\n".join(web_at_lines)
             store().set(WEB_BROWSER_AT, web_at)
             return web_at
         elif "error" in response:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Current behaviour is seen on the left, new behaviour is on the right.

![image](https://github.com/user-attachments/assets/9976b034-6263-49a7-b169-6957d1d3a066)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Only if you rely on base64 image data, which is unlikely.

### Other information:
