### PR TITLE
`ContentReasoning` to represent reasoning blocks

### DIFF
--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -2,6 +2,14 @@
 title: Reasoning
 ---
 
+::: {.callout-note appearance="simple"}
+The reasoning features described below are currently available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
 ## Overview
 
 Reasoning models like OpenAI o1 and o3, Google's Gemini 2.0 Flash Thinking, and DeepSeek's r1 have some additional options that can be used to tailor their behaviour. They also in some cases make available full or partial reasoning traces for the chains of thought that led to their response.
@@ -24,7 +32,7 @@ If you are aware of other providers adding support for `reasoning_effort` please
 
 ## Reasoning Traces
 
-In some cases reasoning models provide traces of their chain of thought as part of assistant responses. When available, these traces are provided by Inspect in a new `reasoning` field of `ChatMessageAssistant`.
+In some cases reasoning models provide traces of their chain of thought as part of assistant responses. When available, these traces are provided by Inspect in a new `ContentReasoning` class that can appear in the `content` field of `ChatMessageAssistant`.
 
 Reasoning traces are currently captured in two ways:
 

--- a/docs/reference/inspect_ai.model.qmd
+++ b/docs/reference/inspect_ai.model.qmd
@@ -26,6 +26,7 @@ title: "inspect_ai.model"
 
 ### Content
 ### ContentText
+### ContentReasoning
 ### ContentImage
 ### ContentAudio
 ### ContentVideo

--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -9,7 +9,7 @@ from textual.containers import ScrollableContainer
 from textual.widget import Widget
 from textual.widgets import Static
 
-from inspect_ai._util.content import ContentText
+from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai._util.rich import lines_display
 from inspect_ai._util.transcript import (
     set_transcript_markdown_options,
@@ -36,7 +36,6 @@ from inspect_ai.log._transcript import (
 )
 from inspect_ai.model._chat_message import (
     ChatMessage,
-    ChatMessageAssistant,
     ChatMessageUser,
 )
 from inspect_ai.model._render import messages_preceding_assistant
@@ -333,11 +332,16 @@ def render_message(message: ChatMessage) -> list[RenderableType]:
         Text(),
     ]
 
-    if isinstance(message, ChatMessageAssistant) and message.reasoning:
-        content.extend(transcript_reasoning(message.reasoning))
-
-    if message.text:
+    # deal with plain text or with content blocks
+    if isinstance(message.content, str):
         content.extend([transcript_markdown(message.text.strip(), escape=True)])
+    else:
+        for c in message.content:
+            if isinstance(c, ContentReasoning):
+                content.extend(transcript_reasoning(c))
+            elif isinstance(c, ContentText):
+                content.extend([transcript_markdown(c.text.strip(), escape=True)])
+
     return content
 
 

--- a/src/inspect_ai/_util/content.py
+++ b/src/inspect_ai/_util/content.py
@@ -13,6 +13,25 @@ class ContentText(BaseModel):
     """Text content."""
 
 
+class ContentReasoning(BaseModel):
+    """Reasoning content.
+
+    See the specification for [thinking blocks](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#understanding-thinking-blocks) for Claude models.
+    """
+
+    type: Literal["reasoning"] = Field(default="reasoning")
+    """Type."""
+
+    reasoning: str
+    """Reasoning content."""
+
+    signature: str | None = Field(default=None)
+    """Signature for reasoning content (used by some models to ensure that reasoning content is not modified for replay)"""
+
+    redacted: bool = Field(default=False)
+    """Indicates that the explicit content of this reasoning block has been redacted."""
+
+
 class ContentImage(BaseModel):
     """Image content."""
 
@@ -55,5 +74,5 @@ class ContentVideo(BaseModel):
     """Format of video data ('mp4', 'mpeg', or 'mov')"""
 
 
-Content = Union[ContentText, ContentImage, ContentAudio, ContentVideo]
+Content = Union[ContentText, ContentReasoning, ContentImage, ContentAudio, ContentVideo]
 """Content sent to or received from a model."""

--- a/src/inspect_ai/_util/transcript.py
+++ b/src/inspect_ai/_util/transcript.py
@@ -10,6 +10,8 @@ from rich.panel import Panel
 from rich.rule import Rule
 from rich.text import Text
 
+from inspect_ai._util.content import ContentReasoning
+
 from .format import format_function_call
 
 
@@ -111,12 +113,16 @@ def transcript_panel(
     )
 
 
-def transcript_reasoning(reasoning: str) -> list[RenderableType]:
+def transcript_reasoning(reasoning: ContentReasoning) -> list[RenderableType]:
     content: list[RenderableType] = []
+    text = (
+        reasoning.reasoning
+        if not reasoning.redacted
+        else "Reasoning encrypted for safety reasons."
+    )
+
     content.append(
-        transcript_markdown(
-            f"**<think>**  \n{reasoning}  \n**</think>**\n\n", escape=True
-        )
+        transcript_markdown(f"**<think>**  \n{text}  \n**</think>**\n\n", escape=True)
     )
     content.append(Text())
     return content

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -15653,9 +15653,6 @@ ul.jsondiffpatch-textdiff {
   border: none;
   padding: 0.1rem 0.5rem;
 }
