### PR TITLE
OpenAI: Support for o1 including native tool calling and `reasoning_effort` generation option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- OpenAI: Support for o1 including native tool calling and `reasoning_effort` generation option.
 - Task API: Introduce `setup` step that always runs even if `solver` is replaced.
 - Bedrock: Support for tool calling on Nova models.
 - Bedrock: Support for custom `model_args` passed through to `session.Client`.

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -362,6 +362,12 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         envvar="INSPECT_EVAL_CACHE_PROMPT",
     )
     @click.option(
+        "--reasoning-effort",
+        type=click.Choice(["low", "medium", "high"]),
+        help="Constrains effort on reasoning for reasoning models. Open AI o1 models only.",
+        envvar="INSPECT_EVAL_REASONING_EFFORT",
+    )
+    @click.option(
         "--log-format",
         type=click.Choice(["eval", "json"], case_sensitive=False),
         envvar=["INSPECT_LOG_FORMAT", "INSPECT_EVAL_LOG_FORMAT"],
@@ -419,6 +425,7 @@ def eval_command(
     parallel_tool_calls: bool | None,
     max_tool_output: int | None,
     cache_prompt: str | None,
+    reasoning_effort: str | None,
     message_limit: int | None,
     token_limit: int | None,
     time_limit: int | None,
@@ -573,6 +580,7 @@ def eval_set_command(
     parallel_tool_calls: bool | None,
     max_tool_output: int | None,
     cache_prompt: str | None,
+    reasoning_effort: str | None,
     message_limit: int | None,
     token_limit: int | None,
     time_limit: int | None,

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -72,6 +72,9 @@ class GenerateConfigArgs(TypedDict, total=False):
     cache_prompt: Literal["auto"] | bool | None
     """Whether to cache the prompt prefix. Defaults to "auto", which will enable caching for requests with tools. Anthropic only."""
 
+    reasoning_effort: Literal["low", "medium", "high"] | None
+    """Constrains effort on reasoning for reasoning models. Open AI o1 models only."""
+
 
 class GenerateConfig(BaseModel):
     """Base class for model generation configs."""
@@ -138,6 +141,9 @@ class GenerateConfig(BaseModel):
 
     cache_prompt: Literal["auto"] | bool | None = Field(default=None)
     """Whether to cache the prompt prefix. Defaults to "auto", which will enable caching for requests with tools. Anthropic only."""
+
+    reasoning_effort: Literal["low", "medium", "high"] | None = Field(default=None)
+    """Constrains effort on reasoning for reasoning models. Open AI o1 models only."""
 
     def merge(
         self, other: Union["GenerateConfig", GenerateConfigArgs]

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -242,7 +242,7 @@ def mockllm() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "1.45.0"
+    MIN_VERSION = "1.58.1"
 
     # verify we have the package
     try:


### PR DESCRIPTION
This PR adds support for access to the full o1 model. PR is marked as draft b/c as of yet I still get "The model `o1` does not exist or you do not have access to it" when trying to access `o1`.  Changes include:

1) Native tool calling API for `o1` (we still fall back to emulation for `o1-preview` an `o1-mini`).
2) Yield the new "developer" message type for system messages when running with `o1`
3) Support `reasoning_effort` generation config option.
4) We now require the latest version of the OpenAI package (1.58.1) to support all of the above.

We'll keep trying out the API tomorrow to see if we can verify that all is working and will merge after that. 

