### PR TITLE
Make sure to increment sample count when retrying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bugfix: Proper handling of text find for eval raw JSON display
 - Bugfix: Correct handling for `--sample-id` integer comparisons.
 - Bugfix: Proper removal of model_args with falsey values (explicit check for `None`)
+- Bugfix: Proper sample count display when retrying an evaluation
 
 ## v0.3.52 (13 December 2024)
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -486,8 +486,8 @@ async def task_run_sample(
                 await logger.log_sample(previous_sample, flush=False)
 
             # return score
-            if previous_sample.scores:
-                return {
+            sample_scores = (
+                {
                     key: SampleScore(
                         sample_id=previous_sample.id,
                         value=score.value,
@@ -497,8 +497,11 @@ async def task_run_sample(
                     )
                     for key, score in previous_sample.scores.items()
                 }
-            else:
-                return {}
+                if previous_sample.scores
+                else {}
+            )
+            sample_complete(sample_scores)
+            return sample_scores
 
     # use semaphore if provided
     semaphore_cm: asyncio.Semaphore | contextlib.AbstractAsyncContextManager[None] = (


### PR DESCRIPTION
The sample count was incorrect when retrying an evaluation (as the sample count wasn't being incremented when a sample was skipped because it was already complete).

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor


