### PR TITLE
Don’t show the input column header when there isn’t an input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Inspect View: never truncate tool result images and display at default width of 800px.
 - Inspect View: display tool error messages in transcript when tool errors occur.
 - Inspect View: display any completed samples even if the task fails because of an error
+- Inspect View: don't display the 'input' column heading if there isn't an input
 - Open AI: Handle additional bad request status codes (mapping them to appropriate `StopReason`)
 - Open AI: Use new `max_completion_tokens` option for o1 full.
 - Tool parameters with a default of `None` are now supported.

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -25837,7 +25837,7 @@ ${events}
         [selectedIndex]
       );
       const listStyle = { ...style2, flex: "1", overflowY: "auto", outline: "none" };
-      const { limit, answer, target } = gridColumns(sampleDescriptor);
+      const { input, limit, answer, target } = gridColumns(sampleDescriptor);
       const headerRow = m$1`<div
     style=${{
         display: "grid",
@@ -25851,7 +25851,7 @@ ${events}
       }}
   >
     <div>Id</div>
-    <div>Input</div>
+    <div>${input !== "0" ? "Input" : ""}</div>
     <div>${target !== "0" ? "Target" : ""}</div>
     <div>${answer !== "0" ? "Answer" : ""}</div>
     <div>${limit !== "0" ? "Limit" : ""}</div>

--- a/src/inspect_ai/_view/www/src/samples/SampleList.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleList.mjs
@@ -161,7 +161,7 @@ export const SampleList = (props) => {
   );
 
   const listStyle = { ...style, flex: "1", overflowY: "auto", outline: "none" };
-  const { limit, answer, target } = gridColumns(sampleDescriptor);
+  const { input, limit, answer, target } = gridColumns(sampleDescriptor);
 
   const headerRow = html`<div
     style=${{
@@ -176,7 +176,7 @@ export const SampleList = (props) => {
     }}
   >
     <div>Id</div>
-    <div>Input</div>
+    <div>${input !== "0" ? "Input" : ""}</div>
     <div>${target !== "0" ? "Target" : ""}</div>
     <div>${answer !== "0" ? "Answer" : ""}</div>
     <div>${limit !== "0" ? "Limit" : ""}</div>


### PR DESCRIPTION
Before:
<img width="537" alt="Screenshot 2025-01-06 at 10 40 41 AM" src="https://github.com/user-attachments/assets/f2c30809-0a84-4ceb-9b92-1272c5f18f98" />

After:
<img width="632" alt="Screenshot 2025-01-06 at 10 40 25 AM" src="https://github.com/user-attachments/assets/8f876547-2fae-4dc1-a4d5-87991effdd8e" />

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

