### PR TITLE
Fix issue with stale rendered tool input

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -38,104 +38,105 @@ var __publicField = (obj, key2, value) => __defNormalProp(obj, typeof key2 !== "
     fetch(link2.href, fetchOpts);
   }
 })();
-var n$2, l$1, u$1, i$2, o$1, r$2, f$1, e$3, c$2, s$1, h$1 = {}, v$1 = [], p$1 = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i, y$1 = Array.isArray;
-function d$1(n2, l2) {
+var n$2, l$1, u$1, i$2, r$2, o$1, e$3, f$1, c$2, s$1, a$1, p$1 = {}, v$1 = [], y$1 = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i, d$1 = Array.isArray;
+function w$1(n2, l2) {
   for (var u2 in l2) n2[u2] = l2[u2];
   return n2;
 }
-function w$1(n2) {
+function _(n2) {
   n2 && n2.parentNode && n2.parentNode.removeChild(n2);
 }
-function _(l2, u2, t2) {
-  var i, o2, r2, f2 = {};
-  for (r2 in u2) "key" == r2 ? i = u2[r2] : "ref" == r2 ? o2 = u2[r2] : f2[r2] = u2[r2];
-  if (arguments.length > 2 && (f2.children = arguments.length > 3 ? n$2.call(arguments, 2) : t2), "function" == typeof l2 && null != l2.defaultProps) for (r2 in l2.defaultProps) void 0 === f2[r2] && (f2[r2] = l2.defaultProps[r2]);
-  return g(l2, f2, i, o2, null);
+function g(l2, u2, t2) {
+  var i, r2, o2, e2 = {};
+  for (o2 in u2) "key" == o2 ? i = u2[o2] : "ref" == o2 ? r2 = u2[o2] : e2[o2] = u2[o2];
+  if (arguments.length > 2 && (e2.children = arguments.length > 3 ? n$2.call(arguments, 2) : t2), "function" == typeof l2 && null != l2.defaultProps) for (o2 in l2.defaultProps) void 0 === e2[o2] && (e2[o2] = l2.defaultProps[o2]);
+  return m$2(l2, e2, i, r2, null);
 }
-function g(n2, t2, i, o2, r2) {
-  var f2 = { type: n2, props: t2, key: i, ref: o2, __k: null, __: null, __b: 0, __e: null, __d: void 0, __c: null, constructor: void 0, __v: null == r2 ? ++u$1 : r2, __i: -1, __u: 0 };
-  return null == r2 && null != l$1.vnode && l$1.vnode(f2), f2;
+function m$2(n2, t2, i, r2, o2) {
+  var e2 = { type: n2, props: t2, key: i, ref: r2, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: null == o2 ? ++u$1 : o2, __i: -1, __u: 0 };
+  return null == o2 && null != l$1.vnode && l$1.vnode(e2), e2;
 }
-function m$2() {
+function b() {
   return { current: null };
 }
-function b(n2) {
+function k$1(n2) {
   return n2.children;
 }
-function k$1(n2, l2) {
+function x$1(n2, l2) {
   this.props = n2, this.context = l2;
 }
-function x$1(n2, l2) {
-  if (null == l2) return n2.__ ? x$1(n2.__, n2.__i + 1) : null;
+function C$1(n2, l2) {
+  if (null == l2) return n2.__ ? C$1(n2.__, n2.__i + 1) : null;
   for (var u2; l2 < n2.__k.length; l2++) if (null != (u2 = n2.__k[l2]) && null != u2.__e) return u2.__e;
-  return "function" == typeof n2.type ? x$1(n2) : null;
+  return "function" == typeof n2.type ? C$1(n2) : null;
 }
-function C$1(n2) {
+function S(n2) {
   var l2, u2;
   if (null != (n2 = n2.__) && null != n2.__c) {
     for (n2.__e = n2.__c.base = null, l2 = 0; l2 < n2.__k.length; l2++) if (null != (u2 = n2.__k[l2]) && null != u2.__e) {
       n2.__e = n2.__c.base = u2.__e;
       break;
     }
-    return C$1(n2);
+    return S(n2);
   }
 }
-function S(n2) {
-  (!n2.__d && (n2.__d = true) && i$2.push(n2) && !M.__r++ || o$1 !== l$1.debounceRendering) && ((o$1 = l$1.debounceRendering) || r$2)(M);
+function M(n2) {
+  (!n2.__d && (n2.__d = true) && i$2.push(n2) && !P$1.__r++ || r$2 !== l$1.debounceRendering) && ((r$2 = l$1.debounceRendering) || o$1)(P$1);
 }
-function M() {
-  var n2, u2, t2, o2, r2, e2, c2, s2;
-  for (i$2.sort(f$1); n2 = i$2.shift(); ) n2.__d && (u2 = i$2.length, o2 = void 0, e2 = (r2 = (t2 = n2).__v).__e, c2 = [], s2 = [], t2.__P && ((o2 = d$1({}, r2)).__v = r2.__v + 1, l$1.vnode && l$1.vnode(o2), O(t2.__P, o2, r2, t2.__n, t2.__P.namespaceURI, 32 & r2.__u ? [e2] : null, c2, null == e2 ? x$1(r2) : e2, !!(32 & r2.__u), s2), o2.__v = r2.__v, o2.__.__k[o2.__i] = o2, j$1(c2, o2, s2), o2.__e != e2 && C$1(o2)), i$2.length > u2 && i$2.sort(f$1));
-  M.__r = 0;
+function P$1() {
+  var n2, u2, t2, r2, o2, f2, c2, s2;
+  for (i$2.sort(e$3); n2 = i$2.shift(); ) n2.__d && (u2 = i$2.length, r2 = void 0, f2 = (o2 = (t2 = n2).__v).__e, c2 = [], s2 = [], t2.__P && ((r2 = w$1({}, o2)).__v = o2.__v + 1, l$1.vnode && l$1.vnode(r2), j$1(t2.__P, r2, o2, t2.__n, t2.__P.namespaceURI, 32 & o2.__u ? [f2] : null, c2, null == f2 ? C$1(o2) : f2, !!(32 & o2.__u), s2), r2.__v = o2.__v, r2.__.__k[r2.__i] = r2, z$1(c2, r2, s2), r2.__e != f2 && S(r2)), i$2.length > u2 && i$2.sort(e$3));
+  P$1.__r = 0;
 }
-function P$1(n2, l2, u2, t2, i, o2, r2, f2, e2, c2, s2) {
-  var a2, p2, y2, d2, w2, _2 = t2 && t2.__k || v$1, g2 = l2.length;
-  for (u2.__d = e2, $(u2, l2, _2), e2 = u2.__d, a2 = 0; a2 < g2; a2++) null != (y2 = u2.__k[a2]) && (p2 = -1 === y2.__i ? h$1 : _2[y2.__i] || h$1, y2.__i = a2, O(n2, y2, p2, i, o2, r2, f2, e2, c2, s2), d2 = y2.__e, y2.ref && p2.ref != y2.ref && (p2.ref && E(p2.ref, null, y2), s2.push(y2.ref, y2.__c || d2, y2)), null == w2 && null != d2 && (w2 = d2), 65536 & y2.__u || p2.__k === y2.__k ? e2 = I(y2, e2, n2) : "function" == typeof y2.type && void 0 !== y2.__d ? e2 = y2.__d : d2 && (e2 = d2.nextSibling), y2.__d = void 0, y2.__u &= -196609);
-  u2.__d = e2, u2.__e = w2;
+function $(n2, l2, u2, t2, i, r2, o2, e2, f2, c2, s2) {
+  var a2, h2, y2, d2, w2, _2, g2 = t2 && t2.__k || v$1, m2 = l2.length;
+  for (f2 = I(u2, l2, g2, f2), a2 = 0; a2 < m2; a2++) null != (y2 = u2.__k[a2]) && (h2 = -1 === y2.__i ? p$1 : g2[y2.__i] || p$1, y2.__i = a2, _2 = j$1(n2, y2, h2, i, r2, o2, e2, f2, c2, s2), d2 = y2.__e, y2.ref && h2.ref != y2.ref && (h2.ref && V(h2.ref, null, y2), s2.push(y2.ref, y2.__c || d2, y2)), null == w2 && null != d2 && (w2 = d2), 4 & y2.__u || h2.__k === y2.__k ? f2 = H(y2, f2, n2) : "function" == typeof y2.type && void 0 !== _2 ? f2 = _2 : d2 && (f2 = d2.nextSibling), y2.__u &= -7);
+  return u2.__e = w2, f2;
 }
-function $(n2, l2, u2) {
-  var t2, i, o2, r2, f2, e2 = l2.length, c2 = u2.length, s2 = c2, a2 = 0;
-  for (n2.__k = [], t2 = 0; t2 < e2; t2++) null != (i = l2[t2]) && "boolean" != typeof i && "function" != typeof i ? (r2 = t2 + a2, (i = n2.__k[t2] = "string" == typeof i || "number" == typeof i || "bigint" == typeof i || i.constructor == String ? g(null, i, null, null, null) : y$1(i) ? g(b, { children: i }, null, null, null) : void 0 === i.constructor && i.__b > 0 ? g(i.type, i.props, i.key, i.ref ? i.ref : null, i.__v) : i).__ = n2, i.__b = n2.__b + 1, o2 = null, -1 !== (f2 = i.__i = L(i, u2, r2, s2)) && (s2--, (o2 = u2[f2]) && (o2.__u |= 131072)), null == o2 || null === o2.__v ? (-1 == f2 && a2--, "function" != typeof i.type && (i.__u |= 65536)) : f2 !== r2 && (f2 == r2 - 1 ? a2-- : f2 == r2 + 1 ? a2++ : (f2 > r2 ? a2-- : a2++, i.__u |= 65536))) : i = n2.__k[t2] = null;
-  if (s2) for (t2 = 0; t2 < c2; t2++) null != (o2 = u2[t2]) && 0 == (131072 & o2.__u) && (o2.__e == n2.__d && (n2.__d = x$1(o2)), N(o2, o2));
+function I(n2, l2, u2, t2) {
+  var i, r2, o2, e2, f2, c2 = l2.length, s2 = u2.length, a2 = s2, h2 = 0;
+  for (n2.__k = [], i = 0; i < c2; i++) null != (r2 = l2[i]) && "boolean" != typeof r2 && "function" != typeof r2 ? (e2 = i + h2, (r2 = n2.__k[i] = "string" == typeof r2 || "number" == typeof r2 || "bigint" == typeof r2 || r2.constructor == String ? m$2(null, r2, null, null, null) : d$1(r2) ? m$2(k$1, { children: r2 }, null, null, null) : void 0 === r2.constructor && r2.__b > 0 ? m$2(r2.type, r2.props, r2.key, r2.ref ? r2.ref : null, r2.__v) : r2).__ = n2, r2.__b = n2.__b + 1, o2 = null, -1 !== (f2 = r2.__i = T$1(r2, u2, e2, a2)) && (a2--, (o2 = u2[f2]) && (o2.__u |= 2)), null == o2 || null === o2.__v ? (-1 == f2 && h2--, "function" != typeof r2.type && (r2.__u |= 4)) : f2 !== e2 && (f2 == e2 - 1 ? h2-- : f2 == e2 + 1 ? h2++ : (f2 > e2 ? h2-- : h2++, r2.__u |= 4))) : r2 = n2.__k[i] = null;
+  if (a2) for (i = 0; i < s2; i++) null != (o2 = u2[i]) && 0 == (2 & o2.__u) && (o2.__e == t2 && (t2 = C$1(o2)), q$1(o2, o2));
+  return t2;
 }
-function I(n2, l2, u2) {
+function H(n2, l2, u2) {
   var t2, i;
   if ("function" == typeof n2.type) {
-    for (t2 = n2.__k, i = 0; t2 && i < t2.length; i++) t2[i] && (t2[i].__ = n2, l2 = I(t2[i], l2, u2));
+    for (t2 = n2.__k, i = 0; t2 && i < t2.length; i++) t2[i] && (t2[i].__ = n2, l2 = H(t2[i], l2, u2));
     return l2;
   }
-  n2.__e != l2 && (l2 && n2.type && !u2.contains(l2) && (l2 = x$1(n2)), u2.insertBefore(n2.__e, l2 || null), l2 = n2.__e);
+  n2.__e != l2 && (l2 && n2.type && !u2.contains(l2) && (l2 = C$1(n2)), u2.insertBefore(n2.__e, l2 || null), l2 = n2.__e);
   do {
     l2 = l2 && l2.nextSibling;
   } while (null != l2 && 8 === l2.nodeType);
   return l2;
 }
-function L(n2, l2, u2, t2) {
-  var i = n2.key, o2 = n2.type, r2 = u2 - 1, f2 = u2 + 1, e2 = l2[u2];
-  if (null === e2 || e2 && i == e2.key && o2 === e2.type && 0 == (131072 & e2.__u)) return u2;
-  if (("function" != typeof o2 || o2 === b || i) && t2 > (null != e2 && 0 == (131072 & e2.__u) ? 1 : 0)) for (; r2 >= 0 || f2 < l2.length; ) {
-    if (r2 >= 0) {
-      if ((e2 = l2[r2]) && 0 == (131072 & e2.__u) && i == e2.key && o2 === e2.type) return r2;
-      r2--;
+function T$1(n2, l2, u2, t2) {
+  var i = n2.key, r2 = n2.type, o2 = u2 - 1, e2 = u2 + 1, f2 = l2[u2];
+  if (null === f2 || f2 && i == f2.key && r2 === f2.type && 0 == (2 & f2.__u)) return u2;
+  if (("function" != typeof r2 || r2 === k$1 || i) && t2 > (null != f2 && 0 == (2 & f2.__u) ? 1 : 0)) for (; o2 >= 0 || e2 < l2.length; ) {
+    if (o2 >= 0) {
+      if ((f2 = l2[o2]) && 0 == (2 & f2.__u) && i == f2.key && r2 === f2.type) return o2;
+      o2--;
     }
-    if (f2 < l2.length) {
-      if ((e2 = l2[f2]) && 0 == (131072 & e2.__u) && i == e2.key && o2 === e2.type) return f2;
-      f2++;
+    if (e2 < l2.length) {
+      if ((f2 = l2[e2]) && 0 == (2 & f2.__u) && i == f2.key && r2 === f2.type) return e2;
+      e2++;
     }
   }
   return -1;
 }
-function T$1(n2, l2, u2) {
-  "-" === l2[0] ? n2.setProperty(l2, null == u2 ? "" : u2) : n2[l2] = null == u2 ? "" : "number" != typeof u2 || p$1.test(l2) ? u2 : u2 + "px";
+function A$1(n2, l2, u2) {
+  "-" === l2[0] ? n2.setProperty(l2, null == u2 ? "" : u2) : n2[l2] = null == u2 ? "" : "number" != typeof u2 || y$1.test(l2) ? u2 : u2 + "px";
 }
-function A$1(n2, l2, u2, t2, i) {
-  var o2;
+function F(n2, l2, u2, t2, i) {
+  var r2;
   n: if ("style" === l2) if ("string" == typeof u2) n2.style.cssText = u2;
   else {
-    if ("string" == typeof t2 && (n2.style.cssText = t2 = ""), t2) for (l2 in t2) u2 && l2 in u2 || T$1(n2.style, l2, "");
-    if (u2) for (l2 in u2) t2 && u2[l2] === t2[l2] || T$1(n2.style, l2, u2[l2]);
+    if ("string" == typeof t2 && (n2.style.cssText = t2 = ""), t2) for (l2 in t2) u2 && l2 in u2 || A$1(n2.style, l2, "");
+    if (u2) for (l2 in u2) t2 && u2[l2] === t2[l2] || A$1(n2.style, l2, u2[l2]);
   }
-  else if ("o" === l2[0] && "n" === l2[1]) o2 = l2 !== (l2 = l2.replace(/(PointerCapture)$|Capture$/i, "$1")), l2 = l2.toLowerCase() in n2 || "onFocusOut" === l2 || "onFocusIn" === l2 ? l2.toLowerCase().slice(2) : l2.slice(2), n2.l || (n2.l = {}), n2.l[l2 + o2] = u2, u2 ? t2 ? u2.u = t2.u : (u2.u = e$3, n2.addEventListener(l2, o2 ? s$1 : c$2, o2)) : n2.removeEventListener(l2, o2 ? s$1 : c$2, o2);
+  else if ("o" === l2[0] && "n" === l2[1]) r2 = l2 !== (l2 = l2.replace(f$1, "$1")), l2 = l2.toLowerCase() in n2 || "onFocusOut" === l2 || "onFocusIn" === l2 ? l2.toLowerCase().slice(2) : l2.slice(2), n2.l || (n2.l = {}), n2.l[l2 + r2] = u2, u2 ? t2 ? u2.u = t2.u : (u2.u = c$2, n2.addEventListener(l2, r2 ? a$1 : s$1, r2)) : n2.removeEventListener(l2, r2 ? a$1 : s$1, r2);
   else {
     if ("http://www.w3.org/2000/svg" == i) l2 = l2.replace(/xlink(H|:h)/, "h").replace(/sName$/, "s");
     else if ("width" != l2 && "height" != l2 && "href" != l2 && "list" != l2 && "form" != l2 && "tabIndex" != l2 && "download" != l2 && "rowSpan" != l2 && "colSpan" != l2 && "role" != l2 && "popover" != l2 && l2 in n2) try {
@@ -146,54 +147,54 @@ function A$1(n2, l2, u2, t2, i) {
     "function" == typeof u2 || (null == u2 || false === u2 && "-" !== l2[4] ? n2.removeAttribute(l2) : n2.setAttribute(l2, "popover" == l2 && 1 == u2 ? "" : u2));
   }
 }
-function F(n2) {
+function O(n2) {
   return function(u2) {
     if (this.l) {
       var t2 = this.l[u2.type + n2];
-      if (null == u2.t) u2.t = e$3++;
+      if (null == u2.t) u2.t = c$2++;
       else if (u2.t < t2.u) return;
-      return l$1.event && (u2 = l$1.event(u2)), "handleEvent" in t2 ? t2.handleEvent(u2) : t2(u2);
+      return t2(l$1.event ? l$1.event(u2) : u2);
     }
   };
 }
-function O(n2, u2, t2, i, o2, r2, f2, e2, c2, s2) {
-  var a2, h2, v2, p2, w2, _2, g2, m2, x, C2, S2, M2, $2, I2, H, L2, T2 = u2.type;
+function j$1(n2, u2, t2, i, r2, o2, e2, f2, c2, s2) {
+  var a2, h2, p2, v2, y2, g2, m2, b2, C2, S2, M2, P2, I2, H2, L, T2, A2, F2 = u2.type;
   if (void 0 !== u2.constructor) return null;
-  128 & t2.__u && (c2 = !!(32 & t2.__u), r2 = [e2 = u2.__e = t2.__e]), (a2 = l$1.__b) && a2(u2);
-  n: if ("function" == typeof T2) try {
-    if (m2 = u2.props, x = "prototype" in T2 && T2.prototype.render, C2 = (a2 = T2.contextType) && i[a2.__c], S2 = a2 ? C2 ? C2.props.value : a2.__ : i, t2.__c ? g2 = (h2 = u2.__c = t2.__c).__ = h2.__E : (x ? u2.__c = h2 = new T2(m2, S2) : (u2.__c = h2 = new k$1(m2, S2), h2.constructor = T2, h2.render = V), C2 && C2.sub(h2), h2.props = m2, h2.state || (h2.state = {}), h2.context = S2, h2.__n = i, v2 = h2.__d = true, h2.__h = [], h2._sb = []), x && null == h2.__s && (h2.__s = h2.state), x && null != T2.getDerivedStateFromProps && (h2.__s == h2.state && (h2.__s = d$1({}, h2.__s)), d$1(h2.__s, T2.getDerivedStateFromProps(m2, h2.__s))), p2 = h2.props, w2 = h2.state, h2.__v = u2, v2) x && null == T2.getDerivedStateFromProps && null != h2.componentWillMount && h2.componentWillMount(), x && null != h2.componentDidMount && h2.__h.push(h2.componentDidMount);
+  128 & t2.__u && (c2 = !!(32 & t2.__u), o2 = [f2 = u2.__e = t2.__e]), (a2 = l$1.__b) && a2(u2);
+  n: if ("function" == typeof F2) try {
+    if (b2 = u2.props, C2 = "prototype" in F2 && F2.prototype.render, S2 = (a2 = F2.contextType) && i[a2.__c], M2 = a2 ? S2 ? S2.props.value : a2.__ : i, t2.__c ? m2 = (h2 = u2.__c = t2.__c).__ = h2.__E : (C2 ? u2.__c = h2 = new F2(b2, M2) : (u2.__c = h2 = new x$1(b2, M2), h2.constructor = F2, h2.render = B$1), S2 && S2.sub(h2), h2.props = b2, h2.state || (h2.state = {}), h2.context = M2, h2.__n = i, p2 = h2.__d = true, h2.__h = [], h2._sb = []), C2 && null == h2.__s && (h2.__s = h2.state), C2 && null != F2.getDerivedStateFromProps && (h2.__s == h2.state && (h2.__s = w$1({}, h2.__s)), w$1(h2.__s, F2.getDerivedStateFromProps(b2, h2.__s))), v2 = h2.props, y2 = h2.state, h2.__v = u2, p2) C2 && null == F2.getDerivedStateFromProps && null != h2.componentWillMount && h2.componentWillMount(), C2 && null != h2.componentDidMount && h2.__h.push(h2.componentDidMount);
     else {
-      if (x && null == T2.getDerivedStateFromProps && m2 !== p2 && null != h2.componentWillReceiveProps && h2.componentWillReceiveProps(m2, S2), !h2.__e && (null != h2.shouldComponentUpdate && false === h2.shouldComponentUpdate(m2, h2.__s, S2) || u2.__v === t2.__v)) {
-        for (u2.__v !== t2.__v && (h2.props = m2, h2.state = h2.__s, h2.__d = false), u2.__e = t2.__e, u2.__k = t2.__k, u2.__k.some(function(n3) {
+      if (C2 && null == F2.getDerivedStateFromProps && b2 !== v2 && null != h2.componentWillReceiveProps && h2.componentWillReceiveProps(b2, M2), !h2.__e && (null != h2.shouldComponentUpdate && false === h2.shouldComponentUpdate(b2, h2.__s, M2) || u2.__v === t2.__v)) {
+        for (u2.__v !== t2.__v && (h2.props = b2, h2.state = h2.__s, h2.__d = false), u2.__e = t2.__e, u2.__k = t2.__k, u2.__k.some(function(n3) {
           n3 && (n3.__ = u2);
-        }), M2 = 0; M2 < h2._sb.length; M2++) h2.__h.push(h2._sb[M2]);
-        h2._sb = [], h2.__h.length && f2.push(h2);
+        }), P2 = 0; P2 < h2._sb.length; P2++) h2.__h.push(h2._sb[P2]);
+        h2._sb = [], h2.__h.length && e2.push(h2);
         break n;
       }
-      null != h2.componentWillUpdate && h2.componentWillUpdate(m2, h2.__s, S2), x && null != h2.componentDidUpdate && h2.__h.push(function() {
-        h2.componentDidUpdate(p2, w2, _2);
+      null != h2.componentWillUpdate && h2.componentWillUpdate(b2, h2.__s, M2), C2 && null != h2.componentDidUpdate && h2.__h.push(function() {
+        h2.componentDidUpdate(v2, y2, g2);
       });
     }
-    if (h2.context = S2, h2.props = m2, h2.__P = n2, h2.__e = false, $2 = l$1.__r, I2 = 0, x) {
-      for (h2.state = h2.__s, h2.__d = false, $2 && $2(u2), a2 = h2.render(h2.props, h2.state, h2.context), H = 0; H < h2._sb.length; H++) h2.__h.push(h2._sb[H]);
+    if (h2.context = M2, h2.props = b2, h2.__P = n2, h2.__e = false, I2 = l$1.__r, H2 = 0, C2) {
+      for (h2.state = h2.__s, h2.__d = false, I2 && I2(u2), a2 = h2.render(h2.props, h2.state, h2.context), L = 0; L < h2._sb.length; L++) h2.__h.push(h2._sb[L]);
       h2._sb = [];
     } else do {
-      h2.__d = false, $2 && $2(u2), a2 = h2.render(h2.props, h2.state, h2.context), h2.state = h2.__s;
-    } while (h2.__d && ++I2 < 25);
-    h2.state = h2.__s, null != h2.getChildContext && (i = d$1(d$1({}, i), h2.getChildContext())), x && !v2 && null != h2.getSnapshotBeforeUpdate && (_2 = h2.getSnapshotBeforeUpdate(p2, w2)), P$1(n2, y$1(L2 = null != a2 && a2.type === b && null == a2.key ? a2.props.children : a2) ? L2 : [L2], u2, t2, i, o2, r2, f2, e2, c2, s2), h2.base = u2.__e, u2.__u &= -161, h2.__h.length && f2.push(h2), g2 && (h2.__E = h2.__ = null);
+      h2.__d = false, I2 && I2(u2), a2 = h2.render(h2.props, h2.state, h2.context), h2.state = h2.__s;
+    } while (h2.__d && ++H2 < 25);
+    h2.state = h2.__s, null != h2.getChildContext && (i = w$1(w$1({}, i), h2.getChildContext())), C2 && !p2 && null != h2.getSnapshotBeforeUpdate && (g2 = h2.getSnapshotBeforeUpdate(v2, y2)), f2 = $(n2, d$1(T2 = null != a2 && a2.type === k$1 && null == a2.key ? a2.props.children : a2) ? T2 : [T2], u2, t2, i, r2, o2, e2, f2, c2, s2), h2.base = u2.__e, u2.__u &= -161, h2.__h.length && e2.push(h2), m2 && (h2.__E = h2.__ = null);
   } catch (n3) {
-    if (u2.__v = null, c2 || null != r2) {
-      for (u2.__u |= c2 ? 160 : 128; e2 && 8 === e2.nodeType && e2.nextSibling; ) e2 = e2.nextSibling;
-      r2[r2.indexOf(e2)] = null, u2.__e = e2;
-    } else u2.__e = t2.__e, u2.__k = t2.__k;
+    if (u2.__v = null, c2 || null != o2) if (n3.then) {
+      for (u2.__u |= c2 ? 160 : 128; f2 && 8 === f2.nodeType && f2.nextSibling; ) f2 = f2.nextSibling;
+      o2[o2.indexOf(f2)] = null, u2.__e = f2;
+    } else for (A2 = o2.length; A2--; ) _(o2[A2]);
+    else u2.__e = t2.__e, u2.__k = t2.__k;
     l$1.__e(n3, u2, t2);
   }
-  else null == r2 && u2.__v === t2.__v ? (u2.__k = t2.__k, u2.__e = t2.__e) : u2.__e = z$1(t2.__e, u2, t2, i, o2, r2, f2, c2, s2);
-  (a2 = l$1.diffed) && a2(u2);
+  else null == o2 && u2.__v === t2.__v ? (u2.__k = t2.__k, u2.__e = t2.__e) : f2 = u2.__e = N(t2.__e, u2, t2, i, r2, o2, e2, c2, s2);
+  return (a2 = l$1.diffed) && a2(u2), 128 & u2.__u ? void 0 : f2;
 }
-function j$1(n2, u2, t2) {
-  u2.__d = void 0;
-  for (var i = 0; i < t2.length; i++) E(t2[i], t2[++i], t2[++i]);
+function z$1(n2, u2, t2) {
+  for (var i = 0; i < t2.length; i++) V(t2[i], t2[++i], t2[++i]);
   l$1.__c && l$1.__c(u2, n2), n2.some(function(u3) {
     try {
       n2 = u3.__h, u3.__h = [], n2.some(function(n3) {
@@ -204,35 +205,35 @@ function j$1(n2, u2, t2) {
     }
   });
 }
-function z$1(u2, t2, i, o2, r2, f2, e2, c2, s2) {
-  var a2, v2, p2, d2, _2, g2, m2, b2 = i.props, k2 = t2.props, C2 = t2.type;
-  if ("svg" === C2 ? r2 = "http://www.w3.org/2000/svg" : "math" === C2 ? r2 = "http://www.w3.org/1998/Math/MathML" : r2 || (r2 = "http://www.w3.org/1999/xhtml"), null != f2) {
-    for (a2 = 0; a2 < f2.length; a2++) if ((_2 = f2[a2]) && "setAttribute" in _2 == !!C2 && (C2 ? _2.localName === C2 : 3 === _2.nodeType)) {
-      u2 = _2, f2[a2] = null;
+function N(u2, t2, i, r2, o2, e2, f2, c2, s2) {
+  var a2, h2, v2, y2, w2, g2, m2, b2 = i.props, k2 = t2.props, x = t2.type;
+  if ("svg" === x ? o2 = "http://www.w3.org/2000/svg" : "math" === x ? o2 = "http://www.w3.org/1998/Math/MathML" : o2 || (o2 = "http://www.w3.org/1999/xhtml"), null != e2) {
+    for (a2 = 0; a2 < e2.length; a2++) if ((w2 = e2[a2]) && "setAttribute" in w2 == !!x && (x ? w2.localName === x : 3 === w2.nodeType)) {
+      u2 = w2, e2[a2] = null;
       break;
     }
   }
   if (null == u2) {
-    if (null === C2) return document.createTextNode(k2);
-    u2 = document.createElementNS(r2, C2, k2.is && k2), c2 && (l$1.__m && l$1.__m(t2, f2), c2 = false), f2 = null;
+    if (null === x) return document.createTextNode(k2);
+    u2 = document.createElementNS(o2, x, k2.is && k2), c2 && (l$1.__m && l$1.__m(t2, e2), c2 = false), e2 = null;
   }
-  if (null === C2) b2 === k2 || c2 && u2.data === k2 || (u2.data = k2);
+  if (null === x) b2 === k2 || c2 && u2.data === k2 || (u2.data = k2);
   else {
-    if (f2 = f2 && n$2.call(u2.childNodes), b2 = i.props || h$1, !c2 && null != f2) for (b2 = {}, a2 = 0; a2 < u2.attributes.length; a2++) b2[(_2 = u2.attributes[a2]).name] = _2.value;
-    for (a2 in b2) if (_2 = b2[a2], "children" == a2) ;
-    else if ("dangerouslySetInnerHTML" == a2) p2 = _2;
+    if (e2 = e2 && n$2.call(u2.childNodes), b2 = i.props || p$1, !c2 && null != e2) for (b2 = {}, a2 = 0; a2 < u2.attributes.length; a2++) b2[(w2 = u2.attributes[a2]).name] = w2.value;
+    for (a2 in b2) if (w2 = b2[a2], "children" == a2) ;
+    else if ("dangerouslySetInnerHTML" == a2) v2 = w2;
     else if (!(a2 in k2)) {
       if ("value" == a2 && "defaultValue" in k2 || "checked" == a2 && "defaultChecked" in k2) continue;
-      A$1(u2, a2, null, _2, r2);
+      F(u2, a2, null, w2, o2);
     }
-    for (a2 in k2) _2 = k2[a2], "children" == a2 ? d2 = _2 : "dangerouslySetInnerHTML" == a2 ? v2 = _2 : "value" == a2 ? g2 = _2 : "checked" == a2 ? m2 = _2 : c2 && "function" != typeof _2 || b2[a2] === _2 || A$1(u2, a2, _2, b2[a2], r2);
-    if (v2) c2 || p2 && (v2.__html === p2.__html || v2.__html === u2.innerHTML) || (u2.innerHTML = v2.__html), t2.__k = [];
-    else if (p2 && (u2.innerHTML = ""), P$1(u2, y$1(d2) ? d2 : [d2], t2, i, o2, "foreignObject" === C2 ? "http://www.w3.org/1999/xhtml" : r2, f2, e2, f2 ? f2[0] : i.__k && x$1(i, 0), c2, s2), null != f2) for (a2 = f2.length; a2--; ) w$1(f2[a2]);
-    c2 || (a2 = "value", "progress" === C2 && null == g2 ? u2.removeAttribute("value") : void 0 !== g2 && (g2 !== u2[a2] || "progress" === C2 && !g2 || "option" === C2 && g2 !== b2[a2]) && A$1(u2, a2, g2, b2[a2], r2), a2 = "checked", void 0 !== m2 && m2 !== u2[a2] && A$1(u2, a2, m2, b2[a2], r2));
+    for (a2 in k2) w2 = k2[a2], "children" == a2 ? y2 = w2 : "dangerouslySetInnerHTML" == a2 ? h2 = w2 : "value" == a2 ? g2 = w2 : "checked" == a2 ? m2 = w2 : c2 && "function" != typeof w2 || b2[a2] === w2 || F(u2, a2, w2, b2[a2], o2);
+    if (h2) c2 || v2 && (h2.__html === v2.__html || h2.__html === u2.innerHTML) || (u2.innerHTML = h2.__html), t2.__k = [];
+    else if (v2 && (u2.innerHTML = ""), $(u2, d$1(y2) ? y2 : [y2], t2, i, r2, "foreignObject" === x ? "http://www.w3.org/1999/xhtml" : o2, e2, f2, e2 ? e2[0] : i.__k && C$1(i, 0), c2, s2), null != e2) for (a2 = e2.length; a2--; ) _(e2[a2]);
+    c2 || (a2 = "value", "progress" === x && null == g2 ? u2.removeAttribute("value") : void 0 !== g2 && (g2 !== u2[a2] || "progress" === x && !g2 || "option" === x && g2 !== b2[a2]) && F(u2, a2, g2, b2[a2], o2), a2 = "checked", void 0 !== m2 && m2 !== u2[a2] && F(u2, a2, m2, b2[a2], o2));
   }
   return u2;
 }
-function E(n2, u2, t2) {
+function V(n2, u2, t2) {
   try {
     if ("function" == typeof n2) {
       var i = "function" == typeof n2.__u;
@@ -242,9 +243,9 @@ function E(n2, u2, t2) {
     l$1.__e(n3, t2);
   }
 }
-function N(n2, u2, t2) {
-  var i, o2;
-  if (l$1.unmount && l$1.unmount(n2), (i = n2.ref) && (i.current && i.current !== n2.__e || E(i, null, u2)), null != (i = n2.__c)) {
+function q$1(n2, u2, t2) {
+  var i, r2;
+  if (l$1.unmount && l$1.unmount(n2), (i = n2.ref) && (i.current && i.current !== n2.__e || V(i, null, u2)), null != (i = n2.__c)) {
     if (i.componentWillUnmount) try {
       i.componentWillUnmount();
     } catch (n3) {
@@ -252,31 +253,31 @@ function N(n2, u2, t2) {
     }
     i.base = i.__P = null;
   }
-  if (i = n2.__k) for (o2 = 0; o2 < i.length; o2++) i[o2] && N(i[o2], u2, t2 || "function" != typeof n2.type);
-  t2 || w$1(n2.__e), n2.__c = n2.__ = n2.__e = n2.__d = void 0;
+  if (i = n2.__k) for (r2 = 0; r2 < i.length; r2++) i[r2] && q$1(i[r2], u2, t2 || "function" != typeof n2.type);
+  t2 || _(n2.__e), n2.__c = n2.__ = n2.__e = void 0;
 }
-function V(n2, l2, u2) {
+function B$1(n2, l2, u2) {
   return this.constructor(n2, u2);
 }
-function q$1(u2, t2, i) {
-  var o2, r2, f2, e2;
-  l$1.__ && l$1.__(u2, t2), r2 = (o2 = "function" == typeof i) ? null : t2.__k, f2 = [], e2 = [], O(t2, u2 = (!o2 && i || t2).__k = _(b, null, [u2]), r2 || h$1, h$1, t2.namespaceURI, !o2 && i ? [i] : r2 ? null : t2.firstChild ? n$2.call(t2.childNodes) : null, f2, !o2 && i ? i : r2 ? r2.__e : t2.firstChild, o2, e2), j$1(f2, u2, e2);
+function D$1(u2, t2, i) {
+  var r2, o2, e2, f2;
+  t2 === document && (t2 = document.documentElement), l$1.__ && l$1.__(u2, t2), o2 = (r2 = "function" == typeof i) ? null : t2.__k, e2 = [], f2 = [], j$1(t2, u2 = (!r2 && i || t2).__k = g(k$1, null, [u2]), o2 || p$1, p$1, t2.namespaceURI, !r2 && i ? [i] : o2 ? null : t2.firstChild ? n$2.call(t2.childNodes) : null, e2, !r2 && i ? i : o2 ? o2.__e : t2.firstChild, r2, f2), z$1(e2, u2, f2);
 }
 n$2 = v$1.slice, l$1 = { __e: function(n2, l2, u2, t2) {
-  for (var i, o2, r2; l2 = l2.__; ) if ((i = l2.__c) && !i.__) try {
-    if ((o2 = i.constructor) && null != o2.getDerivedStateFromError && (i.setState(o2.getDerivedStateFromError(n2)), r2 = i.__d), null != i.componentDidCatch && (i.componentDidCatch(n2, t2 || {}), r2 = i.__d), r2) return i.__E = i;
+  for (var i, r2, o2; l2 = l2.__; ) if ((i = l2.__c) && !i.__) try {
+    if ((r2 = i.constructor) && null != r2.getDerivedStateFromError && (i.setState(r2.getDerivedStateFromError(n2)), o2 = i.__d), null != i.componentDidCatch && (i.componentDidCatch(n2, t2 || {}), o2 = i.__d), o2) return i.__E = i;
   } catch (l3) {
     n2 = l3;
   }
   throw n2;
-} }, u$1 = 0, k$1.prototype.setState = function(n2, l2) {
+} }, u$1 = 0, x$1.prototype.setState = function(n2, l2) {
   var u2;
-  u2 = null != this.__s && this.__s !== this.state ? this.__s : this.__s = d$1({}, this.state), "function" == typeof n2 && (n2 = n2(d$1({}, u2), this.props)), n2 && d$1(u2, n2), null != n2 && this.__v && (l2 && this._sb.push(l2), S(this));
-}, k$1.prototype.forceUpdate = function(n2) {
-  this.__v && (this.__e = true, n2 && this.__h.push(n2), S(this));
-}, k$1.prototype.render = b, i$2 = [], r$2 = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, f$1 = function(n2, l2) {
+  u2 = null != this.__s && this.__s !== this.state ? this.__s : this.__s = w$1({}, this.state), "function" == typeof n2 && (n2 = n2(w$1({}, u2), this.props)), n2 && w$1(u2, n2), null != n2 && this.__v && (l2 && this._sb.push(l2), M(this));
+}, x$1.prototype.forceUpdate = function(n2) {
+  this.__v && (this.__e = true, n2 && this.__h.push(n2), M(this));
+}, x$1.prototype.render = k$1, i$2 = [], o$1 = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, e$3 = function(n2, l2) {
   return n2.__v.__b - l2.__v.__b;
-}, M.__r = 0, e$3 = 0, c$2 = F(false), s$1 = F(true);
+}, P$1.__r = 0, f$1 = /(PointerCapture)$|Capture$/i, c$2 = 0, s$1 = O(false), a$1 = O(true);
 var n$1 = function(t2, s2, r2, e2) {
   var u2;
   s2[0] = 0;
@@ -298,7 +299,7 @@ function e$2(s2) {
     return p2(), h2;
   }(s2)), r2), arguments, [])).length > 1 ? r2 : r2[0];
 }
-var m$1 = e$2.bind(_);
+var m$1 = e$2.bind(g);
 var commonjsGlobal = typeof globalThis !== "undefined" ? globalThis : typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : {};
 function getDefaultExportFromCjs(x) {
   return x && x.__esModule && Object.prototype.hasOwnProperty.call(x, "default") ? x["default"] : x;
@@ -2297,9 +2298,9 @@ var clipboard = { exports: {} };
           279: (
             /***/
             function(module2) {
-              function E2() {
+              function E() {
               }
-              E2.prototype = {
+              E.prototype = {
                 on: function(name, callback, ctx) {
                   var e2 = this.e || (this.e = {});
                   (e2[name] || (e2[name] = [])).push({
@@ -2341,8 +2342,8 @@ var clipboard = { exports: {} };
                   return this;
                 }
               };
-              module2.exports = E2;
-              module2.exports.TinyEmitter = E2;
+              module2.exports = E;
+              module2.exports.TinyEmitter = E;
             }
           )
           /******/
@@ -7951,7 +7952,7 @@ const ErrorPanel = ({ id, classes, title, error: error2 }) => {
     </div>
   `;
 };
-class AppErrorBoundary extends k$1 {
+class AppErrorBoundary extends x$1 {
   constructor(props) {
     super(props);
     this.state = { hasError: false };
@@ -8614,7 +8615,7 @@ const ToolButton = ({ name, classes, icon, onclick, ...rest }) => {
     ...rest
   };
   const iconEl = icon ? m$1`<i class="${icon}" style=${{ marginRight: "0.5em" }}></i>` : "";
-  return _("button", attr, m$1`${iconEl}${name}`);
+  return g("button", attr, m$1`${iconEl}${name}`);
 };
 const ghCommitUrl = (origin, commit) => {
   const baseUrl = origin.replace(/\.git$/, "");
@@ -14726,6 +14727,87 @@ function unescapeCodeHtmlEntities(str) {
     }
   );
 }
+var murmurhash$1 = { exports: {} };
+(function(module) {
+  (function() {
+    const createBuffer = (val) => new TextEncoder().encode(val);
+    function MurmurHashV2(str, seed) {
+      if (typeof str === "string") str = createBuffer(str);
+      let l2 = str.length, h2 = seed ^ l2, i = 0, k2;
+      while (l2 >= 4) {
+        k2 = str[i] & 255 | (str[++i] & 255) << 8 | (str[++i] & 255) << 16 | (str[++i] & 255) << 24;
+        k2 = (k2 & 65535) * 1540483477 + (((k2 >>> 16) * 1540483477 & 65535) << 16);
+        k2 ^= k2 >>> 24;
+        k2 = (k2 & 65535) * 1540483477 + (((k2 >>> 16) * 1540483477 & 65535) << 16);
+        h2 = (h2 & 65535) * 1540483477 + (((h2 >>> 16) * 1540483477 & 65535) << 16) ^ k2;
+        l2 -= 4;
+        ++i;
+      }
+      switch (l2) {
+        case 3:
+          h2 ^= (str[i + 2] & 255) << 16;
+        case 2:
+          h2 ^= (str[i + 1] & 255) << 8;
+        case 1:
+          h2 ^= str[i] & 255;
+          h2 = (h2 & 65535) * 1540483477 + (((h2 >>> 16) * 1540483477 & 65535) << 16);
+      }
+      h2 ^= h2 >>> 13;
+      h2 = (h2 & 65535) * 1540483477 + (((h2 >>> 16) * 1540483477 & 65535) << 16);
+      h2 ^= h2 >>> 15;
+      return h2 >>> 0;
+    }
+    function MurmurHashV3(key2, seed) {
+      if (typeof key2 === "string") key2 = createBuffer(key2);
+      let remainder, bytes, h1, h1b, c1, c2, k1, i;
+      remainder = key2.length & 3;
+      bytes = key2.length - remainder;
+      h1 = seed;
+      c1 = 3432918353;
+      c2 = 461845907;
+      i = 0;
+      while (i < bytes) {
+        k1 = key2[i] & 255 | (key2[++i] & 255) << 8 | (key2[++i] & 255) << 16 | (key2[++i] & 255) << 24;
+        ++i;
+        k1 = (k1 & 65535) * c1 + (((k1 >>> 16) * c1 & 65535) << 16) & 4294967295;
+        k1 = k1 << 15 | k1 >>> 17;
+        k1 = (k1 & 65535) * c2 + (((k1 >>> 16) * c2 & 65535) << 16) & 4294967295;
+        h1 ^= k1;
+        h1 = h1 << 13 | h1 >>> 19;
+        h1b = (h1 & 65535) * 5 + (((h1 >>> 16) * 5 & 65535) << 16) & 4294967295;
+        h1 = (h1b & 65535) + 27492 + (((h1b >>> 16) + 58964 & 65535) << 16);
+      }
+      k1 = 0;
+      switch (remainder) {
+        case 3:
+          k1 ^= (key2[i + 2] & 255) << 16;
+        case 2:
+          k1 ^= (key2[i + 1] & 255) << 8;
+        case 1:
+          k1 ^= key2[i] & 255;
+          k1 = (k1 & 65535) * c1 + (((k1 >>> 16) * c1 & 65535) << 16) & 4294967295;
+          k1 = k1 << 15 | k1 >>> 17;
+          k1 = (k1 & 65535) * c2 + (((k1 >>> 16) * c2 & 65535) << 16) & 4294967295;
+          h1 ^= k1;
+      }
+      h1 ^= key2.length;
+      h1 ^= h1 >>> 16;
+      h1 = (h1 & 65535) * 2246822507 + (((h1 >>> 16) * 2246822507 & 65535) << 16) & 4294967295;
+      h1 ^= h1 >>> 13;
+      h1 = (h1 & 65535) * 3266489909 + (((h1 >>> 16) * 3266489909 & 65535) << 16) & 4294967295;
+      h1 ^= h1 >>> 16;
+      return h1 >>> 0;
+    }
+    const murmur = MurmurHashV3;
+    murmur.v2 = MurmurHashV2;
+    murmur.v3 = MurmurHashV3;
+    {
+      module.exports = murmur;
+    }
+  })();
+})(murmurhash$1);
+var murmurhashExports = murmurhash$1.exports;
+const murmurhash = /* @__PURE__ */ getDefaultExportFromCjs(murmurhashExports);
 Prism.languages.python = {
   "comment": {
     pattern: /(^|[^\\])#.*/,
@@ -15241,6 +15323,8 @@ const ToolInput = ({ type, contents, view, style }) => {
         Prism$1.highlightElement(toolInputRef.current);
       }
     }, [contents, type, view]);
+    contents = typeof contents === "object" || Array.isArray(contents) ? JSON.stringify(contents) : contents;
+    const key2 = murmurhash.v3(contents);
     return m$1`<pre
       class="tool-output"
       style=${{
@@ -15251,12 +15335,12 @@ const ToolInput = ({ type, contents, view, style }) => {
     }}
     >
         <code ref=${toolInputRef} 
-          key=${contents}
+          key=${key2}
           class="sourceCode${type ? ` language-${type}` : ""}" style=${{
       overflowWrap: "anywhere",
       whiteSpace: "pre-wrap"
     }}>
-          ${typeof contents === "object" || Array.isArray(contents) ? JSON.stringify(contents) : contents}
+          ${contents}
           </code>
       </pre>`;
   }
@@ -20370,7 +20454,7 @@ const SampleDialog = ({
 };
 const STYLE_INNER = "position:relative; overflow:hidden; width:100%; min-height:100%;";
 const STYLE_CONTENT = "position:absolute; top:0; left:0; height:100%; width:100%; overflow:visible;";
-class VirtualList extends k$1 {
+class VirtualList extends x$1 {
   constructor(props) {
     super(props);
     this.state = {
@@ -20379,7 +20463,7 @@ class VirtualList extends k$1 {
     };
     this.resize = this.resize.bind(this);
     this.handleScroll = throttle(this.handleScroll.bind(this), 100);
-    this.containerRef = m$2();
+    this.containerRef = b();
   }
   resize() {
     if (this.state.height !== this.base.offsetHeight) {
@@ -26545,7 +26629,7 @@ let initialState = void 0;
 if (vscode) {
   initialState = vscode.getState();
 }
-q$1(m$1`<${App}
+D$1(m$1`<${App}
     api=${api}
     initialState=${initialState}
     saveInitialState=${throttle((state) => {

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -15224,7 +15224,7 @@ const ToolInput = ({ type, contents, view, style }) => {
           }
         }
       }
-    }, [toolInputRef.current]);
+    }, [contents, view, style]);
     return m$1`<${MarkdownDiv}
       markdown=${view.content}
       ref=${toolInputRef}
@@ -15238,14 +15238,9 @@ const ToolInput = ({ type, contents, view, style }) => {
     y(() => {
       const tokens = Prism$1.languages[type];
       if (toolInputRef.current && tokens) {
-        let resolvedContents = contents;
-        if (typeof contents === "object" || Array.isArray(contents)) {
-          resolvedContents = JSON.stringify(contents);
-        }
-        const html = Prism$1.highlight(resolvedContents, tokens, type);
-        toolInputRef.current.innerHTML = html;
+        Prism$1.highlightElement(toolInputRef.current);
       }
-    }, [toolInputRef.current, contents, type, view]);
+    }, [contents, type, view]);
     return m$1`<pre
       class="tool-output"
       style=${{
@@ -15255,11 +15250,13 @@ const ToolInput = ({ type, contents, view, style }) => {
       ...style
     }}
     >
-        <code ref=${toolInputRef} class="sourceCode${type ? ` language-${type}` : ""}" style=${{
+        <code ref=${toolInputRef} 
+          key=${contents}
+          class="sourceCode${type ? ` language-${type}` : ""}" style=${{
       overflowWrap: "anywhere",
       whiteSpace: "pre-wrap"
     }}>
-          ${contents}
+          ${typeof contents === "object" || Array.isArray(contents) ? JSON.stringify(contents) : contents}
           </code>
       </pre>`;
   }

--- a/src/inspect_ai/_view/www/package.json
+++ b/src/inspect_ai/_view/www/package.json
@@ -36,6 +36,7 @@
     "json5": "^2.2.3",
     "jsondiffpatch": "^0.6.0",
     "markdown-it": "^14.1.0",
+    "murmurhash": "^2.0.1",
     "postcss-url": "^10.1.3",
     "preact": "^10.24.3",
     "prismjs": "^1.29.0"

--- a/src/inspect_ai/_view/www/src/components/Tools.mjs
+++ b/src/inspect_ai/_view/www/src/components/Tools.mjs
@@ -133,7 +133,7 @@ export const ToolInput = ({ type, contents, view, style }) => {
           }
         }
       }
-    }, [toolInputRef.current]);
+    }, [contents, view, style]);
     return html`<${MarkdownDiv}
       markdown=${view.content}
       ref=${toolInputRef}
@@ -144,14 +144,9 @@ export const ToolInput = ({ type, contents, view, style }) => {
     useEffect(() => {
       const tokens = Prism.languages[type];
       if (toolInputRef.current && tokens) {
-        let resolvedContents = contents;
-        if (typeof contents === "object" || Array.isArray(contents)) {
-          resolvedContents = JSON.stringify(contents);
-        }
-        const html = Prism.highlight(resolvedContents, tokens, type);
-        toolInputRef.current.innerHTML = html;
+        Prism.highlightElement(toolInputRef.current);
       }
-    }, [toolInputRef.current, contents, type, view]);
+    }, [contents, type, view]);
 
     return html`<pre
       class="tool-output"
@@ -162,13 +157,15 @@ export const ToolInput = ({ type, contents, view, style }) => {
         ...style,
       }}
     >
-        <code ref=${toolInputRef} class="sourceCode${type
-      ? ` language-${type}`
-      : ""}" style=${{
+        <code ref=${toolInputRef} 
+          key=${contents}
+          class="sourceCode${type ? ` language-${type}` : ""}" style=${{
       overflowWrap: "anywhere",
       whiteSpace: "pre-wrap",
     }}>
-          ${contents}
+          ${typeof contents === "object" || Array.isArray(contents)
+      ? JSON.stringify(contents)
+      : contents}
           </code>
       </pre>`;
   }

--- a/src/inspect_ai/_view/www/src/components/Tools.mjs
+++ b/src/inspect_ai/_view/www/src/components/Tools.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 /// <reference path="../types/prism.d.ts" />
 import Prism from "prismjs";
+import murmurhash from "murmurhash";
+
 import "prismjs/components/prism-python";
 import "prismjs/components/prism-bash";
 import "prismjs/components/prism-json";
@@ -148,6 +150,12 @@ export const ToolInput = ({ type, contents, view, style }) => {
       }
     }, [contents, type, view]);
 
+    contents =
+      typeof contents === "object" || Array.isArray(contents)
+        ? JSON.stringify(contents)
+        : contents;
+    const key = murmurhash.v3(contents);
+
     return html`<pre
       class="tool-output"
       style=${{
@@ -158,14 +166,12 @@ export const ToolInput = ({ type, contents, view, style }) => {
       }}
     >
         <code ref=${toolInputRef} 
-          key=${contents}
+          key=${key}
           class="sourceCode${type ? ` language-${type}` : ""}" style=${{
       overflowWrap: "anywhere",
       whiteSpace: "pre-wrap",
     }}>
-          ${typeof contents === "object" || Array.isArray(contents)
-      ? JSON.stringify(contents)
-      : contents}
+          ${contents}
           </code>
       </pre>`;
   }

--- a/src/inspect_ai/_view/www/yarn.lock
+++ b/src/inspect_ai/_view/www/yarn.lock
@@ -1120,6 +1120,11 @@ ms@2.1.2:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
 
+murmurhash@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/murmurhash/-/murmurhash-2.0.1.tgz#4097720e08cf978872194ad84ea5be2dec9b610f"
+  integrity sha512-5vQEh3y+DG/lMPM0mCGPDnyV8chYg/g7rl6v3Gd8WMF9S429ox3Xk8qrk174kWhG767KQMqqxLD1WnGd77hiew==
+
 nanoid@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
@@ -1202,10 +1207,10 @@ postcss@^8.4.40:
     picocolors "^1.0.1"
     source-map-js "^1.2.0"
 
-preact@^10.24.0:
-  version "10.24.2"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.24.2.tgz#42179771d3b06e7adb884e3f8127ddd3d99b78f6"
-  integrity sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==
+preact@^10.24.3:
+  version "10.25.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.25.1.tgz#1c4b84253c42dee874bfbf6a92bdce45e3662665"
+  integrity sha512-frxeZV2vhQSohQwJ7FvlqC40ze89+8friponWUFeVEkaCfhC6Eu4V0iND5C9CXz8JLndV07QRDeXzH1+Anz5Og==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
When transition from a prism highlighted tool input to a non highlighted input (if both appear in identical positions in the overall DOM tree), the stale content would still be rendered. This is addressed by adding a key to the code element itself, which will ensure that input is remounted when the contents change (which is currently not happening since the contents are being mutated ‘behind the back’ of react by prism.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
