### PR TITLE
Improve display for empty subtasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Unreleased
+
+- Inspect View: Improve the display of subtasks with no inputs or events.
 
 ## v0.3.66 (17 February 2025)
 

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -58144,20 +58144,19 @@ ${events}
       depth,
       className: className2
     }) => {
-      const transcript = event.events.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-        TranscriptView,
-        {
-          id: `${id}-subtask`,
-          "data-name": "Transcript",
-          events: event.events,
-          depth: depth + 1
-        }
-      ) : "";
       const body2 = event.type === "fork" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { title: "Summary", className: clsx(styles$l.summary), children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx("text-style-label"), children: "Inputs" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx(styles$l.summaryRendered), children: /* @__PURE__ */ jsxRuntimeExports.jsx(Rendered, { values: event.input }) }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx("text-style-label"), children: "Transcript" }),
-        transcript
+        event.events.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+          TranscriptView,
+          {
+            id: `${id}-subtask`,
+            "data-name": "Transcript",
+            events: event.events,
+            depth: depth + 1
+          }
+        ) : /* @__PURE__ */ jsxRuntimeExports.jsx(None, {})
       ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Fragment, { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           SubtaskSummary,
@@ -58167,7 +58166,15 @@ ${events}
             result: event.result
           }
         ),
-        transcript
+        event.events.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+          TranscriptView,
+          {
+            id: `${id}-subtask`,
+            "data-name": "Transcript",
+            events: event.events,
+            depth: depth + 1
+          }
+        ) : void 0
       ] });
       const type = event.type === "fork" ? "Fork" : "Subtask";
       return /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -58207,10 +58214,17 @@ ${events}
           return /* @__PURE__ */ jsxRuntimeExports.jsx(Rendered, { values: val });
         });
       } else if (values && typeof values === "object") {
-        return /* @__PURE__ */ jsxRuntimeExports.jsx(MetaDataView, { entries: values });
+        if (Object.keys(values).length === 0) {
+          return /* @__PURE__ */ jsxRuntimeExports.jsx(None, {});
+        } else {
+          return /* @__PURE__ */ jsxRuntimeExports.jsx(MetaDataView, { entries: values });
+        }
       } else {
         return values;
       }
+    };
+    const None = () => {
+      return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: clsx("text-size-small", "text-style-secondary"), children: "[None]" });
     };
     const summary = "_summary_1qkjz_1";
     const approval = "_approval_1qkjz_6";

--- a/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.tsx
+++ b/src/inspect_ai/_view/www/src/samples/transcript/SubtaskEventView.tsx
@@ -30,19 +30,6 @@ export const SubtaskEventView: React.FC<SubtaskEventViewProps> = ({
   className,
 }) => {
   // Render Forks specially
-
-  const transcript =
-    event.events.length > 0 ? (
-      <TranscriptView
-        id={`${id}-subtask`}
-        data-name="Transcript"
-        events={event.events}
-        depth={depth + 1}
-      />
-    ) : (
-      ""
-    );
-
   const body =
     event.type === "fork" ? (
       <div title="Summary" className={clsx(styles.summary)}>
@@ -51,7 +38,16 @@ export const SubtaskEventView: React.FC<SubtaskEventViewProps> = ({
           <Rendered values={event.input} />
         </div>
         <div className={clsx("text-style-label")}>Transcript</div>
-        {transcript}
+        {event.events.length > 0 ? (
+          <TranscriptView
+            id={`${id}-subtask`}
+            data-name="Transcript"
+            events={event.events}
+            depth={depth + 1}
+          />
+        ) : (
+          <None />
+        )}
       </div>
     ) : (
       <Fragment>
@@ -60,7 +56,14 @@ export const SubtaskEventView: React.FC<SubtaskEventViewProps> = ({
           input={event.input}
           result={event.result}
         />
-        {transcript}
+        {event.events.length > 0 ? (
+          <TranscriptView
+            id={`${id}-subtask`}
+            data-name="Transcript"
+            events={event.events}
+            depth={depth + 1}
+          />
+        ) : undefined}
       </Fragment>
     );
 
@@ -126,8 +129,20 @@ const Rendered: React.FC<RenderedProps> = ({ values }) => {
       return <Rendered values={val} />;
     });
   } else if (values && typeof values === "object") {
-    return <MetaDataView entries={values as Record<string, unknown>} />;
+    if (Object.keys(values).length === 0) {
+      return <None />;
+    } else {
+      return <MetaDataView entries={values as Record<string, unknown>} />;
+    }
   } else {
     return values;
   }
+};
+
+const None: React.FC = () => {
+  return (
+    <span className={clsx("text-size-small", "text-style-secondary")}>
+      [None]
+    </span>
+  );
 };


### PR DESCRIPTION
Explicitly display that there are no inputs and no transcript events.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Related to #1329 (but does not resolve it)