### PR TITLE
Make docker sandbox compose up wait time configurable

### DIFF
--- a/docs/sandboxing.qmd
+++ b/docs/sandboxing.qmd
@@ -336,3 +336,8 @@ services:
 To diagnose sandbox execution issues (e.g. commands that don't terminate properly, contianer lifecylce issues, etc.) you should use Inspect's [Tracing](tracing.qmd) facility. 
 
 Trace logs record the beginning and end of calls to `subprocess()` (e.g. tool calls that run commands in sandboxes) as well as control commands sent to Docker Compose. The `inspect trace anomalies` subcommand then enables you to query for commands that don't terminate, timeout, or have errors. See the article on [Tracing](tracing.qmd) for additional details.
+
+### Sandbox container startup wait time
+For complicated sandboxes that take multiple minutes to fully spin up, you may run into an error of the form "One or more docker containers failed to start from [...]". This error occurs because by default, Inspect will only wait 120 seconds for all sandbox containers to start.
+
+To override this 120 second default wait time, you can set the environment variable `INSPECT_EVAL_COMPOSE_UP_WAIT` which specifies in seconds how long inspect should wait for sandbox containers to spin up.

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -30,11 +30,14 @@ async def compose_up(project: ComposeProject) -> None:
     # passing the --wait flag (see https://github.com/docker/compose/issues/10596).
     # In practice, we will catch any errors when calling compose_check_running()
     # immediately after we call compose_up().
+    seconds_to_wait_str: str = os.environ.get(
+        "INSPECT_EVAL_COMPOSE_UP_WAIT", COMPOSE_WAIT
+    )
     await compose_command(
-        ["up", "--detach", "--wait", "--wait-timeout", COMPOSE_WAIT],
+        ["up", "--detach", "--wait", "--wait-timeout", seconds_to_wait_str],
         project=project,
-        # wait up to 5 minutes for container to go up (compose wait + 3 minutes)
-        timeout=300,
+        # wait up to (compose wait + 3 minutes) for container to go up
+        timeout=int(seconds_to_wait_str) + 180,
     )
 
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently Inspect will only wait 2 minutes for sandbox containers to start.

### What is the new behavior?
Maintains the default 2 minute wait, but allows this to be overridden using the `INSPECT_EVAL_COMPOSE_UP_WAIT` flag.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
None