### PR TITLE
Simplify JSON Panel rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Inspect View: Various improvements to appearance of tool calls in transcript.
+- Bugfix: Proper handling of text find for eval raw JSON display
 - Bugfix: Correct handling for `--sample-id` integer comparisons.
 
 ## v0.3.52 (13 December 2024)

--- a/src/inspect_ai/_view/www/App.css
+++ b/src/inspect_ai/_view/www/App.css
@@ -717,6 +717,13 @@ pre[class*="language-"].tool-output {
   border-radius: var(--bs-border-radius) !important;
 }
 
+.vscode-dark pre.jsonPanel {
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+  border-radius: var(--bs-border-radius) !important;  
+}
+
 
 /* jsondiffpatch */
 

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -14990,6 +14990,13 @@ pre[class*="language-"].tool-output {
   border-radius: var(--bs-border-radius) !important;
 }
 
+.vscode-dark pre.jsonPanel {
+  background: none !important;
+  border: none !important;
+  box-shadow: none !important;
+  border-radius: var(--bs-border-radius) !important;  
+}
+
 
 /* jsondiffpatch */
 

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -19437,21 +19437,15 @@ const LoggerEventView = ({ id, event, style }) => {
 };
 const kPrismRenderMaxSize = 25e4;
 const JSONPanel = ({ id, json, data, simple, style }) => {
-  const sourceCode = json || JSON.stringify(data, void 0, 2);
   const codeRef = A();
-  if (codeRef.current) {
+  const sourceCode = T(() => {
+    return json || JSON.stringify(data, void 0, 2);
+  }, [json, data]);
+  y(() => {
     if (sourceCode.length < kPrismRenderMaxSize) {
-      codeRef.current.innerHTML = Prism$1.highlight(
-        sourceCode,
-        Prism$1.languages.javascript,
-        "javacript"
-      );
-    } else {
-      const textNode = document.createTextNode(sourceCode);
-      codeRef.current.innerText = "";
-      codeRef.current.appendChild(textNode);
+      Prism$1.highlightElement(codeRef.current);
     }
-  }
+  }, [sourceCode]);
   return m$1`<div>
     <pre
       style=${{
@@ -19461,16 +19455,18 @@ const JSONPanel = ({ id, json, data, simple, style }) => {
     borderRadius: simple ? void 0 : "var(--bs-border-radius)",
     ...style
   }}
+      class="jsonPanel"
     >
     <code 
       id=${id}
       ref=${codeRef}
-      class="sourceCode-json" 
+      class="sourceCode language-javascript" 
       style=${{
     fontSize: FontSize.small,
     whiteSpace: "pre-wrap",
     wordWrap: "anywhere"
   }}>
+      ${sourceCode}
     </code>
     </pre>
   </div>`;
@@ -20283,7 +20279,10 @@ const SampleSummary = ({ parent_id, sample, style, sampleDescriptor }) => {
       clamp: true
     });
   }
-  const fullAnswer = sample && sampleDescriptor ? sampleDescriptor.selectedScorer(sample).answer() : void 0;
+  const fullAnswer = sample && sampleDescriptor ? (
+    // @ts-ignore
+    sampleDescriptor.selectedScorer(sample).answer()
+  ) : void 0;
   if (fullAnswer) {
     columns.push({
       label: "Answer",
@@ -20309,7 +20308,11 @@ const SampleSummary = ({ parent_id, sample, style, sampleDescriptor }) => {
     value: sample.error ? m$1`<${FlatSampleError}
           message=${sample.error.message}
           style=${{ marginTop: "0.4rem" }}
-        />` : sampleDescriptor == null ? void 0 : sampleDescriptor.selectedScore(sample).render(),
+        />` : (
+      // TODO: Cleanup once the PR lands which makes sample / sample summary share common interface
+      // @ts-ignore
+      sampleDescriptor == null ? void 0 : sampleDescriptor.selectedScore(sample).render()
+    ),
     size: "minmax(2em, auto)",
     center: true
   });

--- a/src/inspect_ai/_view/www/src/components/JsonPanel.mjs
+++ b/src/inspect_ai/_view/www/src/components/JsonPanel.mjs
@@ -4,7 +4,7 @@ import Prism from "prismjs";
 import "prismjs/components/prism-json";
 
 import { html } from "htm/preact";
-import { useRef } from "preact/hooks";
+import { useEffect, useMemo, useRef } from "preact/hooks";
 import { FontSize } from "../appearance/Fonts.mjs";
 
 const kPrismRenderMaxSize = 250000;
@@ -22,25 +22,17 @@ const kPrismRenderMaxSize = 250000;
  * @returns {import('preact').JSX.Element} The rendered component.
  */
 export const JSONPanel = ({ id, json, data, simple, style }) => {
-  const sourceCode = json || JSON.stringify(data, undefined, 2);
   const codeRef = useRef();
 
-  if (codeRef.current) {
+  const sourceCode = useMemo(() => {
+    return json || JSON.stringify(data, undefined, 2);
+  }, [json, data]);
+
+  useEffect(() => {
     if (sourceCode.length < kPrismRenderMaxSize) {
-      // @ts-ignore
-      codeRef.current.innerHTML = Prism.highlight(
-        sourceCode,
-        Prism.languages.javascript,
-        "javacript",
-      );
-    } else {
-      const textNode = document.createTextNode(sourceCode);
-      // @ts-ignore
-      codeRef.current.innerText = "";
-      // @ts-ignore
-      codeRef.current.appendChild(textNode);
+      Prism.highlightElement(codeRef.current);
     }
-  }
+  }, [sourceCode]);
 
   return html`<div>
     <pre
@@ -51,16 +43,18 @@ export const JSONPanel = ({ id, json, data, simple, style }) => {
         borderRadius: simple ? undefined : "var(--bs-border-radius)",
         ...style,
       }}
+      class="jsonPanel"
     >
     <code 
       id=${id}
       ref=${codeRef}
-      class="sourceCode-json" 
+      class="sourceCode language-javascript" 
       style=${{
       fontSize: FontSize.small,
       whiteSpace: "pre-wrap",
       wordWrap: "anywhere",
     }}>
+      ${sourceCode}
     </code>
     </pre>
   </div>`;


### PR DESCRIPTION
The panel content would disappear with a re-render caused by showing the find view in vscode.

This converts to reactively highlighting rather than setting the innerhtml.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
