### PR TITLE
fix: detect o-series models when they are served via Azure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Logging: Inspect no longer sets the global log level nor does it allow its own messages to propagate to the global handler (eliminating the possiblity of duplicate display). This should improve compatibility with applications that have their own custom logging configured. 
 - Tasks: For filesystem based tasks, no longer switch to the task file's directory during execution (directory switching still occurs during task loading). Specify `@task(chdir=True)` to preserve the previous behavior.
 - Bugfix: Fix issue with deserializing custom sandbox configuration objects.
+- Bugfix: Handle `parallel_tool_calls` correctly for OpenAI models served through Azure.
 
 ## v0.3.72 (03 March 2025)
 

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -52,7 +52,7 @@ from ._model_output import ModelUsage, StopReason, as_stop_reason
 
 
 def is_o_series(name: str) -> bool:
-    return bool(re.match(r"^o\d+", name))
+    return bool(re.match(r"(^|.*\/)o\d+", name))
 
 
 def is_o1_mini(name: str) -> bool:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Running inspect with a model like `openai/azure/o3-mini-2025-01-31-azr` is not detected as an o-series model and an error about parallel tool calls is raised (see #1460).

### What is the new behavior?
The `is_o_series` check now matches for the start of the string and after a slash (as it is passed a string like `azure/o3...` in this case).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
