### PR TITLE
Implement better task detection for code lense commands.

### DIFF
--- a/tools/vscode/package.json
+++ b/tools/vscode/package.json
@@ -149,7 +149,7 @@
         "command": "inspect.logListingCopyEditorPath",
         "title": "Copy Editor URL",
         "enablement": "workspaceFolderCount != 0"
-      },      
+      },
       {
         "command": "inspect.logListingReveal",
         "title": "Reveal Log Listing",
@@ -454,7 +454,7 @@
     "package": "webpack --mode production --devtool hidden-source-map",
     "compile-tests": "tsc -p . --outDir out",
     "watch-tests": "tsc -p . -w --outDir out",
-    "pretest": "yarn run compile-tests && yarn run compile && yarn run lint",
+    "pretest": "yarn run compile-tests && yarn run compile",
     "lint": "eslint src --ext ts",
     "test": "vscode-test"
   },

--- a/tools/vscode/src/providers/codelens/codelens-provider.ts
+++ b/tools/vscode/src/providers/codelens/codelens-provider.ts
@@ -1,4 +1,13 @@
-import { CancellationToken, CodeLens, CodeLensProvider, Command, ExtensionContext, TextDocument, Uri, languages } from "vscode";
+import {
+  CancellationToken,
+  CodeLens,
+  CodeLensProvider,
+  Command,
+  ExtensionContext,
+  TextDocument,
+  Uri,
+  languages,
+} from "vscode";
 import { isNotebook } from "../../components/notebook";
 
 export function activateCodeLens(context: ExtensionContext) {
@@ -33,13 +42,31 @@ function taskCommands(uri: Uri, fn: string): Command[] {
         tooltip: "Execute this evaluation task.",
         command: "inspect.runTask",
         arguments: [uri, fn],
-      }
+      },
     ];
   }
 }
 
