### PR TITLE
Shuffle Choices for Dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Inspect View: Convert codebase from JS/Preact to Typescript/React
+- Add `shuffle_choices` to dataset and dataset loading funtions. Deprecate `shuffle` parameter to the `multiple_choice` solver.
 
 ## v0.3.62 (03 February 2025)
 

--- a/docs/_shuffling-choices.md
+++ b/docs/_shuffling-choices.md
@@ -1,0 +1,33 @@
+
+::: {.callout-note appearance="simple"}
+The choice shuffling features below is currently available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+
+When working with datasets that contain multiple-choice options, you can randomize the order of these choices during data loading. The shuffling operation automatically updates any corresponding target values to maintain correct answer mappings.
+
+For datasets that contain `choices`, you can shuffle the choices when the data is loaded. Shuffling choices will randomly re-order the choices and update the sample's target value or values to align with the shuffled choices.
+
+There are two ways to shuffle choices:
+
+```python
+# Method 1: Using the dataset method
+dataset = dataset.shuffle_choices()
+
+# Method 2: During dataset loading
+dataset = json_dataset("data.jsonl", shuffle_choices=True)
+```
+
+For reproducible shuffling, you can specify a random seed:
+
+```python
+# Using a seed with the dataset method
+dataset = dataset.shuffle_choices(seed=42)
+
+# Using a seed during loading
+dataset = json_dataset("data.jsonl", shuffle_choices=42)
+```

--- a/docs/datasets.qmd
+++ b/docs/datasets.qmd
@@ -141,6 +141,32 @@ dataset = json_dataset("data.jsonl", shuffle=True)
 
 Note that both of these methods optionally support specifying a random seed for shuffling.
 
