### PR TITLE
Introduce clustered (and heteroskedasticity-robust) standard errors

### DIFF
--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -18,7 +18,7 @@ from inspect_ai.log import (
 )
 from inspect_ai.log._log import EvalSampleReductions
 from inspect_ai.scorer import Metric, Score, Scorer
-from inspect_ai.scorer._metric import SampleScore
+from inspect_ai.scorer._metric import SampleScore 
 from inspect_ai.scorer._reducer import ScoreReducer, mean_score, reducer_log_name
 from inspect_ai.scorer._scorer import (
     SCORER_METRICS,
@@ -364,6 +364,7 @@ def reduce_scores(
                 answer=reduced.answer,
                 explanation=reduced.explanation,
                 metadata=reduced.metadata,
+                children=reduced.children,
             )
         )
 

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -18,7 +18,7 @@ from inspect_ai.log import (
 )
 from inspect_ai.log._log import EvalSampleReductions
 from inspect_ai.scorer import Metric, Score, Scorer
-from inspect_ai.scorer._metric import SampleScore, ReducedScore
+from inspect_ai.scorer._metric import ReducedScore, SampleScore
 from inspect_ai.scorer._reducer import ScoreReducer, mean_score, reducer_log_name
 from inspect_ai.scorer._scorer import (
     SCORER_METRICS,

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -18,7 +18,7 @@ from inspect_ai.log import (
 )
 from inspect_ai.log._log import EvalSampleReductions
 from inspect_ai.scorer import Metric, Score, Scorer
-from inspect_ai.scorer._metric import SampleScore 
+from inspect_ai.scorer._metric import SampleScore, ReducedScore
 from inspect_ai.scorer._reducer import ScoreReducer, mean_score, reducer_log_name
 from inspect_ai.scorer._scorer import (
     SCORER_METRICS,
@@ -74,7 +74,7 @@ def eval_results(
                 sample_reductions.append(reduced_samples)
 
                 # Compute metrics for this scorer
-                simple_scores = cast(list[Score], reduced_scores)
+                simple_scores = cast(list[ReducedScore], reduced_scores)
                 targets = metrics if metrics is not None else scorer_metrics(scorer)
                 if isinstance(targets, list):
                     ## split the metrics into the simple metrics and any dictionary
@@ -158,7 +158,7 @@ def scorer_for_metrics(
     scorer_name: str,
     scorer: Scorer,
     metadata: dict[str, Any],
-    scores: list[Score],
+    scores: list[ReducedScore],
     metrics: list[Metric],
     reducer_name: str | None = None,
 ) -> list[EvalScore]:
@@ -230,7 +230,7 @@ def scorers_from_metric_dict(
     scorer_name: str,
     scorer: Scorer,
     metadata: dict[str, Any],
-    scores: list[Score],
+    scores: list[ReducedScore],
     metrics: dict[str, list[Metric]],
     reducer_name: str | None = None,
 ) -> list[EvalScore]:
@@ -243,7 +243,7 @@ def scorers_from_metric_dict(
 
     for metric_key, metric_list in resolved_metrics.items():
         # filter scores to a list of scalars with the value of the metric name
-        metric_scores: list[Score] = []
+        metric_scores: list[ReducedScore] = []
         for score in scores:
             if isinstance(score.value, dict):
                 if metric_key in score.value:

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -28,8 +28,8 @@ from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 from inspect_ai.util._store import Store
 from inspect_ai.util._store_model import SMT
 
-from ._transcript import Event
 from ..scorer._metric import ReducedScore
+from ._transcript import Event
 
 logger = getLogger(__name__)
 

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -29,6 +29,7 @@ from inspect_ai.util._store import Store
 from inspect_ai.util._store_model import SMT
 
 from ._transcript import Event
+from ..scorer._metric import ReducedScore
 
 logger = getLogger(__name__)
 
@@ -322,7 +323,7 @@ class EvalScore(BaseModel):
     """Additional scorer metadata."""
 
 
-class EvalSampleScore(Score):
+class EvalSampleScore(ReducedScore):
     sample_id: str | int | None = Field(default=None)
 
 

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -53,6 +53,7 @@ __all__ = [
     "bootstrap_std",
     "std",
     "stderr",
+    "clustered_stderr",
     "mean",
     "Metric",
     "metric",

--- a/src/inspect_ai/scorer/_metric.py
+++ b/src/inspect_ai/scorer/_metric.py
@@ -111,6 +111,10 @@ class Score(BaseModel):
             raise ValueError("This score is not a scalar")
 
 
+class ReducedScore(Score):
+    children: list[Score] = Field(default_factory=list)
+    """List of child (unreduced) scores"""
+
 class SampleScore(BaseModel):
     """Score for a Sample
 

--- a/src/inspect_ai/scorer/_metric.py
+++ b/src/inspect_ai/scorer/_metric.py
@@ -115,6 +115,7 @@ class ReducedScore(Score):
     children: list[Score] = Field(default_factory=list)
     """List of child (unreduced) scores"""
 
+
 class SampleScore(BaseModel):
     """Score for a Sample
 

--- a/src/inspect_ai/scorer/_metric.py
+++ b/src/inspect_ai/scorer/_metric.py
@@ -193,13 +193,13 @@ class Metric(Protocol):
     r"""Evaluate scores using a metric.
 
     Args:
-        scores (list[Score]): List of scores.
+        scores (list[ReducedScore]): List of reduced scores.
 
     Returns:
         Metric value
     """
 
-    def __call__(self, scores: list[Score]) -> Value: ...
+    def __call__(self, scores: list[ReducedScore]) -> Value: ...
 
 
 P = ParamSpec("P")

--- a/src/inspect_ai/scorer/_metrics/accuracy.py
+++ b/src/inspect_ai/scorer/_metrics/accuracy.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from .._metric import (
     Metric,
-    Score,
+    ReducedScore,
     ValueToFloat,
     metric,
     value_to_float,
@@ -28,7 +28,7 @@ def accuracy(to_float: ValueToFloat = value_to_float()) -> Metric:
        Accuracy metric
     """
 
-    def metric(scores: list[Score]) -> float:
+    def metric(scores: list[ReducedScore]) -> float:
         total = 0.0
         for item in scores:
             total += to_float(item.value)

--- a/src/inspect_ai/scorer/_metrics/mean.py
+++ b/src/inspect_ai/scorer/_metrics/mean.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .._metric import Metric, Score, metric
+from .._metric import Metric, ReducedScore, metric
 
 
 @metric
@@ -11,7 +11,7 @@ def mean() -> Metric:
        mean metric
     """
 
-    def metric(scores: list[Score]) -> float:
+    def metric(scores: list[ReducedScore]) -> float:
         return np.mean([score.as_float() for score in scores]).item()
 
     return metric
@@ -25,7 +25,7 @@ def var() -> Metric:
        var metric
     """
 
-    def metric(scores: list[Score]) -> float:
+    def metric(scores: list[ReducedScore]) -> float:
         return np.var([score.as_float() for score in scores]).item()
 
     return metric

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from .._metric import (
     Metric,
-    Score,
     ReducedScore,
     ValueToFloat,
     metric,
@@ -50,7 +49,9 @@ def bootstrap_std(
 
 @metric
 def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
-    """Clustered standard error of the mean, where each ``ReducedScore``'s children form a cluster.
+    """Clustered standard error of the mean.
+
+    Where each ``ReducedScore``'s children form a cluster.
     If ``epochs=1`` such that each ``ReducedScore`` has only one child, clustered standard errors
     reduce to heteroskedasticity-robust (White) standard errors.
 
@@ -89,9 +90,8 @@ def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
 
         # Calculate unclustered variance term
         unclustered_var = sum(
-            sum((x - overall_mean) ** 2 for x in cluster)
-            for cluster in fscores
-        ) / (n ** 2)
+            sum((x - overall_mean) ** 2 for x in cluster) for cluster in fscores
+        ) / (n**2)
 
         # Calculate between-observation covariance terms within clusters
         cluster_covar = 0.0
@@ -108,7 +108,7 @@ def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
                 )
 
         # Add covariance term to unclustered variance
-        clustered_var = unclustered_var + (cluster_covar / (n ** 2))
+        clustered_var = unclustered_var + (cluster_covar / (n**2))
 
         # Apply small sample correction g/(g-1) to variance
         clustered_var *= g / (g - 1)

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -77,8 +77,10 @@ def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
             fscores.append(values)
 
         n = sum(len(cluster) for cluster in fscores)  # total number of scores
-        g = len(fscores)  # number of clusters
-        if n < 2:
+        g = len(scores)  # number of clusters
+
+        # Ensure that we won't divide by zero if there is only one cluster
+        if (g - 1) == 0:
             return 0.0
 
         overall_mean = sum(sum(cluster) for cluster in fscores) / n

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -76,8 +76,8 @@ def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
             values = [to_float(child.value) for child in score.children]
             fscores.append(values)
 
-        # Calculate overall mean across all scores
         n = sum(len(cluster) for cluster in fscores)  # total number of scores
+        g = len(fscores)  # number of clusters
         if n < 2:
             return 0.0
 
@@ -105,6 +105,9 @@ def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
 
         # Add covariance term to unclustered variance
         clustered_var = unclustered_var + (cluster_covar / (n ** 2))
+
+        # Apply small sample correction g/(g-1) to variance
+        clustered_var *= g / (g - 1)
 
         # Return standard error
         stderr = np.sqrt(clustered_var)

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -54,6 +54,8 @@ def stderr(to_float: ValueToFloat = value_to_float()) -> Metric:
     If ``epochs=1`` such that each ``ReducedScore`` has only one child, clustered standard errors
     reduce to heteroskedasticity-robust (White) standard errors.
 
+    See also Miller, 'Adding Error Bars to Evals': https://arxiv.org/abs/2411.00640
+
     Args:
         to_float (ValueToFloat): Function for mapping
             Value to float for computing metrics. The default

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -35,7 +35,7 @@ def bootstrap_std(
        bootstrap_std metric
     """
 
-    def metric(scores: list[Score]) -> float:
+    def metric(scores: list[ReducedScore]) -> float:
         values = [to_float(score.value) for score in scores]
         std = np.std(
             [
@@ -135,7 +135,7 @@ def std(to_float: ValueToFloat = value_to_float()) -> Metric:
         std metric
     """
 
-    def metric(scores: list[Score]) -> float:
+    def metric(scores: list[ReducedScore]) -> float:
         values = [to_float(score.value) for score in scores]
         n = len(values)
 

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -4,7 +4,13 @@ from typing import Callable, cast
 
 import numpy as np
 
-from inspect_ai.scorer._metric import Score, Value, ValueToFloat, value_to_float, ReducedScore
+from inspect_ai.scorer._metric import (
+    ReducedScore,
+    Score,
+    Value,
+    ValueToFloat,
+    value_to_float,
+)
 
 from .registry import REDUCER_NAME, score_reducer
 from .types import ScoreReducer

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -4,7 +4,7 @@ from typing import Callable, cast
 
 import numpy as np
 
-from inspect_ai.scorer._metric import Score, Value, ValueToFloat, value_to_float
+from inspect_ai.scorer._metric import Score, Value, ValueToFloat, value_to_float, ReducedScore
 
 from .registry import REDUCER_NAME, score_reducer
 from .types import ScoreReducer
@@ -12,7 +12,7 @@ from .types import ScoreReducer
 
 @score_reducer(name="mode")
 def mode_score() -> ScoreReducer:
-    def reduce(scores: list[Score]) -> Score:
+    def reduce(scores: list[Score]) -> ReducedScore:
         r"""A utility function for the most common score in a list of scores.
 
         Args:
@@ -36,7 +36,7 @@ def mode_score() -> ScoreReducer:
 
 @score_reducer(name="mean")
 def mean_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
-    def reduce(scores: list[Score]) -> Score:
+    def reduce(scores: list[Score]) -> ReducedScore:
         r"""A utility function for taking a mean value over a list of scores.
 
         Args:
@@ -54,7 +54,7 @@ def mean_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
 
 @score_reducer(name="median")
 def median_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
-    def reduce(scores: list[Score]) -> Score:
+    def reduce(scores: list[Score]) -> ReducedScore:
         r"""A utility function for taking a median value over a list of scores.
 
         Args:
@@ -74,7 +74,7 @@ def median_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReduce
 def at_least(
     k: int, value: float = 1.0, value_to_float: ValueToFloat = value_to_float()
 ) -> ScoreReducer:
-    def reduce(scores: list[Score]) -> Score:
+    def reduce(scores: list[Score]) -> ReducedScore:
         r"""A utility function for scoring a value as correct if there are at least n score values greater than or equal to the value
 
         Args:
@@ -104,7 +104,7 @@ def at_least(
 def pass_at(
     k: int, value: float = 1.0, value_to_float: ValueToFloat = value_to_float()
 ) -> ScoreReducer:
-    def reduce(scores: list[Score]) -> Score:
+    def reduce(scores: list[Score]) -> ReducedScore:
         def pass_at_k(values: list[float]) -> float:
             total = len(scores)
             correct = sum(1 for v in values if v == value)
@@ -129,7 +129,7 @@ def pass_at(
 
 @score_reducer(name="max")
 def max_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
-    def reduce(scores: list[Score]) -> Score:
+    def reduce(scores: list[Score]) -> ReducedScore:
         r"""A utility function for taking the maximum value from a list of scores
 
         Args:
@@ -170,7 +170,7 @@ def max_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
 def _count_scalar(
     scores: list[Score],
     counter_fn: Callable[[Counter[str | int | float | bool]], str | int | float | bool],
-) -> Score:
+) -> ReducedScore:
     r"""Counts scores and provides Counter to a counter_fn
 
     Args:
@@ -184,7 +184,7 @@ def _count_scalar(
 def _count_dict(
     scores: list[Score],
     counter_fn: Callable[[Counter[str | int | float | bool]], str | int | float | bool],
-) -> Score:
+) -> ReducedScore:
     r"""Counts scores within a dictionary and provides Counter (for each key) to a counter_fn
 
     Args:
@@ -209,7 +209,7 @@ def _count_dict(
 def _count_list(
     scores: list[Score],
     counter_fn: Callable[[Counter[str | int | float | bool]], str | int | float | bool],
-) -> Score:
+) -> ReducedScore:
     r"""Counts scores within a list and provides Counter (for each index) to a counter_fn
 
     Args:
@@ -233,7 +233,7 @@ def _compute_dict_stat(
     scores: list[Score],
     value_to_float: ValueToFloat,
     statistic: Callable[[list[float]], float],
-) -> Score:
+) -> ReducedScore:
     r"""Applies a statistic function to reduce key by key a dictionary
 
     Args:
@@ -255,7 +255,7 @@ def _compute_list_stat(
     scores: list[Score],
     value_to_float: ValueToFloat,
     statistic: Callable[[list[float]], float],
-) -> Score:
+) -> ReducedScore:
     r"""Applies a statistic function to reduce index by index a list
 
     Args:
@@ -278,7 +278,7 @@ def _compute_scalar_stat(
     scores: list[Score],
     value_to_float: ValueToFloat,
     statistic: Callable[[list[float]], float],
-) -> Score:
+) -> ReducedScore:
     r"""Applies a statistic function to reduce scalar scores
 
     Args:
@@ -315,14 +315,14 @@ def _check_value_list(scores: list[Score]) -> None:
             raise ValueError("Attempting to reduce a list score for a non-list value")
 
 
-def _reduced_score(value: Value, scores: list[Score]) -> Score:
-    r"""Create a Score based upon a single Value and list of Scores that produced it
+def _reduced_score(value: Value, scores: list[Score]) -> ReducedScore:
+    r"""Create a ReducedScore based upon a single Value and list of Scores that produced it
 
     Args:
         value: the reduced Value
         scores: ths list of scores being reduced
     """
-    return Score(
+    return ReducedScore(
         value=value,
         # retain remaining fields only if equal across all Scores
         answer=scores[0].answer
@@ -332,4 +332,5 @@ def _reduced_score(value: Value, scores: list[Score]) -> Score:
         if len(set(score.explanation for score in scores)) == 1
         else None,
         metadata=scores[0].metadata,
+        children=scores,
     )

--- a/src/inspect_ai/scorer/_reducer/types.py
+++ b/src/inspect_ai/scorer/_reducer/types.py
@@ -1,6 +1,6 @@
 from typing import Protocol, runtime_checkable
 
-from .._metric import Score, ReducedScore
+from .._metric import ReducedScore, Score
 
 
 @runtime_checkable

--- a/src/inspect_ai/scorer/_reducer/types.py
+++ b/src/inspect_ai/scorer/_reducer/types.py
@@ -1,11 +1,11 @@
 from typing import Protocol, runtime_checkable
 
-from .._metric import Score
+from .._metric import Score, ReducedScore
 
 
 @runtime_checkable
 class ScoreReducer(Protocol):
-    def __call__(self, scores: list[Score]) -> Score: ...
+    def __call__(self, scores: list[Score]) -> ReducedScore: ...
 
     @property
     def __name__(self) -> str: ...

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -17,7 +17,7 @@ from inspect_ai.scorer import (
     scorer,
     std,
 )
-from inspect_ai.scorer._metric import metric_create, ReducedScore
+from inspect_ai.scorer._metric import ReducedScore, metric_create
 from inspect_ai.scorer._target import Target
 from inspect_ai.solver._task_state import TaskState
 

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -17,7 +17,7 @@ from inspect_ai.scorer import (
     scorer,
     std,
 )
-from inspect_ai.scorer._metric import metric_create
+from inspect_ai.scorer._metric import metric_create, ReducedScore
 from inspect_ai.scorer._target import Target
 from inspect_ai.solver._task_state import TaskState
 
@@ -28,7 +28,7 @@ from inspect_ai.solver._task_state import TaskState
 
 @metric
 def accuracy1(correct: str = "C") -> Metric:
-    def metric(scores: list[Score]) -> int | float:
+    def metric(scores: list[ReducedScore]) -> int | float:
         return 1
 
     return metric
@@ -36,7 +36,7 @@ def accuracy1(correct: str = "C") -> Metric:
 
 @metric(name="accuracy2")
 def acc_fn(correct: str = "C") -> Metric:
-    def metric(scores: list[Score]) -> int | float:
+    def metric(scores: list[ReducedScore]) -> int | float:
         return 1
 
     return metric
@@ -47,7 +47,7 @@ class Accuracy3(Metric):
     def __init__(self, correct: str = "C") -> None:
         self.correct = correct
 
-    def __call__(self, scores: list[Score]) -> int | float:
+    def __call__(self, scores: list[ReducedScore]) -> int | float:
         return 1
 
 
@@ -56,13 +56,13 @@ class AccuracyNamedCls(Metric):
     def __init__(self, correct: str = "C") -> None:
         self.correct = correct
 
-    def __call__(self, scores: list[Score]) -> int | float:
+    def __call__(self, scores: list[ReducedScore]) -> int | float:
         return 1
 
 
 @metric
 def list_metric() -> Metric:
-    def metric(scores: list[Score]) -> Value:
+    def metric(scores: list[ReducedScore]) -> Value:
         return [1, 2, 3]
 
     return metric
@@ -70,7 +70,7 @@ def list_metric() -> Metric:
 
 @metric
 def dict_metric() -> Metric:
-    def metric(scores: list[Score]) -> Value:
+    def metric(scores: list[ReducedScore]) -> Value:
         return {"one": 1, "two": 2, "three": 3}
 
     return metric
@@ -167,7 +167,7 @@ def test_alternative_metrics() -> None:
 
 @metric
 def complex_metric() -> Metric:
-    def metric(scores: list[Score]) -> int | float:
+    def metric(scores: list[ReducedScore]) -> int | float:
         total = 0.0
         for complex_score in scores:
             if isinstance(complex_score.value, dict):
@@ -251,7 +251,7 @@ def metric_create_assert(name: str, **kwargs: Any) -> None:
 
 @metric
 def nested_dict_metric(correct: str = "C") -> Metric:
-    def metric(scores: list[Score]) -> Value:
+    def metric(scores: list[ReducedScore]) -> Value:
         return {"key1": 1.0, "key2": 2.0}
 
     return metric
@@ -291,7 +291,7 @@ def test_nested_dict_metrics() -> None:
 
 @metric
 def nested_list_metric(correct: str = "C") -> Metric:
-    def metric(scores: list[Score]) -> Value:
+    def metric(scores: list[ReducedScore]) -> Value:
         return [1.0, 2.0]
 
     return metric

--- a/tests/scorer/test_metric_stderr.py
+++ b/tests/scorer/test_metric_stderr.py
@@ -25,16 +25,52 @@ def cluster_se(data: pd.DataFrame) -> float:
 ```
 """
 
-def test_stderr_single_score():
-    """Test stderr with a single score"""
+
+def test_stderr_single_cluster():
+    """
+    Backward compatibility: previous implementation of stderr returned 0 for a single reduced score.
+    """
     scores = [
-        ReducedScore(value=1.0, children=[Score(value=1.0)])
+        ReducedScore(value=2.5, children=[
+            Score(value=1.0),
+            Score(value=2.0),
+            Score(value=3.0),
+            Score(value=4.0)
+        ])
     ]
 
     metric = stderr()
     result = metric(scores)
 
-    assert result == 0.0
+    expected = 0
+    assert pytest.approx(result) == expected
+
+
+def test_stderr_singleton_clusters():
+    """
+    Test clustered SE with three clusters of size 1 each.
+    This should reduce to the heteroskedasticity-robust standard error.
+
+    Statsmodels verification:
+    ```python
+    data = pd.DataFrame({
+        "y": [1.0, 2.0, 3.0],
+        "cluster_ids": [1, 2, 3]
+    })
+    print(cluster_se(data))
+    ```
+    """
+    scores = [
+        ReducedScore(value=1.0, children=[Score(value=1.0)]),
+        ReducedScore(value=2.0, children=[Score(value=2.0)]),
+        ReducedScore(value=3.0, children=[Score(value=3.0)])
+    ]
+
+    metric = stderr()
+    result = metric(scores)
+
+    expected = 0.5773502691896258  # from statsmodels
+    assert pytest.approx(result) == expected
 
 
 def test_stderr_empty_cluster():
@@ -49,10 +85,34 @@ def test_stderr_empty_cluster():
         metric(scores)
 
 
-def test_stderr_binary_outcomes():
+def test_stderr_identical_within_varied_between():
     """
-    Test clustered SE with binary outcomes (0/1) across 3 clusters.
+    Test clustered SE where values are identical within clusters but vary between clusters.
 
+    Statsmodels verification:
+    ```python
+    data = pd.DataFrame({
+        "y": [1.0, 1.0, 2.0, 2.0, 3.0, 3.0, 3.0],
+        "cluster_ids": [1, 1, 2, 2, 3, 3, 3]
+    })
+    print(cluster_se(data))
+    ```
+    """
+    scores = [
+        ReducedScore(value=1.0, children=[Score(value=1.0), Score(value=1.0)]),
+        ReducedScore(value=2.0, children=[Score(value=2.0), Score(value=2.0)]),
+        ReducedScore(value=3.0, children=[Score(value=3.0), Score(value=3.0), Score(value=3.0)])
+    ]
+
+    metric = stderr()
+    result = metric(scores)
+
+    expected = 0.6040264729366833  # from statsmodels
+    assert pytest.approx(result) == expected
+
+
+def test_stderr_1():
+    """
     Statsmodels verification:
     ```python
     data = pd.DataFrame({
@@ -73,4 +133,28 @@ def test_stderr_binary_outcomes():
 
     expected = 0.28867513459481303  # from statsmodels
 
+    assert pytest.approx(result) == expected
+
+
+def test_stderr_2():
+    """
+    Statsmodels verification:
+    ```python
+    data = pd.DataFrame({
+        "y": [9.0, 4.0, 11.0, 6.0, 13.0, 8.0],
+        "cluster_ids": [1, 1, 2, 2, 3, 3]
+    })
+    print(cluster_se(data))
+    ```
+    """
+    scores = [
+        ReducedScore(value=6.5, children=[Score(value=9.0), Score(value=4.0)]),
+        ReducedScore(value=8.5, children=[Score(value=11.0), Score(value=6.0)]),
+        ReducedScore(value=10.5, children=[Score(value=13.0), Score(value=8.0)])
+    ]
+
+    metric = stderr()
+    result = metric(scores)
+
+    expected = 1.1547005383792521  # from statsmodels
     assert pytest.approx(result) == expected

--- a/tests/scorer/test_metric_stderr.py
+++ b/tests/scorer/test_metric_stderr.py
@@ -1,8 +1,7 @@
 import pytest
 
-from inspect_ai.scorer._metric import Score, ReducedScore
+from inspect_ai.scorer._metric import ReducedScore, Score
 from inspect_ai.scorer._metrics.std import stderr
-
 
 """
 Comparisons to ``statsmodels`` are done using the following code:
@@ -27,16 +26,17 @@ def cluster_se(data: pd.DataFrame) -> float:
 
 
 def test_stderr_single_cluster():
-    """
-    Backward compatibility: previous implementation of stderr returned 0 for a single reduced score.
-    """
+    """Backward compatibility: previous implementation of stderr returned 0 for a single reduced score."""
     scores = [
-        ReducedScore(value=2.5, children=[
-            Score(value=1.0),
-            Score(value=2.0),
-            Score(value=3.0),
-            Score(value=4.0)
-        ])
+        ReducedScore(
+            value=2.5,
+            children=[
+                Score(value=1.0),
+                Score(value=2.0),
+                Score(value=3.0),
+                Score(value=4.0),
+            ],
+        )
     ]
 
     metric = stderr()
@@ -47,8 +47,8 @@ def test_stderr_single_cluster():
 
 
 def test_stderr_singleton_clusters():
-    """
-    Test clustered SE with three clusters of size 1 each.
+    """Test clustered SE with three clusters of size 1 each.
+
     This should reduce to the heteroskedasticity-robust standard error.
 
     Statsmodels verification:
@@ -63,7 +63,7 @@ def test_stderr_singleton_clusters():
     scores = [
         ReducedScore(value=1.0, children=[Score(value=1.0)]),
         ReducedScore(value=2.0, children=[Score(value=2.0)]),
-        ReducedScore(value=3.0, children=[Score(value=3.0)])
+        ReducedScore(value=3.0, children=[Score(value=3.0)]),
     ]
 
     metric = stderr()
@@ -77,11 +77,13 @@ def test_stderr_empty_cluster():
     """Test stderr raises error with empty clusters"""
     scores = [
         ReducedScore(value=1.0, children=[]),
-        ReducedScore(value=2.0, children=[Score(value=2.0)])
+        ReducedScore(value=2.0, children=[Score(value=2.0)]),
     ]
 
     metric = stderr()
-    with pytest.raises(ValueError, match="Clustered standard error requires non-empty clusters"):
+    with pytest.raises(
+        ValueError, match="Clustered standard error requires non-empty clusters"
+    ):
         metric(scores)
 
 
@@ -101,7 +103,9 @@ def test_stderr_identical_within_varied_between():
     scores = [
         ReducedScore(value=1.0, children=[Score(value=1.0), Score(value=1.0)]),
         ReducedScore(value=2.0, children=[Score(value=2.0), Score(value=2.0)]),
-        ReducedScore(value=3.0, children=[Score(value=3.0), Score(value=3.0), Score(value=3.0)])
+        ReducedScore(
+            value=3.0, children=[Score(value=3.0), Score(value=3.0), Score(value=3.0)]
+        ),
     ]
 
     metric = stderr()
@@ -112,8 +116,8 @@ def test_stderr_identical_within_varied_between():
 
 
 def test_stderr_1():
-    """
-    Statsmodels verification:
+    """Statsmodels verification.
+
     ```python
     data = pd.DataFrame({
         "y": [1, 1, 0, 0, 1, 0],
@@ -125,7 +129,7 @@ def test_stderr_1():
     scores = [
         ReducedScore(value=1.0, children=[Score(value=1.0), Score(value=1.0)]),
         ReducedScore(value=0.0, children=[Score(value=0.0), Score(value=0.0)]),
-        ReducedScore(value=0.5, children=[Score(value=1.0), Score(value=0.0)])
+        ReducedScore(value=0.5, children=[Score(value=1.0), Score(value=0.0)]),
     ]
 
     metric = stderr()
@@ -137,8 +141,8 @@ def test_stderr_1():
 
 
 def test_stderr_2():
-    """
-    Statsmodels verification:
+    """Statsmodels verification.
+
     ```python
     data = pd.DataFrame({
         "y": [9.0, 4.0, 11.0, 6.0, 13.0, 8.0],
@@ -150,7 +154,7 @@ def test_stderr_2():
     scores = [
         ReducedScore(value=6.5, children=[Score(value=9.0), Score(value=4.0)]),
         ReducedScore(value=8.5, children=[Score(value=11.0), Score(value=6.0)]),
-        ReducedScore(value=10.5, children=[Score(value=13.0), Score(value=8.0)])
+        ReducedScore(value=10.5, children=[Score(value=13.0), Score(value=8.0)]),
     ]
 
     metric = stderr()

--- a/tests/scorer/test_metric_stderr.py
+++ b/tests/scorer/test_metric_stderr.py
@@ -1,0 +1,76 @@
+import pytest
+
+from inspect_ai.scorer._metric import Score, ReducedScore
+from inspect_ai.scorer._metrics.std import stderr
+
+
+"""
+Comparisons to ``statsmodels`` are done using the following code:
+```python
+import pandas as pd
+import statsmodels.api as sm
+def cluster_se(data: pd.DataFrame) -> float:
+    # Add constant column of 1s.
+    # We are running a trivial regression where we only estimate the y-intercept
+    data['constant'] = 1
+
+    model = sm.OLS(data['y'], data[['constant']])
+
+    model = model.fit().get_robustcov_results(
+        cov_type='cluster',
+        groups=data['cluster_ids'],
+    )
+    assert len(model.bse) == 1
+    return model.bse[0]
+```
+"""
+
+def test_stderr_single_score():
+    """Test stderr with a single score"""
+    scores = [
+        ReducedScore(value=1.0, children=[Score(value=1.0)])
+    ]
+
+    metric = stderr()
+    result = metric(scores)
+
+    assert result == 0.0
+
+
+def test_stderr_empty_cluster():
+    """Test stderr raises error with empty clusters"""
+    scores = [
+        ReducedScore(value=1.0, children=[]),
+        ReducedScore(value=2.0, children=[Score(value=2.0)])
+    ]
+
+    metric = stderr()
+    with pytest.raises(ValueError, match="Clustered standard error requires non-empty clusters"):
+        metric(scores)
+
+
+def test_stderr_binary_outcomes():
+    """
+    Test clustered SE with binary outcomes (0/1) across 3 clusters.
+
+    Statsmodels verification:
+    ```python
+    data = pd.DataFrame({
+        "y": [1, 1, 0, 0, 1, 0],
+        "cluster_ids": [1, 1, 2, 2, 3, 3]
+    })
+    print(cluster_se(data))
+    ```
+    """
+    scores = [
+        ReducedScore(value=1.0, children=[Score(value=1.0), Score(value=1.0)]),
+        ReducedScore(value=0.0, children=[Score(value=0.0), Score(value=0.0)]),
+        ReducedScore(value=0.5, children=[Score(value=1.0), Score(value=0.0)])
+    ]
+
+    metric = stderr()
+    result = metric(scores)
+
+    expected = 0.28867513459481303  # from statsmodels
+
+    assert pytest.approx(result) == expected

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -20,6 +20,7 @@ from inspect_ai.scorer import (
     score_reducer,
     value_to_float,
 )
+from inspect_ai.scorer._metric import ReducedScore
 from inspect_ai.scorer._reducer import create_reducers
 
 avg_reducer = mean_score()
@@ -218,9 +219,9 @@ def test_complex_metadata_reduce():
 
 @score_reducer(name="add_em_up")
 def sum(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
-    def sum(scores: list[Score]) -> Score:
+    def sum(scores: list[Score]) -> ReducedScore:
         value = reduce(lambda x, y: x + value_to_float(y.value), scores, 0.0)
-        return Score(value=value)
+        return ReducedScore(value=value, children=scores)
 
     return sum
 

--- a/tests/util/test_registry.py
+++ b/tests/util/test_registry.py
@@ -7,7 +7,8 @@ from inspect_ai._util.registry import (
     registry_lookup,
     registry_value,
 )
-from inspect_ai.scorer import Metric, Score, metric
+from inspect_ai.scorer import Metric, metric
+from inspect_ai.scorer._metric import ReducedScore
 from inspect_ai.solver import Plan, Solver, solver, use_tools
 from inspect_ai.tool import Tool, bash
 
@@ -16,7 +17,7 @@ def test_registry_namespaces() -> None:
     # define a local metric which we can lookup by simple name
     @metric(name="local_accuracy")
     def accuracy1(correct: str = "C") -> Metric:
-        def metric(scores: list[Score]) -> int | float:
+        def metric(scores: list[ReducedScore]) -> int | float:
             return 1
 
         return metric


### PR DESCRIPTION
This PR corrects the `stderr` metric by introducing clustered standard errors [0].

# Motivation and previous behaviour
The motivation stems from how Inspect can sample an LLM multiple times (via the `epochs` parameter) for each question in a benchmark. 

Previously, we aggregated (reduced) each question’s samples into a single observation, and then computed standard errors from these question-level observations as if they were known with certainty.

This approach ignored LLM sampling uncertainty — LLM outputs can vary from one epoch to another for the same question. 

With clustered standard errors, we instead think of each benchmark question as a cluster. For `epochs=k`, each cluster has `k` observations. Each cluster’s internal variance contributes to the overall standard error.

The previous approach assumed that within-cluster variation was zero. Just to be clear, this assumption is also incorrect if `epochs=1`. If `epochs=1` we cannot estimate the within-cluster variance, but that does not mean we can assume it is zero.

The clustered standard error reduces to the heteroskedasticity-robust [1] standard error when `epochs=1`.

# Changes to types
I introduced a `ReducedScore` class as a subclass of `Score`. A `ReducedScore` keeps a reference to its “children” (a `list[Score]`), i.e. the scores that were used to calculate the reduced score. This is because the `stderr` metric needs to have access to the unreduced scores to calculate the clustered standard error.

This is not a breaking change to other metrics (e.g. `accuracy` still works without code changes). Metrics can continue to use existing `Score` functionality, without using the `children` field of a `ReducedScore`. 

A `Reducer` still takes in a `Score`, but now returns a `ReducedScore` instead of a `Score`. The `Metric` protocol (e.g., stderr, std, mean, etc.) now operates on lists of `ReducedScore` rather than lists of `Score`. 

A `ReducedScore` could also be used recursively, e.g. when there are thematically related clusters of questions. This was suggested by Miller (Adding Error Bars to Evals, https://arxiv.org/abs/2411.00640):

> We next consider eval questions that are drawn in groups, or clusters. For instance, DROP[6],
> QuAC[5], RACE[13], and SQuAD[17] are reading-comprehension evals having multiple related
> questions about independently selected passages of text, and multilingual evals such as MGSM[18]
> consist of the same question translated into many languages. ... We note that the cluster adjustment in our
real-world example is far from trivial (up to 3X). 


# Tests
I have added tests, including to check that this implementation gets the same numerical results as clustered standard errors in `statsmodels` [2]

[0] : https://en.wikipedia.org/wiki/Clustered_standard_errors
[1] : https://en.wikipedia.org/wiki/Heteroskedasticity-consistent_standard_errors
[2] : https://github.com/statsmodels/statsmodels