### PR TITLE
Properly preserve input when it is a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,8 @@
 - Log: provide `metadata_as` and `store_as` typed accessors for sample metadata and store.
 - Tool parameters with a default of `None` are now supported.
 - More fine graned HTML escaping for sample transcripts displalyed in terminal.
-- Fix an issue that would result in an error when a state or storage value used a tilda or slash in the key name.
+- Bugfix: prevent errors when a state or storage value uses a tilda or slash in the key name.
+- Bugfix: Include input in sample summary when the sample input contains a simple string.
 
 ## v0.3.56 (01 January 2025)
 

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -252,6 +252,8 @@ def text_inputs(inputs: str | list[ChatMessage]) -> str | list[ChatMessage]:
                     filtered_content.append(ContentText(text="(Image)"))
                 message.content = filtered_content
                 input.append(message)
+            else:
+                input.append(message)
 
         return input
     else:


### PR DESCRIPTION
The eval recorder isn't properly capturing sample input for the sample summary when the sample input contains a simple string.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor


