### PR TITLE
Fix tool_choice being dropped in inspect_model_request

### DIFF
--- a/src/inspect_ai/solver/_bridge/patch.py
+++ b/src/inspect_ai/solver/_bridge/patch.py
@@ -114,6 +114,8 @@ async def inspect_model_request(
             )
         )
 
+    tool_choice = json_data.get("tool_choice", None)
+
     # resolve model
     if model_name == "inspect":
         model = get_model()
@@ -123,6 +125,7 @@ async def inspect_model_request(
     output = await model.generate(
         input=input,
         tools=inspect_tools,
+        tool_choice=tool_choice,
         config=generate_config_from_openai(options),
     )
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

`tool_choice` passed from `OpenAI().chat.completions.create(tool_choice=...)` gets replaced with `None`.

### What is the new behavior?

`tool_choice` gets preserved and passed down to `model.generate()`.

### Does this PR introduce a breaking change?

No.

### Other information:
