### PR TITLE
o1-full: remap max_tokens to max_completion_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Inspect View: never truncate tool result images and display at default width of 800px.
 - Inspect View: display tool error messages in transcript when tool errors occur.
 - Inspect View: display any completed samples even if the task fails because of an error
+- Open AI: Use new `max_completion_tokens` option for o1 full.
 - Tool parameters with a default of `None` are now supported.
 - More fine graned HTML escaping for sample transcripts displalyed in terminal.
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -262,7 +262,10 @@ class OpenAIAPI(ModelAPI):
             model=self.model_name,
         )
         if config.max_tokens is not None:
-            params["max_tokens"] = config.max_tokens
+            if self.is_o1_full():
+                params["max_completion_tokens"] = config.max_tokens
+            else:
+                params["max_tokens"] = config.max_tokens
         if config.frequency_penalty is not None:
             params["frequency_penalty"] = config.frequency_penalty
         if config.stop_seqs is not None:


### PR DESCRIPTION
## This PR contains:
- [X] Bug fixes

### What is the current behavior? (You can also link to an open issue here)
The openai provider seems to remap max_tokens to max_completion_tokens for o1-preview and o1-mini, but it doesn't for o1-2024-12-17 (because it currently doesn't use the generate_o1 helper since it's not text-based). This results in an error if you try to pass --max-tokens for an o1-2024-12-17 evaluation

### What is the new behavior?
If o1-full, the OpenAI provider remaps max_tokens to max_completion_tokens

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
The OpenAI API reference says `max_tokens` ["is now deprecated in favor of max_completion_tokens,"](https://platform.openai.com/docs/api-reference/chat/create#:~:text=This%20value%20is,series%20models.) but oddly `max_completion_tokens` doesn't seem to be always supported on previous models. I ran gpt-4o-mini on some test samples with `max_completion_tokens` in the params, and 7/20 (not 0%, nor 100%!?) of samples errored with `400: Unrecognized request argument supplied: max_completion_tokens`. For now, I assume we're still supposed to use `max_tokens` on non-o1 models.