### PR TITLE
Filter pending events from transcript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Inspect View: Improve the display of subtasks with no inputs or events.
+- Inspect View: Fix transcript display of phantom subtask or other phantom events.
 
 ## Unreleased
 

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -58672,7 +58672,8 @@ ${events}
         return e.event === "sample_init";
       });
       const initEvent = events[initEventIndex];
-      const fixedUp = [...events];
+      const finalEvents = events.filter((e) => !e.pending);
+      const fixedUp = [...finalEvents];
       if (initEvent) {
         fixedUp.splice(initEventIndex, 0, {
           timestamp: initEvent.timestamp,

--- a/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.tsx
+++ b/src/inspect_ai/_view/www/src/samples/transcript/TranscriptView.tsx
@@ -387,7 +387,10 @@ const fixupEventStream = (events: Events) => {
   });
   const initEvent = events[initEventIndex];
 
-  const fixedUp = [...events];
+  // Filter pending events
+  const finalEvents = events.filter((e) => !e.pending);
+
+  const fixedUp = [...finalEvents];
   if (initEvent) {
     fixedUp.splice(initEventIndex, 0, {
       timestamp: initEvent.timestamp,


### PR DESCRIPTION
We currently don’t have a visual treatment for pending events, so they are appearing in the event stream and it can be confusing since they have no input or child events.

Fixes #1329

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
