### PR TITLE
Update competition math dataset

### DIFF
--- a/docs/tutorial.qmd
+++ b/docs/tutorial.qmd
@@ -350,8 +350,8 @@ Here is the basic setup for our eval. We `shuffle` the dataset so that when we u
 def math(shuffle=True):
     return Task(
         dataset=hf_dataset(
-            "hendrycks/competition_math",
-            split="test",
+            "qwedsacf/competition_math",
+            split="train",
             sample_fields=FieldSpec(
                 input="problem", 
                 target="solution"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
#1183 , #1283 , #1526 

### What is the new behavior?
The eval runs on the updated dataset

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
Ran this on 50/12500 tests. Here is a snapshot from `inspect eval maths.py`
<img width="1567" alt="Screenshot 2025-03-23 at 2 17 19 PM" src="https://github.com/user-attachments/assets/017a3ec3-0fe9-4ee5-b5a0-52f4bf0df707" />

