### PR TITLE
`think()` tool that provides models with the ability to include an additional thinking step

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- New [think()](https://inspect.aisi.org.uk/tools-standard.html#sec-think) tool that provides models with the ability to include an additional thinking step.
 - OpenAI: Support for the new [Responses API](https://inspect.ai-safety-institute.org.uk/providers.html#responses-api) and [o1-pro](https://platform.openai.com/docs/models/o1-pro) models.
 - OpenAI: Remove base64-encoded audio content from API call JSON in ModelEvent.
 - AzureAI: Support for use of native [OpenAI](https://inspect.ai-safety-institute.org.uk/providers.html#openai-on-azure) and [Mistral](https://inspect.ai-safety-institute.org.uk/providers.html#mistral-on-azure-ai) clients using service qualifiers (e.g. `openai/azure/gpt-4o-mini` or `mistral/azure/Mistral-Large-2411`). 

--- a/docs/_tools-standard.md
+++ b/docs/_tools-standard.md
@@ -11,3 +11,5 @@ Inspect has several standard tools built-in, including:
 -   [Computer](tools-standard.qmd#sec-computer), which provides the model with a desktop computer (viewed through screenshots) that supports mouse and keyboard interaction.
 
 -   [Web Search](tools-standard.qmd#sec-web-search), which uses the Google Search API to execute and summarise web searches.
+
+-   [Think](tools-standard.qmd#sec-think), which provides models the ability to include an additional thinking step as part of getting to its final answer.

--- a/docs/reference/_sidebar.yml
+++ b/docs/reference/_sidebar.yml
@@ -89,6 +89,8 @@ website:
           href: reference/inspect_ai.tool.qmd#computer
         - text: web_search
           href: reference/inspect_ai.tool.qmd#web_search
+        - text: think
+          href: reference/inspect_ai.tool.qmd#think
         - text: tool_with
           href: reference/inspect_ai.tool.qmd#tool_with
         - text: ToolDef

--- a/docs/reference/inspect_ai.tool.qmd
+++ b/docs/reference/inspect_ai.tool.qmd
@@ -11,6 +11,7 @@ title: "inspect_ai.tool"
 ### web_browser
 ### computer
 ### web_search
+### think
 
 ## Dynamic 
 

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -457,7 +457,7 @@ def intercode_ctf():
 
 ### Tool Description
 
-In the original [think tool article]((https://www.anthropic.com/engineering/claude-think-tool)) (which was based on experienting with Claude) they found that providing clear instructions on when and how to use the `think()` tool for the particular problem domain it is being used within could sometimes be helpful. For example, here's the prompt they used with SWE-Bench:
+In the original [think tool article]((https://www.anthropic.com/engineering/claude-think-tool)) (which was based on experimenting with Claude) they found that providing clear instructions on when and how to use the `think()` tool for the particular problem domain it is being used within could sometimes be helpful. For example, here's the prompt they used with SWE-Bench:
 
 ```python
 from textwrap import dedent

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -405,3 +405,144 @@ The `web_search()` tool uses [Google Programmable Search Engine](https://program
 -   `GOOGLE_CSE_ID` — Google Custom Search Engine ID
 
 -   `GOOGLE_CSE_API_KEY` — Google API key used to enable the Search API
+
+
+## Think {#sec-think}
+
+::: {.callout-note appearance="simple"}
+Note that the `think()` tool described below currently works only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+The `think()` tool provides models with the ability to include an additional thinking step as part of getting to its final answer. 
+ 
+Note that the `think()` tool is not a substitute for reasoning and extended thinking, but rather an an alternate way of letting models express thinking that is better suited to some tool use scenarios. 
+
+### Usage
+
+You should read the original [think tool article](https://www.anthropic.com/engineering/claude-think-tool) in its entirely to understand where and where not to use the think tool. In summary, good contexts for the think tool include:
+
+1. Tool output analysis. When models need to carefully process the output of previous tool calls before acting and might need to backtrack in its approach;
+2. Policy-heavy environments. When models need to follow detailed guidelines and verify compliance; and
+3. Sequential decision making. When each action builds on previous ones and mistakes are costly (often found in multi-step domains).
+
+Use the `think()` tool alongside other tools like this:
+
+``` python
+from inspect_ai import Task, task
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, system_message, use_tools
+from inspect_ai.tool import bash_session, text_editor, think
+
+@task
+def intercode_ctf():
+    return Task(
+        dataset=read_dataset(),
+        solver=[
+            system_message("system.txt"),
+            use_tools([
+                bash_session(timeout=180),
+                text_editor(timeout=180),
+                think()
+            ]),
+            generate(),
+        ],
+        scorer=includes(),
+        sandbox=("docker", "compose.yaml")
+    )
+```
+
+### Tool Description
+
+In the original [think tool article]((https://www.anthropic.com/engineering/claude-think-tool)) (which was based on experienting with Claude) they found that providing clear instructions on when and how to use the `think()` tool for the particular problem domain it is being used within could sometimes be helpful. For example, here's the prompt they used with SWE-Bench:
+
+```python
+from textwrap import dedent
+
+from inspect_ai import Task, task
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, system_message, use_tools
+from inspect_ai.tool import bash_session, text_editor, think
+
+@task
+def swe_bench():
+
+    tools = [
+        bash_session(timeout=180),
+        text_editor(timeout=180),  
+        think(dedent("""
+            Use the think tool to think about something. It will not obtain
+            new information or make any changes to the repository, but just 
+            log the thought. Use it when complex reasoning or brainstorming
+            is needed. For example, if you explore the repo and discover
+            the source of a bug, call this tool to brainstorm several unique
+            ways of fixing the bug, and assess which change(s) are likely to 
+            be simplest and most effective. Alternatively, if you receive
+            some test results, call this tool to brainstorm ways to fix the
+            failing tests.
+        """))
+    ])
+
+    return Task(
+        dataset=read_dataset(),
+        solver=[
+            system_message("system.txt"),
+            use_tools(tools),
+            generate(),
+        ),
+        scorer=includes(),
+        sandbox=("docker", "compose.yaml")
+    )
+```
+
+### System Prompt
+
+In the article they also found that when tool instructions are long and/or complex, including instructions about the `think()` tool in the system prompt can be more effective than placing them in the tool description itself. 
+
+Here's an example of moving the custom `think()` prompt into the system prompt (note that this was *not* done in the article's SWE-Bench experiment, this is merely an example):
+
+```python
+from textwrap import dedent
+
+from inspect_ai import Task, task
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, system_message, use_tools
+from inspect_ai.tool import bash_session, text_editor, think
+
+@task
+def swe_bench():
+
+    think_system_message = system_message(dedent("""
+        Use the think tool to think about something. It will not obtain
+        new information or make any changes to the repository, but just 
+        log the thought. Use it when complex reasoning or brainstorming
+        is needed. For example, if you explore the repo and discover
+        the source of a bug, call this tool to brainstorm several unique
+        ways of fixing the bug, and assess which change(s) are likely to 
+        be simplest and most effective. Alternatively, if you receive
+        some test results, call this tool to brainstorm ways to fix the
+        failing tests.
+    """))
+
+    return Task(
+        dataset=read_dataset(),
+        solver=[
+            system_message("system.txt"),
+            think_system_message,
+            use_tools([
+                bash_session(timeout=180),
+                text_editor(timeout=180),  
+                think(),
+            ]),
+            generate(),
+        ],
+        scorer=includes(),
+        sandbox=("docker", "compose.yaml")
+    )
+```
+
+Note that the effectivess of using the system prompt will vary considerably across tasks, tools, and models, so should definitely be the subject of experimentation.
+

--- a/src/inspect_ai/tool/__init__.py
+++ b/src/inspect_ai/tool/__init__.py
@@ -26,6 +26,7 @@ from ._tools._bash_session import bash_session
 from ._tools._computer import computer
 from ._tools._execute import bash, python
 from ._tools._text_editor import text_editor
+from ._tools._think import think
 from ._tools._web_browser import web_browser
 from ._tools._web_search import web_search
 
@@ -36,6 +37,7 @@ __all__ = [
     "python",
     "web_browser",
     "web_search",
+    "think",
     "text_editor",
     "tool",
     "tool_with",

--- a/src/inspect_ai/tool/_tool.py
+++ b/src/inspect_ai/tool/_tool.py
@@ -20,6 +20,7 @@ from inspect_ai._util.content import (
 )
 from inspect_ai._util.registry import (
     RegistryInfo,
+    is_registry_object,
     registry_add,
     registry_name,
     registry_tag,
@@ -200,7 +201,25 @@ def tool(
         # wrap instantiations of scorer so they carry registry info and metrics
         @wraps(tool_type)
         def tool_wrapper(*args: P.args, **kwargs: P.kwargs) -> Tool:
+            # create the tool
             tool = tool_type(*args, **kwargs)
+
+            # this might already have registry info, in that case
+            # capture it and use it as defaults
+            from inspect_ai.tool._tool_def import tool_registry_info
+
+            tool_parallel = parallel
+            tool_viewer = viewer
+            tool_model_input = model_input
+            if is_registry_object(tool):
+                _, _, reg_parallel, reg_viewer, reg_model_input = tool_registry_info(
+                    tool
+                )
+                tool_parallel = parallel and reg_parallel
+                tool_viewer = viewer or reg_viewer
+                tool_model_input = model_input or reg_model_input
+
+            # tag the object
             registry_tag(
                 tool_type,
                 tool,
@@ -209,10 +228,11 @@ def tool(
                     name=tool_name,
                     metadata={
                         TOOL_PROMPT: prompt,
-                        TOOL_PARALLEL: parallel,
-                        TOOL_VIEWER: viewer,
+                        TOOL_PARALLEL: tool_parallel,
+                        TOOL_VIEWER: tool_viewer,
                         TOOL_MODEL_INPUT: (
-                            model_input or getattr(tool, TOOL_INIT_MODEL_INPUT, None)
+                            tool_model_input
+                            or getattr(tool, TOOL_INIT_MODEL_INPUT, None)
                         ),
                     },
                 ),

--- a/src/inspect_ai/tool/_tools/_think.py
+++ b/src/inspect_ai/tool/_tools/_think.py
@@ -1,7 +1,6 @@
-from inspect_ai.tool._tool_with import tool_with
-
 from .._tool import Tool, tool
 from .._tool_call import ToolCall, ToolCallContent, ToolCallView, ToolCallViewer
+from .._tool_def import ToolDef
 
 
 @tool
@@ -38,13 +37,13 @@ def think(
         """
         return ""
 
-    return tool_with(
+    return ToolDef(
         execute,
         name="think",
         description=description,
         parameters=(dict(thought=thought_description) if thought_description else None),
         viewer=think_tool_viewer(),
-    )
+    ).as_tool()
 
 
 def think_tool_viewer() -> ToolCallViewer:

--- a/src/inspect_ai/tool/_tools/_think.py
+++ b/src/inspect_ai/tool/_tools/_think.py
@@ -1,0 +1,57 @@
+from inspect_ai.tool._tool_with import tool_with
+
+from .._tool import Tool, tool
+from .._tool_call import ToolCall, ToolCallContent, ToolCallView, ToolCallViewer
+
+
+@tool
+def think(
+    description: str | None = None,
+    thought_description: str | None = None,
+) -> Tool:
+    """Think tool for extra thinking.
+
+    ::: {.callout-note appearance="simple"}
+    Note that the `think()` tool described below currently works only in the development version of Inspect. To install the development version from GitHub:
+
+    ``` bash
+    pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+    ```
+    :::
+
+    Tool that provides models with the ability to include an additional thinking step as part of getting to its final answer.
+
+    Note that the `think()` tool is not a substitute for reasoning and extended thinking, but rather an an alternate way of letting models express thinking that is better suited to some tool use scenarios. Please see the documentation on using the [think tool](https://inspect.aisi.org.uk/tools-standard.html#sec-think) before using it in your evaluations.
+
+    Args:
+        description: Override the default description of the think tool.
+        thought_description: Override the default description of the thought parameter.
+    """
+
+    async def execute(thought: str) -> str:
+        """Use the tool to think about something.
+
+        The will not obtain new information or change the environment, but just append the thought to the log. Use it when complex reasoning or some cache memory is needed."
+
+        Args:
+            thought: A thought to think about.
+        """
+        return ""
+
+    return tool_with(
+        execute,
+        name="think",
+        description=description,
+        parameters=(dict(thought=thought_description) if thought_description else None),
+        viewer=think_tool_viewer(),
+    )
+
+
+def think_tool_viewer() -> ToolCallViewer:
+    def viewer(tool_call: ToolCall) -> ToolCallView:
+        call = ToolCallContent(
+            format="markdown", content=tool_call.arguments["thought"]
+        )
+        return ToolCallView(call=call)
+
+    return viewer

--- a/tests/tools/test_think_tool.py
+++ b/tests/tools/test_think_tool.py
@@ -8,7 +8,7 @@ from inspect_ai.solver import generate, use_tools
 from inspect_ai.tool import think
 
 
-def check_think_tool(description: str | None):
+def check_think_tool(description: str | None = None):
     task = Task(
         dataset=[
             Sample(

--- a/tests/tools/test_think_tool.py
+++ b/tests/tools/test_think_tool.py
@@ -1,0 +1,45 @@
+from test_helpers.tool_call_utils import get_tool_event
+from test_helpers.utils import skip_if_no_anthropic, skip_if_no_docker
+
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
+from inspect_ai.log._transcript import ModelEvent
+from inspect_ai.solver import generate, use_tools
+from inspect_ai.tool import think
+
+
+def check_think_tool(description: str | None):
+    task = Task(
+        dataset=[
+            Sample(
+                input="Please use the think tool to think about something. Whne you are done with that, please repeat exactly what you thought about as your final answer."
+            )
+        ],
+        solver=[use_tools(think(description=description)), generate()],
+    )
+    log = eval(task, model="anthropic/claude-3-5-haiku-latest")[0]
+    assert log.status == "success"
+    tool_event = get_tool_event(log)
+    assert tool_event
+    assert tool_event.function == "think"
+    assert isinstance(tool_event.arguments["thought"], str)
+    return log
+
+
+@skip_if_no_anthropic
+@skip_if_no_docker
+def test_think_tool():
+    check_think_tool()
+
+
+@skip_if_no_anthropic
+@skip_if_no_docker
+def test_think_tool_description():
+    description = "This is a tool you can use for thinking."
+    log = check_think_tool(description)
+    assert log.samples
+    model_event = next(
+        (event for event in log.samples[0].events if isinstance(event, ModelEvent)),
+        None,
+    )
+    assert model_event.call.request["tools"][0]["description"] == description


### PR DESCRIPTION
Based on <https://www.anthropic.com/engineering/claude-think-tool>

The `think()` tool provides models with the ability to include an additional thinking step as part of getting to its final answer. 
 
Note that the `think()` tool is not a substitute for reasoning and extended thinking, but rather an an alternate way of letting models express thinking that is better suited to some tool use scenarios. 

### Usage

You should read the original [think tool article](https://www.anthropic.com/engineering/claude-think-tool) in its entirely to understand where and where not to use the think tool. In summary, good contexts for the think tool include:

1. Tool output analysis. When models need to carefully process the output of previous tool calls before acting and might need to backtrack in its approach;
2. Policy-heavy environments. When models need to follow detailed guidelines and verify compliance; and
3. Sequential decision making. When each action builds on previous ones and mistakes are costly (often found in multi-step domains).

Use the `think()` tool alongside other tools like this:

``` python
from inspect_ai import Task, task
from inspect_ai.scorer import includes
from inspect_ai.solver import generate, system_message, use_tools
from inspect_ai.tool import bash_session, text_editor, think

@task
def intercode_ctf():
    return Task(
        dataset=read_dataset(),
        solver=[
            system_message("system.txt"),
            use_tools([
                bash_session(timeout=180),
                text_editor(timeout=180),
                think()
            ]),
            generate(),
        ],
        scorer=includes(),
        sandbox=("docker", "compose.yaml")
    )
```

### Tool Description

In the original [think tool article]((https://www.anthropic.com/engineering/claude-think-tool)) (which was based on experimenting with Claude) they found that providing clear instructions on when and how to use the `think()` tool for the particular problem domain it is being used within could sometimes be helpful. For example, here's the prompt they used with SWE-Bench:

```python
from textwrap import dedent

from inspect_ai import Task, task
from inspect_ai.scorer import includes
from inspect_ai.solver import generate, system_message, use_tools
from inspect_ai.tool import bash_session, text_editor, think

@task
def swe_bench():

    tools = [
        bash_session(timeout=180),
        text_editor(timeout=180),  
        think(dedent("""
            Use the think tool to think about something. It will not obtain
            new information or make any changes to the repository, but just 
            log the thought. Use it when complex reasoning or brainstorming
            is needed. For example, if you explore the repo and discover
            the source of a bug, call this tool to brainstorm several unique
            ways of fixing the bug, and assess which change(s) are likely to 
            be simplest and most effective. Alternatively, if you receive
            some test results, call this tool to brainstorm ways to fix the
            failing tests.
        """))
    ])

    return Task(
        dataset=read_dataset(),
        solver=[
            system_message("system.txt"),
            use_tools(tools),
            generate(),
        ),
        scorer=includes(),
        sandbox=("docker", "compose.yaml")
    )
```

### System Prompt

In the article they also found that when tool instructions are long and/or complex, including instructions about the `think()` tool in the system prompt can be more effective than placing them in the tool description itself. 

Here's an example of moving the custom `think()` prompt into the system prompt (note that this was *not* done in the article's SWE-Bench experiment, this is merely an example):

```python
from textwrap import dedent

from inspect_ai import Task, task
from inspect_ai.scorer import includes
from inspect_ai.solver import generate, system_message, use_tools
from inspect_ai.tool import bash_session, text_editor, think

@task
def swe_bench():

    think_system_message = system_message(dedent("""
        Use the think tool to think about something. It will not obtain
        new information or make any changes to the repository, but just 
        log the thought. Use it when complex reasoning or brainstorming
        is needed. For example, if you explore the repo and discover
        the source of a bug, call this tool to brainstorm several unique
        ways of fixing the bug, and assess which change(s) are likely to 
        be simplest and most effective. Alternatively, if you receive
        some test results, call this tool to brainstorm ways to fix the
        failing tests.
    """))

    return Task(
        dataset=read_dataset(),
        solver=[
            system_message("system.txt"),
            think_system_message,
            use_tools([
                bash_session(timeout=180),
                text_editor(timeout=180),  
                think(),
            ]),
            generate(),
        ],
        scorer=includes(),
        sandbox=("docker", "compose.yaml")
    )
```

Note that the effectivess of using the system prompt will vary considerably across tasks, tools, and models, so should definitely be the subject of experimentation.

