### PR TITLE
task display: automatically switch to "plain" mode when running in a background thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support for [audio and video](https://github.com/UKGovernmentBEIS/inspect_ai/pull/1102) inputs for Open AI and Google Gemini models.
 - Task display: Added Timeout Tool button for manually timing out a tool call.
+- Task display: Automatically switch to "plain" mode when running in a background thread
 - Sandboxes: Setup and initialisation errors are now handled at the sample level.
 - Sandboxes: Increase setup script timeout to 5 minutes (from 30 seconds) and do not retry setup scripts (in case they aren't idempotent).
 - Sandboxes: Add `timeout_retry` option (defaulting to `True`) to `exec()` function.

--- a/src/inspect_ai/_util/thread.py
+++ b/src/inspect_ai/_util/thread.py
@@ -1,0 +1,5 @@
+import threading
+
+
+def is_main_thread() -> bool:
+    return threading.current_thread() is threading.main_thread()

--- a/src/inspect_ai/util/_display.py
+++ b/src/inspect_ai/util/_display.py
@@ -3,6 +3,7 @@ from logging import getLogger
 from typing import Literal
 
 from inspect_ai._util.constants import DEFAULT_DISPLAY
+from inspect_ai._util.thread import is_main_thread
 
 logger = getLogger(__name__)
 
@@ -18,6 +19,13 @@ def init_display_type(display: str | None = None) -> DisplayType:
     display = (
         display or os.environ.get("INSPECT_DISPLAY", DEFAULT_DISPLAY).lower().strip()
     )
+
+    # if we are on a background thread then throttle down to "plain"
+    # ("full" requires textual which cannot run in a background thread
+    # b/c it calls the Python signal function; "rich" assumes exclusive
+    # display access which may not be the case for threads)
+    if display in ["full", "rich"] and not is_main_thread():
+        display = "plain"
 
     match display:
         case "full" | "conversation" | "rich" | "plain" | "none":


### PR DESCRIPTION
If we are on a background thread then throttle down to "plain" mode, as "full" requires textual which cannot run in a background thread, b/c it calls the Python signal function, and "rich" assumes exclusive display access which may not be the case for threads.
