### PR TITLE
align with HF datasets `fsspec` version contraints to avoid pip errors when installing alongside `datasets`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+
+## Unreleased
+
+- Align with HF datasets `fsspec` version contraints to avoid pip errors when installing alongside `datasets`.
+
 ## v0.3.69 (20 February 2025)
 
 - Google provider updated to use the [Google Gen AI SDK](https://googleapis.github.io/python-genai/), which is now the recommended API for Gemini 2.0 models.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ beautifulsoup4
 click>=8.1.3
 debugpy
 docstring-parser>=0.16
-fsspec>=2021.09.0
+fsspec>=2023.1.0,<=2024.12.0 # align with hf datasets to prevent pip errors
 httpx
 ijson>=3.2.0
 jsonlines>=3.0.0


### PR DESCRIPTION
HF datasets maintains a manual upper bound of `fsspec` out of general paranoia that they'll be broken on upgrade: https://github.com/huggingface/datasets/issues/7326

This causes no issues for the default install of Inspect (which has no `datasets` dependency) however once `hf_dataset()` is used or Inspect Evals are in play then `datasets` is in play, and the user sees this (non-fatal) error when installing or updating `inspect_ai` alongside `datasets`:

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
datasets 3.3.1 requires fsspec[http]<=2024.12.0,>=2023.1.0, but you have fsspec 2025.2.0 which is incompatible.
```

This PR matches the `datasets` upper bound (the release from 12-2024) to avoid this error message. We'd prefer not to upper bound but so long as HF datasets keeps aggressively bumping their upper bound this is unlikely to cause problems.
