### PR TITLE
Do not set unsupported temperature parameter for o1

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -269,7 +269,7 @@ class OpenAIAPI(ModelAPI):
             params["logit_bias"] = config.logit_bias
         if config.seed is not None:
             params["seed"] = config.seed
-        if config.temperature is not None:
+        if config.temperature is not None and not self.is_o1():
             params["temperature"] = config.temperature
         # TogetherAPI requires temperature w/ num_choices
         elif config.num_choices is not None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
If a task includes a config with a temperature, i.e., 
```
from inspect_ai.model import GenerateConfig
...
    return Task(
        ...
        config=GenerateConfig(temperature=0.5),
    )
```

and this is used with OpenAI's o1 model, an error will be raised as temperature is an unsupported parameter for the model 

```
BadRequestError: Error code: 400 - {'error': {'message': "Unsupported parameter: 'temperature' is not supported with this model.", 'type': 'invalid_request_error', 'param': 'temperature', 'code': 'unsupported_parameter'}}
```

### What is the new behavior?

Like how #1016 added a config option that can only be set for o1, this changes temperature to never be set for o1.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No, what used to be an API error will now work. 

### Other information:
Perhaps this approach is flawed because it means a user could think they're controlling temperature when it's silently being dropped? For my use case where I have a task that's being run against o1 + another model, I'd like to set the temperature when I can and avoid API errors in cases where I cannot.