### PR TITLE
Properly record the score spec

### DIFF
--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -115,16 +115,6 @@ async def eval_run(
         eval_solver = None
         eval_solver_spec = None
 
-    # resolve the task scorers
-    eval_scorer_specs = (
-        [as_scorer_spec(scorer) for scorer in task.scorer]
-        if task.scorer is not None
-        else None
-    )
-
-    # resolve task metrics
-    eval_metrics = to_metric_specs(task.metrics) if task.metrics is not None else None
-
     try:
         # create run tasks
         task_run_options: list[TaskRunOptions] = []
@@ -136,6 +126,18 @@ async def eval_run(
                 # value specified from eval() or the CLI)
                 task = resolved_task.task
                 task_eval_config = eval_config.model_copy()
+
+                # resolve the task scorers
+                eval_scorer_specs = (
+                    [as_scorer_spec(scorer) for scorer in task.scorer]
+                    if task.scorer is not None
+                    else None
+                )
+
+                # resolve task metrics
+                eval_metrics = (
+                    to_metric_specs(task.metrics) if task.metrics is not None else None
+                )
 
                 # epochs
                 if task_eval_config.epochs is None:


### PR DESCRIPTION
In the event of multiple tasks, the previous version was recording the scorer/metric specs for the first task only (and using it as the spec for all subsequent tasks). This corrects this to use the correct spec for each task.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
