### PR TITLE
Properly decode json pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Open AI: Use new `max_completion_tokens` option for o1 full.
 - Tool parameters with a default of `None` are now supported.
 - More fine graned HTML escaping for sample transcripts displalyed in terminal.
+- Fix an issue that would result in an error when a state or storage value used a tilda or slash in the key name.
 
 ## v0.3.56 (01 January 2025)
 

--- a/src/inspect_ai/_util/json.py
+++ b/src/inspect_ai/_util/json.py
@@ -103,10 +103,20 @@ def json_changes(
                 paths = json_change.path.split("/")[1:]
                 replaced = before
                 for path in paths:
-                    index: Any = int(path) if path.isnumeric() else path
+                    decoded_path = decode_json_pointer_segment(path)
+                    index: Any = (
+                        int(decoded_path) if decoded_path.isnumeric() else decoded_path
+                    )
                     replaced = replaced[index]
                 json_change.replaced = replaced
             changes.append(json_change)
         return changes
     else:
         return None
+
+
+def decode_json_pointer_segment(segment: str) -> str:
+    """Decode a single JSON Pointer segment."""
+    # JSON points encode ~ and / because they are special characters
+    # this decodes these values (https://www.rfc-editor.org/rfc/rfc6901)
+    return segment.replace("~1", "/").replace("~0", "~")


### PR DESCRIPTION
Since `~` and `/` have special meanings in JSON pointers (used in json patches), these characters are encoded when generating a patch. Since we’re manually interacting with json pointers in patches directly, we need to decode these values ourselves.

(https://www.rfc-editor.org/rfc/rfc6901)

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

