### PR TITLE
Azure AI: Add `emulate_tools` model arg to force tool emulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Azure AI: Add `emulate_tools` model arg to force tool emulation (emulation is enabled by default for Llama models).
 - Trace: Show custom tool views in `--trace` mode.
 
 ## v0.3.51 (13 December 2024)

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -190,19 +190,19 @@ $ inspect eval --model azureai/llama-2-70b-chat-wnsnw
 #### Tool Emulation
 
 ::: {.callout-note appearance="simple"}
-The `emulated_tools` model argument described below is supported only in the development version of Inspect. To install the development version from GitHub:
+The `emulated_tool` model argument described below is supported only in the development version of Inspect. To install the development version from GitHub:
 ``` bash
 pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
 ```
 :::
 
-When using the `azureai` model provider, tool calling support can be 'emulated' for models that Azure AI has not yet implemented tool calling for. This occurs by default for Llama models. For other models, use the `emulated_tools` model arg to force tool emulation:
+When using the `azureai` model provider, tool calling support can be 'emulated' for models that Azure AI has not yet implemented tool calling for. This occurs by default for Llama models. For other models, use the `emulated_tool` model arg to force tool emulation:
 
 ```bash
-inspect eval ctf.py -M emulated_tools=true
+inspect eval ctf.py -M emulate_tools=true
 ```
 
-You can also use this option to disable tool emulation for Llama models with `emulated_tools=false`.
+You can also use this option to disable tool emulation for Llama models with `emulated_tool=false`.
 
 ### AWS Bedrock {#aws-bedrock}
 

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -190,19 +190,19 @@ $ inspect eval --model azureai/llama-2-70b-chat-wnsnw
 #### Tool Emulation
 
 ::: {.callout-note appearance="simple"}
-The `emulated_tool` model argument described below is supported only in the development version of Inspect. To install the development version from GitHub:
+The `emulate_tools` model argument described below is supported only in the development version of Inspect. To install the development version from GitHub:
 ``` bash
 pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
 ```
 :::
 
-When using the `azureai` model provider, tool calling support can be 'emulated' for models that Azure AI has not yet implemented tool calling for. This occurs by default for Llama models. For other models, use the `emulated_tool` model arg to force tool emulation:
+When using the `azureai` model provider, tool calling support can be 'emulated' for models that Azure AI has not yet implemented tool calling for. This occurs by default for Llama models. For other models, use the `emulate_tools` model arg to force tool emulation:
 
 ```bash
 inspect eval ctf.py -M emulate_tools=true
 ```
 
-You can also use this option to disable tool emulation for Llama models with `emulated_tool=false`.
+You can also use this option to disable tool emulation for Llama models with `emulate_tools=false`.
 
 ### AWS Bedrock {#aws-bedrock}
 

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -187,6 +187,23 @@ $ export AZUREAI_BASE_URL=https://your-url-at.azure.com
 $ inspect eval --model azureai/llama-2-70b-chat-wnsnw
 ```
 
+#### Tool Emulation
+
+::: {.callout-note appearance="simple"}
+The `emulated_tools` model argument described below is supported only in the development version of Inspect. To install the development version from GitHub:
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+When using the `azureai` model provider, tool calling support can be 'emulated' for models that Azure AI has not yet implemented tool calling for. This occurs by default for Llama models. For other models, use the `emulated_tools` model arg to force tool emulation:
+
+```bash
+inspect eval ctf.py -M emulated_tools=true
+```
+
+You can also use this option to disable tool emulation for Llama models with `emulated_tools=false`.
+
 ### AWS Bedrock {#aws-bedrock}
 
 [AWS Bedrock](https://aws.amazon.com/bedrock/) provides hosting of models from Anthropic as well as a wide variety of other open models. Note that all models on AWS Bedrock require that you [request model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html) before using them in a deployment (in some cases access is granted immediately, in other cases it could one or more days).


### PR DESCRIPTION
Emulation is enabled by default for Llama models