+## Shuffling Choices
+
+When working with datasets that contain multiple-choice options, you can randomize the order of these choices during data loading. The shuffling operation automatically updates any corresponding target values to maintain correct answer mappings.
+
+For datasets that contain `choices`, you can shuffle the choices when the data is loaded. Shuffling choices will randomly re-order the choices and update the sample's target value or values to align with the shuffled choices.
+
+There are two ways to shuffle choices:
+
+```python
+# Method 1: Using the dataset method
+dataset = dataset.shuffle_choices()
+
+# Method 2: During dataset loading
+dataset = json_dataset("data.jsonl", shuffle_choices=True)
+```
+
+For reproducible shuffling, you can specify a random seed:
+
+```python
+# Using a seed with the dataset method
+dataset = dataset.shuffle_choices(seed=42)
+
+# Using a seed during loading
+dataset = json_dataset("data.jsonl", shuffle_choices=42)
+```
+
 ## Hugging Face {#sec-hugging-face-datasets}
 
 [Hugging Face Datasets](https://huggingface.co/docs/datasets/en/index) is a library for easily accessing and sharing datasets for machine learning, and features integration with [Hugging Face Hub](https://huggingface.co/datasets), a repository with a broad selection of publicly shared datasets. Typically datasets on Hugging Face will require specification of which split within the dataset to use (e.g. train, test, or validation) as well as some field mapping. Use the `hf_dataset()` function to read a dataset and specify the requisite split and field names:

--- a/docs/datasets.qmd
+++ b/docs/datasets.qmd
@@ -143,29 +143,7 @@ Note that both of these methods optionally support specifying a random seed for 
 
 ## Shuffling Choices
 
-When working with datasets that contain multiple-choice options, you can randomize the order of these choices during data loading. The shuffling operation automatically updates any corresponding target values to maintain correct answer mappings.
-
-For datasets that contain `choices`, you can shuffle the choices when the data is loaded. Shuffling choices will randomly re-order the choices and update the sample's target value or values to align with the shuffled choices.
-
-There are two ways to shuffle choices:
-
-```python
-# Method 1: Using the dataset method
-dataset = dataset.shuffle_choices()
-
-# Method 2: During dataset loading
-dataset = json_dataset("data.jsonl", shuffle_choices=True)
-```
-
-For reproducible shuffling, you can specify a random seed:
-
-```python
-# Using a seed with the dataset method
-dataset = dataset.shuffle_choices(seed=42)
-
-# Using a seed during loading
-dataset = json_dataset("data.jsonl", shuffle_choices=42)
-```
+{{< include _shuffling-choices.md >}}
 
 ## Hugging Face {#sec-hugging-face-datasets}
 

--- a/docs/solvers.qmd
+++ b/docs/solvers.qmd
@@ -161,7 +161,6 @@ def multiple_choice(
     *,
     template: str | None = None,
     cot: bool = False,
-    shuffle: bool | Random = False,
     multiple_correct: bool = False,
     
 ) -> Solver:
@@ -227,11 +226,14 @@ The following options are available for further customisation of the multiple ch
 | `template`         | Use `template` to provide an alternate prompt template (note that if you do this your template should handle prompting for `multiple_correct` directly if required). You can access the built in templates using the `MultipleChoiceTemplate` enum.                                                                                                                                                       |
 | `cot`              | Whether the solver should perform chain-of-thought reasoning before answering (defaults to `False`). NOTE: this has no effect if you provide a custom template.                                                                                                                                                                                                                                           |
 | `multiple_correct` | By default, multiple choice questions have a single correct answer. Set `multiple_correct=True` if your target has defined multiple correct answers (for example, a `target` of `["B", "C"]`). In this case the model is prompted to provide one or more answers, and the sample is scored correct only if each of these answers are provided. NOTE: this has no effect if you provide a custom template. |
-| `shuffle`          | If you specify `shuffle=True`, then the order of the answers presented to the model will be randomised (this may or may not affect results, depending on the nature of the questions and the model being evaluated).                                                                                                                                                                                      |
-
+                                                                                        
 : {tbl-colwidths=\[35,65\]}
 
-### Self Critique
+### Shuffling
+
+{{< include _shuffling-choices.md >}}
+
+## Self Critique
 
 Here is the declaration for the `self_critique()` solver:
 

--- a/docs/solvers.qmd
+++ b/docs/solvers.qmd
@@ -149,7 +149,7 @@ Inspect has a number of built-in solvers, each of which can be customised in som
 
 -   `multiple_choice()`
 
-    A solver which presents A,B,C,D style `choices` from input samples and calls `generate()` to yield model output. This solver should nearly always paired with the `choices()` scorer. Learn more about [Multiple Choice](#sec-multiple-choice) in the section below.
+    A solver which presents A,B,C,D style `choices` from input samples and calls `generate()` to yield model output. Pair this solver with the choices() scorer. For custom answer parsing or scoring needs (like handling complex outputs), use a custom scorer instead. Learn more about [Multiple Choice](#sec-multiple-choice) in the section below.
 
 ## Multiple Choice {#sec-multiple-choice}
 
@@ -170,7 +170,7 @@ We'll present an example and then discuss the various options below (in most cas
 
 1.  The `Sample` must include the available `choices`. Choices should not include letters (as they are automatically included when presenting the choices to the model).
 2.  The `Sample` `target` should be a capital letter (e.g. A, B, C, D, etc.)
-3.  You should always pair it with the `choice()` scorer in your task definition.
+3.  You should always pair it with the `choice()` scorer in your task definition. For custom answer parsing or scoring needs (like handling complex model outputs), implement a custom scorer.
 4.  It calls `generate()` internally, so you do need to separately include the `generate()` solver.
 
 ### Example

--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -23,6 +23,7 @@ def csv_dataset(
     auto_id: bool = False,
     shuffle: bool = False,
     seed: int | None = None,
+    shuffle_choices: bool | int | None = None,
     limit: int | None = None,
     dialect: str = "unix",
     encoding: str = "utf-8",
@@ -45,6 +46,7 @@ def csv_dataset(
         auto_id (bool): Assign an auto-incrementing ID for each sample.
         shuffle (bool): Randomly shuffle the dataset order.
         seed: (int | None): Seed used for random shuffle.
+        shuffle_choices: (bool | int | None): Whether to shuffle the choices. If an int is passed, this will be used as the seed when shuffling.
         limit (int | None): Limit the number of records to read.
         dialect (str): CSV dialect ("unix", "excel" or"excel-tab"). Defaults to "unix". See https://docs.python.org/3/library/csv.html#dialects-and-formatting-parameters for more details
         encoding (str): Text encoding for file (defaults to "utf-8").
@@ -85,6 +87,12 @@ def csv_dataset(
         # shuffle if requested
         if shuffle:
             dataset.shuffle(seed=seed)
+
+        # shuffle choices, if requested
+        if isinstance(shuffle_choices, int):
+            dataset.shuffle_choices(seed=shuffle_choices)
+        elif shuffle_choices is True:
+            dataset.shuffle_choices()
 
         # limit if requested
         if limit:

--- a/src/inspect_ai/dataset/_sources/file.py
+++ b/src/inspect_ai/dataset/_sources/file.py
@@ -16,6 +16,7 @@ def file_dataset(
     auto_id: bool = False,
     shuffle: bool = False,
     seed: int | None = None,
+    shuffle_choices: bool | int | None = None,
     limit: int | None = None,
     dialect: str = "unix",
     encoding: str = "utf-8",
@@ -40,6 +41,7 @@ def file_dataset(
         auto_id (bool): Assign an auto-incrementing ID for each sample.
         shuffle (bool): Randomly shuffle the dataset order.
         seed: (int | None): Seed used for random shuffle.
+        shuffle_choices: (bool | int | None): Whether to shuffle the choices. If an int is passed, this will be used as the seed when shuffling.
         limit (int | None): Limit the number of records to read.
         dialect (str): CSV dialect ("unix" or "excel", defaults to "unix"). Only
             applies to reading CSV files.
@@ -66,6 +68,7 @@ def file_dataset(
                 auto_id=auto_id,
                 shuffle=shuffle,
                 seed=seed,
+                shuffle_choices=shuffle_choices,
                 limit=limit,
                 encoding=encoding,
                 name=name,
@@ -78,6 +81,7 @@ def file_dataset(
                 auto_id=auto_id,
                 shuffle=shuffle,
                 seed=seed,
+                shuffle_choices=shuffle_choices,
                 limit=limit,
                 dialect=dialect,
                 encoding=encoding,

--- a/src/inspect_ai/dataset/_sources/hf.py
+++ b/src/inspect_ai/dataset/_sources/hf.py
@@ -29,6 +29,7 @@ def hf_dataset(
     auto_id: bool = False,
     shuffle: bool = False,
     seed: int | None = None,
+    shuffle_choices: bool | int | None = None,
     limit: int | None = None,
     trust: bool = False,
     cached: bool = True,
@@ -59,6 +60,7 @@ def hf_dataset(
         auto_id (bool): Assign an auto-incrementing ID for each sample.
         shuffle (bool): Randomly shuffle the dataset order.
         seed: (int | None): Seed used for random shuffle.
+        shuffle_choices: (bool | int | None): Whether to shuffle the choices. If an int is passed, this will be used as the seed when shuffling.
         limit (int | None): Limit the number of records to read.
         trust (bool): Whether or not to allow for datasets defined on the Hub
           using a dataset script. This option should only be set to True for
@@ -117,8 +119,16 @@ def hf_dataset(
         dataset = dataset.select(range(limit))
 
     # return the dataset
-    return MemoryDataset(
+    memory_dataset = MemoryDataset(
         samples=data_to_samples(dataset.to_list(), data_to_sample, auto_id),
         name=Path(path).stem if Path(path).exists() else path,
         location=path,
     )
+
+    # maybe shuffle the choices
+    if isinstance(shuffle_choices, int):
+        memory_dataset.shuffle_choices(seed=shuffle_choices)
+    elif shuffle_choices is True:
+        memory_dataset.shuffle_choices()
+
+    return memory_dataset

--- a/src/inspect_ai/dataset/_sources/json.py
+++ b/src/inspect_ai/dataset/_sources/json.py
@@ -25,6 +25,7 @@ def json_dataset(
     auto_id: bool = False,
     shuffle: bool = False,
     seed: int | None = None,
+    shuffle_choices: bool | int | None = None,
     limit: int | None = None,
     encoding: str = "utf-8",
     name: str | None = None,
@@ -49,6 +50,7 @@ def json_dataset(
       auto_id (bool): Assign an auto-incrementing ID for each sample.
       shuffle (bool): Randomly shuffle the dataset order.
       seed: (int | None): Seed used for random shuffle.
+      shuffle_choices: (bool | int | None): Whether to shuffle the choices. If an int is passed, this will be used as the seed when shuffling.
       limit (int | None): Limit the number of records to read.
       encoding (str): Text encoding for file (defaults to "utf-8").
       name (str): Optional name for dataset (for logging). If not specified,
@@ -85,6 +87,12 @@ def json_dataset(
         # shuffle if requested
         if shuffle:
             dataset.shuffle(seed=seed)
+
+        # shuffle choices, if requested
+        if isinstance(shuffle_choices, int):
+            dataset.shuffle_choices(seed=shuffle_choices)
+        elif shuffle_choices is True:
+            dataset.shuffle_choices()
 
         # limit if requested
         if limit:


### PR DESCRIPTION
This is the preferred way to shuffle choices for multiple choice question.

- The `shuffle` param of the multiple choice scorer is deprecated and will warn users.

- The `shuffle_choices` implementation will shuffle the choices within the sample and update the target as well, eliminating the need for any hijinks with target, scoring, and display (relating to unshuffling).

- The various dataset reading functions (e.g. `json_dataset`) take a new `shuffle_choices` param (or call `dataset.shuffle_choices()`

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [x] Code refactor

