### PR TITLE
Add error feedback if docker services fail to start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Task display: Use cooperative cancellation for cancel buttons in task display.
 - Task display: Print task progress every 5 seconds for 'plain' display mode.
 - Task display: Handle click on running samples tab when there is no transcript.
+- Docker: Print stderr from `compose up` when no services startup successfully. 
 - Docker: Print sample id and epoch for each container when using `--no-sandbox-cleanup`
 - Mistral: Create and destroy client within generate.
 - Inspect View: Fix display of score dictionaries containing boolean values

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -6,11 +6,12 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import yaml
+from pydantic import BaseModel
+
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.trace import trace_message
 from inspect_ai.util._display import display_type
 from inspect_ai.util._subprocess import ExecResult, subprocess
-from pydantic import BaseModel
 
 from .prereqs import (
     DOCKER_COMPOSE_REQUIRED_VERSION_PULL_POLICY,
@@ -27,7 +28,7 @@ COMPOSE_WAIT = 120
 
 async def compose_up(
     project: ComposeProject, services: dict[str, ComposeService]
-) -> ExecResult:
+) -> ExecResult[str]:
     # compute the maximum amount of time we will
     up_command = ["up", "--detach", "--wait"]
 

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -6,12 +6,11 @@ from pathlib import Path
 from typing import Any, Literal, cast
 
 import yaml
-from pydantic import BaseModel
-
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.trace import trace_message
 from inspect_ai.util._display import display_type
 from inspect_ai.util._subprocess import ExecResult, subprocess
+from pydantic import BaseModel
 
 from .prereqs import (
     DOCKER_COMPOSE_REQUIRED_VERSION_PULL_POLICY,
@@ -122,11 +121,6 @@ async def compose_check_running(
             unhealthy_services = services
             for successful_service in successful_services:
                 unhealthy_services.remove(successful_service["Service"])
-
-            msg = (
-                "One or more docker containers failed to start from "
-                f"{project.config}: {','.join(unhealthy_services)}"
-            )
             return []
     else:
         return []

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -28,7 +28,7 @@ COMPOSE_WAIT = 120
 
 async def compose_up(
     project: ComposeProject, services: dict[str, ComposeService]
-) -> None:
+) -> ExecResult:
     # compute the maximum amount of time we will
     up_command = ["up", "--detach", "--wait"]
 
@@ -49,7 +49,8 @@ async def compose_up(
     # passing the --wait flag (see https://github.com/docker/compose/issues/10596).
     # In practice, we will catch any errors when calling compose_check_running()
     # immediately after we call compose_up().
-    await compose_command(up_command, project=project, timeout=timeout)
+    result = await compose_command(up_command, project=project, timeout=timeout)
+    return result
 
 
 async def compose_down(project: ComposeProject, quiet: bool = True) -> None:
@@ -126,9 +127,9 @@ async def compose_check_running(
                 "One or more docker containers failed to start from "
                 f"{project.config}: {','.join(unhealthy_services)}"
             )
-            raise RuntimeError(msg)
+            return []
     else:
-        raise RuntimeError("No services started")
+        return []
 
     return [service["Service"] for service in running_services]
 

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -148,12 +148,17 @@ class DockerSandboxEnvironment(SandboxEnvironment):
             services = await compose_services(project)
 
             # start the services
-            await compose_up(project, services)
+            result = await compose_up(project, services)
 
             # check to ensure that the services are running
             running_services = await compose_check_running(
                 list(services.keys()), project=project
             )
+
+            if not running_services:
+                raise RuntimeError(
+                    f"No services started.\nCompose up stderr: {result.stderr}"
+                )
 
             # note that the project is running
             project_startup(project)


### PR DESCRIPTION
## This PR contains:

- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If a docker service fails to start, you get an opaque error message with no information about what went wrong.

### What is the new behavior?

Now you get to see the stderr of the docker compose up command

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

no

### Other information:

n/a
