### PR TITLE
Add docker GitHub workflow for building and pushing tool Docker images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,73 @@
+name: Build and Push Image to Docker Hub
+
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: Image to build
+        required: true
+        type: choice
+        options:
+          - inspect-computer-tool
+          - inspect-web-browser-tool
+      tag:
+        description: Tag to assign to the image
+        required: true
+        type: string
+        default: latest
+      platforms:
+        description: Target platforms (comma-separated list)
+        required: true
+        type: string
+        default: linux/amd64,linux/arm64
+      push:
+        description: Push the image to Docker Hub
+        required: true
+        type: boolean
+        default: true
+      org:
+        description: Docker Hub organization
+        required: true
+        type: string
+        default: aisiuk
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    environment: docker
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Set build context path and image name
+        run: |
+          if [[ "${{ github.event.inputs.image }}" == "inspect-computer-tool" ]]; then
+            echo "BUILD_CONTEXT=src/inspect_ai/tool/_tools/_computer/_resources" >> $GITHUB_ENV
+          elif [[ "${{ github.event.inputs.image }}" == "inspect-web-browser-tool" ]]; then
+            echo "BUILD_CONTEXT=src/inspect_ai/tool/_tools/_web_browser/_resources" >> $GITHUB_ENV
+          else
+            echo "Invalid image name '${{ github.event.inputs.image }}'"
+            exit 1
+          fi
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: arm64,amd64
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+      - name: Build and (optionally) push multi-arch image
+        uses: docker/build-push-action@v4
+        with:
+          context: ${{ env.BUILD_CONTEXT }}
+          push: ${{ github.event.inputs.push }}
+          platforms: ${{ github.event.inputs.platforms }}
+          tags: ${{ github.event.inputs.org }}/${{ github.event.inputs.image }}:${{ github.event.inputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Historically, we've manually run a makefile to build and push the tool (e.g. computer, web browser) images to Docker Hub. This often required coordination between multiple people (sometimes across timezones) as only @tcatling and myself have access to the relevant UK AISI secret used by the makefile.

This PR adds a GitHub workflow which can be triggered manually to allow trusted individuals (I suggest we copy whatever config we have for the PyPI workflow) to build and push these images as and when is needed.

![Screenshot 2025-03-18 at 13 50 06](https://github.com/user-attachments/assets/d1e04759-7f61-4bf2-b772-2b2e280b009f)

We'll need to create 2 secrets in a new `docker` environment. I don't have admin permissions but am happy to share the secrets or create them myself if given admin access:
`DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`

This workflow supports all the same features the makefile does:
* multi architecture builds with QEMU
* building from arbitrary branches
* customising the tag (e.g. latest)
* option to do a dry run to build only (no push)

I've run this in my own repo using my own [Docker Hub account](https://hub.docker.com/repository/docker/craigwaltondsit/inspect-web-browser-tool/tags) to prove this out.
![Screenshot 2025-03-18 at 13 35 42](https://github.com/user-attachments/assets/9f1f1bca-0fae-4a63-8e6a-b3329e026785)
