### PR TITLE
Misc improvements to display=plain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Log warning when a non-fatal sample error occurs (i.e. errors permitted by the `fail_on_error` option) 
 - Inspect View: allow filtering samples by compound expressions including multiple scorers. (thanks @andrei-apollo)
 - Inspect View: improve rendering performance and stability for the viewer when viewing very large eval logs or samples with a large number of steps.
+- Task display: Improved `plain` mode with periodic updates on progress, metrics, etc.
 
 ## v0.3.58 (16 January 2025)
 

--- a/src/inspect_ai/_display/core/panel.py
+++ b/src/inspect_ai/_display/core/panel.py
@@ -50,9 +50,13 @@ def task_panel(
         table.add_row(subtitle_table)
 
     # main progress and task info
-    table.add_row()
-    table.add_row(body)
-    table.add_row()
+    if body:
+        table.add_row()
+        table.add_row(body)
+
+    # spacing if there is more ocontent
+    if footer or log_location:
+        table.add_row()
 
     # footer if specified
     if footer:

--- a/src/inspect_ai/_display/rich/display.py
+++ b/src/inspect_ai/_display/rich/display.py
@@ -129,11 +129,6 @@ class RichDisplay(Display):
     @override
     @contextlib.contextmanager
     def task(self, profile: TaskProfile) -> Iterator[TaskDisplay]:
-        # if there is no ansi display than all of the below will
-        # be a no-op, so we print a simple text message for the task
-        if display_type() == "plain":
-            rich.get_console().print(task_no_ansi(profile))
-
         # for typechekcer
         if self.tasks is None:
             self.tasks = []

--- a/src/inspect_ai/_util/text.py
+++ b/src/inspect_ai/_util/text.py
@@ -108,3 +108,26 @@ def str_to_float(s: str) -> float:
         exponent = 1  # Default exponent is 1 if no superscript is present
 
     return base**exponent
+
+
+def truncate(text: str, length: int, overflow: str = "...", pad: bool = True) -> str:
+    """
+    Truncate text to specified length with optional padding and overflow indicator.
+
+    Args:
+        text (str): Text to truncate
+        length (int): Maximum length including overflow indicator
+        overflow (str): String to indicate truncation (defaults to '...')
+        pad (bool): Whether to pad the result to full length (defaults to padding)
+
+    Returns:
+        Truncated string, padded if requested
+
+    """
+    if len(text) <= length:
+        return text + (" " * (length - len(text))) if pad else text
+
+    overflow_length = len(overflow)
+    truncated = text[: length - overflow_length] + overflow
+
+    return truncated

--- a/tests/util/test_truncate.py
+++ b/tests/util/test_truncate.py
@@ -1,0 +1,21 @@
+from inspect_ai._util.text import truncate
+
+
+def test_basic_truncation():
+    assert truncate("Hello World!", 8) == "Hello..."
+    assert truncate("Short", 8) == "Short   "
+
+
+def test_custom_overflow():
+    assert truncate("Hello World!", 8, overflow=">>") == "Hello >>"
+    assert truncate("Testing", 5, overflow="~") == "Test~"
+
+
+def test_no_padding():
+    assert truncate("Hi", 8, pad=False) == "Hi"
+    assert truncate("Hello World!", 8, pad=False) == "Hello..."
+
+
+def test_exact_length():
+    assert truncate("12345678", 8) == "12345678"
+    assert truncate("1234", 4, pad=False) == "1234"


### PR DESCRIPTION
- Handle multiple models and multiple tasks (display task/model to disambiguate if required)
- Pad display so columns always line up
- Throttle updates to once every second
- Condense task panel when there is no body or footer
- Call rich_initialise in PlainDisplay constructor so ansi colors, etc. are disabled globally for rich printing.
- Remove spurious plain print from rich display (since plain now has its own display handler)

cc @tadamcz 