### PR TITLE
Add `inspect-tool-support` image to Docker Hub workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -10,6 +10,7 @@ on:
         options:
           - inspect-computer-tool
           - inspect-web-browser-tool
+          - inspect-tool-support
       tag:
         description: Tag to assign to the image
         required: true
@@ -44,6 +45,8 @@ jobs:
             echo "BUILD_CONTEXT=src/inspect_ai/tool/_tools/_computer/_resources" >> $GITHUB_ENV
           elif [[ "${{ github.event.inputs.image }}" == "inspect-web-browser-tool" ]]; then
             echo "BUILD_CONTEXT=src/inspect_ai/tool/_tools/_web_browser/_resources" >> $GITHUB_ENV
+          elif [[ "${{ github.event.inputs.image }}" == "inspect-tool-support" ]]; then
+            echo "BUILD_CONTEXT=src/inspect_tool_support" >> $GITHUB_ENV
           else
             echo "Invalid image name '${{ github.event.inputs.image }}'"
             exit 1


### PR DESCRIPTION
See #1498 for more context - just updating this to include the new `inspect-tool-support` image.