### PR TITLE
Fix metrics returning strings

### DIFF
--- a/src/inspect_ai/_display/core/results.py
+++ b/src/inspect_ai/_display/core/results.py
@@ -205,7 +205,7 @@ def task_metrics(scores: list[EvalScore]) -> str:
                 if metric.value == 1
                 else (
                     str(metric.value)
-                    if isinstance(metric.value, int)
+                    if isinstance(metric.value, int | str)
                     else f"{metric.value:.3g}"
                 )
             )

--- a/src/inspect_ai/_display/textual/widgets/task_detail.py
+++ b/src/inspect_ai/_display/textual/widgets/task_detail.py
@@ -210,8 +210,9 @@ class TaskMetrics(Widget):
         for metric in metrics:
             widget = self.value_widgets.get(metric.name)
             if widget:
+                value = metric.value if isinstance(metric.value, str) else f"{metric.value:,.3f}"
                 # Just update the values themselves
-                widget.update(content=f"{metric.value:,.3f}")
+                widget.update(content=value)
             else:
                 # Don't have a widget for this, recompute the whole grid
                 need_recompute = True

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -22,7 +22,7 @@ from inspect_ai.model import (
     ModelOutput,
     ModelUsage,
 )
-from inspect_ai.scorer import Score
+from inspect_ai.scorer import Score, Value
 from inspect_ai.scorer._metric import SampleScore
 from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
@@ -265,7 +265,7 @@ class EvalMetric(BaseModel):
     name: str
     """Metric name."""
 
-    value: int | float
+    value: Value
     """Metric value."""
 
     options: dict[str, Any] = Field(default_factory=dict)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Inspect crashes when a metric returns a string, even though the acceptable return types are "Values" which can be strings.

### What is the new behavior?
Inspect eval no longer crashes when returning a string value from a metric. Unfortunately, the viewer still crashes.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
