### PR TITLE
Relax assertion in test_exec_as_nonexistent_user

### DIFF
--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -458,13 +458,13 @@ async def test_exec_as_user(sandbox_env: SandboxEnvironment) -> None:
 
 
 async def test_exec_as_nonexistent_user(sandbox_env: SandboxEnvironment) -> None:
-    result = await sandbox_env.exec(["whoami"], user="nonexistent")
+    nonexistent_username = "nonexistent"
+    result = await sandbox_env.exec(["whoami"], user=nonexistent_username)
     assert not result.success, "Command should have failed for nonexistent user"
-    expected_error = (
-        "unable to find user nonexistent: no matching entries in passwd file"
-    )
-    assert expected_error in result.stdout, (
-        f"Error string '{expected_error}' not found in error output: '{result.stdout}'"
+    assert (
+        nonexistent_username in result.stdout or nonexistent_username in result.stderr
+    ), (
+        f"Error not found in command output: '{result.stdout}' nor stderr '{result.stderr}"
     )
 
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The sandbox behaviour isn't especially well defined for when the specified user for exec isn't found. The existing self_check test is overly coupled to the existing Docker implementation.

### What is the new behavior?

I think it's good enough to insist the exec returns failure, and that the erroneous username is somewhere in the result stdout/stderr. So the test is relaxed a bit in this PR.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
