### PR TITLE
Factor EvalDescriptor out of SamplesDescriptor, improve JSDoc type annotations and more

### DIFF
--- a/src/inspect_ai/_view/www/.prettierrc.js
+++ b/src/inspect_ai/_view/www/.prettierrc.js
@@ -1,0 +1,12 @@
+// Do not remove this file even if the config is empty!
+// VSCode's "Format Document" will respect this config and use the default
+// settings, which is what we want. Without prettierrc, VSCode falls back to
+// users settings, which could be different.
+
+/**
+ * @see https://prettier.io/docs/en/configuration.html
+ * @type {import("prettier").Config}
+ */
+const config = {};
+
+export default config;

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -8499,7 +8499,10 @@ var require_assets = __commonJS({
       children: children2
     }) => {
       const tabContentsId = computeTabContentsId(id, index);
-      const tabContentsRef = A();
+      const tabContentsRef = A(
+        /** @type {HTMLElement|null} */
+        null
+      );
       y(() => {
         setTimeout(() => {
           if (scrollPosition !== void 0 && tabContentsRef.current && tabContentsRef.current.scrollTop !== scrollPosition) {
@@ -15138,8 +15141,14 @@ var require_assets = __commonJS({
     }) => {
       const [collapsed, setCollapsed] = h(collapse);
       const [showToggle, setShowToggle] = h(false);
-      const contentsRef = A();
-      const observerRef = A();
+      const contentsRef = A(
+        /** @type {HTMLElement|null} */
+        null
+      );
+      const observerRef = A(
+        /** @type {IntersectionObserver|null} */
+        null
+      );
       y(() => {
         setCollapsed(collapse);
       }, [children2, collapse]);
@@ -15313,7 +15322,7 @@ var require_assets = __commonJS({
       }
       if (view) {
         const toolInputRef = A(
-          /** @type {HTMLElement|null} */
+          /** @type {import("preact").Component & { base: Element }} */
           null
         );
         y(() => {
@@ -16531,7 +16540,10 @@ ${entry.value}</pre
         setWarningHidden
       } = props;
       const modalFooter = footer ? m$1`<div class="modal-footer">${footer}</div>` : "";
-      const scrollRef = A();
+      const scrollRef = A(
+        /** @type {HTMLElement|null} */
+        null
+      );
       y(() => {
         if (scrollRef.current) {
           setTimeout(() => {
@@ -25640,26 +25652,26 @@ ${events}
     class VirtualList extends x$1 {
       constructor(props) {
         super(props);
+        /** @type {HTMLElement} */
+        __publicField(this, "base");
         this.state = {
           height: 0,
           offset: 0
         };
-        this.resize = this.resize.bind(this);
-        this.handleScroll = throttle$1(this.handleScroll.bind(this), 100);
+        this.resize = () => {
+          if (this.state.height !== this.base.offsetHeight) {
+            this.setState({ height: this.base.offsetHeight });
+          }
+        };
+        this.handleScroll = throttle$1(() => {
+          if (this.base) {
+            this.setState({ offset: this.base.scrollTop });
+          }
+          if (this.props.sync) {
+            this.forceUpdate();
+          }
+        }, 100);
         this.containerRef = b();
-      }
-      resize() {
-        if (this.state.height !== this.base.offsetHeight) {
-          this.setState({ height: this.base.offsetHeight });
-        }
-      }
-      handleScroll() {
-        if (this.base) {
-          this.setState({ offset: this.base.scrollTop });
-        }
-        if (this.props.sync) {
-          this.forceUpdate();
-        }
       }
       componentDidUpdate() {
         this.resize();
@@ -28418,7 +28430,8 @@ self.onmessage = function (e) {
               };
             });
             return Promise.resolve({
-              files: logs
+              files: logs,
+              log_dir
             });
           } else if (log_file) {
             let evalLog = cache.get();
@@ -28433,7 +28446,8 @@ self.onmessage = function (e) {
               task_id: evalLog.eval.task_id
             };
             return {
-              files: [result]
+              files: [result],
+              log_dir
             };
           } else {
             throw new Error(
@@ -29879,7 +29893,8 @@ self.onmessage = function (e) {
         ...TextStyle.secondary
       }}
       >
-        ${metric.reducer}
+        ${// @ts-expect-error
+      metric.reducer}
       </div>` : "";
       return m$1`<div style=${{ paddingLeft: isFirst ? "0" : "1em" }}>
     <div
@@ -30364,7 +30379,10 @@ self.onmessage = function (e) {
       }
     };
     const FindBand = ({ hideBand }) => {
-      const searchBoxRef = A();
+      const searchBoxRef = A(
+        /** @type {HTMLInputElement|null} */
+        null
+      );
       y(() => {
         searchBoxRef.current.focus();
       }, []);
@@ -30384,13 +30402,16 @@ self.onmessage = function (e) {
           }
           return expandablePanelEl;
         };
-        const focusedElement = document.activeElement;
+        const focusedElement = (
+          /** @type {HTMLElement} */
+          document.activeElement
+        );
         const result = window.find(term, false, !!back, false, false, true, false);
         const noResultEl = window.document.getElementById(
           "inspect-find-no-results"
         );
         if (result) {
-          noResultEl.style.opacity = 0;
+          noResultEl.style.opacity = "0";
           const selection = window.getSelection();
           if (selection.rangeCount > 0) {
             const parentPanel = parentExpandablePanel(selection);
@@ -30411,7 +30432,7 @@ self.onmessage = function (e) {
             }, 100);
           }
         } else {
-          noResultEl.style.opacity = 1;
+          noResultEl.style.opacity = "1";
         }
         if (focusedElement) {
           focusedElement.focus();

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -16775,7 +16775,7 @@ ${entry.value}</pre
       scorer
     }) => {
       if (!sampleDescriptor) {
-        return "";
+        return m$1``;
       }
       const scoreInput = inputString(sample.input);
       if (sample.choices && sample.choices.length > 0) {

--- a/src/inspect_ai/_view/www/src/App.mjs
+++ b/src/inspect_ai/_view/www/src/App.mjs
@@ -76,7 +76,7 @@ export function App({
     initialState?.headersLoading || false,
   );
 
-  // Selected Log
+  /** @type {[import("./Types.mjs").CurrentLog, function(import("./Types.mjs").CurrentLog): void]} */
   const [selectedLog, setSelectedLog] = useState(
     initialState?.selectedLog || {
       contents: undefined,
@@ -95,6 +95,7 @@ export function App({
       ? initialState.selectedSampleIndex
       : -1,
   );
+  /** @type {[import("./types/log").EvalSample, function(import("./types/log").EvalSample): void]} */
   const [selectedSample, setSelectedSample] = useState(
     initialState?.selectedSample,
   );

--- a/src/inspect_ai/_view/www/src/App.mjs
+++ b/src/inspect_ai/_view/www/src/App.mjs
@@ -32,7 +32,10 @@ import { FindBand } from "./components/FindBand.mjs";
 import { isVscode } from "./utils/Html.mjs";
 import { getVscodeApi } from "./utils/vscode.mjs";
 import { kDefaultSort } from "./constants.mjs";
-import { createsSamplesDescriptor } from "./samples/SamplesDescriptor.mjs";
+import {
+  createEvalDescriptor,
+  createSamplesDescriptor,
+} from "./samples/SamplesDescriptor.mjs";
 import { byEpoch, bySample, sortSamples } from "./samples/tools/SortFilter.mjs";
 import { resolveAttachments } from "./utils/attachments.mjs";
 import { filterFnForType } from "./samples/tools/filters.mjs";
@@ -327,7 +330,7 @@ export function App({
 
     // Set the grouping
     let grouping = "none";
-    if (samplesDescriptor?.epochs > 1) {
+    if (samplesDescriptor?.evalDescriptor?.epochs > 1) {
       if (byEpoch(sort) || epoch !== "all") {
         grouping = "epoch";
       } else if (bySample(sort)) {
@@ -340,14 +343,17 @@ export function App({
     setGroupByOrder(order);
   }, [selectedLog, filter, sort, epoch]);
 
-  const samplesDescriptor = useMemo(() => {
-    return createsSamplesDescriptor(
+  const evalDescriptor = useMemo(() => {
+    return createEvalDescriptor(
       scores,
       selectedLog.contents?.sampleSummaries,
       selectedLog.contents?.eval?.config?.epochs || 1,
-      score,
     );
-  }, [selectedLog, scores, score]);
+  }, [selectedLog, scores]);
+
+  const samplesDescriptor = useMemo(() => {
+    return createSamplesDescriptor(evalDescriptor, score);
+  }, [evalDescriptor, score]);
 
   const refreshSampleTab = useCallback(
     (sample) => {

--- a/src/inspect_ai/_view/www/src/Types.mjs
+++ b/src/inspect_ai/_view/www/src/Types.mjs
@@ -8,7 +8,6 @@
  * @typedef {Object} CurrentLog
  * @property {string} name
  * @property {import("./api/Types.mjs").EvalSummary} contents
- * @property {string} raw
  */
 
 /**

--- a/src/inspect_ai/_view/www/src/api/Types.mjs
+++ b/src/inspect_ai/_view/www/src/api/Types.mjs
@@ -30,6 +30,7 @@
  * @property { import("../types/log").Input } input
  * @property { import("../types/log").Target } target
  * @property { import("../types/log").Scores1 } scores
+ * @property { string } [error]
  * @property { import("../types/log").Type11 } [limit]
  */
 

--- a/src/inspect_ai/_view/www/src/api/Types.mjs
+++ b/src/inspect_ai/_view/www/src/api/Types.mjs
@@ -35,11 +35,21 @@
  */
 
 /**
-* @typedef {Object} Capabilities
-* @property {boolean} downloadFiles - Indicates if file downloads are supported.
-* @property {boolean} webWorkers - Indicates if web workers are supported.
-*
+ * Fields shared by EvalSample and SampleSummary.
+ * Contains only fields that are copied verbatim in src/inspect_ai/log/_recorders/eval.py.
+ *
+ * @typedef {Object} BasicSampleData
+ * @property { number | string } id
+ * @property { number } epoch
+ * @property { import("../types/log").Target } target
+ * @property { import("../types/log").Scores1 } scores
+ */
 
+/**
+ * @typedef {Object} Capabilities
+ * @property {boolean} downloadFiles - Indicates if file downloads are supported.
+ * @property {boolean} webWorkers - Indicates if web workers are supported.
+ */
 
 /**
  * @typedef {Object} LogViewAPI

--- a/src/inspect_ai/_view/www/src/api/api-http.mjs
+++ b/src/inspect_ai/_view/www/src/api/api-http.mjs
@@ -56,6 +56,7 @@ function simpleHttpAPI(logInfo) {
         });
         return Promise.resolve({
           files: logs,
+          log_dir,
         });
       } else if (log_file) {
         // Check the cache
@@ -76,6 +77,7 @@ function simpleHttpAPI(logInfo) {
 
         return {
           files: [result],
+          log_dir,
         };
       } else {
         // No log.json could be found, and there isn't a log file,

--- a/src/inspect_ai/_view/www/src/components/ExpandablePanel.mjs
+++ b/src/inspect_ai/_view/www/src/components/ExpandablePanel.mjs
@@ -14,8 +14,8 @@ export const ExpandablePanel = ({
   const [collapsed, setCollapsed] = useState(collapse);
   const [showToggle, setShowToggle] = useState(false);
 
-  const contentsRef = useRef();
-  const observerRef = useRef();
+  const contentsRef = useRef(/** @type {HTMLElement|null} */ (null));
+  const observerRef = useRef(/** @type {IntersectionObserver|null} */ (null));
 
   // Ensure that when content changes, we reset the collapse state.
   useEffect(() => {

--- a/src/inspect_ai/_view/www/src/components/FindBand.mjs
+++ b/src/inspect_ai/_view/www/src/components/FindBand.mjs
@@ -4,7 +4,7 @@ import { ApplicationIcons } from "../appearance/Icons.mjs";
 import { FontSize } from "../appearance/Fonts.mjs";
 
 export const FindBand = ({ hideBand }) => {
-  const searchBoxRef = useRef();
+  const searchBoxRef = useRef(/** @type {HTMLInputElement|null} */ (null));
   useEffect(() => {
     searchBoxRef.current.focus();
   }, []);
@@ -31,13 +31,14 @@ export const FindBand = ({ hideBand }) => {
     };
 
     // capture what is focused
-    const focusedElement = document.activeElement;
+    const focusedElement = /** @type {HTMLElement} */ (document.activeElement);
+    // @ts-expect-error: `Window.find` is non-standard
     const result = window.find(term, false, !!back, false, false, true, false);
     const noResultEl = window.document.getElementById(
       "inspect-find-no-results",
     );
     if (result) {
-      noResultEl.style.opacity = 0;
+      noResultEl.style.opacity = "0";
       const selection = window.getSelection();
       if (selection.rangeCount > 0) {
         // See if the parent is an expandable panel and expand it
@@ -58,7 +59,7 @@ export const FindBand = ({ hideBand }) => {
         }, 100);
       }
     } else {
-      noResultEl.style.opacity = 1;
+      noResultEl.style.opacity = "1";
     }
 
     // Return focus to the previously focused element

--- a/src/inspect_ai/_view/www/src/components/LargeModal.mjs
+++ b/src/inspect_ai/_view/www/src/components/LargeModal.mjs
@@ -31,7 +31,7 @@ export const LargeModal = (props) => {
 
   // Support restoring the scroll position
   // but only do this for the first time that the children are set
-  const scrollRef = useRef();
+  const scrollRef = useRef(/** @type {HTMLElement|null} */ (null));
   useEffect(() => {
     if (scrollRef.current) {
       setTimeout(() => {

--- a/src/inspect_ai/_view/www/src/components/TabSet.mjs
+++ b/src/inspect_ai/_view/www/src/components/TabSet.mjs
@@ -44,7 +44,7 @@ export const TabPanel = ({
   children,
 }) => {
   const tabContentsId = computeTabContentsId(id, index);
-  const tabContentsRef = useRef();
+  const tabContentsRef = useRef(/** @type {HTMLElement|null} */ (null));
   useEffect(() => {
     setTimeout(() => {
       if (

--- a/src/inspect_ai/_view/www/src/components/Tools.mjs
+++ b/src/inspect_ai/_view/www/src/components/Tools.mjs
@@ -152,10 +152,13 @@ export const ToolInput = ({ type, contents, view, style }) => {
   }
 
   if (view) {
-    const toolInputRef = useRef(/** @type {HTMLElement|null} */ (null));
+    const toolInputRef = useRef(
+      /** @type {import("preact").Component & { base: Element }} */ (null),
+    );
     useEffect(() => {
       // Sniff around for code in the view that could be text highlighted
       if (toolInputRef.current) {
+        // @ts-expect-error: TS doesn't know that `HTMLCollection` is iterable.
         for (const child of toolInputRef.current.base.children) {
           if (child.tagName === "PRE") {
             const childChild = child.firstElementChild;

--- a/src/inspect_ai/_view/www/src/components/VirtualList.mjs
+++ b/src/inspect_ai/_view/www/src/components/VirtualList.mjs
@@ -10,30 +10,28 @@ const STYLE_CONTENT =
   "position:absolute; top:0; left:0; height:100%; width:100%; overflow:visible;";
 
 export class VirtualList extends Component {
+  /** @type {HTMLElement} */ base;
+
   constructor(props) {
     super(props);
     this.state = {
       height: 0,
       offset: 0,
     };
-    this.resize = this.resize.bind(this);
-    this.handleScroll = throttle(this.handleScroll.bind(this), 100);
+    this.resize = () => {
+      if (this.state.height !== this.base.offsetHeight) {
+        this.setState({ height: this.base.offsetHeight });
+      }
+    };
+    this.handleScroll = throttle(() => {
+      if (this.base) {
+        this.setState({ offset: this.base.scrollTop });
+      }
+      if (this.props.sync) {
+        this.forceUpdate();
+      }
+    }, 100);
     this.containerRef = createRef();
-  }
-
-  resize() {
-    if (this.state.height !== this.base.offsetHeight) {
-      this.setState({ height: this.base.offsetHeight });
-    }
-  }
-
-  handleScroll() {
-    if (this.base) {
-      this.setState({ offset: this.base.scrollTop });
-    }
-    if (this.props.sync) {
-      this.forceUpdate();
-    }
   }
 
   componentDidUpdate() {

--- a/src/inspect_ai/_view/www/src/navbar/Navbar.mjs
+++ b/src/inspect_ai/_view/www/src/navbar/Navbar.mjs
@@ -298,6 +298,7 @@ const ResultsPanel = ({ results }) => {
  * @returns {import("preact").JSX.Element} The TranscriptView component.
  */
 const VerticalMetric = ({ metric, isFirst }) => {
+  // @ts-expect-error
   const reducer_component = metric.reducer
     ? html` <div
         style=${{
@@ -309,7 +310,10 @@ const VerticalMetric = ({ metric, isFirst }) => {
           ...TextStyle.secondary,
         }}
       >
-        ${metric.reducer}
+        ${
+          // @ts-expect-error
+          metric.reducer
+        }
       </div>`
     : "";
 

--- a/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
@@ -422,8 +422,7 @@ const SampleSummary = ({ parent_id, sample, style, sampleDescriptor }) => {
 
   const fullAnswer =
     sample && sampleDescriptor
-      ? // @ts-ignore
-        sampleDescriptor.selectedScorer(sample).answer()
+      ? sampleDescriptor.selectedScorerDescriptor(sample).answer()
       : undefined;
   if (fullAnswer) {
     columns.push({

--- a/src/inspect_ai/_view/www/src/samples/SampleList.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleList.mjs
@@ -17,7 +17,22 @@ import { inputString } from "../utils/Format.mjs";
 const kSampleHeight = 88;
 const kSeparatorHeight = 24;
 
-// Convert samples to a datastructure which contemplates grouping, etc...
+/**
+ * Convert samples to a datastructure which contemplates grouping, etc...
+ *
+ * @param {Object} props - The parameters for the component.
+ * @param {Object} props.listRef - The ref for the list.
+ * @param {import("./SamplesTab.mjs").ListItem[]} props.items - The samples.
+ * @param {import("../samples/SamplesDescriptor.mjs").SamplesDescriptor} props.sampleDescriptor - The sample descriptor.
+ * @param {Object} props.style - The style for the element
+ * @param {number} props.selectedIndex - The index of the selected sample.
+ * @param {(index: number) => void} props.setSelectedIndex - The function to set the selected sample index.
+ * @param {import("../Types.mjs").ScoreLabel} props.selectedScore - The function to get the selected score.
+ * @param {() => void} props.nextSample - The function to move to the next sample.
+ * @param {() => void} props.prevSample - The function to move to the previous sample.
+ * @param {(index: number) => void} props.showSample - The function to show the sample.
+ * @returns {import("preact").JSX.Element} The SampleList component.
+ */
 export const SampleList = (props) => {
   const {
     listRef,
@@ -93,6 +108,7 @@ export const SampleList = (props) => {
     }
   }, [selectedIndex, rowMap, listRef]);
 
+  /** @param {import("./SamplesTab.mjs").ListItem} item */
   const renderRow = (item) => {
     if (item.type === "sample") {
       return html`
@@ -192,6 +208,7 @@ export const SampleList = (props) => {
   // Count any sample errors and display a bad alerting the user
   // to any errors
   const errorCount = items?.reduce((previous, item) => {
+    // @ts-expect-error
     if (item.data.error) {
       return previous + 1;
     } else {
@@ -201,6 +218,7 @@ export const SampleList = (props) => {
 
   // Count limits
   const limitCount = items?.reduce((previous, item) => {
+    // @ts-expect-error
     if (item.data.limit) {
       return previous + 1;
     } else {
@@ -260,6 +278,17 @@ const SeparatorRow = ({ id, title, height }) => {
   </div>`;
 };
 
+/**
+ * @param {Object} props - The parameters for the component.
+ * @param {string} props.id - The unique identifier for the sample.
+ * @param {number} props.index - The index of the sample.
+ * @param {import("../api/Types.mjs").SampleSummary} props.sample - The sample.
+ * @param {import("../samples/SamplesDescriptor.mjs").SamplesDescriptor} props.sampleDescriptor - The sample descriptor.
+ * @param {number} props.height - The height of the sample row.
+ * @param {boolean} props.selected - Whether the sample is selected.
+ * @param {(index: number) => void} props.showSample - The function to show the sample.
+ * @returns {import("preact").JSX.Element} The SampleRow component.
+ */
 const SampleRow = ({
   id,
   index,

--- a/src/inspect_ai/_view/www/src/samples/SampleList.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleList.mjs
@@ -368,7 +368,9 @@ const SampleRow = ({
         ${sample
           ? html`
               <${MarkdownDiv}
-                markdown=${sampleDescriptor?.selectedScorer(sample).answer()}
+                markdown=${sampleDescriptor
+                  ?.selectedScorerDescriptor(sample)
+                  .answer()}
                 style=${{ paddingLeft: "0" }}
                 class="no-last-para-padding"
               />

--- a/src/inspect_ai/_view/www/src/samples/SampleScoreView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleScoreView.mjs
@@ -42,7 +42,10 @@ export const SampleScoreView = ({
     );
   }
 
-  const scorerDescriptor = sampleDescriptor.scorer(sample, scorer);
+  const scorerDescriptor = sampleDescriptor.evalDescriptor.scorerDescriptor(
+    sample,
+    { scorer, name: scorer },
+  );
   const explanation = scorerDescriptor.explanation() || "(No Explanation)";
   const answer = scorerDescriptor.answer();
   const metadata = scorerDescriptor.metadata();

--- a/src/inspect_ai/_view/www/src/samples/SampleScoreView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleScoreView.mjs
@@ -14,6 +14,14 @@ const labelStyle = {
   ...TextStyle.secondary,
 };
 
+/**
+ * @param {Object} props - The component props.
+ * @param {import("../types/log").EvalSample} props.sample - The sample.
+ * @param {import("../samples/SamplesDescriptor.mjs").SamplesDescriptor} props.sampleDescriptor - The sample descriptor.
+ * @param {Object} props.style - The style for the element.
+ * @param {string} props.scorer - The scorer.
+ * @returns {import("preact").JSX.Element} The SampleScoreView component.
+ */
 export const SampleScoreView = ({
   sample,
   sampleDescriptor,
@@ -21,7 +29,7 @@ export const SampleScoreView = ({
   scorer,
 }) => {
   if (!sampleDescriptor) {
-    return "";
+    return html``;
   }
 
   const scoreInput = inputString(sample.input);

--- a/src/inspect_ai/_view/www/src/samples/SampleScores.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleScores.mjs
@@ -9,8 +9,10 @@ import { html } from "htm/preact";
  */
 export const SampleScores = ({ sample, sampleDescriptor, scorer }) => {
   const scores = scorer
-    ? sampleDescriptor.scorer(sample, scorer).scores()
-    : sampleDescriptor.selectedScorer(sample).scores();
+    ? sampleDescriptor.evalDescriptor
+        .scorerDescriptor(sample, { scorer, name: scorer })
+        .scores()
+    : sampleDescriptor.selectedScorerDescriptor(sample).scores();
 
   if (scores.length === 1) {
     return scores[0].rendered();

--- a/src/inspect_ai/_view/www/src/samples/SampleScores.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleScores.mjs
@@ -1,5 +1,12 @@
 import { html } from "htm/preact";
 
+/**
+ * @param {Object} props
+ * @param {import("../api/Types.mjs").SampleSummary} props.sample
+ * @param {import("../samples/SamplesDescriptor.mjs").SamplesDescriptor} props.sampleDescriptor
+ * @param {string} props.scorer
+ * @returns {import("preact").JSX.Element}
+ */
 export const SampleScores = ({ sample, sampleDescriptor, scorer }) => {
   const scores = scorer
     ? sampleDescriptor.scorer(sample, scorer).scores()

--- a/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
@@ -23,10 +23,11 @@ import {
  * @property {number} epochs - The number of epochs.
  * @property {import("../api/Types.mjs").SampleSummary[]} samples - The list of sample summaries.
  * @property {import("../Types.mjs").ScoreLabel[]} scores - the list of available scores
- * @property {(sample: import("../api/Types.mjs").SampleSummary, scoreLabel: import("../Types.mjs").ScoreLabel) => ScorerDescriptor} scorerDescriptor - Returns the scorer descriptor for a sample and a specified scorer.
+ * @property {(sample: import("../api/Types.mjs").BasicSampleData, scoreLabel: import("../Types.mjs").ScoreLabel) => ScorerDescriptor} scorerDescriptor - Returns the scorer descriptor for a sample and a specified scorer.
  * @property {(scoreLabel: import("../Types.mjs").ScoreLabel) => ScoreDescriptor} scoreDescriptor - Provides information about the score types and how to render them.
- * @property {(sample: import("../api/Types.mjs").SampleSummary, scoreLabel: import("../Types.mjs").ScoreLabel) => SelectedScore} score - Returns information about a score for a sample.
- * @property {(sample: import("../api/Types.mjs").SampleSummary, scorer: string) => string} scoreAnswer - Returns the answer for a sample and a specified scorer.
+ * @property {(sample: import("../api/Types.mjs").BasicSampleData, scoreLabel: import("../Types.mjs").ScoreLabel) => SelectedScore} score - Returns information about a score for a sample.
+ * @property {(sample: import("../api/Types.mjs").BasicSampleData, scorer: string) => string} scoreAnswer - Returns the answer for a sample and a specified scorer.
+ */
 
 /**
  * Represents a utility summary of the samples.
@@ -34,8 +35,8 @@ import {
  * @property {EvalDescriptor} evalDescriptor - The EvalDescriptor.
  * @property {MessageShape} messageShape - The normalized sizes of input, target, and answer messages.
  * @property {ScoreDescriptor} selectedScoreDescriptor - Provides information about the score types and how to render them.
- * @property {(sample: import("../api/Types.mjs").SampleSummary) => SelectedScore} selectedScore - Returns the selected score for a sample.
- * @property {(sample: import("../api/Types.mjs").SampleSummary) => ScorerDescriptor} selectedScorerDescriptor - Returns the scorer descriptor for a sample using the selected scorer.
+ * @property {(sample: import("../api/Types.mjs").BasicSampleData) => SelectedScore} selectedScore - Returns the selected score for a sample.
+ * @property {(sample: import("../api/Types.mjs").BasicSampleData) => ScorerDescriptor} selectedScorerDescriptor - Returns the scorer descriptor for a sample using the selected scorer.
  */
 
 /**
@@ -94,7 +95,7 @@ export const createEvalDescriptor = (scores, samples, epochs) => {
   }
 
   /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
+   * @param {import("../api/Types.mjs").BasicSampleData} sample - the currently selected score
    * @param {import("../Types.mjs").ScoreLabel} scoreLabel - the score label
    * @returns {import("../types/log").Value2} The Score
    */
@@ -118,7 +119,7 @@ export const createEvalDescriptor = (scores, samples, epochs) => {
   };
 
   /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
+   * @param {import("../api/Types.mjs").BasicSampleData} sample - the currently selected score
    * @param {string} scorer - the scorer name
    * @returns {string} The answer
    */
@@ -134,7 +135,7 @@ export const createEvalDescriptor = (scores, samples, epochs) => {
   };
 
   /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
+   * @param {import("../api/Types.mjs").BasicSampleData} sample - the currently selected score
    * @param {string} scorer - the scorer name
    * @returns {string} The explanation
    */
@@ -150,7 +151,7 @@ export const createEvalDescriptor = (scores, samples, epochs) => {
 
   // Retrieve the metadata for a sample
   /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
+   * @param {import("../api/Types.mjs").BasicSampleData} sample - the currently selected score
    * @param {string} scorer - the scorer name
    * @returns {Object} The explanation
    */
@@ -232,7 +233,7 @@ export const createEvalDescriptor = (scores, samples, epochs) => {
   };
 
   /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample
+   * @param {import("../api/Types.mjs").BasicSampleData} sample
    * @param {import("../Types.mjs").ScoreLabel} scoreLabel
    * @returns {any}
    */
@@ -249,7 +250,7 @@ export const createEvalDescriptor = (scores, samples, epochs) => {
   };
 
   /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample
+   * @param {import("../api/Types.mjs").BasicSampleData} sample
    * @param {import("../Types.mjs").ScoreLabel} scoreLabel
    * @returns {ScorerDescriptor}
    */
@@ -332,7 +333,7 @@ export const createEvalDescriptor = (scores, samples, epochs) => {
   };
 
   /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample
+   * @param {import("../api/Types.mjs").BasicSampleData} sample
    * @param {import("../Types.mjs").ScoreLabel} scoreLabel
    * @returns {SelectedScore}
    */

--- a/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
@@ -18,14 +18,24 @@ import {
 } from "../constants.mjs";
 
 /**
+ * Represents a utility summary of the samples that doesn't change with the selected score.
+ * @typedef {Object} EvalDescriptor
+ * @property {number} epochs - The number of epochs.
+ * @property {import("../api/Types.mjs").SampleSummary[]} samples - The list of sample summaries.
+ * @property {import("../Types.mjs").ScoreLabel[]} scores - the list of available scores
+ * @property {(sample: import("../api/Types.mjs").SampleSummary, scoreLabel: import("../Types.mjs").ScoreLabel) => ScorerDescriptor} scorerDescriptor - Returns the scorer descriptor for a sample and a specified scorer.
+ * @property {(scoreLabel: import("../Types.mjs").ScoreLabel) => ScoreDescriptor} scoreDescriptor - Provides information about the score types and how to render them.
+ * @property {(sample: import("../api/Types.mjs").SampleSummary, scoreLabel: import("../Types.mjs").ScoreLabel) => SelectedScore} score - Returns information about a score for a sample.
+ * @property {(sample: import("../api/Types.mjs").SampleSummary, scorer: string) => string} scoreAnswer - Returns the answer for a sample and a specified scorer.
+
+/**
  * Represents a utility summary of the samples.
  * @typedef {Object} SamplesDescriptor
- * @property {ScoreDescriptor} scoreDescriptor - Provides information about the score types and how to render them.
- * @property {number} epochs - The number of epochs.
+ * @property {EvalDescriptor} evalDescriptor - The EvalDescriptor.
  * @property {MessageShape} messageShape - The normalized sizes of input, target, and answer messages.
+ * @property {ScoreDescriptor} selectedScoreDescriptor - Provides information about the score types and how to render them.
  * @property {(sample: import("../api/Types.mjs").SampleSummary) => SelectedScore} selectedScore - Returns the selected score for a sample.
- * @property {(sample: import("../api/Types.mjs").SampleSummary, scorer: string) => ScorerDescriptor} scorer - Returns the scorer descriptor for a sample and a specified scorer.
- * @property {(sample: import("../api/Types.mjs").SampleSummary) => ScorerDescriptor} selectedScorer - Returns the scorer descriptor for a sample using the selected scorer.
+ * @property {(sample: import("../api/Types.mjs").SampleSummary) => ScorerDescriptor} selectedScorerDescriptor - Returns the scorer descriptor for a sample using the selected scorer.
  */
 
 /**
@@ -49,7 +59,7 @@ import {
  */
 
 /**
- * Represents the selected score for a sample, including its value and render function.
+ * Represents a score for a sample, including its value and render function.
  * @typedef {Object} SelectedScore
  * @property {import("../types/log").Value2} value - The value of the selected score.
  * @property {function(): any} render - Function to render the selected score.
@@ -73,61 +83,40 @@ import {
  */
 
 /**
- * Provides a utility summary of the samples
- *
- * @param {import("../Types.mjs").ScoreLabel[]} scorers - the list of available scores
+ * @param {import("../Types.mjs").ScoreLabel[]} scores - the list of available scores
  * @param {import("../api/Types.mjs").SampleSummary[]} samples - the list of sample summaries
  * @param {number} epochs - The number of epochs
- * @param {import("../Types.mjs").ScoreLabel} [selectedScore] - the currently selected score
- * @returns {SamplesDescriptor} The SamplesDescriptor
+ * @returns {EvalDescriptor} The EvalDescriptor
  */
-export const createsSamplesDescriptor = (
-  scorers,
-  samples,
-  epochs,
-  selectedScore,
-) => {
+export const createEvalDescriptor = (scores, samples, epochs) => {
   if (!samples) {
     return undefined;
   }
 
   /**
    * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
-   * @param {string} scorer - the scorer name
-   * @returns {import("../types/log").Score} The Score
-   */
-  const score = (sample, scorer = selectedScore?.scorer) => {
-    if (sample.scores[scorer]) {
-      return sample.scores[scorer];
-    } else {
-      return undefined;
-    }
-  };
-
-  /**
-   * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
+   * @param {import("../Types.mjs").ScoreLabel} scoreLabel - the score label
    * @returns {import("../types/log").Value2} The Score
    */
-  const scoreValue = (sample) => {
+  const scoreValue = (sample, scoreLabel) => {
     // no scores, no value
-    if (Object.keys(sample.scores).length === 0 || !selectedScore) {
+    if (Object.keys(sample.scores).length === 0 || !scoreLabel) {
       return undefined;
     }
 
     if (
-      selectedScore.scorer !== selectedScore.name &&
-      sample.scores[selectedScore.scorer] &&
-      sample.scores[selectedScore.scorer].value
+      scoreLabel.scorer !== scoreLabel.name &&
+      sample.scores[scoreLabel.scorer] &&
+      sample.scores[scoreLabel.scorer].value
     ) {
-      return sample.scores[selectedScore.scorer].value[selectedScore.name];
-    } else if (sample.scores[selectedScore.name]) {
-      return sample.scores[selectedScore.name].value;
+      return sample.scores[scoreLabel.scorer].value[scoreLabel.name];
+    } else if (sample.scores[scoreLabel.name]) {
+      return sample.scores[scoreLabel.name].value;
     } else {
       return undefined;
     }
   };
 
-  // Retrieve the answer for a sample
   /**
    * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
    * @param {string} scorer - the scorer name
@@ -135,7 +124,7 @@ export const createsSamplesDescriptor = (
    */
   const scoreAnswer = (sample, scorer) => {
     if (sample) {
-      const sampleScore = score(sample, scorer);
+      const sampleScore = sample.scores[scorer];
       if (sampleScore && sampleScore.answer) {
         return sampleScore.answer;
       }
@@ -144,7 +133,6 @@ export const createsSamplesDescriptor = (
     }
   };
 
-  // Retrieve the answer for a sample
   /**
    * @param {import("../api/Types.mjs").SampleSummary} sample - the currently selected score
    * @param {string} scorer - the scorer name
@@ -152,7 +140,7 @@ export const createsSamplesDescriptor = (
    */
   const scoreExplanation = (sample, scorer) => {
     if (sample) {
-      const sampleScore = score(sample, scorer);
+      const sampleScore = sample.scores[scorer];
       if (sampleScore && sampleScore.explanation) {
         return sampleScore.explanation;
       }
@@ -168,7 +156,7 @@ export const createsSamplesDescriptor = (
    */
   const scoreMetadata = (sample, scorer) => {
     if (sample) {
-      const sampleScore = score(sample, scorer);
+      const sampleScore = sample.scores[scorer];
       if (sampleScore && sampleScore.metadata) {
         return sampleScore.metadata;
       }
@@ -176,53 +164,216 @@ export const createsSamplesDescriptor = (
     return undefined;
   };
 
-  const uniqScoreValues = [
-    ...new Set(
-      samples
-        .filter((sample) => !!sample.scores)
-        .filter((sample) => {
-          // There is no selected scorer, so include this value
-          if (!selectedScore) {
-            return true;
-          }
+  /**
+   * @param {import("../Types.mjs").ScoreLabel} scoreLabel
+   * @returns {string}
+   */
+  const scoreLabelKey = (scoreLabel) => {
+    return `${scoreLabel.scorer}.${scoreLabel.name}`;
+  };
 
-          if (selectedScore.scorer !== selectedScore.name) {
-            return (
-              Object.keys(sample.scores).includes(selectedScore.scorer) &&
-              Object.keys(sample.scores[selectedScore.scorer].value).includes(
-                selectedScore.name,
-              )
-            );
-          } else {
-            return Object.keys(sample.scores).includes(selectedScore.name);
-          }
-        })
-        .map((sample) => {
-          return scoreValue(sample);
-        })
-        .filter((value) => {
-          return value !== null;
-        }),
-    ),
-  ];
-  const uniqScoreTypes = [
-    ...new Set(uniqScoreValues.map((scoreValue) => typeof scoreValue)),
-  ];
+  /**
+   * The EvalDescriptor is memoized. Compute all descriptors now to avoid duplicate work.
+   * @type {Map<string, ScoreDescriptor>}
+   */
+  const scoreDescriptorMap = new Map();
+  for (const scoreLabel of scores) {
+    const uniqScoreValues = [
+      ...new Set(
+        samples
+          .filter((sample) => !!sample.scores)
+          .filter((sample) => {
+            // There is no selected scorer, so include this value
+            if (!scoreLabel) {
+              return true;
+            }
 
-  /** @type {ScoreDescriptor} */
-  let scoreDescriptor;
-  for (const categorizer of scoreCategorizers) {
-    scoreDescriptor = categorizer.describe(uniqScoreValues, uniqScoreTypes);
-    if (scoreDescriptor) {
-      break;
+            if (scoreLabel.scorer !== scoreLabel.name) {
+              return (
+                Object.keys(sample.scores).includes(scoreLabel.scorer) &&
+                Object.keys(sample.scores[scoreLabel.scorer].value).includes(
+                  scoreLabel.name,
+                )
+              );
+            } else {
+              return Object.keys(sample.scores).includes(scoreLabel.name);
+            }
+          })
+          .map((sample) => {
+            return scoreValue(sample, scoreLabel);
+          })
+          .filter((value) => {
+            return value !== null;
+          }),
+      ),
+    ];
+    const uniqScoreTypes = [
+      ...new Set(uniqScoreValues.map((scoreValue) => typeof scoreValue)),
+    ];
+
+    for (const categorizer of scoreCategorizers) {
+      const scoreDescriptor = categorizer.describe(
+        uniqScoreValues,
+        uniqScoreTypes,
+      );
+      if (scoreDescriptor) {
+        scoreDescriptorMap.set(scoreLabelKey(scoreLabel), scoreDescriptor);
+        break;
+      }
     }
   }
 
+  /**
+   * @param {import("../Types.mjs").ScoreLabel} scoreLabel
+   * @returns {ScoreDescriptor}
+   */
+  const scoreDescriptor = (scoreLabel) => {
+    return scoreDescriptorMap.get(scoreLabelKey(scoreLabel));
+  };
+
+  /**
+   * @param {import("../api/Types.mjs").SampleSummary} sample
+   * @param {import("../Types.mjs").ScoreLabel} scoreLabel
+   * @returns {any}
+   */
+  const scoreRendered = (sample, scoreLabel) => {
+    const descriptor = scoreDescriptor(scoreLabel);
+    const score = scoreValue(sample, scoreLabel);
+    if (score === null || score === "undefined") {
+      return "null";
+    } else if (descriptor.render) {
+      return descriptor.render(score);
+    } else {
+      return score;
+    }
+  };
+
+  /**
+   * @param {import("../api/Types.mjs").SampleSummary} sample
+   * @param {import("../Types.mjs").ScoreLabel} scoreLabel
+   * @returns {ScorerDescriptor}
+   */
+  const scorerDescriptor = (sample, scoreLabel) => {
+    return {
+      metadata: () => {
+        return scoreMetadata(sample, scoreLabel.scorer);
+      },
+      explanation: () => {
+        return scoreExplanation(sample, scoreLabel.scorer);
+      },
+      answer: () => {
+        return scoreAnswer(sample, scoreLabel.scorer);
+      },
+      scores: () => {
+        if (!sample || !sample.scores) {
+          return [];
+        }
+        const myScoreDescriptor = scoreDescriptor(scoreLabel);
+        if (!myScoreDescriptor) {
+          return [];
+        }
+
+        // Make a list of all the valid score names (this is
+        // used to distinguish between dictionaries that contain
+        // scores that should be treated as standlone scores and
+        // dictionaries that just contain random values, which is allowed)
+        const scoreNames = scores.map((score) => {
+          return score.name;
+        });
+        const sampleScorer = sample.scores[scoreLabel.scorer];
+        const scoreVal = sampleScorer.value;
+
+        if (typeof scoreVal === "object") {
+          const names = Object.keys(scoreVal);
+
+          // See if this is a dictionary of score names
+          // if any of the score names match, treat it
+          // as a scorer dictionary
+          if (
+            names.find((name) => {
+              return scoreNames.includes(name);
+            })
+          ) {
+            // Since this dictionary contains keys which are  scores
+            // we actually render the individual scores
+            const scores = names.map((name) => {
+              return {
+                name,
+                rendered: () => {
+                  return myScoreDescriptor.render(scoreVal[name]);
+                },
+              };
+            });
+            return scores;
+          } else {
+            // Since this dictionary contains keys which are not scores
+            // we just treat it like an opaque dictionary
+            return [
+              {
+                name: scoreLabel.scorer,
+                rendered: () => {
+                  return myScoreDescriptor.render(scoreVal);
+                },
+              },
+            ];
+          }
+        } else {
+          return [
+            {
+              name: scoreLabel.scorer,
+              rendered: () => {
+                return myScoreDescriptor.render(scoreVal);
+              },
+            },
+          ];
+        }
+      },
+    };
+  };
+
+  /**
+   * @param {import("../api/Types.mjs").SampleSummary} sample
+   * @param {import("../Types.mjs").ScoreLabel} scoreLabel
+   * @returns {SelectedScore}
+   */
+  const score = (sample, scoreLabel) => {
+    return {
+      value: scoreValue(sample, scoreLabel),
+      render: () => {
+        return scoreRendered(sample, scoreLabel);
+      },
+    };
+  };
+
+  return {
+    epochs,
+    samples,
+    scores,
+    scorerDescriptor,
+    scoreDescriptor,
+    score,
+    scoreAnswer,
+  };
+};
+
+/**
+ * Provides a utility summary of the samples
+ *
+ * @param {EvalDescriptor} evalDescriptor - The EvalDescriptor.
+ * @param {import("../Types.mjs").ScoreLabel} selectedScore - Selected score.
+ * @returns {SamplesDescriptor} - The SamplesDescriptor.
+ */
+export const createSamplesDescriptor = (evalDescriptor, selectedScore) => {
+  if (!evalDescriptor) {
+    return undefined;
+  }
+
   // Find the total length of the value so we can compute an average
-  const sizes = samples.reduce(
+  const sizes = evalDescriptor.samples.reduce(
     (previous, current) => {
       const text = inputString(current.input).join(" ");
-      const scoreText = scoreValue(current) ? String(scoreValue(current)) : "";
+      const scoreValue = evalDescriptor.score(current, selectedScore).value;
+      const scoreText = scoreValue ? String(scoreValue) : "";
       previous[0] = Math.min(Math.max(previous[0], text.length), 300);
       previous[1] = Math.min(
         Math.max(previous[1], arrayToString(current.target).length),
@@ -231,7 +382,7 @@ export const createsSamplesDescriptor = (
       previous[2] = Math.min(
         Math.max(
           previous[2],
-          scoreAnswer(current, selectedScore?.name)?.length || 0,
+          evalDescriptor.scoreAnswer(current, selectedScore?.name)?.length || 0,
         ),
         300,
       );
@@ -285,109 +436,13 @@ export const createsSamplesDescriptor = (
     },
   };
 
-  const scoreRendered = (sample) => {
-    const score = scoreValue(sample);
-    if (score === null || score === "undefined") {
-      return "null";
-    } else if (scoreDescriptor.render) {
-      return scoreDescriptor.render(score);
-    } else {
-      return score;
-    }
-  };
-
-  const scorerDescriptor = (sample, scorer) => {
-    return {
-      metadata: () => {
-        return scoreMetadata(sample, scorer);
-      },
-      explanation: () => {
-        return scoreExplanation(sample, scorer);
-      },
-      answer: () => {
-        return scoreAnswer(sample, scorer);
-      },
-      scores: () => {
-        if (!sample || !sample.scores) {
-          return [];
-        }
-
-        // Make a list of all the valid score names (this is
-        // used to distinguish between dictionaries that contain
-        // scores that should be treated as standlone scores and
-        // dictionaries that just contain random values, which is allowed)
-        const scoreNames = scorers.map((score) => {
-          return score.name;
-        });
-        const sampleScorer = sample.scores[scorer];
-        const scoreVal = sampleScorer.value;
-
-        if (typeof scoreVal === "object") {
-          const names = Object.keys(scoreVal);
-
-          // See if this is a dictionary of score names
-          // if any of the score names match, treat it
-          // as a scorer dictionary
-          if (
-            names.find((name) => {
-              return scoreNames.includes(name);
-            })
-          ) {
-            // Since this dictionary contains keys which are  scores
-            // we actually render the individual scores
-            const scores = names.map((name) => {
-              return {
-                name,
-                rendered: () => {
-                  return scoreDescriptor.render(scoreVal[name]);
-                },
-              };
-            });
-            return scores;
-          } else {
-            // Since this dictionary contains keys which are not scores
-            // we just treat it like an opaque dictionary
-            return [
-              {
-                name: scorer,
-                rendered: () => {
-                  return scoreDescriptor.render(scoreVal);
-                },
-              },
-            ];
-          }
-        } else {
-          return [
-            {
-              name: scorer,
-              rendered: () => {
-                return scoreDescriptor.render(scoreVal);
-              },
-            },
-          ];
-        }
-      },
-    };
-  };
-
   return {
-    scoreDescriptor,
-    epochs,
+    evalDescriptor,
     messageShape,
-    selectedScore: (sample) => {
-      return {
-        value: scoreValue(sample),
-        render: () => {
-          return scoreRendered(sample);
-        },
-      };
-    },
-    scorer: (sample, scorer) => {
-      return scorerDescriptor(sample, scorer);
-    },
-    selectedScorer: (sample) => {
-      return scorerDescriptor(sample, selectedScore?.scorer);
-    },
+    selectedScoreDescriptor: evalDescriptor.scoreDescriptor(selectedScore),
+    selectedScore: (sample) => evalDescriptor.score(sample, selectedScore),
+    selectedScorerDescriptor: (sample) =>
+      evalDescriptor.scorerDescriptor(sample, selectedScore),
   };
 };
 

--- a/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
@@ -42,6 +42,7 @@ import {
 /**
  * Provides descriptor functions for a scorer.
  * @typedef {Object} ScorerDescriptor
+ * @property {() => string} metadata - Function to retrieve the metadata of the score.
  * @property {() => string} explanation - Function to retrieve the explanation of the score.
  * @property {() => string} answer - Function to retrieve the answer associated with the score.
  * @property {function(): Array<{name: string, rendered: function(): any}>} scores - Function to retrieve scores with their render functions.

--- a/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
@@ -55,7 +55,9 @@ export const SamplesTab = ({
   sampleScrollPositionRef,
   setSampleScrollPosition,
 }) => {
+  /** @type {[ListItem[], function(ListItem[]): void]} */
   const [items, setItems] = useState([]);
+  /** @type {[ListItem[], function(ListItem[]): void]} */
   const [sampleItems, setSampleItems] = useState([]);
 
   const sampleListRef = useRef(/** @type {HTMLElement|null} */ (null));

--- a/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
@@ -289,7 +289,7 @@ const groupBySample = (samples, sampleDescriptor, order) => {
       }
     }
   });
-  const groupCount = samples.length / sampleDescriptor.epochs;
+  const groupCount = samples.length / sampleDescriptor.evalDescriptor.epochs;
   const itemCount = samples.length / groupCount;
   const counter = getCounter(itemCount, groupCount, order);
   return (sample, index, previousSample) => {
@@ -330,7 +330,7 @@ const groupBySample = (samples, sampleDescriptor, order) => {
  * @returns {(sample: import("../api/Types.mjs").SampleSummary, index: number, previousSample: import("../api/Types.mjs").SampleSummary) => ListItem[]} The list
  */
 const groupByEpoch = (samples, sampleDescriptor, order) => {
-  const groupCount = sampleDescriptor.epochs;
+  const groupCount = sampleDescriptor.evalDescriptor.epochs;
   const itemCount = samples.length / groupCount;
   const counter = getCounter(itemCount, groupCount, order);
 

--- a/src/inspect_ai/_view/www/src/samples/tools/SampleFilter.mjs
+++ b/src/inspect_ai/_view/www/src/samples/tools/SampleFilter.mjs
@@ -30,11 +30,11 @@ export const SampleFilter = ({ descriptor, filter, filterChanged }) => {
     }
   };
 
-  switch (descriptor?.scoreDescriptor?.scoreType) {
+  switch (descriptor?.selectedScoreDescriptor?.scoreType) {
     case kScoreTypePassFail: {
       const options = [{ text: "All", value: "all" }];
       options.push(
-        ...descriptor.scoreDescriptor.categories.map((cat) => {
+        ...descriptor.selectedScoreDescriptor.categories.map((cat) => {
           return { text: cat.text, value: cat.val };
         }),
       );
@@ -48,7 +48,7 @@ export const SampleFilter = ({ descriptor, filter, filterChanged }) => {
     case kScoreTypeCategorical: {
       const options = [{ text: "All", value: "all" }];
       options.push(
-        ...descriptor.scoreDescriptor.categories.map((cat) => {
+        ...descriptor.selectedScoreDescriptor.categories.map((cat) => {
           return { text: cat, value: cat };
         }),
       );
@@ -79,12 +79,12 @@ export const SampleFilter = ({ descriptor, filter, filterChanged }) => {
     }
 
     case kScoreTypeObject: {
-      if (!descriptor.scoreDescriptor.categories) {
+      if (!descriptor.selectedScoreDescriptor.categories) {
         return "";
       }
       const options = [{ text: "All", value: "all" }];
       options.push(
-        ...descriptor.scoreDescriptor.categories.map((cat) => {
+        ...descriptor.selectedScoreDescriptor.categories.map((cat) => {
           return { text: cat.text, value: cat.value };
         }),
       );

--- a/src/inspect_ai/_view/www/src/samples/tools/SelectScorer.mjs
+++ b/src/inspect_ai/_view/www/src/samples/tools/SelectScorer.mjs
@@ -1,6 +1,13 @@
 import { html } from "htm/preact";
 import { FontSize, TextStyle } from "../../appearance/Fonts.mjs";
 
+/**
+ * @param {Object} props
+ * @param {import("../../Types.mjs").ScoreLabel[]} props.scores
+ * @param {import("../../Types.mjs").ScoreLabel} props.score
+ * @param {(score: import("../../Types.mjs").ScoreLabel) => void} props.setScore
+ * @returns {import("preact").JSX.Element}
+ */
 export const SelectScorer = ({ scores, score, setScore }) => {
   const scorers = scores.reduce((accum, scorer) => {
     if (

--- a/src/inspect_ai/_view/www/src/samples/tools/SortFilter.mjs
+++ b/src/inspect_ai/_view/www/src/samples/tools/SortFilter.mjs
@@ -25,7 +25,7 @@ export const SortFilter = ({ sampleDescriptor, sort, setSort, epochs }) => {
       val: kEpochDescVal,
     });
   }
-  if (sampleDescriptor?.scoreDescriptor?.compare) {
+  if (sampleDescriptor?.selectedScoreDescriptor?.compare) {
     options.push({
       label: "score asc",
       val: kScoreAscVal,
@@ -130,12 +130,12 @@ export const sortSamples = (sort, samples, samplesDescriptor) => {
       }
 
       case kScoreAscVal:
-        return samplesDescriptor.scoreDescriptor.compare(
+        return samplesDescriptor.selectedScoreDescriptor.compare(
           samplesDescriptor.selectedScore(a).value,
           samplesDescriptor.selectedScore(b).value,
         );
       case kScoreDescVal:
-        return samplesDescriptor.scoreDescriptor.compare(
+        return samplesDescriptor.selectedScoreDescriptor.compare(
           samplesDescriptor.selectedScore(b).value,
           samplesDescriptor.selectedScore(a).value,
         );


### PR DESCRIPTION
This PR contains multiple non-user-visible changes to Inspect view. It is mostly (but not entirely) a subset of https://github.com/UKGovernmentBEIS/inspect_ai/pull/911.

The only substantial change is factoring `EvalDescriptor` out of `SamplesDescriptor`. The `EvalDescriptor` is computed once per eval and contains information that doesn't change with the selected score. The `SamplesDescriptor` is now focused on data that depends on the selected score. I find that this separation improves readability, it should make caching better, and it is required for the fancy filter which doesn't depend on the selected score.

This PR also contains a lot of new JSDoc type annotations and type fixes.

Finally, it adds a prettierrc to ensure that per-user prettier settings don't break formatting.

---

Bonus pro-tip.

With all type errors fixed, it is now possible to enable type checking globally (not just in the open files) in VSCode/Cursor. I did this locally by creating a VSCode workspace file, `inspect-ai.code-workspace`, with the following content:

```json
{
  "folders": [
    {
      "path": "."
    }
  ],
  "settings": {
    "typescript.tsserver.experimental.enableProjectDiagnostics": true
  }
}
```

Unfortunately, there is catch. We still have type errors in the generated files, and the TS plugin doesn't allow to exclude paths from type checking. So now I'm permanently using this error filter in VSCode:

```
!dist/*,!ansi-output.js,!tsconfig.json
```

Even with the filter, “Problems” counter includes these phantom errors, which is annoying, but when I navigate to the “Problems” tab, I only see real errors. Personally I find this to be an improvement, because I like global type checking. But I understand that this setup is far from ideal, so I'm not suggesting we enable it by default until I find a better way to suppress errors in generated files.