### PR TITLE
Add support for rate limit detection on Bedrock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Eval: `--sample-id` option for evaluating specific sample id(s).
+- Bedrock: Detect and report HTTP rate limit errors.
 - Azure AI: Add `emulate_tools` model arg to force tool emulation (emulation is enabled by default for Llama models).
 - Basic agent: Add `max_tool_output` parameter to override default max tool output from generate config.
 - Trace: Show custom tool views in `--trace` mode.


### PR DESCRIPTION
Add support for detecting Bedrock http rate limits. The log configuration for these errors is described here:

https://boto3.amazonaws.com/v1/documentation/api/latest/guide/retries.html#validating-retry-attempts

We now will inspect debug messages from botocore and respond appropriately to messages.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

