### PR TITLE
Add documentation for DeepSeek

### DIFF
--- a/docs/_model-providers.md
+++ b/docs/_model-providers.md
@@ -1,7 +1,7 @@
 
 |  |  |
 |------------------------------------|------------------------------------|
-| Lab APIs | [OpenAI](providers.qmd#openai), [Anthropic](providers.qmd#anthropic), [Google](providers.qmd#google), [Grok](providers.qmd#grok), [Mistral](providers.qmd#mistral) |
+| Lab APIs | [OpenAI](providers.qmd#openai), [Anthropic](providers.qmd#anthropic), [Google](providers.qmd#google), [Grok](providers.qmd#grok), [Mistral](providers.qmd#mistral), [DeepSeek](providers.qmd#deepseek) |
 | Cloud APIs | [AWS Bedrock](providers.qmd#aws-bedrock), [Azure AI](providers.qmd#azure-ai), [Vertex AI](providers.qmd#vertex-ai) |
 | Open (Hosted) | [Groq](providers.qmd#groq), [Together AI](providers.qmd#together-ai), [Cloudflare](providers.qmd#cloudflare), [Goodfire](providers.qmd#goodfire) |
 | Open (Local) | [Hugging Face](providers.qmd#hugging-face), [vLLM](providers.qmd#vllm), [Ollama](providers.qmd#ollama), [Lllama-cpp-python](providers.qmd#llama-cpp-python) |
@@ -15,5 +15,3 @@ If the provider you are using is not listed above, you may still be able to use 
 2. It provides an OpenAI compatible API endpoint. In this scenario, use the Inspect [OpenAI](providers.qmd#openai) interface and set the `OPENAI_BASE_URL` environment variable to the apprpriate value for your provider.
 
 You can also create [Model API Extensions](extensions.qmd#model-apis) to add model providers using their native interface.
-
-

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -204,7 +204,7 @@ inspect eval --model mistral/mistral-large-ctwi
 
 ## DeepSeek {#deepseek}
 
-To use [DeepSeek](https://www.deepseek.com/) models, install the `openai` package (which DeepSeek provides a compatible backend for) and set your credentials using the `OPENAI_API_KEY` environment variable. Then, when running inspect, use the  `--model-base-url` option to point to DeepSeek's base URL, and the `--model` option to specify the name of the DeepSeek model you wish to use:
+To use [DeepSeek](https://www.deepseek.com/) models, install the `openai` package (which DeepSeek provides a compatible backend for) and set your credentials using the `OPENAI_API_KEY` environment variable. Then, when running inspect, use the  `--model-base-url` option to point to DeepSeek's base URL, and the `--model` option to specify a model:
 
 ```bash
 pip install openai

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -202,6 +202,16 @@ export AZUREAI_MISTRAL_BASE_URL=https://your-url-at.azure.com
 inspect eval --model mistral/mistral-large-ctwi
 ```
 
+## DeepSeek {#deepseek}
+
+To use [DeepSeek](https://www.deepseek.com/) models, install the `openai` package (which DeepSeek provides a compatible backend for) and set your credentials using the `OPENAI_API_KEY` environment variable. Then, when running inspect, use the  `--model-base-url` option to point to DeepSeek's base URL, and the `--model` option to specify the name of the DeepSeek model you wish to use:
+
+```bash
+pip install openai
+export OPENAI_API_KEY=your-deepseek-api-key
+inspect eval arc.py --model-base-url https://api.deepseek.com --model openai/deepseek-reasoner 
+```
+
 ## Grok {#grok}
 
 To use the [Grok](https://x.ai/) provider, install the `openai` package (which the Grok service provides a compatible backend for), set your credentials, and specify a model using the `--model` option:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,5 +147,5 @@ dev = [
     "types-psutil",
     "types-python-dateutil"
 ]
-doc = ["quarto-cli==1.5.57", "jupyter", "panflute", "markdown"]
+doc = ["quarto-cli==1.5.57", "jupyter", "panflute", "markdown", "griffe"]
 dist = ["twine", "build"]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The documentation for model providers at https://inspect.ai-safety-institute.org.uk/providers.html does not contain instructions for how to use DeepSeek models.

### What is the new behavior?

* Adds a new section to the "Providers" docs with instructions for using DeepSeek models. Screenshots below, referencing @dragonstyle's instructions on Slack ([link](https://inspectcommunity.slack.com/archives/C080K7SQ4SG/p1741124519095879?thread_ts=1741124349.312469&cid=C080K7SQ4SG)). 

* Adds `griffe` as a `doc` dependency, since `pip install ".[doc]"` followed by `quarto render docs` gave me a dependency error that the `griffe` package was missing (it's used in `docs/reference/filter.py`).

![image](https://github.com/user-attachments/assets/1a7a526c-6de6-4e1a-9405-134d6a463620)

![image](https://github.com/user-attachments/assets/f0d21f91-27dc-4df0-89f3-31ae6cd2076f)


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No


### Other information:
