### PR TITLE
fix incorrect warning when parsing task arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 - OpenAI: Support for .wav files in audio inputs for gpt-4o-audio-preview.
 - Bugfix: Resolve issue when deserialising a SubtaskEvent from a log file which does not have a completed time.
 - Bugfix: Fix unnecessary warnings about task arguments.
+- Bugfix: When a task does not take a kwargs argument, only warn if the provided argument is not valid.
+
+
 
 ## v0.3.75 (18 March 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Structured Output: Properly handle Pydantic BaseModel that contains other BaseModel definitions in its schema.
 - OpenAI: Support for .wav files in audio inputs for gpt-4o-audio-preview.
 - Bugfix: Resolve issue when deserialising a SubtaskEvent from a log file which does not have a completed time.
+- Bugfix: Fix unnecessary warnings about task arguments.
 
 ## v0.3.75 (18 March 2025)
 

--- a/src/inspect_ai/_eval/registry.py
+++ b/src/inspect_ai/_eval/registry.py
@@ -75,12 +75,10 @@ def task_create(name: str, **kwargs: Any) -> Task:
     task_params: list[str] = task_info.metadata["params"]
     task_args: dict[str, Any] = {}
     for param in kwargs.keys():
-        if param in task_params:
+        if param in task_params or "kwargs" in task_params:
             task_args[param] = kwargs[param]
-            if "kwargs" in task_params:
-                task_args[param] = kwargs[param]
-            else:
-                logger.warning(f"param '{param}' not used by task '{name}'")
+        else:
+            logger.warning(f"param '{param}' not used by task '{name}'")
 
     return cast(Task, registry_create("task", name, **task_args))
 


### PR DESCRIPTION
When a task does not take a kwargs argument, warnings should only be raised if the provided argument is not valid.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
If a task does not define a `kwargs` parameter, warnings will be generated for every `-T` argument set.

Consider a file `mytask.py` that defines a task, `sometask`
```py
@task
def sometask(some_arg = None):
   ...
```

Running `inspect eval mytask.py -T some_arg=foo` will print an incorrect warning
```
WARNING  param 'some_arg' not used by task 'sometask'
```

### What is the new behavior?

A warning will only be printed if the task method does not take the specified argument AND does not take a `kwargs` argument.

Something unchanged by this PR but perhaps notable is that the check here is focused on an argument _named_ kwargs, if someone defined a method using a different name with the same `**` syntax, the check would fail (e.g., `def some_task(**mykwargs): ...`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, the only change is a warning is no longer printed.

### Other information:
