### PR TITLE
Fix `SubtaskEvent` deserialisation error when `completed` is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [bash_session()](https://inspect.ai-safety-institute.org.uk/tools-standard.html#sec-bash-session) tool for creating a stateful bash shell that retains its state across calls from the model.
 - [text_editor()](https://inspect.ai-safety-institute.org.uk/tools-standard.html#sec-text-editor) tool which enables viewing, creating and editing text files.
 - Structured Output: Properly handle Pydantic BaseModel that contains other BaseModel definitions in its schema.
+- Bugfix: Resolve issue when deserialising a SubtaskEvent from a log file which does not have a completed time.
 
 ## v0.3.75 (18 March 2025)
 

--- a/src/inspect_ai/log/_transcript.py
+++ b/src/inspect_ai/log/_transcript.py
@@ -146,7 +146,7 @@ class ModelEvent(BaseEvent):
     """working time for model call that succeeded (i.e. was not retried)."""
 
     @field_serializer("completed")
-    def serialize_completed(self, dt: datetime) -> str:
+    def serialize_completed(self, dt: datetime | None) -> str | None:
         if dt is None:
             return None
         return dt.astimezone().isoformat()
@@ -235,7 +235,9 @@ class ToolEvent(BaseEvent):
     """Required so that we can include '_cancel_fn' as a member."""
 
     @field_serializer("completed")
-    def serialize_completed(self, dt: datetime) -> str:
+    def serialize_completed(self, dt: datetime | None) -> str | None:
+        if dt is None:
+            return None
         return dt.astimezone().isoformat()
 
 
@@ -270,7 +272,9 @@ class SandboxEvent(BaseEvent):
     """Time that sandbox action completed (see `timestamp` for started)"""
 
     @field_serializer("completed")
-    def serialize_completed(self, dt: datetime) -> str:
+    def serialize_completed(self, dt: datetime | None) -> str | None:
+        if dt is None:
+            return None
         return dt.astimezone().isoformat()
 
 
@@ -412,7 +416,9 @@ class SubtaskEvent(BaseEvent):
     """Working time for subtask (i.e. time not spent waiting on semaphores or model retries)."""
 
     @field_serializer("completed")
-    def serialize_completed(self, dt: datetime) -> str:
+    def serialize_completed(self, dt: datetime | None) -> str | None:
+        if dt is None:
+            return None
         return dt.astimezone().isoformat()
 
 

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -1,7 +1,7 @@
 import math
 import os
 import tempfile
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 import pytest
 from pydantic_core import PydanticSerializationError
@@ -108,7 +108,7 @@ def test_can_round_trip_serialize_subtask_event():
     # If we set the timestamp to a timezone-naive datetime object (default behaviour),
     # the deserialized object will have a timezone-aware datetime object and the
     # assert will fail.
-    original = SubtaskEvent(name="name", input={}, timestamp=datetime.now(UTC))
+    original = SubtaskEvent(name="name", input={}, timestamp=datetime.now(timezone.utc))
 
     serialized = original.model_dump_json()
     deserialized = SubtaskEvent.model_validate_json(serialized)

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -12,7 +12,9 @@ from inspect_ai.dataset import Sample
 from inspect_ai.log import read_eval_log
 from inspect_ai.log._file import read_eval_log_sample, write_eval_log
 from inspect_ai.log._log import EvalLog
-from inspect_ai.log._transcript import SubtaskEvent
+from inspect_ai.log._transcript import ModelEvent, SandboxEvent, SubtaskEvent, ToolEvent
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.solver import (
     Generate,
     TaskState,
@@ -102,16 +104,53 @@ def test_log_location():
     check_log_location(eval_log_file)
 
 
+def test_can_round_trip_serialize_model_event():
+    original = ModelEvent(
+        model="model",
+        input=[],
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput(),
+        # Set timestamp to a timezone-aware datetime object because when serializing to
+        # JSON, the datetime is converted to a timezone-aware string.
+        # If we set the timestamp to a timezone-naive datetime object (default
+        # behaviour), the deserialized object will have a timezone-aware datetime object
+        # and the assert will fail.
+        timestamp=datetime.now(timezone.utc),
+    )
+
+    serialized = original.model_dump_json()
+    deserialized = ModelEvent.model_validate_json(serialized)
+
+    assert original == deserialized
+
+
 def test_can_round_trip_serialize_subtask_event():
-    # Note we set the timestamp to a timezone-aware datetime object because when
-    # serializing to JSON, the datetime is converted to a timezone-aware string.
-    # If we set the timestamp to a timezone-naive datetime object (default behaviour),
-    # the deserialized object will have a timezone-aware datetime object and the
-    # assert will fail.
     original = SubtaskEvent(name="name", input={}, timestamp=datetime.now(timezone.utc))
 
     serialized = original.model_dump_json()
     deserialized = SubtaskEvent.model_validate_json(serialized)
+
+    assert original == deserialized
+
+
+def test_can_round_trip_serialize_sandbox_event():
+    original = SandboxEvent(action="exec", timestamp=datetime.now(timezone.utc))
+
+    serialized = original.model_dump_json()
+    deserialized = SandboxEvent.model_validate_json(serialized)
+
+    assert original == deserialized
+
+
+def test_can_round_trip_serialize_tool_event():
+    original = ToolEvent(
+        id="id", function="fn", arguments={}, timestamp=datetime.now(timezone.utc)
+    )
+
+    serialized = original.model_dump_json()
+    deserialized = ToolEvent.model_validate_json(serialized)
 
     assert original == deserialized
 

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -126,11 +126,13 @@ def test_can_round_trip_serialize_model_event():
     assert original == deserialized
 
 
-def test_can_round_trip_serialize_subtask_event():
-    original = SubtaskEvent(name="name", input={}, timestamp=datetime.now(timezone.utc))
+def test_can_round_trip_serialize_tool_event():
+    original = ToolEvent(
+        id="id", function="fn", arguments={}, timestamp=datetime.now(timezone.utc)
+    )
 
     serialized = original.model_dump_json()
-    deserialized = SubtaskEvent.model_validate_json(serialized)
+    deserialized = ToolEvent.model_validate_json(serialized)
 
     assert original == deserialized
 
@@ -144,13 +146,11 @@ def test_can_round_trip_serialize_sandbox_event():
     assert original == deserialized
 
 
-def test_can_round_trip_serialize_tool_event():
-    original = ToolEvent(
-        id="id", function="fn", arguments={}, timestamp=datetime.now(timezone.utc)
-    )
+def test_can_round_trip_serialize_subtask_event():
+    original = SubtaskEvent(name="name", input={}, timestamp=datetime.now(timezone.utc))
 
     serialized = original.model_dump_json()
-    deserialized = ToolEvent.model_validate_json(serialized)
+    deserialized = SubtaskEvent.model_validate_json(serialized)
 
     assert original == deserialized
 


### PR DESCRIPTION
This resolves the issue that @tbroadley kindly reported: when trying to serialise a `SubtaskEvent` which was deserialised from

```json
{
  "timestamp": "2025-02-18T21:03:28.265168-08:00",
  "working_start": 0,
  "pending": true,
  "event": "subtask",
  "name": "test",
  "input": {},
  "events": []
}
```

Pydantic fails because the `SubtaskEvent` serialisation function assumes that `completed` is always non-`None` (despite the schema types specifying it as optional).

I've made similar fixes to `ToolEvent` and `SandboxEvent`. `ModelEvent` already handled this correctly (but I fixed the type hint).