### PR TITLE
Event when scores provided by solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Sandboxes: Docker now uses `tee` for write_file operations.
 - Bugfix: Change `type` parameter of `answer()` to `pattern` to address registry serialisation error.
 - Bugfix: Restore printing of request payloads for 400 errors from Anthropic.
+- Bugfix: Log transcript event for solver provided scores (improves log viewer display of solver scoring)
 
 ## v0.3.62 (03 February 2025)
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -711,6 +711,9 @@ async def task_run_sample(
                                     results[name] = SampleScore(
                                         score=score, sample_id=state.sample_id
                                     )
+                                    transcript()._event(
+                                        ScoreEvent(score=score, target=sample.target)
+                                    )
 
                             # propagate results into scores
                             state.scores = {k: v.score for k, v in results.items()}


### PR DESCRIPTION
This change adds a transcript event when a solver score is recorded. This event will then be properly rendered by the log viewer, properly displaying the score when provided by a solver.


## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

