### PR TITLE
runslow determinism

### DIFF
--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -445,7 +445,8 @@ async def test_exec_stdout_is_limited(sandbox_env: SandboxEnvironment) -> None:
     assert "limit of 10 MiB was exceeded" in str(e_info.value)
     truncated_output = e_info.value.truncated_output
     # `yes` outputs 'y\n' (ASCII) so the size equals the string length.
-    assert truncated_output and len(truncated_output) == 10 * 1024**2
+    # some shells additionally output 'canceled\n' so we add fudge factor for that
+    assert truncated_output and (len(truncated_output) - 10 * 1024**2) < 10
 
 
 async def test_exec_stderr_is_limited(sandbox_env: SandboxEnvironment) -> None:

--- a/tests/tools/test_web_browser.py
+++ b/tests/tools/test_web_browser.py
@@ -132,7 +132,7 @@ def test_web_browser_input():
     task = Task(
         dataset=[
             Sample(
-                input="Please use the web browser tool to navigate to https://inspect.ai-safety-institute.org.uk/. Then, once there, use the page's search interface to search for 'solvers'"
+                input="Please use the web browser tool to navigate to https://www.google.com. Then, once there, use the page's search interface to search for 'large language models'"
             )
         ],
         solver=[use_tools(web_browser()), generate()],
@@ -141,9 +141,7 @@ def test_web_browser_input():
 
     log = eval(task, model="openai/gpt-4o")[0]
 
-    type_call = get_tool_call(
-        log.samples[0].messages, "web_browser_click"
-    ) or get_tool_call(log.samples[0].messages, "web_browser_type_submit")
+    type_call = get_tool_call(log.samples[0].messages, "web_browser_type_submit")
     assert type_call
 
 


### PR DESCRIPTION
- accommodate that some shells output 'canceled\n' to stdout for aborted `yes` process
- pick a search target for web_browser_input which has less potential of trip ups for the model