### PR TITLE
Add `stop_words` param to f1 scorer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Inspect View: Convert codebase from JS/Preact to Typescript/React
+- Add `stop_words` param to the `f1` scorer. `stop_words` will be removed from the target and answer during normalization.
 
 ## v0.3.62 (03 February 2025)
 

--- a/tests/scorer/test_classification.py
+++ b/tests/scorer/test_classification.py
@@ -67,3 +67,21 @@ async def test_f1_partial_match():
     result = await scorer(state, Target(["Paris, Texas"]))
 
     assert result.text == "0.67"
+
+
+@pytest.mark.asyncio
+async def test_stop_words():
+    scorer = f1(stop_words=["Paris"])
+    state = simple_task_state(model_output="Paris")
+    result = await scorer(state, Target(["Paris, Texas"]))
+
+    assert result.text == "0.0"
+
+
+@pytest.mark.asyncio
+async def test_stop_words2():
+    scorer = f1(stop_words=["Texas"])
+    state = simple_task_state(model_output="Paris")
+    result = await scorer(state, Target(["Paris, Texas"]))
+
+    assert result.text == "1.0"


### PR DESCRIPTION
This allows user to pass a list of stop words which will be normalized out of the text when processing.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