-.markdown-ordered-list-item {
-  margin-bottom: 0.2em;
-}
 ._message_xh8qq_1 {
   font-weight: 300;
   padding-bottom: 0.5em;
@@ -15684,6 +15681,9 @@ ul.jsondiffpatch-textdiff {
 ._messageContents_xh8qq_21._indented_xh8qq_26 {
   margin-left: 1.1rem;
   padding-bottom: 0.8rem;
+}
+.markdown-ordered-list-item {
+  margin-bottom: 0.2em;
 }
 ._contentImage_121dp_1 {
   max-width: 800px;

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -16069,6 +16069,18 @@ var require_assets = __commonJS({
         }
       ) }) });
     };
+    const message$1 = "_message_xh8qq_1";
+    const systemRole = "_systemRole_xh8qq_9";
+    const messageGrid = "_messageGrid_xh8qq_13";
+    const messageContents = "_messageContents_xh8qq_21";
+    const indented = "_indented_xh8qq_26";
+    const styles$12 = {
+      message: message$1,
+      systemRole,
+      messageGrid,
+      messageContents,
+      indented
+    };
     const decodeCache = {};
     function getDecodeCache(exclude) {
       let cache = decodeCache[exclude];
@@ -21319,18 +21331,6 @@ var require_assets = __commonJS({
         }
       );
     }
-    const message$1 = "_message_xh8qq_1";
-    const systemRole = "_systemRole_xh8qq_9";
-    const messageGrid = "_messageGrid_xh8qq_13";
-    const messageContents = "_messageContents_xh8qq_21";
-    const indented = "_indented_xh8qq_26";
-    const styles$12 = {
-      message: message$1,
-      systemRole,
-      messageGrid,
-      messageContents,
-      indented
-    };
     const contentImage = "_contentImage_121dp_1";
     const styles$11 = {
       contentImage
@@ -21433,6 +21433,15 @@ var require_assets = __commonJS({
             },
             key2
           );
+        }
+      },
+      reasoning: {
+        render: (key2, content2, isLast) => {
+          const r2 = content2;
+          return /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Fragment, { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx("text-style-label", "text-style-secondary", isLast ? "no-last-para-padding" : ""), children: "Reasoning" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(ExpandablePanel, { collapse: true, children: /* @__PURE__ */ jsxRuntimeExports.jsx(MarkdownDiv, { markdown: r2.reasoning }) })
+          ] }, key2);
         }
       },
       image: {
@@ -21835,29 +21844,22 @@ var require_assets = __commonJS({
               /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: iconForMsg(message2) }),
               message2.role
             ] }),
-            message2.role === "assistant" && message2.reasoning ? /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Fragment, { children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx("text-style-label", "text-style-secondary"), children: "Reasoning" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(ExpandablePanel, { collapse: true, children: /* @__PURE__ */ jsxRuntimeExports.jsx(MarkdownDiv, { markdown: message2.reasoning }) })
-            ] }, `${id}-response-label`) : void 0,
-            /* @__PURE__ */ jsxRuntimeExports.jsxs(
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
               "div",
               {
                 className: clsx(
                   styles$12.messageContents,
                   indented2 ? styles$12.indented : void 0
                 ),
-                children: [
-                  message2.role === "assistant" && message2.reasoning ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx("text-style-label", "text-style-secondary"), children: "Response" }) : void 0,
-                  /* @__PURE__ */ jsxRuntimeExports.jsx(ExpandablePanel, { collapse, children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-                    MessageContents,
-                    {
-                      message: message2,
-                      toolMessages,
-                      toolCallStyle
-                    },
-                    `${id}-contents`
-                  ) })
-                ]
+                children: /* @__PURE__ */ jsxRuntimeExports.jsx(ExpandablePanel, { collapse, lines: 30, children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  MessageContents,
+                  {
+                    message: message2,
+                    toolMessages,
+                    toolCallStyle
+                  },
+                  `${id}-contents`
+                ) })
               }
             )
           ]

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -217,6 +217,9 @@
                     "$ref": "#/$defs/ContentText"
                   },
                   {
+                    "$ref": "#/$defs/ContentReasoning"
+                  },
+                  {
                     "$ref": "#/$defs/ContentImage"
                   },
                   {
@@ -262,26 +265,13 @@
           ],
           "default": null,
           "title": "Tool Calls"
-        },
-        "reasoning": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Reasoning"
         }
       },
       "required": [
         "role",
         "content",
         "source",
-        "tool_calls",
-        "reasoning"
+        "tool_calls"
       ],
       "title": "ChatMessageAssistant",
       "type": "object",
