### PR TITLE
prompt templates: Ignore template placeholders that don't map to passed parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 
 ## Unreleased
 
-- User and system message solvers: Ignore template placeholders that don't map to passed parameters.
+- Prompt templates: Ignore template placeholders that don't map to passed parameters in `prompt_template()`, `user_message()`, and `system_message()`.
 
 ## v0.3.66 (17 February 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 
+## Unreleased
+
+- User and system message solvers: Ignore template placeholders that don't map to passed parameters.
+
 ## v0.3.66 (17 February 2025)
 
 - Docker: Correct compose file generation for Dockerfiles w/ custom stem or extension.

--- a/src/inspect_ai/_util/format.py
+++ b/src/inspect_ai/_util/format.py
@@ -1,4 +1,5 @@
 import pprint
+from string import Formatter
 from textwrap import indent
 from typing import Any
 
@@ -33,3 +34,60 @@ def format_progress_time(time: float, pad_hours: bool = True) -> str:
     hours, minutes = divmod(minutes, 60)
     hours_fmt = f"{hours:2.0f}" if pad_hours else f"{hours:.0f}"
     return f"{hours_fmt}:{minutes:02.0f}:{seconds:02.0f}"
+
+
+def format_template(
+    template: str,
+    params: dict[str, Any],
+    skip_unknown: bool = True,
+) -> str:
+    """Format a template string, optionally preserving unknown placeholders.
+
+    Args:
+        template: A string containing {placeholders} to be formatted
+        params: Dictionary of parameters to substitute into the template
+        skip_unknown: If True, preserve unknown placeholders; if False, raise KeyError
+
+    Returns:
+        The formatted string with parameters substituted
+
+    Examples:
+        >>> format_template("Hello {name}!", {"name": "World"})
+        'Hello World!'
+        >>> format_template("Hello {name}!", {}, skip_unknown=True)
+        'Hello {name}!'
+    """
+
+    class SafeFormatter(Formatter):
+        def get_field(self, field_name: str, args: Any, kwargs: Any) -> Any:
+            try:
+                # Handle array indexing and nested attributes
+                first, rest = (
+                    field_name.split(".", 1)
+                    if "." in field_name
+                    else (field_name, None)
+                )
+                first = first.split("[")[0]  # Remove any array indexing for the check
+
+                if first not in params and skip_unknown:
+                    return "{" + field_name + "}", field_name
+
+                obj = params.get(first)
+                if obj is None and skip_unknown:
+                    return "{" + field_name + "}", field_name
+
+                return super().get_field(field_name, args, kwargs)
+            except (AttributeError, KeyError, IndexError) as e:
+                if skip_unknown:
+                    return "{" + field_name + "}", field_name
+                raise KeyError(f"Failed to format field '{field_name}'") from e
+
+        def format_field(self, value: Any, format_spec: str) -> Any:
+            try:
+                return super().format_field(value, format_spec)
+            except (ValueError, TypeError):
+                if skip_unknown:
+                    return "{" + str(value) + ":" + format_spec + "}"
+                raise
+
+    return SafeFormatter().format(template, **params)

--- a/src/inspect_ai/solver/_prompt.py
+++ b/src/inspect_ai/solver/_prompt.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 from inspect_ai._util.dict import omit
+from inspect_ai._util.format import format_template
 from inspect_ai.model import ChatMessageSystem
 from inspect_ai.model._chat_message import ChatMessageUser
 from inspect_ai.util import resource
@@ -32,7 +33,7 @@ def prompt_template(template: str, **params: Any) -> Solver:
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         prompt = state.user_prompt
         kwargs = omit(state.metadata | state.store._data, ["prompt"]) | params
-        prompt.text = prompt_template.format(prompt=prompt.text, **kwargs)
+        prompt.text = format_template(prompt_template, {"prompt": prompt.text} | kwargs)
         return state
 
     return solve
@@ -63,7 +64,7 @@ def system_message(template: str, **params: Any) -> Solver:
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         kwargs = state.metadata | state.store._data | params
         append_system_message(
-            state.messages, ChatMessageSystem(content=content.format(**kwargs))
+            state.messages, ChatMessageSystem(content=format_template(content, kwargs))
         )
         return state
 
@@ -91,7 +92,7 @@ def user_message(template: str, **params: Any) -> Solver:
 
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         kwargs = state.metadata | state.store._data | params
-        state.messages.append(ChatMessageUser(content=content.format(**kwargs)))
+        state.messages.append(ChatMessageUser(content=format_template(content, kwargs)))
         return state
 
     return solve

--- a/tests/solver/test_prompt.py
+++ b/tests/solver/test_prompt.py
@@ -13,6 +13,10 @@ Please answer this question.
 {variable}
 
 {prompt}
