### PR TITLE
Fix duplication of summaries when eval log file is rewritten

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - HuggingFace: Support models that don't provide a chat template (e.g. gpt2)
 - Eval Set: Ensure that logs with status 'started' are retried.
 - Rename the built in `bootstrap_std` metric to `bootstrap_stderr` (deprecate `bootstrap_std`)
+- Bugfix: Fix duplication of summaries when eval log file is rewritten.
 
 ## v0.3.57 (09 January 2025)
 

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -95,9 +95,11 @@ class EvalRecorder(FileRecorder):
         self.data: dict[str, ZipLogFile] = {}
 
     @override
-    async def log_init(self, eval: EvalSpec, location: str | None = None) -> str:
+    async def log_init(
+        self, eval: EvalSpec, location: str | None = None, *, clean: bool = False
+    ) -> str:
         # if the file exists then read summaries
-        if location is not None and self.fs.exists(location):
+        if not clean and location is not None and self.fs.exists(location):
             with file(location, "rb") as f:
                 with ZipFile(f, "r") as zip:
                     log_start = _read_start(zip)
@@ -234,7 +236,7 @@ class EvalRecorder(FileRecorder):
     async def write_log(cls, location: str, log: EvalLog) -> None:
         # write using the recorder (so we get all of the extra streams)
         recorder = EvalRecorder(dirname(location))
-        await recorder.log_init(log.eval, location)
+        await recorder.log_init(log.eval, location, clean=True)
         await recorder.log_start(log.eval, log.plan)
         for sample in log.samples or []:
             await recorder.log_sample(log.eval, sample)

--- a/tests/log/test_log_formats.py
+++ b/tests/log/test_log_formats.py
@@ -1,5 +1,6 @@
 import json
 import os
+import shutil
 import tempfile
 import zipfile
 from pathlib import Path
@@ -40,6 +41,26 @@ def test_log_format_round_trip_single(original_log, temp_dir):
 
         # Compare the logs
         assert original_log == new_log, f"Round-trip failed for {format} format"
+
+
+def test_eval_format_round_trip_overwrite(original_log, temp_dir):
+    format = "eval"
+
+    # Write it to a new file in the current format
+    new_log_path = (temp_dir / f"new_log.{format}").as_posix()
+    write_eval_log(original_log, new_log_path, format=format)
+
+    # make a copy of the log file for later comparison
+    copy_log_path = (temp_dir / f"new_log_copy.{format}").as_posix()
+    shutil.copy(new_log_path, copy_log_path)
+
+    # Overwrite the file
+    write_eval_log(original_log, new_log_path, format=format)
+
+    # ensure the zip file matches the original after overwriting
+    assert compare_zip_contents(new_log_path, copy_log_path), (
+        "EVAL zip file contents changed after rewriting file"
+    )
 
 
 def test_log_format_round_trip_cross(original_log, temp_dir):


### PR DESCRIPTION
This only will occur when we rewrite an eval log file (e.g. overwrite an existing file with a new EvalLog) - we were reading summaries from the original file, then adding summaries as the new EvalLog was written, causing duplication.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
