### PR TITLE
Support dynamic metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Basic Agent: Add `max_tool_output` parameter to override default max tool output from generate config.
 - Inspect View: Correct display of sample ID for single sample tasks.
 - Trace: Show custom tool views in `--trace` mode.
+- Bugfix: Support for dynamic metric names in realtime scoring display.
 
 
 ## v0.3.51 (13 December 2024)


### PR DESCRIPTION
The first implementation assumed that metric names would be static through the eval, but there are cases (e.g. agentharm) where keys may be changed (for example, a category level metric). This removes the assumption that metric names are static.

We use metric names to pick widgets to update (so we update only the value, not recomputing the whole grid constantly) - when we encounter a metric that we don’t have a value widget for, this means the grid is stale and needs to be re-computed.

Fixes #1002 

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
