### PR TITLE
Add .vscode/bookmarks.json to .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,10 @@ target/
 profile_default/
 ipython_config.py
 
+# VSCode
+# Ignore developer specific files.
+.vscode/bookmarks.json
+
 # pyenv
 #   For a library or package, you might want to ignore these files since the code is
 #   intended to run in multiple environments; otherwise, check them in:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Developer specific VSCode bookmarks are within `git`'s scope.

### What is the new behavior?
`.vscode/bookmarks.json` is ignored.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
