### PR TITLE
AzureAI: Support for use of native OpenAI and Mistral clients using service qualifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - OpenAI: Support for the new [Responses API](https://inspect.ai-safety-institute.org.uk/providers.html#responses-api) and [o1-pro](https://platform.openai.com/docs/models/o1-pro) models.
+- AzureAI: Support for use of native [OpenAI](https://inspect.ai-safety-institute.org.uk/providers.html#openai-on-azure) and [Mistral](https://inspect.ai-safety-institute.org.uk/providers.html#mistral-on-azure-ai) clients using service qualifiers (e.g. `openai/azure/gpt-4o-mini` or `mistral/azure/Mistral-Large-2411`). 
 - Added `--metadata` option to eval for associating metadata with eval runs.
 - Task display: Show reasoning tokens for models that report them.
 - Anthropic: Include reasoning tokens in computation of total tokens

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -51,15 +51,30 @@ inspect eval math.py --model openai/gpt-4o -M responses_api=true
 
 ### OpenAI on Azure {#openai-on-azure}
 
-To use OpenAI models on Azure AI, specify an `AZUREAI_OPENAI_API_KEY` along with an `AZUREAI_OPENAI_BASE_URL`. You can then use the normal `openai` provider with the `azure` qualifier, specifying a model name that corresponds to the [Azure Deployment Name](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal#deploy-a-model) of your model. For example, if your deployed model name was `gpt4-1106-preview-ythre:`
+::: {.callout-note appearance="simple"}
+Note that the OpenAI on Azure feature described below currently works only in the development version of Inspect. To install the development version from GitHub:
 
 ``` bash
-export AZUREAI_OPENAI_API_KEY=key
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+To use OpenAI models on Azure AI, specify the following environment variables:
+
+- `AZUREAI_OPENAI_API_KEY`
+- `AZUREAI_OPENAI_BASE_URL` 
+- `AZUREAI_OPENAI_API_VERSION`. 
+
+You can then use the normal `openai` provider with the `azure` qualifier and the name of your model deployment (in this case `gpt-4o-mini`). For example:
+
+``` bash
+export AZUREAI_OPENAI_API_KEY=your-api-key
 export AZUREAI_OPENAI_BASE_URL=https://your-url-at.azure.com
-inspect eval --model openai/azure/gpt4-1106-preview-ythre
+export AZUREAI_OPENAI_API_VERSION=2025-02-01-preview
+inspect eval math.py --model openai/azure/gpt-4o-mini
 ```
 
-In addition to these variables, you can also set the `OPENAI_API_VERSION` environment variable to specify a specific version of the OpenAI interface on Azure.
+Note that if the `AZUREAI_OPENAI_API_VERSION` is not specified, Inspect will generally default to the latest deployed version, which as of this writing is `2025-02-01-preview`.
 
 ## Anthropic {#anthropic}
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -59,7 +59,7 @@ pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
 ```
 :::
 
-To use OpenAI models on Azure AI, specify the following environment variables:
+The `openai` provider supports OpenAI models deployed on the [Azure AI Foundary](https://ai.azure.com/). To use OpenAI models on Azure AI, specify the following environment variables:
 
 - `AZUREAI_OPENAI_API_KEY`
 - `AZUREAI_OPENAI_BASE_URL` 
@@ -287,13 +287,15 @@ If you are using Anthropic models on Bedrock, you can alternatively use the [Ant
 
 ## Azure AI {#azure-ai}
 
-To use the [Azure AI](https://azure.microsoft.com/en-us/solutions/ai) provider, install the `azure-ai-inference` package, set your credentials and base URL, and specify an [Azure Deployment Name](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal#deploy-a-model) as the model name:
+The `azureai` provider supports models deployed on the [Azure AI Foundary](https://ai.azure.com/).
+
+To use the `azureai` provider, install the `azure-ai-inference` package, set your credentials and base URL, and specify the name of the model you have deployed (e.g. `Llama-3.3-70B-Instruct`). For example:
 
 ``` bash
 pip install azure-ai-inference
 export AZUREAI_API_KEY=api-key
-export AZUREAI_BASE_URL=https://your-url-at.azure.com
-$ inspect eval --model azureai/llama-2-70b-chat-wnsnw
+export AZUREAI_BASE_URL=https://your-url-at.azure.com/models
+$ inspect eval math.py --model azureai/Llama-3.3-70B-Instruct
 ```
 
 For the `azureai` provider, custom model args (`-M`) are forwarded to the constructor of the `ChatCompletionsClient` class.
@@ -306,6 +308,7 @@ The following environment variables are supported by the Azure AI provider
 | `AZUREAI_BASE_URL` | Base URL for requests (required) |
 
 If you are using Open AI or Mistral on Azure AI, you can alternatively use the [OpenAI provider](#openai-on-azure) or [Mistral provider](#mistral-on-azure-ai) as your means of access.
+
 
 ### Tool Emulation
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -52,7 +52,7 @@ inspect eval math.py --model openai/gpt-4o -M responses_api=true
 ### OpenAI on Azure {#openai-on-azure}
 
 ::: {.callout-note appearance="simple"}
-Note that the OpenAI on Azure feature described below currently works only in the development version of Inspect. To install the development version from GitHub:
+Note that the OpenAI on Azure AI feature described below currently works only in the development version of Inspect. To install the development version from GitHub:
 
 ``` bash
 pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
@@ -65,7 +65,7 @@ The `openai` provider supports OpenAI models deployed on the [Azure AI Foundary]
 - `AZUREAI_OPENAI_BASE_URL` 
 - `AZUREAI_OPENAI_API_VERSION`. 
 
-You can then use the normal `openai` provider with the `azure` qualifier and the name of your model deployment (in this case `gpt-4o-mini`). For example:
+You can then use the normal `openai` provider with the `azure` qualifier and the name of your model deployment (e.g. `gpt-4o-mini`). For example:
 
 ``` bash
 export AZUREAI_OPENAI_API_KEY=your-api-key
@@ -229,12 +229,25 @@ The following environment variables are supported by the Mistral provider
 
 ### Mistral on Azure AI {#mistral-on-azure-ai}
 
-To use Mistral models on Azure AI, specify an `AZURE_MISTRAL_API_KEY` along with an `AZUREAI_MISTRAL_BASE_URL`. You can then use the normal `mistral` provider, but you'll need to specify a model name that corresponds to the [Azure Deployment Name](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/create-resource?pivots=web-portal#deploy-a-model) of your model. For example, if your deployment model name was `mistral-large-ctwi:`
+::: {.callout-note appearance="simple"}
+Note that the Mistral on Azure AI feature described below currently works only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+The `mistral` provider supports Mistral models deployed on the [Azure AI Foundary](https://ai.azure.com/). To use Mistral models on Azure AI, specify the following environment variables:
+
+- `AZURE_MISTRAL_API_KEY`
+- `AZUREAI_MISTRAL_BASE_URL`
+
+You can then use the normal `mistral` provider with the `azure` qualifier and the name of your model deployment (e.g. `Mistral-Large-2411`). For example:
 
 ``` bash
 export AZUREAI_MISTRAL_API_KEY=key
-export AZUREAI_MISTRAL_BASE_URL=https://your-url-at.azure.com
-inspect eval --model mistral/mistral-large-ctwi
+export AZUREAI_MISTRAL_BASE_URL=https://your-url-at.azure.com/models
+inspect eval math.py --model mistral/azure/Mistral-Large-2411
 ```
 
 ## DeepSeek {#deepseek}
@@ -308,7 +321,6 @@ The following environment variables are supported by the Azure AI provider
 | `AZUREAI_BASE_URL` | Base URL for requests (required) |
 
 If you are using Open AI or Mistral on Azure AI, you can alternatively use the [OpenAI provider](#openai-on-azure) or [Mistral provider](#mistral-on-azure-ai) as your means of access.
-
 
 ### Tool Emulation
 


### PR DESCRIPTION
e.g. `openai/azure/gpt-4o-mini` or `mistral/azure/Mistral-Large-2411`

Also improve documentation to provide examples that match expected semantics and clarify that the deployment target is Azure AI Foundary.


