### PR TITLE
make full test suite more deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Task display: Use cooperative cancellation for cancel buttons in task display.
 - Task display: Print task progress every 5 seconds for 'plain' display mode.
 - Task display: Handle click on running samples tab when there is no transcript.
+- Mistral: Create and destroy client within generate.
 - Inspect View: Fix display of score dictionaries containing boolean values
 - Bugfix: Catch standard `TimeoutError` for subprocess timeouts (ensure kill/cleanup of timed out process).
 

--- a/tests/tools/test_tool_types.py
+++ b/tests/tools/test_tool_types.py
@@ -196,6 +196,10 @@ def check_list_of_numbers(model: str) -> None:
 
 
 def check_list_of_objects(model: str) -> None:
+    # grok sometimes doesn't get this one (just says 'I have extracted, how would you like to proceed')
+    if "grok" in model:
+        return
+
     task = Task(
         dataset=MemoryDataset(
             [

--- a/tests/tools/test_tool_types.py
+++ b/tests/tools/test_tool_types.py
@@ -7,7 +7,6 @@ from test_helpers.utils import (
     skip_if_no_anthropic,
     skip_if_no_google,
     skip_if_no_grok,
-    skip_if_no_groq,
     skip_if_no_mistral,
     skip_if_no_openai,
     skip_if_no_vertex,
@@ -295,9 +294,11 @@ def test_grok_tool_types() -> None:
     check_tool_types("grok/grok-beta")
 
 
-@skip_if_no_groq
-def test_groq_tool_types() -> None:
-    check_tool_types("groq/mixtral-8x7b-32768")
+# groq tool calling is extremely unreliable and consequently causes
+# failed tests that are red herrings. don't exercise this for now.
+# @skip_if_no_groq
+# def test_groq_tool_types() -> None:
+#     check_tool_types("groq/mixtral-8x7b-32768")
 
 
 def verify_tool_call(log: EvalLog, includes: str):

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -10,7 +10,6 @@ from test_helpers.tools import addition, raise_error, read_file
 from test_helpers.utils import (
     skip_if_no_anthropic,
     skip_if_no_google,
-    skip_if_no_groq,
     skip_if_no_mistral,
     skip_if_no_openai,
     skip_if_no_vertex,
@@ -177,9 +176,11 @@ def test_mistral_tools():
     check_tools("mistral/mistral-large-latest")
 
 
-@skip_if_no_groq
-def test_groq_tools():
-    check_tools("groq/mixtral-8x7b-32768")
+# groq tool calling is extremely unreliable and consequently causes
+# failed tests that are red herrings. don't exercise this for now.
+# @skip_if_no_groq
+# def test_groq_tools():
+#     check_tools("groq/mixtral-8x7b-32768")
 
 
 @skip_if_no_google

--- a/tests/tools/test_web_browser.py
+++ b/tests/tools/test_web_browser.py
@@ -141,7 +141,9 @@ def test_web_browser_input():
 
     log = eval(task, model="openai/gpt-4o")[0]
 
-    type_call = get_tool_call(log.samples[0].messages, "web_browser_type_submit")
+    type_call = get_tool_call(
+        log.samples[0].messages, "web_browser_click"
+    ) or get_tool_call(log.samples[0].messages, "web_browser_type_submit")
     assert type_call
 
 


### PR DESCRIPTION
The full test suite includes `--runapi` and `--runslow`, however due to cost/techincal constraints we don't currently run all of these in CI. Some of these additional tests have some non-determinism (due to models being erratic in their behavior) so when running the whole suite you can get failures due to various vagaries of model behavior.  This PR uses a combination of selective skipping and more flexible output checking to make `--runapi` and `--runslow` succeed or fail more deterministically.