### PR TITLE
consolidate o1 max tokens logic

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -263,7 +263,7 @@ class OpenAIAPI(ModelAPI):
             model=self.model_name,
         )
         if config.max_tokens is not None:
-            if self.is_o1_full():
+            if self.is_o1():
                 params["max_completion_tokens"] = config.max_tokens
             else:
                 params["max_tokens"] = config.max_tokens

--- a/src/inspect_ai/model/_providers/openai_o1.py
+++ b/src/inspect_ai/model/_providers/openai_o1.py
@@ -48,12 +48,6 @@ async def generate_o1(
     # create chatapi handler
     handler = O1PreviewChatAPIHandler()
 
-    # map max_tokens => max_completion_tokens
-    max_tokens = params.get("max_tokens", None)
-    if max_tokens:
-        params["max_completion_tokens"] = max_tokens
-        del params["max_tokens"]
-
     # call model
     request = dict(
         model=model,


### PR DESCRIPTION
o1 models use `max_completion_tokens` rather than `max_tokens`. We previously handled this separately for `o1-preview` and `o1-mini`, now the logic is consolidated.