### PR TITLE
Fix invalid SemVer string parsing on Ubuntu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add `@wraps` to functions wrapped by Inspect decorators to preserve type information.
+- Docker: More robust parsing of version strings (handle development versions).
 
 ## v0.3.59 (24 January 2025)
 

--- a/src/inspect_ai/util/_sandbox/docker/prereqs.py
+++ b/src/inspect_ai/util/_sandbox/docker/prereqs.py
@@ -57,7 +57,7 @@ async def validate_docker_compose(
     version: str = DOCKER_COMPOSE_REQUIRED_VERSION,
 ) -> None:
     def parse_version(stdout: str) -> semver.Version:
-        version = json.loads(stdout)["version"].removeprefix("v")
+        version = json.loads(stdout)["version"].removeprefix("v").split("+")[0]
         return semver.Version.parse(version)
 
     await validate_version(


### PR DESCRIPTION
This commit updates the version parsing logic in prereqs.py to correctly handle Docker Compose version strings that include additional metadata.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The previous implementation failed to parse versions like 2.27.1+ds1-0ubuntu1~24.04.1, resulting in an invalid SemVer error.
Example:
```
WARNING  Unexpected error executing docker: 2.27.1+ds1-0ubuntu1~24.04.1 is not valid SemVer string                                                                                                                        prereqs.py:88

ERROR: Docker sandbox environments require Docker Engine
...
```
### What is the new behavior?

The updated logic removes the "v" prefix and separates the version string at the "+" character, additional metadata after the "+" character which might be included in the output of `docker compose version --format json` is removed.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Other information:
