### PR TITLE
Separate multiple resources in display=plain

### DIFF
--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -174,7 +174,7 @@ class PlainTaskDisplay(TaskDisplay):
             resources_dict: dict[str, str] = {}
             for model, resource in concurrency_status().items():
                 resources_dict[model] = f"{resource[0]:2d}/{resource[1]:2d}"
-            resources = "".join(
+            resources = ", ".join(
                 [f"{key}: {value}" for key, value in resources_dict.items()]
             )
             status_parts.append(resources)


### PR DESCRIPTION
Caught this just after you merged https://github.com/UKGovernmentBEIS/inspect_ai/pull/1166

Previous:
```
Steps:   1/16   6% | Samples:   1/ 16 | accuracy:  n/a | google:  0/10openai:  9/10 | HTTP rate limits: 0
```

Fixed (comma-separated):
```
Steps:   1/16   6% | Samples:   1/ 16 | accuracy:  n/a | google:  0/10, openai:  9/10 | HTTP rate limits: 0
```

Feel free to make the separating character something else based on your taste (like a single space or a pipe)