### PR TITLE
input panel api: minor improvements + make public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Task display: Show completed samples and align progress more closely to completed samples (as opposed to steps).
 - Task display: Show sample messages/tokens used (plus limits if specified).
 - Human approval: Use fullcreen display (makes approval UI async and enables rapid processing of approvals via the `Enter` key).
+- Added `input_panel()` API for adding custom panels to the fullscreen task display.
 - Log recorder: Methods are now async which will improve performance for fsspec filesystems with async implementations (e.g. S3)
 - Log recorder: Improve `.eval` log reading performance for remote filesystem (eaglery fetch log to local buffer).
 - Add `token_usage` property to `TaskState` which has current total tokens used across all calls to `generate()` (same value that is used for enforcing token limits).

--- a/src/inspect_ai/_display/core/display.py
+++ b/src/inspect_ai/_display/core/display.py
@@ -19,7 +19,7 @@ from rich.console import Console
 from inspect_ai.log import EvalConfig, EvalResults, EvalStats
 from inspect_ai.model import GenerateConfig, ModelName
 
-from .input import InputPanel
+from ...util._panel import InputPanel
 
 
 @runtime_checkable

--- a/src/inspect_ai/_display/core/input.py
+++ b/src/inspect_ai/_display/core/input.py
@@ -4,6 +4,8 @@ from textual.containers import Container
 
 
 class InputPanel(Container):
+    DEFAULT_CLASSES = "task-input-panel"
+
     class Host(Protocol):
         def set_title(self, title: str) -> None: ...
         def activate(self) -> None: ...
@@ -11,7 +13,7 @@ class InputPanel(Container):
         def close(self) -> None: ...
 
     def __init__(self, host: Host) -> None:
-        super().__init__(classes="task-input-panel")
+        super().__init__()
         self._host = host
 
     async def __aenter__(self) -> "InputPanel":

--- a/src/inspect_ai/_display/textual/app.py
+++ b/src/inspect_ai/_display/textual/app.py
@@ -18,6 +18,7 @@ from inspect_ai._util.html import as_html_id
 from inspect_ai.log._samples import active_samples
 from inspect_ai.log._transcript import InputEvent, transcript
 
