### PR TITLE
Use global variable to track rate limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - Azure AI: Fix schema validation error that occurred when model API returns `None` for `content`.
 - Display: Throttle updating of sample list based on number of samples.
 - Display: Add explicit 'ctrl+c' keybinding (as textual now disables this by default).
+- Bugfix: Correct rate limit error display when running in fullscreen mode.
 - Bugfix: `hf_dataset` now explicitly requires the `split` argument (previously, it would crash when not specified).
 - Bugfix: Prevent cascading textual error when an error occurs during task initialisation.
 - Bugfix: Correctly restore sample summaries from log file after abend.

--- a/src/inspect_ai/_util/logger.py
+++ b/src/inspect_ai/_util/logger.py
@@ -1,5 +1,4 @@
 import os
-from contextvars import ContextVar
 from logging import (
     INFO,
     WARNING,
@@ -154,19 +153,21 @@ def notify_logger_record(record: LogRecord, write: bool) -> None:
 
     if write:
         transcript()._event(LoggerEvent(message=LoggingMessage.from_log_record(record)))
+    global _rate_limit_count
     if record.levelno <= INFO and "429" in record.getMessage():
-        _rate_limit_count_context_var.set(_rate_limit_count_context_var.get() + 1)
+        _rate_limit_count = _rate_limit_count + 1
 
 
-_rate_limit_count_context_var = ContextVar[int]("rate_limit_count", default=0)
+_rate_limit_count = 0
 
 
 def init_http_rate_limit_count() -> None:
-    _rate_limit_count_context_var.set(0)
+    global _rate_limit_count
+    _rate_limit_count = 0
 
 
 def http_rate_limit_count() -> int:
-    return _rate_limit_count_context_var.get()
+    return _rate_limit_count
 
 
 def warn_once(logger: Logger, message: str) -> None:


### PR DESCRIPTION
Since the main task display app is in a difference context than the logger, it can’t use a context variable to hold this value.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
