### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,7 +65,7 @@
 - Memoize calls to `get_model()` so that model instances with the same parameters are cached and re-used (pass `memoize=False` to disable).
 - Async context manager for `Model` class for optional scoped usage of model clients.
 - New `assistant_message()` solver.
-- Prompt templates: Ignore template placeholders that don't map to passed parameters in `prompt_template()`, and system/user/assistnat solvers.
+- Prompt templates: Ignore template placeholders that don't map to passed parameters in `prompt_template()`, and system/user/assistant solvers.
 - Google: Handle system messages with content lists and input with system but no user messages.
 - Google: Ensure that a completion choice is provided even when none are returned by the service.
 - Inspect View: Improve the display of subtasks with no inputs or events.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

There was a typo in the changelog

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
