### PR TITLE
Append tools in _basic_agent.py

### DIFF
--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -119,7 +119,7 @@ def basic_agent(
     # resolve tools
     if tools is None:
         tools = []
-    tools = tools if isinstance(tools, Solver) else use_tools(tools)
+    tools = tools if isinstance(tools, Solver) else use_tools(tools, append=True)
 
     # resolve score_value function
     score_value_fn = score_value or value_to_float()


### PR DESCRIPTION
If tools were added to the state in `init` we should not override this.

## This PR contains:
- [ x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
If tools were added to the state in `init`, they are later overridden.

### What is the new behavior?
Tools are appended.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
