### PR TITLE
`hf_dataset` now explicitly requires the `split` argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,9 +17,10 @@
 - Hugging Face: Support for native HF tool calling for Llama, Mistral, Qwen, and others if they conform to various standard schemas.
 - Hugging Face: `tokenizer_call_args` dict to specify custom args during tokenization, such as `max_length` and `truncation`.
 - Azure AI: Fix schema validation error that occurred when model API returns `None` for `content`.
+- Bugfix: `hf_dataset` now explicitly requires the `split` argument (previously, it would crash when not specified).
 - Bugfix: Prevent cascading textual error when an error occurs during task initialisation.
 - Bugfix: Correctly restore sample summaries from log file after abend.
-= Bugfix: Report errors that occur during task finalisation.
+- Bugfix: Report errors that occur during task finalisation.
   
 ## v0.3.49 (03 December 2024)
 

--- a/src/inspect_ai/dataset/_sources/hf.py
+++ b/src/inspect_ai/dataset/_sources/hf.py
@@ -21,9 +21,9 @@ from .._util import data_to_samples, record_to_sample_fn
 
 def hf_dataset(
     path: str,
+    split: str,
     name: str | None = None,
     data_dir: str | None = None,
-    split: str | None = None,
     revision: str | None = None,
     sample_fields: FieldSpec | RecordToSample | None = None,
     auto_id: bool = False,
@@ -44,10 +44,10 @@ def hf_dataset(
           builder that is used comes from a generic dataset script (JSON, CSV,
           Parquet, text etc.) or from the dataset script (a python file) inside
           the dataset directory.
+        split (str): Which split of the data to load.
         name (str | None): Name of the dataset configuration.
         data_dir (str | None): data_dir of the dataset configuration
           to read data from.
-        split (str | None): Which split of the data to load.
         revision (str | None): Specific revision to load (e.g. "main", a branch
           name, or a specific commit SHA). When using `revision` the `cached` option
           is ignored and datasets are revalidated on Hugging Face before loading.


### PR DESCRIPTION
Previously, it would crash when not specified.
