### PR TITLE
Ensure OpenAI Responses API assistant message IDs start with msg_ 

### DIFF
--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -74,7 +74,7 @@ async def openai_responses_input(
         reasoning_content = openai_responses_reasponing_content_params(message.content)
         if message.content:
             formatted_id = str(message.id).replace("resp_", "msg_", 1)
-            if not formatted_id.startswith("resp_"):
+            if not formatted_id.startswith("msg_"):
                 # These messages MUST start with `msg_`.
                 # As `store=False` for this provider, OpenAI doesn't validate the IDs.
                 # This will keep them consistent across calls though.

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -73,11 +73,17 @@ async def openai_responses_input(
     elif message.role == "assistant":
         reasoning_content = openai_responses_reasponing_content_params(message.content)
         if message.content:
+            formatted_id = str(message.id).replace("resp_", "msg_", 1)
+            if not formatted_id.startswith("resp_"):
+                # These messages MUST start with `msg_`.
+                # As `store=False` for this provider, OpenAI doesn't validate the IDs.
+                # This will keep them consistent across calls though.
+                formatted_id = f"msg_{formatted_id}"
             text_content = [
                 ResponseOutputMessageParam(
                     type="message",
                     role="assistant",
-                    id=str(message.id).replace("resp_", "msg_", 1),
+                    id=formatted_id,
                     content=openai_responses_text_content_params(message.content),
                     status="completed",
                 )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

In the case of invalid prompt errors, Inspect will handle them using openai_handle_bad_request in the generic provider. Invalid Prompt responses are coded with the `invalid_prompt` code, which causes the OpenAI provider to return a `ModelOutput` without an ID but with content present.

In this case, because we are deserialising from the response, Inspect will generate a message UUID for that message. However, when we go to pass this back to the Responses API, it is lacking the `msg_` prefix and therefore causes an API error.

Normally, the old API doesn't seem to be sensitive to ID formatting, though the new Responses API does seem to be pretty sensitive. Note that even though we are randomly generating these IDs, OpenAI doesn't seem to care, likely because we are using the `store=False` flag for the Responses API, which doesn't store the history (and consequently there wouldn't be IDs to check actually exist.)

### What is the new behavior?

Whenever an ID of a `ChatMessageAssistant` doesn't start with `msg_` we will append the `msg_` prefix.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

I don't believe this will break anything due to the usage of `store=False`. However, if we ever set `store=True`, this may introduce unexpected behavior.

### Other information:

I tested using a custom test case where I had a sample with input consisting of a list of `ChatMessage`s, and I didn't provide an ID for a `ChatMessageAssistant`. Before this change the API calls fail, and after the change they succeed.