### PR TITLE
Fix inconsistent naming of bootstrap standard error

### DIFF
--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -72,7 +72,7 @@ Task(
 ```
 
 ::: {#stderr-note .callout-note}
-The current development version of Inspect replaces the use of the `bootstrap_std` metric with `stderr` for the built in scorers enumerated above.
+The current development version of Inspect replaces the use of the `bootstrap_stderr` metric with `stderr` for the built in scorers enumerated above.
 
 Since eval scores are means of numbers having finite variance, we can compute standard errors using the Central Limit Theorem rather than bootstrapping. Bootstrapping is generally useful in contexts with more complex structure or non-mean summary statistics (e.g. quantiles). You will notice that the bootstrap numbers will come in quite close to the analytic numbers, since they are estimating the same thing.
 
@@ -217,7 +217,7 @@ def includes(ignore_case: bool = True):
 1.  The function applies the `@scorer` decorator and registers two metrics for use with the scorer.
 2.  The `score()` function is declared as `async`. This is so that it can participate in Inspect's optimised scheduling for expensive model generation calls (this scorer doesn't call a model but others will).
 3.  We make use of the `text` property on the `Target`. This is a convenience property to get a simple text value out of the `Target` (as targets can technically be a list of strings).
-4.  We use the special constants `CORRECT` and `INCORRECT` for the score value (as the `accuracy()`, `stderr()`, and `bootstrap_std()` metrics know how to convert these special constants to float values (1.0 and 0.0 respectively).
+4.  We use the special constants `CORRECT` and `INCORRECT` for the score value (as the `accuracy()`, `stderr()`, and `bootstrap_stderr()` metrics know how to convert these special constants to float values (1.0 and 0.0 respectively).
 5.  We provide the full model completion as the answer for the score (`answer` is optional, but highly recommended as it is often useful to refer to during evaluation development).
 
 ### Example: Model Grading
@@ -514,7 +514,7 @@ Inspect includes some simple built in metrics for calculating accuracy, mean, et
 
     Standard error of the mean.
 
--   `bootstrap_std()`
+-   `bootstrap_stderr()`
 
     Standard deviation of a bootstrapped estimate of the mean. 1000 samples are taken by default (modify this using the `num_samples` option).
 

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -16,7 +16,7 @@ from ._metric import (
 )
 from ._metrics.accuracy import accuracy
 from ._metrics.mean import mean
-from ._metrics.std import bootstrap_std, std, stderr
+from ._metrics.std import bootstrap_stderr, std, stderr
 from ._model import model_graded_fact, model_graded_qa
 from ._multi import multi_scorer
 from ._pattern import pattern
@@ -50,7 +50,7 @@ __all__ = [
     "Target",
     "scorer",
     "accuracy",
-    "bootstrap_std",
+    "bootstrap_stderr",
     "std",
     "stderr",
     "mean",

--- a/src/inspect_ai/scorer/_metrics/__init__.py
+++ b/src/inspect_ai/scorer/_metrics/__init__.py
@@ -1,12 +1,12 @@
 from .accuracy import accuracy
 from .mean import mean, var
-from .std import bootstrap_std, std, stderr
+from .std import bootstrap_stderr, std, stderr
 
 __all__ = [
     "accuracy",
     "mean",
     "var",
-    "bootstrap_std",
+    "bootstrap_stderr",
     "std",
     "stderr",
 ]

--- a/src/inspect_ai/scorer/_metrics/std.py
+++ b/src/inspect_ai/scorer/_metrics/std.py
@@ -15,10 +15,10 @@ logger = getLogger(__name__)
 
 
 @metric
-def bootstrap_std(
+def bootstrap_stderr(
     num_samples: int = 1000, to_float: ValueToFloat = value_to_float()
 ) -> Metric:
-    """Standard deviation of a bootstrapped estimate of the mean.
+    """Standard error of the mean using bootstrap.
 
     Args:
        num_samples (int): Number of bootstrap samples to take.


### PR DESCRIPTION
Fixes the very confusing (arguably incorrect) name of the metric that computes the standard error of the mean via bootstrap. Also clarified the docstring.


The previous naming would lead to absurd outputs like:
```
╭─ math (50 samples): google/gemini-1.5-flash-002 ─────────────────────────────╮
│                                                                              │
│  stderr: 0.0714  std: 0.505  bootstrap_std: 0.0702                           │
│                                                                              │
╰──────────────────────────────────────────────────────────────────────────────╯
```

I understand that a breaking change is not ideal here, but the fact that `std` and `bootstrap_std` calculate two completely different things is pretty bad in my opinion. 