### PR TITLE
provide retry for docker compose commands 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [Action tracing](https://github.com/UKGovernmentBEIS/inspect_ai/pull/1038) for diagnosing runs with unterminated action (e.g. model calls, docker commands, etc.).
+- Provide default timeout/retry for docker compose commands to mitigate unreliability in some configurations.
 - Task display: Added `--no-score-display` option to disable realtime scoring metrics.
 - Bugfix: Fix failure to fully clone samples that have message lists as input.
 

--- a/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
@@ -362,7 +362,7 @@ async def web_browser_cmd(cmd: str, *args: str) -> str:
     else:
         arg_list = ["python3", WEB_CLIENT_REQUEST, cmd] + list(args)
 
-    result = await sandbox_env.exec(arg_list)
+    result = await sandbox_env.exec(arg_list, timeout=180)
     if not result.success:
         raise RuntimeError(
             f"Error executing web browser command {cmd}({', '.join(args)}): {result.stderr}"

--- a/src/inspect_ai/util/_sandbox/context.py
+++ b/src/inspect_ai/util/_sandbox/context.py
@@ -191,7 +191,12 @@ async def setup_sandbox_environment(
 
     # chmod, execute, and remove
     async def exec(cmd: list[str]) -> None:
-        result = await env.exec(cmd)
+        try:
+            result = await env.exec(cmd, timeout=30)
+        except TimeoutError:
+            raise RuntimeError(
+                f"Timed out executing command {' '.join(cmd)} in sandbox"
+            )
 
         if not result.success:
             raise RuntimeError(

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -154,7 +154,7 @@ async def compose_exec(
     command: list[str],
     project: ComposeProject,
     timeout: int | None = None,
-    timeout_retry: bool = False,
+    timeout_retry: bool = True,
     input: str | bytes | None = None,
     output_limit: int | None = None,
 ) -> ExecResult[str]:

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -263,9 +263,9 @@ class DockerSandboxEnvironment(SandboxEnvironment):
 
     @override
     async def write_file(self, file: str, contents: str | bytes) -> None:
-        TIMEOUT = 120
+        WRITE_TIMEOUT = 120
         try:
-            async with timeout(TIMEOUT):
+            async with timeout(WRITE_TIMEOUT):
                 # resolve relative file paths
                 file = self.container_file(file)
 
@@ -362,7 +362,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                         )
         except TimeoutError:
             raise RuntimeError(
-                f"Failed to write file {file}: timed out after {TIMEOUT} seconds."
+                f"Failed to write file {file}: timed out after {WRITE_TIMEOUT} seconds."
             )
 
     @overload
@@ -453,7 +453,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
 async def container_working_dir(
     service: str, project: ComposeProject, default: str = "/"
 ) -> str:
-    result = await compose_exec([service, "sh", "-c", "pwd"], project)
+    result = await compose_exec([service, "sh", "-c", "pwd"], project, timeout_retry=True)
     if result.success:
         return result.stdout.strip()
     else:


### PR DESCRIPTION
We have discovered that under some configurations (in this case Ubuntu 24.04 on EC2 t3.2xlarge instance w/ the latest version of Docker) docker compose commands can hang (at a low rate e.g. something like 1/1000 commands). This might be a race condition in the docker daemon (as it likely doesn't normally get the density/volume of commands we send when running so many parallel samples/containers).

Issue here: https://github.com/UKGovernmentBEIS/inspect_ai/issues/1034

The resolution is to treat `docker compose` commands as inherently unreliable and prone to this hanging. The mitigate this we do the following:

1) Provide a default timeout for docker compose commands (60 seconds) and retry twice for commands that time out (there first retry waits the lower of 60 seconds and the original timeout, the second waits half of that). We cap the retry times so they don't get too far away from what is specified in e.g. the `bash()` or `python()` tool.

2) Provide an explicit timeout in places where there wasn't one (e.g. the `web_browser()` tool, sandbox service calls, etc.).

Note that one thing we don't do here is provide default timeouts for the `bash()` and `python()` tools. Perhaps we should, but this will possibly break some existing evals that rely on the default no timeout behavior (e.g. an AI R&D eval that trains a model using a tool call) so bears more discussion.


