### PR TITLE
Fix tool args passthrough on kwargs

### DIFF
--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -329,7 +329,7 @@ def tool_params(input: dict[str, Any], func: Callable[..., Any]) -> dict[str, An
     docstring = inspect.getdoc(func)
 
     # if the function takes **kwargs: Any then just pass the tool arguments through
-    if type_hints == {"kwargs": Any}:
+    if "kwargs" in type_hints and type_hints["kwargs"] == Any:
         return input
 
     # build params


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The fix from #1137  would fail for the following value of type_hints
```python
{'kwargs': typing.Any, 'return': <class 'str'>}
```

### What is the new behavior?
The condition is now broader: it now matches any dict which contains `kwargs: Any` instead of requiring the dictionary to equal `{"kwargs": Any}`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
Not sure if you wanted tests for this; I couldn't find any in the previous PR or other parts of the code. However it seems like it'd be useful to have tests for `tool_params` for the different possible values