### PR TITLE
Fast follow changes to for the tool support functionality.

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/config.py
+++ b/src/inspect_ai/util/_sandbox/docker/config.py
@@ -82,7 +82,7 @@ COMPOSE_COMMENT = """# inspect auto-generated docker compose file
 COMPOSE_GENERIC_YAML = f"""{COMPOSE_COMMENT}
 services:
   default:
-    image: "python:3.12-bookworm"
+    image: "aisiuk/inspect-tool-support:latest"
     command: "tail -f /dev/null"
     init: true
     network_mode: none

--- a/src/inspect_ai/util/_sandbox/docker/config.py
+++ b/src/inspect_ai/util/_sandbox/docker/config.py
@@ -82,7 +82,7 @@ COMPOSE_COMMENT = """# inspect auto-generated docker compose file
 COMPOSE_GENERIC_YAML = f"""{COMPOSE_COMMENT}
 services:
   default:
-    image: "aisiuk/inspect-tool-support:latest"
+    image: "aisiuk/inspect-tool-support"
     command: "tail -f /dev/null"
     init: true
     network_mode: none

--- a/src/inspect_tool_support/CHANGELOG.md
+++ b/src/inspect_tool_support/CHANGELOG.md
@@ -1,0 +1,4 @@
+## v0.1.17 (19 March 2025)
+
+- Fixed `bash_session` handling of commands whose `stdout` output do not include a trailing newline.
+- Include container side exception details in JSON RPC error response so that they appear in eval logs.

--- a/src/inspect_tool_support/MANIFEST.in
+++ b/src/inspect_tool_support/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
+include CHANGELOG.md
 include *.svg
 include LICENSE
 recursive-include src/inspect_tool_support *.py *.svg *.md

--- a/src/inspect_tool_support/pyproject.toml
+++ b/src/inspect_tool_support/pyproject.toml
@@ -65,7 +65,7 @@ ignore = ["W002", "W009"]
 
 [project]
 name = "inspect_tool_support"
-version = "0.1.6"
+version = "0.1.7"
 description = "Sandbox container tool code for inspect_ai"
 authors = [{ name = "UK AI Security Institute" }]
 readme = "README.md"

--- a/src/inspect_tool_support/pyproject.toml
+++ b/src/inspect_tool_support/pyproject.toml
@@ -96,6 +96,7 @@ dependencies = [
 ]
 
 [project.urls]
+CHANGELOG="https://raw.githubusercontent.com/UKGovernmentBEIS/inspect_ai/refs/heads/feature/tool-support-fast-follow/src/inspect_tool_support/CHANGELOG.md"
 
 [project.scripts]
 inspect-tool-support = "inspect_tool_support._cli.main:main"

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/bash_process.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/bash_process.py
@@ -135,6 +135,18 @@ class BashProcess:
                 break
 
             line_str = line.decode("utf-8")
+
+            # TODO: Temporary bug fix hack. Another PR is changing this to no longer
+            # be line oriented
+            if stdout and self._current_marker and self._current_marker in line_str:
+                # if the process did not include a trailing \n in their output, the
+                # line with the marker will be prefixed by whatever the last process
+                # output was. This code will essentially break the line before the marker
+                parts = line_str.split(self._current_marker)
+                if len(parts) == 2:
+                    data.append(parts[0])
+                    line_str = self._current_marker
+
             data.append(line_str)
 
             # Check if line contains our marker indicating command completion

--- a/src/inspect_tool_support/src/inspect_tool_support/_util/_json_rpc_helpers.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_util/_json_rpc_helpers.py
@@ -79,7 +79,7 @@ async def with_validated_rpc_method_params(
                 # so that this info will be included in the eval log. This will still
                 # fail the eval since it represents an inspect coding error.
                 return jsonrpcserver.Error(
-                    code=-32603, message=str(e), data=traceback.format_exc()
+                    code=-32603, message=repr(e), data=traceback.format_exc()
                 )
         case _:
             return jsonrpcserver.Error(

--- a/src/inspect_tool_support/src/inspect_tool_support/_util/_json_rpc_helpers.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_util/_json_rpc_helpers.py
@@ -1,4 +1,5 @@
 import json
+import traceback
 from typing import Awaitable, Callable, Type, TypeVar
 
 import httpx
@@ -73,6 +74,13 @@ async def with_validated_rpc_method_params(
                         )
             except ToolException as e:
                 return jsonrpcserver.Error(code=-32000, message=e.message)
+            except Exception as e:
+                # Customize the jsonrpc error with the exception message and traceback
+                # so that this info will be included in the eval log. This will still
+                # fail the eval since it represents an inspect coding error.
+                return jsonrpcserver.Error(
+                    code=-32603, message=str(e), data=traceback.format_exc()
+                )
         case _:
             return jsonrpcserver.Error(
                 -32602,


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
- `bash_session` commands whose `stdout` output did not end in a newline character, would cause an eval to fail.
- Unexpected errors in the `inspect-tool-support` container code yield an inspect side error with no details.

### What is the new behavior?
- `bash_session` now properly supports lack of a trailing newline.
- Exception details are now properly marshaled back to the Inspect process via a fleshed out JSON RPC error.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
