### PR TITLE
bugfix: Enable passing `solver` list to `eval()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Model API: Specifying a default model (e.g. `--model`) is no longer required (as some evals have no model or use `get_model()` for model access).
 - Tasks can now directly specify a `model`, and model is no longer a required axis for parallel tasks.
 - Eval Set: Improved parallelisation in scheduler (all pending tasks are now run together rather than in model groups).
+- Bugfix: Enable passing `solver` list to `eval()` (decorate `chain` function with `@solver`).
 
 ## v0.3.73 (14 March 2025)
 

--- a/src/inspect_ai/solver/_chain.py
+++ b/src/inspect_ai/solver/_chain.py
@@ -2,10 +2,11 @@ from typing import Sequence, overload
 
 from typing_extensions import override
 
-from ._solver import Generate, Solver
+from ._solver import Generate, Solver, solver
 from ._task_state import TaskState
 
 
+@solver
 def chain(*solvers: Solver | list[Solver]) -> Solver:
     """Compose a solver from multiple other solvers.
 
@@ -22,8 +23,8 @@ def chain(*solvers: Solver | list[Solver]) -> Solver:
     """
     # flatten lists and chains
     all_solvers: list[Solver] = []
-    for solver in solvers:
-        all_solvers.extend(unroll(solver))
+    for s in solvers:
+        all_solvers.extend(unroll(s))
 
     return Chain(all_solvers)
 


### PR DESCRIPTION
decorate `chain` function with `@solver`

