### PR TITLE
report errors that occur during task finalisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - Azure AI: Fix schema validation error that occurred when model API returns `None` for `content`.
 - Bugfix: Prevent cascading textual error when an error occurs during task initialisation.
 - Bugfix: Correctly restore sample summaries from log file after abend.
+= Bugfix: Report errors that occur during task finalisation.
   
 ## v0.3.49 (03 December 2024)
 

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -289,6 +289,12 @@ async def run_multiple(tasks: list[TaskRunOptions], parallel: int) -> list[EvalL
                 await task
                 result = task.result()
                 results.append(result)
+            except Exception as ex:
+                # errors generally don't escape from tasks (the exception being if an error
+                # occurs during the final write of the log)
+                log.error(
+                    f"Task '{task_options.task.name}' encountered an error during finalisation: {ex}"
+                )
 
             # tracking
             tasks_completed += 1


### PR DESCRIPTION
Previously, when running with `max_tasks > 1` errors occurring during the final write of the log file were not reported (and the task scheduler exited abnormally). 
