### PR TITLE
[MINOR] typo in _basic_agent.DEFAULT_SYSTEM_MESSAGE

### DIFF
--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -24,7 +24,7 @@ logger = getLogger(__name__)
 
 DEFAULT_SYSTEM_MESSAGE = """
 You are a helpful assistant attempting to submit the correct answer. You have
-several functions available to help with finding the answer. Each message may
+several functions available to help with finding the answer. Each message
 may perform one function call. You will see the result of the function right
 after sending the message. If you need to perform multiple actions, you can
 always send more messages with subsequent function calls. Do some reasoning


### PR DESCRIPTION
Removed duplicate "may" in DEFAULT_SYSTEM_MESSAGE

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The prompt contains the sentence "Each message may may perform one function call."

### What is the new behavior?
The sentence is now "Each message may perform one function call."

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Minor typo