### PR TITLE
rename type param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add `stop_words` param to the `f1` scorer. `stop_words` will be removed from the target and answer during normalization.
 - Tools: Handle return of empty list from tool calls.
 - Sandboxes: Docker now uses `tee` for write_file operations.
+- Bugfix: Change `type` parameter of `answer()` to `pattern` to address registry serialisation error.
 
 ## v0.3.62 (03 February 2025)
 

--- a/src/inspect_ai/scorer/_answer.py
+++ b/src/inspect_ai/scorer/_answer.py
@@ -8,7 +8,7 @@ from inspect_ai._util.pattern import (
 )
 
 from ._metrics import accuracy, stderr
-from ._pattern import pattern
+from ._pattern import pattern as make_pattern
 from ._scorer import Scorer, scorer
 
 
@@ -33,7 +33,7 @@ class AnswerPattern(str, Enum):
 
 
 @scorer(metrics=[accuracy(), stderr()])
-def answer(type: Literal["letter", "word", "line"]) -> Scorer:
+def answer(pattern: Literal["letter", "word", "line"]) -> Scorer:
     """Scorer for model output that preceded answers with ANSWER:.
 
     Some solvers including multiple_choice solicit answers from
@@ -43,7 +43,7 @@ def answer(type: Literal["letter", "word", "line"]) -> Scorer:
     Note that you must specify a `type` for the answer scorer.
 
     Args:
-      type: (Literal["letter", "word", "line"]): Type of answer
+      pattern: (Literal["letter", "word", "line"]): Type of answer
         to extract. "letter" is used with multiple choice and
         extracts a single letter; "word" will extract the next
         word (often used for yes/no answers); "line" will take
@@ -53,10 +53,10 @@ def answer(type: Literal["letter", "word", "line"]) -> Scorer:
         with a separate line at the end.
 
     """
-    match type:
+    match pattern:
         case "letter":
-            return pattern(AnswerPattern.LETTER)
+            return make_pattern(AnswerPattern.LETTER)
         case "word":
-            return pattern(AnswerPattern.WORD)
+            return make_pattern(AnswerPattern.WORD)
         case "line":
-            return pattern(AnswerPattern.LINE)
+            return make_pattern(AnswerPattern.LINE)


### PR DESCRIPTION
This avoids a registry tagging error if the named param is used when using the answer scorer (duplicate arg type when tagging)

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
