### PR TITLE
_call_tools.py: iterate through items not keys

### DIFF
--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -407,7 +407,7 @@ def tool_param(type_hint: Type[Any], input: Any) -> Any:
             return tuple(input)
     elif origin is dict or origin is Dict:
         if args and len(args) > 1:
-            return {k: tool_param(args[1], v) for k, v in input}
+            return {k: tool_param(args[1], v) for k, v in input.items()}
         else:
             return input
     elif origin is Union or origin is types.UnionType:


### PR DESCRIPTION
This fixes bugs of the form
```
│
│ ╭───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────╮  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:324 in task_run                                  │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:738 in task_run_sample                           │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:542 in handle_error                              │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/error.py:24 in __call__                                 │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:653 in task_run_sample                           │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:542 in handle_error                              │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/error.py:24 in __call__                                 │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:597 in task_run_sample                           │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/solver/_plan.py:105 in __call__                                    │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/solver/_basic_agent.py:188 in solve                                │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/model/_call_tools.py:193 in call_tools                             │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/model/_call_tools.py:88 in call_tool_task                          │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/model/_call_tools.py:266 in call_tool                              │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/model/_call_tools.py:356 in tool_params                            │  │
│ │                                                                                                                      │  │
│ │ /uv/.venv/lib/python3.12/site-packages/inspect_ai/model/_call_tools.py:412 in tool_param                             │  │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯  │
│ ValueError: too many values to unpack (expected 2)                                                                        │
│                                                                                                                           │
│ Task interrupted (no samples completed before interruption)                                                               │
│                                                                                                                           │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```
which seem to come up when a tool expects a dict as an argument.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
