### PR TITLE
Google: handle FinishReason.MALFORMED_FUNCTION_CALL

### DIFF
--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -558,10 +558,13 @@ def chat_tool_config(tool_choice: ToolChoice) -> ToolConfig:
 
 
 def completion_choice_from_candidate(candidate: Candidate) -> ChatCompletionChoice:
-    # check for completion text
-    content = ""
     # content can be None when the finish_reason is SAFETY
-    if candidate.content is not None:
+    if candidate.content is None:
+        content = ""
+    # content.parts can be None when the finish_reason is MALFORMED_FUNCTION_CALL
+    elif candidate.content.parts is None:
+        content = ""
+    else:
         content = " ".join(
             [
                 part.text
@@ -709,6 +712,8 @@ def finish_reason_to_stop_reason(finish_reason: FinishReason) -> StopReason:
         ):
             return "content_filter"
         case _:
+            # Note: to avoid adding another option to StopReason,
+            # this includes FinishReason.MALFORMED_FUNCTION_CALL
             return "unknown"
 
 

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -3,6 +3,8 @@ from test_helpers.utils import skip_if_no_google, skip_if_trio
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
 from inspect_ai.scorer import includes
+from google.genai.types import Candidate, Content, FinishReason  # type: ignore
+from inspect_ai.model._providers.google import completion_choice_from_candidate
 
 
 @skip_if_no_google
@@ -43,3 +45,26 @@ def test_google_block_reason():
     # TODO: comment in once we have an input that triggers the filter
     # assert log.samples
     # assert log.samples[0].output.stop_reason == "content_filter"
+
+
+def test_completion_choice_malformed_function_call():
+    # Copied from the ``Candidate`` object actually returned by the Google API
+    candidate = Candidate(
+        content=Content(parts=None, role=None),
+        finish_reason=FinishReason.MALFORMED_FUNCTION_CALL,
+        citation_metadata=None,
+        finish_message=None,
+        token_count=None,
+        avg_logprobs=None,
+        grounding_metadata=None,
+        index=None,
+        logprobs_result=None,
+        safety_ratings=None
+    )
+
+    choice = completion_choice_from_candidate(candidate)
+    
+    # Verify the conversion
+    assert choice.message.content == ""  # Empty content for malformed calls
+    assert choice.stop_reason == "unknown"  # MALFORMED_FUNCTION_CALL maps to "unknown"
+    assert choice.message.tool_calls is None  # No tool calls for malformed function calls

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1,10 +1,10 @@
+from google.genai.types import Candidate, Content, FinishReason  # type: ignore
 from test_helpers.utils import skip_if_no_google, skip_if_trio
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
-from inspect_ai.scorer import includes
-from google.genai.types import Candidate, Content, FinishReason  # type: ignore
 from inspect_ai.model._providers.google import completion_choice_from_candidate
+from inspect_ai.scorer import includes
 
 
 @skip_if_no_google
@@ -59,12 +59,14 @@ def test_completion_choice_malformed_function_call():
         grounding_metadata=None,
         index=None,
         logprobs_result=None,
-        safety_ratings=None
+        safety_ratings=None,
     )
 
     choice = completion_choice_from_candidate(candidate)
-    
+
     # Verify the conversion
     assert choice.message.content == ""  # Empty content for malformed calls
     assert choice.stop_reason == "unknown"  # MALFORMED_FUNCTION_CALL maps to "unknown"
-    assert choice.message.tool_calls is None  # No tool calls for malformed function calls
+    assert (
+        choice.message.tool_calls is None
+    )  # No tool calls for malformed function calls


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When FinishReason.MALFORMED_FUNCTION_CALL, Inspect raises inside `completion_choice_from_candidate` because `content.parts` is None

https://github.com/UKGovernmentBEIS/inspect_ai/blob/db5f35996129c4e9dea75433ba9cdee1d1960b48/src/inspect_ai/model/_providers/google.py#L560

### What is the new behavior?
Properly handle the case FinishReason.MALFORMED_FUNCTION_CALL. I decided to map it to `StopReason` "unknown", but I am also open to adding a new option to `StopReason` if that is preferred. 

Added a test
