### PR TITLE
Properly handle dicts and lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Bugfix: Proper handling of text find for eval raw JSON display
 - Bugfix: Correct handling for `--sample-id` integer comparisons.
 - Bugfix: Proper removal of model_args with falsey values (explicit check for `None`)
+- Bugfix: Properly handle custom metrics that return dictionaries or lists
 
 ## v0.3.52 (13 December 2024)
 

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -293,17 +293,16 @@ def scorers_from_metric_dict(
         # create a scorer result for this metric
         # TODO: What if there is separate simple scorer which has a name collision with
         # a score created by this scorer
-        if len(result_metrics.values()) > 0:
-            results.append(
-                EvalScore(
-                    scorer=scorer_name,
-                    reducer=reducer_name,
-                    name=metric_key,
-                    params=registry_params(scorer),
-                    metadata=metadata if len(metadata.keys()) > 0 else None,
-                    metrics=result_metrics,
-                )
+        results.append(
+            EvalScore(
+                scorer=scorer_name,
+                reducer=reducer_name,
+                name=metric_key,
+                params=registry_params(scorer),
+                metadata=metadata if len(metadata.keys()) > 0 else None,
+                metrics=result_metrics,
             )
+        )
     return results
 
 


### PR DESCRIPTION
`metric`s return value is `Value` which means that a list or dict is allowed to be returned, like so:

```
@metric
def nested_dict_metric() -> Metric:
    def metric(scores: list[Score]) ->  Value:

        total = 0
        for score in scores:
          if not isinstance(score.value, dict) and not isinstance(score.value, list):
            total = int(score.value)+ total

        return {
                "total": total,
                "ratio": total/26
            }

    return metric
```

or

```
@metric
def nested_array_metric() -> Metric:
    def metric(scores: list[Score]) ->  Value:

        total = 0
        for score in scores:
          if not isinstance(score.value, dict) and not isinstance(score.value, list):
            total = int(score.value)+ total

        return [total, total/26]

    return metric

@scorer(
    metrics={"*": [nested_dict_metric(), nested_array_metric()]}
)
```

This properly handles this case (which currently just throws) by created named metrics based upon either the key name in the dict, or the index of the item in the array.

Since Sept we've supported `Value` being returned from metrics (previously they had to return `int | float`), but haven't been properly handling it.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
