### PR TITLE
use_tools append

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Tools: Improved typing/schema support (unions, optional params, enums).
+- Tools: Added `append` argument to `use_tools()` for adding (rather than replacing) the currently available tools.
 - Docker sandbox: Streamed reads of stderr/stdout (enabling us to enforce output limits for read_file and exec at the source).
 - Sandbox API: Enable passing `BaseModel` types for sandbox `config` (formerly only a file path could be passed).
 - Task display: Show completed samples and align progress more closely to completed samples (as opposed to steps).

--- a/src/inspect_ai/solver/_use_tools.py
+++ b/src/inspect_ai/solver/_use_tools.py
@@ -9,6 +9,7 @@ from ._task_state import TaskState
 def use_tools(
     *tools: Tool | list[Tool],
     tool_choice: ToolChoice | None = "auto",
+    append: bool = False,
 ) -> Solver:
     """
     Inject tools into the task state to be used in generate().
@@ -20,6 +21,9 @@ def use_tools(
         tool_choice (ToolChoice | None): Directive indicating which
           tools the model should use. If `None` is passed, then no
           change to `tool_choice` is made.
+        append (bool): If `True`, then the passed-in tools are appended
+            to the existing tools; otherwise any existing tools are
+            replaced (the default)
 
     Returns:
         A solver that injects the tools and tool_choice into the task state.
@@ -42,7 +46,11 @@ def use_tools(
             else:
                 add_tool(tool)
         if len(tools_update) > 0:
-            state.tools = tools_update
+            if append:
+                existing_tools = state.tools
+                state.tools = existing_tools + tools_update
+            else:
+                state.tools = tools_update
 
         # set tool choice if specified
         if tool_choice is not None:

--- a/tests/tools/test_use_tools.py
+++ b/tests/tools/test_use_tools.py
@@ -10,16 +10,16 @@ from inspect_ai.solver import TaskState, use_tools
 
 
 def null_generate(
-        state: TaskState,
-        tool_calls: Literal["loop", "single", "none"] = "loop",
-        cache: bool | CachePolicy = False,
-        **kwargs: Unpack[GenerateConfigArgs],
-    ) -> TaskState:
-        return state
+    state: TaskState,
+    tool_calls: Literal["loop", "single", "none"] = "loop",
+    cache: bool | CachePolicy = False,
+    **kwargs: Unpack[GenerateConfigArgs],
+) -> TaskState:
+    return state
+
 
 @pytest.mark.asyncio
 async def test_use_tools():
-
     state = simple_task_state()
 
     addition_tool = addition()
@@ -44,9 +44,9 @@ async def test_use_tools():
     assert state.tools == [addition_tool]
     assert state.tool_choice == "auto"
 
+
 @pytest.mark.asyncio
 async def test_use_tools_append():
-
     state = simple_task_state()
 
     addition_tool = addition()
@@ -56,8 +56,10 @@ async def test_use_tools_append():
     state = await (use_tools([addition_tool, read_file_tool]))(state, null_generate)
     assert state.tools == [addition_tool, read_file_tool]
 
-    state = await (use_tools([list_files_tool]))(state, null_generate)
+    # append to the tools
+    state = await (use_tools([list_files_tool], append=True))(state, null_generate)
     assert state.tools == [addition_tool, read_file_tool, list_files_tool]
 
-    state = await (use_tools([addition_tool, read_file_tool]))(state, null_generate)
-    assert state.tools == [addition_tool, read_file_tool]
+    # now replace the tools
+    state = await (use_tools([addition_tool]))(state, null_generate)
+    assert state.tools == [addition_tool]

--- a/tests/tools/test_use_tools.py
+++ b/tests/tools/test_use_tools.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 import pytest
-from test_helpers.tools import addition, read_file
+from test_helpers.tools import addition, list_files, read_file
 from test_helpers.utils import simple_task_state
 from typing_extensions import Unpack
 
@@ -9,9 +9,7 @@ from inspect_ai.model import CachePolicy, GenerateConfigArgs
 from inspect_ai.solver import TaskState, use_tools
 
 
-@pytest.mark.asyncio
-async def test_use_tools():
-    def generate(
+def null_generate(
         state: TaskState,
         tool_calls: Literal["loop", "single", "none"] = "loop",
         cache: bool | CachePolicy = False,
@@ -19,26 +17,47 @@ async def test_use_tools():
     ) -> TaskState:
         return state
 
+@pytest.mark.asyncio
+async def test_use_tools():
+
     state = simple_task_state()
 
     addition_tool = addition()
     read_file_tool = read_file()
 
-    state = await (use_tools([addition_tool, read_file_tool]))(state, generate)
+    state = await (use_tools([addition_tool, read_file_tool]))(state, null_generate)
     assert state.tools == [addition_tool, read_file_tool]
 
-    state = await (use_tools([addition_tool, read_file_tool]))(state, generate)
+    state = await (use_tools([addition_tool, read_file_tool]))(state, null_generate)
     assert state.tools == [addition_tool, read_file_tool]
 
-    state = await (use_tools(addition_tool, read_file_tool))(state, generate)
+    state = await (use_tools(addition_tool, read_file_tool))(state, null_generate)
     assert state.tools == [addition_tool, read_file_tool]
 
-    state = await (use_tools([addition_tool]))(state, generate)
+    state = await (use_tools([addition_tool]))(state, null_generate)
     assert state.tools == [addition_tool]
 
-    state = await (use_tools(addition_tool))(state, generate)
+    state = await (use_tools(addition_tool))(state, null_generate)
     assert state.tools == [addition_tool]
 
-    state = await (use_tools(tool_choice="auto"))(state, generate)
+    state = await (use_tools(tool_choice="auto"))(state, null_generate)
     assert state.tools == [addition_tool]
     assert state.tool_choice == "auto"
+
+@pytest.mark.asyncio
+async def test_use_tools_append():
+
+    state = simple_task_state()
+
+    addition_tool = addition()
+    read_file_tool = read_file()
+    list_files_tool = list_files()
+
+    state = await (use_tools([addition_tool, read_file_tool]))(state, null_generate)
+    assert state.tools == [addition_tool, read_file_tool]
+
+    state = await (use_tools([list_files_tool]))(state, null_generate)
+    assert state.tools == [addition_tool, read_file_tool, list_files_tool]
+
+    state = await (use_tools([addition_tool, read_file_tool]))(state, null_generate)
+    assert state.tools == [addition_tool, read_file_tool]


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

use_tools always replaces the existing tools, so you can't for example chain it

### What is the new behavior?

There's a new optional parameter `append` (defaults to false) to allow you to append instead of replacing

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

Prior discussion https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1733830171419849
