### PR TITLE
Retain compatibility with the older sandbox config

### DIFF
--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -347,10 +347,11 @@ class SandboxEnvironmentSpec(BaseModel, frozen=True):
 
     @model_validator(mode="before")
     @classmethod
-    def load_config_model(cls, data: dict[str, Any]) -> dict[str, Any]:
+    def load_config_model(cls, data: dict[str, Any] | list) -> dict[str, Any]:
         if isinstance(data, list):
           # Backwards compatibility with the older schema
-          type, config = data
+          type = data[0]
+          config = data[1] if len(data) >= 1 else None
           data = {"type": type, "config": config}
         type = data["type"]
         config = data.get("config")

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -348,6 +348,10 @@ class SandboxEnvironmentSpec(BaseModel, frozen=True):
     @model_validator(mode="before")
     @classmethod
     def load_config_model(cls, data: dict[str, Any]) -> dict[str, Any]:
+        if isinstance(data, list):
+          # Backwards compatibility with the older schema
+          type, config = data
+          data = {"type": type, "config": config}
         type = data["type"]
         config = data.get("config")
         # Pydantic won't know what concrete type to instantiate for config, so


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Attempting to load a previously recorded eval file (e.g. with `read_eval_log_samples`) crashes with "list indices must be integers or slices, not str".

### What is the new behavior?

It detects the old "named tuple" format and loads accordingly.

### Does this PR introduce a breaking change?

No (it fixes one).

### Other information:
