### PR TITLE
Handle Anthropic 413 http status code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - OpenAI: Handle `reasoning_effort`, `max_tokens`, `temperature`, and `parallel_tool_calls` correctly for o3 models.
 - OpenAI: Map some additional 400 status codes to `content_filter` stop reason.
+- Anthropic: Handle 413 status code (Payload Too Large) and map to `model_length` StopReason.
 - Tasks: Log sample with error prior to raising task-ending exception.
 - Bugfix: Don't download full log from S3 for header_only reads.
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -12,6 +12,7 @@ else:
 
 from anthropic import (
     APIConnectionError,
+    APIStatusError,
     AsyncAnthropic,
     AsyncAnthropicBedrock,
     AsyncAnthropicVertex,
@@ -214,6 +215,17 @@ class AnthropicAPI(ModelAPI):
 
             # return output and call
             return output, model_call()
+
+        except APIStatusError as ex:
+            if ex.status_code == 413:
+                return ModelOutput.from_content(
+                    model=self.model_name,
+                    content=ex.message,
+                    stop_reason="model_length",
+                    error=ex.message,
+                ), model_call()
+            else:
+                raise ex
 
         except BadRequestError as ex:
             return self.handle_bad_request(ex), model_call()


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?
I have observed Anthropic return an http standard [413 Content Too Large](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/413). This PR catches that error and turns it into a more graceful stop message.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
