### PR TITLE
concurrency: do not use `max_tasks` as a lower bound for `max_samples`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Inspect View: Various improvements to appearance of tool calls in transcript.
 - Task display: Ensure that widths of progress elements are kept consistant across tasks.
 - Sandboxes: Remove use of aiofiles to mitigate potential for threading deadlocks.
+- Concurrency: Do not use `max_tasks` as a lower bound for `max_samples`.
 - Bugfix: Proper handling of text find for eval raw JSON display
 - Bugfix: Correct handling for `--sample-id` integer comparisons.
 - Bugfix: Proper removal of model_args with falsey values (explicit check for `None`)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -873,10 +873,5 @@ def create_sample_semaphore(
         else DEFAULT_MAX_CONNECTIONS
     )
 
-    # if max_tasks is specified and max_samples is less
-    # than max_tasks then bump it up
-    if config.max_tasks is not None:
-        max_samples = max(max_samples, config.max_tasks)
-
     # return the semaphore
     return asyncio.Semaphore(max_samples)


### PR DESCRIPTION
This was originally done b/c `max_samples` was global, after the change to per-task `max_samples` this no longer makes sense.