### PR TITLE
Raise error for duplicate sample ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Task display: Show all task scores in realtime (expand task progress to see scores).
 - Task display: Show completed samples and align progress more closely to completed samples (as opposed to steps).
 - Task display: Show sample messages/tokens used (plus limits if specified).
+- Datasets: Validate that all IDs in datasets are unique (as several downstream problems occur w/ duplicate IDs).
 - Inspect View: Fix issue with incorrectly displayed custom tool views.
 - Human approval: Use fullcreen display (makes approval UI async and enables rapid processing of approvals via the `Enter` key).
 - Added `input_panel()` API for adding custom panels to the fullscreen task display.

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -12,9 +12,10 @@ from inspect_ai._display.core.active import (
     init_task_screen,
 )
 from inspect_ai._display.core.display import TaskSpec
-from inspect_ai._util.error import exception_message
+from inspect_ai._util.error import PrerequisiteError, exception_message
 from inspect_ai._util.path import chdir
 from inspect_ai._util.registry import registry_unqualified_name
+from inspect_ai.dataset._dataset import Dataset
 from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._recorders import Recorder
 from inspect_ai.model import GenerateConfigArgs
@@ -149,6 +150,9 @@ async def eval_run(
                 for id, sample in enumerate(task.dataset):
                     if sample.id is None:
                         sample.id = id + 1
+
+                # Ensure sample ids are unique
+                # ensure_unique_ids(task.dataset)
 
                 # create and track the logger
                 logger = TaskLogger(
@@ -385,3 +389,24 @@ def task_specs(tasks: list[TaskRunOptions]) -> list[TaskSpec]:
         TaskSpec(registry_unqualified_name(task.task.name), ModelName(task.model))
         for task in tasks
     ]
+
+
+def ensure_unique_ids(dataset: Dataset) -> None:
+    """
+    Validates that all samples in the dataset have unique IDs.
+
+    Raises a error if duplicates are found.
+
+    Args:
+        dataset (Datatset): The dataset
+
+    Raises:
+        PrerequisiteError: If duplicate IDs are found in the dataset.
+    """
+    seen_ids = set()
+    for sample in dataset:
+        if sample.id in seen_ids:
+            raise PrerequisiteError(
+                f"The dataset contains duplicate sample ids (duplicate id: {sample.id}). Please ensure each sample has a unique id."
+            )
+        seen_ids.add(sample.id)

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -151,9 +151,6 @@ async def eval_run(
                     if sample.id is None:
                         sample.id = id + 1
 
-                # Ensure sample ids are unique
-                # ensure_unique_ids(task.dataset)
-
                 # create and track the logger
                 logger = TaskLogger(
                     task_name=task.name,

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -151,6 +151,9 @@ async def eval_run(
                     if sample.id is None:
                         sample.id = id + 1
 
+                # Ensure sample ids are unique
+                ensure_unique_ids(task.dataset)
+
                 # create and track the logger
                 logger = TaskLogger(
                     task_name=task.name,

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -756,7 +756,6 @@ async def resolve_dataset(
     # TODO: Test with new UI - does error just appear before UI
     # TODO: check eval set behavior
     # TODO: pass 2 evals command line, second eval has error (UI experience should be good for second eval)
-    ensure_unique_ids(dataset)
 
     # apply limit to dataset
     dataset = slice_dataset(dataset, limit)
@@ -876,24 +875,3 @@ def create_sample_semaphore(
 
     # return the semaphore
     return asyncio.Semaphore(max_samples)
-
-
-def ensure_unique_ids(dataset: Dataset) -> None:
-    """
-    Validates that all samples in the dataset have unique IDs.
-
-    Raises a error if duplicates are found.
-
-    Args:
-        dataset (Datatset): The dataset
-
-    Raises:
-        PrerequisiteError: If duplicate IDs are found in the dataset.
-    """
-    seen_ids = set()
-    for sample in dataset:
-        if sample.id in seen_ids:
-            raise PrerequisiteError(
-                f"The dataset contains duplicate sample ids (duplicate id: {sample.id}). Please ensure each sample has a unique id."
-            )
-        seen_ids.add(sample.id)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -24,7 +24,7 @@ from inspect_ai._util.constants import (
     SAMPLE_SUBTASK,
 )
 from inspect_ai._util.datetime import iso_now
-from inspect_ai._util.error import PrerequisiteError, exception_message
+from inspect_ai._util.error import exception_message
 from inspect_ai._util.hooks import send_telemetry
 from inspect_ai._util.registry import (
     is_registry_object,
@@ -752,11 +752,6 @@ async def resolve_dataset(
     message_limit: int | None,
     token_limit: int | None,
 ) -> tuple[Dataset, list[Sample], list[TaskState]]:
-    # TODO: throw prerequisite error for duplicate samples ids
-    # TODO: Test with new UI - does error just appear before UI
-    # TODO: check eval set behavior
-    # TODO: pass 2 evals command line, second eval has error (UI experience should be good for second eval)
-
     # apply limit to dataset
     dataset = slice_dataset(dataset, limit)
 

--- a/tests/test_run_dir/task2/task2.py
+++ b/tests/test_run_dir/task2/task2.py
@@ -9,7 +9,9 @@ from inspect_ai.solver import generate
 @task
 def task2():
     return Task(
-        dataset=[Sample(input="What is 1+1?", target="2")] * 10,
+        dataset=[
+            Sample(id=id, input="What is 1+1?", target="2") for id in range(0, 10)
+        ],
         solver=[file_check("task2.py"), generate()],
         scorer=includes(),
         metadata={"task_idx": 2},


### PR DESCRIPTION
The system requires unique sample ids (for example, it is used when naming sample data files in the eval log format).

Fixes #972

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
