### PR TITLE
Update `tool_params` to support default values of `None` if supported by the type hint.

### DIFF
--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -3,13 +3,16 @@ import inspect
 from dataclasses import is_dataclass
 from logging import getLogger
 from textwrap import dedent
+from types import UnionType
 from typing import (
     Any,
     Callable,
     Dict,
     List,
     NamedTuple,
+    Optional,
     Type,
+    Union,
     get_args,
     get_origin,
     get_type_hints,
@@ -25,10 +28,7 @@ from inspect_ai._util.text import truncate_string_to_bytes
 from inspect_ai._util.trace import trace_action
 from inspect_ai.model._trace import trace_tool_mesage
 from inspect_ai.tool import Tool, ToolCall, ToolError, ToolInfo
-from inspect_ai.tool._tool import (
-    ToolApprovalError,
-    ToolParsingError,
-)
+from inspect_ai.tool._tool import ToolApprovalError, ToolParsingError
 from inspect_ai.tool._tool_call import ToolCallContent, ToolCallError
 from inspect_ai.tool._tool_def import ToolDef, tool_defs
 from inspect_ai.tool._tool_info import parse_docstring
@@ -268,6 +268,16 @@ def disable_parallel_tools(
     return False
 
 
+def type_hint_includes_none(type_hint: Type[Any] | None) -> bool:
+    origin = get_origin(type_hint)
+
+    if origin in {Union, UnionType}:
+        return type(None) in get_args(type_hint)
+    elif origin is Optional:
+        return True
+    return False
+
+
 def tool_params(input: dict[str, Any], func: Callable[..., Any]) -> dict[str, Any]:
     # parse function typeinfo
     signature = inspect.signature(func)
@@ -296,7 +306,7 @@ def tool_params(input: dict[str, Any], func: Callable[..., Any]) -> dict[str, An
         # yield parameter (fail if not passed and there is no default)
         if param_name in input:
             params[param_name] = tool_param(type_hint, input.get(param_name))
-        elif param.default is not None:
+        elif param.default is not None or type_hint_includes_none(type_hint):
             params[param_name] = param.default
         else:
             raise ToolParsingError(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

## TODO
- [ ] Failing unit test

### What is the current behavior? (You can also link to an open issue here)

A tool call with an appropriately missing parameter still throws "Required parameter {param_name} not provided to tool call." from `tool_params`. For example, `text` is not required in calls to the following tool:
```python
  async def execute(
      action: str,
      text: str | None = None,
      coordinate: tuple[int, int] | None = None,
  ) -> ToolResult:
```

### What is the new behavior?

The `tool_params` code will no longer throw in this condition.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
