### PR TITLE
Fix filtering in presence of sample errors and nullable scores

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -25185,6 +25185,13 @@ categories: ${categories.join(" ")}`;
     const filterExpression = (evalDescriptor, sample2, filterValue) => {
       var _a2, _b2;
       try {
+        if (sample2.error) {
+          return {
+            matches: false,
+            error: void 0
+            // sample error does not indicate a problem with the filter
+          };
+        }
         const inputContains = (regex2) => {
           return inputString(sample2.input).some(
             (msg) => msg.match(new RegExp(regex2, "i"))

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -25086,7 +25086,7 @@ var require_assets = __commonJS({
         return value2;
       }
     };
-    const isFilteringSupportedForValue = (value2) => ["string", "number", "boolean"].includes(typeof value2);
+    const isFilteringSupportedForValue = (value2) => ["string", "number", "boolean"].includes(typeof value2) || value2 === null;
     const bannedShortScoreNames = (scores2) => {
       const used = /* @__PURE__ */ new Set();
       const banned = /* @__PURE__ */ new Set();
@@ -25099,6 +25099,11 @@ var require_assets = __commonJS({
         }
       }
       return banned;
+    };
+    const filterExpressionConstants = {
+      True: true,
+      False: false,
+      None: null
     };
     const scoreVariables = (evalDescriptor, sampleScores) => {
       const bannedShortNames = bannedShortScoreNames(evalDescriptor.scores);
@@ -25205,7 +25210,10 @@ categories: ${categories.join(" ")}`;
           input_contains: inputContains,
           target_contains: targetContains
         };
