### PR TITLE
Switch to sync S3 logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Action tracing](https://github.com/UKGovernmentBEIS/inspect_ai/pull/1038) for diagnosing runs with unterminated action (e.g. model calls, docker commands, etc.).
 - Provide default timeout/retry for docker compose commands to mitigate unreliability in some configurations.
+- Switch to sync S3 writes to overcome unreliability observed when using async interface.
 - Task display: Added `--no-score-display` option to disable realtime scoring metrics.
 - Bugfix: Fix failure to fully clone samples that have message lists as input.
 - llama-cpp-python: Support for `logprobs`.

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -353,22 +353,9 @@ class ZipLogFile:
             log_bytes = self._temp_file.read()
 
             with trace_action(logger, "Log Write", self._file):
-                # attempt async write
-                written = False
                 try:
-                    if self._async_fs:
-                        await self._async_fs._pipe_file(self._file, log_bytes)
-                        written = True
-                except Exception as ex:
-                    logger.warning(
-                        f"Error occurred during async write to {self._file}: {ex}. Falling back to sync write."
-                    )
-
-                try:
-                    # write sync if we need to
-                    if not written:
-                        with file(self._file, "wb") as f:
-                            f.write(log_bytes)
+                    with file(self._file, "wb") as f:
+                        f.write(log_bytes)
                 finally:
                     # re-open zip file w/ self.temp_file pointer at end
                     self._open()


### PR DESCRIPTION
In testing large eval-sets with high sample frequency (many small samples with short generates), we observe hangs when attempting to write eval logs to S3. Those hangs go away when writing synchronously, so switch to pure sync writes for the time being to improve stability.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