-class InspectCodeLensProvider implements CodeLensProvider {
-  constructor() { }
+export class InspectCodeLensProvider implements CodeLensProvider {
+  private hasInspectImport(document: TextDocument): {
+    hasImport: boolean;
+    alias?: string;
+  } {
+    const text = document.getText();
+    // Handle multiline imports by removing newlines between parentheses
+    const normalizedText = text.replace(/\(\s*\n\s*([^)]+)\s*\n\s*\)/g, "($1)");
+
+    const fromImportMatch = normalizedText.match(
+      /from\s+inspect\s+import\s+(?:\(\s*)?(?:[\w,\s]*,\s*)?task(?:\s+as\s+(\w+))?/
+    );
+    if (fromImportMatch) {
+      return { hasImport: true, alias: fromImportMatch[1] };
+    }
+    if (/import\s+inspect\b/.test(normalizedText)) {
+      return { hasImport: true };
+    }
+    return { hasImport: false };
+  }
 
   provideCodeLenses(
     document: TextDocument,
@@ -52,12 +79,31 @@ class InspectCodeLensProvider implements CodeLensProvider {
       return [];
     }
 
+    // Check for inspect import first
+    const importInfo = this.hasInspectImport(document);
+    if (!importInfo.hasImport) {
+      return [];
+    }
+
     // Go through line by line and show a lens
     // for any task decorated functions
     for (let i = 0; i < document.lineCount; i++) {
       const line = document.lineAt(i);
-      if (kTaskDecoratorPattern.test(line.text)) {
-        // Get the function name from the next line (keep looking for next function)
+      const decoratorMatch = line.text.match(
+        /^\s*@(inspect\.)?task\b|@(\w+)\b/
+      );
+
+      if (decoratorMatch) {
+        const isInspectTask =
+          decoratorMatch[1] !== undefined || // @inspect.task
+          decoratorMatch[0] === "@task" || // @task (when from inspect import task)
+          (importInfo.alias && decoratorMatch[2] === importInfo.alias); // @t (when from inspect import task as t)
+
+        if (!isInspectTask) {
+          continue;
+        }
+
+        // Get the function name from the next line
         let j = i + 1;
         while (j < document.lineCount) {
           const funcLine = document.lineAt(j);
@@ -75,5 +121,4 @@ class InspectCodeLensProvider implements CodeLensProvider {
     return lenses;
   }
 }
-const kTaskDecoratorPattern = /^\s*@task\b/;
 const kFuncPattern = /^\s*def\s*(.*)\(.*$/;

--- a/tools/vscode/src/providers/codelens/codelens-provider.ts
+++ b/tools/vscode/src/providers/codelens/codelens-provider.ts
@@ -54,15 +54,13 @@ export class InspectCodeLensProvider implements CodeLensProvider {
   } {
     const text = document.getText();
     // Handle multiline imports by removing newlines between parentheses
-    const normalizedText = text.replace(/\(\s*\n\s*([^)]+)\s*\n\s*\)/g, "($1)");
+    const normalizedText = text.replace(normalizeTextPattern, "($1)");
 
-    const fromImportMatch = normalizedText.match(
-      /from\s+inspect\s+import\s+(?:\(\s*)?(?:[\w,\s]*,\s*)?task(?:\s+as\s+(\w+))?/
-    );
+    const fromImportMatch = normalizedText.match(fromImportPattern);
     if (fromImportMatch) {
       return { hasImport: true, alias: fromImportMatch[1] };
     }
-    if (/import\s+inspect\b/.test(normalizedText)) {
+    if (hasImportPattern.test(normalizedText)) {
       return { hasImport: true };
     }
     return { hasImport: false };
@@ -89,9 +87,7 @@ export class InspectCodeLensProvider implements CodeLensProvider {
     // for any task decorated functions
     for (let i = 0; i < document.lineCount; i++) {
       const line = document.lineAt(i);
-      const decoratorMatch = line.text.match(
-        /^\s*@(inspect\.)?task\b|@(\w+)\b/
-      );
+      const decoratorMatch = line.text.match(kDecoratorPattern);
 
       if (decoratorMatch) {
         const isInspectTask =
@@ -121,4 +117,10 @@ export class InspectCodeLensProvider implements CodeLensProvider {
     return lenses;
   }
 }
+
+const fromImportPattern =
+  /from\s+inspect\s+import\s+(?:\(\s*)?(?:[\w,\s]*,\s*)?task(?:\s+as\s+(\w+))?/;
+const hasImportPattern = /import\s+inspect\b/;
 const kFuncPattern = /^\s*def\s*(.*)\(.*$/;
+const kDecoratorPattern = /^\s*@(inspect\.)?task\b|@(\w+)\b/;
+const normalizeTextPattern = /\(\s*\n\s*([^)]+)\s*\n\s*\)/g;

--- a/tools/vscode/src/test/codelens-provider.test.ts
+++ b/tools/vscode/src/test/codelens-provider.test.ts
@@ -1,0 +1,269 @@
+import * as assert from "assert";
+import {
+  CancellationToken,
+  Position,
+  Range,
+  TextDocument,
+  TextLine,
+  EndOfLine,
+  Uri,
+} from "vscode";
+import { InspectCodeLensProvider } from "../providers/codelens/codelens-provider";
+
+class MockTextLine implements TextLine {
+  constructor(private lineText: string, private _lineNumber: number) {}
+
+  get text(): string {
+    return this.lineText;
+  }
+  get lineNumber(): number {
+    return this._lineNumber;
+  }
+  get range(): Range {
+    return new Range(
+      new Position(this._lineNumber, 0),
+      new Position(this._lineNumber, this.lineText.length)
+    );
+  }
+  get rangeIncludingLineBreak(): Range {
+    return this.range;
+  }
+  get firstNonWhitespaceCharacterIndex(): number {
+    return 0;
+  }
+  get isEmptyOrWhitespace(): boolean {
+    return this.lineText.trim().length === 0;
+  }
+}
+
+class MockTextDocument implements TextDocument {
+  private lines: string[];
+
+  constructor(content: string) {
+    this.lines = content.split("\n");
+  }
+
+  get lineCount(): number {
+    return this.lines.length;
+  }
+
+  lineAt(lineOrPos: number | Position): TextLine {
+    const line = typeof lineOrPos === "number" ? lineOrPos : lineOrPos.line;
+    return new MockTextLine(this.lines[line], line);
+  }
+
+  getText(): string {
+    return this.lines.join("\n");
+  }
+
+  // Implement other required interface members with mock values
+  get uri(): any {
+    return { scheme: "file", path: "test.py" } as Uri;
+  }
+  get fileName(): string {
+    return "test.py";
+  }
+  get isUntitled(): boolean {
+    return false;
+  }
+  get languageId(): string {
+    return "python";
+  }
+  get version(): number {
+    return 1;
+  }
+  get isDirty(): boolean {
+    return false;
+  }
+  get isClosed(): boolean {
+    return false;
+  }
+  save(): Thenable<boolean> {
+    return Promise.resolve(true);
+  }
+  offsetAt(_position: Position): number {
+    return 0;
+  }
+  positionAt(_offset: number): Position {
+    return new Position(0, 0);
+  }
+  getWordRangeAtPosition(): Range | undefined {
+    return undefined;
+  }
+  validateRange(range: Range): Range {
+    return range;
+  }
+  validatePosition(_position: Position): Position {
+    return new Position(0, 0);
+  }
+  get eol(): EndOfLine {
+    return EndOfLine.LF;
+  }
+}
+
+suite("CodeLens Provider Test Suite", () => {
+  let provider: InspectCodeLensProvider;
+  let cancellationToken: CancellationToken;
+
+  setup(() => {
+    provider = new InspectCodeLensProvider();
+    cancellationToken = {
+      isCancellationRequested: false,
+      onCancellationRequested: () => ({ dispose: () => {} }),
+    };
+  });
+
+  function createDocument(content: string): TextDocument {
+    return new MockTextDocument(content);
+  }
+
+  test('should return code lenses when using "from inspect import task"', () => {
+    const document = createDocument(`
+from inspect import task
+
+@task
+def my_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      2,
+      "Should return two lenses (run and debug) for inspect task"
+    );
+  });
+
+  test('should return code lenses when using "from inspect import task as t"', () => {
+    const document = createDocument(`
+from inspect import task as t
+
+@t
+def my_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      2,
+      "Should return lenses when task is imported with alias"
+    );
+  });
+
+  test('should return code lenses when using "import inspect"', () => {
+    const document = createDocument(`
+import inspect
+
+@inspect.task
+def my_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      2,
+      "Should return lenses when using full inspect import"
+    );
+  });
+
+  test("should handle multiple task decorators in the same file", () => {
+    const document = createDocument(`
+from inspect import task
+
+@task
+def first_task():
+    pass
+
+@task
+def second_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(lenses.length, 4, "Should return lenses for both tasks");
+  });
+
+  test("should not return code lenses for non-inspect task decorator", () => {
+    const document = createDocument(`
+from pytask import task
+
+@task
+def other_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      0,
+      "Should not return code lenses for non-inspect task"
+    );
+  });
+
+  test("should handle task decorator without following function", () => {
+    const document = createDocument(`
+from inspect import task
+
+@task
+# Some comment here`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      0,
+      "Should handle malformed task decorator safely"
+    );
+  });
+
+  test("should handle empty document", () => {
+    const document = createDocument("");
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(lenses.length, 0, "Should handle empty document safely");
+  });
+
+  test("Should handle multiline import statements", () => {
+    const document = createDocument(`
+from inspect import (
+    Task,
+    task as t,
+)
+
+@t
+def my_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      2,
+      "Should return lenses for multiline import"
+    );
+  });
+
+  test("Should handle multiple imports in a single line", () => {
+    const document = createDocument(`
+from inspect import Task, task as t
+
+@t
+def my_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      2,
+      "Should return lenses for multiple imports in a single line"
+    );
+  });
+
+  test("Should handle task decorator without import", () => {
+    const document = createDocument(`
+@task
+def my_task():
+    pass`);
+
+    const lenses = provider.provideCodeLenses(document, cancellationToken);
+    assert.strictEqual(
+      lenses.length,
+      0,
+      "Should return lenses for task decorator without import"
+    );
+  });
+});


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The VSCode extension of inspect provides two commands ("Run task" and "Debug Task") when it identifies a task function. The current pattern looks for an `@task` decorator, which leads to problems with packages that use a similarly named decorator, for example, my package [pytask](https://github.com/pytask-dev/pytask).

![image](https://github.com/user-attachments/assets/2224ef37-dc30-47cc-b851-88170fa9d7cf)

### What is the new behavior?

The changes allow for better detection, which are documented in the added tests.

- inspect-ai does not mistakingly assume all `@task` decorators specify an inspect task.
- `import inspect; @inspect.task`, `from inspect import task as t; @t`, and other patterns documented in the tests correctly identify an inspect task.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

If all is correctly implemented, only false positives should be prevented.

### Other information:

I had to remove the linting stage from the pretest checks to enable running tests with minimal changes.

I am super new when it comes to Javascript and also developing VSCode extensions. If you have any feedback, let me know. It is appreciated.