### PR TITLE
task display: timeout tool button for manually timing out a tool call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Support for [audio and video](https://github.com/UKGovernmentBEIS/inspect_ai/pull/1102) inputs for Open AI and Google Gemini models.
+- Task display: Added Timeout Tool button for manually timing out a tool call.
 - `task_with()` function for creating task variants.
 - Added `--filter` argument to trace CLI commands for filtering on trace log message content.
 - Print model conversations to terminal with `--display=conversation` (was formerly `--trace`, which is now deprecated).

--- a/src/inspect_ai/_display/textual/widgets/samples.py
+++ b/src/inspect_ai/_display/textual/widgets/samples.py
@@ -25,6 +25,7 @@ from textual.widgets.option_list import Option, Separator
 from inspect_ai._util.format import format_progress_time
 from inspect_ai._util.registry import registry_unqualified_name
 from inspect_ai.log._samples import ActiveSample
+from inspect_ai.log._transcript import ToolEvent
 
 from .clock import Clock
 from .transcript import TranscriptView
@@ -332,16 +333,28 @@ class SandboxesView(Vertical):
 
 
 class SampleToolbar(Horizontal):
+    STATUS_GROUP = "status_group"
+    TIMEOUT_TOOL_CALL = "timeout_tool_call"
     CANCEL_SCORE_OUTPUT = "cancel_score_output"
     CANCEL_RAISE_ERROR = "cancel_raise_error"
     PENDING_STATUS = "pending_status"
     PENDING_CAPTION = "pending_caption"
 
     DEFAULT_CSS = f"""
+    SampleToolbar {{
+        grid-size: 5 1;
+        grid-columns: auto auto 1fr auto auto;
+    }}
+    SampleToolbar #{STATUS_GROUP} {{
+        min-width: 20;
+    }}
     SampleToolbar Button {{
         margin-bottom: 1;
         margin-right: 2;
-        min-width: 20;
+        min-width: 18;
+    }}
+    SampleToolbar #{TIMEOUT_TOOL_CALL} {{
+        color: $error-darken-3;
     }}
     SampleToolbar #{CANCEL_SCORE_OUTPUT} {{
         color: $primary-darken-3;
@@ -356,9 +369,16 @@ class SampleToolbar(Horizontal):
         self.sample: ActiveSample | None = None
 
     def compose(self) -> ComposeResult:
-        with VerticalGroup(id=self.PENDING_STATUS):
-            yield Static("Executing...", id=self.PENDING_CAPTION)
-            yield HorizontalGroup(EventLoadingIndicator(), Clock())
+        with HorizontalGroup(id=self.STATUS_GROUP):
+            with VerticalGroup(id=self.PENDING_STATUS):
+                yield Static("Executing...", id=self.PENDING_CAPTION)
+                yield HorizontalGroup(EventLoadingIndicator(), Clock())
+        yield Button(
+            Text("Timeout Tool"),
+            id=self.TIMEOUT_TOOL_CALL,
+            tooltip="Cancel the tool call and report a timeout to the model.",
+        )
+        yield Horizontal()
         yield Button(
             Text("Cancel (Score)"),
             id=self.CANCEL_SCORE_OUTPUT,
@@ -372,12 +392,21 @@ class SampleToolbar(Horizontal):
 
     def on_mount(self) -> None:
         self.query_one("#" + self.PENDING_STATUS).visible = False
+        self.query_one("#" + self.TIMEOUT_TOOL_CALL).display = False
         self.query_one("#" + self.CANCEL_SCORE_OUTPUT).display = False
         self.query_one("#" + self.CANCEL_RAISE_ERROR).display = False
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if self.sample:
-            if event.button.id == self.CANCEL_SCORE_OUTPUT:
+            if event.button.id == self.TIMEOUT_TOOL_CALL:
+                last_event = (
+                    self.sample.transcript.events[-1]
+                    if self.sample.transcript.events
+                    else None
+                )
+                if isinstance(last_event, ToolEvent):
+                    last_event.cancel()
+            elif event.button.id == self.CANCEL_SCORE_OUTPUT:
                 self.sample.interrupt("score")
             elif event.button.id == self.CANCEL_RAISE_ERROR:
                 self.sample.interrupt("error")
@@ -389,6 +418,7 @@ class SampleToolbar(Horizontal):
         self.sample = sample
 
         pending_status = self.query_one("#" + self.PENDING_STATUS)
+        timeout_tool = self.query_one("#" + self.TIMEOUT_TOOL_CALL)
         clock = self.query_one(Clock)
         cancel_score_output = cast(
             Button, self.query_one("#" + self.CANCEL_SCORE_OUTPUT)
@@ -419,14 +449,19 @@ class SampleToolbar(Horizontal):
                 pending_caption.update(
                     Text.from_markup(f"[italic]{pending_caption_text}[/italic]")
                 )
+
+                timeout_tool.display = isinstance(last_event, ToolEvent)
+
                 clock.start(last_event.timestamp.timestamp())
             else:
                 pending_status.visible = False
+                timeout_tool.display = False
                 clock.stop()
 
         else:
             self.display = False
             pending_status.visible = False
+            timeout_tool.display = False
             clock.stop()
 
 

--- a/src/inspect_ai/_display/textual/widgets/samples.py
+++ b/src/inspect_ai/_display/textual/widgets/samples.py
@@ -354,7 +354,8 @@ class SampleToolbar(Horizontal):
         min-width: 18;
     }}
     SampleToolbar #{TIMEOUT_TOOL_CALL} {{
-        color: $error-darken-3;
+        color: $secondary-darken-3;
+        min-width: 16;
     }}
     SampleToolbar #{CANCEL_SCORE_OUTPUT} {{
         color: $primary-darken-3;


### PR DESCRIPTION
Long running tool calls can now be timed out manually by the operator from the running sample display.
