### PR TITLE
Fix KeyError "type" for untagged content encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Improved async implementation using AnyIO (can now optionally run Trio rather than asyncio as the [async backend](https://inspect.ai-safety-institute.org.uk/parallelism.html#async-backends)).
 - Agent Bridge: Correct handling for `tool_choice` option.
 - Model API: `ChatMessage` now includes an `id` field (defaults to auto-generated uuid).
+- OpenAI: More flexible parsing of content parts (some providers omit the "type" field); support for "reasoning" content parts.
 - Mistral: Update to new Mistral API (v1.5.1 of `mistralai` is now required).
 - Logging: Inspect no longer sets the global log level nor does it allow its own messages to propagate to the global handler (eliminating the possiblity of duplicate display). This should improve compatibility with applications that have their own custom logging configured. 
 - Tasks: For filesystem based tasks, no longer switch to the task file's directory during execution (directory switching still occurs during task loading). Specify `@task(chdir=True)` to preserve the previous behavior.

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -397,10 +397,9 @@ def content_from_openai(
     parse_reasoning: bool = False,
 ) -> list[Content]:
     # Some providers omit the type tag and use "object-with-a-single-field" encoding
-    keys = list(content) if isinstance(content, dict) else []
-    fallback = keys[0] if len(keys) == 1 else None
-    type = content.get("type", fallback)
-    if type == "text":
+    if "type" not in content and len(content) == 1:
+      content["type"] = list(content.keys())[0]
+    if content["type"] == "text":
         text = content["text"]
         if parse_reasoning:
             result = parse_content_with_reasoning(text)
@@ -417,22 +416,22 @@ def content_from_openai(
                 return [ContentText(text=text)]
         else:
             return [ContentText(text=text)]
-    elif type == "reasoning":
+    elif content["type"] == "reasoning":
         return [ContentReasoning(reasoning=content["reasoning"])]
-    elif type == "image_url":
+    elif content["type"] == "image_url":
         return [
             ContentImage(
                 image=content["image_url"]["url"], detail=content["image_url"]["detail"]
             )
         ]
-    elif type == "input_audio":
+    elif content["type"] == "input_audio":
         return [
             ContentAudio(
                 audio=content["input_audio"]["data"],
                 format=content["input_audio"]["format"],
             )
         ]
-    elif type == "refusal":
+    elif content["type"] == "refusal":
         return [ContentText(text=content["refusal"])]
 
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Some providers return content untagged -- as `{"type": "content"}` instead of `{"type": "type", "type": "content"}`.
Getting "type" unconditionally results in KeyError despite the actual content being present in the expected place.

### What is the new behavior?

`content_from_openai` will now check for such tagless (self-tagging?) encoding and use that single field as tag.

Additionally, the code now recognizes stand-alone "reasoning" content.

### Does this PR introduce a breaking change?

No.

### Other information:

The linter spots missing final `else:` clause which returns `None`, contrary to the type annotation.