+
+{unknown}
+
+{{escaped}}
 """
 
 PARAM_VALUE = "param_value"
@@ -46,6 +50,8 @@ def check_template_variables(template_solver: Solver, index: int = 0):
 
     assert VARIABLE_VALUE in message
     assert PARAM_VALUE in message
+    assert "{unknown}" in message
+    assert "{escaped}" in message
 
     return message
 

--- a/tests/util/test_format_template.py
+++ b/tests/util/test_format_template.py
@@ -1,0 +1,190 @@
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from inspect_ai._util.format import format_template
+
+
+@dataclass
+class FormatterCase:
+    """Test case for format_template function."""
+
+    params: dict[str, Any]
+    template: str
+    expected: str
+    skip_unknown: bool = field(default=True)
+    should_raise: bool = field(default=False)
+
+
+def test_basic_substitution() -> None:
+    """Test basic parameter substitution."""
+    params = {"name": "World"}
+    result = format_template("Hello {name}!", params)
+    assert result == "Hello World!"
+
+
+def test_multiple_substitutions() -> None:
+    """Test multiple parameter substitutions."""
+    params = {"first": "John", "last": "Doe"}
+    result = format_template("Hello {first} {last}!", params)
+    assert result == "Hello John Doe!"
+
+
+def test_unknown_placeholder_skipping() -> None:
+    """Test that unknown placeholders are preserved when skip_unknown is True."""
+    result = format_template("Hello {unknown}!", {})
+    assert result == "Hello {unknown}!"
+
+
+def test_unknown_placeholder_raising() -> None:
+    """Test that unknown placeholders raise KeyError when skip_unknown is False."""
+    with pytest.raises(KeyError):
+        format_template("Hello {unknown}!", {}, skip_unknown=False)
+
+
+def test_escaped_braces() -> None:
+    """Test that escaped braces are handled correctly."""
+    test_cases: list[FormatterCase] = [
+        FormatterCase(
+            params={"name": "John"}, template="{{name}} {name}", expected="{name} John"
+        ),
+        FormatterCase(params={}, template="{{literal}}", expected="{literal}"),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_nested_attributes() -> None:
+    """Test handling of nested attribute access."""
+
+    @dataclass
+    class Person:
+        name: str
+        age: int
+
+    params = {"person": Person(name="John", age=30)}
+    result = format_template("{person.name} is {person.age}", params)
+    assert result == "John is 30"
+
+
+def test_nested_dict() -> None:
+    """Test handling of nested dictionary access."""
+    params = {"obj": {"attr": "value"}}
+    result = format_template("{obj[attr]}", params)
+    assert result == "value"
+
+
+def test_invalid_nested_attributes() -> None:
+    """Test handling of invalid nested attribute access."""
+    test_cases: list[FormatterCase] = [
+        FormatterCase(
+            params={"obj": {}}, template="{obj.missing}", expected="{obj.missing}"
+        ),
+        FormatterCase(
+            params={"obj": None}, template="{obj.anything}", expected="{obj.anything}"
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_format_specifications() -> None:
+    """Test handling of format specifications."""
+    test_cases: list[FormatterCase] = [
+        FormatterCase(params={"num": 42}, template="{num:03d}", expected="042"),
+        FormatterCase(params={"pi": 3.14159}, template="{pi:.2f}", expected="3.14"),
+        FormatterCase(
+            params={"text": "center"}, template="{text:^10}", expected="  center  "
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_array_indexing() -> None:
+    """Test handling of array indexing."""
+    test_cases: list[FormatterCase] = [
+        FormatterCase(
+            params={"arr": [1, 2, 3]},
+            template="{arr[0]} {arr[1]} {arr[2]}",
+            expected="1 2 3",
+        ),
+        FormatterCase(
+            params={"arr": ["first", "second"]}, template="{arr[0]}", expected="first"
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_mixed_known_unknown() -> None:
+    """Test mixing known and unknown parameters."""
+    test_cases: list[FormatterCase] = [
+        FormatterCase(
+            params={"known": "value"},
+            template="{known} and {unknown}",
+            expected="value and {unknown}",
+        ),
+        FormatterCase(
+            params={"a": 1, "b": 2},
+            template="{a} {missing} {b}",
+            expected="1 {missing} 2",
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected
+
+
+def test_empty_template() -> None:
+    """Test handling of empty template."""
+    result = format_template("", {})
+    assert result == ""
+
+
+def test_complex_nested_structures() -> None:
+    """Test handling of complex nested data structures."""
+
+    @dataclass
+    class Address:
+        street: str
+        city: str
+
+    @dataclass
+    class Person:
+        name: str
+        address: Address
+        scores: list[int]
+
+    person = Person(
+        name="John",
+        address=Address(street="123 Main St", city="Anytown"),
+        scores=[95, 87, 91],
+    )
+
+    test_cases: list[FormatterCase] = [
+        FormatterCase(
+            params={"person": person},
+            template="{person.name} lives in {person.address.city}",
+            expected="John lives in Anytown",
+        ),
+        FormatterCase(
+            params={"person": person},
+            template="Best score: {person.scores[0]}",
+            expected="Best score: 95",
+        ),
+    ]
+
+    for case in test_cases:
+        result = format_template(case.template, case.params)
+        assert result == case.expected


### PR DESCRIPTION
Applies to `prompt_template()`, `user_message()`, and `system_message()` solvers.