### PR TITLE
Normalize windows URIs to double slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@
 - Inspect View: Fix layout issue with sample error display in sample detail summary.
 - Inspect View: Better support large eval files (in excess of 4GB).
 - Inspect View: Correctly display 'None' when passed in tool calls.
+- Inspect View: Fix 'Access Denied' error when using `inspect view` and viewing the log in a browser.
 - Bugfix: Properly handle nested Pydantic models when reading typed store (`store_as()`) from log.
 - Bugfix: Enable passing `solver` list to `eval()` (decorate `chain` function with `@solver`).
 - Bugfix: Support deserializing custom sandbox configuration objects when said sandbox plugin is not installed.
 - Bugfix: Fix error in sample filtering autocomplete (could cause autocomplete to fail and show an error in js console).
+
 
 ## v0.3.74 (15 March 2025)
 


### PR DESCRIPTION
triple is allowed, but fsspec and others normalize to double slash

Fixes #1499

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
