### PR TITLE
Explicitly handle scorers created from TaskState

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Scoring: Always provide half-again the sample time limit for scoring.
 - Bugfix: Fix issue w/ approvals for samples with id==0.
 - Bugfix: Use "plain" display when running eval_async() outside of eval().
+- Bugfix: Fix issue with multiple scorers of the same type in a task.
 
 ## v0.3.59 (24 January 2025)
 

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -5,7 +5,7 @@ from typing import Callable, cast
 from inspect_ai._display import display
 from inspect_ai._util.path import chdir_python
 from inspect_ai._util.platform import platform_init
-from inspect_ai._util.registry import registry_create
+from inspect_ai._util.registry import registry_create, registry_unqualified_name
 from inspect_ai.log import (
     EvalLog,
     EvalMetric,
@@ -185,6 +185,7 @@ async def run_score_task(
         results[scorer_name] = SampleScore(
             score=result,
             sample_id=state.sample_id,
+            scorer=registry_unqualified_name(scorer),
         )
 
     progress()

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -65,11 +65,12 @@ def eval_results(
     # extract scorers info from scorers then create scorers info for any
     # scores not already accounted for by a scorer name
     scorers_info = [ScorerInfo.from_scorer(scorer) for scorer in (scorers or [])]
-    scorer_names = [info.name for info in scorers_info]
-    for name in set(key for sample_scores in scores for key in sample_scores):
-        if name not in scorer_names:
-            scorers_info.append(ScorerInfo.from_name(name))
-            scorer_names.append(name)
+    scorer_names = {info.name for info in scorers_info}
+    for sample_scores in scores:
+        for name, sample_score in sample_scores.items():
+            if sample_score.scorer is None and name not in scorer_names:
+                scorers_info.append(ScorerInfo.from_name(name))
+                scorer_names.add(name)
 
     # record scorer
     if len(scorers_info) > 0:

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -27,7 +27,11 @@ from inspect_ai._util.constants import (
 from inspect_ai._util.datetime import iso_now
 from inspect_ai._util.error import exception_message
 from inspect_ai._util.hooks import send_telemetry
-from inspect_ai._util.registry import is_registry_object, registry_log_name
+from inspect_ai._util.registry import (
+    is_registry_object,
+    registry_log_name,
+    registry_unqualified_name,
+)
 from inspect_ai._util.timeouts import Timeout, timeout
 from inspect_ai._view.notify import view_notify_eval
 from inspect_ai.dataset import Dataset, Sample
@@ -685,6 +689,7 @@ async def task_run_sample(
                                         sample_score = SampleScore(
                                             score=score_result,
                                             sample_id=sample.id,
+                                            scorer=registry_unqualified_name(scorer),
                                         )
                                         transcript()._event(
                                             ScoreEvent(

--- a/src/inspect_ai/scorer/_metric.py
+++ b/src/inspect_ai/scorer/_metric.py
@@ -125,6 +125,9 @@ class SampleScore(BaseModel):
     sample_id: str | int | None = Field(default=None)
     """A sample id"""
 
+    scorer: str | None = Field(default=None)
+    """Registry name of scorer that created this score."""
+
 
 ValueToFloat = Callable[[Value], float]
 """Function used by metrics to translate from a Score value to a float value."""


### PR DESCRIPTION
When a solver returns a score, we synthesize scorer info for it. The previous logic was using key/name matching to determine whether to synthesize scorer info. Instead, explicitly note the scorer that produced the SampleScore and only synthesize score info for sample scores whose scorer is None.

Fixes #1200

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
