### PR TITLE
Improve display when `DisplayType` is `plain`

### DIFF
--- a/src/inspect_ai/_display/core/active.py
+++ b/src/inspect_ai/_display/core/active.py
@@ -4,6 +4,7 @@ from contextvars import ContextVar
 import rich
 
 from inspect_ai.util._display import display_type
+from ..plain.display import PlainDisplay
 
 from ..rich.display import RichDisplay
 from ..textual.display import TextualDisplay
@@ -13,7 +14,9 @@ from .display import Display, TaskScreen
 def display() -> Display:
     global _active_display
     if _active_display is None:
-        if (
+        if display_type() == "plain":
+            _active_display = PlainDisplay()
+        elif (
             display_type() == "full"
             and sys.stdout.isatty()
             and not rich.get_console().is_jupyter

--- a/src/inspect_ai/_display/core/active.py
+++ b/src/inspect_ai/_display/core/active.py
@@ -4,8 +4,8 @@ from contextvars import ContextVar
 import rich
 
 from inspect_ai.util._display import display_type
-from ..plain.display import PlainDisplay
 
+from ..plain.display import PlainDisplay
 from ..rich.display import RichDisplay
 from ..textual.display import TextualDisplay
 from .display import Display, TaskScreen

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -74,9 +74,8 @@ class PlainDisplay(Display):
             footer=None,
             log_location=None,
         )
-        print("\n")
+        print("Running task:")
         rich.print(panel)
-        print("\n")  # Add space before progress starts
 
         # Create and yield task display
         task = TaskWithResult(profile, None)

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -12,7 +12,7 @@ from ..core.display import (
     TaskResult,
     TaskScreen,
     TaskSpec,
-    TaskWithResult, TR,
+    TaskWithResult, TR, TaskError,
 )
 from ..core.footer import task_footer, task_resources, task_http_rate_limits
 from ..core.panel import task_targets, task_title, task_panel
@@ -85,22 +85,8 @@ class PlainDisplay(Display):
 
     def _print_results(self) -> None:
         """Print final results using rich panels"""
-        for task in self.tasks:
-            if task.result:
-                # Use rich panel for final summary
-                panel = task_panel(
-                    profile=task.profile,
-                    show_model=True,
-                    body=task_stats(task.result.stats),
-                    subtitle=(
-                        task_config(task.profile),
-                        task_targets(task.profile)
-                    ),
-                    footer=task_footer(),
-                    log_location=task.profile.log_location
-                )
-                print("\n")
-                rich.print(panel)
+        panels = tasks_results(self.tasks)
+        rich.print(panels)
 
 
 class PlainProgress(Progress):

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -1,17 +1,29 @@
+import asyncio
 import contextlib
-from typing import Any, Coroutine, Iterator, AsyncIterator
+from typing import Any, AsyncIterator, Coroutine, Iterator
 
+from ..core.config import task_config
 from ..core.display import (
     Display,
     Progress,
     TaskDisplay,
+    TaskDisplayMetric,
     TaskProfile,
+    TaskResult,
     TaskScreen,
-    TaskSpec, TR, TaskDisplayMetric, TaskResult,
+    TaskSpec,
+    TaskWithResult, TR,
 )
-import asyncio
+from ..core.panel import task_targets, task_title
+from ..core.results import task_metric, tasks_results
+
 
 class PlainDisplay(Display):
+    def __init__(self) -> None:
+        self.total_tasks: int = 0
+        self.tasks: list[TaskWithResult] = []
+        self.parallel = False
+
     def print(self, message: str) -> None:
         print(message)
 
@@ -30,11 +42,61 @@ class PlainDisplay(Display):
     async def task_screen(
             self, tasks: list[TaskSpec], parallel: bool
     ) -> AsyncIterator[TaskScreen]:
-        yield TaskScreen()
+        self.total_tasks = len(tasks)
+        self.tasks = []
+        self.parallel = parallel
+        try:
+            # Print header for task(s)
+            if parallel:
+                print(f"Running {self.total_tasks} tasks...")
+            yield TaskScreen()
+        finally:
+            # Print final results
+            if self.tasks:
+                print("\nResults:")
+                print("-" * 40)
+                self._print_results()
 
     @contextlib.contextmanager
     def task(self, profile: TaskProfile) -> Iterator[TaskDisplay]:
-        yield PlainTaskDisplay(profile)
+        # Print task header
+        print("\n" + "=" * 40)
+        print(task_title(profile, show_model=True))
+
+        # Print config and targets
+        config = task_config(profile)
+        if config:
+            print(f"Config: {config}")
+        targets = task_targets(profile)
+        if targets:
+            print(f"Dataset: {targets}")
+        print("-" * 40)
+
+        # Create and yield task display
+        task = TaskWithResult(profile, None)
+        self.tasks.append(task)
+        yield PlainTaskDisplay(task)
+
+    def _print_results(self) -> None:
+        for task in self.tasks:
+            if task.result:
+                print(f"\nTask: {task_title(task.profile, show_model=True)}")
+
+                # Print token usage stats
+                if task.result.stats and task.result.stats.model_usage:
+                    print("\nToken Usage:")
+                    for model, usage in task.result.stats.model_usage.items():
+                        total = usage.total_tokens
+                        input = usage.input_tokens
+                        output = usage.output_tokens
+                        print(f"{model}: {total:,} tokens [I: {input:,}, O: {output:,}]")
+
+                # Print evaluation results
+                if task.result.results and task.result.results.scores:
+                    print("\nScores:")
+                    for score in task.result.results.scores:
+                        for name, metric in score.metrics.items():
+                            print(f"{name}: {metric.value:.3f}")
 
 
 class PlainProgress(Progress):
@@ -44,28 +106,42 @@ class PlainProgress(Progress):
 
     def update(self, n: int = 1) -> None:
         self.current += n
-        print(f"\rProgress: {self.current}/{self.total} ({int(self.current / self.total * 100)}%)",
-              end="", flush=True)
+        percent = int(self.current / self.total * 100)
+        print(f"\rProgress: {self.current}/{self.total} ({percent}%)", end="", flush=True)
 
     def complete(self) -> None:
         print("\rProgress: Complete (100%)")
+        print()  # Add newline after completion
 
 
 class PlainTaskDisplay(TaskDisplay):
-    def __init__(self, profile: TaskProfile):
-        self.profile = profile
+    def __init__(self, task: TaskWithResult):
+        self.task = task
+        self.progress_display: PlainProgress | None = None
+        self.samples_complete = 0
+        self.samples_total = 0
 
     @contextlib.contextmanager
     def progress(self) -> Iterator[Progress]:
-        yield PlainProgress(self.profile.steps)
+        self.progress_display = PlainProgress(self.task.profile.steps)
+        yield self.progress_display
 
     def sample_complete(self, complete: int, total: int) -> None:
-        # Could add additional progress info here if desired
-        pass
+        self.samples_complete = complete
+        self.samples_total = total
+        print(f"\rSamples: {complete}/{total} ", end="", flush=True)
 
     def update_metrics(self, metrics: list[TaskDisplayMetric]) -> None:
-        # Could add metrics display here if desired
-        pass
+        if metrics:
+            # Print metrics on same line as samples
+            metric_str = task_metric(metrics)
+            print(f"| {metric_str}", end="", flush=True)
 
     def complete(self, result: TaskResult) -> None:
-        pass
+        self.task.result = result
+        if self.progress_display:
+            self.progress_display.complete()
+
+        # Print final sample/metric status on new line
+        if self.samples_total > 0:
+            print(f"Final: {self.samples_complete}/{self.samples_total} samples processed")

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -1,0 +1,71 @@
+import contextlib
+from typing import Any, Coroutine, Iterator, AsyncIterator
+
+from ..core.display import (
+    Display,
+    Progress,
+    TaskDisplay,
+    TaskProfile,
+    TaskScreen,
+    TaskSpec, TR, TaskDisplayMetric, TaskResult,
+)
+import asyncio
+
+class PlainDisplay(Display):
+    def print(self, message: str) -> None:
+        print(message)
+
+    @contextlib.contextmanager
+    def progress(self, total: int) -> Iterator[Progress]:
+        yield PlainProgress(total)
+
+    def run_task_app(self, main: Coroutine[Any, Any, TR]) -> TR:
+        return asyncio.run(main)
+
+    @contextlib.contextmanager
+    def suspend_task_app(self) -> Iterator[None]:
+        yield
+
+    @contextlib.asynccontextmanager
+    async def task_screen(
+            self, tasks: list[TaskSpec], parallel: bool
+    ) -> AsyncIterator[TaskScreen]:
+        yield TaskScreen()
+
+    @contextlib.contextmanager
+    def task(self, profile: TaskProfile) -> Iterator[TaskDisplay]:
+        yield PlainTaskDisplay(profile)
+
+
+class PlainProgress(Progress):
+    def __init__(self, total: int):
+        self.total = total
+        self.current = 0
+
+    def update(self, n: int = 1) -> None:
+        self.current += n
+        print(f"\rProgress: {self.current}/{self.total} ({int(self.current / self.total * 100)}%)",
+              end="", flush=True)
+
+    def complete(self) -> None:
+        print("\rProgress: Complete (100%)")
+
+
+class PlainTaskDisplay(TaskDisplay):
+    def __init__(self, profile: TaskProfile):
+        self.profile = profile
+
+    @contextlib.contextmanager
+    def progress(self) -> Iterator[Progress]:
+        yield PlainProgress(self.profile.steps)
+
+    def sample_complete(self, complete: int, total: int) -> None:
+        # Could add additional progress info here if desired
+        pass
+
+    def update_metrics(self, metrics: list[TaskDisplayMetric]) -> None:
+        # Could add metrics display here if desired
+        pass
+
+    def complete(self, result: TaskResult) -> None:
+        pass

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -169,10 +169,3 @@ class PlainTaskDisplay(TaskDisplay):
     def complete(self, result: TaskResult) -> None:
         self.task.result = result
         print("Task complete.")
-
-        # Print final status
-        if self.samples_total > 0:
-            print(f"Final: {self.samples_complete}/{self.samples_total} samples processed")
-            if self.current_metrics:
-                metric_str = task_metric(self.current_metrics)
-                print(f"Metrics: {metric_str}")

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -2,8 +2,12 @@ import asyncio
 import contextlib
 from typing import Any, AsyncIterator, Coroutine, Iterator
 
+import rich
+
+from ...util._concurrency import concurrency_status
 from ..core.config import task_config
 from ..core.display import (
+    TR,
     Display,
     Progress,
     TaskDisplay,
@@ -12,14 +16,11 @@ from ..core.display import (
     TaskResult,
     TaskScreen,
     TaskSpec,
-    TaskWithResult, TR, TaskError,
+    TaskWithResult,
 )
-from ..core.footer import task_footer, task_resources, task_http_rate_limits
-from ..core.panel import task_targets, task_title, task_panel
-from ..core.results import task_metric, tasks_results, task_stats
-import rich
-
-from ...util._concurrency import concurrency_status
+from ..core.footer import task_http_rate_limits
+from ..core.panel import task_panel, task_targets
+from ..core.results import task_metric, tasks_results
 
 
 class PlainDisplay(Display):
@@ -44,7 +45,7 @@ class PlainDisplay(Display):
 
     @contextlib.asynccontextmanager
     async def task_screen(
-            self, tasks: list[TaskSpec], parallel: bool
+        self, tasks: list[TaskSpec], parallel: bool
     ) -> AsyncIterator[TaskScreen]:
         self.total_tasks = len(tasks)
         self.tasks = []
@@ -67,10 +68,7 @@ class PlainDisplay(Display):
             profile=profile,
             show_model=True,
             body="",  # Empty body since we haven't started yet
-            subtitle=(
-                task_config(profile),
-                task_targets(profile)
-            ),
+            subtitle=(task_config(profile), task_targets(profile)),
             footer=None,
             log_location=None,
         )
@@ -121,7 +119,9 @@ class PlainTaskDisplay(TaskDisplay):
             return
 
         # Calculate current progress percentage
-        current_progress = int(self.progress_display.current / self.progress_display.total * 100)
+        current_progress = int(
+            self.progress_display.current / self.progress_display.total * 100
+        )
 
         # Only print on percentage changes to avoid too much output
         if current_progress != self.last_progress:
@@ -133,7 +133,9 @@ class PlainTaskDisplay(TaskDisplay):
             )
 
             # Add sample progress
