### PR TITLE
PlainTaskDisplay: print on every step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Google provider updated to use the [Google Gen AI SDK](https://googleapis.github.io/python-genai/), which is now the recommended API for Gemini 2.0 models.
+- Task display: Print task progress every 5 seconds for 'plain' display mode.
 
 ## v0.3.68 (19 February 2025)
 

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -119,7 +119,7 @@ class PlainTaskDisplay(TaskDisplay):
         self.samples_complete = 0
         self.samples_total = 0
         self.current_metrics: list[TaskDisplayMetric] | None = None
-        self.last_progress = 0  # Track last progress percentage
+        self.last_progress = 0
 
     @contextlib.contextmanager
     def progress(self) -> Iterator[Progress]:

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -126,7 +126,7 @@ class PlainTaskDisplay(TaskDisplay):
         self.progress_display = PlainProgress(self.task.profile.steps)
         yield self.progress_display
 
-    @throttle(10)
+    @throttle(5)
     def _print_status_throttled(self) -> None:
         self._print_status()
 

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -126,7 +126,7 @@ class PlainTaskDisplay(TaskDisplay):
         self.progress_display = PlainProgress(self.task.profile.steps)
         yield self.progress_display
 
-    @throttle(1)
+    @throttle(10)
     def _print_status_throttled(self) -> None:
         self._print_status()
 
@@ -135,13 +135,8 @@ class PlainTaskDisplay(TaskDisplay):
         if not self.progress_display:
             return
 
-        # Calculate current progress percentage
-        current_progress = int(
-            self.progress_display.current / self.progress_display.total * 100
-        )
-
-        # Only print on percentage changes to avoid too much output
-        if current_progress != self.last_progress:
+        # Only print when step count changes to avoid too much output
+        if self.progress_display.current != self.last_progress:
             status_parts: list[str] = []
 
             # if this is parallel print task and model to distinguish (limit both to 12 chars)
@@ -154,8 +149,11 @@ class PlainTaskDisplay(TaskDisplay):
                 )
 
             # Add step progress
+            progress_percent = int(
+                self.progress_display.current / self.progress_display.total * 100
+            )
             status_parts.append(
-                f"Steps: {self.progress_display.current:3d}/{self.progress_display.total} {current_progress:3d}%"
+                f"Steps: {self.progress_display.current:3d}/{self.progress_display.total} {progress_percent:3d}%"
             )
 
             # Add sample progress
@@ -187,7 +185,7 @@ class PlainTaskDisplay(TaskDisplay):
             # Print on new line
             print(" | ".join(status_parts))
 
-            self.last_progress = current_progress
+            self.last_progress = self.progress_display.current
 
     def sample_complete(self, complete: int, total: int) -> None:
         self.samples_complete = complete


### PR DESCRIPTION
Would you be open to this change?

### What is the current behavior?
Prints on every integer percentage change, at most once every second.

This is not ideal because, for evaluations with many samples, 1% can take a long time, so it's hard to tell if the eval is completely stuck or just slow.

### What is the new behavior?
Print on every "step" change, at most once every 10 seconds. I'm open to other options.