### PR TITLE
Small sample progress fixes

### DIFF
--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -190,8 +190,8 @@ class TaskStatusIcon(Static):
             return Text("⠿", style=running)
 
 
-min_progress_percent = 0.02
-max_progress_percent = 0.98
+MAX_PROGRESS_PERCENT = 0.02
+MIN_PROGRESS_PERCENT = 0.98
 
 
 class TaskProgress(Progress):
@@ -201,7 +201,7 @@ class TaskProgress(Progress):
 
         # always show a minimum amount of progress
         minimum_steps = (
-            min_progress_percent * progress_bar.total
+            MAX_PROGRESS_PERCENT * progress_bar.total
             if progress_bar.total is not None
             else 0
         )
@@ -213,7 +213,7 @@ class TaskProgress(Progress):
 
         # enforce a maximum cap on task progress
         max_progress = (
-            max_progress_percent * self.progress_bar.total
+            MIN_PROGRESS_PERCENT * self.progress_bar.total
             if self.progress_bar.total is not None
             else 0
         )

--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -130,7 +130,7 @@ class TaskProgressView(Widget):
         self.description_width = description_width
         self.model_name_width = model_name_width
         self.progress_bar = ProgressBar(total=task.profile.steps, show_eta=False)
-        self.segments = Static()
+        self.count_display = Static()
         self.task_progress = TaskProgress(self.progress_bar)
 
     def compose(self) -> ComposeResult:
@@ -142,7 +142,7 @@ class TaskProgressView(Widget):
             progress_model_name(self.t.profile.model, self.model_name_width, pad=True)
         )
         yield self.progress_bar
-        yield self.segments
+        yield self.count_display
         yield Clock()
 
     def on_mount(self) -> None:
@@ -162,7 +162,7 @@ class TaskProgressView(Widget):
         self.task_progress.complete()
 
     def sample_complete(self, complete: int, total: int) -> None:
-        self.segments.update(f"[{complete:,}/{total:,}]")
+        self.count_display.update(f"[{complete:,}/{total:,}]")
 
 
 class TaskStatusIcon(Static):

--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -190,13 +190,38 @@ class TaskStatusIcon(Static):
             return Text("⠿", style=running)
 
 
+min_progress_percent = 0.02
+max_progress_percent = 0.98
+
+
 class TaskProgress(Progress):
     def __init__(self, progress_bar: ProgressBar) -> None:
         self.progress_bar = progress_bar
+        self.current_progress = 0
+
+        # always show a minimum amount of progress
+        minimum_steps = (
+            min_progress_percent * progress_bar.total
+            if progress_bar.total is not None
+            else 0
+        )
+        self.progress_bar.update(progress=minimum_steps)
 
     @override
     def update(self, n: int = 1) -> None:
-        self.progress_bar.update(advance=n)
+        self.current_progress = self.current_progress + n
+
+        # enforce a maximum cap on task progress
+        max_progress = (
+            max_progress_percent * self.progress_bar.total
+            if self.progress_bar.total is not None
+            else 0
+        )
+        if (
+            self.current_progress > self.progress_bar.progress
+            and self.current_progress < max_progress
+        ):
+            self.progress_bar.update(progress=self.current_progress)
 
     @override
     def complete(self) -> None:

--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -107,8 +107,8 @@ class TaskProgressView(Widget):
         height: auto;
         width: 1fr;
         layout: grid;
-        grid-size: 5 1;
-        grid-columns: auto auto auto 1fr auto;
+        grid-size: 6 1;
+        grid-columns: auto auto auto 1fr auto auto;
         grid-gutter: 1;
     }
     TaskProgressView Bar {

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -96,9 +96,7 @@ EvalSampleSource = Callable[[int | str, int], EvalSample | None]
 # represents the total units of progress for an individual sample
 # the remainder are increments of progress within a sample (and
 # must sum to the total_progress_units when the sample is complete)
-SAMPLE_TOTAL_PROGRESS_UNITS = 10
-SAMPLE_INIT_PROGRESS_UNITS = 3
-SAMPLE_COMPLETE_PROGRESS_UNITS = 7
+SAMPLE_TOTAL_PROGRESS_UNITS = 1
 
 
 @dataclass
@@ -461,9 +459,6 @@ async def task_run_sample(
             transcript=sample_transcript,
         ) as active,
     ):
-        # Initial progress
-        progress(SAMPLE_INIT_PROGRESS_UNITS)
-
         error: EvalError | None = None
         try:
             async with timeout_cm:
@@ -586,7 +581,7 @@ async def task_run_sample(
             error = handle_error(ex)
 
         # complete the sample
-        progress(SAMPLE_COMPLETE_PROGRESS_UNITS)
+        progress(SAMPLE_TOTAL_PROGRESS_UNITS)
 
         # log it
         if logger is not None:


### PR DESCRIPTION
- Place floor (2%) and ceiling (98%) on task progress (2%) 
- Restore the clock
- Only tick sample progress when a sample is completed

This change will make the % complete exactly match the total number of samples completed which will match the progress bar completion display as well. 

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
