### PR TITLE
Add Zip64 Support to JS Zip Reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add `stop_words` param to the `f1` scorer. `stop_words` will be removed from the target and answer during normalization.
 - Tools: Handle return of empty list from tool calls.
 - Sandboxes: Docker now uses `tee` for write_file operations.
+- Inspect View: Handle Zip64 zip files (for log files greater than 4GB)
 - Bugfix: Change `type` parameter of `answer()` to `pattern` to address registry serialisation error.
 - Bugfix: Restore printing of request payloads for 400 errors from Anthropic.
 - Bugfix: Log transcript event for solver provided scores (improves log viewer display of solver scoring)

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -47323,6 +47323,7 @@ self.onmessage = function (e) {
         data
       };
     };
+    const kFileHeaderSize = 46;
     const parseCentralDirectory = (buffer2) => {
       let offset = 0;
       const view = new DataView(buffer2.buffer);
@@ -47333,17 +47334,33 @@ self.onmessage = function (e) {
         const extraFieldLength = view.getUint16(offset + 30, true);
         const fileCommentLength = view.getUint16(offset + 32, true);
         const filename2 = new TextDecoder().decode(
-          buffer2.subarray(offset + 46, offset + 46 + filenameLength)
+          buffer2.subarray(
+            offset + kFileHeaderSize,
+            offset + kFileHeaderSize + filenameLength
+          )
         );
+        let fileOffset = view.getUint32(offset + 42, true);
+        if (fileOffset === 4294967295) {
+          let extraOffset = offset + kFileHeaderSize + filenameLength;
+          while (extraOffset < offset + kFileHeaderSize + filenameLength + extraFieldLength) {
+            const tag = view.getUint16(extraOffset, true);
+            const size = view.getUint16(extraOffset + 2, true);
+            if (tag === 1) {
+              fileOffset = Number(view.getBigUint64(extraOffset + 4, true));
+              break;
+            }
+            extraOffset += 4 + size;
+          }
+        }
         const entry2 = {
           filename: filename2,
           compressionMethod: view.getUint16(offset + 10, true),
           compressedSize: view.getUint32(offset + 20, true),
           uncompressedSize: view.getUint32(offset + 24, true),
-          fileOffset: view.getUint32(offset + 42, true)
+          fileOffset
         };
         entries.set(filename2, entry2);
-        offset += 46 + filenameLength + extraFieldLength + fileCommentLength;
+        offset += kFileHeaderSize + filenameLength + extraFieldLength + fileCommentLength;
       }
       return entries;
     };


### PR DESCRIPTION
As eval files get larger (approaching 4GB), the central directory will stop using 32 bit ints and instead use 64 bit ints to store offsets to byte ranges.

This is signaled by the file offset being a sentinel value, in which case we need to look through the extra fields to find the 64 bit offset and use that instead.

This change adds support for reading these large zip files.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
