### PR TITLE
Fix regression caused by inverted except block order.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Tools: Handle return of empty list from tool calls.
 - Sandboxes: Docker now uses `tee` for write_file operations.
 - Bugfix: Change `type` parameter of `answer()` to `pattern` to address registry serialisation error.
+- Bugfix: Restore printing of request payloads for 400 errors from Anthropic.
 
 ## v0.3.62 (03 February 2025)
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -216,6 +216,9 @@ class AnthropicAPI(ModelAPI):
             # return output and call
             return output, model_call()
 
+        except BadRequestError as ex:
+            return self.handle_bad_request(ex), model_call()
+
         except APIStatusError as ex:
             if ex.status_code == 413:
                 return ModelOutput.from_content(
@@ -226,9 +229,6 @@ class AnthropicAPI(ModelAPI):
                 ), model_call()
             else:
                 raise ex
-
-        except BadRequestError as ex:
-            return self.handle_bad_request(ex), model_call()
 
     def completion_params(self, config: GenerateConfig) -> dict[str, Any]:
         params = dict(model=self.model_name, max_tokens=cast(int, config.max_tokens))


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`400 BadRequestError`'s are not handled properly. #1234 regressed the behavior because it used the wrong order of `except` blocks. The rule is that they should be in most specific to most general order. Because `APIStatusError` is the base class of `BadRequestError`, the `400`'s were handled by the `APIStatusError` block essentially shadowing the more appropriate `BadRequestError` block.

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
