### PR TITLE
Fix docs to suggest the correct type for sandbox

### DIFF
--- a/docs/sandboxing.qmd
+++ b/docs/sandboxing.qmd
@@ -126,7 +126,7 @@ The `Sample` class includes `sandbox`, `files` and `setup` fields that are used 
 
 You can either define a default `sandbox` for an entire `Task` as illustrated above, or alternatively define a per-sample `sandbox`. For example, you might want to do this if each sample has its own Dockerfile and/or custom compose configuration file. (Note, each sample gets its own sandbox *instance*, even if the sandbox is defined at Task level. So samples do not interfere with each other's sandboxes.)
 
-The `sandbox` can be specified as a string (e.g. `"docker`") or a list of sandbox type and config file (e.g. `["docker", "compose.yaml"]`).
+The `sandbox` can be specified as a string (e.g. `"docker`") or a tuple of sandbox type and config file (e.g. `("docker", "compose.yaml")`).
 
 ### Files
 


### PR DESCRIPTION
The type checker gives an error if you do what the docs suggest and specify a list of strings. Instead, a `tuple[str, str]` is required, as can be seen [here](https://github.com/UKGovernmentBEIS/inspect_ai/blob/37befa145cf8034a7b38df9181f27028f74573e7/src/inspect_ai/util/_sandbox/environment.py#L295):

```
SandboxEnvironmentType = SandboxEnvironmentSpec | str | tuple[str, str]
```

In this PR, I change the relevant line of the docs to be consistent with this type specification.