### PR TITLE
sandboxes: apply dataset filters (limit and sample id) prior to sandbox initialisation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Inspect View: display any completed samples even if the task fails because of an error
 - Open AI: Handle additional bad request status codes (mapping them to appropriate `StopReason`)
 - Open AI: Use new `max_completion_tokens` option for o1 full.
+- Sandboxes: Apply dataset filters (limit and sample id) prior to sandbox initialisation.
 - Tool parameters with a default of `None` are now supported.
 - More fine graned HTML escaping for sample transcripts displalyed in terminal.
 


### PR DESCRIPTION
This PR addresses https://github.com/UKGovernmentBEIS/inspect_ai/issues/1078

Currently all sandboxes referenced by a task are initialised prior to running the task's samples. However, if sandboxes are provided at the sample level (as is done by Cybench and the GDM In House CTF evals) they all end up getting initialised even if some samples are filtered out. This PR moves some of our sample id logic to before sandbox initialisation, and then applies active filters (`--limit` and `--sample-id`) to the list of sandboxes to be initialised.

@dragonstyle Could you do a close review of this? I recall you and I originally introduced the `slice_dataset()` function and I want to make sure I'm not missing any subtleties.
