### PR TITLE
Properly deal with windows triple slash uris in view server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Inspect View: Fix layout issue with sample error display in sample detail summary.
 - Inspect View: Better support large eval files (in excess of 4GB).
 - Inspect View: Correctly display 'None' when passed in tool calls.
+- Inspect View: Fix 'Access Denied' error when using `inspect view` and viewing the log in a browser.
 - Bugfix: Properly handle nested Pydantic models when reading typed store (`store_as()`) from log.
 - Bugfix: Enable passing `solver` list to `eval()` (decorate `chain` function with `@solver`).
 - Bugfix: Support deserializing custom sandbox configuration objects when said sandbox plugin is not installed.


### PR DESCRIPTION
The previous fix failed to decode url encoded params in non-file uris. Fixes #1499 Take 2.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
