### PR TITLE
Fix self_check: alpine test_exec_as_user

### DIFF
--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -262,12 +262,20 @@ async def test_exec_as_user(sandbox_env: SandboxEnvironment) -> None:
 
     # Neither adduser nor useradd are part of POSIX, so we need some brittle logic here
     adduser_help_exec_result = await sandbox_env.exec(["adduser", "--help"])
-    adduser_help_text = adduser_help_exec_result.stdout + adduser_help_exec_result.stderr
+    adduser_help_text = (
+        adduser_help_exec_result.stdout + adduser_help_exec_result.stderr
+    )
 
     if "BusyBox" in adduser_help_text:
-        adduser_command=["adduser", "-D", username]
+        adduser_command = ["adduser", "-D", username]
     else:
-        adduser_command=["adduser", "--comment", "self_check.py", "--disabled-password", username]
+        adduser_command = [
+            "adduser",
+            "--comment",
+            "self_check.py",
+            "--disabled-password",
+            username,
+        ]
 
     try:
         # Create a new user

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -259,10 +259,20 @@ async def test_exec_permission_error(sandbox_env: SandboxEnvironment) -> None:
 
 async def test_exec_as_user(sandbox_env: SandboxEnvironment) -> None:
     username = "inspect-ai-test-exec-as-user"
+
+    # Neither adduser nor useradd are part of POSIX, so we need some brittle logic here
+    adduser_help_exec_result = await sandbox_env.exec(["adduser", "--help"])
+    adduser_help_text = adduser_help_exec_result.stdout + adduser_help_exec_result.stderr
+
+    if "BusyBox" in adduser_help_text:
+        adduser_command=["adduser", "-D", username]
+    else:
+        adduser_command=["adduser", "--comment", "self_check.py", "--disabled-password", username]
+
     try:
         # Create a new user
         add_user_result = await sandbox_env.exec(
-            ["adduser", "--comment", "self_check.py", "--disabled-password", username],
+            adduser_command,
             user="root",
             timeout=10,  # in one case adduser decided to ask for input which caused the test to hang indefinitely
         )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

On alpine the test_exec_as_user was failing because it's using busybox adduser

### What is the new behavior?

The test figures out which adduser is available and uses the appropriate syntax

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
