### PR TITLE
Improve Handling of Partial Dictionary Scores

### DIFF
--- a/src/inspect_ai/_display/textual/widgets/task_detail.py
+++ b/src/inspect_ai/_display/textual/widgets/task_detail.py
@@ -1,3 +1,4 @@
+import re
 from dataclasses import dataclass
 
 import numpy as np
@@ -103,7 +104,7 @@ class TaskDetail(Widget):
         # Makes keys for tracking Task Metric widgets
         def metric_key(reducer: str | None, scorer: str) -> str:
             reducer = reducer or "none"
-            return f"task-{reducer}-{scorer}-tbl"
+            return valid_id(f"task-{reducer}-{scorer}-tbl")
 
         # Remove keys that are no longer present
         existing_keys = set(self.existing_metrics.keys())
@@ -217,3 +218,15 @@ class TaskMetrics(Widget):
             return " n/a "
         else:
             return f"{val:.3f}"
+
+
+def valid_id(identifier: str) -> str:
+    # Remove invalid characters
+    valid_part = re.sub(r"[^a-zA-Z0-9_-]", "_", identifier)
+
+    # Ensure it doesn't start with a number
+    if valid_part and valid_part[0].isdigit():
+        valid_part = "_" + valid_part
+
+    # If the string is empty return a default valid identifier
+    return valid_part or "default_identifier"

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -25449,35 +25449,22 @@ const createsSamplesDescriptor = (scorers, samples, epochs, selectedScore) => {
         if (!sample || !sample.scores) {
           return [];
         }
-        const scoreNames = scorers.map((score2) => {
+        scorers.map((score2) => {
           return score2.name;
         });
         const sampleScorer = sample.scores[scorer];
         const scoreVal = sampleScorer.value;
         if (typeof scoreVal === "object") {
           const names = Object.keys(scoreVal);
-          if (names.find((name) => {
-            return !scoreNames.includes(name);
-          })) {
-            return [
-              {
-                name: scorer,
-                rendered: () => {
-                  return scoreDescriptor.render(scoreVal);
-                }
+          const scores = names.map((name) => {
+            return {
+              name,
+              rendered: () => {
+                return scoreDescriptor.render(scoreVal[name]);
               }
-            ];
-          } else {
-            const scores = names.map((name) => {
-              return {
-                name,
-                rendered: () => {
-                  return scoreDescriptor.render(scoreVal[name]);
-                }
-              };
-            });
-            return scores;
-          }
+            };
+          });
+          return scores;
         } else {
           return [
             {
@@ -25530,7 +25517,7 @@ const scoreCategorizers = [
      * @returns {ScoreDescriptor} a ScoreDescriptor
      */
     describe: (values) => {
-      if ((values.length === 1 || values.length === 2) && values.every((val) => {
+      if (values.length === 2 && values.every((val) => {
         return val === 1 || val === 0;
       })) {
         return booleanScoreCategorizer();

--- a/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
@@ -409,7 +409,7 @@ const scoreCategorizers = [
      */
     describe: (values) => {
       if (
-        (values.length === 1 || values.length === 2) &&
+        (values.length === 2) &&
         values.every((val) => {
           return val === 1 || val === 0;
         })

--- a/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesDescriptor.mjs
@@ -320,24 +320,18 @@ export const createsSamplesDescriptor = (
         });
         const sampleScorer = sample.scores[scorer];
         const scoreVal = sampleScorer.value;
+
         if (typeof scoreVal === "object") {
           const names = Object.keys(scoreVal);
+
+          // See if this is a dictionary of score names
+          // if any of the score names match, treat it
+          // as a scorer dictionary
           if (
             names.find((name) => {
-              return !scoreNames.includes(name);
+              return scoreNames.includes(name);
             })
           ) {
-            // Since this dictionary contains keys which are not scores
-            // we just treat it like an opaque dictionary
-            return [
-              {
-                name: scorer,
-                rendered: () => {
-                  return scoreDescriptor.render(scoreVal);
-                },
-              },
-            ];
-          } else {
             // Since this dictionary contains keys which are  scores
             // we actually render the individual scores
             const scores = names.map((name) => {
@@ -349,6 +343,17 @@ export const createsSamplesDescriptor = (
               };
             });
             return scores;
+          } else {
+            // Since this dictionary contains keys which are not scores
+            // we just treat it like an opaque dictionary
+            return [
+              {
+                name: scorer,
+                rendered: () => {
+                  return scoreDescriptor.render(scoreVal);
+                },
+              },
+            ];
           }
         } else {
           return [
@@ -409,7 +414,7 @@ const scoreCategorizers = [
      */
     describe: (values) => {
       if (
-        (values.length === 2) &&
+        values.length === 2 &&
         values.every((val) => {
           return val === 1 || val === 0;
         })


### PR DESCRIPTION
- only bind boolean scoring when there are 1s and 0s (not just 0s)
- bind to individual score rendering when at least one dictionary key is used in a metric
- don't error if glob makes it through to metrics keys (which is can since metrics are computed before scoring, preventing any metrics from being expanded against score values)

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