-        const expression = compileExpression(filterValue, { extraFunctions });
+        const expression = compileExpression(filterValue, {
+          extraFunctions,
+          constants: filterExpressionConstants
+        });
         const vars = scoreVariables(evalDescriptor, sample2.scores);
         const result = expression(vars);
         if (typeof result === "boolean") {

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -45978,8 +45978,10 @@ categories: ${categories.join(" ")}`;
             return element;
           }
         };
-        const priorityLabels = new Set(priorityCompletions.map((c2) => c2.label));
-        const defaultCompletionsAdjusted = defaultCompletionItems.filter((c2) => !priorityLabels.has(c2.label)).map((c2) => ({ ...c2, section: miscSection }));
+        const priorityLabels = new Set(
+          priorityCompletions.map((c2) => c2.label.trim())
+        );
+        const defaultCompletionsAdjusted = defaultCompletionItems.filter((c2) => !priorityLabels.has(c2.label.trim())).map((c2) => ({ ...c2, section: miscSection }));
         return {
           from: completionStart,
           options: [...priorityCompletionsAdjusted, ...defaultCompletionsAdjusted]

--- a/src/inspect_ai/_view/www/src/samples/sample-tools/filters.ts
+++ b/src/inspect_ai/_view/www/src/samples/sample-tools/filters.ts
@@ -35,7 +35,7 @@ const coerceValue = (value: unknown, descriptor: ScoreDescriptor): unknown => {
 
 // Whether a particular value is filter-able
 const isFilteringSupportedForValue = (value: unknown): boolean =>
-  ["string", "number", "boolean"].includes(typeof value);
+  ["string", "number", "boolean"].includes(typeof value) || value === null;
 
 /**
  * Returns the names of scores that are not allowed to be used as short names in
@@ -54,6 +54,16 @@ const bannedShortScoreNames = (scores: ScoreLabel[]): Set<string> => {
     }
   }
   return banned;
+};
+
+// Pseudo-variables added to all filter expressions. These are not needed in most cases.
+// Normally one could check a boolean value `foo` by simply typing `foo` or `not foo`.
+// However, some evals use tristate values that can be true, false or null. This is where
+// these constants come in handy.
+const filterExpressionConstants: Record<string, unknown> = {
+  True: true,
+  False: false,
+  None: null,
 };
 
 /**
@@ -199,7 +209,10 @@ export const filterExpression = (
       input_contains: inputContains,
       target_contains: targetContains,
     };
-    const expression = compileExpression(filterValue, { extraFunctions });
+    const expression = compileExpression(filterValue, {
+      extraFunctions,
+      constants: filterExpressionConstants,
+    });
     const vars = scoreVariables(evalDescriptor, sample.scores);
     const result = expression(vars);
     if (typeof result === "boolean") {

--- a/src/inspect_ai/_view/www/src/samples/sample-tools/filters.ts
+++ b/src/inspect_ai/_view/www/src/samples/sample-tools/filters.ts
@@ -176,6 +176,13 @@ export const filterExpression = (
   filterValue: string,
 ) => {
   try {
+    if (sample.error) {
+      return {
+        matches: false,
+        error: undefined, // sample error does not indicate a problem with the filter
+      };
+    }
+
     const inputContains = (regex: string): boolean => {
       return inputString(sample.input).some((msg) =>
         msg.match(new RegExp(regex, "i")),

--- a/src/inspect_ai/_view/www/src/samples/sample-tools/filters.ts
+++ b/src/inspect_ai/_view/www/src/samples/sample-tools/filters.ts
@@ -61,15 +61,11 @@ const bannedShortScoreNames = (scores: ScoreLabel[]): Set<string> => {
  * High-level scorer metrics can be accessed by name directly.
  * Child metrics are accessed using dot notation (e.g. `scorer_name.score_name`) or
  * directly by name when it is unique.
- *
- * @param {import("../../samples/descriptor/samplesDescriptor").EvalDescriptor} evalDescriptor
- * @param {import("../../types/log").Scores1} sampleScores
- * @returns {Object<string, any>}
  */
 const scoreVariables = (
   evalDescriptor: EvalDescriptor,
   sampleScores: Scores1,
-) => {
+): Record<string, unknown> => {
   const bannedShortNames = bannedShortScoreNames(evalDescriptor.scores);
   const variables: Record<string, unknown> = {};
 
@@ -77,7 +73,7 @@ const scoreVariables = (
     variableName: string,
     scoreLabel: ScoreLabel,
     value: unknown,
-  ) => {
+  ): void => {
     const coercedValue = coerceValue(
       value,
       evalDescriptor.scoreDescriptor(scoreLabel),
@@ -115,11 +111,6 @@ export const scoreFilterItems = (
   const valueToString = (value: unknown) =>
     typeof value === "string" ? `"${value}"` : String(value);
 
-  /**
-   * @param {string | undefined} shortName
-   * @param {string | undefined} qualifiedName
-   * @param {import("../../types").ScoreLabel} scoreLabel
-   */
   const addScore = (
     scoreLabel: ScoreLabel,
     shortName?: string,
@@ -263,12 +254,6 @@ export const filterExpression = (
   }
 };
 
-/**
- * @param {import("../../samples/descriptor/samplesDescriptor").EvalDescriptor} evalDescriptor
- * @param {import("../../api/types").SampleSummary[]} samples
- * @param {string} filterValue
- * @returns {}
- */
 export const filterSamples = (
   evalDescriptor: EvalDescriptor,
   samples: SampleSummary[],

--- a/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/SampleFilter.tsx
+++ b/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/SampleFilter.tsx
@@ -39,7 +39,8 @@ interface SampleFilterProps {
 const FILTER_TOOLTIP = `
 Filter samples by:
   • Scores
-  • Input and target regex search: input_contains, target_contains
+  • Samples with errors: has_error
+  • Input, target and error regex search: input_contains, target_contains, error_contains
 
 Supported expressions:
   • Arithmetic: +, -, *, /, mod, ^

--- a/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/completions.ts
+++ b/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/completions.ts
@@ -13,7 +13,12 @@ import {
   kScoreTypePassFail,
 } from "../../../constants";
 import { ScoreFilterItem } from "../filters";
-import { KEYWORDS, MATH_FUNCTIONS, SAMPLE_FUNCTIONS } from "./language";
+import {
+  KEYWORDS,
+  MATH_FUNCTIONS,
+  SAMPLE_FUNCTIONS,
+  SAMPLE_VARIABLES,
+} from "./language";
 import { Token, tokenize } from "./tokenize";
 
 interface CompletionOptions {
@@ -76,10 +81,20 @@ const makeSampleFunctionCompletion = ([label, info]: [
   boost: 0,
 });
 
+const makeSampleVariableCompletion = ([label, info]: [
+  string,
+  string,
+]): Completion => ({
+  label,
+  type: "variable",
+  info,
+  boost: 10,
+});
+
 const makeLiteralCompletion = (k: string): Completion => ({
   label: k,
   type: "text",
-  boost: 10,
+  boost: 20,
 });
 
 const makeCanonicalNameCompletion = (
@@ -89,14 +104,14 @@ const makeCanonicalNameCompletion = (
   label: item.canonicalName + (autoSpaceIf(item) ? " " : ""),
   type: "variable",
   info: item.tooltip,
-  boost: 20,
+  boost: 30,
 });
 
 const makeMemberAccessCompletion = (item: ScoreFilterItem): Completion => ({
   label: item.qualifiedName?.split(".")[1] || "",
   type: "variable",
   info: item.tooltip,
-  boost: 20,
+  boost: 40,
 });
 
 const getMemberScoreItems = (
@@ -130,6 +145,9 @@ export function getCompletions(
   const sampleFunctionCompletionItems = SAMPLE_FUNCTIONS.map(
     makeSampleFunctionCompletion,
   );
+  const sampleVariableCompletionItems = SAMPLE_VARIABLES.map(
+    makeSampleVariableCompletion,
+  );
   const variableCompletionItems = filterItems.map((item) =>
     makeCanonicalNameCompletion(item),
   );
@@ -138,6 +156,7 @@ export function getCompletions(
     ...keywordCompletionItems,
     ...mathFunctionCompletionItems,
     ...sampleFunctionCompletionItems,
+    ...sampleVariableCompletionItems,
     ...variableCompletionItems,
   ];
 
@@ -240,6 +259,7 @@ export function getCompletions(
             completingAtEnd && item.scoreType !== kScoreTypeBoolean,
         }),
       ),
+      ...sampleVariableCompletionItems,
       ...sampleFunctionCompletionItems,
     ]);
 

