### PR TITLE
Modify web-browser to properly display errors

### DIFF
--- a/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
@@ -372,7 +372,9 @@ async def web_browser_cmd(cmd: str, *args: str) -> str:
         )
     else:
         response = parse_web_browser_output(result.stdout)
-        if "web_at" in response:
+        if "error" in response:
+            raise ToolError(str(response.get("error")) or "(unknown error)")
+        elif "web_at" in response:
             web_at = (
                 str(response.get("web_at")) or "(no web accessiblity tree available)"
             )
@@ -384,8 +386,6 @@ async def web_browser_cmd(cmd: str, *args: str) -> str:
             web_at = "\n".join(web_at_lines)
             store_as(WebBrowserStore).web_at = web_at
             return web_at
-        elif "error" in response:
-            raise ToolError(str(response.get("error")) or "(unknown error)")
         else:
             raise RuntimeError(
                 f"web_browser output must contain either 'error' or 'web_at' field: {result.stdout}"

--- a/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
@@ -372,7 +372,7 @@ async def web_browser_cmd(cmd: str, *args: str) -> str:
         )
     else:
         response = parse_web_browser_output(result.stdout)
-        if "error" in response:
+        if "error" in response and response.get("error").strip() != "":
             raise ToolError(str(response.get("error")) or "(unknown error)")
         elif "web_at" in response:
             web_at = (


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Right now, the web-browsing tool does not display errors when both the `error` field and the `web_at` field are present in the response. However, sometimes both are present when an error occurs. 
### What is the new behavior?
In this fix, a `ToolError` is returned whenever the `response` contains an error that is not just whitespace.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Other information:
N/A