### PR TITLE
Fix off-by-one error in message limit

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -851,7 +851,7 @@ def handle_sample_message_limit(input: str | list[ChatMessage]) -> None:
     total_messages = 1 if isinstance(input, str) else len(input)
     message_limit = active_sample_message_limit()
     if message_limit is not None:
-        if total_messages > message_limit:
+        if total_messages >= message_limit:
             raise SampleLimitExceededError(
                 "message", value=total_messages, limit=message_limit
             )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
PR #1126 introduced an off-by-one error in message limits by changing `>=` to `>`.

This caused the following test in our codebase (and multiple others) to fail:
```python
def test_scheming_solver_message_limit():
    custom_outputs = [
        ModelOutput.from_content(
            model="mockllm/model",
            content="Message",
        )
        for _ in range(5)
    ]

    model = get_model(
        "mockllm/model",
        custom_outputs=custom_outputs,
    )

    log = run_scheming_solver(
        [ToolDef(addition())],
        ExitCondition(None),
        model=model,
        message_limit=3,
    )

    assert log.samples is not None
    messages = log.samples[0].messages

    assert len(messages) == 3
    assert log.status == "success"
```


### What is the new behavior?
I've reverted the change to the equality to remove the change in behaviour.

However, semantically it seems slightly strange because we are raising SampleLimit*Exceeded*Error if total messages EQUALs the message limit. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Reverts a breaking change, which I guess in itself is a breaking change

### Other information:
I think it would be good to add a version of the included test to this codebase (would need to be adapted)
