### PR TITLE
Clean up outdated / unused lines in common scorer code

### DIFF
--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -29,7 +29,9 @@ def str_match_scorer(match: Callable[[str, str], tuple[str, bool]]) -> Scorer:
                     value=CORRECT, answer=answer, explanation=state.output.completion
                 )
 
-        return Score(value=INCORRECT, answer=answer, explanation=state.output.completion)
+        return Score(
+            value=INCORRECT, answer=answer, explanation=state.output.completion
+        )
 
     return score
 

--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -29,10 +29,7 @@ def str_match_scorer(match: Callable[[str, str], tuple[str, bool]]) -> Scorer:
                     value=CORRECT, answer=answer, explanation=state.output.completion
                 )
 
-        explanation = (
-            state.output.completion if state.output.completion != answer else None
-        )
-        return Score(value=INCORRECT, answer=answer, explanation=explanation)
+        return Score(value=INCORRECT, answer=answer, explanation=state.output.completion)
 
     return score
 

--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -25,11 +25,6 @@ def str_match_scorer(match: Callable[[str, str], tuple[str, bool]]) -> Scorer:
         for value in target:
             answer, matched = match(state.output.completion, value)
             if matched:
-                explanation = (
-                    state.output.completion
-                    if state.output.completion != answer
-                    else None
-                )
                 return Score(
                     value=CORRECT, answer=answer, explanation=state.output.completion
                 )


### PR DESCRIPTION
This PR removes multiple snippets of the form

```
explanation = (
    state.output.completion
    if state.output.completion != answer
    else None
)
```
from `str_match_scorer`, which is employed by both the `includes()` scorer and the `match()` scorer. The first instance of this snippet appears to be unused, while it looks like the second is irrelevant and `state.output.completion` can be used instead. (In the second case, the `match` function passed to `str_match_scorer` seems like it would have to be quite weird for `state.output.completion == answer` to trigger for the case of an *incorrect* score, which is what the second deleted snippet is addressing. Anyhow, it's likely useful for the completion to be returned as an explanation regardless.)