### PR TITLE
Remove root logging handlers upon Inspect logger initialisation

### DIFF
--- a/src/inspect_ai/_util/logger.py
+++ b/src/inspect_ai/_util/logger.py
@@ -160,7 +160,9 @@ def init_logger(
 
     # init logging handler on demand
     global _logHandler
+    removed_root_handlers = False
     if not _logHandler:
+        removed_root_handlers = remove_non_pytest_root_logger_handlers()
         _logHandler = LogHandler(min(DEBUG, levelno), transcript_levelno)
         getLogger().addHandler(_logHandler)
 
@@ -173,11 +175,28 @@ def init_logger(
     getLogger("httpx").setLevel(capture_level)
     getLogger("botocore").setLevel(DEBUG)
 
+    if removed_root_handlers:
+        getLogger(PKG_NAME).warning(
+            "Inspect removed pre-existing root logger handlers and replaced them with its own handler."
+        )
+
     # set the levelno on the global handler
     _logHandler.display_level = levelno
 
 
 _logHandler: LogHandler | None = None
+
+
+def remove_non_pytest_root_logger_handlers() -> bool:
+    root_logger = getLogger()
+    non_pytest_handlers = [
+        handler
+        for handler in root_logger.handlers
+        if handler.__module__ != "_pytest.logging"
+    ]
+    for handler in non_pytest_handlers:
+        root_logger.removeHandler(handler)
+    return len(non_pytest_handlers) > 0
 
 
 def notify_logger_record(record: LogRecord, write: bool) -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Relevant Slack thread is [here](https://inspectcommunity.slack.com/archives/C080K7SQ4SG/p1740066834687599).

Right now, if there are root logging handlers present before Inspect initialises its logger, they will receive all of the logs which Inspect is interested in (like DEBUG logs from botocore and TRACE logs from other libraries.) 

### What is the new behavior?
If root loggers are present, Inspect will remove them and also print a WARNING message to the console.

To test this, I ran the test pasted below, as well as imported this into the AS evaluation codebase and verified it fixed the issue.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
If people had root logging handlers they depend on, they will break. While we could add a CLI option to disable this behavior, I don't think anyone depends on that behavior (and they'll get a ton of log spam from Inspect.) We could also alter the docs to specify this behavior will occur.

### Other information:
I tried implementing a test which passes when run individually but breaks when run as a part of the entire Pytest group. I don't have time to debug it but it's below if you're curious. 
```python
import logging
import tempfile

import pytest
from inspect_ai import Task, task
from test_helpers.utils import (
    failing_task,
    sleep_for_solver,
)

from inspect_ai._eval.evalset import (
    eval_set,
)


@pytest.mark.usefixtures("caplog")
def test_preexisting_eval_log_handler(caplog) -> None:
    new_handler = logging.StreamHandler()
    logging.getLogger().addHandler(new_handler)

    with tempfile.TemporaryDirectory() as log_dir:
        success, logs = eval_set(
            tasks=sleep_for_1_task("hello"),
            log_dir=log_dir,
            retry_attempts=1000,
            retry_wait=0.1,
            model="mockllm/model",
        )
        assert success
        assert logs[0].status == "success"

    caplog_messages = [record.message for record in caplog.records]
    assert any("root logger handler" in message for message in caplog_messages)
    assert new_handler not in logging.getLogger().handlers
    # Clean up
    del new_handler


@pytest.mark.usefixtures("caplog")
def test_no_preexisting_eval_log_handler(caplog) -> None:
    with tempfile.TemporaryDirectory() as log_dir:
        success, logs = eval_set(
            tasks=failing_task(rate=0.1, samples=10),
            log_dir=log_dir,
            retry_attempts=1000,
            retry_wait=0.1,
            model="mockllm/model",
        )
        assert success
        assert logs[0].status == "success"

    caplog_messages = [record.message for record in caplog.records]
    assert all("root logger handler" not in message for message in caplog_messages)

@task
def sleep_for_1_task(task_arg: str):
    return Task(
        solver=[sleep_for_solver(1)],
    )
```