### PR TITLE
Add trace logging level to log model

### DIFF
--- a/src/inspect_ai/log/_message.py
+++ b/src/inspect_ai/log/_message.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, Type, cast
 from pydantic import BaseModel, Field, model_validator
 
 LoggingLevel = Literal[
-    "debug", "http", "sandbox", "info", "warning", "error", "critical"
+    "debug", "trace", "http", "sandbox", "info", "warning", "error", "critical"
 ]
 """Logging level."""
 


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)
If you use `--log-level-transcript` with TRACE or DEBUG, runs fail because the pydantic model can't validate records with the `trace` log level

`inspect eval inspect_evals/blah --log-level-transcript TRACE --model ....`