### PR TITLE
Allow tool parameters to be optional

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -17285,8 +17285,9 @@ const RenderableChangeTypes = [
 ];
 const Tools = ({ toolDefinitions }) => {
   return toolDefinitions.map((toolDefinition) => {
+    var _a2;
     const toolName = toolDefinition.name;
-    const toolArgs = Object.keys(toolDefinition.parameters.properties);
+    const toolArgs = ((_a2 = toolDefinition.parameters) == null ? void 0 : _a2.properties) ? Object.keys(toolDefinition.parameters.properties) : [];
     return m$1`<${Tool} toolName=${toolName} toolArgs=${toolArgs} />`;
   });
 };

--- a/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventRenderers.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventRenderers.mjs
@@ -154,7 +154,7 @@ export const RenderableChangeTypes = [
  * @typedef {Object} ToolDefinition
  * @property {string} name - The name of the tool (e.g., "python").
  * @property {string} description - A brief description of what the tool does.
- * @property {ToolParameters} parameters - An object describing the parameters that the tool accepts.
+ * @property {ToolParameters} [parameters] - An object describing the parameters that the tool accepts.
  */
 
 /**
@@ -168,7 +168,9 @@ export const RenderableChangeTypes = [
 export const Tools = ({ toolDefinitions }) => {
   return toolDefinitions.map((toolDefinition) => {
     const toolName = toolDefinition.name;
-    const toolArgs = Object.keys(toolDefinition.parameters.properties);
+    const toolArgs = toolDefinition.parameters?.properties
+      ? Object.keys(toolDefinition.parameters.properties)
+      : [];
     return html`<${Tool} toolName=${toolName} toolArgs=${toolArgs} />`;
   });
 };


### PR DESCRIPTION
In some cases (particularly when rendering tools out of state changes)

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
