### PR TITLE
Fix Docker name breaking on _-

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Open AI: Use new `max_completion_tokens` option for o1 full.
 - Web Browser: raise error when both `error` and `web_at` fields are present in response.
 - Sandboxes: Apply dataset filters (limit and sample id) prior to sandbox initialisation.
+- Docker: Prevent issue with container/project names that have a trailing underscore. 
 - Store: initialise `Store` from existing dictionary.
 - Log: provide `metadata_as` and `store_as` typed accessors for sample metadata and store.
 - Tool parameters with a default of `None` are now supported.

--- a/src/inspect_ai/util/_sandbox/docker/util.py
+++ b/src/inspect_ai/util/_sandbox/docker/util.py
@@ -84,7 +84,8 @@ def task_project_name(task: str) -> str:
     if len(task) == 0:
         task = "task"
 
-    return f"inspect-{task[:12]}-i{uuid().lower()[:6]}"
+    # _- breaks docker project name constraints so we strip trailing underscores.
+    return f"inspect-{task[:12].rstrip('_')}-i{uuid().lower()[:6]}"
 
 
 inspect_project_pattern = r"^inspect-[a-z\d\-_]*-i[a-z\d]{6,}$"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When the 12th character of a task is an underscore, this leads to something like "inspect-evaluation_is_-abcdef". The "_-" breaks Docker for an unknown reason.

### What is the new behavior?

We now strip trailing underscores, so "evaluation_is_" becomes "evaluation_is", preventing the behaviour from occuring.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

This can easily be tested by using docker compose commands to create a name with _-, and identify it failing.