### PR TITLE
Virtualize Sample Transcript and Chat view

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -7690,10 +7690,17 @@ var require_assets = __commonJS({
         return `${seconds} sec`;
       } else if (seconds < 60 * 60) {
         return `${Math.floor(seconds / 60)} min ${seconds % 60} sec`;
+      } else if (seconds < 60 * 60 * 24) {
+        const hours = Math.floor(seconds / (60 * 60));
+        const minutes = Math.floor(seconds % (60 * 60) / 60);
+        const remainingSeconds = seconds % 60;
+        return `${hours} hr ${minutes} min ${remainingSeconds} sec`;
       } else {
-        return `${Math.floor(seconds / (60 * 60 * 24))} days ${Math.floor(
-          seconds / 60
-        )} min ${seconds % 60} sec`;
+        const days = Math.floor(seconds / (60 * 60 * 24));
+        const hours = Math.floor(seconds % (60 * 60 * 24) / (60 * 60));
+        const minutes = Math.floor(seconds % (60 * 60) / 60);
+        const remainingSeconds = seconds % 60;
+        return `${days} days ${hours} hr ${minutes} min ${remainingSeconds} sec`;
       }
     };
     function formatPrettyDecimal(num) {
@@ -15616,6 +15623,4439 @@ var require_assets = __commonJS({
         }
       }
     };
+    function g(n2, t2) {
+      for (var e2 in n2) if ("__source" !== e2 && !(e2 in t2)) return true;
+      for (var r2 in t2) if ("__source" !== r2 && n2[r2] !== t2[r2]) return true;
+      return false;
+    }
+    function E(n2, t2) {
+      var e2 = t2(), r2 = h({ t: { __: e2, u: t2 } }), u2 = r2[0].t, o2 = r2[1];
+      return _(function() {
+        u2.__ = e2, u2.u = t2, C(u2) && o2({ t: u2 });
+      }, [n2, e2, t2]), y(function() {
+        return C(u2) && o2({ t: u2 }), n2(function() {
+          C(u2) && o2({ t: u2 });
+        });
+      }, [n2]), e2;
+    }
+    function C(n2) {
+      var t2, e2, r2 = n2.u, u2 = n2.__;
+      try {
+        var o2 = r2();
+        return !((t2 = u2) === (e2 = o2) && (0 !== t2 || 1 / t2 == 1 / e2) || t2 != t2 && e2 != e2);
+      } catch (n3) {
+        return true;
+      }
+    }
+    function x$1(n2) {
+      n2();
+    }
+    function R(n2) {
+      return n2;
+    }
+    function w() {
+      return [false, x$1];
+    }
+    var k = _;
+    function I(n2, t2) {
+      this.props = n2, this.context = t2;
+    }
+    function N(n2, e2) {
+      function r2(n3) {
+        var t2 = this.props.ref, r3 = t2 == n3.ref;
+        return !r3 && t2 && (t2.call ? t2(null) : t2.current = null), e2 ? !e2(this.props, n3) || !r3 : g(this.props, n3);
+      }
+      function u2(e3) {
+        return this.shouldComponentUpdate = r2, g$2(n2, e3);
+      }
+      return u2.displayName = "Memo(" + (n2.displayName || n2.name) + ")", u2.prototype.isReactComponent = true, u2.__f = true, u2;
+    }
+    (I.prototype = new x$3()).isPureReactComponent = true, I.prototype.shouldComponentUpdate = function(n2, t2) {
+      return g(this.props, n2) || g(this.state, t2);
+    };
+    var M = l$1.__b;
+    l$1.__b = function(n2) {
+      n2.type && n2.type.__f && n2.ref && (n2.props.ref = n2.ref, n2.ref = null), M && M(n2);
+    };
+    var T = "undefined" != typeof Symbol && Symbol.for && Symbol.for("react.forward_ref") || 3911;
+    function A(n2) {
+      function t2(t3) {
+        if (!("ref" in t3)) return n2(t3, null);
+        var e2 = t3.ref;
+        delete t3.ref;
+        var r2 = n2(t3, e2);
+        return t3.ref = e2, r2;
+      }
+      return t2.$$typeof = T, t2.render = t2, t2.prototype.isReactComponent = t2.__f = true, t2.displayName = "ForwardRef(" + (n2.displayName || n2.name) + ")", t2;
+    }
+    var D = function(n2, t2) {
+      return null == n2 ? null : L$1(L$1(n2).map(t2));
+    }, L = { map: D, forEach: D, count: function(n2) {
+      return n2 ? L$1(n2).length : 0;
+    }, only: function(n2) {
+      var t2 = L$1(n2);
+      if (1 !== t2.length) throw "Children.only";
+      return t2[0];
+    }, toArray: L$1 }, O = l$1.__e;
+    l$1.__e = function(n2, t2, e2, r2) {
+      if (n2.then) {
+        for (var u2, o2 = t2; o2 = o2.__; ) if ((u2 = o2.__c) && u2.__c) return null == t2.__e && (t2.__e = e2.__e, t2.__k = e2.__k), u2.__c(n2, t2);
+      }
+      O(n2, t2, e2, r2);
+    };
+    var F = l$1.unmount;
+    function U(n2, t2, e2) {
+      return n2 && (n2.__c && n2.__c.__H && (n2.__c.__H.__.forEach(function(n3) {
+        "function" == typeof n3.__c && n3.__c();
+      }), n2.__c.__H = null), null != (n2 = function(n3, t3) {
+        for (var e3 in t3) n3[e3] = t3[e3];
+        return n3;
+      }({}, n2)).__c && (n2.__c.__P === e2 && (n2.__c.__P = t2), n2.__c = null), n2.__k = n2.__k && n2.__k.map(function(n3) {
+        return U(n3, t2, e2);
+      })), n2;
+    }
+    function V(n2, t2, e2) {
+      return n2 && e2 && (n2.__v = null, n2.__k = n2.__k && n2.__k.map(function(n3) {
+        return V(n3, t2, e2);
+      }), n2.__c && n2.__c.__P === t2 && (n2.__e && e2.appendChild(n2.__e), n2.__c.__e = true, n2.__c.__P = e2)), n2;
+    }
+    function W() {
+      this.__u = 0, this.o = null, this.__b = null;
+    }
+    function P(n2) {
+      var t2 = n2.__.__c;
+      return t2 && t2.__a && t2.__a(n2);
+    }
+    function j(n2) {
+      var e2, r2, u2;
+      function o2(o3) {
+        if (e2 || (e2 = n2()).then(function(n3) {
+          r2 = n3.default || n3;
+        }, function(n3) {
+          u2 = n3;
+        }), u2) throw u2;
+        if (!r2) throw e2;
+        return g$2(r2, o3);
+      }
+      return o2.displayName = "Lazy", o2.__f = true, o2;
+    }
+    function z() {
+      this.i = null, this.l = null;
+    }
+    l$1.unmount = function(n2) {
+      var t2 = n2.__c;
+      t2 && t2.__R && t2.__R(), t2 && 32 & n2.__u && (n2.type = null), F && F(n2);
+    }, (W.prototype = new x$3()).__c = function(n2, t2) {
+      var e2 = t2.__c, r2 = this;
+      null == r2.o && (r2.o = []), r2.o.push(e2);
+      var u2 = P(r2.__v), o2 = false, i2 = function() {
+        o2 || (o2 = true, e2.__R = null, u2 ? u2(c2) : c2());
+      };
+      e2.__R = i2;
+      var c2 = function() {
+        if (!--r2.__u) {
+          if (r2.state.__a) {
+            var n3 = r2.state.__a;
+            r2.__v.__k[0] = V(n3, n3.__c.__P, n3.__c.__O);
+          }
+          var t3;
+          for (r2.setState({ __a: r2.__b = null }); t3 = r2.o.pop(); ) t3.forceUpdate();
+        }
+      };
+      r2.__u++ || 32 & t2.__u || r2.setState({ __a: r2.__b = r2.__v.__k[0] }), n2.then(i2, i2);
+    }, W.prototype.componentWillUnmount = function() {
+      this.o = [];
+    }, W.prototype.render = function(n2, e2) {
+      if (this.__b) {
+        if (this.__v.__k) {
+          var r2 = document.createElement("div"), o2 = this.__v.__k[0].__c;
+          this.__v.__k[0] = U(this.__b, r2, o2.__O = o2.__P);
+        }
+        this.__b = null;
+      }
+      var i2 = e2.__a && g$2(k$2, null, n2.fallback);
+      return i2 && (i2.__u &= -33), [g$2(k$2, null, e2.__a ? null : n2.children), i2];
+    };
+    var B = function(n2, t2, e2) {
+      if (++e2[1] === e2[0] && n2.l.delete(t2), n2.props.revealOrder && ("t" !== n2.props.revealOrder[0] || !n2.l.size)) for (e2 = n2.i; e2; ) {
+        for (; e2.length > 3; ) e2.pop()();
+        if (e2[1] < e2[0]) break;
+        n2.i = e2 = e2[2];
+      }
+    };
+    function H(n2) {
+      return this.getChildContext = function() {
+        return n2.context;
+      }, n2.children;
+    }
+    function Z(n2) {
+      var e2 = this, r2 = n2.h;
+      e2.componentWillUnmount = function() {
+        D$2(null, e2.v), e2.v = null, e2.h = null;
+      }, e2.h && e2.h !== r2 && e2.componentWillUnmount(), e2.v || (e2.h = r2, e2.v = { nodeType: 1, parentNode: r2, childNodes: [], contains: function() {
+        return true;
+      }, appendChild: function(n3) {
+        this.childNodes.push(n3), e2.h.appendChild(n3);
+      }, insertBefore: function(n3, t2) {
+        this.childNodes.push(n3), e2.h.insertBefore(n3, t2);
+      }, removeChild: function(n3) {
+        this.childNodes.splice(this.childNodes.indexOf(n3) >>> 1, 1), e2.h.removeChild(n3);
+      } }), D$2(g$2(H, { context: e2.context }, n2.__v), e2.v);
+    }
+    function Y(n2, e2) {
+      var r2 = g$2(Z, { __v: n2, h: e2 });
+      return r2.containerInfo = e2, r2;
+    }
+    (z.prototype = new x$3()).__a = function(n2) {
+      var t2 = this, e2 = P(t2.__v), r2 = t2.l.get(n2);
+      return r2[0]++, function(u2) {
+        var o2 = function() {
+          t2.props.revealOrder ? (r2.push(u2), B(t2, n2, r2)) : u2();
+        };
+        e2 ? e2(o2) : o2();
+      };
+    }, z.prototype.render = function(n2) {
+      this.i = null, this.l = /* @__PURE__ */ new Map();
+      var t2 = L$1(n2.children);
+      n2.revealOrder && "b" === n2.revealOrder[0] && t2.reverse();
+      for (var e2 = t2.length; e2--; ) this.l.set(t2[e2], this.i = [1, 0, this.i]);
+      return n2.children;
+    }, z.prototype.componentDidUpdate = z.prototype.componentDidMount = function() {
+      var n2 = this;
+      this.l.forEach(function(t2, e2) {
+        B(n2, e2, t2);
+      });
+    };
+    var $ = "undefined" != typeof Symbol && Symbol.for && Symbol.for("react.element") || 60103, q = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/, G = /^on(Ani|Tra|Tou|BeforeInp|Compo)/, J = /[A-Z0-9]/g, K = "undefined" != typeof document, Q = function(n2) {
+      return ("undefined" != typeof Symbol && "symbol" == typeof Symbol() ? /fil|che|rad/ : /fil|che|ra/).test(n2);
+    };
+    function X(n2, t2, e2) {
+      return null == t2.__k && (t2.textContent = ""), D$2(n2, t2), "function" == typeof e2 && e2(), n2 ? n2.__c : null;
+    }
+    function nn(n2, t2, e2) {
+      return E$1(n2, t2), "function" == typeof e2 && e2(), n2 ? n2.__c : null;
+    }
+    x$3.prototype.isReactComponent = {}, ["componentWillMount", "componentWillReceiveProps", "componentWillUpdate"].forEach(function(t2) {
+      Object.defineProperty(x$3.prototype, t2, { configurable: true, get: function() {
+        return this["UNSAFE_" + t2];
+      }, set: function(n2) {
+        Object.defineProperty(this, t2, { configurable: true, writable: true, value: n2 });
+      } });
+    });
+    var tn = l$1.event;
+    function en() {
+    }
+    function rn() {
+      return this.cancelBubble;
+    }
+    function un() {
+      return this.defaultPrevented;
+    }
+    l$1.event = function(n2) {
+      return tn && (n2 = tn(n2)), n2.persist = en, n2.isPropagationStopped = rn, n2.isDefaultPrevented = un, n2.nativeEvent = n2;
+    };
+    var on, cn = { enumerable: false, configurable: true, get: function() {
+      return this.class;
+    } }, fn = l$1.vnode;
+    l$1.vnode = function(n2) {
+      "string" == typeof n2.type && function(n3) {
+        var t2 = n3.props, e2 = n3.type, u2 = {}, o2 = -1 === e2.indexOf("-");
+        for (var i2 in t2) {
+          var c2 = t2[i2];
+          if (!("value" === i2 && "defaultValue" in t2 && null == c2 || K && "children" === i2 && "noscript" === e2 || "class" === i2 || "className" === i2)) {
+            var f2 = i2.toLowerCase();
+            "defaultValue" === i2 && "value" in t2 && null == t2.value ? i2 = "value" : "download" === i2 && true === c2 ? c2 = "" : "translate" === f2 && "no" === c2 ? c2 = false : "o" === f2[0] && "n" === f2[1] ? "ondoubleclick" === f2 ? i2 = "ondblclick" : "onchange" !== f2 || "input" !== e2 && "textarea" !== e2 || Q(t2.type) ? "onfocus" === f2 ? i2 = "onfocusin" : "onblur" === f2 ? i2 = "onfocusout" : G.test(i2) && (i2 = f2) : f2 = i2 = "oninput" : o2 && q.test(i2) ? i2 = i2.replace(J, "-$&").toLowerCase() : null === c2 && (c2 = void 0), "oninput" === f2 && u2[i2 = f2] && (i2 = "oninputCapture"), u2[i2] = c2;
+          }
+        }
+        "select" == e2 && u2.multiple && Array.isArray(u2.value) && (u2.value = L$1(t2.children).forEach(function(n4) {
+          n4.props.selected = -1 != u2.value.indexOf(n4.props.value);
+        })), "select" == e2 && null != u2.defaultValue && (u2.value = L$1(t2.children).forEach(function(n4) {
+          n4.props.selected = u2.multiple ? -1 != u2.defaultValue.indexOf(n4.props.value) : u2.defaultValue == n4.props.value;
+        })), t2.class && !t2.className ? (u2.class = t2.class, Object.defineProperty(u2, "className", cn)) : (t2.className && !t2.class || t2.class && t2.className) && (u2.class = u2.className = t2.className), n3.props = u2;
+      }(n2), n2.$$typeof = $, fn && fn(n2);
+    };
+    var ln = l$1.__r;
+    l$1.__r = function(n2) {
+      ln && ln(n2), on = n2.__c;
+    };
+    var an = l$1.diffed;
+    l$1.diffed = function(n2) {
+      an && an(n2);
+      var t2 = n2.props, e2 = n2.__e;
+      null != e2 && "textarea" === n2.type && "value" in t2 && t2.value !== e2.value && (e2.value = null == t2.value ? "" : t2.value), on = null;
+    };
+    var sn = { ReactCurrentDispatcher: { current: { readContext: function(n2) {
+      return on.__n[n2.__c].props.value;
+    }, useCallback: q$1, useContext: x$2, useDebugValue: P$2, useDeferredValue: R, useEffect: y, useId: g$1, useImperativeHandle: F$1, useInsertionEffect: k, useLayoutEffect: _, useMemo: T$1, useReducer: p, useRef: A$1, useState: h, useSyncExternalStore: E, useTransition: w } } };
+    function vn(n2) {
+      return g$2.bind(null, n2);
+    }
+    function dn(n2) {
+      return !!n2 && n2.$$typeof === $;
+    }
+    function pn(n2) {
+      return dn(n2) && n2.type === k$2;
+    }
+    function mn(n2) {
+      return !!n2 && !!n2.displayName && ("string" == typeof n2.displayName || n2.displayName instanceof String) && n2.displayName.startsWith("Memo(");
+    }
+    function yn(n2) {
+      return dn(n2) ? G$1.apply(null, arguments) : n2;
+    }
+    function _n(n2) {
+      return !!n2.__k && (D$2(null, n2), true);
+    }
+    function bn(n2) {
+      return n2 && (n2.base || 1 === n2.nodeType && n2) || null;
+    }
+    var Sn = function(n2, t2) {
+      return n2(t2);
+    }, gn = function(n2, t2) {
+      return n2(t2);
+    }, En = k$2, Cn = dn, xn = { useState: h, useId: g$1, useReducer: p, useEffect: y, useLayoutEffect: _, useInsertionEffect: k, useTransition: w, useDeferredValue: R, useSyncExternalStore: E, startTransition: x$1, useRef: A$1, useImperativeHandle: F$1, useMemo: T$1, useCallback: q$1, useContext: x$2, useDebugValue: P$2, version: "18.3.1", Children: L, render: X, hydrate: nn, unmountComponentAtNode: _n, createPortal: Y, createElement: g$2, createContext: J$1, createFactory: vn, cloneElement: yn, createRef: b, Fragment: k$2, isValidElement: dn, isElement: Cn, isFragment: pn, isMemo: mn, findDOMNode: bn, Component: x$3, PureComponent: I, memo: N, forwardRef: A, flushSync: gn, unstable_batchedUpdates: Sn, StrictMode: En, Suspense: W, SuspenseList: z, lazy: j, __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: sn };
+    var f = 0;
+    function u(e2, t2, n2, o2, i2, u2) {
+      t2 || (t2 = {});
+      var a2, c2, l2 = t2;
+      "ref" in t2 && (a2 = t2.ref, delete t2.ref);
+      var p2 = { type: e2, props: l2, key: n2, ref: a2, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: --f, __i: -1, __u: 0, __source: i2, __self: u2 };
+      if ("function" == typeof e2 && (a2 = e2.defaultProps)) for (c2 in a2) void 0 === l2[c2] && (l2[c2] = a2[c2]);
+      return l$1.vnode && l$1.vnode(p2), p2;
+    }
+    const PUBLISH = 0;
+    const SUBSCRIBE = 1;
+    const RESET = 2;
+    const VALUE = 4;
+    function compose$1(a2, b2) {
+      return (arg) => a2(b2(arg));
+    }
+    function thrush(arg, proc) {
+      return proc(arg);
+    }
+    function curry2to1(proc, arg1) {
+      return (arg2) => proc(arg1, arg2);
+    }
+    function curry1to0(proc, arg) {
+      return () => proc(arg);
+    }
+    function tap(arg, proc) {
+      proc(arg);
+      return arg;
+    }
+    function tup(...args) {
+      return args;
+    }
+    function call(proc) {
+      proc();
+    }
+    function always(value) {
+      return () => value;
+    }
+    function joinProc(...procs) {
+      return () => {
+        procs.map(call);
+      };
+    }
+    function isDefined(arg) {
+      return arg !== void 0;
+    }
+    function noop() {
+    }
+    function subscribe(emitter, subscription) {
+      return emitter(SUBSCRIBE, subscription);
+    }
+    function publish(publisher, value) {
+      publisher(PUBLISH, value);
+    }
+    function reset(emitter) {
+      emitter(RESET);
+    }
+    function getValue(depot) {
+      return depot(VALUE);
+    }
+    function connect(emitter, publisher) {
+      return subscribe(emitter, curry2to1(publisher, PUBLISH));
+    }
+    function handleNext(emitter, subscription) {
+      const unsub = emitter(SUBSCRIBE, (value) => {
+        unsub();
+        subscription(value);
+      });
+      return unsub;
+    }
+    function stream() {
+      const subscriptions = [];
+      return (action, arg) => {
+        switch (action) {
+          case RESET:
+            subscriptions.splice(0, subscriptions.length);
+            return;
+          case SUBSCRIBE:
+            subscriptions.push(arg);
+            return () => {
+              const indexOf = subscriptions.indexOf(arg);
+              if (indexOf > -1) {
+                subscriptions.splice(indexOf, 1);
+              }
+            };
+          case PUBLISH:
+            subscriptions.slice().forEach((subscription) => {
+              subscription(arg);
+            });
+            return;
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function statefulStream(initial) {
+      let value = initial;
+      const innerSubject = stream();
+      return (action, arg) => {
+        switch (action) {
+          case SUBSCRIBE:
+            const subscription = arg;
+            subscription(value);
+            break;
+          case PUBLISH:
+            value = arg;
+            break;
+          case VALUE:
+            return value;
+        }
+        return innerSubject(action, arg);
+      };
+    }
+    function eventHandler$1(emitter) {
+      let unsub;
+      let currentSubscription;
+      const cleanup = () => unsub && unsub();
+      return function(action, subscription) {
+        switch (action) {
+          case SUBSCRIBE:
+            if (subscription) {
+              if (currentSubscription === subscription) {
+                return;
+              }
+              cleanup();
+              currentSubscription = subscription;
+              unsub = subscribe(emitter, subscription);
+              return unsub;
+            } else {
+              cleanup();
+              return noop;
+            }
+          case RESET:
+            cleanup();
+            currentSubscription = null;
+            return;
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function streamFromEmitter(emitter) {
+      return tap(stream(), (stream2) => connect(emitter, stream2));
+    }
+    function statefulStreamFromEmitter(emitter, initial) {
+      return tap(statefulStream(initial), (stream2) => connect(emitter, stream2));
+    }
+    function combineOperators(...operators) {
+      return (subscriber) => {
+        return operators.reduceRight(thrush, subscriber);
+      };
+    }
+    function pipe(source2, ...operators) {
+      const project = combineOperators(...operators);
+      return (action, subscription) => {
+        switch (action) {
+          case SUBSCRIBE:
+            return subscribe(source2, project(subscription));
+          case RESET:
+            reset(source2);
+            return;
+        }
+      };
+    }
+    function defaultComparator(previous, next) {
+      return previous === next;
+    }
+    function distinctUntilChanged(comparator = defaultComparator) {
+      let current;
+      return (done) => (next) => {
+        if (!comparator(current, next)) {
+          current = next;
+          done(next);
+        }
+      };
+    }
+    function filter(predicate) {
+      return (done) => (value) => {
+        predicate(value) && done(value);
+      };
+    }
+    function map(project) {
+      return (done) => compose$1(done, project);
+    }
+    function mapTo(value) {
+      return (done) => () => done(value);
+    }
+    function scan(scanner, initial) {
+      return (done) => (value) => done(initial = scanner(initial, value));
+    }
+    function skip(times) {
+      return (done) => (value) => {
+        times > 0 ? times-- : done(value);
+      };
+    }
+    function throttleTime(interval) {
+      let currentValue = null;
+      let timeout;
+      return (done) => (value) => {
+        currentValue = value;
+        if (timeout) {
+          return;
+        }
+        timeout = setTimeout(() => {
+          timeout = void 0;
+          done(currentValue);
+        }, interval);
+      };
+    }
+    function debounceTime(interval) {
+      let currentValue;
+      let timeout;
+      return (done) => (value) => {
+        currentValue = value;
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        timeout = setTimeout(() => {
+          done(currentValue);
+        }, interval);
+      };
+    }
+    function withLatestFrom(...sources) {
+      const values = new Array(sources.length);
+      let called = 0;
+      let pendingCall = null;
+      const allCalled = Math.pow(2, sources.length) - 1;
+      sources.forEach((source2, index) => {
+        const bit = Math.pow(2, index);
+        subscribe(source2, (value) => {
+          const prevCalled = called;
+          called = called | bit;
+          values[index] = value;
+          if (prevCalled !== allCalled && called === allCalled && pendingCall) {
+            pendingCall();
+            pendingCall = null;
+          }
+        });
+      });
+      return (done) => (value) => {
+        const call2 = () => done([value].concat(values));
+        if (called === allCalled) {
+          call2();
+        } else {
+          pendingCall = call2;
+        }
+      };
+    }
+    function merge(...sources) {
+      return function(action, subscription) {
+        switch (action) {
+          case SUBSCRIBE:
+            return joinProc(...sources.map((source2) => subscribe(source2, subscription)));
+          case RESET:
+            return;
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function duc(source2, comparator = defaultComparator) {
+      return pipe(source2, distinctUntilChanged(comparator));
+    }
+    function combineLatest(...emitters) {
+      const innerSubject = stream();
+      const values = new Array(emitters.length);
+      let called = 0;
+      const allCalled = Math.pow(2, emitters.length) - 1;
+      emitters.forEach((source2, index) => {
+        const bit = Math.pow(2, index);
+        subscribe(source2, (value) => {
+          values[index] = value;
+          called = called | bit;
+          if (called === allCalled) {
+            publish(innerSubject, values);
+          }
+        });
+      });
+      return function(action, subscription) {
+        switch (action) {
+          case SUBSCRIBE:
+            if (called === allCalled) {
+              subscription(values);
+            }
+            return subscribe(innerSubject, subscription);
+          case RESET:
+            return reset(innerSubject);
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function system(constructor, dependencies = [], { singleton } = { singleton: true }) {
+      return {
+        id: id(),
+        constructor,
+        dependencies,
+        singleton
+      };
+    }
+    const id = () => Symbol();
+    function init(systemSpec) {
+      const singletons = /* @__PURE__ */ new Map();
+      const _init = ({ id: id2, constructor, dependencies, singleton }) => {
+        if (singleton && singletons.has(id2)) {
+          return singletons.get(id2);
+        }
+        const system2 = constructor(dependencies.map((e2) => _init(e2)));
+        if (singleton) {
+          singletons.set(id2, system2);
+        }
+        return system2;
+      };
+      return _init(systemSpec);
+    }
+    function omit(keys, obj) {
+      const result = {};
+      const index = {};
+      let idx = 0;
+      const len = keys.length;
+      while (idx < len) {
+        index[keys[idx]] = 1;
+        idx += 1;
+      }
+      for (const prop in obj) {
+        if (!index.hasOwnProperty(prop)) {
+          result[prop] = obj[prop];
+        }
+      }
+      return result;
+    }
+    const useIsomorphicLayoutEffect$1 = typeof document !== "undefined" ? xn.useLayoutEffect : xn.useEffect;
+    function systemToComponent(systemSpec, map2, Root) {
+      const requiredPropNames = Object.keys(map2.required || {});
+      const optionalPropNames = Object.keys(map2.optional || {});
+      const methodNames = Object.keys(map2.methods || {});
+      const eventNames = Object.keys(map2.events || {});
+      const Context2 = xn.createContext({});
+      function applyPropsToSystem(system2, props) {
+        if (system2["propsReady"]) {
+          publish(system2["propsReady"], false);
+        }
+        for (const requiredPropName of requiredPropNames) {
+          const stream2 = system2[map2.required[requiredPropName]];
+          publish(stream2, props[requiredPropName]);
+        }
+        for (const optionalPropName of optionalPropNames) {
+          if (optionalPropName in props) {
+            const stream2 = system2[map2.optional[optionalPropName]];
+            publish(stream2, props[optionalPropName]);
+          }
+        }
+        if (system2["propsReady"]) {
+          publish(system2["propsReady"], true);
+        }
+      }
+      function buildMethods(system2) {
+        return methodNames.reduce((acc, methodName) => {
+          acc[methodName] = (value) => {
+            const stream2 = system2[map2.methods[methodName]];
+            publish(stream2, value);
+          };
+          return acc;
+        }, {});
+      }
+      function buildEventHandlers(system2) {
+        return eventNames.reduce((handlers, eventName) => {
+          handlers[eventName] = eventHandler$1(system2[map2.events[eventName]]);
+          return handlers;
+        }, {});
+      }
+      const Component = xn.forwardRef((propsWithChildren, ref) => {
+        const { children: children2, ...props } = propsWithChildren;
+        const [system2] = xn.useState(() => {
+          return tap(init(systemSpec), (system22) => applyPropsToSystem(system22, props));
+        });
+        const [handlers] = xn.useState(curry1to0(buildEventHandlers, system2));
+        useIsomorphicLayoutEffect$1(() => {
+          for (const eventName of eventNames) {
+            if (eventName in props) {
+              subscribe(handlers[eventName], props[eventName]);
+            }
+          }
+          return () => {
+            Object.values(handlers).map(reset);
+          };
+        }, [props, handlers, system2]);
+        useIsomorphicLayoutEffect$1(() => {
+          applyPropsToSystem(system2, props);
+        });
+        xn.useImperativeHandle(ref, always(buildMethods(system2)));
+        const RootComponent = Root;
+        return /* @__PURE__ */ u(Context2.Provider, { value: system2, children: Root ? /* @__PURE__ */ u(RootComponent, { ...omit([...requiredPropNames, ...optionalPropNames, ...eventNames], props), children: children2 }) : children2 });
+      });
+      const usePublisher2 = (key2) => {
+        return xn.useCallback(curry2to1(publish, xn.useContext(Context2)[key2]), [key2]);
+      };
+      const useEmitterValue18 = (key2) => {
+        const system2 = xn.useContext(Context2);
+        const source2 = system2[key2];
+        const cb = xn.useCallback(
+          (c2) => {
+            return subscribe(source2, c2);
+          },
+          [source2]
+        );
+        return xn.useSyncExternalStore(
+          cb,
+          () => getValue(source2),
+          () => getValue(source2)
+        );
+      };
+      const useEmitterValueLegacy = (key2) => {
+        const system2 = xn.useContext(Context2);
+        const source2 = system2[key2];
+        const [value, setValue] = xn.useState(curry1to0(getValue, source2));
+        useIsomorphicLayoutEffect$1(
+          () => subscribe(source2, (next) => {
+            if (next !== value) {
+              setValue(always(next));
+            }
+          }),
+          [source2, value]
+        );
+        return value;
+      };
+      const useEmitterValue2 = xn.version.startsWith("18") ? useEmitterValue18 : useEmitterValueLegacy;
+      const useEmitter2 = (key2, callback) => {
+        const context = xn.useContext(Context2);
+        const source2 = context[key2];
+        useIsomorphicLayoutEffect$1(() => subscribe(source2, callback), [callback, source2]);
+      };
+      return {
+        Component,
+        usePublisher: usePublisher2,
+        useEmitterValue: useEmitterValue2,
+        useEmitter: useEmitter2
+      };
+    }
+    const useIsomorphicLayoutEffect = typeof document !== "undefined" ? xn.useLayoutEffect : xn.useEffect;
+    var LogLevel = /* @__PURE__ */ ((LogLevel2) => {
+      LogLevel2[LogLevel2["DEBUG"] = 0] = "DEBUG";
+      LogLevel2[LogLevel2["INFO"] = 1] = "INFO";
+      LogLevel2[LogLevel2["WARN"] = 2] = "WARN";
+      LogLevel2[LogLevel2["ERROR"] = 3] = "ERROR";
+      return LogLevel2;
+    })(LogLevel || {});
+    const CONSOLE_METHOD_MAP = {
+      [
+        0
+        /* DEBUG */
+      ]: "debug",
+      [
+        1
+        /* INFO */
+      ]: "log",
+      [
+        2
+        /* WARN */
+      ]: "warn",
+      [
+        3
+        /* ERROR */
+      ]: "error"
+    };
+    const getGlobalThis = () => typeof globalThis === "undefined" ? window : globalThis;
+    const loggerSystem = system(
+      () => {
+        const logLevel = statefulStream(
+          3
+          /* ERROR */
+        );
+        const log = statefulStream((label, message, level = 1) => {
+          var _a2;
+          const currentLevel = (_a2 = getGlobalThis()["VIRTUOSO_LOG_LEVEL"]) != null ? _a2 : getValue(logLevel);
+          if (level >= currentLevel) {
+            console[CONSOLE_METHOD_MAP[level]](
+              "%creact-virtuoso: %c%s %o",
+              "color: #0253b3; font-weight: bold",
+              "color: initial",
+              label,
+              message
+            );
+          }
+        });
+        return {
+          log,
+          logLevel
+        };
+      },
+      [],
+      { singleton: true }
+    );
+    function useSizeWithElRef(callback, enabled, skipAnimationFrame) {
+      const ref = xn.useRef(null);
+      let callbackRef = (_el) => {
+      };
+      if (typeof ResizeObserver !== "undefined") {
+        const observer = xn.useMemo(() => {
+          return new ResizeObserver((entries) => {
+            const code2 = () => {
+              const element = entries[0].target;
+              if (element.offsetParent !== null) {
+                callback(element);
+              }
+            };
+            skipAnimationFrame ? code2() : requestAnimationFrame(code2);
+          });
+        }, [callback]);
+        callbackRef = (elRef) => {
+          if (elRef && enabled) {
+            observer.observe(elRef);
+            ref.current = elRef;
+          } else {
+            if (ref.current) {
+              observer.unobserve(ref.current);
+            }
+            ref.current = null;
+          }
+        };
+      }
+      return { ref, callbackRef };
+    }
+    function useSize(callback, enabled, skipAnimationFrame) {
+      return useSizeWithElRef(callback, enabled, skipAnimationFrame).callbackRef;
+    }
+    function useChangedListContentsSizes(callback, itemSize, enabled, scrollContainerStateCallback, log, gap, customScrollParent, horizontalDirection, skipAnimationFrame) {
+      const memoedCallback = xn.useCallback(
+        (el) => {
+          const ranges = getChangedChildSizes(el.children, itemSize, horizontalDirection ? "offsetWidth" : "offsetHeight", log);
+          let scrollableElement = el.parentElement;
+          while (!scrollableElement.dataset["virtuosoScroller"]) {
+            scrollableElement = scrollableElement.parentElement;
+          }
+          const windowScrolling = scrollableElement.lastElementChild.dataset["viewportType"] === "window";
+          const scrollTop = customScrollParent ? horizontalDirection ? customScrollParent.scrollLeft : customScrollParent.scrollTop : windowScrolling ? horizontalDirection ? window.pageXOffset || document.documentElement.scrollLeft : window.pageYOffset || document.documentElement.scrollTop : horizontalDirection ? scrollableElement.scrollLeft : scrollableElement.scrollTop;
+          const scrollHeight = customScrollParent ? horizontalDirection ? customScrollParent.scrollWidth : customScrollParent.scrollHeight : windowScrolling ? horizontalDirection ? document.documentElement.scrollWidth : document.documentElement.scrollHeight : horizontalDirection ? scrollableElement.scrollWidth : scrollableElement.scrollHeight;
+          const viewportHeight = customScrollParent ? horizontalDirection ? customScrollParent.offsetWidth : customScrollParent.offsetHeight : windowScrolling ? horizontalDirection ? window.innerWidth : window.innerHeight : horizontalDirection ? scrollableElement.offsetWidth : scrollableElement.offsetHeight;
+          scrollContainerStateCallback({
+            scrollTop: Math.max(scrollTop, 0),
+            scrollHeight,
+            viewportHeight
+          });
+          gap == null ? void 0 : gap(
+            horizontalDirection ? resolveGapValue$1("column-gap", getComputedStyle(el).columnGap, log) : resolveGapValue$1("row-gap", getComputedStyle(el).rowGap, log)
+          );
+          if (ranges !== null) {
+            callback(ranges);
+          }
+        },
+        [callback, itemSize, log, gap, customScrollParent, scrollContainerStateCallback]
+      );
+      return useSizeWithElRef(memoedCallback, enabled, skipAnimationFrame);
+    }
+    function getChangedChildSizes(children2, itemSize, field, log) {
+      const length = children2.length;
+      if (length === 0) {
+        return null;
+      }
+      const results = [];
+      for (let i2 = 0; i2 < length; i2++) {
+        const child = children2.item(i2);
+        if (!child || child.dataset.index === void 0) {
+          continue;
+        }
+        const index = parseInt(child.dataset.index);
+        const knownSize = parseFloat(child.dataset.knownSize);
+        const size = itemSize(child, field);
+        if (size === 0) {
+          log("Zero-sized element, this should not happen", { child }, LogLevel.ERROR);
+        }
+        if (size === knownSize) {
+          continue;
+        }
+        const lastResult = results[results.length - 1];
+        if (results.length === 0 || lastResult.size !== size || lastResult.endIndex !== index - 1) {
+          results.push({ startIndex: index, endIndex: index, size });
+        } else {
+          results[results.length - 1].endIndex++;
+        }
+      }
+      return results;
+    }
+    function resolveGapValue$1(property, value, log) {
+      if (value !== "normal" && !(value == null ? void 0 : value.endsWith("px"))) {
+        log(`${property} was not resolved to pixel value correctly`, value, LogLevel.WARN);
+      }
+      if (value === "normal") {
+        return 0;
+      }
+      return parseInt(value != null ? value : "0", 10);
+    }
+    function correctItemSize(el, dimension) {
+      return Math.round(el.getBoundingClientRect()[dimension]);
+    }
+    function approximatelyEqual(num1, num2) {
+      return Math.abs(num1 - num2) < 1.01;
+    }
+    function useScrollTop(scrollContainerStateCallback, smoothScrollTargetReached, scrollerElement, scrollerRefCallback = noop, customScrollParent, horizontalDirection) {
+      const scrollerRef = xn.useRef(null);
+      const scrollTopTarget = xn.useRef(null);
+      const timeoutRef = xn.useRef(null);
+      const handler = xn.useCallback(
+        (ev) => {
+          const el = ev.target;
+          const windowScroll = el === window || el === document;
+          const scrollTop = horizontalDirection ? windowScroll ? window.pageXOffset || document.documentElement.scrollLeft : el.scrollLeft : windowScroll ? window.pageYOffset || document.documentElement.scrollTop : el.scrollTop;
+          const scrollHeight = horizontalDirection ? windowScroll ? document.documentElement.scrollWidth : el.scrollWidth : windowScroll ? document.documentElement.scrollHeight : el.scrollHeight;
+          const viewportHeight = horizontalDirection ? windowScroll ? window.innerWidth : el.offsetWidth : windowScroll ? window.innerHeight : el.offsetHeight;
+          const call2 = () => {
+            scrollContainerStateCallback({
+              scrollTop: Math.max(scrollTop, 0),
+              scrollHeight,
+              viewportHeight
+            });
+          };
+          if (ev.suppressFlushSync) {
+            call2();
+          } else {
+            xn.flushSync(call2);
+          }
+          if (scrollTopTarget.current !== null) {
+            if (scrollTop === scrollTopTarget.current || scrollTop <= 0 || scrollTop === scrollHeight - viewportHeight) {
+              scrollTopTarget.current = null;
+              smoothScrollTargetReached(true);
+              if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+              }
+            }
+          }
+        },
+        [scrollContainerStateCallback, smoothScrollTargetReached]
+      );
+      xn.useEffect(() => {
+        const localRef = customScrollParent ? customScrollParent : scrollerRef.current;
+        scrollerRefCallback(customScrollParent ? customScrollParent : scrollerRef.current);
+        handler({ target: localRef, suppressFlushSync: true });
+        localRef.addEventListener("scroll", handler, { passive: true });
+        return () => {
+          scrollerRefCallback(null);
+          localRef.removeEventListener("scroll", handler);
+        };
+      }, [scrollerRef, handler, scrollerElement, scrollerRefCallback, customScrollParent]);
+      function scrollToCallback(location) {
+        const scrollerElement2 = scrollerRef.current;
+        if (!scrollerElement2 || (horizontalDirection ? "offsetWidth" in scrollerElement2 && scrollerElement2.offsetWidth === 0 : "offsetHeight" in scrollerElement2 && scrollerElement2.offsetHeight === 0)) {
+          return;
+        }
+        const isSmooth = location.behavior === "smooth";
+        let offsetHeight;
+        let scrollHeight;
+        let scrollTop;
+        if (scrollerElement2 === window) {
+          scrollHeight = Math.max(
+            correctItemSize(document.documentElement, horizontalDirection ? "width" : "height"),
+            horizontalDirection ? document.documentElement.scrollWidth : document.documentElement.scrollHeight
+          );
+          offsetHeight = horizontalDirection ? window.innerWidth : window.innerHeight;
+          scrollTop = horizontalDirection ? document.documentElement.scrollLeft : document.documentElement.scrollTop;
+        } else {
+          scrollHeight = scrollerElement2[horizontalDirection ? "scrollWidth" : "scrollHeight"];
+          offsetHeight = correctItemSize(scrollerElement2, horizontalDirection ? "width" : "height");
+          scrollTop = scrollerElement2[horizontalDirection ? "scrollLeft" : "scrollTop"];
+        }
+        const maxScrollTop = scrollHeight - offsetHeight;
+        location.top = Math.ceil(Math.max(Math.min(maxScrollTop, location.top), 0));
+        if (approximatelyEqual(offsetHeight, scrollHeight) || location.top === scrollTop) {
+          scrollContainerStateCallback({ scrollTop, scrollHeight, viewportHeight: offsetHeight });
+          if (isSmooth) {
+            smoothScrollTargetReached(true);
+          }
+          return;
+        }
+        if (isSmooth) {
+          scrollTopTarget.current = location.top;
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+          }
+          timeoutRef.current = setTimeout(() => {
+            timeoutRef.current = null;
+            scrollTopTarget.current = null;
+            smoothScrollTargetReached(true);
+          }, 1e3);
+        } else {
+          scrollTopTarget.current = null;
+        }
+        if (horizontalDirection) {
+          location = { left: location.top, behavior: location.behavior };
+        }
+        scrollerElement2.scrollTo(location);
+      }
+      function scrollByCallback(location) {
+        if (horizontalDirection) {
+          location = { left: location.top, behavior: location.behavior };
+        }
+        scrollerRef.current.scrollBy(location);
+      }
+      return { scrollerRef, scrollByCallback, scrollToCallback };
+    }
+    const domIOSystem = system(
+      () => {
+        const scrollContainerState = stream();
+        const scrollTop = stream();
+        const deviation = statefulStream(0);
+        const smoothScrollTargetReached = stream();
+        const statefulScrollTop = statefulStream(0);
+        const viewportHeight = stream();
+        const scrollHeight = stream();
+        const headerHeight = statefulStream(0);
+        const fixedHeaderHeight = statefulStream(0);
+        const fixedFooterHeight = statefulStream(0);
+        const footerHeight = statefulStream(0);
+        const scrollTo = stream();
+        const scrollBy = stream();
+        const scrollingInProgress = statefulStream(false);
+        const horizontalDirection = statefulStream(false);
+        const skipAnimationFrameInResizeObserver = statefulStream(false);
+        connect(
+          pipe(
+            scrollContainerState,
+            map(({ scrollTop: scrollTop2 }) => scrollTop2)
+          ),
+          scrollTop
+        );
+        connect(
+          pipe(
+            scrollContainerState,
+            map(({ scrollHeight: scrollHeight2 }) => scrollHeight2)
+          ),
+          scrollHeight
+        );
+        connect(scrollTop, statefulScrollTop);
+        return {
+          // input
+          scrollContainerState,
+          scrollTop,
+          viewportHeight,
+          headerHeight,
+          fixedHeaderHeight,
+          fixedFooterHeight,
+          footerHeight,
+          scrollHeight,
+          smoothScrollTargetReached,
+          horizontalDirection,
+          skipAnimationFrameInResizeObserver,
+          // signals
+          scrollTo,
+          scrollBy,
+          // state
+          statefulScrollTop,
+          deviation,
+          scrollingInProgress
+        };
+      },
+      [],
+      { singleton: true }
+    );
+    const NIL_NODE = { lvl: 0 };
+    function newAANode(k2, v2, lvl, l2 = NIL_NODE, r2 = NIL_NODE) {
+      return { k: k2, v: v2, lvl, l: l2, r: r2 };
+    }
+    function empty(node) {
+      return node === NIL_NODE;
+    }
+    function newTree() {
+      return NIL_NODE;
+    }
+    function remove(node, key2) {
+      if (empty(node)) return NIL_NODE;
+      const { k: k2, l: l2, r: r2 } = node;
+      if (key2 === k2) {
+        if (empty(l2)) {
+          return r2;
+        } else if (empty(r2)) {
+          return l2;
+        } else {
+          const [lastKey, lastValue] = last(l2);
+          return adjust(clone$1(node, { k: lastKey, v: lastValue, l: deleteLast(l2) }));
+        }
+      } else if (key2 < k2) {
+        return adjust(clone$1(node, { l: remove(l2, key2) }));
+      } else {
+        return adjust(clone$1(node, { r: remove(r2, key2) }));
+      }
+    }
+    function find(node, key2) {
+      if (empty(node)) {
+        return;
+      }
+      if (key2 === node.k) {
+        return node.v;
+      } else if (key2 < node.k) {
+        return find(node.l, key2);
+      } else {
+        return find(node.r, key2);
+      }
+    }
+    function findMaxKeyValue(node, value, field = "k") {
+      if (empty(node)) {
+        return [-Infinity, void 0];
+      }
+      if (Number(node[field]) === value) {
+        return [node.k, node.v];
+      }
+      if (Number(node[field]) < value) {
+        const r2 = findMaxKeyValue(node.r, value, field);
+        if (r2[0] === -Infinity) {
+          return [node.k, node.v];
+        } else {
+          return r2;
+        }
+      }
+      return findMaxKeyValue(node.l, value, field);
+    }
+    function insert$1(node, k2, v2) {
+      if (empty(node)) {
+        return newAANode(k2, v2, 1);
+      }
+      if (k2 === node.k) {
+        return clone$1(node, { k: k2, v: v2 });
+      } else if (k2 < node.k) {
+        return rebalance(clone$1(node, { l: insert$1(node.l, k2, v2) }));
+      } else {
+        return rebalance(clone$1(node, { r: insert$1(node.r, k2, v2) }));
+      }
+    }
+    function walkWithin(node, start2, end2) {
+      if (empty(node)) {
+        return [];
+      }
+      const { k: k2, v: v2, l: l2, r: r2 } = node;
+      let result = [];
+      if (k2 > start2) {
+        result = result.concat(walkWithin(l2, start2, end2));
+      }
+      if (k2 >= start2 && k2 <= end2) {
+        result.push({ k: k2, v: v2 });
+      }
+      if (k2 <= end2) {
+        result = result.concat(walkWithin(r2, start2, end2));
+      }
+      return result;
+    }
+    function walk(node) {
+      if (empty(node)) {
+        return [];
+      }
+      return [...walk(node.l), { k: node.k, v: node.v }, ...walk(node.r)];
+    }
+    function last(node) {
+      return empty(node.r) ? [node.k, node.v] : last(node.r);
+    }
+    function deleteLast(node) {
+      return empty(node.r) ? node.l : adjust(clone$1(node, { r: deleteLast(node.r) }));
+    }
+    function clone$1(node, args) {
+      return newAANode(
+        args.k !== void 0 ? args.k : node.k,
+        args.v !== void 0 ? args.v : node.v,
+        args.lvl !== void 0 ? args.lvl : node.lvl,
+        args.l !== void 0 ? args.l : node.l,
+        args.r !== void 0 ? args.r : node.r
+      );
+    }
+    function isSingle(node) {
+      return empty(node) || node.lvl > node.r.lvl;
+    }
+    function rebalance(node) {
+      return split(skew(node));
+    }
+    function adjust(node) {
+      const { l: l2, r: r2, lvl } = node;
+      if (r2.lvl >= lvl - 1 && l2.lvl >= lvl - 1) {
+        return node;
+      } else if (lvl > r2.lvl + 1) {
+        if (isSingle(l2)) {
+          return skew(clone$1(node, { lvl: lvl - 1 }));
+        } else {
+          if (!empty(l2) && !empty(l2.r)) {
+            return clone$1(l2.r, {
+              l: clone$1(l2, { r: l2.r.l }),
+              r: clone$1(node, {
+                l: l2.r.r,
+                lvl: lvl - 1
+              }),
+              lvl
+            });
+          } else {
+            throw new Error("Unexpected empty nodes");
+          }
+        }
+      } else {
+        if (isSingle(node)) {
+          return split(clone$1(node, { lvl: lvl - 1 }));
+        } else {
+          if (!empty(r2) && !empty(r2.l)) {
+            const rl = r2.l;
+            const rlvl = isSingle(rl) ? r2.lvl - 1 : r2.lvl;
+            return clone$1(rl, {
+              l: clone$1(node, {
+                r: rl.l,
+                lvl: lvl - 1
+              }),
+              r: split(clone$1(r2, { l: rl.r, lvl: rlvl })),
+              lvl: rl.lvl + 1
+            });
+          } else {
+            throw new Error("Unexpected empty nodes");
+          }
+        }
+      }
+    }
+    function rangesWithin(node, startIndex, endIndex) {
+      if (empty(node)) {
+        return [];
+      }
+      const adjustedStart = findMaxKeyValue(node, startIndex)[0];
+      return toRanges(walkWithin(node, adjustedStart, endIndex));
+    }
+    function arrayToRanges(items, parser) {
+      const length = items.length;
+      if (length === 0) {
+        return [];
+      }
+      let { index: start2, value } = parser(items[0]);
+      const result = [];
+      for (let i2 = 1; i2 < length; i2++) {
+        const { index: nextIndex, value: nextValue } = parser(items[i2]);
+        result.push({ start: start2, end: nextIndex - 1, value });
+        start2 = nextIndex;
+        value = nextValue;
+      }
+      result.push({ start: start2, end: Infinity, value });
+      return result;
+    }
+    function toRanges(nodes) {
+      return arrayToRanges(nodes, ({ k: index, v: value }) => ({ index, value }));
+    }
+    function split(node) {
+      const { r: r2, lvl } = node;
+      return !empty(r2) && !empty(r2.r) && r2.lvl === lvl && r2.r.lvl === lvl ? clone$1(r2, { l: clone$1(node, { r: r2.l }), lvl: lvl + 1 }) : node;
+    }
+    function skew(node) {
+      const { l: l2 } = node;
+      return !empty(l2) && l2.lvl === node.lvl ? clone$1(l2, { r: clone$1(node, { l: l2.r }) }) : node;
+    }
+    function findIndexOfClosestSmallerOrEqual(items, value, comparator, start2 = 0) {
+      let end2 = items.length - 1;
+      while (start2 <= end2) {
+        const index = Math.floor((start2 + end2) / 2);
+        const item = items[index];
+        const match = comparator(item, value);
+        if (match === 0) {
+          return index;
+        }
+        if (match === -1) {
+          if (end2 - start2 < 2) {
+            return index - 1;
+          }
+          end2 = index - 1;
+        } else {
+          if (end2 === start2) {
+            return index;
+          }
+          start2 = index + 1;
+        }
+      }
+      throw new Error(`Failed binary finding record in array - ${items.join(",")}, searched for ${value}`);
+    }
+    function findClosestSmallerOrEqual(items, value, comparator) {
+      return items[findIndexOfClosestSmallerOrEqual(items, value, comparator)];
+    }
+    function findRange(items, startValue, endValue, comparator) {
+      const startIndex = findIndexOfClosestSmallerOrEqual(items, startValue, comparator);
+      const endIndex = findIndexOfClosestSmallerOrEqual(items, endValue, comparator, startIndex);
+      return items.slice(startIndex, endIndex + 1);
+    }
+    const recalcSystem = system(
+      () => {
+        const recalcInProgress = statefulStream(false);
+        return { recalcInProgress };
+      },
+      [],
+      { singleton: true }
+    );
+    function rangeIncludes(refRange) {
+      const { size, startIndex, endIndex } = refRange;
+      return (range) => {
+        return range.start === startIndex && (range.end === endIndex || range.end === Infinity) && range.value === size;
+      };
+    }
+    function affectedGroupCount(offset2, groupIndices) {
+      let recognizedOffsetItems = 0;
+      let groupIndex = 0;
+      while (recognizedOffsetItems < offset2) {
+        recognizedOffsetItems += groupIndices[groupIndex + 1] - groupIndices[groupIndex] - 1;
+        groupIndex++;
+      }
+      const offsetIsExact = recognizedOffsetItems === offset2;
+      return groupIndex - (offsetIsExact ? 0 : 1);
+    }
+    function insertRanges(sizeTree, ranges) {
+      let syncStart = empty(sizeTree) ? 0 : Infinity;
+      for (const range of ranges) {
+        const { size, startIndex, endIndex } = range;
+        syncStart = Math.min(syncStart, startIndex);
+        if (empty(sizeTree)) {
+          sizeTree = insert$1(sizeTree, 0, size);
+          continue;
+        }
+        const overlappingRanges = rangesWithin(sizeTree, startIndex - 1, endIndex + 1);
+        if (overlappingRanges.some(rangeIncludes(range))) {
+          continue;
+        }
+        let firstPassDone = false;
+        let shouldInsert = false;
+        for (const { start: rangeStart, end: rangeEnd, value: rangeValue } of overlappingRanges) {
+          if (!firstPassDone) {
+            shouldInsert = rangeValue !== size;
+            firstPassDone = true;
+          } else {
+            if (endIndex >= rangeStart || size === rangeValue) {
+              sizeTree = remove(sizeTree, rangeStart);
+            }
+          }
+          if (rangeEnd > endIndex && endIndex >= rangeStart) {
+            if (rangeValue !== size) {
+              sizeTree = insert$1(sizeTree, endIndex + 1, rangeValue);
+            }
+          }
+        }
+        if (shouldInsert) {
+          sizeTree = insert$1(sizeTree, startIndex, size);
+        }
+      }
+      return [sizeTree, syncStart];
+    }
+    function initialSizeState() {
+      return {
+        offsetTree: [],
+        sizeTree: newTree(),
+        groupOffsetTree: newTree(),
+        lastIndex: 0,
+        lastOffset: 0,
+        lastSize: 0,
+        groupIndices: []
+      };
+    }
+    function indexComparator({ index: itemIndex }, index) {
+      return index === itemIndex ? 0 : index < itemIndex ? -1 : 1;
+    }
+    function offsetComparator({ offset: itemOffset }, offset2) {
+      return offset2 === itemOffset ? 0 : offset2 < itemOffset ? -1 : 1;
+    }
+    function offsetPointParser(point) {
+      return { index: point.index, value: point };
+    }
+    function rangesWithinOffsets(tree, startOffset, endOffset, minStartIndex = 0) {
+      if (minStartIndex > 0) {
+        startOffset = Math.max(startOffset, findClosestSmallerOrEqual(tree, minStartIndex, indexComparator).offset);
+      }
+      return arrayToRanges(findRange(tree, startOffset, endOffset, offsetComparator), offsetPointParser);
+    }
+    function createOffsetTree(prevOffsetTree, syncStart, sizeTree, gap) {
+      let offsetTree = prevOffsetTree;
+      let prevIndex = 0;
+      let prevSize = 0;
+      let prevOffset = 0;
+      let startIndex = 0;
+      if (syncStart !== 0) {
+        startIndex = findIndexOfClosestSmallerOrEqual(offsetTree, syncStart - 1, indexComparator);
+        const offsetInfo = offsetTree[startIndex];
+        prevOffset = offsetInfo.offset;
+        const kv = findMaxKeyValue(sizeTree, syncStart - 1);
+        prevIndex = kv[0];
+        prevSize = kv[1];
+        if (offsetTree.length && offsetTree[startIndex].size === findMaxKeyValue(sizeTree, syncStart)[1]) {
+          startIndex -= 1;
+        }
+        offsetTree = offsetTree.slice(0, startIndex + 1);
+      } else {
+        offsetTree = [];
+      }
+      for (const { start: startIndex2, value } of rangesWithin(sizeTree, syncStart, Infinity)) {
+        const indexOffset = startIndex2 - prevIndex;
+        const aOffset = indexOffset * prevSize + prevOffset + indexOffset * gap;
+        offsetTree.push({
+          offset: aOffset,
+          size: value,
+          index: startIndex2
+        });
+        prevIndex = startIndex2;
+        prevOffset = aOffset;
+        prevSize = value;
+      }
+      return {
+        offsetTree,
+        lastIndex: prevIndex,
+        lastOffset: prevOffset,
+        lastSize: prevSize
+      };
+    }
+    function sizeStateReducer(state, [ranges, groupIndices, log, gap]) {
+      if (ranges.length > 0) {
+        log("received item sizes", ranges, LogLevel.DEBUG);
+      }
+      const sizeTree = state.sizeTree;
+      let newSizeTree = sizeTree;
+      let syncStart = 0;
+      if (groupIndices.length > 0 && empty(sizeTree) && ranges.length === 2) {
+        const groupSize = ranges[0].size;
+        const itemSize = ranges[1].size;
+        newSizeTree = groupIndices.reduce((tree, groupIndex) => {
+          return insert$1(insert$1(tree, groupIndex, groupSize), groupIndex + 1, itemSize);
+        }, newSizeTree);
+      } else {
+        [newSizeTree, syncStart] = insertRanges(newSizeTree, ranges);
+      }
+      if (newSizeTree === sizeTree) {
+        return state;
+      }
+      const { offsetTree: newOffsetTree, lastIndex, lastSize, lastOffset } = createOffsetTree(state.offsetTree, syncStart, newSizeTree, gap);
+      return {
+        sizeTree: newSizeTree,
+        offsetTree: newOffsetTree,
+        lastIndex,
+        lastOffset,
+        lastSize,
+        groupOffsetTree: groupIndices.reduce((tree, index) => {
+          return insert$1(tree, index, offsetOf(index, newOffsetTree, gap));
+        }, newTree()),
+        groupIndices
+      };
+    }
+    function offsetOf(index, tree, gap) {
+      if (tree.length === 0) {
+        return 0;
+      }
+      const { offset: offset2, index: startIndex, size } = findClosestSmallerOrEqual(tree, index, indexComparator);
+      const itemCount = index - startIndex;
+      const top2 = size * itemCount + (itemCount - 1) * gap + offset2;
+      return top2 > 0 ? top2 + gap : top2;
+    }
+    function isGroupLocation(location) {
+      return typeof location.groupIndex !== "undefined";
+    }
+    function originalIndexFromLocation(location, sizes, lastIndex) {
+      if (isGroupLocation(location)) {
+        return sizes.groupIndices[location.groupIndex] + 1;
+      } else {
+        const numericIndex = location.index === "LAST" ? lastIndex : location.index;
+        let result = originalIndexFromItemIndex(numericIndex, sizes);
+        result = Math.max(0, result, Math.min(lastIndex, result));
+        return result;
+      }
+    }
+    function originalIndexFromItemIndex(itemIndex, sizes) {
+      if (!hasGroups(sizes)) {
+        return itemIndex;
+      }
+      let groupOffset = 0;
+      while (sizes.groupIndices[groupOffset] <= itemIndex + groupOffset) {
+        groupOffset++;
+      }
+      return itemIndex + groupOffset;
+    }
+    function hasGroups(sizes) {
+      return !empty(sizes.groupOffsetTree);
+    }
+    function sizeTreeToRanges(sizeTree) {
+      return walk(sizeTree).map(({ k: startIndex, v: size }, index, sizeArray) => {
+        const nextSize = sizeArray[index + 1];
+        const endIndex = nextSize ? nextSize.k - 1 : Infinity;
+        return { startIndex, endIndex, size };
+      });
+    }
+    const SIZE_MAP = {
+      offsetHeight: "height",
+      offsetWidth: "width"
+    };
+    const sizeSystem = system(
+      ([{ log }, { recalcInProgress }]) => {
+        const sizeRanges = stream();
+        const totalCount = stream();
+        const statefulTotalCount = statefulStreamFromEmitter(totalCount, 0);
+        const unshiftWith = stream();
+        const shiftWith = stream();
+        const firstItemIndex = statefulStream(0);
+        const groupIndices = statefulStream([]);
+        const fixedItemSize = statefulStream(void 0);
+        const defaultItemSize = statefulStream(void 0);
+        const itemSize = statefulStream((el, field) => correctItemSize(el, SIZE_MAP[field]));
+        const data = statefulStream(void 0);
+        const gap = statefulStream(0);
+        const initial = initialSizeState();
+        const sizes = statefulStreamFromEmitter(
+          pipe(sizeRanges, withLatestFrom(groupIndices, log, gap), scan(sizeStateReducer, initial), distinctUntilChanged()),
+          initial
+        );
+        const prevGroupIndices = statefulStreamFromEmitter(
+          pipe(
+            groupIndices,
+            distinctUntilChanged(),
+            scan((prev, curr) => ({ prev: prev.current, current: curr }), {
+              prev: [],
+              current: []
+            }),
+            map(({ prev }) => prev)
+          ),
+          []
+        );
+        connect(
+          pipe(
+            groupIndices,
+            filter((indexes) => indexes.length > 0),
+            withLatestFrom(sizes, gap),
+            map(([groupIndices2, sizes2, gap2]) => {
+              const groupOffsetTree = groupIndices2.reduce((tree, index, idx) => {
+                return insert$1(tree, index, offsetOf(index, sizes2.offsetTree, gap2) || idx);
+              }, newTree());
+              return {
+                ...sizes2,
+                groupIndices: groupIndices2,
+                groupOffsetTree
+              };
+            })
+          ),
+          sizes
+        );
+        connect(
+          pipe(
+            totalCount,
+            withLatestFrom(sizes),
+            filter(([totalCount2, { lastIndex }]) => {
+              return totalCount2 < lastIndex;
+            }),
+            map(([totalCount2, { lastIndex, lastSize }]) => {
+              return [
+                {
+                  startIndex: totalCount2,
+                  endIndex: lastIndex,
+                  size: lastSize
+                }
+              ];
+            })
+          ),
+          sizeRanges
+        );
+        connect(fixedItemSize, defaultItemSize);
+        const trackItemSizes = statefulStreamFromEmitter(
+          pipe(
+            fixedItemSize,
+            map((size) => size === void 0)
+          ),
+          true
+        );
+        connect(
+          pipe(
+            defaultItemSize,
+            filter((value) => {
+              return value !== void 0 && empty(getValue(sizes).sizeTree);
+            }),
+            map((size) => [{ startIndex: 0, endIndex: 0, size }])
+          ),
+          sizeRanges
+        );
+        const listRefresh = streamFromEmitter(
+          pipe(
+            sizeRanges,
+            withLatestFrom(sizes),
+            scan(
+              ({ sizes: oldSizes }, [_2, newSizes]) => {
+                return {
+                  changed: newSizes !== oldSizes,
+                  sizes: newSizes
+                };
+              },
+              { changed: false, sizes: initial }
+            ),
+            map((value) => value.changed)
+          )
+        );
+        subscribe(
+          pipe(
+            firstItemIndex,
+            scan(
+              (prev, next) => {
+                return { diff: prev.prev - next, prev: next };
+              },
+              { diff: 0, prev: 0 }
+            ),
+            map((val) => val.diff)
+          ),
+          (offset2) => {
+            const { groupIndices: groupIndices2 } = getValue(sizes);
+            if (offset2 > 0) {
+              publish(recalcInProgress, true);
+              publish(unshiftWith, offset2 + affectedGroupCount(offset2, groupIndices2));
+            } else if (offset2 < 0) {
+              const prevGroupIndicesValue = getValue(prevGroupIndices);
+              if (prevGroupIndicesValue.length > 0) {
+                offset2 -= affectedGroupCount(-offset2, prevGroupIndicesValue);
+              }
+              publish(shiftWith, offset2);
+            }
+          }
+        );
+        subscribe(pipe(firstItemIndex, withLatestFrom(log)), ([index, log2]) => {
+          if (index < 0) {
+            log2(
+              "`firstItemIndex` prop should not be set to less than zero. If you don't know the total count, just use a very high value",
+              { firstItemIndex },
+              LogLevel.ERROR
+            );
+          }
+        });
+        const beforeUnshiftWith = streamFromEmitter(unshiftWith);
+        connect(
+          pipe(
+            unshiftWith,
+            withLatestFrom(sizes),
+            map(([unshiftWith2, sizes2]) => {
+              const groupedMode = sizes2.groupIndices.length > 0;
+              const initialRanges = [];
+              const defaultSize = sizes2.lastSize;
+              if (groupedMode) {
+                const firstGroupSize = find(sizes2.sizeTree, 0);
+                let prependedGroupItemsCount = 0;
+                let groupIndex = 0;
+                while (prependedGroupItemsCount < unshiftWith2) {
+                  const theGroupIndex = sizes2.groupIndices[groupIndex];
+                  const groupItemCount = sizes2.groupIndices.length === groupIndex + 1 ? Infinity : sizes2.groupIndices[groupIndex + 1] - theGroupIndex - 1;
+                  initialRanges.push({
+                    startIndex: theGroupIndex,
+                    endIndex: theGroupIndex,
+                    size: firstGroupSize
+                  });
+                  initialRanges.push({
+                    startIndex: theGroupIndex + 1,
+                    endIndex: theGroupIndex + 1 + groupItemCount - 1,
+                    size: defaultSize
+                  });
+                  groupIndex++;
+                  prependedGroupItemsCount += groupItemCount + 1;
+                }
+                const sizeTreeKV = walk(sizes2.sizeTree);
+                const firstGroupIsExpanded = prependedGroupItemsCount !== unshiftWith2;
+                if (firstGroupIsExpanded) {
+                  sizeTreeKV.shift();
+                }
+                return sizeTreeKV.reduce(
+                  (acc, { k: index, v: size }) => {
+                    let ranges = acc.ranges;
+                    if (acc.prevSize !== 0) {
+                      ranges = [
+                        ...acc.ranges,
+                        {
+                          startIndex: acc.prevIndex,
+                          endIndex: index + unshiftWith2 - 1,
+                          size: acc.prevSize
+                        }
+                      ];
+                    }
+                    return {
+                      ranges,
+                      prevIndex: index + unshiftWith2,
+                      prevSize: size
+                    };
+                  },
+                  {
+                    ranges: initialRanges,
+                    prevIndex: unshiftWith2,
+                    prevSize: 0
+                  }
+                ).ranges;
+              }
+              return walk(sizes2.sizeTree).reduce(
+                (acc, { k: index, v: size }) => {
+                  return {
+                    ranges: [...acc.ranges, { startIndex: acc.prevIndex, endIndex: index + unshiftWith2 - 1, size: acc.prevSize }],
+                    prevIndex: index + unshiftWith2,
+                    prevSize: size
+                  };
+                },
+                {
+                  ranges: [],
+                  prevIndex: 0,
+                  prevSize: defaultSize
+                }
+              ).ranges;
+            })
+          ),
+          sizeRanges
+        );
+        const shiftWithOffset = streamFromEmitter(
+          pipe(
+            shiftWith,
+            withLatestFrom(sizes, gap),
+            map(([shiftWith2, { offsetTree }, gap2]) => {
+              const newFirstItemIndex = -shiftWith2;
+              return offsetOf(newFirstItemIndex, offsetTree, gap2);
+            })
+          )
+        );
+        connect(
+          pipe(
+            shiftWith,
+            withLatestFrom(sizes, gap),
+            map(([shiftWith2, sizes2, gap2]) => {
+              const groupedMode = sizes2.groupIndices.length > 0;
+              if (groupedMode) {
+                if (empty(sizes2.sizeTree)) {
+                  return sizes2;
+                }
+                let newSizeTree = newTree();
+                const prevGroupIndicesValue = getValue(prevGroupIndices);
+                let removedItemsCount = 0;
+                let groupIndex = 0;
+                let groupOffset = 0;
+                while (removedItemsCount < -shiftWith2) {
+                  groupOffset = prevGroupIndicesValue[groupIndex];
+                  const groupItemCount = prevGroupIndicesValue[groupIndex + 1] - groupOffset - 1;
+                  groupIndex++;
+                  removedItemsCount += groupItemCount + 1;
+                }
+                newSizeTree = walk(sizes2.sizeTree).reduce((acc, { k: k2, v: v2 }) => {
+                  return insert$1(acc, Math.max(0, k2 + shiftWith2), v2);
+                }, newSizeTree);
+                const aGroupIsShrunk = removedItemsCount !== -shiftWith2;
+                if (aGroupIsShrunk) {
+                  const firstGroupSize = find(sizes2.sizeTree, groupOffset);
+                  newSizeTree = insert$1(newSizeTree, 0, firstGroupSize);
+                  const nextItemSize = findMaxKeyValue(sizes2.sizeTree, -shiftWith2 + 1)[1];
+                  newSizeTree = insert$1(newSizeTree, 1, nextItemSize);
+                }
+                return {
+                  ...sizes2,
+                  sizeTree: newSizeTree,
+                  ...createOffsetTree(sizes2.offsetTree, 0, newSizeTree, gap2)
+                };
+              } else {
+                const newSizeTree = walk(sizes2.sizeTree).reduce((acc, { k: k2, v: v2 }) => {
+                  return insert$1(acc, Math.max(0, k2 + shiftWith2), v2);
+                }, newTree());
+                return {
+                  ...sizes2,
+                  sizeTree: newSizeTree,
+                  ...createOffsetTree(sizes2.offsetTree, 0, newSizeTree, gap2)
+                };
+              }
+            })
+          ),
+          sizes
+        );
+        return {
+          // input
+          data,
+          totalCount,
+          sizeRanges,
+          groupIndices,
+          defaultItemSize,
+          fixedItemSize,
+          unshiftWith,
+          shiftWith,
+          shiftWithOffset,
+          beforeUnshiftWith,
+          firstItemIndex,
+          gap,
+          // output
+          sizes,
+          listRefresh,
+          statefulTotalCount,
+          trackItemSizes,
+          itemSize
+        };
+      },
+      tup(loggerSystem, recalcSystem),
+      { singleton: true }
+    );
+    const SUPPORTS_SCROLL_TO_OPTIONS = typeof document !== "undefined" && "scrollBehavior" in document.documentElement.style;
+    function normalizeIndexLocation(location) {
+      const result = typeof location === "number" ? { index: location } : location;
+      if (!result.align) {
+        result.align = "start";
+      }
+      if (!result.behavior || !SUPPORTS_SCROLL_TO_OPTIONS) {
+        result.behavior = "auto";
+      }
+      if (!result.offset) {
+        result.offset = 0;
+      }
+      return result;
+    }
+    const scrollToIndexSystem = system(
+      ([
+        { sizes, totalCount, listRefresh, gap },
+        {
+          scrollingInProgress,
+          viewportHeight,
+          scrollTo,
+          smoothScrollTargetReached,
+          headerHeight,
+          footerHeight,
+          fixedHeaderHeight,
+          fixedFooterHeight
+        },
+        { log }
+      ]) => {
+        const scrollToIndex = stream();
+        const scrollTargetReached = stream();
+        const topListHeight = statefulStream(0);
+        let unsubscribeNextListRefresh = null;
+        let cleartTimeoutRef = null;
+        let unsubscribeListRefresh = null;
+        function cleanup() {
+          if (unsubscribeNextListRefresh) {
+            unsubscribeNextListRefresh();
+            unsubscribeNextListRefresh = null;
+          }
+          if (unsubscribeListRefresh) {
+            unsubscribeListRefresh();
+            unsubscribeListRefresh = null;
+          }
+          if (cleartTimeoutRef) {
+            clearTimeout(cleartTimeoutRef);
+            cleartTimeoutRef = null;
+          }
+          publish(scrollingInProgress, false);
+        }
+        connect(
+          pipe(
+            scrollToIndex,
+            withLatestFrom(sizes, viewportHeight, totalCount, topListHeight, headerHeight, footerHeight, log),
+            withLatestFrom(gap, fixedHeaderHeight, fixedFooterHeight),
+            map(
+              ([
+                [location, sizes2, viewportHeight2, totalCount2, topListHeight2, headerHeight2, footerHeight2, log2],
+                gap2,
+                fixedHeaderHeight2,
+                fixedFooterHeight2
+              ]) => {
+                const normalLocation = normalizeIndexLocation(location);
+                const { align, behavior, offset: offset2 } = normalLocation;
+                const lastIndex = totalCount2 - 1;
+                const index = originalIndexFromLocation(normalLocation, sizes2, lastIndex);
+                let top2 = offsetOf(index, sizes2.offsetTree, gap2) + headerHeight2;
+                if (align === "end") {
+                  top2 += fixedHeaderHeight2 + findMaxKeyValue(sizes2.sizeTree, index)[1] - viewportHeight2 + fixedFooterHeight2;
+                  if (index === lastIndex) {
+                    top2 += footerHeight2;
+                  }
+                } else if (align === "center") {
+                  top2 += (fixedHeaderHeight2 + findMaxKeyValue(sizes2.sizeTree, index)[1] - viewportHeight2 + fixedFooterHeight2) / 2;
+                } else {
+                  top2 -= topListHeight2;
+                }
+                if (offset2) {
+                  top2 += offset2;
+                }
+                const retry = (listChanged) => {
+                  cleanup();
+                  if (listChanged) {
+                    log2("retrying to scroll to", { location }, LogLevel.DEBUG);
+                    publish(scrollToIndex, location);
+                  } else {
+                    publish(scrollTargetReached, true);
+                    log2("list did not change, scroll successful", {}, LogLevel.DEBUG);
+                  }
+                };
+                cleanup();
+                if (behavior === "smooth") {
+                  let listChanged = false;
+                  unsubscribeListRefresh = subscribe(listRefresh, (changed) => {
+                    listChanged = listChanged || changed;
+                  });
+                  unsubscribeNextListRefresh = handleNext(smoothScrollTargetReached, () => {
+                    retry(listChanged);
+                  });
+                } else {
+                  unsubscribeNextListRefresh = handleNext(pipe(listRefresh, watchChangesFor(150)), retry);
+                }
+                cleartTimeoutRef = setTimeout(() => {
+                  cleanup();
+                }, 1200);
+                publish(scrollingInProgress, true);
+                log2("scrolling from index to", { index, top: top2, behavior }, LogLevel.DEBUG);
+                return { top: top2, behavior };
+              }
+            )
+          ),
+          scrollTo
+        );
+        return {
+          scrollToIndex,
+          scrollTargetReached,
+          topListHeight
+        };
+      },
+      tup(sizeSystem, domIOSystem, loggerSystem),
+      { singleton: true }
+    );
+    function watchChangesFor(limit) {
+      return (done) => {
+        const timeoutRef = setTimeout(() => {
+          done(false);
+        }, limit);
+        return (value) => {
+          if (value) {
+            done(true);
+            clearTimeout(timeoutRef);
+          }
+        };
+      };
+    }
+    const UP = "up";
+    const DOWN = "down";
+    const NONE$1 = "none";
+    const INITIAL_BOTTOM_STATE = {
+      atBottom: false,
+      notAtBottomBecause: "NOT_SHOWING_LAST_ITEM",
+      state: {
+        offsetBottom: 0,
+        scrollTop: 0,
+        viewportHeight: 0,
+        scrollHeight: 0
+      }
+    };
+    const DEFAULT_AT_TOP_THRESHOLD = 0;
+    const stateFlagsSystem = system(([{ scrollContainerState, scrollTop, viewportHeight, headerHeight, footerHeight, scrollBy }]) => {
+      const isAtBottom = statefulStream(false);
+      const isAtTop = statefulStream(true);
+      const atBottomStateChange = stream();
+      const atTopStateChange = stream();
+      const atBottomThreshold = statefulStream(4);
+      const atTopThreshold = statefulStream(DEFAULT_AT_TOP_THRESHOLD);
+      const isScrolling = statefulStreamFromEmitter(
+        pipe(
+          merge(pipe(duc(scrollTop), skip(1), mapTo(true)), pipe(duc(scrollTop), skip(1), mapTo(false), debounceTime(100))),
+          distinctUntilChanged()
+        ),
+        false
+      );
+      const isScrollingBy = statefulStreamFromEmitter(
+        pipe(merge(pipe(scrollBy, mapTo(true)), pipe(scrollBy, mapTo(false), debounceTime(200))), distinctUntilChanged()),
+        false
+      );
+      connect(
+        pipe(
+          combineLatest(duc(scrollTop), duc(atTopThreshold)),
+          map(([top2, atTopThreshold2]) => top2 <= atTopThreshold2),
+          distinctUntilChanged()
+        ),
+        isAtTop
+      );
+      connect(pipe(isAtTop, throttleTime(50)), atTopStateChange);
+      const atBottomState = streamFromEmitter(
+        pipe(
+          combineLatest(scrollContainerState, duc(viewportHeight), duc(headerHeight), duc(footerHeight), duc(atBottomThreshold)),
+          scan((current, [{ scrollTop: scrollTop2, scrollHeight }, viewportHeight2, _headerHeight, _footerHeight, atBottomThreshold2]) => {
+            const isAtBottom2 = scrollTop2 + viewportHeight2 - scrollHeight > -atBottomThreshold2;
+            const state = {
+              viewportHeight: viewportHeight2,
+              scrollTop: scrollTop2,
+              scrollHeight
+            };
+            if (isAtBottom2) {
+              let atBottomBecause;
+              let scrollTopDelta;
+              if (scrollTop2 > current.state.scrollTop) {
+                atBottomBecause = "SCROLLED_DOWN";
+                scrollTopDelta = current.state.scrollTop - scrollTop2;
+              } else {
+                atBottomBecause = "SIZE_DECREASED";
+                scrollTopDelta = current.state.scrollTop - scrollTop2 || current.scrollTopDelta;
+              }
+              return {
+                atBottom: true,
+                state,
+                atBottomBecause,
+                scrollTopDelta
+              };
+            }
+            let notAtBottomBecause;
+            if (state.scrollHeight > current.state.scrollHeight) {
+              notAtBottomBecause = "SIZE_INCREASED";
+            } else if (viewportHeight2 < current.state.viewportHeight) {
+              notAtBottomBecause = "VIEWPORT_HEIGHT_DECREASING";
+            } else if (scrollTop2 < current.state.scrollTop) {
+              notAtBottomBecause = "SCROLLING_UPWARDS";
+            } else {
+              notAtBottomBecause = "NOT_FULLY_SCROLLED_TO_LAST_ITEM_BOTTOM";
+            }
+            return {
+              atBottom: false,
+              notAtBottomBecause,
+              state
+            };
+          }, INITIAL_BOTTOM_STATE),
+          distinctUntilChanged((prev, next) => {
+            return prev && prev.atBottom === next.atBottom;
+          })
+        )
+      );
+      const lastJumpDueToItemResize = statefulStreamFromEmitter(
+        pipe(
+          scrollContainerState,
+          scan(
+            (current, { scrollTop: scrollTop2, scrollHeight, viewportHeight: viewportHeight2 }) => {
+              if (!approximatelyEqual(current.scrollHeight, scrollHeight)) {
+                const atBottom = scrollHeight - (scrollTop2 + viewportHeight2) < 1;
+                if (current.scrollTop !== scrollTop2 && atBottom) {
+                  return {
+                    scrollHeight,
+                    scrollTop: scrollTop2,
+                    jump: current.scrollTop - scrollTop2,
+                    changed: true
+                  };
+                } else {
+                  return {
+                    scrollHeight,
+                    scrollTop: scrollTop2,
+                    jump: 0,
+                    changed: true
+                  };
+                }
+              } else {
+                return {
+                  scrollTop: scrollTop2,
+                  scrollHeight,
+                  jump: 0,
+                  changed: false
+                };
+              }
+            },
+            { scrollHeight: 0, jump: 0, scrollTop: 0, changed: false }
+          ),
+          filter((value) => value.changed),
+          map((value) => value.jump)
+        ),
+        0
+      );
+      connect(
+        pipe(
+          atBottomState,
+          map((state) => state.atBottom)
+        ),
+        isAtBottom
+      );
+      connect(pipe(isAtBottom, throttleTime(50)), atBottomStateChange);
+      const scrollDirection = statefulStream(DOWN);
+      connect(
+        pipe(
+          scrollContainerState,
+          map(({ scrollTop: scrollTop2 }) => scrollTop2),
+          distinctUntilChanged(),
+          scan(
+            (acc, scrollTop2) => {
+              if (getValue(isScrollingBy)) {
+                return { direction: acc.direction, prevScrollTop: scrollTop2 };
+              }
+              return { direction: scrollTop2 < acc.prevScrollTop ? UP : DOWN, prevScrollTop: scrollTop2 };
+            },
+            { direction: DOWN, prevScrollTop: 0 }
+          ),
+          map((value) => value.direction)
+        ),
+        scrollDirection
+      );
+      connect(pipe(scrollContainerState, throttleTime(50), mapTo(NONE$1)), scrollDirection);
+      const scrollVelocity = statefulStream(0);
+      connect(
+        pipe(
+          isScrolling,
+          filter((value) => !value),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          mapTo(0)
+        ),
+        scrollVelocity
+      );
+      connect(
+        pipe(
+          scrollTop,
+          throttleTime(100),
+          withLatestFrom(isScrolling),
+          filter(([_2, isScrolling2]) => !!isScrolling2),
+          scan(([_2, prev], [next]) => [prev, next], [0, 0]),
+          map(([prev, next]) => next - prev)
+        ),
+        scrollVelocity
+      );
+      return {
+        isScrolling,
+        isAtTop,
+        isAtBottom,
+        atBottomState,
+        atTopStateChange,
+        atBottomStateChange,
+        scrollDirection,
+        atBottomThreshold,
+        atTopThreshold,
+        scrollVelocity,
+        lastJumpDueToItemResize
+      };
+    }, tup(domIOSystem));
+    const propsReadySystem = system(
+      ([{ log }]) => {
+        const propsReady = statefulStream(false);
+        const didMount = streamFromEmitter(
+          pipe(
+            propsReady,
+            filter((ready) => ready),
+            distinctUntilChanged()
+          )
+        );
+        subscribe(propsReady, (value) => {
+          value && getValue(log)("props updated", {}, LogLevel.DEBUG);
+        });
+        return { propsReady, didMount };
+      },
+      tup(loggerSystem),
+      { singleton: true }
+    );
+    function skipFrames(frameCount, callback) {
+      if (frameCount == 0) {
+        callback();
+      } else {
+        requestAnimationFrame(() => skipFrames(frameCount - 1, callback));
+      }
+    }
+    function getInitialTopMostItemIndexNumber(location, totalCount) {
+      const lastIndex = totalCount - 1;
+      const index = typeof location === "number" ? location : location.index === "LAST" ? lastIndex : location.index;
+      return index;
+    }
+    const initialTopMostItemIndexSystem = system(
+      ([{ sizes, listRefresh, defaultItemSize }, { scrollTop }, { scrollToIndex, scrollTargetReached }, { didMount }]) => {
+        const scrolledToInitialItem = statefulStream(true);
+        const initialTopMostItemIndex = statefulStream(0);
+        const initialItemFinalLocationReached = statefulStream(true);
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(initialTopMostItemIndex),
+            filter(([_2, location]) => !!location),
+            mapTo(false)
+          ),
+          scrolledToInitialItem
+        );
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(initialTopMostItemIndex),
+            filter(([_2, location]) => !!location),
+            mapTo(false)
+          ),
+          initialItemFinalLocationReached
+        );
+        subscribe(
+          pipe(
+            combineLatest(listRefresh, didMount),
+            withLatestFrom(scrolledToInitialItem, sizes, defaultItemSize, initialItemFinalLocationReached),
+            filter(([[, didMount2], scrolledToInitialItem2, { sizeTree }, defaultItemSize2, scrollScheduled]) => {
+              return didMount2 && (!empty(sizeTree) || isDefined(defaultItemSize2)) && !scrolledToInitialItem2 && !scrollScheduled;
+            }),
+            withLatestFrom(initialTopMostItemIndex)
+          ),
+          ([, initialTopMostItemIndex2]) => {
+            handleNext(scrollTargetReached, () => {
+              publish(initialItemFinalLocationReached, true);
+            });
+            skipFrames(4, () => {
+              handleNext(scrollTop, () => {
+                publish(scrolledToInitialItem, true);
+              });
+              publish(scrollToIndex, initialTopMostItemIndex2);
+            });
+          }
+        );
+        return {
+          scrolledToInitialItem,
+          initialTopMostItemIndex,
+          initialItemFinalLocationReached
+        };
+      },
+      tup(sizeSystem, domIOSystem, scrollToIndexSystem, propsReadySystem),
+      { singleton: true }
+    );
+    function normalizeFollowOutput(follow) {
+      if (!follow) {
+        return false;
+      }
+      return follow === "smooth" ? "smooth" : "auto";
+    }
+    const behaviorFromFollowOutput = (follow, isAtBottom) => {
+      if (typeof follow === "function") {
+        return normalizeFollowOutput(follow(isAtBottom));
+      }
+      return isAtBottom && normalizeFollowOutput(follow);
+    };
+    const followOutputSystem = system(
+      ([
+        { totalCount, listRefresh },
+        { isAtBottom, atBottomState },
+        { scrollToIndex },
+        { scrolledToInitialItem },
+        { propsReady, didMount },
+        { log },
+        { scrollingInProgress }
+      ]) => {
+        const followOutput = statefulStream(false);
+        const autoscrollToBottom = stream();
+        let pendingScrollHandle = null;
+        function scrollToBottom(followOutputBehavior) {
+          publish(scrollToIndex, {
+            index: "LAST",
+            align: "end",
+            behavior: followOutputBehavior
+          });
+        }
+        subscribe(
+          pipe(
+            combineLatest(pipe(duc(totalCount), skip(1)), didMount),
+            withLatestFrom(duc(followOutput), isAtBottom, scrolledToInitialItem, scrollingInProgress),
+            map(([[totalCount2, didMount2], followOutput2, isAtBottom2, scrolledToInitialItem2, scrollingInProgress2]) => {
+              let shouldFollow = didMount2 && scrolledToInitialItem2;
+              let followOutputBehavior = "auto";
+              if (shouldFollow) {
+                followOutputBehavior = behaviorFromFollowOutput(followOutput2, isAtBottom2 || scrollingInProgress2);
+                shouldFollow = shouldFollow && !!followOutputBehavior;
+              }
+              return { totalCount: totalCount2, shouldFollow, followOutputBehavior };
+            }),
+            filter(({ shouldFollow }) => shouldFollow)
+          ),
+          ({ totalCount: totalCount2, followOutputBehavior }) => {
+            if (pendingScrollHandle) {
+              pendingScrollHandle();
+              pendingScrollHandle = null;
+            }
+            pendingScrollHandle = handleNext(listRefresh, () => {
+              getValue(log)("following output to ", { totalCount: totalCount2 }, LogLevel.DEBUG);
+              scrollToBottom(followOutputBehavior);
+              pendingScrollHandle = null;
+            });
+          }
+        );
+        function trapNextSizeIncrease(followOutput2) {
+          const cancel = handleNext(atBottomState, (state) => {
+            if (followOutput2 && !state.atBottom && state.notAtBottomBecause === "SIZE_INCREASED" && !pendingScrollHandle) {
+              getValue(log)("scrolling to bottom due to increased size", {}, LogLevel.DEBUG);
+              scrollToBottom("auto");
+            }
+          });
+          setTimeout(cancel, 100);
+        }
+        subscribe(
+          pipe(
+            combineLatest(duc(followOutput), totalCount, propsReady),
+            filter(([follow, , ready]) => follow && ready),
+            scan(
+              ({ value }, [, next]) => {
+                return { refreshed: value === next, value: next };
+              },
+              { refreshed: false, value: 0 }
+            ),
+            filter(({ refreshed }) => refreshed),
+            withLatestFrom(followOutput, totalCount)
+          ),
+          ([, followOutput2]) => {
+            if (getValue(scrolledToInitialItem)) {
+              trapNextSizeIncrease(followOutput2 !== false);
+            }
+          }
+        );
+        subscribe(autoscrollToBottom, () => {
+          trapNextSizeIncrease(getValue(followOutput) !== false);
+        });
+        subscribe(combineLatest(duc(followOutput), atBottomState), ([followOutput2, state]) => {
+          if (followOutput2 && !state.atBottom && state.notAtBottomBecause === "VIEWPORT_HEIGHT_DECREASING") {
+            scrollToBottom("auto");
+          }
+        });
+        return { followOutput, autoscrollToBottom };
+      },
+      tup(sizeSystem, stateFlagsSystem, scrollToIndexSystem, initialTopMostItemIndexSystem, propsReadySystem, loggerSystem, domIOSystem)
+    );
+    function groupCountsToIndicesAndCount(counts) {
+      return counts.reduce(
+        (acc, groupCount) => {
+          acc.groupIndices.push(acc.totalCount);
+          acc.totalCount += groupCount + 1;
+          return acc;
+        },
+        {
+          totalCount: 0,
+          groupIndices: []
+        }
+      );
+    }
+    const groupedListSystem = system(([{ totalCount, groupIndices, sizes }, { scrollTop, headerHeight }]) => {
+      const groupCounts = stream();
+      const topItemsIndexes = stream();
+      const groupIndicesAndCount = streamFromEmitter(pipe(groupCounts, map(groupCountsToIndicesAndCount)));
+      connect(
+        pipe(
+          groupIndicesAndCount,
+          map((value) => value.totalCount)
+        ),
+        totalCount
+      );
+      connect(
+        pipe(
+          groupIndicesAndCount,
+          map((value) => value.groupIndices)
+        ),
+        groupIndices
+      );
+      connect(
+        pipe(
+          combineLatest(scrollTop, sizes, headerHeight),
+          filter(([_2, sizes2]) => hasGroups(sizes2)),
+          map(([scrollTop2, state, headerHeight2]) => findMaxKeyValue(state.groupOffsetTree, Math.max(scrollTop2 - headerHeight2, 0), "v")[0]),
+          distinctUntilChanged(),
+          map((index) => [index])
+        ),
+        topItemsIndexes
+      );
+      return { groupCounts, topItemsIndexes };
+    }, tup(sizeSystem, domIOSystem));
+    function tupleComparator(prev, current) {
+      return !!(prev && prev[0] === current[0] && prev[1] === current[1]);
+    }
+    function rangeComparator(prev, next) {
+      return !!(prev && prev.startIndex === next.startIndex && prev.endIndex === next.endIndex);
+    }
+    const TOP = "top";
+    const BOTTOM = "bottom";
+    const NONE = "none";
+    function getOverscan(overscan, end2, direction) {
+      if (typeof overscan === "number") {
+        return direction === UP && end2 === TOP || direction === DOWN && end2 === BOTTOM ? overscan : 0;
+      } else {
+        if (direction === UP) {
+          return end2 === TOP ? overscan.main : overscan.reverse;
+        } else {
+          return end2 === BOTTOM ? overscan.main : overscan.reverse;
+        }
+      }
+    }
+    function getViewportIncrease(value, end2) {
+      return typeof value === "number" ? value : value[end2] || 0;
+    }
+    const sizeRangeSystem = system(
+      ([{ scrollTop, viewportHeight, deviation, headerHeight, fixedHeaderHeight }]) => {
+        const listBoundary = stream();
+        const topListHeight = statefulStream(0);
+        const increaseViewportBy = statefulStream(0);
+        const overscan = statefulStream(0);
+        const visibleRange = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(
+              duc(scrollTop),
+              duc(viewportHeight),
+              duc(headerHeight),
+              duc(listBoundary, tupleComparator),
+              duc(overscan),
+              duc(topListHeight),
+              duc(fixedHeaderHeight),
+              duc(deviation),
+              duc(increaseViewportBy)
+            ),
+            map(
+              ([
+                scrollTop2,
+                viewportHeight2,
+                headerHeight2,
+                [listTop, listBottom],
+                overscan2,
+                topListHeight2,
+                fixedHeaderHeight2,
+                deviation2,
+                increaseViewportBy2
+              ]) => {
+                const top2 = scrollTop2 - deviation2;
+                const stickyHeaderHeight = topListHeight2 + fixedHeaderHeight2;
+                const headerVisible = Math.max(headerHeight2 - top2, 0);
+                let direction = NONE;
+                const topViewportAddition = getViewportIncrease(increaseViewportBy2, TOP);
+                const bottomViewportAddition = getViewportIncrease(increaseViewportBy2, BOTTOM);
+                listTop -= deviation2;
+                listTop += headerHeight2 + fixedHeaderHeight2;
+                listBottom += headerHeight2 + fixedHeaderHeight2;
+                listBottom -= deviation2;
+                if (listTop > scrollTop2 + stickyHeaderHeight - topViewportAddition) {
+                  direction = UP;
+                }
+                if (listBottom < scrollTop2 - headerVisible + viewportHeight2 + bottomViewportAddition) {
+                  direction = DOWN;
+                }
+                if (direction !== NONE) {
+                  return [
+                    Math.max(top2 - headerHeight2 - getOverscan(overscan2, TOP, direction) - topViewportAddition, 0),
+                    top2 - headerVisible - fixedHeaderHeight2 + viewportHeight2 + getOverscan(overscan2, BOTTOM, direction) + bottomViewportAddition
+                  ];
+                }
+                return null;
+              }
+            ),
+            filter((value) => value != null),
+            distinctUntilChanged(tupleComparator)
+          ),
+          [0, 0]
+        );
+        return {
+          // input
+          listBoundary,
+          overscan,
+          topListHeight,
+          increaseViewportBy,
+          // output
+          visibleRange
+        };
+      },
+      tup(domIOSystem),
+      { singleton: true }
+    );
+    function probeItemSet(index, sizes, data) {
+      if (hasGroups(sizes)) {
+        const itemIndex = originalIndexFromItemIndex(index, sizes);
+        const groupIndex = findMaxKeyValue(sizes.groupOffsetTree, itemIndex)[0];
+        return [
+          { index: groupIndex, size: 0, offset: 0 },
+          { index: itemIndex, size: 0, offset: 0, data: data && data[0] }
+        ];
+      }
+      return [{ index, size: 0, offset: 0, data: data && data[0] }];
+    }
+    const EMPTY_LIST_STATE = {
+      items: [],
+      topItems: [],
+      offsetTop: 0,
+      offsetBottom: 0,
+      top: 0,
+      bottom: 0,
+      topListHeight: 0,
+      totalCount: 0,
+      firstItemIndex: 0
+    };
+    function transposeItems(items, sizes, firstItemIndex) {
+      if (items.length === 0) {
+        return [];
+      }
+      if (!hasGroups(sizes)) {
+        return items.map((item) => ({ ...item, index: item.index + firstItemIndex, originalIndex: item.index }));
+      }
+      const startIndex = items[0].index;
+      const endIndex = items[items.length - 1].index;
+      const transposedItems = [];
+      const groupRanges = rangesWithin(sizes.groupOffsetTree, startIndex, endIndex);
+      let currentRange = void 0;
+      let currentGroupIndex = 0;
+      for (const item of items) {
+        if (!currentRange || currentRange.end < item.index) {
+          currentRange = groupRanges.shift();
+          currentGroupIndex = sizes.groupIndices.indexOf(currentRange.start);
+        }
+        let transposedItem;
+        if (item.index === currentRange.start) {
+          transposedItem = {
+            type: "group",
+            index: currentGroupIndex
+          };
+        } else {
+          transposedItem = {
+            index: item.index - (currentGroupIndex + 1) + firstItemIndex,
+            groupIndex: currentGroupIndex
+          };
+        }
+        transposedItems.push({
+          ...transposedItem,
+          size: item.size,
+          offset: item.offset,
+          originalIndex: item.index,
+          data: item.data
+        });
+      }
+      return transposedItems;
+    }
+    function buildListState(items, topItems, totalCount, gap, sizes, firstItemIndex) {
+      const { lastSize, lastOffset, lastIndex } = sizes;
+      let offsetTop = 0;
+      let bottom2 = 0;
+      if (items.length > 0) {
+        offsetTop = items[0].offset;
+        const lastItem = items[items.length - 1];
+        bottom2 = lastItem.offset + lastItem.size;
+      }
+      const itemCount = totalCount - lastIndex;
+      const total = lastOffset + itemCount * lastSize + (itemCount - 1) * gap;
+      const top2 = offsetTop;
+      const offsetBottom = total - bottom2;
+      return {
+        items: transposeItems(items, sizes, firstItemIndex),
+        topItems: transposeItems(topItems, sizes, firstItemIndex),
+        topListHeight: topItems.reduce((height, item) => item.size + height, 0),
+        offsetTop,
+        offsetBottom,
+        top: top2,
+        bottom: bottom2,
+        totalCount,
+        firstItemIndex
+      };
+    }
+    function buildListStateFromItemCount(itemCount, initialTopMostItemIndex, sizes, firstItemIndex, gap, data) {
+      let includedGroupsCount = 0;
+      if (sizes.groupIndices.length > 0) {
+        for (const index of sizes.groupIndices) {
+          if (index - includedGroupsCount >= itemCount) {
+            break;
+          }
+          includedGroupsCount++;
+        }
+      }
+      const adjustedCount = itemCount + includedGroupsCount;
+      const initialTopMostItemIndexNumber = getInitialTopMostItemIndexNumber(initialTopMostItemIndex, adjustedCount);
+      const items = Array.from({ length: adjustedCount }).map((_2, index) => ({
+        index: index + initialTopMostItemIndexNumber,
+        size: 0,
+        offset: 0,
+        data: data[index + initialTopMostItemIndexNumber]
+      }));
+      return buildListState(items, [], adjustedCount, gap, sizes, firstItemIndex);
+    }
+    const listStateSystem = system(
+      ([
+        { sizes, totalCount, data, firstItemIndex, gap },
+        groupedListSystem2,
+        { visibleRange, listBoundary, topListHeight: rangeTopListHeight },
+        { scrolledToInitialItem, initialTopMostItemIndex },
+        { topListHeight },
+        stateFlags,
+        { didMount },
+        { recalcInProgress }
+      ]) => {
+        const topItemsIndexes = statefulStream([]);
+        const initialItemCount = statefulStream(0);
+        const itemsRendered = stream();
+        connect(groupedListSystem2.topItemsIndexes, topItemsIndexes);
+        const listState = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(
+              didMount,
+              recalcInProgress,
+              duc(visibleRange, tupleComparator),
+              duc(totalCount),
+              duc(sizes),
+              duc(initialTopMostItemIndex),
+              scrolledToInitialItem,
+              duc(topItemsIndexes),
+              duc(firstItemIndex),
+              duc(gap),
+              data
+            ),
+            filter(([mount, recalcInProgress2, , totalCount2, , , , , , , data2]) => {
+              const dataChangeInProgress = data2 && data2.length !== totalCount2;
+              return mount && !recalcInProgress2 && !dataChangeInProgress;
+            }),
+            map(
+              ([
+                ,
+                ,
+                [startOffset, endOffset],
+                totalCount2,
+                sizes2,
+                initialTopMostItemIndex2,
+                scrolledToInitialItem2,
+                topItemsIndexes2,
+                firstItemIndex2,
+                gap2,
+                data2
+              ]) => {
+                const sizesValue = sizes2;
+                const { sizeTree, offsetTree } = sizesValue;
+                const initialItemCountValue = getValue(initialItemCount);
+                if (totalCount2 === 0) {
+                  return { ...EMPTY_LIST_STATE, totalCount: totalCount2 };
+                }
+                if (startOffset === 0 && endOffset === 0) {
+                  if (initialItemCountValue === 0) {
+                    return { ...EMPTY_LIST_STATE, totalCount: totalCount2 };
+                  } else {
+                    return buildListStateFromItemCount(initialItemCountValue, initialTopMostItemIndex2, sizes2, firstItemIndex2, gap2, data2 || []);
+                  }
+                }
+                if (empty(sizeTree)) {
+                  if (initialItemCountValue > 0) {
+                    return null;
+                  }
+                  const state = buildListState(
+                    probeItemSet(getInitialTopMostItemIndexNumber(initialTopMostItemIndex2, totalCount2), sizesValue, data2),
+                    [],
+                    totalCount2,
+                    gap2,
+                    sizesValue,
+                    firstItemIndex2
+                  );
+                  return state;
+                }
+                const topItems = [];
+                if (topItemsIndexes2.length > 0) {
+                  const startIndex = topItemsIndexes2[0];
+                  const endIndex = topItemsIndexes2[topItemsIndexes2.length - 1];
+                  let offset2 = 0;
+                  for (const range of rangesWithin(sizeTree, startIndex, endIndex)) {
+                    const size = range.value;
+                    const rangeStartIndex = Math.max(range.start, startIndex);
+                    const rangeEndIndex = Math.min(range.end, endIndex);
+                    for (let i2 = rangeStartIndex; i2 <= rangeEndIndex; i2++) {
+                      topItems.push({ index: i2, size, offset: offset2, data: data2 && data2[i2] });
+                      offset2 += size;
+                    }
+                  }
+                }
+                if (!scrolledToInitialItem2) {
+                  return buildListState([], topItems, totalCount2, gap2, sizesValue, firstItemIndex2);
+                }
+                const minStartIndex = topItemsIndexes2.length > 0 ? topItemsIndexes2[topItemsIndexes2.length - 1] + 1 : 0;
+                const offsetPointRanges = rangesWithinOffsets(offsetTree, startOffset, endOffset, minStartIndex);
+                if (offsetPointRanges.length === 0) {
+                  return null;
+                }
+                const maxIndex = totalCount2 - 1;
+                const items = tap([], (result) => {
+                  for (const range of offsetPointRanges) {
+                    const point = range.value;
+                    let offset2 = point.offset;
+                    let rangeStartIndex = range.start;
+                    const size = point.size;
+                    if (point.offset < startOffset) {
+                      rangeStartIndex += Math.floor((startOffset - point.offset + gap2) / (size + gap2));
+                      const itemCount = rangeStartIndex - range.start;
+                      offset2 += itemCount * size + itemCount * gap2;
+                    }
+                    if (rangeStartIndex < minStartIndex) {
+                      offset2 += (minStartIndex - rangeStartIndex) * size;
+                      rangeStartIndex = minStartIndex;
+                    }
+                    const endIndex = Math.min(range.end, maxIndex);
+                    for (let i2 = rangeStartIndex; i2 <= endIndex; i2++) {
+                      if (offset2 >= endOffset) {
+                        break;
+                      }
+                      result.push({ index: i2, size, offset: offset2, data: data2 && data2[i2] });
+                      offset2 += size + gap2;
+                    }
+                  }
+                });
+                return buildListState(items, topItems, totalCount2, gap2, sizesValue, firstItemIndex2);
+              }
+            ),
+            //@ts-expect-error filter needs to be fixed
+            filter((value) => value !== null),
+            distinctUntilChanged()
+          ),
+          EMPTY_LIST_STATE
+        );
+        connect(
+          pipe(
+            data,
+            filter(isDefined),
+            map((data2) => data2 == null ? void 0 : data2.length)
+          ),
+          totalCount
+        );
+        connect(
+          pipe(
+            listState,
+            map((value) => value.topListHeight)
+          ),
+          topListHeight
+        );
+        connect(topListHeight, rangeTopListHeight);
+        connect(
+          pipe(
+            listState,
+            map((state) => [state.top, state.bottom])
+          ),
+          listBoundary
+        );
+        connect(
+          pipe(
+            listState,
+            map((state) => state.items)
+          ),
+          itemsRendered
+        );
+        const endReached = streamFromEmitter(
+          pipe(
+            listState,
+            filter(({ items }) => items.length > 0),
+            withLatestFrom(totalCount, data),
+            filter(([{ items }, totalCount2]) => items[items.length - 1].originalIndex === totalCount2 - 1),
+            map(([, totalCount2, data2]) => [totalCount2 - 1, data2]),
+            distinctUntilChanged(tupleComparator),
+            map(([count]) => count)
+          )
+        );
+        const startReached = streamFromEmitter(
+          pipe(
+            listState,
+            throttleTime(200),
+            filter(({ items, topItems }) => {
+              return items.length > 0 && items[0].originalIndex === topItems.length;
+            }),
+            map(({ items }) => items[0].index),
+            distinctUntilChanged()
+          )
+        );
+        const rangeChanged = streamFromEmitter(
+          pipe(
+            listState,
+            filter(({ items }) => items.length > 0),
+            map(({ items }) => {
+              let startIndex = 0;
+              let endIndex = items.length - 1;
+              while (items[startIndex].type === "group" && startIndex < endIndex) {
+                startIndex++;
+              }
+              while (items[endIndex].type === "group" && endIndex > startIndex) {
+                endIndex--;
+              }
+              return {
+                startIndex: items[startIndex].index,
+                endIndex: items[endIndex].index
+              };
+            }),
+            distinctUntilChanged(rangeComparator)
+          )
+        );
+        return { listState, topItemsIndexes, endReached, startReached, rangeChanged, itemsRendered, initialItemCount, ...stateFlags };
+      },
+      tup(
+        sizeSystem,
+        groupedListSystem,
+        sizeRangeSystem,
+        initialTopMostItemIndexSystem,
+        scrollToIndexSystem,
+        stateFlagsSystem,
+        propsReadySystem,
+        recalcSystem
+      ),
+      { singleton: true }
+    );
+    const initialItemCountSystem = system(
+      ([{ sizes, firstItemIndex, data, gap }, { initialTopMostItemIndex }, { initialItemCount, listState }, { didMount }]) => {
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(initialItemCount),
+            filter(([, count]) => count !== 0),
+            withLatestFrom(initialTopMostItemIndex, sizes, firstItemIndex, gap, data),
+            map(([[, count], initialTopMostItemIndexValue, sizes2, firstItemIndex2, gap2, data2 = []]) => {
+              return buildListStateFromItemCount(count, initialTopMostItemIndexValue, sizes2, firstItemIndex2, gap2, data2);
+            })
+          ),
+          listState
+        );
+        return {};
+      },
+      tup(sizeSystem, initialTopMostItemIndexSystem, listStateSystem, propsReadySystem),
+      { singleton: true }
+    );
+    const scrollSeekSystem = system(
+      ([{ scrollVelocity }]) => {
+        const isSeeking = statefulStream(false);
+        const rangeChanged = stream();
+        const scrollSeekConfiguration = statefulStream(false);
+        connect(
+          pipe(
+            scrollVelocity,
+            withLatestFrom(scrollSeekConfiguration, isSeeking, rangeChanged),
+            filter(([_2, config2]) => !!config2),
+            map(([speed, config2, isSeeking2, range]) => {
+              const { exit, enter } = config2;
+              if (isSeeking2) {
+                if (exit(speed, range)) {
+                  return false;
+                }
+              } else {
+                if (enter(speed, range)) {
+                  return true;
+                }
+              }
+              return isSeeking2;
+            }),
+            distinctUntilChanged()
+          ),
+          isSeeking
+        );
+        subscribe(
+          pipe(combineLatest(isSeeking, scrollVelocity, rangeChanged), withLatestFrom(scrollSeekConfiguration)),
+          ([[isSeeking2, velocity, range], config2]) => isSeeking2 && config2 && config2.change && config2.change(velocity, range)
+        );
+        return { isSeeking, scrollSeekConfiguration, scrollVelocity, scrollSeekRangeChanged: rangeChanged };
+      },
+      tup(stateFlagsSystem),
+      { singleton: true }
+    );
+    const topItemCountSystem = system(([{ topItemsIndexes }]) => {
+      const topItemCount = statefulStream(0);
+      connect(
+        pipe(
+          topItemCount,
+          filter((length) => length >= 0),
+          map((length) => Array.from({ length }).map((_2, index) => index))
+        ),
+        topItemsIndexes
+      );
+      return { topItemCount };
+    }, tup(listStateSystem));
+    const totalListHeightSystem = system(
+      ([{ footerHeight, headerHeight, fixedHeaderHeight, fixedFooterHeight }, { listState }]) => {
+        const totalListHeightChanged = stream();
+        const totalListHeight = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(footerHeight, fixedFooterHeight, headerHeight, fixedHeaderHeight, listState),
+            map(([footerHeight2, fixedFooterHeight2, headerHeight2, fixedHeaderHeight2, listState2]) => {
+              return footerHeight2 + fixedFooterHeight2 + headerHeight2 + fixedHeaderHeight2 + listState2.offsetBottom + listState2.bottom;
+            })
+          ),
+          0
+        );
+        connect(duc(totalListHeight), totalListHeightChanged);
+        return { totalListHeight, totalListHeightChanged };
+      },
+      tup(domIOSystem, listStateSystem),
+      { singleton: true }
+    );
+    function simpleMemoize(func) {
+      let called = false;
+      let result;
+      return () => {
+        if (!called) {
+          called = true;
+          result = func();
+        }
+        return result;
+      };
+    }
+    const isMobileSafari = simpleMemoize(() => {
+      return /iP(ad|od|hone)/i.test(navigator.userAgent) && /WebKit/i.test(navigator.userAgent);
+    });
+    const upwardScrollFixSystem = system(
+      ([
+        { scrollBy, scrollTop, deviation, scrollingInProgress },
+        { isScrolling, isAtBottom, scrollDirection, lastJumpDueToItemResize },
+        { listState },
+        { beforeUnshiftWith, shiftWithOffset, sizes, gap },
+        { log },
+        { recalcInProgress }
+      ]) => {
+        const deviationOffset = streamFromEmitter(
+          pipe(
+            listState,
+            withLatestFrom(lastJumpDueToItemResize),
+            scan(
+              ([, prevItems, prevTotalCount, prevTotalHeight], [{ items, totalCount, bottom: bottom2, offsetBottom }, lastJumpDueToItemResize2]) => {
+                const totalHeight = bottom2 + offsetBottom;
+                let newDev = 0;
+                if (prevTotalCount === totalCount) {
+                  if (prevItems.length > 0 && items.length > 0) {
+                    const atStart = items[0].originalIndex === 0 && prevItems[0].originalIndex === 0;
+                    if (!atStart) {
+                      newDev = totalHeight - prevTotalHeight;
+                      if (newDev !== 0) {
+                        newDev += lastJumpDueToItemResize2;
+                      }
+                    }
+                  }
+                }
+                return [newDev, items, totalCount, totalHeight];
+              },
+              [0, [], 0, 0]
+            ),
+            filter(([amount]) => amount !== 0),
+            withLatestFrom(scrollTop, scrollDirection, scrollingInProgress, isAtBottom, log, recalcInProgress),
+            filter(([, scrollTop2, scrollDirection2, scrollingInProgress2, , , recalcInProgress2]) => {
+              return !recalcInProgress2 && !scrollingInProgress2 && scrollTop2 !== 0 && scrollDirection2 === UP;
+            }),
+            map(([[amount], , , , , log2]) => {
+              log2("Upward scrolling compensation", { amount }, LogLevel.DEBUG);
+              return amount;
+            })
+          )
+        );
+        function scrollByWith(offset2) {
+          if (offset2 > 0) {
+            publish(scrollBy, { top: -offset2, behavior: "auto" });
+            publish(deviation, 0);
+          } else {
+            publish(deviation, 0);
+            publish(scrollBy, { top: -offset2, behavior: "auto" });
+          }
+        }
+        subscribe(pipe(deviationOffset, withLatestFrom(deviation, isScrolling)), ([offset2, deviationAmount, isScrolling2]) => {
+          if (isScrolling2 && isMobileSafari()) {
+            publish(deviation, deviationAmount - offset2);
+          } else {
+            scrollByWith(-offset2);
+          }
+        });
+        subscribe(
+          pipe(
+            combineLatest(statefulStreamFromEmitter(isScrolling, false), deviation, recalcInProgress),
+            filter(([is, deviation2, recalc]) => !is && !recalc && deviation2 !== 0),
+            map(([_2, deviation2]) => deviation2),
+            throttleTime(1)
+          ),
+          scrollByWith
+        );
+        connect(
+          pipe(
+            shiftWithOffset,
+            map((offset2) => {
+              return { top: -offset2 };
+            })
+          ),
+          scrollBy
+        );
+        subscribe(
+          pipe(
+            beforeUnshiftWith,
+            withLatestFrom(sizes, gap),
+            map(([offset2, { lastSize: defaultItemSize, groupIndices, sizeTree }, gap2]) => {
+              function getItemOffset(itemCount) {
+                return itemCount * (defaultItemSize + gap2);
+              }
+              if (groupIndices.length === 0) {
+                return getItemOffset(offset2);
+              } else {
+                let amount = 0;
+                const defaultGroupSize = find(sizeTree, 0);
+                let recognizedOffsetItems = 0;
+                let groupIndex = 0;
+                while (recognizedOffsetItems < offset2) {
+                  recognizedOffsetItems++;
+                  amount += defaultGroupSize;
+                  let groupItemCount = groupIndices.length === groupIndex + 1 ? Infinity : groupIndices[groupIndex + 1] - groupIndices[groupIndex] - 1;
+                  if (recognizedOffsetItems + groupItemCount > offset2) {
+                    amount -= defaultGroupSize;
+                    groupItemCount = offset2 - recognizedOffsetItems + 1;
+                  }
+                  recognizedOffsetItems += groupItemCount;
+                  amount += getItemOffset(groupItemCount);
+                  groupIndex++;
+                }
+                return amount;
+              }
+            })
+          ),
+          (offset2) => {
+            publish(deviation, offset2);
+            requestAnimationFrame(() => {
+              publish(scrollBy, { top: offset2 });
+              requestAnimationFrame(() => {
+                publish(deviation, 0);
+                publish(recalcInProgress, false);
+              });
+            });
+          }
+        );
+        return { deviation };
+      },
+      tup(domIOSystem, stateFlagsSystem, listStateSystem, sizeSystem, loggerSystem, recalcSystem)
+    );
+    const initialScrollTopSystem = system(
+      ([{ didMount }, { scrollTo }, { listState }]) => {
+        const initialScrollTop = statefulStream(0);
+        subscribe(
+          pipe(
+            didMount,
+            withLatestFrom(initialScrollTop),
+            filter(([, offset2]) => offset2 !== 0),
+            map(([, offset2]) => ({ top: offset2 }))
+          ),
+          (location) => {
+            handleNext(
+              pipe(
+                listState,
+                skip(1),
+                filter((state) => state.items.length > 1)
+              ),
+              () => {
+                requestAnimationFrame(() => {
+                  publish(scrollTo, location);
+                });
+              }
+            );
+          }
+        );
+        return {
+          initialScrollTop
+        };
+      },
+      tup(propsReadySystem, domIOSystem, listStateSystem),
+      { singleton: true }
+    );
+    const alignToBottomSystem = system(
+      ([{ viewportHeight }, { totalListHeight }]) => {
+        const alignToBottom = statefulStream(false);
+        const paddingTopAddition = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(alignToBottom, viewportHeight, totalListHeight),
+            filter(([enabled]) => enabled),
+            map(([, viewportHeight2, totalListHeight2]) => {
+              return Math.max(0, viewportHeight2 - totalListHeight2);
+            }),
+            throttleTime(0),
+            distinctUntilChanged()
+          ),
+          0
+        );
+        return { alignToBottom, paddingTopAddition };
+      },
+      tup(domIOSystem, totalListHeightSystem),
+      { singleton: true }
+    );
+    const windowScrollerSystem = system(([{ scrollTo, scrollContainerState }]) => {
+      const windowScrollContainerState = stream();
+      const windowViewportRect = stream();
+      const windowScrollTo = stream();
+      const useWindowScroll = statefulStream(false);
+      const customScrollParent = statefulStream(void 0);
+      connect(
+        pipe(
+          combineLatest(windowScrollContainerState, windowViewportRect),
+          map(([{ viewportHeight, scrollTop: windowScrollTop, scrollHeight }, { offsetTop }]) => {
+            return {
+              scrollTop: Math.max(0, windowScrollTop - offsetTop),
+              scrollHeight,
+              viewportHeight
+            };
+          })
+        ),
+        scrollContainerState
+      );
+      connect(
+        pipe(
+          scrollTo,
+          withLatestFrom(windowViewportRect),
+          map(([scrollTo2, { offsetTop }]) => {
+            return {
+              ...scrollTo2,
+              top: scrollTo2.top + offsetTop
+            };
+          })
+        ),
+        windowScrollTo
+      );
+      return {
+        // config
+        useWindowScroll,
+        customScrollParent,
+        // input
+        windowScrollContainerState,
+        windowViewportRect,
+        // signals
+        windowScrollTo
+      };
+    }, tup(domIOSystem));
+    const defaultCalculateViewLocation = ({
+      itemTop: itemTop2,
+      itemBottom,
+      viewportTop,
+      viewportBottom,
+      locationParams: { behavior, align, ...rest }
+    }) => {
+      if (itemTop2 < viewportTop) {
+        return { ...rest, behavior, align: align != null ? align : "start" };
+      }
+      if (itemBottom > viewportBottom) {
+        return { ...rest, behavior, align: align != null ? align : "end" };
+      }
+      return null;
+    };
+    const scrollIntoViewSystem = system(
+      ([
+        { sizes, totalCount, gap },
+        { scrollTop, viewportHeight, headerHeight, fixedHeaderHeight, fixedFooterHeight, scrollingInProgress },
+        { scrollToIndex }
+      ]) => {
+        const scrollIntoView = stream();
+        connect(
+          pipe(
+            scrollIntoView,
+            withLatestFrom(sizes, viewportHeight, totalCount, headerHeight, fixedHeaderHeight, fixedFooterHeight, scrollTop),
+            withLatestFrom(gap),
+            map(([[viewLocation, sizes2, viewportHeight2, totalCount2, headerHeight2, fixedHeaderHeight2, fixedFooterHeight2, scrollTop2], gap2]) => {
+              const { done, behavior, align, calculateViewLocation = defaultCalculateViewLocation, ...rest } = viewLocation;
+              const actualIndex = originalIndexFromLocation(viewLocation, sizes2, totalCount2 - 1);
+              const itemTop2 = offsetOf(actualIndex, sizes2.offsetTree, gap2) + headerHeight2 + fixedHeaderHeight2;
+              const itemBottom = itemTop2 + findMaxKeyValue(sizes2.sizeTree, actualIndex)[1];
+              const viewportTop = scrollTop2 + fixedHeaderHeight2;
+              const viewportBottom = scrollTop2 + viewportHeight2 - fixedFooterHeight2;
+              const location = calculateViewLocation({
+                itemTop: itemTop2,
+                itemBottom,
+                viewportTop,
+                viewportBottom,
+                locationParams: { behavior, align, ...rest }
+              });
+              if (location) {
+                done && handleNext(
+                  pipe(
+                    scrollingInProgress,
+                    filter((value) => value === false),
+                    // skips the initial publish of false, and the cleanup call.
+                    // but if scrollingInProgress is true, we skip the initial publish.
+                    skip(getValue(scrollingInProgress) ? 1 : 2)
+                  ),
+                  done
+                );
+              } else {
+                done && done();
+              }
+              return location;
+            }),
+            filter((value) => value !== null)
+          ),
+          scrollToIndex
+        );
+        return {
+          scrollIntoView
+        };
+      },
+      tup(sizeSystem, domIOSystem, scrollToIndexSystem, listStateSystem, loggerSystem),
+      { singleton: true }
+    );
+    const stateLoadSystem = system(
+      ([
+        { sizes, sizeRanges },
+        { scrollTop, headerHeight },
+        { initialTopMostItemIndex },
+        { didMount },
+        { useWindowScroll, windowScrollContainerState, windowViewportRect }
+      ]) => {
+        const getState = stream();
+        const restoreStateFrom = statefulStream(void 0);
+        const statefulWindowScrollContainerState = statefulStream(null);
+        const statefulWindowViewportRect = statefulStream(null);
+        connect(windowScrollContainerState, statefulWindowScrollContainerState);
+        connect(windowViewportRect, statefulWindowViewportRect);
+        subscribe(
+          pipe(
+            getState,
+            withLatestFrom(sizes, scrollTop, useWindowScroll, statefulWindowScrollContainerState, statefulWindowViewportRect, headerHeight)
+          ),
+          ([callback, sizes2, scrollTop2, useWindowScroll2, windowScrollContainerState2, windowViewportRect2, headerHeight2]) => {
+            const ranges = sizeTreeToRanges(sizes2.sizeTree);
+            if (useWindowScroll2 && windowScrollContainerState2 !== null && windowViewportRect2 !== null) {
+              scrollTop2 = windowScrollContainerState2.scrollTop - windowViewportRect2.offsetTop;
+            }
+            scrollTop2 -= headerHeight2;
+            callback({ ranges, scrollTop: scrollTop2 });
+          }
+        );
+        connect(pipe(restoreStateFrom, filter(isDefined), map(locationFromSnapshot)), initialTopMostItemIndex);
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(restoreStateFrom),
+            filter(([, state]) => state !== void 0),
+            distinctUntilChanged(),
+            map(([, snapshot]) => {
+              return snapshot.ranges;
+            })
+          ),
+          sizeRanges
+        );
+        return {
+          getState,
+          restoreStateFrom
+        };
+      },
+      tup(sizeSystem, domIOSystem, initialTopMostItemIndexSystem, propsReadySystem, windowScrollerSystem)
+    );
+    function locationFromSnapshot(snapshot) {
+      return { offset: snapshot.scrollTop, index: 0, align: "start" };
+    }
+    const featureGroup1System = system(
+      ([
+        sizeRange,
+        initialItemCount,
+        propsReady,
+        scrollSeek,
+        totalListHeight,
+        initialScrollTopSystem2,
+        alignToBottom,
+        windowScroller,
+        scrollIntoView,
+        logger
+      ]) => {
+        return {
+          ...sizeRange,
+          ...initialItemCount,
+          ...propsReady,
+          ...scrollSeek,
+          ...totalListHeight,
+          ...initialScrollTopSystem2,
+          ...alignToBottom,
+          ...windowScroller,
+          ...scrollIntoView,
+          ...logger
+        };
+      },
+      tup(
+        sizeRangeSystem,
+        initialItemCountSystem,
+        propsReadySystem,
+        scrollSeekSystem,
+        totalListHeightSystem,
+        initialScrollTopSystem,
+        alignToBottomSystem,
+        windowScrollerSystem,
+        scrollIntoViewSystem,
+        loggerSystem
+      )
+    );
+    const listSystem = system(
+      ([
+        {
+          totalCount,
+          sizeRanges,
+          fixedItemSize,
+          defaultItemSize,
+          trackItemSizes,
+          itemSize,
+          data,
+          firstItemIndex,
+          groupIndices,
+          statefulTotalCount,
+          gap,
+          sizes
+        },
+        { initialTopMostItemIndex, scrolledToInitialItem, initialItemFinalLocationReached },
+        domIO,
+        stateLoad,
+        followOutput,
+        { listState, topItemsIndexes, ...flags },
+        { scrollToIndex },
+        _2,
+        { topItemCount },
+        { groupCounts },
+        featureGroup1
+      ]) => {
+        connect(flags.rangeChanged, featureGroup1.scrollSeekRangeChanged);
+        connect(
+          pipe(
+            featureGroup1.windowViewportRect,
+            map((value) => value.visibleHeight)
+          ),
+          domIO.viewportHeight
+        );
+        return {
+          // input
+          totalCount,
+          data,
+          firstItemIndex,
+          sizeRanges,
+          initialTopMostItemIndex,
+          scrolledToInitialItem,
+          initialItemFinalLocationReached,
+          topItemsIndexes,
+          topItemCount,
+          groupCounts,
+          fixedItemHeight: fixedItemSize,
+          defaultItemHeight: defaultItemSize,
+          gap,
+          ...followOutput,
+          // output
+          statefulTotalCount,
+          listState,
+          scrollToIndex,
+          trackItemSizes,
+          itemSize,
+          groupIndices,
+          // exported from stateFlagsSystem
+          ...flags,
+          // the bag of IO from featureGroup1System
+          ...featureGroup1,
+          ...domIO,
+          sizes,
+          ...stateLoad
+        };
+      },
+      tup(
+        sizeSystem,
+        initialTopMostItemIndexSystem,
+        domIOSystem,
+        stateLoadSystem,
+        followOutputSystem,
+        listStateSystem,
+        scrollToIndexSystem,
+        upwardScrollFixSystem,
+        topItemCountSystem,
+        groupedListSystem,
+        featureGroup1System
+      )
+    );
+    const WEBKIT_STICKY = "-webkit-sticky";
+    const STICKY = "sticky";
+    const positionStickyCssValue = simpleMemoize(() => {
+      if (typeof document === "undefined") {
+        return STICKY;
+      }
+      const node = document.createElement("div");
+      node.style.position = WEBKIT_STICKY;
+      return node.style.position === WEBKIT_STICKY ? WEBKIT_STICKY : STICKY;
+    });
+    function useWindowViewportRectRef(callback, customScrollParent, skipAnimationFrame) {
+      const viewportInfo = xn.useRef(null);
+      const calculateInfo = xn.useCallback(
+        (element) => {
+          if (element === null || !element.offsetParent) {
+            return;
+          }
+          const rect = element.getBoundingClientRect();
+          const visibleWidth = rect.width;
+          let visibleHeight, offsetTop;
+          if (customScrollParent) {
+            const customScrollParentRect = customScrollParent.getBoundingClientRect();
+            const deltaTop = rect.top - customScrollParentRect.top;
+            visibleHeight = customScrollParentRect.height - Math.max(0, deltaTop);
+            offsetTop = deltaTop + customScrollParent.scrollTop;
+          } else {
+            visibleHeight = window.innerHeight - Math.max(0, rect.top);
+            offsetTop = rect.top + window.pageYOffset;
+          }
+          viewportInfo.current = {
+            offsetTop,
+            visibleHeight,
+            visibleWidth
+          };
+          callback(viewportInfo.current);
+        },
+        [callback, customScrollParent]
+      );
+      const { callbackRef, ref } = useSizeWithElRef(calculateInfo, true, skipAnimationFrame);
+      const scrollAndResizeEventHandler = xn.useCallback(() => {
+        calculateInfo(ref.current);
+      }, [calculateInfo, ref]);
+      xn.useEffect(() => {
+        if (customScrollParent) {
+          customScrollParent.addEventListener("scroll", scrollAndResizeEventHandler);
+          const observer = new ResizeObserver(() => {
+            requestAnimationFrame(scrollAndResizeEventHandler);
+          });
+          observer.observe(customScrollParent);
+          return () => {
+            customScrollParent.removeEventListener("scroll", scrollAndResizeEventHandler);
+            observer.unobserve(customScrollParent);
+          };
+        } else {
+          window.addEventListener("scroll", scrollAndResizeEventHandler);
+          window.addEventListener("resize", scrollAndResizeEventHandler);
+          return () => {
+            window.removeEventListener("scroll", scrollAndResizeEventHandler);
+            window.removeEventListener("resize", scrollAndResizeEventHandler);
+          };
+        }
+      }, [scrollAndResizeEventHandler, customScrollParent]);
+      return callbackRef;
+    }
+    const VirtuosoMockContext = xn.createContext(void 0);
+    const VirtuosoGridMockContext = xn.createContext(void 0);
+    function identity(value) {
+      return value;
+    }
+    const listComponentPropsSystem = /* @__PURE__ */ system(() => {
+      const itemContent = statefulStream((index) => `Item ${index}`);
+      const context = statefulStream(null);
+      const groupContent = statefulStream((index) => `Group ${index}`);
+      const components = statefulStream({});
+      const computeItemKey = statefulStream(identity);
+      const HeaderFooterTag = statefulStream("div");
+      const scrollerRef = statefulStream(noop);
+      const distinctProp = (propName, defaultValue = null) => {
+        return statefulStreamFromEmitter(
+          pipe(
+            components,
+            map((components2) => components2[propName]),
+            distinctUntilChanged()
+          ),
+          defaultValue
+        );
+      };
+      return {
+        context,
+        itemContent,
+        groupContent,
+        components,
+        computeItemKey,
+        HeaderFooterTag,
+        scrollerRef,
+        FooterComponent: distinctProp("Footer"),
+        HeaderComponent: distinctProp("Header"),
+        TopItemListComponent: distinctProp("TopItemList"),
+        ListComponent: distinctProp("List", "div"),
+        ItemComponent: distinctProp("Item", "div"),
+        GroupComponent: distinctProp("Group", "div"),
+        ScrollerComponent: distinctProp("Scroller", "div"),
+        EmptyPlaceholder: distinctProp("EmptyPlaceholder"),
+        ScrollSeekPlaceholder: distinctProp("ScrollSeekPlaceholder")
+      };
+    });
+    const combinedSystem$2 = /* @__PURE__ */ system(([listSystem2, propsSystem]) => {
+      return { ...listSystem2, ...propsSystem };
+    }, tup(listSystem, listComponentPropsSystem));
+    const DefaultScrollSeekPlaceholder$1 = ({ height }) => /* @__PURE__ */ u("div", { style: { height } });
+    const GROUP_STYLE = { position: positionStickyCssValue(), zIndex: 1, overflowAnchor: "none" };
+    const ITEM_STYLE$1 = { overflowAnchor: "none" };
+    const HORIZONTAL_ITEM_STYLE = { ...ITEM_STYLE$1, display: "inline-block", height: "100%" };
+    const Items$1 = /* @__PURE__ */ xn.memo(function VirtuosoItems({ showTopList = false }) {
+      const listState = useEmitterValue$2("listState");
+      const sizeRanges = usePublisher$2("sizeRanges");
+      const useWindowScroll = useEmitterValue$2("useWindowScroll");
+      const customScrollParent = useEmitterValue$2("customScrollParent");
+      const windowScrollContainerStateCallback = usePublisher$2("windowScrollContainerState");
+      const _scrollContainerStateCallback = usePublisher$2("scrollContainerState");
+      const scrollContainerStateCallback = customScrollParent || useWindowScroll ? windowScrollContainerStateCallback : _scrollContainerStateCallback;
+      const itemContent = useEmitterValue$2("itemContent");
+      const context = useEmitterValue$2("context");
+      const groupContent = useEmitterValue$2("groupContent");
+      const trackItemSizes = useEmitterValue$2("trackItemSizes");
+      const itemSize = useEmitterValue$2("itemSize");
+      const log = useEmitterValue$2("log");
+      const listGap = usePublisher$2("gap");
+      const horizontalDirection = useEmitterValue$2("horizontalDirection");
+      const { callbackRef } = useChangedListContentsSizes(
+        sizeRanges,
+        itemSize,
+        trackItemSizes,
+        showTopList ? noop : scrollContainerStateCallback,
+        log,
+        listGap,
+        customScrollParent,
+        horizontalDirection,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const [deviation, setDeviation] = xn.useState(0);
+      useEmitter$2("deviation", (value) => {
+        if (deviation !== value) {
+          setDeviation(value);
+        }
+      });
+      const EmptyPlaceholder = useEmitterValue$2("EmptyPlaceholder");
+      const ScrollSeekPlaceholder = useEmitterValue$2("ScrollSeekPlaceholder") || DefaultScrollSeekPlaceholder$1;
+      const ListComponent = useEmitterValue$2("ListComponent");
+      const ItemComponent = useEmitterValue$2("ItemComponent");
+      const GroupComponent = useEmitterValue$2("GroupComponent");
+      const computeItemKey = useEmitterValue$2("computeItemKey");
+      const isSeeking = useEmitterValue$2("isSeeking");
+      const hasGroups2 = useEmitterValue$2("groupIndices").length > 0;
+      const alignToBottom = useEmitterValue$2("alignToBottom");
+      const initialItemFinalLocationReached = useEmitterValue$2("initialItemFinalLocationReached");
+      const containerStyle = showTopList ? {} : {
+        boxSizing: "border-box",
+        ...horizontalDirection ? {
+          whiteSpace: "nowrap",
+          display: "inline-block",
+          height: "100%",
+          paddingLeft: listState.offsetTop,
+          paddingRight: listState.offsetBottom,
+          marginLeft: deviation !== 0 ? deviation : alignToBottom ? "auto" : 0
+        } : {
+          marginTop: deviation !== 0 ? deviation : alignToBottom ? "auto" : 0,
+          paddingTop: listState.offsetTop,
+          paddingBottom: listState.offsetBottom
+        },
+        ...initialItemFinalLocationReached ? {} : { visibility: "hidden" }
+      };
+      if (!showTopList && listState.totalCount === 0 && EmptyPlaceholder) {
+        return /* @__PURE__ */ u(EmptyPlaceholder, { ...contextPropIfNotDomElement(EmptyPlaceholder, context) });
+      }
+      return /* @__PURE__ */ u(
+        ListComponent,
+        {
+          ...contextPropIfNotDomElement(ListComponent, context),
+          ref: callbackRef,
+          style: containerStyle,
+          "data-testid": showTopList ? "virtuoso-top-item-list" : "virtuoso-item-list",
+          children: (showTopList ? listState.topItems : listState.items).map((item) => {
+            const index = item.originalIndex;
+            const key2 = computeItemKey(index + listState.firstItemIndex, item.data, context);
+            if (isSeeking) {
+              return /* @__PURE__ */ g$2(
+                ScrollSeekPlaceholder,
+                {
+                  ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
+                  key: key2,
+                  index: item.index,
+                  height: item.size,
+                  type: item.type || "item",
+                  ...item.type === "group" ? {} : { groupIndex: item.groupIndex }
+                }
+              );
+            }
+            if (item.type === "group") {
+              return /* @__PURE__ */ g$2(
+                GroupComponent,
+                {
+                  ...contextPropIfNotDomElement(GroupComponent, context),
+                  key: key2,
+                  "data-index": index,
+                  "data-known-size": item.size,
+                  "data-item-index": item.index,
+                  style: GROUP_STYLE
+                },
+                groupContent(item.index, context)
+              );
+            } else {
+              return /* @__PURE__ */ g$2(
+                ItemComponent,
+                {
+                  ...contextPropIfNotDomElement(ItemComponent, context),
+                  ...itemPropIfNotDomElement(ItemComponent, item.data),
+                  key: key2,
+                  "data-index": index,
+                  "data-known-size": item.size,
+                  "data-item-index": item.index,
+                  "data-item-group-index": item.groupIndex,
+                  style: horizontalDirection ? HORIZONTAL_ITEM_STYLE : ITEM_STYLE$1
+                },
+                hasGroups2 ? itemContent(item.index, item.groupIndex, item.data, context) : itemContent(item.index, item.data, context)
+              );
+            }
+          })
+        }
+      );
+    });
+    const scrollerStyle = {
+      height: "100%",
+      outline: "none",
+      overflowY: "auto",
+      position: "relative",
+      WebkitOverflowScrolling: "touch"
+    };
+    const horizontalScrollerStyle = {
+      outline: "none",
+      overflowX: "auto",
+      position: "relative"
+    };
+    const viewportStyle = (alignToBottom) => ({
+      width: "100%",
+      height: "100%",
+      position: "absolute",
+      top: 0,
+      ...alignToBottom ? { display: "flex", flexDirection: "column" } : {}
+    });
+    const topItemListStyle = {
+      width: "100%",
+      position: positionStickyCssValue(),
+      top: 0,
+      zIndex: 1
+    };
+    function contextPropIfNotDomElement(element, context) {
+      if (typeof element === "string") {
+        return void 0;
+      }
+      return { context };
+    }
+    function itemPropIfNotDomElement(element, item) {
+      return { item: typeof element === "string" ? void 0 : item };
+    }
+    const Header$1 = /* @__PURE__ */ xn.memo(function VirtuosoHeader() {
+      const Header2 = useEmitterValue$2("HeaderComponent");
+      const headerHeight = usePublisher$2("headerHeight");
+      const HeaderFooterTag = useEmitterValue$2("HeaderFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => headerHeight(correctItemSize(el, "height")), [headerHeight]),
+        true,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const context = useEmitterValue$2("context");
+      return Header2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Header2, { ...contextPropIfNotDomElement(Header2, context) }) }) : null;
+    });
+    const Footer$1 = /* @__PURE__ */ xn.memo(function VirtuosoFooter() {
+      const Footer2 = useEmitterValue$2("FooterComponent");
+      const footerHeight = usePublisher$2("footerHeight");
+      const HeaderFooterTag = useEmitterValue$2("HeaderFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => footerHeight(correctItemSize(el, "height")), [footerHeight]),
+        true,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const context = useEmitterValue$2("context");
+      return Footer2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Footer2, { ...contextPropIfNotDomElement(Footer2, context) }) }) : null;
+    });
+    function buildScroller({ usePublisher: usePublisher2, useEmitter: useEmitter2, useEmitterValue: useEmitterValue2 }) {
+      const Scroller2 = xn.memo(function VirtuosoScroller({ style: style2, children: children2, ...props }) {
+        const scrollContainerStateCallback = usePublisher2("scrollContainerState");
+        const ScrollerComponent = useEmitterValue2("ScrollerComponent");
+        const smoothScrollTargetReached = usePublisher2("smoothScrollTargetReached");
+        const scrollerRefCallback = useEmitterValue2("scrollerRef");
+        const context = useEmitterValue2("context");
+        const horizontalDirection = useEmitterValue2("horizontalDirection") || false;
+        const { scrollerRef, scrollByCallback, scrollToCallback } = useScrollTop(
+          scrollContainerStateCallback,
+          smoothScrollTargetReached,
+          ScrollerComponent,
+          scrollerRefCallback,
+          void 0,
+          horizontalDirection
+        );
+        useEmitter2("scrollTo", scrollToCallback);
+        useEmitter2("scrollBy", scrollByCallback);
+        const defaultStyle = horizontalDirection ? horizontalScrollerStyle : scrollerStyle;
+        return /* @__PURE__ */ u(
+          ScrollerComponent,
+          {
+            ref: scrollerRef,
+            style: { ...defaultStyle, ...style2 },
+            "data-testid": "virtuoso-scroller",
+            "data-virtuoso-scroller": true,
+            tabIndex: 0,
+            ...props,
+            ...contextPropIfNotDomElement(ScrollerComponent, context),
+            children: children2
+          }
+        );
+      });
+      return Scroller2;
+    }
+    function buildWindowScroller({ usePublisher: usePublisher2, useEmitter: useEmitter2, useEmitterValue: useEmitterValue2 }) {
+      const Scroller2 = xn.memo(function VirtuosoWindowScroller({ style: style2, children: children2, ...props }) {
+        const scrollContainerStateCallback = usePublisher2("windowScrollContainerState");
+        const ScrollerComponent = useEmitterValue2("ScrollerComponent");
+        const smoothScrollTargetReached = usePublisher2("smoothScrollTargetReached");
+        const totalListHeight = useEmitterValue2("totalListHeight");
+        const deviation = useEmitterValue2("deviation");
+        const customScrollParent = useEmitterValue2("customScrollParent");
+        const context = useEmitterValue2("context");
+        const { scrollerRef, scrollByCallback, scrollToCallback } = useScrollTop(
+          scrollContainerStateCallback,
+          smoothScrollTargetReached,
+          ScrollerComponent,
+          noop,
+          customScrollParent
+        );
+        useIsomorphicLayoutEffect(() => {
+          scrollerRef.current = customScrollParent ? customScrollParent : window;
+          return () => {
+            scrollerRef.current = null;
+          };
+        }, [scrollerRef, customScrollParent]);
+        useEmitter2("windowScrollTo", scrollToCallback);
+        useEmitter2("scrollBy", scrollByCallback);
+        return /* @__PURE__ */ u(
+          ScrollerComponent,
+          {
+            style: { position: "relative", ...style2, ...totalListHeight !== 0 ? { height: totalListHeight + deviation } : {} },
+            "data-virtuoso-scroller": true,
+            ...props,
+            ...contextPropIfNotDomElement(ScrollerComponent, context),
+            children: children2
+          }
+        );
+      });
+      return Scroller2;
+    }
+    const Viewport$2 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoMockContext);
+      const viewportHeight = usePublisher$2("viewportHeight");
+      const fixedItemHeight = usePublisher$2("fixedItemHeight");
+      const alignToBottom = useEmitterValue$2("alignToBottom");
+      const horizontalDirection = useEmitterValue$2("horizontalDirection");
+      const viewportSizeCallbackMemo = xn.useMemo(
+        () => compose$1(viewportHeight, (el) => correctItemSize(el, horizontalDirection ? "width" : "height")),
+        [viewportHeight, horizontalDirection]
+      );
+      const viewportRef = useSize(viewportSizeCallbackMemo, true, useEmitterValue$2("skipAnimationFrameInResizeObserver"));
+      xn.useEffect(() => {
+        if (ctx) {
+          viewportHeight(ctx.viewportHeight);
+          fixedItemHeight(ctx.itemHeight);
+        }
+      }, [ctx, viewportHeight, fixedItemHeight]);
+      return /* @__PURE__ */ u("div", { style: viewportStyle(alignToBottom), ref: viewportRef, "data-viewport-type": "element", children: children2 });
+    };
+    const WindowViewport$2 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoMockContext);
+      const windowViewportRect = usePublisher$2("windowViewportRect");
+      const fixedItemHeight = usePublisher$2("fixedItemHeight");
+      const customScrollParent = useEmitterValue$2("customScrollParent");
+      const viewportRef = useWindowViewportRectRef(
+        windowViewportRect,
+        customScrollParent,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const alignToBottom = useEmitterValue$2("alignToBottom");
+      xn.useEffect(() => {
+        if (ctx) {
+          fixedItemHeight(ctx.itemHeight);
+          windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: 100 });
+        }
+      }, [ctx, windowViewportRect, fixedItemHeight]);
+      return /* @__PURE__ */ u("div", { ref: viewportRef, style: viewportStyle(alignToBottom), "data-viewport-type": "window", children: children2 });
+    };
+    const TopItemListContainer = ({ children: children2 }) => {
+      const TopItemList = useEmitterValue$2("TopItemListComponent") || "div";
+      const headerHeight = useEmitterValue$2("headerHeight");
+      const style2 = { ...topItemListStyle, marginTop: `${headerHeight}px` };
+      const context = useEmitterValue$2("context");
+      return /* @__PURE__ */ u(TopItemList, { style: style2, ...contextPropIfNotDomElement(TopItemList, context), children: children2 });
+    };
+    const ListRoot = /* @__PURE__ */ xn.memo(function VirtuosoRoot(props) {
+      const useWindowScroll = useEmitterValue$2("useWindowScroll");
+      const showTopList = useEmitterValue$2("topItemsIndexes").length > 0;
+      const customScrollParent = useEmitterValue$2("customScrollParent");
+      const TheScroller = customScrollParent || useWindowScroll ? WindowScroller$2 : Scroller$2;
+      const TheViewport = customScrollParent || useWindowScroll ? WindowViewport$2 : Viewport$2;
+      return /* @__PURE__ */ u(TheScroller, { ...props, children: [
+        showTopList && /* @__PURE__ */ u(TopItemListContainer, { children: /* @__PURE__ */ u(Items$1, { showTopList: true }) }),
+        /* @__PURE__ */ u(TheViewport, { children: [
+          /* @__PURE__ */ u(Header$1, {}),
+          /* @__PURE__ */ u(Items$1, {}),
+          /* @__PURE__ */ u(Footer$1, {})
+        ] })
+      ] });
+    });
+    const {
+      Component: List,
+      usePublisher: usePublisher$2,
+      useEmitterValue: useEmitterValue$2,
+      useEmitter: useEmitter$2
+    } = /* @__PURE__ */ systemToComponent(
+      combinedSystem$2,
+      {
+        required: {},
+        optional: {
+          restoreStateFrom: "restoreStateFrom",
+          context: "context",
+          followOutput: "followOutput",
+          itemContent: "itemContent",
+          groupContent: "groupContent",
+          overscan: "overscan",
+          increaseViewportBy: "increaseViewportBy",
+          totalCount: "totalCount",
+          groupCounts: "groupCounts",
+          topItemCount: "topItemCount",
+          firstItemIndex: "firstItemIndex",
+          initialTopMostItemIndex: "initialTopMostItemIndex",
+          components: "components",
+          atBottomThreshold: "atBottomThreshold",
+          atTopThreshold: "atTopThreshold",
+          computeItemKey: "computeItemKey",
+          defaultItemHeight: "defaultItemHeight",
+          fixedItemHeight: "fixedItemHeight",
+          itemSize: "itemSize",
+          scrollSeekConfiguration: "scrollSeekConfiguration",
+          headerFooterTag: "HeaderFooterTag",
+          data: "data",
+          initialItemCount: "initialItemCount",
+          initialScrollTop: "initialScrollTop",
+          alignToBottom: "alignToBottom",
+          useWindowScroll: "useWindowScroll",
+          customScrollParent: "customScrollParent",
+          scrollerRef: "scrollerRef",
+          logLevel: "logLevel",
+          horizontalDirection: "horizontalDirection",
+          skipAnimationFrameInResizeObserver: "skipAnimationFrameInResizeObserver"
+        },
+        methods: {
+          scrollToIndex: "scrollToIndex",
+          scrollIntoView: "scrollIntoView",
+          scrollTo: "scrollTo",
+          scrollBy: "scrollBy",
+          autoscrollToBottom: "autoscrollToBottom",
+          getState: "getState"
+        },
+        events: {
+          isScrolling: "isScrolling",
+          endReached: "endReached",
+          startReached: "startReached",
+          rangeChanged: "rangeChanged",
+          atBottomStateChange: "atBottomStateChange",
+          atTopStateChange: "atTopStateChange",
+          totalListHeightChanged: "totalListHeightChanged",
+          itemsRendered: "itemsRendered",
+          groupIndices: "groupIndices"
+        }
+      },
+      ListRoot
+    );
+    const Scroller$2 = /* @__PURE__ */ buildScroller({ usePublisher: usePublisher$2, useEmitterValue: useEmitterValue$2, useEmitter: useEmitter$2 });
+    const WindowScroller$2 = /* @__PURE__ */ buildWindowScroller({ usePublisher: usePublisher$2, useEmitterValue: useEmitterValue$2, useEmitter: useEmitter$2 });
+    const Virtuoso = List;
+    const INITIAL_GRID_STATE = {
+      items: [],
+      offsetBottom: 0,
+      offsetTop: 0,
+      top: 0,
+      bottom: 0,
+      itemHeight: 0,
+      itemWidth: 0
+    };
+    const PROBE_GRID_STATE = {
+      items: [{ index: 0 }],
+      offsetBottom: 0,
+      offsetTop: 0,
+      top: 0,
+      bottom: 0,
+      itemHeight: 0,
+      itemWidth: 0
+    };
+    const { round, ceil, floor, min: min$1, max: max$2 } = Math;
+    function buildProbeGridState(items) {
+      return {
+        ...PROBE_GRID_STATE,
+        items
+      };
+    }
+    function buildItems(startIndex, endIndex, data) {
+      return Array.from({ length: endIndex - startIndex + 1 }).map((_2, i2) => {
+        const dataItem = data === null ? null : data[i2 + startIndex];
+        return { index: i2 + startIndex, data: dataItem };
+      });
+    }
+    function gapComparator(prev, next) {
+      return prev && prev.column === next.column && prev.row === next.row;
+    }
+    function dimensionComparator(prev, next) {
+      return prev && prev.width === next.width && prev.height === next.height;
+    }
+    const gridSystem = /* @__PURE__ */ system(
+      ([
+        { overscan, visibleRange, listBoundary, increaseViewportBy },
+        { scrollTop, viewportHeight, scrollBy, scrollTo, smoothScrollTargetReached, scrollContainerState, footerHeight, headerHeight },
+        stateFlags,
+        scrollSeek,
+        { propsReady, didMount },
+        { windowViewportRect, useWindowScroll, customScrollParent, windowScrollContainerState, windowScrollTo },
+        log
+      ]) => {
+        const totalCount = statefulStream(0);
+        const initialItemCount = statefulStream(0);
+        const gridState = statefulStream(INITIAL_GRID_STATE);
+        const viewportDimensions = statefulStream({ height: 0, width: 0 });
+        const itemDimensions = statefulStream({ height: 0, width: 0 });
+        const scrollToIndex = stream();
+        const scrollHeight = stream();
+        const deviation = statefulStream(0);
+        const data = statefulStream(null);
+        const gap = statefulStream({ row: 0, column: 0 });
+        const stateChanged = stream();
+        const restoreStateFrom = stream();
+        const stateRestoreInProgress = statefulStream(false);
+        const initialTopMostItemIndex = statefulStream(0);
+        const scrolledToInitialItem = statefulStream(true);
+        const scrollScheduled = statefulStream(false);
+        const horizontalDirection = statefulStream(false);
+        subscribe(
+          pipe(
+            didMount,
+            withLatestFrom(initialTopMostItemIndex),
+            filter(([_2, location]) => !!location)
+          ),
+          () => {
+            publish(scrolledToInitialItem, false);
+          }
+        );
+        subscribe(
+          pipe(
+            combineLatest(didMount, scrolledToInitialItem, itemDimensions, viewportDimensions, initialTopMostItemIndex, scrollScheduled),
+            filter(([didMount2, scrolledToInitialItem2, itemDimensions2, viewportDimensions2, , scrollScheduled2]) => {
+              return didMount2 && !scrolledToInitialItem2 && itemDimensions2.height !== 0 && viewportDimensions2.height !== 0 && !scrollScheduled2;
+            })
+          ),
+          ([, , , , initialTopMostItemIndex2]) => {
+            publish(scrollScheduled, true);
+            skipFrames(1, () => {
+              publish(scrollToIndex, initialTopMostItemIndex2);
+            });
+            handleNext(pipe(scrollTop), () => {
+              publish(listBoundary, [0, 0]);
+              publish(scrolledToInitialItem, true);
+            });
+          }
+        );
+        connect(
+          pipe(
+            restoreStateFrom,
+            filter((value) => value !== void 0 && value !== null && value.scrollTop > 0),
+            mapTo(0)
+          ),
+          initialItemCount
+        );
+        subscribe(
+          pipe(
+            didMount,
+            withLatestFrom(restoreStateFrom),
+            filter(([, snapshot]) => snapshot !== void 0 && snapshot !== null)
+          ),
+          ([, snapshot]) => {
+            if (!snapshot) {
+              return;
+            }
+            publish(viewportDimensions, snapshot.viewport), publish(itemDimensions, snapshot == null ? void 0 : snapshot.item);
+            publish(gap, snapshot.gap);
+            if (snapshot.scrollTop > 0) {
+              publish(stateRestoreInProgress, true);
+              handleNext(pipe(scrollTop, skip(1)), (_value) => {
+                publish(stateRestoreInProgress, false);
+              });
+              publish(scrollTo, { top: snapshot.scrollTop });
+            }
+          }
+        );
+        connect(
+          pipe(
+            viewportDimensions,
+            map(({ height }) => height)
+          ),
+          viewportHeight
+        );
+        connect(
+          pipe(
+            combineLatest(
+              duc(viewportDimensions, dimensionComparator),
+              duc(itemDimensions, dimensionComparator),
+              duc(gap, (prev, next) => prev && prev.column === next.column && prev.row === next.row),
+              duc(scrollTop)
+            ),
+            map(([viewport2, item, gap2, scrollTop2]) => ({
+              viewport: viewport2,
+              item,
+              gap: gap2,
+              scrollTop: scrollTop2
+            }))
+          ),
+          stateChanged
+        );
+        connect(
+          pipe(
+            combineLatest(
+              duc(totalCount),
+              visibleRange,
+              duc(gap, gapComparator),
+              duc(itemDimensions, dimensionComparator),
+              duc(viewportDimensions, dimensionComparator),
+              duc(data),
+              duc(initialItemCount),
+              duc(stateRestoreInProgress),
+              duc(scrolledToInitialItem),
+              duc(initialTopMostItemIndex)
+            ),
+            filter(([, , , , , , , stateRestoreInProgress2]) => {
+              return !stateRestoreInProgress2;
+            }),
+            map(
+              ([
+                totalCount2,
+                [startOffset, endOffset],
+                gap2,
+                item,
+                viewport2,
+                data2,
+                initialItemCount2,
+                ,
+                scrolledToInitialItem2,
+                initialTopMostItemIndex2
+              ]) => {
+                const { row: rowGap, column: columnGap } = gap2;
+                const { height: itemHeight, width: itemWidth } = item;
+                const { width: viewportWidth } = viewport2;
+                if (initialItemCount2 === 0 && (totalCount2 === 0 || viewportWidth === 0)) {
+                  return INITIAL_GRID_STATE;
+                }
+                if (itemWidth === 0) {
+                  const startIndex2 = getInitialTopMostItemIndexNumber(initialTopMostItemIndex2, totalCount2);
+                  const endIndex2 = startIndex2 + Math.max(initialItemCount2 - 1, 0);
+                  return buildProbeGridState(buildItems(startIndex2, endIndex2, data2));
+                }
+                const perRow = itemsPerRow(viewportWidth, itemWidth, columnGap);
+                let startIndex;
+                let endIndex;
+                if (!scrolledToInitialItem2) {
+                  startIndex = 0;
+                  endIndex = -1;
+                } else if (startOffset === 0 && endOffset === 0 && initialItemCount2 > 0) {
+                  startIndex = 0;
+                  endIndex = initialItemCount2 - 1;
+                } else {
+                  startIndex = perRow * floor((startOffset + rowGap) / (itemHeight + rowGap));
+                  endIndex = perRow * ceil((endOffset + rowGap) / (itemHeight + rowGap)) - 1;
+                  endIndex = min$1(totalCount2 - 1, max$2(endIndex, perRow - 1));
+                  startIndex = min$1(endIndex, max$2(0, startIndex));
+                }
+                const items = buildItems(startIndex, endIndex, data2);
+                const { top: top2, bottom: bottom2 } = gridLayout(viewport2, gap2, item, items);
+                const rowCount = ceil(totalCount2 / perRow);
+                const totalHeight = rowCount * itemHeight + (rowCount - 1) * rowGap;
+                const offsetBottom = totalHeight - bottom2;
+                return { items, offsetTop: top2, offsetBottom, top: top2, bottom: bottom2, itemHeight, itemWidth };
+              }
+            )
+          ),
+          gridState
+        );
+        connect(
+          pipe(
+            data,
+            filter((data2) => data2 !== null),
+            map((data2) => data2.length)
+          ),
+          totalCount
+        );
+        connect(
+          pipe(
+            combineLatest(viewportDimensions, itemDimensions, gridState, gap),
+            filter(([viewportDimensions2, itemDimensions2, { items }]) => {
+              return items.length > 0 && itemDimensions2.height !== 0 && viewportDimensions2.height !== 0;
+            }),
+            map(([viewportDimensions2, itemDimensions2, { items }, gap2]) => {
+              const { top: top2, bottom: bottom2 } = gridLayout(viewportDimensions2, gap2, itemDimensions2, items);
+              return [top2, bottom2];
+            }),
+            distinctUntilChanged(tupleComparator)
+          ),
+          listBoundary
+        );
+        const hasScrolled = statefulStream(false);
+        connect(
+          pipe(
+            scrollTop,
+            withLatestFrom(hasScrolled),
+            map(([scrollTop2, hasScrolled2]) => {
+              return hasScrolled2 || scrollTop2 !== 0;
+            })
+          ),
+          hasScrolled
+        );
+        const endReached = streamFromEmitter(
+          pipe(
+            combineLatest(gridState, totalCount),
+            filter(([{ items }]) => items.length > 0),
+            withLatestFrom(hasScrolled),
+            filter(([[gridState2, totalCount2], hasScrolled2]) => {
+              const lastIndex = gridState2.items[gridState2.items.length - 1].index;
+              const isLastItemRendered = lastIndex === totalCount2 - 1;
+              if (hasScrolled2) return isLastItemRendered;
+              const isFullyRendered = gridState2.bottom > 0 && gridState2.itemHeight > 0 && gridState2.offsetBottom === 0 && gridState2.items.length === totalCount2;
+              return isFullyRendered && isLastItemRendered;
+            }),
+            map(([[, totalCount2]]) => {
+              return totalCount2 - 1;
+            }),
+            distinctUntilChanged()
+          )
+        );
+        const startReached = streamFromEmitter(
+          pipe(
+            duc(gridState),
+            filter(({ items }) => {
+              return items.length > 0 && items[0].index === 0;
+            }),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            mapTo(0),
+            distinctUntilChanged()
+          )
+        );
+        const rangeChanged = streamFromEmitter(
+          pipe(
+            duc(gridState),
+            withLatestFrom(stateRestoreInProgress),
+            filter(([{ items }, stateRestoreInProgress2]) => items.length > 0 && !stateRestoreInProgress2),
+            map(([{ items }]) => {
+              return {
+                startIndex: items[0].index,
+                endIndex: items[items.length - 1].index
+              };
+            }),
+            distinctUntilChanged(rangeComparator),
+            throttleTime(0)
+          )
+        );
+        connect(rangeChanged, scrollSeek.scrollSeekRangeChanged);
+        connect(
+          pipe(
+            scrollToIndex,
+            withLatestFrom(viewportDimensions, itemDimensions, totalCount, gap),
+            map(([location, viewportDimensions2, itemDimensions2, totalCount2, gap2]) => {
+              const normalLocation = normalizeIndexLocation(location);
+              const { align, behavior, offset: offset2 } = normalLocation;
+              let index = normalLocation.index;
+              if (index === "LAST") {
+                index = totalCount2 - 1;
+              }
+              index = max$2(0, index, min$1(totalCount2 - 1, index));
+              let top2 = itemTop(viewportDimensions2, gap2, itemDimensions2, index);
+              if (align === "end") {
+                top2 = round(top2 - viewportDimensions2.height + itemDimensions2.height);
+              } else if (align === "center") {
+                top2 = round(top2 - viewportDimensions2.height / 2 + itemDimensions2.height / 2);
+              }
+              if (offset2) {
+                top2 += offset2;
+              }
+              return { top: top2, behavior };
+            })
+          ),
+          scrollTo
+        );
+        const totalListHeight = statefulStreamFromEmitter(
+          pipe(
+            gridState,
+            map((gridState2) => {
+              return gridState2.offsetBottom + gridState2.bottom;
+            })
+          ),
+          0
+        );
+        connect(
+          pipe(
+            windowViewportRect,
+            map((viewportInfo) => ({ width: viewportInfo.visibleWidth, height: viewportInfo.visibleHeight }))
+          ),
+          viewportDimensions
+        );
+        return {
+          // input
+          data,
+          totalCount,
+          viewportDimensions,
+          itemDimensions,
+          scrollTop,
+          scrollHeight,
+          overscan,
+          increaseViewportBy,
+          scrollBy,
+          scrollTo,
+          scrollToIndex,
+          smoothScrollTargetReached,
+          windowViewportRect,
+          windowScrollTo,
+          useWindowScroll,
+          customScrollParent,
+          windowScrollContainerState,
+          deviation,
+          scrollContainerState,
+          footerHeight,
+          headerHeight,
+          initialItemCount,
+          gap,
+          restoreStateFrom,
+          ...scrollSeek,
+          initialTopMostItemIndex,
+          horizontalDirection,
+          // output
+          gridState,
+          totalListHeight,
+          ...stateFlags,
+          startReached,
+          endReached,
+          rangeChanged,
+          stateChanged,
+          propsReady,
+          stateRestoreInProgress,
+          ...log
+        };
+      },
+      tup(sizeRangeSystem, domIOSystem, stateFlagsSystem, scrollSeekSystem, propsReadySystem, windowScrollerSystem, loggerSystem)
+    );
+    function gridLayout(viewport2, gap, item, items) {
+      const { height: itemHeight } = item;
+      if (itemHeight === void 0 || items.length === 0) {
+        return { top: 0, bottom: 0 };
+      }
+      const top2 = itemTop(viewport2, gap, item, items[0].index);
+      const bottom2 = itemTop(viewport2, gap, item, items[items.length - 1].index) + itemHeight;
+      return { top: top2, bottom: bottom2 };
+    }
+    function itemTop(viewport2, gap, item, index) {
+      const perRow = itemsPerRow(viewport2.width, item.width, gap.column);
+      const rowCount = floor(index / perRow);
+      const top2 = rowCount * item.height + max$2(0, rowCount - 1) * gap.row;
+      return top2 > 0 ? top2 + gap.row : top2;
+    }
+    function itemsPerRow(viewportWidth, itemWidth, gap) {
+      return max$2(1, floor((viewportWidth + gap) / (floor(itemWidth) + gap)));
+    }
+    const gridComponentPropsSystem = /* @__PURE__ */ system(() => {
+      const itemContent = statefulStream((index) => `Item ${index}`);
+      const components = statefulStream({});
+      const context = statefulStream(null);
+      const itemClassName = statefulStream("virtuoso-grid-item");
+      const listClassName = statefulStream("virtuoso-grid-list");
+      const computeItemKey = statefulStream(identity);
+      const headerFooterTag = statefulStream("div");
+      const scrollerRef = statefulStream(noop);
+      const distinctProp = (propName, defaultValue = null) => {
+        return statefulStreamFromEmitter(
+          pipe(
+            components,
+            map((components2) => components2[propName]),
+            distinctUntilChanged()
+          ),
+          defaultValue
+        );
+      };
+      const readyStateChanged = statefulStream(false);
+      const reportReadyState = statefulStream(false);
+      connect(duc(reportReadyState), readyStateChanged);
+      return {
+        readyStateChanged,
+        reportReadyState,
+        context,
+        itemContent,
+        components,
+        computeItemKey,
+        itemClassName,
+        listClassName,
+        headerFooterTag,
+        scrollerRef,
+        FooterComponent: distinctProp("Footer"),
+        HeaderComponent: distinctProp("Header"),
+        ListComponent: distinctProp("List", "div"),
+        ItemComponent: distinctProp("Item", "div"),
+        ScrollerComponent: distinctProp("Scroller", "div"),
+        ScrollSeekPlaceholder: distinctProp("ScrollSeekPlaceholder", "div")
+      };
+    });
+    const combinedSystem$1 = /* @__PURE__ */ system(([gridSystem2, gridComponentPropsSystem2]) => {
+      return { ...gridSystem2, ...gridComponentPropsSystem2 };
+    }, tup(gridSystem, gridComponentPropsSystem));
+    const GridItems = /* @__PURE__ */ xn.memo(function GridItems2() {
+      const gridState = useEmitterValue$1("gridState");
+      const listClassName = useEmitterValue$1("listClassName");
+      const itemClassName = useEmitterValue$1("itemClassName");
+      const itemContent = useEmitterValue$1("itemContent");
+      const computeItemKey = useEmitterValue$1("computeItemKey");
+      const isSeeking = useEmitterValue$1("isSeeking");
+      const scrollHeightCallback = usePublisher$1("scrollHeight");
+      const ItemComponent = useEmitterValue$1("ItemComponent");
+      const ListComponent = useEmitterValue$1("ListComponent");
+      const ScrollSeekPlaceholder = useEmitterValue$1("ScrollSeekPlaceholder");
+      const context = useEmitterValue$1("context");
+      const itemDimensions = usePublisher$1("itemDimensions");
+      const gridGap = usePublisher$1("gap");
+      const log = useEmitterValue$1("log");
+      const stateRestoreInProgress = useEmitterValue$1("stateRestoreInProgress");
+      const reportReadyState = usePublisher$1("reportReadyState");
+      const listRef = useSize(
+        xn.useMemo(
+          () => (el) => {
+            const scrollHeight = el.parentElement.parentElement.scrollHeight;
+            scrollHeightCallback(scrollHeight);
+            const firstItem = el.firstChild;
+            if (firstItem) {
+              const { width, height } = firstItem.getBoundingClientRect();
+              itemDimensions({ width, height });
+            }
+            gridGap({
+              row: resolveGapValue("row-gap", getComputedStyle(el).rowGap, log),
+              column: resolveGapValue("column-gap", getComputedStyle(el).columnGap, log)
+            });
+          },
+          [scrollHeightCallback, itemDimensions, gridGap, log]
+        ),
+        true,
+        false
+      );
+      useIsomorphicLayoutEffect(() => {
+        if (gridState.itemHeight > 0 && gridState.itemWidth > 0) {
+          reportReadyState(true);
+        }
+      }, [gridState]);
+      if (stateRestoreInProgress) {
+        return null;
+      }
+      return /* @__PURE__ */ u(
+        ListComponent,
+        {
+          ref: listRef,
+          className: listClassName,
+          ...contextPropIfNotDomElement(ListComponent, context),
+          style: { paddingTop: gridState.offsetTop, paddingBottom: gridState.offsetBottom },
+          "data-testid": "virtuoso-item-list",
+          children: gridState.items.map((item) => {
+            const key2 = computeItemKey(item.index, item.data, context);
+            return isSeeking ? /* @__PURE__ */ u(
+              ScrollSeekPlaceholder,
+              {
+                ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
+                index: item.index,
+                height: gridState.itemHeight,
+                width: gridState.itemWidth
+              },
+              key2
+            ) : /* @__PURE__ */ g$2(
+              ItemComponent,
+              {
+                ...contextPropIfNotDomElement(ItemComponent, context),
+                className: itemClassName,
+                "data-index": item.index,
+                key: key2
+              },
+              itemContent(item.index, item.data, context)
+            );
+          })
+        }
+      );
+    });
+    const Header = xn.memo(function VirtuosoHeader2() {
+      const Header2 = useEmitterValue$1("HeaderComponent");
+      const headerHeight = usePublisher$1("headerHeight");
+      const HeaderFooterTag = useEmitterValue$1("headerFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => headerHeight(correctItemSize(el, "height")), [headerHeight]),
+        true,
+        false
+      );
+      const context = useEmitterValue$1("context");
+      return Header2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Header2, { ...contextPropIfNotDomElement(Header2, context) }) }) : null;
+    });
+    const Footer = xn.memo(function VirtuosoGridFooter() {
+      const Footer2 = useEmitterValue$1("FooterComponent");
+      const footerHeight = usePublisher$1("footerHeight");
+      const HeaderFooterTag = useEmitterValue$1("headerFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => footerHeight(correctItemSize(el, "height")), [footerHeight]),
+        true,
+        false
+      );
+      const context = useEmitterValue$1("context");
+      return Footer2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Footer2, { ...contextPropIfNotDomElement(Footer2, context) }) }) : null;
+    });
+    const Viewport$1 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoGridMockContext);
+      const itemDimensions = usePublisher$1("itemDimensions");
+      const viewportDimensions = usePublisher$1("viewportDimensions");
+      const viewportRef = useSize(
+        xn.useMemo(
+          () => (el) => {
+            viewportDimensions(el.getBoundingClientRect());
+          },
+          [viewportDimensions]
+        ),
+        true,
+        false
+      );
+      xn.useEffect(() => {
+        if (ctx) {
+          viewportDimensions({ height: ctx.viewportHeight, width: ctx.viewportWidth });
+          itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth });
+        }
+      }, [ctx, viewportDimensions, itemDimensions]);
+      return /* @__PURE__ */ u("div", { style: viewportStyle(false), ref: viewportRef, children: children2 });
+    };
+    const WindowViewport$1 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoGridMockContext);
+      const windowViewportRect = usePublisher$1("windowViewportRect");
+      const itemDimensions = usePublisher$1("itemDimensions");
+      const customScrollParent = useEmitterValue$1("customScrollParent");
+      const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent, false);
+      xn.useEffect(() => {
+        if (ctx) {
+          itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth });
+          windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: ctx.viewportWidth });
+        }
+      }, [ctx, windowViewportRect, itemDimensions]);
+      return /* @__PURE__ */ u("div", { ref: viewportRef, style: viewportStyle(false), children: children2 });
+    };
+    const GridRoot = /* @__PURE__ */ xn.memo(function GridRoot2({ ...props }) {
+      const useWindowScroll = useEmitterValue$1("useWindowScroll");
+      const customScrollParent = useEmitterValue$1("customScrollParent");
+      const TheScroller = customScrollParent || useWindowScroll ? WindowScroller$1 : Scroller$1;
+      const TheViewport = customScrollParent || useWindowScroll ? WindowViewport$1 : Viewport$1;
+      return /* @__PURE__ */ u(TheScroller, { ...props, children: /* @__PURE__ */ u(TheViewport, { children: [
+        /* @__PURE__ */ u(Header, {}),
+        /* @__PURE__ */ u(GridItems, {}),
+        /* @__PURE__ */ u(Footer, {})
+      ] }) });
+    });
+    const {
+      Component: Grid,
+      usePublisher: usePublisher$1,
+      useEmitterValue: useEmitterValue$1,
+      useEmitter: useEmitter$1
+    } = /* @__PURE__ */ systemToComponent(
+      combinedSystem$1,
+      {
+        optional: {
+          context: "context",
+          totalCount: "totalCount",
+          overscan: "overscan",
+          itemContent: "itemContent",
+          components: "components",
+          computeItemKey: "computeItemKey",
+          data: "data",
+          initialItemCount: "initialItemCount",
+          scrollSeekConfiguration: "scrollSeekConfiguration",
+          headerFooterTag: "headerFooterTag",
+          listClassName: "listClassName",
+          itemClassName: "itemClassName",
+          useWindowScroll: "useWindowScroll",
+          customScrollParent: "customScrollParent",
+          scrollerRef: "scrollerRef",
+          logLevel: "logLevel",
+          restoreStateFrom: "restoreStateFrom",
+          initialTopMostItemIndex: "initialTopMostItemIndex",
+          increaseViewportBy: "increaseViewportBy"
+        },
+        methods: {
+          scrollTo: "scrollTo",
+          scrollBy: "scrollBy",
+          scrollToIndex: "scrollToIndex"
+        },
+        events: {
+          isScrolling: "isScrolling",
+          endReached: "endReached",
+          startReached: "startReached",
+          rangeChanged: "rangeChanged",
+          atBottomStateChange: "atBottomStateChange",
+          atTopStateChange: "atTopStateChange",
+          stateChanged: "stateChanged",
+          readyStateChanged: "readyStateChanged"
+        }
+      },
+      GridRoot
+    );
+    const Scroller$1 = /* @__PURE__ */ buildScroller({ usePublisher: usePublisher$1, useEmitterValue: useEmitterValue$1, useEmitter: useEmitter$1 });
+    const WindowScroller$1 = /* @__PURE__ */ buildWindowScroller({ usePublisher: usePublisher$1, useEmitterValue: useEmitterValue$1, useEmitter: useEmitter$1 });
+    function resolveGapValue(property, value, log) {
+      if (value !== "normal" && !(value == null ? void 0 : value.endsWith("px"))) {
+        log(`${property} was not resolved to pixel value correctly`, value, LogLevel.WARN);
+      }
+      if (value === "normal") {
+        return 0;
+      }
+      return parseInt(value != null ? value : "0", 10);
+    }
     const ChatView = ({
       id: id2,
       messages,
@@ -15624,6 +20064,64 @@ var require_assets = __commonJS({
       indented,
       numbered = true
     }) => {
+      const collapsedMessages = resolveMessages(messages);
+      const result = m$1`
+    <div style=${style2}>
+      ${collapsedMessages.map((msg, index) => {
+        const number = collapsedMessages.length > 1 && numbered ? index + 1 : void 0;
+        return m$1`<${ChatMessageRow}
+              id=${id2}
+              number=${number}
+              resolvedMessage=${msg}
+              indented=${indented}
+              toolCallStyle=${toolCallStyle}/>`;
+      })}
+    </div>`;
+      return result;
+    };
+    const ChatMessageRow = ({
+      id: id2,
+      number,
+      resolvedMessage,
+      toolCallStyle,
+      indented
+    }) => {
+      if (number) {
+        return m$1` <div
+        style=${{
+          display: "grid",
+          gridTemplateColumns: "max-content auto",
+          columnGap: "0.4em"
+        }}
+      >
+        <div
+          style=${{
+          fontSize: FontSize.smaller,
+          ...TextStyle.secondary,
+          marginTop: "0.1em"
+        }}
+        >
+          ${number}
+        </div>
+        <${ChatMessage}
+          id=${`${id2}-chat-messages`}
+          message=${resolvedMessage.message}
+          toolMessages=${resolvedMessage.toolMessages}
+          indented=${indented}
+          toolCallStyle=${toolCallStyle}
+        />
+      </div>`;
+      } else {
+        return m$1`<${ChatMessage}
+        id=${`${id2}-chat-messages`}
+        message=${resolvedMessage.message}
+        toolMessages=${resolvedMessage.toolMessages}
+        indented=${indented}
+        toolCallStyle=${toolCallStyle}
+      />`;
+      }
+    };
+    const resolveMessages = (messages) => {
       const resolvedMessages = [];
       for (const message of messages) {
         if (message.role === "tool") {
@@ -15657,47 +20155,7 @@ var require_assets = __commonJS({
       if (systemMessage && systemMessage.content.length > 0) {
         collapsedMessages.unshift({ message: systemMessage });
       }
-      const result = m$1`
-    <div style=${style2}>
-      ${collapsedMessages.map((msg, index) => {
-        if (collapsedMessages.length > 1 && numbered) {
-          return m$1` <div
-            style=${{
-            display: "grid",
-            gridTemplateColumns: "max-content auto",
-            columnGap: "0.4em"
-          }}
-          >
-            <div
-              style=${{
-            fontSize: FontSize.smaller,
-            ...TextStyle.secondary,
-            marginTop: "0.1em"
-          }}
-            >
-              ${index + 1}
-            </div>
-            <${ChatMessage}
-              id=${`${id2}-chat-messages`}
-              message=${msg.message}
-              toolMessages=${msg.toolMessages}
-              indented=${indented}
-              toolCallStyle=${toolCallStyle}
-            />
-          </div>`;
-        } else {
-          return m$1` <${ChatMessage}
-            id=${`${id2}-chat-messages`}
-            message=${msg.message}
-            toolMessages=${msg.toolMessages}
-            indented=${indented}
-            toolCallStyle=${toolCallStyle}
-          />`;
-        }
-      })}
-    </div>
-  `;
-      return result;
+      return collapsedMessages;
     };
     const normalizeContent = (content) => {
       if (typeof content === "string") {
@@ -17956,7 +22414,7 @@ ${entry.value}</pre
       let disposer;
       createRoot((dispose2) => {
         disposer = dispose2;
-        element === document ? code2() : insert$1(element, code2(), element.firstChild ? null : void 0, init2);
+        element === document ? code2() : insert(element, code2(), element.firstChild ? null : void 0, init2);
       }, options.owner);
       return () => {
         disposer();
@@ -17975,7 +22433,7 @@ ${entry.value}</pre
         const name = eventNames[i2];
         if (!e2.has(name)) {
           e2.add(name);
-          document2.addEventListener(name, eventHandler$1);
+          document2.addEventListener(name, eventHandler);
         }
       }
     }
@@ -18018,12 +22476,12 @@ ${entry.value}</pre
     function use(fn2, element, arg) {
       return untrack(() => fn2(element, arg));
     }
-    function insert$1(parent, accessor, marker, initial) {
+    function insert(parent, accessor, marker, initial) {
       if (marker !== void 0 && !initial) initial = [];
       if (typeof accessor !== "function") return insertExpression(parent, accessor, initial, marker);
       createRenderEffect((current) => insertExpression(parent, accessor(), current, marker), initial);
     }
-    function eventHandler$1(e2) {
+    function eventHandler(e2) {
       const key2 = `$$${e2.type}`;
       let node = e2.composedPath && e2.composedPath()[0] || e2.target;
       if (e2.target !== node) {
@@ -19411,7 +23869,7 @@ ${val.stack}`;
       const className$1 = createMemo(() => buildClassName(props.pen, codePoint(), props.extraClass));
       return (() => {
         const _el$ = _tmpl$$9.cloneNode(true);
-        insert$1(_el$, text2);
+        insert(_el$, text2);
         createRenderEffect((_p$) => {
           const _v$ = className$1(), _v$2 = style$1();
           _v$ !== _p$._v$ && className(_el$, _p$._v$ = _v$);
@@ -19529,7 +23987,7 @@ ${val.stack}`;
       };
       return (() => {
         const _el$ = _tmpl$$8.cloneNode(true);
-        insert$1(_el$, createComponent(Index, {
+        insert(_el$, createComponent(Index, {
           get each() {
             return segments();
           },
@@ -19563,7 +24021,7 @@ ${val.stack}`;
         const _el$ = _tmpl$$7.cloneNode(true);
         const _ref$ = props.ref;
         typeof _ref$ === "function" ? use(_ref$, _el$) : props.ref = _el$;
-        insert$1(_el$, createComponent(For, {
+        insert(_el$, createComponent(For, {
           get each() {
             return props.lines;
           },
@@ -19673,14 +24131,14 @@ ${val.stack}`;
         const _el$ = _tmpl$5.cloneNode(true), _el$5 = _el$.firstChild, _el$6 = _el$5.firstChild, _el$7 = _el$6.nextSibling, _el$12 = _el$5.nextSibling;
         const _ref$ = props.ref;
         typeof _ref$ === "function" ? use(_ref$, _el$) : props.ref = _el$;
-        insert$1(_el$, createComponent(Show, {
+        insert(_el$, createComponent(Show, {
           get when() {
             return props.isPausable;
           },
           get children() {
             const _el$2 = _tmpl$3.cloneNode(true);
             addEventListener(_el$2, "click", e2(props.onPlayClick));
-            insert$1(_el$2, createComponent(Switch, {
+            insert(_el$2, createComponent(Switch, {
               get children() {
                 return [createComponent(Match, {
                   get when() {
@@ -19702,9 +24160,9 @@ ${val.stack}`;
             return _el$2;
           }
         }), _el$5);
-        insert$1(_el$6, currentTime);
-        insert$1(_el$7, remainingTime);
-        insert$1(_el$, createComponent(Show, {
+        insert(_el$6, currentTime);
+        insert(_el$7, remainingTime);
+        insert(_el$, createComponent(Show, {
           get when() {
             return typeof props.progress === "number" || props.isSeekable;
           },
@@ -19712,7 +24170,7 @@ ${val.stack}`;
             const _el$8 = _tmpl$4.cloneNode(true), _el$9 = _el$8.firstChild, _el$10 = _el$9.firstChild, _el$11 = _el$10.nextSibling;
             _el$9.$$mousemove = onMove;
             _el$9.$$mousedown = onMouseDown;
-            insert$1(_el$9, createComponent(For, {
+            insert(_el$9, createComponent(For, {
               get each() {
                 return markers();
               },
@@ -19722,7 +24180,7 @@ ${val.stack}`;
                   e3._marker = true;
                 };
                 addEventListener(_el$13, "click", seekToMarker(i2()));
-                insert$1(_el$15, () => markerText(m2));
+                insert(_el$15, () => markerText(m2));
                 createRenderEffect((_p$) => {
                   const _v$ = markerPosition(m2), _v$2 = !!isPastMarker(m2);
                   _v$ !== _p$._v$ && _el$13.style.setProperty("left", _p$._v$ = _v$);
@@ -19762,7 +24220,7 @@ ${val.stack}`;
       };
       return (() => {
         const _el$ = _tmpl$$3.cloneNode(true), _el$2 = _el$.firstChild;
-        insert$1(_el$2, () => props.message);
+        insert(_el$2, () => props.message);
         createRenderEffect((_$p) => style(_el$2, style$1(), _$p));
         return _el$;
       })();
@@ -20239,7 +24697,7 @@ ${val.stack}`;
         typeof _ref$2 === "function" ? use(_ref$2, _el$2) : playerRef = _el$2;
         _el$2.$$mousemove = () => onUserActive(true);
         _el$2.addEventListener("mouseleave", playerOnMouseLeave);
-        insert$1(_el$2, createComponent(Terminal, {
+        insert(_el$2, createComponent(Terminal, {
           get cols() {
             return terminalCols();
           },
@@ -20272,7 +24730,7 @@ ${val.stack}`;
             typeof _ref$3 === "function" ? _ref$3(r$) : terminalRef = r$;
           }
         }), null);
-        insert$1(_el$2, createComponent(Show, {
+        insert(_el$2, createComponent(Show, {
           get when() {
             return props.controls !== false;
           },
@@ -20310,7 +24768,7 @@ ${val.stack}`;
             });
           }
         }), null);
-        insert$1(_el$2, createComponent(Switch, {
+        insert(_el$2, createComponent(Switch, {
           get children() {
             return [createComponent(Match, {
               get when() {
@@ -20352,7 +24810,7 @@ ${val.stack}`;
             })];
           }
         }), null);
-        insert$1(_el$2, createComponent(Show, {
+        insert(_el$2, createComponent(Show, {
           get when() {
             return isHelpVisible();
           },
@@ -20462,7 +24920,7 @@ ${val.stack}`;
         let v2 = 0;
         let values = [];
         let flushed = false;
-        const xf = compose$1(this.xfs, (val) => values.push(val));
+        const xf = compose(this.xfs, (val) => values.push(val));
         return {
           next: () => {
             if (v2 === values.length) {
@@ -20540,7 +24998,7 @@ ${val.stack}`;
         };
       };
     }
-    function compose$1(xfs, push2) {
+    function compose(xfs, push2) {
       return xfs.reverse().reduce((next, curr) => {
         const xf = toXf(curr(next.step));
         return {
@@ -21486,8 +25944,8 @@ ${events}
           return bufferTime;
         }
         latencies = latencies.slice(-windowSize);
-        const currentMinJitter = min$1(latencies);
-        const currentMaxJitter = max$2(latencies);
+        const currentMinJitter = min(latencies);
+        const currentMaxJitter = max$1(latencies);
         const currentJitterRange = currentMaxJitter - currentMinJitter;
         maxJitter = currentMaxJitter * smoothingFactor + maxJitter * (1 - smoothingFactor);
         jitterRange = currentJitterRange * smoothingFactor + jitterRange * (1 - smoothingFactor);
@@ -21527,10 +25985,10 @@ ${events}
         return bufferTime;
       };
     }
-    function min$1(numbers) {
+    function min(numbers) {
       return numbers.reduce((prev, cur) => cur < prev ? cur : prev);
     }
-    function max$2(numbers) {
+    function max$1(numbers) {
       return numbers.reduce((prev, cur) => cur > prev ? cur : prev);
     }
     function exponentialDelay(attempt) {
@@ -22744,7 +27202,7 @@ ${events}
       const regexMatch = /^\/(.*)\/([gimyu]*)$/.exec(re.toString());
       return new RegExp(regexMatch[1], regexMatch[2]);
     }
-    function clone$1(arg) {
+    function clone(arg) {
       if (typeof arg !== "object") {
         return arg;
       }
@@ -22752,7 +27210,7 @@ ${events}
         return null;
       }
       if (Array.isArray(arg)) {
-        return arg.map(clone$1);
+        return arg.map(clone);
       }
       if (arg instanceof Date) {
         return new Date(arg.getTime());
@@ -22763,7 +27221,7 @@ ${events}
       const cloned = {};
       for (const name in arg) {
         if (Object.prototype.hasOwnProperty.call(arg, name)) {
-          cloned[name] = clone$1(arg[name]);
+          cloned[name] = clone(arg[name]);
         }
       }
       return cloned;
@@ -22777,12 +27235,12 @@ ${events}
       }
       setResult(result) {
         if (this.options.cloneDiffValues && typeof result === "object") {
-          const clone2 = typeof this.options.cloneDiffValues === "function" ? this.options.cloneDiffValues : clone$1;
+          const clone$12 = typeof this.options.cloneDiffValues === "function" ? this.options.cloneDiffValues : clone;
           if (typeof result[0] === "object") {
-            result[0] = clone2(result[0]);
+            result[0] = clone$12(result[0]);
           }
           if (typeof result[1] === "object") {
-            result[1] = clone2(result[1]);
+            result[1] = clone$12(result[1]);
           }
         }
         return super.setResult(result);
@@ -23606,7 +28064,7 @@ ${events}
         return this.patch(right2, this.reverse(delta));
       }
       clone(value) {
-        return clone$1(value);
+        return clone(value);
       }
     }
     let defaultInstance$1;
@@ -24955,4453 +29413,21 @@ ${events}
         this.depth = depth;
       }
     }
-    function g(n2, t2) {
-      for (var e2 in n2) if ("__source" !== e2 && !(e2 in t2)) return true;
-      for (var r2 in t2) if ("__source" !== r2 && n2[r2] !== t2[r2]) return true;
-      return false;
-    }
-    function E(n2, t2) {
-      var e2 = t2(), r2 = h({ t: { __: e2, u: t2 } }), u2 = r2[0].t, o2 = r2[1];
-      return _(function() {
-        u2.__ = e2, u2.u = t2, C(u2) && o2({ t: u2 });
-      }, [n2, e2, t2]), y(function() {
-        return C(u2) && o2({ t: u2 }), n2(function() {
-          C(u2) && o2({ t: u2 });
-        });
-      }, [n2]), e2;
-    }
-    function C(n2) {
-      var t2, e2, r2 = n2.u, u2 = n2.__;
-      try {
-        var o2 = r2();
-        return !((t2 = u2) === (e2 = o2) && (0 !== t2 || 1 / t2 == 1 / e2) || t2 != t2 && e2 != e2);
-      } catch (n3) {
-        return true;
-      }
-    }
-    function x$1(n2) {
-      n2();
-    }
-    function R(n2) {
-      return n2;
-    }
-    function w() {
-      return [false, x$1];
-    }
-    var k = _;
-    function I(n2, t2) {
-      this.props = n2, this.context = t2;
-    }
-    function N(n2, e2) {
-      function r2(n3) {
-        var t2 = this.props.ref, r3 = t2 == n3.ref;
-        return !r3 && t2 && (t2.call ? t2(null) : t2.current = null), e2 ? !e2(this.props, n3) || !r3 : g(this.props, n3);
-      }
-      function u2(e3) {
-        return this.shouldComponentUpdate = r2, g$2(n2, e3);
-      }
-      return u2.displayName = "Memo(" + (n2.displayName || n2.name) + ")", u2.prototype.isReactComponent = true, u2.__f = true, u2;
-    }
-    (I.prototype = new x$3()).isPureReactComponent = true, I.prototype.shouldComponentUpdate = function(n2, t2) {
-      return g(this.props, n2) || g(this.state, t2);
-    };
-    var M = l$1.__b;
-    l$1.__b = function(n2) {
-      n2.type && n2.type.__f && n2.ref && (n2.props.ref = n2.ref, n2.ref = null), M && M(n2);
-    };
-    var T = "undefined" != typeof Symbol && Symbol.for && Symbol.for("react.forward_ref") || 3911;
-    function A(n2) {
-      function t2(t3) {
-        if (!("ref" in t3)) return n2(t3, null);
-        var e2 = t3.ref;
-        delete t3.ref;
-        var r2 = n2(t3, e2);
-        return t3.ref = e2, r2;
-      }
-      return t2.$$typeof = T, t2.render = t2, t2.prototype.isReactComponent = t2.__f = true, t2.displayName = "ForwardRef(" + (n2.displayName || n2.name) + ")", t2;
-    }
-    var D = function(n2, t2) {
-      return null == n2 ? null : L$1(L$1(n2).map(t2));
-    }, L = { map: D, forEach: D, count: function(n2) {
-      return n2 ? L$1(n2).length : 0;
-    }, only: function(n2) {
-      var t2 = L$1(n2);
-      if (1 !== t2.length) throw "Children.only";
-      return t2[0];
-    }, toArray: L$1 }, O = l$1.__e;
-    l$1.__e = function(n2, t2, e2, r2) {
-      if (n2.then) {
-        for (var u2, o2 = t2; o2 = o2.__; ) if ((u2 = o2.__c) && u2.__c) return null == t2.__e && (t2.__e = e2.__e, t2.__k = e2.__k), u2.__c(n2, t2);
-      }
-      O(n2, t2, e2, r2);
-    };
-    var F = l$1.unmount;
-    function U(n2, t2, e2) {
-      return n2 && (n2.__c && n2.__c.__H && (n2.__c.__H.__.forEach(function(n3) {
-        "function" == typeof n3.__c && n3.__c();
-      }), n2.__c.__H = null), null != (n2 = function(n3, t3) {
-        for (var e3 in t3) n3[e3] = t3[e3];
-        return n3;
-      }({}, n2)).__c && (n2.__c.__P === e2 && (n2.__c.__P = t2), n2.__c = null), n2.__k = n2.__k && n2.__k.map(function(n3) {
-        return U(n3, t2, e2);
-      })), n2;
-    }
-    function V(n2, t2, e2) {
-      return n2 && e2 && (n2.__v = null, n2.__k = n2.__k && n2.__k.map(function(n3) {
-        return V(n3, t2, e2);
-      }), n2.__c && n2.__c.__P === t2 && (n2.__e && e2.appendChild(n2.__e), n2.__c.__e = true, n2.__c.__P = e2)), n2;
-    }
-    function W() {
-      this.__u = 0, this.o = null, this.__b = null;
-    }
-    function P(n2) {
-      var t2 = n2.__.__c;
-      return t2 && t2.__a && t2.__a(n2);
-    }
-    function j(n2) {
-      var e2, r2, u2;
-      function o2(o3) {
-        if (e2 || (e2 = n2()).then(function(n3) {
-          r2 = n3.default || n3;
-        }, function(n3) {
-          u2 = n3;
-        }), u2) throw u2;
-        if (!r2) throw e2;
-        return g$2(r2, o3);
-      }
-      return o2.displayName = "Lazy", o2.__f = true, o2;
-    }
-    function z() {
-      this.i = null, this.l = null;
-    }
-    l$1.unmount = function(n2) {
-      var t2 = n2.__c;
-      t2 && t2.__R && t2.__R(), t2 && 32 & n2.__u && (n2.type = null), F && F(n2);
-    }, (W.prototype = new x$3()).__c = function(n2, t2) {
-      var e2 = t2.__c, r2 = this;
-      null == r2.o && (r2.o = []), r2.o.push(e2);
-      var u2 = P(r2.__v), o2 = false, i2 = function() {
-        o2 || (o2 = true, e2.__R = null, u2 ? u2(c2) : c2());
-      };
-      e2.__R = i2;
-      var c2 = function() {
-        if (!--r2.__u) {
-          if (r2.state.__a) {
-            var n3 = r2.state.__a;
-            r2.__v.__k[0] = V(n3, n3.__c.__P, n3.__c.__O);
-          }
-          var t3;
-          for (r2.setState({ __a: r2.__b = null }); t3 = r2.o.pop(); ) t3.forceUpdate();
-        }
-      };
-      r2.__u++ || 32 & t2.__u || r2.setState({ __a: r2.__b = r2.__v.__k[0] }), n2.then(i2, i2);
-    }, W.prototype.componentWillUnmount = function() {
-      this.o = [];
-    }, W.prototype.render = function(n2, e2) {
-      if (this.__b) {
-        if (this.__v.__k) {
-          var r2 = document.createElement("div"), o2 = this.__v.__k[0].__c;
-          this.__v.__k[0] = U(this.__b, r2, o2.__O = o2.__P);
-        }
-        this.__b = null;
-      }
-      var i2 = e2.__a && g$2(k$2, null, n2.fallback);
-      return i2 && (i2.__u &= -33), [g$2(k$2, null, e2.__a ? null : n2.children), i2];
-    };
-    var B = function(n2, t2, e2) {
-      if (++e2[1] === e2[0] && n2.l.delete(t2), n2.props.revealOrder && ("t" !== n2.props.revealOrder[0] || !n2.l.size)) for (e2 = n2.i; e2; ) {
-        for (; e2.length > 3; ) e2.pop()();
-        if (e2[1] < e2[0]) break;
-        n2.i = e2 = e2[2];
-      }
-    };
-    function H(n2) {
-      return this.getChildContext = function() {
-        return n2.context;
-      }, n2.children;
-    }
-    function Z(n2) {
-      var e2 = this, r2 = n2.h;
-      e2.componentWillUnmount = function() {
-        D$2(null, e2.v), e2.v = null, e2.h = null;
-      }, e2.h && e2.h !== r2 && e2.componentWillUnmount(), e2.v || (e2.h = r2, e2.v = { nodeType: 1, parentNode: r2, childNodes: [], contains: function() {
-        return true;
-      }, appendChild: function(n3) {
-        this.childNodes.push(n3), e2.h.appendChild(n3);
-      }, insertBefore: function(n3, t2) {
-        this.childNodes.push(n3), e2.h.insertBefore(n3, t2);
-      }, removeChild: function(n3) {
-        this.childNodes.splice(this.childNodes.indexOf(n3) >>> 1, 1), e2.h.removeChild(n3);
-      } }), D$2(g$2(H, { context: e2.context }, n2.__v), e2.v);
-    }
-    function Y(n2, e2) {
-      var r2 = g$2(Z, { __v: n2, h: e2 });
-      return r2.containerInfo = e2, r2;
-    }
-    (z.prototype = new x$3()).__a = function(n2) {
-      var t2 = this, e2 = P(t2.__v), r2 = t2.l.get(n2);
-      return r2[0]++, function(u2) {
-        var o2 = function() {
-          t2.props.revealOrder ? (r2.push(u2), B(t2, n2, r2)) : u2();
-        };
-        e2 ? e2(o2) : o2();
-      };
-    }, z.prototype.render = function(n2) {
-      this.i = null, this.l = /* @__PURE__ */ new Map();
-      var t2 = L$1(n2.children);
-      n2.revealOrder && "b" === n2.revealOrder[0] && t2.reverse();
-      for (var e2 = t2.length; e2--; ) this.l.set(t2[e2], this.i = [1, 0, this.i]);
-      return n2.children;
-    }, z.prototype.componentDidUpdate = z.prototype.componentDidMount = function() {
-      var n2 = this;
-      this.l.forEach(function(t2, e2) {
-        B(n2, e2, t2);
-      });
-    };
-    var $ = "undefined" != typeof Symbol && Symbol.for && Symbol.for("react.element") || 60103, q = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/, G = /^on(Ani|Tra|Tou|BeforeInp|Compo)/, J = /[A-Z0-9]/g, K = "undefined" != typeof document, Q = function(n2) {
-      return ("undefined" != typeof Symbol && "symbol" == typeof Symbol() ? /fil|che|rad/ : /fil|che|ra/).test(n2);
-    };
-    function X(n2, t2, e2) {
-      return null == t2.__k && (t2.textContent = ""), D$2(n2, t2), "function" == typeof e2 && e2(), n2 ? n2.__c : null;
-    }
-    function nn(n2, t2, e2) {
-      return E$1(n2, t2), "function" == typeof e2 && e2(), n2 ? n2.__c : null;
-    }
-    x$3.prototype.isReactComponent = {}, ["componentWillMount", "componentWillReceiveProps", "componentWillUpdate"].forEach(function(t2) {
-      Object.defineProperty(x$3.prototype, t2, { configurable: true, get: function() {
-        return this["UNSAFE_" + t2];
-      }, set: function(n2) {
-        Object.defineProperty(this, t2, { configurable: true, writable: true, value: n2 });
-      } });
-    });
-    var tn = l$1.event;
-    function en() {
-    }
-    function rn() {
-      return this.cancelBubble;
-    }
-    function un() {
-      return this.defaultPrevented;
-    }
-    l$1.event = function(n2) {
-      return tn && (n2 = tn(n2)), n2.persist = en, n2.isPropagationStopped = rn, n2.isDefaultPrevented = un, n2.nativeEvent = n2;
-    };
-    var on, cn = { enumerable: false, configurable: true, get: function() {
-      return this.class;
-    } }, fn = l$1.vnode;
-    l$1.vnode = function(n2) {
-      "string" == typeof n2.type && function(n3) {
-        var t2 = n3.props, e2 = n3.type, u2 = {}, o2 = -1 === e2.indexOf("-");
-        for (var i2 in t2) {
-          var c2 = t2[i2];
-          if (!("value" === i2 && "defaultValue" in t2 && null == c2 || K && "children" === i2 && "noscript" === e2 || "class" === i2 || "className" === i2)) {
-            var f2 = i2.toLowerCase();
-            "defaultValue" === i2 && "value" in t2 && null == t2.value ? i2 = "value" : "download" === i2 && true === c2 ? c2 = "" : "translate" === f2 && "no" === c2 ? c2 = false : "o" === f2[0] && "n" === f2[1] ? "ondoubleclick" === f2 ? i2 = "ondblclick" : "onchange" !== f2 || "input" !== e2 && "textarea" !== e2 || Q(t2.type) ? "onfocus" === f2 ? i2 = "onfocusin" : "onblur" === f2 ? i2 = "onfocusout" : G.test(i2) && (i2 = f2) : f2 = i2 = "oninput" : o2 && q.test(i2) ? i2 = i2.replace(J, "-$&").toLowerCase() : null === c2 && (c2 = void 0), "oninput" === f2 && u2[i2 = f2] && (i2 = "oninputCapture"), u2[i2] = c2;
-          }
-        }
-        "select" == e2 && u2.multiple && Array.isArray(u2.value) && (u2.value = L$1(t2.children).forEach(function(n4) {
-          n4.props.selected = -1 != u2.value.indexOf(n4.props.value);
-        })), "select" == e2 && null != u2.defaultValue && (u2.value = L$1(t2.children).forEach(function(n4) {
-          n4.props.selected = u2.multiple ? -1 != u2.defaultValue.indexOf(n4.props.value) : u2.defaultValue == n4.props.value;
-        })), t2.class && !t2.className ? (u2.class = t2.class, Object.defineProperty(u2, "className", cn)) : (t2.className && !t2.class || t2.class && t2.className) && (u2.class = u2.className = t2.className), n3.props = u2;
-      }(n2), n2.$$typeof = $, fn && fn(n2);
-    };
-    var ln = l$1.__r;
-    l$1.__r = function(n2) {
-      ln && ln(n2), on = n2.__c;
-    };
-    var an = l$1.diffed;
-    l$1.diffed = function(n2) {
-      an && an(n2);
-      var t2 = n2.props, e2 = n2.__e;
-      null != e2 && "textarea" === n2.type && "value" in t2 && t2.value !== e2.value && (e2.value = null == t2.value ? "" : t2.value), on = null;
-    };
-    var sn = { ReactCurrentDispatcher: { current: { readContext: function(n2) {
-      return on.__n[n2.__c].props.value;
-    }, useCallback: q$1, useContext: x$2, useDebugValue: P$2, useDeferredValue: R, useEffect: y, useId: g$1, useImperativeHandle: F$1, useInsertionEffect: k, useLayoutEffect: _, useMemo: T$1, useReducer: p, useRef: A$1, useState: h, useSyncExternalStore: E, useTransition: w } } };
-    function vn(n2) {
-      return g$2.bind(null, n2);
-    }
-    function dn(n2) {
-      return !!n2 && n2.$$typeof === $;
-    }
-    function pn(n2) {
-      return dn(n2) && n2.type === k$2;
-    }
-    function mn(n2) {
-      return !!n2 && !!n2.displayName && ("string" == typeof n2.displayName || n2.displayName instanceof String) && n2.displayName.startsWith("Memo(");
-    }
-    function yn(n2) {
-      return dn(n2) ? G$1.apply(null, arguments) : n2;
-    }
-    function _n(n2) {
-      return !!n2.__k && (D$2(null, n2), true);
-    }
-    function bn(n2) {
-      return n2 && (n2.base || 1 === n2.nodeType && n2) || null;
-    }
-    var Sn = function(n2, t2) {
-      return n2(t2);
-    }, gn = function(n2, t2) {
-      return n2(t2);
-    }, En = k$2, Cn = dn, xn = { useState: h, useId: g$1, useReducer: p, useEffect: y, useLayoutEffect: _, useInsertionEffect: k, useTransition: w, useDeferredValue: R, useSyncExternalStore: E, startTransition: x$1, useRef: A$1, useImperativeHandle: F$1, useMemo: T$1, useCallback: q$1, useContext: x$2, useDebugValue: P$2, version: "18.3.1", Children: L, render: X, hydrate: nn, unmountComponentAtNode: _n, createPortal: Y, createElement: g$2, createContext: J$1, createFactory: vn, cloneElement: yn, createRef: b, Fragment: k$2, isValidElement: dn, isElement: Cn, isFragment: pn, isMemo: mn, findDOMNode: bn, Component: x$3, PureComponent: I, memo: N, forwardRef: A, flushSync: gn, unstable_batchedUpdates: Sn, StrictMode: En, Suspense: W, SuspenseList: z, lazy: j, __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: sn };
-    var f = 0;
-    function u(e2, t2, n2, o2, i2, u2) {
-      t2 || (t2 = {});
-      var a2, c2, l2 = t2;
-      "ref" in t2 && (a2 = t2.ref, delete t2.ref);
-      var p2 = { type: e2, props: l2, key: n2, ref: a2, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: --f, __i: -1, __u: 0, __source: i2, __self: u2 };
-      if ("function" == typeof e2 && (a2 = e2.defaultProps)) for (c2 in a2) void 0 === l2[c2] && (l2[c2] = a2[c2]);
-      return l$1.vnode && l$1.vnode(p2), p2;
-    }
-    const PUBLISH = 0;
-    const SUBSCRIBE = 1;
-    const RESET = 2;
-    const VALUE = 4;
-    function compose(a2, b2) {
-      return (arg) => a2(b2(arg));
-    }
-    function thrush(arg, proc) {
-      return proc(arg);
-    }
-    function curry2to1(proc, arg1) {
-      return (arg2) => proc(arg1, arg2);
-    }
-    function curry1to0(proc, arg) {
-      return () => proc(arg);
-    }
-    function tap(arg, proc) {
-      proc(arg);
-      return arg;
-    }
-    function tup(...args) {
-      return args;
-    }
-    function call(proc) {
-      proc();
-    }
-    function always(value) {
-      return () => value;
-    }
-    function joinProc(...procs) {
-      return () => {
-        procs.map(call);
-      };
-    }
-    function isDefined(arg) {
-      return arg !== void 0;
-    }
-    function noop() {
-    }
-    function subscribe(emitter, subscription) {
-      return emitter(SUBSCRIBE, subscription);
-    }
-    function publish(publisher, value) {
-      publisher(PUBLISH, value);
-    }
-    function reset(emitter) {
-      emitter(RESET);
-    }
-    function getValue(depot) {
-      return depot(VALUE);
-    }
-    function connect(emitter, publisher) {
-      return subscribe(emitter, curry2to1(publisher, PUBLISH));
-    }
-    function handleNext(emitter, subscription) {
-      const unsub = emitter(SUBSCRIBE, (value) => {
-        unsub();
-        subscription(value);
-      });
-      return unsub;
-    }
-    function stream() {
-      const subscriptions = [];
-      return (action, arg) => {
-        switch (action) {
-          case RESET:
-            subscriptions.splice(0, subscriptions.length);
-            return;
-          case SUBSCRIBE:
-            subscriptions.push(arg);
-            return () => {
-              const indexOf = subscriptions.indexOf(arg);
-              if (indexOf > -1) {
-                subscriptions.splice(indexOf, 1);
-              }
-            };
-          case PUBLISH:
-            subscriptions.slice().forEach((subscription) => {
-              subscription(arg);
-            });
-            return;
-          default:
-            throw new Error(`unrecognized action ${action}`);
-        }
-      };
-    }
-    function statefulStream(initial) {
-      let value = initial;
-      const innerSubject = stream();
-      return (action, arg) => {
-        switch (action) {
-          case SUBSCRIBE:
-            const subscription = arg;
-            subscription(value);
-            break;
-          case PUBLISH:
-            value = arg;
-            break;
-          case VALUE:
-            return value;
-        }
-        return innerSubject(action, arg);
-      };
-    }
-    function eventHandler(emitter) {
-      let unsub;
-      let currentSubscription;
-      const cleanup = () => unsub && unsub();
-      return function(action, subscription) {
-        switch (action) {
-          case SUBSCRIBE:
-            if (subscription) {
-              if (currentSubscription === subscription) {
-                return;
-              }
-              cleanup();
-              currentSubscription = subscription;
-              unsub = subscribe(emitter, subscription);
-              return unsub;
-            } else {
-              cleanup();
-              return noop;
-            }
-          case RESET:
-            cleanup();
-            currentSubscription = null;
-            return;
-          default:
-            throw new Error(`unrecognized action ${action}`);
-        }
-      };
-    }
-    function streamFromEmitter(emitter) {
-      return tap(stream(), (stream2) => connect(emitter, stream2));
-    }
-    function statefulStreamFromEmitter(emitter, initial) {
-      return tap(statefulStream(initial), (stream2) => connect(emitter, stream2));
-    }
-    function combineOperators(...operators) {
-      return (subscriber) => {
-        return operators.reduceRight(thrush, subscriber);
-      };
-    }
-    function pipe(source2, ...operators) {
-      const project = combineOperators(...operators);
-      return (action, subscription) => {
-        switch (action) {
-          case SUBSCRIBE:
-            return subscribe(source2, project(subscription));
-          case RESET:
-            reset(source2);
-            return;
-        }
-      };
-    }
-    function defaultComparator(previous, next) {
-      return previous === next;
-    }
-    function distinctUntilChanged(comparator = defaultComparator) {
-      let current;
-      return (done) => (next) => {
-        if (!comparator(current, next)) {
-          current = next;
-          done(next);
-        }
-      };
-    }
-    function filter(predicate) {
-      return (done) => (value) => {
-        predicate(value) && done(value);
-      };
-    }
-    function map(project) {
-      return (done) => compose(done, project);
-    }
-    function mapTo(value) {
-      return (done) => () => done(value);
-    }
-    function scan(scanner, initial) {
-      return (done) => (value) => done(initial = scanner(initial, value));
-    }
-    function skip(times) {
-      return (done) => (value) => {
-        times > 0 ? times-- : done(value);
-      };
-    }
-    function throttleTime(interval) {
-      let currentValue = null;
-      let timeout;
-      return (done) => (value) => {
-        currentValue = value;
-        if (timeout) {
-          return;
-        }
-        timeout = setTimeout(() => {
-          timeout = void 0;
-          done(currentValue);
-        }, interval);
-      };
-    }
-    function debounceTime(interval) {
-      let currentValue;
-      let timeout;
-      return (done) => (value) => {
-        currentValue = value;
-        if (timeout) {
-          clearTimeout(timeout);
-        }
-        timeout = setTimeout(() => {
-          done(currentValue);
-        }, interval);
-      };
-    }
-    function withLatestFrom(...sources) {
-      const values = new Array(sources.length);
-      let called = 0;
-      let pendingCall = null;
-      const allCalled = Math.pow(2, sources.length) - 1;
-      sources.forEach((source2, index) => {
-        const bit = Math.pow(2, index);
-        subscribe(source2, (value) => {
-          const prevCalled = called;
-          called = called | bit;
-          values[index] = value;
-          if (prevCalled !== allCalled && called === allCalled && pendingCall) {
-            pendingCall();
-            pendingCall = null;
-          }
-        });
-      });
-      return (done) => (value) => {
-        const call2 = () => done([value].concat(values));
-        if (called === allCalled) {
-          call2();
-        } else {
-          pendingCall = call2;
-        }
-      };
-    }
-    function merge(...sources) {
-      return function(action, subscription) {
-        switch (action) {
-          case SUBSCRIBE:
-            return joinProc(...sources.map((source2) => subscribe(source2, subscription)));
-          case RESET:
-            return;
-          default:
-            throw new Error(`unrecognized action ${action}`);
-        }
-      };
-    }
-    function duc(source2, comparator = defaultComparator) {
-      return pipe(source2, distinctUntilChanged(comparator));
-    }
-    function combineLatest(...emitters) {
-      const innerSubject = stream();
-      const values = new Array(emitters.length);
-      let called = 0;
-      const allCalled = Math.pow(2, emitters.length) - 1;
-      emitters.forEach((source2, index) => {
-        const bit = Math.pow(2, index);
-        subscribe(source2, (value) => {
-          values[index] = value;
-          called = called | bit;
-          if (called === allCalled) {
-            publish(innerSubject, values);
-          }
-        });
-      });
-      return function(action, subscription) {
-        switch (action) {
-          case SUBSCRIBE:
-            if (called === allCalled) {
-              subscription(values);
-            }
-            return subscribe(innerSubject, subscription);
-          case RESET:
-            return reset(innerSubject);
-          default:
-            throw new Error(`unrecognized action ${action}`);
-        }
-      };
-    }
-    function system(constructor, dependencies = [], { singleton } = { singleton: true }) {
-      return {
-        id: id(),
-        constructor,
-        dependencies,
-        singleton
-      };
-    }
-    const id = () => Symbol();
-    function init(systemSpec) {
-      const singletons = /* @__PURE__ */ new Map();
-      const _init = ({ id: id2, constructor, dependencies, singleton }) => {
-        if (singleton && singletons.has(id2)) {
-          return singletons.get(id2);
-        }
-        const system2 = constructor(dependencies.map((e2) => _init(e2)));
-        if (singleton) {
-          singletons.set(id2, system2);
-        }
-        return system2;
-      };
-      return _init(systemSpec);
-    }
-    function omit(keys, obj) {
-      const result = {};
-      const index = {};
-      let idx = 0;
-      const len = keys.length;
-      while (idx < len) {
-        index[keys[idx]] = 1;
-        idx += 1;
-      }
-      for (const prop in obj) {
-        if (!index.hasOwnProperty(prop)) {
-          result[prop] = obj[prop];
-        }
-      }
-      return result;
-    }
-    const useIsomorphicLayoutEffect$1 = typeof document !== "undefined" ? xn.useLayoutEffect : xn.useEffect;
-    function systemToComponent(systemSpec, map2, Root) {
-      const requiredPropNames = Object.keys(map2.required || {});
-      const optionalPropNames = Object.keys(map2.optional || {});
-      const methodNames = Object.keys(map2.methods || {});
-      const eventNames = Object.keys(map2.events || {});
-      const Context2 = xn.createContext({});
-      function applyPropsToSystem(system2, props) {
-        if (system2["propsReady"]) {
-          publish(system2["propsReady"], false);
-        }
-        for (const requiredPropName of requiredPropNames) {
-          const stream2 = system2[map2.required[requiredPropName]];
-          publish(stream2, props[requiredPropName]);
-        }
-        for (const optionalPropName of optionalPropNames) {
-          if (optionalPropName in props) {
-            const stream2 = system2[map2.optional[optionalPropName]];
-            publish(stream2, props[optionalPropName]);
-          }
-        }
-        if (system2["propsReady"]) {
-          publish(system2["propsReady"], true);
-        }
-      }
-      function buildMethods(system2) {
-        return methodNames.reduce((acc, methodName) => {
-          acc[methodName] = (value) => {
-            const stream2 = system2[map2.methods[methodName]];
-            publish(stream2, value);
-          };
-          return acc;
-        }, {});
-      }
-      function buildEventHandlers(system2) {
-        return eventNames.reduce((handlers, eventName) => {
-          handlers[eventName] = eventHandler(system2[map2.events[eventName]]);
-          return handlers;
-        }, {});
-      }
-      const Component = xn.forwardRef((propsWithChildren, ref) => {
-        const { children: children2, ...props } = propsWithChildren;
-        const [system2] = xn.useState(() => {
-          return tap(init(systemSpec), (system22) => applyPropsToSystem(system22, props));
-        });
-        const [handlers] = xn.useState(curry1to0(buildEventHandlers, system2));
-        useIsomorphicLayoutEffect$1(() => {
-          for (const eventName of eventNames) {
-            if (eventName in props) {
-              subscribe(handlers[eventName], props[eventName]);
-            }
-          }
-          return () => {
-            Object.values(handlers).map(reset);
-          };
-        }, [props, handlers, system2]);
-        useIsomorphicLayoutEffect$1(() => {
-          applyPropsToSystem(system2, props);
-        });
-        xn.useImperativeHandle(ref, always(buildMethods(system2)));
-        const RootComponent = Root;
-        return /* @__PURE__ */ u(Context2.Provider, { value: system2, children: Root ? /* @__PURE__ */ u(RootComponent, { ...omit([...requiredPropNames, ...optionalPropNames, ...eventNames], props), children: children2 }) : children2 });
-      });
-      const usePublisher2 = (key2) => {
-        return xn.useCallback(curry2to1(publish, xn.useContext(Context2)[key2]), [key2]);
-      };
-      const useEmitterValue18 = (key2) => {
-        const system2 = xn.useContext(Context2);
-        const source2 = system2[key2];
-        const cb = xn.useCallback(
-          (c2) => {
-            return subscribe(source2, c2);
-          },
-          [source2]
-        );
-        return xn.useSyncExternalStore(
-          cb,
-          () => getValue(source2),
-          () => getValue(source2)
-        );
-      };
-      const useEmitterValueLegacy = (key2) => {
-        const system2 = xn.useContext(Context2);
-        const source2 = system2[key2];
-        const [value, setValue] = xn.useState(curry1to0(getValue, source2));
-        useIsomorphicLayoutEffect$1(
-          () => subscribe(source2, (next) => {
-            if (next !== value) {
-              setValue(always(next));
-            }
-          }),
-          [source2, value]
-        );
-        return value;
-      };
-      const useEmitterValue2 = xn.version.startsWith("18") ? useEmitterValue18 : useEmitterValueLegacy;
-      const useEmitter2 = (key2, callback) => {
-        const context = xn.useContext(Context2);
-        const source2 = context[key2];
-        useIsomorphicLayoutEffect$1(() => subscribe(source2, callback), [callback, source2]);
-      };
-      return {
-        Component,
-        usePublisher: usePublisher2,
-        useEmitterValue: useEmitterValue2,
-        useEmitter: useEmitter2
-      };
-    }
-    const useIsomorphicLayoutEffect = typeof document !== "undefined" ? xn.useLayoutEffect : xn.useEffect;
-    var LogLevel = /* @__PURE__ */ ((LogLevel2) => {
-      LogLevel2[LogLevel2["DEBUG"] = 0] = "DEBUG";
-      LogLevel2[LogLevel2["INFO"] = 1] = "INFO";
-      LogLevel2[LogLevel2["WARN"] = 2] = "WARN";
-      LogLevel2[LogLevel2["ERROR"] = 3] = "ERROR";
-      return LogLevel2;
-    })(LogLevel || {});
-    const CONSOLE_METHOD_MAP = {
-      [
-        0
-        /* DEBUG */
-      ]: "debug",
-      [
-        1
-        /* INFO */
-      ]: "log",
-      [
-        2
-        /* WARN */
-      ]: "warn",
-      [
-        3
-        /* ERROR */
-      ]: "error"
-    };
-    const getGlobalThis = () => typeof globalThis === "undefined" ? window : globalThis;
-    const loggerSystem = system(
-      () => {
-        const logLevel = statefulStream(
-          3
-          /* ERROR */
-        );
-        const log = statefulStream((label, message, level = 1) => {
-          var _a2;
-          const currentLevel = (_a2 = getGlobalThis()["VIRTUOSO_LOG_LEVEL"]) != null ? _a2 : getValue(logLevel);
-          if (level >= currentLevel) {
-            console[CONSOLE_METHOD_MAP[level]](
-              "%creact-virtuoso: %c%s %o",
-              "color: #0253b3; font-weight: bold",
-              "color: initial",
-              label,
-              message
-            );
-          }
-        });
-        return {
-          log,
-          logLevel
-        };
-      },
-      [],
-      { singleton: true }
-    );
-    function useSizeWithElRef(callback, enabled, skipAnimationFrame) {
-      const ref = xn.useRef(null);
-      let callbackRef = (_el) => {
-      };
-      if (typeof ResizeObserver !== "undefined") {
-        const observer = xn.useMemo(() => {
-          return new ResizeObserver((entries) => {
-            const code2 = () => {
-              const element = entries[0].target;
-              if (element.offsetParent !== null) {
-                callback(element);
-              }
-            };
-            skipAnimationFrame ? code2() : requestAnimationFrame(code2);
-          });
-        }, [callback]);
-        callbackRef = (elRef) => {
-          if (elRef && enabled) {
-            observer.observe(elRef);
-            ref.current = elRef;
-          } else {
-            if (ref.current) {
-              observer.unobserve(ref.current);
-            }
-            ref.current = null;
-          }
-        };
-      }
-      return { ref, callbackRef };
-    }
-    function useSize(callback, enabled, skipAnimationFrame) {
-      return useSizeWithElRef(callback, enabled, skipAnimationFrame).callbackRef;
-    }
-    function useChangedListContentsSizes(callback, itemSize, enabled, scrollContainerStateCallback, log, gap, customScrollParent, horizontalDirection, skipAnimationFrame) {
-      const memoedCallback = xn.useCallback(
-        (el) => {
-          const ranges = getChangedChildSizes(el.children, itemSize, horizontalDirection ? "offsetWidth" : "offsetHeight", log);
-          let scrollableElement = el.parentElement;
-          while (!scrollableElement.dataset["virtuosoScroller"]) {
-            scrollableElement = scrollableElement.parentElement;
-          }
-          const windowScrolling = scrollableElement.lastElementChild.dataset["viewportType"] === "window";
-          const scrollTop = customScrollParent ? horizontalDirection ? customScrollParent.scrollLeft : customScrollParent.scrollTop : windowScrolling ? horizontalDirection ? window.pageXOffset || document.documentElement.scrollLeft : window.pageYOffset || document.documentElement.scrollTop : horizontalDirection ? scrollableElement.scrollLeft : scrollableElement.scrollTop;
-          const scrollHeight = customScrollParent ? horizontalDirection ? customScrollParent.scrollWidth : customScrollParent.scrollHeight : windowScrolling ? horizontalDirection ? document.documentElement.scrollWidth : document.documentElement.scrollHeight : horizontalDirection ? scrollableElement.scrollWidth : scrollableElement.scrollHeight;
-          const viewportHeight = customScrollParent ? horizontalDirection ? customScrollParent.offsetWidth : customScrollParent.offsetHeight : windowScrolling ? horizontalDirection ? window.innerWidth : window.innerHeight : horizontalDirection ? scrollableElement.offsetWidth : scrollableElement.offsetHeight;
-          scrollContainerStateCallback({
-            scrollTop: Math.max(scrollTop, 0),
-            scrollHeight,
-            viewportHeight
-          });
-          gap == null ? void 0 : gap(
-            horizontalDirection ? resolveGapValue$1("column-gap", getComputedStyle(el).columnGap, log) : resolveGapValue$1("row-gap", getComputedStyle(el).rowGap, log)
-          );
-          if (ranges !== null) {
-            callback(ranges);
-          }
-        },
-        [callback, itemSize, log, gap, customScrollParent, scrollContainerStateCallback]
-      );
-      return useSizeWithElRef(memoedCallback, enabled, skipAnimationFrame);
-    }
-    function getChangedChildSizes(children2, itemSize, field, log) {
-      const length = children2.length;
-      if (length === 0) {
-        return null;
-      }
-      const results = [];
-      for (let i2 = 0; i2 < length; i2++) {
-        const child = children2.item(i2);
-        if (!child || child.dataset.index === void 0) {
-          continue;
-        }
-        const index = parseInt(child.dataset.index);
-        const knownSize = parseFloat(child.dataset.knownSize);
-        const size = itemSize(child, field);
-        if (size === 0) {
-          log("Zero-sized element, this should not happen", { child }, LogLevel.ERROR);
-        }
-        if (size === knownSize) {
-          continue;
-        }
-        const lastResult = results[results.length - 1];
-        if (results.length === 0 || lastResult.size !== size || lastResult.endIndex !== index - 1) {
-          results.push({ startIndex: index, endIndex: index, size });
-        } else {
-          results[results.length - 1].endIndex++;
-        }
-      }
-      return results;
-    }
-    function resolveGapValue$1(property, value, log) {
-      if (value !== "normal" && !(value == null ? void 0 : value.endsWith("px"))) {
-        log(`${property} was not resolved to pixel value correctly`, value, LogLevel.WARN);
-      }
-      if (value === "normal") {
-        return 0;
-      }
-      return parseInt(value != null ? value : "0", 10);
-    }
-    function correctItemSize(el, dimension) {
-      return Math.round(el.getBoundingClientRect()[dimension]);
-    }
-    function approximatelyEqual(num1, num2) {
-      return Math.abs(num1 - num2) < 1.01;
-    }
-    function useScrollTop(scrollContainerStateCallback, smoothScrollTargetReached, scrollerElement, scrollerRefCallback = noop, customScrollParent, horizontalDirection) {
-      const scrollerRef = xn.useRef(null);
-      const scrollTopTarget = xn.useRef(null);
-      const timeoutRef = xn.useRef(null);
-      const handler = xn.useCallback(
-        (ev) => {
-          const el = ev.target;
-          const windowScroll = el === window || el === document;
-          const scrollTop = horizontalDirection ? windowScroll ? window.pageXOffset || document.documentElement.scrollLeft : el.scrollLeft : windowScroll ? window.pageYOffset || document.documentElement.scrollTop : el.scrollTop;
-          const scrollHeight = horizontalDirection ? windowScroll ? document.documentElement.scrollWidth : el.scrollWidth : windowScroll ? document.documentElement.scrollHeight : el.scrollHeight;
-          const viewportHeight = horizontalDirection ? windowScroll ? window.innerWidth : el.offsetWidth : windowScroll ? window.innerHeight : el.offsetHeight;
-          const call2 = () => {
-            scrollContainerStateCallback({
-              scrollTop: Math.max(scrollTop, 0),
-              scrollHeight,
-              viewportHeight
-            });
-          };
-          if (ev.suppressFlushSync) {
-            call2();
-          } else {
-            xn.flushSync(call2);
-          }
-          if (scrollTopTarget.current !== null) {
-            if (scrollTop === scrollTopTarget.current || scrollTop <= 0 || scrollTop === scrollHeight - viewportHeight) {
-              scrollTopTarget.current = null;
-              smoothScrollTargetReached(true);
-              if (timeoutRef.current) {
-                clearTimeout(timeoutRef.current);
-                timeoutRef.current = null;
-              }
-            }
-          }
-        },
-        [scrollContainerStateCallback, smoothScrollTargetReached]
-      );
-      xn.useEffect(() => {
-        const localRef = customScrollParent ? customScrollParent : scrollerRef.current;
-        scrollerRefCallback(customScrollParent ? customScrollParent : scrollerRef.current);
-        handler({ target: localRef, suppressFlushSync: true });
-        localRef.addEventListener("scroll", handler, { passive: true });
-        return () => {
-          scrollerRefCallback(null);
-          localRef.removeEventListener("scroll", handler);
-        };
-      }, [scrollerRef, handler, scrollerElement, scrollerRefCallback, customScrollParent]);
-      function scrollToCallback(location) {
-        const scrollerElement2 = scrollerRef.current;
-        if (!scrollerElement2 || (horizontalDirection ? "offsetWidth" in scrollerElement2 && scrollerElement2.offsetWidth === 0 : "offsetHeight" in scrollerElement2 && scrollerElement2.offsetHeight === 0)) {
-          return;
-        }
-        const isSmooth = location.behavior === "smooth";
-        let offsetHeight;
-        let scrollHeight;
-        let scrollTop;
-        if (scrollerElement2 === window) {
-          scrollHeight = Math.max(
-            correctItemSize(document.documentElement, horizontalDirection ? "width" : "height"),
-            horizontalDirection ? document.documentElement.scrollWidth : document.documentElement.scrollHeight
-          );
-          offsetHeight = horizontalDirection ? window.innerWidth : window.innerHeight;
-          scrollTop = horizontalDirection ? document.documentElement.scrollLeft : document.documentElement.scrollTop;
-        } else {
-          scrollHeight = scrollerElement2[horizontalDirection ? "scrollWidth" : "scrollHeight"];
-          offsetHeight = correctItemSize(scrollerElement2, horizontalDirection ? "width" : "height");
-          scrollTop = scrollerElement2[horizontalDirection ? "scrollLeft" : "scrollTop"];
-        }
-        const maxScrollTop = scrollHeight - offsetHeight;
-        location.top = Math.ceil(Math.max(Math.min(maxScrollTop, location.top), 0));
-        if (approximatelyEqual(offsetHeight, scrollHeight) || location.top === scrollTop) {
-          scrollContainerStateCallback({ scrollTop, scrollHeight, viewportHeight: offsetHeight });
-          if (isSmooth) {
-            smoothScrollTargetReached(true);
-          }
-          return;
-        }
-        if (isSmooth) {
-          scrollTopTarget.current = location.top;
-          if (timeoutRef.current) {
-            clearTimeout(timeoutRef.current);
-          }
-          timeoutRef.current = setTimeout(() => {
-            timeoutRef.current = null;
-            scrollTopTarget.current = null;
-            smoothScrollTargetReached(true);
-          }, 1e3);
-        } else {
-          scrollTopTarget.current = null;
-        }
-        if (horizontalDirection) {
-          location = { left: location.top, behavior: location.behavior };
-        }
-        scrollerElement2.scrollTo(location);
-      }
-      function scrollByCallback(location) {
-        if (horizontalDirection) {
-          location = { left: location.top, behavior: location.behavior };
-        }
-        scrollerRef.current.scrollBy(location);
-      }
-      return { scrollerRef, scrollByCallback, scrollToCallback };
-    }
-    const domIOSystem = system(
-      () => {
-        const scrollContainerState = stream();
-        const scrollTop = stream();
-        const deviation = statefulStream(0);
-        const smoothScrollTargetReached = stream();
-        const statefulScrollTop = statefulStream(0);
-        const viewportHeight = stream();
-        const scrollHeight = stream();
-        const headerHeight = statefulStream(0);
-        const fixedHeaderHeight = statefulStream(0);
-        const fixedFooterHeight = statefulStream(0);
-        const footerHeight = statefulStream(0);
-        const scrollTo = stream();
-        const scrollBy = stream();
-        const scrollingInProgress = statefulStream(false);
-        const horizontalDirection = statefulStream(false);
-        const skipAnimationFrameInResizeObserver = statefulStream(false);
-        connect(
-          pipe(
-            scrollContainerState,
-            map(({ scrollTop: scrollTop2 }) => scrollTop2)
-          ),
-          scrollTop
-        );
-        connect(
-          pipe(
-            scrollContainerState,
-            map(({ scrollHeight: scrollHeight2 }) => scrollHeight2)
-          ),
-          scrollHeight
-        );
-        connect(scrollTop, statefulScrollTop);
-        return {
-          // input
-          scrollContainerState,
-          scrollTop,
-          viewportHeight,
-          headerHeight,
-          fixedHeaderHeight,
-          fixedFooterHeight,
-          footerHeight,
-          scrollHeight,
-          smoothScrollTargetReached,
-          horizontalDirection,
-          skipAnimationFrameInResizeObserver,
-          // signals
-          scrollTo,
-          scrollBy,
-          // state
-          statefulScrollTop,
-          deviation,
-          scrollingInProgress
-        };
-      },
-      [],
-      { singleton: true }
-    );
-    const NIL_NODE = { lvl: 0 };
-    function newAANode(k2, v2, lvl, l2 = NIL_NODE, r2 = NIL_NODE) {
-      return { k: k2, v: v2, lvl, l: l2, r: r2 };
-    }
-    function empty(node) {
-      return node === NIL_NODE;
-    }
-    function newTree() {
-      return NIL_NODE;
-    }
-    function remove(node, key2) {
-      if (empty(node)) return NIL_NODE;
-      const { k: k2, l: l2, r: r2 } = node;
-      if (key2 === k2) {
-        if (empty(l2)) {
-          return r2;
-        } else if (empty(r2)) {
-          return l2;
-        } else {
-          const [lastKey, lastValue] = last(l2);
-          return adjust(clone(node, { k: lastKey, v: lastValue, l: deleteLast(l2) }));
-        }
-      } else if (key2 < k2) {
-        return adjust(clone(node, { l: remove(l2, key2) }));
-      } else {
-        return adjust(clone(node, { r: remove(r2, key2) }));
-      }
-    }
-    function find(node, key2) {
-      if (empty(node)) {
-        return;
-      }
-      if (key2 === node.k) {
-        return node.v;
-      } else if (key2 < node.k) {
-        return find(node.l, key2);
-      } else {
-        return find(node.r, key2);
-      }
-    }
-    function findMaxKeyValue(node, value, field = "k") {
-      if (empty(node)) {
-        return [-Infinity, void 0];
-      }
-      if (Number(node[field]) === value) {
-        return [node.k, node.v];
-      }
-      if (Number(node[field]) < value) {
-        const r2 = findMaxKeyValue(node.r, value, field);
-        if (r2[0] === -Infinity) {
-          return [node.k, node.v];
-        } else {
-          return r2;
-        }
-      }
-      return findMaxKeyValue(node.l, value, field);
-    }
-    function insert(node, k2, v2) {
-      if (empty(node)) {
-        return newAANode(k2, v2, 1);
-      }
-      if (k2 === node.k) {
-        return clone(node, { k: k2, v: v2 });
-      } else if (k2 < node.k) {
-        return rebalance(clone(node, { l: insert(node.l, k2, v2) }));
-      } else {
-        return rebalance(clone(node, { r: insert(node.r, k2, v2) }));
-      }
-    }
-    function walkWithin(node, start2, end2) {
-      if (empty(node)) {
-        return [];
-      }
-      const { k: k2, v: v2, l: l2, r: r2 } = node;
-      let result = [];
-      if (k2 > start2) {
-        result = result.concat(walkWithin(l2, start2, end2));
-      }
-      if (k2 >= start2 && k2 <= end2) {
-        result.push({ k: k2, v: v2 });
-      }
-      if (k2 <= end2) {
-        result = result.concat(walkWithin(r2, start2, end2));
-      }
-      return result;
-    }
-    function walk(node) {
-      if (empty(node)) {
-        return [];
-      }
-      return [...walk(node.l), { k: node.k, v: node.v }, ...walk(node.r)];
-    }
-    function last(node) {
-      return empty(node.r) ? [node.k, node.v] : last(node.r);
-    }
-    function deleteLast(node) {
-      return empty(node.r) ? node.l : adjust(clone(node, { r: deleteLast(node.r) }));
-    }
-    function clone(node, args) {
-      return newAANode(
-        args.k !== void 0 ? args.k : node.k,
-        args.v !== void 0 ? args.v : node.v,
-        args.lvl !== void 0 ? args.lvl : node.lvl,
-        args.l !== void 0 ? args.l : node.l,
-        args.r !== void 0 ? args.r : node.r
-      );
-    }
-    function isSingle(node) {
-      return empty(node) || node.lvl > node.r.lvl;
-    }
-    function rebalance(node) {
-      return split(skew(node));
-    }
-    function adjust(node) {
-      const { l: l2, r: r2, lvl } = node;
-      if (r2.lvl >= lvl - 1 && l2.lvl >= lvl - 1) {
-        return node;
-      } else if (lvl > r2.lvl + 1) {
-        if (isSingle(l2)) {
-          return skew(clone(node, { lvl: lvl - 1 }));
-        } else {
-          if (!empty(l2) && !empty(l2.r)) {
-            return clone(l2.r, {
-              l: clone(l2, { r: l2.r.l }),
-              r: clone(node, {
-                l: l2.r.r,
-                lvl: lvl - 1
-              }),
-              lvl
-            });
-          } else {
-            throw new Error("Unexpected empty nodes");
-          }
-        }
-      } else {
-        if (isSingle(node)) {
-          return split(clone(node, { lvl: lvl - 1 }));
-        } else {
-          if (!empty(r2) && !empty(r2.l)) {
-            const rl = r2.l;
-            const rlvl = isSingle(rl) ? r2.lvl - 1 : r2.lvl;
-            return clone(rl, {
-              l: clone(node, {
-                r: rl.l,
-                lvl: lvl - 1
-              }),
-              r: split(clone(r2, { l: rl.r, lvl: rlvl })),
-              lvl: rl.lvl + 1
-            });
-          } else {
-            throw new Error("Unexpected empty nodes");
-          }
-        }
-      }
-    }
-    function rangesWithin(node, startIndex, endIndex) {
-      if (empty(node)) {
-        return [];
-      }
-      const adjustedStart = findMaxKeyValue(node, startIndex)[0];
-      return toRanges(walkWithin(node, adjustedStart, endIndex));
-    }
-    function arrayToRanges(items, parser) {
-      const length = items.length;
-      if (length === 0) {
-        return [];
-      }
-      let { index: start2, value } = parser(items[0]);
-      const result = [];
-      for (let i2 = 1; i2 < length; i2++) {
-        const { index: nextIndex, value: nextValue } = parser(items[i2]);
-        result.push({ start: start2, end: nextIndex - 1, value });
-        start2 = nextIndex;
-        value = nextValue;
-      }
-      result.push({ start: start2, end: Infinity, value });
-      return result;
-    }
-    function toRanges(nodes) {
-      return arrayToRanges(nodes, ({ k: index, v: value }) => ({ index, value }));
-    }
-    function split(node) {
-      const { r: r2, lvl } = node;
-      return !empty(r2) && !empty(r2.r) && r2.lvl === lvl && r2.r.lvl === lvl ? clone(r2, { l: clone(node, { r: r2.l }), lvl: lvl + 1 }) : node;
-    }
-    function skew(node) {
-      const { l: l2 } = node;
-      return !empty(l2) && l2.lvl === node.lvl ? clone(l2, { r: clone(node, { l: l2.r }) }) : node;
-    }
-    function findIndexOfClosestSmallerOrEqual(items, value, comparator, start2 = 0) {
-      let end2 = items.length - 1;
-      while (start2 <= end2) {
-        const index = Math.floor((start2 + end2) / 2);
-        const item = items[index];
-        const match = comparator(item, value);
-        if (match === 0) {
-          return index;
-        }
-        if (match === -1) {
-          if (end2 - start2 < 2) {
-            return index - 1;
-          }
-          end2 = index - 1;
-        } else {
-          if (end2 === start2) {
-            return index;
-          }
-          start2 = index + 1;
-        }
-      }
-      throw new Error(`Failed binary finding record in array - ${items.join(",")}, searched for ${value}`);
-    }
-    function findClosestSmallerOrEqual(items, value, comparator) {
-      return items[findIndexOfClosestSmallerOrEqual(items, value, comparator)];
-    }
-    function findRange(items, startValue, endValue, comparator) {
-      const startIndex = findIndexOfClosestSmallerOrEqual(items, startValue, comparator);
-      const endIndex = findIndexOfClosestSmallerOrEqual(items, endValue, comparator, startIndex);
-      return items.slice(startIndex, endIndex + 1);
-    }
-    const recalcSystem = system(
-      () => {
-        const recalcInProgress = statefulStream(false);
-        return { recalcInProgress };
-      },
-      [],
-      { singleton: true }
-    );
-    function rangeIncludes(refRange) {
-      const { size, startIndex, endIndex } = refRange;
-      return (range) => {
-        return range.start === startIndex && (range.end === endIndex || range.end === Infinity) && range.value === size;
-      };
-    }
-    function affectedGroupCount(offset2, groupIndices) {
-      let recognizedOffsetItems = 0;
-      let groupIndex = 0;
-      while (recognizedOffsetItems < offset2) {
-        recognizedOffsetItems += groupIndices[groupIndex + 1] - groupIndices[groupIndex] - 1;
-        groupIndex++;
-      }
-      const offsetIsExact = recognizedOffsetItems === offset2;
-      return groupIndex - (offsetIsExact ? 0 : 1);
-    }
-    function insertRanges(sizeTree, ranges) {
-      let syncStart = empty(sizeTree) ? 0 : Infinity;
-      for (const range of ranges) {
-        const { size, startIndex, endIndex } = range;
-        syncStart = Math.min(syncStart, startIndex);
-        if (empty(sizeTree)) {
-          sizeTree = insert(sizeTree, 0, size);
-          continue;
-        }
-        const overlappingRanges = rangesWithin(sizeTree, startIndex - 1, endIndex + 1);
-        if (overlappingRanges.some(rangeIncludes(range))) {
-          continue;
-        }
-        let firstPassDone = false;
-        let shouldInsert = false;
-        for (const { start: rangeStart, end: rangeEnd, value: rangeValue } of overlappingRanges) {
-          if (!firstPassDone) {
-            shouldInsert = rangeValue !== size;
-            firstPassDone = true;
-          } else {
-            if (endIndex >= rangeStart || size === rangeValue) {
-              sizeTree = remove(sizeTree, rangeStart);
-            }
-          }
-          if (rangeEnd > endIndex && endIndex >= rangeStart) {
-            if (rangeValue !== size) {
-              sizeTree = insert(sizeTree, endIndex + 1, rangeValue);
-            }
-          }
-        }
-        if (shouldInsert) {
-          sizeTree = insert(sizeTree, startIndex, size);
-        }
-      }
-      return [sizeTree, syncStart];
-    }
-    function initialSizeState() {
-      return {
-        offsetTree: [],
-        sizeTree: newTree(),
-        groupOffsetTree: newTree(),
-        lastIndex: 0,
-        lastOffset: 0,
-        lastSize: 0,
-        groupIndices: []
-      };
-    }
-    function indexComparator({ index: itemIndex }, index) {
-      return index === itemIndex ? 0 : index < itemIndex ? -1 : 1;
-    }
-    function offsetComparator({ offset: itemOffset }, offset2) {
-      return offset2 === itemOffset ? 0 : offset2 < itemOffset ? -1 : 1;
-    }
-    function offsetPointParser(point) {
-      return { index: point.index, value: point };
-    }
-    function rangesWithinOffsets(tree, startOffset, endOffset, minStartIndex = 0) {
-      if (minStartIndex > 0) {
-        startOffset = Math.max(startOffset, findClosestSmallerOrEqual(tree, minStartIndex, indexComparator).offset);
-      }
-      return arrayToRanges(findRange(tree, startOffset, endOffset, offsetComparator), offsetPointParser);
-    }
-    function createOffsetTree(prevOffsetTree, syncStart, sizeTree, gap) {
-      let offsetTree = prevOffsetTree;
-      let prevIndex = 0;
-      let prevSize = 0;
-      let prevOffset = 0;
-      let startIndex = 0;
-      if (syncStart !== 0) {
-        startIndex = findIndexOfClosestSmallerOrEqual(offsetTree, syncStart - 1, indexComparator);
-        const offsetInfo = offsetTree[startIndex];
-        prevOffset = offsetInfo.offset;
-        const kv = findMaxKeyValue(sizeTree, syncStart - 1);
-        prevIndex = kv[0];
-        prevSize = kv[1];
-        if (offsetTree.length && offsetTree[startIndex].size === findMaxKeyValue(sizeTree, syncStart)[1]) {
-          startIndex -= 1;
-        }
-        offsetTree = offsetTree.slice(0, startIndex + 1);
-      } else {
-        offsetTree = [];
-      }
-      for (const { start: startIndex2, value } of rangesWithin(sizeTree, syncStart, Infinity)) {
-        const indexOffset = startIndex2 - prevIndex;
-        const aOffset = indexOffset * prevSize + prevOffset + indexOffset * gap;
-        offsetTree.push({
-          offset: aOffset,
-          size: value,
-          index: startIndex2
-        });
-        prevIndex = startIndex2;
-        prevOffset = aOffset;
-        prevSize = value;
-      }
-      return {
-        offsetTree,
-        lastIndex: prevIndex,
-        lastOffset: prevOffset,
-        lastSize: prevSize
-      };
-    }
-    function sizeStateReducer(state, [ranges, groupIndices, log, gap]) {
-      if (ranges.length > 0) {
-        log("received item sizes", ranges, LogLevel.DEBUG);
-      }
-      const sizeTree = state.sizeTree;
-      let newSizeTree = sizeTree;
-      let syncStart = 0;
-      if (groupIndices.length > 0 && empty(sizeTree) && ranges.length === 2) {
-        const groupSize = ranges[0].size;
-        const itemSize = ranges[1].size;
-        newSizeTree = groupIndices.reduce((tree, groupIndex) => {
-          return insert(insert(tree, groupIndex, groupSize), groupIndex + 1, itemSize);
-        }, newSizeTree);
-      } else {
-        [newSizeTree, syncStart] = insertRanges(newSizeTree, ranges);
-      }
-      if (newSizeTree === sizeTree) {
-        return state;
-      }
-      const { offsetTree: newOffsetTree, lastIndex, lastSize, lastOffset } = createOffsetTree(state.offsetTree, syncStart, newSizeTree, gap);
-      return {
-        sizeTree: newSizeTree,
-        offsetTree: newOffsetTree,
-        lastIndex,
-        lastOffset,
-        lastSize,
-        groupOffsetTree: groupIndices.reduce((tree, index) => {
-          return insert(tree, index, offsetOf(index, newOffsetTree, gap));
-        }, newTree()),
-        groupIndices
-      };
-    }
-    function offsetOf(index, tree, gap) {
-      if (tree.length === 0) {
-        return 0;
-      }
-      const { offset: offset2, index: startIndex, size } = findClosestSmallerOrEqual(tree, index, indexComparator);
-      const itemCount = index - startIndex;
-      const top2 = size * itemCount + (itemCount - 1) * gap + offset2;
-      return top2 > 0 ? top2 + gap : top2;
-    }
-    function isGroupLocation(location) {
-      return typeof location.groupIndex !== "undefined";
-    }
-    function originalIndexFromLocation(location, sizes, lastIndex) {
-      if (isGroupLocation(location)) {
-        return sizes.groupIndices[location.groupIndex] + 1;
-      } else {
-        const numericIndex = location.index === "LAST" ? lastIndex : location.index;
-        let result = originalIndexFromItemIndex(numericIndex, sizes);
-        result = Math.max(0, result, Math.min(lastIndex, result));
-        return result;
-      }
-    }
-    function originalIndexFromItemIndex(itemIndex, sizes) {
-      if (!hasGroups(sizes)) {
-        return itemIndex;
-      }
-      let groupOffset = 0;
-      while (sizes.groupIndices[groupOffset] <= itemIndex + groupOffset) {
-        groupOffset++;
-      }
-      return itemIndex + groupOffset;
-    }
-    function hasGroups(sizes) {
-      return !empty(sizes.groupOffsetTree);
-    }
-    function sizeTreeToRanges(sizeTree) {
-      return walk(sizeTree).map(({ k: startIndex, v: size }, index, sizeArray) => {
-        const nextSize = sizeArray[index + 1];
-        const endIndex = nextSize ? nextSize.k - 1 : Infinity;
-        return { startIndex, endIndex, size };
-      });
-    }
-    const SIZE_MAP = {
-      offsetHeight: "height",
-      offsetWidth: "width"
-    };
-    const sizeSystem = system(
-      ([{ log }, { recalcInProgress }]) => {
-        const sizeRanges = stream();
-        const totalCount = stream();
-        const statefulTotalCount = statefulStreamFromEmitter(totalCount, 0);
-        const unshiftWith = stream();
-        const shiftWith = stream();
-        const firstItemIndex = statefulStream(0);
-        const groupIndices = statefulStream([]);
-        const fixedItemSize = statefulStream(void 0);
-        const defaultItemSize = statefulStream(void 0);
-        const itemSize = statefulStream((el, field) => correctItemSize(el, SIZE_MAP[field]));
-        const data = statefulStream(void 0);
-        const gap = statefulStream(0);
-        const initial = initialSizeState();
-        const sizes = statefulStreamFromEmitter(
-          pipe(sizeRanges, withLatestFrom(groupIndices, log, gap), scan(sizeStateReducer, initial), distinctUntilChanged()),
-          initial
-        );
-        const prevGroupIndices = statefulStreamFromEmitter(
-          pipe(
-            groupIndices,
-            distinctUntilChanged(),
-            scan((prev, curr) => ({ prev: prev.current, current: curr }), {
-              prev: [],
-              current: []
-            }),
-            map(({ prev }) => prev)
-          ),
-          []
-        );
-        connect(
-          pipe(
-            groupIndices,
-            filter((indexes) => indexes.length > 0),
-            withLatestFrom(sizes, gap),
-            map(([groupIndices2, sizes2, gap2]) => {
-              const groupOffsetTree = groupIndices2.reduce((tree, index, idx) => {
-                return insert(tree, index, offsetOf(index, sizes2.offsetTree, gap2) || idx);
-              }, newTree());
-              return {
-                ...sizes2,
-                groupIndices: groupIndices2,
-                groupOffsetTree
-              };
-            })
-          ),
-          sizes
-        );
-        connect(
-          pipe(
-            totalCount,
-            withLatestFrom(sizes),
-            filter(([totalCount2, { lastIndex }]) => {
-              return totalCount2 < lastIndex;
-            }),
-            map(([totalCount2, { lastIndex, lastSize }]) => {
-              return [
-                {
-                  startIndex: totalCount2,
-                  endIndex: lastIndex,
-                  size: lastSize
-                }
-              ];
-            })
-          ),
-          sizeRanges
-        );
-        connect(fixedItemSize, defaultItemSize);
-        const trackItemSizes = statefulStreamFromEmitter(
-          pipe(
-            fixedItemSize,
-            map((size) => size === void 0)
-          ),
-          true
-        );
-        connect(
-          pipe(
-            defaultItemSize,
-            filter((value) => {
-              return value !== void 0 && empty(getValue(sizes).sizeTree);
-            }),
-            map((size) => [{ startIndex: 0, endIndex: 0, size }])
-          ),
-          sizeRanges
-        );
-        const listRefresh = streamFromEmitter(
-          pipe(
-            sizeRanges,
-            withLatestFrom(sizes),
-            scan(
-              ({ sizes: oldSizes }, [_2, newSizes]) => {
-                return {
-                  changed: newSizes !== oldSizes,
-                  sizes: newSizes
-                };
-              },
-              { changed: false, sizes: initial }
-            ),
-            map((value) => value.changed)
-          )
-        );
-        subscribe(
-          pipe(
-            firstItemIndex,
-            scan(
-              (prev, next) => {
-                return { diff: prev.prev - next, prev: next };
-              },
-              { diff: 0, prev: 0 }
-            ),
-            map((val) => val.diff)
-          ),
-          (offset2) => {
-            const { groupIndices: groupIndices2 } = getValue(sizes);
-            if (offset2 > 0) {
-              publish(recalcInProgress, true);
-              publish(unshiftWith, offset2 + affectedGroupCount(offset2, groupIndices2));
-            } else if (offset2 < 0) {
-              const prevGroupIndicesValue = getValue(prevGroupIndices);
-              if (prevGroupIndicesValue.length > 0) {
-                offset2 -= affectedGroupCount(-offset2, prevGroupIndicesValue);
-              }
-              publish(shiftWith, offset2);
-            }
-          }
-        );
-        subscribe(pipe(firstItemIndex, withLatestFrom(log)), ([index, log2]) => {
-          if (index < 0) {
-            log2(
-              "`firstItemIndex` prop should not be set to less than zero. If you don't know the total count, just use a very high value",
-              { firstItemIndex },
-              LogLevel.ERROR
-            );
-          }
-        });
-        const beforeUnshiftWith = streamFromEmitter(unshiftWith);
-        connect(
-          pipe(
-            unshiftWith,
-            withLatestFrom(sizes),
-            map(([unshiftWith2, sizes2]) => {
-              const groupedMode = sizes2.groupIndices.length > 0;
-              const initialRanges = [];
-              const defaultSize = sizes2.lastSize;
-              if (groupedMode) {
-                const firstGroupSize = find(sizes2.sizeTree, 0);
-                let prependedGroupItemsCount = 0;
-                let groupIndex = 0;
-                while (prependedGroupItemsCount < unshiftWith2) {
-                  const theGroupIndex = sizes2.groupIndices[groupIndex];
-                  const groupItemCount = sizes2.groupIndices.length === groupIndex + 1 ? Infinity : sizes2.groupIndices[groupIndex + 1] - theGroupIndex - 1;
-                  initialRanges.push({
-                    startIndex: theGroupIndex,
-                    endIndex: theGroupIndex,
-                    size: firstGroupSize
-                  });
-                  initialRanges.push({
-                    startIndex: theGroupIndex + 1,
-                    endIndex: theGroupIndex + 1 + groupItemCount - 1,
-                    size: defaultSize
-                  });
-                  groupIndex++;
-                  prependedGroupItemsCount += groupItemCount + 1;
-                }
-                const sizeTreeKV = walk(sizes2.sizeTree);
-                const firstGroupIsExpanded = prependedGroupItemsCount !== unshiftWith2;
-                if (firstGroupIsExpanded) {
-                  sizeTreeKV.shift();
-                }
-                return sizeTreeKV.reduce(
-                  (acc, { k: index, v: size }) => {
-                    let ranges = acc.ranges;
-                    if (acc.prevSize !== 0) {
-                      ranges = [
-                        ...acc.ranges,
-                        {
-                          startIndex: acc.prevIndex,
-                          endIndex: index + unshiftWith2 - 1,
-                          size: acc.prevSize
-                        }
-                      ];
-                    }
-                    return {
-                      ranges,
-                      prevIndex: index + unshiftWith2,
-                      prevSize: size
-                    };
-                  },
-                  {
-                    ranges: initialRanges,
-                    prevIndex: unshiftWith2,
-                    prevSize: 0
-                  }
-                ).ranges;
-              }
-              return walk(sizes2.sizeTree).reduce(
-                (acc, { k: index, v: size }) => {
-                  return {
-                    ranges: [...acc.ranges, { startIndex: acc.prevIndex, endIndex: index + unshiftWith2 - 1, size: acc.prevSize }],
-                    prevIndex: index + unshiftWith2,
-                    prevSize: size
-                  };
-                },
-                {
-                  ranges: [],
-                  prevIndex: 0,
-                  prevSize: defaultSize
-                }
-              ).ranges;
-            })
-          ),
-          sizeRanges
-        );
-        const shiftWithOffset = streamFromEmitter(
-          pipe(
-            shiftWith,
-            withLatestFrom(sizes, gap),
-            map(([shiftWith2, { offsetTree }, gap2]) => {
-              const newFirstItemIndex = -shiftWith2;
-              return offsetOf(newFirstItemIndex, offsetTree, gap2);
-            })
-          )
-        );
-        connect(
-          pipe(
-            shiftWith,
-            withLatestFrom(sizes, gap),
-            map(([shiftWith2, sizes2, gap2]) => {
-              const groupedMode = sizes2.groupIndices.length > 0;
-              if (groupedMode) {
-                if (empty(sizes2.sizeTree)) {
-                  return sizes2;
-                }
-                let newSizeTree = newTree();
-                const prevGroupIndicesValue = getValue(prevGroupIndices);
-                let removedItemsCount = 0;
-                let groupIndex = 0;
-                let groupOffset = 0;
-                while (removedItemsCount < -shiftWith2) {
-                  groupOffset = prevGroupIndicesValue[groupIndex];
-                  const groupItemCount = prevGroupIndicesValue[groupIndex + 1] - groupOffset - 1;
-                  groupIndex++;
-                  removedItemsCount += groupItemCount + 1;
-                }
-                newSizeTree = walk(sizes2.sizeTree).reduce((acc, { k: k2, v: v2 }) => {
-                  return insert(acc, Math.max(0, k2 + shiftWith2), v2);
-                }, newSizeTree);
-                const aGroupIsShrunk = removedItemsCount !== -shiftWith2;
-                if (aGroupIsShrunk) {
-                  const firstGroupSize = find(sizes2.sizeTree, groupOffset);
-                  newSizeTree = insert(newSizeTree, 0, firstGroupSize);
-                  const nextItemSize = findMaxKeyValue(sizes2.sizeTree, -shiftWith2 + 1)[1];
-                  newSizeTree = insert(newSizeTree, 1, nextItemSize);
-                }
-                return {
-                  ...sizes2,
-                  sizeTree: newSizeTree,
-                  ...createOffsetTree(sizes2.offsetTree, 0, newSizeTree, gap2)
-                };
-              } else {
-                const newSizeTree = walk(sizes2.sizeTree).reduce((acc, { k: k2, v: v2 }) => {
-                  return insert(acc, Math.max(0, k2 + shiftWith2), v2);
-                }, newTree());
-                return {
-                  ...sizes2,
-                  sizeTree: newSizeTree,
-                  ...createOffsetTree(sizes2.offsetTree, 0, newSizeTree, gap2)
-                };
-              }
-            })
-          ),
-          sizes
-        );
-        return {
-          // input
-          data,
-          totalCount,
-          sizeRanges,
-          groupIndices,
-          defaultItemSize,
-          fixedItemSize,
-          unshiftWith,
-          shiftWith,
-          shiftWithOffset,
-          beforeUnshiftWith,
-          firstItemIndex,
-          gap,
-          // output
-          sizes,
-          listRefresh,
-          statefulTotalCount,
-          trackItemSizes,
-          itemSize
-        };
-      },
-      tup(loggerSystem, recalcSystem),
-      { singleton: true }
-    );
-    const SUPPORTS_SCROLL_TO_OPTIONS = typeof document !== "undefined" && "scrollBehavior" in document.documentElement.style;
-    function normalizeIndexLocation(location) {
-      const result = typeof location === "number" ? { index: location } : location;
-      if (!result.align) {
-        result.align = "start";
-      }
-      if (!result.behavior || !SUPPORTS_SCROLL_TO_OPTIONS) {
-        result.behavior = "auto";
-      }
-      if (!result.offset) {
-        result.offset = 0;
-      }
-      return result;
-    }
-    const scrollToIndexSystem = system(
-      ([
-        { sizes, totalCount, listRefresh, gap },
-        {
-          scrollingInProgress,
-          viewportHeight,
-          scrollTo,
-          smoothScrollTargetReached,
-          headerHeight,
-          footerHeight,
-          fixedHeaderHeight,
-          fixedFooterHeight
-        },
-        { log }
-      ]) => {
-        const scrollToIndex = stream();
-        const scrollTargetReached = stream();
-        const topListHeight = statefulStream(0);
-        let unsubscribeNextListRefresh = null;
-        let cleartTimeoutRef = null;
-        let unsubscribeListRefresh = null;
-        function cleanup() {
-          if (unsubscribeNextListRefresh) {
-            unsubscribeNextListRefresh();
-            unsubscribeNextListRefresh = null;
-          }
-          if (unsubscribeListRefresh) {
-            unsubscribeListRefresh();
-            unsubscribeListRefresh = null;
-          }
-          if (cleartTimeoutRef) {
-            clearTimeout(cleartTimeoutRef);
-            cleartTimeoutRef = null;
-          }
-          publish(scrollingInProgress, false);
-        }
-        connect(
-          pipe(
-            scrollToIndex,
-            withLatestFrom(sizes, viewportHeight, totalCount, topListHeight, headerHeight, footerHeight, log),
-            withLatestFrom(gap, fixedHeaderHeight, fixedFooterHeight),
-            map(
-              ([
-                [location, sizes2, viewportHeight2, totalCount2, topListHeight2, headerHeight2, footerHeight2, log2],
-                gap2,
-                fixedHeaderHeight2,
-                fixedFooterHeight2
-              ]) => {
-                const normalLocation = normalizeIndexLocation(location);
-                const { align, behavior, offset: offset2 } = normalLocation;
-                const lastIndex = totalCount2 - 1;
-                const index = originalIndexFromLocation(normalLocation, sizes2, lastIndex);
-                let top2 = offsetOf(index, sizes2.offsetTree, gap2) + headerHeight2;
-                if (align === "end") {
-                  top2 += fixedHeaderHeight2 + findMaxKeyValue(sizes2.sizeTree, index)[1] - viewportHeight2 + fixedFooterHeight2;
-                  if (index === lastIndex) {
-                    top2 += footerHeight2;
-                  }
-                } else if (align === "center") {
-                  top2 += (fixedHeaderHeight2 + findMaxKeyValue(sizes2.sizeTree, index)[1] - viewportHeight2 + fixedFooterHeight2) / 2;
-                } else {
-                  top2 -= topListHeight2;
-                }
-                if (offset2) {
-                  top2 += offset2;
-                }
-                const retry = (listChanged) => {
-                  cleanup();
-                  if (listChanged) {
-                    log2("retrying to scroll to", { location }, LogLevel.DEBUG);
-                    publish(scrollToIndex, location);
-                  } else {
-                    publish(scrollTargetReached, true);
-                    log2("list did not change, scroll successful", {}, LogLevel.DEBUG);
-                  }
-                };
-                cleanup();
-                if (behavior === "smooth") {
-                  let listChanged = false;
-                  unsubscribeListRefresh = subscribe(listRefresh, (changed) => {
-                    listChanged = listChanged || changed;
-                  });
-                  unsubscribeNextListRefresh = handleNext(smoothScrollTargetReached, () => {
-                    retry(listChanged);
-                  });
-                } else {
-                  unsubscribeNextListRefresh = handleNext(pipe(listRefresh, watchChangesFor(150)), retry);
-                }
-                cleartTimeoutRef = setTimeout(() => {
-                  cleanup();
-                }, 1200);
-                publish(scrollingInProgress, true);
-                log2("scrolling from index to", { index, top: top2, behavior }, LogLevel.DEBUG);
-                return { top: top2, behavior };
-              }
-            )
-          ),
-          scrollTo
-        );
-        return {
-          scrollToIndex,
-          scrollTargetReached,
-          topListHeight
-        };
-      },
-      tup(sizeSystem, domIOSystem, loggerSystem),
-      { singleton: true }
-    );
-    function watchChangesFor(limit) {
-      return (done) => {
-        const timeoutRef = setTimeout(() => {
-          done(false);
-        }, limit);
-        return (value) => {
-          if (value) {
-            done(true);
-            clearTimeout(timeoutRef);
-          }
-        };
-      };
-    }
-    const UP = "up";
-    const DOWN = "down";
-    const NONE$1 = "none";
-    const INITIAL_BOTTOM_STATE = {
-      atBottom: false,
-      notAtBottomBecause: "NOT_SHOWING_LAST_ITEM",
-      state: {
-        offsetBottom: 0,
-        scrollTop: 0,
-        viewportHeight: 0,
-        scrollHeight: 0
-      }
-    };
-    const DEFAULT_AT_TOP_THRESHOLD = 0;
-    const stateFlagsSystem = system(([{ scrollContainerState, scrollTop, viewportHeight, headerHeight, footerHeight, scrollBy }]) => {
-      const isAtBottom = statefulStream(false);
-      const isAtTop = statefulStream(true);
-      const atBottomStateChange = stream();
-      const atTopStateChange = stream();
-      const atBottomThreshold = statefulStream(4);
-      const atTopThreshold = statefulStream(DEFAULT_AT_TOP_THRESHOLD);
-      const isScrolling = statefulStreamFromEmitter(
-        pipe(
-          merge(pipe(duc(scrollTop), skip(1), mapTo(true)), pipe(duc(scrollTop), skip(1), mapTo(false), debounceTime(100))),
-          distinctUntilChanged()
-        ),
-        false
-      );
-      const isScrollingBy = statefulStreamFromEmitter(
-        pipe(merge(pipe(scrollBy, mapTo(true)), pipe(scrollBy, mapTo(false), debounceTime(200))), distinctUntilChanged()),
-        false
-      );
-      connect(
-        pipe(
-          combineLatest(duc(scrollTop), duc(atTopThreshold)),
-          map(([top2, atTopThreshold2]) => top2 <= atTopThreshold2),
-          distinctUntilChanged()
-        ),
-        isAtTop
-      );
-      connect(pipe(isAtTop, throttleTime(50)), atTopStateChange);
-      const atBottomState = streamFromEmitter(
-        pipe(
-          combineLatest(scrollContainerState, duc(viewportHeight), duc(headerHeight), duc(footerHeight), duc(atBottomThreshold)),
-          scan((current, [{ scrollTop: scrollTop2, scrollHeight }, viewportHeight2, _headerHeight, _footerHeight, atBottomThreshold2]) => {
-            const isAtBottom2 = scrollTop2 + viewportHeight2 - scrollHeight > -atBottomThreshold2;
-            const state = {
-              viewportHeight: viewportHeight2,
-              scrollTop: scrollTop2,
-              scrollHeight
-            };
-            if (isAtBottom2) {
-              let atBottomBecause;
-              let scrollTopDelta;
-              if (scrollTop2 > current.state.scrollTop) {
-                atBottomBecause = "SCROLLED_DOWN";
-                scrollTopDelta = current.state.scrollTop - scrollTop2;
-              } else {
-                atBottomBecause = "SIZE_DECREASED";
-                scrollTopDelta = current.state.scrollTop - scrollTop2 || current.scrollTopDelta;
-              }
-              return {
-                atBottom: true,
-                state,
-                atBottomBecause,
-                scrollTopDelta
-              };
-            }
-            let notAtBottomBecause;
-            if (state.scrollHeight > current.state.scrollHeight) {
-              notAtBottomBecause = "SIZE_INCREASED";
-            } else if (viewportHeight2 < current.state.viewportHeight) {
-              notAtBottomBecause = "VIEWPORT_HEIGHT_DECREASING";
-            } else if (scrollTop2 < current.state.scrollTop) {
-              notAtBottomBecause = "SCROLLING_UPWARDS";
-            } else {
-              notAtBottomBecause = "NOT_FULLY_SCROLLED_TO_LAST_ITEM_BOTTOM";
-            }
-            return {
-              atBottom: false,
-              notAtBottomBecause,
-              state
-            };
-          }, INITIAL_BOTTOM_STATE),
-          distinctUntilChanged((prev, next) => {
-            return prev && prev.atBottom === next.atBottom;
-          })
-        )
-      );
-      const lastJumpDueToItemResize = statefulStreamFromEmitter(
-        pipe(
-          scrollContainerState,
-          scan(
-            (current, { scrollTop: scrollTop2, scrollHeight, viewportHeight: viewportHeight2 }) => {
-              if (!approximatelyEqual(current.scrollHeight, scrollHeight)) {
-                const atBottom = scrollHeight - (scrollTop2 + viewportHeight2) < 1;
-                if (current.scrollTop !== scrollTop2 && atBottom) {
-                  return {
-                    scrollHeight,
-                    scrollTop: scrollTop2,
-                    jump: current.scrollTop - scrollTop2,
-                    changed: true
-                  };
-                } else {
-                  return {
-                    scrollHeight,
-                    scrollTop: scrollTop2,
-                    jump: 0,
-                    changed: true
-                  };
-                }
-              } else {
-                return {
-                  scrollTop: scrollTop2,
-                  scrollHeight,
-                  jump: 0,
-                  changed: false
-                };
-              }
-            },
-            { scrollHeight: 0, jump: 0, scrollTop: 0, changed: false }
-          ),
-          filter((value) => value.changed),
-          map((value) => value.jump)
-        ),
-        0
-      );
-      connect(
-        pipe(
-          atBottomState,
-          map((state) => state.atBottom)
-        ),
-        isAtBottom
-      );
-      connect(pipe(isAtBottom, throttleTime(50)), atBottomStateChange);
-      const scrollDirection = statefulStream(DOWN);
-      connect(
-        pipe(
-          scrollContainerState,
-          map(({ scrollTop: scrollTop2 }) => scrollTop2),
-          distinctUntilChanged(),
-          scan(
-            (acc, scrollTop2) => {
-              if (getValue(isScrollingBy)) {
-                return { direction: acc.direction, prevScrollTop: scrollTop2 };
-              }
-              return { direction: scrollTop2 < acc.prevScrollTop ? UP : DOWN, prevScrollTop: scrollTop2 };
-            },
-            { direction: DOWN, prevScrollTop: 0 }
-          ),
-          map((value) => value.direction)
-        ),
-        scrollDirection
-      );
-      connect(pipe(scrollContainerState, throttleTime(50), mapTo(NONE$1)), scrollDirection);
-      const scrollVelocity = statefulStream(0);
-      connect(
-        pipe(
-          isScrolling,
-          filter((value) => !value),
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          mapTo(0)
-        ),
-        scrollVelocity
-      );
-      connect(
-        pipe(
-          scrollTop,
-          throttleTime(100),
-          withLatestFrom(isScrolling),
-          filter(([_2, isScrolling2]) => !!isScrolling2),
-          scan(([_2, prev], [next]) => [prev, next], [0, 0]),
-          map(([prev, next]) => next - prev)
-        ),
-        scrollVelocity
-      );
-      return {
-        isScrolling,
-        isAtTop,
-        isAtBottom,
-        atBottomState,
-        atTopStateChange,
-        atBottomStateChange,
-        scrollDirection,
-        atBottomThreshold,
-        atTopThreshold,
-        scrollVelocity,
-        lastJumpDueToItemResize
-      };
-    }, tup(domIOSystem));
-    const propsReadySystem = system(
-      ([{ log }]) => {
-        const propsReady = statefulStream(false);
-        const didMount = streamFromEmitter(
-          pipe(
-            propsReady,
-            filter((ready) => ready),
-            distinctUntilChanged()
-          )
-        );
-        subscribe(propsReady, (value) => {
-          value && getValue(log)("props updated", {}, LogLevel.DEBUG);
-        });
-        return { propsReady, didMount };
-      },
-      tup(loggerSystem),
-      { singleton: true }
-    );
-    function skipFrames(frameCount, callback) {
-      if (frameCount == 0) {
-        callback();
-      } else {
-        requestAnimationFrame(() => skipFrames(frameCount - 1, callback));
-      }
-    }
-    function getInitialTopMostItemIndexNumber(location, totalCount) {
-      const lastIndex = totalCount - 1;
-      const index = typeof location === "number" ? location : location.index === "LAST" ? lastIndex : location.index;
-      return index;
-    }
-    const initialTopMostItemIndexSystem = system(
-      ([{ sizes, listRefresh, defaultItemSize }, { scrollTop }, { scrollToIndex, scrollTargetReached }, { didMount }]) => {
-        const scrolledToInitialItem = statefulStream(true);
-        const initialTopMostItemIndex = statefulStream(0);
-        const initialItemFinalLocationReached = statefulStream(true);
-        connect(
-          pipe(
-            didMount,
-            withLatestFrom(initialTopMostItemIndex),
-            filter(([_2, location]) => !!location),
-            mapTo(false)
-          ),
-          scrolledToInitialItem
-        );
-        connect(
-          pipe(
-            didMount,
-            withLatestFrom(initialTopMostItemIndex),
-            filter(([_2, location]) => !!location),
-            mapTo(false)
-          ),
-          initialItemFinalLocationReached
-        );
-        subscribe(
-          pipe(
-            combineLatest(listRefresh, didMount),
-            withLatestFrom(scrolledToInitialItem, sizes, defaultItemSize, initialItemFinalLocationReached),
-            filter(([[, didMount2], scrolledToInitialItem2, { sizeTree }, defaultItemSize2, scrollScheduled]) => {
-              return didMount2 && (!empty(sizeTree) || isDefined(defaultItemSize2)) && !scrolledToInitialItem2 && !scrollScheduled;
-            }),
-            withLatestFrom(initialTopMostItemIndex)
-          ),
-          ([, initialTopMostItemIndex2]) => {
-            handleNext(scrollTargetReached, () => {
-              publish(initialItemFinalLocationReached, true);
-            });
-            skipFrames(4, () => {
-              handleNext(scrollTop, () => {
-                publish(scrolledToInitialItem, true);
-              });
-              publish(scrollToIndex, initialTopMostItemIndex2);
-            });
-          }
-        );
-        return {
-          scrolledToInitialItem,
-          initialTopMostItemIndex,
-          initialItemFinalLocationReached
-        };
-      },
-      tup(sizeSystem, domIOSystem, scrollToIndexSystem, propsReadySystem),
-      { singleton: true }
-    );
-    function normalizeFollowOutput(follow) {
-      if (!follow) {
-        return false;
-      }
-      return follow === "smooth" ? "smooth" : "auto";
-    }
-    const behaviorFromFollowOutput = (follow, isAtBottom) => {
-      if (typeof follow === "function") {
-        return normalizeFollowOutput(follow(isAtBottom));
-      }
-      return isAtBottom && normalizeFollowOutput(follow);
-    };
-    const followOutputSystem = system(
-      ([
-        { totalCount, listRefresh },
-        { isAtBottom, atBottomState },
-        { scrollToIndex },
-        { scrolledToInitialItem },
-        { propsReady, didMount },
-        { log },
-        { scrollingInProgress }
-      ]) => {
-        const followOutput = statefulStream(false);
-        const autoscrollToBottom = stream();
-        let pendingScrollHandle = null;
-        function scrollToBottom(followOutputBehavior) {
-          publish(scrollToIndex, {
-            index: "LAST",
-            align: "end",
-            behavior: followOutputBehavior
-          });
-        }
-        subscribe(
-          pipe(
-            combineLatest(pipe(duc(totalCount), skip(1)), didMount),
-            withLatestFrom(duc(followOutput), isAtBottom, scrolledToInitialItem, scrollingInProgress),
-            map(([[totalCount2, didMount2], followOutput2, isAtBottom2, scrolledToInitialItem2, scrollingInProgress2]) => {
-              let shouldFollow = didMount2 && scrolledToInitialItem2;
-              let followOutputBehavior = "auto";
-              if (shouldFollow) {
-                followOutputBehavior = behaviorFromFollowOutput(followOutput2, isAtBottom2 || scrollingInProgress2);
-                shouldFollow = shouldFollow && !!followOutputBehavior;
-              }
-              return { totalCount: totalCount2, shouldFollow, followOutputBehavior };
-            }),
-            filter(({ shouldFollow }) => shouldFollow)
-          ),
-          ({ totalCount: totalCount2, followOutputBehavior }) => {
-            if (pendingScrollHandle) {
-              pendingScrollHandle();
-              pendingScrollHandle = null;
-            }
-            pendingScrollHandle = handleNext(listRefresh, () => {
-              getValue(log)("following output to ", { totalCount: totalCount2 }, LogLevel.DEBUG);
-              scrollToBottom(followOutputBehavior);
-              pendingScrollHandle = null;
-            });
-          }
-        );
-        function trapNextSizeIncrease(followOutput2) {
-          const cancel = handleNext(atBottomState, (state) => {
-            if (followOutput2 && !state.atBottom && state.notAtBottomBecause === "SIZE_INCREASED" && !pendingScrollHandle) {
-              getValue(log)("scrolling to bottom due to increased size", {}, LogLevel.DEBUG);
-              scrollToBottom("auto");
-            }
-          });
-          setTimeout(cancel, 100);
-        }
-        subscribe(
-          pipe(
-            combineLatest(duc(followOutput), totalCount, propsReady),
-            filter(([follow, , ready]) => follow && ready),
-            scan(
-              ({ value }, [, next]) => {
-                return { refreshed: value === next, value: next };
-              },
-              { refreshed: false, value: 0 }
-            ),
-            filter(({ refreshed }) => refreshed),
-            withLatestFrom(followOutput, totalCount)
-          ),
-          ([, followOutput2]) => {
-            if (getValue(scrolledToInitialItem)) {
-              trapNextSizeIncrease(followOutput2 !== false);
-            }
-          }
-        );
-        subscribe(autoscrollToBottom, () => {
-          trapNextSizeIncrease(getValue(followOutput) !== false);
-        });
-        subscribe(combineLatest(duc(followOutput), atBottomState), ([followOutput2, state]) => {
-          if (followOutput2 && !state.atBottom && state.notAtBottomBecause === "VIEWPORT_HEIGHT_DECREASING") {
-            scrollToBottom("auto");
-          }
-        });
-        return { followOutput, autoscrollToBottom };
-      },
-      tup(sizeSystem, stateFlagsSystem, scrollToIndexSystem, initialTopMostItemIndexSystem, propsReadySystem, loggerSystem, domIOSystem)
-    );
-    function groupCountsToIndicesAndCount(counts) {
-      return counts.reduce(
-        (acc, groupCount) => {
-          acc.groupIndices.push(acc.totalCount);
-          acc.totalCount += groupCount + 1;
-          return acc;
-        },
-        {
-          totalCount: 0,
-          groupIndices: []
-        }
-      );
-    }
-    const groupedListSystem = system(([{ totalCount, groupIndices, sizes }, { scrollTop, headerHeight }]) => {
-      const groupCounts = stream();
-      const topItemsIndexes = stream();
-      const groupIndicesAndCount = streamFromEmitter(pipe(groupCounts, map(groupCountsToIndicesAndCount)));
-      connect(
-        pipe(
-          groupIndicesAndCount,
-          map((value) => value.totalCount)
-        ),
-        totalCount
-      );
-      connect(
-        pipe(
-          groupIndicesAndCount,
-          map((value) => value.groupIndices)
-        ),
-        groupIndices
-      );
-      connect(
-        pipe(
-          combineLatest(scrollTop, sizes, headerHeight),
-          filter(([_2, sizes2]) => hasGroups(sizes2)),
-          map(([scrollTop2, state, headerHeight2]) => findMaxKeyValue(state.groupOffsetTree, Math.max(scrollTop2 - headerHeight2, 0), "v")[0]),
-          distinctUntilChanged(),
-          map((index) => [index])
-        ),
-        topItemsIndexes
-      );
-      return { groupCounts, topItemsIndexes };
-    }, tup(sizeSystem, domIOSystem));
-    function tupleComparator(prev, current) {
-      return !!(prev && prev[0] === current[0] && prev[1] === current[1]);
-    }
-    function rangeComparator(prev, next) {
-      return !!(prev && prev.startIndex === next.startIndex && prev.endIndex === next.endIndex);
-    }
-    const TOP = "top";
-    const BOTTOM = "bottom";
-    const NONE = "none";
-    function getOverscan(overscan, end2, direction) {
-      if (typeof overscan === "number") {
-        return direction === UP && end2 === TOP || direction === DOWN && end2 === BOTTOM ? overscan : 0;
-      } else {
-        if (direction === UP) {
-          return end2 === TOP ? overscan.main : overscan.reverse;
-        } else {
-          return end2 === BOTTOM ? overscan.main : overscan.reverse;
-        }
-      }
-    }
-    function getViewportIncrease(value, end2) {
-      return typeof value === "number" ? value : value[end2] || 0;
-    }
-    const sizeRangeSystem = system(
-      ([{ scrollTop, viewportHeight, deviation, headerHeight, fixedHeaderHeight }]) => {
-        const listBoundary = stream();
-        const topListHeight = statefulStream(0);
-        const increaseViewportBy = statefulStream(0);
-        const overscan = statefulStream(0);
-        const visibleRange = statefulStreamFromEmitter(
-          pipe(
-            combineLatest(
-              duc(scrollTop),
-              duc(viewportHeight),
-              duc(headerHeight),
-              duc(listBoundary, tupleComparator),
-              duc(overscan),
-              duc(topListHeight),
-              duc(fixedHeaderHeight),
-              duc(deviation),
-              duc(increaseViewportBy)
-            ),
-            map(
-              ([
-                scrollTop2,
-                viewportHeight2,
-                headerHeight2,
-                [listTop, listBottom],
-                overscan2,
-                topListHeight2,
-                fixedHeaderHeight2,
-                deviation2,
-                increaseViewportBy2
-              ]) => {
-                const top2 = scrollTop2 - deviation2;
-                const stickyHeaderHeight = topListHeight2 + fixedHeaderHeight2;
-                const headerVisible = Math.max(headerHeight2 - top2, 0);
-                let direction = NONE;
-                const topViewportAddition = getViewportIncrease(increaseViewportBy2, TOP);
-                const bottomViewportAddition = getViewportIncrease(increaseViewportBy2, BOTTOM);
-                listTop -= deviation2;
-                listTop += headerHeight2 + fixedHeaderHeight2;
-                listBottom += headerHeight2 + fixedHeaderHeight2;
-                listBottom -= deviation2;
-                if (listTop > scrollTop2 + stickyHeaderHeight - topViewportAddition) {
-                  direction = UP;
-                }
-                if (listBottom < scrollTop2 - headerVisible + viewportHeight2 + bottomViewportAddition) {
-                  direction = DOWN;
-                }
-                if (direction !== NONE) {
-                  return [
-                    Math.max(top2 - headerHeight2 - getOverscan(overscan2, TOP, direction) - topViewportAddition, 0),
-                    top2 - headerVisible - fixedHeaderHeight2 + viewportHeight2 + getOverscan(overscan2, BOTTOM, direction) + bottomViewportAddition
-                  ];
-                }
-                return null;
-              }
-            ),
-            filter((value) => value != null),
-            distinctUntilChanged(tupleComparator)
-          ),
-          [0, 0]
-        );
-        return {
-          // input
-          listBoundary,
-          overscan,
-          topListHeight,
-          increaseViewportBy,
-          // output
-          visibleRange
-        };
-      },
-      tup(domIOSystem),
-      { singleton: true }
-    );
-    function probeItemSet(index, sizes, data) {
-      if (hasGroups(sizes)) {
-        const itemIndex = originalIndexFromItemIndex(index, sizes);
-        const groupIndex = findMaxKeyValue(sizes.groupOffsetTree, itemIndex)[0];
-        return [
-          { index: groupIndex, size: 0, offset: 0 },
-          { index: itemIndex, size: 0, offset: 0, data: data && data[0] }
-        ];
-      }
-      return [{ index, size: 0, offset: 0, data: data && data[0] }];
-    }
-    const EMPTY_LIST_STATE = {
-      items: [],
-      topItems: [],
-      offsetTop: 0,
-      offsetBottom: 0,
-      top: 0,
-      bottom: 0,
-      topListHeight: 0,
-      totalCount: 0,
-      firstItemIndex: 0
-    };
-    function transposeItems(items, sizes, firstItemIndex) {
-      if (items.length === 0) {
-        return [];
-      }
-      if (!hasGroups(sizes)) {
-        return items.map((item) => ({ ...item, index: item.index + firstItemIndex, originalIndex: item.index }));
-      }
-      const startIndex = items[0].index;
-      const endIndex = items[items.length - 1].index;
-      const transposedItems = [];
-      const groupRanges = rangesWithin(sizes.groupOffsetTree, startIndex, endIndex);
-      let currentRange = void 0;
-      let currentGroupIndex = 0;
-      for (const item of items) {
-        if (!currentRange || currentRange.end < item.index) {
-          currentRange = groupRanges.shift();
-          currentGroupIndex = sizes.groupIndices.indexOf(currentRange.start);
-        }
-        let transposedItem;
-        if (item.index === currentRange.start) {
-          transposedItem = {
-            type: "group",
-            index: currentGroupIndex
-          };
-        } else {
-          transposedItem = {
-            index: item.index - (currentGroupIndex + 1) + firstItemIndex,
-            groupIndex: currentGroupIndex
-          };
-        }
-        transposedItems.push({
-          ...transposedItem,
-          size: item.size,
-          offset: item.offset,
-          originalIndex: item.index,
-          data: item.data
-        });
-      }
-      return transposedItems;
-    }
-    function buildListState(items, topItems, totalCount, gap, sizes, firstItemIndex) {
-      const { lastSize, lastOffset, lastIndex } = sizes;
-      let offsetTop = 0;
-      let bottom2 = 0;
-      if (items.length > 0) {
-        offsetTop = items[0].offset;
-        const lastItem = items[items.length - 1];
-        bottom2 = lastItem.offset + lastItem.size;
-      }
-      const itemCount = totalCount - lastIndex;
-      const total = lastOffset + itemCount * lastSize + (itemCount - 1) * gap;
-      const top2 = offsetTop;
-      const offsetBottom = total - bottom2;
-      return {
-        items: transposeItems(items, sizes, firstItemIndex),
-        topItems: transposeItems(topItems, sizes, firstItemIndex),
-        topListHeight: topItems.reduce((height, item) => item.size + height, 0),
-        offsetTop,
-        offsetBottom,
-        top: top2,
-        bottom: bottom2,
-        totalCount,
-        firstItemIndex
-      };
-    }
-    function buildListStateFromItemCount(itemCount, initialTopMostItemIndex, sizes, firstItemIndex, gap, data) {
-      let includedGroupsCount = 0;
-      if (sizes.groupIndices.length > 0) {
-        for (const index of sizes.groupIndices) {
-          if (index - includedGroupsCount >= itemCount) {
-            break;
-          }
-          includedGroupsCount++;
-        }
-      }
-      const adjustedCount = itemCount + includedGroupsCount;
-      const initialTopMostItemIndexNumber = getInitialTopMostItemIndexNumber(initialTopMostItemIndex, adjustedCount);
-      const items = Array.from({ length: adjustedCount }).map((_2, index) => ({
-        index: index + initialTopMostItemIndexNumber,
-        size: 0,
-        offset: 0,
-        data: data[index + initialTopMostItemIndexNumber]
-      }));
-      return buildListState(items, [], adjustedCount, gap, sizes, firstItemIndex);
-    }
-    const listStateSystem = system(
-      ([
-        { sizes, totalCount, data, firstItemIndex, gap },
-        groupedListSystem2,
-        { visibleRange, listBoundary, topListHeight: rangeTopListHeight },
-        { scrolledToInitialItem, initialTopMostItemIndex },
-        { topListHeight },
-        stateFlags,
-        { didMount },
-        { recalcInProgress }
-      ]) => {
-        const topItemsIndexes = statefulStream([]);
-        const initialItemCount = statefulStream(0);
-        const itemsRendered = stream();
-        connect(groupedListSystem2.topItemsIndexes, topItemsIndexes);
-        const listState = statefulStreamFromEmitter(
-          pipe(
-            combineLatest(
-              didMount,
-              recalcInProgress,
-              duc(visibleRange, tupleComparator),
-              duc(totalCount),
-              duc(sizes),
-              duc(initialTopMostItemIndex),
-              scrolledToInitialItem,
-              duc(topItemsIndexes),
-              duc(firstItemIndex),
-              duc(gap),
-              data
-            ),
-            filter(([mount, recalcInProgress2, , totalCount2, , , , , , , data2]) => {
-              const dataChangeInProgress = data2 && data2.length !== totalCount2;
-              return mount && !recalcInProgress2 && !dataChangeInProgress;
-            }),
-            map(
-              ([
-                ,
-                ,
-                [startOffset, endOffset],
-                totalCount2,
-                sizes2,
-                initialTopMostItemIndex2,
-                scrolledToInitialItem2,
-                topItemsIndexes2,
-                firstItemIndex2,
-                gap2,
-                data2
-              ]) => {
-                const sizesValue = sizes2;
-                const { sizeTree, offsetTree } = sizesValue;
-                const initialItemCountValue = getValue(initialItemCount);
-                if (totalCount2 === 0) {
-                  return { ...EMPTY_LIST_STATE, totalCount: totalCount2 };
-                }
-                if (startOffset === 0 && endOffset === 0) {
-                  if (initialItemCountValue === 0) {
-                    return { ...EMPTY_LIST_STATE, totalCount: totalCount2 };
-                  } else {
-                    return buildListStateFromItemCount(initialItemCountValue, initialTopMostItemIndex2, sizes2, firstItemIndex2, gap2, data2 || []);
-                  }
-                }
-                if (empty(sizeTree)) {
-                  if (initialItemCountValue > 0) {
-                    return null;
-                  }
-                  const state = buildListState(
-                    probeItemSet(getInitialTopMostItemIndexNumber(initialTopMostItemIndex2, totalCount2), sizesValue, data2),
-                    [],
-                    totalCount2,
-                    gap2,
-                    sizesValue,
-                    firstItemIndex2
-                  );
-                  return state;
-                }
-                const topItems = [];
-                if (topItemsIndexes2.length > 0) {
-                  const startIndex = topItemsIndexes2[0];
-                  const endIndex = topItemsIndexes2[topItemsIndexes2.length - 1];
-                  let offset2 = 0;
-                  for (const range of rangesWithin(sizeTree, startIndex, endIndex)) {
-                    const size = range.value;
-                    const rangeStartIndex = Math.max(range.start, startIndex);
-                    const rangeEndIndex = Math.min(range.end, endIndex);
-                    for (let i2 = rangeStartIndex; i2 <= rangeEndIndex; i2++) {
-                      topItems.push({ index: i2, size, offset: offset2, data: data2 && data2[i2] });
-                      offset2 += size;
-                    }
-                  }
-                }
-                if (!scrolledToInitialItem2) {
-                  return buildListState([], topItems, totalCount2, gap2, sizesValue, firstItemIndex2);
-                }
-                const minStartIndex = topItemsIndexes2.length > 0 ? topItemsIndexes2[topItemsIndexes2.length - 1] + 1 : 0;
-                const offsetPointRanges = rangesWithinOffsets(offsetTree, startOffset, endOffset, minStartIndex);
-                if (offsetPointRanges.length === 0) {
-                  return null;
-                }
-                const maxIndex = totalCount2 - 1;
-                const items = tap([], (result) => {
-                  for (const range of offsetPointRanges) {
-                    const point = range.value;
-                    let offset2 = point.offset;
-                    let rangeStartIndex = range.start;
-                    const size = point.size;
-                    if (point.offset < startOffset) {
-                      rangeStartIndex += Math.floor((startOffset - point.offset + gap2) / (size + gap2));
-                      const itemCount = rangeStartIndex - range.start;
-                      offset2 += itemCount * size + itemCount * gap2;
-                    }
-                    if (rangeStartIndex < minStartIndex) {
-                      offset2 += (minStartIndex - rangeStartIndex) * size;
-                      rangeStartIndex = minStartIndex;
-                    }
-                    const endIndex = Math.min(range.end, maxIndex);
-                    for (let i2 = rangeStartIndex; i2 <= endIndex; i2++) {
-                      if (offset2 >= endOffset) {
-                        break;
-                      }
-                      result.push({ index: i2, size, offset: offset2, data: data2 && data2[i2] });
-                      offset2 += size + gap2;
-                    }
-                  }
-                });
-                return buildListState(items, topItems, totalCount2, gap2, sizesValue, firstItemIndex2);
-              }
-            ),
-            //@ts-expect-error filter needs to be fixed
-            filter((value) => value !== null),
-            distinctUntilChanged()
-          ),
-          EMPTY_LIST_STATE
-        );
-        connect(
-          pipe(
-            data,
-            filter(isDefined),
-            map((data2) => data2 == null ? void 0 : data2.length)
-          ),
-          totalCount
-        );
-        connect(
-          pipe(
-            listState,
-            map((value) => value.topListHeight)
-          ),
-          topListHeight
-        );
-        connect(topListHeight, rangeTopListHeight);
-        connect(
-          pipe(
-            listState,
-            map((state) => [state.top, state.bottom])
-          ),
-          listBoundary
-        );
-        connect(
-          pipe(
-            listState,
-            map((state) => state.items)
-          ),
-          itemsRendered
-        );
-        const endReached = streamFromEmitter(
-          pipe(
-            listState,
-            filter(({ items }) => items.length > 0),
-            withLatestFrom(totalCount, data),
-            filter(([{ items }, totalCount2]) => items[items.length - 1].originalIndex === totalCount2 - 1),
-            map(([, totalCount2, data2]) => [totalCount2 - 1, data2]),
-            distinctUntilChanged(tupleComparator),
-            map(([count]) => count)
-          )
-        );
-        const startReached = streamFromEmitter(
-          pipe(
-            listState,
-            throttleTime(200),
-            filter(({ items, topItems }) => {
-              return items.length > 0 && items[0].originalIndex === topItems.length;
-            }),
-            map(({ items }) => items[0].index),
-            distinctUntilChanged()
-          )
-        );
-        const rangeChanged = streamFromEmitter(
-          pipe(
-            listState,
-            filter(({ items }) => items.length > 0),
-            map(({ items }) => {
-              let startIndex = 0;
-              let endIndex = items.length - 1;
-              while (items[startIndex].type === "group" && startIndex < endIndex) {
-                startIndex++;
-              }
-              while (items[endIndex].type === "group" && endIndex > startIndex) {
-                endIndex--;
-              }
-              return {
-                startIndex: items[startIndex].index,
-                endIndex: items[endIndex].index
-              };
-            }),
-            distinctUntilChanged(rangeComparator)
-          )
-        );
-        return { listState, topItemsIndexes, endReached, startReached, rangeChanged, itemsRendered, initialItemCount, ...stateFlags };
-      },
-      tup(
-        sizeSystem,
-        groupedListSystem,
-        sizeRangeSystem,
-        initialTopMostItemIndexSystem,
-        scrollToIndexSystem,
-        stateFlagsSystem,
-        propsReadySystem,
-        recalcSystem
-      ),
-      { singleton: true }
-    );
-    const initialItemCountSystem = system(
-      ([{ sizes, firstItemIndex, data, gap }, { initialTopMostItemIndex }, { initialItemCount, listState }, { didMount }]) => {
-        connect(
-          pipe(
-            didMount,
-            withLatestFrom(initialItemCount),
-            filter(([, count]) => count !== 0),
-            withLatestFrom(initialTopMostItemIndex, sizes, firstItemIndex, gap, data),
-            map(([[, count], initialTopMostItemIndexValue, sizes2, firstItemIndex2, gap2, data2 = []]) => {
-              return buildListStateFromItemCount(count, initialTopMostItemIndexValue, sizes2, firstItemIndex2, gap2, data2);
-            })
-          ),
-          listState
-        );
-        return {};
-      },
-      tup(sizeSystem, initialTopMostItemIndexSystem, listStateSystem, propsReadySystem),
-      { singleton: true }
-    );
-    const scrollSeekSystem = system(
-      ([{ scrollVelocity }]) => {
-        const isSeeking = statefulStream(false);
-        const rangeChanged = stream();
-        const scrollSeekConfiguration = statefulStream(false);
-        connect(
-          pipe(
-            scrollVelocity,
-            withLatestFrom(scrollSeekConfiguration, isSeeking, rangeChanged),
-            filter(([_2, config2]) => !!config2),
-            map(([speed, config2, isSeeking2, range]) => {
-              const { exit, enter } = config2;
-              if (isSeeking2) {
-                if (exit(speed, range)) {
-                  return false;
-                }
-              } else {
-                if (enter(speed, range)) {
-                  return true;
-                }
-              }
-              return isSeeking2;
-            }),
-            distinctUntilChanged()
-          ),
-          isSeeking
-        );
-        subscribe(
-          pipe(combineLatest(isSeeking, scrollVelocity, rangeChanged), withLatestFrom(scrollSeekConfiguration)),
-          ([[isSeeking2, velocity, range], config2]) => isSeeking2 && config2 && config2.change && config2.change(velocity, range)
-        );
-        return { isSeeking, scrollSeekConfiguration, scrollVelocity, scrollSeekRangeChanged: rangeChanged };
-      },
-      tup(stateFlagsSystem),
-      { singleton: true }
-    );
-    const topItemCountSystem = system(([{ topItemsIndexes }]) => {
-      const topItemCount = statefulStream(0);
-      connect(
-        pipe(
-          topItemCount,
-          filter((length) => length >= 0),
-          map((length) => Array.from({ length }).map((_2, index) => index))
-        ),
-        topItemsIndexes
-      );
-      return { topItemCount };
-    }, tup(listStateSystem));
-    const totalListHeightSystem = system(
-      ([{ footerHeight, headerHeight, fixedHeaderHeight, fixedFooterHeight }, { listState }]) => {
-        const totalListHeightChanged = stream();
-        const totalListHeight = statefulStreamFromEmitter(
-          pipe(
-            combineLatest(footerHeight, fixedFooterHeight, headerHeight, fixedHeaderHeight, listState),
-            map(([footerHeight2, fixedFooterHeight2, headerHeight2, fixedHeaderHeight2, listState2]) => {
-              return footerHeight2 + fixedFooterHeight2 + headerHeight2 + fixedHeaderHeight2 + listState2.offsetBottom + listState2.bottom;
-            })
-          ),
-          0
-        );
-        connect(duc(totalListHeight), totalListHeightChanged);
-        return { totalListHeight, totalListHeightChanged };
-      },
-      tup(domIOSystem, listStateSystem),
-      { singleton: true }
-    );
-    function simpleMemoize(func) {
-      let called = false;
-      let result;
-      return () => {
-        if (!called) {
-          called = true;
-          result = func();
-        }
-        return result;
-      };
-    }
-    const isMobileSafari = simpleMemoize(() => {
-      return /iP(ad|od|hone)/i.test(navigator.userAgent) && /WebKit/i.test(navigator.userAgent);
-    });
-    const upwardScrollFixSystem = system(
-      ([
-        { scrollBy, scrollTop, deviation, scrollingInProgress },
-        { isScrolling, isAtBottom, scrollDirection, lastJumpDueToItemResize },
-        { listState },
-        { beforeUnshiftWith, shiftWithOffset, sizes, gap },
-        { log },
-        { recalcInProgress }
-      ]) => {
-        const deviationOffset = streamFromEmitter(
-          pipe(
-            listState,
-            withLatestFrom(lastJumpDueToItemResize),
-            scan(
-              ([, prevItems, prevTotalCount, prevTotalHeight], [{ items, totalCount, bottom: bottom2, offsetBottom }, lastJumpDueToItemResize2]) => {
-                const totalHeight = bottom2 + offsetBottom;
-                let newDev = 0;
-                if (prevTotalCount === totalCount) {
-                  if (prevItems.length > 0 && items.length > 0) {
-                    const atStart = items[0].originalIndex === 0 && prevItems[0].originalIndex === 0;
-                    if (!atStart) {
-                      newDev = totalHeight - prevTotalHeight;
-                      if (newDev !== 0) {
-                        newDev += lastJumpDueToItemResize2;
-                      }
-                    }
-                  }
-                }
-                return [newDev, items, totalCount, totalHeight];
-              },
-              [0, [], 0, 0]
-            ),
-            filter(([amount]) => amount !== 0),
-            withLatestFrom(scrollTop, scrollDirection, scrollingInProgress, isAtBottom, log, recalcInProgress),
-            filter(([, scrollTop2, scrollDirection2, scrollingInProgress2, , , recalcInProgress2]) => {
-              return !recalcInProgress2 && !scrollingInProgress2 && scrollTop2 !== 0 && scrollDirection2 === UP;
-            }),
-            map(([[amount], , , , , log2]) => {
-              log2("Upward scrolling compensation", { amount }, LogLevel.DEBUG);
-              return amount;
-            })
-          )
-        );
-        function scrollByWith(offset2) {
-          if (offset2 > 0) {
-            publish(scrollBy, { top: -offset2, behavior: "auto" });
-            publish(deviation, 0);
-          } else {
-            publish(deviation, 0);
-            publish(scrollBy, { top: -offset2, behavior: "auto" });
-          }
-        }
-        subscribe(pipe(deviationOffset, withLatestFrom(deviation, isScrolling)), ([offset2, deviationAmount, isScrolling2]) => {
-          if (isScrolling2 && isMobileSafari()) {
-            publish(deviation, deviationAmount - offset2);
-          } else {
-            scrollByWith(-offset2);
-          }
-        });
-        subscribe(
-          pipe(
-            combineLatest(statefulStreamFromEmitter(isScrolling, false), deviation, recalcInProgress),
-            filter(([is, deviation2, recalc]) => !is && !recalc && deviation2 !== 0),
-            map(([_2, deviation2]) => deviation2),
-            throttleTime(1)
-          ),
-          scrollByWith
-        );
-        connect(
-          pipe(
-            shiftWithOffset,
-            map((offset2) => {
-              return { top: -offset2 };
-            })
-          ),
-          scrollBy
-        );
-        subscribe(
-          pipe(
-            beforeUnshiftWith,
-            withLatestFrom(sizes, gap),
-            map(([offset2, { lastSize: defaultItemSize, groupIndices, sizeTree }, gap2]) => {
-              function getItemOffset(itemCount) {
-                return itemCount * (defaultItemSize + gap2);
-              }
-              if (groupIndices.length === 0) {
-                return getItemOffset(offset2);
-              } else {
-                let amount = 0;
-                const defaultGroupSize = find(sizeTree, 0);
-                let recognizedOffsetItems = 0;
-                let groupIndex = 0;
-                while (recognizedOffsetItems < offset2) {
-                  recognizedOffsetItems++;
-                  amount += defaultGroupSize;
-                  let groupItemCount = groupIndices.length === groupIndex + 1 ? Infinity : groupIndices[groupIndex + 1] - groupIndices[groupIndex] - 1;
-                  if (recognizedOffsetItems + groupItemCount > offset2) {
-                    amount -= defaultGroupSize;
-                    groupItemCount = offset2 - recognizedOffsetItems + 1;
-                  }
-                  recognizedOffsetItems += groupItemCount;
-                  amount += getItemOffset(groupItemCount);
-                  groupIndex++;
-                }
-                return amount;
-              }
-            })
-          ),
-          (offset2) => {
-            publish(deviation, offset2);
-            requestAnimationFrame(() => {
-              publish(scrollBy, { top: offset2 });
-              requestAnimationFrame(() => {
-                publish(deviation, 0);
-                publish(recalcInProgress, false);
-              });
-            });
-          }
-        );
-        return { deviation };
-      },
-      tup(domIOSystem, stateFlagsSystem, listStateSystem, sizeSystem, loggerSystem, recalcSystem)
-    );
-    const initialScrollTopSystem = system(
-      ([{ didMount }, { scrollTo }, { listState }]) => {
-        const initialScrollTop = statefulStream(0);
-        subscribe(
-          pipe(
-            didMount,
-            withLatestFrom(initialScrollTop),
-            filter(([, offset2]) => offset2 !== 0),
-            map(([, offset2]) => ({ top: offset2 }))
-          ),
-          (location) => {
-            handleNext(
-              pipe(
-                listState,
-                skip(1),
-                filter((state) => state.items.length > 1)
-              ),
-              () => {
-                requestAnimationFrame(() => {
-                  publish(scrollTo, location);
-                });
-              }
-            );
-          }
-        );
-        return {
-          initialScrollTop
-        };
-      },
-      tup(propsReadySystem, domIOSystem, listStateSystem),
-      { singleton: true }
-    );
-    const alignToBottomSystem = system(
-      ([{ viewportHeight }, { totalListHeight }]) => {
-        const alignToBottom = statefulStream(false);
-        const paddingTopAddition = statefulStreamFromEmitter(
-          pipe(
-            combineLatest(alignToBottom, viewportHeight, totalListHeight),
-            filter(([enabled]) => enabled),
-            map(([, viewportHeight2, totalListHeight2]) => {
-              return Math.max(0, viewportHeight2 - totalListHeight2);
-            }),
-            throttleTime(0),
-            distinctUntilChanged()
-          ),
-          0
-        );
-        return { alignToBottom, paddingTopAddition };
-      },
-      tup(domIOSystem, totalListHeightSystem),
-      { singleton: true }
-    );
-    const windowScrollerSystem = system(([{ scrollTo, scrollContainerState }]) => {
-      const windowScrollContainerState = stream();
-      const windowViewportRect = stream();
-      const windowScrollTo = stream();
-      const useWindowScroll = statefulStream(false);
-      const customScrollParent = statefulStream(void 0);
-      connect(
-        pipe(
-          combineLatest(windowScrollContainerState, windowViewportRect),
-          map(([{ viewportHeight, scrollTop: windowScrollTop, scrollHeight }, { offsetTop }]) => {
-            return {
-              scrollTop: Math.max(0, windowScrollTop - offsetTop),
-              scrollHeight,
-              viewportHeight
-            };
-          })
-        ),
-        scrollContainerState
-      );
-      connect(
-        pipe(
-          scrollTo,
-          withLatestFrom(windowViewportRect),
-          map(([scrollTo2, { offsetTop }]) => {
-            return {
-              ...scrollTo2,
-              top: scrollTo2.top + offsetTop
-            };
-          })
-        ),
-        windowScrollTo
-      );
-      return {
-        // config
-        useWindowScroll,
-        customScrollParent,
-        // input
-        windowScrollContainerState,
-        windowViewportRect,
-        // signals
-        windowScrollTo
-      };
-    }, tup(domIOSystem));
-    const defaultCalculateViewLocation = ({
-      itemTop: itemTop2,
-      itemBottom,
-      viewportTop,
-      viewportBottom,
-      locationParams: { behavior, align, ...rest }
-    }) => {
-      if (itemTop2 < viewportTop) {
-        return { ...rest, behavior, align: align != null ? align : "start" };
-      }
-      if (itemBottom > viewportBottom) {
-        return { ...rest, behavior, align: align != null ? align : "end" };
-      }
-      return null;
-    };
-    const scrollIntoViewSystem = system(
-      ([
-        { sizes, totalCount, gap },
-        { scrollTop, viewportHeight, headerHeight, fixedHeaderHeight, fixedFooterHeight, scrollingInProgress },
-        { scrollToIndex }
-      ]) => {
-        const scrollIntoView = stream();
-        connect(
-          pipe(
-            scrollIntoView,
-            withLatestFrom(sizes, viewportHeight, totalCount, headerHeight, fixedHeaderHeight, fixedFooterHeight, scrollTop),
-            withLatestFrom(gap),
-            map(([[viewLocation, sizes2, viewportHeight2, totalCount2, headerHeight2, fixedHeaderHeight2, fixedFooterHeight2, scrollTop2], gap2]) => {
-              const { done, behavior, align, calculateViewLocation = defaultCalculateViewLocation, ...rest } = viewLocation;
-              const actualIndex = originalIndexFromLocation(viewLocation, sizes2, totalCount2 - 1);
-              const itemTop2 = offsetOf(actualIndex, sizes2.offsetTree, gap2) + headerHeight2 + fixedHeaderHeight2;
-              const itemBottom = itemTop2 + findMaxKeyValue(sizes2.sizeTree, actualIndex)[1];
-              const viewportTop = scrollTop2 + fixedHeaderHeight2;
-              const viewportBottom = scrollTop2 + viewportHeight2 - fixedFooterHeight2;
-              const location = calculateViewLocation({
-                itemTop: itemTop2,
-                itemBottom,
-                viewportTop,
-                viewportBottom,
-                locationParams: { behavior, align, ...rest }
-              });
-              if (location) {
-                done && handleNext(
-                  pipe(
-                    scrollingInProgress,
-                    filter((value) => value === false),
-                    // skips the initial publish of false, and the cleanup call.
-                    // but if scrollingInProgress is true, we skip the initial publish.
-                    skip(getValue(scrollingInProgress) ? 1 : 2)
-                  ),
-                  done
-                );
-              } else {
-                done && done();
-              }
-              return location;
-            }),
-            filter((value) => value !== null)
-          ),
-          scrollToIndex
-        );
-        return {
-          scrollIntoView
-        };
-      },
-      tup(sizeSystem, domIOSystem, scrollToIndexSystem, listStateSystem, loggerSystem),
-      { singleton: true }
-    );
-    const stateLoadSystem = system(
-      ([
-        { sizes, sizeRanges },
-        { scrollTop, headerHeight },
-        { initialTopMostItemIndex },
-        { didMount },
-        { useWindowScroll, windowScrollContainerState, windowViewportRect }
-      ]) => {
-        const getState = stream();
-        const restoreStateFrom = statefulStream(void 0);
-        const statefulWindowScrollContainerState = statefulStream(null);
-        const statefulWindowViewportRect = statefulStream(null);
-        connect(windowScrollContainerState, statefulWindowScrollContainerState);
-        connect(windowViewportRect, statefulWindowViewportRect);
-        subscribe(
-          pipe(
-            getState,
-            withLatestFrom(sizes, scrollTop, useWindowScroll, statefulWindowScrollContainerState, statefulWindowViewportRect, headerHeight)
-          ),
-          ([callback, sizes2, scrollTop2, useWindowScroll2, windowScrollContainerState2, windowViewportRect2, headerHeight2]) => {
-            const ranges = sizeTreeToRanges(sizes2.sizeTree);
-            if (useWindowScroll2 && windowScrollContainerState2 !== null && windowViewportRect2 !== null) {
-              scrollTop2 = windowScrollContainerState2.scrollTop - windowViewportRect2.offsetTop;
-            }
-            scrollTop2 -= headerHeight2;
-            callback({ ranges, scrollTop: scrollTop2 });
-          }
-        );
-        connect(pipe(restoreStateFrom, filter(isDefined), map(locationFromSnapshot)), initialTopMostItemIndex);
-        connect(
-          pipe(
-            didMount,
-            withLatestFrom(restoreStateFrom),
-            filter(([, state]) => state !== void 0),
-            distinctUntilChanged(),
-            map(([, snapshot]) => {
-              return snapshot.ranges;
-            })
-          ),
-          sizeRanges
-        );
-        return {
-          getState,
-          restoreStateFrom
-        };
-      },
-      tup(sizeSystem, domIOSystem, initialTopMostItemIndexSystem, propsReadySystem, windowScrollerSystem)
-    );
-    function locationFromSnapshot(snapshot) {
-      return { offset: snapshot.scrollTop, index: 0, align: "start" };
-    }
-    const featureGroup1System = system(
-      ([
-        sizeRange,
-        initialItemCount,
-        propsReady,
-        scrollSeek,
-        totalListHeight,
-        initialScrollTopSystem2,
-        alignToBottom,
-        windowScroller,
-        scrollIntoView,
-        logger
-      ]) => {
-        return {
-          ...sizeRange,
-          ...initialItemCount,
-          ...propsReady,
-          ...scrollSeek,
-          ...totalListHeight,
-          ...initialScrollTopSystem2,
-          ...alignToBottom,
-          ...windowScroller,
-          ...scrollIntoView,
-          ...logger
-        };
-      },
-      tup(
-        sizeRangeSystem,
-        initialItemCountSystem,
-        propsReadySystem,
-        scrollSeekSystem,
-        totalListHeightSystem,
-        initialScrollTopSystem,
-        alignToBottomSystem,
-        windowScrollerSystem,
-        scrollIntoViewSystem,
-        loggerSystem
-      )
-    );
-    const listSystem = system(
-      ([
-        {
-          totalCount,
-          sizeRanges,
-          fixedItemSize,
-          defaultItemSize,
-          trackItemSizes,
-          itemSize,
-          data,
-          firstItemIndex,
-          groupIndices,
-          statefulTotalCount,
-          gap,
-          sizes
-        },
-        { initialTopMostItemIndex, scrolledToInitialItem, initialItemFinalLocationReached },
-        domIO,
-        stateLoad,
-        followOutput,
-        { listState, topItemsIndexes, ...flags },
-        { scrollToIndex },
-        _2,
-        { topItemCount },
-        { groupCounts },
-        featureGroup1
-      ]) => {
-        connect(flags.rangeChanged, featureGroup1.scrollSeekRangeChanged);
-        connect(
-          pipe(
-            featureGroup1.windowViewportRect,
-            map((value) => value.visibleHeight)
-          ),
-          domIO.viewportHeight
-        );
-        return {
-          // input
-          totalCount,
-          data,
-          firstItemIndex,
-          sizeRanges,
-          initialTopMostItemIndex,
-          scrolledToInitialItem,
-          initialItemFinalLocationReached,
-          topItemsIndexes,
-          topItemCount,
-          groupCounts,
-          fixedItemHeight: fixedItemSize,
-          defaultItemHeight: defaultItemSize,
-          gap,
-          ...followOutput,
-          // output
-          statefulTotalCount,
-          listState,
-          scrollToIndex,
-          trackItemSizes,
-          itemSize,
-          groupIndices,
-          // exported from stateFlagsSystem
-          ...flags,
-          // the bag of IO from featureGroup1System
-          ...featureGroup1,
-          ...domIO,
-          sizes,
-          ...stateLoad
-        };
-      },
-      tup(
-        sizeSystem,
-        initialTopMostItemIndexSystem,
-        domIOSystem,
-        stateLoadSystem,
-        followOutputSystem,
-        listStateSystem,
-        scrollToIndexSystem,
-        upwardScrollFixSystem,
-        topItemCountSystem,
-        groupedListSystem,
-        featureGroup1System
-      )
-    );
-    const WEBKIT_STICKY = "-webkit-sticky";
-    const STICKY = "sticky";
-    const positionStickyCssValue = simpleMemoize(() => {
-      if (typeof document === "undefined") {
-        return STICKY;
-      }
-      const node = document.createElement("div");
-      node.style.position = WEBKIT_STICKY;
-      return node.style.position === WEBKIT_STICKY ? WEBKIT_STICKY : STICKY;
-    });
-    function useWindowViewportRectRef(callback, customScrollParent, skipAnimationFrame) {
-      const viewportInfo = xn.useRef(null);
-      const calculateInfo = xn.useCallback(
-        (element) => {
-          if (element === null || !element.offsetParent) {
-            return;
-          }
-          const rect = element.getBoundingClientRect();
-          const visibleWidth = rect.width;
-          let visibleHeight, offsetTop;
-          if (customScrollParent) {
-            const customScrollParentRect = customScrollParent.getBoundingClientRect();
-            const deltaTop = rect.top - customScrollParentRect.top;
-            visibleHeight = customScrollParentRect.height - Math.max(0, deltaTop);
-            offsetTop = deltaTop + customScrollParent.scrollTop;
-          } else {
-            visibleHeight = window.innerHeight - Math.max(0, rect.top);
-            offsetTop = rect.top + window.pageYOffset;
-          }
-          viewportInfo.current = {
-            offsetTop,
-            visibleHeight,
-            visibleWidth
-          };
-          callback(viewportInfo.current);
-        },
-        [callback, customScrollParent]
-      );
-      const { callbackRef, ref } = useSizeWithElRef(calculateInfo, true, skipAnimationFrame);
-      const scrollAndResizeEventHandler = xn.useCallback(() => {
-        calculateInfo(ref.current);
-      }, [calculateInfo, ref]);
-      xn.useEffect(() => {
-        if (customScrollParent) {
-          customScrollParent.addEventListener("scroll", scrollAndResizeEventHandler);
-          const observer = new ResizeObserver(() => {
-            requestAnimationFrame(scrollAndResizeEventHandler);
-          });
-          observer.observe(customScrollParent);
-          return () => {
-            customScrollParent.removeEventListener("scroll", scrollAndResizeEventHandler);
-            observer.unobserve(customScrollParent);
-          };
-        } else {
-          window.addEventListener("scroll", scrollAndResizeEventHandler);
-          window.addEventListener("resize", scrollAndResizeEventHandler);
-          return () => {
-            window.removeEventListener("scroll", scrollAndResizeEventHandler);
-            window.removeEventListener("resize", scrollAndResizeEventHandler);
-          };
-        }
-      }, [scrollAndResizeEventHandler, customScrollParent]);
-      return callbackRef;
-    }
-    const VirtuosoMockContext = xn.createContext(void 0);
-    const VirtuosoGridMockContext = xn.createContext(void 0);
-    function identity(value) {
-      return value;
-    }
-    const listComponentPropsSystem = /* @__PURE__ */ system(() => {
-      const itemContent = statefulStream((index) => `Item ${index}`);
-      const context = statefulStream(null);
-      const groupContent = statefulStream((index) => `Group ${index}`);
-      const components = statefulStream({});
-      const computeItemKey = statefulStream(identity);
-      const HeaderFooterTag = statefulStream("div");
-      const scrollerRef = statefulStream(noop);
-      const distinctProp = (propName, defaultValue = null) => {
-        return statefulStreamFromEmitter(
-          pipe(
-            components,
-            map((components2) => components2[propName]),
-            distinctUntilChanged()
-          ),
-          defaultValue
-        );
-      };
-      return {
-        context,
-        itemContent,
-        groupContent,
-        components,
-        computeItemKey,
-        HeaderFooterTag,
-        scrollerRef,
-        FooterComponent: distinctProp("Footer"),
-        HeaderComponent: distinctProp("Header"),
-        TopItemListComponent: distinctProp("TopItemList"),
-        ListComponent: distinctProp("List", "div"),
-        ItemComponent: distinctProp("Item", "div"),
-        GroupComponent: distinctProp("Group", "div"),
-        ScrollerComponent: distinctProp("Scroller", "div"),
-        EmptyPlaceholder: distinctProp("EmptyPlaceholder"),
-        ScrollSeekPlaceholder: distinctProp("ScrollSeekPlaceholder")
-      };
-    });
-    const combinedSystem$2 = /* @__PURE__ */ system(([listSystem2, propsSystem]) => {
-      return { ...listSystem2, ...propsSystem };
-    }, tup(listSystem, listComponentPropsSystem));
-    const DefaultScrollSeekPlaceholder$1 = ({ height }) => /* @__PURE__ */ u("div", { style: { height } });
-    const GROUP_STYLE = { position: positionStickyCssValue(), zIndex: 1, overflowAnchor: "none" };
-    const ITEM_STYLE$1 = { overflowAnchor: "none" };
-    const HORIZONTAL_ITEM_STYLE = { ...ITEM_STYLE$1, display: "inline-block", height: "100%" };
-    const Items$1 = /* @__PURE__ */ xn.memo(function VirtuosoItems({ showTopList = false }) {
-      const listState = useEmitterValue$2("listState");
-      const sizeRanges = usePublisher$2("sizeRanges");
-      const useWindowScroll = useEmitterValue$2("useWindowScroll");
-      const customScrollParent = useEmitterValue$2("customScrollParent");
-      const windowScrollContainerStateCallback = usePublisher$2("windowScrollContainerState");
-      const _scrollContainerStateCallback = usePublisher$2("scrollContainerState");
-      const scrollContainerStateCallback = customScrollParent || useWindowScroll ? windowScrollContainerStateCallback : _scrollContainerStateCallback;
-      const itemContent = useEmitterValue$2("itemContent");
-      const context = useEmitterValue$2("context");
-      const groupContent = useEmitterValue$2("groupContent");
-      const trackItemSizes = useEmitterValue$2("trackItemSizes");
-      const itemSize = useEmitterValue$2("itemSize");
-      const log = useEmitterValue$2("log");
-      const listGap = usePublisher$2("gap");
-      const horizontalDirection = useEmitterValue$2("horizontalDirection");
-      const { callbackRef } = useChangedListContentsSizes(
-        sizeRanges,
-        itemSize,
-        trackItemSizes,
-        showTopList ? noop : scrollContainerStateCallback,
-        log,
-        listGap,
-        customScrollParent,
-        horizontalDirection,
-        useEmitterValue$2("skipAnimationFrameInResizeObserver")
-      );
-      const [deviation, setDeviation] = xn.useState(0);
-      useEmitter$2("deviation", (value) => {
-        if (deviation !== value) {
-          setDeviation(value);
-        }
-      });
-      const EmptyPlaceholder = useEmitterValue$2("EmptyPlaceholder");
-      const ScrollSeekPlaceholder = useEmitterValue$2("ScrollSeekPlaceholder") || DefaultScrollSeekPlaceholder$1;
-      const ListComponent = useEmitterValue$2("ListComponent");
-      const ItemComponent = useEmitterValue$2("ItemComponent");
-      const GroupComponent = useEmitterValue$2("GroupComponent");
-      const computeItemKey = useEmitterValue$2("computeItemKey");
-      const isSeeking = useEmitterValue$2("isSeeking");
-      const hasGroups2 = useEmitterValue$2("groupIndices").length > 0;
-      const alignToBottom = useEmitterValue$2("alignToBottom");
-      const initialItemFinalLocationReached = useEmitterValue$2("initialItemFinalLocationReached");
-      const containerStyle = showTopList ? {} : {
-        boxSizing: "border-box",
-        ...horizontalDirection ? {
-          whiteSpace: "nowrap",
-          display: "inline-block",
-          height: "100%",
-          paddingLeft: listState.offsetTop,
-          paddingRight: listState.offsetBottom,
-          marginLeft: deviation !== 0 ? deviation : alignToBottom ? "auto" : 0
-        } : {
-          marginTop: deviation !== 0 ? deviation : alignToBottom ? "auto" : 0,
-          paddingTop: listState.offsetTop,
-          paddingBottom: listState.offsetBottom
-        },
-        ...initialItemFinalLocationReached ? {} : { visibility: "hidden" }
-      };
-      if (!showTopList && listState.totalCount === 0 && EmptyPlaceholder) {
-        return /* @__PURE__ */ u(EmptyPlaceholder, { ...contextPropIfNotDomElement(EmptyPlaceholder, context) });
-      }
-      return /* @__PURE__ */ u(
-        ListComponent,
-        {
-          ...contextPropIfNotDomElement(ListComponent, context),
-          ref: callbackRef,
-          style: containerStyle,
-          "data-testid": showTopList ? "virtuoso-top-item-list" : "virtuoso-item-list",
-          children: (showTopList ? listState.topItems : listState.items).map((item) => {
-            const index = item.originalIndex;
-            const key2 = computeItemKey(index + listState.firstItemIndex, item.data, context);
-            if (isSeeking) {
-              return /* @__PURE__ */ g$2(
-                ScrollSeekPlaceholder,
-                {
-                  ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
-                  key: key2,
-                  index: item.index,
-                  height: item.size,
-                  type: item.type || "item",
-                  ...item.type === "group" ? {} : { groupIndex: item.groupIndex }
-                }
-              );
-            }
-            if (item.type === "group") {
-              return /* @__PURE__ */ g$2(
-                GroupComponent,
-                {
-                  ...contextPropIfNotDomElement(GroupComponent, context),
-                  key: key2,
-                  "data-index": index,
-                  "data-known-size": item.size,
-                  "data-item-index": item.index,
-                  style: GROUP_STYLE
-                },
-                groupContent(item.index, context)
-              );
-            } else {
-              return /* @__PURE__ */ g$2(
-                ItemComponent,
-                {
-                  ...contextPropIfNotDomElement(ItemComponent, context),
-                  ...itemPropIfNotDomElement(ItemComponent, item.data),
-                  key: key2,
-                  "data-index": index,
-                  "data-known-size": item.size,
-                  "data-item-index": item.index,
-                  "data-item-group-index": item.groupIndex,
-                  style: horizontalDirection ? HORIZONTAL_ITEM_STYLE : ITEM_STYLE$1
-                },
-                hasGroups2 ? itemContent(item.index, item.groupIndex, item.data, context) : itemContent(item.index, item.data, context)
-              );
-            }
-          })
-        }
-      );
-    });
-    const scrollerStyle = {
-      height: "100%",
-      outline: "none",
-      overflowY: "auto",
-      position: "relative",
-      WebkitOverflowScrolling: "touch"
-    };
-    const horizontalScrollerStyle = {
-      outline: "none",
-      overflowX: "auto",
-      position: "relative"
-    };
-    const viewportStyle = (alignToBottom) => ({
-      width: "100%",
-      height: "100%",
-      position: "absolute",
-      top: 0,
-      ...alignToBottom ? { display: "flex", flexDirection: "column" } : {}
-    });
-    const topItemListStyle = {
-      width: "100%",
-      position: positionStickyCssValue(),
-      top: 0,
-      zIndex: 1
-    };
-    function contextPropIfNotDomElement(element, context) {
-      if (typeof element === "string") {
-        return void 0;
-      }
-      return { context };
-    }
-    function itemPropIfNotDomElement(element, item) {
-      return { item: typeof element === "string" ? void 0 : item };
-    }
-    const Header$1 = /* @__PURE__ */ xn.memo(function VirtuosoHeader() {
-      const Header2 = useEmitterValue$2("HeaderComponent");
-      const headerHeight = usePublisher$2("headerHeight");
-      const HeaderFooterTag = useEmitterValue$2("HeaderFooterTag");
-      const ref = useSize(
-        xn.useMemo(() => (el) => headerHeight(correctItemSize(el, "height")), [headerHeight]),
-        true,
-        useEmitterValue$2("skipAnimationFrameInResizeObserver")
-      );
-      const context = useEmitterValue$2("context");
-      return Header2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Header2, { ...contextPropIfNotDomElement(Header2, context) }) }) : null;
-    });
-    const Footer$1 = /* @__PURE__ */ xn.memo(function VirtuosoFooter() {
-      const Footer2 = useEmitterValue$2("FooterComponent");
-      const footerHeight = usePublisher$2("footerHeight");
-      const HeaderFooterTag = useEmitterValue$2("HeaderFooterTag");
-      const ref = useSize(
-        xn.useMemo(() => (el) => footerHeight(correctItemSize(el, "height")), [footerHeight]),
-        true,
-        useEmitterValue$2("skipAnimationFrameInResizeObserver")
-      );
-      const context = useEmitterValue$2("context");
-      return Footer2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Footer2, { ...contextPropIfNotDomElement(Footer2, context) }) }) : null;
-    });
-    function buildScroller({ usePublisher: usePublisher2, useEmitter: useEmitter2, useEmitterValue: useEmitterValue2 }) {
-      const Scroller2 = xn.memo(function VirtuosoScroller({ style: style2, children: children2, ...props }) {
-        const scrollContainerStateCallback = usePublisher2("scrollContainerState");
-        const ScrollerComponent = useEmitterValue2("ScrollerComponent");
-        const smoothScrollTargetReached = usePublisher2("smoothScrollTargetReached");
-        const scrollerRefCallback = useEmitterValue2("scrollerRef");
-        const context = useEmitterValue2("context");
-        const horizontalDirection = useEmitterValue2("horizontalDirection") || false;
-        const { scrollerRef, scrollByCallback, scrollToCallback } = useScrollTop(
-          scrollContainerStateCallback,
-          smoothScrollTargetReached,
-          ScrollerComponent,
-          scrollerRefCallback,
-          void 0,
-          horizontalDirection
-        );
-        useEmitter2("scrollTo", scrollToCallback);
-        useEmitter2("scrollBy", scrollByCallback);
-        const defaultStyle = horizontalDirection ? horizontalScrollerStyle : scrollerStyle;
-        return /* @__PURE__ */ u(
-          ScrollerComponent,
-          {
-            ref: scrollerRef,
-            style: { ...defaultStyle, ...style2 },
-            "data-testid": "virtuoso-scroller",
-            "data-virtuoso-scroller": true,
-            tabIndex: 0,
-            ...props,
-            ...contextPropIfNotDomElement(ScrollerComponent, context),
-            children: children2
-          }
-        );
-      });
-      return Scroller2;
-    }
-    function buildWindowScroller({ usePublisher: usePublisher2, useEmitter: useEmitter2, useEmitterValue: useEmitterValue2 }) {
-      const Scroller2 = xn.memo(function VirtuosoWindowScroller({ style: style2, children: children2, ...props }) {
-        const scrollContainerStateCallback = usePublisher2("windowScrollContainerState");
-        const ScrollerComponent = useEmitterValue2("ScrollerComponent");
-        const smoothScrollTargetReached = usePublisher2("smoothScrollTargetReached");
-        const totalListHeight = useEmitterValue2("totalListHeight");
-        const deviation = useEmitterValue2("deviation");
-        const customScrollParent = useEmitterValue2("customScrollParent");
-        const context = useEmitterValue2("context");
-        const { scrollerRef, scrollByCallback, scrollToCallback } = useScrollTop(
-          scrollContainerStateCallback,
-          smoothScrollTargetReached,
-          ScrollerComponent,
-          noop,
-          customScrollParent
-        );
-        useIsomorphicLayoutEffect(() => {
-          scrollerRef.current = customScrollParent ? customScrollParent : window;
-          return () => {
-            scrollerRef.current = null;
-          };
-        }, [scrollerRef, customScrollParent]);
-        useEmitter2("windowScrollTo", scrollToCallback);
-        useEmitter2("scrollBy", scrollByCallback);
-        return /* @__PURE__ */ u(
-          ScrollerComponent,
-          {
-            style: { position: "relative", ...style2, ...totalListHeight !== 0 ? { height: totalListHeight + deviation } : {} },
-            "data-virtuoso-scroller": true,
-            ...props,
-            ...contextPropIfNotDomElement(ScrollerComponent, context),
-            children: children2
-          }
-        );
-      });
-      return Scroller2;
-    }
-    const Viewport$2 = ({ children: children2 }) => {
-      const ctx = xn.useContext(VirtuosoMockContext);
-      const viewportHeight = usePublisher$2("viewportHeight");
-      const fixedItemHeight = usePublisher$2("fixedItemHeight");
-      const alignToBottom = useEmitterValue$2("alignToBottom");
-      const horizontalDirection = useEmitterValue$2("horizontalDirection");
-      const viewportSizeCallbackMemo = xn.useMemo(
-        () => compose(viewportHeight, (el) => correctItemSize(el, horizontalDirection ? "width" : "height")),
-        [viewportHeight, horizontalDirection]
-      );
-      const viewportRef = useSize(viewportSizeCallbackMemo, true, useEmitterValue$2("skipAnimationFrameInResizeObserver"));
-      xn.useEffect(() => {
-        if (ctx) {
-          viewportHeight(ctx.viewportHeight);
-          fixedItemHeight(ctx.itemHeight);
-        }
-      }, [ctx, viewportHeight, fixedItemHeight]);
-      return /* @__PURE__ */ u("div", { style: viewportStyle(alignToBottom), ref: viewportRef, "data-viewport-type": "element", children: children2 });
-    };
-    const WindowViewport$2 = ({ children: children2 }) => {
-      const ctx = xn.useContext(VirtuosoMockContext);
-      const windowViewportRect = usePublisher$2("windowViewportRect");
-      const fixedItemHeight = usePublisher$2("fixedItemHeight");
-      const customScrollParent = useEmitterValue$2("customScrollParent");
-      const viewportRef = useWindowViewportRectRef(
-        windowViewportRect,
-        customScrollParent,
-        useEmitterValue$2("skipAnimationFrameInResizeObserver")
-      );
-      const alignToBottom = useEmitterValue$2("alignToBottom");
-      xn.useEffect(() => {
-        if (ctx) {
-          fixedItemHeight(ctx.itemHeight);
-          windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: 100 });
-        }
-      }, [ctx, windowViewportRect, fixedItemHeight]);
-      return /* @__PURE__ */ u("div", { ref: viewportRef, style: viewportStyle(alignToBottom), "data-viewport-type": "window", children: children2 });
-    };
-    const TopItemListContainer = ({ children: children2 }) => {
-      const TopItemList = useEmitterValue$2("TopItemListComponent") || "div";
-      const headerHeight = useEmitterValue$2("headerHeight");
-      const style2 = { ...topItemListStyle, marginTop: `${headerHeight}px` };
-      const context = useEmitterValue$2("context");
-      return /* @__PURE__ */ u(TopItemList, { style: style2, ...contextPropIfNotDomElement(TopItemList, context), children: children2 });
-    };
-    const ListRoot = /* @__PURE__ */ xn.memo(function VirtuosoRoot(props) {
-      const useWindowScroll = useEmitterValue$2("useWindowScroll");
-      const showTopList = useEmitterValue$2("topItemsIndexes").length > 0;
-      const customScrollParent = useEmitterValue$2("customScrollParent");
-      const TheScroller = customScrollParent || useWindowScroll ? WindowScroller$2 : Scroller$2;
-      const TheViewport = customScrollParent || useWindowScroll ? WindowViewport$2 : Viewport$2;
-      return /* @__PURE__ */ u(TheScroller, { ...props, children: [
-        showTopList && /* @__PURE__ */ u(TopItemListContainer, { children: /* @__PURE__ */ u(Items$1, { showTopList: true }) }),
-        /* @__PURE__ */ u(TheViewport, { children: [
-          /* @__PURE__ */ u(Header$1, {}),
-          /* @__PURE__ */ u(Items$1, {}),
-          /* @__PURE__ */ u(Footer$1, {})
-        ] })
-      ] });
-    });
-    const {
-      Component: List,
-      usePublisher: usePublisher$2,
-      useEmitterValue: useEmitterValue$2,
-      useEmitter: useEmitter$2
-    } = /* @__PURE__ */ systemToComponent(
-      combinedSystem$2,
-      {
-        required: {},
-        optional: {
-          restoreStateFrom: "restoreStateFrom",
-          context: "context",
-          followOutput: "followOutput",
-          itemContent: "itemContent",
-          groupContent: "groupContent",
-          overscan: "overscan",
-          increaseViewportBy: "increaseViewportBy",
-          totalCount: "totalCount",
-          groupCounts: "groupCounts",
-          topItemCount: "topItemCount",
-          firstItemIndex: "firstItemIndex",
-          initialTopMostItemIndex: "initialTopMostItemIndex",
-          components: "components",
-          atBottomThreshold: "atBottomThreshold",
-          atTopThreshold: "atTopThreshold",
-          computeItemKey: "computeItemKey",
-          defaultItemHeight: "defaultItemHeight",
-          fixedItemHeight: "fixedItemHeight",
-          itemSize: "itemSize",
-          scrollSeekConfiguration: "scrollSeekConfiguration",
-          headerFooterTag: "HeaderFooterTag",
-          data: "data",
-          initialItemCount: "initialItemCount",
-          initialScrollTop: "initialScrollTop",
-          alignToBottom: "alignToBottom",
-          useWindowScroll: "useWindowScroll",
-          customScrollParent: "customScrollParent",
-          scrollerRef: "scrollerRef",
-          logLevel: "logLevel",
-          horizontalDirection: "horizontalDirection",
-          skipAnimationFrameInResizeObserver: "skipAnimationFrameInResizeObserver"
-        },
-        methods: {
-          scrollToIndex: "scrollToIndex",
-          scrollIntoView: "scrollIntoView",
-          scrollTo: "scrollTo",
-          scrollBy: "scrollBy",
-          autoscrollToBottom: "autoscrollToBottom",
-          getState: "getState"
-        },
-        events: {
-          isScrolling: "isScrolling",
-          endReached: "endReached",
-          startReached: "startReached",
-          rangeChanged: "rangeChanged",
-          atBottomStateChange: "atBottomStateChange",
-          atTopStateChange: "atTopStateChange",
-          totalListHeightChanged: "totalListHeightChanged",
-          itemsRendered: "itemsRendered",
-          groupIndices: "groupIndices"
-        }
-      },
-      ListRoot
-    );
-    const Scroller$2 = /* @__PURE__ */ buildScroller({ usePublisher: usePublisher$2, useEmitterValue: useEmitterValue$2, useEmitter: useEmitter$2 });
-    const WindowScroller$2 = /* @__PURE__ */ buildWindowScroller({ usePublisher: usePublisher$2, useEmitterValue: useEmitterValue$2, useEmitter: useEmitter$2 });
-    const Virtuoso = List;
-    const INITIAL_GRID_STATE = {
-      items: [],
-      offsetBottom: 0,
-      offsetTop: 0,
-      top: 0,
-      bottom: 0,
-      itemHeight: 0,
-      itemWidth: 0
-    };
-    const PROBE_GRID_STATE = {
-      items: [{ index: 0 }],
-      offsetBottom: 0,
-      offsetTop: 0,
-      top: 0,
-      bottom: 0,
-      itemHeight: 0,
-      itemWidth: 0
-    };
-    const { round, ceil, floor, min, max: max$1 } = Math;
-    function buildProbeGridState(items) {
-      return {
-        ...PROBE_GRID_STATE,
-        items
-      };
-    }
-    function buildItems(startIndex, endIndex, data) {
-      return Array.from({ length: endIndex - startIndex + 1 }).map((_2, i2) => {
-        const dataItem = data === null ? null : data[i2 + startIndex];
-        return { index: i2 + startIndex, data: dataItem };
-      });
-    }
-    function gapComparator(prev, next) {
-      return prev && prev.column === next.column && prev.row === next.row;
-    }
-    function dimensionComparator(prev, next) {
-      return prev && prev.width === next.width && prev.height === next.height;
-    }
-    const gridSystem = /* @__PURE__ */ system(
-      ([
-        { overscan, visibleRange, listBoundary, increaseViewportBy },
-        { scrollTop, viewportHeight, scrollBy, scrollTo, smoothScrollTargetReached, scrollContainerState, footerHeight, headerHeight },
-        stateFlags,
-        scrollSeek,
-        { propsReady, didMount },
-        { windowViewportRect, useWindowScroll, customScrollParent, windowScrollContainerState, windowScrollTo },
-        log
-      ]) => {
-        const totalCount = statefulStream(0);
-        const initialItemCount = statefulStream(0);
-        const gridState = statefulStream(INITIAL_GRID_STATE);
-        const viewportDimensions = statefulStream({ height: 0, width: 0 });
-        const itemDimensions = statefulStream({ height: 0, width: 0 });
-        const scrollToIndex = stream();
-        const scrollHeight = stream();
-        const deviation = statefulStream(0);
-        const data = statefulStream(null);
-        const gap = statefulStream({ row: 0, column: 0 });
-        const stateChanged = stream();
-        const restoreStateFrom = stream();
-        const stateRestoreInProgress = statefulStream(false);
-        const initialTopMostItemIndex = statefulStream(0);
-        const scrolledToInitialItem = statefulStream(true);
-        const scrollScheduled = statefulStream(false);
-        const horizontalDirection = statefulStream(false);
-        subscribe(
-          pipe(
-            didMount,
-            withLatestFrom(initialTopMostItemIndex),
-            filter(([_2, location]) => !!location)
-          ),
-          () => {
-            publish(scrolledToInitialItem, false);
-          }
-        );
-        subscribe(
-          pipe(
-            combineLatest(didMount, scrolledToInitialItem, itemDimensions, viewportDimensions, initialTopMostItemIndex, scrollScheduled),
-            filter(([didMount2, scrolledToInitialItem2, itemDimensions2, viewportDimensions2, , scrollScheduled2]) => {
-              return didMount2 && !scrolledToInitialItem2 && itemDimensions2.height !== 0 && viewportDimensions2.height !== 0 && !scrollScheduled2;
-            })
-          ),
-          ([, , , , initialTopMostItemIndex2]) => {
-            publish(scrollScheduled, true);
-            skipFrames(1, () => {
-              publish(scrollToIndex, initialTopMostItemIndex2);
-            });
-            handleNext(pipe(scrollTop), () => {
-              publish(listBoundary, [0, 0]);
-              publish(scrolledToInitialItem, true);
-            });
-          }
-        );
-        connect(
-          pipe(
-            restoreStateFrom,
-            filter((value) => value !== void 0 && value !== null && value.scrollTop > 0),
-            mapTo(0)
-          ),
-          initialItemCount
-        );
-        subscribe(
-          pipe(
-            didMount,
-            withLatestFrom(restoreStateFrom),
-            filter(([, snapshot]) => snapshot !== void 0 && snapshot !== null)
-          ),
-          ([, snapshot]) => {
-            if (!snapshot) {
-              return;
-            }
-            publish(viewportDimensions, snapshot.viewport), publish(itemDimensions, snapshot == null ? void 0 : snapshot.item);
-            publish(gap, snapshot.gap);
-            if (snapshot.scrollTop > 0) {
-              publish(stateRestoreInProgress, true);
-              handleNext(pipe(scrollTop, skip(1)), (_value) => {
-                publish(stateRestoreInProgress, false);
-              });
-              publish(scrollTo, { top: snapshot.scrollTop });
-            }
-          }
-        );
-        connect(
-          pipe(
-            viewportDimensions,
-            map(({ height }) => height)
-          ),
-          viewportHeight
-        );
-        connect(
-          pipe(
-            combineLatest(
-              duc(viewportDimensions, dimensionComparator),
-              duc(itemDimensions, dimensionComparator),
-              duc(gap, (prev, next) => prev && prev.column === next.column && prev.row === next.row),
-              duc(scrollTop)
-            ),
-            map(([viewport2, item, gap2, scrollTop2]) => ({
-              viewport: viewport2,
-              item,
-              gap: gap2,
-              scrollTop: scrollTop2
-            }))
-          ),
-          stateChanged
-        );
-        connect(
-          pipe(
-            combineLatest(
-              duc(totalCount),
-              visibleRange,
-              duc(gap, gapComparator),
-              duc(itemDimensions, dimensionComparator),
-              duc(viewportDimensions, dimensionComparator),
-              duc(data),
-              duc(initialItemCount),
-              duc(stateRestoreInProgress),
-              duc(scrolledToInitialItem),
-              duc(initialTopMostItemIndex)
-            ),
-            filter(([, , , , , , , stateRestoreInProgress2]) => {
-              return !stateRestoreInProgress2;
-            }),
-            map(
-              ([
-                totalCount2,
-                [startOffset, endOffset],
-                gap2,
-                item,
-                viewport2,
-                data2,
-                initialItemCount2,
-                ,
-                scrolledToInitialItem2,
-                initialTopMostItemIndex2
-              ]) => {
-                const { row: rowGap, column: columnGap } = gap2;
-                const { height: itemHeight, width: itemWidth } = item;
-                const { width: viewportWidth } = viewport2;
-                if (initialItemCount2 === 0 && (totalCount2 === 0 || viewportWidth === 0)) {
-                  return INITIAL_GRID_STATE;
-                }
-                if (itemWidth === 0) {
-                  const startIndex2 = getInitialTopMostItemIndexNumber(initialTopMostItemIndex2, totalCount2);
-                  const endIndex2 = startIndex2 + Math.max(initialItemCount2 - 1, 0);
-                  return buildProbeGridState(buildItems(startIndex2, endIndex2, data2));
-                }
-                const perRow = itemsPerRow(viewportWidth, itemWidth, columnGap);
-                let startIndex;
-                let endIndex;
-                if (!scrolledToInitialItem2) {
-                  startIndex = 0;
-                  endIndex = -1;
-                } else if (startOffset === 0 && endOffset === 0 && initialItemCount2 > 0) {
-                  startIndex = 0;
-                  endIndex = initialItemCount2 - 1;
-                } else {
-                  startIndex = perRow * floor((startOffset + rowGap) / (itemHeight + rowGap));
-                  endIndex = perRow * ceil((endOffset + rowGap) / (itemHeight + rowGap)) - 1;
-                  endIndex = min(totalCount2 - 1, max$1(endIndex, perRow - 1));
-                  startIndex = min(endIndex, max$1(0, startIndex));
-                }
-                const items = buildItems(startIndex, endIndex, data2);
-                const { top: top2, bottom: bottom2 } = gridLayout(viewport2, gap2, item, items);
-                const rowCount = ceil(totalCount2 / perRow);
-                const totalHeight = rowCount * itemHeight + (rowCount - 1) * rowGap;
-                const offsetBottom = totalHeight - bottom2;
-                return { items, offsetTop: top2, offsetBottom, top: top2, bottom: bottom2, itemHeight, itemWidth };
-              }
-            )
-          ),
-          gridState
-        );
-        connect(
-          pipe(
-            data,
-            filter((data2) => data2 !== null),
-            map((data2) => data2.length)
-          ),
-          totalCount
-        );
-        connect(
-          pipe(
-            combineLatest(viewportDimensions, itemDimensions, gridState, gap),
-            filter(([viewportDimensions2, itemDimensions2, { items }]) => {
-              return items.length > 0 && itemDimensions2.height !== 0 && viewportDimensions2.height !== 0;
-            }),
-            map(([viewportDimensions2, itemDimensions2, { items }, gap2]) => {
-              const { top: top2, bottom: bottom2 } = gridLayout(viewportDimensions2, gap2, itemDimensions2, items);
-              return [top2, bottom2];
-            }),
-            distinctUntilChanged(tupleComparator)
-          ),
-          listBoundary
-        );
-        const hasScrolled = statefulStream(false);
-        connect(
-          pipe(
-            scrollTop,
-            withLatestFrom(hasScrolled),
-            map(([scrollTop2, hasScrolled2]) => {
-              return hasScrolled2 || scrollTop2 !== 0;
-            })
-          ),
-          hasScrolled
-        );
-        const endReached = streamFromEmitter(
-          pipe(
-            combineLatest(gridState, totalCount),
-            filter(([{ items }]) => items.length > 0),
-            withLatestFrom(hasScrolled),
-            filter(([[gridState2, totalCount2], hasScrolled2]) => {
-              const lastIndex = gridState2.items[gridState2.items.length - 1].index;
-              const isLastItemRendered = lastIndex === totalCount2 - 1;
-              if (hasScrolled2) return isLastItemRendered;
-              const isFullyRendered = gridState2.bottom > 0 && gridState2.itemHeight > 0 && gridState2.offsetBottom === 0 && gridState2.items.length === totalCount2;
-              return isFullyRendered && isLastItemRendered;
-            }),
-            map(([[, totalCount2]]) => {
-              return totalCount2 - 1;
-            }),
-            distinctUntilChanged()
-          )
-        );
-        const startReached = streamFromEmitter(
-          pipe(
-            duc(gridState),
-            filter(({ items }) => {
-              return items.length > 0 && items[0].index === 0;
-            }),
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            mapTo(0),
-            distinctUntilChanged()
-          )
-        );
-        const rangeChanged = streamFromEmitter(
-          pipe(
-            duc(gridState),
-            withLatestFrom(stateRestoreInProgress),
-            filter(([{ items }, stateRestoreInProgress2]) => items.length > 0 && !stateRestoreInProgress2),
-            map(([{ items }]) => {
-              return {
-                startIndex: items[0].index,
-                endIndex: items[items.length - 1].index
-              };
-            }),
-            distinctUntilChanged(rangeComparator),
-            throttleTime(0)
-          )
-        );
-        connect(rangeChanged, scrollSeek.scrollSeekRangeChanged);
-        connect(
-          pipe(
-            scrollToIndex,
-            withLatestFrom(viewportDimensions, itemDimensions, totalCount, gap),
-            map(([location, viewportDimensions2, itemDimensions2, totalCount2, gap2]) => {
-              const normalLocation = normalizeIndexLocation(location);
-              const { align, behavior, offset: offset2 } = normalLocation;
-              let index = normalLocation.index;
-              if (index === "LAST") {
-                index = totalCount2 - 1;
-              }
-              index = max$1(0, index, min(totalCount2 - 1, index));
-              let top2 = itemTop(viewportDimensions2, gap2, itemDimensions2, index);
-              if (align === "end") {
-                top2 = round(top2 - viewportDimensions2.height + itemDimensions2.height);
-              } else if (align === "center") {
-                top2 = round(top2 - viewportDimensions2.height / 2 + itemDimensions2.height / 2);
-              }
-              if (offset2) {
-                top2 += offset2;
-              }
-              return { top: top2, behavior };
-            })
-          ),
-          scrollTo
-        );
-        const totalListHeight = statefulStreamFromEmitter(
-          pipe(
-            gridState,
-            map((gridState2) => {
-              return gridState2.offsetBottom + gridState2.bottom;
-            })
-          ),
-          0
-        );
-        connect(
-          pipe(
-            windowViewportRect,
-            map((viewportInfo) => ({ width: viewportInfo.visibleWidth, height: viewportInfo.visibleHeight }))
-          ),
-          viewportDimensions
-        );
-        return {
-          // input
-          data,
-          totalCount,
-          viewportDimensions,
-          itemDimensions,
-          scrollTop,
-          scrollHeight,
-          overscan,
-          increaseViewportBy,
-          scrollBy,
-          scrollTo,
-          scrollToIndex,
-          smoothScrollTargetReached,
-          windowViewportRect,
-          windowScrollTo,
-          useWindowScroll,
-          customScrollParent,
-          windowScrollContainerState,
-          deviation,
-          scrollContainerState,
-          footerHeight,
-          headerHeight,
-          initialItemCount,
-          gap,
-          restoreStateFrom,
-          ...scrollSeek,
-          initialTopMostItemIndex,
-          horizontalDirection,
-          // output
-          gridState,
-          totalListHeight,
-          ...stateFlags,
-          startReached,
-          endReached,
-          rangeChanged,
-          stateChanged,
-          propsReady,
-          stateRestoreInProgress,
-          ...log
-        };
-      },
-      tup(sizeRangeSystem, domIOSystem, stateFlagsSystem, scrollSeekSystem, propsReadySystem, windowScrollerSystem, loggerSystem)
-    );
-    function gridLayout(viewport2, gap, item, items) {
-      const { height: itemHeight } = item;
-      if (itemHeight === void 0 || items.length === 0) {
-        return { top: 0, bottom: 0 };
-      }
-      const top2 = itemTop(viewport2, gap, item, items[0].index);
-      const bottom2 = itemTop(viewport2, gap, item, items[items.length - 1].index) + itemHeight;
-      return { top: top2, bottom: bottom2 };
-    }
-    function itemTop(viewport2, gap, item, index) {
-      const perRow = itemsPerRow(viewport2.width, item.width, gap.column);
-      const rowCount = floor(index / perRow);
-      const top2 = rowCount * item.height + max$1(0, rowCount - 1) * gap.row;
-      return top2 > 0 ? top2 + gap.row : top2;
-    }
-    function itemsPerRow(viewportWidth, itemWidth, gap) {
-      return max$1(1, floor((viewportWidth + gap) / (floor(itemWidth) + gap)));
-    }
-    const gridComponentPropsSystem = /* @__PURE__ */ system(() => {
-      const itemContent = statefulStream((index) => `Item ${index}`);
-      const components = statefulStream({});
-      const context = statefulStream(null);
-      const itemClassName = statefulStream("virtuoso-grid-item");
-      const listClassName = statefulStream("virtuoso-grid-list");
-      const computeItemKey = statefulStream(identity);
-      const headerFooterTag = statefulStream("div");
-      const scrollerRef = statefulStream(noop);
-      const distinctProp = (propName, defaultValue = null) => {
-        return statefulStreamFromEmitter(
-          pipe(
-            components,
-            map((components2) => components2[propName]),
-            distinctUntilChanged()
-          ),
-          defaultValue
-        );
-      };
-      const readyStateChanged = statefulStream(false);
-      const reportReadyState = statefulStream(false);
-      connect(duc(reportReadyState), readyStateChanged);
-      return {
-        readyStateChanged,
-        reportReadyState,
-        context,
-        itemContent,
-        components,
-        computeItemKey,
-        itemClassName,
-        listClassName,
-        headerFooterTag,
-        scrollerRef,
-        FooterComponent: distinctProp("Footer"),
-        HeaderComponent: distinctProp("Header"),
-        ListComponent: distinctProp("List", "div"),
-        ItemComponent: distinctProp("Item", "div"),
-        ScrollerComponent: distinctProp("Scroller", "div"),
-        ScrollSeekPlaceholder: distinctProp("ScrollSeekPlaceholder", "div")
-      };
-    });
-    const combinedSystem$1 = /* @__PURE__ */ system(([gridSystem2, gridComponentPropsSystem2]) => {
-      return { ...gridSystem2, ...gridComponentPropsSystem2 };
-    }, tup(gridSystem, gridComponentPropsSystem));
-    const GridItems = /* @__PURE__ */ xn.memo(function GridItems2() {
-      const gridState = useEmitterValue$1("gridState");
-      const listClassName = useEmitterValue$1("listClassName");
-      const itemClassName = useEmitterValue$1("itemClassName");
-      const itemContent = useEmitterValue$1("itemContent");
-      const computeItemKey = useEmitterValue$1("computeItemKey");
-      const isSeeking = useEmitterValue$1("isSeeking");
-      const scrollHeightCallback = usePublisher$1("scrollHeight");
-      const ItemComponent = useEmitterValue$1("ItemComponent");
-      const ListComponent = useEmitterValue$1("ListComponent");
-      const ScrollSeekPlaceholder = useEmitterValue$1("ScrollSeekPlaceholder");
-      const context = useEmitterValue$1("context");
-      const itemDimensions = usePublisher$1("itemDimensions");
-      const gridGap = usePublisher$1("gap");
-      const log = useEmitterValue$1("log");
-      const stateRestoreInProgress = useEmitterValue$1("stateRestoreInProgress");
-      const reportReadyState = usePublisher$1("reportReadyState");
-      const listRef = useSize(
-        xn.useMemo(
-          () => (el) => {
-            const scrollHeight = el.parentElement.parentElement.scrollHeight;
-            scrollHeightCallback(scrollHeight);
-            const firstItem = el.firstChild;
-            if (firstItem) {
-              const { width, height } = firstItem.getBoundingClientRect();
-              itemDimensions({ width, height });
-            }
-            gridGap({
-              row: resolveGapValue("row-gap", getComputedStyle(el).rowGap, log),
-              column: resolveGapValue("column-gap", getComputedStyle(el).columnGap, log)
-            });
-          },
-          [scrollHeightCallback, itemDimensions, gridGap, log]
-        ),
-        true,
-        false
-      );
-      useIsomorphicLayoutEffect(() => {
-        if (gridState.itemHeight > 0 && gridState.itemWidth > 0) {
-          reportReadyState(true);
-        }
-      }, [gridState]);
-      if (stateRestoreInProgress) {
-        return null;
-      }
-      return /* @__PURE__ */ u(
-        ListComponent,
-        {
-          ref: listRef,
-          className: listClassName,
-          ...contextPropIfNotDomElement(ListComponent, context),
-          style: { paddingTop: gridState.offsetTop, paddingBottom: gridState.offsetBottom },
-          "data-testid": "virtuoso-item-list",
-          children: gridState.items.map((item) => {
-            const key2 = computeItemKey(item.index, item.data, context);
-            return isSeeking ? /* @__PURE__ */ u(
-              ScrollSeekPlaceholder,
-              {
-                ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
-                index: item.index,
-                height: gridState.itemHeight,
-                width: gridState.itemWidth
-              },
-              key2
-            ) : /* @__PURE__ */ g$2(
-              ItemComponent,
-              {
-                ...contextPropIfNotDomElement(ItemComponent, context),
-                className: itemClassName,
-                "data-index": item.index,
-                key: key2
-              },
-              itemContent(item.index, item.data, context)
-            );
-          })
-        }
-      );
-    });
-    const Header = xn.memo(function VirtuosoHeader2() {
-      const Header2 = useEmitterValue$1("HeaderComponent");
-      const headerHeight = usePublisher$1("headerHeight");
-      const HeaderFooterTag = useEmitterValue$1("headerFooterTag");
-      const ref = useSize(
-        xn.useMemo(() => (el) => headerHeight(correctItemSize(el, "height")), [headerHeight]),
-        true,
-        false
-      );
-      const context = useEmitterValue$1("context");
-      return Header2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Header2, { ...contextPropIfNotDomElement(Header2, context) }) }) : null;
-    });
-    const Footer = xn.memo(function VirtuosoGridFooter() {
-      const Footer2 = useEmitterValue$1("FooterComponent");
-      const footerHeight = usePublisher$1("footerHeight");
-      const HeaderFooterTag = useEmitterValue$1("headerFooterTag");
-      const ref = useSize(
-        xn.useMemo(() => (el) => footerHeight(correctItemSize(el, "height")), [footerHeight]),
-        true,
-        false
-      );
-      const context = useEmitterValue$1("context");
-      return Footer2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Footer2, { ...contextPropIfNotDomElement(Footer2, context) }) }) : null;
-    });
-    const Viewport$1 = ({ children: children2 }) => {
-      const ctx = xn.useContext(VirtuosoGridMockContext);
-      const itemDimensions = usePublisher$1("itemDimensions");
-      const viewportDimensions = usePublisher$1("viewportDimensions");
-      const viewportRef = useSize(
-        xn.useMemo(
-          () => (el) => {
-            viewportDimensions(el.getBoundingClientRect());
-          },
-          [viewportDimensions]
-        ),
-        true,
-        false
-      );
-      xn.useEffect(() => {
-        if (ctx) {
-          viewportDimensions({ height: ctx.viewportHeight, width: ctx.viewportWidth });
-          itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth });
-        }
-      }, [ctx, viewportDimensions, itemDimensions]);
-      return /* @__PURE__ */ u("div", { style: viewportStyle(false), ref: viewportRef, children: children2 });
-    };
-    const WindowViewport$1 = ({ children: children2 }) => {
-      const ctx = xn.useContext(VirtuosoGridMockContext);
-      const windowViewportRect = usePublisher$1("windowViewportRect");
-      const itemDimensions = usePublisher$1("itemDimensions");
-      const customScrollParent = useEmitterValue$1("customScrollParent");
-      const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent, false);
-      xn.useEffect(() => {
-        if (ctx) {
-          itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth });
-          windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: ctx.viewportWidth });
-        }
-      }, [ctx, windowViewportRect, itemDimensions]);
-      return /* @__PURE__ */ u("div", { ref: viewportRef, style: viewportStyle(false), children: children2 });
-    };
-    const GridRoot = /* @__PURE__ */ xn.memo(function GridRoot2({ ...props }) {
-      const useWindowScroll = useEmitterValue$1("useWindowScroll");
-      const customScrollParent = useEmitterValue$1("customScrollParent");
-      const TheScroller = customScrollParent || useWindowScroll ? WindowScroller$1 : Scroller$1;
-      const TheViewport = customScrollParent || useWindowScroll ? WindowViewport$1 : Viewport$1;
-      return /* @__PURE__ */ u(TheScroller, { ...props, children: /* @__PURE__ */ u(TheViewport, { children: [
-        /* @__PURE__ */ u(Header, {}),
-        /* @__PURE__ */ u(GridItems, {}),
-        /* @__PURE__ */ u(Footer, {})
-      ] }) });
-    });
-    const {
-      Component: Grid,
-      usePublisher: usePublisher$1,
-      useEmitterValue: useEmitterValue$1,
-      useEmitter: useEmitter$1
-    } = /* @__PURE__ */ systemToComponent(
-      combinedSystem$1,
-      {
-        optional: {
-          context: "context",
-          totalCount: "totalCount",
-          overscan: "overscan",
-          itemContent: "itemContent",
-          components: "components",
-          computeItemKey: "computeItemKey",
-          data: "data",
-          initialItemCount: "initialItemCount",
-          scrollSeekConfiguration: "scrollSeekConfiguration",
-          headerFooterTag: "headerFooterTag",
-          listClassName: "listClassName",
-          itemClassName: "itemClassName",
-          useWindowScroll: "useWindowScroll",
-          customScrollParent: "customScrollParent",
-          scrollerRef: "scrollerRef",
-          logLevel: "logLevel",
-          restoreStateFrom: "restoreStateFrom",
-          initialTopMostItemIndex: "initialTopMostItemIndex",
-          increaseViewportBy: "increaseViewportBy"
-        },
-        methods: {
-          scrollTo: "scrollTo",
-          scrollBy: "scrollBy",
-          scrollToIndex: "scrollToIndex"
-        },
-        events: {
-          isScrolling: "isScrolling",
-          endReached: "endReached",
-          startReached: "startReached",
-          rangeChanged: "rangeChanged",
-          atBottomStateChange: "atBottomStateChange",
-          atTopStateChange: "atTopStateChange",
-          stateChanged: "stateChanged",
-          readyStateChanged: "readyStateChanged"
-        }
-      },
-      GridRoot
-    );
-    const Scroller$1 = /* @__PURE__ */ buildScroller({ usePublisher: usePublisher$1, useEmitterValue: useEmitterValue$1, useEmitter: useEmitter$1 });
-    const WindowScroller$1 = /* @__PURE__ */ buildWindowScroller({ usePublisher: usePublisher$1, useEmitterValue: useEmitterValue$1, useEmitter: useEmitter$1 });
-    function resolveGapValue(property, value, log) {
-      if (value !== "normal" && !(value == null ? void 0 : value.endsWith("px"))) {
-        log(`${property} was not resolved to pixel value correctly`, value, LogLevel.WARN);
-      }
-      if (value === "normal") {
-        return 0;
-      }
-      return parseInt(value != null ? value : "0", 10);
-    }
     const TranscriptView = ({ id: id2, events, depth = 0 }) => {
       const resolvedEvents = fixupEventStream(events);
       const eventNodes = treeifyEvents(resolvedEvents, depth);
       return m$1` <${TranscriptComponent} id=${id2} eventNodes=${eventNodes} /> `;
     };
-    const TranscriptVirtualList = ({ id: id2, scrollRef, events, depth, style: style2 }) => {
+    const TranscriptVirtualList = (props) => {
+      let { id: id2, scrollRef, events, depth, style: style2 } = props;
       const resolvedEvents = fixupEventStream(events);
       const eventNodes = treeifyEvents(resolvedEvents, depth);
-      const count = eventNodes ? eventNodes.length : 0;
       return m$1`<${Virtuoso}
       id=${`${id2}-virtual-list`}
+      logLevel=${LogLevel.DEBUG}
       style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
       customScrollParent=${scrollRef.current}
-      totalCount=${count}
+      data=${eventNodes}
       overscan=${{
         reverse: 3,
         main: 2
@@ -29863,16 +29889,18 @@ ${events}
       </${TabPanel}>`
         );
       }
-      tabs.push(m$1`<${TabPanel} 
-          id=${kSampleJsonTabId} 
-          classes="sample-tab"
-          title="JSON" 
-          onSelected=${onSelectedTab} 
-          selected=${selectedTab === kSampleJsonTabId}>
-         <div style=${{ paddingLeft: "0.8em", marginTop: "0.4em" }}> 
-          <${JSONPanel} data=${sample} simple=${true}/>
-        </div>
-      </${TabPanel}>`);
+      if (sample.messages.length < 100) {
+        tabs.push(m$1`<${TabPanel} 
+        id=${kSampleJsonTabId} 
+        classes="sample-tab"
+        title="JSON" 
+        onSelected=${onSelectedTab} 
+        selected=${selectedTab === kSampleJsonTabId}>
+      <div style=${{ paddingLeft: "0.8em", marginTop: "0.4em" }}> 
+        <${JSONPanel} data=${sample} simple=${true}/>
+      </div>
+    </${TabPanel}>`);
+      }
       const tabsetId = `task-sample-details-tab-${id2}`;
       const targetId = `${tabsetId}-content`;
       const printSample = () => {
@@ -30899,6 +30927,8 @@ ${events}
       };
     };
     const asyncJsonParse = async (text2) => {
+      const encoder = new TextEncoder();
+      const encodedText = encoder.encode(text2);
       const blob = new Blob([kWorkerCode], { type: "application/javascript" });
       const blobURL = URL.createObjectURL(blob);
       const worker = new Worker(blobURL);
@@ -30915,7 +30945,7 @@ ${events}
             reject(new Error(error2.message));
           };
         });
-        worker.postMessage({ scriptContent: kJson5ScriptBase64, text: text2 });
+        worker.postMessage({ scriptContent: kJson5ScriptBase64, encodedText }, [encodedText.buffer]);
         return await result;
       } finally {
         worker.terminate();
@@ -30925,12 +30955,14 @@ ${events}
     const kWorkerCode = `
 self.onmessage = function (e) {
   eval(atob(e.data.scriptContent));
-  const text = e.data.text;
+  const { encodedText } = e.data;
+  const decoder = new TextDecoder();
+  const text = decoder.decode(encodedText);
   try {
-    const result = JSON5.parse(text);
-    self.postMessage({ success: true, result });
-  } catch (error) {
-    self.postMessage({ success: false, error: error.message });
+    const result = JSON.parse(text);
+    postMessage({ success: true, result });
+  } catch (err) {
+    postMessage({ success: false, error: err.message });
   }
 };`;
     const kJson5ScriptBase64 = `IWZ1bmN0aW9uKHUsRCl7Im9iamVjdCI9PXR5cGVvZiBleHBvcnRzJiYidW5kZWZpbmVkIiE9dHlwZW9mIG1vZHVsZT9tb2R1bGUuZXhwb3J0cz1EKCk6ImZ1bmN0aW9uIj09dHlwZW9mIGRlZmluZSYmZGVmaW5lLmFtZD9kZWZpbmUoRCk6dS5KU09ONT1EKCl9KHRoaXMsZnVuY3Rpb24oKXsidXNlIHN0cmljdCI7ZnVuY3Rpb24gdSh1LEQpe3JldHVybiB1KEQ9e2V4cG9ydHM6e319LEQuZXhwb3J0cyksRC5leHBvcnRzfXZhciBEPXUoZnVuY3Rpb24odSl7dmFyIEQ9dS5leHBvcnRzPSJ1bmRlZmluZWQiIT10eXBlb2Ygd2luZG93JiZ3aW5kb3cuTWF0aD09TWF0aD93aW5kb3c6InVuZGVmaW5lZCIhPXR5cGVvZiBzZWxmJiZzZWxmLk1hdGg9PU1hdGg/c2VsZjpGdW5jdGlvbigicmV0dXJuIHRoaXMiKSgpOyJudW1iZXIiPT10eXBlb2YgX19nJiYoX19nPUQpfSksZT11KGZ1bmN0aW9uKHUpe3ZhciBEPXUuZXhwb3J0cz17dmVyc2lvbjoiMi42LjUifTsibnVtYmVyIj09dHlwZW9mIF9fZSYmKF9fZT1EKX0pLHI9KGUudmVyc2lvbixmdW5jdGlvbih1KXtyZXR1cm4ib2JqZWN0Ij09dHlwZW9mIHU/bnVsbCE9PXU6ImZ1bmN0aW9uIj09dHlwZW9mIHV9KSx0PWZ1bmN0aW9uKHUpe2lmKCFyKHUpKXRocm93IFR5cGVFcnJvcih1KyIgaXMgbm90IGFuIG9iamVjdCEiKTtyZXR1cm4gdX0sbj1mdW5jdGlvbih1KXt0cnl7cmV0dXJuISF1KCl9Y2F0Y2godSl7cmV0dXJuITB9fSxGPSFuKGZ1bmN0aW9uKCl7cmV0dXJuIDchPU9iamVjdC5kZWZpbmVQcm9wZXJ0eSh7fSwiYSIse2dldDpmdW5jdGlvbigpe3JldHVybiA3fX0pLmF9KSxDPUQuZG9jdW1lbnQsQT1yKEMpJiZyKEMuY3JlYXRlRWxlbWVudCksaT0hRiYmIW4oZnVuY3Rpb24oKXtyZXR1cm4gNyE9T2JqZWN0LmRlZmluZVByb3BlcnR5KCh1PSJkaXYiLEE/Qy5jcmVhdGVFbGVtZW50KHUpOnt9KSwiYSIse2dldDpmdW5jdGlvbigpe3JldHVybiA3fX0pLmE7dmFyIHV9KSxFPU9iamVjdC5kZWZpbmVQcm9wZXJ0eSxvPXtmOkY/T2JqZWN0LmRlZmluZVByb3BlcnR5OmZ1bmN0aW9uKHUsRCxlKXtpZih0KHUpLEQ9ZnVuY3Rpb24odSxEKXtpZighcih1KSlyZXR1cm4gdTt2YXIgZSx0O2lmKEQmJiJmdW5jdGlvbiI9PXR5cGVvZihlPXUudG9TdHJpbmcpJiYhcih0PWUuY2FsbCh1KSkpcmV0dXJuIHQ7aWYoImZ1bmN0aW9uIj09dHlwZW9mKGU9dS52YWx1ZU9mKSYmIXIodD1lLmNhbGwodSkpKXJldHVybiB0O2lmKCFEJiYiZnVuY3Rpb24iPT10eXBlb2YoZT11LnRvU3RyaW5nKSYmIXIodD1lLmNhbGwodSkpKXJldHVybiB0O3Rocm93IFR5cGVFcnJvcigiQ2FuJ3QgY29udmVydCBvYmplY3QgdG8gcHJpbWl0aXZlIHZhbHVlIil9KEQsITApLHQoZSksaSl0cnl7cmV0dXJuIEUodSxELGUpfWNhdGNoKHUpe31pZigiZ2V0ImluIGV8fCJzZXQiaW4gZSl0aHJvdyBUeXBlRXJyb3IoIkFjY2Vzc29ycyBub3Qgc3VwcG9ydGVkISIpO3JldHVybiJ2YWx1ZSJpbiBlJiYodVtEXT1lLnZhbHVlKSx1fX0sYT1GP2Z1bmN0aW9uKHUsRCxlKXtyZXR1cm4gby5mKHUsRCxmdW5jdGlvbih1LEQpe3JldHVybntlbnVtZXJhYmxlOiEoMSZ1KSxjb25maWd1cmFibGU6ISgyJnUpLHdyaXRhYmxlOiEoNCZ1KSx2YWx1ZTpEfX0oMSxlKSl9OmZ1bmN0aW9uKHUsRCxlKXtyZXR1cm4gdVtEXT1lLHV9LGM9e30uaGFzT3duUHJvcGVydHksQj1mdW5jdGlvbih1LEQpe3JldHVybiBjLmNhbGwodSxEKX0scz0wLGY9TWF0aC5yYW5kb20oKSxsPXUoZnVuY3Rpb24odSl7dmFyIHI9RFsiX19jb3JlLWpzX3NoYXJlZF9fIl18fChEWyJfX2NvcmUtanNfc2hhcmVkX18iXT17fSk7KHUuZXhwb3J0cz1mdW5jdGlvbih1LEQpe3JldHVybiByW3VdfHwoclt1XT12b2lkIDAhPT1EP0Q6e30pfSkoInZlcnNpb25zIixbXSkucHVzaCh7dmVyc2lvbjplLnZlcnNpb24sbW9kZToiZ2xvYmFsIixjb3B5cmlnaHQ6IsKpIDIwMTkgRGVuaXMgUHVzaGthcmV2ICh6bG9pcm9jay5ydSkifSl9KSgibmF0aXZlLWZ1bmN0aW9uLXRvLXN0cmluZyIsRnVuY3Rpb24udG9TdHJpbmcpLGQ9dShmdW5jdGlvbih1KXt2YXIgcix0PSJTeW1ib2woIi5jb25jYXQodm9pZCAwPT09KHI9InNyYyIpPyIiOnIsIilfIiwoKytzK2YpLnRvU3RyaW5nKDM2KSksbj0oIiIrbCkuc3BsaXQoInRvU3RyaW5nIik7ZS5pbnNwZWN0U291cmNlPWZ1bmN0aW9uKHUpe3JldHVybiBsLmNhbGwodSl9LCh1LmV4cG9ydHM9ZnVuY3Rpb24odSxlLHIsRil7dmFyIEM9ImZ1bmN0aW9uIj09dHlwZW9mIHI7QyYmKEIociwibmFtZSIpfHxhKHIsIm5hbWUiLGUpKSx1W2VdIT09ciYmKEMmJihCKHIsdCl8fGEocix0LHVbZV0/IiIrdVtlXTpuLmpvaW4oU3RyaW5nKGUpKSkpLHU9PT1EP3VbZV09cjpGP3VbZV0/dVtlXT1yOmEodSxlLHIpOihkZWxldGUgdVtlXSxhKHUsZSxyKSkpfSkoRnVuY3Rpb24ucHJvdG90eXBlLCJ0b1N0cmluZyIsZnVuY3Rpb24oKXtyZXR1cm4iZnVuY3Rpb24iPT10eXBlb2YgdGhpcyYmdGhpc1t0XXx8bC5jYWxsKHRoaXMpfSl9KSx2PWZ1bmN0aW9uKHUsRCxlKXtpZihmdW5jdGlvbih1KXtpZigiZnVuY3Rpb24iIT10eXBlb2YgdSl0aHJvdyBUeXBlRXJyb3IodSsiIGlzIG5vdCBhIGZ1bmN0aW9uISIpfSh1KSx2b2lkIDA9PT1EKXJldHVybiB1O3N3aXRjaChlKXtjYXNlIDE6cmV0dXJuIGZ1bmN0aW9uKGUpe3JldHVybiB1LmNhbGwoRCxlKX07Y2FzZSAyOnJldHVybiBmdW5jdGlvbihlLHIpe3JldHVybiB1LmNhbGwoRCxlLHIpfTtjYXNlIDM6cmV0dXJuIGZ1bmN0aW9uKGUscix0KXtyZXR1cm4gdS5jYWxsKEQsZSxyLHQpfX1yZXR1cm4gZnVuY3Rpb24oKXtyZXR1cm4gdS5hcHBseShELGFyZ3VtZW50cyl9fSxwPWZ1bmN0aW9uKHUscix0KXt2YXIgbixGLEMsQSxpPXUmcC5GLEU9dSZwLkcsbz11JnAuUyxjPXUmcC5QLEI9dSZwLkIscz1FP0Q6bz9EW3JdfHwoRFtyXT17fSk6KERbcl18fHt9KS5wcm90b3R5cGUsZj1FP2U6ZVtyXXx8KGVbcl09e30pLGw9Zi5wcm90b3R5cGV8fChmLnByb3RvdHlwZT17fSk7Zm9yKG4gaW4gRSYmKHQ9ciksdClDPSgoRj0haSYmcyYmdm9pZCAwIT09c1tuXSk/czp0KVtuXSxBPUImJkY/dihDLEQpOmMmJiJmdW5jdGlvbiI9PXR5cGVvZiBDP3YoRnVuY3Rpb24uY2FsbCxDKTpDLHMmJmQocyxuLEMsdSZwLlUpLGZbbl0hPUMmJmEoZixuLEEpLGMmJmxbbl0hPUMmJihsW25dPUMpfTtELmNvcmU9ZSxwLkY9MSxwLkc9MixwLlM9NCxwLlA9OCxwLkI9MTYscC5XPTMyLHAuVT02NCxwLlI9MTI4O3ZhciBoLG09cCxnPU1hdGguY2VpbCx5PU1hdGguZmxvb3Isdz1mdW5jdGlvbih1KXtyZXR1cm4gaXNOYU4odT0rdSk/MDoodT4wP3k6ZykodSl9LGI9KGg9ITEsZnVuY3Rpb24odSxEKXt2YXIgZSxyLHQ9U3RyaW5nKGZ1bmN0aW9uKHUpe2lmKG51bGw9PXUpdGhyb3cgVHlwZUVycm9yKCJDYW4ndCBjYWxsIG1ldGhvZCBvbiAgIit1KTtyZXR1cm4gdX0odSkpLG49dyhEKSxGPXQubGVuZ3RoO3JldHVybiBuPDB8fG4+PUY/aD8iIjp2b2lkIDA6KGU9dC5jaGFyQ29kZUF0KG4pKTw1NTI5Nnx8ZT41NjMxOXx8bisxPT09Rnx8KHI9dC5jaGFyQ29kZUF0KG4rMSkpPDU2MzIwfHxyPjU3MzQzP2g/dC5jaGFyQXQobik6ZTpoP3Quc2xpY2UobixuKzIpOnItNTYzMjArKGUtNTUyOTY8PDEwKSs2NTUzNn0pO20obS5QLCJTdHJpbmciLHtjb2RlUG9pbnRBdDpmdW5jdGlvbih1KXtyZXR1cm4gYih0aGlzLHUpfX0pO2UuU3RyaW5nLmNvZGVQb2ludEF0O3ZhciBTPU1hdGgubWF4LHg9TWF0aC5taW4sTj1TdHJpbmcuZnJvbUNoYXJDb2RlLFA9U3RyaW5nLmZyb21Db2RlUG9pbnQ7bShtLlMrbS5GKighIVAmJjEhPVAubGVuZ3RoKSwiU3RyaW5nIix7ZnJvbUNvZGVQb2ludDpmdW5jdGlvbih1KXtmb3IodmFyIEQsZSxyLHQ9YXJndW1lbnRzLG49W10sRj1hcmd1bWVudHMubGVuZ3RoLEM9MDtGPkM7KXtpZihEPSt0W0MrK10scj0xMTE0MTExLCgoZT13KGU9RCkpPDA/UyhlK3IsMCk6eChlLHIpKSE9PUQpdGhyb3cgUmFuZ2VFcnJvcihEKyIgaXMgbm90IGEgdmFsaWQgY29kZSBwb2ludCIpO24ucHVzaChEPDY1NTM2P04oRCk6Tig1NTI5NisoKEQtPTY1NTM2KT4+MTApLEQlMTAyNCs1NjMyMCkpfXJldHVybiBuLmpvaW4oIiIpfX0pO2UuU3RyaW5nLmZyb21Db2RlUG9pbnQ7dmFyIF8sTyxqLEksVixKLE0sayxMLFQseixILCQsUixHPXtTcGFjZV9TZXBhcmF0b3I6L1tcdTE2ODBcdTIwMDAtXHUyMDBBXHUyMDJGXHUyMDVGXHUzMDAwXS8sSURfU3RhcnQ6L1tceEFBXHhCNVx4QkFceEMwLVx4RDZceEQ4LVx4RjZceEY4LVx1MDJDMVx1MDJDNi1cdTAyRDFcdTAyRTAtXHUwMkU0XHUwMkVDXHUwMkVFXHUwMzcwLVx1MDM3NFx1MDM3Nlx1MDM3N1x1MDM3QS1cdTAzN0RcdTAzN0ZcdTAzODZcdTAzODgtXHUwMzhBXHUwMzhDXHUwMzhFLVx1MDNBMVx1MDNBMy1cdTAzRjVcdTAzRjctXHUwNDgxXHUwNDhBLVx1MDUyRlx1MDUzMS1cdTA1NTZcdTA1NTlcdTA1NjEtXHUwNTg3XHUwNUQwLVx1MDVFQVx1MDVGMC1cdTA1RjJcdTA2MjAtXHUwNjRBXHUwNjZFXHUwNjZGXHUwNjcxLVx1MDZEM1x1MDZENVx1MDZFNVx1MDZFNlx1MDZFRVx1MDZFRlx1MDZGQS1cdTA2RkNcdTA2RkZcdTA3MTBcdTA3MTItXHUwNzJGXHUwNzRELVx1MDdBNVx1MDdCMVx1MDdDQS1cdTA3RUFcdTA3RjRcdTA3RjVcdTA3RkFcdTA4MDAtXHUwODE1XHUwODFBXHUwODI0XHUwODI4XHUwODQwLVx1MDg1OFx1MDg2MC1cdTA4NkFcdTA4QTAtXHUwOEI0XHUwOEI2LVx1MDhCRFx1MDkwNC1cdTA5MzlcdTA5M0RcdTA5NTBcdTA5NTgtXHUwOTYxXHUwOTcxLVx1MDk4MFx1MDk4NS1cdTA5OENcdTA5OEZcdTA5OTBcdTA5OTMtXHUwOUE4XHUwOUFBLVx1MDlCMFx1MDlCMlx1MDlCNi1cdTA5QjlcdTA5QkRcdTA5Q0VcdTA5RENcdTA5RERcdTA5REYtXHUwOUUxXHUwOUYwXHUwOUYxXHUwOUZDXHUwQTA1LVx1MEEwQVx1MEEwRlx1MEExMFx1MEExMy1cdTBBMjhcdTBBMkEtXHUwQTMwXHUwQTMyXHUwQTMzXHUwQTM1XHUwQTM2XHUwQTM4XHUwQTM5XHUwQTU5LVx1MEE1Q1x1MEE1RVx1MEE3Mi1cdTBBNzRcdTBBODUtXHUwQThEXHUwQThGLVx1MEE5MVx1MEE5My1cdTBBQThcdTBBQUEtXHUwQUIwXHUwQUIyXHUwQUIzXHUwQUI1LVx1MEFCOVx1MEFCRFx1MEFEMFx1MEFFMFx1MEFFMVx1MEFGOVx1MEIwNS1cdTBCMENcdTBCMEZcdTBCMTBcdTBCMTMtXHUwQjI4XHUwQjJBLVx1MEIzMFx1MEIzMlx1MEIzM1x1MEIzNS1cdTBCMzlcdTBCM0RcdTBCNUNcdTBCNURcdTBCNUYtXHUwQjYxXHUwQjcxXHUwQjgzXHUwQjg1LVx1MEI4QVx1MEI4RS1cdTBCOTBcdTBCOTItXHUwQjk1XHUwQjk5XHUwQjlBXHUwQjlDXHUwQjlFXHUwQjlGXHUwQkEzXHUwQkE0XHUwQkE4LVx1MEJBQVx1MEJBRS1cdTBCQjlcdTBCRDBcdTBDMDUtXHUwQzBDXHUwQzBFLVx1MEMxMFx1MEMxMi1cdTBDMjhcdTBDMkEtXHUwQzM5XHUwQzNEXHUwQzU4LVx1MEM1QVx1MEM2MFx1MEM2MVx1MEM4MFx1MEM4NS1cdTBDOENcdTBDOEUtXHUwQzkwXHUwQzkyLVx1MENBOFx1MENBQS1cdTBDQjNcdTBDQjUtXHUwQ0I5XHUwQ0JEXHUwQ0RFXHUwQ0UwXHUwQ0UxXHUwQ0YxXHUwQ0YyXHUwRDA1LVx1MEQwQ1x1MEQwRS1cdTBEMTBcdTBEMTItXHUwRDNBXHUwRDNEXHUwRDRFXHUwRDU0LVx1MEQ1Nlx1MEQ1Ri1cdTBENjFcdTBEN0EtXHUwRDdGXHUwRDg1LVx1MEQ5Nlx1MEQ5QS1cdTBEQjFcdTBEQjMtXHUwREJCXHUwREJEXHUwREMwLVx1MERDNlx1MEUwMS1cdTBFMzBcdTBFMzJcdTBFMzNcdTBFNDAtXHUwRTQ2XHUwRTgxXHUwRTgyXHUwRTg0XHUwRTg3XHUwRTg4XHUwRThBXHUwRThEXHUwRTk0LVx1MEU5N1x1MEU5OS1cdTBFOUZcdTBFQTEtXHUwRUEzXHUwRUE1XHUwRUE3XHUwRUFBXHUwRUFCXHUwRUFELVx1MEVCMFx1MEVCMlx1MEVCM1x1MEVCRFx1MEVDMC1cdTBFQzRcdTBFQzZcdTBFREMtXHUwRURGXHUwRjAwXHUwRjQwLVx1MEY0N1x1MEY0OS1cdTBGNkNcdTBGODgtXHUwRjhDXHUxMDAwLVx1MTAyQVx1MTAzRlx1MTA1MC1cdTEwNTVcdTEwNUEtXHUxMDVEXHUxMDYxXHUxMDY1XHUxMDY2XHUxMDZFLVx1MTA3MFx1MTA3NS1cdTEwODFcdTEwOEVcdTEwQTAtXHUxMEM1XHUxMEM3XHUxMENEXHUxMEQwLVx1MTBGQVx1MTBGQy1cdTEyNDhcdTEyNEEtXHUxMjREXHUxMjUwLVx1MTI1Nlx1MTI1OFx1MTI1QS1cdTEyNURcdTEyNjAtXHUxMjg4XHUxMjhBLVx1MTI4RFx1MTI5MC1cdTEyQjBcdTEyQjItXHUxMkI1XHUxMkI4LVx1MTJCRVx1MTJDMFx1MTJDMi1cdTEyQzVcdTEyQzgtXHUxMkQ2XHUxMkQ4LVx1MTMxMFx1MTMxMi1cdTEzMTVcdTEzMTgtXHUxMzVBXHUxMzgwLVx1MTM4Rlx1MTNBMC1cdTEzRjVcdTEzRjgtXHUxM0ZEXHUxNDAxLVx1MTY2Q1x1MTY2Ri1cdTE2N0ZcdTE2ODEtXHUxNjlBXHUxNkEwLVx1MTZFQVx1MTZFRS1cdTE2RjhcdTE3MDAtXHUxNzBDXHUxNzBFLVx1MTcxMVx1MTcyMC1cdTE3MzFcdTE3NDAtXHUxNzUxXHUxNzYwLVx1MTc2Q1x1MTc2RS1cdTE3NzBcdTE3ODAtXHUxN0IzXHUxN0Q3XHUxN0RDXHUxODIwLVx1MTg3N1x1MTg4MC1cdTE4ODRcdTE4ODctXHUxOEE4XHUxOEFBXHUxOEIwLVx1MThGNVx1MTkwMC1cdTE5MUVcdTE5NTAtXHUxOTZEXHUxOTcwLVx1MTk3NFx1MTk4MC1cdTE5QUJcdTE5QjAtXHUxOUM5XHUxQTAwLVx1MUExNlx1MUEyMC1cdTFBNTRcdTFBQTdcdTFCMDUtXHUxQjMzXHUxQjQ1LVx1MUI0Qlx1MUI4My1cdTFCQTBcdTFCQUVcdTFCQUZcdTFCQkEtXHUxQkU1XHUxQzAwLVx1MUMyM1x1MUM0RC1cdTFDNEZcdTFDNUEtXHUxQzdEXHUxQzgwLVx1MUM4OFx1MUNFOS1cdTFDRUNcdTFDRUUtXHUxQ0YxXHUxQ0Y1XHUxQ0Y2XHUxRDAwLVx1MURCRlx1MUUwMC1cdTFGMTVcdTFGMTgtXHUxRjFEXHUxRjIwLVx1MUY0NVx1MUY0OC1cdTFGNERcdTFGNTAtXHUxRjU3XHUxRjU5XHUxRjVCXHUxRjVEXHUxRjVGLVx1MUY3RFx1MUY4MC1cdTFGQjRcdTFGQjYtXHUxRkJDXHUxRkJFXHUxRkMyLVx1MUZDNFx1MUZDNi1cdTFGQ0NcdTFGRDAtXHUxRkQzXHUxRkQ2LVx1MUZEQlx1MUZFMC1cdTFGRUNcdTFGRjItXHUxRkY0XHUxRkY2LVx1MUZGQ1x1MjA3MVx1MjA3Rlx1MjA5MC1cdTIwOUNcdTIxMDJcdTIxMDdcdTIxMEEtXHUyMTEzXHUyMTE1XHUyMTE5LVx1MjExRFx1MjEyNFx1MjEyNlx1MjEyOFx1MjEyQS1cdTIxMkRcdTIxMkYtXHUyMTM5XHUyMTNDLVx1MjEzRlx1MjE0NS1cdTIxNDlcdTIxNEVcdTIxNjAtXHUyMTg4XHUyQzAwLVx1MkMyRVx1MkMzMC1cdTJDNUVcdTJDNjAtXHUyQ0U0XHUyQ0VCLVx1MkNFRVx1MkNGMlx1MkNGM1x1MkQwMC1cdTJEMjVcdTJEMjdcdTJEMkRcdTJEMzAtXHUyRDY3XHUyRDZGXHUyRDgwLVx1MkQ5Nlx1MkRBMC1cdTJEQTZcdTJEQTgtXHUyREFFXHUyREIwLVx1MkRCNlx1MkRCOC1cdTJEQkVcdTJEQzAtXHUyREM2XHUyREM4LVx1MkRDRVx1MkREMC1cdTJERDZcdTJERDgtXHUyRERFXHUyRTJGXHUzMDA1LVx1MzAwN1x1MzAyMS1cdTMwMjlcdTMwMzEtXHUzMDM1XHUzMDM4LVx1MzAzQ1x1MzA0MS1cdTMwOTZcdTMwOUQtXHUzMDlGXHUzMEExLVx1MzBGQVx1MzBGQy1cdTMwRkZcdTMxMDUtXHUzMTJFXHUzMTMxLVx1MzE4RVx1MzFBMC1cdTMxQkFcdTMxRjAtXHUzMUZGXHUzNDAwLVx1NERCNVx1NEUwMC1cdTlGRUFcdUEwMDAtXHVBNDhDXHVBNEQwLVx1QTRGRFx1QTUwMC1cdUE2MENcdUE2MTAtXHVBNjFGXHVBNjJBXHVBNjJCXHVBNjQwLVx1QTY2RVx1QTY3Ri1cdUE2OURcdUE2QTAtXHVBNkVGXHVBNzE3LVx1QTcxRlx1QTcyMi1cdUE3ODhcdUE3OEItXHVBN0FFXHVBN0IwLVx1QTdCN1x1QTdGNy1cdUE4MDFcdUE4MDMtXHVBODA1XHVBODA3LVx1QTgwQVx1QTgwQy1cdUE4MjJcdUE4NDAtXHVBODczXHVBODgyLVx1QThCM1x1QThGMi1cdUE4RjdcdUE4RkJcdUE4RkRcdUE5MEEtXHVBOTI1XHVBOTMwLVx1QTk0Nlx1QTk2MC1cdUE5N0NcdUE5ODQtXHVBOUIyXHVBOUNGXHVBOUUwLVx1QTlFNFx1QTlFNi1cdUE5RUZcdUE5RkEtXHVBOUZFXHVBQTAwLVx1QUEyOFx1QUE0MC1cdUFBNDJcdUFBNDQtXHVBQTRCXHVBQTYwLVx1QUE3Nlx1QUE3QVx1QUE3RS1cdUFBQUZcdUFBQjFcdUFBQjVcdUFBQjZcdUFBQjktXHVBQUJEXHVBQUMwXHVBQUMyXHVBQURCLVx1QUFERFx1QUFFMC1cdUFBRUFcdUFBRjItXHVBQUY0XHVBQjAxLVx1QUIwNlx1QUIwOS1cdUFCMEVcdUFCMTEtXHVBQjE2XHVBQjIwLVx1QUIyNlx1QUIyOC1cdUFCMkVcdUFCMzAtXHVBQjVBXHVBQjVDLVx1QUI2NVx1QUI3MC1cdUFCRTJcdUFDMDAtXHVEN0EzXHVEN0IwLVx1RDdDNlx1RDdDQi1cdUQ3RkJcdUY5MDAtXHVGQTZEXHVGQTcwLVx1RkFEOVx1RkIwMC1cdUZCMDZcdUZCMTMtXHVGQjE3XHVGQjFEXHVGQjFGLVx1RkIyOFx1RkIyQS1cdUZCMzZcdUZCMzgtXHVGQjNDXHVGQjNFXHVGQjQwXHVGQjQxXHVGQjQzXHVGQjQ0XHVGQjQ2LVx1RkJCMVx1RkJEMy1cdUZEM0RcdUZENTAtXHVGRDhGXHVGRDkyLVx1RkRDN1x1RkRGMC1cdUZERkJcdUZFNzAtXHVGRTc0XHVGRTc2LVx1RkVGQ1x1RkYyMS1cdUZGM0FcdUZGNDEtXHVGRjVBXHVGRjY2LVx1RkZCRVx1RkZDMi1cdUZGQzdcdUZGQ0EtXHVGRkNGXHVGRkQyLVx1RkZEN1x1RkZEQS1cdUZGRENdfFx1RDgwMFtcdURDMDAtXHVEQzBCXHVEQzBELVx1REMyNlx1REMyOC1cdURDM0FcdURDM0NcdURDM0RcdURDM0YtXHVEQzREXHVEQzUwLVx1REM1RFx1REM4MC1cdURDRkFcdURENDAtXHVERDc0XHVERTgwLVx1REU5Q1x1REVBMC1cdURFRDBcdURGMDAtXHVERjFGXHVERjJELVx1REY0QVx1REY1MC1cdURGNzVcdURGODAtXHVERjlEXHVERkEwLVx1REZDM1x1REZDOC1cdURGQ0ZcdURGRDEtXHVERkQ1XXxcdUQ4MDFbXHVEQzAwLVx1REM5RFx1RENCMC1cdURDRDNcdURDRDgtXHVEQ0ZCXHVERDAwLVx1REQyN1x1REQzMC1cdURENjNcdURFMDAtXHVERjM2XHVERjQwLVx1REY1NVx1REY2MC1cdURGNjddfFx1RDgwMltcdURDMDAtXHVEQzA1XHVEQzA4XHVEQzBBLVx1REMzNVx1REMzN1x1REMzOFx1REMzQ1x1REMzRi1cdURDNTVcdURDNjAtXHVEQzc2XHVEQzgwLVx1REM5RVx1RENFMC1cdURDRjJcdURDRjRcdURDRjVcdUREMDAtXHVERDE1XHVERDIwLVx1REQzOVx1REQ4MC1cdUREQjdcdUREQkVcdUREQkZcdURFMDBcdURFMTAtXHVERTEzXHVERTE1LVx1REUxN1x1REUxOS1cdURFMzNcdURFNjAtXHVERTdDXHVERTgwLVx1REU5Q1x1REVDMC1cdURFQzdcdURFQzktXHVERUU0XHVERjAwLVx1REYzNVx1REY0MC1cdURGNTVcdURGNjAtXHVERjcyXHVERjgwLVx1REY5MV18XHVEODAzW1x1REMwMC1cdURDNDhcdURDODAtXHVEQ0IyXHVEQ0MwLVx1RENGMl18XHVEODA0W1x1REMwMy1cdURDMzdcdURDODMtXHVEQ0FGXHVEQ0QwLVx1RENFOFx1REQwMy1cdUREMjZcdURENTAtXHVERDcyXHVERDc2XHVERDgzLVx1RERCMlx1RERDMS1cdUREQzRcdUREREFcdURERENcdURFMDAtXHVERTExXHVERTEzLVx1REUyQlx1REU4MC1cdURFODZcdURFODhcdURFOEEtXHVERThEXHVERThGLVx1REU5RFx1REU5Ri1cdURFQThcdURFQjAtXHVERURFXHVERjA1LVx1REYwQ1x1REYwRlx1REYxMFx1REYxMy1cdURGMjhcdURGMkEtXHVERjMwXHVERjMyXHVERjMzXHVERjM1LVx1REYzOVx1REYzRFx1REY1MFx1REY1RC1cdURGNjFdfFx1RDgwNVtcdURDMDAtXHVEQzM0XHVEQzQ3LVx1REM0QVx1REM4MC1cdURDQUZcdURDQzRcdURDQzVcdURDQzdcdUREODAtXHVEREFFXHVEREQ4LVx1REREQlx1REUwMC1cdURFMkZcdURFNDRcdURFODAtXHVERUFBXHVERjAwLVx1REYxOV18XHVEODA2W1x1RENBMC1cdURDREZcdURDRkZcdURFMDBcdURFMEItXHVERTMyXHVERTNBXHVERTUwXHVERTVDLVx1REU4M1x1REU4Ni1cdURFODlcdURFQzAtXHVERUY4XXxcdUQ4MDdbXHVEQzAwLVx1REMwOFx1REMwQS1cdURDMkVcdURDNDBcdURDNzItXHVEQzhGXHVERDAwLVx1REQwNlx1REQwOFx1REQwOVx1REQwQi1cdUREMzBcdURENDZdfFx1RDgwOFtcdURDMDAtXHVERjk5XXxcdUQ4MDlbXHVEQzAwLVx1REM2RVx1REM4MC1cdURENDNdfFtcdUQ4MENcdUQ4MUMtXHVEODIwXHVEODQwLVx1RDg2OFx1RDg2QS1cdUQ4NkNcdUQ4NkYtXHVEODcyXHVEODc0LVx1RDg3OV1bXHVEQzAwLVx1REZGRl18XHVEODBEW1x1REMwMC1cdURDMkVdfFx1RDgxMVtcdURDMDAtXHVERTQ2XXxcdUQ4MUFbXHVEQzAwLVx1REUzOFx1REU0MC1cdURFNUVcdURFRDAtXHVERUVEXHVERjAwLVx1REYyRlx1REY0MC1cdURGNDNcdURGNjMtXHVERjc3XHVERjdELVx1REY4Rl18XHVEODFCW1x1REYwMC1cdURGNDRcdURGNTBcdURGOTMtXHVERjlGXHVERkUwXHVERkUxXXxcdUQ4MjFbXHVEQzAwLVx1REZFQ118XHVEODIyW1x1REMwMC1cdURFRjJdfFx1RDgyQ1tcdURDMDAtXHVERDFFXHVERDcwLVx1REVGQl18XHVEODJGW1x1REMwMC1cdURDNkFcdURDNzAtXHVEQzdDXHVEQzgwLVx1REM4OFx1REM5MC1cdURDOTldfFx1RDgzNVtcdURDMDAtXHVEQzU0XHVEQzU2LVx1REM5Q1x1REM5RVx1REM5Rlx1RENBMlx1RENBNVx1RENBNlx1RENBOS1cdURDQUNcdURDQUUtXHVEQ0I5XHVEQ0JCXHVEQ0JELVx1RENDM1x1RENDNS1cdUREMDVcdUREMDctXHVERDBBXHVERDBELVx1REQxNFx1REQxNi1cdUREMUNcdUREMUUtXHVERDM5XHVERDNCLVx1REQzRVx1REQ0MC1cdURENDRcdURENDZcdURENEEtXHVERDUwXHVERDUyLVx1REVBNVx1REVBOC1cdURFQzBcdURFQzItXHVERURBXHVERURDLVx1REVGQVx1REVGQy1cdURGMTRcdURGMTYtXHVERjM0XHVERjM2LVx1REY0RVx1REY1MC1cdURGNkVcdURGNzAtXHVERjg4XHVERjhBLVx1REZBOFx1REZBQS1cdURGQzJcdURGQzQtXHVERkNCXXxcdUQ4M0FbXHVEQzAwLVx1RENDNFx1REQwMC1cdURENDNdfFx1RDgzQltcdURFMDAtXHVERTAzXHVERTA1LVx1REUxRlx1REUyMVx1REUyMlx1REUyNFx1REUyN1x1REUyOS1cdURFMzJcdURFMzQtXHVERTM3XHVERTM5XHVERTNCXHVERTQyXHVERTQ3XHVERTQ5XHVERTRCXHVERTRELVx1REU0Rlx1REU1MVx1REU1Mlx1REU1NFx1REU1N1x1REU1OVx1REU1Qlx1REU1RFx1REU1Rlx1REU2MVx1REU2Mlx1REU2NFx1REU2Ny1cdURFNkFcdURFNkMtXHVERTcyXHVERTc0LVx1REU3N1x1REU3OS1cdURFN0NcdURFN0VcdURFODAtXHVERTg5XHVERThCLVx1REU5Qlx1REVBMS1cdURFQTNcdURFQTUtXHVERUE5XHVERUFCLVx1REVCQl18XHVEODY5W1x1REMwMC1cdURFRDZcdURGMDAtXHVERkZGXXxcdUQ4NkRbXHVEQzAwLVx1REYzNFx1REY0MC1cdURGRkZdfFx1RDg2RVtcdURDMDAtXHVEQzFEXHVEQzIwLVx1REZGRl18XHVEODczW1x1REMwMC1cdURFQTFcdURFQjAtXHVERkZGXXxcdUQ4N0FbXHVEQzAwLVx1REZFMF18XHVEODdFW1x1REMwMC1cdURFMURdLyxJRF9Db250aW51ZTovW1x4QUFceEI1XHhCQVx4QzAtXHhENlx4RDgtXHhGNlx4RjgtXHUwMkMxXHUwMkM2LVx1MDJEMVx1MDJFMC1cdTAyRTRcdTAyRUNcdTAyRUVcdTAzMDAtXHUwMzc0XHUwMzc2XHUwMzc3XHUwMzdBLVx1MDM3RFx1MDM3Rlx1MDM4Nlx1MDM4OC1cdTAzOEFcdTAzOENcdTAzOEUtXHUwM0ExXHUwM0EzLVx1MDNGNVx1MDNGNy1cdTA0ODFcdTA0ODMtXHUwNDg3XHUwNDhBLVx1MDUyRlx1MDUzMS1cdTA1NTZcdTA1NTlcdTA1NjEtXHUwNTg3XHUwNTkxLVx1MDVCRFx1MDVCRlx1MDVDMVx1MDVDMlx1MDVDNFx1MDVDNVx1MDVDN1x1MDVEMC1cdTA1RUFcdTA1RjAtXHUwNUYyXHUwNjEwLVx1MDYxQVx1MDYyMC1cdTA2NjlcdTA2NkUtXHUwNkQzXHUwNkQ1LVx1MDZEQ1x1MDZERi1cdTA2RThcdTA2RUEtXHUwNkZDXHUwNkZGXHUwNzEwLVx1MDc0QVx1MDc0RC1cdTA3QjFcdTA3QzAtXHUwN0Y1XHUwN0ZBXHUwODAwLVx1MDgyRFx1MDg0MC1cdTA4NUJcdTA4NjAtXHUwODZBXHUwOEEwLVx1MDhCNFx1MDhCNi1cdTA4QkRcdTA4RDQtXHUwOEUxXHUwOEUzLVx1MDk2M1x1MDk2Ni1cdTA5NkZcdTA5NzEtXHUwOTgzXHUwOTg1LVx1MDk4Q1x1MDk4Rlx1MDk5MFx1MDk5My1cdTA5QThcdTA5QUEtXHUwOUIwXHUwOUIyXHUwOUI2LVx1MDlCOVx1MDlCQy1cdTA5QzRcdTA5QzdcdTA5QzhcdTA5Q0ItXHUwOUNFXHUwOUQ3XHUwOURDXHUwOUREXHUwOURGLVx1MDlFM1x1MDlFNi1cdTA5RjFcdTA5RkNcdTBBMDEtXHUwQTAzXHUwQTA1LVx1MEEwQVx1MEEwRlx1MEExMFx1MEExMy1cdTBBMjhcdTBBMkEtXHUwQTMwXHUwQTMyXHUwQTMzXHUwQTM1XHUwQTM2XHUwQTM4XHUwQTM5XHUwQTNDXHUwQTNFLVx1MEE0Mlx1MEE0N1x1MEE0OFx1MEE0Qi1cdTBBNERcdTBBNTFcdTBBNTktXHUwQTVDXHUwQTVFXHUwQTY2LVx1MEE3NVx1MEE4MS1cdTBBODNcdTBBODUtXHUwQThEXHUwQThGLVx1MEE5MVx1MEE5My1cdTBBQThcdTBBQUEtXHUwQUIwXHUwQUIyXHUwQUIzXHUwQUI1LVx1MEFCOVx1MEFCQy1cdTBBQzVcdTBBQzctXHUwQUM5XHUwQUNCLVx1MEFDRFx1MEFEMFx1MEFFMC1cdTBBRTNcdTBBRTYtXHUwQUVGXHUwQUY5LVx1MEFGRlx1MEIwMS1cdTBCMDNcdTBCMDUtXHUwQjBDXHUwQjBGXHUwQjEwXHUwQjEzLVx1MEIyOFx1MEIyQS1cdTBCMzBcdTBCMzJcdTBCMzNcdTBCMzUtXHUwQjM5XHUwQjNDLVx1MEI0NFx1MEI0N1x1MEI0OFx1MEI0Qi1cdTBCNERcdTBCNTZcdTBCNTdcdTBCNUNcdTBCNURcdTBCNUYtXHUwQjYzXHUwQjY2LVx1MEI2Rlx1MEI3MVx1MEI4Mlx1MEI4M1x1MEI4NS1cdTBCOEFcdTBCOEUtXHUwQjkwXHUwQjkyLVx1MEI5NVx1MEI5OVx1MEI5QVx1MEI5Q1x1MEI5RVx1MEI5Rlx1MEJBM1x1MEJBNFx1MEJBOC1cdTBCQUFcdTBCQUUtXHUwQkI5XHUwQkJFLVx1MEJDMlx1MEJDNi1cdTBCQzhcdTBCQ0EtXHUwQkNEXHUwQkQwXHUwQkQ3XHUwQkU2LVx1MEJFRlx1MEMwMC1cdTBDMDNcdTBDMDUtXHUwQzBDXHUwQzBFLVx1MEMxMFx1MEMxMi1cdTBDMjhcdTBDMkEtXHUwQzM5XHUwQzNELVx1MEM0NFx1MEM0Ni1cdTBDNDhcdTBDNEEtXHUwQzREXHUwQzU1XHUwQzU2XHUwQzU4LVx1MEM1QVx1MEM2MC1cdTBDNjNcdTBDNjYtXHUwQzZGXHUwQzgwLVx1MEM4M1x1MEM4NS1cdTBDOENcdTBDOEUtXHUwQzkwXHUwQzkyLVx1MENBOFx1MENBQS1cdTBDQjNcdTBDQjUtXHUwQ0I5XHUwQ0JDLVx1MENDNFx1MENDNi1cdTBDQzhcdTBDQ0EtXHUwQ0NEXHUwQ0Q1XHUwQ0Q2XHUwQ0RFXHUwQ0UwLVx1MENFM1x1MENFNi1cdTBDRUZcdTBDRjFcdTBDRjJcdTBEMDAtXHUwRDAzXHUwRDA1LVx1MEQwQ1x1MEQwRS1cdTBEMTBcdTBEMTItXHUwRDQ0XHUwRDQ2LVx1MEQ0OFx1MEQ0QS1cdTBENEVcdTBENTQtXHUwRDU3XHUwRDVGLVx1MEQ2M1x1MEQ2Ni1cdTBENkZcdTBEN0EtXHUwRDdGXHUwRDgyXHUwRDgzXHUwRDg1LVx1MEQ5Nlx1MEQ5QS1cdTBEQjFcdTBEQjMtXHUwREJCXHUwREJEXHUwREMwLVx1MERDNlx1MERDQVx1MERDRi1cdTBERDRcdTBERDZcdTBERDgtXHUwRERGXHUwREU2LVx1MERFRlx1MERGMlx1MERGM1x1MEUwMS1cdTBFM0FcdTBFNDAtXHUwRTRFXHUwRTUwLVx1MEU1OVx1MEU4MVx1MEU4Mlx1MEU4NFx1MEU4N1x1MEU4OFx1MEU4QVx1MEU4RFx1MEU5NC1cdTBFOTdcdTBFOTktXHUwRTlGXHUwRUExLVx1MEVBM1x1MEVBNVx1MEVBN1x1MEVBQVx1MEVBQlx1MEVBRC1cdTBFQjlcdTBFQkItXHUwRUJEXHUwRUMwLVx1MEVDNFx1MEVDNlx1MEVDOC1cdTBFQ0RcdTBFRDAtXHUwRUQ5XHUwRURDLVx1MEVERlx1MEYwMFx1MEYxOFx1MEYxOVx1MEYyMC1cdTBGMjlcdTBGMzVcdTBGMzdcdTBGMzlcdTBGM0UtXHUwRjQ3XHUwRjQ5LVx1MEY2Q1x1MEY3MS1cdTBGODRcdTBGODYtXHUwRjk3XHUwRjk5LVx1MEZCQ1x1MEZDNlx1MTAwMC1cdTEwNDlcdTEwNTAtXHUxMDlEXHUxMEEwLVx1MTBDNVx1MTBDN1x1MTBDRFx1MTBEMC1cdTEwRkFcdTEwRkMtXHUxMjQ4XHUxMjRBLVx1MTI0RFx1MTI1MC1cdTEyNTZcdTEyNThcdTEyNUEtXHUxMjVEXHUxMjYwLVx1MTI4OFx1MTI4QS1cdTEyOERcdTEyOTAtXHUxMkIwXHUxMkIyLVx1MTJCNVx1MTJCOC1cdTEyQkVcdTEyQzBcdTEyQzItXHUxMkM1XHUxMkM4LVx1MTJENlx1MTJEOC1cdTEzMTBcdTEzMTItXHUxMzE1XHUxMzE4LVx1MTM1QVx1MTM1RC1cdTEzNUZcdTEzODAtXHUxMzhGXHUxM0EwLVx1MTNGNVx1MTNGOC1cdTEzRkRcdTE0MDEtXHUxNjZDXHUxNjZGLVx1MTY3Rlx1MTY4MS1cdTE2OUFcdTE2QTAtXHUxNkVBXHUxNkVFLVx1MTZGOFx1MTcwMC1cdTE3MENcdTE3MEUtXHUxNzE0XHUxNzIwLVx1MTczNFx1MTc0MC1cdTE3NTNcdTE3NjAtXHUxNzZDXHUxNzZFLVx1MTc3MFx1MTc3Mlx1MTc3M1x1MTc4MC1cdTE3RDNcdTE3RDdcdTE3RENcdTE3RERcdTE3RTAtXHUxN0U5XHUxODBCLVx1MTgwRFx1MTgxMC1cdTE4MTlcdTE4MjAtXHUxODc3XHUxODgwLVx1MThBQVx1MThCMC1cdTE4RjVcdTE5MDAtXHUxOTFFXHUxOTIwLVx1MTkyQlx1MTkzMC1cdTE5M0JcdTE5NDYtXHUxOTZEXHUxOTcwLVx1MTk3NFx1MTk4MC1cdTE5QUJcdTE5QjAtXHUxOUM5XHUxOUQwLVx1MTlEOVx1MUEwMC1cdTFBMUJcdTFBMjAtXHUxQTVFXHUxQTYwLVx1MUE3Q1x1MUE3Ri1cdTFBODlcdTFBOTAtXHUxQTk5XHUxQUE3XHUxQUIwLVx1MUFCRFx1MUIwMC1cdTFCNEJcdTFCNTAtXHUxQjU5XHUxQjZCLVx1MUI3M1x1MUI4MC1cdTFCRjNcdTFDMDAtXHUxQzM3XHUxQzQwLVx1MUM0OVx1MUM0RC1cdTFDN0RcdTFDODAtXHUxQzg4XHUxQ0QwLVx1MUNEMlx1MUNENC1cdTFDRjlcdTFEMDAtXHUxREY5XHUxREZCLVx1MUYxNVx1MUYxOC1cdTFGMURcdTFGMjAtXHUxRjQ1XHUxRjQ4LVx1MUY0RFx1MUY1MC1cdTFGNTdcdTFGNTlcdTFGNUJcdTFGNURcdTFGNUYtXHUxRjdEXHUxRjgwLVx1MUZCNFx1MUZCNi1cdTFGQkNcdTFGQkVcdTFGQzItXHUxRkM0XHUxRkM2LVx1MUZDQ1x1MUZEMC1cdTFGRDNcdTFGRDYtXHUxRkRCXHUxRkUwLVx1MUZFQ1x1MUZGMi1cdTFGRjRcdTFGRjYtXHUxRkZDXHUyMDNGXHUyMDQwXHUyMDU0XHUyMDcxXHUyMDdGXHUyMDkwLVx1MjA5Q1x1MjBEMC1cdTIwRENcdTIwRTFcdTIwRTUtXHUyMEYwXHUyMTAyXHUyMTA3XHUyMTBBLVx1MjExM1x1MjExNVx1MjExOS1cdTIxMURcdTIxMjRcdTIxMjZcdTIxMjhcdTIxMkEtXHUyMTJEXHUyMTJGLVx1MjEzOVx1MjEzQy1cdTIxM0ZcdTIxNDUtXHUyMTQ5XHUyMTRFXHUyMTYwLVx1MjE4OFx1MkMwMC1cdTJDMkVcdTJDMzAtXHUyQzVFXHUyQzYwLVx1MkNFNFx1MkNFQi1cdTJDRjNcdTJEMDAtXHUyRDI1XHUyRDI3XHUyRDJEXHUyRDMwLVx1MkQ2N1x1MkQ2Rlx1MkQ3Ri1cdTJEOTZcdTJEQTAtXHUyREE2XHUyREE4LVx1MkRBRVx1MkRCMC1cdTJEQjZcdTJEQjgtXHUyREJFXHUyREMwLVx1MkRDNlx1MkRDOC1cdTJEQ0VcdTJERDAtXHUyREQ2XHUyREQ4LVx1MkRERVx1MkRFMC1cdTJERkZcdTJFMkZcdTMwMDUtXHUzMDA3XHUzMDIxLVx1MzAyRlx1MzAzMS1cdTMwMzVcdTMwMzgtXHUzMDNDXHUzMDQxLVx1MzA5Nlx1MzA5OVx1MzA5QVx1MzA5RC1cdTMwOUZcdTMwQTEtXHUzMEZBXHUzMEZDLVx1MzBGRlx1MzEwNS1cdTMxMkVcdTMxMzEtXHUzMThFXHUzMUEwLVx1MzFCQVx1MzFGMC1cdTMxRkZcdTM0MDAtXHU0REI1XHU0RTAwLVx1OUZFQVx1QTAwMC1cdUE0OENcdUE0RDAtXHVBNEZEXHVBNTAwLVx1QTYwQ1x1QTYxMC1cdUE2MkJcdUE2NDAtXHVBNjZGXHVBNjc0LVx1QTY3RFx1QTY3Ri1cdUE2RjFcdUE3MTctXHVBNzFGXHVBNzIyLVx1QTc4OFx1QTc4Qi1cdUE3QUVcdUE3QjAtXHVBN0I3XHVBN0Y3LVx1QTgyN1x1QTg0MC1cdUE4NzNcdUE4ODAtXHVBOEM1XHVBOEQwLVx1QThEOVx1QThFMC1cdUE4RjdcdUE4RkJcdUE4RkRcdUE5MDAtXHVBOTJEXHVBOTMwLVx1QTk1M1x1QTk2MC1cdUE5N0NcdUE5ODAtXHVBOUMwXHVBOUNGLVx1QTlEOVx1QTlFMC1cdUE5RkVcdUFBMDAtXHVBQTM2XHVBQTQwLVx1QUE0RFx1QUE1MC1cdUFBNTlcdUFBNjAtXHVBQTc2XHVBQTdBLVx1QUFDMlx1QUFEQi1cdUFBRERcdUFBRTAtXHVBQUVGXHVBQUYyLVx1QUFGNlx1QUIwMS1cdUFCMDZcdUFCMDktXHVBQjBFXHVBQjExLVx1QUIxNlx1QUIyMC1cdUFCMjZcdUFCMjgtXHVBQjJFXHVBQjMwLVx1QUI1QVx1QUI1Qy1cdUFCNjVcdUFCNzAtXHVBQkVBXHVBQkVDXHVBQkVEXHVBQkYwLVx1QUJGOVx1QUMwMC1cdUQ3QTNcdUQ3QjAtXHVEN0M2XHVEN0NCLVx1RDdGQlx1RjkwMC1cdUZBNkRcdUZBNzAtXHVGQUQ5XHVGQjAwLVx1RkIwNlx1RkIxMy1cdUZCMTdcdUZCMUQtXHVGQjI4XHVGQjJBLVx1RkIzNlx1RkIzOC1cdUZCM0NcdUZCM0VcdUZCNDBcdUZCNDFcdUZCNDNcdUZCNDRcdUZCNDYtXHVGQkIxXHVGQkQzLVx1RkQzRFx1RkQ1MC1cdUZEOEZcdUZEOTItXHVGREM3XHVGREYwLVx1RkRGQlx1RkUwMC1cdUZFMEZcdUZFMjAtXHVGRTJGXHVGRTMzXHVGRTM0XHVGRTRELVx1RkU0Rlx1RkU3MC1cdUZFNzRcdUZFNzYtXHVGRUZDXHVGRjEwLVx1RkYxOVx1RkYyMS1cdUZGM0FcdUZGM0ZcdUZGNDEtXHVGRjVBXHVGRjY2LVx1RkZCRVx1RkZDMi1cdUZGQzdcdUZGQ0EtXHVGRkNGXHVGRkQyLVx1RkZEN1x1RkZEQS1cdUZGRENdfFx1RDgwMFtcdURDMDAtXHVEQzBCXHVEQzBELVx1REMyNlx1REMyOC1cdURDM0FcdURDM0NcdURDM0RcdURDM0YtXHVEQzREXHVEQzUwLVx1REM1RFx1REM4MC1cdURDRkFcdURENDAtXHVERDc0XHVEREZEXHVERTgwLVx1REU5Q1x1REVBMC1cdURFRDBcdURFRTBcdURGMDAtXHVERjFGXHVERjJELVx1REY0QVx1REY1MC1cdURGN0FcdURGODAtXHVERjlEXHVERkEwLVx1REZDM1x1REZDOC1cdURGQ0ZcdURGRDEtXHVERkQ1XXxcdUQ4MDFbXHVEQzAwLVx1REM5RFx1RENBMC1cdURDQTlcdURDQjAtXHVEQ0QzXHVEQ0Q4LVx1RENGQlx1REQwMC1cdUREMjdcdUREMzAtXHVERDYzXHVERTAwLVx1REYzNlx1REY0MC1cdURGNTVcdURGNjAtXHVERjY3XXxcdUQ4MDJbXHVEQzAwLVx1REMwNVx1REMwOFx1REMwQS1cdURDMzVcdURDMzdcdURDMzhcdURDM0NcdURDM0YtXHVEQzU1XHVEQzYwLVx1REM3Nlx1REM4MC1cdURDOUVcdURDRTAtXHVEQ0YyXHVEQ0Y0XHVEQ0Y1XHVERDAwLVx1REQxNVx1REQyMC1cdUREMzlcdUREODAtXHVEREI3XHVEREJFXHVEREJGXHVERTAwLVx1REUwM1x1REUwNVx1REUwNlx1REUwQy1cdURFMTNcdURFMTUtXHVERTE3XHVERTE5LVx1REUzM1x1REUzOC1cdURFM0FcdURFM0ZcdURFNjAtXHVERTdDXHVERTgwLVx1REU5Q1x1REVDMC1cdURFQzdcdURFQzktXHVERUU2XHVERjAwLVx1REYzNVx1REY0MC1cdURGNTVcdURGNjAtXHVERjcyXHVERjgwLVx1REY5MV18XHVEODAzW1x1REMwMC1cdURDNDhcdURDODAtXHVEQ0IyXHVEQ0MwLVx1RENGMl18XHVEODA0W1x1REMwMC1cdURDNDZcdURDNjYtXHVEQzZGXHVEQzdGLVx1RENCQVx1RENEMC1cdURDRThcdURDRjAtXHVEQ0Y5XHVERDAwLVx1REQzNFx1REQzNi1cdUREM0ZcdURENTAtXHVERDczXHVERDc2XHVERDgwLVx1RERDNFx1RERDQS1cdUREQ0NcdURERDAtXHVERERBXHVERERDXHVERTAwLVx1REUxMVx1REUxMy1cdURFMzdcdURFM0VcdURFODAtXHVERTg2XHVERTg4XHVERThBLVx1REU4RFx1REU4Ri1cdURFOURcdURFOUYtXHVERUE4XHVERUIwLVx1REVFQVx1REVGMC1cdURFRjlcdURGMDAtXHVERjAzXHVERjA1LVx1REYwQ1x1REYwRlx1REYxMFx1REYxMy1cdURGMjhcdURGMkEtXHVERjMwXHVERjMyXHVERjMzXHVERjM1LVx1REYzOVx1REYzQy1cdURGNDRcdURGNDdcdURGNDhcdURGNEItXHVERjREXHVERjUwXHVERjU3XHVERjVELVx1REY2M1x1REY2Ni1cdURGNkNcdURGNzAtXHVERjc0XXxcdUQ4MDVbXHVEQzAwLVx1REM0QVx1REM1MC1cdURDNTlcdURDODAtXHVEQ0M1XHVEQ0M3XHVEQ0QwLVx1RENEOVx1REQ4MC1cdUREQjVcdUREQjgtXHVEREMwXHVEREQ4LVx1RERERFx1REUwMC1cdURFNDBcdURFNDRcdURFNTAtXHVERTU5XHVERTgwLVx1REVCN1x1REVDMC1cdURFQzlcdURGMDAtXHVERjE5XHVERjFELVx1REYyQlx1REYzMC1cdURGMzldfFx1RDgwNltcdURDQTAtXHVEQ0U5XHVEQ0ZGXHVERTAwLVx1REUzRVx1REU0N1x1REU1MC1cdURFODNcdURFODYtXHVERTk5XHVERUMwLVx1REVGOF18XHVEODA3W1x1REMwMC1cdURDMDhcdURDMEEtXHVEQzM2XHVEQzM4LVx1REM0MFx1REM1MC1cdURDNTlcdURDNzItXHVEQzhGXHVEQzkyLVx1RENBN1x1RENBOS1cdURDQjZcdUREMDAtXHVERDA2XHVERDA4XHVERDA5XHVERDBCLVx1REQzNlx1REQzQVx1REQzQ1x1REQzRFx1REQzRi1cdURENDdcdURENTAtXHVERDU5XXxcdUQ4MDhbXHVEQzAwLVx1REY5OV18XHVEODA5W1x1REMwMC1cdURDNkVcdURDODAtXHVERDQzXXxbXHVEODBDXHVEODFDLVx1RDgyMFx1RDg0MC1cdUQ4NjhcdUQ4NkEtXHVEODZDXHVEODZGLVx1RDg3Mlx1RDg3NC1cdUQ4NzldW1x1REMwMC1cdURGRkZdfFx1RDgwRFtcdURDMDAtXHVEQzJFXXxcdUQ4MTFbXHVEQzAwLVx1REU0Nl18XHVEODFBW1x1REMwMC1cdURFMzhcdURFNDAtXHVERTVFXHVERTYwLVx1REU2OVx1REVEMC1cdURFRURcdURFRjAtXHVERUY0XHVERjAwLVx1REYzNlx1REY0MC1cdURGNDNcdURGNTAtXHVERjU5XHVERjYzLVx1REY3N1x1REY3RC1cdURGOEZdfFx1RDgxQltcdURGMDAtXHVERjQ0XHVERjUwLVx1REY3RVx1REY4Ri1cdURGOUZcdURGRTBcdURGRTFdfFx1RDgyMVtcdURDMDAtXHVERkVDXXxcdUQ4MjJbXHVEQzAwLVx1REVGMl18XHVEODJDW1x1REMwMC1cdUREMUVcdURENzAtXHVERUZCXXxcdUQ4MkZbXHVEQzAwLVx1REM2QVx1REM3MC1cdURDN0NcdURDODAtXHVEQzg4XHVEQzkwLVx1REM5OVx1REM5RFx1REM5RV18XHVEODM0W1x1REQ2NS1cdURENjlcdURENkQtXHVERDcyXHVERDdCLVx1REQ4Mlx1REQ4NS1cdUREOEJcdUREQUEtXHVEREFEXHVERTQyLVx1REU0NF18XHVEODM1W1x1REMwMC1cdURDNTRcdURDNTYtXHVEQzlDXHVEQzlFXHVEQzlGXHVEQ0EyXHVEQ0E1XHVEQ0E2XHVEQ0E5LVx1RENBQ1x1RENBRS1cdURDQjlcdURDQkJcdURDQkQtXHVEQ0MzXHVEQ0M1LVx1REQwNVx1REQwNy1cdUREMEFcdUREMEQtXHVERDE0XHVERDE2LVx1REQxQ1x1REQxRS1cdUREMzlcdUREM0ItXHVERDNFXHVERDQwLVx1REQ0NFx1REQ0Nlx1REQ0QS1cdURENTBcdURENTItXHVERUE1XHVERUE4LVx1REVDMFx1REVDMi1cdURFREFcdURFREMtXHVERUZBXHVERUZDLVx1REYxNFx1REYxNi1cdURGMzRcdURGMzYtXHVERjRFXHVERjUwLVx1REY2RVx1REY3MC1cdURGODhcdURGOEEtXHVERkE4XHVERkFBLVx1REZDMlx1REZDNC1cdURGQ0JcdURGQ0UtXHVERkZGXXxcdUQ4MzZbXHVERTAwLVx1REUzNlx1REUzQi1cdURFNkNcdURFNzVcdURFODRcdURFOUItXHVERTlGXHVERUExLVx1REVBRl18XHVEODM4W1x1REMwMC1cdURDMDZcdURDMDgtXHVEQzE4XHVEQzFCLVx1REMyMVx1REMyM1x1REMyNFx1REMyNi1cdURDMkFdfFx1RDgzQVtcdURDMDAtXHVEQ0M0XHVEQ0QwLVx1RENENlx1REQwMC1cdURENEFcdURENTAtXHVERDU5XXxcdUQ4M0JbXHVERTAwLVx1REUwM1x1REUwNS1cdURFMUZcdURFMjFcdURFMjJcdURFMjRcdURFMjdcdURFMjktXHVERTMyXHVERTM0LVx1REUzN1x1REUzOVx1REUzQlx1REU0Mlx1REU0N1x1REU0OVx1REU0Qlx1REU0RC1cdURFNEZcdURFNTFcdURFNTJcdURFNTRcdURFNTdcdURFNTlcdURFNUJcdURFNURcdURFNUZcdURFNjFcdURFNjJcdURFNjRcdURFNjctXHVERTZBXHVERTZDLVx1REU3Mlx1REU3NC1cdURFNzdcdURFNzktXHVERTdDXHVERTdFXHVERTgwLVx1REU4OVx1REU4Qi1cdURFOUJcdURFQTEtXHVERUEzXHVERUE1LVx1REVBOVx1REVBQi1cdURFQkJdfFx1RDg2OVtcdURDMDAtXHVERUQ2XHVERjAwLVx1REZGRl18XHVEODZEW1x1REMwMC1cdURGMzRcdURGNDAtXHVERkZGXXxcdUQ4NkVbXHVEQzAwLVx1REMxRFx1REMyMC1cdURGRkZdfFx1RDg3M1tcdURDMDAtXHVERUExXHVERUIwLVx1REZGRl18XHVEODdBW1x1REMwMC1cdURGRTBdfFx1RDg3RVtcdURDMDAtXHVERTFEXXxcdURCNDBbXHVERDAwLVx1RERFRl0vfSxVPXtpc1NwYWNlU2VwYXJhdG9yOmZ1bmN0aW9uKHUpe3JldHVybiJzdHJpbmciPT10eXBlb2YgdSYmRy5TcGFjZV9TZXBhcmF0b3IudGVzdCh1KX0saXNJZFN0YXJ0Q2hhcjpmdW5jdGlvbih1KXtyZXR1cm4ic3RyaW5nIj09dHlwZW9mIHUmJih1Pj0iYSImJnU8PSJ6Inx8dT49IkEiJiZ1PD0iWiJ8fCIkIj09PXV8fCJfIj09PXV8fEcuSURfU3RhcnQudGVzdCh1KSl9LGlzSWRDb250aW51ZUNoYXI6ZnVuY3Rpb24odSl7cmV0dXJuInN0cmluZyI9PXR5cGVvZiB1JiYodT49ImEiJiZ1PD0ieiJ8fHU+PSJBIiYmdTw9IloifHx1Pj0iMCImJnU8PSI5Inx8IiQiPT09dXx8Il8iPT09dXx8IuKAjCI9PT11fHwi4oCNIj09PXV8fEcuSURfQ29udGludWUudGVzdCh1KSl9LGlzRGlnaXQ6ZnVuY3Rpb24odSl7cmV0dXJuInN0cmluZyI9PXR5cGVvZiB1JiYvWzAtOV0vLnRlc3QodSl9LGlzSGV4RGlnaXQ6ZnVuY3Rpb24odSl7cmV0dXJuInN0cmluZyI9PXR5cGVvZiB1JiYvWzAtOUEtRmEtZl0vLnRlc3QodSl9fTtmdW5jdGlvbiBaKCl7Zm9yKFQ9ImRlZmF1bHQiLHo9IiIsSD0hMSwkPTE7Oyl7Uj1xKCk7dmFyIHU9WFtUXSgpO2lmKHUpcmV0dXJuIHV9fWZ1bmN0aW9uIHEoKXtpZihfW0ldKXJldHVybiBTdHJpbmcuZnJvbUNvZGVQb2ludChfLmNvZGVQb2ludEF0KEkpKX1mdW5jdGlvbiBXKCl7dmFyIHU9cSgpO3JldHVybiJcbiI9PT11PyhWKyssSj0wKTp1P0orPXUubGVuZ3RoOkorKyx1JiYoSSs9dS5sZW5ndGgpLHV9dmFyIFg9e2RlZmF1bHQ6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSJcdCI6Y2FzZSJcdiI6Y2FzZSJcZiI6Y2FzZSIgIjpjYXNlIiAiOmNhc2UiXHVmZWZmIjpjYXNlIlxuIjpjYXNlIlxyIjpjYXNlIlx1MjAyOCI6Y2FzZSJcdTIwMjkiOnJldHVybiB2b2lkIFcoKTtjYXNlIi8iOnJldHVybiBXKCksdm9pZChUPSJjb21tZW50Iik7Y2FzZSB2b2lkIDA6cmV0dXJuIFcoKSxLKCJlb2YiKX1pZighVS5pc1NwYWNlU2VwYXJhdG9yKFIpKXJldHVybiBYW09dKCk7VygpfSxjb21tZW50OmZ1bmN0aW9uKCl7c3dpdGNoKFIpe2Nhc2UiKiI6cmV0dXJuIFcoKSx2b2lkKFQ9Im11bHRpTGluZUNvbW1lbnQiKTtjYXNlIi8iOnJldHVybiBXKCksdm9pZChUPSJzaW5nbGVMaW5lQ29tbWVudCIpfXRocm93IHJ1KFcoKSl9LG11bHRpTGluZUNvbW1lbnQ6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSIqIjpyZXR1cm4gVygpLHZvaWQoVD0ibXVsdGlMaW5lQ29tbWVudEFzdGVyaXNrIik7Y2FzZSB2b2lkIDA6dGhyb3cgcnUoVygpKX1XKCl9LG11bHRpTGluZUNvbW1lbnRBc3RlcmlzazpmdW5jdGlvbigpe3N3aXRjaChSKXtjYXNlIioiOnJldHVybiB2b2lkIFcoKTtjYXNlIi8iOnJldHVybiBXKCksdm9pZChUPSJkZWZhdWx0Iik7Y2FzZSB2b2lkIDA6dGhyb3cgcnUoVygpKX1XKCksVD0ibXVsdGlMaW5lQ29tbWVudCJ9LHNpbmdsZUxpbmVDb21tZW50OmZ1bmN0aW9uKCl7c3dpdGNoKFIpe2Nhc2UiXG4iOmNhc2UiXHIiOmNhc2UiXHUyMDI4IjpjYXNlIlx1MjAyOSI6cmV0dXJuIFcoKSx2b2lkKFQ9ImRlZmF1bHQiKTtjYXNlIHZvaWQgMDpyZXR1cm4gVygpLEsoImVvZiIpfVcoKX0sdmFsdWU6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSJ7IjpjYXNlIlsiOnJldHVybiBLKCJwdW5jdHVhdG9yIixXKCkpO2Nhc2UibiI6cmV0dXJuIFcoKSxRKCJ1bGwiKSxLKCJudWxsIixudWxsKTtjYXNlInQiOnJldHVybiBXKCksUSgicnVlIiksSygiYm9vbGVhbiIsITApO2Nhc2UiZiI6cmV0dXJuIFcoKSxRKCJhbHNlIiksSygiYm9vbGVhbiIsITEpO2Nhc2UiLSI6Y2FzZSIrIjpyZXR1cm4iLSI9PT1XKCkmJigkPS0xKSx2b2lkKFQ9InNpZ24iKTtjYXNlIi4iOnJldHVybiB6PVcoKSx2b2lkKFQ9ImRlY2ltYWxQb2ludExlYWRpbmciKTtjYXNlIjAiOnJldHVybiB6PVcoKSx2b2lkKFQ9Inplcm8iKTtjYXNlIjEiOmNhc2UiMiI6Y2FzZSIzIjpjYXNlIjQiOmNhc2UiNSI6Y2FzZSI2IjpjYXNlIjciOmNhc2UiOCI6Y2FzZSI5IjpyZXR1cm4gej1XKCksdm9pZChUPSJkZWNpbWFsSW50ZWdlciIpO2Nhc2UiSSI6cmV0dXJuIFcoKSxRKCJuZmluaXR5IiksSygibnVtZXJpYyIsMS8wKTtjYXNlIk4iOnJldHVybiBXKCksUSgiYU4iKSxLKCJudW1lcmljIixOYU4pO2Nhc2UnIic6Y2FzZSInIjpyZXR1cm4gSD0nIic9PT1XKCksej0iIix2b2lkKFQ9InN0cmluZyIpfXRocm93IHJ1KFcoKSl9LGlkZW50aWZpZXJOYW1lU3RhcnRFc2NhcGU6ZnVuY3Rpb24oKXtpZigidSIhPT1SKXRocm93IHJ1KFcoKSk7VygpO3ZhciB1PVkoKTtzd2l0Y2godSl7Y2FzZSIkIjpjYXNlIl8iOmJyZWFrO2RlZmF1bHQ6aWYoIVUuaXNJZFN0YXJ0Q2hhcih1KSl0aHJvdyBudSgpfXorPXUsVD0iaWRlbnRpZmllck5hbWUifSxpZGVudGlmaWVyTmFtZTpmdW5jdGlvbigpe3N3aXRjaChSKXtjYXNlIiQiOmNhc2UiXyI6Y2FzZSLigIwiOmNhc2Ui4oCNIjpyZXR1cm4gdm9pZCh6Kz1XKCkpO2Nhc2UiXFwiOnJldHVybiBXKCksdm9pZChUPSJpZGVudGlmaWVyTmFtZUVzY2FwZSIpfWlmKCFVLmlzSWRDb250aW51ZUNoYXIoUikpcmV0dXJuIEsoImlkZW50aWZpZXIiLHopO3orPVcoKX0saWRlbnRpZmllck5hbWVFc2NhcGU6ZnVuY3Rpb24oKXtpZigidSIhPT1SKXRocm93IHJ1KFcoKSk7VygpO3ZhciB1PVkoKTtzd2l0Y2godSl7Y2FzZSIkIjpjYXNlIl8iOmNhc2Ui4oCMIjpjYXNlIuKAjSI6YnJlYWs7ZGVmYXVsdDppZighVS5pc0lkQ29udGludWVDaGFyKHUpKXRocm93IG51KCl9eis9dSxUPSJpZGVudGlmaWVyTmFtZSJ9LHNpZ246ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSIuIjpyZXR1cm4gej1XKCksdm9pZChUPSJkZWNpbWFsUG9pbnRMZWFkaW5nIik7Y2FzZSIwIjpyZXR1cm4gej1XKCksdm9pZChUPSJ6ZXJvIik7Y2FzZSIxIjpjYXNlIjIiOmNhc2UiMyI6Y2FzZSI0IjpjYXNlIjUiOmNhc2UiNiI6Y2FzZSI3IjpjYXNlIjgiOmNhc2UiOSI6cmV0dXJuIHo9VygpLHZvaWQoVD0iZGVjaW1hbEludGVnZXIiKTtjYXNlIkkiOnJldHVybiBXKCksUSgibmZpbml0eSIpLEsoIm51bWVyaWMiLCQqKDEvMCkpO2Nhc2UiTiI6cmV0dXJuIFcoKSxRKCJhTiIpLEsoIm51bWVyaWMiLE5hTil9dGhyb3cgcnUoVygpKX0semVybzpmdW5jdGlvbigpe3N3aXRjaChSKXtjYXNlIi4iOnJldHVybiB6Kz1XKCksdm9pZChUPSJkZWNpbWFsUG9pbnQiKTtjYXNlImUiOmNhc2UiRSI6cmV0dXJuIHorPVcoKSx2b2lkKFQ9ImRlY2ltYWxFeHBvbmVudCIpO2Nhc2UieCI6Y2FzZSJYIjpyZXR1cm4geis9VygpLHZvaWQoVD0iaGV4YWRlY2ltYWwiKX1yZXR1cm4gSygibnVtZXJpYyIsMCokKX0sZGVjaW1hbEludGVnZXI6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSIuIjpyZXR1cm4geis9VygpLHZvaWQoVD0iZGVjaW1hbFBvaW50Iik7Y2FzZSJlIjpjYXNlIkUiOnJldHVybiB6Kz1XKCksdm9pZChUPSJkZWNpbWFsRXhwb25lbnQiKX1pZighVS5pc0RpZ2l0KFIpKXJldHVybiBLKCJudW1lcmljIiwkKk51bWJlcih6KSk7eis9VygpfSxkZWNpbWFsUG9pbnRMZWFkaW5nOmZ1bmN0aW9uKCl7aWYoVS5pc0RpZ2l0KFIpKXJldHVybiB6Kz1XKCksdm9pZChUPSJkZWNpbWFsRnJhY3Rpb24iKTt0aHJvdyBydShXKCkpfSxkZWNpbWFsUG9pbnQ6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSJlIjpjYXNlIkUiOnJldHVybiB6Kz1XKCksdm9pZChUPSJkZWNpbWFsRXhwb25lbnQiKX1yZXR1cm4gVS5pc0RpZ2l0KFIpPyh6Kz1XKCksdm9pZChUPSJkZWNpbWFsRnJhY3Rpb24iKSk6SygibnVtZXJpYyIsJCpOdW1iZXIoeikpfSxkZWNpbWFsRnJhY3Rpb246ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSJlIjpjYXNlIkUiOnJldHVybiB6Kz1XKCksdm9pZChUPSJkZWNpbWFsRXhwb25lbnQiKX1pZighVS5pc0RpZ2l0KFIpKXJldHVybiBLKCJudW1lcmljIiwkKk51bWJlcih6KSk7eis9VygpfSxkZWNpbWFsRXhwb25lbnQ6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSIrIjpjYXNlIi0iOnJldHVybiB6Kz1XKCksdm9pZChUPSJkZWNpbWFsRXhwb25lbnRTaWduIil9aWYoVS5pc0RpZ2l0KFIpKXJldHVybiB6Kz1XKCksdm9pZChUPSJkZWNpbWFsRXhwb25lbnRJbnRlZ2VyIik7dGhyb3cgcnUoVygpKX0sZGVjaW1hbEV4cG9uZW50U2lnbjpmdW5jdGlvbigpe2lmKFUuaXNEaWdpdChSKSlyZXR1cm4geis9VygpLHZvaWQoVD0iZGVjaW1hbEV4cG9uZW50SW50ZWdlciIpO3Rocm93IHJ1KFcoKSl9LGRlY2ltYWxFeHBvbmVudEludGVnZXI6ZnVuY3Rpb24oKXtpZighVS5pc0RpZ2l0KFIpKXJldHVybiBLKCJudW1lcmljIiwkKk51bWJlcih6KSk7eis9VygpfSxoZXhhZGVjaW1hbDpmdW5jdGlvbigpe2lmKFUuaXNIZXhEaWdpdChSKSlyZXR1cm4geis9VygpLHZvaWQoVD0iaGV4YWRlY2ltYWxJbnRlZ2VyIik7dGhyb3cgcnUoVygpKX0saGV4YWRlY2ltYWxJbnRlZ2VyOmZ1bmN0aW9uKCl7aWYoIVUuaXNIZXhEaWdpdChSKSlyZXR1cm4gSygibnVtZXJpYyIsJCpOdW1iZXIoeikpO3orPVcoKX0sc3RyaW5nOmZ1bmN0aW9uKCl7c3dpdGNoKFIpe2Nhc2UiXFwiOnJldHVybiBXKCksdm9pZCh6Kz1mdW5jdGlvbigpe3N3aXRjaChxKCkpe2Nhc2UiYiI6cmV0dXJuIFcoKSwiXGIiO2Nhc2UiZiI6cmV0dXJuIFcoKSwiXGYiO2Nhc2UibiI6cmV0dXJuIFcoKSwiXG4iO2Nhc2UiciI6cmV0dXJuIFcoKSwiXHIiO2Nhc2UidCI6cmV0dXJuIFcoKSwiXHQiO2Nhc2UidiI6cmV0dXJuIFcoKSwiXHYiO2Nhc2UiMCI6aWYoVygpLFUuaXNEaWdpdChxKCkpKXRocm93IHJ1KFcoKSk7cmV0dXJuIlwwIjtjYXNlIngiOnJldHVybiBXKCksZnVuY3Rpb24oKXt2YXIgdT0iIixEPXEoKTtpZighVS5pc0hleERpZ2l0KEQpKXRocm93IHJ1KFcoKSk7aWYodSs9VygpLEQ9cSgpLCFVLmlzSGV4RGlnaXQoRCkpdGhyb3cgcnUoVygpKTtyZXR1cm4gdSs9VygpLFN0cmluZy5mcm9tQ29kZVBvaW50KHBhcnNlSW50KHUsMTYpKX0oKTtjYXNlInUiOnJldHVybiBXKCksWSgpO2Nhc2UiXG4iOmNhc2UiXHUyMDI4IjpjYXNlIlx1MjAyOSI6cmV0dXJuIFcoKSwiIjtjYXNlIlxyIjpyZXR1cm4gVygpLCJcbiI9PT1xKCkmJlcoKSwiIjtjYXNlIjEiOmNhc2UiMiI6Y2FzZSIzIjpjYXNlIjQiOmNhc2UiNSI6Y2FzZSI2IjpjYXNlIjciOmNhc2UiOCI6Y2FzZSI5IjpjYXNlIHZvaWQgMDp0aHJvdyBydShXKCkpfXJldHVybiBXKCl9KCkpO2Nhc2UnIic6cmV0dXJuIEg/KFcoKSxLKCJzdHJpbmciLHopKTp2b2lkKHorPVcoKSk7Y2FzZSInIjpyZXR1cm4gSD92b2lkKHorPVcoKSk6KFcoKSxLKCJzdHJpbmciLHopKTtjYXNlIlxuIjpjYXNlIlxyIjp0aHJvdyBydShXKCkpO2Nhc2UiXHUyMDI4IjpjYXNlIlx1MjAyOSI6IWZ1bmN0aW9uKHUpe2NvbnNvbGUud2FybigiSlNPTjU6ICciK0Z1KHUpKyInIGluIHN0cmluZ3MgaXMgbm90IHZhbGlkIEVDTUFTY3JpcHQ7IGNvbnNpZGVyIGVzY2FwaW5nIil9KFIpO2JyZWFrO2Nhc2Ugdm9pZCAwOnRocm93IHJ1KFcoKSl9eis9VygpfSxzdGFydDpmdW5jdGlvbigpe3N3aXRjaChSKXtjYXNlInsiOmNhc2UiWyI6cmV0dXJuIEsoInB1bmN0dWF0b3IiLFcoKSl9VD0idmFsdWUifSxiZWZvcmVQcm9wZXJ0eU5hbWU6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSIkIjpjYXNlIl8iOnJldHVybiB6PVcoKSx2b2lkKFQ9ImlkZW50aWZpZXJOYW1lIik7Y2FzZSJcXCI6cmV0dXJuIFcoKSx2b2lkKFQ9ImlkZW50aWZpZXJOYW1lU3RhcnRFc2NhcGUiKTtjYXNlIn0iOnJldHVybiBLKCJwdW5jdHVhdG9yIixXKCkpO2Nhc2UnIic6Y2FzZSInIjpyZXR1cm4gSD0nIic9PT1XKCksdm9pZChUPSJzdHJpbmciKX1pZihVLmlzSWRTdGFydENoYXIoUikpcmV0dXJuIHorPVcoKSx2b2lkKFQ9ImlkZW50aWZpZXJOYW1lIik7dGhyb3cgcnUoVygpKX0sYWZ0ZXJQcm9wZXJ0eU5hbWU6ZnVuY3Rpb24oKXtpZigiOiI9PT1SKXJldHVybiBLKCJwdW5jdHVhdG9yIixXKCkpO3Rocm93IHJ1KFcoKSl9LGJlZm9yZVByb3BlcnR5VmFsdWU6ZnVuY3Rpb24oKXtUPSJ2YWx1ZSJ9LGFmdGVyUHJvcGVydHlWYWx1ZTpmdW5jdGlvbigpe3N3aXRjaChSKXtjYXNlIiwiOmNhc2UifSI6cmV0dXJuIEsoInB1bmN0dWF0b3IiLFcoKSl9dGhyb3cgcnUoVygpKX0sYmVmb3JlQXJyYXlWYWx1ZTpmdW5jdGlvbigpe2lmKCJdIj09PVIpcmV0dXJuIEsoInB1bmN0dWF0b3IiLFcoKSk7VD0idmFsdWUifSxhZnRlckFycmF5VmFsdWU6ZnVuY3Rpb24oKXtzd2l0Y2goUil7Y2FzZSIsIjpjYXNlIl0iOnJldHVybiBLKCJwdW5jdHVhdG9yIixXKCkpfXRocm93IHJ1KFcoKSl9LGVuZDpmdW5jdGlvbigpe3Rocm93IHJ1KFcoKSl9fTtmdW5jdGlvbiBLKHUsRCl7cmV0dXJue3R5cGU6dSx2YWx1ZTpELGxpbmU6Vixjb2x1bW46Sn19ZnVuY3Rpb24gUSh1KXtmb3IodmFyIEQ9MCxlPXU7RDxlLmxlbmd0aDtEKz0xKXt2YXIgcj1lW0RdO2lmKHEoKSE9PXIpdGhyb3cgcnUoVygpKTtXKCl9fWZ1bmN0aW9uIFkoKXtmb3IodmFyIHU9IiIsRD00O0QtLSA+MDspe3ZhciBlPXEoKTtpZighVS5pc0hleERpZ2l0KGUpKXRocm93IHJ1KFcoKSk7dSs9VygpfXJldHVybiBTdHJpbmcuZnJvbUNvZGVQb2ludChwYXJzZUludCh1LDE2KSl9dmFyIHV1PXtzdGFydDpmdW5jdGlvbigpe2lmKCJlb2YiPT09TS50eXBlKXRocm93IHR1KCk7RHUoKX0sYmVmb3JlUHJvcGVydHlOYW1lOmZ1bmN0aW9uKCl7c3dpdGNoKE0udHlwZSl7Y2FzZSJpZGVudGlmaWVyIjpjYXNlInN0cmluZyI6cmV0dXJuIGs9TS52YWx1ZSx2b2lkKE89ImFmdGVyUHJvcGVydHlOYW1lIik7Y2FzZSJwdW5jdHVhdG9yIjpyZXR1cm4gdm9pZCBldSgpO2Nhc2UiZW9mIjp0aHJvdyB0dSgpfX0sYWZ0ZXJQcm9wZXJ0eU5hbWU6ZnVuY3Rpb24oKXtpZigiZW9mIj09PU0udHlwZSl0aHJvdyB0dSgpO089ImJlZm9yZVByb3BlcnR5VmFsdWUifSxiZWZvcmVQcm9wZXJ0eVZhbHVlOmZ1bmN0aW9uKCl7aWYoImVvZiI9PT1NLnR5cGUpdGhyb3cgdHUoKTtEdSgpfSxiZWZvcmVBcnJheVZhbHVlOmZ1bmN0aW9uKCl7aWYoImVvZiI9PT1NLnR5cGUpdGhyb3cgdHUoKTsicHVuY3R1YXRvciIhPT1NLnR5cGV8fCJdIiE9PU0udmFsdWU/RHUoKTpldSgpfSxhZnRlclByb3BlcnR5VmFsdWU6ZnVuY3Rpb24oKXtpZigiZW9mIj09PU0udHlwZSl0aHJvdyB0dSgpO3N3aXRjaChNLnZhbHVlKXtjYXNlIiwiOnJldHVybiB2b2lkKE89ImJlZm9yZVByb3BlcnR5TmFtZSIpO2Nhc2UifSI6ZXUoKX19LGFmdGVyQXJyYXlWYWx1ZTpmdW5jdGlvbigpe2lmKCJlb2YiPT09TS50eXBlKXRocm93IHR1KCk7c3dpdGNoKE0udmFsdWUpe2Nhc2UiLCI6cmV0dXJuIHZvaWQoTz0iYmVmb3JlQXJyYXlWYWx1ZSIpO2Nhc2UiXSI6ZXUoKX19LGVuZDpmdW5jdGlvbigpe319O2Z1bmN0aW9uIER1KCl7dmFyIHU7c3dpdGNoKE0udHlwZSl7Y2FzZSJwdW5jdHVhdG9yIjpzd2l0Y2goTS52YWx1ZSl7Y2FzZSJ7Ijp1PXt9O2JyZWFrO2Nhc2UiWyI6dT1bXX1icmVhaztjYXNlIm51bGwiOmNhc2UiYm9vbGVhbiI6Y2FzZSJudW1lcmljIjpjYXNlInN0cmluZyI6dT1NLnZhbHVlfWlmKHZvaWQgMD09PUwpTD11O2Vsc2V7dmFyIEQ9altqLmxlbmd0aC0xXTtBcnJheS5pc0FycmF5KEQpP0QucHVzaCh1KTpPYmplY3QuZGVmaW5lUHJvcGVydHkoRCxrLHt2YWx1ZTp1LHdyaXRhYmxlOiEwLGVudW1lcmFibGU6ITAsY29uZmlndXJhYmxlOiEwfSl9aWYobnVsbCE9PXUmJiJvYmplY3QiPT10eXBlb2YgdSlqLnB1c2godSksTz1BcnJheS5pc0FycmF5KHUpPyJiZWZvcmVBcnJheVZhbHVlIjoiYmVmb3JlUHJvcGVydHlOYW1lIjtlbHNle3ZhciBlPWpbai5sZW5ndGgtMV07Tz1udWxsPT1lPyJlbmQiOkFycmF5LmlzQXJyYXkoZSk/ImFmdGVyQXJyYXlWYWx1ZSI6ImFmdGVyUHJvcGVydHlWYWx1ZSJ9fWZ1bmN0aW9uIGV1KCl7ai5wb3AoKTt2YXIgdT1qW2oubGVuZ3RoLTFdO089bnVsbD09dT8iZW5kIjpBcnJheS5pc0FycmF5KHUpPyJhZnRlckFycmF5VmFsdWUiOiJhZnRlclByb3BlcnR5VmFsdWUifWZ1bmN0aW9uIHJ1KHUpe3JldHVybiBDdSh2b2lkIDA9PT11PyJKU09ONTogaW52YWxpZCBlbmQgb2YgaW5wdXQgYXQgIitWKyI6IitKOiJKU09ONTogaW52YWxpZCBjaGFyYWN0ZXIgJyIrRnUodSkrIicgYXQgIitWKyI6IitKKX1mdW5jdGlvbiB0dSgpe3JldHVybiBDdSgiSlNPTjU6IGludmFsaWQgZW5kIG9mIGlucHV0IGF0ICIrVisiOiIrSil9ZnVuY3Rpb24gbnUoKXtyZXR1cm4gQ3UoIkpTT041OiBpbnZhbGlkIGlkZW50aWZpZXIgY2hhcmFjdGVyIGF0ICIrVisiOiIrKEotPTUpKX1mdW5jdGlvbiBGdSh1KXt2YXIgRD17IiciOiJcXCciLCciJzonXFwiJywiXFwiOiJcXFxcIiwiXGIiOiJcXGIiLCJcZiI6IlxcZiIsIlxuIjoiXFxuIiwiXHIiOiJcXHIiLCJcdCI6IlxcdCIsIlx2IjoiXFx2IiwiXDAiOiJcXDAiLCJcdTIwMjgiOiJcXHUyMDI4IiwiXHUyMDI5IjoiXFx1MjAyOSJ9O2lmKERbdV0pcmV0dXJuIERbdV07aWYodTwiICIpe3ZhciBlPXUuY2hhckNvZGVBdCgwKS50b1N0cmluZygxNik7cmV0dXJuIlxceCIrKCIwMCIrZSkuc3Vic3RyaW5nKGUubGVuZ3RoKX1yZXR1cm4gdX1mdW5jdGlvbiBDdSh1KXt2YXIgRD1uZXcgU3ludGF4RXJyb3IodSk7cmV0dXJuIEQubGluZU51bWJlcj1WLEQuY29sdW1uTnVtYmVyPUosRH1yZXR1cm57cGFyc2U6ZnVuY3Rpb24odSxEKXtfPVN0cmluZyh1KSxPPSJzdGFydCIsaj1bXSxJPTAsVj0xLEo9MCxNPXZvaWQgMCxrPXZvaWQgMCxMPXZvaWQgMDtkb3tNPVooKSx1dVtPXSgpfXdoaWxlKCJlb2YiIT09TS50eXBlKTtyZXR1cm4iZnVuY3Rpb24iPT10eXBlb2YgRD9mdW5jdGlvbiB1KEQsZSxyKXt2YXIgdD1EW2VdO2lmKG51bGwhPXQmJiJvYmplY3QiPT10eXBlb2YgdClpZihBcnJheS5pc0FycmF5KHQpKWZvcih2YXIgbj0wO248dC5sZW5ndGg7bisrKXt2YXIgRj1TdHJpbmcobiksQz11KHQsRixyKTt2b2lkIDA9PT1DP2RlbGV0ZSB0W0ZdOk9iamVjdC5kZWZpbmVQcm9wZXJ0eSh0LEYse3ZhbHVlOkMsd3JpdGFibGU6ITAsZW51bWVyYWJsZTohMCxjb25maWd1cmFibGU6ITB9KX1lbHNlIGZvcih2YXIgQSBpbiB0KXt2YXIgaT11KHQsQSxyKTt2b2lkIDA9PT1pP2RlbGV0ZSB0W0FdOk9iamVjdC5kZWZpbmVQcm9wZXJ0eSh0LEEse3ZhbHVlOmksd3JpdGFibGU6ITAsZW51bWVyYWJsZTohMCxjb25maWd1cmFibGU6ITB9KX1yZXR1cm4gci5jYWxsKEQsZSx0KX0oeyIiOkx9LCIiLEQpOkx9LHN0cmluZ2lmeTpmdW5jdGlvbih1LEQsZSl7dmFyIHIsdCxuLEY9W10sQz0iIixBPSIiO2lmKG51bGw9PUR8fCJvYmplY3QiIT10eXBlb2YgRHx8QXJyYXkuaXNBcnJheShEKXx8KGU9RC5zcGFjZSxuPUQucXVvdGUsRD1ELnJlcGxhY2VyKSwiZnVuY3Rpb24iPT10eXBlb2YgRCl0PUQ7ZWxzZSBpZihBcnJheS5pc0FycmF5KEQpKXtyPVtdO2Zvcih2YXIgaT0wLEU9RDtpPEUubGVuZ3RoO2krPTEpe3ZhciBvPUVbaV0sYT12b2lkIDA7InN0cmluZyI9PXR5cGVvZiBvP2E9bzooIm51bWJlciI9PXR5cGVvZiBvfHxvIGluc3RhbmNlb2YgU3RyaW5nfHxvIGluc3RhbmNlb2YgTnVtYmVyKSYmKGE9U3RyaW5nKG8pKSx2b2lkIDAhPT1hJiZyLmluZGV4T2YoYSk8MCYmci5wdXNoKGEpfX1yZXR1cm4gZSBpbnN0YW5jZW9mIE51bWJlcj9lPU51bWJlcihlKTplIGluc3RhbmNlb2YgU3RyaW5nJiYoZT1TdHJpbmcoZSkpLCJudW1iZXIiPT10eXBlb2YgZT9lPjAmJihlPU1hdGgubWluKDEwLE1hdGguZmxvb3IoZSkpLEE9IiAgICAgICAgICAiLnN1YnN0cigwLGUpKToic3RyaW5nIj09dHlwZW9mIGUmJihBPWUuc3Vic3RyKDAsMTApKSxjKCIiLHsiIjp1fSk7ZnVuY3Rpb24gYyh1LEQpe3ZhciBlPURbdV07c3dpdGNoKG51bGwhPWUmJigiZnVuY3Rpb24iPT10eXBlb2YgZS50b0pTT041P2U9ZS50b0pTT041KHUpOiJmdW5jdGlvbiI9PXR5cGVvZiBlLnRvSlNPTiYmKGU9ZS50b0pTT04odSkpKSx0JiYoZT10LmNhbGwoRCx1LGUpKSxlIGluc3RhbmNlb2YgTnVtYmVyP2U9TnVtYmVyKGUpOmUgaW5zdGFuY2VvZiBTdHJpbmc/ZT1TdHJpbmcoZSk6ZSBpbnN0YW5jZW9mIEJvb2xlYW4mJihlPWUudmFsdWVPZigpKSxlKXtjYXNlIG51bGw6cmV0dXJuIm51bGwiO2Nhc2UhMDpyZXR1cm4idHJ1ZSI7Y2FzZSExOnJldHVybiJmYWxzZSJ9cmV0dXJuInN0cmluZyI9PXR5cGVvZiBlP0IoZSk6Im51bWJlciI9PXR5cGVvZiBlP1N0cmluZyhlKToib2JqZWN0Ij09dHlwZW9mIGU/QXJyYXkuaXNBcnJheShlKT9mdW5jdGlvbih1KXtpZihGLmluZGV4T2YodSk+PTApdGhyb3cgVHlwZUVycm9yKCJDb252ZXJ0aW5nIGNpcmN1bGFyIHN0cnVjdHVyZSB0byBKU09ONSIpO0YucHVzaCh1KTt2YXIgRD1DO0MrPUE7Zm9yKHZhciBlLHI9W10sdD0wO3Q8dS5sZW5ndGg7dCsrKXt2YXIgbj1jKFN0cmluZyh0KSx1KTtyLnB1c2godm9pZCAwIT09bj9uOiJudWxsIil9aWYoMD09PXIubGVuZ3RoKWU9IltdIjtlbHNlIGlmKCIiPT09QSl7dmFyIGk9ci5qb2luKCIsIik7ZT0iWyIraSsiXSJ9ZWxzZXt2YXIgRT0iLFxuIitDLG89ci5qb2luKEUpO2U9IltcbiIrQytvKyIsXG4iK0QrIl0ifXJldHVybiBGLnBvcCgpLEM9RCxlfShlKTpmdW5jdGlvbih1KXtpZihGLmluZGV4T2YodSk+PTApdGhyb3cgVHlwZUVycm9yKCJDb252ZXJ0aW5nIGNpcmN1bGFyIHN0cnVjdHVyZSB0byBKU09ONSIpO0YucHVzaCh1KTt2YXIgRD1DO0MrPUE7Zm9yKHZhciBlLHQsbj1yfHxPYmplY3Qua2V5cyh1KSxpPVtdLEU9MCxvPW47RTxvLmxlbmd0aDtFKz0xKXt2YXIgYT1vW0VdLEI9YyhhLHUpO2lmKHZvaWQgMCE9PUIpe3ZhciBmPXMoYSkrIjoiOyIiIT09QSYmKGYrPSIgIiksZis9QixpLnB1c2goZil9fWlmKDA9PT1pLmxlbmd0aCllPSJ7fSI7ZWxzZSBpZigiIj09PUEpdD1pLmpvaW4oIiwiKSxlPSJ7Iit0KyJ9IjtlbHNle3ZhciBsPSIsXG4iK0M7dD1pLmpvaW4obCksZT0ie1xuIitDK3QrIixcbiIrRCsifSJ9cmV0dXJuIEYucG9wKCksQz1ELGV9KGUpOnZvaWQgMH1mdW5jdGlvbiBCKHUpe2Zvcih2YXIgRD17IiciOi4xLCciJzouMn0sZT17IiciOiJcXCciLCciJzonXFwiJywiXFwiOiJcXFxcIiwiXGIiOiJcXGIiLCJcZiI6IlxcZiIsIlxuIjoiXFxuIiwiXHIiOiJcXHIiLCJcdCI6IlxcdCIsIlx2IjoiXFx2IiwiXDAiOiJcXDAiLCJcdTIwMjgiOiJcXHUyMDI4IiwiXHUyMDI5IjoiXFx1MjAyOSJ9LHI9IiIsdD0wO3Q8dS5sZW5ndGg7dCsrKXt2YXIgRj11W3RdO3N3aXRjaChGKXtjYXNlIiciOmNhc2UnIic6RFtGXSsrLHIrPUY7Y29udGludWU7Y2FzZSJcMCI6aWYoVS5pc0RpZ2l0KHVbdCsxXSkpe3IrPSJcXHgwMCI7Y29udGludWV9fWlmKGVbRl0pcis9ZVtGXTtlbHNlIGlmKEY8IiAiKXt2YXIgQz1GLmNoYXJDb2RlQXQoMCkudG9TdHJpbmcoMTYpO3IrPSJcXHgiKygiMDAiK0MpLnN1YnN0cmluZyhDLmxlbmd0aCl9ZWxzZSByKz1GfXZhciBBPW58fE9iamVjdC5rZXlzKEQpLnJlZHVjZShmdW5jdGlvbih1LGUpe3JldHVybiBEW3VdPERbZV0/dTplfSk7cmV0dXJuIEErKHI9ci5yZXBsYWNlKG5ldyBSZWdFeHAoQSwiZyIpLGVbQV0pKStBfWZ1bmN0aW9uIHModSl7aWYoMD09PXUubGVuZ3RoKXJldHVybiBCKHUpO3ZhciBEPVN0cmluZy5mcm9tQ29kZVBvaW50KHUuY29kZVBvaW50QXQoMCkpO2lmKCFVLmlzSWRTdGFydENoYXIoRCkpcmV0dXJuIEIodSk7Zm9yKHZhciBlPUQubGVuZ3RoO2U8dS5sZW5ndGg7ZSsrKWlmKCFVLmlzSWRDb250aW51ZUNoYXIoU3RyaW5nLmZyb21Db2RlUG9pbnQodS5jb2RlUG9pbnRBdChlKSkpKXJldHVybiBCKHUpO3JldHVybiB1fX19fSk7`;

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -29875,12 +29875,12 @@ ${events}
       };
       const tabs = [
         m$1`
-    <${TabPanel} id=${kSampleMessagesTabId} classes="sample-tab" title="Messages" onSelected=${onSelectedTab} selected=${selectedTab === kSampleMessagesTabId}>
+    <${TabPanel} id=${kSampleMessagesTabId} classes="sample-tab" title="Messages" onSelected=${onSelectedTab} selected=${selectedTab === kSampleMessagesTabId} scrollable=${false}>
       <${ChatViewVirtualList} 
         key=${`${baseId}-chat-${id2}`} 
         id=${`${baseId}-chat-${id2}`} 
         messages=${sample.messages} 
-        style=${{ paddingLeft: ".8em", paddingTop: "1em" }}
+        style=${{ marginLeft: ".8em", marginTop: "1em" }}
         indented=${true}
         scrollRef=${scrollRef}
       />

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -20056,6 +20056,43 @@ var require_assets = __commonJS({
       }
       return parseInt(value != null ? value : "0", 10);
     }
+    const ChatViewVirtualList = ({
+      id: id2,
+      messages,
+      toolCallStyle,
+      style: style2,
+      indented,
+      numbered = true,
+      scrollRef
+    }) => {
+      const collapsedMessages = resolveMessages(messages);
+      const result = m$1` <${Virtuoso}
+    id=${`${id2}-virtual-list`}
+    style=${{
+        width: "100%",
+        overflowY: "unset",
+        boxSizing: "border-box",
+        ...style2
+      }}
+    customScrollParent=${scrollRef.current}
+    totalCount=${collapsedMessages.length}
+    increaseViewportBy=${{
+        top: 1e3,
+        bottom: 1e3
+      }}
+    itemContent=${(index) => {
+        const number = collapsedMessages.length > 1 && numbered ? index + 1 : void 0;
+        return m$1`<${ChatMessageRow}
+        id=${id2}
+        number=${number}
+        resolvedMessage=${collapsedMessages[index]}
+        indented=${indented}
+        toolCallStyle=${toolCallStyle}
+      />`;
+      }}
+  />`;
+      return result;
+    };
     const ChatView = ({
       id: id2,
       messages,
@@ -20065,18 +20102,18 @@ var require_assets = __commonJS({
       numbered = true
     }) => {
       const collapsedMessages = resolveMessages(messages);
-      const result = m$1`
-    <div style=${style2}>
-      ${collapsedMessages.map((msg, index) => {
+      const result = m$1` <div style=${style2}>
+    ${collapsedMessages.map((msg, index) => {
         const number = collapsedMessages.length > 1 && numbered ? index + 1 : void 0;
         return m$1`<${ChatMessageRow}
-              id=${id2}
-              number=${number}
-              resolvedMessage=${msg}
-              indented=${indented}
-              toolCallStyle=${toolCallStyle}/>`;
+        id=${id2}
+        number=${number}
+        resolvedMessage=${msg}
+        indented=${indented}
+        toolCallStyle=${toolCallStyle}
+      />`;
       })}
-    </div>`;
+  </div>`;
       return result;
     };
     const ChatMessageRow = ({
@@ -20088,37 +20125,37 @@ var require_assets = __commonJS({
     }) => {
       if (number) {
         return m$1` <div
-        style=${{
+      style=${{
           display: "grid",
           gridTemplateColumns: "max-content auto",
           columnGap: "0.4em"
         }}
-      >
-        <div
-          style=${{
+    >
+      <div
+        style=${{
           fontSize: FontSize.smaller,
           ...TextStyle.secondary,
           marginTop: "0.1em"
         }}
-        >
-          ${number}
-        </div>
-        <${ChatMessage}
-          id=${`${id2}-chat-messages`}
-          message=${resolvedMessage.message}
-          toolMessages=${resolvedMessage.toolMessages}
-          indented=${indented}
-          toolCallStyle=${toolCallStyle}
-        />
-      </div>`;
-      } else {
-        return m$1`<${ChatMessage}
+      >
+        ${number}
+      </div>
+      <${ChatMessage}
         id=${`${id2}-chat-messages`}
         message=${resolvedMessage.message}
         toolMessages=${resolvedMessage.toolMessages}
         indented=${indented}
         toolCallStyle=${toolCallStyle}
-      />`;
+      />
+    </div>`;
+      } else {
+        return m$1`<${ChatMessage}
+      id=${`${id2}-chat-messages`}
+      message=${resolvedMessage.message}
+      toolMessages=${resolvedMessage.toolMessages}
+      indented=${indented}
+      toolCallStyle=${toolCallStyle}
+    />`;
       }
     };
     const resolveMessages = (messages) => {
@@ -29424,23 +29461,28 @@ ${events}
       const resolvedEvents = fixupEventStream(events);
       const eventNodes = treeifyEvents(resolvedEvents, depth);
       return m$1`<${TranscriptVirtualListComponent}
-                  id=${id2}
-                  eventNodes=${eventNodes}
-                  style=${style2}
-                  scrollRef=${scrollRef}/>`;
+    id=${id2}
+    eventNodes=${eventNodes}
+    style=${style2}
+    scrollRef=${scrollRef}
+  />`;
     };
-    const TranscriptVirtualListComponent = ({ id: id2, eventNodes, style: style2, scrollRef }) => {
+    const TranscriptVirtualListComponent = ({
+      id: id2,
+      eventNodes,
+      style: style2,
+      scrollRef
+    }) => {
       return m$1`<${Virtuoso}
-                id=${`${id2}-virtual-list`}
-                logLevel=${LogLevel.DEBUG}
-                style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
-                customScrollParent=${scrollRef.current}
-                data=${eventNodes}
-                overscan=${{
-        reverse: 3,
-        main: 2
+    id=${`${id2}-virtual-list`}
+    style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
+    customScrollParent=${scrollRef.current}
+    data=${eventNodes}
+    increaseViewportBy=${{
+        top: 1e3,
+        bottom: 1e3
       }}
-                itemContent=${(index) => {
+    itemContent=${(index) => {
         const node = eventNodes[index];
         const toggleStyle = {};
         if (node.depth % 2 == 0) {
@@ -29453,18 +29495,18 @@ ${events}
           paddingTop = ".5em";
         }
         return m$1`<div style=${{ paddingTop, paddingBottom: ".5em" }}>
-                                  <${RenderedEventNode}
-                                    id=${`${id2}-event${index}`}
-                                    node=${node}
-                                    style=${{
+        <${RenderedEventNode}
+          id=${`${id2}-event${index}`}
+          node=${node}
+          style=${{
           ...toggleStyle,
           ...style2
         }}
-                                    scrollRef=${scrollRef}
-                                  />
-                                </div>`;
+          scrollRef=${scrollRef}
+        />
+      </div>`;
       }}
-              />`;
+  />`;
     };
     const TranscriptComponent = ({ id: id2, eventNodes, style: style2 }) => {
       const rows = eventNodes.map((eventNode, index) => {
@@ -29485,14 +29527,14 @@ ${events}
         }
         const row = m$1`
       <div style=${{ paddingBottom }}>
-      <${RenderedEventNode}
-        id=${`${id2}-event${index}`}
-        node=${eventNode}
-        style=${{
+        <${RenderedEventNode}
+          id=${`${id2}-event${index}`}
+          node=${eventNode}
+          style=${{
           ...toggleStyle,
           ...style2
         }}
-      />
+        />
       </div>
     `;
         return row;
@@ -29659,7 +29701,11 @@ ${events}
       return rootNodes;
     }
     const SampleTranscript = ({ id: id2, evalEvents, scrollRef }) => {
-      return m$1`<${TranscriptVirtualList} id=${id2} events=${evalEvents} scrollRef=${scrollRef}/>`;
+      return m$1`<${TranscriptVirtualList}
+    id=${id2}
+    events=${evalEvents}
+    scrollRef=${scrollRef}
+  />`;
     };
     const SampleError = ({ message, align, style: style2 }) => {
       align = align || "center";
@@ -29830,12 +29876,13 @@ ${events}
       const tabs = [
         m$1`
     <${TabPanel} id=${kSampleMessagesTabId} classes="sample-tab" title="Messages" onSelected=${onSelectedTab} selected=${selectedTab === kSampleMessagesTabId}>
-      <${ChatView} 
+      <${ChatViewVirtualList} 
         key=${`${baseId}-chat-${id2}`} 
         id=${`${baseId}-chat-${id2}`} 
         messages=${sample.messages} 
         style=${{ paddingLeft: ".8em", paddingTop: "1em" }}
         indented=${true}
+        scrollRef=${scrollRef}
       />
     </${TabPanel}>`
       ];
@@ -30955,7 +31002,9 @@ ${events}
             reject(new Error(error2.message));
           };
         });
-        worker.postMessage({ scriptContent: kJson5ScriptBase64, encodedText }, [encodedText.buffer]);
+        worker.postMessage({ scriptContent: kJson5ScriptBase64, encodedText }, [
+          encodedText.buffer
+        ]);
         return await result;
       } finally {
         worker.terminate();

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -20066,7 +20066,7 @@ var require_assets = __commonJS({
       scrollRef
     }) => {
       const collapsedMessages = resolveMessages(messages);
-      const result = m$1` <${Virtuoso}
+      const result = m$1`<${Virtuoso}
     id=${`${id2}-virtual-list`}
     style=${{
         width: "100%",
@@ -20080,6 +20080,7 @@ var require_assets = __commonJS({
         top: 1e3,
         bottom: 1e3
       }}
+    skipAnimationFrameInResizeObserver=${true}
     itemContent=${(index) => {
         const number = collapsedMessages.length > 1 && numbered ? index + 1 : void 0;
         return m$1`<${ChatMessageRow}
@@ -29478,6 +29479,7 @@ ${events}
     style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
     customScrollParent=${scrollRef.current}
     data=${eventNodes}
+    skipAnimationFrameInResizeObserver=${true}
     increaseViewportBy=${{
         top: 1e3,
         bottom: 1e3

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -28624,7 +28624,7 @@ ${events}
     function initializeObject(current) {
       return current ?? {};
     }
-    const StepEventView = ({ event, children: children2, style: style2 }) => {
+    const StepEventView = ({ event, children: children2, style: style2, scrollRef }) => {
       const descriptor = stepDescriptor(event);
       const title = descriptor.name || `${event.type ? event.type + ": " : "Step: "}${event.name}`;
       const text2 = summarize(children2);
@@ -28639,9 +28639,10 @@ ${events}
     collapse=${false}
     text=${text2}
   >
-    <${TranscriptComponent}
+    <${TranscriptVirtualListComponent}
       id=${`step-${event.name}-transcript`}
       eventNodes=${children2}
+      scrollRef=${scrollRef}
     />
   </EventPanel>
   `;
@@ -29422,17 +29423,24 @@ ${events}
       let { id: id2, scrollRef, events, depth, style: style2 } = props;
       const resolvedEvents = fixupEventStream(events);
       const eventNodes = treeifyEvents(resolvedEvents, depth);
+      return m$1`<${TranscriptVirtualListComponent}
+                  id=${id2}
+                  eventNodes=${eventNodes}
+                  style=${style2}
+                  scrollRef=${scrollRef}/>`;
+    };
+    const TranscriptVirtualListComponent = ({ id: id2, eventNodes, style: style2, scrollRef }) => {
       return m$1`<${Virtuoso}
-      id=${`${id2}-virtual-list`}
-      logLevel=${LogLevel.DEBUG}
-      style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
-      customScrollParent=${scrollRef.current}
-      data=${eventNodes}
-      overscan=${{
+                id=${`${id2}-virtual-list`}
+                logLevel=${LogLevel.DEBUG}
+                style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
+                customScrollParent=${scrollRef.current}
+                data=${eventNodes}
+                overscan=${{
         reverse: 3,
         main: 2
       }}
-      itemContent=${(index) => {
+                itemContent=${(index) => {
         const node = eventNodes[index];
         const toggleStyle = {};
         if (node.depth % 2 == 0) {
@@ -29445,17 +29453,18 @@ ${events}
           paddingTop = ".5em";
         }
         return m$1`<div style=${{ paddingTop, paddingBottom: ".5em" }}>
-                        <${RenderedEventNode}
-                          id=${`${id2}-event${index}`}
-                          node=${node}
-                          style=${{
+                                  <${RenderedEventNode}
+                                    id=${`${id2}-event${index}`}
+                                    node=${node}
+                                    style=${{
           ...toggleStyle,
           ...style2
         }}
-                        />
-                      </div>`;
+                                    scrollRef=${scrollRef}
+                                  />
+                                </div>`;
       }}
-    />`;
+              />`;
     };
     const TranscriptComponent = ({ id: id2, eventNodes, style: style2 }) => {
       const rows = eventNodes.map((eventNode, index) => {
@@ -29501,7 +29510,7 @@ ${events}
     ${rows}
   </div>`;
     };
-    const RenderedEventNode = ({ id: id2, node, style: style2 }) => {
+    const RenderedEventNode = ({ id: id2, node, style: style2, scrollRef }) => {
       switch (node.event.event) {
         case "sample_init":
           return m$1`<${SampleInitEventView}
@@ -29551,6 +29560,7 @@ ${events}
         event=${node.event}
         children=${node.children}
         style=${style2}
+        scrollRef=${scrollRef}
       />`;
         case "store":
           return m$1`<${StateEventView}

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -44,37 +44,37 @@ var require_assets = __commonJS({
         fetch(link2.href, fetchOpts);
       }
     })();
-    var n$2, l$1, u$1, i$2, r$2, o$1, e$3, f$1, c$2, s$1, a$1, p$1 = {}, v$1 = [], y$1 = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i, d$1 = Array.isArray;
-    function w$1(n2, l2) {
+    var n$2, l$1, u$2, i$2, r$2, o$1, e$3, f$2, c$2, s$1, a$1, h$1, p$1 = {}, v$1 = [], y$1 = /acit|ex(?:s|g|n|p|$)|rph|grid|ows|mnc|ntw|ine[ch]|zoo|^ord|itera/i, d$1 = Array.isArray;
+    function w$2(n2, l2) {
       for (var u2 in l2) n2[u2] = l2[u2];
       return n2;
     }
-    function _(n2) {
+    function _$1(n2) {
       n2 && n2.parentNode && n2.parentNode.removeChild(n2);
     }
-    function g(l2, u2, t2) {
+    function g$2(l2, u2, t2) {
       var i2, r2, o2, e2 = {};
       for (o2 in u2) "key" == o2 ? i2 = u2[o2] : "ref" == o2 ? r2 = u2[o2] : e2[o2] = u2[o2];
       if (arguments.length > 2 && (e2.children = arguments.length > 3 ? n$2.call(arguments, 2) : t2), "function" == typeof l2 && null != l2.defaultProps) for (o2 in l2.defaultProps) void 0 === e2[o2] && (e2[o2] = l2.defaultProps[o2]);
       return m$2(l2, e2, i2, r2, null);
     }
     function m$2(n2, t2, i2, r2, o2) {
-      var e2 = { type: n2, props: t2, key: i2, ref: r2, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: null == o2 ? ++u$1 : o2, __i: -1, __u: 0 };
+      var e2 = { type: n2, props: t2, key: i2, ref: r2, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: null == o2 ? ++u$2 : o2, __i: -1, __u: 0 };
       return null == o2 && null != l$1.vnode && l$1.vnode(e2), e2;
     }
     function b() {
       return { current: null };
     }
-    function k$1(n2) {
+    function k$2(n2) {
       return n2.children;
     }
-    function x$1(n2, l2) {
+    function x$3(n2, l2) {
       this.props = n2, this.context = l2;
     }
-    function C$1(n2, l2) {
-      if (null == l2) return n2.__ ? C$1(n2.__, n2.__i + 1) : null;
+    function C$2(n2, l2) {
+      if (null == l2) return n2.__ ? C$2(n2.__, n2.__i + 1) : null;
       for (var u2; l2 < n2.__k.length; l2++) if (null != (u2 = n2.__k[l2]) && null != u2.__e) return u2.__e;
-      return "function" == typeof n2.type ? C$1(n2) : null;
+      return "function" == typeof n2.type ? C$2(n2) : null;
     }
     function S(n2) {
       var l2, u2;
@@ -86,41 +86,46 @@ var require_assets = __commonJS({
         return S(n2);
       }
     }
-    function M(n2) {
-      (!n2.__d && (n2.__d = true) && i$2.push(n2) && !P$1.__r++ || r$2 !== l$1.debounceRendering) && ((r$2 = l$1.debounceRendering) || o$1)(P$1);
+    function M$1(n2) {
+      (!n2.__d && (n2.__d = true) && i$2.push(n2) && !P$3.__r++ || r$2 !== l$1.debounceRendering) && ((r$2 = l$1.debounceRendering) || o$1)(P$3);
     }
-    function P$1() {
+    function P$3() {
       var n2, u2, t2, r2, o2, f2, c2, s2;
-      for (i$2.sort(e$3); n2 = i$2.shift(); ) n2.__d && (u2 = i$2.length, r2 = void 0, f2 = (o2 = (t2 = n2).__v).__e, c2 = [], s2 = [], t2.__P && ((r2 = w$1({}, o2)).__v = o2.__v + 1, l$1.vnode && l$1.vnode(r2), j$1(t2.__P, r2, o2, t2.__n, t2.__P.namespaceURI, 32 & o2.__u ? [f2] : null, c2, null == f2 ? C$1(o2) : f2, !!(32 & o2.__u), s2), r2.__v = o2.__v, r2.__.__k[r2.__i] = r2, z$1(c2, r2, s2), r2.__e != f2 && S(r2)), i$2.length > u2 && i$2.sort(e$3));
-      P$1.__r = 0;
+      for (i$2.sort(e$3); n2 = i$2.shift(); ) n2.__d && (u2 = i$2.length, r2 = void 0, f2 = (o2 = (t2 = n2).__v).__e, c2 = [], s2 = [], t2.__P && ((r2 = w$2({}, o2)).__v = o2.__v + 1, l$1.vnode && l$1.vnode(r2), j$2(t2.__P, r2, o2, t2.__n, t2.__P.namespaceURI, 32 & o2.__u ? [f2] : null, c2, null == f2 ? C$2(o2) : f2, !!(32 & o2.__u), s2), r2.__v = o2.__v, r2.__.__k[r2.__i] = r2, z$2(c2, r2, s2), r2.__e != f2 && S(r2)), i$2.length > u2 && i$2.sort(e$3));
+      P$3.__r = 0;
     }
-    function $(n2, l2, u2, t2, i2, r2, o2, e2, f2, c2, s2) {
+    function $$1(n2, l2, u2, t2, i2, r2, o2, e2, f2, c2, s2) {
       var a2, h2, y2, d2, w2, _2, g2 = t2 && t2.__k || v$1, m2 = l2.length;
-      for (f2 = I(u2, l2, g2, f2), a2 = 0; a2 < m2; a2++) null != (y2 = u2.__k[a2]) && (h2 = -1 === y2.__i ? p$1 : g2[y2.__i] || p$1, y2.__i = a2, _2 = j$1(n2, y2, h2, i2, r2, o2, e2, f2, c2, s2), d2 = y2.__e, y2.ref && h2.ref != y2.ref && (h2.ref && V(h2.ref, null, y2), s2.push(y2.ref, y2.__c || d2, y2)), null == w2 && null != d2 && (w2 = d2), 4 & y2.__u || h2.__k === y2.__k ? f2 = H(y2, f2, n2) : "function" == typeof y2.type && void 0 !== _2 ? f2 = _2 : d2 && (f2 = d2.nextSibling), y2.__u &= -7);
+      for (f2 = I$1(u2, l2, g2, f2), a2 = 0; a2 < m2; a2++) null != (y2 = u2.__k[a2]) && (h2 = -1 === y2.__i ? p$1 : g2[y2.__i] || p$1, y2.__i = a2, _2 = j$2(n2, y2, h2, i2, r2, o2, e2, f2, c2, s2), d2 = y2.__e, y2.ref && h2.ref != y2.ref && (h2.ref && V$1(h2.ref, null, y2), s2.push(y2.ref, y2.__c || d2, y2)), null == w2 && null != d2 && (w2 = d2), 4 & y2.__u || h2.__k === y2.__k ? f2 = H$1(y2, f2, n2) : "function" == typeof y2.type && void 0 !== _2 ? f2 = _2 : d2 && (f2 = d2.nextSibling), y2.__u &= -7);
       return u2.__e = w2, f2;
     }
-    function I(n2, l2, u2, t2) {
+    function I$1(n2, l2, u2, t2) {
       var i2, r2, o2, e2, f2, c2 = l2.length, s2 = u2.length, a2 = s2, h2 = 0;
-      for (n2.__k = [], i2 = 0; i2 < c2; i2++) null != (r2 = l2[i2]) && "boolean" != typeof r2 && "function" != typeof r2 ? (e2 = i2 + h2, (r2 = n2.__k[i2] = "string" == typeof r2 || "number" == typeof r2 || "bigint" == typeof r2 || r2.constructor == String ? m$2(null, r2, null, null, null) : d$1(r2) ? m$2(k$1, { children: r2 }, null, null, null) : void 0 === r2.constructor && r2.__b > 0 ? m$2(r2.type, r2.props, r2.key, r2.ref ? r2.ref : null, r2.__v) : r2).__ = n2, r2.__b = n2.__b + 1, o2 = null, -1 !== (f2 = r2.__i = T$1(r2, u2, e2, a2)) && (a2--, (o2 = u2[f2]) && (o2.__u |= 2)), null == o2 || null === o2.__v ? (-1 == f2 && h2--, "function" != typeof r2.type && (r2.__u |= 4)) : f2 !== e2 && (f2 == e2 - 1 ? h2-- : f2 == e2 + 1 ? h2++ : (f2 > e2 ? h2-- : h2++, r2.__u |= 4))) : r2 = n2.__k[i2] = null;
-      if (a2) for (i2 = 0; i2 < s2; i2++) null != (o2 = u2[i2]) && 0 == (2 & o2.__u) && (o2.__e == t2 && (t2 = C$1(o2)), q$1(o2, o2));
+      for (n2.__k = [], i2 = 0; i2 < c2; i2++) null != (r2 = l2[i2]) && "boolean" != typeof r2 && "function" != typeof r2 ? (e2 = i2 + h2, (r2 = n2.__k[i2] = "string" == typeof r2 || "number" == typeof r2 || "bigint" == typeof r2 || r2.constructor == String ? m$2(null, r2, null, null, null) : d$1(r2) ? m$2(k$2, { children: r2 }, null, null, null) : void 0 === r2.constructor && r2.__b > 0 ? m$2(r2.type, r2.props, r2.key, r2.ref ? r2.ref : null, r2.__v) : r2).__ = n2, r2.__b = n2.__b + 1, o2 = null, -1 !== (f2 = r2.__i = T$2(r2, u2, e2, a2)) && (a2--, (o2 = u2[f2]) && (o2.__u |= 2)), null == o2 || null === o2.__v ? (-1 == f2 && h2--, "function" != typeof r2.type && (r2.__u |= 4)) : f2 !== e2 && (f2 == e2 - 1 ? h2-- : f2 == e2 + 1 ? h2++ : (f2 > e2 ? h2-- : h2++, r2.__u |= 4))) : r2 = n2.__k[i2] = null;
+      if (a2) for (i2 = 0; i2 < s2; i2++) null != (o2 = u2[i2]) && 0 == (2 & o2.__u) && (o2.__e == t2 && (t2 = C$2(o2)), q$2(o2, o2));
       return t2;
     }
-    function H(n2, l2, u2) {
+    function H$1(n2, l2, u2) {
       var t2, i2;
       if ("function" == typeof n2.type) {
-        for (t2 = n2.__k, i2 = 0; t2 && i2 < t2.length; i2++) t2[i2] && (t2[i2].__ = n2, l2 = H(t2[i2], l2, u2));
+        for (t2 = n2.__k, i2 = 0; t2 && i2 < t2.length; i2++) t2[i2] && (t2[i2].__ = n2, l2 = H$1(t2[i2], l2, u2));
         return l2;
       }
-      n2.__e != l2 && (l2 && n2.type && !u2.contains(l2) && (l2 = C$1(n2)), u2.insertBefore(n2.__e, l2 || null), l2 = n2.__e);
+      n2.__e != l2 && (l2 && n2.type && !u2.contains(l2) && (l2 = C$2(n2)), u2.insertBefore(n2.__e, l2 || null), l2 = n2.__e);
       do {
         l2 = l2 && l2.nextSibling;
       } while (null != l2 && 8 === l2.nodeType);
       return l2;
     }
-    function T$1(n2, l2, u2, t2) {
+    function L$1(n2, l2) {
+      return l2 = l2 || [], null == n2 || "boolean" == typeof n2 || (d$1(n2) ? n2.some(function(n3) {
+        L$1(n3, l2);
+      }) : l2.push(n2)), l2;
+    }
+    function T$2(n2, l2, u2, t2) {
       var i2 = n2.key, r2 = n2.type, o2 = u2 - 1, e2 = u2 + 1, f2 = l2[u2];
       if (null === f2 || f2 && i2 == f2.key && r2 === f2.type && 0 == (2 & f2.__u)) return u2;
-      if (("function" != typeof r2 || r2 === k$1 || i2) && t2 > (null != f2 && 0 == (2 & f2.__u) ? 1 : 0)) for (; o2 >= 0 || e2 < l2.length; ) {
+      if (("function" != typeof r2 || r2 === k$2 || i2) && t2 > (null != f2 && 0 == (2 & f2.__u) ? 1 : 0)) for (; o2 >= 0 || e2 < l2.length; ) {
         if (o2 >= 0) {
           if ((f2 = l2[o2]) && 0 == (2 & f2.__u) && i2 == f2.key && r2 === f2.type) return o2;
           o2--;
@@ -132,17 +137,17 @@ var require_assets = __commonJS({
       }
       return -1;
     }
-    function A$1(n2, l2, u2) {
+    function A$2(n2, l2, u2) {
       "-" === l2[0] ? n2.setProperty(l2, null == u2 ? "" : u2) : n2[l2] = null == u2 ? "" : "number" != typeof u2 || y$1.test(l2) ? u2 : u2 + "px";
     }
-    function F(n2, l2, u2, t2, i2) {
+    function F$2(n2, l2, u2, t2, i2) {
       var r2;
       n: if ("style" === l2) if ("string" == typeof u2) n2.style.cssText = u2;
       else {
-        if ("string" == typeof t2 && (n2.style.cssText = t2 = ""), t2) for (l2 in t2) u2 && l2 in u2 || A$1(n2.style, l2, "");
-        if (u2) for (l2 in u2) t2 && u2[l2] === t2[l2] || A$1(n2.style, l2, u2[l2]);
+        if ("string" == typeof t2 && (n2.style.cssText = t2 = ""), t2) for (l2 in t2) u2 && l2 in u2 || A$2(n2.style, l2, "");
+        if (u2) for (l2 in u2) t2 && u2[l2] === t2[l2] || A$2(n2.style, l2, u2[l2]);
       }
-      else if ("o" === l2[0] && "n" === l2[1]) r2 = l2 !== (l2 = l2.replace(f$1, "$1")), l2 = l2.toLowerCase() in n2 || "onFocusOut" === l2 || "onFocusIn" === l2 ? l2.toLowerCase().slice(2) : l2.slice(2), n2.l || (n2.l = {}), n2.l[l2 + r2] = u2, u2 ? t2 ? u2.u = t2.u : (u2.u = c$2, n2.addEventListener(l2, r2 ? a$1 : s$1, r2)) : n2.removeEventListener(l2, r2 ? a$1 : s$1, r2);
+      else if ("o" === l2[0] && "n" === l2[1]) r2 = l2 !== (l2 = l2.replace(f$2, "$1")), l2 = l2.toLowerCase() in n2 || "onFocusOut" === l2 || "onFocusIn" === l2 ? l2.toLowerCase().slice(2) : l2.slice(2), n2.l || (n2.l = {}), n2.l[l2 + r2] = u2, u2 ? t2 ? u2.u = t2.u : (u2.u = c$2, n2.addEventListener(l2, r2 ? a$1 : s$1, r2)) : n2.removeEventListener(l2, r2 ? a$1 : s$1, r2);
       else {
         if ("http://www.w3.org/2000/svg" == i2) l2 = l2.replace(/xlink(H|:h)/, "h").replace(/sName$/, "s");
         else if ("width" != l2 && "height" != l2 && "href" != l2 && "list" != l2 && "form" != l2 && "tabIndex" != l2 && "download" != l2 && "rowSpan" != l2 && "colSpan" != l2 && "role" != l2 && "popover" != l2 && l2 in n2) try {
@@ -153,7 +158,7 @@ var require_assets = __commonJS({
         "function" == typeof u2 || (null == u2 || false === u2 && "-" !== l2[4] ? n2.removeAttribute(l2) : n2.setAttribute(l2, "popover" == l2 && 1 == u2 ? "" : u2));
       }
     }
-    function O(n2) {
+    function O$1(n2) {
       return function(u2) {
         if (this.l) {
           var t2 = this.l[u2.type + n2];
@@ -163,12 +168,12 @@ var require_assets = __commonJS({
         }
       };
     }
-    function j$1(n2, u2, t2, i2, r2, o2, e2, f2, c2, s2) {
-      var a2, h2, p2, v2, y2, g2, m2, b2, C2, S2, M2, P2, I2, H2, L, T2, A2, F2 = u2.type;
+    function j$2(n2, u2, t2, i2, r2, o2, e2, f2, c2, s2) {
+      var a2, h2, p2, v2, y2, g2, m2, b2, C2, S2, M2, P2, I2, H2, L2, T2, A2, F2 = u2.type;
       if (void 0 !== u2.constructor) return null;
       128 & t2.__u && (c2 = !!(32 & t2.__u), o2 = [f2 = u2.__e = t2.__e]), (a2 = l$1.__b) && a2(u2);
       n: if ("function" == typeof F2) try {
-        if (b2 = u2.props, C2 = "prototype" in F2 && F2.prototype.render, S2 = (a2 = F2.contextType) && i2[a2.__c], M2 = a2 ? S2 ? S2.props.value : a2.__ : i2, t2.__c ? m2 = (h2 = u2.__c = t2.__c).__ = h2.__E : (C2 ? u2.__c = h2 = new F2(b2, M2) : (u2.__c = h2 = new x$1(b2, M2), h2.constructor = F2, h2.render = B$1), S2 && S2.sub(h2), h2.props = b2, h2.state || (h2.state = {}), h2.context = M2, h2.__n = i2, p2 = h2.__d = true, h2.__h = [], h2._sb = []), C2 && null == h2.__s && (h2.__s = h2.state), C2 && null != F2.getDerivedStateFromProps && (h2.__s == h2.state && (h2.__s = w$1({}, h2.__s)), w$1(h2.__s, F2.getDerivedStateFromProps(b2, h2.__s))), v2 = h2.props, y2 = h2.state, h2.__v = u2, p2) C2 && null == F2.getDerivedStateFromProps && null != h2.componentWillMount && h2.componentWillMount(), C2 && null != h2.componentDidMount && h2.__h.push(h2.componentDidMount);
+        if (b2 = u2.props, C2 = "prototype" in F2 && F2.prototype.render, S2 = (a2 = F2.contextType) && i2[a2.__c], M2 = a2 ? S2 ? S2.props.value : a2.__ : i2, t2.__c ? m2 = (h2 = u2.__c = t2.__c).__ = h2.__E : (C2 ? u2.__c = h2 = new F2(b2, M2) : (u2.__c = h2 = new x$3(b2, M2), h2.constructor = F2, h2.render = B$2), S2 && S2.sub(h2), h2.props = b2, h2.state || (h2.state = {}), h2.context = M2, h2.__n = i2, p2 = h2.__d = true, h2.__h = [], h2._sb = []), C2 && null == h2.__s && (h2.__s = h2.state), C2 && null != F2.getDerivedStateFromProps && (h2.__s == h2.state && (h2.__s = w$2({}, h2.__s)), w$2(h2.__s, F2.getDerivedStateFromProps(b2, h2.__s))), v2 = h2.props, y2 = h2.state, h2.__v = u2, p2) C2 && null == F2.getDerivedStateFromProps && null != h2.componentWillMount && h2.componentWillMount(), C2 && null != h2.componentDidMount && h2.__h.push(h2.componentDidMount);
         else {
           if (C2 && null == F2.getDerivedStateFromProps && b2 !== v2 && null != h2.componentWillReceiveProps && h2.componentWillReceiveProps(b2, M2), !h2.__e && (null != h2.shouldComponentUpdate && false === h2.shouldComponentUpdate(b2, h2.__s, M2) || u2.__v === t2.__v)) {
             for (u2.__v !== t2.__v && (h2.props = b2, h2.state = h2.__s, h2.__d = false), u2.__e = t2.__e, u2.__k = t2.__k, u2.__k.some(function(n3) {
@@ -182,25 +187,25 @@ var require_assets = __commonJS({
           });
         }
         if (h2.context = M2, h2.props = b2, h2.__P = n2, h2.__e = false, I2 = l$1.__r, H2 = 0, C2) {
-          for (h2.state = h2.__s, h2.__d = false, I2 && I2(u2), a2 = h2.render(h2.props, h2.state, h2.context), L = 0; L < h2._sb.length; L++) h2.__h.push(h2._sb[L]);
+          for (h2.state = h2.__s, h2.__d = false, I2 && I2(u2), a2 = h2.render(h2.props, h2.state, h2.context), L2 = 0; L2 < h2._sb.length; L2++) h2.__h.push(h2._sb[L2]);
           h2._sb = [];
         } else do {
           h2.__d = false, I2 && I2(u2), a2 = h2.render(h2.props, h2.state, h2.context), h2.state = h2.__s;
         } while (h2.__d && ++H2 < 25);
-        h2.state = h2.__s, null != h2.getChildContext && (i2 = w$1(w$1({}, i2), h2.getChildContext())), C2 && !p2 && null != h2.getSnapshotBeforeUpdate && (g2 = h2.getSnapshotBeforeUpdate(v2, y2)), f2 = $(n2, d$1(T2 = null != a2 && a2.type === k$1 && null == a2.key ? a2.props.children : a2) ? T2 : [T2], u2, t2, i2, r2, o2, e2, f2, c2, s2), h2.base = u2.__e, u2.__u &= -161, h2.__h.length && e2.push(h2), m2 && (h2.__E = h2.__ = null);
+        h2.state = h2.__s, null != h2.getChildContext && (i2 = w$2(w$2({}, i2), h2.getChildContext())), C2 && !p2 && null != h2.getSnapshotBeforeUpdate && (g2 = h2.getSnapshotBeforeUpdate(v2, y2)), f2 = $$1(n2, d$1(T2 = null != a2 && a2.type === k$2 && null == a2.key ? a2.props.children : a2) ? T2 : [T2], u2, t2, i2, r2, o2, e2, f2, c2, s2), h2.base = u2.__e, u2.__u &= -161, h2.__h.length && e2.push(h2), m2 && (h2.__E = h2.__ = null);
       } catch (n3) {
         if (u2.__v = null, c2 || null != o2) if (n3.then) {
           for (u2.__u |= c2 ? 160 : 128; f2 && 8 === f2.nodeType && f2.nextSibling; ) f2 = f2.nextSibling;
           o2[o2.indexOf(f2)] = null, u2.__e = f2;
-        } else for (A2 = o2.length; A2--; ) _(o2[A2]);
+        } else for (A2 = o2.length; A2--; ) _$1(o2[A2]);
         else u2.__e = t2.__e, u2.__k = t2.__k;
         l$1.__e(n3, u2, t2);
       }
-      else null == o2 && u2.__v === t2.__v ? (u2.__k = t2.__k, u2.__e = t2.__e) : f2 = u2.__e = N(t2.__e, u2, t2, i2, r2, o2, e2, c2, s2);
+      else null == o2 && u2.__v === t2.__v ? (u2.__k = t2.__k, u2.__e = t2.__e) : f2 = u2.__e = N$1(t2.__e, u2, t2, i2, r2, o2, e2, c2, s2);
       return (a2 = l$1.diffed) && a2(u2), 128 & u2.__u ? void 0 : f2;
     }
-    function z$1(n2, u2, t2) {
-      for (var i2 = 0; i2 < t2.length; i2++) V(t2[i2], t2[++i2], t2[++i2]);
+    function z$2(n2, u2, t2) {
+      for (var i2 = 0; i2 < t2.length; i2++) V$1(t2[i2], t2[++i2], t2[++i2]);
       l$1.__c && l$1.__c(u2, n2), n2.some(function(u3) {
         try {
           n2 = u3.__h, u3.__h = [], n2.some(function(n3) {
@@ -211,7 +216,7 @@ var require_assets = __commonJS({
         }
       });
     }
-    function N(u2, t2, i2, r2, o2, e2, f2, c2, s2) {
+    function N$1(u2, t2, i2, r2, o2, e2, f2, c2, s2) {
       var a2, h2, v2, y2, w2, g2, m2, b2 = i2.props, k2 = t2.props, x2 = t2.type;
       if ("svg" === x2 ? o2 = "http://www.w3.org/2000/svg" : "math" === x2 ? o2 = "http://www.w3.org/1998/Math/MathML" : o2 || (o2 = "http://www.w3.org/1999/xhtml"), null != e2) {
         for (a2 = 0; a2 < e2.length; a2++) if ((w2 = e2[a2]) && "setAttribute" in w2 == !!x2 && (x2 ? w2.localName === x2 : 3 === w2.nodeType)) {
@@ -230,16 +235,16 @@ var require_assets = __commonJS({
         else if ("dangerouslySetInnerHTML" == a2) v2 = w2;
         else if (!(a2 in k2)) {
           if ("value" == a2 && "defaultValue" in k2 || "checked" == a2 && "defaultChecked" in k2) continue;
-          F(u2, a2, null, w2, o2);
+          F$2(u2, a2, null, w2, o2);
         }
-        for (a2 in k2) w2 = k2[a2], "children" == a2 ? y2 = w2 : "dangerouslySetInnerHTML" == a2 ? h2 = w2 : "value" == a2 ? g2 = w2 : "checked" == a2 ? m2 = w2 : c2 && "function" != typeof w2 || b2[a2] === w2 || F(u2, a2, w2, b2[a2], o2);
+        for (a2 in k2) w2 = k2[a2], "children" == a2 ? y2 = w2 : "dangerouslySetInnerHTML" == a2 ? h2 = w2 : "value" == a2 ? g2 = w2 : "checked" == a2 ? m2 = w2 : c2 && "function" != typeof w2 || b2[a2] === w2 || F$2(u2, a2, w2, b2[a2], o2);
         if (h2) c2 || v2 && (h2.__html === v2.__html || h2.__html === u2.innerHTML) || (u2.innerHTML = h2.__html), t2.__k = [];
-        else if (v2 && (u2.innerHTML = ""), $(u2, d$1(y2) ? y2 : [y2], t2, i2, r2, "foreignObject" === x2 ? "http://www.w3.org/1999/xhtml" : o2, e2, f2, e2 ? e2[0] : i2.__k && C$1(i2, 0), c2, s2), null != e2) for (a2 = e2.length; a2--; ) _(e2[a2]);
-        c2 || (a2 = "value", "progress" === x2 && null == g2 ? u2.removeAttribute("value") : void 0 !== g2 && (g2 !== u2[a2] || "progress" === x2 && !g2 || "option" === x2 && g2 !== b2[a2]) && F(u2, a2, g2, b2[a2], o2), a2 = "checked", void 0 !== m2 && m2 !== u2[a2] && F(u2, a2, m2, b2[a2], o2));
+        else if (v2 && (u2.innerHTML = ""), $$1(u2, d$1(y2) ? y2 : [y2], t2, i2, r2, "foreignObject" === x2 ? "http://www.w3.org/1999/xhtml" : o2, e2, f2, e2 ? e2[0] : i2.__k && C$2(i2, 0), c2, s2), null != e2) for (a2 = e2.length; a2--; ) _$1(e2[a2]);
+        c2 || (a2 = "value", "progress" === x2 && null == g2 ? u2.removeAttribute("value") : void 0 !== g2 && (g2 !== u2[a2] || "progress" === x2 && !g2 || "option" === x2 && g2 !== b2[a2]) && F$2(u2, a2, g2, b2[a2], o2), a2 = "checked", void 0 !== m2 && m2 !== u2[a2] && F$2(u2, a2, m2, b2[a2], o2));
       }
       return u2;
     }
-    function V(n2, u2, t2) {
+    function V$1(n2, u2, t2) {
       try {
         if ("function" == typeof n2) {
           var i2 = "function" == typeof n2.__u;
@@ -249,9 +254,9 @@ var require_assets = __commonJS({
         l$1.__e(n3, t2);
       }
     }
-    function q$1(n2, u2, t2) {
+    function q$2(n2, u2, t2) {
       var i2, r2;
-      if (l$1.unmount && l$1.unmount(n2), (i2 = n2.ref) && (i2.current && i2.current !== n2.__e || V(i2, null, u2)), null != (i2 = n2.__c)) {
+      if (l$1.unmount && l$1.unmount(n2), (i2 = n2.ref) && (i2.current && i2.current !== n2.__e || V$1(i2, null, u2)), null != (i2 = n2.__c)) {
         if (i2.componentWillUnmount) try {
           i2.componentWillUnmount();
         } catch (n3) {
@@ -259,15 +264,46 @@ var require_assets = __commonJS({
         }
         i2.base = i2.__P = null;
       }
-      if (i2 = n2.__k) for (r2 = 0; r2 < i2.length; r2++) i2[r2] && q$1(i2[r2], u2, t2 || "function" != typeof n2.type);
-      t2 || _(n2.__e), n2.__c = n2.__ = n2.__e = void 0;
+      if (i2 = n2.__k) for (r2 = 0; r2 < i2.length; r2++) i2[r2] && q$2(i2[r2], u2, t2 || "function" != typeof n2.type);
+      t2 || _$1(n2.__e), n2.__c = n2.__ = n2.__e = void 0;
     }
-    function B$1(n2, l2, u2) {
+    function B$2(n2, l2, u2) {
       return this.constructor(n2, u2);
     }
-    function D$1(u2, t2, i2) {
+    function D$2(u2, t2, i2) {
       var r2, o2, e2, f2;
-      t2 === document && (t2 = document.documentElement), l$1.__ && l$1.__(u2, t2), o2 = (r2 = "function" == typeof i2) ? null : t2.__k, e2 = [], f2 = [], j$1(t2, u2 = (!r2 && i2 || t2).__k = g(k$1, null, [u2]), o2 || p$1, p$1, t2.namespaceURI, !r2 && i2 ? [i2] : o2 ? null : t2.firstChild ? n$2.call(t2.childNodes) : null, e2, !r2 && i2 ? i2 : o2 ? o2.__e : t2.firstChild, r2, f2), z$1(e2, u2, f2);
+      t2 === document && (t2 = document.documentElement), l$1.__ && l$1.__(u2, t2), o2 = (r2 = "function" == typeof i2) ? null : i2 && i2.__k || t2.__k, e2 = [], f2 = [], j$2(t2, u2 = (!r2 && i2 || t2).__k = g$2(k$2, null, [u2]), o2 || p$1, p$1, t2.namespaceURI, !r2 && i2 ? [i2] : o2 ? null : t2.firstChild ? n$2.call(t2.childNodes) : null, e2, !r2 && i2 ? i2 : o2 ? o2.__e : t2.firstChild, r2, f2), z$2(e2, u2, f2);
+    }
+    function E$1(n2, l2) {
+      D$2(n2, l2, E$1);
+    }
+    function G$1(l2, u2, t2) {
+      var i2, r2, o2, e2, f2 = w$2({}, l2.props);
+      for (o2 in l2.type && l2.type.defaultProps && (e2 = l2.type.defaultProps), u2) "key" == o2 ? i2 = u2[o2] : "ref" == o2 ? r2 = u2[o2] : f2[o2] = void 0 === u2[o2] && void 0 !== e2 ? e2[o2] : u2[o2];
+      return arguments.length > 2 && (f2.children = arguments.length > 3 ? n$2.call(arguments, 2) : t2), m$2(l2.type, f2, i2 || l2.key, r2 || l2.ref, null);
+    }
+    function J$1(n2, l2) {
+      var u2 = { __c: l2 = "__cC" + h$1++, __: n2, Consumer: function(n3, l3) {
+        return n3.children(l3);
+      }, Provider: function(n3) {
+        var u3, t2;
+        return this.getChildContext || (u3 = /* @__PURE__ */ new Set(), (t2 = {})[l2] = this, this.getChildContext = function() {
+          return t2;
+        }, this.componentWillUnmount = function() {
+          u3 = null;
+        }, this.shouldComponentUpdate = function(n4) {
+          this.props.value !== n4.value && u3.forEach(function(n5) {
+            n5.__e = true, M$1(n5);
+          });
+        }, this.sub = function(n4) {
+          u3.add(n4);
+          var l3 = n4.componentWillUnmount;
+          n4.componentWillUnmount = function() {
+            u3 && u3.delete(n4), l3 && l3.call(n4);
+          };
+        }), n3.children;
+      } };
+      return u2.Provider.__ = u2.Consumer.contextType = u2;
     }
     n$2 = v$1.slice, l$1 = { __e: function(n2, l2, u2, t2) {
       for (var i2, r2, o2; l2 = l2.__; ) if ((i2 = l2.__c) && !i2.__) try {
@@ -276,14 +312,14 @@ var require_assets = __commonJS({
         n2 = l3;
       }
       throw n2;
-    } }, u$1 = 0, x$1.prototype.setState = function(n2, l2) {
+    } }, u$2 = 0, x$3.prototype.setState = function(n2, l2) {
       var u2;
-      u2 = null != this.__s && this.__s !== this.state ? this.__s : this.__s = w$1({}, this.state), "function" == typeof n2 && (n2 = n2(w$1({}, u2), this.props)), n2 && w$1(u2, n2), null != n2 && this.__v && (l2 && this._sb.push(l2), M(this));
-    }, x$1.prototype.forceUpdate = function(n2) {
-      this.__v && (this.__e = true, n2 && this.__h.push(n2), M(this));
-    }, x$1.prototype.render = k$1, i$2 = [], o$1 = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, e$3 = function(n2, l2) {
+      u2 = null != this.__s && this.__s !== this.state ? this.__s : this.__s = w$2({}, this.state), "function" == typeof n2 && (n2 = n2(w$2({}, u2), this.props)), n2 && w$2(u2, n2), null != n2 && this.__v && (l2 && this._sb.push(l2), M$1(this));
+    }, x$3.prototype.forceUpdate = function(n2) {
+      this.__v && (this.__e = true, n2 && this.__h.push(n2), M$1(this));
+    }, x$3.prototype.render = k$2, i$2 = [], o$1 = "function" == typeof Promise ? Promise.prototype.then.bind(Promise.resolve()) : setTimeout, e$3 = function(n2, l2) {
       return n2.__v.__b - l2.__v.__b;
-    }, P$1.__r = 0, f$1 = /(PointerCapture)$|Capture$/i, c$2 = 0, s$1 = O(false), a$1 = O(true);
+    }, P$3.__r = 0, f$2 = /(PointerCapture)$|Capture$/i, c$2 = 0, s$1 = O$1(false), a$1 = O$1(true), h$1 = 0;
     var n$1 = function(t2, s2, r2, e2) {
       var u2;
       s2[0] = 0;
@@ -305,7 +341,7 @@ var require_assets = __commonJS({
         return p2(), h2;
       }(s2)), r2), arguments, [])).length > 1 ? r2 : r2[0];
     }
-    var m$1 = e$2.bind(g);
+    var m$1 = e$2.bind(g$2);
     var commonjsGlobal = typeof globalThis !== "undefined" ? globalThis : typeof window !== "undefined" ? window : typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : {};
     function getDefaultExportFromCjs(x2) {
       return x2 && x2.__esModule && Object.prototype.hasOwnProperty.call(x2, "default") ? x2["default"] : x2;
@@ -433,16 +469,16 @@ var require_assets = __commonJS({
             clone: function deepClone(o2, visited) {
               visited = visited || {};
               var clone2;
-              var id;
+              var id2;
               switch (_2.util.type(o2)) {
                 case "Object":
-                  id = _2.util.objId(o2);
-                  if (visited[id]) {
-                    return visited[id];
+                  id2 = _2.util.objId(o2);
+                  if (visited[id2]) {
+                    return visited[id2];
                   }
                   clone2 = /** @type {Record<string, any>} */
                   {};
-                  visited[id] = clone2;
+                  visited[id2] = clone2;
                   for (var key2 in o2) {
                     if (o2.hasOwnProperty(key2)) {
                       clone2[key2] = deepClone(o2[key2], visited);
@@ -453,12 +489,12 @@ var require_assets = __commonJS({
                     clone2
                   );
                 case "Array":
-                  id = _2.util.objId(o2);
-                  if (visited[id]) {
-                    return visited[id];
+                  id2 = _2.util.objId(o2);
+                  if (visited[id2]) {
+                    return visited[id2];
                   }
                   clone2 = [];
-                  visited[id] = clone2;
+                  visited[id2] = clone2;
                   /** @type {Array} */
                   /** @type {any} */
                   o2.forEach(function(v2, i2) {
@@ -610,8 +646,8 @@ var require_assets = __commonJS({
              *     'color': /\b(?:red|green|blue)\b/
              * });
              */
-            extend: function(id, redef) {
-              var lang2 = _2.util.clone(_2.languages[id]);
+            extend: function(id2, redef) {
+              var lang2 = _2.util.clone(_2.languages[id2]);
               for (var key2 in redef) {
                 lang2[key2] = redef[key2];
               }
@@ -1953,9 +1989,9 @@ var require_assets = __commonJS({
                       return _possibleConstructorReturn(this, result);
                     };
                   }
-                  function _possibleConstructorReturn(self2, call) {
-                    if (call && (clipboard_typeof(call) === "object" || typeof call === "function")) {
-                      return call;
+                  function _possibleConstructorReturn(self2, call2) {
+                    if (call2 && (clipboard_typeof(call2) === "object" || typeof call2 === "function")) {
+                      return call2;
                     }
                     return _assertThisInitialized(self2);
                   }
@@ -2304,9 +2340,9 @@ var require_assets = __commonJS({
               279: (
                 /***/
                 function(module3) {
-                  function E() {
+                  function E2() {
                   }
-                  E.prototype = {
+                  E2.prototype = {
                     on: function(name, callback, ctx) {
                       var e2 = this.e || (this.e = {});
                       (e2[name] || (e2[name] = [])).push({
@@ -2348,8 +2384,8 @@ var require_assets = __commonJS({
                       return this;
                     }
                   };
-                  module3.exports = E;
-                  module3.exports.TinyEmitter = E;
+                  module3.exports = E2;
+                  module3.exports.TinyEmitter = E2;
                 }
               )
               /******/
@@ -2534,9 +2570,9 @@ var require_assets = __commonJS({
     function getBasePlacement(placement) {
       return placement.split("-")[0];
     }
-    var max$2 = Math.max;
-    var min$1 = Math.min;
-    var round = Math.round;
+    var max$3 = Math.max;
+    var min$2 = Math.min;
+    var round$1 = Math.round;
     function getUAString() {
       var uaData = navigator.userAgentData;
       if (uaData != null && uaData.brands && Array.isArray(uaData.brands)) {
@@ -2560,8 +2596,8 @@ var require_assets = __commonJS({
       var scaleX = 1;
       var scaleY = 1;
       if (includeScale && isHTMLElement(element)) {
-        scaleX = element.offsetWidth > 0 ? round(clientRect.width) / element.offsetWidth || 1 : 1;
-        scaleY = element.offsetHeight > 0 ? round(clientRect.height) / element.offsetHeight || 1 : 1;
+        scaleX = element.offsetWidth > 0 ? round$1(clientRect.width) / element.offsetWidth || 1 : 1;
+        scaleY = element.offsetHeight > 0 ? round$1(clientRect.height) / element.offsetHeight || 1 : 1;
       }
       var _ref = isElement$1(element) ? getWindow(element) : window, visualViewport = _ref.visualViewport;
       var addVisualOffsets = !isLayoutViewport() && isFixedStrategy;
@@ -2684,7 +2720,7 @@ var require_assets = __commonJS({
       return ["top", "bottom"].indexOf(placement) >= 0 ? "x" : "y";
     }
     function within(min2, value, max2) {
-      return max$2(min2, min$1(value, max2));
+      return max$3(min2, min$2(value, max2));
     }
     function withinMaxClamp(min2, value, max2) {
       var v2 = within(min2, value, max2);
@@ -2780,8 +2816,8 @@ var require_assets = __commonJS({
       var x2 = _ref.x, y2 = _ref.y;
       var dpr = win.devicePixelRatio || 1;
       return {
-        x: round(x2 * dpr) / dpr || 0,
-        y: round(y2 * dpr) / dpr || 0
+        x: round$1(x2 * dpr) / dpr || 0,
+        y: round$1(y2 * dpr) / dpr || 0
       };
     }
     function mapToStyles(_ref2) {
@@ -2920,7 +2956,7 @@ var require_assets = __commonJS({
       name: "eventListeners",
       enabled: true,
       phase: "write",
-      fn: function fn() {
+      fn: function fn2() {
       },
       effect,
       data: {}
@@ -2986,12 +3022,12 @@ var require_assets = __commonJS({
       var html = getDocumentElement(element);
       var winScroll = getWindowScroll(element);
       var body = (_element$ownerDocumen = element.ownerDocument) == null ? void 0 : _element$ownerDocumen.body;
-      var width = max$2(html.scrollWidth, html.clientWidth, body ? body.scrollWidth : 0, body ? body.clientWidth : 0);
-      var height = max$2(html.scrollHeight, html.clientHeight, body ? body.scrollHeight : 0, body ? body.clientHeight : 0);
+      var width = max$3(html.scrollWidth, html.clientWidth, body ? body.scrollWidth : 0, body ? body.clientWidth : 0);
+      var height = max$3(html.scrollHeight, html.clientHeight, body ? body.scrollHeight : 0, body ? body.clientHeight : 0);
       var x2 = -winScroll.scrollLeft + getWindowScrollBarX(element);
       var y2 = -winScroll.scrollTop;
       if (getComputedStyle$1(body || html).direction === "rtl") {
-        x2 += max$2(html.clientWidth, body ? body.clientWidth : 0) - width;
+        x2 += max$3(html.clientWidth, body ? body.clientWidth : 0) - width;
       }
       return {
         width,
@@ -3068,10 +3104,10 @@ var require_assets = __commonJS({
       var firstClippingParent = clippingParents2[0];
       var clippingRect = clippingParents2.reduce(function(accRect, clippingParent) {
         var rect = getClientRectFromMixedType(element, clippingParent, strategy);
-        accRect.top = max$2(rect.top, accRect.top);
-        accRect.right = min$1(rect.right, accRect.right);
-        accRect.bottom = min$1(rect.bottom, accRect.bottom);
-        accRect.left = max$2(rect.left, accRect.left);
+        accRect.top = max$3(rect.top, accRect.top);
+        accRect.right = min$2(rect.right, accRect.right);
+        accRect.bottom = min$2(rect.bottom, accRect.bottom);
+        accRect.left = max$3(rect.left, accRect.left);
         return accRect;
       }, getClientRectFromMixedType(element, firstClippingParent, strategy));
       clippingRect.width = clippingRect.right - clippingRect.left;
@@ -3469,7 +3505,7 @@ var require_assets = __commonJS({
         var offsetModifierValue = (_offsetModifierState$ = offsetModifierState == null ? void 0 : offsetModifierState[mainAxis]) != null ? _offsetModifierState$ : 0;
         var tetherMin = offset2 + minOffset - offsetModifierValue - clientOffset;
         var tetherMax = offset2 + maxOffset - offsetModifierValue;
-        var preventedOffset = within(tether ? min$1(min2, tetherMin) : min2, offset2, tether ? max$2(max2, tetherMax) : max2);
+        var preventedOffset = within(tether ? min$2(min2, tetherMin) : min2, offset2, tether ? max$3(max2, tetherMax) : max2);
         popperOffsets2[mainAxis] = preventedOffset;
         data[mainAxis] = preventedOffset - offset2;
       }
@@ -3513,8 +3549,8 @@ var require_assets = __commonJS({
     }
     function isElementScaled(element) {
       var rect = element.getBoundingClientRect();
-      var scaleX = round(rect.width) / element.offsetWidth || 1;
-      var scaleY = round(rect.height) / element.offsetHeight || 1;
+      var scaleX = round$1(rect.width) / element.offsetWidth || 1;
+      var scaleY = round$1(rect.height) / element.offsetHeight || 1;
       return scaleX !== 1 || scaleY !== 1;
     }
     function getCompositeRect(elementOrVirtualElement, offsetParent, isFixed) {
@@ -3588,14 +3624,14 @@ var require_assets = __commonJS({
         }));
       }, []);
     }
-    function debounce$2(fn) {
+    function debounce$2(fn2) {
       var pending;
       return function() {
         if (!pending) {
           pending = new Promise(function(resolve) {
             Promise.resolve().then(function() {
               pending = void 0;
-              resolve(fn());
+              resolve(fn2());
             });
           });
         }
@@ -3696,9 +3732,9 @@ var require_assets = __commonJS({
                 index = -1;
                 continue;
               }
-              var _state$orderedModifie = state.orderedModifiers[index], fn = _state$orderedModifie.fn, _state$orderedModifie2 = _state$orderedModifie.options, _options = _state$orderedModifie2 === void 0 ? {} : _state$orderedModifie2, name = _state$orderedModifie.name;
-              if (typeof fn === "function") {
-                state = fn({
+              var _state$orderedModifie = state.orderedModifiers[index], fn2 = _state$orderedModifie.fn, _state$orderedModifie2 = _state$orderedModifie.options, _options = _state$orderedModifie2 === void 0 ? {} : _state$orderedModifie2, name = _state$orderedModifie.name;
+              if (typeof fn2 === "function") {
+                state = fn2({
                   state,
                   options: _options,
                   name,
@@ -3745,8 +3781,8 @@ var require_assets = __commonJS({
           });
         }
         function cleanupModifierEffects() {
-          effectCleanupFns.forEach(function(fn) {
-            return fn();
+          effectCleanupFns.forEach(function(fn2) {
+            return fn2();
           });
           effectCleanupFns = [];
         }
@@ -3843,7 +3879,7 @@ var require_assets = __commonJS({
     const TRANSITION_END = "transitionend";
     const parseSelector = (selector) => {
       if (selector && window.CSS && window.CSS.escape) {
-        selector = selector.replace(/#([^\s"#']+)/g, (match, id) => `#${CSS.escape(id)}`);
+        selector = selector.replace(/#([^\s"#']+)/g, (match, id2) => `#${CSS.escape(id2)}`);
       }
       return selector;
     };
@@ -3945,7 +3981,7 @@ var require_assets = __commonJS({
       }
       return findShadowRoot(element.parentNode);
     };
-    const noop = () => {
+    const noop$1 = () => {
     };
     const reflow = (element) => {
       element.offsetHeight;
@@ -4046,18 +4082,18 @@ var require_assets = __commonJS({
       eventRegistry[uid] = eventRegistry[uid] || {};
       return eventRegistry[uid];
     }
-    function bootstrapHandler(element, fn) {
+    function bootstrapHandler(element, fn2) {
       return function handler(event) {
         hydrateObj(event, {
           delegateTarget: element
         });
         if (handler.oneOff) {
-          EventHandler.off(element, event.type, fn);
+          EventHandler.off(element, event.type, fn2);
         }
-        return fn.apply(element, [event]);
+        return fn2.apply(element, [event]);
       };
     }
-    function bootstrapDelegationHandler(element, selector, fn) {
+    function bootstrapDelegationHandler(element, selector, fn2) {
       return function handler(event) {
         const domElements = element.querySelectorAll(selector);
         for (let {
@@ -4071,9 +4107,9 @@ var require_assets = __commonJS({
               delegateTarget: target
             });
             if (handler.oneOff) {
-              EventHandler.off(element, event.type, selector, fn);
+              EventHandler.off(element, event.type, selector, fn2);
             }
-            return fn.apply(target, [event]);
+            return fn2.apply(target, [event]);
           }
         }
       };
@@ -4096,10 +4132,10 @@ var require_assets = __commonJS({
       }
       let [isDelegated, callable, typeEvent] = normalizeParameters(originalTypeEvent, handler, delegationFunction);
       if (originalTypeEvent in customEvents) {
-        const wrapFunction = (fn2) => {
+        const wrapFunction = (fn3) => {
           return function(event) {
             if (!event.relatedTarget || event.relatedTarget !== event.delegateTarget && !event.delegateTarget.contains(event.relatedTarget)) {
-              return fn2.call(this, event);
+              return fn3.call(this, event);
             }
           };
         };
@@ -4113,21 +4149,21 @@ var require_assets = __commonJS({
         return;
       }
       const uid = makeEventUid(callable, originalTypeEvent.replace(namespaceRegex, ""));
-      const fn = isDelegated ? bootstrapDelegationHandler(element, handler, callable) : bootstrapHandler(element, callable);
-      fn.delegationSelector = isDelegated ? handler : null;
-      fn.callable = callable;
-      fn.oneOff = oneOff;
-      fn.uidEvent = uid;
-      handlers[uid] = fn;
-      element.addEventListener(typeEvent, fn, isDelegated);
+      const fn2 = isDelegated ? bootstrapDelegationHandler(element, handler, callable) : bootstrapHandler(element, callable);
+      fn2.delegationSelector = isDelegated ? handler : null;
+      fn2.callable = callable;
+      fn2.oneOff = oneOff;
+      fn2.uidEvent = uid;
+      handlers[uid] = fn2;
+      element.addEventListener(typeEvent, fn2, isDelegated);
     }
     function removeHandler(element, events, typeEvent, handler, delegationSelector) {
-      const fn = findHandler(events[typeEvent], handler, delegationSelector);
-      if (!fn) {
+      const fn2 = findHandler(events[typeEvent], handler, delegationSelector);
+      if (!fn2) {
         return;
       }
-      element.removeEventListener(typeEvent, fn, Boolean(delegationSelector));
-      delete events[typeEvent][fn.uidEvent];
+      element.removeEventListener(typeEvent, fn2, Boolean(delegationSelector));
+      delete events[typeEvent][fn2.uidEvent];
     }
     function removeNamespacedHandlers(element, events, typeEvent, namespace) {
       const storeElementEvent = events[typeEvent] || {};
@@ -5238,7 +5274,7 @@ var require_assets = __commonJS({
         this._createPopper();
         if ("ontouchstart" in document.documentElement && !this._parent.closest(SELECTOR_NAVBAR_NAV)) {
           for (const element of [].concat(...document.body.children)) {
-            EventHandler.on(element, "mouseover", noop);
+            EventHandler.on(element, "mouseover", noop$1);
           }
         }
         this._element.focus();
@@ -5276,7 +5312,7 @@ var require_assets = __commonJS({
         }
         if ("ontouchstart" in document.documentElement) {
           for (const element of [].concat(...document.body.children)) {
-            EventHandler.off(element, "mouseover", noop);
+            EventHandler.off(element, "mouseover", noop$1);
           }
         }
         if (this._popper) {
@@ -6517,7 +6553,7 @@ var require_assets = __commonJS({
         tip.classList.add(CLASS_NAME_SHOW$2);
         if ("ontouchstart" in document.documentElement) {
           for (const element of [].concat(...document.body.children)) {
-            EventHandler.on(element, "mouseover", noop);
+            EventHandler.on(element, "mouseover", noop$1);
           }
         }
         const complete = () => {
@@ -6541,7 +6577,7 @@ var require_assets = __commonJS({
         tip.classList.remove(CLASS_NAME_SHOW$2);
         if ("ontouchstart" in document.documentElement) {
           for (const element of [].concat(...document.body.children)) {
-            EventHandler.off(element, "mouseover", noop);
+            EventHandler.off(element, "mouseover", noop$1);
           }
         }
         this._activeTrigger[TRIGGER_CLICK] = false;
@@ -7457,18 +7493,18 @@ var require_assets = __commonJS({
     }
     enableDismissTrigger(Toast);
     defineJQueryPlugin(Toast);
-    var t$1, r$1, u, i$1, o = 0, f = [], c$1 = l$1, e$1 = c$1.__b, a = c$1.__r, v = c$1.diffed, l = c$1.__c, m = c$1.unmount, s = c$1.__;
+    var t$1, r$1, u$1, i$1, o = 0, f$1 = [], c$1 = l$1, e$1 = c$1.__b, a = c$1.__r, v = c$1.diffed, l = c$1.__c, m = c$1.unmount, s = c$1.__;
     function d(n2, t2) {
       c$1.__h && c$1.__h(r$1, n2, o || t2), o = 0;
       var u2 = r$1.__H || (r$1.__H = { __: [], __h: [] });
       return n2 >= u2.__.length && u2.__.push({}), u2.__[n2];
     }
     function h(n2) {
-      return o = 1, p(D, n2);
+      return o = 1, p(D$1, n2);
     }
     function p(n2, u2, i2) {
       var o2 = d(t$1++, 2);
-      if (o2.t = n2, !o2.__c && (o2.__ = [D(void 0, u2), function(n3) {
+      if (o2.t = n2, !o2.__c && (o2.__ = [i2 ? i2(u2) : D$1(void 0, u2), function(n3) {
         var t2 = o2.__N ? o2.__N[0] : o2.__[0], r2 = o2.t(t2, n3);
         t2 !== r2 && (o2.__N = [r2, o2.__[1]], o2.__c.setState({}));
       }], o2.__c = r$1, !r$1.u)) {
@@ -7502,25 +7538,54 @@ var require_assets = __commonJS({
     }
     function y(n2, u2) {
       var i2 = d(t$1++, 3);
-      !c$1.__s && C(i2.__H, u2) && (i2.__ = n2, i2.i = u2, r$1.__H.__h.push(i2));
+      !c$1.__s && C$1(i2.__H, u2) && (i2.__ = n2, i2.i = u2, r$1.__H.__h.push(i2));
     }
-    function A(n2) {
-      return o = 5, T(function() {
+    function _(n2, u2) {
+      var i2 = d(t$1++, 4);
+      !c$1.__s && C$1(i2.__H, u2) && (i2.__ = n2, i2.i = u2, r$1.__h.push(i2));
+    }
+    function A$1(n2) {
+      return o = 5, T$1(function() {
         return { current: n2 };
       }, []);
     }
-    function T(n2, r2) {
-      var u2 = d(t$1++, 7);
-      return C(u2.__H, r2) && (u2.__ = n2(), u2.__H = r2, u2.__h = n2), u2.__;
+    function F$1(n2, t2, r2) {
+      o = 6, _(function() {
+        return "function" == typeof n2 ? (n2(t2()), function() {
+          return n2(null);
+        }) : n2 ? (n2.current = t2(), function() {
+          return n2.current = null;
+        }) : void 0;
+      }, null == r2 ? r2 : r2.concat(n2));
     }
-    function q(n2, t2) {
-      return o = 8, T(function() {
+    function T$1(n2, r2) {
+      var u2 = d(t$1++, 7);
+      return C$1(u2.__H, r2) && (u2.__ = n2(), u2.__H = r2, u2.__h = n2), u2.__;
+    }
+    function q$1(n2, t2) {
+      return o = 8, T$1(function() {
         return n2;
       }, t2);
     }
-    function j() {
-      for (var n2; n2 = f.shift(); ) if (n2.__P && n2.__H) try {
-        n2.__H.__h.forEach(z), n2.__H.__h.forEach(B), n2.__H.__h = [];
+    function x$2(n2) {
+      var u2 = r$1.context[n2.__c], i2 = d(t$1++, 9);
+      return i2.c = n2, u2 ? (null == i2.__ && (i2.__ = true, u2.sub(r$1)), u2.props.value) : n2.__;
+    }
+    function P$2(n2, t2) {
+      c$1.useDebugValue && c$1.useDebugValue(t2 ? t2(n2) : n2);
+    }
+    function g$1() {
+      var n2 = d(t$1++, 11);
+      if (!n2.__) {
+        for (var u2 = r$1.__v; null !== u2 && !u2.__m && null !== u2.__; ) u2 = u2.__;
+        var i2 = u2.__m || (u2.__m = [0, 0]);
+        n2.__ = "P" + i2[0] + "-" + i2[1]++;
+      }
+      return n2.__;
+    }
+    function j$1() {
+      for (var n2; n2 = f$1.shift(); ) if (n2.__P && n2.__H) try {
+        n2.__H.__h.forEach(z$1), n2.__H.__h.forEach(B$1), n2.__H.__h = [];
       } catch (t2) {
         n2.__H.__h = [], c$1.__e(t2, n2.__v);
       }
@@ -7532,20 +7597,20 @@ var require_assets = __commonJS({
     }, c$1.__r = function(n2) {
       a && a(n2), t$1 = 0;
       var i2 = (r$1 = n2.__c).__H;
-      i2 && (u === r$1 ? (i2.__h = [], r$1.__h = [], i2.__.forEach(function(n3) {
+      i2 && (u$1 === r$1 ? (i2.__h = [], r$1.__h = [], i2.__.forEach(function(n3) {
         n3.__N && (n3.__ = n3.__N), n3.i = n3.__N = void 0;
-      })) : (i2.__h.forEach(z), i2.__h.forEach(B), i2.__h = [], t$1 = 0)), u = r$1;
+      })) : (i2.__h.forEach(z$1), i2.__h.forEach(B$1), i2.__h = [], t$1 = 0)), u$1 = r$1;
     }, c$1.diffed = function(n2) {
       v && v(n2);
       var t2 = n2.__c;
-      t2 && t2.__H && (t2.__H.__h.length && (1 !== f.push(t2) && i$1 === c$1.requestAnimationFrame || ((i$1 = c$1.requestAnimationFrame) || w)(j)), t2.__H.__.forEach(function(n3) {
+      t2 && t2.__H && (t2.__H.__h.length && (1 !== f$1.push(t2) && i$1 === c$1.requestAnimationFrame || ((i$1 = c$1.requestAnimationFrame) || w$1)(j$1)), t2.__H.__.forEach(function(n3) {
         n3.i && (n3.__H = n3.i), n3.i = void 0;
-      })), u = r$1 = null;
+      })), u$1 = r$1 = null;
     }, c$1.__c = function(n2, t2) {
       t2.some(function(n3) {
         try {
-          n3.__h.forEach(z), n3.__h = n3.__h.filter(function(n4) {
-            return !n4.__ || B(n4);
+          n3.__h.forEach(z$1), n3.__h = n3.__h.filter(function(n4) {
+            return !n4.__ || B$1(n4);
           });
         } catch (r2) {
           t2.some(function(n4) {
@@ -7558,33 +7623,33 @@ var require_assets = __commonJS({
       var t2, r2 = n2.__c;
       r2 && r2.__H && (r2.__H.__.forEach(function(n3) {
         try {
-          z(n3);
+          z$1(n3);
         } catch (n4) {
           t2 = n4;
         }
       }), r2.__H = void 0, t2 && c$1.__e(t2, r2.__v));
     };
-    var k = "function" == typeof requestAnimationFrame;
-    function w(n2) {
+    var k$1 = "function" == typeof requestAnimationFrame;
+    function w$1(n2) {
       var t2, r2 = function() {
-        clearTimeout(u2), k && cancelAnimationFrame(t2), setTimeout(n2);
+        clearTimeout(u2), k$1 && cancelAnimationFrame(t2), setTimeout(n2);
       }, u2 = setTimeout(r2, 100);
-      k && (t2 = requestAnimationFrame(r2));
+      k$1 && (t2 = requestAnimationFrame(r2));
     }
-    function z(n2) {
+    function z$1(n2) {
       var t2 = r$1, u2 = n2.__c;
       "function" == typeof u2 && (n2.__c = void 0, u2()), r$1 = t2;
     }
-    function B(n2) {
+    function B$1(n2) {
       var t2 = r$1;
       n2.__c = n2.__(), r$1 = t2;
     }
-    function C(n2, t2) {
+    function C$1(n2, t2) {
       return !n2 || n2.length !== t2.length || t2.some(function(t3, r2) {
         return t3 !== n2[r2];
       });
     }
-    function D(n2, t2) {
+    function D$1(n2, t2) {
       return "function" == typeof t2 ? t2(n2) : t2;
     }
     const arrayToString = (val) => {
@@ -7741,9 +7806,9 @@ var require_assets = __commonJS({
       let timeout, context, args, result;
       let lastCallTime = null;
       const later = () => {
-        const last = Date.now() - lastCallTime;
-        if (last < wait && last >= 0) {
-          timeout = setTimeout(later, wait - last);
+        const last2 = Date.now() - lastCallTime;
+        if (last2 < wait && last2 >= 0) {
+          timeout = setTimeout(later, wait - last2);
         } else {
           timeout = null;
           if (!options.leading) {
@@ -7899,7 +7964,7 @@ var require_assets = __commonJS({
         color: "var(--bs-tertiary-color)"
       }
     };
-    const ErrorPanel = ({ id, classes, title, error: error2 }) => {
+    const ErrorPanel = ({ id: id2, classes, title, error: error2 }) => {
       const emptyStyle = {
         display: "flex",
         flex: "0 0 content",
@@ -7911,7 +7976,7 @@ var require_assets = __commonJS({
       return m$1`
     <div style=${{ overflowY: "auto", height: "100vh" }}>
       <div
-        ...${{ id }}
+        ...${{ id: id2 }}
         class="${classes ? classes : ""}"
         style=${{
         ...emptyStyle,
@@ -7959,7 +8024,7 @@ var require_assets = __commonJS({
     </div>
   `;
     };
-    class AppErrorBoundary extends x$1 {
+    class AppErrorBoundary extends x$3 {
       constructor(props) {
         super(props);
         this.state = { hasError: false };
@@ -8445,7 +8510,7 @@ var require_assets = __commonJS({
     </span>`;
       }
     };
-    const EmptyPanel = ({ id, classes, height, style: style2, children: children2 }) => {
+    const EmptyPanel = ({ id: id2, classes, height, style: style2, children: children2 }) => {
       const emptyStyle = {
         display: "flex",
         textAlign: "center",
@@ -8456,7 +8521,7 @@ var require_assets = __commonJS({
       };
       return m$1`
     <div
-      ...${{ id }}
+      ...${{ id: id2 }}
       class="${classes ? classes : ""}"
       style=${{ width: "100%" }}
     >
@@ -8466,8 +8531,8 @@ var require_assets = __commonJS({
     </div>
   `;
     };
-    const TabSet = ({ id, type, classes, tools, styles, children: children2 }) => {
-      if (!id) {
+    const TabSet = ({ id: id2, type, classes, tools, styles, children: children2 }) => {
+      if (!id2) {
         throw new Error("Tabsets require an id to function properly");
       }
       const tabs = children2;
@@ -8476,7 +8541,7 @@ var require_assets = __commonJS({
         alignItems: "space-between"
       };
       return m$1`<ul
-      ...${{ id }}
+      ...${{ id: id2 }}
       class="nav nav-${tabType} ${classes ? classes : ""}"
       role="tablist"
       aria-orientation="horizontal"
@@ -8485,21 +8550,22 @@ var require_assets = __commonJS({
       <${Tabs} tabs=${tabs} type=${tabType} style=${styles.tabs} />
       <${TabTools} tools=${tools} />
     </ul>
-    <${TabPanels} id=${id} tabs=${tabs} style=${styles.tabBody} />`;
+    <${TabPanels} id=${id2} tabs=${tabs} style=${styles.tabBody} />`;
     };
     const TabPanel = ({
-      id,
+      id: id2,
       index,
       selected,
       style: style2,
       scrollable,
+      scrollRef,
       classes,
       scrollPosition,
       setScrollPosition,
       children: children2
     }) => {
-      const tabContentsId = computeTabContentsId(id, index);
-      const tabContentsRef = A(
+      const tabContentsId = computeTabContentsId(id2, index);
+      const tabContentsRef = scrollRef || A$1(
         /** @type {HTMLElement|null} */
         null
       );
@@ -8510,7 +8576,7 @@ var require_assets = __commonJS({
           }
         }, 0);
       });
-      const onScroll = q(
+      const onScroll = q$1(
         (e2) => {
           setScrollPosition(e2.srcElement.scrollTop);
         },
@@ -8603,19 +8669,19 @@ var require_assets = __commonJS({
     ${tools}
   </div>`;
     };
-    const TabPanels = ({ id, tabs, style: style2 }) => {
-      return m$1`<div class="tab-content" id="${id}-content" style=${{ ...style2 }}>
+    const TabPanels = ({ id: id2, tabs, style: style2 }) => {
+      return m$1`<div class="tab-content" id="${id2}-content" style=${{ ...style2 }}>
     ${tabs.map((tab, index) => {
         tab.props.index = index;
         return tab;
       })}
   </div>`;
     };
-    const computeTabId = (id, index) => {
-      return `${id}-${index}`;
+    const computeTabId = (id2, index) => {
+      return `${id2}-${index}`;
     };
-    const computeTabContentsId = (id, index) => {
-      return `${id}-contents-${index}`;
+    const computeTabContentsId = (id2, index) => {
+      return `${id2}-contents-${index}`;
     };
     const ToolButton = ({ name, classes, icon, onclick, ...rest }) => {
       const attr = {
@@ -8625,16 +8691,16 @@ var require_assets = __commonJS({
         ...rest
       };
       const iconEl = icon ? m$1`<i class="${icon}" style=${{ marginRight: "0.5em" }}></i>` : "";
-      return g("button", attr, m$1`${iconEl}${name}`);
+      return g$2("button", attr, m$1`${iconEl}${name}`);
     };
     const ghCommitUrl = (origin, commit) => {
       const baseUrl = origin.replace(/\.git$/, "");
       return `${baseUrl}/commit/${commit}`;
     };
-    const CardHeader = ({ id, icon, label, classes, style: style2, children: children2 }) => {
+    const CardHeader = ({ id: id2, icon, label, classes, style: style2, children: children2 }) => {
       return m$1`<div
     class="${classes || ""}"
-    ...${{ id }}
+    ...${{ id: id2 }}
     style=${{
         display: "grid",
         gridTemplateColumns: "max-content auto",
@@ -8659,10 +8725,10 @@ var require_assets = __commonJS({
     ${label ? label : ""} ${children2}
   </div> `;
     };
-    const CardBody = ({ id, classes, style: style2, children: children2 }) => {
+    const CardBody = ({ id: id2, classes, style: style2, children: children2 }) => {
       return m$1`<div
     class="${classes || ""}"
-    ...${{ id }}
+    ...${{ id: id2 }}
     style=${{
         backgroundColor: "var(--bs-body-bg)",
         border: "solid 1px var(--bs-light-border-subtle)",
@@ -8675,11 +8741,11 @@ var require_assets = __commonJS({
     ${children2}
   </div>`;
     };
-    const Card = ({ id, classes, style: style2, children: children2 }) => {
+    const Card = ({ id: id2, classes, style: style2, children: children2 }) => {
       return m$1`
     <div
       class="${classes || ""}"
-      ...${{ id }}
+      ...${{ id: id2 }}
       style=${{
         backgroundColor: "var(--bs-light-bg-subtle)",
         border: "solid 1px var(--bs-light-border-subtle)",
@@ -9837,17 +9903,17 @@ var require_assets = __commonJS({
     const Any = /[\0-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/;
     const Cc = /[\0-\x1F\x7F-\x9F]/;
     const regex$1 = /[\xAD\u0600-\u0605\u061C\u06DD\u070F\u0890\u0891\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB]|\uD804[\uDCBD\uDCCD]|\uD80D[\uDC30-\uDC3F]|\uD82F[\uDCA0-\uDCA3]|\uD834[\uDD73-\uDD7A]|\uDB40[\uDC01\uDC20-\uDC7F]/;
-    const P = /[!-#%-\*,-\/:;\?@\[-\]_\{\}\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061D-\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0A76\u0AF0\u0C77\u0C84\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1B7D\u1B7E\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E4F\u2E52-\u2E5D\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD803[\uDEAD\uDF55-\uDF59\uDF86-\uDF89]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC8\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5A\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDEB9\uDF3C-\uDF3E]|\uD806[\uDC3B\uDD44-\uDD46\uDDE2\uDE3F-\uDE46\uDE9A-\uDE9C\uDE9E-\uDEA2\uDF00-\uDF09]|\uD807[\uDC41-\uDC45\uDC70\uDC71\uDEF7\uDEF8\uDF43-\uDF4F\uDFFF]|\uD809[\uDC70-\uDC74]|\uD80B[\uDFF1\uDFF2]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD81B[\uDE97-\uDE9A\uDFE2]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/;
+    const P$1 = /[!-#%-\*,-\/:;\?@\[-\]_\{\}\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061D-\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0A76\u0AF0\u0C77\u0C84\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1B7D\u1B7E\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E4F\u2E52-\u2E5D\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD803[\uDEAD\uDF55-\uDF59\uDF86-\uDF89]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC8\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5A\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDEB9\uDF3C-\uDF3E]|\uD806[\uDC3B\uDD44-\uDD46\uDDE2\uDE3F-\uDE46\uDE9A-\uDE9C\uDE9E-\uDEA2\uDF00-\uDF09]|\uD807[\uDC41-\uDC45\uDC70\uDC71\uDEF7\uDEF8\uDF43-\uDF4F\uDFFF]|\uD809[\uDC70-\uDC74]|\uD80B[\uDFF1\uDFF2]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD81B[\uDE97-\uDE9A\uDFE2]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/;
     const regex = /[\$\+<->\^`\|~\xA2-\xA6\xA8\xA9\xAC\xAE-\xB1\xB4\xB8\xD7\xF7\u02C2-\u02C5\u02D2-\u02DF\u02E5-\u02EB\u02ED\u02EF-\u02FF\u0375\u0384\u0385\u03F6\u0482\u058D-\u058F\u0606-\u0608\u060B\u060E\u060F\u06DE\u06E9\u06FD\u06FE\u07F6\u07FE\u07FF\u0888\u09F2\u09F3\u09FA\u09FB\u0AF1\u0B70\u0BF3-\u0BFA\u0C7F\u0D4F\u0D79\u0E3F\u0F01-\u0F03\u0F13\u0F15-\u0F17\u0F1A-\u0F1F\u0F34\u0F36\u0F38\u0FBE-\u0FC5\u0FC7-\u0FCC\u0FCE\u0FCF\u0FD5-\u0FD8\u109E\u109F\u1390-\u1399\u166D\u17DB\u1940\u19DE-\u19FF\u1B61-\u1B6A\u1B74-\u1B7C\u1FBD\u1FBF-\u1FC1\u1FCD-\u1FCF\u1FDD-\u1FDF\u1FED-\u1FEF\u1FFD\u1FFE\u2044\u2052\u207A-\u207C\u208A-\u208C\u20A0-\u20C0\u2100\u2101\u2103-\u2106\u2108\u2109\u2114\u2116-\u2118\u211E-\u2123\u2125\u2127\u2129\u212E\u213A\u213B\u2140-\u2144\u214A-\u214D\u214F\u218A\u218B\u2190-\u2307\u230C-\u2328\u232B-\u2426\u2440-\u244A\u249C-\u24E9\u2500-\u2767\u2794-\u27C4\u27C7-\u27E5\u27F0-\u2982\u2999-\u29D7\u29DC-\u29FB\u29FE-\u2B73\u2B76-\u2B95\u2B97-\u2BFF\u2CE5-\u2CEA\u2E50\u2E51\u2E80-\u2E99\u2E9B-\u2EF3\u2F00-\u2FD5\u2FF0-\u2FFF\u3004\u3012\u3013\u3020\u3036\u3037\u303E\u303F\u309B\u309C\u3190\u3191\u3196-\u319F\u31C0-\u31E3\u31EF\u3200-\u321E\u322A-\u3247\u3250\u3260-\u327F\u328A-\u32B0\u32C0-\u33FF\u4DC0-\u4DFF\uA490-\uA4C6\uA700-\uA716\uA720\uA721\uA789\uA78A\uA828-\uA82B\uA836-\uA839\uAA77-\uAA79\uAB5B\uAB6A\uAB6B\uFB29\uFBB2-\uFBC2\uFD40-\uFD4F\uFDCF\uFDFC-\uFDFF\uFE62\uFE64-\uFE66\uFE69\uFF04\uFF0B\uFF1C-\uFF1E\uFF3E\uFF40\uFF5C\uFF5E\uFFE0-\uFFE6\uFFE8-\uFFEE\uFFFC\uFFFD]|\uD800[\uDD37-\uDD3F\uDD79-\uDD89\uDD8C-\uDD8E\uDD90-\uDD9C\uDDA0\uDDD0-\uDDFC]|\uD802[\uDC77\uDC78\uDEC8]|\uD805\uDF3F|\uD807[\uDFD5-\uDFF1]|\uD81A[\uDF3C-\uDF3F\uDF45]|\uD82F\uDC9C|\uD833[\uDF50-\uDFC3]|\uD834[\uDC00-\uDCF5\uDD00-\uDD26\uDD29-\uDD64\uDD6A-\uDD6C\uDD83\uDD84\uDD8C-\uDDA9\uDDAE-\uDDEA\uDE00-\uDE41\uDE45\uDF00-\uDF56]|\uD835[\uDEC1\uDEDB\uDEFB\uDF15\uDF35\uDF4F\uDF6F\uDF89\uDFA9\uDFC3]|\uD836[\uDC00-\uDDFF\uDE37-\uDE3A\uDE6D-\uDE74\uDE76-\uDE83\uDE85\uDE86]|\uD838[\uDD4F\uDEFF]|\uD83B[\uDCAC\uDCB0\uDD2E\uDEF0\uDEF1]|\uD83C[\uDC00-\uDC2B\uDC30-\uDC93\uDCA0-\uDCAE\uDCB1-\uDCBF\uDCC1-\uDCCF\uDCD1-\uDCF5\uDD0D-\uDDAD\uDDE6-\uDE02\uDE10-\uDE3B\uDE40-\uDE48\uDE50\uDE51\uDE60-\uDE65\uDF00-\uDFFF]|\uD83D[\uDC00-\uDED7\uDEDC-\uDEEC\uDEF0-\uDEFC\uDF00-\uDF76\uDF7B-\uDFD9\uDFE0-\uDFEB\uDFF0]|\uD83E[\uDC00-\uDC0B\uDC10-\uDC47\uDC50-\uDC59\uDC60-\uDC87\uDC90-\uDCAD\uDCB0\uDCB1\uDD00-\uDE53\uDE60-\uDE6D\uDE70-\uDE7C\uDE80-\uDE88\uDE90-\uDEBD\uDEBF-\uDEC5\uDECE-\uDEDB\uDEE0-\uDEE8\uDEF0-\uDEF8\uDF00-\uDF92\uDF94-\uDFCA]/;
-    const Z = /[ \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]/;
+    const Z$1 = /[ \xA0\u1680\u2000-\u200A\u2028\u2029\u202F\u205F\u3000]/;
     const ucmicro = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
       __proto__: null,
       Any,
       Cc,
       Cf: regex$1,
-      P,
+      P: P$1,
       S: regex,
-      Z
+      Z: Z$1
     }, Symbol.toStringTag, { value: "Module" }));
     const htmlDecodeTree = new Uint16Array(
       // prettier-ignore
@@ -10422,7 +10488,7 @@ var require_assets = __commonJS({
       return false;
     }
     function isPunctChar(ch3) {
-      return P.test(ch3) || regex.test(ch3);
+      return P$1.test(ch3) || regex.test(ch3);
     }
     function isMdAsciiPunct(ch3) {
       switch (ch3) {
@@ -10853,17 +10919,17 @@ var require_assets = __commonJS({
         });
       });
     };
-    Ruler.prototype.at = function(name, fn, options) {
+    Ruler.prototype.at = function(name, fn2, options) {
       const index = this.__find__(name);
       const opt = options || {};
       if (index === -1) {
         throw new Error("Parser rule not found: " + name);
       }
-      this.__rules__[index].fn = fn;
+      this.__rules__[index].fn = fn2;
       this.__rules__[index].alt = opt.alt || [];
       this.__cache__ = null;
     };
-    Ruler.prototype.before = function(beforeName, ruleName, fn, options) {
+    Ruler.prototype.before = function(beforeName, ruleName, fn2, options) {
       const index = this.__find__(beforeName);
       const opt = options || {};
       if (index === -1) {
@@ -10872,12 +10938,12 @@ var require_assets = __commonJS({
       this.__rules__.splice(index, 0, {
         name: ruleName,
         enabled: true,
-        fn,
+        fn: fn2,
         alt: opt.alt || []
       });
       this.__cache__ = null;
     };
-    Ruler.prototype.after = function(afterName, ruleName, fn, options) {
+    Ruler.prototype.after = function(afterName, ruleName, fn2, options) {
       const index = this.__find__(afterName);
       const opt = options || {};
       if (index === -1) {
@@ -10886,17 +10952,17 @@ var require_assets = __commonJS({
       this.__rules__.splice(index + 1, 0, {
         name: ruleName,
         enabled: true,
-        fn,
+        fn: fn2,
         alt: opt.alt || []
       });
       this.__cache__ = null;
     };
-    Ruler.prototype.push = function(ruleName, fn, options) {
+    Ruler.prototype.push = function(ruleName, fn2, options) {
       const opt = options || {};
       this.__rules__.push({
         name: ruleName,
         enabled: true,
-        fn,
+        fn: fn2,
         alt: opt.alt || []
       });
       this.__cache__ = null;
@@ -11096,21 +11162,21 @@ var require_assets = __commonJS({
             if (links.length > 0 && links[0].index === 0 && i2 > 0 && tokens[i2 - 1].type === "text_special") {
               links = links.slice(1);
             }
-            for (let ln = 0; ln < links.length; ln++) {
-              const url = links[ln].url;
+            for (let ln2 = 0; ln2 < links.length; ln2++) {
+              const url = links[ln2].url;
               const fullUrl = state.md.normalizeLink(url);
               if (!state.md.validateLink(fullUrl)) {
                 continue;
               }
-              let urlText = links[ln].text;
-              if (!links[ln].schema) {
+              let urlText = links[ln2].text;
+              if (!links[ln2].schema) {
                 urlText = state.md.normalizeLinkText("http://" + urlText).replace(/^http:\/\//, "");
-              } else if (links[ln].schema === "mailto:" && !/^mailto:/i.test(urlText)) {
+              } else if (links[ln2].schema === "mailto:" && !/^mailto:/i.test(urlText)) {
                 urlText = state.md.normalizeLinkText("mailto:" + urlText).replace(/^mailto:/, "");
               } else {
                 urlText = state.md.normalizeLinkText(urlText);
               }
-              const pos2 = links[ln].index;
+              const pos2 = links[ln2].index;
               if (pos2 > lastPos) {
                 const token2 = new state.Token("text", "", 0);
                 token2.content = text2.slice(lastPos, pos2);
@@ -11132,7 +11198,7 @@ var require_assets = __commonJS({
               token_c.markup = "linkify";
               token_c.info = "auto";
               nodes.push(token_c);
-              lastPos = links[ln].lastIndex;
+              lastPos = links[ln2].lastIndex;
             }
             if (lastPos < text2.length) {
               const token2 = new state.Token("text", "", 0);
@@ -11239,7 +11305,7 @@ var require_assets = __commonJS({
             let canOpen = true;
             let canClose = true;
             pos2 = t2.index + 1;
-            const isSingle = t2[0] === "'";
+            const isSingle2 = t2[0] === "'";
             let lastChar = 32;
             if (t2.index - 1 >= 0) {
               lastChar = text2.charCodeAt(t2.index - 1);
@@ -11290,7 +11356,7 @@ var require_assets = __commonJS({
               canClose = isNextPunctChar;
             }
             if (!canOpen && !canClose) {
-              if (isSingle) {
+              if (isSingle2) {
                 token2.content = replaceAt(token2.content, t2.index, APOSTROPHE);
               }
               continue;
@@ -11301,11 +11367,11 @@ var require_assets = __commonJS({
                 if (stack2[j2].level < thisLevel) {
                   break;
                 }
-                if (item.single === isSingle && stack2[j2].level === thisLevel) {
+                if (item.single === isSingle2 && stack2[j2].level === thisLevel) {
                   item = stack2[j2];
                   let openQuote;
                   let closeQuote;
-                  if (isSingle) {
+                  if (isSingle2) {
                     openQuote = state.md.options.quotes[2];
                     closeQuote = state.md.options.quotes[3];
                   } else {
@@ -11333,10 +11399,10 @@ var require_assets = __commonJS({
               stack2.push({
                 token: i2,
                 pos: t2.index,
-                single: isSingle,
+                single: isSingle2,
                 level: thisLevel
               });
-            } else if (canClose && isSingle) {
+            } else if (canClose && isSingle2) {
               token2.content = replaceAt(token2.content, t2.index, APOSTROPHE);
             }
           }
@@ -11354,7 +11420,7 @@ var require_assets = __commonJS({
       }
     }
     function text_join(state) {
-      let curr, last;
+      let curr, last2;
       const blockTokens = state.tokens;
       const l2 = blockTokens.length;
       for (let j2 = 0; j2 < l2; j2++) {
@@ -11366,18 +11432,18 @@ var require_assets = __commonJS({
             tokens[curr].type = "text";
           }
         }
-        for (curr = last = 0; curr < max2; curr++) {
+        for (curr = last2 = 0; curr < max2; curr++) {
           if (tokens[curr].type === "text" && curr + 1 < max2 && tokens[curr + 1].type === "text") {
             tokens[curr + 1].content = tokens[curr].content + tokens[curr + 1].content;
           } else {
-            if (curr !== last) {
-              tokens[last] = tokens[curr];
+            if (curr !== last2) {
+              tokens[last2] = tokens[curr];
             }
-            last++;
+            last2++;
           }
         }
-        if (curr !== last) {
-          tokens.length = last;
+        if (curr !== last2) {
+          tokens.length = last2;
         }
       }
     }
@@ -11529,13 +11595,13 @@ var require_assets = __commonJS({
         let lineIndent = 0;
         const lineStart = this.bMarks[line2];
         let first = lineStart;
-        let last;
+        let last2;
         if (line2 + 1 < end2 || keepLastLF) {
-          last = this.eMarks[line2] + 1;
+          last2 = this.eMarks[line2] + 1;
         } else {
-          last = this.eMarks[line2];
+          last2 = this.eMarks[line2];
         }
-        while (first < last && lineIndent < indent) {
+        while (first < last2 && lineIndent < indent) {
           const ch3 = this.src.charCodeAt(first);
           if (isSpace(ch3)) {
             if (ch3 === 9) {
@@ -11551,9 +11617,9 @@ var require_assets = __commonJS({
           first++;
         }
         if (lineIndent > indent) {
-          queue[i2] = new Array(lineIndent - indent + 1).join(" ") + this.src.slice(first, last);
+          queue[i2] = new Array(lineIndent - indent + 1).join(" ") + this.src.slice(first, last2);
         } else {
-          queue[i2] = this.src.slice(first, last);
+          queue[i2] = this.src.slice(first, last2);
         }
       }
       return queue.join("");
@@ -11752,7 +11818,7 @@ var require_assets = __commonJS({
         return false;
       }
       let nextLine = startLine + 1;
-      let last = nextLine;
+      let last2 = nextLine;
       while (nextLine < endLine) {
         if (state.isEmpty(nextLine)) {
           nextLine++;
@@ -11760,14 +11826,14 @@ var require_assets = __commonJS({
         }
         if (state.sCount[nextLine] - state.blkIndent >= 4) {
           nextLine++;
-          last = nextLine;
+          last2 = nextLine;
           continue;
         }
         break;
       }
-      state.line = last;
+      state.line = last2;
       const token2 = state.push("code_block", "code", 0);
-      token2.content = state.getLines(startLine, last, 4 + state.blkIndent, false) + "\n";
+      token2.content = state.getLines(startLine, last2, 4 + state.blkIndent, false) + "\n";
       token2.map = [startLine, state.line];
       return true;
     }
@@ -13587,25 +13653,25 @@ var require_assets = __commonJS({
       }
     }
     function fragments_join(state) {
-      let curr, last;
+      let curr, last2;
       let level = 0;
       const tokens = state.tokens;
       const max2 = state.tokens.length;
-      for (curr = last = 0; curr < max2; curr++) {
+      for (curr = last2 = 0; curr < max2; curr++) {
         if (tokens[curr].nesting < 0) level--;
         tokens[curr].level = level;
         if (tokens[curr].nesting > 0) level++;
         if (tokens[curr].type === "text" && curr + 1 < max2 && tokens[curr + 1].type === "text") {
           tokens[curr + 1].content = tokens[curr].content + tokens[curr + 1].content;
         } else {
-          if (curr !== last) {
-            tokens[last] = tokens[curr];
+          if (curr !== last2) {
+            tokens[last2] = tokens[curr];
           }
-          last++;
+          last2++;
         }
       }
-      if (curr !== last) {
-        tokens.length = last;
+      if (curr !== last2) {
+        tokens.length = last2;
       }
     }
     const _rules = [
@@ -13717,8 +13783,8 @@ var require_assets = __commonJS({
       opts = opts || {};
       re.src_Any = Any.source;
       re.src_Cc = Cc.source;
-      re.src_Z = Z.source;
-      re.src_P = P.source;
+      re.src_Z = Z$1.source;
+      re.src_P = P$1.source;
       re.src_ZPCc = [re.src_Z, re.src_P, re.src_Cc].join("|");
       re.src_ZCc = [re.src_Z, re.src_Cc].join("|");
       const text_separators = "[><｜]";
@@ -14106,7 +14172,7 @@ var require_assets = __commonJS({
     const base = 36;
     const tMin = 1;
     const tMax = 26;
-    const skew = 38;
+    const skew$1 = 38;
     const damp = 700;
     const initialBias = 72;
     const initialN = 128;
@@ -14120,12 +14186,12 @@ var require_assets = __commonJS({
       "invalid-input": "Invalid input"
     };
     const baseMinusTMin = base - tMin;
-    const floor = Math.floor;
+    const floor$1 = Math.floor;
     const stringFromCharCode = String.fromCharCode;
     function error(type) {
       throw new RangeError(errors[type]);
     }
-    function map(array, callback) {
+    function map$1(array, callback) {
       const result = [];
       let length = array.length;
       while (length--) {
@@ -14142,7 +14208,7 @@ var require_assets = __commonJS({
       }
       domain = domain.replace(regexSeparators, ".");
       const labels = domain.split(".");
-      const encoded = map(labels, callback).join(".");
+      const encoded = map$1(labels, callback).join(".");
       return result + encoded;
     }
     function ucs2decode(string) {
@@ -14183,12 +14249,12 @@ var require_assets = __commonJS({
     };
     const adapt = function(delta, numPoints, firstTime) {
       let k2 = 0;
-      delta = firstTime ? floor(delta / damp) : delta >> 1;
-      delta += floor(delta / numPoints);
+      delta = firstTime ? floor$1(delta / damp) : delta >> 1;
+      delta += floor$1(delta / numPoints);
       for (; delta > baseMinusTMin * tMax >> 1; k2 += base) {
-        delta = floor(delta / baseMinusTMin);
+        delta = floor$1(delta / baseMinusTMin);
       }
-      return floor(k2 + (baseMinusTMin + 1) * delta / (delta + skew));
+      return floor$1(k2 + (baseMinusTMin + 1) * delta / (delta + skew$1));
     };
     const decode = function(input) {
       const output = [];
@@ -14216,7 +14282,7 @@ var require_assets = __commonJS({
           if (digit >= base) {
             error("invalid-input");
           }
-          if (digit > floor((maxInt - i2) / w2)) {
+          if (digit > floor$1((maxInt - i2) / w2)) {
             error("overflow");
           }
           i2 += digit * w2;
@@ -14225,17 +14291,17 @@ var require_assets = __commonJS({
             break;
           }
           const baseMinusT = base - t2;
-          if (w2 > floor(maxInt / baseMinusT)) {
+          if (w2 > floor$1(maxInt / baseMinusT)) {
             error("overflow");
           }
           w2 *= baseMinusT;
         }
         const out = output.length + 1;
         bias = adapt(i2 - oldi, out, oldi == 0);
-        if (floor(i2 / out) > maxInt - n2) {
+        if (floor$1(i2 / out) > maxInt - n2) {
           error("overflow");
         }
-        n2 += floor(i2 / out);
+        n2 += floor$1(i2 / out);
         i2 %= out;
         output.splice(i2++, 0, n2);
       }
@@ -14266,7 +14332,7 @@ var require_assets = __commonJS({
           }
         }
         const handledCPCountPlusOne = handledCPCount + 1;
-        if (m2 - n2 > floor((maxInt - delta) / handledCPCountPlusOne)) {
+        if (m2 - n2 > floor$1((maxInt - delta) / handledCPCountPlusOne)) {
           error("overflow");
         }
         delta += (m2 - n2) * handledCPCountPlusOne;
@@ -14287,7 +14353,7 @@ var require_assets = __commonJS({
               output.push(
                 stringFromCharCode(digitToBasic(t2 + qMinusT % baseMinusT, 0))
               );
-              q2 = floor(qMinusT / baseMinusT);
+              q2 = floor$1(qMinusT / baseMinusT);
             }
             output.push(stringFromCharCode(digitToBasic(q2, 0)));
             bias = adapt(delta, handledCPCountPlusOne, handledCPCount === basicLength);
@@ -15141,18 +15207,18 @@ var require_assets = __commonJS({
     }) => {
       const [collapsed, setCollapsed] = h(collapse);
       const [showToggle, setShowToggle] = h(false);
-      const contentsRef = A(
+      const contentsRef = A$1(
         /** @type {HTMLElement|null} */
         null
       );
-      const observerRef = A(
+      const observerRef = A$1(
         /** @type {IntersectionObserver|null} */
         null
       );
       y(() => {
         setCollapsed(collapse);
       }, [children2, collapse]);
-      const refreshCollapse = q(() => {
+      const refreshCollapse = q$1(() => {
         if (collapse && contentsRef.current) {
           const isScrollable = contentsRef.current.offsetHeight < contentsRef.current.scrollHeight;
           setShowToggle(isScrollable);
@@ -15188,9 +15254,6 @@ var require_assets = __commonJS({
       }
       if (border) {
         contentsStyle.border = "solid var(--bs-light-border-subtle) 1px";
-      }
-      if (!showToggle) {
-        contentsStyle.marginBottom = "1em";
       }
       return m$1`<div
       class="expandable-panel"
@@ -15248,8 +15311,8 @@ var require_assets = __commonJS({
     </div>
   `;
     };
-    const resolveToolInput = (fn, toolArgs) => {
-      const toolName = fn;
+    const resolveToolInput = (fn2, toolArgs) => {
+      const toolName = fn2;
       const [inputKey, inputType] = extractInputMetadata(toolName);
       const { input, args } = extractInput(inputKey, toolArgs);
       const functionCall = args.length > 0 ? `${toolName}(${args.join(",")})` : toolName;
@@ -15330,7 +15393,7 @@ var require_assets = __commonJS({
         return "";
       }
       if (view) {
-        const toolInputRef = A(
+        const toolInputRef = A$1(
           /** @type {import("preact").Component & { base: Element }} */
           null
         );
@@ -15358,7 +15421,7 @@ var require_assets = __commonJS({
       style=${style2}
     />`;
       } else {
-        const toolInputRef = A(
+        const toolInputRef = A$1(
           /** @type {HTMLElement|null} */
           null
         );
@@ -15554,7 +15617,7 @@ var require_assets = __commonJS({
       }
     };
     const ChatView = ({
-      id,
+      id: id2,
       messages,
       toolCallStyle,
       style: style2,
@@ -15615,7 +15678,7 @@ var require_assets = __commonJS({
               ${index + 1}
             </div>
             <${ChatMessage}
-              id=${`${id}-chat-messages`}
+              id=${`${id2}-chat-messages`}
               message=${msg.message}
               toolMessages=${msg.toolMessages}
               indented=${indented}
@@ -15624,7 +15687,7 @@ var require_assets = __commonJS({
           </div>`;
         } else {
           return m$1` <${ChatMessage}
-            id=${`${id}-chat-messages`}
+            id=${`${id2}-chat-messages`}
             message=${msg.message}
             toolMessages=${msg.toolMessages}
             indented=${indented}
@@ -15647,7 +15710,7 @@ var require_assets = __commonJS({
       }
     };
     const ChatMessage = ({
-      id,
+      id: id2,
       message,
       toolMessages,
       indented,
@@ -15681,7 +15744,7 @@ var require_assets = __commonJS({
       <div style=${{ marginLeft: indented ? "1.1rem" : "0", paddingBottom: indented ? "0.8rem" : "0" }}>
       <${ExpandablePanel} collapse=${collapse}>
         <${MessageContents}
-          key=${`${id}-contents`}
+          key=${`${id2}-contents`}
           message=${message}
           toolMessages=${toolMessages}
           toolCallStyle=${toolCallStyle}
@@ -15841,18 +15904,18 @@ var require_assets = __commonJS({
         const val = entry.value;
         return Array.isArray(val) && val.length > 0 && ((_a2 = val[0]) == null ? void 0 : _a2.role) !== void 0 && ((_b2 = val[0]) == null ? void 0 : _b2.content) !== void 0;
       },
-      render: (id, entry) => {
+      render: (id2, entry) => {
         return {
           rendered: m$1`
         <${NavPills}>
-        <${ChatSummary} title="Last Turn" id=${id} messages=${entry.value} />
-        <${ChatView} title="All" id=${id} messages=${entry.value} />
+        <${ChatSummary} title="Last Turn" id=${id2} messages=${entry.value} />
+        <${ChatView} title="All" id=${id2} messages=${entry.value} />
         </${NavPills}>
         `
         };
       }
     };
-    const ChatSummary = ({ id, messages }) => {
+    const ChatSummary = ({ id: id2, messages }) => {
       const summaryMessages = [];
       for (const message of messages.slice().reverse()) {
         summaryMessages.unshift(message);
@@ -15860,9 +15923,9 @@ var require_assets = __commonJS({
           break;
         }
       }
-      return m$1`<${ChatView} id=${id} messages=${summaryMessages} />`;
+      return m$1`<${ChatView} id=${id2} messages=${summaryMessages} />`;
     };
-    const RenderedContent = ({ id, entry }) => {
+    const RenderedContent = ({ id: id2, entry }) => {
       if (entry.value === null) {
         return "[null]";
       }
@@ -15875,7 +15938,7 @@ var require_assets = __commonJS({
       });
       let value = entry.value;
       if (renderer) {
-        const { rendered } = renderer.render(id, entry);
+        const { rendered } = renderer.render(id2, entry);
         if (rendered !== void 0) {
           value = rendered;
         }
@@ -15888,7 +15951,7 @@ var require_assets = __commonJS({
         canRender: (entry) => {
           return typeof entry.value === "string" && entry.value.indexOf("\x1B") > -1;
         },
-        render: (id, entry) => {
+        render: (id2, entry) => {
           return {
             rendered: m$1`<${ANSIDisplay} output=${entry.value} />`
           };
@@ -15910,9 +15973,9 @@ var require_assets = __commonJS({
         canRender: (entry) => {
           return typeof entry.value === "boolean";
         },
-        render: (id, entry) => {
+        render: (id2, entry) => {
           entry.value = entry.value.toString();
-          return contentRenderers.String.render(id, entry);
+          return contentRenderers.String.render(id2, entry);
         }
       },
       Number: {
@@ -15920,9 +15983,9 @@ var require_assets = __commonJS({
         canRender: (entry) => {
           return typeof entry.value === "number";
         },
-        render: (id, entry) => {
+        render: (id2, entry) => {
           entry.value = formatNumber(entry.value);
-          return contentRenderers.String.render(id, entry);
+          return contentRenderers.String.render(id2, entry);
         }
       },
       String: {
@@ -15952,13 +16015,13 @@ var require_assets = __commonJS({
             return false;
           }
         },
-        render: (id, entry) => {
+        render: (id2, entry) => {
           const arrayMap = {};
           entry.value.forEach((entry2, index) => {
             arrayMap[`[${index}]`] = entry2;
           });
           const arrayRendered = m$1`<${MetaDataView}
-        id=${id}
+        id=${id2}
         style=${{ fontSize: FontSize.small }}
         entries="${arrayMap}"
         tableOptions="borderless,sm"
@@ -16018,7 +16081,7 @@ ${entry.value}</pre
         canRender: (entry) => {
           return typeof entry.value === "object" && entry.value._html;
         },
-        render: (id, entry) => {
+        render: (id2, entry) => {
           return {
             rendered: entry.value._html
           };
@@ -16029,7 +16092,7 @@ ${entry.value}</pre
         canRender: (entry) => {
           return typeof entry.value === "string" && entry.value.startsWith("data:image/");
         },
-        render: (id, entry) => {
+        render: (id2, entry) => {
           return {
             rendered: m$1`<img src=${entry.value} />`
           };
@@ -16040,7 +16103,7 @@ ${entry.value}</pre
         canRender: (entry) => {
           return typeof entry.value === "object";
         },
-        render: (id, entry) => {
+        render: (id2, entry) => {
           const summary = [];
           const keys = Object.keys(entry.value);
           if (keys.length > 4) {
@@ -16052,7 +16115,7 @@ ${entry.value}</pre
           }
           return {
             rendered: m$1`<${MetaDataView}
-          id=${id}
+          id=${id2}
           style=${{ fontSize: FontSize.smaller }}
           entries="${entry.value}"
           tableOptions="borderless,sm"
@@ -16063,7 +16126,7 @@ ${entry.value}</pre
       }
     };
     const MetaDataView = ({
-      id,
+      id: id2,
       baseClass,
       classes,
       style: style2,
@@ -16106,7 +16169,7 @@ ${entry.value}</pre
         }
       }
       const entryEls = (coercedEntries || []).map((entry, index) => {
-        const id2 = `${baseId}-value-${index}`;
+        const id3 = `${baseId}-value-${index}`;
         return m$1`<tr class="${baseId}-row">
       <td
         class="${baseId}-key"
@@ -16115,12 +16178,12 @@ ${entry.value}</pre
         ${entry.name}
       </td>
       <td class="${baseId}-value" style=${{ ...cellStyle, ...cellValueStyle }}>
-        <${RenderedContent} id=${id2} entry=${entry} />
+        <${RenderedContent} id=${id3} entry=${entry} />
       </td>
     </tr>`;
       });
       return m$1`<table
-    ...${{ id }}
+    ...${{ id: id2 }}
     class="${classes || ""} table ${tblClz.join(" ")}"
     style=${{
         paddingLeft: "0",
@@ -16530,26 +16593,26 @@ ${entry.value}</pre
     </div>
   `;
     };
-    const LargeModal = (props) => {
-      const {
-        id,
-        title,
-        detail,
-        detailTools,
-        footer,
-        onkeyup,
-        visible,
-        onHide,
-        showProgress,
-        children: children2,
-        initialScrollPositionRef,
-        setInitialScrollPosition,
-        warning,
-        warningHidden,
-        setWarningHidden
-      } = props;
+    const LargeModal = ({
+      id: id2,
+      title,
+      detail,
+      detailTools,
+      footer,
+      onkeyup,
+      visible,
+      onHide,
+      showProgress,
+      children: children2,
+      initialScrollPositionRef,
+      setInitialScrollPosition,
+      warning,
+      warningHidden,
+      setWarningHidden,
+      scrollRef
+    }) => {
       const modalFooter = footer ? m$1`<div class="modal-footer">${footer}</div>` : "";
-      const scrollRef = A(
+      scrollRef = scrollRef || A$1(
         /** @type {HTMLElement|null} */
         null
       );
@@ -16562,7 +16625,7 @@ ${entry.value}</pre
           }, 0);
         }
       }, []);
-      const onScroll = q(
+      const onScroll = q$1(
         (e2) => {
           setInitialScrollPosition(e2.srcElement.scrollTop);
         },
@@ -16625,7 +16688,7 @@ ${entry.value}</pre
       <${HtmlEntity}>&times;</${HtmlEntity}>
     </button>`);
       return m$1`<div
-    id=${id}
+    id=${id2}
     class="modal"
     tabindex="0"
     role="dialog"
@@ -16692,8 +16755,8 @@ ${entry.value}</pre
     <i class="${icon}" />
   </button>`;
     };
-    function escapeSelector(id) {
-      return id.replace(/([ #.;,?!+*~'":^$[\]()=>|/\\])/g, "\\$1");
+    function escapeSelector(id2) {
+      return id2.replace(/([ #.;,?!+*~'":^$[\]()=>|/\\])/g, "\\$1");
     }
     const isVscode = () => {
       const bodyEl = document.querySelector("body");
@@ -16721,7 +16784,7 @@ ${entry.value}</pre
     </div>`;
       }
     };
-    const MetaDataGrid = ({ id, entries, classes, style: style2, plain }) => {
+    const MetaDataGrid = ({ id: id2, entries, classes, style: style2, plain }) => {
       const baseId = "metadata-grid";
       const cellKeyStyle = {
         fontWeight: "400",
@@ -16750,7 +16813,7 @@ ${entry.value}</pre
         }
       };
       const entryEls = entryRecords(entries).map((entry, index) => {
-        const id2 = `${baseId}-value-${index}`;
+        const id3 = `${baseId}-value-${index}`;
         return m$1`
       <div
         style=${{
@@ -16765,12 +16828,12 @@ ${entry.value}</pre
         ${entry.name}
       </div>
       <div class="${baseId}-value" style=${{ ...cellValueStyle }}>
-        <${RenderedContent} id=${id2} entry=${entry} />
+        <${RenderedContent} id=${id3} entry=${entry} />
       </div>
     `;
       });
       return m$1`<div
-    ...${{ id }}
+    ...${{ id: id2 }}
     class="${classes || ""}"
     style=${{
         display: "grid",
@@ -16927,7 +16990,7 @@ ${entry.value}</pre
   `;
     };
     const EventPanel = ({
-      id,
+      id: id2,
       classes,
       title,
       subTitle,
@@ -16942,7 +17005,7 @@ ${entry.value}</pre
       const hasCollapse = collapse !== void 0;
       const [collapsed, setCollapsed] = h(!!collapse);
       const [selectedNav, setSelectedNav] = h("");
-      const filteredArrChildren = T(() => {
+      const filteredArrChildren = T$1(() => {
         const arrChildren = Array.isArray(children2) ? children2 : [children2];
         return arrChildren.filter((child) => !!child);
       }, [children2]);
@@ -16950,7 +17013,7 @@ ${entry.value}</pre
         setSelectedNav(pillId(0));
       }, [filteredArrChildren]);
       const pillId = (index) => {
-        return `${id}-nav-pill-${index}`;
+        return `${id2}-nav-pill-${index}`;
       };
       const gridColumns2 = [];
       if (hasCollapse) {
@@ -17036,7 +17099,7 @@ ${entry.value}</pre
         const defaultTitle = `Tab ${index}`;
         const title2 = child && typeof child === "object" ? ((_a2 = child["props"]) == null ? void 0 : _a2.name) || defaultTitle : defaultTitle;
         return {
-          id: `eventpanel-${id}-${index}`,
+          id: `eventpanel-${id2}-${index}`,
           title: title2,
           target: pillId(index)
         };
@@ -17047,10 +17110,9 @@ ${entry.value}</pre
           </div>
         </div>` : "";
       const card = m$1` <div
-    id=${id}
+    id=${id2}
     style=${{
         padding: "0.625rem",
-        marginBottom: "0.625rem",
         border: "solid 1px var(--bs-light-border-subtle)",
         borderRadius: "var(--bs-border-radius)",
         ...style2
@@ -17066,10 +17128,10 @@ ${entry.value}</pre
       }}
     >
       ${filteredArrChildren == null ? void 0 : filteredArrChildren.map((child, index) => {
-        const id2 = pillId(index);
+        const id3 = pillId(index);
         return m$1`<div
-          id=${id2}
-          class="tab-pane show ${id2 === selectedNav ? "active" : ""}"
+          id=${id3}
+          class="tab-pane show ${id3 === selectedNav ? "active" : ""}"
         >
           ${child}
         </div>`;
@@ -17151,7 +17213,7 @@ ${entry.value}</pre
         return [val];
       }
     };
-    const SampleInitEventView = ({ id, event, style: style2 }) => {
+    const SampleInitEventView = ({ id: id2, event, style: style2 }) => {
       const stateObj = event.state;
       const sections = [];
       if (event.sample.files && Object.keys(event.sample.files).length > 0) {
@@ -17169,7 +17231,7 @@ ${entry.value}</pre
   `);
       }
       return m$1`
-  <${EventPanel} id=${id} style=${style2} title="Sample" icon=${ApplicationIcons.sample} subTitle=${formatDateTime(new Date(event.timestamp))}>
+  <${EventPanel} id=${id2} style=${style2} title="Sample" icon=${ApplicationIcons.sample} subTitle=${formatDateTime(new Date(event.timestamp))}>
     <div name="Sample" style=${{ margin: "1em 0em" }}>
       <${ChatView} messages=${stateObj["messages"]}/>
       <div>
@@ -17226,13 +17288,13 @@ ${entry.value}</pre
     let Updates = null;
     let Effects = null;
     let ExecCount = 0;
-    function createRoot(fn, detachedOwner) {
-      const listener = Listener, owner = Owner, unowned = fn.length === 0, root2 = unowned ? UNOWNED : {
+    function createRoot(fn2, detachedOwner) {
+      const listener = Listener, owner = Owner, unowned = fn2.length === 0, root2 = unowned ? UNOWNED : {
         owned: null,
         cleanups: null,
         context: null,
         owner: detachedOwner === void 0 ? owner : detachedOwner
-      }, updateFn = unowned ? fn : () => fn(() => untrack(() => cleanNode(root2)));
+      }, updateFn = unowned ? fn2 : () => fn2(() => untrack(() => cleanNode(root2)));
       Owner = root2;
       Listener = null;
       try {
@@ -17258,52 +17320,52 @@ ${entry.value}</pre
       };
       return [readSignal.bind(s2), setter];
     }
-    function createRenderEffect(fn, value, options) {
-      const c2 = createComputation(fn, value, false, STALE);
+    function createRenderEffect(fn2, value, options) {
+      const c2 = createComputation(fn2, value, false, STALE);
       updateComputation(c2);
     }
-    function createEffect(fn, value, options) {
+    function createEffect(fn2, value, options) {
       runEffects = runUserEffects;
-      const c2 = createComputation(fn, value, false, STALE);
+      const c2 = createComputation(fn2, value, false, STALE);
       c2.user = true;
       Effects ? Effects.push(c2) : updateComputation(c2);
     }
-    function createMemo(fn, value, options) {
+    function createMemo(fn2, value, options) {
       options = options ? Object.assign({}, signalOptions, options) : signalOptions;
-      const c2 = createComputation(fn, value, true, 0);
+      const c2 = createComputation(fn2, value, true, 0);
       c2.observers = null;
       c2.observerSlots = null;
       c2.comparator = options.equals || void 0;
       updateComputation(c2);
       return readSignal.bind(c2);
     }
-    function batch(fn) {
-      return runUpdates(fn, false);
+    function batch(fn2) {
+      return runUpdates(fn2, false);
     }
-    function untrack(fn) {
-      if (Listener === null) return fn();
+    function untrack(fn2) {
+      if (Listener === null) return fn2();
       const listener = Listener;
       Listener = null;
       try {
-        return fn();
+        return fn2();
       } finally {
         Listener = listener;
       }
     }
-    function onMount(fn) {
-      createEffect(() => untrack(fn));
+    function onMount(fn2) {
+      createEffect(() => untrack(fn2));
     }
-    function onCleanup(fn) {
+    function onCleanup(fn2) {
       if (Owner === null) ;
-      else if (Owner.cleanups === null) Owner.cleanups = [fn];
-      else Owner.cleanups.push(fn);
-      return fn;
+      else if (Owner.cleanups === null) Owner.cleanups = [fn2];
+      else Owner.cleanups.push(fn2);
+      return fn2;
     }
     function getListener() {
       return Listener;
     }
-    function children(fn) {
-      const children2 = createMemo(fn);
+    function children(fn2) {
+      const children2 = createMemo(fn2);
       const memo = createMemo(() => resolveChildren(children2()));
       memo.toArray = () => {
         const c2 = memo();
@@ -17399,16 +17461,16 @@ ${entry.value}</pre
         node.updatedAt = time;
       }
     }
-    function createComputation(fn, init, pure, state = STALE, options) {
+    function createComputation(fn2, init2, pure, state = STALE, options) {
       const c2 = {
-        fn,
+        fn: fn2,
         state,
         updatedAt: null,
         owned: null,
         sources: null,
         sourceSlots: null,
         cleanups: null,
-        value: init,
+        value: init2,
         owner: Owner,
         context: null,
         pure
@@ -17443,15 +17505,15 @@ ${entry.value}</pre
         }
       }
     }
-    function runUpdates(fn, init) {
-      if (Updates) return fn();
+    function runUpdates(fn2, init2) {
+      if (Updates) return fn2();
       let wait = false;
-      if (!init) Updates = [];
+      if (!init2) Updates = [];
       if (Effects) wait = true;
       else Effects = [];
       ExecCount++;
       try {
-        const res = fn();
+        const res = fn2();
         completeUpdates(wait);
         return res;
       } catch (err2) {
@@ -17804,9 +17866,9 @@ ${entry.value}</pre
         const c2 = condition();
         if (c2) {
           const child = props.children;
-          const fn = typeof child === "function" && child.length > 0;
-          strictEqual = keyed || fn;
-          return fn ? untrack(() => child(c2)) : child;
+          const fn2 = typeof child === "function" && child.length > 0;
+          strictEqual = keyed || fn2;
+          return fn2 ? untrack(() => child(c2)) : child;
         }
         return props.fallback;
       }, void 0, void 0);
@@ -17833,9 +17895,9 @@ ${entry.value}</pre
         const [index, when, cond] = evalConditions();
         if (index < 0) return props.fallback;
         const c2 = cond.children;
-        const fn = typeof c2 === "function" && c2.length > 0;
-        strictEqual = keyed || fn;
-        return fn ? untrack(() => c2(when)) : c2;
+        const fn2 = typeof c2 === "function" && c2.length > 0;
+        strictEqual = keyed || fn2;
+        return fn2 ? untrack(() => c2(when)) : c2;
       }, void 0, void 0);
     }
     function Match(props) {
@@ -17890,11 +17952,11 @@ ${entry.value}</pre
       }
     }
     const $$EVENTS = "_$DX_DELEGATE";
-    function render(code2, element, init, options = {}) {
+    function render(code2, element, init2, options = {}) {
       let disposer;
       createRoot((dispose2) => {
         disposer = dispose2;
-        element === document ? code2() : insert(element, code2(), element.firstChild ? null : void 0, init);
+        element === document ? code2() : insert$1(element, code2(), element.firstChild ? null : void 0, init2);
       }, options.owner);
       return () => {
         disposer();
@@ -17913,7 +17975,7 @@ ${entry.value}</pre
         const name = eventNames[i2];
         if (!e2.has(name)) {
           e2.add(name);
-          document2.addEventListener(name, eventHandler);
+          document2.addEventListener(name, eventHandler$1);
         }
       }
     }
@@ -17953,15 +18015,15 @@ ${entry.value}</pre
       }
       return prev;
     }
-    function use(fn, element, arg) {
-      return untrack(() => fn(element, arg));
+    function use(fn2, element, arg) {
+      return untrack(() => fn2(element, arg));
     }
-    function insert(parent, accessor, marker, initial) {
+    function insert$1(parent, accessor, marker, initial) {
       if (marker !== void 0 && !initial) initial = [];
       if (typeof accessor !== "function") return insertExpression(parent, accessor, initial, marker);
       createRenderEffect((current) => insertExpression(parent, accessor(), current, marker), initial);
     }
-    function eventHandler(e2) {
+    function eventHandler$1(e2) {
       const key2 = `$$${e2.type}`;
       let node = e2.composedPath && e2.composedPath()[0] || e2.target;
       if (e2.target !== node) {
@@ -18775,14 +18837,14 @@ ${val.stack}`;
         const now = this.now.bind(this);
         const setTimeout2 = (f2, t2) => window.setTimeout(f2, t2 / this.speed);
         const setInterval2 = (f2, t2) => window.setInterval(f2, t2 / this.speed);
-        const reset = this.resetVt.bind(this);
+        const reset2 = this.resetVt.bind(this);
         const setState = this.setState.bind(this);
         const posterTime = this.poster.type === "npt" ? this.poster.value : void 0;
         this.driver = this.driverFn({
           feed,
           onInput,
           onMarker,
-          reset,
+          reset: reset2,
           now,
           setTimeout: setTimeout2,
           setInterval: setInterval2,
@@ -18983,14 +19045,14 @@ ${val.stack}`;
         });
       }
       resetVt(cols, rows) {
-        let init = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : void 0;
+        let init2 = arguments.length > 2 && arguments[2] !== void 0 ? arguments[2] : void 0;
         let theme = arguments.length > 3 && arguments[3] !== void 0 ? arguments[3] : void 0;
         this.cols = cols;
         this.rows = rows;
         this.cursor = void 0;
         this.initializeVt(cols, rows);
-        if (init !== void 0 && init !== "") {
-          this.doFeed(init);
+        if (init2 !== void 0 && init2 !== "") {
+          this.doFeed(init2);
         }
         this.dispatchEvent("reset", {
           cols,
@@ -19251,7 +19313,7 @@ ${val.stack}`;
       return [wrappedStore, setStore];
     }
     const $ROOT = Symbol("store-root");
-    function applyState(target, parent, property, merge, key2) {
+    function applyState(target, parent, property, merge2, key2) {
       const previous = parent[property];
       if (target === previous) return;
       if (!isWrappable(target) || !isWrappable(previous) || key2 && target[key2] !== previous[key2]) {
@@ -19262,10 +19324,10 @@ ${val.stack}`;
         return;
       }
       if (Array.isArray(target)) {
-        if (target.length && previous.length && (!merge || key2 && target[0] && target[0][key2] != null)) {
+        if (target.length && previous.length && (!merge2 || key2 && target[0] && target[0][key2] != null)) {
           let i2, j2, start2, end2, newEnd, item, newIndicesNext, keyVal;
           for (start2 = 0, end2 = Math.min(previous.length, target.length); start2 < end2 && (previous[start2] === target[start2] || key2 && previous[start2] && target[start2] && previous[start2][key2] === target[start2][key2]); start2++) {
-            applyState(target[start2], previous, start2, merge, key2);
+            applyState(target[start2], previous, start2, merge2, key2);
           }
           const temp = new Array(target.length), newIndices = /* @__PURE__ */ new Map();
           for (end2 = previous.length - 1, newEnd = target.length - 1; end2 >= start2 && newEnd >= start2 && (previous[end2] === target[newEnd] || key2 && previous[start2] && target[start2] && previous[end2][key2] === target[newEnd][key2]); end2--, newEnd--) {
@@ -19275,7 +19337,7 @@ ${val.stack}`;
             for (j2 = start2; j2 <= newEnd; j2++) setProperty(previous, j2, target[j2]);
             for (; j2 < target.length; j2++) {
               setProperty(previous, j2, temp[j2]);
-              applyState(target[j2], previous, j2, merge, key2);
+              applyState(target[j2], previous, j2, merge2, key2);
             }
             if (previous.length > target.length) setProperty(previous, "length", target.length);
             return;
@@ -19301,12 +19363,12 @@ ${val.stack}`;
           for (j2 = start2; j2 < target.length; j2++) {
             if (j2 in temp) {
               setProperty(previous, j2, temp[j2]);
-              applyState(target[j2], previous, j2, merge, key2);
+              applyState(target[j2], previous, j2, merge2, key2);
             } else setProperty(previous, j2, target[j2]);
           }
         } else {
           for (let i2 = 0, len = target.length; i2 < len; i2++) {
-            applyState(target[i2], previous, i2, merge, key2);
+            applyState(target[i2], previous, i2, merge2, key2);
           }
         }
         if (previous.length > target.length) setProperty(previous, "length", target.length);
@@ -19314,7 +19376,7 @@ ${val.stack}`;
       }
       const targetKeys = Object.keys(target);
       for (let i2 = 0, len = targetKeys.length; i2 < len; i2++) {
-        applyState(target[targetKeys[i2]], previous, targetKeys[i2], merge, key2);
+        applyState(target[targetKeys[i2]], previous, targetKeys[i2], merge2, key2);
       }
       const previousKeys = Object.keys(previous);
       for (let i2 = 0, len = previousKeys.length; i2 < len; i2++) {
@@ -19323,14 +19385,14 @@ ${val.stack}`;
     }
     function reconcile(value, options = {}) {
       const {
-        merge,
+        merge: merge2,
         key: key2 = "id"
       } = options, v2 = unwrap(value);
       return (state) => {
         if (!isWrappable(state) || !isWrappable(v2)) return v2;
         const res = applyState(v2, {
           [$ROOT]: state
-        }, $ROOT, merge, key2);
+        }, $ROOT, merge2, key2);
         return res === void 0 ? state : res;
       };
     }
@@ -19349,7 +19411,7 @@ ${val.stack}`;
       const className$1 = createMemo(() => buildClassName(props.pen, codePoint(), props.extraClass));
       return (() => {
         const _el$ = _tmpl$$9.cloneNode(true);
-        insert(_el$, text2);
+        insert$1(_el$, text2);
         createRenderEffect((_p$) => {
           const _v$ = className$1(), _v$2 = style$1();
           _v$ !== _p$._v$ && className(_el$, _p$._v$ = _v$);
@@ -19467,7 +19529,7 @@ ${val.stack}`;
       };
       return (() => {
         const _el$ = _tmpl$$8.cloneNode(true);
-        insert(_el$, createComponent(Index, {
+        insert$1(_el$, createComponent(Index, {
           get each() {
             return segments();
           },
@@ -19501,7 +19563,7 @@ ${val.stack}`;
         const _el$ = _tmpl$$7.cloneNode(true);
         const _ref$ = props.ref;
         typeof _ref$ === "function" ? use(_ref$, _el$) : props.ref = _el$;
-        insert(_el$, createComponent(For, {
+        insert$1(_el$, createComponent(For, {
           get each() {
             return props.lines;
           },
@@ -19611,14 +19673,14 @@ ${val.stack}`;
         const _el$ = _tmpl$5.cloneNode(true), _el$5 = _el$.firstChild, _el$6 = _el$5.firstChild, _el$7 = _el$6.nextSibling, _el$12 = _el$5.nextSibling;
         const _ref$ = props.ref;
         typeof _ref$ === "function" ? use(_ref$, _el$) : props.ref = _el$;
-        insert(_el$, createComponent(Show, {
+        insert$1(_el$, createComponent(Show, {
           get when() {
             return props.isPausable;
           },
           get children() {
             const _el$2 = _tmpl$3.cloneNode(true);
             addEventListener(_el$2, "click", e2(props.onPlayClick));
-            insert(_el$2, createComponent(Switch, {
+            insert$1(_el$2, createComponent(Switch, {
               get children() {
                 return [createComponent(Match, {
                   get when() {
@@ -19640,9 +19702,9 @@ ${val.stack}`;
             return _el$2;
           }
         }), _el$5);
-        insert(_el$6, currentTime);
-        insert(_el$7, remainingTime);
-        insert(_el$, createComponent(Show, {
+        insert$1(_el$6, currentTime);
+        insert$1(_el$7, remainingTime);
+        insert$1(_el$, createComponent(Show, {
           get when() {
             return typeof props.progress === "number" || props.isSeekable;
           },
@@ -19650,7 +19712,7 @@ ${val.stack}`;
             const _el$8 = _tmpl$4.cloneNode(true), _el$9 = _el$8.firstChild, _el$10 = _el$9.firstChild, _el$11 = _el$10.nextSibling;
             _el$9.$$mousemove = onMove;
             _el$9.$$mousedown = onMouseDown;
-            insert(_el$9, createComponent(For, {
+            insert$1(_el$9, createComponent(For, {
               get each() {
                 return markers();
               },
@@ -19660,7 +19722,7 @@ ${val.stack}`;
                   e3._marker = true;
                 };
                 addEventListener(_el$13, "click", seekToMarker(i2()));
-                insert(_el$15, () => markerText(m2));
+                insert$1(_el$15, () => markerText(m2));
                 createRenderEffect((_p$) => {
                   const _v$ = markerPosition(m2), _v$2 = !!isPastMarker(m2);
                   _v$ !== _p$._v$ && _el$13.style.setProperty("left", _p$._v$ = _v$);
@@ -19700,7 +19762,7 @@ ${val.stack}`;
       };
       return (() => {
         const _el$ = _tmpl$$3.cloneNode(true), _el$2 = _el$.firstChild;
-        insert(_el$2, () => props.message);
+        insert$1(_el$2, () => props.message);
         createRenderEffect((_$p) => style(_el$2, style$1(), _$p));
         return _el$;
       })();
@@ -20177,7 +20239,7 @@ ${val.stack}`;
         typeof _ref$2 === "function" ? use(_ref$2, _el$2) : playerRef = _el$2;
         _el$2.$$mousemove = () => onUserActive(true);
         _el$2.addEventListener("mouseleave", playerOnMouseLeave);
-        insert(_el$2, createComponent(Terminal, {
+        insert$1(_el$2, createComponent(Terminal, {
           get cols() {
             return terminalCols();
           },
@@ -20210,7 +20272,7 @@ ${val.stack}`;
             typeof _ref$3 === "function" ? _ref$3(r$) : terminalRef = r$;
           }
         }), null);
-        insert(_el$2, createComponent(Show, {
+        insert$1(_el$2, createComponent(Show, {
           get when() {
             return props.controls !== false;
           },
@@ -20248,7 +20310,7 @@ ${val.stack}`;
             });
           }
         }), null);
-        insert(_el$2, createComponent(Switch, {
+        insert$1(_el$2, createComponent(Switch, {
           get children() {
             return [createComponent(Match, {
               get when() {
@@ -20290,7 +20352,7 @@ ${val.stack}`;
             })];
           }
         }), null);
-        insert(_el$2, createComponent(Show, {
+        insert$1(_el$2, createComponent(Show, {
           get when() {
             return isHelpVisible();
           },
@@ -20400,7 +20462,7 @@ ${val.stack}`;
         let v2 = 0;
         let values = [];
         let flushed = false;
-        const xf = compose(this.xfs, (val) => values.push(val));
+        const xf = compose$1(this.xfs, (val) => values.push(val));
         return {
           next: () => {
             if (v2 === values.length) {
@@ -20478,7 +20540,7 @@ ${val.stack}`;
         };
       };
     }
-    function compose(xfs, push2) {
+    function compose$1(xfs, push2) {
       return xfs.reverse().reduce((next, curr) => {
         const xf = toXf(curr(next.step));
         return {
@@ -20685,7 +20747,7 @@ ${events}
       let startTime;
       let pauseElapsedTime;
       let playCount = 0;
-      async function init() {
+      async function init2() {
         const {
           parser,
           minFrameTime,
@@ -20960,7 +21022,7 @@ ${events}
         feed(`\x1B[8;${initialRows};${initialCols};t`);
       }
       return {
-        init,
+        init: init2,
         play,
         pause,
         seek,
@@ -21424,8 +21486,8 @@ ${events}
           return bufferTime;
         }
         latencies = latencies.slice(-windowSize);
-        const currentMinJitter = min(latencies);
-        const currentMaxJitter = max$1(latencies);
+        const currentMinJitter = min$1(latencies);
+        const currentMaxJitter = max$2(latencies);
         const currentJitterRange = currentMaxJitter - currentMinJitter;
         maxJitter = currentMaxJitter * smoothingFactor + maxJitter * (1 - smoothingFactor);
         jitterRange = currentJitterRange * smoothingFactor + jitterRange * (1 - smoothingFactor);
@@ -21465,10 +21527,10 @@ ${events}
         return bufferTime;
       };
     }
-    function min(numbers) {
+    function min$1(numbers) {
       return numbers.reduce((prev, cur) => cur < prev ? cur : prev);
     }
-    function max$1(numbers) {
+    function max$2(numbers) {
       return numbers.reduce((prev, cur) => cur > prev ? cur : prev);
     }
     function exponentialDelay(attempt) {
@@ -21483,7 +21545,7 @@ ${events}
       } = _ref;
       let {
         feed,
-        reset,
+        reset: reset2,
         setState,
         logger
       } = _ref2;
@@ -21574,12 +21636,12 @@ ${events}
           }
           const initLen = view.getUint32(offset2, true);
           offset2 += 4;
-          let init;
+          let init2;
           if (initLen > 0) {
-            init = utfDecoder.decode(new Uint8Array(buffer2, offset2, initLen));
+            init2 = utfDecoder.decode(new Uint8Array(buffer2, offset2, initLen));
             offset2 += initLen;
           }
-          handleResetMessage(cols, rows, time, init, theme);
+          handleResetMessage(cols, rows, time, init2, theme);
         } else if (type === 111) {
           const time = view.getFloat32(1, true);
           const len = view.getUint32(5, true);
@@ -21618,11 +21680,11 @@ ${events}
       function handleRawTextMessage(event) {
         buf.pushText(utfDecoder.decode(event.data));
       }
-      function handleResetMessage(cols, rows, time, init, theme) {
+      function handleResetMessage(cols, rows, time, init2, theme) {
         logger.debug(`stream reset (${cols}x${rows} @${time})`);
         setState("playing");
         initBuffer(time);
-        reset(cols, rows, init, theme);
+        reset2(cols, rows, init2, theme);
         clock2 = new Clock();
         wasOnline = true;
         if (typeof time === "number") {
@@ -21642,7 +21704,7 @@ ${events}
         }
         clock2 = new NullClock();
       }
-      function connect() {
+      function connect2() {
         socket = new WebSocket(url);
         socket.binaryType = "arraybuffer";
         socket.onopen = () => {
@@ -21663,14 +21725,14 @@ ${events}
             const delay = reconnectDelay(reconnectAttempt++);
             logger.info(`unclean close, reconnecting in ${delay}...`);
             setState("loading");
-            setTimeout(connect, delay);
+            setTimeout(connect2, delay);
           }
         };
         wasOnline = false;
       }
       return {
         play: () => {
-          connect();
+          connect2();
         },
         stop: () => {
           stop = true;
@@ -21688,7 +21750,7 @@ ${events}
       } = _ref;
       let {
         feed,
-        reset,
+        reset: reset2,
         setState,
         logger
       } = _ref2;
@@ -21724,7 +21786,7 @@ ${events}
               logger.debug(`vt reset (${cols}x${rows})`);
               setState("playing");
               initBuffer(e2.time);
-              reset(cols, rows, e2.init ?? void 0);
+              reset2(cols, rows, e2.init ?? void 0);
               clock2 = new Clock();
               if (typeof e2.time === "number") {
                 clock2.setTime(e2.time);
@@ -22003,7 +22065,7 @@ ${events}
       return metrics;
     }
     const AsciiCinemaPlayer = ({
-      id,
+      id: id2,
       rows,
       cols,
       inputUrl,
@@ -22017,7 +22079,7 @@ ${events}
       idleTimeLimit = 2,
       style: style2
     }) => {
-      const playerContainerRef = A();
+      const playerContainerRef = A$1();
       y(() => {
         const player = create(
           {
@@ -22043,7 +22105,7 @@ ${events}
       }, []);
       return m$1`
     <div
-      id="asciinema-player-${id || "default"}"
+      id="asciinema-player-${id2 || "default"}"
       ref=${playerContainerRef}
       style=${{ ...style2 }}
     ></div>
@@ -22069,12 +22131,12 @@ ${events}
           return () => clearTimeout(timer);
         }
       }, [isOpen, showOverlay]);
-      const showNext = q(() => {
+      const showNext = q$1(() => {
         setCurrentIndex((prev) => {
           return (prev + 1) % slides.length;
         });
       }, [slides]);
-      const showPrev = q(() => {
+      const showPrev = q$1(() => {
         setCurrentIndex((prev) => (prev - 1 + slides.length) % slides.length);
       }, [slides]);
       y(() => {
@@ -22508,29 +22570,29 @@ ${events}
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       pipe(name, pipeArg) {
-        let pipe = pipeArg;
+        let pipe2 = pipeArg;
         if (typeof name === "string") {
-          if (typeof pipe === "undefined") {
+          if (typeof pipe2 === "undefined") {
             return this.pipes[name];
           } else {
-            this.pipes[name] = pipe;
+            this.pipes[name] = pipe2;
           }
         }
         if (name && name.name) {
-          pipe = name;
-          if (pipe.processor === this) {
-            return pipe;
+          pipe2 = name;
+          if (pipe2.processor === this) {
+            return pipe2;
           }
-          this.pipes[pipe.name] = pipe;
+          this.pipes[pipe2.name] = pipe2;
         }
-        pipe.processor = this;
-        return pipe;
+        pipe2.processor = this;
+        return pipe2;
       }
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      process(input, pipe) {
+      process(input, pipe2) {
         let context = input;
         context.options = this.options();
-        let nextPipe = pipe || input.pipe || "default";
+        let nextPipe = pipe2 || input.pipe || "default";
         let lastPipe;
         while (nextPipe) {
           if (typeof context.nextAfterChildren !== "undefined") {
@@ -22566,11 +22628,11 @@ ${events}
         const length = this.filters.length;
         const context = input;
         for (let index = 0; index < length; index++) {
-          const filter = this.filters[index];
+          const filter2 = this.filters[index];
           if (debug) {
-            this.log(`filter: ${filter.filterName}`);
+            this.log(`filter: ${filter2.filterName}`);
           }
-          filter(context);
+          filter2(context);
           if (typeof context === "object" && context.exiting) {
             context.exiting = false;
             break;
@@ -22596,8 +22658,8 @@ ${events}
           throw new Error("a filter name is required");
         }
         for (let index = 0; index < this.filters.length; index++) {
-          const filter = this.filters[index];
-          if (filter.filterName === filterName) {
+          const filter2 = this.filters[index];
+          if (filter2.filterName === filterName) {
             return index;
           }
         }
@@ -22682,7 +22744,7 @@ ${events}
       const regexMatch = /^\/(.*)\/([gimyu]*)$/.exec(re.toString());
       return new RegExp(regexMatch[1], regexMatch[2]);
     }
-    function clone(arg) {
+    function clone$1(arg) {
       if (typeof arg !== "object") {
         return arg;
       }
@@ -22690,7 +22752,7 @@ ${events}
         return null;
       }
       if (Array.isArray(arg)) {
-        return arg.map(clone);
+        return arg.map(clone$1);
       }
       if (arg instanceof Date) {
         return new Date(arg.getTime());
@@ -22701,7 +22763,7 @@ ${events}
       const cloned = {};
       for (const name in arg) {
         if (Object.prototype.hasOwnProperty.call(arg, name)) {
-          cloned[name] = clone(arg[name]);
+          cloned[name] = clone$1(arg[name]);
         }
       }
       return cloned;
@@ -22715,12 +22777,12 @@ ${events}
       }
       setResult(result) {
         if (this.options.cloneDiffValues && typeof result === "object") {
-          const clone$1 = typeof this.options.cloneDiffValues === "function" ? this.options.cloneDiffValues : clone;
+          const clone2 = typeof this.options.cloneDiffValues === "function" ? this.options.cloneDiffValues : clone$1;
           if (typeof result[0] === "object") {
-            result[0] = clone$1(result[0]);
+            result[0] = clone2(result[0]);
           }
           if (typeof result[1] === "object") {
-            result[1] = clone$1(result[1]);
+            result[1] = clone2(result[1]);
           }
         }
         return super.setResult(result);
@@ -23544,7 +23606,7 @@ ${events}
         return this.patch(right2, this.reverse(delta));
       }
       clone(value) {
-        return clone(value);
+        return clone$1(value);
       }
     }
     let defaultInstance$1;
@@ -23632,7 +23694,7 @@ ${events}
           this.recurse(context, delta[key2], left2 ? left2[leftKey] : void 0, key2, leftKey, movedFrom, isLast);
         });
       }
-      forEachDeltaKey(delta, left2, fn) {
+      forEachDeltaKey(delta, left2, fn2) {
         const keys = Object.keys(delta);
         const arrayKeys = delta._t === "a";
         const moveDestinations = {};
@@ -23675,7 +23737,7 @@ ${events}
           }
           const leftKey = arrayKeys ? parseInt(trimUnderscore(key2), 10) : key2;
           const isLast = index === length - 1;
-          fn(key2, leftKey, moveDestinations[leftKey], isLast);
+          fn2(key2, leftKey, moveDestinations[leftKey], isLast);
         }
       }
       getDeltaType(delta, movedFrom) {
@@ -23862,15 +23924,15 @@ ${events}
     const adjustArrows = function jsondiffpatchHtmlFormatterAdjustArrows(nodeArg) {
       const node = nodeArg || document;
       const getElementText = ({ textContent, innerText }) => textContent || innerText;
-      const eachByQuery = (el, query, fn) => {
+      const eachByQuery = (el, query, fn2) => {
         const elems = el.querySelectorAll(query);
         for (let i2 = 0, l2 = elems.length; i2 < l2; i2++) {
-          fn(elems[i2]);
+          fn2(elems[i2]);
         }
       };
-      const eachChildren = ({ children: children2 }, fn) => {
+      const eachChildren = ({ children: children2 }, fn2) => {
         for (let i2 = 0, l2 = children2.length; i2 < l2; i2++) {
-          fn(children2[i2], i2);
+          fn2(children2[i2], i2);
         }
       };
       eachByQuery(node, ".jsondiffpatch-arrow", ({ parentNode, children: children2, style: style2 }) => {
@@ -23939,7 +24001,7 @@ ${events}
         ])
       );
     }
-    const StateEventView = ({ id, event, isStore, style: style2 }) => {
+    const StateEventView = ({ id: id2, event, isStore, style: style2 }) => {
       const summary = summarizeChanges(event.changes);
       const [before, after] = synthesizeComparable(event.changes);
       const tabs = [
@@ -23964,7 +24026,7 @@ ${events}
       }
       const title = event.event === "state" ? "State Updated" : "Store Updated";
       return m$1`
-  <${EventPanel} id=${id} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} text=${tabs.length === 1 ? summary : void 0} collapse=${changePreview === void 0 ? true : void 0} style=${style2}>
+  <${EventPanel} id=${id2} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} text=${tabs.length === 1 ? summary : void 0} collapse=${changePreview === void 0 ? true : void 0} style=${style2}>
     ${tabs}
   </${EventPanel}>`;
     };
@@ -24215,9 +24277,9 @@ ${events}
         }
       }
     };
-    const SubtaskEventView = ({ id, event, style: style2, depth }) => {
+    const SubtaskEventView = ({ id: id2, event, style: style2, depth }) => {
       const transcript = event.events.length > 0 ? m$1`<${TranscriptView}
-          id="${id}-subtask"
+          id="${id2}-subtask"
           name="Transcript"
           events=${event.events}
           depth=${depth + 1}
@@ -24241,7 +24303,7 @@ ${events}
         `;
       const type = event.type === "fork" ? "Fork" : "Subtask";
       return m$1`
-    <${EventPanel} id=${id} title="${type}: ${event.name}" subTitle=${formatDateTime(new Date(event.timestamp))} style=${style2} collapse=${false}>
+    <${EventPanel} id=${id2} title="${type}: ${event.name}" subTitle=${formatDateTime(new Date(event.timestamp))} style=${style2} collapse=${false}>
       ${body}
     </${EventPanel}>`;
     };
@@ -24466,7 +24528,7 @@ ${events}
       })}
   </div>`;
     };
-    const ModelEventView = ({ id, event, style: style2 }) => {
+    const ModelEventView = ({ id: id2, event, style: style2 }) => {
       var _a2, _b2;
       const totalUsage = (_a2 = event.output.usage) == null ? void 0 : _a2.total_tokens;
       const callTime = event.output.time;
@@ -24498,11 +24560,11 @@ ${events}
         }
       }
       return m$1`
-  <${EventPanel} id=${id} title="Model Call: ${event.model} ${subtitle}"  subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.model} style=${style2}>
+  <${EventPanel} id=${id2} title="Model Call: ${event.model} ${subtitle}"  subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.model} style=${style2}>
   
     <div name="Summary" style=${{ margin: "0.5em 0" }}>
     <${ChatView}
-      id="${id}-model-output"
+      id="${id2}-model-output"
       messages=${[...userMessages, ...outputMessages || []]}
       style=${{ paddingTop: "1em" }}
       numbered=${false}
@@ -24529,7 +24591,7 @@ ${events}
 
       <${EventSection} title="Messages">
         <${ChatView}
-          id="${id}-model-input-full"
+          id="${id2}-model-input-full"
           messages=${[...event.input, ...outputMessages || []]}
           />      
       </${EventSection}>
@@ -24540,27 +24602,27 @@ ${events}
    
   </${EventPanel}>`;
     };
-    const APIView = ({ call, style: style2 }) => {
-      if (!call) {
+    const APIView = ({ call: call2, style: style2 }) => {
+      if (!call2) {
         return "";
       }
       return m$1`<div style=${style2}>
 
     <${EventSection} title="Request">
-      <${APICodeCell} contents=${call.request} />
+      <${APICodeCell} contents=${call2.request} />
     </${EventSection}>
     <${EventSection} title="Response">
-      <${APICodeCell} contents=${call.response} />
+      <${APICodeCell} contents=${call2.response} />
     </${EventSection}>
 
     </div>`;
     };
-    const APICodeCell = ({ id, contents }) => {
+    const APICodeCell = ({ id: id2, contents }) => {
       if (!contents) {
         return "";
       }
       const sourceCode = JSON.stringify(contents, void 0, 2);
-      const codeRef = A();
+      const codeRef = A$1();
       y(() => {
         if (codeRef.current) {
           codeRef.current.innerHTML = Prism$1.highlight(
@@ -24580,7 +24642,7 @@ ${events}
       }}
     >
       <code 
-        id=${id} 
+        id=${id2} 
         ref=${codeRef}
         class="sourceCode-js" 
         style=${{
@@ -24628,7 +24690,7 @@ ${events}
     class="card"
     style=${{
         padding: "0.4em",
-        marginBottom: "0.4em",
+        marginBottom: "0",
         border: "solid 1px var(--bs-light-border-subtle)",
         borderRadius: "var(--bs-border-radius)",
         ...style2
@@ -24638,10 +24700,10 @@ ${events}
   </div>`;
       return card;
     };
-    const LoggerEventView = ({ id, event, style: style2 }) => {
+    const LoggerEventView = ({ id: id2, event, style: style2 }) => {
       return m$1`
   <${EventRow} 
-    id=${id}
+    id=${id2}
     title=${event.message.level} 
     icon=${ApplicationIcons.logging[event.message.level.toLowerCase()]}  
     style=${style2}
@@ -24655,9 +24717,9 @@ ${events}
   </${EventRow}>`;
     };
     const kPrismRenderMaxSize = 25e4;
-    const JSONPanel = ({ id, json, data, simple, style: style2 }) => {
-      const codeRef = A();
-      const sourceCode = T(() => {
+    const JSONPanel = ({ id: id2, json, data, simple, style: style2 }) => {
+      const codeRef = A$1();
+      const sourceCode = T$1(() => {
         return json || JSON.stringify(data, void 0, 2);
       }, [json, data]);
       y(() => {
@@ -24677,7 +24739,7 @@ ${events}
       class="jsonPanel"
     >
     <code 
-      id=${id}
+      id=${id2}
       ref=${codeRef}
       class="sourceCode language-javascript" 
       style=${{
@@ -24690,7 +24752,7 @@ ${events}
     </pre>
   </div>`;
     };
-    const InfoEventView = ({ id, event, style: style2 }) => {
+    const InfoEventView = ({ id: id2, event, style: style2 }) => {
       const panels = [];
       if (typeof event.data === "string") {
         panels.push(
@@ -24705,14 +24767,14 @@ ${events}
         );
       }
       return m$1`
-  <${EventPanel} id=${id} title="Info" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.info} style=${style2}>
+  <${EventPanel} id=${id2} title="Info" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.info} style=${style2}>
     ${panels}
   </${EventPanel}>`;
     };
-    const ScoreEventView = ({ id, event, style: style2 }) => {
+    const ScoreEventView = ({ id: id2, event, style: style2 }) => {
       const resolvedTarget = event.target ? Array.isArray(event.target) ? event.target.join("\n") : event.target : void 0;
       return m$1`
-  <${EventPanel} id=${id} title="Score" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.scorer} style=${style2}>
+  <${EventPanel} id=${id2} title="Score" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.scorer} style=${style2}>
   
     <div
       name="Explanation"
@@ -24755,10 +24817,10 @@ ${events}
         return value;
       }
     };
-    const ApprovalEventView = ({ id, event, style: style2 }) => {
+    const ApprovalEventView = ({ id: id2, event, style: style2 }) => {
       return m$1`
   <${EventRow}
-      id=${id}
+      id=${id2}
       title="${decisionLabel(event.decision)}"
       icon=${decisionIcon(event.decision)}  
       style=${style2}
@@ -24798,7 +24860,7 @@ ${events}
           return ApplicationIcons.approve;
       }
     };
-    const ToolEventView = ({ id, event, style: style2, depth }) => {
+    const ToolEventView = ({ id: id2, event, style: style2, depth }) => {
       var _a2, _b2;
       const { input, functionCall, inputType } = resolveToolInput(
         event.function,
@@ -24809,7 +24871,7 @@ ${events}
       });
       const title = `Tool: ${((_a2 = event.view) == null ? void 0 : _a2.title) || event.function}`;
       return m$1`
-  <${EventPanel} id=${id} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.solvers.use_tools} style=${style2}>  
+  <${EventPanel} id=${id2} title="${title}" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.solvers.use_tools} style=${style2}>  
   <div name="Summary" style=${{ margin: "0.5em 0", width: "100%" }}>
     <${ToolCallView}
       functionCall=${functionCall}
@@ -24820,32 +24882,32 @@ ${events}
       view=${event.view}
       />
       ${approvalEvent ? m$1`<${ApprovalEventView}
-              id="${id}-approval"
+              id="${id2}-approval"
               event=${approvalEvent}
               style=${{ border: "none", padding: 0, marginBottom: 0 }}
             />` : ""}
   </div>
     ${event.events.length > 0 ? m$1`<${TranscriptView}
-            id="${id}-subtask"
+            id="${id2}-subtask"
             name="Transcript"
             events=${event.events}
             depth=${depth + 1}
           />` : ""}
   </${EventPanel}>`;
     };
-    const ErrorEventView = ({ id, event, style: style2 }) => {
+    const ErrorEventView = ({ id: id2, event, style: style2 }) => {
       return m$1`
-  <${EventPanel} id=${id} title="Error" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.error} style=${style2}>
+  <${EventPanel} id=${id2} title="Error" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.error} style=${style2}>
     <${ANSIDisplay} output=${event.error.traceback_ansi} style=${{ fontSize: "clamp(0.5rem, calc(0.25em + 1vw), 0.8rem)", margin: "0.5em 0" }}/>
   </${EventPanel}>`;
     };
-    const InputEventView = ({ id, event, style: style2 }) => {
+    const InputEventView = ({ id: id2, event, style: style2 }) => {
       return m$1`
-  <${EventPanel} id=${id} title="Input" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.input} style=${style2}>
+  <${EventPanel} id=${id2} title="Input" subTitle=${formatDateTime(new Date(event.timestamp))} icon=${ApplicationIcons.input} style=${style2}>
     <${ANSIDisplay} output=${event.input_ansi} style=${{ fontSize: "clamp(0.4rem, 1.15vw, 0.9rem)", ...style2 }}/>
   </${EventPanel}>`;
     };
-    const SampleLimitEventView = ({ id, event, style: style2 }) => {
+    const SampleLimitEventView = ({ id: id2, event, style: style2 }) => {
       const resolve_title = (type) => {
         switch (type) {
           case "context":
@@ -24877,7 +24939,7 @@ ${events}
       const title = resolve_title(event.type);
       const icon = resolve_icon(event.type);
       return m$1`
-  <${EventPanel} id=${id} title=${title} icon=${icon} style=${style2}>
+  <${EventPanel} id=${id2} title=${title} icon=${icon} style=${style2}>
     ${event.message}
   </${EventPanel}>`;
     };
@@ -24893,12 +24955,4483 @@ ${events}
         this.depth = depth;
       }
     }
-    const TranscriptView = ({ id, events, depth = 0 }) => {
+    function g(n2, t2) {
+      for (var e2 in n2) if ("__source" !== e2 && !(e2 in t2)) return true;
+      for (var r2 in t2) if ("__source" !== r2 && n2[r2] !== t2[r2]) return true;
+      return false;
+    }
+    function E(n2, t2) {
+      var e2 = t2(), r2 = h({ t: { __: e2, u: t2 } }), u2 = r2[0].t, o2 = r2[1];
+      return _(function() {
+        u2.__ = e2, u2.u = t2, C(u2) && o2({ t: u2 });
+      }, [n2, e2, t2]), y(function() {
+        return C(u2) && o2({ t: u2 }), n2(function() {
+          C(u2) && o2({ t: u2 });
+        });
+      }, [n2]), e2;
+    }
+    function C(n2) {
+      var t2, e2, r2 = n2.u, u2 = n2.__;
+      try {
+        var o2 = r2();
+        return !((t2 = u2) === (e2 = o2) && (0 !== t2 || 1 / t2 == 1 / e2) || t2 != t2 && e2 != e2);
+      } catch (n3) {
+        return true;
+      }
+    }
+    function x$1(n2) {
+      n2();
+    }
+    function R(n2) {
+      return n2;
+    }
+    function w() {
+      return [false, x$1];
+    }
+    var k = _;
+    function I(n2, t2) {
+      this.props = n2, this.context = t2;
+    }
+    function N(n2, e2) {
+      function r2(n3) {
+        var t2 = this.props.ref, r3 = t2 == n3.ref;
+        return !r3 && t2 && (t2.call ? t2(null) : t2.current = null), e2 ? !e2(this.props, n3) || !r3 : g(this.props, n3);
+      }
+      function u2(e3) {
+        return this.shouldComponentUpdate = r2, g$2(n2, e3);
+      }
+      return u2.displayName = "Memo(" + (n2.displayName || n2.name) + ")", u2.prototype.isReactComponent = true, u2.__f = true, u2;
+    }
+    (I.prototype = new x$3()).isPureReactComponent = true, I.prototype.shouldComponentUpdate = function(n2, t2) {
+      return g(this.props, n2) || g(this.state, t2);
+    };
+    var M = l$1.__b;
+    l$1.__b = function(n2) {
+      n2.type && n2.type.__f && n2.ref && (n2.props.ref = n2.ref, n2.ref = null), M && M(n2);
+    };
+    var T = "undefined" != typeof Symbol && Symbol.for && Symbol.for("react.forward_ref") || 3911;
+    function A(n2) {
+      function t2(t3) {
+        if (!("ref" in t3)) return n2(t3, null);
+        var e2 = t3.ref;
+        delete t3.ref;
+        var r2 = n2(t3, e2);
+        return t3.ref = e2, r2;
+      }
+      return t2.$$typeof = T, t2.render = t2, t2.prototype.isReactComponent = t2.__f = true, t2.displayName = "ForwardRef(" + (n2.displayName || n2.name) + ")", t2;
+    }
+    var D = function(n2, t2) {
+      return null == n2 ? null : L$1(L$1(n2).map(t2));
+    }, L = { map: D, forEach: D, count: function(n2) {
+      return n2 ? L$1(n2).length : 0;
+    }, only: function(n2) {
+      var t2 = L$1(n2);
+      if (1 !== t2.length) throw "Children.only";
+      return t2[0];
+    }, toArray: L$1 }, O = l$1.__e;
+    l$1.__e = function(n2, t2, e2, r2) {
+      if (n2.then) {
+        for (var u2, o2 = t2; o2 = o2.__; ) if ((u2 = o2.__c) && u2.__c) return null == t2.__e && (t2.__e = e2.__e, t2.__k = e2.__k), u2.__c(n2, t2);
+      }
+      O(n2, t2, e2, r2);
+    };
+    var F = l$1.unmount;
+    function U(n2, t2, e2) {
+      return n2 && (n2.__c && n2.__c.__H && (n2.__c.__H.__.forEach(function(n3) {
+        "function" == typeof n3.__c && n3.__c();
+      }), n2.__c.__H = null), null != (n2 = function(n3, t3) {
+        for (var e3 in t3) n3[e3] = t3[e3];
+        return n3;
+      }({}, n2)).__c && (n2.__c.__P === e2 && (n2.__c.__P = t2), n2.__c = null), n2.__k = n2.__k && n2.__k.map(function(n3) {
+        return U(n3, t2, e2);
+      })), n2;
+    }
+    function V(n2, t2, e2) {
+      return n2 && e2 && (n2.__v = null, n2.__k = n2.__k && n2.__k.map(function(n3) {
+        return V(n3, t2, e2);
+      }), n2.__c && n2.__c.__P === t2 && (n2.__e && e2.appendChild(n2.__e), n2.__c.__e = true, n2.__c.__P = e2)), n2;
+    }
+    function W() {
+      this.__u = 0, this.o = null, this.__b = null;
+    }
+    function P(n2) {
+      var t2 = n2.__.__c;
+      return t2 && t2.__a && t2.__a(n2);
+    }
+    function j(n2) {
+      var e2, r2, u2;
+      function o2(o3) {
+        if (e2 || (e2 = n2()).then(function(n3) {
+          r2 = n3.default || n3;
+        }, function(n3) {
+          u2 = n3;
+        }), u2) throw u2;
+        if (!r2) throw e2;
+        return g$2(r2, o3);
+      }
+      return o2.displayName = "Lazy", o2.__f = true, o2;
+    }
+    function z() {
+      this.i = null, this.l = null;
+    }
+    l$1.unmount = function(n2) {
+      var t2 = n2.__c;
+      t2 && t2.__R && t2.__R(), t2 && 32 & n2.__u && (n2.type = null), F && F(n2);
+    }, (W.prototype = new x$3()).__c = function(n2, t2) {
+      var e2 = t2.__c, r2 = this;
+      null == r2.o && (r2.o = []), r2.o.push(e2);
+      var u2 = P(r2.__v), o2 = false, i2 = function() {
+        o2 || (o2 = true, e2.__R = null, u2 ? u2(c2) : c2());
+      };
+      e2.__R = i2;
+      var c2 = function() {
+        if (!--r2.__u) {
+          if (r2.state.__a) {
+            var n3 = r2.state.__a;
+            r2.__v.__k[0] = V(n3, n3.__c.__P, n3.__c.__O);
+          }
+          var t3;
+          for (r2.setState({ __a: r2.__b = null }); t3 = r2.o.pop(); ) t3.forceUpdate();
+        }
+      };
+      r2.__u++ || 32 & t2.__u || r2.setState({ __a: r2.__b = r2.__v.__k[0] }), n2.then(i2, i2);
+    }, W.prototype.componentWillUnmount = function() {
+      this.o = [];
+    }, W.prototype.render = function(n2, e2) {
+      if (this.__b) {
+        if (this.__v.__k) {
+          var r2 = document.createElement("div"), o2 = this.__v.__k[0].__c;
+          this.__v.__k[0] = U(this.__b, r2, o2.__O = o2.__P);
+        }
+        this.__b = null;
+      }
+      var i2 = e2.__a && g$2(k$2, null, n2.fallback);
+      return i2 && (i2.__u &= -33), [g$2(k$2, null, e2.__a ? null : n2.children), i2];
+    };
+    var B = function(n2, t2, e2) {
+      if (++e2[1] === e2[0] && n2.l.delete(t2), n2.props.revealOrder && ("t" !== n2.props.revealOrder[0] || !n2.l.size)) for (e2 = n2.i; e2; ) {
+        for (; e2.length > 3; ) e2.pop()();
+        if (e2[1] < e2[0]) break;
+        n2.i = e2 = e2[2];
+      }
+    };
+    function H(n2) {
+      return this.getChildContext = function() {
+        return n2.context;
+      }, n2.children;
+    }
+    function Z(n2) {
+      var e2 = this, r2 = n2.h;
+      e2.componentWillUnmount = function() {
+        D$2(null, e2.v), e2.v = null, e2.h = null;
+      }, e2.h && e2.h !== r2 && e2.componentWillUnmount(), e2.v || (e2.h = r2, e2.v = { nodeType: 1, parentNode: r2, childNodes: [], contains: function() {
+        return true;
+      }, appendChild: function(n3) {
+        this.childNodes.push(n3), e2.h.appendChild(n3);
+      }, insertBefore: function(n3, t2) {
+        this.childNodes.push(n3), e2.h.insertBefore(n3, t2);
+      }, removeChild: function(n3) {
+        this.childNodes.splice(this.childNodes.indexOf(n3) >>> 1, 1), e2.h.removeChild(n3);
+      } }), D$2(g$2(H, { context: e2.context }, n2.__v), e2.v);
+    }
+    function Y(n2, e2) {
+      var r2 = g$2(Z, { __v: n2, h: e2 });
+      return r2.containerInfo = e2, r2;
+    }
+    (z.prototype = new x$3()).__a = function(n2) {
+      var t2 = this, e2 = P(t2.__v), r2 = t2.l.get(n2);
+      return r2[0]++, function(u2) {
+        var o2 = function() {
+          t2.props.revealOrder ? (r2.push(u2), B(t2, n2, r2)) : u2();
+        };
+        e2 ? e2(o2) : o2();
+      };
+    }, z.prototype.render = function(n2) {
+      this.i = null, this.l = /* @__PURE__ */ new Map();
+      var t2 = L$1(n2.children);
+      n2.revealOrder && "b" === n2.revealOrder[0] && t2.reverse();
+      for (var e2 = t2.length; e2--; ) this.l.set(t2[e2], this.i = [1, 0, this.i]);
+      return n2.children;
+    }, z.prototype.componentDidUpdate = z.prototype.componentDidMount = function() {
+      var n2 = this;
+      this.l.forEach(function(t2, e2) {
+        B(n2, e2, t2);
+      });
+    };
+    var $ = "undefined" != typeof Symbol && Symbol.for && Symbol.for("react.element") || 60103, q = /^(?:accent|alignment|arabic|baseline|cap|clip(?!PathU)|color|dominant|fill|flood|font|glyph(?!R)|horiz|image(!S)|letter|lighting|marker(?!H|W|U)|overline|paint|pointer|shape|stop|strikethrough|stroke|text(?!L)|transform|underline|unicode|units|v|vector|vert|word|writing|x(?!C))[A-Z]/, G = /^on(Ani|Tra|Tou|BeforeInp|Compo)/, J = /[A-Z0-9]/g, K = "undefined" != typeof document, Q = function(n2) {
+      return ("undefined" != typeof Symbol && "symbol" == typeof Symbol() ? /fil|che|rad/ : /fil|che|ra/).test(n2);
+    };
+    function X(n2, t2, e2) {
+      return null == t2.__k && (t2.textContent = ""), D$2(n2, t2), "function" == typeof e2 && e2(), n2 ? n2.__c : null;
+    }
+    function nn(n2, t2, e2) {
+      return E$1(n2, t2), "function" == typeof e2 && e2(), n2 ? n2.__c : null;
+    }
+    x$3.prototype.isReactComponent = {}, ["componentWillMount", "componentWillReceiveProps", "componentWillUpdate"].forEach(function(t2) {
+      Object.defineProperty(x$3.prototype, t2, { configurable: true, get: function() {
+        return this["UNSAFE_" + t2];
+      }, set: function(n2) {
+        Object.defineProperty(this, t2, { configurable: true, writable: true, value: n2 });
+      } });
+    });
+    var tn = l$1.event;
+    function en() {
+    }
+    function rn() {
+      return this.cancelBubble;
+    }
+    function un() {
+      return this.defaultPrevented;
+    }
+    l$1.event = function(n2) {
+      return tn && (n2 = tn(n2)), n2.persist = en, n2.isPropagationStopped = rn, n2.isDefaultPrevented = un, n2.nativeEvent = n2;
+    };
+    var on, cn = { enumerable: false, configurable: true, get: function() {
+      return this.class;
+    } }, fn = l$1.vnode;
+    l$1.vnode = function(n2) {
+      "string" == typeof n2.type && function(n3) {
+        var t2 = n3.props, e2 = n3.type, u2 = {}, o2 = -1 === e2.indexOf("-");
+        for (var i2 in t2) {
+          var c2 = t2[i2];
+          if (!("value" === i2 && "defaultValue" in t2 && null == c2 || K && "children" === i2 && "noscript" === e2 || "class" === i2 || "className" === i2)) {
+            var f2 = i2.toLowerCase();
+            "defaultValue" === i2 && "value" in t2 && null == t2.value ? i2 = "value" : "download" === i2 && true === c2 ? c2 = "" : "translate" === f2 && "no" === c2 ? c2 = false : "o" === f2[0] && "n" === f2[1] ? "ondoubleclick" === f2 ? i2 = "ondblclick" : "onchange" !== f2 || "input" !== e2 && "textarea" !== e2 || Q(t2.type) ? "onfocus" === f2 ? i2 = "onfocusin" : "onblur" === f2 ? i2 = "onfocusout" : G.test(i2) && (i2 = f2) : f2 = i2 = "oninput" : o2 && q.test(i2) ? i2 = i2.replace(J, "-$&").toLowerCase() : null === c2 && (c2 = void 0), "oninput" === f2 && u2[i2 = f2] && (i2 = "oninputCapture"), u2[i2] = c2;
+          }
+        }
+        "select" == e2 && u2.multiple && Array.isArray(u2.value) && (u2.value = L$1(t2.children).forEach(function(n4) {
+          n4.props.selected = -1 != u2.value.indexOf(n4.props.value);
+        })), "select" == e2 && null != u2.defaultValue && (u2.value = L$1(t2.children).forEach(function(n4) {
+          n4.props.selected = u2.multiple ? -1 != u2.defaultValue.indexOf(n4.props.value) : u2.defaultValue == n4.props.value;
+        })), t2.class && !t2.className ? (u2.class = t2.class, Object.defineProperty(u2, "className", cn)) : (t2.className && !t2.class || t2.class && t2.className) && (u2.class = u2.className = t2.className), n3.props = u2;
+      }(n2), n2.$$typeof = $, fn && fn(n2);
+    };
+    var ln = l$1.__r;
+    l$1.__r = function(n2) {
+      ln && ln(n2), on = n2.__c;
+    };
+    var an = l$1.diffed;
+    l$1.diffed = function(n2) {
+      an && an(n2);
+      var t2 = n2.props, e2 = n2.__e;
+      null != e2 && "textarea" === n2.type && "value" in t2 && t2.value !== e2.value && (e2.value = null == t2.value ? "" : t2.value), on = null;
+    };
+    var sn = { ReactCurrentDispatcher: { current: { readContext: function(n2) {
+      return on.__n[n2.__c].props.value;
+    }, useCallback: q$1, useContext: x$2, useDebugValue: P$2, useDeferredValue: R, useEffect: y, useId: g$1, useImperativeHandle: F$1, useInsertionEffect: k, useLayoutEffect: _, useMemo: T$1, useReducer: p, useRef: A$1, useState: h, useSyncExternalStore: E, useTransition: w } } };
+    function vn(n2) {
+      return g$2.bind(null, n2);
+    }
+    function dn(n2) {
+      return !!n2 && n2.$$typeof === $;
+    }
+    function pn(n2) {
+      return dn(n2) && n2.type === k$2;
+    }
+    function mn(n2) {
+      return !!n2 && !!n2.displayName && ("string" == typeof n2.displayName || n2.displayName instanceof String) && n2.displayName.startsWith("Memo(");
+    }
+    function yn(n2) {
+      return dn(n2) ? G$1.apply(null, arguments) : n2;
+    }
+    function _n(n2) {
+      return !!n2.__k && (D$2(null, n2), true);
+    }
+    function bn(n2) {
+      return n2 && (n2.base || 1 === n2.nodeType && n2) || null;
+    }
+    var Sn = function(n2, t2) {
+      return n2(t2);
+    }, gn = function(n2, t2) {
+      return n2(t2);
+    }, En = k$2, Cn = dn, xn = { useState: h, useId: g$1, useReducer: p, useEffect: y, useLayoutEffect: _, useInsertionEffect: k, useTransition: w, useDeferredValue: R, useSyncExternalStore: E, startTransition: x$1, useRef: A$1, useImperativeHandle: F$1, useMemo: T$1, useCallback: q$1, useContext: x$2, useDebugValue: P$2, version: "18.3.1", Children: L, render: X, hydrate: nn, unmountComponentAtNode: _n, createPortal: Y, createElement: g$2, createContext: J$1, createFactory: vn, cloneElement: yn, createRef: b, Fragment: k$2, isValidElement: dn, isElement: Cn, isFragment: pn, isMemo: mn, findDOMNode: bn, Component: x$3, PureComponent: I, memo: N, forwardRef: A, flushSync: gn, unstable_batchedUpdates: Sn, StrictMode: En, Suspense: W, SuspenseList: z, lazy: j, __SECRET_INTERNALS_DO_NOT_USE_OR_YOU_WILL_BE_FIRED: sn };
+    var f = 0;
+    function u(e2, t2, n2, o2, i2, u2) {
+      t2 || (t2 = {});
+      var a2, c2, l2 = t2;
+      "ref" in t2 && (a2 = t2.ref, delete t2.ref);
+      var p2 = { type: e2, props: l2, key: n2, ref: a2, __k: null, __: null, __b: 0, __e: null, __c: null, constructor: void 0, __v: --f, __i: -1, __u: 0, __source: i2, __self: u2 };
+      if ("function" == typeof e2 && (a2 = e2.defaultProps)) for (c2 in a2) void 0 === l2[c2] && (l2[c2] = a2[c2]);
+      return l$1.vnode && l$1.vnode(p2), p2;
+    }
+    const PUBLISH = 0;
+    const SUBSCRIBE = 1;
+    const RESET = 2;
+    const VALUE = 4;
+    function compose(a2, b2) {
+      return (arg) => a2(b2(arg));
+    }
+    function thrush(arg, proc) {
+      return proc(arg);
+    }
+    function curry2to1(proc, arg1) {
+      return (arg2) => proc(arg1, arg2);
+    }
+    function curry1to0(proc, arg) {
+      return () => proc(arg);
+    }
+    function tap(arg, proc) {
+      proc(arg);
+      return arg;
+    }
+    function tup(...args) {
+      return args;
+    }
+    function call(proc) {
+      proc();
+    }
+    function always(value) {
+      return () => value;
+    }
+    function joinProc(...procs) {
+      return () => {
+        procs.map(call);
+      };
+    }
+    function isDefined(arg) {
+      return arg !== void 0;
+    }
+    function noop() {
+    }
+    function subscribe(emitter, subscription) {
+      return emitter(SUBSCRIBE, subscription);
+    }
+    function publish(publisher, value) {
+      publisher(PUBLISH, value);
+    }
+    function reset(emitter) {
+      emitter(RESET);
+    }
+    function getValue(depot) {
+      return depot(VALUE);
+    }
+    function connect(emitter, publisher) {
+      return subscribe(emitter, curry2to1(publisher, PUBLISH));
+    }
+    function handleNext(emitter, subscription) {
+      const unsub = emitter(SUBSCRIBE, (value) => {
+        unsub();
+        subscription(value);
+      });
+      return unsub;
+    }
+    function stream() {
+      const subscriptions = [];
+      return (action, arg) => {
+        switch (action) {
+          case RESET:
+            subscriptions.splice(0, subscriptions.length);
+            return;
+          case SUBSCRIBE:
+            subscriptions.push(arg);
+            return () => {
+              const indexOf = subscriptions.indexOf(arg);
+              if (indexOf > -1) {
+                subscriptions.splice(indexOf, 1);
+              }
+            };
+          case PUBLISH:
+            subscriptions.slice().forEach((subscription) => {
+              subscription(arg);
+            });
+            return;
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function statefulStream(initial) {
+      let value = initial;
+      const innerSubject = stream();
+      return (action, arg) => {
+        switch (action) {
+          case SUBSCRIBE:
+            const subscription = arg;
+            subscription(value);
+            break;
+          case PUBLISH:
+            value = arg;
+            break;
+          case VALUE:
+            return value;
+        }
+        return innerSubject(action, arg);
+      };
+    }
+    function eventHandler(emitter) {
+      let unsub;
+      let currentSubscription;
+      const cleanup = () => unsub && unsub();
+      return function(action, subscription) {
+        switch (action) {
+          case SUBSCRIBE:
+            if (subscription) {
+              if (currentSubscription === subscription) {
+                return;
+              }
+              cleanup();
+              currentSubscription = subscription;
+              unsub = subscribe(emitter, subscription);
+              return unsub;
+            } else {
+              cleanup();
+              return noop;
+            }
+          case RESET:
+            cleanup();
+            currentSubscription = null;
+            return;
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function streamFromEmitter(emitter) {
+      return tap(stream(), (stream2) => connect(emitter, stream2));
+    }
+    function statefulStreamFromEmitter(emitter, initial) {
+      return tap(statefulStream(initial), (stream2) => connect(emitter, stream2));
+    }
+    function combineOperators(...operators) {
+      return (subscriber) => {
+        return operators.reduceRight(thrush, subscriber);
+      };
+    }
+    function pipe(source2, ...operators) {
+      const project = combineOperators(...operators);
+      return (action, subscription) => {
+        switch (action) {
+          case SUBSCRIBE:
+            return subscribe(source2, project(subscription));
+          case RESET:
+            reset(source2);
+            return;
+        }
+      };
+    }
+    function defaultComparator(previous, next) {
+      return previous === next;
+    }
+    function distinctUntilChanged(comparator = defaultComparator) {
+      let current;
+      return (done) => (next) => {
+        if (!comparator(current, next)) {
+          current = next;
+          done(next);
+        }
+      };
+    }
+    function filter(predicate) {
+      return (done) => (value) => {
+        predicate(value) && done(value);
+      };
+    }
+    function map(project) {
+      return (done) => compose(done, project);
+    }
+    function mapTo(value) {
+      return (done) => () => done(value);
+    }
+    function scan(scanner, initial) {
+      return (done) => (value) => done(initial = scanner(initial, value));
+    }
+    function skip(times) {
+      return (done) => (value) => {
+        times > 0 ? times-- : done(value);
+      };
+    }
+    function throttleTime(interval) {
+      let currentValue = null;
+      let timeout;
+      return (done) => (value) => {
+        currentValue = value;
+        if (timeout) {
+          return;
+        }
+        timeout = setTimeout(() => {
+          timeout = void 0;
+          done(currentValue);
+        }, interval);
+      };
+    }
+    function debounceTime(interval) {
+      let currentValue;
+      let timeout;
+      return (done) => (value) => {
+        currentValue = value;
+        if (timeout) {
+          clearTimeout(timeout);
+        }
+        timeout = setTimeout(() => {
+          done(currentValue);
+        }, interval);
+      };
+    }
+    function withLatestFrom(...sources) {
+      const values = new Array(sources.length);
+      let called = 0;
+      let pendingCall = null;
+      const allCalled = Math.pow(2, sources.length) - 1;
+      sources.forEach((source2, index) => {
+        const bit = Math.pow(2, index);
+        subscribe(source2, (value) => {
+          const prevCalled = called;
+          called = called | bit;
+          values[index] = value;
+          if (prevCalled !== allCalled && called === allCalled && pendingCall) {
+            pendingCall();
+            pendingCall = null;
+          }
+        });
+      });
+      return (done) => (value) => {
+        const call2 = () => done([value].concat(values));
+        if (called === allCalled) {
+          call2();
+        } else {
+          pendingCall = call2;
+        }
+      };
+    }
+    function merge(...sources) {
+      return function(action, subscription) {
+        switch (action) {
+          case SUBSCRIBE:
+            return joinProc(...sources.map((source2) => subscribe(source2, subscription)));
+          case RESET:
+            return;
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function duc(source2, comparator = defaultComparator) {
+      return pipe(source2, distinctUntilChanged(comparator));
+    }
+    function combineLatest(...emitters) {
+      const innerSubject = stream();
+      const values = new Array(emitters.length);
+      let called = 0;
+      const allCalled = Math.pow(2, emitters.length) - 1;
+      emitters.forEach((source2, index) => {
+        const bit = Math.pow(2, index);
+        subscribe(source2, (value) => {
+          values[index] = value;
+          called = called | bit;
+          if (called === allCalled) {
+            publish(innerSubject, values);
+          }
+        });
+      });
+      return function(action, subscription) {
+        switch (action) {
+          case SUBSCRIBE:
+            if (called === allCalled) {
+              subscription(values);
+            }
+            return subscribe(innerSubject, subscription);
+          case RESET:
+            return reset(innerSubject);
+          default:
+            throw new Error(`unrecognized action ${action}`);
+        }
+      };
+    }
+    function system(constructor, dependencies = [], { singleton } = { singleton: true }) {
+      return {
+        id: id(),
+        constructor,
+        dependencies,
+        singleton
+      };
+    }
+    const id = () => Symbol();
+    function init(systemSpec) {
+      const singletons = /* @__PURE__ */ new Map();
+      const _init = ({ id: id2, constructor, dependencies, singleton }) => {
+        if (singleton && singletons.has(id2)) {
+          return singletons.get(id2);
+        }
+        const system2 = constructor(dependencies.map((e2) => _init(e2)));
+        if (singleton) {
+          singletons.set(id2, system2);
+        }
+        return system2;
+      };
+      return _init(systemSpec);
+    }
+    function omit(keys, obj) {
+      const result = {};
+      const index = {};
+      let idx = 0;
+      const len = keys.length;
+      while (idx < len) {
+        index[keys[idx]] = 1;
+        idx += 1;
+      }
+      for (const prop in obj) {
+        if (!index.hasOwnProperty(prop)) {
+          result[prop] = obj[prop];
+        }
+      }
+      return result;
+    }
+    const useIsomorphicLayoutEffect$1 = typeof document !== "undefined" ? xn.useLayoutEffect : xn.useEffect;
+    function systemToComponent(systemSpec, map2, Root) {
+      const requiredPropNames = Object.keys(map2.required || {});
+      const optionalPropNames = Object.keys(map2.optional || {});
+      const methodNames = Object.keys(map2.methods || {});
+      const eventNames = Object.keys(map2.events || {});
+      const Context2 = xn.createContext({});
+      function applyPropsToSystem(system2, props) {
+        if (system2["propsReady"]) {
+          publish(system2["propsReady"], false);
+        }
+        for (const requiredPropName of requiredPropNames) {
+          const stream2 = system2[map2.required[requiredPropName]];
+          publish(stream2, props[requiredPropName]);
+        }
+        for (const optionalPropName of optionalPropNames) {
+          if (optionalPropName in props) {
+            const stream2 = system2[map2.optional[optionalPropName]];
+            publish(stream2, props[optionalPropName]);
+          }
+        }
+        if (system2["propsReady"]) {
+          publish(system2["propsReady"], true);
+        }
+      }
+      function buildMethods(system2) {
+        return methodNames.reduce((acc, methodName) => {
+          acc[methodName] = (value) => {
+            const stream2 = system2[map2.methods[methodName]];
+            publish(stream2, value);
+          };
+          return acc;
+        }, {});
+      }
+      function buildEventHandlers(system2) {
+        return eventNames.reduce((handlers, eventName) => {
+          handlers[eventName] = eventHandler(system2[map2.events[eventName]]);
+          return handlers;
+        }, {});
+      }
+      const Component = xn.forwardRef((propsWithChildren, ref) => {
+        const { children: children2, ...props } = propsWithChildren;
+        const [system2] = xn.useState(() => {
+          return tap(init(systemSpec), (system22) => applyPropsToSystem(system22, props));
+        });
+        const [handlers] = xn.useState(curry1to0(buildEventHandlers, system2));
+        useIsomorphicLayoutEffect$1(() => {
+          for (const eventName of eventNames) {
+            if (eventName in props) {
+              subscribe(handlers[eventName], props[eventName]);
+            }
+          }
+          return () => {
+            Object.values(handlers).map(reset);
+          };
+        }, [props, handlers, system2]);
+        useIsomorphicLayoutEffect$1(() => {
+          applyPropsToSystem(system2, props);
+        });
+        xn.useImperativeHandle(ref, always(buildMethods(system2)));
+        const RootComponent = Root;
+        return /* @__PURE__ */ u(Context2.Provider, { value: system2, children: Root ? /* @__PURE__ */ u(RootComponent, { ...omit([...requiredPropNames, ...optionalPropNames, ...eventNames], props), children: children2 }) : children2 });
+      });
+      const usePublisher2 = (key2) => {
+        return xn.useCallback(curry2to1(publish, xn.useContext(Context2)[key2]), [key2]);
+      };
+      const useEmitterValue18 = (key2) => {
+        const system2 = xn.useContext(Context2);
+        const source2 = system2[key2];
+        const cb = xn.useCallback(
+          (c2) => {
+            return subscribe(source2, c2);
+          },
+          [source2]
+        );
+        return xn.useSyncExternalStore(
+          cb,
+          () => getValue(source2),
+          () => getValue(source2)
+        );
+      };
+      const useEmitterValueLegacy = (key2) => {
+        const system2 = xn.useContext(Context2);
+        const source2 = system2[key2];
+        const [value, setValue] = xn.useState(curry1to0(getValue, source2));
+        useIsomorphicLayoutEffect$1(
+          () => subscribe(source2, (next) => {
+            if (next !== value) {
+              setValue(always(next));
+            }
+          }),
+          [source2, value]
+        );
+        return value;
+      };
+      const useEmitterValue2 = xn.version.startsWith("18") ? useEmitterValue18 : useEmitterValueLegacy;
+      const useEmitter2 = (key2, callback) => {
+        const context = xn.useContext(Context2);
+        const source2 = context[key2];
+        useIsomorphicLayoutEffect$1(() => subscribe(source2, callback), [callback, source2]);
+      };
+      return {
+        Component,
+        usePublisher: usePublisher2,
+        useEmitterValue: useEmitterValue2,
+        useEmitter: useEmitter2
+      };
+    }
+    const useIsomorphicLayoutEffect = typeof document !== "undefined" ? xn.useLayoutEffect : xn.useEffect;
+    var LogLevel = /* @__PURE__ */ ((LogLevel2) => {
+      LogLevel2[LogLevel2["DEBUG"] = 0] = "DEBUG";
+      LogLevel2[LogLevel2["INFO"] = 1] = "INFO";
+      LogLevel2[LogLevel2["WARN"] = 2] = "WARN";
+      LogLevel2[LogLevel2["ERROR"] = 3] = "ERROR";
+      return LogLevel2;
+    })(LogLevel || {});
+    const CONSOLE_METHOD_MAP = {
+      [
+        0
+        /* DEBUG */
+      ]: "debug",
+      [
+        1
+        /* INFO */
+      ]: "log",
+      [
+        2
+        /* WARN */
+      ]: "warn",
+      [
+        3
+        /* ERROR */
+      ]: "error"
+    };
+    const getGlobalThis = () => typeof globalThis === "undefined" ? window : globalThis;
+    const loggerSystem = system(
+      () => {
+        const logLevel = statefulStream(
+          3
+          /* ERROR */
+        );
+        const log = statefulStream((label, message, level = 1) => {
+          var _a2;
+          const currentLevel = (_a2 = getGlobalThis()["VIRTUOSO_LOG_LEVEL"]) != null ? _a2 : getValue(logLevel);
+          if (level >= currentLevel) {
+            console[CONSOLE_METHOD_MAP[level]](
+              "%creact-virtuoso: %c%s %o",
+              "color: #0253b3; font-weight: bold",
+              "color: initial",
+              label,
+              message
+            );
+          }
+        });
+        return {
+          log,
+          logLevel
+        };
+      },
+      [],
+      { singleton: true }
+    );
+    function useSizeWithElRef(callback, enabled, skipAnimationFrame) {
+      const ref = xn.useRef(null);
+      let callbackRef = (_el) => {
+      };
+      if (typeof ResizeObserver !== "undefined") {
+        const observer = xn.useMemo(() => {
+          return new ResizeObserver((entries) => {
+            const code2 = () => {
+              const element = entries[0].target;
+              if (element.offsetParent !== null) {
+                callback(element);
+              }
+            };
+            skipAnimationFrame ? code2() : requestAnimationFrame(code2);
+          });
+        }, [callback]);
+        callbackRef = (elRef) => {
+          if (elRef && enabled) {
+            observer.observe(elRef);
+            ref.current = elRef;
+          } else {
+            if (ref.current) {
+              observer.unobserve(ref.current);
+            }
+            ref.current = null;
+          }
+        };
+      }
+      return { ref, callbackRef };
+    }
+    function useSize(callback, enabled, skipAnimationFrame) {
+      return useSizeWithElRef(callback, enabled, skipAnimationFrame).callbackRef;
+    }
+    function useChangedListContentsSizes(callback, itemSize, enabled, scrollContainerStateCallback, log, gap, customScrollParent, horizontalDirection, skipAnimationFrame) {
+      const memoedCallback = xn.useCallback(
+        (el) => {
+          const ranges = getChangedChildSizes(el.children, itemSize, horizontalDirection ? "offsetWidth" : "offsetHeight", log);
+          let scrollableElement = el.parentElement;
+          while (!scrollableElement.dataset["virtuosoScroller"]) {
+            scrollableElement = scrollableElement.parentElement;
+          }
+          const windowScrolling = scrollableElement.lastElementChild.dataset["viewportType"] === "window";
+          const scrollTop = customScrollParent ? horizontalDirection ? customScrollParent.scrollLeft : customScrollParent.scrollTop : windowScrolling ? horizontalDirection ? window.pageXOffset || document.documentElement.scrollLeft : window.pageYOffset || document.documentElement.scrollTop : horizontalDirection ? scrollableElement.scrollLeft : scrollableElement.scrollTop;
+          const scrollHeight = customScrollParent ? horizontalDirection ? customScrollParent.scrollWidth : customScrollParent.scrollHeight : windowScrolling ? horizontalDirection ? document.documentElement.scrollWidth : document.documentElement.scrollHeight : horizontalDirection ? scrollableElement.scrollWidth : scrollableElement.scrollHeight;
+          const viewportHeight = customScrollParent ? horizontalDirection ? customScrollParent.offsetWidth : customScrollParent.offsetHeight : windowScrolling ? horizontalDirection ? window.innerWidth : window.innerHeight : horizontalDirection ? scrollableElement.offsetWidth : scrollableElement.offsetHeight;
+          scrollContainerStateCallback({
+            scrollTop: Math.max(scrollTop, 0),
+            scrollHeight,
+            viewportHeight
+          });
+          gap == null ? void 0 : gap(
+            horizontalDirection ? resolveGapValue$1("column-gap", getComputedStyle(el).columnGap, log) : resolveGapValue$1("row-gap", getComputedStyle(el).rowGap, log)
+          );
+          if (ranges !== null) {
+            callback(ranges);
+          }
+        },
+        [callback, itemSize, log, gap, customScrollParent, scrollContainerStateCallback]
+      );
+      return useSizeWithElRef(memoedCallback, enabled, skipAnimationFrame);
+    }
+    function getChangedChildSizes(children2, itemSize, field, log) {
+      const length = children2.length;
+      if (length === 0) {
+        return null;
+      }
+      const results = [];
+      for (let i2 = 0; i2 < length; i2++) {
+        const child = children2.item(i2);
+        if (!child || child.dataset.index === void 0) {
+          continue;
+        }
+        const index = parseInt(child.dataset.index);
+        const knownSize = parseFloat(child.dataset.knownSize);
+        const size = itemSize(child, field);
+        if (size === 0) {
+          log("Zero-sized element, this should not happen", { child }, LogLevel.ERROR);
+        }
+        if (size === knownSize) {
+          continue;
+        }
+        const lastResult = results[results.length - 1];
+        if (results.length === 0 || lastResult.size !== size || lastResult.endIndex !== index - 1) {
+          results.push({ startIndex: index, endIndex: index, size });
+        } else {
+          results[results.length - 1].endIndex++;
+        }
+      }
+      return results;
+    }
+    function resolveGapValue$1(property, value, log) {
+      if (value !== "normal" && !(value == null ? void 0 : value.endsWith("px"))) {
+        log(`${property} was not resolved to pixel value correctly`, value, LogLevel.WARN);
+      }
+      if (value === "normal") {
+        return 0;
+      }
+      return parseInt(value != null ? value : "0", 10);
+    }
+    function correctItemSize(el, dimension) {
+      return Math.round(el.getBoundingClientRect()[dimension]);
+    }
+    function approximatelyEqual(num1, num2) {
+      return Math.abs(num1 - num2) < 1.01;
+    }
+    function useScrollTop(scrollContainerStateCallback, smoothScrollTargetReached, scrollerElement, scrollerRefCallback = noop, customScrollParent, horizontalDirection) {
+      const scrollerRef = xn.useRef(null);
+      const scrollTopTarget = xn.useRef(null);
+      const timeoutRef = xn.useRef(null);
+      const handler = xn.useCallback(
+        (ev) => {
+          const el = ev.target;
+          const windowScroll = el === window || el === document;
+          const scrollTop = horizontalDirection ? windowScroll ? window.pageXOffset || document.documentElement.scrollLeft : el.scrollLeft : windowScroll ? window.pageYOffset || document.documentElement.scrollTop : el.scrollTop;
+          const scrollHeight = horizontalDirection ? windowScroll ? document.documentElement.scrollWidth : el.scrollWidth : windowScroll ? document.documentElement.scrollHeight : el.scrollHeight;
+          const viewportHeight = horizontalDirection ? windowScroll ? window.innerWidth : el.offsetWidth : windowScroll ? window.innerHeight : el.offsetHeight;
+          const call2 = () => {
+            scrollContainerStateCallback({
+              scrollTop: Math.max(scrollTop, 0),
+              scrollHeight,
+              viewportHeight
+            });
+          };
+          if (ev.suppressFlushSync) {
+            call2();
+          } else {
+            xn.flushSync(call2);
+          }
+          if (scrollTopTarget.current !== null) {
+            if (scrollTop === scrollTopTarget.current || scrollTop <= 0 || scrollTop === scrollHeight - viewportHeight) {
+              scrollTopTarget.current = null;
+              smoothScrollTargetReached(true);
+              if (timeoutRef.current) {
+                clearTimeout(timeoutRef.current);
+                timeoutRef.current = null;
+              }
+            }
+          }
+        },
+        [scrollContainerStateCallback, smoothScrollTargetReached]
+      );
+      xn.useEffect(() => {
+        const localRef = customScrollParent ? customScrollParent : scrollerRef.current;
+        scrollerRefCallback(customScrollParent ? customScrollParent : scrollerRef.current);
+        handler({ target: localRef, suppressFlushSync: true });
+        localRef.addEventListener("scroll", handler, { passive: true });
+        return () => {
+          scrollerRefCallback(null);
+          localRef.removeEventListener("scroll", handler);
+        };
+      }, [scrollerRef, handler, scrollerElement, scrollerRefCallback, customScrollParent]);
+      function scrollToCallback(location) {
+        const scrollerElement2 = scrollerRef.current;
+        if (!scrollerElement2 || (horizontalDirection ? "offsetWidth" in scrollerElement2 && scrollerElement2.offsetWidth === 0 : "offsetHeight" in scrollerElement2 && scrollerElement2.offsetHeight === 0)) {
+          return;
+        }
+        const isSmooth = location.behavior === "smooth";
+        let offsetHeight;
+        let scrollHeight;
+        let scrollTop;
+        if (scrollerElement2 === window) {
+          scrollHeight = Math.max(
+            correctItemSize(document.documentElement, horizontalDirection ? "width" : "height"),
+            horizontalDirection ? document.documentElement.scrollWidth : document.documentElement.scrollHeight
+          );
+          offsetHeight = horizontalDirection ? window.innerWidth : window.innerHeight;
+          scrollTop = horizontalDirection ? document.documentElement.scrollLeft : document.documentElement.scrollTop;
+        } else {
+          scrollHeight = scrollerElement2[horizontalDirection ? "scrollWidth" : "scrollHeight"];
+          offsetHeight = correctItemSize(scrollerElement2, horizontalDirection ? "width" : "height");
+          scrollTop = scrollerElement2[horizontalDirection ? "scrollLeft" : "scrollTop"];
+        }
+        const maxScrollTop = scrollHeight - offsetHeight;
+        location.top = Math.ceil(Math.max(Math.min(maxScrollTop, location.top), 0));
+        if (approximatelyEqual(offsetHeight, scrollHeight) || location.top === scrollTop) {
+          scrollContainerStateCallback({ scrollTop, scrollHeight, viewportHeight: offsetHeight });
+          if (isSmooth) {
+            smoothScrollTargetReached(true);
+          }
+          return;
+        }
+        if (isSmooth) {
+          scrollTopTarget.current = location.top;
+          if (timeoutRef.current) {
+            clearTimeout(timeoutRef.current);
+          }
+          timeoutRef.current = setTimeout(() => {
+            timeoutRef.current = null;
+            scrollTopTarget.current = null;
+            smoothScrollTargetReached(true);
+          }, 1e3);
+        } else {
+          scrollTopTarget.current = null;
+        }
+        if (horizontalDirection) {
+          location = { left: location.top, behavior: location.behavior };
+        }
+        scrollerElement2.scrollTo(location);
+      }
+      function scrollByCallback(location) {
+        if (horizontalDirection) {
+          location = { left: location.top, behavior: location.behavior };
+        }
+        scrollerRef.current.scrollBy(location);
+      }
+      return { scrollerRef, scrollByCallback, scrollToCallback };
+    }
+    const domIOSystem = system(
+      () => {
+        const scrollContainerState = stream();
+        const scrollTop = stream();
+        const deviation = statefulStream(0);
+        const smoothScrollTargetReached = stream();
+        const statefulScrollTop = statefulStream(0);
+        const viewportHeight = stream();
+        const scrollHeight = stream();
+        const headerHeight = statefulStream(0);
+        const fixedHeaderHeight = statefulStream(0);
+        const fixedFooterHeight = statefulStream(0);
+        const footerHeight = statefulStream(0);
+        const scrollTo = stream();
+        const scrollBy = stream();
+        const scrollingInProgress = statefulStream(false);
+        const horizontalDirection = statefulStream(false);
+        const skipAnimationFrameInResizeObserver = statefulStream(false);
+        connect(
+          pipe(
+            scrollContainerState,
+            map(({ scrollTop: scrollTop2 }) => scrollTop2)
+          ),
+          scrollTop
+        );
+        connect(
+          pipe(
+            scrollContainerState,
+            map(({ scrollHeight: scrollHeight2 }) => scrollHeight2)
+          ),
+          scrollHeight
+        );
+        connect(scrollTop, statefulScrollTop);
+        return {
+          // input
+          scrollContainerState,
+          scrollTop,
+          viewportHeight,
+          headerHeight,
+          fixedHeaderHeight,
+          fixedFooterHeight,
+          footerHeight,
+          scrollHeight,
+          smoothScrollTargetReached,
+          horizontalDirection,
+          skipAnimationFrameInResizeObserver,
+          // signals
+          scrollTo,
+          scrollBy,
+          // state
+          statefulScrollTop,
+          deviation,
+          scrollingInProgress
+        };
+      },
+      [],
+      { singleton: true }
+    );
+    const NIL_NODE = { lvl: 0 };
+    function newAANode(k2, v2, lvl, l2 = NIL_NODE, r2 = NIL_NODE) {
+      return { k: k2, v: v2, lvl, l: l2, r: r2 };
+    }
+    function empty(node) {
+      return node === NIL_NODE;
+    }
+    function newTree() {
+      return NIL_NODE;
+    }
+    function remove(node, key2) {
+      if (empty(node)) return NIL_NODE;
+      const { k: k2, l: l2, r: r2 } = node;
+      if (key2 === k2) {
+        if (empty(l2)) {
+          return r2;
+        } else if (empty(r2)) {
+          return l2;
+        } else {
+          const [lastKey, lastValue] = last(l2);
+          return adjust(clone(node, { k: lastKey, v: lastValue, l: deleteLast(l2) }));
+        }
+      } else if (key2 < k2) {
+        return adjust(clone(node, { l: remove(l2, key2) }));
+      } else {
+        return adjust(clone(node, { r: remove(r2, key2) }));
+      }
+    }
+    function find(node, key2) {
+      if (empty(node)) {
+        return;
+      }
+      if (key2 === node.k) {
+        return node.v;
+      } else if (key2 < node.k) {
+        return find(node.l, key2);
+      } else {
+        return find(node.r, key2);
+      }
+    }
+    function findMaxKeyValue(node, value, field = "k") {
+      if (empty(node)) {
+        return [-Infinity, void 0];
+      }
+      if (Number(node[field]) === value) {
+        return [node.k, node.v];
+      }
+      if (Number(node[field]) < value) {
+        const r2 = findMaxKeyValue(node.r, value, field);
+        if (r2[0] === -Infinity) {
+          return [node.k, node.v];
+        } else {
+          return r2;
+        }
+      }
+      return findMaxKeyValue(node.l, value, field);
+    }
+    function insert(node, k2, v2) {
+      if (empty(node)) {
+        return newAANode(k2, v2, 1);
+      }
+      if (k2 === node.k) {
+        return clone(node, { k: k2, v: v2 });
+      } else if (k2 < node.k) {
+        return rebalance(clone(node, { l: insert(node.l, k2, v2) }));
+      } else {
+        return rebalance(clone(node, { r: insert(node.r, k2, v2) }));
+      }
+    }
+    function walkWithin(node, start2, end2) {
+      if (empty(node)) {
+        return [];
+      }
+      const { k: k2, v: v2, l: l2, r: r2 } = node;
+      let result = [];
+      if (k2 > start2) {
+        result = result.concat(walkWithin(l2, start2, end2));
+      }
+      if (k2 >= start2 && k2 <= end2) {
+        result.push({ k: k2, v: v2 });
+      }
+      if (k2 <= end2) {
+        result = result.concat(walkWithin(r2, start2, end2));
+      }
+      return result;
+    }
+    function walk(node) {
+      if (empty(node)) {
+        return [];
+      }
+      return [...walk(node.l), { k: node.k, v: node.v }, ...walk(node.r)];
+    }
+    function last(node) {
+      return empty(node.r) ? [node.k, node.v] : last(node.r);
+    }
+    function deleteLast(node) {
+      return empty(node.r) ? node.l : adjust(clone(node, { r: deleteLast(node.r) }));
+    }
+    function clone(node, args) {
+      return newAANode(
+        args.k !== void 0 ? args.k : node.k,
+        args.v !== void 0 ? args.v : node.v,
+        args.lvl !== void 0 ? args.lvl : node.lvl,
+        args.l !== void 0 ? args.l : node.l,
+        args.r !== void 0 ? args.r : node.r
+      );
+    }
+    function isSingle(node) {
+      return empty(node) || node.lvl > node.r.lvl;
+    }
+    function rebalance(node) {
+      return split(skew(node));
+    }
+    function adjust(node) {
+      const { l: l2, r: r2, lvl } = node;
+      if (r2.lvl >= lvl - 1 && l2.lvl >= lvl - 1) {
+        return node;
+      } else if (lvl > r2.lvl + 1) {
+        if (isSingle(l2)) {
+          return skew(clone(node, { lvl: lvl - 1 }));
+        } else {
+          if (!empty(l2) && !empty(l2.r)) {
+            return clone(l2.r, {
+              l: clone(l2, { r: l2.r.l }),
+              r: clone(node, {
+                l: l2.r.r,
+                lvl: lvl - 1
+              }),
+              lvl
+            });
+          } else {
+            throw new Error("Unexpected empty nodes");
+          }
+        }
+      } else {
+        if (isSingle(node)) {
+          return split(clone(node, { lvl: lvl - 1 }));
+        } else {
+          if (!empty(r2) && !empty(r2.l)) {
+            const rl = r2.l;
+            const rlvl = isSingle(rl) ? r2.lvl - 1 : r2.lvl;
+            return clone(rl, {
+              l: clone(node, {
+                r: rl.l,
+                lvl: lvl - 1
+              }),
+              r: split(clone(r2, { l: rl.r, lvl: rlvl })),
+              lvl: rl.lvl + 1
+            });
+          } else {
+            throw new Error("Unexpected empty nodes");
+          }
+        }
+      }
+    }
+    function rangesWithin(node, startIndex, endIndex) {
+      if (empty(node)) {
+        return [];
+      }
+      const adjustedStart = findMaxKeyValue(node, startIndex)[0];
+      return toRanges(walkWithin(node, adjustedStart, endIndex));
+    }
+    function arrayToRanges(items, parser) {
+      const length = items.length;
+      if (length === 0) {
+        return [];
+      }
+      let { index: start2, value } = parser(items[0]);
+      const result = [];
+      for (let i2 = 1; i2 < length; i2++) {
+        const { index: nextIndex, value: nextValue } = parser(items[i2]);
+        result.push({ start: start2, end: nextIndex - 1, value });
+        start2 = nextIndex;
+        value = nextValue;
+      }
+      result.push({ start: start2, end: Infinity, value });
+      return result;
+    }
+    function toRanges(nodes) {
+      return arrayToRanges(nodes, ({ k: index, v: value }) => ({ index, value }));
+    }
+    function split(node) {
+      const { r: r2, lvl } = node;
+      return !empty(r2) && !empty(r2.r) && r2.lvl === lvl && r2.r.lvl === lvl ? clone(r2, { l: clone(node, { r: r2.l }), lvl: lvl + 1 }) : node;
+    }
+    function skew(node) {
+      const { l: l2 } = node;
+      return !empty(l2) && l2.lvl === node.lvl ? clone(l2, { r: clone(node, { l: l2.r }) }) : node;
+    }
+    function findIndexOfClosestSmallerOrEqual(items, value, comparator, start2 = 0) {
+      let end2 = items.length - 1;
+      while (start2 <= end2) {
+        const index = Math.floor((start2 + end2) / 2);
+        const item = items[index];
+        const match = comparator(item, value);
+        if (match === 0) {
+          return index;
+        }
+        if (match === -1) {
+          if (end2 - start2 < 2) {
+            return index - 1;
+          }
+          end2 = index - 1;
+        } else {
+          if (end2 === start2) {
+            return index;
+          }
+          start2 = index + 1;
+        }
+      }
+      throw new Error(`Failed binary finding record in array - ${items.join(",")}, searched for ${value}`);
+    }
+    function findClosestSmallerOrEqual(items, value, comparator) {
+      return items[findIndexOfClosestSmallerOrEqual(items, value, comparator)];
+    }
+    function findRange(items, startValue, endValue, comparator) {
+      const startIndex = findIndexOfClosestSmallerOrEqual(items, startValue, comparator);
+      const endIndex = findIndexOfClosestSmallerOrEqual(items, endValue, comparator, startIndex);
+      return items.slice(startIndex, endIndex + 1);
+    }
+    const recalcSystem = system(
+      () => {
+        const recalcInProgress = statefulStream(false);
+        return { recalcInProgress };
+      },
+      [],
+      { singleton: true }
+    );
+    function rangeIncludes(refRange) {
+      const { size, startIndex, endIndex } = refRange;
+      return (range) => {
+        return range.start === startIndex && (range.end === endIndex || range.end === Infinity) && range.value === size;
+      };
+    }
+    function affectedGroupCount(offset2, groupIndices) {
+      let recognizedOffsetItems = 0;
+      let groupIndex = 0;
+      while (recognizedOffsetItems < offset2) {
+        recognizedOffsetItems += groupIndices[groupIndex + 1] - groupIndices[groupIndex] - 1;
+        groupIndex++;
+      }
+      const offsetIsExact = recognizedOffsetItems === offset2;
+      return groupIndex - (offsetIsExact ? 0 : 1);
+    }
+    function insertRanges(sizeTree, ranges) {
+      let syncStart = empty(sizeTree) ? 0 : Infinity;
+      for (const range of ranges) {
+        const { size, startIndex, endIndex } = range;
+        syncStart = Math.min(syncStart, startIndex);
+        if (empty(sizeTree)) {
+          sizeTree = insert(sizeTree, 0, size);
+          continue;
+        }
+        const overlappingRanges = rangesWithin(sizeTree, startIndex - 1, endIndex + 1);
+        if (overlappingRanges.some(rangeIncludes(range))) {
+          continue;
+        }
+        let firstPassDone = false;
+        let shouldInsert = false;
+        for (const { start: rangeStart, end: rangeEnd, value: rangeValue } of overlappingRanges) {
+          if (!firstPassDone) {
+            shouldInsert = rangeValue !== size;
+            firstPassDone = true;
+          } else {
+            if (endIndex >= rangeStart || size === rangeValue) {
+              sizeTree = remove(sizeTree, rangeStart);
+            }
+          }
+          if (rangeEnd > endIndex && endIndex >= rangeStart) {
+            if (rangeValue !== size) {
+              sizeTree = insert(sizeTree, endIndex + 1, rangeValue);
+            }
+          }
+        }
+        if (shouldInsert) {
+          sizeTree = insert(sizeTree, startIndex, size);
+        }
+      }
+      return [sizeTree, syncStart];
+    }
+    function initialSizeState() {
+      return {
+        offsetTree: [],
+        sizeTree: newTree(),
+        groupOffsetTree: newTree(),
+        lastIndex: 0,
+        lastOffset: 0,
+        lastSize: 0,
+        groupIndices: []
+      };
+    }
+    function indexComparator({ index: itemIndex }, index) {
+      return index === itemIndex ? 0 : index < itemIndex ? -1 : 1;
+    }
+    function offsetComparator({ offset: itemOffset }, offset2) {
+      return offset2 === itemOffset ? 0 : offset2 < itemOffset ? -1 : 1;
+    }
+    function offsetPointParser(point) {
+      return { index: point.index, value: point };
+    }
+    function rangesWithinOffsets(tree, startOffset, endOffset, minStartIndex = 0) {
+      if (minStartIndex > 0) {
+        startOffset = Math.max(startOffset, findClosestSmallerOrEqual(tree, minStartIndex, indexComparator).offset);
+      }
+      return arrayToRanges(findRange(tree, startOffset, endOffset, offsetComparator), offsetPointParser);
+    }
+    function createOffsetTree(prevOffsetTree, syncStart, sizeTree, gap) {
+      let offsetTree = prevOffsetTree;
+      let prevIndex = 0;
+      let prevSize = 0;
+      let prevOffset = 0;
+      let startIndex = 0;
+      if (syncStart !== 0) {
+        startIndex = findIndexOfClosestSmallerOrEqual(offsetTree, syncStart - 1, indexComparator);
+        const offsetInfo = offsetTree[startIndex];
+        prevOffset = offsetInfo.offset;
+        const kv = findMaxKeyValue(sizeTree, syncStart - 1);
+        prevIndex = kv[0];
+        prevSize = kv[1];
+        if (offsetTree.length && offsetTree[startIndex].size === findMaxKeyValue(sizeTree, syncStart)[1]) {
+          startIndex -= 1;
+        }
+        offsetTree = offsetTree.slice(0, startIndex + 1);
+      } else {
+        offsetTree = [];
+      }
+      for (const { start: startIndex2, value } of rangesWithin(sizeTree, syncStart, Infinity)) {
+        const indexOffset = startIndex2 - prevIndex;
+        const aOffset = indexOffset * prevSize + prevOffset + indexOffset * gap;
+        offsetTree.push({
+          offset: aOffset,
+          size: value,
+          index: startIndex2
+        });
+        prevIndex = startIndex2;
+        prevOffset = aOffset;
+        prevSize = value;
+      }
+      return {
+        offsetTree,
+        lastIndex: prevIndex,
+        lastOffset: prevOffset,
+        lastSize: prevSize
+      };
+    }
+    function sizeStateReducer(state, [ranges, groupIndices, log, gap]) {
+      if (ranges.length > 0) {
+        log("received item sizes", ranges, LogLevel.DEBUG);
+      }
+      const sizeTree = state.sizeTree;
+      let newSizeTree = sizeTree;
+      let syncStart = 0;
+      if (groupIndices.length > 0 && empty(sizeTree) && ranges.length === 2) {
+        const groupSize = ranges[0].size;
+        const itemSize = ranges[1].size;
+        newSizeTree = groupIndices.reduce((tree, groupIndex) => {
+          return insert(insert(tree, groupIndex, groupSize), groupIndex + 1, itemSize);
+        }, newSizeTree);
+      } else {
+        [newSizeTree, syncStart] = insertRanges(newSizeTree, ranges);
+      }
+      if (newSizeTree === sizeTree) {
+        return state;
+      }
+      const { offsetTree: newOffsetTree, lastIndex, lastSize, lastOffset } = createOffsetTree(state.offsetTree, syncStart, newSizeTree, gap);
+      return {
+        sizeTree: newSizeTree,
+        offsetTree: newOffsetTree,
+        lastIndex,
+        lastOffset,
+        lastSize,
+        groupOffsetTree: groupIndices.reduce((tree, index) => {
+          return insert(tree, index, offsetOf(index, newOffsetTree, gap));
+        }, newTree()),
+        groupIndices
+      };
+    }
+    function offsetOf(index, tree, gap) {
+      if (tree.length === 0) {
+        return 0;
+      }
+      const { offset: offset2, index: startIndex, size } = findClosestSmallerOrEqual(tree, index, indexComparator);
+      const itemCount = index - startIndex;
+      const top2 = size * itemCount + (itemCount - 1) * gap + offset2;
+      return top2 > 0 ? top2 + gap : top2;
+    }
+    function isGroupLocation(location) {
+      return typeof location.groupIndex !== "undefined";
+    }
+    function originalIndexFromLocation(location, sizes, lastIndex) {
+      if (isGroupLocation(location)) {
+        return sizes.groupIndices[location.groupIndex] + 1;
+      } else {
+        const numericIndex = location.index === "LAST" ? lastIndex : location.index;
+        let result = originalIndexFromItemIndex(numericIndex, sizes);
+        result = Math.max(0, result, Math.min(lastIndex, result));
+        return result;
+      }
+    }
+    function originalIndexFromItemIndex(itemIndex, sizes) {
+      if (!hasGroups(sizes)) {
+        return itemIndex;
+      }
+      let groupOffset = 0;
+      while (sizes.groupIndices[groupOffset] <= itemIndex + groupOffset) {
+        groupOffset++;
+      }
+      return itemIndex + groupOffset;
+    }
+    function hasGroups(sizes) {
+      return !empty(sizes.groupOffsetTree);
+    }
+    function sizeTreeToRanges(sizeTree) {
+      return walk(sizeTree).map(({ k: startIndex, v: size }, index, sizeArray) => {
+        const nextSize = sizeArray[index + 1];
+        const endIndex = nextSize ? nextSize.k - 1 : Infinity;
+        return { startIndex, endIndex, size };
+      });
+    }
+    const SIZE_MAP = {
+      offsetHeight: "height",
+      offsetWidth: "width"
+    };
+    const sizeSystem = system(
+      ([{ log }, { recalcInProgress }]) => {
+        const sizeRanges = stream();
+        const totalCount = stream();
+        const statefulTotalCount = statefulStreamFromEmitter(totalCount, 0);
+        const unshiftWith = stream();
+        const shiftWith = stream();
+        const firstItemIndex = statefulStream(0);
+        const groupIndices = statefulStream([]);
+        const fixedItemSize = statefulStream(void 0);
+        const defaultItemSize = statefulStream(void 0);
+        const itemSize = statefulStream((el, field) => correctItemSize(el, SIZE_MAP[field]));
+        const data = statefulStream(void 0);
+        const gap = statefulStream(0);
+        const initial = initialSizeState();
+        const sizes = statefulStreamFromEmitter(
+          pipe(sizeRanges, withLatestFrom(groupIndices, log, gap), scan(sizeStateReducer, initial), distinctUntilChanged()),
+          initial
+        );
+        const prevGroupIndices = statefulStreamFromEmitter(
+          pipe(
+            groupIndices,
+            distinctUntilChanged(),
+            scan((prev, curr) => ({ prev: prev.current, current: curr }), {
+              prev: [],
+              current: []
+            }),
+            map(({ prev }) => prev)
+          ),
+          []
+        );
+        connect(
+          pipe(
+            groupIndices,
+            filter((indexes) => indexes.length > 0),
+            withLatestFrom(sizes, gap),
+            map(([groupIndices2, sizes2, gap2]) => {
+              const groupOffsetTree = groupIndices2.reduce((tree, index, idx) => {
+                return insert(tree, index, offsetOf(index, sizes2.offsetTree, gap2) || idx);
+              }, newTree());
+              return {
+                ...sizes2,
+                groupIndices: groupIndices2,
+                groupOffsetTree
+              };
+            })
+          ),
+          sizes
+        );
+        connect(
+          pipe(
+            totalCount,
+            withLatestFrom(sizes),
+            filter(([totalCount2, { lastIndex }]) => {
+              return totalCount2 < lastIndex;
+            }),
+            map(([totalCount2, { lastIndex, lastSize }]) => {
+              return [
+                {
+                  startIndex: totalCount2,
+                  endIndex: lastIndex,
+                  size: lastSize
+                }
+              ];
+            })
+          ),
+          sizeRanges
+        );
+        connect(fixedItemSize, defaultItemSize);
+        const trackItemSizes = statefulStreamFromEmitter(
+          pipe(
+            fixedItemSize,
+            map((size) => size === void 0)
+          ),
+          true
+        );
+        connect(
+          pipe(
+            defaultItemSize,
+            filter((value) => {
+              return value !== void 0 && empty(getValue(sizes).sizeTree);
+            }),
+            map((size) => [{ startIndex: 0, endIndex: 0, size }])
+          ),
+          sizeRanges
+        );
+        const listRefresh = streamFromEmitter(
+          pipe(
+            sizeRanges,
+            withLatestFrom(sizes),
+            scan(
+              ({ sizes: oldSizes }, [_2, newSizes]) => {
+                return {
+                  changed: newSizes !== oldSizes,
+                  sizes: newSizes
+                };
+              },
+              { changed: false, sizes: initial }
+            ),
+            map((value) => value.changed)
+          )
+        );
+        subscribe(
+          pipe(
+            firstItemIndex,
+            scan(
+              (prev, next) => {
+                return { diff: prev.prev - next, prev: next };
+              },
+              { diff: 0, prev: 0 }
+            ),
+            map((val) => val.diff)
+          ),
+          (offset2) => {
+            const { groupIndices: groupIndices2 } = getValue(sizes);
+            if (offset2 > 0) {
+              publish(recalcInProgress, true);
+              publish(unshiftWith, offset2 + affectedGroupCount(offset2, groupIndices2));
+            } else if (offset2 < 0) {
+              const prevGroupIndicesValue = getValue(prevGroupIndices);
+              if (prevGroupIndicesValue.length > 0) {
+                offset2 -= affectedGroupCount(-offset2, prevGroupIndicesValue);
+              }
+              publish(shiftWith, offset2);
+            }
+          }
+        );
+        subscribe(pipe(firstItemIndex, withLatestFrom(log)), ([index, log2]) => {
+          if (index < 0) {
+            log2(
+              "`firstItemIndex` prop should not be set to less than zero. If you don't know the total count, just use a very high value",
+              { firstItemIndex },
+              LogLevel.ERROR
+            );
+          }
+        });
+        const beforeUnshiftWith = streamFromEmitter(unshiftWith);
+        connect(
+          pipe(
+            unshiftWith,
+            withLatestFrom(sizes),
+            map(([unshiftWith2, sizes2]) => {
+              const groupedMode = sizes2.groupIndices.length > 0;
+              const initialRanges = [];
+              const defaultSize = sizes2.lastSize;
+              if (groupedMode) {
+                const firstGroupSize = find(sizes2.sizeTree, 0);
+                let prependedGroupItemsCount = 0;
+                let groupIndex = 0;
+                while (prependedGroupItemsCount < unshiftWith2) {
+                  const theGroupIndex = sizes2.groupIndices[groupIndex];
+                  const groupItemCount = sizes2.groupIndices.length === groupIndex + 1 ? Infinity : sizes2.groupIndices[groupIndex + 1] - theGroupIndex - 1;
+                  initialRanges.push({
+                    startIndex: theGroupIndex,
+                    endIndex: theGroupIndex,
+                    size: firstGroupSize
+                  });
+                  initialRanges.push({
+                    startIndex: theGroupIndex + 1,
+                    endIndex: theGroupIndex + 1 + groupItemCount - 1,
+                    size: defaultSize
+                  });
+                  groupIndex++;
+                  prependedGroupItemsCount += groupItemCount + 1;
+                }
+                const sizeTreeKV = walk(sizes2.sizeTree);
+                const firstGroupIsExpanded = prependedGroupItemsCount !== unshiftWith2;
+                if (firstGroupIsExpanded) {
+                  sizeTreeKV.shift();
+                }
+                return sizeTreeKV.reduce(
+                  (acc, { k: index, v: size }) => {
+                    let ranges = acc.ranges;
+                    if (acc.prevSize !== 0) {
+                      ranges = [
+                        ...acc.ranges,
+                        {
+                          startIndex: acc.prevIndex,
+                          endIndex: index + unshiftWith2 - 1,
+                          size: acc.prevSize
+                        }
+                      ];
+                    }
+                    return {
+                      ranges,
+                      prevIndex: index + unshiftWith2,
+                      prevSize: size
+                    };
+                  },
+                  {
+                    ranges: initialRanges,
+                    prevIndex: unshiftWith2,
+                    prevSize: 0
+                  }
+                ).ranges;
+              }
+              return walk(sizes2.sizeTree).reduce(
+                (acc, { k: index, v: size }) => {
+                  return {
+                    ranges: [...acc.ranges, { startIndex: acc.prevIndex, endIndex: index + unshiftWith2 - 1, size: acc.prevSize }],
+                    prevIndex: index + unshiftWith2,
+                    prevSize: size
+                  };
+                },
+                {
+                  ranges: [],
+                  prevIndex: 0,
+                  prevSize: defaultSize
+                }
+              ).ranges;
+            })
+          ),
+          sizeRanges
+        );
+        const shiftWithOffset = streamFromEmitter(
+          pipe(
+            shiftWith,
+            withLatestFrom(sizes, gap),
+            map(([shiftWith2, { offsetTree }, gap2]) => {
+              const newFirstItemIndex = -shiftWith2;
+              return offsetOf(newFirstItemIndex, offsetTree, gap2);
+            })
+          )
+        );
+        connect(
+          pipe(
+            shiftWith,
+            withLatestFrom(sizes, gap),
+            map(([shiftWith2, sizes2, gap2]) => {
+              const groupedMode = sizes2.groupIndices.length > 0;
+              if (groupedMode) {
+                if (empty(sizes2.sizeTree)) {
+                  return sizes2;
+                }
+                let newSizeTree = newTree();
+                const prevGroupIndicesValue = getValue(prevGroupIndices);
+                let removedItemsCount = 0;
+                let groupIndex = 0;
+                let groupOffset = 0;
+                while (removedItemsCount < -shiftWith2) {
+                  groupOffset = prevGroupIndicesValue[groupIndex];
+                  const groupItemCount = prevGroupIndicesValue[groupIndex + 1] - groupOffset - 1;
+                  groupIndex++;
+                  removedItemsCount += groupItemCount + 1;
+                }
+                newSizeTree = walk(sizes2.sizeTree).reduce((acc, { k: k2, v: v2 }) => {
+                  return insert(acc, Math.max(0, k2 + shiftWith2), v2);
+                }, newSizeTree);
+                const aGroupIsShrunk = removedItemsCount !== -shiftWith2;
+                if (aGroupIsShrunk) {
+                  const firstGroupSize = find(sizes2.sizeTree, groupOffset);
+                  newSizeTree = insert(newSizeTree, 0, firstGroupSize);
+                  const nextItemSize = findMaxKeyValue(sizes2.sizeTree, -shiftWith2 + 1)[1];
+                  newSizeTree = insert(newSizeTree, 1, nextItemSize);
+                }
+                return {
+                  ...sizes2,
+                  sizeTree: newSizeTree,
+                  ...createOffsetTree(sizes2.offsetTree, 0, newSizeTree, gap2)
+                };
+              } else {
+                const newSizeTree = walk(sizes2.sizeTree).reduce((acc, { k: k2, v: v2 }) => {
+                  return insert(acc, Math.max(0, k2 + shiftWith2), v2);
+                }, newTree());
+                return {
+                  ...sizes2,
+                  sizeTree: newSizeTree,
+                  ...createOffsetTree(sizes2.offsetTree, 0, newSizeTree, gap2)
+                };
+              }
+            })
+          ),
+          sizes
+        );
+        return {
+          // input
+          data,
+          totalCount,
+          sizeRanges,
+          groupIndices,
+          defaultItemSize,
+          fixedItemSize,
+          unshiftWith,
+          shiftWith,
+          shiftWithOffset,
+          beforeUnshiftWith,
+          firstItemIndex,
+          gap,
+          // output
+          sizes,
+          listRefresh,
+          statefulTotalCount,
+          trackItemSizes,
+          itemSize
+        };
+      },
+      tup(loggerSystem, recalcSystem),
+      { singleton: true }
+    );
+    const SUPPORTS_SCROLL_TO_OPTIONS = typeof document !== "undefined" && "scrollBehavior" in document.documentElement.style;
+    function normalizeIndexLocation(location) {
+      const result = typeof location === "number" ? { index: location } : location;
+      if (!result.align) {
+        result.align = "start";
+      }
+      if (!result.behavior || !SUPPORTS_SCROLL_TO_OPTIONS) {
+        result.behavior = "auto";
+      }
+      if (!result.offset) {
+        result.offset = 0;
+      }
+      return result;
+    }
+    const scrollToIndexSystem = system(
+      ([
+        { sizes, totalCount, listRefresh, gap },
+        {
+          scrollingInProgress,
+          viewportHeight,
+          scrollTo,
+          smoothScrollTargetReached,
+          headerHeight,
+          footerHeight,
+          fixedHeaderHeight,
+          fixedFooterHeight
+        },
+        { log }
+      ]) => {
+        const scrollToIndex = stream();
+        const scrollTargetReached = stream();
+        const topListHeight = statefulStream(0);
+        let unsubscribeNextListRefresh = null;
+        let cleartTimeoutRef = null;
+        let unsubscribeListRefresh = null;
+        function cleanup() {
+          if (unsubscribeNextListRefresh) {
+            unsubscribeNextListRefresh();
+            unsubscribeNextListRefresh = null;
+          }
+          if (unsubscribeListRefresh) {
+            unsubscribeListRefresh();
+            unsubscribeListRefresh = null;
+          }
+          if (cleartTimeoutRef) {
+            clearTimeout(cleartTimeoutRef);
+            cleartTimeoutRef = null;
+          }
+          publish(scrollingInProgress, false);
+        }
+        connect(
+          pipe(
+            scrollToIndex,
+            withLatestFrom(sizes, viewportHeight, totalCount, topListHeight, headerHeight, footerHeight, log),
+            withLatestFrom(gap, fixedHeaderHeight, fixedFooterHeight),
+            map(
+              ([
+                [location, sizes2, viewportHeight2, totalCount2, topListHeight2, headerHeight2, footerHeight2, log2],
+                gap2,
+                fixedHeaderHeight2,
+                fixedFooterHeight2
+              ]) => {
+                const normalLocation = normalizeIndexLocation(location);
+                const { align, behavior, offset: offset2 } = normalLocation;
+                const lastIndex = totalCount2 - 1;
+                const index = originalIndexFromLocation(normalLocation, sizes2, lastIndex);
+                let top2 = offsetOf(index, sizes2.offsetTree, gap2) + headerHeight2;
+                if (align === "end") {
+                  top2 += fixedHeaderHeight2 + findMaxKeyValue(sizes2.sizeTree, index)[1] - viewportHeight2 + fixedFooterHeight2;
+                  if (index === lastIndex) {
+                    top2 += footerHeight2;
+                  }
+                } else if (align === "center") {
+                  top2 += (fixedHeaderHeight2 + findMaxKeyValue(sizes2.sizeTree, index)[1] - viewportHeight2 + fixedFooterHeight2) / 2;
+                } else {
+                  top2 -= topListHeight2;
+                }
+                if (offset2) {
+                  top2 += offset2;
+                }
+                const retry = (listChanged) => {
+                  cleanup();
+                  if (listChanged) {
+                    log2("retrying to scroll to", { location }, LogLevel.DEBUG);
+                    publish(scrollToIndex, location);
+                  } else {
+                    publish(scrollTargetReached, true);
+                    log2("list did not change, scroll successful", {}, LogLevel.DEBUG);
+                  }
+                };
+                cleanup();
+                if (behavior === "smooth") {
+                  let listChanged = false;
+                  unsubscribeListRefresh = subscribe(listRefresh, (changed) => {
+                    listChanged = listChanged || changed;
+                  });
+                  unsubscribeNextListRefresh = handleNext(smoothScrollTargetReached, () => {
+                    retry(listChanged);
+                  });
+                } else {
+                  unsubscribeNextListRefresh = handleNext(pipe(listRefresh, watchChangesFor(150)), retry);
+                }
+                cleartTimeoutRef = setTimeout(() => {
+                  cleanup();
+                }, 1200);
+                publish(scrollingInProgress, true);
+                log2("scrolling from index to", { index, top: top2, behavior }, LogLevel.DEBUG);
+                return { top: top2, behavior };
+              }
+            )
+          ),
+          scrollTo
+        );
+        return {
+          scrollToIndex,
+          scrollTargetReached,
+          topListHeight
+        };
+      },
+      tup(sizeSystem, domIOSystem, loggerSystem),
+      { singleton: true }
+    );
+    function watchChangesFor(limit) {
+      return (done) => {
+        const timeoutRef = setTimeout(() => {
+          done(false);
+        }, limit);
+        return (value) => {
+          if (value) {
+            done(true);
+            clearTimeout(timeoutRef);
+          }
+        };
+      };
+    }
+    const UP = "up";
+    const DOWN = "down";
+    const NONE$1 = "none";
+    const INITIAL_BOTTOM_STATE = {
+      atBottom: false,
+      notAtBottomBecause: "NOT_SHOWING_LAST_ITEM",
+      state: {
+        offsetBottom: 0,
+        scrollTop: 0,
+        viewportHeight: 0,
+        scrollHeight: 0
+      }
+    };
+    const DEFAULT_AT_TOP_THRESHOLD = 0;
+    const stateFlagsSystem = system(([{ scrollContainerState, scrollTop, viewportHeight, headerHeight, footerHeight, scrollBy }]) => {
+      const isAtBottom = statefulStream(false);
+      const isAtTop = statefulStream(true);
+      const atBottomStateChange = stream();
+      const atTopStateChange = stream();
+      const atBottomThreshold = statefulStream(4);
+      const atTopThreshold = statefulStream(DEFAULT_AT_TOP_THRESHOLD);
+      const isScrolling = statefulStreamFromEmitter(
+        pipe(
+          merge(pipe(duc(scrollTop), skip(1), mapTo(true)), pipe(duc(scrollTop), skip(1), mapTo(false), debounceTime(100))),
+          distinctUntilChanged()
+        ),
+        false
+      );
+      const isScrollingBy = statefulStreamFromEmitter(
+        pipe(merge(pipe(scrollBy, mapTo(true)), pipe(scrollBy, mapTo(false), debounceTime(200))), distinctUntilChanged()),
+        false
+      );
+      connect(
+        pipe(
+          combineLatest(duc(scrollTop), duc(atTopThreshold)),
+          map(([top2, atTopThreshold2]) => top2 <= atTopThreshold2),
+          distinctUntilChanged()
+        ),
+        isAtTop
+      );
+      connect(pipe(isAtTop, throttleTime(50)), atTopStateChange);
+      const atBottomState = streamFromEmitter(
+        pipe(
+          combineLatest(scrollContainerState, duc(viewportHeight), duc(headerHeight), duc(footerHeight), duc(atBottomThreshold)),
+          scan((current, [{ scrollTop: scrollTop2, scrollHeight }, viewportHeight2, _headerHeight, _footerHeight, atBottomThreshold2]) => {
+            const isAtBottom2 = scrollTop2 + viewportHeight2 - scrollHeight > -atBottomThreshold2;
+            const state = {
+              viewportHeight: viewportHeight2,
+              scrollTop: scrollTop2,
+              scrollHeight
+            };
+            if (isAtBottom2) {
+              let atBottomBecause;
+              let scrollTopDelta;
+              if (scrollTop2 > current.state.scrollTop) {
+                atBottomBecause = "SCROLLED_DOWN";
+                scrollTopDelta = current.state.scrollTop - scrollTop2;
+              } else {
+                atBottomBecause = "SIZE_DECREASED";
+                scrollTopDelta = current.state.scrollTop - scrollTop2 || current.scrollTopDelta;
+              }
+              return {
+                atBottom: true,
+                state,
+                atBottomBecause,
+                scrollTopDelta
+              };
+            }
+            let notAtBottomBecause;
+            if (state.scrollHeight > current.state.scrollHeight) {
+              notAtBottomBecause = "SIZE_INCREASED";
+            } else if (viewportHeight2 < current.state.viewportHeight) {
+              notAtBottomBecause = "VIEWPORT_HEIGHT_DECREASING";
+            } else if (scrollTop2 < current.state.scrollTop) {
+              notAtBottomBecause = "SCROLLING_UPWARDS";
+            } else {
+              notAtBottomBecause = "NOT_FULLY_SCROLLED_TO_LAST_ITEM_BOTTOM";
+            }
+            return {
+              atBottom: false,
+              notAtBottomBecause,
+              state
+            };
+          }, INITIAL_BOTTOM_STATE),
+          distinctUntilChanged((prev, next) => {
+            return prev && prev.atBottom === next.atBottom;
+          })
+        )
+      );
+      const lastJumpDueToItemResize = statefulStreamFromEmitter(
+        pipe(
+          scrollContainerState,
+          scan(
+            (current, { scrollTop: scrollTop2, scrollHeight, viewportHeight: viewportHeight2 }) => {
+              if (!approximatelyEqual(current.scrollHeight, scrollHeight)) {
+                const atBottom = scrollHeight - (scrollTop2 + viewportHeight2) < 1;
+                if (current.scrollTop !== scrollTop2 && atBottom) {
+                  return {
+                    scrollHeight,
+                    scrollTop: scrollTop2,
+                    jump: current.scrollTop - scrollTop2,
+                    changed: true
+                  };
+                } else {
+                  return {
+                    scrollHeight,
+                    scrollTop: scrollTop2,
+                    jump: 0,
+                    changed: true
+                  };
+                }
+              } else {
+                return {
+                  scrollTop: scrollTop2,
+                  scrollHeight,
+                  jump: 0,
+                  changed: false
+                };
+              }
+            },
+            { scrollHeight: 0, jump: 0, scrollTop: 0, changed: false }
+          ),
+          filter((value) => value.changed),
+          map((value) => value.jump)
+        ),
+        0
+      );
+      connect(
+        pipe(
+          atBottomState,
+          map((state) => state.atBottom)
+        ),
+        isAtBottom
+      );
+      connect(pipe(isAtBottom, throttleTime(50)), atBottomStateChange);
+      const scrollDirection = statefulStream(DOWN);
+      connect(
+        pipe(
+          scrollContainerState,
+          map(({ scrollTop: scrollTop2 }) => scrollTop2),
+          distinctUntilChanged(),
+          scan(
+            (acc, scrollTop2) => {
+              if (getValue(isScrollingBy)) {
+                return { direction: acc.direction, prevScrollTop: scrollTop2 };
+              }
+              return { direction: scrollTop2 < acc.prevScrollTop ? UP : DOWN, prevScrollTop: scrollTop2 };
+            },
+            { direction: DOWN, prevScrollTop: 0 }
+          ),
+          map((value) => value.direction)
+        ),
+        scrollDirection
+      );
+      connect(pipe(scrollContainerState, throttleTime(50), mapTo(NONE$1)), scrollDirection);
+      const scrollVelocity = statefulStream(0);
+      connect(
+        pipe(
+          isScrolling,
+          filter((value) => !value),
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          mapTo(0)
+        ),
+        scrollVelocity
+      );
+      connect(
+        pipe(
+          scrollTop,
+          throttleTime(100),
+          withLatestFrom(isScrolling),
+          filter(([_2, isScrolling2]) => !!isScrolling2),
+          scan(([_2, prev], [next]) => [prev, next], [0, 0]),
+          map(([prev, next]) => next - prev)
+        ),
+        scrollVelocity
+      );
+      return {
+        isScrolling,
+        isAtTop,
+        isAtBottom,
+        atBottomState,
+        atTopStateChange,
+        atBottomStateChange,
+        scrollDirection,
+        atBottomThreshold,
+        atTopThreshold,
+        scrollVelocity,
+        lastJumpDueToItemResize
+      };
+    }, tup(domIOSystem));
+    const propsReadySystem = system(
+      ([{ log }]) => {
+        const propsReady = statefulStream(false);
+        const didMount = streamFromEmitter(
+          pipe(
+            propsReady,
+            filter((ready) => ready),
+            distinctUntilChanged()
+          )
+        );
+        subscribe(propsReady, (value) => {
+          value && getValue(log)("props updated", {}, LogLevel.DEBUG);
+        });
+        return { propsReady, didMount };
+      },
+      tup(loggerSystem),
+      { singleton: true }
+    );
+    function skipFrames(frameCount, callback) {
+      if (frameCount == 0) {
+        callback();
+      } else {
+        requestAnimationFrame(() => skipFrames(frameCount - 1, callback));
+      }
+    }
+    function getInitialTopMostItemIndexNumber(location, totalCount) {
+      const lastIndex = totalCount - 1;
+      const index = typeof location === "number" ? location : location.index === "LAST" ? lastIndex : location.index;
+      return index;
+    }
+    const initialTopMostItemIndexSystem = system(
+      ([{ sizes, listRefresh, defaultItemSize }, { scrollTop }, { scrollToIndex, scrollTargetReached }, { didMount }]) => {
+        const scrolledToInitialItem = statefulStream(true);
+        const initialTopMostItemIndex = statefulStream(0);
+        const initialItemFinalLocationReached = statefulStream(true);
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(initialTopMostItemIndex),
+            filter(([_2, location]) => !!location),
+            mapTo(false)
+          ),
+          scrolledToInitialItem
+        );
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(initialTopMostItemIndex),
+            filter(([_2, location]) => !!location),
+            mapTo(false)
+          ),
+          initialItemFinalLocationReached
+        );
+        subscribe(
+          pipe(
+            combineLatest(listRefresh, didMount),
+            withLatestFrom(scrolledToInitialItem, sizes, defaultItemSize, initialItemFinalLocationReached),
+            filter(([[, didMount2], scrolledToInitialItem2, { sizeTree }, defaultItemSize2, scrollScheduled]) => {
+              return didMount2 && (!empty(sizeTree) || isDefined(defaultItemSize2)) && !scrolledToInitialItem2 && !scrollScheduled;
+            }),
+            withLatestFrom(initialTopMostItemIndex)
+          ),
+          ([, initialTopMostItemIndex2]) => {
+            handleNext(scrollTargetReached, () => {
+              publish(initialItemFinalLocationReached, true);
+            });
+            skipFrames(4, () => {
+              handleNext(scrollTop, () => {
+                publish(scrolledToInitialItem, true);
+              });
+              publish(scrollToIndex, initialTopMostItemIndex2);
+            });
+          }
+        );
+        return {
+          scrolledToInitialItem,
+          initialTopMostItemIndex,
+          initialItemFinalLocationReached
+        };
+      },
+      tup(sizeSystem, domIOSystem, scrollToIndexSystem, propsReadySystem),
+      { singleton: true }
+    );
+    function normalizeFollowOutput(follow) {
+      if (!follow) {
+        return false;
+      }
+      return follow === "smooth" ? "smooth" : "auto";
+    }
+    const behaviorFromFollowOutput = (follow, isAtBottom) => {
+      if (typeof follow === "function") {
+        return normalizeFollowOutput(follow(isAtBottom));
+      }
+      return isAtBottom && normalizeFollowOutput(follow);
+    };
+    const followOutputSystem = system(
+      ([
+        { totalCount, listRefresh },
+        { isAtBottom, atBottomState },
+        { scrollToIndex },
+        { scrolledToInitialItem },
+        { propsReady, didMount },
+        { log },
+        { scrollingInProgress }
+      ]) => {
+        const followOutput = statefulStream(false);
+        const autoscrollToBottom = stream();
+        let pendingScrollHandle = null;
+        function scrollToBottom(followOutputBehavior) {
+          publish(scrollToIndex, {
+            index: "LAST",
+            align: "end",
+            behavior: followOutputBehavior
+          });
+        }
+        subscribe(
+          pipe(
+            combineLatest(pipe(duc(totalCount), skip(1)), didMount),
+            withLatestFrom(duc(followOutput), isAtBottom, scrolledToInitialItem, scrollingInProgress),
+            map(([[totalCount2, didMount2], followOutput2, isAtBottom2, scrolledToInitialItem2, scrollingInProgress2]) => {
+              let shouldFollow = didMount2 && scrolledToInitialItem2;
+              let followOutputBehavior = "auto";
+              if (shouldFollow) {
+                followOutputBehavior = behaviorFromFollowOutput(followOutput2, isAtBottom2 || scrollingInProgress2);
+                shouldFollow = shouldFollow && !!followOutputBehavior;
+              }
+              return { totalCount: totalCount2, shouldFollow, followOutputBehavior };
+            }),
+            filter(({ shouldFollow }) => shouldFollow)
+          ),
+          ({ totalCount: totalCount2, followOutputBehavior }) => {
+            if (pendingScrollHandle) {
+              pendingScrollHandle();
+              pendingScrollHandle = null;
+            }
+            pendingScrollHandle = handleNext(listRefresh, () => {
+              getValue(log)("following output to ", { totalCount: totalCount2 }, LogLevel.DEBUG);
+              scrollToBottom(followOutputBehavior);
+              pendingScrollHandle = null;
+            });
+          }
+        );
+        function trapNextSizeIncrease(followOutput2) {
+          const cancel = handleNext(atBottomState, (state) => {
+            if (followOutput2 && !state.atBottom && state.notAtBottomBecause === "SIZE_INCREASED" && !pendingScrollHandle) {
+              getValue(log)("scrolling to bottom due to increased size", {}, LogLevel.DEBUG);
+              scrollToBottom("auto");
+            }
+          });
+          setTimeout(cancel, 100);
+        }
+        subscribe(
+          pipe(
+            combineLatest(duc(followOutput), totalCount, propsReady),
+            filter(([follow, , ready]) => follow && ready),
+            scan(
+              ({ value }, [, next]) => {
+                return { refreshed: value === next, value: next };
+              },
+              { refreshed: false, value: 0 }
+            ),
+            filter(({ refreshed }) => refreshed),
+            withLatestFrom(followOutput, totalCount)
+          ),
+          ([, followOutput2]) => {
+            if (getValue(scrolledToInitialItem)) {
+              trapNextSizeIncrease(followOutput2 !== false);
+            }
+          }
+        );
+        subscribe(autoscrollToBottom, () => {
+          trapNextSizeIncrease(getValue(followOutput) !== false);
+        });
+        subscribe(combineLatest(duc(followOutput), atBottomState), ([followOutput2, state]) => {
+          if (followOutput2 && !state.atBottom && state.notAtBottomBecause === "VIEWPORT_HEIGHT_DECREASING") {
+            scrollToBottom("auto");
+          }
+        });
+        return { followOutput, autoscrollToBottom };
+      },
+      tup(sizeSystem, stateFlagsSystem, scrollToIndexSystem, initialTopMostItemIndexSystem, propsReadySystem, loggerSystem, domIOSystem)
+    );
+    function groupCountsToIndicesAndCount(counts) {
+      return counts.reduce(
+        (acc, groupCount) => {
+          acc.groupIndices.push(acc.totalCount);
+          acc.totalCount += groupCount + 1;
+          return acc;
+        },
+        {
+          totalCount: 0,
+          groupIndices: []
+        }
+      );
+    }
+    const groupedListSystem = system(([{ totalCount, groupIndices, sizes }, { scrollTop, headerHeight }]) => {
+      const groupCounts = stream();
+      const topItemsIndexes = stream();
+      const groupIndicesAndCount = streamFromEmitter(pipe(groupCounts, map(groupCountsToIndicesAndCount)));
+      connect(
+        pipe(
+          groupIndicesAndCount,
+          map((value) => value.totalCount)
+        ),
+        totalCount
+      );
+      connect(
+        pipe(
+          groupIndicesAndCount,
+          map((value) => value.groupIndices)
+        ),
+        groupIndices
+      );
+      connect(
+        pipe(
+          combineLatest(scrollTop, sizes, headerHeight),
+          filter(([_2, sizes2]) => hasGroups(sizes2)),
+          map(([scrollTop2, state, headerHeight2]) => findMaxKeyValue(state.groupOffsetTree, Math.max(scrollTop2 - headerHeight2, 0), "v")[0]),
+          distinctUntilChanged(),
+          map((index) => [index])
+        ),
+        topItemsIndexes
+      );
+      return { groupCounts, topItemsIndexes };
+    }, tup(sizeSystem, domIOSystem));
+    function tupleComparator(prev, current) {
+      return !!(prev && prev[0] === current[0] && prev[1] === current[1]);
+    }
+    function rangeComparator(prev, next) {
+      return !!(prev && prev.startIndex === next.startIndex && prev.endIndex === next.endIndex);
+    }
+    const TOP = "top";
+    const BOTTOM = "bottom";
+    const NONE = "none";
+    function getOverscan(overscan, end2, direction) {
+      if (typeof overscan === "number") {
+        return direction === UP && end2 === TOP || direction === DOWN && end2 === BOTTOM ? overscan : 0;
+      } else {
+        if (direction === UP) {
+          return end2 === TOP ? overscan.main : overscan.reverse;
+        } else {
+          return end2 === BOTTOM ? overscan.main : overscan.reverse;
+        }
+      }
+    }
+    function getViewportIncrease(value, end2) {
+      return typeof value === "number" ? value : value[end2] || 0;
+    }
+    const sizeRangeSystem = system(
+      ([{ scrollTop, viewportHeight, deviation, headerHeight, fixedHeaderHeight }]) => {
+        const listBoundary = stream();
+        const topListHeight = statefulStream(0);
+        const increaseViewportBy = statefulStream(0);
+        const overscan = statefulStream(0);
+        const visibleRange = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(
+              duc(scrollTop),
+              duc(viewportHeight),
+              duc(headerHeight),
+              duc(listBoundary, tupleComparator),
+              duc(overscan),
+              duc(topListHeight),
+              duc(fixedHeaderHeight),
+              duc(deviation),
+              duc(increaseViewportBy)
+            ),
+            map(
+              ([
+                scrollTop2,
+                viewportHeight2,
+                headerHeight2,
+                [listTop, listBottom],
+                overscan2,
+                topListHeight2,
+                fixedHeaderHeight2,
+                deviation2,
+                increaseViewportBy2
+              ]) => {
+                const top2 = scrollTop2 - deviation2;
+                const stickyHeaderHeight = topListHeight2 + fixedHeaderHeight2;
+                const headerVisible = Math.max(headerHeight2 - top2, 0);
+                let direction = NONE;
+                const topViewportAddition = getViewportIncrease(increaseViewportBy2, TOP);
+                const bottomViewportAddition = getViewportIncrease(increaseViewportBy2, BOTTOM);
+                listTop -= deviation2;
+                listTop += headerHeight2 + fixedHeaderHeight2;
+                listBottom += headerHeight2 + fixedHeaderHeight2;
+                listBottom -= deviation2;
+                if (listTop > scrollTop2 + stickyHeaderHeight - topViewportAddition) {
+                  direction = UP;
+                }
+                if (listBottom < scrollTop2 - headerVisible + viewportHeight2 + bottomViewportAddition) {
+                  direction = DOWN;
+                }
+                if (direction !== NONE) {
+                  return [
+                    Math.max(top2 - headerHeight2 - getOverscan(overscan2, TOP, direction) - topViewportAddition, 0),
+                    top2 - headerVisible - fixedHeaderHeight2 + viewportHeight2 + getOverscan(overscan2, BOTTOM, direction) + bottomViewportAddition
+                  ];
+                }
+                return null;
+              }
+            ),
+            filter((value) => value != null),
+            distinctUntilChanged(tupleComparator)
+          ),
+          [0, 0]
+        );
+        return {
+          // input
+          listBoundary,
+          overscan,
+          topListHeight,
+          increaseViewportBy,
+          // output
+          visibleRange
+        };
+      },
+      tup(domIOSystem),
+      { singleton: true }
+    );
+    function probeItemSet(index, sizes, data) {
+      if (hasGroups(sizes)) {
+        const itemIndex = originalIndexFromItemIndex(index, sizes);
+        const groupIndex = findMaxKeyValue(sizes.groupOffsetTree, itemIndex)[0];
+        return [
+          { index: groupIndex, size: 0, offset: 0 },
+          { index: itemIndex, size: 0, offset: 0, data: data && data[0] }
+        ];
+      }
+      return [{ index, size: 0, offset: 0, data: data && data[0] }];
+    }
+    const EMPTY_LIST_STATE = {
+      items: [],
+      topItems: [],
+      offsetTop: 0,
+      offsetBottom: 0,
+      top: 0,
+      bottom: 0,
+      topListHeight: 0,
+      totalCount: 0,
+      firstItemIndex: 0
+    };
+    function transposeItems(items, sizes, firstItemIndex) {
+      if (items.length === 0) {
+        return [];
+      }
+      if (!hasGroups(sizes)) {
+        return items.map((item) => ({ ...item, index: item.index + firstItemIndex, originalIndex: item.index }));
+      }
+      const startIndex = items[0].index;
+      const endIndex = items[items.length - 1].index;
+      const transposedItems = [];
+      const groupRanges = rangesWithin(sizes.groupOffsetTree, startIndex, endIndex);
+      let currentRange = void 0;
+      let currentGroupIndex = 0;
+      for (const item of items) {
+        if (!currentRange || currentRange.end < item.index) {
+          currentRange = groupRanges.shift();
+          currentGroupIndex = sizes.groupIndices.indexOf(currentRange.start);
+        }
+        let transposedItem;
+        if (item.index === currentRange.start) {
+          transposedItem = {
+            type: "group",
+            index: currentGroupIndex
+          };
+        } else {
+          transposedItem = {
+            index: item.index - (currentGroupIndex + 1) + firstItemIndex,
+            groupIndex: currentGroupIndex
+          };
+        }
+        transposedItems.push({
+          ...transposedItem,
+          size: item.size,
+          offset: item.offset,
+          originalIndex: item.index,
+          data: item.data
+        });
+      }
+      return transposedItems;
+    }
+    function buildListState(items, topItems, totalCount, gap, sizes, firstItemIndex) {
+      const { lastSize, lastOffset, lastIndex } = sizes;
+      let offsetTop = 0;
+      let bottom2 = 0;
+      if (items.length > 0) {
+        offsetTop = items[0].offset;
+        const lastItem = items[items.length - 1];
+        bottom2 = lastItem.offset + lastItem.size;
+      }
+      const itemCount = totalCount - lastIndex;
+      const total = lastOffset + itemCount * lastSize + (itemCount - 1) * gap;
+      const top2 = offsetTop;
+      const offsetBottom = total - bottom2;
+      return {
+        items: transposeItems(items, sizes, firstItemIndex),
+        topItems: transposeItems(topItems, sizes, firstItemIndex),
+        topListHeight: topItems.reduce((height, item) => item.size + height, 0),
+        offsetTop,
+        offsetBottom,
+        top: top2,
+        bottom: bottom2,
+        totalCount,
+        firstItemIndex
+      };
+    }
+    function buildListStateFromItemCount(itemCount, initialTopMostItemIndex, sizes, firstItemIndex, gap, data) {
+      let includedGroupsCount = 0;
+      if (sizes.groupIndices.length > 0) {
+        for (const index of sizes.groupIndices) {
+          if (index - includedGroupsCount >= itemCount) {
+            break;
+          }
+          includedGroupsCount++;
+        }
+      }
+      const adjustedCount = itemCount + includedGroupsCount;
+      const initialTopMostItemIndexNumber = getInitialTopMostItemIndexNumber(initialTopMostItemIndex, adjustedCount);
+      const items = Array.from({ length: adjustedCount }).map((_2, index) => ({
+        index: index + initialTopMostItemIndexNumber,
+        size: 0,
+        offset: 0,
+        data: data[index + initialTopMostItemIndexNumber]
+      }));
+      return buildListState(items, [], adjustedCount, gap, sizes, firstItemIndex);
+    }
+    const listStateSystem = system(
+      ([
+        { sizes, totalCount, data, firstItemIndex, gap },
+        groupedListSystem2,
+        { visibleRange, listBoundary, topListHeight: rangeTopListHeight },
+        { scrolledToInitialItem, initialTopMostItemIndex },
+        { topListHeight },
+        stateFlags,
+        { didMount },
+        { recalcInProgress }
+      ]) => {
+        const topItemsIndexes = statefulStream([]);
+        const initialItemCount = statefulStream(0);
+        const itemsRendered = stream();
+        connect(groupedListSystem2.topItemsIndexes, topItemsIndexes);
+        const listState = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(
+              didMount,
+              recalcInProgress,
+              duc(visibleRange, tupleComparator),
+              duc(totalCount),
+              duc(sizes),
+              duc(initialTopMostItemIndex),
+              scrolledToInitialItem,
+              duc(topItemsIndexes),
+              duc(firstItemIndex),
+              duc(gap),
+              data
+            ),
+            filter(([mount, recalcInProgress2, , totalCount2, , , , , , , data2]) => {
+              const dataChangeInProgress = data2 && data2.length !== totalCount2;
+              return mount && !recalcInProgress2 && !dataChangeInProgress;
+            }),
+            map(
+              ([
+                ,
+                ,
+                [startOffset, endOffset],
+                totalCount2,
+                sizes2,
+                initialTopMostItemIndex2,
+                scrolledToInitialItem2,
+                topItemsIndexes2,
+                firstItemIndex2,
+                gap2,
+                data2
+              ]) => {
+                const sizesValue = sizes2;
+                const { sizeTree, offsetTree } = sizesValue;
+                const initialItemCountValue = getValue(initialItemCount);
+                if (totalCount2 === 0) {
+                  return { ...EMPTY_LIST_STATE, totalCount: totalCount2 };
+                }
+                if (startOffset === 0 && endOffset === 0) {
+                  if (initialItemCountValue === 0) {
+                    return { ...EMPTY_LIST_STATE, totalCount: totalCount2 };
+                  } else {
+                    return buildListStateFromItemCount(initialItemCountValue, initialTopMostItemIndex2, sizes2, firstItemIndex2, gap2, data2 || []);
+                  }
+                }
+                if (empty(sizeTree)) {
+                  if (initialItemCountValue > 0) {
+                    return null;
+                  }
+                  const state = buildListState(
+                    probeItemSet(getInitialTopMostItemIndexNumber(initialTopMostItemIndex2, totalCount2), sizesValue, data2),
+                    [],
+                    totalCount2,
+                    gap2,
+                    sizesValue,
+                    firstItemIndex2
+                  );
+                  return state;
+                }
+                const topItems = [];
+                if (topItemsIndexes2.length > 0) {
+                  const startIndex = topItemsIndexes2[0];
+                  const endIndex = topItemsIndexes2[topItemsIndexes2.length - 1];
+                  let offset2 = 0;
+                  for (const range of rangesWithin(sizeTree, startIndex, endIndex)) {
+                    const size = range.value;
+                    const rangeStartIndex = Math.max(range.start, startIndex);
+                    const rangeEndIndex = Math.min(range.end, endIndex);
+                    for (let i2 = rangeStartIndex; i2 <= rangeEndIndex; i2++) {
+                      topItems.push({ index: i2, size, offset: offset2, data: data2 && data2[i2] });
+                      offset2 += size;
+                    }
+                  }
+                }
+                if (!scrolledToInitialItem2) {
+                  return buildListState([], topItems, totalCount2, gap2, sizesValue, firstItemIndex2);
+                }
+                const minStartIndex = topItemsIndexes2.length > 0 ? topItemsIndexes2[topItemsIndexes2.length - 1] + 1 : 0;
+                const offsetPointRanges = rangesWithinOffsets(offsetTree, startOffset, endOffset, minStartIndex);
+                if (offsetPointRanges.length === 0) {
+                  return null;
+                }
+                const maxIndex = totalCount2 - 1;
+                const items = tap([], (result) => {
+                  for (const range of offsetPointRanges) {
+                    const point = range.value;
+                    let offset2 = point.offset;
+                    let rangeStartIndex = range.start;
+                    const size = point.size;
+                    if (point.offset < startOffset) {
+                      rangeStartIndex += Math.floor((startOffset - point.offset + gap2) / (size + gap2));
+                      const itemCount = rangeStartIndex - range.start;
+                      offset2 += itemCount * size + itemCount * gap2;
+                    }
+                    if (rangeStartIndex < minStartIndex) {
+                      offset2 += (minStartIndex - rangeStartIndex) * size;
+                      rangeStartIndex = minStartIndex;
+                    }
+                    const endIndex = Math.min(range.end, maxIndex);
+                    for (let i2 = rangeStartIndex; i2 <= endIndex; i2++) {
+                      if (offset2 >= endOffset) {
+                        break;
+                      }
+                      result.push({ index: i2, size, offset: offset2, data: data2 && data2[i2] });
+                      offset2 += size + gap2;
+                    }
+                  }
+                });
+                return buildListState(items, topItems, totalCount2, gap2, sizesValue, firstItemIndex2);
+              }
+            ),
+            //@ts-expect-error filter needs to be fixed
+            filter((value) => value !== null),
+            distinctUntilChanged()
+          ),
+          EMPTY_LIST_STATE
+        );
+        connect(
+          pipe(
+            data,
+            filter(isDefined),
+            map((data2) => data2 == null ? void 0 : data2.length)
+          ),
+          totalCount
+        );
+        connect(
+          pipe(
+            listState,
+            map((value) => value.topListHeight)
+          ),
+          topListHeight
+        );
+        connect(topListHeight, rangeTopListHeight);
+        connect(
+          pipe(
+            listState,
+            map((state) => [state.top, state.bottom])
+          ),
+          listBoundary
+        );
+        connect(
+          pipe(
+            listState,
+            map((state) => state.items)
+          ),
+          itemsRendered
+        );
+        const endReached = streamFromEmitter(
+          pipe(
+            listState,
+            filter(({ items }) => items.length > 0),
+            withLatestFrom(totalCount, data),
+            filter(([{ items }, totalCount2]) => items[items.length - 1].originalIndex === totalCount2 - 1),
+            map(([, totalCount2, data2]) => [totalCount2 - 1, data2]),
+            distinctUntilChanged(tupleComparator),
+            map(([count]) => count)
+          )
+        );
+        const startReached = streamFromEmitter(
+          pipe(
+            listState,
+            throttleTime(200),
+            filter(({ items, topItems }) => {
+              return items.length > 0 && items[0].originalIndex === topItems.length;
+            }),
+            map(({ items }) => items[0].index),
+            distinctUntilChanged()
+          )
+        );
+        const rangeChanged = streamFromEmitter(
+          pipe(
+            listState,
+            filter(({ items }) => items.length > 0),
+            map(({ items }) => {
+              let startIndex = 0;
+              let endIndex = items.length - 1;
+              while (items[startIndex].type === "group" && startIndex < endIndex) {
+                startIndex++;
+              }
+              while (items[endIndex].type === "group" && endIndex > startIndex) {
+                endIndex--;
+              }
+              return {
+                startIndex: items[startIndex].index,
+                endIndex: items[endIndex].index
+              };
+            }),
+            distinctUntilChanged(rangeComparator)
+          )
+        );
+        return { listState, topItemsIndexes, endReached, startReached, rangeChanged, itemsRendered, initialItemCount, ...stateFlags };
+      },
+      tup(
+        sizeSystem,
+        groupedListSystem,
+        sizeRangeSystem,
+        initialTopMostItemIndexSystem,
+        scrollToIndexSystem,
+        stateFlagsSystem,
+        propsReadySystem,
+        recalcSystem
+      ),
+      { singleton: true }
+    );
+    const initialItemCountSystem = system(
+      ([{ sizes, firstItemIndex, data, gap }, { initialTopMostItemIndex }, { initialItemCount, listState }, { didMount }]) => {
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(initialItemCount),
+            filter(([, count]) => count !== 0),
+            withLatestFrom(initialTopMostItemIndex, sizes, firstItemIndex, gap, data),
+            map(([[, count], initialTopMostItemIndexValue, sizes2, firstItemIndex2, gap2, data2 = []]) => {
+              return buildListStateFromItemCount(count, initialTopMostItemIndexValue, sizes2, firstItemIndex2, gap2, data2);
+            })
+          ),
+          listState
+        );
+        return {};
+      },
+      tup(sizeSystem, initialTopMostItemIndexSystem, listStateSystem, propsReadySystem),
+      { singleton: true }
+    );
+    const scrollSeekSystem = system(
+      ([{ scrollVelocity }]) => {
+        const isSeeking = statefulStream(false);
+        const rangeChanged = stream();
+        const scrollSeekConfiguration = statefulStream(false);
+        connect(
+          pipe(
+            scrollVelocity,
+            withLatestFrom(scrollSeekConfiguration, isSeeking, rangeChanged),
+            filter(([_2, config2]) => !!config2),
+            map(([speed, config2, isSeeking2, range]) => {
+              const { exit, enter } = config2;
+              if (isSeeking2) {
+                if (exit(speed, range)) {
+                  return false;
+                }
+              } else {
+                if (enter(speed, range)) {
+                  return true;
+                }
+              }
+              return isSeeking2;
+            }),
+            distinctUntilChanged()
+          ),
+          isSeeking
+        );
+        subscribe(
+          pipe(combineLatest(isSeeking, scrollVelocity, rangeChanged), withLatestFrom(scrollSeekConfiguration)),
+          ([[isSeeking2, velocity, range], config2]) => isSeeking2 && config2 && config2.change && config2.change(velocity, range)
+        );
+        return { isSeeking, scrollSeekConfiguration, scrollVelocity, scrollSeekRangeChanged: rangeChanged };
+      },
+      tup(stateFlagsSystem),
+      { singleton: true }
+    );
+    const topItemCountSystem = system(([{ topItemsIndexes }]) => {
+      const topItemCount = statefulStream(0);
+      connect(
+        pipe(
+          topItemCount,
+          filter((length) => length >= 0),
+          map((length) => Array.from({ length }).map((_2, index) => index))
+        ),
+        topItemsIndexes
+      );
+      return { topItemCount };
+    }, tup(listStateSystem));
+    const totalListHeightSystem = system(
+      ([{ footerHeight, headerHeight, fixedHeaderHeight, fixedFooterHeight }, { listState }]) => {
+        const totalListHeightChanged = stream();
+        const totalListHeight = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(footerHeight, fixedFooterHeight, headerHeight, fixedHeaderHeight, listState),
+            map(([footerHeight2, fixedFooterHeight2, headerHeight2, fixedHeaderHeight2, listState2]) => {
+              return footerHeight2 + fixedFooterHeight2 + headerHeight2 + fixedHeaderHeight2 + listState2.offsetBottom + listState2.bottom;
+            })
+          ),
+          0
+        );
+        connect(duc(totalListHeight), totalListHeightChanged);
+        return { totalListHeight, totalListHeightChanged };
+      },
+      tup(domIOSystem, listStateSystem),
+      { singleton: true }
+    );
+    function simpleMemoize(func) {
+      let called = false;
+      let result;
+      return () => {
+        if (!called) {
+          called = true;
+          result = func();
+        }
+        return result;
+      };
+    }
+    const isMobileSafari = simpleMemoize(() => {
+      return /iP(ad|od|hone)/i.test(navigator.userAgent) && /WebKit/i.test(navigator.userAgent);
+    });
+    const upwardScrollFixSystem = system(
+      ([
+        { scrollBy, scrollTop, deviation, scrollingInProgress },
+        { isScrolling, isAtBottom, scrollDirection, lastJumpDueToItemResize },
+        { listState },
+        { beforeUnshiftWith, shiftWithOffset, sizes, gap },
+        { log },
+        { recalcInProgress }
+      ]) => {
+        const deviationOffset = streamFromEmitter(
+          pipe(
+            listState,
+            withLatestFrom(lastJumpDueToItemResize),
+            scan(
+              ([, prevItems, prevTotalCount, prevTotalHeight], [{ items, totalCount, bottom: bottom2, offsetBottom }, lastJumpDueToItemResize2]) => {
+                const totalHeight = bottom2 + offsetBottom;
+                let newDev = 0;
+                if (prevTotalCount === totalCount) {
+                  if (prevItems.length > 0 && items.length > 0) {
+                    const atStart = items[0].originalIndex === 0 && prevItems[0].originalIndex === 0;
+                    if (!atStart) {
+                      newDev = totalHeight - prevTotalHeight;
+                      if (newDev !== 0) {
+                        newDev += lastJumpDueToItemResize2;
+                      }
+                    }
+                  }
+                }
+                return [newDev, items, totalCount, totalHeight];
+              },
+              [0, [], 0, 0]
+            ),
+            filter(([amount]) => amount !== 0),
+            withLatestFrom(scrollTop, scrollDirection, scrollingInProgress, isAtBottom, log, recalcInProgress),
+            filter(([, scrollTop2, scrollDirection2, scrollingInProgress2, , , recalcInProgress2]) => {
+              return !recalcInProgress2 && !scrollingInProgress2 && scrollTop2 !== 0 && scrollDirection2 === UP;
+            }),
+            map(([[amount], , , , , log2]) => {
+              log2("Upward scrolling compensation", { amount }, LogLevel.DEBUG);
+              return amount;
+            })
+          )
+        );
+        function scrollByWith(offset2) {
+          if (offset2 > 0) {
+            publish(scrollBy, { top: -offset2, behavior: "auto" });
+            publish(deviation, 0);
+          } else {
+            publish(deviation, 0);
+            publish(scrollBy, { top: -offset2, behavior: "auto" });
+          }
+        }
+        subscribe(pipe(deviationOffset, withLatestFrom(deviation, isScrolling)), ([offset2, deviationAmount, isScrolling2]) => {
+          if (isScrolling2 && isMobileSafari()) {
+            publish(deviation, deviationAmount - offset2);
+          } else {
+            scrollByWith(-offset2);
+          }
+        });
+        subscribe(
+          pipe(
+            combineLatest(statefulStreamFromEmitter(isScrolling, false), deviation, recalcInProgress),
+            filter(([is, deviation2, recalc]) => !is && !recalc && deviation2 !== 0),
+            map(([_2, deviation2]) => deviation2),
+            throttleTime(1)
+          ),
+          scrollByWith
+        );
+        connect(
+          pipe(
+            shiftWithOffset,
+            map((offset2) => {
+              return { top: -offset2 };
+            })
+          ),
+          scrollBy
+        );
+        subscribe(
+          pipe(
+            beforeUnshiftWith,
+            withLatestFrom(sizes, gap),
+            map(([offset2, { lastSize: defaultItemSize, groupIndices, sizeTree }, gap2]) => {
+              function getItemOffset(itemCount) {
+                return itemCount * (defaultItemSize + gap2);
+              }
+              if (groupIndices.length === 0) {
+                return getItemOffset(offset2);
+              } else {
+                let amount = 0;
+                const defaultGroupSize = find(sizeTree, 0);
+                let recognizedOffsetItems = 0;
+                let groupIndex = 0;
+                while (recognizedOffsetItems < offset2) {
+                  recognizedOffsetItems++;
+                  amount += defaultGroupSize;
+                  let groupItemCount = groupIndices.length === groupIndex + 1 ? Infinity : groupIndices[groupIndex + 1] - groupIndices[groupIndex] - 1;
+                  if (recognizedOffsetItems + groupItemCount > offset2) {
+                    amount -= defaultGroupSize;
+                    groupItemCount = offset2 - recognizedOffsetItems + 1;
+                  }
+                  recognizedOffsetItems += groupItemCount;
+                  amount += getItemOffset(groupItemCount);
+                  groupIndex++;
+                }
+                return amount;
+              }
+            })
+          ),
+          (offset2) => {
+            publish(deviation, offset2);
+            requestAnimationFrame(() => {
+              publish(scrollBy, { top: offset2 });
+              requestAnimationFrame(() => {
+                publish(deviation, 0);
+                publish(recalcInProgress, false);
+              });
+            });
+          }
+        );
+        return { deviation };
+      },
+      tup(domIOSystem, stateFlagsSystem, listStateSystem, sizeSystem, loggerSystem, recalcSystem)
+    );
+    const initialScrollTopSystem = system(
+      ([{ didMount }, { scrollTo }, { listState }]) => {
+        const initialScrollTop = statefulStream(0);
+        subscribe(
+          pipe(
+            didMount,
+            withLatestFrom(initialScrollTop),
+            filter(([, offset2]) => offset2 !== 0),
+            map(([, offset2]) => ({ top: offset2 }))
+          ),
+          (location) => {
+            handleNext(
+              pipe(
+                listState,
+                skip(1),
+                filter((state) => state.items.length > 1)
+              ),
+              () => {
+                requestAnimationFrame(() => {
+                  publish(scrollTo, location);
+                });
+              }
+            );
+          }
+        );
+        return {
+          initialScrollTop
+        };
+      },
+      tup(propsReadySystem, domIOSystem, listStateSystem),
+      { singleton: true }
+    );
+    const alignToBottomSystem = system(
+      ([{ viewportHeight }, { totalListHeight }]) => {
+        const alignToBottom = statefulStream(false);
+        const paddingTopAddition = statefulStreamFromEmitter(
+          pipe(
+            combineLatest(alignToBottom, viewportHeight, totalListHeight),
+            filter(([enabled]) => enabled),
+            map(([, viewportHeight2, totalListHeight2]) => {
+              return Math.max(0, viewportHeight2 - totalListHeight2);
+            }),
+            throttleTime(0),
+            distinctUntilChanged()
+          ),
+          0
+        );
+        return { alignToBottom, paddingTopAddition };
+      },
+      tup(domIOSystem, totalListHeightSystem),
+      { singleton: true }
+    );
+    const windowScrollerSystem = system(([{ scrollTo, scrollContainerState }]) => {
+      const windowScrollContainerState = stream();
+      const windowViewportRect = stream();
+      const windowScrollTo = stream();
+      const useWindowScroll = statefulStream(false);
+      const customScrollParent = statefulStream(void 0);
+      connect(
+        pipe(
+          combineLatest(windowScrollContainerState, windowViewportRect),
+          map(([{ viewportHeight, scrollTop: windowScrollTop, scrollHeight }, { offsetTop }]) => {
+            return {
+              scrollTop: Math.max(0, windowScrollTop - offsetTop),
+              scrollHeight,
+              viewportHeight
+            };
+          })
+        ),
+        scrollContainerState
+      );
+      connect(
+        pipe(
+          scrollTo,
+          withLatestFrom(windowViewportRect),
+          map(([scrollTo2, { offsetTop }]) => {
+            return {
+              ...scrollTo2,
+              top: scrollTo2.top + offsetTop
+            };
+          })
+        ),
+        windowScrollTo
+      );
+      return {
+        // config
+        useWindowScroll,
+        customScrollParent,
+        // input
+        windowScrollContainerState,
+        windowViewportRect,
+        // signals
+        windowScrollTo
+      };
+    }, tup(domIOSystem));
+    const defaultCalculateViewLocation = ({
+      itemTop: itemTop2,
+      itemBottom,
+      viewportTop,
+      viewportBottom,
+      locationParams: { behavior, align, ...rest }
+    }) => {
+      if (itemTop2 < viewportTop) {
+        return { ...rest, behavior, align: align != null ? align : "start" };
+      }
+      if (itemBottom > viewportBottom) {
+        return { ...rest, behavior, align: align != null ? align : "end" };
+      }
+      return null;
+    };
+    const scrollIntoViewSystem = system(
+      ([
+        { sizes, totalCount, gap },
+        { scrollTop, viewportHeight, headerHeight, fixedHeaderHeight, fixedFooterHeight, scrollingInProgress },
+        { scrollToIndex }
+      ]) => {
+        const scrollIntoView = stream();
+        connect(
+          pipe(
+            scrollIntoView,
+            withLatestFrom(sizes, viewportHeight, totalCount, headerHeight, fixedHeaderHeight, fixedFooterHeight, scrollTop),
+            withLatestFrom(gap),
+            map(([[viewLocation, sizes2, viewportHeight2, totalCount2, headerHeight2, fixedHeaderHeight2, fixedFooterHeight2, scrollTop2], gap2]) => {
+              const { done, behavior, align, calculateViewLocation = defaultCalculateViewLocation, ...rest } = viewLocation;
+              const actualIndex = originalIndexFromLocation(viewLocation, sizes2, totalCount2 - 1);
+              const itemTop2 = offsetOf(actualIndex, sizes2.offsetTree, gap2) + headerHeight2 + fixedHeaderHeight2;
+              const itemBottom = itemTop2 + findMaxKeyValue(sizes2.sizeTree, actualIndex)[1];
+              const viewportTop = scrollTop2 + fixedHeaderHeight2;
+              const viewportBottom = scrollTop2 + viewportHeight2 - fixedFooterHeight2;
+              const location = calculateViewLocation({
+                itemTop: itemTop2,
+                itemBottom,
+                viewportTop,
+                viewportBottom,
+                locationParams: { behavior, align, ...rest }
+              });
+              if (location) {
+                done && handleNext(
+                  pipe(
+                    scrollingInProgress,
+                    filter((value) => value === false),
+                    // skips the initial publish of false, and the cleanup call.
+                    // but if scrollingInProgress is true, we skip the initial publish.
+                    skip(getValue(scrollingInProgress) ? 1 : 2)
+                  ),
+                  done
+                );
+              } else {
+                done && done();
+              }
+              return location;
+            }),
+            filter((value) => value !== null)
+          ),
+          scrollToIndex
+        );
+        return {
+          scrollIntoView
+        };
+      },
+      tup(sizeSystem, domIOSystem, scrollToIndexSystem, listStateSystem, loggerSystem),
+      { singleton: true }
+    );
+    const stateLoadSystem = system(
+      ([
+        { sizes, sizeRanges },
+        { scrollTop, headerHeight },
+        { initialTopMostItemIndex },
+        { didMount },
+        { useWindowScroll, windowScrollContainerState, windowViewportRect }
+      ]) => {
+        const getState = stream();
+        const restoreStateFrom = statefulStream(void 0);
+        const statefulWindowScrollContainerState = statefulStream(null);
+        const statefulWindowViewportRect = statefulStream(null);
+        connect(windowScrollContainerState, statefulWindowScrollContainerState);
+        connect(windowViewportRect, statefulWindowViewportRect);
+        subscribe(
+          pipe(
+            getState,
+            withLatestFrom(sizes, scrollTop, useWindowScroll, statefulWindowScrollContainerState, statefulWindowViewportRect, headerHeight)
+          ),
+          ([callback, sizes2, scrollTop2, useWindowScroll2, windowScrollContainerState2, windowViewportRect2, headerHeight2]) => {
+            const ranges = sizeTreeToRanges(sizes2.sizeTree);
+            if (useWindowScroll2 && windowScrollContainerState2 !== null && windowViewportRect2 !== null) {
+              scrollTop2 = windowScrollContainerState2.scrollTop - windowViewportRect2.offsetTop;
+            }
+            scrollTop2 -= headerHeight2;
+            callback({ ranges, scrollTop: scrollTop2 });
+          }
+        );
+        connect(pipe(restoreStateFrom, filter(isDefined), map(locationFromSnapshot)), initialTopMostItemIndex);
+        connect(
+          pipe(
+            didMount,
+            withLatestFrom(restoreStateFrom),
+            filter(([, state]) => state !== void 0),
+            distinctUntilChanged(),
+            map(([, snapshot]) => {
+              return snapshot.ranges;
+            })
+          ),
+          sizeRanges
+        );
+        return {
+          getState,
+          restoreStateFrom
+        };
+      },
+      tup(sizeSystem, domIOSystem, initialTopMostItemIndexSystem, propsReadySystem, windowScrollerSystem)
+    );
+    function locationFromSnapshot(snapshot) {
+      return { offset: snapshot.scrollTop, index: 0, align: "start" };
+    }
+    const featureGroup1System = system(
+      ([
+        sizeRange,
+        initialItemCount,
+        propsReady,
+        scrollSeek,
+        totalListHeight,
+        initialScrollTopSystem2,
+        alignToBottom,
+        windowScroller,
+        scrollIntoView,
+        logger
+      ]) => {
+        return {
+          ...sizeRange,
+          ...initialItemCount,
+          ...propsReady,
+          ...scrollSeek,
+          ...totalListHeight,
+          ...initialScrollTopSystem2,
+          ...alignToBottom,
+          ...windowScroller,
+          ...scrollIntoView,
+          ...logger
+        };
+      },
+      tup(
+        sizeRangeSystem,
+        initialItemCountSystem,
+        propsReadySystem,
+        scrollSeekSystem,
+        totalListHeightSystem,
+        initialScrollTopSystem,
+        alignToBottomSystem,
+        windowScrollerSystem,
+        scrollIntoViewSystem,
+        loggerSystem
+      )
+    );
+    const listSystem = system(
+      ([
+        {
+          totalCount,
+          sizeRanges,
+          fixedItemSize,
+          defaultItemSize,
+          trackItemSizes,
+          itemSize,
+          data,
+          firstItemIndex,
+          groupIndices,
+          statefulTotalCount,
+          gap,
+          sizes
+        },
+        { initialTopMostItemIndex, scrolledToInitialItem, initialItemFinalLocationReached },
+        domIO,
+        stateLoad,
+        followOutput,
+        { listState, topItemsIndexes, ...flags },
+        { scrollToIndex },
+        _2,
+        { topItemCount },
+        { groupCounts },
+        featureGroup1
+      ]) => {
+        connect(flags.rangeChanged, featureGroup1.scrollSeekRangeChanged);
+        connect(
+          pipe(
+            featureGroup1.windowViewportRect,
+            map((value) => value.visibleHeight)
+          ),
+          domIO.viewportHeight
+        );
+        return {
+          // input
+          totalCount,
+          data,
+          firstItemIndex,
+          sizeRanges,
+          initialTopMostItemIndex,
+          scrolledToInitialItem,
+          initialItemFinalLocationReached,
+          topItemsIndexes,
+          topItemCount,
+          groupCounts,
+          fixedItemHeight: fixedItemSize,
+          defaultItemHeight: defaultItemSize,
+          gap,
+          ...followOutput,
+          // output
+          statefulTotalCount,
+          listState,
+          scrollToIndex,
+          trackItemSizes,
+          itemSize,
+          groupIndices,
+          // exported from stateFlagsSystem
+          ...flags,
+          // the bag of IO from featureGroup1System
+          ...featureGroup1,
+          ...domIO,
+          sizes,
+          ...stateLoad
+        };
+      },
+      tup(
+        sizeSystem,
+        initialTopMostItemIndexSystem,
+        domIOSystem,
+        stateLoadSystem,
+        followOutputSystem,
+        listStateSystem,
+        scrollToIndexSystem,
+        upwardScrollFixSystem,
+        topItemCountSystem,
+        groupedListSystem,
+        featureGroup1System
+      )
+    );
+    const WEBKIT_STICKY = "-webkit-sticky";
+    const STICKY = "sticky";
+    const positionStickyCssValue = simpleMemoize(() => {
+      if (typeof document === "undefined") {
+        return STICKY;
+      }
+      const node = document.createElement("div");
+      node.style.position = WEBKIT_STICKY;
+      return node.style.position === WEBKIT_STICKY ? WEBKIT_STICKY : STICKY;
+    });
+    function useWindowViewportRectRef(callback, customScrollParent, skipAnimationFrame) {
+      const viewportInfo = xn.useRef(null);
+      const calculateInfo = xn.useCallback(
+        (element) => {
+          if (element === null || !element.offsetParent) {
+            return;
+          }
+          const rect = element.getBoundingClientRect();
+          const visibleWidth = rect.width;
+          let visibleHeight, offsetTop;
+          if (customScrollParent) {
+            const customScrollParentRect = customScrollParent.getBoundingClientRect();
+            const deltaTop = rect.top - customScrollParentRect.top;
+            visibleHeight = customScrollParentRect.height - Math.max(0, deltaTop);
+            offsetTop = deltaTop + customScrollParent.scrollTop;
+          } else {
+            visibleHeight = window.innerHeight - Math.max(0, rect.top);
+            offsetTop = rect.top + window.pageYOffset;
+          }
+          viewportInfo.current = {
+            offsetTop,
+            visibleHeight,
+            visibleWidth
+          };
+          callback(viewportInfo.current);
+        },
+        [callback, customScrollParent]
+      );
+      const { callbackRef, ref } = useSizeWithElRef(calculateInfo, true, skipAnimationFrame);
+      const scrollAndResizeEventHandler = xn.useCallback(() => {
+        calculateInfo(ref.current);
+      }, [calculateInfo, ref]);
+      xn.useEffect(() => {
+        if (customScrollParent) {
+          customScrollParent.addEventListener("scroll", scrollAndResizeEventHandler);
+          const observer = new ResizeObserver(() => {
+            requestAnimationFrame(scrollAndResizeEventHandler);
+          });
+          observer.observe(customScrollParent);
+          return () => {
+            customScrollParent.removeEventListener("scroll", scrollAndResizeEventHandler);
+            observer.unobserve(customScrollParent);
+          };
+        } else {
+          window.addEventListener("scroll", scrollAndResizeEventHandler);
+          window.addEventListener("resize", scrollAndResizeEventHandler);
+          return () => {
+            window.removeEventListener("scroll", scrollAndResizeEventHandler);
+            window.removeEventListener("resize", scrollAndResizeEventHandler);
+          };
+        }
+      }, [scrollAndResizeEventHandler, customScrollParent]);
+      return callbackRef;
+    }
+    const VirtuosoMockContext = xn.createContext(void 0);
+    const VirtuosoGridMockContext = xn.createContext(void 0);
+    function identity(value) {
+      return value;
+    }
+    const listComponentPropsSystem = /* @__PURE__ */ system(() => {
+      const itemContent = statefulStream((index) => `Item ${index}`);
+      const context = statefulStream(null);
+      const groupContent = statefulStream((index) => `Group ${index}`);
+      const components = statefulStream({});
+      const computeItemKey = statefulStream(identity);
+      const HeaderFooterTag = statefulStream("div");
+      const scrollerRef = statefulStream(noop);
+      const distinctProp = (propName, defaultValue = null) => {
+        return statefulStreamFromEmitter(
+          pipe(
+            components,
+            map((components2) => components2[propName]),
+            distinctUntilChanged()
+          ),
+          defaultValue
+        );
+      };
+      return {
+        context,
+        itemContent,
+        groupContent,
+        components,
+        computeItemKey,
+        HeaderFooterTag,
+        scrollerRef,
+        FooterComponent: distinctProp("Footer"),
+        HeaderComponent: distinctProp("Header"),
+        TopItemListComponent: distinctProp("TopItemList"),
+        ListComponent: distinctProp("List", "div"),
+        ItemComponent: distinctProp("Item", "div"),
+        GroupComponent: distinctProp("Group", "div"),
+        ScrollerComponent: distinctProp("Scroller", "div"),
+        EmptyPlaceholder: distinctProp("EmptyPlaceholder"),
+        ScrollSeekPlaceholder: distinctProp("ScrollSeekPlaceholder")
+      };
+    });
+    const combinedSystem$2 = /* @__PURE__ */ system(([listSystem2, propsSystem]) => {
+      return { ...listSystem2, ...propsSystem };
+    }, tup(listSystem, listComponentPropsSystem));
+    const DefaultScrollSeekPlaceholder$1 = ({ height }) => /* @__PURE__ */ u("div", { style: { height } });
+    const GROUP_STYLE = { position: positionStickyCssValue(), zIndex: 1, overflowAnchor: "none" };
+    const ITEM_STYLE$1 = { overflowAnchor: "none" };
+    const HORIZONTAL_ITEM_STYLE = { ...ITEM_STYLE$1, display: "inline-block", height: "100%" };
+    const Items$1 = /* @__PURE__ */ xn.memo(function VirtuosoItems({ showTopList = false }) {
+      const listState = useEmitterValue$2("listState");
+      const sizeRanges = usePublisher$2("sizeRanges");
+      const useWindowScroll = useEmitterValue$2("useWindowScroll");
+      const customScrollParent = useEmitterValue$2("customScrollParent");
+      const windowScrollContainerStateCallback = usePublisher$2("windowScrollContainerState");
+      const _scrollContainerStateCallback = usePublisher$2("scrollContainerState");
+      const scrollContainerStateCallback = customScrollParent || useWindowScroll ? windowScrollContainerStateCallback : _scrollContainerStateCallback;
+      const itemContent = useEmitterValue$2("itemContent");
+      const context = useEmitterValue$2("context");
+      const groupContent = useEmitterValue$2("groupContent");
+      const trackItemSizes = useEmitterValue$2("trackItemSizes");
+      const itemSize = useEmitterValue$2("itemSize");
+      const log = useEmitterValue$2("log");
+      const listGap = usePublisher$2("gap");
+      const horizontalDirection = useEmitterValue$2("horizontalDirection");
+      const { callbackRef } = useChangedListContentsSizes(
+        sizeRanges,
+        itemSize,
+        trackItemSizes,
+        showTopList ? noop : scrollContainerStateCallback,
+        log,
+        listGap,
+        customScrollParent,
+        horizontalDirection,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const [deviation, setDeviation] = xn.useState(0);
+      useEmitter$2("deviation", (value) => {
+        if (deviation !== value) {
+          setDeviation(value);
+        }
+      });
+      const EmptyPlaceholder = useEmitterValue$2("EmptyPlaceholder");
+      const ScrollSeekPlaceholder = useEmitterValue$2("ScrollSeekPlaceholder") || DefaultScrollSeekPlaceholder$1;
+      const ListComponent = useEmitterValue$2("ListComponent");
+      const ItemComponent = useEmitterValue$2("ItemComponent");
+      const GroupComponent = useEmitterValue$2("GroupComponent");
+      const computeItemKey = useEmitterValue$2("computeItemKey");
+      const isSeeking = useEmitterValue$2("isSeeking");
+      const hasGroups2 = useEmitterValue$2("groupIndices").length > 0;
+      const alignToBottom = useEmitterValue$2("alignToBottom");
+      const initialItemFinalLocationReached = useEmitterValue$2("initialItemFinalLocationReached");
+      const containerStyle = showTopList ? {} : {
+        boxSizing: "border-box",
+        ...horizontalDirection ? {
+          whiteSpace: "nowrap",
+          display: "inline-block",
+          height: "100%",
+          paddingLeft: listState.offsetTop,
+          paddingRight: listState.offsetBottom,
+          marginLeft: deviation !== 0 ? deviation : alignToBottom ? "auto" : 0
+        } : {
+          marginTop: deviation !== 0 ? deviation : alignToBottom ? "auto" : 0,
+          paddingTop: listState.offsetTop,
+          paddingBottom: listState.offsetBottom
+        },
+        ...initialItemFinalLocationReached ? {} : { visibility: "hidden" }
+      };
+      if (!showTopList && listState.totalCount === 0 && EmptyPlaceholder) {
+        return /* @__PURE__ */ u(EmptyPlaceholder, { ...contextPropIfNotDomElement(EmptyPlaceholder, context) });
+      }
+      return /* @__PURE__ */ u(
+        ListComponent,
+        {
+          ...contextPropIfNotDomElement(ListComponent, context),
+          ref: callbackRef,
+          style: containerStyle,
+          "data-testid": showTopList ? "virtuoso-top-item-list" : "virtuoso-item-list",
+          children: (showTopList ? listState.topItems : listState.items).map((item) => {
+            const index = item.originalIndex;
+            const key2 = computeItemKey(index + listState.firstItemIndex, item.data, context);
+            if (isSeeking) {
+              return /* @__PURE__ */ g$2(
+                ScrollSeekPlaceholder,
+                {
+                  ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
+                  key: key2,
+                  index: item.index,
+                  height: item.size,
+                  type: item.type || "item",
+                  ...item.type === "group" ? {} : { groupIndex: item.groupIndex }
+                }
+              );
+            }
+            if (item.type === "group") {
+              return /* @__PURE__ */ g$2(
+                GroupComponent,
+                {
+                  ...contextPropIfNotDomElement(GroupComponent, context),
+                  key: key2,
+                  "data-index": index,
+                  "data-known-size": item.size,
+                  "data-item-index": item.index,
+                  style: GROUP_STYLE
+                },
+                groupContent(item.index, context)
+              );
+            } else {
+              return /* @__PURE__ */ g$2(
+                ItemComponent,
+                {
+                  ...contextPropIfNotDomElement(ItemComponent, context),
+                  ...itemPropIfNotDomElement(ItemComponent, item.data),
+                  key: key2,
+                  "data-index": index,
+                  "data-known-size": item.size,
+                  "data-item-index": item.index,
+                  "data-item-group-index": item.groupIndex,
+                  style: horizontalDirection ? HORIZONTAL_ITEM_STYLE : ITEM_STYLE$1
+                },
+                hasGroups2 ? itemContent(item.index, item.groupIndex, item.data, context) : itemContent(item.index, item.data, context)
+              );
+            }
+          })
+        }
+      );
+    });
+    const scrollerStyle = {
+      height: "100%",
+      outline: "none",
+      overflowY: "auto",
+      position: "relative",
+      WebkitOverflowScrolling: "touch"
+    };
+    const horizontalScrollerStyle = {
+      outline: "none",
+      overflowX: "auto",
+      position: "relative"
+    };
+    const viewportStyle = (alignToBottom) => ({
+      width: "100%",
+      height: "100%",
+      position: "absolute",
+      top: 0,
+      ...alignToBottom ? { display: "flex", flexDirection: "column" } : {}
+    });
+    const topItemListStyle = {
+      width: "100%",
+      position: positionStickyCssValue(),
+      top: 0,
+      zIndex: 1
+    };
+    function contextPropIfNotDomElement(element, context) {
+      if (typeof element === "string") {
+        return void 0;
+      }
+      return { context };
+    }
+    function itemPropIfNotDomElement(element, item) {
+      return { item: typeof element === "string" ? void 0 : item };
+    }
+    const Header$1 = /* @__PURE__ */ xn.memo(function VirtuosoHeader() {
+      const Header2 = useEmitterValue$2("HeaderComponent");
+      const headerHeight = usePublisher$2("headerHeight");
+      const HeaderFooterTag = useEmitterValue$2("HeaderFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => headerHeight(correctItemSize(el, "height")), [headerHeight]),
+        true,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const context = useEmitterValue$2("context");
+      return Header2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Header2, { ...contextPropIfNotDomElement(Header2, context) }) }) : null;
+    });
+    const Footer$1 = /* @__PURE__ */ xn.memo(function VirtuosoFooter() {
+      const Footer2 = useEmitterValue$2("FooterComponent");
+      const footerHeight = usePublisher$2("footerHeight");
+      const HeaderFooterTag = useEmitterValue$2("HeaderFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => footerHeight(correctItemSize(el, "height")), [footerHeight]),
+        true,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const context = useEmitterValue$2("context");
+      return Footer2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Footer2, { ...contextPropIfNotDomElement(Footer2, context) }) }) : null;
+    });
+    function buildScroller({ usePublisher: usePublisher2, useEmitter: useEmitter2, useEmitterValue: useEmitterValue2 }) {
+      const Scroller2 = xn.memo(function VirtuosoScroller({ style: style2, children: children2, ...props }) {
+        const scrollContainerStateCallback = usePublisher2("scrollContainerState");
+        const ScrollerComponent = useEmitterValue2("ScrollerComponent");
+        const smoothScrollTargetReached = usePublisher2("smoothScrollTargetReached");
+        const scrollerRefCallback = useEmitterValue2("scrollerRef");
+        const context = useEmitterValue2("context");
+        const horizontalDirection = useEmitterValue2("horizontalDirection") || false;
+        const { scrollerRef, scrollByCallback, scrollToCallback } = useScrollTop(
+          scrollContainerStateCallback,
+          smoothScrollTargetReached,
+          ScrollerComponent,
+          scrollerRefCallback,
+          void 0,
+          horizontalDirection
+        );
+        useEmitter2("scrollTo", scrollToCallback);
+        useEmitter2("scrollBy", scrollByCallback);
+        const defaultStyle = horizontalDirection ? horizontalScrollerStyle : scrollerStyle;
+        return /* @__PURE__ */ u(
+          ScrollerComponent,
+          {
+            ref: scrollerRef,
+            style: { ...defaultStyle, ...style2 },
+            "data-testid": "virtuoso-scroller",
+            "data-virtuoso-scroller": true,
+            tabIndex: 0,
+            ...props,
+            ...contextPropIfNotDomElement(ScrollerComponent, context),
+            children: children2
+          }
+        );
+      });
+      return Scroller2;
+    }
+    function buildWindowScroller({ usePublisher: usePublisher2, useEmitter: useEmitter2, useEmitterValue: useEmitterValue2 }) {
+      const Scroller2 = xn.memo(function VirtuosoWindowScroller({ style: style2, children: children2, ...props }) {
+        const scrollContainerStateCallback = usePublisher2("windowScrollContainerState");
+        const ScrollerComponent = useEmitterValue2("ScrollerComponent");
+        const smoothScrollTargetReached = usePublisher2("smoothScrollTargetReached");
+        const totalListHeight = useEmitterValue2("totalListHeight");
+        const deviation = useEmitterValue2("deviation");
+        const customScrollParent = useEmitterValue2("customScrollParent");
+        const context = useEmitterValue2("context");
+        const { scrollerRef, scrollByCallback, scrollToCallback } = useScrollTop(
+          scrollContainerStateCallback,
+          smoothScrollTargetReached,
+          ScrollerComponent,
+          noop,
+          customScrollParent
+        );
+        useIsomorphicLayoutEffect(() => {
+          scrollerRef.current = customScrollParent ? customScrollParent : window;
+          return () => {
+            scrollerRef.current = null;
+          };
+        }, [scrollerRef, customScrollParent]);
+        useEmitter2("windowScrollTo", scrollToCallback);
+        useEmitter2("scrollBy", scrollByCallback);
+        return /* @__PURE__ */ u(
+          ScrollerComponent,
+          {
+            style: { position: "relative", ...style2, ...totalListHeight !== 0 ? { height: totalListHeight + deviation } : {} },
+            "data-virtuoso-scroller": true,
+            ...props,
+            ...contextPropIfNotDomElement(ScrollerComponent, context),
+            children: children2
+          }
+        );
+      });
+      return Scroller2;
+    }
+    const Viewport$2 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoMockContext);
+      const viewportHeight = usePublisher$2("viewportHeight");
+      const fixedItemHeight = usePublisher$2("fixedItemHeight");
+      const alignToBottom = useEmitterValue$2("alignToBottom");
+      const horizontalDirection = useEmitterValue$2("horizontalDirection");
+      const viewportSizeCallbackMemo = xn.useMemo(
+        () => compose(viewportHeight, (el) => correctItemSize(el, horizontalDirection ? "width" : "height")),
+        [viewportHeight, horizontalDirection]
+      );
+      const viewportRef = useSize(viewportSizeCallbackMemo, true, useEmitterValue$2("skipAnimationFrameInResizeObserver"));
+      xn.useEffect(() => {
+        if (ctx) {
+          viewportHeight(ctx.viewportHeight);
+          fixedItemHeight(ctx.itemHeight);
+        }
+      }, [ctx, viewportHeight, fixedItemHeight]);
+      return /* @__PURE__ */ u("div", { style: viewportStyle(alignToBottom), ref: viewportRef, "data-viewport-type": "element", children: children2 });
+    };
+    const WindowViewport$2 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoMockContext);
+      const windowViewportRect = usePublisher$2("windowViewportRect");
+      const fixedItemHeight = usePublisher$2("fixedItemHeight");
+      const customScrollParent = useEmitterValue$2("customScrollParent");
+      const viewportRef = useWindowViewportRectRef(
+        windowViewportRect,
+        customScrollParent,
+        useEmitterValue$2("skipAnimationFrameInResizeObserver")
+      );
+      const alignToBottom = useEmitterValue$2("alignToBottom");
+      xn.useEffect(() => {
+        if (ctx) {
+          fixedItemHeight(ctx.itemHeight);
+          windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: 100 });
+        }
+      }, [ctx, windowViewportRect, fixedItemHeight]);
+      return /* @__PURE__ */ u("div", { ref: viewportRef, style: viewportStyle(alignToBottom), "data-viewport-type": "window", children: children2 });
+    };
+    const TopItemListContainer = ({ children: children2 }) => {
+      const TopItemList = useEmitterValue$2("TopItemListComponent") || "div";
+      const headerHeight = useEmitterValue$2("headerHeight");
+      const style2 = { ...topItemListStyle, marginTop: `${headerHeight}px` };
+      const context = useEmitterValue$2("context");
+      return /* @__PURE__ */ u(TopItemList, { style: style2, ...contextPropIfNotDomElement(TopItemList, context), children: children2 });
+    };
+    const ListRoot = /* @__PURE__ */ xn.memo(function VirtuosoRoot(props) {
+      const useWindowScroll = useEmitterValue$2("useWindowScroll");
+      const showTopList = useEmitterValue$2("topItemsIndexes").length > 0;
+      const customScrollParent = useEmitterValue$2("customScrollParent");
+      const TheScroller = customScrollParent || useWindowScroll ? WindowScroller$2 : Scroller$2;
+      const TheViewport = customScrollParent || useWindowScroll ? WindowViewport$2 : Viewport$2;
+      return /* @__PURE__ */ u(TheScroller, { ...props, children: [
+        showTopList && /* @__PURE__ */ u(TopItemListContainer, { children: /* @__PURE__ */ u(Items$1, { showTopList: true }) }),
+        /* @__PURE__ */ u(TheViewport, { children: [
+          /* @__PURE__ */ u(Header$1, {}),
+          /* @__PURE__ */ u(Items$1, {}),
+          /* @__PURE__ */ u(Footer$1, {})
+        ] })
+      ] });
+    });
+    const {
+      Component: List,
+      usePublisher: usePublisher$2,
+      useEmitterValue: useEmitterValue$2,
+      useEmitter: useEmitter$2
+    } = /* @__PURE__ */ systemToComponent(
+      combinedSystem$2,
+      {
+        required: {},
+        optional: {
+          restoreStateFrom: "restoreStateFrom",
+          context: "context",
+          followOutput: "followOutput",
+          itemContent: "itemContent",
+          groupContent: "groupContent",
+          overscan: "overscan",
+          increaseViewportBy: "increaseViewportBy",
+          totalCount: "totalCount",
+          groupCounts: "groupCounts",
+          topItemCount: "topItemCount",
+          firstItemIndex: "firstItemIndex",
+          initialTopMostItemIndex: "initialTopMostItemIndex",
+          components: "components",
+          atBottomThreshold: "atBottomThreshold",
+          atTopThreshold: "atTopThreshold",
+          computeItemKey: "computeItemKey",
+          defaultItemHeight: "defaultItemHeight",
+          fixedItemHeight: "fixedItemHeight",
+          itemSize: "itemSize",
+          scrollSeekConfiguration: "scrollSeekConfiguration",
+          headerFooterTag: "HeaderFooterTag",
+          data: "data",
+          initialItemCount: "initialItemCount",
+          initialScrollTop: "initialScrollTop",
+          alignToBottom: "alignToBottom",
+          useWindowScroll: "useWindowScroll",
+          customScrollParent: "customScrollParent",
+          scrollerRef: "scrollerRef",
+          logLevel: "logLevel",
+          horizontalDirection: "horizontalDirection",
+          skipAnimationFrameInResizeObserver: "skipAnimationFrameInResizeObserver"
+        },
+        methods: {
+          scrollToIndex: "scrollToIndex",
+          scrollIntoView: "scrollIntoView",
+          scrollTo: "scrollTo",
+          scrollBy: "scrollBy",
+          autoscrollToBottom: "autoscrollToBottom",
+          getState: "getState"
+        },
+        events: {
+          isScrolling: "isScrolling",
+          endReached: "endReached",
+          startReached: "startReached",
+          rangeChanged: "rangeChanged",
+          atBottomStateChange: "atBottomStateChange",
+          atTopStateChange: "atTopStateChange",
+          totalListHeightChanged: "totalListHeightChanged",
+          itemsRendered: "itemsRendered",
+          groupIndices: "groupIndices"
+        }
+      },
+      ListRoot
+    );
+    const Scroller$2 = /* @__PURE__ */ buildScroller({ usePublisher: usePublisher$2, useEmitterValue: useEmitterValue$2, useEmitter: useEmitter$2 });
+    const WindowScroller$2 = /* @__PURE__ */ buildWindowScroller({ usePublisher: usePublisher$2, useEmitterValue: useEmitterValue$2, useEmitter: useEmitter$2 });
+    const Virtuoso = List;
+    const INITIAL_GRID_STATE = {
+      items: [],
+      offsetBottom: 0,
+      offsetTop: 0,
+      top: 0,
+      bottom: 0,
+      itemHeight: 0,
+      itemWidth: 0
+    };
+    const PROBE_GRID_STATE = {
+      items: [{ index: 0 }],
+      offsetBottom: 0,
+      offsetTop: 0,
+      top: 0,
+      bottom: 0,
+      itemHeight: 0,
+      itemWidth: 0
+    };
+    const { round, ceil, floor, min, max: max$1 } = Math;
+    function buildProbeGridState(items) {
+      return {
+        ...PROBE_GRID_STATE,
+        items
+      };
+    }
+    function buildItems(startIndex, endIndex, data) {
+      return Array.from({ length: endIndex - startIndex + 1 }).map((_2, i2) => {
+        const dataItem = data === null ? null : data[i2 + startIndex];
+        return { index: i2 + startIndex, data: dataItem };
+      });
+    }
+    function gapComparator(prev, next) {
+      return prev && prev.column === next.column && prev.row === next.row;
+    }
+    function dimensionComparator(prev, next) {
+      return prev && prev.width === next.width && prev.height === next.height;
+    }
+    const gridSystem = /* @__PURE__ */ system(
+      ([
+        { overscan, visibleRange, listBoundary, increaseViewportBy },
+        { scrollTop, viewportHeight, scrollBy, scrollTo, smoothScrollTargetReached, scrollContainerState, footerHeight, headerHeight },
+        stateFlags,
+        scrollSeek,
+        { propsReady, didMount },
+        { windowViewportRect, useWindowScroll, customScrollParent, windowScrollContainerState, windowScrollTo },
+        log
+      ]) => {
+        const totalCount = statefulStream(0);
+        const initialItemCount = statefulStream(0);
+        const gridState = statefulStream(INITIAL_GRID_STATE);
+        const viewportDimensions = statefulStream({ height: 0, width: 0 });
+        const itemDimensions = statefulStream({ height: 0, width: 0 });
+        const scrollToIndex = stream();
+        const scrollHeight = stream();
+        const deviation = statefulStream(0);
+        const data = statefulStream(null);
+        const gap = statefulStream({ row: 0, column: 0 });
+        const stateChanged = stream();
+        const restoreStateFrom = stream();
+        const stateRestoreInProgress = statefulStream(false);
+        const initialTopMostItemIndex = statefulStream(0);
+        const scrolledToInitialItem = statefulStream(true);
+        const scrollScheduled = statefulStream(false);
+        const horizontalDirection = statefulStream(false);
+        subscribe(
+          pipe(
+            didMount,
+            withLatestFrom(initialTopMostItemIndex),
+            filter(([_2, location]) => !!location)
+          ),
+          () => {
+            publish(scrolledToInitialItem, false);
+          }
+        );
+        subscribe(
+          pipe(
+            combineLatest(didMount, scrolledToInitialItem, itemDimensions, viewportDimensions, initialTopMostItemIndex, scrollScheduled),
+            filter(([didMount2, scrolledToInitialItem2, itemDimensions2, viewportDimensions2, , scrollScheduled2]) => {
+              return didMount2 && !scrolledToInitialItem2 && itemDimensions2.height !== 0 && viewportDimensions2.height !== 0 && !scrollScheduled2;
+            })
+          ),
+          ([, , , , initialTopMostItemIndex2]) => {
+            publish(scrollScheduled, true);
+            skipFrames(1, () => {
+              publish(scrollToIndex, initialTopMostItemIndex2);
+            });
+            handleNext(pipe(scrollTop), () => {
+              publish(listBoundary, [0, 0]);
+              publish(scrolledToInitialItem, true);
+            });
+          }
+        );
+        connect(
+          pipe(
+            restoreStateFrom,
+            filter((value) => value !== void 0 && value !== null && value.scrollTop > 0),
+            mapTo(0)
+          ),
+          initialItemCount
+        );
+        subscribe(
+          pipe(
+            didMount,
+            withLatestFrom(restoreStateFrom),
+            filter(([, snapshot]) => snapshot !== void 0 && snapshot !== null)
+          ),
+          ([, snapshot]) => {
+            if (!snapshot) {
+              return;
+            }
+            publish(viewportDimensions, snapshot.viewport), publish(itemDimensions, snapshot == null ? void 0 : snapshot.item);
+            publish(gap, snapshot.gap);
+            if (snapshot.scrollTop > 0) {
+              publish(stateRestoreInProgress, true);
+              handleNext(pipe(scrollTop, skip(1)), (_value) => {
+                publish(stateRestoreInProgress, false);
+              });
+              publish(scrollTo, { top: snapshot.scrollTop });
+            }
+          }
+        );
+        connect(
+          pipe(
+            viewportDimensions,
+            map(({ height }) => height)
+          ),
+          viewportHeight
+        );
+        connect(
+          pipe(
+            combineLatest(
+              duc(viewportDimensions, dimensionComparator),
+              duc(itemDimensions, dimensionComparator),
+              duc(gap, (prev, next) => prev && prev.column === next.column && prev.row === next.row),
+              duc(scrollTop)
+            ),
+            map(([viewport2, item, gap2, scrollTop2]) => ({
+              viewport: viewport2,
+              item,
+              gap: gap2,
+              scrollTop: scrollTop2
+            }))
+          ),
+          stateChanged
+        );
+        connect(
+          pipe(
+            combineLatest(
+              duc(totalCount),
+              visibleRange,
+              duc(gap, gapComparator),
+              duc(itemDimensions, dimensionComparator),
+              duc(viewportDimensions, dimensionComparator),
+              duc(data),
+              duc(initialItemCount),
+              duc(stateRestoreInProgress),
+              duc(scrolledToInitialItem),
+              duc(initialTopMostItemIndex)
+            ),
+            filter(([, , , , , , , stateRestoreInProgress2]) => {
+              return !stateRestoreInProgress2;
+            }),
+            map(
+              ([
+                totalCount2,
+                [startOffset, endOffset],
+                gap2,
+                item,
+                viewport2,
+                data2,
+                initialItemCount2,
+                ,
+                scrolledToInitialItem2,
+                initialTopMostItemIndex2
+              ]) => {
+                const { row: rowGap, column: columnGap } = gap2;
+                const { height: itemHeight, width: itemWidth } = item;
+                const { width: viewportWidth } = viewport2;
+                if (initialItemCount2 === 0 && (totalCount2 === 0 || viewportWidth === 0)) {
+                  return INITIAL_GRID_STATE;
+                }
+                if (itemWidth === 0) {
+                  const startIndex2 = getInitialTopMostItemIndexNumber(initialTopMostItemIndex2, totalCount2);
+                  const endIndex2 = startIndex2 + Math.max(initialItemCount2 - 1, 0);
+                  return buildProbeGridState(buildItems(startIndex2, endIndex2, data2));
+                }
+                const perRow = itemsPerRow(viewportWidth, itemWidth, columnGap);
+                let startIndex;
+                let endIndex;
+                if (!scrolledToInitialItem2) {
+                  startIndex = 0;
+                  endIndex = -1;
+                } else if (startOffset === 0 && endOffset === 0 && initialItemCount2 > 0) {
+                  startIndex = 0;
+                  endIndex = initialItemCount2 - 1;
+                } else {
+                  startIndex = perRow * floor((startOffset + rowGap) / (itemHeight + rowGap));
+                  endIndex = perRow * ceil((endOffset + rowGap) / (itemHeight + rowGap)) - 1;
+                  endIndex = min(totalCount2 - 1, max$1(endIndex, perRow - 1));
+                  startIndex = min(endIndex, max$1(0, startIndex));
+                }
+                const items = buildItems(startIndex, endIndex, data2);
+                const { top: top2, bottom: bottom2 } = gridLayout(viewport2, gap2, item, items);
+                const rowCount = ceil(totalCount2 / perRow);
+                const totalHeight = rowCount * itemHeight + (rowCount - 1) * rowGap;
+                const offsetBottom = totalHeight - bottom2;
+                return { items, offsetTop: top2, offsetBottom, top: top2, bottom: bottom2, itemHeight, itemWidth };
+              }
+            )
+          ),
+          gridState
+        );
+        connect(
+          pipe(
+            data,
+            filter((data2) => data2 !== null),
+            map((data2) => data2.length)
+          ),
+          totalCount
+        );
+        connect(
+          pipe(
+            combineLatest(viewportDimensions, itemDimensions, gridState, gap),
+            filter(([viewportDimensions2, itemDimensions2, { items }]) => {
+              return items.length > 0 && itemDimensions2.height !== 0 && viewportDimensions2.height !== 0;
+            }),
+            map(([viewportDimensions2, itemDimensions2, { items }, gap2]) => {
+              const { top: top2, bottom: bottom2 } = gridLayout(viewportDimensions2, gap2, itemDimensions2, items);
+              return [top2, bottom2];
+            }),
+            distinctUntilChanged(tupleComparator)
+          ),
+          listBoundary
+        );
+        const hasScrolled = statefulStream(false);
+        connect(
+          pipe(
+            scrollTop,
+            withLatestFrom(hasScrolled),
+            map(([scrollTop2, hasScrolled2]) => {
+              return hasScrolled2 || scrollTop2 !== 0;
+            })
+          ),
+          hasScrolled
+        );
+        const endReached = streamFromEmitter(
+          pipe(
+            combineLatest(gridState, totalCount),
+            filter(([{ items }]) => items.length > 0),
+            withLatestFrom(hasScrolled),
+            filter(([[gridState2, totalCount2], hasScrolled2]) => {
+              const lastIndex = gridState2.items[gridState2.items.length - 1].index;
+              const isLastItemRendered = lastIndex === totalCount2 - 1;
+              if (hasScrolled2) return isLastItemRendered;
+              const isFullyRendered = gridState2.bottom > 0 && gridState2.itemHeight > 0 && gridState2.offsetBottom === 0 && gridState2.items.length === totalCount2;
+              return isFullyRendered && isLastItemRendered;
+            }),
+            map(([[, totalCount2]]) => {
+              return totalCount2 - 1;
+            }),
+            distinctUntilChanged()
+          )
+        );
+        const startReached = streamFromEmitter(
+          pipe(
+            duc(gridState),
+            filter(({ items }) => {
+              return items.length > 0 && items[0].index === 0;
+            }),
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            mapTo(0),
+            distinctUntilChanged()
+          )
+        );
+        const rangeChanged = streamFromEmitter(
+          pipe(
+            duc(gridState),
+            withLatestFrom(stateRestoreInProgress),
+            filter(([{ items }, stateRestoreInProgress2]) => items.length > 0 && !stateRestoreInProgress2),
+            map(([{ items }]) => {
+              return {
+                startIndex: items[0].index,
+                endIndex: items[items.length - 1].index
+              };
+            }),
+            distinctUntilChanged(rangeComparator),
+            throttleTime(0)
+          )
+        );
+        connect(rangeChanged, scrollSeek.scrollSeekRangeChanged);
+        connect(
+          pipe(
+            scrollToIndex,
+            withLatestFrom(viewportDimensions, itemDimensions, totalCount, gap),
+            map(([location, viewportDimensions2, itemDimensions2, totalCount2, gap2]) => {
+              const normalLocation = normalizeIndexLocation(location);
+              const { align, behavior, offset: offset2 } = normalLocation;
+              let index = normalLocation.index;
+              if (index === "LAST") {
+                index = totalCount2 - 1;
+              }
+              index = max$1(0, index, min(totalCount2 - 1, index));
+              let top2 = itemTop(viewportDimensions2, gap2, itemDimensions2, index);
+              if (align === "end") {
+                top2 = round(top2 - viewportDimensions2.height + itemDimensions2.height);
+              } else if (align === "center") {
+                top2 = round(top2 - viewportDimensions2.height / 2 + itemDimensions2.height / 2);
+              }
+              if (offset2) {
+                top2 += offset2;
+              }
+              return { top: top2, behavior };
+            })
+          ),
+          scrollTo
+        );
+        const totalListHeight = statefulStreamFromEmitter(
+          pipe(
+            gridState,
+            map((gridState2) => {
+              return gridState2.offsetBottom + gridState2.bottom;
+            })
+          ),
+          0
+        );
+        connect(
+          pipe(
+            windowViewportRect,
+            map((viewportInfo) => ({ width: viewportInfo.visibleWidth, height: viewportInfo.visibleHeight }))
+          ),
+          viewportDimensions
+        );
+        return {
+          // input
+          data,
+          totalCount,
+          viewportDimensions,
+          itemDimensions,
+          scrollTop,
+          scrollHeight,
+          overscan,
+          increaseViewportBy,
+          scrollBy,
+          scrollTo,
+          scrollToIndex,
+          smoothScrollTargetReached,
+          windowViewportRect,
+          windowScrollTo,
+          useWindowScroll,
+          customScrollParent,
+          windowScrollContainerState,
+          deviation,
+          scrollContainerState,
+          footerHeight,
+          headerHeight,
+          initialItemCount,
+          gap,
+          restoreStateFrom,
+          ...scrollSeek,
+          initialTopMostItemIndex,
+          horizontalDirection,
+          // output
+          gridState,
+          totalListHeight,
+          ...stateFlags,
+          startReached,
+          endReached,
+          rangeChanged,
+          stateChanged,
+          propsReady,
+          stateRestoreInProgress,
+          ...log
+        };
+      },
+      tup(sizeRangeSystem, domIOSystem, stateFlagsSystem, scrollSeekSystem, propsReadySystem, windowScrollerSystem, loggerSystem)
+    );
+    function gridLayout(viewport2, gap, item, items) {
+      const { height: itemHeight } = item;
+      if (itemHeight === void 0 || items.length === 0) {
+        return { top: 0, bottom: 0 };
+      }
+      const top2 = itemTop(viewport2, gap, item, items[0].index);
+      const bottom2 = itemTop(viewport2, gap, item, items[items.length - 1].index) + itemHeight;
+      return { top: top2, bottom: bottom2 };
+    }
+    function itemTop(viewport2, gap, item, index) {
+      const perRow = itemsPerRow(viewport2.width, item.width, gap.column);
+      const rowCount = floor(index / perRow);
+      const top2 = rowCount * item.height + max$1(0, rowCount - 1) * gap.row;
+      return top2 > 0 ? top2 + gap.row : top2;
+    }
+    function itemsPerRow(viewportWidth, itemWidth, gap) {
+      return max$1(1, floor((viewportWidth + gap) / (floor(itemWidth) + gap)));
+    }
+    const gridComponentPropsSystem = /* @__PURE__ */ system(() => {
+      const itemContent = statefulStream((index) => `Item ${index}`);
+      const components = statefulStream({});
+      const context = statefulStream(null);
+      const itemClassName = statefulStream("virtuoso-grid-item");
+      const listClassName = statefulStream("virtuoso-grid-list");
+      const computeItemKey = statefulStream(identity);
+      const headerFooterTag = statefulStream("div");
+      const scrollerRef = statefulStream(noop);
+      const distinctProp = (propName, defaultValue = null) => {
+        return statefulStreamFromEmitter(
+          pipe(
+            components,
+            map((components2) => components2[propName]),
+            distinctUntilChanged()
+          ),
+          defaultValue
+        );
+      };
+      const readyStateChanged = statefulStream(false);
+      const reportReadyState = statefulStream(false);
+      connect(duc(reportReadyState), readyStateChanged);
+      return {
+        readyStateChanged,
+        reportReadyState,
+        context,
+        itemContent,
+        components,
+        computeItemKey,
+        itemClassName,
+        listClassName,
+        headerFooterTag,
+        scrollerRef,
+        FooterComponent: distinctProp("Footer"),
+        HeaderComponent: distinctProp("Header"),
+        ListComponent: distinctProp("List", "div"),
+        ItemComponent: distinctProp("Item", "div"),
+        ScrollerComponent: distinctProp("Scroller", "div"),
+        ScrollSeekPlaceholder: distinctProp("ScrollSeekPlaceholder", "div")
+      };
+    });
+    const combinedSystem$1 = /* @__PURE__ */ system(([gridSystem2, gridComponentPropsSystem2]) => {
+      return { ...gridSystem2, ...gridComponentPropsSystem2 };
+    }, tup(gridSystem, gridComponentPropsSystem));
+    const GridItems = /* @__PURE__ */ xn.memo(function GridItems2() {
+      const gridState = useEmitterValue$1("gridState");
+      const listClassName = useEmitterValue$1("listClassName");
+      const itemClassName = useEmitterValue$1("itemClassName");
+      const itemContent = useEmitterValue$1("itemContent");
+      const computeItemKey = useEmitterValue$1("computeItemKey");
+      const isSeeking = useEmitterValue$1("isSeeking");
+      const scrollHeightCallback = usePublisher$1("scrollHeight");
+      const ItemComponent = useEmitterValue$1("ItemComponent");
+      const ListComponent = useEmitterValue$1("ListComponent");
+      const ScrollSeekPlaceholder = useEmitterValue$1("ScrollSeekPlaceholder");
+      const context = useEmitterValue$1("context");
+      const itemDimensions = usePublisher$1("itemDimensions");
+      const gridGap = usePublisher$1("gap");
+      const log = useEmitterValue$1("log");
+      const stateRestoreInProgress = useEmitterValue$1("stateRestoreInProgress");
+      const reportReadyState = usePublisher$1("reportReadyState");
+      const listRef = useSize(
+        xn.useMemo(
+          () => (el) => {
+            const scrollHeight = el.parentElement.parentElement.scrollHeight;
+            scrollHeightCallback(scrollHeight);
+            const firstItem = el.firstChild;
+            if (firstItem) {
+              const { width, height } = firstItem.getBoundingClientRect();
+              itemDimensions({ width, height });
+            }
+            gridGap({
+              row: resolveGapValue("row-gap", getComputedStyle(el).rowGap, log),
+              column: resolveGapValue("column-gap", getComputedStyle(el).columnGap, log)
+            });
+          },
+          [scrollHeightCallback, itemDimensions, gridGap, log]
+        ),
+        true,
+        false
+      );
+      useIsomorphicLayoutEffect(() => {
+        if (gridState.itemHeight > 0 && gridState.itemWidth > 0) {
+          reportReadyState(true);
+        }
+      }, [gridState]);
+      if (stateRestoreInProgress) {
+        return null;
+      }
+      return /* @__PURE__ */ u(
+        ListComponent,
+        {
+          ref: listRef,
+          className: listClassName,
+          ...contextPropIfNotDomElement(ListComponent, context),
+          style: { paddingTop: gridState.offsetTop, paddingBottom: gridState.offsetBottom },
+          "data-testid": "virtuoso-item-list",
+          children: gridState.items.map((item) => {
+            const key2 = computeItemKey(item.index, item.data, context);
+            return isSeeking ? /* @__PURE__ */ u(
+              ScrollSeekPlaceholder,
+              {
+                ...contextPropIfNotDomElement(ScrollSeekPlaceholder, context),
+                index: item.index,
+                height: gridState.itemHeight,
+                width: gridState.itemWidth
+              },
+              key2
+            ) : /* @__PURE__ */ g$2(
+              ItemComponent,
+              {
+                ...contextPropIfNotDomElement(ItemComponent, context),
+                className: itemClassName,
+                "data-index": item.index,
+                key: key2
+              },
+              itemContent(item.index, item.data, context)
+            );
+          })
+        }
+      );
+    });
+    const Header = xn.memo(function VirtuosoHeader2() {
+      const Header2 = useEmitterValue$1("HeaderComponent");
+      const headerHeight = usePublisher$1("headerHeight");
+      const HeaderFooterTag = useEmitterValue$1("headerFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => headerHeight(correctItemSize(el, "height")), [headerHeight]),
+        true,
+        false
+      );
+      const context = useEmitterValue$1("context");
+      return Header2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Header2, { ...contextPropIfNotDomElement(Header2, context) }) }) : null;
+    });
+    const Footer = xn.memo(function VirtuosoGridFooter() {
+      const Footer2 = useEmitterValue$1("FooterComponent");
+      const footerHeight = usePublisher$1("footerHeight");
+      const HeaderFooterTag = useEmitterValue$1("headerFooterTag");
+      const ref = useSize(
+        xn.useMemo(() => (el) => footerHeight(correctItemSize(el, "height")), [footerHeight]),
+        true,
+        false
+      );
+      const context = useEmitterValue$1("context");
+      return Footer2 ? /* @__PURE__ */ u(HeaderFooterTag, { ref, children: /* @__PURE__ */ u(Footer2, { ...contextPropIfNotDomElement(Footer2, context) }) }) : null;
+    });
+    const Viewport$1 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoGridMockContext);
+      const itemDimensions = usePublisher$1("itemDimensions");
+      const viewportDimensions = usePublisher$1("viewportDimensions");
+      const viewportRef = useSize(
+        xn.useMemo(
+          () => (el) => {
+            viewportDimensions(el.getBoundingClientRect());
+          },
+          [viewportDimensions]
+        ),
+        true,
+        false
+      );
+      xn.useEffect(() => {
+        if (ctx) {
+          viewportDimensions({ height: ctx.viewportHeight, width: ctx.viewportWidth });
+          itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth });
+        }
+      }, [ctx, viewportDimensions, itemDimensions]);
+      return /* @__PURE__ */ u("div", { style: viewportStyle(false), ref: viewportRef, children: children2 });
+    };
+    const WindowViewport$1 = ({ children: children2 }) => {
+      const ctx = xn.useContext(VirtuosoGridMockContext);
+      const windowViewportRect = usePublisher$1("windowViewportRect");
+      const itemDimensions = usePublisher$1("itemDimensions");
+      const customScrollParent = useEmitterValue$1("customScrollParent");
+      const viewportRef = useWindowViewportRectRef(windowViewportRect, customScrollParent, false);
+      xn.useEffect(() => {
+        if (ctx) {
+          itemDimensions({ height: ctx.itemHeight, width: ctx.itemWidth });
+          windowViewportRect({ offsetTop: 0, visibleHeight: ctx.viewportHeight, visibleWidth: ctx.viewportWidth });
+        }
+      }, [ctx, windowViewportRect, itemDimensions]);
+      return /* @__PURE__ */ u("div", { ref: viewportRef, style: viewportStyle(false), children: children2 });
+    };
+    const GridRoot = /* @__PURE__ */ xn.memo(function GridRoot2({ ...props }) {
+      const useWindowScroll = useEmitterValue$1("useWindowScroll");
+      const customScrollParent = useEmitterValue$1("customScrollParent");
+      const TheScroller = customScrollParent || useWindowScroll ? WindowScroller$1 : Scroller$1;
+      const TheViewport = customScrollParent || useWindowScroll ? WindowViewport$1 : Viewport$1;
+      return /* @__PURE__ */ u(TheScroller, { ...props, children: /* @__PURE__ */ u(TheViewport, { children: [
+        /* @__PURE__ */ u(Header, {}),
+        /* @__PURE__ */ u(GridItems, {}),
+        /* @__PURE__ */ u(Footer, {})
+      ] }) });
+    });
+    const {
+      Component: Grid,
+      usePublisher: usePublisher$1,
+      useEmitterValue: useEmitterValue$1,
+      useEmitter: useEmitter$1
+    } = /* @__PURE__ */ systemToComponent(
+      combinedSystem$1,
+      {
+        optional: {
+          context: "context",
+          totalCount: "totalCount",
+          overscan: "overscan",
+          itemContent: "itemContent",
+          components: "components",
+          computeItemKey: "computeItemKey",
+          data: "data",
+          initialItemCount: "initialItemCount",
+          scrollSeekConfiguration: "scrollSeekConfiguration",
+          headerFooterTag: "headerFooterTag",
+          listClassName: "listClassName",
+          itemClassName: "itemClassName",
+          useWindowScroll: "useWindowScroll",
+          customScrollParent: "customScrollParent",
+          scrollerRef: "scrollerRef",
+          logLevel: "logLevel",
+          restoreStateFrom: "restoreStateFrom",
+          initialTopMostItemIndex: "initialTopMostItemIndex",
+          increaseViewportBy: "increaseViewportBy"
+        },
+        methods: {
+          scrollTo: "scrollTo",
+          scrollBy: "scrollBy",
+          scrollToIndex: "scrollToIndex"
+        },
+        events: {
+          isScrolling: "isScrolling",
+          endReached: "endReached",
+          startReached: "startReached",
+          rangeChanged: "rangeChanged",
+          atBottomStateChange: "atBottomStateChange",
+          atTopStateChange: "atTopStateChange",
+          stateChanged: "stateChanged",
+          readyStateChanged: "readyStateChanged"
+        }
+      },
+      GridRoot
+    );
+    const Scroller$1 = /* @__PURE__ */ buildScroller({ usePublisher: usePublisher$1, useEmitterValue: useEmitterValue$1, useEmitter: useEmitter$1 });
+    const WindowScroller$1 = /* @__PURE__ */ buildWindowScroller({ usePublisher: usePublisher$1, useEmitterValue: useEmitterValue$1, useEmitter: useEmitter$1 });
+    function resolveGapValue(property, value, log) {
+      if (value !== "normal" && !(value == null ? void 0 : value.endsWith("px"))) {
+        log(`${property} was not resolved to pixel value correctly`, value, LogLevel.WARN);
+      }
+      if (value === "normal") {
+        return 0;
+      }
+      return parseInt(value != null ? value : "0", 10);
+    }
+    const TranscriptView = ({ id: id2, events, depth = 0 }) => {
       const resolvedEvents = fixupEventStream(events);
       const eventNodes = treeifyEvents(resolvedEvents, depth);
-      return m$1` <${TranscriptComponent} id=${id} eventNodes=${eventNodes} /> `;
+      return m$1` <${TranscriptComponent} id=${id2} eventNodes=${eventNodes} /> `;
     };
-    const TranscriptComponent = ({ id, eventNodes, style: style2 }) => {
+    const TranscriptVirtualList = ({ id: id2, scrollRef, events, depth, style: style2 }) => {
+      const resolvedEvents = fixupEventStream(events);
+      const eventNodes = treeifyEvents(resolvedEvents, depth);
+      const count = eventNodes ? eventNodes.length : 0;
+      return m$1`<${Virtuoso}
+      id=${`${id2}-virtual-list`}
+      style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
+      customScrollParent=${scrollRef.current}
+      totalCount=${count}
+      overscan=${{
+        reverse: 3,
+        main: 2
+      }}
+      itemContent=${(index) => {
+        const node = eventNodes[index];
+        const toggleStyle = {};
+        if (node.depth % 2 == 0) {
+          toggleStyle.backgroundColor = "var(--bs-light-bg-subtle)";
+        } else {
+          toggleStyle.backgroundColor = "var(--bs-body-bg)";
+        }
+        let paddingTop = "0";
+        if (index === 0) {
+          paddingTop = ".5em";
+        }
+        return m$1`<div style=${{ paddingTop, paddingBottom: ".5em" }}>
+                        <${RenderedEventNode}
+                          id=${`${id2}-event${index}`}
+                          node=${node}
+                          style=${{
+          ...toggleStyle,
+          ...style2
+        }}
+                        />
+                      </div>`;
+      }}
+    />`;
+    };
+    const TranscriptComponent = ({ id: id2, eventNodes, style: style2 }) => {
       const rows = eventNodes.map((eventNode, index) => {
         const toggleStyle = {};
         if (eventNode.depth % 2 == 0) {
@@ -24911,21 +29444,27 @@ ${events}
         } else if (eventNode.depth === 0) {
           toggleStyle.marginBottom = "1.5em";
         }
+        let paddingBottom = ".5em";
+        if (index === eventNodes.length - 1) {
+          paddingBottom = "0";
+        }
         const row = m$1`
+      <div style=${{ paddingBottom }}>
       <${RenderedEventNode}
-        id=${`${id}-event${index}`}
+        id=${`${id2}-event${index}`}
         node=${eventNode}
         style=${{
           ...toggleStyle,
           ...style2
         }}
       />
+      </div>
     `;
         return row;
       });
       return m$1`<div
-    id=${id}
-    key=${id}
+    id=${id2}
+    key=${id2}
     style=${{
         fontSize: FontSize.small,
         display: "grid",
@@ -24936,93 +29475,93 @@ ${events}
     ${rows}
   </div>`;
     };
-    const RenderedEventNode = ({ id, node, style: style2 }) => {
+    const RenderedEventNode = ({ id: id2, node, style: style2 }) => {
       switch (node.event.event) {
         case "sample_init":
           return m$1`<${SampleInitEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "sample_limit":
           return m$1`<${SampleLimitEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "info":
           return m$1`<${InfoEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "logger":
           return m$1`<${LoggerEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "model":
           return m$1`<${ModelEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "score":
           return m$1`<${ScoreEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "state":
           return m$1`<${StateEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "step":
           return m$1`<${StepEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         children=${node.children}
         style=${style2}
       />`;
         case "store":
           return m$1`<${StateEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
         isStore=${true}
       />`;
         case "subtask":
           return m$1`<${SubtaskEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
         depth=${node.depth}
       />`;
         case "tool":
           return m$1`<${ToolEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
         depth=${node.depth}
       />`;
         case "input":
           return m$1`<${InputEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "error":
           return m$1`<${ErrorEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
         case "approval":
           return m$1`<${ApprovalEventView}
-        id=${id}
+        id=${id2}
         event=${node.event}
         style=${style2}
       />`;
@@ -25083,8 +29622,8 @@ ${events}
       });
       return rootNodes;
     }
-    const SampleTranscript = ({ id, evalEvents }) => {
-      return m$1`<${TranscriptView} id=${id} events=${evalEvents} />`;
+    const SampleTranscript = ({ id: id2, evalEvents, scrollRef }) => {
+      return m$1`<${TranscriptVirtualList} id=${id2} events=${evalEvents} scrollRef=${scrollRef}/>`;
     };
     const SampleError = ({ message, align, style: style2 }) => {
       align = align || "center";
@@ -25204,13 +29743,14 @@ ${events}
     const kScoreDescVal = "score-desc";
     const kDefaultSort = kSampleAscVal;
     const InlineSampleDisplay = ({
-      id,
+      id: id2,
       sample,
       sampleStatus,
       sampleError,
       sampleDescriptor,
       selectedTab,
-      setSelectedTab
+      setSelectedTab,
+      scrollRef
     }) => {
       return m$1`<div style=${{ flexDirection: "row", width: "100%" }}>
     <${ProgressBar}
@@ -25224,37 +29764,39 @@ ${events}
             title="Unable to load sample"
             error=${sampleError}
           />` : m$1` <${SampleDisplay}
-            id=${id}
+            id=${id2}
             sample=${sample}
             sampleDescriptor=${sampleDescriptor}
             selectedTab=${selectedTab}
             setSelectedTab=${setSelectedTab}
+            scrollRef=${scrollRef}
           />`}
     </div>
   </div>`;
     };
     const SampleDisplay = ({
-      id,
+      id: id2,
       sample,
       sampleDescriptor,
       selectedTab,
-      setSelectedTab
+      setSelectedTab,
+      scrollRef
     }) => {
       const baseId = `sample-dialog`;
       if (!sample) {
         return m$1`<${EmptyPanel} />`;
       }
       const onSelectedTab = (e2) => {
-        const id2 = e2.currentTarget.id;
-        setSelectedTab(id2);
+        const id3 = e2.currentTarget.id;
+        setSelectedTab(id3);
         return false;
       };
       const tabs = [
         m$1`
     <${TabPanel} id=${kSampleMessagesTabId} classes="sample-tab" title="Messages" onSelected=${onSelectedTab} selected=${selectedTab === kSampleMessagesTabId}>
       <${ChatView} 
-        key=${`${baseId}-chat-${id}`} 
-        id=${`${baseId}-chat-${id}`} 
+        key=${`${baseId}-chat-${id2}`} 
+        id=${`${baseId}-chat-${id2}`} 
         messages=${sample.messages} 
         style=${{ paddingLeft: ".8em", paddingTop: "1em" }}
         indented=${true}
@@ -25264,7 +29806,7 @@ ${events}
       if (sample.events && sample.events.length > 0) {
         tabs.unshift(m$1`
       <${TabPanel} id=${kSampleTranscriptTabId} classes="sample-tab" title="Transcript" onSelected=${onSelectedTab} selected=${selectedTab === kSampleTranscriptTabId || selectedTab === void 0} scrollable=${false}>
-        <${SampleTranscript} key=${`${baseId}-transcript-display-${id}`} id=${`${baseId}-transcript-display-${id}`} evalEvents=${sample.events}/>
+        <${SampleTranscript} key=${`${baseId}-transcript-display-${id2}`} id=${`${baseId}-transcript-display-${id2}`} evalEvents=${sample.events} scrollRef=${scrollRef}/>
       </${TabPanel}>`);
       }
       const scorerNames = Object.keys(sample.scores);
@@ -25290,7 +29832,7 @@ ${events}
         </${TabPanel}>`);
         }
       }
-      const sampleMetadatas = metadataViewsForSample(`${baseId}-${id}`, sample);
+      const sampleMetadatas = metadataViewsForSample(`${baseId}-${id2}`, sample);
       if (sampleMetadatas.length > 0) {
         tabs.push(
           m$1`
@@ -25331,7 +29873,7 @@ ${events}
           <${JSONPanel} data=${sample} simple=${true}/>
         </div>
       </${TabPanel}>`);
-      const tabsetId = `task-sample-details-tab-${id}`;
+      const tabsetId = `task-sample-details-tab-${id2}`;
       const targetId = `${tabsetId}-content`;
       const printSample = () => {
         const targetTabEl = document.querySelector(
@@ -25340,7 +29882,7 @@ ${events}
         if (targetTabEl) {
           const targetEl = targetTabEl.firstElementChild;
           if (targetEl) {
-            const headingId = `sample-heading-${id}`;
+            const headingId = `sample-heading-${id2}`;
             const headingEl = document.getElementById(headingId);
             const headingHtml = printHeadingHtml();
             const css = `
@@ -25398,7 +29940,7 @@ ${events}
         );
       }
       return m$1`<${SampleSummary}
-    id=${id}
+    id=${id2}
     sample=${sample}
     sampleDescriptor=${sampleDescriptor}/>
 
@@ -25412,7 +29954,7 @@ ${events}
     ${tabs}
   </${TabSet}>`;
     };
-    const metadataViewsForSample = (id, sample) => {
+    const metadataViewsForSample = (id2, sample) => {
       const sampleMetadatas = [];
       if (sample.model_usage && Object.keys(sample.model_usage).length > 0) {
         sampleMetadatas.push(m$1`
@@ -25430,7 +29972,7 @@ ${events}
         <${CardHeader} label="Metadata"/>
         <${CardBody}>
           <${MetaDataView}
-            id="task-sample-metadata-${id}"
+            id="task-sample-metadata-${id2}"
             classes="tab-pane"
             entries="${sample == null ? void 0 : sample.metadata}"
             style=${{ marginTop: "0" }}
@@ -25446,7 +29988,7 @@ ${events}
         <${CardHeader} label="Store"/>
         <${CardBody}>
           <${MetaDataView}
-            id="task-sample-store-${id}"
+            id="task-sample-store-${id2}"
             classes="tab-pane"
             entries="${sample == null ? void 0 : sample.store}"
             style=${{ marginTop: "0" }}
@@ -25576,7 +30118,7 @@ ${events}
   `;
     };
     const SampleDialog = ({
-      id,
+      id: id2,
       title,
       sample,
       sampleDescriptor,
@@ -25591,7 +30133,11 @@ ${events}
       sampleScrollPositionRef,
       setSampleScrollPosition
     }) => {
-      const tools = T(() => {
+      const scrollRef = A$1(
+        /** @type {HTMLElement|null} */
+        null
+      );
+      const tools = T$1(() => {
         const nextTool = {
           label: "Next Sample",
           icon: ApplicationIcons.next,
@@ -25609,7 +30155,7 @@ ${events}
           right: [nextTool]
         };
       }, [prevSample, nextSample]);
-      const handleKeyUp = q(
+      const handleKeyUp = q$1(
         (e2) => {
           switch (e2.key) {
             case "ArrowRight":
@@ -25629,21 +30175,22 @@ ${events}
         },
         [prevSample, nextSample]
       );
-      const children2 = T(() => {
+      const children2 = T$1(() => {
         return sampleError ? m$1`<${ErrorPanel} title="Sample Error" error=${sampleError} />` : m$1`<${SampleDisplay}
-          id=${id}
+          id=${id2}
           sample=${sample}
           sampleDescriptor=${sampleDescriptor}
           selectedTab=${selectedTab}
           setSelectedTab=${setSelectedTab}
+          scrollRef=${scrollRef}
         />`;
-      }, [id, sample, sampleDescriptor, selectedTab, setSelectedTab, sampleError]);
-      const onHide = q(() => {
+      }, [id2, sample, sampleDescriptor, selectedTab, setSelectedTab, sampleError]);
+      const onHide = q$1(() => {
         setShowingSampleDialog(false);
       }, [setShowingSampleDialog]);
       return m$1`
     <${LargeModal} 
-      id=${id} 
+      id=${id2} 
       detail=${title}
       detailTools=${tools}
       onkeyup=${handleKeyUp}   
@@ -25652,13 +30199,14 @@ ${events}
       showProgress=${sampleStatus === "loading"}
       initialScrollPositionRef=${sampleScrollPositionRef}
       setInitialScrollPosition=${setSampleScrollPosition}
+      scrollRef=${scrollRef}
     >
         ${children2}
     </${LargeModal}>`;
     };
     const STYLE_INNER = "position:relative; overflow:hidden; width:100%; min-height:100%;";
     const STYLE_CONTENT = "position:absolute; top:0; left:0; height:100%; width:100%; overflow:visible;";
-    class VirtualList extends x$1 {
+    class VirtualList extends x$3 {
       constructor(props) {
         super(props);
         /** @type {HTMLElement} */
@@ -25751,7 +30299,7 @@ ${events}
       const heightForType = (type) => {
         return type === "sample" ? kSampleHeight : kSeparatorHeight;
       };
-      const rowMap = T(() => {
+      const rowMap = T$1(() => {
         return items.reduce((values, current, index) => {
           const height = heightForType(current.type);
           const previous = values.length > 0 ? values[values.length - 1] : void 0;
@@ -25769,15 +30317,15 @@ ${events}
         if (listEl) {
           const selected = rowMap[selectedIndex];
           if (selected) {
-            const itemTop = selected.start;
+            const itemTop2 = selected.start;
             const itemBottom = selected.start + selected.height;
             const scrollTop = listEl.base.scrollTop;
             const scrollBottom = scrollTop + listEl.base.offsetHeight;
-            if (itemTop >= scrollTop && itemBottom <= scrollBottom) {
+            if (itemTop2 >= scrollTop && itemBottom <= scrollBottom) {
               return;
             }
-            if (itemTop < scrollTop) {
-              listEl.base.scrollTo({ top: itemTop });
+            if (itemTop2 < scrollTop) {
+              listEl.base.scrollTo({ top: itemTop2 });
               return;
             }
             if (itemBottom > scrollBottom) {
@@ -25814,7 +30362,7 @@ ${events}
           return "";
         }
       };
-      const onkeydown = q(
+      const onkeydown = q$1(
         (e2) => {
           switch (e2.key) {
             case "ArrowUp":
@@ -25917,9 +30465,9 @@ ${events}
     ${footerRow}
   </div>`;
     };
-    const SeparatorRow = ({ id, title, height }) => {
+    const SeparatorRow = ({ id: id2, title, height }) => {
       return m$1`<div
-    id=${id}
+    id=${id2}
     style=${{
         padding: ".25em 1em .25em 1em",
         textTransform: "uppercase",
@@ -25934,7 +30482,7 @@ ${events}
   </div>`;
     };
     const SampleRow = ({
-      id,
+      id: id2,
       index,
       sample,
       sampleDescriptor,
@@ -25951,7 +30499,7 @@ ${events}
       };
       return m$1`
     <div
-      id=${`sample-${id}`}
+      id=${`sample-${id2}`}
       onclick=${() => {
         showSample(index);
       }}
@@ -26038,10 +30586,10 @@ ${events}
   `;
     };
     const gridColumnStyles = (sampleDescriptor) => {
-      const { input, target, answer, limit, id, score } = gridColumns(sampleDescriptor);
+      const { input, target, answer, limit, id: id2, score } = gridColumns(sampleDescriptor);
       return {
         gridGap: "10px",
-        gridTemplateColumns: `${id} ${input} ${target} ${answer} ${limit} ${score}`,
+        gridTemplateColumns: `${id2} ${input} ${target} ${answer} ${limit} ${score}`,
         paddingLeft: "1rem",
         paddingRight: "1rem"
       };
@@ -26051,7 +30599,7 @@ ${events}
       const target = (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.normalized.target) > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.target) : 0;
       const answer = (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.normalized.answer) > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.answer) : 0;
       const limit = (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.normalized.limit) > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.limit) : 0;
-      const id = Math.max(2, Math.min(10, sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.raw.id));
+      const id2 = Math.max(2, Math.min(10, sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.raw.id));
       const score = Math.max(
         3,
         Math.min(10, sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.raw.score)
@@ -26068,7 +30616,7 @@ ${events}
         target: frSize(target),
         answer: frSize(answer),
         limit: frSize(limit),
-        id: `${id}rem`,
+        id: `${id2}rem`,
         score: `${score}rem`
       };
     };
@@ -26090,19 +30638,20 @@ ${events}
       selectedSampleTab,
       setSelectedSampleTab,
       sampleScrollPositionRef,
-      setSampleScrollPosition
+      setSampleScrollPosition,
+      sampleTabScrollRef
     }) => {
       const [items, setItems] = h([]);
       const [sampleItems, setSampleItems] = h([]);
-      const sampleListRef = A(
+      const sampleListRef = A$1(
         /** @type {HTMLElement|null} */
         null
       );
-      const sampleDialogRef = A(
+      const sampleDialogRef = A$1(
         /** @type {HTMLElement|null} */
         null
       );
-      const showSample = q(
+      const showSample = q$1(
         (index2) => {
           setSelectedSampleIndex(index2);
           setShowingSampleDialog(true);
@@ -26143,23 +30692,23 @@ ${events}
           })
         );
       }, [samples, groupBy, groupByOrder, sampleDescriptor]);
-      const nextSampleIndex = q(() => {
+      const nextSampleIndex = q$1(() => {
         if (selectedSampleIndex < sampleItems.length - 1) {
           return selectedSampleIndex + 1;
         } else {
           return -1;
         }
       }, [selectedSampleIndex, items]);
-      const previousSampleIndex = q(() => {
+      const previousSampleIndex = q$1(() => {
         return selectedSampleIndex > 0 ? selectedSampleIndex - 1 : -1;
       }, [selectedSampleIndex, items]);
-      const nextSample = q(() => {
+      const nextSample = q$1(() => {
         const next = nextSampleIndex();
         if (sampleStatus !== "loading" && next > -1) {
           setSelectedSampleIndex(next);
         }
       }, [selectedSampleIndex, samples, sampleStatus, nextSampleIndex]);
-      const previousSample = q(() => {
+      const previousSample = q$1(() => {
         const prev = previousSampleIndex();
         if (sampleStatus !== "loading" && prev > -1) {
           setSelectedSampleIndex(prev);
@@ -26177,6 +30726,7 @@ ${events}
         sampleDescriptor=${sampleDescriptor}
         selectedTab=${selectedSampleTab}
         setSelectedTab=${setSelectedSampleTab}
+        scrollRef=${sampleTabScrollRef}
       />`
         );
       } else if (sampleMode === "many") {
@@ -27726,8 +32276,8 @@ self.onmessage = function (e) {
       open_log_file
     };
     var ch2 = {};
-    var wk = function(c2, id, msg, transfer, cb) {
-      var w2 = new Worker(ch2[id] || (ch2[id] = URL.createObjectURL(new Blob([
+    var wk = function(c2, id2, msg, transfer, cb) {
+      var w2 = new Worker(ch2[id2] || (ch2[id2] = URL.createObjectURL(new Blob([
         c2 + ';addEventListener("error",function(e){e=e.error;postMessage({$e$:[e.message,e.code,e.stack]})})'
       ], { type: "text/javascript" }))));
       w2.onmessage = function(e2) {
@@ -28091,9 +32641,9 @@ self.onmessage = function (e) {
         o2[k2] = b2[k2];
       return o2;
     };
-    var wcln = function(fn, fnStr, td2) {
-      var dt = fn();
-      var st = fn.toString();
+    var wcln = function(fn2, fnStr, td2) {
+      var dt = fn2();
+      var st = fn2.toString();
       var ks = st.slice(st.indexOf("[") + 1, st.lastIndexOf("]")).replace(/\s+/g, "").split(",");
       for (var i2 = 0; i2 < dt.length; ++i2) {
         var v2 = dt[i2], k2 = ks[i2];
@@ -28126,15 +32676,15 @@ self.onmessage = function (e) {
       }
       return tl;
     };
-    var wrkr = function(fns, init, id, cb) {
-      if (!ch[id]) {
+    var wrkr = function(fns, init2, id2, cb) {
+      if (!ch[id2]) {
         var fnStr = "", td_1 = {}, m2 = fns.length - 1;
         for (var i2 = 0; i2 < m2; ++i2)
           fnStr = wcln(fns[i2], fnStr, td_1);
-        ch[id] = { c: wcln(fns[m2], fnStr, td_1), e: td_1 };
+        ch[id2] = { c: wcln(fns[m2], fnStr, td_1), e: td_1 };
       }
-      var td2 = mrg({}, ch[id].e);
-      return wk(ch[id].c + ";onmessage=function(e){for(var k in e.data)self[k]=e.data[k];onmessage=" + init.toString() + "}", id, td2, cbfs(td2), cb);
+      var td2 = mrg({}, ch[id2].e);
+      return wk(ch[id2].c + ";onmessage=function(e){for(var k in e.data)self[k]=e.data[k];onmessage=" + init2.toString() + "}", id2, td2, cbfs(td2), cb);
     };
     var bInflt = function() {
       return [u8, u16, i32, fleb, fdeb, clim, fl, fd, flrm, fdrm, rev, ec, hMap, max, bits, bits16, shft, slc, err, inflt, inflateSync, pbf, gopt];
@@ -28154,8 +32704,8 @@ self.onmessage = function (e) {
         dictionary: o2.dictionary
       };
     };
-    var cbify = function(dat, opts, fns, init, id, cb) {
-      var w2 = wrkr(fns, init, id, function(err2, dat2) {
+    var cbify = function(dat, opts, fns, init2, id2, cb) {
+      var w2 = wrkr(fns, init2, id2, function(err2, dat2) {
         w2.terminate();
         cb(err2, dat2);
       });
@@ -28794,12 +33344,12 @@ self.onmessage = function (e) {
        * @param {number} epoch - The name of the file that caused the error.
        * @param {number} maxBytes - The maximum allowed size for the file, in bytes.
        */
-      constructor(id, epoch, maxBytes) {
+      constructor(id2, epoch, maxBytes) {
         super(
-          `Sample ${id} in epoch ${epoch} exceeds the maximum supported size (${maxBytes / 1024 / 1024}MB) and cannot be loaded.`
+          `Sample ${id2} in epoch ${epoch} exceeds the maximum supported size (${maxBytes / 1024 / 1024}MB) and cannot be loaded.`
         );
         this.name = "SampleSizeLimitedExceededError";
-        this.id = id;
+        this.id = id2;
         this.epoch = epoch;
         this.maxBytes = maxBytes;
         this.displayStack = false;
@@ -28870,15 +33420,15 @@ self.onmessage = function (e) {
           };
         }
       };
-      const get_log_sample = async (log_file, id, epoch) => {
+      const get_log_sample = async (log_file, id2, epoch) => {
         if (isEvalFile(log_file)) {
           const remoteLogFile = await remoteEvalFile(log_file, true);
           try {
-            const sample = await remoteLogFile.readSample(id, epoch);
+            const sample = await remoteLogFile.readSample(id2, epoch);
             return sample;
           } catch (error2) {
             if (error2 instanceof FileSizeLimitError) {
-              throw new SampleSizeLimitedExceededError(id, epoch, error2.maxBytes);
+              throw new SampleSizeLimitedExceededError(id2, epoch, error2.maxBytes);
             } else {
               throw error2;
             }
@@ -28887,7 +33437,7 @@ self.onmessage = function (e) {
           const logContents = await get_log(log_file, true);
           if (logContents.parsed.samples && logContents.parsed.samples.length > 0) {
             return logContents.parsed.samples.find((sample) => {
-              return sample.id === id && sample.epoch === epoch;
+              return sample.id === id2 && sample.epoch === epoch;
             });
           }
         }
@@ -29191,7 +33741,7 @@ self.onmessage = function (e) {
         order: sort === kSampleAscVal || sort === kEpochAscVal || sort === kScoreAscVal ? "asc" : "desc"
       };
     };
-    const SampleFilter = ({ descriptor, filter, filterChanged }) => {
+    const SampleFilter = ({ descriptor, filter: filter2, filterChanged }) => {
       var _a2;
       const updateCategoryValue = (e2) => {
         const val = e2.currentTarget.value;
@@ -29213,7 +33763,7 @@ self.onmessage = function (e) {
             })
           );
           return m$1`<${SelectFilter}
-        value=${filter.value || "all"}
+        value=${filter2.value || "all"}
         options=${options}
         onChange=${updateCategoryValue}
       />`;
@@ -29226,7 +33776,7 @@ self.onmessage = function (e) {
             })
           );
           return m$1`<${SelectFilter}
-        value=${filter.value || "all"}
+        value=${filter2.value || "all"}
         options=${options}
         onChange=${updateCategoryValue}
       />`;
@@ -29236,7 +33786,7 @@ self.onmessage = function (e) {
         <input
           type="text"
           class="form-control"
-          value=${filter.value}
+          value=${filter2.value}
           placeholder="Filter Samples (score)"
           style=${{ width: "150px" }}
           onInput=${(e2) => {
@@ -29259,7 +33809,7 @@ self.onmessage = function (e) {
             })
           );
           return m$1`<${SelectFilter}
-        value=${filter.value || "all"}
+        value=${filter2.value || "all"}
         options=${options}
         onChange=${updateCategoryValue}
       />`;
@@ -29418,7 +33968,7 @@ self.onmessage = function (e) {
       const {
         epoch,
         setEpoch,
-        filter,
+        filter: filter2,
         filterChanged,
         sort,
         setSort,
@@ -29450,7 +34000,7 @@ self.onmessage = function (e) {
       }
       tools.push(
         m$1`<${SampleFilter}
-      filter=${filter}
+      filter=${filter2}
       filterChanged=${filterChanged}
       descriptor=${sampleDescriptor}
     />`
@@ -30032,7 +34582,7 @@ self.onmessage = function (e) {
       epochs,
       epoch,
       setEpoch,
-      filter,
+      filter: filter2,
       setFilter,
       score,
       setScore,
@@ -30044,7 +34594,7 @@ self.onmessage = function (e) {
       workspaceTabScrollPositionRef,
       setWorkspaceTabScrollPosition
     }) => {
-      const divRef = A(
+      const divRef = A$1(
         /** @type {HTMLElement|null} */
         null
       );
@@ -30060,12 +34610,17 @@ self.onmessage = function (e) {
           divRef.current.scrollTop = 0;
         }
       }, [divRef, task_id]);
-      const resolvedTabs = T(() => {
+      const sampleTabScrollRef = A$1(
+        /** @type {HTMLElement|null} */
+        null
+      );
+      const resolvedTabs = T$1(() => {
         const resolvedTabs2 = {};
         if (sampleMode !== "none") {
           resolvedTabs2.samples = {
             id: kEvalWorkspaceTabId,
             scrollable: samples.length === 1,
+            scrollRef: sampleTabScrollRef,
             label: (samples == null ? void 0 : samples.length) > 1 ? "Samples" : "Sample",
             content: () => {
               return m$1` <${SamplesTab}
@@ -30085,11 +34640,12 @@ self.onmessage = function (e) {
             sampleDescriptor=${samplesDescriptor}
             selectedSampleTab=${selectedSampleTab}
             setSelectedSampleTab=${setSelectedSampleTab}
-            filter=${filter}
+            filter=${filter2}
             sort=${sort}
             epoch=${epoch}
             sampleScrollPositionRef=${sampleScrollPositionRef}
             setSampleScrollPosition=${setSampleScrollPosition}
+            sampleTabScrollRef=${sampleTabScrollRef}
           />`;
             },
             tools: () => {
@@ -30101,7 +34657,7 @@ self.onmessage = function (e) {
               epoch=${epoch}
               epochs=${epochs}
               setEpoch=${setEpoch}
-              filter=${filter}
+              filter=${filter2}
               filterChanged=${setFilter}
               sort=${sort}
               setSort=${setSort}
@@ -30233,7 +34789,7 @@ self.onmessage = function (e) {
         samplesDescriptor,
         selectedSampleTab,
         setSelectedSampleTab,
-        filter,
+        filter2,
         sort,
         epoch,
         sampleScrollPositionRef,
@@ -30306,20 +34862,20 @@ self.onmessage = function (e) {
             return "";
           }
         });
-        const onScroll = q(
-          debounce$1((id, position) => {
-            setWorkspaceTabScrollPosition(id, position);
+        const onScroll = q$1(
+          debounce$1((id2, position) => {
+            setWorkspaceTabScrollPosition(id2, position);
           }, 100),
           [setWorkspaceTabScrollPosition]
         );
-        const onSelected = q(
+        const onSelected = q$1(
           (e2) => {
-            const id = e2.currentTarget.id;
-            setSelectedTab(id);
+            const id2 = e2.currentTarget.id;
+            setSelectedTab(id2);
           },
           [setSelectedTab]
         );
-        const tabPanels = T(() => {
+        const tabPanels = T$1(() => {
           return Object.keys(tabs).map((key2) => {
             const tab = tabs[key2];
             return m$1`<${TabPanel}
@@ -30328,8 +34884,9 @@ self.onmessage = function (e) {
         onSelected=${onSelected}
         selected=${selectedTab === tab.id}
         scrollable=${!!tab.scrollable}
+        scrollRef=${tab.scrollRef}
         scrollPosition=${workspaceTabScrollPositionRef.current[tab.id]}
-        setScrollPosition=${q(
+        setScrollPosition=${q$1(
               (position) => {
                 onScroll(tab.id, position);
               },
@@ -30394,7 +34951,7 @@ self.onmessage = function (e) {
       }
     };
     const FindBand = ({ hideBand }) => {
-      const searchBoxRef = A(
+      const searchBoxRef = A$1(
         /** @type {HTMLInputElement|null} */
         null
       );
@@ -31088,9 +35645,9 @@ self.onmessage = function (e) {
       }
       return value;
     };
-    const filterFnForType = (filter) => {
-      if (filter.type) {
-        return filterFnsForType[filter.type];
+    const filterFnForType = (filter2) => {
+      if (filter2.type) {
+        return filterFnsForType[filter2.type];
       } else {
         return void 0;
       }
@@ -31155,14 +35712,14 @@ self.onmessage = function (e) {
               }
             }
           ];
-          for (const filter of filters) {
-            if (value == null ? void 0 : value.startsWith(filter.prefix)) {
-              const val = value.slice(filter.prefix.length).trim();
+          for (const filter2 of filters) {
+            if (value == null ? void 0 : value.startsWith(filter2.prefix)) {
+              const val = value.slice(filter2.prefix.length).trim();
               if (!val) {
                 return true;
               }
               const num = Number(val);
-              return filter.fn(score.value, num);
+              return filter2.fn(score.value, num);
             }
           }
           if (typeof score.value === "string") {
@@ -31214,9 +35771,9 @@ self.onmessage = function (e) {
       const [selectedSampleTab, setSelectedSampleTab] = h(
         initialState2 == null ? void 0 : initialState2.selectedSampleTab
       );
-      const sampleScrollPosition = A((initialState2 == null ? void 0 : initialState2.sampleScrollPosition) || 0);
-      const loadingSampleIndexRef = A(null);
-      const workspaceTabScrollPosition = A(
+      const sampleScrollPosition = A$1((initialState2 == null ? void 0 : initialState2.sampleScrollPosition) || 0);
+      const loadingSampleIndexRef = A$1(null);
+      const workspaceTabScrollPosition = A$1(
         (initialState2 == null ? void 0 : initialState2.workspaceTabScrollPosition) || {}
       );
       const [showingSampleDialog, setShowingSampleDialog] = h(
@@ -31236,7 +35793,7 @@ self.onmessage = function (e) {
       );
       const [offcanvas, setOffcanvas] = h((initialState2 == null ? void 0 : initialState2.offcanvas) || false);
       const [showFind, setShowFind] = h((initialState2 == null ? void 0 : initialState2.showFind) || false);
-      const [filter, setFilter] = h((initialState2 == null ? void 0 : initialState2.filter) || {});
+      const [filter2, setFilter] = h((initialState2 == null ? void 0 : initialState2.filter) || {});
       const [epoch, setEpoch] = h((initialState2 == null ? void 0 : initialState2.epoch) || "all");
       const [sort, setSort] = h((initialState2 == null ? void 0 : initialState2.sort) || kDefaultSort);
       const [scores, setScores] = h((initialState2 == null ? void 0 : initialState2.scores) || []);
@@ -31249,7 +35806,7 @@ self.onmessage = function (e) {
         (initialState2 == null ? void 0 : initialState2.groupByOrder) || "asc"
       );
       const afterBodyElements = [];
-      const saveState = q(() => {
+      const saveState = q$1(() => {
         const state = {
           logs,
           selectedLogIndex,
@@ -31267,7 +35824,7 @@ self.onmessage = function (e) {
           capabilities,
           offcanvas,
           showFind,
-          filter,
+          filter: filter2,
           epoch,
           sort,
           scores,
@@ -31298,7 +35855,7 @@ self.onmessage = function (e) {
         capabilities,
         offcanvas,
         showFind,
-        filter,
+        filter2,
         epoch,
         sort,
         scores,
@@ -31307,18 +35864,18 @@ self.onmessage = function (e) {
         groupBy,
         groupByOrder
       ]);
-      const saveStateRef = A(saveState);
+      const saveStateRef = A$1(saveState);
       y(() => {
         saveStateRef.current = saveState;
       }, [saveState]);
-      const setSampleScrollPosition = q(
+      const setSampleScrollPosition = q$1(
         debounce$1((position) => {
           sampleScrollPosition.current = position;
           saveStateRef.current();
         }, 1e3),
         []
       );
-      const setWorkspaceTabScrollPosition = q(
+      const setWorkspaceTabScrollPosition = q$1(
         debounce$1((tab, position) => {
           if (workspaceTabScrollPosition.current[tab] !== position) {
             workspaceTabScrollPosition.current = {
@@ -31349,7 +35906,7 @@ self.onmessage = function (e) {
         capabilities,
         offcanvas,
         showFind,
-        filter,
+        filter2,
         epoch,
         sort,
         scores,
@@ -31358,7 +35915,7 @@ self.onmessage = function (e) {
         groupBy,
         groupByOrder
       ]);
-      const handleSampleShowingDialog = q(
+      const handleSampleShowingDialog = q$1(
         (show) => {
           setShowingSampleDialog(show);
           if (!show) {
@@ -31382,9 +35939,9 @@ self.onmessage = function (e) {
               return false;
             }
           }
-          const filterFn = filterFnForType(filter);
-          if (filterFn && filter.value) {
-            return filterFn(samplesDescriptor, sample, filter.value);
+          const filterFn = filterFnForType(filter2);
+          if (filterFn && filter2.value) {
+            return filterFn(samplesDescriptor, sample, filter2.value);
           } else {
             return true;
           }
@@ -31401,8 +35958,8 @@ self.onmessage = function (e) {
         setFilteredSamples(sorted);
         setGroupBy(grouping);
         setGroupByOrder(order2);
-      }, [selectedLog, filter, sort, epoch]);
-      const evalDescriptor = T(() => {
+      }, [selectedLog, filter2, sort, epoch]);
+      const evalDescriptor = T$1(() => {
         var _a3, _b3, _c2, _d2;
         return createEvalDescriptor(
           scores,
@@ -31410,10 +35967,10 @@ self.onmessage = function (e) {
           ((_d2 = (_c2 = (_b3 = selectedLog.contents) == null ? void 0 : _b3.eval) == null ? void 0 : _c2.config) == null ? void 0 : _d2.epochs) || 1
         );
       }, [selectedLog, scores]);
-      const samplesDescriptor = T(() => {
+      const samplesDescriptor = T$1(() => {
         return createSamplesDescriptor(evalDescriptor, score);
       }, [evalDescriptor, score]);
-      const refreshSampleTab = q(
+      const refreshSampleTab = q$1(
         (sample) => {
           if (selectedSampleTab === void 0) {
             const defaultTab = sample.events && sample.events.length > 0 ? kSampleTranscriptTabId : kSampleMessagesTabId;
@@ -31422,7 +35979,7 @@ self.onmessage = function (e) {
         },
         [selectedSampleTab, showingSampleDialog]
       );
-      const mainAppRef = A();
+      const mainAppRef = A$1();
       y(() => {
         if (!selectedLog || selectedSampleIndex === -1) {
           setSelectedSample(void 0);
@@ -31514,7 +36071,7 @@ self.onmessage = function (e) {
         };
         loadHeaders();
       }, [logs, setStatus, setLogHeaders, setHeadersLoading]);
-      const resetWorkspace = q(
+      const resetWorkspace = q$1(
         /**
          * @param {import("./api/Types.mjs").EvalSummary} log
          */
@@ -31598,7 +36155,7 @@ self.onmessage = function (e) {
           setStatus({ loading: false, error: e2 });
         }
       };
-      const refreshLog = q(async () => {
+      const refreshLog = q$1(async () => {
         try {
           setStatus({ loading: true, error: void 0 });
           const targetLog = logs.files[selectedLogIndex];
@@ -31632,7 +36189,7 @@ self.onmessage = function (e) {
           setStatus({ loading: false, error: e2 });
         }
       }, [logs, selectedLogIndex, setStatus, setSelectedLog, setLogHeaders]);
-      const showLogFile = q(
+      const showLogFile = q$1(
         async (logUrl) => {
           const index = logs.files.findIndex((val) => {
             return logUrl.endsWith(val.name);
@@ -31650,7 +36207,7 @@ self.onmessage = function (e) {
         },
         [logs, setSelectedLogIndex, setLogs]
       );
-      const refreshLogList = q(async () => {
+      const refreshLogList = q$1(async () => {
         const currentLog = logs.files[selectedLogIndex > -1 ? selectedLogIndex : 0];
         const refreshedLogs = await loadLogs();
         const newIndex = refreshedLogs.files.findIndex((file) => {
@@ -31659,7 +36216,7 @@ self.onmessage = function (e) {
         setLogs(refreshedLogs);
         setSelectedLogIndex(newIndex);
       }, [logs, selectedLogIndex, setSelectedLogIndex, setLogs]);
-      const onMessage = T(() => {
+      const onMessage = T$1(() => {
         return async (e2) => {
           const type = e2.data.type || e2.data.message;
           switch (type) {
@@ -31782,7 +36339,7 @@ self.onmessage = function (e) {
         ` : "";
       const fullScreenClz = fullScreen ? " full-screen" : "";
       const offcanvasClz = offcanvas ? " off-canvas" : "";
-      const hideFind = q(() => {
+      const hideFind = q$1(() => {
         clearDocumentSelection();
         if (showFind) {
           setShowFind(false);
@@ -31847,7 +36404,7 @@ self.onmessage = function (e) {
               epochs=${(_m = (_l = (_k = selectedLog == null ? void 0 : selectedLog.contents) == null ? void 0 : _k.eval) == null ? void 0 : _l.config) == null ? void 0 : _m.epochs}
               epoch=${epoch}
               setEpoch=${setEpoch}
-              filter=${filter}
+              filter=${filter2}
               setFilter=${setFilter}
               score=${score}
               setScore=${setScore}
@@ -31905,7 +36462,7 @@ self.onmessage = function (e) {
     if (vscode) {
       initialState = vscode.getState();
     }
-    D$1(m$1`<${App}
+    D$2(m$1`<${App}
     api=${api}
     initialState=${initialState}
     saveInitialState=${throttle$1((state) => {

--- a/src/inspect_ai/_view/www/package.json
+++ b/src/inspect_ai/_view/www/package.json
@@ -40,6 +40,7 @@
     "murmurhash": "^2.0.1",
     "postcss-url": "^10.1.3",
     "preact": "^10.24.3",
-    "prismjs": "^1.29.0"
+    "prismjs": "^1.29.0",
+    "react-virtuoso": "^4.12.3"
   }
 }

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -9,7 +9,6 @@ import { FontSize, TextStyle } from "../appearance/Fonts.mjs";
 import { resolveToolInput, ToolCallView } from "./Tools.mjs";
 import { Virtuoso } from "react-virtuoso";
 
-
 /**
  * Renders the ChatViewVirtualList component.
  *
@@ -30,35 +29,38 @@ export const ChatViewVirtualList = ({
   style,
   indented,
   numbered = true,
-  scrollRef
+  scrollRef,
 }) => {
-
   const collapsedMessages = resolveMessages(messages);
 
-  const result = html`
-    <${Virtuoso}
-      id=${`${id}-virtual-list`}
-      style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box", ...style }}
-      customScrollParent=${scrollRef.current}
-      totalCount=${collapsedMessages.length}
-      overscan=${{
-        reverse: 3,
-        main: 2
-      }}
-      itemContent=${(index) => {
-        const number = collapsedMessages.length > 1 && numbered ? index + 1 : undefined;
-        return html`<${ChatMessageRow}
-              id=${id}
-              number=${number}
-              resolvedMessage=${collapsedMessages[index]}
-              indented=${indented}
-              toolCallStyle=${toolCallStyle}/>`;
-      }
-      }
+  const result = html` <${Virtuoso}
+    id=${`${id}-virtual-list`}
+    style=${{
+      width: "100%",
+      overflowY: "unset",
+      boxSizing: "border-box",
+      ...style,
+    }}
+    customScrollParent=${scrollRef.current}
+    totalCount=${collapsedMessages.length}
+    overscan=${{
+      reverse: 3,
+      main: 2,
+    }}
+    itemContent=${(index) => {
+      const number =
+        collapsedMessages.length > 1 && numbered ? index + 1 : undefined;
+      return html`<${ChatMessageRow}
+        id=${id}
+        number=${number}
+        resolvedMessage=${collapsedMessages[index]}
+        indented=${indented}
+        toolCallStyle=${toolCallStyle}
       />`;
+    }}
+  />`;
   return result;
 };
-
 
 /**
  * Renders the ChatView component.
@@ -81,20 +83,19 @@ export const ChatView = ({
   numbered = true,
 }) => {
   const collapsedMessages = resolveMessages(messages);
-  const result = html`
-    <div style=${style}>
-      ${
-        collapsedMessages.map((msg, index) => {
-          const number = collapsedMessages.length > 1 && numbered ? index + 1 : undefined;
-            return html`<${ChatMessageRow}
-              id=${id}
-              number=${number}
-              resolvedMessage=${msg}
-              indented=${indented}
-              toolCallStyle=${toolCallStyle}/>`;
-        })        
-      }
-    </div>`;
+  const result = html` <div style=${style}>
+    ${collapsedMessages.map((msg, index) => {
+      const number =
+        collapsedMessages.length > 1 && numbered ? index + 1 : undefined;
+      return html`<${ChatMessageRow}
+        id=${id}
+        number=${number}
+        resolvedMessage=${msg}
+        indented=${indented}
+        toolCallStyle=${toolCallStyle}
+      />`;
+    })}
+  </div>`;
   return result;
 };
 
@@ -114,50 +115,49 @@ export const ChatMessageRow = ({
   number,
   resolvedMessage,
   toolCallStyle,
-  indented
+  indented,
 }) => {
-    if (number) {
-      return html` <div
+  if (number) {
+    return html` <div
+      style=${{
+        display: "grid",
+        gridTemplateColumns: "max-content auto",
+        columnGap: "0.4em",
+      }}
+    >
+      <div
         style=${{
-          display: "grid",
-          gridTemplateColumns: "max-content auto",
-          columnGap: "0.4em",
+          fontSize: FontSize.smaller,
+          ...TextStyle.secondary,
+          marginTop: "0.1em",
         }}
       >
-        <div
-          style=${{
-            fontSize: FontSize.smaller,
-            ...TextStyle.secondary,
-            marginTop: "0.1em",
-          }}
-        >
-          ${number}
-        </div>
-        <${ChatMessage}
-          id=${`${id}-chat-messages`}
-          message=${resolvedMessage.message}
-          toolMessages=${resolvedMessage.toolMessages}
-          indented=${indented}
-          toolCallStyle=${toolCallStyle}
-        />
-      </div>`;
-    } else {
-      return html`<${ChatMessage}
+        ${number}
+      </div>
+      <${ChatMessage}
         id=${`${id}-chat-messages`}
         message=${resolvedMessage.message}
         toolMessages=${resolvedMessage.toolMessages}
         indented=${indented}
         toolCallStyle=${toolCallStyle}
-      />`;
-    }
+      />
+    </div>`;
+  } else {
+    return html`<${ChatMessage}
+      id=${`${id}-chat-messages`}
+      message=${resolvedMessage.message}
+      toolMessages=${resolvedMessage.toolMessages}
+      indented=${indented}
+      toolCallStyle=${toolCallStyle}
+    />`;
   }
+};
 
 /**
  * @typedef {Object} ResolvedMessage
  * @property {import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser} message - The main chat message.
  * @property {import("../types/log").ChatMessageTool[]} [toolMessages] - Optional array of tool-related messages.
  */
-
 
 /**
  * Renders the ChatView component.
@@ -166,7 +166,7 @@ export const ChatMessageRow = ({
  * @returns {ResolvedMessage[]} The component.
  */
 export const resolveMessages = (messages) => {
-// Filter tool messages into a sidelist that the chat stream
+  // Filter tool messages into a sidelist that the chat stream
   // can use to lookup the tool responses
 
   /**
@@ -225,9 +225,9 @@ export const resolveMessages = (messages) => {
   // Converge them
   if (systemMessage && systemMessage.content.length > 0) {
     collapsedMessages.unshift({ message: systemMessage });
-  }  
+  }
   return collapsedMessages;
-}
+};
 
 /**
  * Ensure that content is a proper content type

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -33,7 +33,7 @@ export const ChatViewVirtualList = ({
 }) => {
   const collapsedMessages = resolveMessages(messages);
 
-  const result = html` <${Virtuoso}
+  const result = html`<${Virtuoso}
     id=${`${id}-virtual-list`}
     style=${{
       width: "100%",
@@ -47,6 +47,7 @@ export const ChatViewVirtualList = ({
       top: 1000,
       bottom: 1000,
     }}
+    skipAnimationFrameInResizeObserver=${true}
     itemContent=${(index) => {
       const number =
         collapsedMessages.length > 1 && numbered ? index + 1 : undefined;

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -7,6 +7,58 @@ import { MessageContent } from "./MessageContent.mjs";
 import { ExpandablePanel } from "./ExpandablePanel.mjs";
 import { FontSize, TextStyle } from "../appearance/Fonts.mjs";
 import { resolveToolInput, ToolCallView } from "./Tools.mjs";
+import { Virtuoso } from "react-virtuoso";
+
+
+/**
+ * Renders the ChatViewVirtualList component.
+ *
+ * @param {Object} props - The properties passed to the component.
+ * @param {string} props.id - The ID for the chat view.
+ * @param {import("../types/log").Messages} props.messages - The array of chat messages.
+ * @param {"compact" | "complete"} [props.toolCallStyle] - Whether to show tool calls
+ * @param {Object} [props.style] - Inline styles for the chat view.
+ * @param {boolean} props.indented - Whether the chatview has indented messages
+ * @param {boolean} [props.numbered] - Whether the chatview is numbered
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable parent element
+ * @returns {import("preact").JSX.Element} The component.
+ */
+export const ChatViewVirtualList = ({
+  id,
+  messages,
+  toolCallStyle,
+  style,
+  indented,
+  numbered = true,
+  scrollRef
+}) => {
+
+  const collapsedMessages = resolveMessages(messages);
+
+  const result = html`
+    <${Virtuoso}
+      id=${`${id}-virtual-list`}
+      style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box", ...style }}
+      customScrollParent=${scrollRef.current}
+      totalCount=${collapsedMessages.length}
+      overscan=${{
+        reverse: 3,
+        main: 2
+      }}
+      itemContent=${(index) => {
+        const number = collapsedMessages.length > 1 && numbered ? index + 1 : undefined;
+        return html`<${ChatMessageRow}
+              id=${id}
+              number=${number}
+              resolvedMessage=${collapsedMessages[index]}
+              indented=${indented}
+              toolCallStyle=${toolCallStyle}/>`;
+      }
+      }
+      />`;
+  return result;
+};
+
 
 /**
  * Renders the ChatView component.
@@ -28,7 +80,93 @@ export const ChatView = ({
   indented,
   numbered = true,
 }) => {
-  // Filter tool messages into a sidelist that the chat stream
+  const collapsedMessages = resolveMessages(messages);
+  const result = html`
+    <div style=${style}>
+      ${
+        collapsedMessages.map((msg, index) => {
+          const number = collapsedMessages.length > 1 && numbered ? index + 1 : undefined;
+            return html`<${ChatMessageRow}
+              id=${id}
+              number=${number}
+              resolvedMessage=${msg}
+              indented=${indented}
+              toolCallStyle=${toolCallStyle}/>`;
+        })        
+      }
+    </div>`;
+  return result;
+};
+
+/**
+ * Renders the ChatMessage component.
+ *
+ * @param {Object} props - The properties passed to the component.
+ * @param {string} props.id - The ID for the chat view.
+ * @param {number} [props.number] - The message number
+ * @param {ResolvedMessage} props.resolvedMessage - The array of chat messages.
+ * @param {"compact" | "complete"} [props.toolCallStyle] - Whether to show tool calls
+ * @param {boolean} props.indented - Whether the chatview has indented messages
+ * @returns {import("preact").JSX.Element} The component.
+ */
+export const ChatMessageRow = ({
+  id,
+  number,
+  resolvedMessage,
+  toolCallStyle,
+  indented
+}) => {
+    if (number) {
+      return html` <div
+        style=${{
+          display: "grid",
+          gridTemplateColumns: "max-content auto",
+          columnGap: "0.4em",
+        }}
+      >
+        <div
+          style=${{
+            fontSize: FontSize.smaller,
+            ...TextStyle.secondary,
+            marginTop: "0.1em",
+          }}
+        >
+          ${number}
+        </div>
+        <${ChatMessage}
+          id=${`${id}-chat-messages`}
+          message=${resolvedMessage.message}
+          toolMessages=${resolvedMessage.toolMessages}
+          indented=${indented}
+          toolCallStyle=${toolCallStyle}
+        />
+      </div>`;
+    } else {
+      return html`<${ChatMessage}
+        id=${`${id}-chat-messages`}
+        message=${resolvedMessage.message}
+        toolMessages=${resolvedMessage.toolMessages}
+        indented=${indented}
+        toolCallStyle=${toolCallStyle}
+      />`;
+    }
+  }
+
+/**
+ * @typedef {Object} ResolvedMessage
+ * @property {import("../types/log").ChatMessageAssistant | import("../types/log").ChatMessageSystem | import("../types/log").ChatMessageUser} message - The main chat message.
+ * @property {import("../types/log").ChatMessageTool[]} [toolMessages] - Optional array of tool-related messages.
+ */
+
+
+/**
+ * Renders the ChatView component.
+ *
+ * @param {import("../types/log").Messages} messages - The array of chat messages.
+ * @returns {ResolvedMessage[]} The component.
+ */
+export const resolveMessages = (messages) => {
+// Filter tool messages into a sidelist that the chat stream
   // can use to lookup the tool responses
 
   /**
@@ -87,51 +225,9 @@ export const ChatView = ({
   // Converge them
   if (systemMessage && systemMessage.content.length > 0) {
     collapsedMessages.unshift({ message: systemMessage });
-  }
-
-  const result = html`
-    <div style=${style}>
-      ${collapsedMessages.map((msg, index) => {
-        if (collapsedMessages.length > 1 && numbered) {
-          return html` <div
-            style=${{
-              display: "grid",
-              gridTemplateColumns: "max-content auto",
-              columnGap: "0.4em",
-            }}
-          >
-            <div
-              style=${{
-                fontSize: FontSize.smaller,
-                ...TextStyle.secondary,
-                marginTop: "0.1em",
-              }}
-            >
-              ${index + 1}
-            </div>
-            <${ChatMessage}
-              id=${`${id}-chat-messages`}
-              message=${msg.message}
-              toolMessages=${msg.toolMessages}
-              indented=${indented}
-              toolCallStyle=${toolCallStyle}
-            />
-          </div>`;
-        } else {
-          return html` <${ChatMessage}
-            id=${`${id}-chat-messages`}
-            message=${msg.message}
-            toolMessages=${msg.toolMessages}
-            indented=${indented}
-            toolCallStyle=${toolCallStyle}
-          />`;
-        }
-      })}
-    </div>
-  `;
-
-  return result;
-};
+  }  
+  return collapsedMessages;
+}
 
 /**
  * Ensure that content is a proper content type

--- a/src/inspect_ai/_view/www/src/components/ChatView.mjs
+++ b/src/inspect_ai/_view/www/src/components/ChatView.mjs
@@ -43,9 +43,9 @@ export const ChatViewVirtualList = ({
     }}
     customScrollParent=${scrollRef.current}
     totalCount=${collapsedMessages.length}
-    overscan=${{
-      reverse: 3,
-      main: 2,
+    increaseViewportBy=${{
+      top: 1000,
+      bottom: 1000,
     }}
     itemContent=${(index) => {
       const number =

--- a/src/inspect_ai/_view/www/src/components/ExpandablePanel.mjs
+++ b/src/inspect_ai/_view/www/src/components/ExpandablePanel.mjs
@@ -70,10 +70,6 @@ export const ExpandablePanel = ({
     contentsStyle.border = "solid var(--bs-light-border-subtle) 1px";
   }
 
-  if (!showToggle) {
-    contentsStyle.marginBottom = "1em";
-  }
-
   return html`<div
       class="expandable-panel"
       ref=${contentsRef}

--- a/src/inspect_ai/_view/www/src/components/LargeModal.mjs
+++ b/src/inspect_ai/_view/www/src/components/LargeModal.mjs
@@ -21,9 +21,8 @@ export const LargeModal = ({
   warning,
   warningHidden,
   setWarningHidden,
-  scrollRef
+  scrollRef,
 }) => {
-
   // The footer
   const modalFooter = footer
     ? html`<div class="modal-footer">${footer}</div>`

--- a/src/inspect_ai/_view/www/src/components/LargeModal.mjs
+++ b/src/inspect_ai/_view/www/src/components/LargeModal.mjs
@@ -5,24 +5,24 @@ import { FontSize } from "../appearance/Fonts.mjs";
 import { ProgressBar } from "./ProgressBar.mjs";
 import { MessageBand } from "./MessageBand.mjs";
 
-export const LargeModal = (props) => {
-  const {
-    id,
-    title,
-    detail,
-    detailTools,
-    footer,
-    onkeyup,
-    visible,
-    onHide,
-    showProgress,
-    children,
-    initialScrollPositionRef,
-    setInitialScrollPosition,
-    warning,
-    warningHidden,
-    setWarningHidden,
-  } = props;
+export const LargeModal = ({
+  id,
+  title,
+  detail,
+  detailTools,
+  footer,
+  onkeyup,
+  visible,
+  onHide,
+  showProgress,
+  children,
+  initialScrollPositionRef,
+  setInitialScrollPosition,
+  warning,
+  warningHidden,
+  setWarningHidden,
+  scrollRef
+}) => {
 
   // The footer
   const modalFooter = footer
@@ -31,7 +31,7 @@ export const LargeModal = (props) => {
 
   // Support restoring the scroll position
   // but only do this for the first time that the children are set
-  const scrollRef = useRef(/** @type {HTMLElement|null} */ (null));
+  scrollRef = scrollRef || useRef(/** @type {HTMLElement|null} */ (null));
   useEffect(() => {
     if (scrollRef.current) {
       setTimeout(() => {

--- a/src/inspect_ai/_view/www/src/components/TabSet.mjs
+++ b/src/inspect_ai/_view/www/src/components/TabSet.mjs
@@ -45,7 +45,8 @@ export const TabPanel = ({
   children,
 }) => {
   const tabContentsId = computeTabContentsId(id, index);
-  const tabContentsRef = scrollRef || useRef(/** @type {HTMLElement|null} */ (null));
+  const tabContentsRef =
+    scrollRef || useRef(/** @type {HTMLElement|null} */ (null));
   useEffect(() => {
     setTimeout(() => {
       if (

--- a/src/inspect_ai/_view/www/src/components/TabSet.mjs
+++ b/src/inspect_ai/_view/www/src/components/TabSet.mjs
@@ -38,13 +38,14 @@ export const TabPanel = ({
   selected,
   style,
   scrollable,
+  scrollRef,
   classes,
   scrollPosition,
   setScrollPosition,
   children,
 }) => {
   const tabContentsId = computeTabContentsId(id, index);
-  const tabContentsRef = useRef(/** @type {HTMLElement|null} */ (null));
+  const tabContentsRef = scrollRef || useRef(/** @type {HTMLElement|null} */ (null));
   useEffect(() => {
     setTimeout(() => {
       if (

--- a/src/inspect_ai/_view/www/src/samples/SampleDialog.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDialog.mjs
@@ -1,5 +1,5 @@
 import { html } from "htm/preact";
-import { useCallback, useMemo } from "preact/hooks";
+import { useCallback, useMemo, useRef } from "preact/hooks";
 
 import { ApplicationIcons } from "../appearance/Icons.mjs";
 import { LargeModal } from "../components/LargeModal.mjs";
@@ -43,6 +43,8 @@ export const SampleDialog = ({
   sampleScrollPositionRef,
   setSampleScrollPosition,
 }) => {
+  const scrollRef = useRef(/** @type {HTMLElement|null} */ (null));
+
   const tools = useMemo(() => {
     const nextTool = {
       label: "Next Sample",
@@ -94,6 +96,7 @@ export const SampleDialog = ({
           sampleDescriptor=${sampleDescriptor}
           selectedTab=${selectedTab}
           setSelectedTab=${setSelectedTab}
+          scrollRef=${scrollRef}
         />`;
   }, [id, sample, sampleDescriptor, selectedTab, setSelectedTab, sampleError]);
 
@@ -113,6 +116,7 @@ export const SampleDialog = ({
       showProgress=${sampleStatus === "loading"}
       initialScrollPositionRef=${sampleScrollPositionRef}
       setInitialScrollPosition=${setSampleScrollPosition}
+      scrollRef=${scrollRef}
     >
         ${children}
     </${LargeModal}>`;

--- a/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
@@ -125,12 +125,12 @@ export const SampleDisplay = ({
     html`
     <${TabPanel} id=${kSampleMessagesTabId} classes="sample-tab" title="Messages" onSelected=${onSelectedTab} selected=${
       selectedTab === kSampleMessagesTabId
-    }>
+    } scrollable=${false}>
       <${ChatViewVirtualList} 
         key=${`${baseId}-chat-${id}`} 
         id=${`${baseId}-chat-${id}`} 
         messages=${sample.messages} 
-        style=${{ paddingLeft: ".8em", paddingTop: "1em" }}
+        style=${{ marginLeft: ".8em", marginTop: "1em" }}
         indented=${true}
         scrollRef=${scrollRef}
       />

--- a/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
@@ -57,6 +57,7 @@ export const InlineSampleDisplay = ({
   sampleDescriptor,
   selectedTab,
   setSelectedTab,
+  scrollRef,
 }) => {
   return html`<div style=${{ flexDirection: "row", width: "100%" }}>
     <${ProgressBar}
@@ -77,6 +78,7 @@ export const InlineSampleDisplay = ({
             sampleDescriptor=${sampleDescriptor}
             selectedTab=${selectedTab}
             setSelectedTab=${setSelectedTab}
+            scrollRef=${scrollRef}
           />`}
     </div>
   </div>`;
@@ -91,6 +93,7 @@ export const InlineSampleDisplay = ({
  * @param {import("../samples/SamplesDescriptor.mjs").SamplesDescriptor} props.sampleDescriptor - the sample descriptor
  * @param {string} props.selectedTab - The selected tab
  * @param {(tab: string) => void} props.setSelectedTab - function to set the selected tab
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable parent element
  * @returns {import("preact").JSX.Element} The TranscriptView component.
  */
 export const SampleDisplay = ({
@@ -99,6 +102,7 @@ export const SampleDisplay = ({
   sampleDescriptor,
   selectedTab,
   setSelectedTab,
+  scrollRef
 }) => {
   // Tab ids
   const baseId = `sample-dialog`;
@@ -136,7 +140,7 @@ export const SampleDisplay = ({
       <${TabPanel} id=${kSampleTranscriptTabId} classes="sample-tab" title="Transcript" onSelected=${onSelectedTab} selected=${
         selectedTab === kSampleTranscriptTabId || selectedTab === undefined
       } scrollable=${false}>
-        <${SampleTranscript} key=${`${baseId}-transcript-display-${id}`} id=${`${baseId}-transcript-display-${id}`} evalEvents=${sample.events}/>
+        <${SampleTranscript} key=${`${baseId}-transcript-display-${id}`} id=${`${baseId}-transcript-display-${id}`} evalEvents=${sample.events} scrollRef=${scrollRef}/>
       </${TabPanel}>`);
   }
 

--- a/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
@@ -1,6 +1,6 @@
 import { html } from "htm/preact";
 
-import { ChatView, ChatViewVirtualList } from "../components/ChatView.mjs";
+import { ChatViewVirtualList } from "../components/ChatView.mjs";
 import { MetaDataView } from "../components/MetaDataView.mjs";
 import { TabSet, TabPanel } from "../components/TabSet.mjs";
 
@@ -103,7 +103,7 @@ export const SampleDisplay = ({
   sampleDescriptor,
   selectedTab,
   setSelectedTab,
-  scrollRef
+  scrollRef,
 }) => {
   // Tab ids
   const baseId = `sample-dialog`;
@@ -126,7 +126,7 @@ export const SampleDisplay = ({
     <${TabPanel} id=${kSampleMessagesTabId} classes="sample-tab" title="Messages" onSelected=${onSelectedTab} selected=${
       selectedTab === kSampleMessagesTabId
     }>
-      <${ChatView} 
+      <${ChatViewVirtualList} 
         key=${`${baseId}-chat-${id}`} 
         id=${`${baseId}-chat-${id}`} 
         messages=${sample.messages} 
@@ -217,7 +217,6 @@ export const SampleDisplay = ({
         <${JSONPanel} data=${sample} simple=${true}/>
       </div>
     </${TabPanel}>`);
-
   }
 
   const tabsetId = `task-sample-details-tab-${id}`;

--- a/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
@@ -132,6 +132,7 @@ export const SampleDisplay = ({
         messages=${sample.messages} 
         style=${{ paddingLeft: ".8em", paddingTop: "1em" }}
         indented=${true}
+        scrollRef=${scrollRef}
       />
     </${TabPanel}>`,
   ];

--- a/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleDisplay.mjs
@@ -1,6 +1,6 @@
 import { html } from "htm/preact";
 
-import { ChatView } from "../components/ChatView.mjs";
+import { ChatView, ChatViewVirtualList } from "../components/ChatView.mjs";
 import { MetaDataView } from "../components/MetaDataView.mjs";
 import { TabSet, TabPanel } from "../components/TabSet.mjs";
 
@@ -47,6 +47,7 @@ import {
  * @param {import("../samples/SamplesDescriptor.mjs").SamplesDescriptor} props.sampleDescriptor - the sample descriptor
  * @param {string} props.selectedTab - The selected tab
  * @param {(tab: string) => void} props.setSelectedTab - function to set the selected tab
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable element whic contains this display
  * @returns {import("preact").JSX.Element} The TranscriptView component.
  */
 export const InlineSampleDisplay = ({
@@ -205,16 +206,19 @@ export const SampleDisplay = ({
     );
   }
 
-  tabs.push(html`<${TabPanel} 
-          id=${kSampleJsonTabId} 
-          classes="sample-tab"
-          title="JSON" 
-          onSelected=${onSelectedTab} 
-          selected=${selectedTab === kSampleJsonTabId}>
-         <div style=${{ paddingLeft: "0.8em", marginTop: "0.4em" }}> 
-          <${JSONPanel} data=${sample} simple=${true}/>
-        </div>
-      </${TabPanel}>`);
+  if (sample.messages.length < 100) {
+    tabs.push(html`<${TabPanel} 
+        id=${kSampleJsonTabId} 
+        classes="sample-tab"
+        title="JSON" 
+        onSelected=${onSelectedTab} 
+        selected=${selectedTab === kSampleJsonTabId}>
+      <div style=${{ paddingLeft: "0.8em", marginTop: "0.4em" }}> 
+        <${JSONPanel} data=${sample} simple=${true}/>
+      </div>
+    </${TabPanel}>`);
+
+  }
 
   const tabsetId = `task-sample-details-tab-${id}`;
   const targetId = `${tabsetId}-content`;

--- a/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 import { html } from "htm/preact";
-import { TranscriptView } from "./transcript/TranscriptView.mjs";
+import { TranscriptVirtualList } from "./transcript/TranscriptView.mjs";
 
 /**
  * Renders the SampleTranscript component.
@@ -8,8 +8,9 @@ import { TranscriptView } from "./transcript/TranscriptView.mjs";
  * @param {Object} props - The parameters for the component.
  * @param {string} props.id - The id of this component
  * @param {import("../types/log").Events} props.evalEvents - The transcript to display.
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable parent element
  * @returns {import("preact").JSX.Element} The SampleTranscript component.
  */
-export const SampleTranscript = ({ id, evalEvents }) => {
-  return html`<${TranscriptView} id=${id} events=${evalEvents} />`;
+export const SampleTranscript = ({ id, evalEvents, scrollRef }) => {
+  return html`<${TranscriptVirtualList} id=${id} events=${evalEvents} scrollRef=${scrollRef}/>`;
 };

--- a/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SampleTranscript.mjs
@@ -12,5 +12,9 @@ import { TranscriptVirtualList } from "./transcript/TranscriptView.mjs";
  * @returns {import("preact").JSX.Element} The SampleTranscript component.
  */
 export const SampleTranscript = ({ id, evalEvents, scrollRef }) => {
-  return html`<${TranscriptVirtualList} id=${id} events=${evalEvents} scrollRef=${scrollRef}/>`;
+  return html`<${TranscriptVirtualList}
+    id=${id}
+    events=${evalEvents}
+    scrollRef=${scrollRef}
+  />`;
 };

--- a/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
@@ -31,7 +31,7 @@ import { EmptyPanel } from "../components/EmptyPanel.mjs";
  * @param {import("../Types.mjs").ScoreFilter} props.filter - the selected filter
  * @param {import("htm/preact").MutableRef<number>} props.sampleScrollPositionRef - the sample scroll position
  * @param {(position: number) => void} props.setSampleScrollPosition - sets the sample scroll position
- * @param {import("htm/preact").MutableRef<HTMLElement>} props.sampleTabScrollRef - the sample scroll element 
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.sampleTabScrollRef - the sample scroll element
  * @param {any} props.sort - the selected sort
  *
  * @returns {import("preact").JSX.Element[]} The TranscriptView component.
@@ -55,7 +55,7 @@ export const SamplesTab = ({
   setSelectedSampleTab,
   sampleScrollPositionRef,
   setSampleScrollPosition,
-  sampleTabScrollRef
+  sampleTabScrollRef,
 }) => {
   /** @type {[ListItem[], function(ListItem[]): void]} */
   const [items, setItems] = useState([]);

--- a/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
+++ b/src/inspect_ai/_view/www/src/samples/SamplesTab.mjs
@@ -31,6 +31,7 @@ import { EmptyPanel } from "../components/EmptyPanel.mjs";
  * @param {import("../Types.mjs").ScoreFilter} props.filter - the selected filter
  * @param {import("htm/preact").MutableRef<number>} props.sampleScrollPositionRef - the sample scroll position
  * @param {(position: number) => void} props.setSampleScrollPosition - sets the sample scroll position
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.sampleTabScrollRef - the sample scroll element 
  * @param {any} props.sort - the selected sort
  *
  * @returns {import("preact").JSX.Element[]} The TranscriptView component.
@@ -54,6 +55,7 @@ export const SamplesTab = ({
   setSelectedSampleTab,
   sampleScrollPositionRef,
   setSampleScrollPosition,
+  sampleTabScrollRef
 }) => {
   /** @type {[ListItem[], function(ListItem[]): void]} */
   const [items, setItems] = useState([]);
@@ -152,6 +154,7 @@ export const SamplesTab = ({
         sampleDescriptor=${sampleDescriptor}
         selectedTab=${selectedSampleTab}
         setSelectedTab=${setSelectedSampleTab}
+        scrollRef=${sampleTabScrollRef}
       />`,
     );
   } else if (sampleMode === "many") {

--- a/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/EventPanel.mjs
@@ -172,7 +172,6 @@ export const EventPanel = ({
     id=${id}
     style=${{
       padding: "0.625rem",
-      marginBottom: "0.625rem",
       border: "solid 1px var(--bs-light-border-subtle)",
       borderRadius: "var(--bs-border-radius)",
       ...style,

--- a/src/inspect_ai/_view/www/src/samples/transcript/EventRow.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/EventRow.mjs
@@ -34,7 +34,7 @@ export const EventRow = ({ title, icon, style, children }) => {
     class="card"
     style=${{
       padding: "0.4em",
-      marginBottom: "0.4em",
+      marginBottom: "0",
       border: "solid 1px var(--bs-light-border-subtle)",
       borderRadius: "var(--bs-border-radius)",
       ...style,

--- a/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
@@ -1,9 +1,7 @@
 // @ts-check
 import { html } from "htm/preact";
 import { EventPanel } from "./EventPanel.mjs";
-import {
-  TranscriptVirtualListComponent,
-} from "./TranscriptView.mjs";
+import { TranscriptVirtualListComponent } from "./TranscriptView.mjs";
 import { formatDateTime } from "../../utils/Format.mjs";
 
 /**

--- a/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/StepEventView.mjs
@@ -1,7 +1,9 @@
 // @ts-check
 import { html } from "htm/preact";
 import { EventPanel } from "./EventPanel.mjs";
-import { TranscriptComponent } from "./TranscriptView.mjs";
+import {
+  TranscriptVirtualListComponent,
+} from "./TranscriptView.mjs";
 import { formatDateTime } from "../../utils/Format.mjs";
 
 /**
@@ -11,9 +13,10 @@ import { formatDateTime } from "../../utils/Format.mjs";
  * @param {Object} props.style - The style properties passed to the component.
  * @param {import("../../types/log").StepEvent} props.event - The event object to display.
  * @param {import("./Types.mjs").EventNode[]} props.children - The event notes children of this step
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable parent element
  * @returns {import("preact").JSX.Element} The component that displays event details.
  */
-export const StepEventView = ({ event, children, style }) => {
+export const StepEventView = ({ event, children, style, scrollRef }) => {
   const descriptor = stepDescriptor(event);
   const title =
     descriptor.name ||
@@ -31,9 +34,10 @@ export const StepEventView = ({ event, children, style }) => {
     collapse=${false}
     text=${text}
   >
-    <${TranscriptComponent}
+    <${TranscriptVirtualListComponent}
       id=${`step-${event.name}-transcript`}
       eventNodes=${children}
+      scrollRef=${scrollRef}
     />
   </EventPanel>
   `;

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -15,7 +15,8 @@ import { ApprovalEventView } from "./ApprovalEventView.mjs";
 import { SampleLimitEventView } from "./SampleLimitEventView.mjs";
 import { FontSize } from "../../appearance/Fonts.mjs";
 import { EventNode } from "./Types.mjs";
-import { Virtuoso } from "react-virtuoso";
+// @ts-ignore
+import { Virtuoso, LogLevel } from "react-virtuoso";
 
 /**
  * Renders the TranscriptView component.
@@ -33,7 +34,6 @@ export const TranscriptView = ({ id, events, depth = 0 }) => {
   return html` <${TranscriptComponent} id=${id} eventNodes=${eventNodes} /> `;
 };
 
-
 /**
  * Renders the Transcript component.
  *
@@ -45,23 +45,28 @@ export const TranscriptView = ({ id, events, depth = 0 }) => {
  * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable parent element
  * @returns {import("preact").JSX.Element} The TranscriptView component.
  */
-export const TranscriptVirtualList = ({ id, scrollRef, events, depth, style }) => {
+export const TranscriptVirtualList = (props) => {
+  let { id, scrollRef, events, depth, style } = props;
+
   // Normalize Events themselves
   const resolvedEvents = fixupEventStream(events);
   const eventNodes = treeifyEvents(resolvedEvents, depth);
-  
-  const count = eventNodes ? eventNodes.length : 0;
+
+
+
   return html`<${Virtuoso}
       id=${`${id}-virtual-list`}
+      logLevel=${LogLevel.DEBUG}
       style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
       customScrollParent=${scrollRef.current}
-      totalCount=${count}
+      data=${eventNodes}
       overscan=${{
         reverse: 3,
         main: 2
       }}
       itemContent=${(index) => {
           const node = eventNodes[index];
+          
           const toggleStyle = {};
           if (node.depth % 2 == 0) {
             toggleStyle.backgroundColor = "var(--bs-light-bg-subtle)";

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -78,13 +78,12 @@ export const TranscriptVirtualListComponent = ({
 }) => {
   return html`<${Virtuoso}
     id=${`${id}-virtual-list`}
-    logLevel=${LogLevel.DEBUG}
     style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
     customScrollParent=${scrollRef.current}
     data=${eventNodes}
-    overscan=${{
-      reverse: 3,
-      main: 2,
+    increaseViewportBy=${{
+      top: 1000,
+      bottom: 1000,
     }}
     itemContent=${(index) => {
       const node = eventNodes[index];

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -52,48 +52,69 @@ export const TranscriptVirtualList = (props) => {
   const resolvedEvents = fixupEventStream(events);
   const eventNodes = treeifyEvents(resolvedEvents, depth);
 
+  return html`<${TranscriptVirtualListComponent}
+    id=${id}
+    eventNodes=${eventNodes}
+    style=${style}
+    scrollRef=${scrollRef}
+  />`;
+};
 
-
+/**
+ * Renders the Transcript component.
+ *
+ * @param {Object} props - The parameters for the component.
+ * @param {string} props.id - The identifier for this view
+ * @param {EventNode[]} props.eventNodes - The transcript events nodes to display.
+ * @param {Object} props.style - The transcript style to display.
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable parent element
+ * @returns {import("preact").JSX.Element} The TranscriptView component.
+ */
+export const TranscriptVirtualListComponent = ({
+  id,
+  eventNodes,
+  style,
+  scrollRef,
+}) => {
   return html`<${Virtuoso}
-      id=${`${id}-virtual-list`}
-      logLevel=${LogLevel.DEBUG}
-      style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
-      customScrollParent=${scrollRef.current}
-      data=${eventNodes}
-      overscan=${{
-        reverse: 3,
-        main: 2
-      }}
-      itemContent=${(index) => {
-          const node = eventNodes[index];
-          
-          const toggleStyle = {};
-          if (node.depth % 2 == 0) {
-            toggleStyle.backgroundColor = "var(--bs-light-bg-subtle)";
-          } else {
-            toggleStyle.backgroundColor = "var(--bs-body-bg)";
-          }
-          
-          let paddingTop = "0";
-          if (index === 0) {
-            paddingTop = ".5em";
-          }
+    id=${`${id}-virtual-list`}
+    logLevel=${LogLevel.DEBUG}
+    style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
+    customScrollParent=${scrollRef.current}
+    data=${eventNodes}
+    overscan=${{
+      reverse: 3,
+      main: 2,
+    }}
+    itemContent=${(index) => {
+      const node = eventNodes[index];
 
-          return html`<div style=${{ paddingTop, paddingBottom: ".5em"}}>
-                        <${RenderedEventNode}
-                          id=${`${id}-event${index}`}
-                          node=${node}
-                          style=${{
-                            ...toggleStyle,
-                            ...style,
-                          }}
-                        />
-                      </div>`
-        }
+      const toggleStyle = {};
+      if (node.depth % 2 == 0) {
+        toggleStyle.backgroundColor = "var(--bs-light-bg-subtle)";
+      } else {
+        toggleStyle.backgroundColor = "var(--bs-body-bg)";
       }
-    />`
 
-}
+      let paddingTop = "0";
+      if (index === 0) {
+        paddingTop = ".5em";
+      }
+
+      return html`<div style=${{ paddingTop, paddingBottom: ".5em" }}>
+        <${RenderedEventNode}
+          id=${`${id}-event${index}`}
+          node=${node}
+          style=${{
+            ...toggleStyle,
+            ...style,
+          }}
+          scrollRef=${scrollRef}
+        />
+      </div>`;
+    }}
+  />`;
+};
 
 /**
  * Renders the Transcript component.
@@ -125,14 +146,14 @@ export const TranscriptComponent = ({ id, eventNodes, style }) => {
 
     const row = html`
       <div style=${{ paddingBottom }}>
-      <${RenderedEventNode}
-        id=${`${id}-event${index}`}
-        node=${eventNode}
-        style=${{
-          ...toggleStyle,
-          ...style,
-        }}
-      />
+        <${RenderedEventNode}
+          id=${`${id}-event${index}`}
+          node=${eventNode}
+          style=${{
+            ...toggleStyle,
+            ...style,
+          }}
+        />
       </div>
     `;
     return row;
@@ -159,9 +180,10 @@ export const TranscriptComponent = ({ id, eventNodes, style }) => {
  * @param {string} props.id - The id for this event.
  * @param { EventNode } props.node - This event.
  * @param { Object } props.style - The style for this node.
+ * @param {import("htm/preact").MutableRef<HTMLElement>} props.scrollRef - The scrollable parent element
  * @returns {import("preact").JSX.Element} The rendered event.
  */
-export const RenderedEventNode = ({ id, node, style }) => {
+export const RenderedEventNode = ({ id, node, style, scrollRef }) => {
   switch (node.event.event) {
     case "sample_init":
       return html`<${SampleInitEventView}
@@ -218,6 +240,7 @@ export const RenderedEventNode = ({ id, node, style }) => {
         event=${node.event}
         children=${node.children}
         style=${style}
+        scrollRef=${scrollRef}
       />`;
 
     case "store":

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -81,6 +81,7 @@ export const TranscriptVirtualListComponent = ({
     style=${{ width: "100%", overflowY: "unset", boxSizing: "border-box" }}
     customScrollParent=${scrollRef.current}
     data=${eventNodes}
+    skipAnimationFrameInResizeObserver=${true}
     increaseViewportBy=${{
       top: 1000,
       bottom: 1000,

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.mjs
@@ -16,7 +16,7 @@ import { SampleLimitEventView } from "./SampleLimitEventView.mjs";
 import { FontSize } from "../../appearance/Fonts.mjs";
 import { EventNode } from "./Types.mjs";
 // @ts-ignore
-import { Virtuoso, LogLevel } from "react-virtuoso";
+import { Virtuoso } from "react-virtuoso";
 
 /**
  * Renders the TranscriptView component.

--- a/src/inspect_ai/_view/www/src/utils/Format.mjs
+++ b/src/inspect_ai/_view/www/src/utils/Format.mjs
@@ -126,10 +126,17 @@ export const formatTime = (seconds) => {
     return `${seconds} sec`;
   } else if (seconds < 60 * 60) {
     return `${Math.floor(seconds / 60)} min ${seconds % 60} sec`;
+  } else if (seconds < 60 * 60 * 24) {
+    const hours = Math.floor(seconds / (60 * 60));
+    const minutes = Math.floor((seconds % (60 * 60)) / 60);
+    const remainingSeconds = seconds % 60;
+    return `${hours} hr ${minutes} min ${remainingSeconds} sec`;
   } else {
-    return `${Math.floor(seconds / (60 * 60 * 24))} days ${Math.floor(
-      seconds / 60,
-    )} min ${seconds % 60} sec`;
+    const days = Math.floor(seconds / (60 * 60 * 24));
+    const hours = Math.floor((seconds % (60 * 60 * 24)) / (60 * 60));
+    const minutes = Math.floor((seconds % (60 * 60)) / 60);
+    const remainingSeconds = seconds % 60;
+    return `${days} days ${hours} hr ${minutes} min ${remainingSeconds} sec`;
   }
 };
 

--- a/src/inspect_ai/_view/www/src/utils/Json.mjs
+++ b/src/inspect_ai/_view/www/src/utils/Json.mjs
@@ -1,6 +1,8 @@
 // @ts-check
 
 export const asyncJsonParse = async (text) => {
+  const encoder = new TextEncoder();
+  const encodedText = encoder.encode(text);
   const blob = new Blob([kWorkerCode], { type: "application/javascript" });
   const blobURL = URL.createObjectURL(blob);
   const worker = new Worker(blobURL);
@@ -17,7 +19,7 @@ export const asyncJsonParse = async (text) => {
         reject(new Error(error.message));
       };
     });
-    worker.postMessage({ scriptContent: kJson5ScriptBase64, text });
+    worker.postMessage({ scriptContent: kJson5ScriptBase64, encodedText }, [encodedText.buffer]);
     return await result;
   } finally {
     worker.terminate();
@@ -28,12 +30,14 @@ export const asyncJsonParse = async (text) => {
 const kWorkerCode = `
 self.onmessage = function (e) {
   eval(atob(e.data.scriptContent));
-  const text = e.data.text;
+  const { encodedText } = e.data;
+  const decoder = new TextDecoder();
+  const text = decoder.decode(encodedText);
   try {
-    const result = JSON5.parse(text);
-    self.postMessage({ success: true, result });
-  } catch (error) {
-    self.postMessage({ success: false, error: error.message });
+    const result = JSON.parse(text);
+    postMessage({ success: true, result });
+  } catch (err) {
+    postMessage({ success: false, error: err.message });
   }
 };`;
 

--- a/src/inspect_ai/_view/www/src/utils/Json.mjs
+++ b/src/inspect_ai/_view/www/src/utils/Json.mjs
@@ -19,7 +19,9 @@ export const asyncJsonParse = async (text) => {
         reject(new Error(error.message));
       };
     });
-    worker.postMessage({ scriptContent: kJson5ScriptBase64, encodedText }, [encodedText.buffer]);
+    worker.postMessage({ scriptContent: kJson5ScriptBase64, encodedText }, [
+      encodedText.buffer,
+    ]);
     return await result;
   } finally {
     worker.terminate();

--- a/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
+++ b/src/inspect_ai/_view/www/src/workspace/WorkSpace.mjs
@@ -142,6 +142,8 @@ export const WorkSpace = ({
     }
   }, [divRef, task_id]);
 
+  const sampleTabScrollRef = useRef(/** @type {HTMLElement|null} */ (null));
+
   const resolvedTabs = useMemo(() => {
     // Tabs that are available within the app
     // Include the tab contents as well as any tools that the tab provides
@@ -154,6 +156,7 @@ export const WorkSpace = ({
       resolvedTabs.samples = {
         id: kEvalWorkspaceTabId,
         scrollable: samples.length === 1,
+        scrollRef: sampleTabScrollRef,
         label: samples?.length > 1 ? "Samples" : "Sample",
         content: () => {
           return html` <${SamplesTab}
@@ -178,6 +181,7 @@ export const WorkSpace = ({
             epoch=${epoch}
             sampleScrollPositionRef=${sampleScrollPositionRef}
             setSampleScrollPosition=${setSampleScrollPosition}
+            sampleTabScrollRef=${sampleTabScrollRef}
           />`;
         },
         tools: () => {
@@ -442,6 +446,7 @@ const WorkspaceDisplay = ({
         onSelected=${onSelected}
         selected=${selectedTab === tab.id}
         scrollable=${!!tab.scrollable}
+        scrollRef=${tab.scrollRef}
         scrollPosition=${workspaceTabScrollPositionRef.current[tab.id]}
         setScrollPosition=${useCallback(
           (position) => {

--- a/src/inspect_ai/_view/www/vite.config.js
+++ b/src/inspect_ai/_view/www/vite.config.js
@@ -26,4 +26,11 @@ export default defineConfig({
       css: true,
     }),
   ],
+  resolve: {
+    alias: {
+      'react': 'preact/compat',
+      'react-dom': 'preact/compat',
+      'react-dom/test-utils': 'preact/test-utils'
+    }
+  }  
 });

--- a/src/inspect_ai/_view/www/yarn.lock
+++ b/src/inspect_ai/_view/www/yarn.lock
@@ -1267,6 +1267,11 @@ regenerator-runtime@^0.14.0:
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz#356ade10263f685dda125100cd862c1db895327f"
   integrity sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==
 
+react-virtuoso@^4.12.3:
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/react-virtuoso/-/react-virtuoso-4.12.3.tgz#beecf0582b31058c5a6ed3ec58fc43fd780e5844"
+  integrity sha512-6X1p/sU7hecmjDZMAwN+r3go9EVjofKhwkUbVlL8lXhBZecPv9XVCkZ/kBPYOr0Mv0Vl5+Ziwgexg9Kh7+NNXQ==
+
 resolve-from@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"


### PR DESCRIPTION
This PR is designed to improve the performance of the log viewer with samples with a large number of 'turns' or transcript events. Changes include:

- both transcript and chatview now use virtual lists to render only visible items
- improve performance of json parsing by using a transferableObject rather than copying a string
- Use the Virtuoso react virtual list which has additional feature our internal implementation lacks (most importantly dynamically computed element heights).


## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

