### PR TITLE
Make remoteZipFile handle Content-Length not being present in HEAD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Inspect View: Live updates to running evaluation logs.
+- Inspect View: Fallback to content range request if inital HEAD request fails.
 
 ## v0.3.79 (26 March 2025)
 

--- a/src/inspect_ai/_view/www/src/logfile/remoteZipFile.ts
+++ b/src/inspect_ai/_view/www/src/logfile/remoteZipFile.ts
@@ -180,9 +180,24 @@ export const openRemoteZipFile = async (
 };
 
 export const fetchSize = async (url: string): Promise<number> => {
-  const response = await fetch(`${url}`, { method: "HEAD" });
-  const contentLength = Number(response.headers.get("Content-Length"));
-  return contentLength;
+  // First try HEAD request to get Content-Length
+  const headResponse = await fetch(`${url}`, { method: "HEAD" });
+  const contentLength = headResponse.headers.get("Content-Length");
+
+  if (contentLength !== null) {
+    return Number(contentLength);
+  }
+
+  // If Content-Length is not present, use a GET with an 1 byte range request:
+  const getResponse = await fetch(`${url}`, { method: "GET", headers: { Range: "bytes=0-0" } });
+  const contentRange = getResponse.headers.get('Content-Range');
+  if (contentRange !== null) {
+    const rangeMatch = contentRange.match(/bytes (\d+)-(\d+)\/(\d+)/);
+    if (rangeMatch !== null) {
+      return Number(rangeMatch[3]);
+    }
+  }
+  throw new Error("Could not determine content length");
 };
 
 /**


### PR DESCRIPTION
When log data is being proxied by Cloudflare the HEAD request to fetch the content size will not contain the `Content-Length` field (this is valid HTTP, so other servers might behave the same way).

This falls back to performing a 1 byte Range request instead and uses the `Content-Range` response header to get the content length. This is still not guaranteed to return the full content size, but it is more likely to do so than the HEAD request.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When opening log files proxied by Cloudflare you get an ugly error `Error: Failed to read or parse file _journal/start.json: File not found: _journal/start.json`

### What is the new behavior?

Opening log files work.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.