--- a/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/completions.ts
+++ b/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/completions.ts
@@ -237,9 +237,11 @@ export function getCompletions(
       },
     };
 
-    const priorityLabels = new Set(priorityCompletions.map((c) => c.label));
+    const priorityLabels = new Set(
+      priorityCompletions.map((c) => c.label.trim()),
+    );
     const defaultCompletionsAdjusted = defaultCompletionItems
-      .filter((c) => !priorityLabels.has(c.label))
+      .filter((c) => !priorityLabels.has(c.label.trim()))
       .map((c) => ({ ...c, section: miscSection }));
 
     return {

--- a/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/language.ts
+++ b/src/inspect_ai/_view/www/src/samples/sample-tools/sample-filter/language.ts
@@ -13,7 +13,12 @@ export const MATH_FUNCTIONS: [string, string][] = [
   ["log10", "Base 10 logarithm"],
 ];
 
+export const SAMPLE_VARIABLES: [string, string][] = [
+  ["has_error", "Checks if the sample has an error"],
+];
+
 export const SAMPLE_FUNCTIONS: [string, string][] = [
   ["input_contains", "Checks if input contains a regular expression"],
   ["target_contains", "Checks if target contains a regular expression"],
+  ["error_contains", "Checks if error contains a regular expression"],
 ];


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
1. Sample filter fails if the eval contains failed samples (only possible with `--no-fail-on-error`).
2. Impossible to filter samples with errors.
3. It is impossible to filter by scores that could be `None`.
4. Completions are sometimes duplicated.

### What is the new behavior?
1. Failed samples are considered to not match any score filter.
2. Can filter samples with errors via `has_error` and `error_contains()`.
3. It is possible to filter by a tristate score `foo: bool | None`. The filter expression should be `foo == True`, `foo == False` or `Foo == None`. Note that this is different from `foo: bool` score, where `foo == True` and `foo == False` still work, but the recommended form is just `foo` and `not foo`.
4. Completions are always unique.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
—