### PR TITLE
Anthropic: Support for `extra_body` model arg (for adding additional JSON properties to the request)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - OpenAI: Use qualifiers rather than model args for OpenAI on other providers (`openai/azure`)
 - Anthropic: Don't insert '(no content)' into cannonical messages list (do only on replay)
 - Anthropic: Use qualifiers rather than model args for Anthropic on other providers (`anthropic/bedrock`, `anthropic/vertex`).
+- Anthropic: Suport for `extra_body` model arg (for adding additional JSON properties to the request)
 - Scoring: Always provide half-again the sample time limit for scoring.
 - Bugfix: Fix issue w/ approvals for samples with id==0.
 - Bugfix: Use "plain" display when running eval_async() outside of eval().

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -20,6 +20,7 @@ from anthropic import (
     NotGiven,
     RateLimitError,
 )
+from anthropic._types import Body
 from anthropic.types import (
     ImageBlockParam,
     Message,
@@ -75,6 +76,16 @@ class AnthropicAPI(ModelAPI):
             model_name = "/".join(parts[1:])
         else:
             self.service = None
+
+        # collect gemerate model_args (then delete them so we can pass the rest on)
+        def collect_model_arg(name: str) -> Any | None:
+            nonlocal model_args
+            value = model_args.get(name, None)
+            if value is not None:
+                model_args.pop(name)
+            return value
+
+        self.extra_body: Body | None = collect_model_arg("extra_body")
 
         # call super
         super().__init__(
@@ -187,6 +198,10 @@ class AnthropicAPI(ModelAPI):
             # computer use beta
             if computer_use:
                 request["extra_headers"] = {"anthropic-beta": "computer-use-2024-10-22"}
+
+            # extra_body
+            if self.extra_body is not None:
+                request["extra_body"] = self.extra_body
 
             # make request
             message = await self.client.messages.create(**request, stream=False)


### PR DESCRIPTION
For example, here we override `max_tokens`:

```python
from inspect_ai import Task, eval, task
from inspect_ai.dataset import Sample
from inspect_ai.scorer import exact
from inspect_ai.solver import generate

@task
def hello_world():
    return Task(
        dataset=[
            Sample(
                input="Just reply with Hello World",
                target="Hello World",
            )
        ],
        solver=[
            generate(),
        ],
        scorer=exact(),
    )


if __name__ == "__main__":
    eval(
        hello_world(),
        model="anthropic/claude-3-5-sonnet-latest",
        model_args={"extra_body": {"max_tokens": 1}},
    )
```

You can also set `model_args` on the command line with careful quoting and removal of spaces:

```bash
inspect eval hello.py -M extra_body="{'max_tokens':1}"
```