### PR TITLE
add total and working time to model, tool, and subtask events

### DIFF
--- a/src/inspect_ai/log/_transcript.py
+++ b/src/inspect_ai/log/_transcript.py
@@ -252,6 +252,9 @@ class SandboxEvent(BaseEvent):
     output: str | None = Field(default=None)
     """Output (for exec and read_file). Truncated to 100 lines."""
 
+    completed: datetime | None = Field(default=None)
+    """Time that sandbox action completed (see `timestamp` for started)"""
+
 
 class ApprovalEvent(BaseEvent):
     """Tool approval."""
@@ -383,6 +386,12 @@ class SubtaskEvent(BaseEvent):
 
     events: list["Event"] = Field(default_factory=list)
     """Transcript of events for subtask."""
+
+    completed: datetime | None = Field(default=None)
+    """Time that subtask completed (see `timestamp` for started)"""
+
+    working: float | None = Field(default=None)
+    """Working time for subtask (i.e. time not spent waiting on semaphores or model retries)."""
 
 
 Event: TypeAlias = Union[

--- a/src/inspect_ai/util/_subtask.py
+++ b/src/inspect_ai/util/_subtask.py
@@ -1,5 +1,6 @@
 import asyncio
 import inspect
+from datetime import datetime
 from functools import wraps
 from logging import getLogger
 from typing import (
@@ -15,6 +16,7 @@ from typing import (
 from inspect_ai._util._async import is_callable_coroutine
 from inspect_ai._util.content import Content
 from inspect_ai._util.trace import trace_action
+from inspect_ai._util.working import sample_waiting_time
 from inspect_ai.util._store import Store, dict_jsonable, init_subtask_store
 
 SubtaskResult = str | int | float | bool | list[Content]
@@ -130,6 +132,7 @@ def subtask(
                 return result, list(transcript().events)
 
             # create subtask event
+            waiting_time_start = sample_waiting_time()
             event = SubtaskEvent(
                 name=subtask_name, input=log_input, type=type, pending=True
             )
@@ -138,6 +141,14 @@ def subtask(
             # create and run the task as a coroutine
             asyncio_task = asyncio.create_task(run())
             result, events = await asyncio_task
+
+            # time accounting
+            completed = datetime.now()
+            waiting_time_end = sample_waiting_time()
+            event.completed = completed
+            event.working = (completed - event.timestamp).total_seconds() - (
+                waiting_time_end - waiting_time_start
+            )
 
             # update event
             event.result = result


### PR DESCRIPTION
All events currently carry a `timestamp` for when the start, with this PR we add the following fields to the 3 events which (a) represent a range of execution; and (b) have the potential for waiting time within them:

```python
completed: datetime | None = Field(default=None)
"""Time that model call completed (see `timestamp` for started)"""

working: float | None = Field(default=None)
"""working time for model call that succeeded (i.e. was not retried)."""
```

For`ToolEvent` and `SubtaskEvent` this is trivial as we start the execution, create the event, and update the event all in the same stack frame.

For `ModelEvent`, we start execution outside of a semaphore and then potentially several `ModelEvent` instances can be added to the transcript (none of which are visible in the outer stack frame). We navigate this by searching for and updating the last `ModelEvent` in the transcript from the outer stack frame.

@dragonstyle We need to add time / working time displays to these events in the viewer.