### PR TITLE
Fixing error for HF models with no chat_template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `task_with()` function for creating task variants.
 - Added `--filter` argument to trace CLI commands for filtering on trace log message content.
 - Print model conversations to terminal with `--display=conversation` (was formerly `--trace`, which is now deprecated).
+- HuggingFace: Support models that don't provide a chat template (e.g. gpt2)
 
 ## v0.3.57 (09 January 2025)
 

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -239,12 +239,17 @@ class HuggingFaceAPI(ModelAPI):
                 hf_messages = inspect_tools_to_string(hf_messages)
 
         # apply chat template
-        chat = self.tokenizer.apply_chat_template(
-            hf_messages,
-            add_generation_prompt=True,
-            tokenize=False,
-            tools=tools_list if len(tools_list) > 0 else None,
-        )
+        if self.tokenizer.chat_template is not None:
+            chat = self.tokenizer.apply_chat_template(
+                hf_messages,
+                add_generation_prompt=True,
+                tokenize=False,
+                tools=tools_list if len(tools_list) > 0 else None,
+            )
+        else:
+            chat = ""
+            for message in hf_messages:
+                chat += f"{message.role}: {message.content}\n"
         # return
         return cast(str, chat)
 


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)
#1103 Error when using models that don't have a chat template.

### What is the new behavior?
We extract the role and content from messages without using chat template.
Doesn't support tool usage, but most likely such old models won't used for tool based evals.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
None

