### PR TITLE
Do not assume that `result.choices` will contain elements 

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -523,7 +523,8 @@ class Model:
         ) -> None:
             # trace
             if isinstance(result, ModelOutput):
-                conversation_assistant_message(input, result.choices[0].message)
+                if result.choices:
+                    conversation_assistant_message(input, result.choices[0].message)
                 event.output = result
             else:
                 conversation_assistant_error(result)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Exception is raised if a model responds with no choices (can be the case for content/safety violations)

### What is the new behavior?
Exception will not be raised as we don't try to access index 0 of empty list.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
I'm not too familiar with the conversation display type behaviour and if not calling `conversation_assistant_message` in the case that there are no choices will have any adverse effects.

Lmk if it would be better to fabricate an empty `ChatMessageAssistant` to pass to `conversation_assistant_message()` instead!
