### PR TITLE
Allow Dockerfiles to be named Dockerfile.{name}

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/config.py
+++ b/src/inspect_ai/util/_sandbox/docker/config.py
@@ -43,7 +43,7 @@ def find_compose_file(parent: str = "") -> str | None:
 
 def is_dockerfile(file: str) -> bool:
     path = Path(file)
-    return path.name == DOCKERFILE or path.suffix == f".{DOCKERFILE}"
+    return path.stem == DOCKERFILE or path.suffix == f".{DOCKERFILE}"
 
 
 def has_dockerfile(parent: str = "") -> bool:

--- a/tests/util/sandbox/test_sandbox_setup.py
+++ b/tests/util/sandbox/test_sandbox_setup.py
@@ -88,6 +88,7 @@ def test_docker_sandbox_setup_fail_on_error():
 def test_is_dockerfile():
     assert is_dockerfile("/path/to/Dockerfile")
     assert is_dockerfile("/path/to/name.Dockerfile")
+    assert is_dockerfile("/path/to/Dockerfile.name")
     assert not is_dockerfile("/path/to/not_a_dockerfile.txt")
 
 

--- a/tests/util/sandbox/test_sandbox_setup.py
+++ b/tests/util/sandbox/test_sandbox_setup.py
@@ -89,6 +89,11 @@ def test_is_dockerfile():
     assert is_dockerfile("/path/to/Dockerfile")
     assert is_dockerfile("/path/to/name.Dockerfile")
     assert is_dockerfile("/path/to/Dockerfile.name")
+    assert not is_dockerfile("/path/to/Dockerfile-name")
+    assert not is_dockerfile("/path/to/Dockerfile_name")
+    assert not is_dockerfile("/path/to/name-Dockerfile")
+    assert not is_dockerfile("/path/to/name_Dockerfile")
+    assert not is_dockerfile("/path/to/docker-compose.yaml")
     assert not is_dockerfile("/path/to/not_a_dockerfile.txt")
 
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [x] Bug fixes

(I'm not sure if this counts as a new feature or a bug fix. It allows for a wider convention of file naming for Dockerfiles.)

### What is the current behavior? (You can also link to an open issue here)

Currently, `is_dockerfile` does not detect files named `Dockerfile.{name}`. It only detects either `Dockerfile` or `{name}.Dockerfile`.

This relates to a secondary issue raised in #1321.

### What is the new behavior?

This PR causes `is_dockerfile` to return true on `Dockerfile.{name}` as well.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. However, undoing this might constitute a breaking change.

### Other information:

Conventions often allow Dockerfiles to be named as `Dockerfile.{name}` (e.g. see [here](https://stackoverflow.com/questions/26077543/how-to-name-dockerfiles)).

However, I'm not completely sure this change is desirable. Are there reasons you might want users to not be able to specify a Dockerfile with a custom name that looks like a file extension, even if this is sometimes accepted practice?

I also add some extra tests for `is_dockerfile` that do not necessarily relate to the change but potentially clarify the behavior.