### PR TITLE
Fix typo in link in Tools doc

### DIFF
--- a/docs/tools.qmd
+++ b/docs/tools.qmd
@@ -342,7 +342,7 @@ services:
     init: true
 ```
 
-Rather than using the `aisiuk/inspect-web-browser-tool` image, you can also just include the web browser service components in a custom image (see [Custom Images](#sec-custom-image) below for details).
+Rather than using the `aisiuk/inspect-web-browser-tool` image, you can also just include the web browser service components in a custom image (see [Custom Images](#sec-custom-images) below for details).
 
 ### Task Setup
 
@@ -398,7 +398,7 @@ use_tools(web_browser(interactive=False))
 
 In this mode, the interactive tools (`web_browser_click()`, `web_browser_type()`, and `web_browser_type_submit()`) are not made available to the model.
 
-### Custom Images {#sec-custom-image}
+### Custom Images {#sec-custom-images}
 
 Above we demonstrated how to use the pre-configured Inspect web browser container. If you prefer to incorporate the headless web browser and its dependencies into another container that is also supported.
 

--- a/docs/tools.qmd
+++ b/docs/tools.qmd
@@ -342,7 +342,7 @@ services:
     init: true
 ```
 
-Rather than using the `aisiuk/inspect-web-browser-tool` image, you can also just include the web browser service components in a custom image (see [Custom Images](#sec-custom-images) below for details).
+Rather than using the `aisiuk/inspect-web-browser-tool` image, you can also just include the web browser service components in a custom image (see [Custom Images](#sec-custom-image) below for details).
 
 ### Task Setup
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Broken link to #sec-custom-images in configuration section, section anchor is #sec-custom-image

### What is the new behavior?
Updated anchor to #sec-custom-images

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
