### PR TITLE
Update py doc strings to reflect new 10 MiB exec output limit

### DIFF
--- a/docs/_sandboxenv-interface.md
+++ b/docs/_sandboxenv-interface.md
@@ -19,7 +19,7 @@ class SandboxEnvironment:
           PermissionError: If the user does not have
             permission to execute the command.
           OutputLimitExceededError: If an output stream
-            exceeds the 1 MiB limit.
+            exceeds the 10 MiB limit.
         """
         ...
 

--- a/docs/tools.qmd
+++ b/docs/tools.qmd
@@ -100,7 +100,7 @@ If you do not explicitly handle errors, then Inspect provides some default error
 
 -   `UnicodeDecodeError` — Occurs when the output from executing a process or reading a file is binary rather than text.
 
--   `OutputLimitExceededError` - Occurs when one or both of the output streams from `sandbox().exec()` exceed 1 MiB or when attempting to read a file over 100 MiB in size.
+-   `OutputLimitExceededError` - Occurs when one or both of the output streams from `sandbox().exec()` exceed 10 MiB or when attempting to read a file over 100 MiB in size.
 
 -   `ToolError` — Special error thrown by tools to indicate they'd like to report an error to the model.
 

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -143,7 +143,7 @@ class SandboxEnvironment(abc.ABC):
         The current working directory for execution will be the per-sample
         filesystem context.
 
-        Each output stream (stdout and stderr) is limited to 1 MiB. If exceeded, an
+        Each output stream (stdout and stderr) is limited to 10 MiB. If exceeded, an
         `OutputLimitExceededError` will be raised.
 
         Args:
@@ -164,7 +164,7 @@ class SandboxEnvironment(abc.ABC):
           PermissionError: If the user does not have
             permission to execute the command.
           OutputLimitExceededError: If an output stream
-            exceeds the 1 MiB limit.
+            exceeds the 10 MiB limit.
         """
         ...
 

--- a/src/inspect_ai/util/_sandbox/limits.py
+++ b/src/inspect_ai/util/_sandbox/limits.py
@@ -29,7 +29,7 @@ def verify_exec_result_size(exec_result: ExecResult[str]) -> None:
     """Verify the size of the output streams in an `ExecResult`.
 
     Raises:
-      OutputLimitExceededError: If an output stream exceeds the 1 MiB limit.
+      OutputLimitExceededError: If an output stream exceeds the limit.
     """
     limit = SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE
     stdout_truncated = truncate_string_to_bytes(exec_result.stdout, limit)


### PR DESCRIPTION
This was updated in #833 - just updating the places the value was referenced.