### PR TITLE
Making the formatting on the system_message solver optional

### DIFF
--- a/src/inspect_ai/solver/_prompt.py
+++ b/src/inspect_ai/solver/_prompt.py
@@ -39,7 +39,9 @@ def prompt_template(template: str, **params: Any) -> Solver:
 
 
 @solver
-def system_message(template: str, format_template: bool = True, **params: Any) -> Solver:
+def system_message(
+    template: str, format_template: bool = True, **params: Any
+) -> Solver:
     """Solver which inserts a system message into the conversation.
 
     System message template containing any number of optional `params`.
@@ -66,8 +68,10 @@ def system_message(template: str, format_template: bool = True, **params: Any) -
         if format_template:
             kwargs = state.metadata | state.store._data | params
             message_content = message_content.format(**kwargs)
-        
-        append_system_message(state.messages, ChatMessageSystem(content=message_content))
+
+        append_system_message(
+            state.messages, ChatMessageSystem(content=message_content)
+        )
         return state
 
     return solve

--- a/src/inspect_ai/solver/_prompt.py
+++ b/src/inspect_ai/solver/_prompt.py
@@ -39,7 +39,7 @@ def prompt_template(template: str, **params: Any) -> Solver:
 
 
 @solver
-def system_message(template: str, **params: Any) -> Solver:
+def system_message(template: str, format_template: bool = True, **params: Any) -> Solver:
     """Solver which inserts a system message into the conversation.
 
     System message template containing any number of optional `params`.
@@ -52,6 +52,7 @@ def system_message(template: str, **params: Any) -> Solver:
 
     Args:
       template: Template for system message.
+      format_template: Whether to format the template. Set to 'False' if the template is already formatted, and contains placeholders which you wish to pass directly to the model.
       **params: Parameters to fill into the template.
 
     Returns:
@@ -61,10 +62,12 @@ def system_message(template: str, **params: Any) -> Solver:
     content = resource(template)
 
     async def solve(state: TaskState, generate: Generate) -> TaskState:
-        kwargs = state.metadata | state.store._data | params
-        append_system_message(
-            state.messages, ChatMessageSystem(content=content.format(**kwargs))
-        )
+        message_content = content
+        if format_template:
+            kwargs = state.metadata | state.store._data | params
+            message_content = message_content.format(**kwargs)
+        
+        append_system_message(state.messages, ChatMessageSystem(content=message_content))
         return state
 
     return solve


### PR DESCRIPTION
## This PR contains:
- [X ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
I'm passing a system message into the model which contains a substring which python's .format() method takes to be a formatting substring, My system prompt contains a JSON schema generated by pydantic, which contains a lot of "{" and "}".

Currently, this causes system_message to error - this PR has a suggested change (which I'm not married to) to make that .format() call optional.