### PR TITLE
Transform Inspect tool name back to model native name if needed when creating `ChatMessageTool`'s.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,24 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: Module",
+      "type": "debugpy",
+      "request": "launch",
+      "module": "inspect_ai",
+      "args": "${input:argsPrompt}",
+      "cwd": "${workspaceFolder}/src"
+    }
+  ],
+  "inputs": [
+    {
+      "id": "argsPrompt",
+      "type": "promptString",
+      "description": "Enter arguments for the module",
+      "default": ""
+    }
+  ]
+}

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -200,8 +200,16 @@
       "description": "Assistant chat message.",
       "properties": {
         "id": {
-          "title": "Id",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
         },
         "content": {
           "anyOf": [
@@ -286,8 +294,16 @@
       "description": "System chat message.",
       "properties": {
         "id": {
-          "title": "Id",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
         },
         "content": {
           "anyOf": [
@@ -356,8 +372,16 @@
       "description": "Tool chat message.",
       "properties": {
         "id": {
-          "title": "Id",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
         },
         "content": {
           "anyOf": [
@@ -435,6 +459,18 @@
           "default": null,
           "title": "Function"
         },
+        "internal_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Internal Name"
+        },
         "error": {
           "anyOf": [
             {
@@ -454,6 +490,7 @@
         "role",
         "tool_call_id",
         "function",
+        "internal_name",
         "error"
       ],
       "title": "ChatMessageTool",
@@ -464,8 +501,16 @@
       "description": "User chat message.",
       "properties": {
         "id": {
-          "title": "Id",
-          "type": "string"
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Id"
         },
         "content": {
           "anyOf": [
@@ -4431,9 +4476,20 @@
           "type": "object"
         },
         "type": {
-          "const": "function",
           "title": "Type",
           "type": "string"
+        },
+        "internal_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Internal Name"
         },
         "parse_error": {
           "anyOf": [
@@ -4464,6 +4520,7 @@
         "function",
         "arguments",
         "type",
+        "internal_name",
         "parse_error",
         "view"
       ],
@@ -4622,6 +4679,18 @@
           },
           "title": "Arguments",
           "type": "object"
+        },
+        "internal_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Internal Name"
         },
         "view": {
           "anyOf": [
@@ -4809,6 +4878,7 @@
         "id",
         "function",
         "arguments",
+        "internal_name",
         "view",
         "result",
         "truncated",

--- a/src/inspect_ai/_view/www/src/types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/types/log.d.ts
@@ -148,7 +148,7 @@ export type Input =
       | ChatMessageAssistant
       | ChatMessageTool
     )[];
-export type Id1 = string;
+export type Id1 = string | null;
 export type Content =
   | string
   | (
@@ -175,7 +175,7 @@ export type Video = string;
 export type Format1 = "mp4" | "mpeg" | "mov";
 export type Source = ("input" | "generate") | null;
 export type Role = "system";
-export type Id2 = string;
+export type Id2 = string | null;
 export type Content1 =
   | string
   | (
@@ -188,7 +188,7 @@ export type Content1 =
 export type Source1 = ("input" | "generate") | null;
 export type Role1 = "user";
 export type ToolCallId = string[] | null;
-export type Id3 = string;
+export type Id3 = string | null;
 export type Content2 =
   | string
   | (
@@ -203,12 +203,13 @@ export type Role2 = "assistant";
 export type ToolCalls = ToolCall[] | null;
 export type Id4 = string;
 export type Function = string;
-export type Type8 = "function";
+export type Type8 = string;
+export type InternalName = string | null;
 export type ParseError = string | null;
 export type Title = string | null;
 export type Format2 = "text" | "markdown";
 export type Content3 = string;
-export type Id5 = string;
+export type Id5 = string | null;
 export type Content4 =
   | string
   | (
@@ -222,6 +223,7 @@ export type Source3 = ("input" | "generate") | null;
 export type Role3 = "tool";
 export type ToolCallId1 = string | null;
 export type Function1 = string | null;
+export type InternalName1 = string | null;
 export type Type9 =
   | "parsing"
   | "timeout"
@@ -369,6 +371,7 @@ export type Event6 = "tool";
 export type Type12 = "function";
 export type Id7 = string;
 export type Function2 = string;
+export type InternalName2 = string | null;
 export type Result1 =
   | string
   | number
@@ -911,6 +914,7 @@ export interface ToolCall {
   function: Function;
   arguments: Arguments;
   type: Type8;
+  internal_name: InternalName;
   parse_error: ParseError;
   view: ToolCallContent | null;
 }
@@ -933,6 +937,7 @@ export interface ChatMessageTool {
   role: Role3;
   tool_call_id: ToolCallId1;
   function: Function1;
+  internal_name: InternalName1;
   error: ToolCallError | null;
 }
 export interface ToolCallError {
@@ -1201,6 +1206,7 @@ export interface ToolEvent {
   id: Id7;
   function: Function2;
   arguments: Arguments1;
+  internal_name: InternalName2;
   view: ToolCallContent | null;
   result: Result1;
   truncated: Truncated;

--- a/src/inspect_ai/log/_transcript.py
+++ b/src/inspect_ai/log/_transcript.py
@@ -170,6 +170,9 @@ class ToolEvent(BaseEvent):
     arguments: dict[str, JsonValue]
     """Arguments to function."""
 
+    internal_name: str | None = Field(default=None)
+    """Internal name for tool (if any)."""
+
     view: ToolCallContent | None = Field(default=None)
     """Custom view of tool call input."""
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -202,6 +202,7 @@ async def call_tools(
                 id=call.id,
                 function=call.function,
                 arguments=call.arguments,
+                internal_name=call.internal_name,
                 view=call.view,
                 pending=True,
             )

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -512,7 +512,9 @@ def parse_tool_call(
     """Parse a tool call from a JSON payload.
 
     Note that this function doesn't know about internal tool names so the caller
-    should ammend the returned `ToolCall` with an internal name as appropriate
+    should ammend the returned `ToolCall` by mapping the parsed `function` field from
+    from an internal name to an inspect tool name and fixing up the `ToolCall` object
+    as required to reflect this change.
     """
     error: str | None = None
     arguments_dict: dict[str, Any] = {}

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -552,8 +552,7 @@ def parse_tool_call(
                 # If the yaml parser fails, we treat it as a string argument.
                 arguments_dict[param_names[0]] = arguments
 
-    # return ToolCall with error payload (if there is an internal_name the
-    # caller should ammend the ToolCall with it)
+    # return ToolCall with error payload
     return ToolCall(
         id=id,
         function=function,

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -165,7 +165,7 @@ async def call_tools(
             # create event
             event = ToolEvent(
                 id=call.id,
-                function=call.function,
+                function=call.native_name or call.function,
                 arguments=call.arguments,
                 result=content,
                 truncated=truncated,
@@ -181,7 +181,7 @@ async def call_tools(
                         ChatMessageTool(
                             content=content,
                             tool_call_id=call.id,
-                            function=call.function,
+                            function=call.native_name or call.function,
                             error=tool_error,
                         ),
                         event,
@@ -222,7 +222,7 @@ async def call_tools(
             if event.cancelled:
                 tool_message = ChatMessageTool(
                     content="",
-                    function=call.function,
+                    function=call.native_name or call.function,
                     tool_call_id=call.id,
                     error=ToolCallError(
                         "timeout", "Command timed out before completing."
@@ -230,7 +230,7 @@ async def call_tools(
                 )
                 result_event = ToolEvent(
                     id=call.id,
-                    function=call.function,
+                    function=call.native_name or call.function,
                     arguments=call.arguments,
                     result=tool_message.content,
                     truncated=None,
@@ -545,6 +545,8 @@ def parse_tool_call(
     return ToolCall(
         id=id,
         function=function,
+        # TODO: ???
+        native_name=None,
         arguments=arguments_dict,
         type="function",
         parse_error=error,

--- a/src/inspect_ai/model/_chat_message.py
+++ b/src/inspect_ai/model/_chat_message.py
@@ -158,6 +158,9 @@ class ChatMessageTool(ChatMessageBase):
     function: str | None = Field(default=None)
     """Name of function called."""
 
+    internal_name: str | None = Field(default=None)
+    """Internal name for tool (if any)."""
+
     error: ToolCallError | None = Field(default=None)
     """Error which occurred during tool call."""
 

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1114,6 +1114,7 @@ def tool_result_images_reducer(
                     id=message.id,
                     content=edited_tool_message_content,
                     tool_call_id=message.tool_call_id,
+                    # TODO: What about native_name here?
                     function=message.function,
                 )
             ],

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1114,8 +1114,8 @@ def tool_result_images_reducer(
                     id=message.id,
                     content=edited_tool_message_content,
                     tool_call_id=message.tool_call_id,
-                    # TODO: What about native_name here?
                     function=message.function,
+                    internal_name=message.internal_name,
                 )
             ],
             pending_content + new_user_message_content,

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -187,9 +187,11 @@ class ModelOutput(BaseModel):
     def for_tool_call(
         model: str,
         tool_name: str,
+        native_tool_name: str,
         tool_arguments: dict[str, Any],
         tool_call_id: str | None = None,
         content: str | None = None,
+        type: str = "function",
     ) -> "ModelOutput":
         """
         Returns a ModelOutput for requesting a tool call.
@@ -197,6 +199,8 @@ class ModelOutput(BaseModel):
         Args:
             model: model name
             tool_name: The name of the tool.
+            native_tool_name: The name of the tool.
+            type: The model's type for the tool. e.g. "function", "computer_use_preview"
             tool_arguments: The arguments passed to the tool.
             tool_call_id: Optional ID for the tool call. Defaults to a random UUID.
             content: Optional content to include in the message. Defaults to "tool call for tool {tool_name}".
@@ -221,8 +225,9 @@ class ModelOutput(BaseModel):
                             ToolCall(
                                 id=tool_call_id,
                                 function=tool_name,
+                                native_name=native_tool_name,
                                 arguments=tool_arguments,
-                                type="function",
+                                type=type,
                             )
                         ],
                     ),

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -187,8 +187,8 @@ class ModelOutput(BaseModel):
     def for_tool_call(
         model: str,
         tool_name: str,
-        native_tool_name: str,
         tool_arguments: dict[str, Any],
+        native_tool_name: str | None = None,
         tool_call_id: str | None = None,
         content: str | None = None,
         type: str = "function",

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -188,7 +188,7 @@ class ModelOutput(BaseModel):
         model: str,
         tool_name: str,
         tool_arguments: dict[str, Any],
-        native_tool_name: str | None = None,
+        internal_tool_name: str | None = None,
         tool_call_id: str | None = None,
         content: str | None = None,
         type: str = "function",
@@ -199,7 +199,7 @@ class ModelOutput(BaseModel):
         Args:
             model: model name
             tool_name: The name of the tool.
-            native_tool_name: The name of the tool.
+            internal_tool_name: The model's internal name for the tool (if any).
             type: The model's type for the tool. e.g. "function", "computer_use_preview"
             tool_arguments: The arguments passed to the tool.
             tool_call_id: Optional ID for the tool call. Defaults to a random UUID.
@@ -225,7 +225,7 @@ class ModelOutput(BaseModel):
                             ToolCall(
                                 id=tool_call_id,
                                 function=tool_name,
-                                native_name=native_tool_name,
+                                internal_name=internal_tool_name,
                                 arguments=tool_arguments,
                                 type=type,
                             )

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -83,12 +83,13 @@ def openai_chat_tool_call(tool_call: ToolCall) -> ChatCompletionMessageToolCall:
 def openai_chat_tool_call_param(
     tool_call: ToolCall,
 ) -> ChatCompletionMessageToolCallParam:
+    assert tool_call.type == "function", f"Unexpected tool call type {tool_call.type}"
     return ChatCompletionMessageToolCallParam(
         id=tool_call.id,
         function=dict(
             name=tool_call.function, arguments=json.dumps(tool_call.arguments)
         ),
-        type=tool_call.type,
+        type="function",  # Type narrowing couldn't figure it out
     )
 
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1,23 +1,12 @@
 import functools
 import os
 import re
-import sys
 from copy import copy
 from logging import getLogger
-from typing import Any, Literal, Optional, Tuple, TypedDict, cast
+from typing import Any, Literal, NamedTuple, Optional, Tuple, cast
 
 import httpcore
 import httpx
-
-from inspect_ai._util.http import is_retryable_http_status
-
-from .util.hooks import HttpxHooks
-
-if sys.version_info >= (3, 11):
-    from typing import NotRequired
-else:
-    from typing_extensions import NotRequired
-
 from anthropic import (
     APIConnectionError,
     APIStatusError,
@@ -39,12 +28,15 @@ from anthropic.types import (
     TextBlockParam,
     ThinkingBlock,
     ThinkingBlockParam,
+    ToolBash20250124Param,
     ToolParam,
     ToolResultBlockParam,
+    ToolTextEditor20250124Param,
     ToolUseBlock,
     ToolUseBlockParam,
     message_create_params,
 )
+from anthropic.types.beta import BetaToolComputerUse20250124Param
 from pydantic import JsonValue
 from typing_extensions import override
 
@@ -56,6 +48,7 @@ from inspect_ai._util.content import (
     ContentText,
 )
 from inspect_ai._util.error import exception_message
+from inspect_ai._util.http import is_retryable_http_status
 from inspect_ai._util.images import file_as_data_uri
 from inspect_ai._util.logger import warn_once
 from inspect_ai._util.url import data_uri_mime_type, data_uri_to_base64
@@ -67,25 +60,13 @@ from .._model import ModelAPI
 from .._model_call import ModelCall
 from .._model_output import ChatCompletionChoice, ModelOutput, ModelUsage, StopReason
 from .util import environment_prerequisite_error, model_base_url
+from .util.hooks import HttpxHooks
 
 logger = getLogger(__name__)
 
 ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
 
 NATIVE_COMPUTER_TOOL_NAME = "computer"
-_native_tool_name_mappings = {
-    NATIVE_COMPUTER_TOOL_NAME: "computer",
-    "str_replace_editor": "text_editor",
-    "bash": "bash_session",
-}
-"""
-A dictionary mapping native tool names from Anthropic to Inspect tool names.
-
-Anthropic prescribes names for their native tools - `computer`, `bash`, and
-`str_replace_editor`. For a variety of reasons, Inspect's tool names to not
-necessarily conform to native names. This table enables us to map from
-Anthropic names back to Inspect names.
-"""
 
 
 class AnthropicAPI(ModelAPI):
@@ -511,7 +492,7 @@ class AnthropicAPI(ModelAPI):
 
     def computer_use_tool_param(
         self, tool: ToolInfo
-    ) -> Optional["ComputerUseToolParam"]:
+    ) -> Optional[BetaToolComputerUse20250124Param]:
         # check for compatible 'computer' tool
         if tool.name == "computer" and (
             sorted(tool.parameters.properties.keys())
@@ -533,7 +514,7 @@ class AnthropicAPI(ModelAPI):
                     "Use of Anthropic's native computer use support is not enabled in Claude 3.5. Please use 3.7 or later to leverage the native support.",
                 )
                 return None
-            return ComputerUseToolParam(
+            return BetaToolComputerUse20250124Param(
                 type="computer_20250124",
                 name="computer",
                 # Note: The dimensions passed here for display_width_px and display_height_px should
@@ -550,7 +531,9 @@ class AnthropicAPI(ModelAPI):
         else:
             return None
 
-    def text_editor_tool_param(self, tool: ToolInfo) -> Optional["TextEditorToolParam"]:
+    def text_editor_tool_param(
+        self, tool: ToolInfo
+    ) -> Optional[ToolTextEditor20250124Param]:
         # check for compatible 'text editor' tool
         if tool.name == "text_editor" and (
             sorted(tool.parameters.properties.keys())
@@ -566,54 +549,39 @@ class AnthropicAPI(ModelAPI):
                 ]
             )
         ):
-            return TextEditorToolParam(
+            return ToolTextEditor20250124Param(
                 type="text_editor_20250124", name="str_replace_editor"
             )
         # not a text_editor tool
         else:
             return None
 
-    def bash_tool_param(self, tool: ToolInfo) -> Optional["BashToolParam"]:
+    def bash_tool_param(self, tool: ToolInfo) -> Optional[ToolBash20250124Param]:
         # check for compatible 'bash' tool
         if tool.name == "bash_session" and (
             sorted(tool.parameters.properties.keys()) == sorted(["command", "restart"])
         ):
-            return BashToolParam(type="bash_20250124", name="bash")
+            return ToolBash20250124Param(type="bash_20250124", name="bash")
         # not a bash tool
         else:
             return None
 
 
-# native anthropic tool definitions for computer use beta
-# https://docs.anthropic.com/en/docs/build-with-claude/computer-use
-class ComputerUseToolParam(TypedDict):
-    type: Literal["computer_20250124"]
-    name: Literal["computer"]
-    display_width_px: NotRequired[int]
-    display_height_px: NotRequired[int]
-    display_number: NotRequired[int]
-
-
-class TextEditorToolParam(TypedDict):
-    type: Literal["text_editor_20250124"]
-    name: Literal["str_replace_editor"]
-
-
-class BashToolParam(TypedDict):
-    type: Literal["bash_20250124"]
-    name: Literal["bash"]
-
-
 # tools can be either a stock tool param or a special Anthropic native use tool param
-ToolParamDef = ToolParam | ComputerUseToolParam | TextEditorToolParam | BashToolParam
+ToolParamDef = (
+    ToolParam
+    | BetaToolComputerUse20250124Param
+    | ToolTextEditor20250124Param
+    | ToolBash20250124Param
+)
 
 
 def add_cache_control(
     param: TextBlockParam
     | ToolParam
-    | ComputerUseToolParam
-    | TextEditorToolParam
-    | BashToolParam
+    | BetaToolComputerUse20250124Param
+    | ToolTextEditor20250124Param
+    | ToolBash20250124Param
     | dict[str, Any],
 ) -> None:
     cast(dict[str, Any], param)["cache_control"] = {"type": "ephemeral"}
@@ -639,6 +607,7 @@ def consecutive_message_reducer(
 
 
 def combine_messages(a: MessageParam, b: MessageParam) -> MessageParam:
+    # TODO: Fix this code as it currently drops interesting properties when combining
     role = a["role"]
     a_content = a["content"]
     b_content = b["content"]
@@ -805,11 +774,13 @@ async def model_output_from_message(
             content.append(ContentText(type="text", text=content_text))
         elif isinstance(content_block, ToolUseBlock):
             tool_calls = tool_calls or []
+            info = maybe_mapped_call_info(content_block.name, tools)
             tool_calls.append(
                 ToolCall(
-                    type="function",
+                    type=info.native_type,
                     id=content_block.id,
-                    function=maybe_map_from_native_tool(content_block.name, tools),
+                    function=info.inspect_name,
+                    native_name=info.native_name,
                     arguments=content_block.model_dump().get("input", {}),
                 )
             )
@@ -859,20 +830,35 @@ async def model_output_from_message(
     )
 
 
-def maybe_map_from_native_tool(tool_called: str, tools: list[ToolInfo]) -> str:
-    # does this tool have a native tool mapping?
-    inspect_tool = _native_tool_name_mappings.get(tool_called, None)
-    if inspect_tool is not None:
-        # is the inspect tool actually in the list of available tools?
-        # (it might not be in the case where the native tool is 'bash'
-        # and we are actually targeting the original Inspect 'bash' tool
-        # rather than 'bash_session')
-        if any([tool.name == inspect_tool for tool in tools]):
-            return inspect_tool
-        else:
-            return tool_called
-    else:
-        return tool_called
+class CallInfo(NamedTuple):
+    native_name: str | None
+    native_type: str
+    inspect_name: str
+
+
+def maybe_mapped_call_info(tool_called: str, tools: list[ToolInfo]) -> CallInfo:
+    """
+    Return call info - potentially transformed by native tool mappings.
+
+    Anthropic prescribes names for their native tools - `computer`, `bash`, and
+    `str_replace_editor`. For a variety of reasons, Inspect's tool names to not
+    necessarily conform to native names. Anthropic also provides specific tool
+    types for these built-in tools.
+    """
+    mappings = (
+        (NATIVE_COMPUTER_TOOL_NAME, "computer_20250124", "computer"),
+        ("str_replace_editor", "text_editor_20250124", "text_editor"),
+        ("bash", "bash_20250124", "bash_session"),
+    )
+
+    return next(
+        (
+            CallInfo(entry[0], entry[1], entry[2])
+            for entry in mappings
+            if entry[0] == tool_called and any(tool.name == entry[2] for tool in tools)
+        ),
+        CallInfo(None, "function", tool_called),
+    )
 
 
 def message_stop_reason(message: Message) -> StopReason:

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -66,7 +66,7 @@ logger = getLogger(__name__)
 
 ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
 
-NATIVE_COMPUTER_TOOL_NAME = "computer"
+INTERNAL_COMPUTER_TOOL_NAME = "computer"
 
 
 class AnthropicAPI(ModelAPI):
@@ -727,7 +727,7 @@ async def message_param(message: ChatMessage) -> MessageParam:
                 ToolUseBlockParam(
                     type="tool_use",
                     id=tool_call.id,
-                    name=tool_call.function,
+                    name=tool_call.internal_name or tool_call.function,
                     input=tool_call.arguments,
                 )
             )
@@ -777,10 +777,10 @@ async def model_output_from_message(
             info = maybe_mapped_call_info(content_block.name, tools)
             tool_calls.append(
                 ToolCall(
-                    type=info.native_type,
+                    type=info.internal_type,
                     id=content_block.id,
                     function=info.inspect_name,
-                    native_name=info.native_name,
+                    internal_name=info.internal_name,
                     arguments=content_block.model_dump().get("input", {}),
                 )
             )
@@ -831,8 +831,8 @@ async def model_output_from_message(
 
 
 class CallInfo(NamedTuple):
-    native_name: str | None
-    native_type: str
+    internal_name: str | None
+    internal_type: str
     inspect_name: str
 
 
@@ -842,11 +842,11 @@ def maybe_mapped_call_info(tool_called: str, tools: list[ToolInfo]) -> CallInfo:
 
     Anthropic prescribes names for their native tools - `computer`, `bash`, and
     `str_replace_editor`. For a variety of reasons, Inspect's tool names to not
-    necessarily conform to native names. Anthropic also provides specific tool
+    necessarily conform to internal names. Anthropic also provides specific tool
     types for these built-in tools.
     """
     mappings = (
-        (NATIVE_COMPUTER_TOOL_NAME, "computer_20250124", "computer"),
+        (INTERNAL_COMPUTER_TOOL_NAME, "computer_20250124", "computer"),
         ("str_replace_editor", "text_editor_20250124", "text_editor"),
         ("bash", "bash_20250124", "bash_session"),
     )

--- a/src/inspect_ai/tool/_tool_call.py
+++ b/src/inspect_ai/tool/_tool_call.py
@@ -45,10 +45,10 @@ class ToolCall:
     """Arguments to function."""
 
     type: str
-    """Type of tool call ('function' or a model specific built-in tool type)"""
+    """Type of tool call ('function' or a model specific internal tool type)"""
 
-    native_name: str | None = field(default=None)
-    """Model's native name of the tool - if any."""
+    internal_name: str | None = field(default=None)
+    """Model's internal name for the tool - if any."""
 
     parse_error: str | None = field(default=None)
     """Error which occurred parsing tool call."""

--- a/src/inspect_ai/tool/_tool_call.py
+++ b/src/inspect_ai/tool/_tool_call.py
@@ -44,8 +44,11 @@ class ToolCall:
     arguments: dict[str, Any]
     """Arguments to function."""
 
-    type: Literal["function"]
-    """Type of tool call (currently only 'function')"""
+    type: str
+    """Type of tool call ('function' or a model specific built-in tool type)"""
+
+    native_name: str | None = field(default=None)
+    """Model's native name of the tool - if any."""
 
     parse_error: str | None = field(default=None)
     """Error which occurred parsing tool call."""

--- a/tests/tools/test_tool_internal_name.py
+++ b/tests/tools/test_tool_internal_name.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from test_helpers.utils import skip_if_no_anthropic, skip_if_no_docker
+
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
+from inspect_ai.solver import generate, use_tools
+from inspect_ai.tool import bash_session
+
+
+@skip_if_no_docker
+@skip_if_no_anthropic
+def test_anthropic_internal_tool_name():
+    log = eval(
+        Task(
+            dataset=[
+                Sample(
+                    input="Please use the bash tool to list the contents of the current directory. What are its contents?"
+                )
+            ],
+            solver=[use_tools(bash_session()), generate()],
+            sandbox="docker",
+        ),
+        model="anthropic/claude-3-7-sonnet-latest",
+    )[0]
+    assert log.status == "success"
+    assert log.samples
+
+    # tool call was mapped to bash_session and internal_name "bash was tracked"
+    def check_tool_call(tool_call: Any) -> None:
+        assert tool_call.function == "bash_session"
+        assert tool_call.internal_name == "bash"
+
+    # check tool call in assistant message
+    assistant_message = log.samples[0].messages[1]
+    assert assistant_message.tool_calls
+    check_tool_call(assistant_message.tool_calls[0])
+
+    # check that we use the internal name for the raw interaction w/ the model
+    model_event = next(
+        (event for event in log.samples[0].events if event.event == "model")
+    )
+    model_bash_tool = model_event.call.request["tools"][0]
+    assert model_bash_tool["type"] == "bash_20250124"
+    assert model_bash_tool["name"] == "bash"
+    model_tool_call = model_event.call.response["content"][1]
+    assert model_tool_call["name"] == "bash"
+
+    # check that our tool event maps back to bash_session
+    tool_event = next(
+        (event for event in log.samples[0].events if event.event == "tool")
+    )
+    assert tool_event.function == "bash_session"
+    assert tool_event.internal_name == "bash"
+
+    # check tool call in tool message
+    tool_message = log.samples[0].messages[2]
+    check_tool_call(tool_message)

--- a/tools/vscode/src/@types/log.d.ts
+++ b/tools/vscode/src/@types/log.d.ts
@@ -148,7 +148,7 @@ export type Input =
       | ChatMessageAssistant
       | ChatMessageTool
     )[];
-export type Id1 = string;
+export type Id1 = string | null;
 export type Content =
   | string
   | (
@@ -175,7 +175,7 @@ export type Video = string;
 export type Format1 = "mp4" | "mpeg" | "mov";
 export type Source = ("input" | "generate") | null;
 export type Role = "system";
-export type Id2 = string;
+export type Id2 = string | null;
 export type Content1 =
   | string
   | (
@@ -188,7 +188,7 @@ export type Content1 =
 export type Source1 = ("input" | "generate") | null;
 export type Role1 = "user";
 export type ToolCallId = string[] | null;
-export type Id3 = string;
+export type Id3 = string | null;
 export type Content2 =
   | string
   | (
@@ -203,12 +203,13 @@ export type Role2 = "assistant";
 export type ToolCalls = ToolCall[] | null;
 export type Id4 = string;
 export type Function = string;
-export type Type8 = "function";
+export type Type8 = string;
+export type InternalName = string | null;
 export type ParseError = string | null;
 export type Title = string | null;
 export type Format2 = "text" | "markdown";
 export type Content3 = string;
-export type Id5 = string;
+export type Id5 = string | null;
 export type Content4 =
   | string
   | (
@@ -222,6 +223,7 @@ export type Source3 = ("input" | "generate") | null;
 export type Role3 = "tool";
 export type ToolCallId1 = string | null;
 export type Function1 = string | null;
+export type InternalName1 = string | null;
 export type Type9 =
   | "parsing"
   | "timeout"
@@ -369,6 +371,7 @@ export type Event6 = "tool";
 export type Type12 = "function";
 export type Id7 = string;
 export type Function2 = string;
+export type InternalName2 = string | null;
 export type Result1 =
   | string
   | number
@@ -911,6 +914,7 @@ export interface ToolCall {
   function: Function;
   arguments: Arguments;
   type: Type8;
+  internal_name: InternalName;
   parse_error: ParseError;
   view: ToolCallContent | null;
 }
@@ -933,6 +937,7 @@ export interface ChatMessageTool {
   role: Role3;
   tool_call_id: ToolCallId1;
   function: Function1;
+  internal_name: InternalName1;
   error: ToolCallError | null;
 }
 export interface ToolCallError {
@@ -1201,6 +1206,7 @@ export interface ToolEvent {
   id: Id7;
   function: Function2;
   arguments: Arguments1;
+  internal_name: InternalName2;
   view: ToolCallContent | null;
   result: Result1;
   truncated: Truncated;


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
As mentioned by @jeremyschlatter in #1507 [here](https://github.com/UKGovernmentBEIS/inspect_ai/issues/1507#issuecomment-2735383777) our built-in tool name rewriting code left misleading information in the chat history sent back to the model. 

### What is the new behavior?

We now translate back to the model/native tool name when writing `ChatMessageTool`'s into the history.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