-            status_parts.append(f"Samples: {self.samples_complete}/{self.samples_total}")
+            status_parts.append(
+                f"Samples: {self.samples_complete}/{self.samples_total}"
+            )
 
             # Add metrics
             if self.current_metrics:
@@ -146,7 +148,9 @@ class PlainTaskDisplay(TaskDisplay):
             resources_dict: dict[str, str] = {}
             for model, resource in concurrency_status().items():
                 resources_dict[model] = f"{resource[0]}/{resource[1]}"
-            resources = "".join([f"{key}: {value}" for key, value in resources_dict.items()])
+            resources = "".join(
+                [f"{key}: {value}" for key, value in resources_dict.items()]
+            )
             status_parts.append(resources)
 
             # Add rate limits
@@ -158,7 +162,6 @@ class PlainTaskDisplay(TaskDisplay):
             print(" | ".join(status_parts))
 
             self.last_progress = current_progress
-
 
     def sample_complete(self, complete: int, total: int) -> None:
         self.samples_complete = complete


### PR DESCRIPTION
The recent addition of `DisplayType` is a very welcome one, thank you.

I am especially interested in `plain` for plain-text logging and for use in environments where ANSI escape sequences are not supported.

# Current behaviour
No progress is shown in `plain` mode

# New features
This PR adds `PlainDisplay` and `PlainTaskDisplay`, inheriting from `Display` and `TaskDisplay`. They behave as follows:

* During an evaluation, progress is shown in plain text.
* At the start and end of an evaluation, information is shown once in `rich` panels. (The end-of-evaluation behaviour is identical to the current behaviour with `DisplayType` set to `rich`)
* No ANSI escape sequences are used


# Comments
I care about having this functionality available in some form, but I don't feel strongly about the specific aesthetic choices. Feel free to amend what I've done (e.g. by pushing to the branch).