@@ -306,6 +296,9 @@
                 "anyOf": [
                   {
                     "$ref": "#/$defs/ContentText"
+                  },
+                  {
+                    "$ref": "#/$defs/ContentReasoning"
                   },
                   {
                     "$ref": "#/$defs/ContentImage"
@@ -368,6 +361,9 @@
                 "anyOf": [
                   {
                     "$ref": "#/$defs/ContentText"
+                  },
+                  {
+                    "$ref": "#/$defs/ContentReasoning"
                   },
                   {
                     "$ref": "#/$defs/ContentImage"
@@ -468,6 +464,9 @@
                 "anyOf": [
                   {
                     "$ref": "#/$defs/ContentText"
+                  },
+                  {
+                    "$ref": "#/$defs/ContentReasoning"
                   },
                   {
                     "$ref": "#/$defs/ContentImage"
@@ -588,6 +587,47 @@
         "detail"
       ],
       "title": "ContentImage",
+      "type": "object",
+      "additionalProperties": false
+    },
+    "ContentReasoning": {
+      "description": "Reasoning content.\n\nSee the specification for [thinking blocks](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#understanding-thinking-blocks) for Claude models.",
+      "properties": {
+        "type": {
+          "const": "reasoning",
+          "default": "reasoning",
+          "title": "Type",
+          "type": "string"
+        },
+        "reasoning": {
+          "title": "Reasoning",
+          "type": "string"
+        },
+        "signature": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Signature"
+        },
+        "redacted": {
+          "default": false,
+          "title": "Redacted",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "type",
+        "reasoning",
+        "signature",
+        "redacted"
+      ],
+      "title": "ContentReasoning",
       "type": "object",
       "additionalProperties": false
     },
@@ -1556,6 +1596,18 @@
           "default": null,
           "title": "Working Time"
         },
+        "uuid": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Uuid"
+        },
         "error": {
           "anyOf": [
             {
@@ -1604,6 +1656,7 @@
         "model_usage",
         "total_time",
         "working_time",
+        "uuid",
         "error",
         "attachments",
         "limit"
@@ -2861,6 +2914,7 @@
               "type": "null"
             }
           ],
+          "default": null,
           "title": "Time"
         }
       },
@@ -4216,6 +4270,9 @@
               "$ref": "#/$defs/ContentText"
             },
             {
+              "$ref": "#/$defs/ContentReasoning"
+            },
+            {
               "$ref": "#/$defs/ContentImage"
             },
             {
@@ -4229,6 +4286,9 @@
                 "anyOf": [
                   {
                     "$ref": "#/$defs/ContentText"
+                  },
+                  {
+                    "$ref": "#/$defs/ContentReasoning"
                   },
                   {
                     "$ref": "#/$defs/ContentImage"

--- a/src/inspect_ai/_view/www/src/samples/chat/ChatMessage.tsx
+++ b/src/inspect_ai/_view/www/src/samples/chat/ChatMessage.tsx
@@ -1,7 +1,5 @@
 import clsx from "clsx";
-import { Fragment } from "react";
 import ExpandablePanel from "../../components/ExpandablePanel";
-import { MarkdownDiv } from "../../components/MarkdownDiv";
 import {
   ChatMessageAssistant,
   ChatMessageSystem,
@@ -41,28 +39,13 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
         <i className={iconForMsg(message)} />
         {message.role}
       </div>
-      {message.role === "assistant" && message.reasoning ? (
-        <Fragment key={`${id}-response-label`}>
-          <div className={clsx("text-style-label", "text-style-secondary")}>
-            Reasoning
-          </div>
-          <ExpandablePanel collapse={true}>
-            <MarkdownDiv markdown={message.reasoning} />
-          </ExpandablePanel>
-        </Fragment>
-      ) : undefined}
       <div
         className={clsx(
           styles.messageContents,
           indented ? styles.indented : undefined,
         )}
       >
-        {message.role === "assistant" && message.reasoning ? (
-          <div className={clsx("text-style-label", "text-style-secondary")}>
-            Response
-          </div>
-        ) : undefined}
-        <ExpandablePanel collapse={collapse}>
+        <ExpandablePanel collapse={collapse} lines={30}>
           <MessageContents
             key={`${id}-contents`}
             message={message}

--- a/src/inspect_ai/_view/www/src/samples/chat/MessageContent.tsx
+++ b/src/inspect_ai/_view/www/src/samples/chat/MessageContent.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { Fragment } from "react"
+import { Fragment } from "react";
 import { MarkdownDiv } from "../../components/MarkdownDiv";
 import { ContentTool } from "../../types";
 import {
@@ -109,14 +109,20 @@ const messageRenderers: Record<string, MessageRenderer> = {
     render: (key, content, isLast) => {
       const r = content as ContentReasoning;
       return (
-          <Fragment key={key}>
-            <div className={clsx("text-style-label", "text-style-secondary", isLast ? "no-last-para-padding" : "")}>
-              Reasoning
-            </div>
-            <ExpandablePanel collapse={true}>
-              <MarkdownDiv markdown={r.reasoning} />
-            </ExpandablePanel>
-          </Fragment>
+        <Fragment key={key}>
+          <div
+            className={clsx(
+              "text-style-label",
+              "text-style-secondary",
+              isLast ? "no-last-para-padding" : "",
+            )}
+          >
+            Reasoning
+          </div>
+          <ExpandablePanel collapse={true}>
+            <MarkdownDiv markdown={r.reasoning} />
+          </ExpandablePanel>
+        </Fragment>
       );
     },
   },

--- a/src/inspect_ai/_view/www/src/samples/chat/MessageContent.tsx
+++ b/src/inspect_ai/_view/www/src/samples/chat/MessageContent.tsx
@@ -1,8 +1,11 @@
+import clsx from "clsx";
+import { Fragment } from "react"
 import { MarkdownDiv } from "../../components/MarkdownDiv";
 import { ContentTool } from "../../types";
 import {
   ContentAudio,
   ContentImage,
+  ContentReasoning,
   ContentText,
   ContentVideo,
   Format,
@@ -10,11 +13,13 @@ import {
 } from "../../types/log";
 import styles from "./MessageContent.module.css";
 import { ToolOutput } from "./tools/ToolOutput";
+import ExpandablePanel from "../../components/ExpandablePanel";
 
 type ContentType =
   | string
   | string[]
   | ContentText
+  | ContentReasoning
   | ContentImage
   | ContentAudio
   | ContentVideo
@@ -26,6 +31,7 @@ interface MessageContentProps {
     | string[]
     | (
         | ContentText
+        | ContentReasoning
         | ContentImage
         | ContentAudio
         | ContentVideo
@@ -96,6 +102,21 @@ const messageRenderers: Record<string, MessageRenderer> = {
           markdown={c.text}
           className={isLast ? "no-last-para-padding" : ""}
         />
+      );
+    },
+  },
+  reasoning: {
+    render: (key, content, isLast) => {
+      const r = content as ContentReasoning;
+      return (
+          <Fragment key={key}>
+            <div className={clsx("text-style-label", "text-style-secondary", isLast ? "no-last-para-padding" : "")}>
+              Reasoning
+            </div>
+            <ExpandablePanel collapse={true}>
+              <MarkdownDiv markdown={r.reasoning} />
+            </ExpandablePanel>
+          </Fragment>
       );
     },
   },

--- a/src/inspect_ai/_view/www/src/types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/types/log.d.ts
@@ -139,47 +139,74 @@ export type Input =
 export type Role = "system";
 export type Content =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Type1 = "text";
 export type Text = string;
-export type Type2 = "image";
+export type Type2 = "reasoning";
+export type Reasoning = string;
+export type Signature = string | null;
+export type Redacted = boolean;
+export type Type3 = "image";
 export type Image = string;
 export type Detail = "auto" | "low" | "high";
-export type Type3 = "audio";
+export type Type4 = "audio";
 export type Audio = string;
 export type Format = "wav" | "mp3";
-export type Type4 = "video";
+export type Type5 = "video";
 export type Video = string;
 export type Format1 = "mp4" | "mpeg" | "mov";
 export type Source = ("input" | "generate") | null;
 export type Role1 = "user";
 export type Content1 =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Source1 = ("input" | "generate") | null;
 export type ToolCallId = string[] | null;
 export type Role2 = "assistant";
 export type Content2 =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Source2 = ("input" | "generate") | null;
 export type ToolCalls = ToolCall[] | null;
 export type Id1 = string;
 export type Function = string;
-export type Type5 = "function";
+export type Type6 = "function";
 export type ParseError = string | null;
 export type Title = string | null;
 export type Format2 = "text" | "markdown";
 export type Content3 = string;
-export type Reasoning = string | null;
 export type Role3 = "tool";
 export type Content4 =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Source3 = ("input" | "generate") | null;
 export type ToolCallId1 = string | null;
 export type Function1 = string | null;
-export type Type6 =
+export type Type7 =
   | "parsing"
   | "timeout"
   | "unicode_decode"
@@ -257,7 +284,7 @@ export type JsonValue = unknown;
 export type Timestamp1 = string;
 export type Pending1 = boolean | null;
 export type Event1 = "sample_limit";
-export type Type7 =
+export type Type8 =
   | "message"
   | "time"
   | "working"
@@ -301,8 +328,8 @@ export type Input3 = (
 )[];
 export type Name7 = string;
 export type Description = string;
-export type Type8 = "object";
-export type Type9 =
+export type Type9 = "object";
+export type Type10 =
   | ("string" | "integer" | "number" | "boolean" | "array" | "object" | "null")
   | null;
 export type Description1 = string | null;
@@ -324,7 +351,7 @@ export type Time1 = number | null;
 export type Timestamp6 = string;
 export type Pending6 = boolean | null;
 export type Event6 = "tool";
-export type Type10 = "function";
+export type Type11 = "function";
 export type Id3 = string;
 export type Function2 = string;
 export type Result1 =
@@ -332,10 +359,17 @@ export type Result1 =
   | number
   | boolean
   | ContentText
+  | ContentReasoning
   | ContentImage
   | ContentAudio
   | ContentVideo
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Truncated = [unknown, unknown] | null;
 export type Timestamp7 = string;
 export type Pending7 = boolean | null;
@@ -388,13 +422,13 @@ export type Timestamp13 = string;
 export type Pending13 = boolean | null;
 export type Event13 = "step";
 export type Action1 = "begin" | "end";
-export type Type11 = string | null;
+export type Type12 = string | null;
 export type Name10 = string;
 export type Timestamp14 = string;
 export type Pending14 = boolean | null;
 export type Event14 = "subtask";
 export type Name11 = string;
-export type Type12 = string | null;
+export type Type13 = string | null;
 export type Events2 = (
   | SampleInitEvent
   | SampleLimitEvent
@@ -448,7 +482,8 @@ export type Events = (
 )[];
 export type TotalTime = number | null;
 export type WorkingTime = number | null;
-export type Type13 =
+export type Uuid = string | null;
+export type Type14 =
   | "context"
   | "time"
   | "working"
@@ -729,6 +764,7 @@ export interface EvalSample {
   model_usage: ModelUsage2;
   total_time: TotalTime;
   working_time: WorkingTime;
+  uuid: Uuid;
   error: EvalError | null;
   attachments: Attachments;
   limit: EvalSampleLimit | null;
@@ -749,10 +785,21 @@ export interface ContentText {
   text: Text;
 }
 /**
+ * Reasoning content.
+ *
+ * See the specification for [thinking blocks](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#understanding-thinking-blocks) for Claude models.
+ */
+export interface ContentReasoning {
+  type: Type2;
+  reasoning: Reasoning;
+  signature: Signature;
+  redacted: Redacted;
+}
+/**
  * Image content.
  */
 export interface ContentImage {
-  type: Type2;
+  type: Type3;
   image: Image;
   detail: Detail;
 }
@@ -760,7 +807,7 @@ export interface ContentImage {
  * Audio content.
  */
 export interface ContentAudio {
-  type: Type3;
+  type: Type4;
   audio: Audio;
   format: Format;
 }
@@ -768,7 +815,7 @@ export interface ContentAudio {
  * Video content.
  */
 export interface ContentVideo {
-  type: Type4;
+  type: Type5;
   video: Video;
   format: Format1;
 }
@@ -789,13 +836,12 @@ export interface ChatMessageAssistant {
   content: Content2;
   source: Source2;
   tool_calls: ToolCalls;
-  reasoning: Reasoning;
 }
 export interface ToolCall {
   id: Id1;
   function: Function;
   arguments: Arguments;
-  type: Type5;
+  type: Type6;
   parse_error: ParseError;
   view: ToolCallContent | null;
 }
@@ -820,7 +866,7 @@ export interface ChatMessageTool {
   error: ToolCallError | null;
 }
 export interface ToolCallError {
-  type: Type6;
+  type: Type7;
   message: Message1;
 }
 /**
@@ -906,7 +952,7 @@ export interface SampleLimitEvent {
   timestamp: Timestamp1;
   pending: Pending1;
   event: Event1;
-  type: Type7;
+  type: Type8;
   message: Message2;
   limit: Limit1;
 }
@@ -1009,7 +1055,7 @@ export interface ToolInfo {
  * Description of tool parameters object in JSON Schema format.
  */
 export interface ToolParams {
-  type: Type8;
+  type: Type9;
   properties: Properties;
   required: Required1;
   additionalProperties: Additionalproperties1;
@@ -1021,7 +1067,7 @@ export interface Properties {
  * Description of tool parameter in JSON Schema format.
  */
 export interface ToolParam {
-  type: Type9;
+  type: Type10;
   description: Description1;
   default: Default;
   enum: Enum;
@@ -1086,7 +1132,7 @@ export interface ToolEvent {
   timestamp: Timestamp6;
   pending: Pending6;
   event: Event6;
-  type: Type10;
+  type: Type11;
   id: Id3;
   function: Function2;
   arguments: Arguments1;
@@ -1196,7 +1242,7 @@ export interface StepEvent {
   pending: Pending13;
   event: Event13;
   action: Action1;
-  type: Type11;
+  type: Type12;
   name: Name10;
 }
 /**
@@ -1207,7 +1253,7 @@ export interface SubtaskEvent {
   pending: Pending14;
   event: Event14;
   name: Name11;
-  type: Type12;
+  type: Type13;
   input: Input5;
   result: Result2;
   events: Events2;
@@ -1226,7 +1272,7 @@ export interface Attachments {
  * Limit encontered by sample.
  */
 export interface EvalSampleLimit {
-  type: Type13;
+  type: Type14;
   limit: Limit2;
 }
 /**

--- a/src/inspect_ai/log/_condense.py
+++ b/src/inspect_ai/log/_condense.py
@@ -10,6 +10,7 @@ from inspect_ai._util.content import (
     Content,
     ContentAudio,
     ContentImage,
+    ContentReasoning,
     ContentText,
     ContentVideo,
 )
@@ -315,3 +316,5 @@ def walk_content(content: Content, content_fn: Callable[[str], str]) -> Content:
         return content.model_copy(update=dict(audio=content_fn(content.audio)))
     elif isinstance(content, ContentVideo):
         return content.model_copy(update=dict(video=content_fn(content.video)))
+    elif isinstance(content, ContentReasoning):
+        return content.model_copy(update=dict(reasoning=content_fn(content.reasoning)))

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -16,6 +16,7 @@ from inspect_ai._util.constants import LOG_SCHEMA_VERSION
 from inspect_ai._util.content import (
     ContentAudio,
     ContentImage,
+    ContentReasoning,
     ContentText,
     ContentVideo,
 )
@@ -252,7 +253,11 @@ def text_inputs(inputs: str | list[ChatMessage]) -> str | list[ChatMessage]:
         for message in inputs:
             if not isinstance(message.content, str):
                 filtered_content: list[
-                    ContentText | ContentImage | ContentAudio | ContentVideo
+                    ContentText
+                    | ContentReasoning
+                    | ContentImage
+                    | ContentAudio
+                    | ContentVideo
                 ] = []
                 for content in message.content:
                     if content.type == "text":

--- a/src/inspect_ai/model/__init__.py
+++ b/src/inspect_ai/model/__init__.py
@@ -4,6 +4,7 @@ from inspect_ai._util.content import (
     Content,
     ContentAudio,
     ContentImage,
+    ContentReasoning,
     ContentText,
     ContentVideo,
 )
@@ -51,6 +52,7 @@ __all__ = [
     "CachePolicy",
     "ContentAudio",
     "ContentImage",
+    "ContentReasoning",
     "ContentText",
     "ContentVideo",
     "Content",

--- a/src/inspect_ai/model/_chat_message.py
+++ b/src/inspect_ai/model/_chat_message.py
@@ -3,7 +3,7 @@ from typing import Any, Literal, Type, Union
 
 from pydantic import BaseModel, Field, model_validator
 
-from inspect_ai._util.content import Content, ContentText
+from inspect_ai._util.content import Content, ContentReasoning, ContentText
 from inspect_ai.tool import ToolCall
 from inspect_ai.tool._tool_call import ToolCallError
 
@@ -64,7 +64,7 @@ class ChatMessageBase(BaseModel):
             self.content = text
         else:
             all_other = [content for content in self.content if content.type != "text"]
-            self.content = [ContentText(text=text)] + all_other
+            self.content = all_other + [ContentText(text=text)]
 
 
 class ChatMessageSystem(ChatMessageBase):
@@ -110,12 +110,30 @@ class ChatMessageAssistant(ChatMessageBase):
     @classmethod
     def extract_reasoning(cls, data: Any) -> Any:
         if isinstance(data, dict):
+            # cleave apart <think> blocks
             content = data.get("content", None)
             if isinstance(content, str):
                 parsed = parse_content_with_reasoning(content)
                 if parsed:
-                    data["reasoning"] = parsed.reasoning
-                    data["content"] = parsed.content
+                    data["content"] = [
+                        ContentReasoning(reasoning=parsed.reasoning),
+                        ContentText(text=parsed.content),
+                    ]
+            # migrate messages that has explicit 'reasoning' field
+            # (which was our original representation of reasoning)
+            reasoning = data.get("reasoning", None)
+            if isinstance(reasoning, str):
+                # ensure that content is a list
+                content = data.get("content", None)
+                if content is None:
+                    data["content"] = []
+                elif isinstance(content, str):
+                    data["content"] = [ContentText(text=content)]
+                elif not isinstance(content, list):
+                    data["content"] = []
+                data["content"].insert(0, ContentReasoning(reasoning=reasoning))
+
+                del data["reasoning"]
         return data
 
 

--- a/src/inspect_ai/model/_chat_message.py
+++ b/src/inspect_ai/model/_chat_message.py
@@ -93,9 +93,6 @@ class ChatMessageAssistant(ChatMessageBase):
     tool_calls: list[ToolCall] | None = Field(default=None)
     """Tool calls made by the model."""
 
-    reasoning: str | None = Field(default=None)
-    """Reasoning content."""
-
     # Some OpenAI compatible REST endpoints include reasoning as a field alongside
     # content, however since this field doesn't exist in the OpenAI interface,
     # hosting providers (so far we've seen this with Together and Groq) may

--- a/src/inspect_ai/model/_conversation.py
+++ b/src/inspect_ai/model/_conversation.py
@@ -1,6 +1,7 @@
 from rich.console import RenderableType
 from rich.text import Text
 
+from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai._util.rich import lines_display
 from inspect_ai._util.transcript import transcript_markdown, transcript_reasoning
 from inspect_ai.util._conversation import conversation_panel
@@ -41,14 +42,15 @@ def conversation_assistant_message(
         # build content
         content: list[RenderableType] = []
 
-        # reasoning
-        if message.reasoning:
-            content.extend(transcript_reasoning(message.reasoning))
-
-        # message text
-        content.extend(
-            [transcript_markdown(message.text, escape=True)] if message.text else []
-        )
+        # deal with plain text or with content blocks
+        if isinstance(message.content, str):
+            content.extend([transcript_markdown(message.text.strip(), escape=True)])
+        else:
+            for c in message.content:
+                if isinstance(c, ContentReasoning):
+                    content.extend(transcript_reasoning(c))
+                elif isinstance(c, ContentText) and c.text:
+                    content.extend([transcript_markdown(c.text.strip(), escape=True)])
 
         # print tool calls
         if message.tool_calls:

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -28,7 +28,7 @@ from inspect_ai._util.constants import (
     DEFAULT_MAX_RETRIES,
     DEFAULT_MAX_TOKENS,
 )
-from inspect_ai._util.content import Content
+from inspect_ai._util.content import Content, ContentReasoning, ContentText
 from inspect_ai._util.images import file_as_data_uri
 from inspect_ai._util.url import is_http_url
 from inspect_ai.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo
@@ -326,12 +326,17 @@ def chat_tool_calls(message: Any, tools: list[ToolInfo]) -> Optional[List[ToolCa
 def chat_message_assistant(message: Any, tools: list[ToolInfo]) -> ChatMessageAssistant:
     reasoning = getattr(message, "reasoning", None)
     if reasoning is not None:
-        reasoning = str(reasoning)
+        content: str | list[Content] = [
+            ContentReasoning(reasoning=str(reasoning)),
+            ContentText(text=message.content or ""),
+        ]
+    else:
+        content = message.content or ""
+
     return ChatMessageAssistant(
-        content=message.content or "",
+        content=content,
         source="generate",
         tool_calls=chat_tool_calls(message, tools),
-        reasoning=reasoning,
     )
 
 

--- a/src/inspect_ai/tool/__init__.py
+++ b/src/inspect_ai/tool/__init__.py
@@ -2,6 +2,7 @@ from inspect_ai._util.content import (
     Content,
     ContentAudio,
     ContentImage,
+    ContentReasoning,
     ContentText,
     ContentVideo,
 )
@@ -41,6 +42,7 @@ __all__ = [
     "Content",
     "ContentAudio",
     "ContentImage",
+    "ContentReasoning",
     "ContentText",
     "ContentVideo",
     "ToolCall",

--- a/src/inspect_ai/tool/_tool.py
+++ b/src/inspect_ai/tool/_tool.py
@@ -14,6 +14,7 @@ from typing import (
 from inspect_ai._util.content import (
     ContentAudio,
     ContentImage,
+    ContentReasoning,
     ContentText,
     ContentVideo,
 )
@@ -35,10 +36,11 @@ ToolResult = (
     | float
     | bool
     | ContentText
+    | ContentReasoning
     | ContentImage
     | ContentAudio
     | ContentVideo
-    | list[ContentText | ContentImage | ContentAudio | ContentVideo]
+    | list[ContentText | ContentReasoning | ContentImage | ContentAudio | ContentVideo]
 )
 """Valid types for results from tool calls."""
 

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -41,13 +41,3 @@ def test_google_block_reason():
     # TODO: comment in once we have an input that triggers the filter
     # assert log.samples
     # assert log.samples[0].output.stop_reason == "content_filter"
-
-
-@skip_if_no_google
-def test_google_reasoning_content():
-    log = eval(
-        Task(dataset=[Sample(input="Solve 3*x^3-5*x=1")]),
-        model="google/gemini-2.0-flash-thinking-exp",
-    )[0]
-    assert log.samples
-    assert log.samples[0].output.message.reasoning

--- a/tools/vscode/src/@types/log.d.ts
+++ b/tools/vscode/src/@types/log.d.ts
@@ -139,47 +139,74 @@ export type Input =
 export type Role = "system";
 export type Content =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Type1 = "text";
 export type Text = string;
-export type Type2 = "image";
+export type Type2 = "reasoning";
+export type Reasoning = string;
+export type Signature = string | null;
+export type Redacted = boolean;
+export type Type3 = "image";
 export type Image = string;
 export type Detail = "auto" | "low" | "high";
-export type Type3 = "audio";
+export type Type4 = "audio";
 export type Audio = string;
 export type Format = "wav" | "mp3";
-export type Type4 = "video";
+export type Type5 = "video";
 export type Video = string;
 export type Format1 = "mp4" | "mpeg" | "mov";
 export type Source = ("input" | "generate") | null;
 export type Role1 = "user";
 export type Content1 =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Source1 = ("input" | "generate") | null;
 export type ToolCallId = string[] | null;
 export type Role2 = "assistant";
 export type Content2 =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Source2 = ("input" | "generate") | null;
 export type ToolCalls = ToolCall[] | null;
 export type Id1 = string;
 export type Function = string;
-export type Type5 = "function";
+export type Type6 = "function";
 export type ParseError = string | null;
 export type Title = string | null;
 export type Format2 = "text" | "markdown";
 export type Content3 = string;
-export type Reasoning = string | null;
 export type Role3 = "tool";
 export type Content4 =
   | string
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Source3 = ("input" | "generate") | null;
 export type ToolCallId1 = string | null;
 export type Function1 = string | null;
-export type Type6 =
+export type Type7 =
   | "parsing"
   | "timeout"
   | "unicode_decode"
@@ -257,7 +284,7 @@ export type JsonValue = unknown;
 export type Timestamp1 = string;
 export type Pending1 = boolean | null;
 export type Event1 = "sample_limit";
-export type Type7 =
+export type Type8 =
   | "message"
   | "time"
   | "working"
@@ -301,8 +328,8 @@ export type Input3 = (
 )[];
 export type Name7 = string;
 export type Description = string;
-export type Type8 = "object";
-export type Type9 =
+export type Type9 = "object";
+export type Type10 =
   | ("string" | "integer" | "number" | "boolean" | "array" | "object" | "null")
   | null;
 export type Description1 = string | null;
@@ -324,7 +351,7 @@ export type Time1 = number | null;
 export type Timestamp6 = string;
 export type Pending6 = boolean | null;
 export type Event6 = "tool";
-export type Type10 = "function";
+export type Type11 = "function";
 export type Id3 = string;
 export type Function2 = string;
 export type Result1 =
@@ -332,10 +359,17 @@ export type Result1 =
   | number
   | boolean
   | ContentText
+  | ContentReasoning
   | ContentImage
   | ContentAudio
   | ContentVideo
-  | (ContentText | ContentImage | ContentAudio | ContentVideo)[];
+  | (
+      | ContentText
+      | ContentReasoning
+      | ContentImage
+      | ContentAudio
+      | ContentVideo
+    )[];
 export type Truncated = [unknown, unknown] | null;
 export type Timestamp7 = string;
 export type Pending7 = boolean | null;
@@ -388,13 +422,13 @@ export type Timestamp13 = string;
 export type Pending13 = boolean | null;
 export type Event13 = "step";
 export type Action1 = "begin" | "end";
-export type Type11 = string | null;
+export type Type12 = string | null;
 export type Name10 = string;
 export type Timestamp14 = string;
 export type Pending14 = boolean | null;
 export type Event14 = "subtask";
 export type Name11 = string;
-export type Type12 = string | null;
+export type Type13 = string | null;
 export type Events2 = (
   | SampleInitEvent
   | SampleLimitEvent
@@ -448,7 +482,8 @@ export type Events = (
 )[];
 export type TotalTime = number | null;
 export type WorkingTime = number | null;
-export type Type13 =
+export type Uuid = string | null;
+export type Type14 =
   | "context"
   | "time"
   | "working"
@@ -729,6 +764,7 @@ export interface EvalSample {
   model_usage: ModelUsage2;
   total_time: TotalTime;
   working_time: WorkingTime;
+  uuid: Uuid;
   error: EvalError | null;
   attachments: Attachments;
   limit: EvalSampleLimit | null;
@@ -749,10 +785,21 @@ export interface ContentText {
   text: Text;
 }
 /**
+ * Reasoning content.
+ *
+ * See the specification for [thinking blocks](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#understanding-thinking-blocks) for Claude models.
+ */
+export interface ContentReasoning {
+  type: Type2;
+  reasoning: Reasoning;
+  signature: Signature;
+  redacted: Redacted;
+}
+/**
  * Image content.
  */
 export interface ContentImage {
-  type: Type2;
+  type: Type3;
   image: Image;
   detail: Detail;
 }
@@ -760,7 +807,7 @@ export interface ContentImage {
  * Audio content.
  */
 export interface ContentAudio {
-  type: Type3;
+  type: Type4;
   audio: Audio;
   format: Format;
 }
@@ -768,7 +815,7 @@ export interface ContentAudio {
  * Video content.
  */
 export interface ContentVideo {
-  type: Type4;
+  type: Type5;
   video: Video;
   format: Format1;
 }
@@ -789,13 +836,12 @@ export interface ChatMessageAssistant {
   content: Content2;
   source: Source2;
   tool_calls: ToolCalls;
-  reasoning: Reasoning;
 }
 export interface ToolCall {
   id: Id1;
   function: Function;
   arguments: Arguments;
-  type: Type5;
+  type: Type6;
   parse_error: ParseError;
   view: ToolCallContent | null;
 }
@@ -820,7 +866,7 @@ export interface ChatMessageTool {
   error: ToolCallError | null;
 }
 export interface ToolCallError {
-  type: Type6;
+  type: Type7;
   message: Message1;
 }
 /**
@@ -906,7 +952,7 @@ export interface SampleLimitEvent {
   timestamp: Timestamp1;
   pending: Pending1;
   event: Event1;
-  type: Type7;
+  type: Type8;
   message: Message2;
   limit: Limit1;
 }
@@ -1009,7 +1055,7 @@ export interface ToolInfo {
  * Description of tool parameters object in JSON Schema format.
  */
 export interface ToolParams {
-  type: Type8;
+  type: Type9;
   properties: Properties;
   required: Required1;
   additionalProperties: Additionalproperties1;
@@ -1021,7 +1067,7 @@ export interface Properties {
  * Description of tool parameter in JSON Schema format.
  */
 export interface ToolParam {
-  type: Type9;
+  type: Type10;
   description: Description1;
   default: Default;
   enum: Enum;
@@ -1086,7 +1132,7 @@ export interface ToolEvent {
   timestamp: Timestamp6;
   pending: Pending6;
   event: Event6;
-  type: Type10;
+  type: Type11;
   id: Id3;
   function: Function2;
   arguments: Arguments1;
@@ -1196,7 +1242,7 @@ export interface StepEvent {
   pending: Pending13;
   event: Event13;
   action: Action1;
-  type: Type11;
+  type: Type12;
   name: Name10;
 }
 /**
@@ -1207,7 +1253,7 @@ export interface SubtaskEvent {
   pending: Pending14;
   event: Event14;
   name: Name11;
-  type: Type12;
+  type: Type13;
   input: Input5;
   result: Result2;
   events: Events2;
@@ -1226,7 +1272,7 @@ export interface Attachments {
  * Limit encontered by sample.
  */
 export interface EvalSampleLimit {
-  type: Type13;
+  type: Type14;
   limit: Limit2;
 }
 /**


### PR DESCRIPTION
This PR introduces a new `ContentReasoning` content block type to represent reasoning yielded by models. This replaces the `reasoning` field we had previously added to `ChatMessageAssistant`. The new scheme accommodates additional properties of reasoning blocks (which will be required by Anthropic) and matches the way Anthropic represents reasoning (as a block that is a peer of text, images, etc.). Straightforward conversions to this schema are done for other models that use a simpler/flatter approach.

