### PR TITLE
Properly terminate `inspect view` when the extension is disposed

### DIFF
--- a/tools/vscode/CHANGELOG.md
+++ b/tools/vscode/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.48
+
+- Properly shutdown the `inspect view` process when exiting VSCode.
+
 ## 0.3.47
 
 - Minor improvements

--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -7,7 +7,7 @@
   "author": {
     "name": "UK AI Safety Institute"
   },
-  "version": "0.3.47",
+  "version": "0.3.48",
   "license": "MIT",
   "homepage": "https://inspect.ai-safety-institute.org.uk/",
   "repository": {

--- a/tools/vscode/src/extension.ts
+++ b/tools/vscode/src/extension.ts
@@ -101,6 +101,7 @@ export async function activate(context: ExtensionContext) {
 
   // initialiaze view server
   const server = new InspectViewServer(context, inspectManager);
+  context.subscriptions.push(server);
 
   // initialise logs watcher
   const logsWatcher = new InspectLogsWatcher(stateManager);


### PR DESCRIPTION
Properly terminate `inspect view` when the extension is disposed

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
