### PR TITLE
emulated tools for bedrock/nova

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## Unreleased
 
+- Bedrock: Support for emulated tool use (enabled by default for Nova, opt-in for other models).
+- Bedrock: Support for custom `model_args` passed through to `session.Client`.
 - Inspect View: Various improvements to appearance of tool calls in transcript.
 - Bugfix: Correct handling for `--sample-id` integer comparisons.
+- Bugfix: Proper removal of model_args with falsey values (explicit check for `None`)
 
 ## v0.3.52 (13 December 2024)
 

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -215,6 +215,23 @@ $ inspect eval bedrock/meta.llama2-70b-chat-v1
 
 You aren't likely to need to, but you can also specify a custom base URL for AWS Bedrock using the `BEDROCK_BASE_URL` environment variable.
 
+#### Tool Emulation
+
+::: {.callout-note appearance="simple"}
+The `emulate_tools` model argument described below is supported only in the development version of Inspect. To install the development version from GitHub:
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+When using the `bedrock` model provider, tool calling support can be 'emulated' for models that Bedrock has not yet properly implemented converse tool calling for. This occurs by default for Nova models. For other models, use the `emulate_tools` model arg to force tool emulation:
+
+```bash
+inspect eval ctf.py -M emulate_tools=true
+```
+
+You can also use this option to disable tool emulation for Nova models with `emulate_tools=false`.
+
 ### Google {#google}
 
 Google models make available [safety settings](https://ai.google.dev/gemini-api/docs/safety-settings) that you can adjust to determine what sorts of requests will be handled (or refused) by the model. The four categories of safety settings are as follows:
@@ -438,7 +455,8 @@ The additional `model_args` are forwarded as follows for the various providers:
 | llama-cpp-python | `AsyncOpenAI`                          |
 | TogetherAI       | `AsyncOpenAI`                          |
 | Groq             | `AsyncGroq`                            |
-| AzureAI          | Chat HTTP Post Body                    |
+| Bedrock          | `session.Client`                       |
+| AzureAI          | `ChatCompletionsClient`                |
 | Cloudflare       | Chat HTTP Post Body                    |
 
 : {tbl-colwidths="\[30,70\]"}

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -93,7 +93,7 @@ class AzureAIAPI(ModelAPI):
         def collect_model_arg(name: str) -> Any | None:
             nonlocal model_args
             value = model_args.get(name, None)
-            if value:
+            if value is not None:
                 model_args.pop(name)
             return value
 

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -64,7 +64,7 @@ class HuggingFaceAPI(ModelAPI):
         def collect_model_arg(name: str) -> Any | None:
             nonlocal model_args
             value = model_args.get(name, None)
-            if value:
+            if value is not None:
                 model_args.pop(name)
             return value
 

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -75,7 +75,7 @@ class VLLMAPI(ModelAPI):
         def collect_model_arg(name: str) -> Any | None:
             nonlocal model_args
             value = model_args.get(name, None)
-            if value:
+            if value is not None:
                 model_args.pop(name)
             return value
 


### PR DESCRIPTION
When using the `bedrock` model provider, tool calling support can be 'emulated' for models that Bedrock has not yet properly implemented converse tool calling for. This occurs by default for Nova models. For other models, use the `emulate_tools` model arg to force tool emulation:

```bash
inspect eval ctf.py -M emulate_tools=true
```

You can also use this option to disable tool emulation for Nova models with `emulate_tools=false`.