### PR TITLE
support for tool parameters with a default of `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Inspect View: never truncate tool result images and display at default width of 800px.
-- Tool paramters with a default of `None` are now supported.
+- Tool parameters with a default of `None` are now supported.
 
 ## v0.3.56 (01 January 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Inspect View: never truncate tool result images and display at default width of 800px.
+- Tool paramters with a default of `None` are now supported.
 
 ## v0.3.56 (01 January 2025)
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -3,13 +3,16 @@ import inspect
 from dataclasses import is_dataclass
 from logging import getLogger
 from textwrap import dedent
+from types import UnionType
 from typing import (
     Any,
     Callable,
     Dict,
     List,
     NamedTuple,
+    Optional,
     Type,
+    Union,
     get_args,
     get_origin,
     get_type_hints,
@@ -25,10 +28,7 @@ from inspect_ai._util.text import truncate_string_to_bytes
 from inspect_ai._util.trace import trace_action
 from inspect_ai.model._trace import trace_tool_mesage
 from inspect_ai.tool import Tool, ToolCall, ToolError, ToolInfo
-from inspect_ai.tool._tool import (
-    ToolApprovalError,
-    ToolParsingError,
-)
+from inspect_ai.tool._tool import ToolApprovalError, ToolParsingError
 from inspect_ai.tool._tool_call import ToolCallContent, ToolCallError
 from inspect_ai.tool._tool_def import ToolDef, tool_defs
 from inspect_ai.tool._tool_info import parse_docstring
@@ -268,6 +268,16 @@ def disable_parallel_tools(
     return False
 
 
+def type_hint_includes_none(type_hint: Type[Any] | None) -> bool:
+    origin = get_origin(type_hint)
+
+    if origin in {Union, UnionType}:
+        return type(None) in get_args(type_hint)
+    elif origin is Optional:
+        return True
+    return False
+
+
 def tool_params(input: dict[str, Any], func: Callable[..., Any]) -> dict[str, Any]:
     # parse function typeinfo
     signature = inspect.signature(func)
@@ -296,7 +306,7 @@ def tool_params(input: dict[str, Any], func: Callable[..., Any]) -> dict[str, An
         # yield parameter (fail if not passed and there is no default)
         if param_name in input:
             params[param_name] = tool_param(type_hint, input.get(param_name))
-        elif param.default is not None:
+        elif param.default is not None or type_hint_includes_none(type_hint):
             params[param_name] = param.default
         else:
             raise ToolParsingError(

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+import types
 from dataclasses import is_dataclass
 from logging import getLogger
 from textwrap import dedent
@@ -11,6 +12,7 @@ from typing import (
     List,
     NamedTuple,
     Optional,
+    Tuple,
     Type,
     Union,
     get_args,
@@ -349,9 +351,19 @@ def tool_param(type_hint: Type[Any], input: Any) -> Any:
             return [tool_param(args[0], x) for x in input]
         else:
             return input
+    elif origin is tuple or origin is Tuple:
+        if args:
+            return tuple([tool_param(args[0], x) for x in input])
+        else:
+            return tuple(input)
     elif origin is dict or origin is Dict:
         if args and len(args) > 1:
             return {k: tool_param(args[1], v) for k, v in input}
+        else:
+            return input
+    elif origin is Union or origin is types.UnionType:
+        if args[1] is type(None):
+            return tool_param(args[0], input)
         else:
             return input
     else:

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -410,25 +410,34 @@ def chat_tools(tools: list[ToolInfo]) -> list[Tool]:
 # https://ai.google.dev/gemini-api/tutorials/extract_structured_data#define_the_schema
 
 
-def schema_from_param(param: ToolParam | ToolParams) -> Schema:
+def schema_from_param(param: ToolParam | ToolParams, nullable: bool = False) -> Schema:
     if isinstance(param, ToolParams):
         param = ToolParam(
             type=param.type, properties=param.properties, required=param.required
         )
 
     if param.type == "number":
-        return Schema(type=Type.NUMBER, description=param.description)
+        return Schema(
+            type=Type.NUMBER, description=param.description, nullable=nullable
+        )
     elif param.type == "integer":
-        return Schema(type=Type.INTEGER, description=param.description)
+        return Schema(
+            type=Type.INTEGER, description=param.description, nullable=nullable
+        )
     elif param.type == "boolean":
-        return Schema(type=Type.BOOLEAN, description=param.description)
+        return Schema(
+            type=Type.BOOLEAN, description=param.description, nullable=nullable
+        )
     elif param.type == "string":
-        return Schema(type=Type.STRING, description=param.description)
+        return Schema(
+            type=Type.STRING, description=param.description, nullable=nullable
+        )
     elif param.type == "array":
         return Schema(
             type=Type.ARRAY,
             description=param.description,
             items=schema_from_param(param.items) if param.items else None,
+            nullable=nullable,
         )
     elif param.type == "object":
         return Schema(
@@ -438,7 +447,14 @@ def schema_from_param(param: ToolParam | ToolParams) -> Schema:
             if param.properties is not None
             else None,
             required=param.required,
+            nullable=nullable,
         )
+    # convert unions to optional params if the second type is 'null'
+    elif param.anyOf:
+        if len(param.anyOf) == 2 and param.anyOf[1].type == "null":
+            return schema_from_param(param.anyOf[0], nullable=True)
+        else:
+            return Schema(type=Type.TYPE_UNSPECIFIED)
     else:
         return Schema(type=Type.TYPE_UNSPECIFIED)
 

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -194,7 +194,9 @@ class GoogleAPI(ModelAPI):
                 model=self.model_name, content=ex.message, stop_reason="model_length"
             )
         else:
-            raise ex
+            return ModelOutput.from_content(
+                model=self.model_name, content=ex.message, stop_reason="unknown"
+            )
 
     @override
     def is_rate_limit(self, ex: BaseException) -> bool:

--- a/src/inspect_ai/tool/_tool_info.py
+++ b/src/inspect_ai/tool/_tool_info.py
@@ -8,6 +8,7 @@ from typing import (
     Dict,
     List,
     Optional,
+    Tuple,
     Type,
     Union,
     get_args,
@@ -155,7 +156,7 @@ def parse_type(type_hint: Type[Any]) -> ToolParam:
             return ToolParam(type="null")
         else:
             return ToolParam()
-    elif origin is list or origin is List:
+    elif origin is list or origin is List or origin is tuple or origin is Tuple:
         return ToolParam(
             type="array", items=parse_type(args[0]) if args else ToolParam()
         )

--- a/tests/tools/test_tool_types.py
+++ b/tests/tools/test_tool_types.py
@@ -126,6 +126,28 @@ def sound_check():
     return execute
 
 
+@tool
+def computer_action():
+    async def execute(
+        action: str,
+        text: str | None = None,
+        coordinate: tuple[int, int] | None = None,
+    ) -> str:
+        """Take an action using a computer.
+
+        Args:
+          action: Action to take.
+          text: Text related to the action
+          coordinate: Coordinate related to the action.
+
+        Returns:
+          The sound that was passed to check.
+        """
+        return action
+
+    return execute
+
+
 def check_point(model: str, tool: Tool, function_name: str) -> None:
     task = Task(
         dataset=MemoryDataset(
@@ -211,12 +233,32 @@ def check_optional_args(model: str) -> None:
     verify_tool_call(log, "stuff")
 
 
+def check_none_default_arg(model: str) -> None:
+    task = Task(
+        dataset=MemoryDataset(
+            [
+                Sample(
+                    input="Please call the computer_action function with the action='click' argument."
+                )
+            ]
+        ),
+        solver=[
+            use_tools([computer_action()], tool_choice=ToolFunction("computer_action")),
+            generate(),
+        ],
+    )
+
+    log = eval(task, model=model)[0]
+    verify_tool_call(log, "click")
+
+
 def check_tool_types(model: str):
     check_typed_dict(model)
     check_dataclass(model)
     check_list_of_numbers(model)
     check_list_of_objects(model)
     check_optional_args(model)
+    check_none_default_arg(model)
 
 
 @skip_if_no_openai


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

## TODO
- [ ] Failing unit test

### What is the current behavior? (You can also link to an open issue here)

A tool call with an appropriately missing parameter still throws "Required parameter {param_name} not provided to tool call." from `tool_params`. For example, `text` is not required in calls to the following tool:
```python
  async def execute(
      action: str,
      text: str | None = None,
      coordinate: tuple[int, int] | None = None,
  ) -> ToolResult:
```

### What is the new behavior?

The `tool_params` code will no longer throw in this condition.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
