### PR TITLE
Retry all OpenAI rate limit errors

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -249,12 +249,7 @@ class OpenAIAPI(ModelAPI):
     @override
     def is_rate_limit(self, ex: BaseException) -> bool:
         if isinstance(ex, RateLimitError):
-            # Do not retry on these rate limit errors
-            if (
-                "Request too large" not in ex.message
-                and "You exceeded your current quota" not in ex.message
-            ):
-                return True
+            return True
         elif isinstance(
             ex, (APIConnectionError | APITimeoutError | InternalServerError)
         ):

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -251,9 +251,7 @@ class OpenAIAPI(ModelAPI):
         if isinstance(ex, RateLimitError):
             # Do not retry on these rate limit errors
             # The quota exceeded one is related to monthly account quotas.
-            if (
-                "You exceeded your current quota" not in ex.message
-            ):
+            if "You exceeded your current quota" not in ex.message:
                 return True
         elif isinstance(
             ex, (APIConnectionError | APITimeoutError | InternalServerError)

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -249,7 +249,12 @@ class OpenAIAPI(ModelAPI):
     @override
     def is_rate_limit(self, ex: BaseException) -> bool:
         if isinstance(ex, RateLimitError):
-            return True
+            # Do not retry on these rate limit errors
+            # The quota exceeded one is related to monthly account quotas.
+            if (
+                "You exceeded your current quota" not in ex.message
+            ):
+                return True
         elif isinstance(
             ex, (APIConnectionError | APITimeoutError | InternalServerError)
         ):


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Right now, if we get 429 errors with the string "Request too large" in them, we will error the sample. Example error below:

```
Error code: 429 - {'error': {'message': 'Request too large for organization org-XXXXXXXXXXXXX on tokens per min (TPM): Limit 250000, Requested 546. The input or output tokens must be reduced in order to run successfully. Visit         https://platform.openai.com/account/rate-limits to learn more.', 'type': 'tokens', 'param': None, 'code': 'rate_limit_exceeded'}}
```

I checked with OpenAI and they said 
> This is just another rate-limiting error, effectively 'Your prompt can't fit in your current rate limit allocation"

I haven't seen ones with "You exceeded your current quota" but I don't see why we wouldn't retry those as well.

### What is the new behavior?

These requests will be retried.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

My guess is the reason this was put in place was to prevent requests which provided more tokens than fit into the context window from being retried. However, I'm not sure why those would be 429s as opposed to another error code.

### Other information:

I think a change to the OpenAI APIs might be making this error more frequent based on us observing it recently. 
