### PR TITLE
escape brackets when rendering task config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Docker: Correct compose file generation for Dockerfiles w/ custom stem or extension.
+- Escape brackets when rendering task config (another textual 2.0 fix)
 
 ## v0.3.65 (16 February 2025)
 

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -637,14 +637,17 @@ You can also add your own reducer with `@score_reducer` decorated functions. Her
 ``` python
 import statistics
 
-from inspect_ai.scorer import Score, ScoreReducer, score_reducer
+from inspect_ai.scorer import (
+    Score, ScoreReducer, score_reducer, value_to_float
+)
 
 @score_reducer(name="mean")
 def mean_score() -> ScoreReducer:
-    def reduce(scores: list[SampleScore]) -> Score:
-        """Compute a mean value of all scores."""
+    to_float = value_to_float()
 
-        values = [float(score.score.value) for score in scores]
+    def reduce(scores: list[Score]) -> Score:
+        """Compute a mean value of all scores."""
+        values = [to_float(score.value) for score in scores]
         mean_value = statistics.mean(values)
 
         return Score(value=mean_value)

--- a/src/inspect_ai/_display/core/config.py
+++ b/src/inspect_ai/_display/core/config.py
@@ -35,6 +35,10 @@ def task_config(
             value = [str(v) for v in value]
             config_print.append(f"{name}: {','.join(value)}")
         elif name not in ["limit", "model"]:
+            if isinstance(value, list):
+                value = ",".join(value)
+            if isinstance(value, str):
+                value = value.replace("[", "\\[")
             config_print.append(f"{name}: {value}")
     values = ", ".join(config_print)
     if values:


### PR DESCRIPTION
This is another textual 2.0 fix

Also made some corretions to the custom score reducer example.

