### PR TITLE
docker sandbox: introduce 120 second timeout on `docker compose cp`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Docker sandbox: Introduce 120 second timeout on `docker compose cp`.
 - Bugfix: Fix failure to fully clone samples that have message lists as input.
 
 ## v0.3.53 (20 December 2024)

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -70,15 +70,23 @@ async def compose_down(project: ComposeProject, quiet: bool = True) -> None:
         )
 
 
+# NOTE: We have observed at least one instance of docker compose cp hanging
+# indefinitely (which makes the task/sample hang indefinitely). We introduce
+# a default timeout so that this instead fails with a clear TimeoutError
 async def compose_cp(
     src: str,
     dest: str,
     project: ComposeProject,
     cwd: str | Path | None = None,
     output_limit: int | None = None,
+    timeout: int | None = 120,
 ) -> None:
     result = await compose_command(
-        ["cp", "--", src, dest], project=project, cwd=cwd, output_limit=output_limit
+        ["cp", "--", src, dest],
+        project=project,
+        cwd=cwd,
+        output_limit=output_limit,
+        timeout=timeout,
     )
     if not result.success:
         msg = f"Failed to copy file from '{src}' to '{dest}': {result.stderr}"


### PR DESCRIPTION
Temporary mitigation for https://github.com/UKGovernmentBEIS/inspect_ai/issues/1034 while we decide whether we can get rid of `docker compose cp` entirely.