+from ...util._panel import InputPanel
 from ..core.config import task_config
 from ..core.display import (
     TP,
@@ -29,7 +30,6 @@ from ..core.display import (
     TaskWithResult,
 )
 from ..core.footer import task_footer
-from ..core.input import InputPanel
 from ..core.panel import task_targets, task_title, tasks_title
 from ..core.rich import record_console_input, rich_initialise, rich_theme
 from .theme import inspect_dark, inspect_light

--- a/src/inspect_ai/_display/textual/app.py
+++ b/src/inspect_ai/_display/textual/app.py
@@ -425,7 +425,10 @@ class TextualTaskScreen(TaskScreen, Generic[TR]):
             panel_widget = self.app.get_input_panel(title)
             if panel_widget is None:
                 panel_widget = panel(
-                    TaskScreenApp[TR].InputPanelHost(self.app, as_input_panel_id(title))
+                    title,
+                    TaskScreenApp[TR].InputPanelHost(
+                        self.app, as_input_panel_id(title)
+                    ),
                 )
                 await self.app.add_input_panel(title, panel_widget)
             return cast(TP, panel_widget)

--- a/src/inspect_ai/_display/textual/app.py
+++ b/src/inspect_ai/_display/textual/app.py
@@ -222,7 +222,7 @@ class TaskScreenApp(App[TR]):
         self.update_tasks()
         self.update_samples()
         self.update_footer()
-        for input_panel in self.query(".task-input-panel"):
+        for input_panel in self.query(f".{InputPanel.DEFAULT_CLASSES}"):
             cast(InputPanel, input_panel).update()
 
     # update the header title

--- a/src/inspect_ai/approval/_human/console.py
+++ b/src/inspect_ai/approval/_human/console.py
@@ -2,6 +2,7 @@ from rich.prompt import Prompt
 
 from inspect_ai._util.transcript import transcript_panel
 from inspect_ai.tool._tool_call import ToolCallView
+from inspect_ai.util._console import input_screen
 
 from .._approval import Approval, ApprovalDecision
 from .util import (
@@ -16,9 +17,7 @@ from .util import (
 def console_approval(
     message: str, view: ToolCallView, choices: list[ApprovalDecision]
 ) -> Approval:
-    from inspect_ai._display.core.active import task_screen
-
-    with task_screen().input_screen(width=None) as console:
+    with input_screen(width=None) as console:
         console.print(
             transcript_panel(
                 title="Approve Tool", content=render_tool_approval(message, view)

--- a/src/inspect_ai/approval/_human/panel.py
+++ b/src/inspect_ai/approval/_human/panel.py
@@ -9,10 +9,10 @@ from textual.reactive import reactive
 from textual.widgets import Button, Static
 from typing_extensions import override
 
-from inspect_ai._display.core.input import InputPanel
 from inspect_ai._util.registry import registry_unqualified_name
 from inspect_ai.solver._task_state import TaskState
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
+from inspect_ai.util._panel import InputPanel, input_panel
 
 from .._approval import Approval, ApprovalDecision
 from .manager import ApprovalRequest, PendingApprovalRequest, human_approval_manager
@@ -34,10 +34,8 @@ async def panel_approval(
     state: TaskState | None,
     choices: list[ApprovalDecision],
 ) -> Approval:
-    from inspect_ai._display.core.active import task_screen
-
     # ensure the approvals panel is shown
-    await task_screen().input_panel(PANEL_TITLE, ApprovalInputPanel)
+    await input_panel(PANEL_TITLE, ApprovalInputPanel)
 
     # submit to human approval manager (will be picked up by panel)
     approvals = human_approval_manager()

--- a/src/inspect_ai/approval/_human/panel.py
+++ b/src/inspect_ai/approval/_human/panel.py
@@ -88,7 +88,7 @@ class ApprovalInputPanel(InputPanel):
         self._approvals = human_approval_manager().approval_requests()
         if len(self._approvals) > 0:
             approval_id, approval_request = self._approvals[0]
-            self.set_title(f"{PANEL_TITLE} ({len(self._approvals):,})")
+            self.title = f"{PANEL_TITLE} ({len(self._approvals):,})"
             heading.request = approval_request
             content.approval = approval_request.request
             actions.approval_request = approval_id, approval_request
@@ -97,7 +97,7 @@ class ApprovalInputPanel(InputPanel):
                 actions.activate()
             self.visible = True
         else:
-            self.set_title(PANEL_TITLE)
+            self.title = PANEL_TITLE
             heading.request = None
             content.approval = None
             actions.approval_request = None

--- a/src/inspect_ai/util/_panel.py
+++ b/src/inspect_ai/util/_panel.py
@@ -12,8 +12,9 @@ class InputPanel(Container):
         def deactivate(self) -> None: ...
         def close(self) -> None: ...
 
-    def __init__(self, host: Host) -> None:
+    def __init__(self, title: str, host: Host) -> None:
         super().__init__()
+        self._title = title
         self._host = host
 
     async def __aenter__(self) -> "InputPanel":
@@ -26,7 +27,13 @@ class InputPanel(Container):
     ) -> None:
         self.close()
 
-    def set_title(self, title: str) -> None:
+    @property
+    def title(self) -> str:
+        return self._title
+
+    @title.setter
+    def title(self, title: str) -> None:
+        self._title = title
         self._host.set_title(title)
 
     def activate(self) -> None:

--- a/src/inspect_ai/util/_panel.py
+++ b/src/inspect_ai/util/_panel.py
@@ -1,4 +1,4 @@
-from typing import Any, Protocol
+from typing import Any, Protocol, TypeVar
 
 from textual.containers import Container
 
@@ -41,3 +41,28 @@ class InputPanel(Container):
     def update(self) -> None:
         """Update method (called periodically e.g. once every second)"""
         pass
+
+
+TP = TypeVar("TP", bound=InputPanel)
+
+
+async def input_panel(title: str, panel: type[TP]) -> TP:
+    """Create an input panel in the task display.
+
+    There can only be a single instance of an InputPanel with a given
+    'title' running at once. Therefore, if the panel doesn't exist it
+    is created, otherwise a reference to the existing panel is returned.
+
+    Args:
+       title (str): Input panel title.
+       panel (type[TP]): Type of panel widget (must derive from `InputPanel`)
+
+    Returns:
+       InputPanel: Instance of widget running in the task display.
+
+    Raises:
+       NotImplementedError: If Inspect is not running in display='full' model.
+    """
+    from inspect_ai._display.core.active import task_screen
+
+    return await task_screen().input_panel(title, panel)


### PR DESCRIPTION
This PR makes available a new `input_panel()` API for adding custom panels to the fullscreen display (e.g. we use this API for the new approvals UI: https://github.com/UKGovernmentBEIS/inspect_ai/pull/958