### PR TITLE
Omit empty reasoning

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -27110,6 +27110,9 @@ self.onmessage = function (e) {
       reasoning: {
         render: (key2, content2, isLast) => {
           const r2 = content2;
+          if (!r2.reasoning && !r2.redacted) {
+            return void 0;
+          }
           return /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Fragment, { children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "div",

--- a/src/inspect_ai/_view/www/src/samples/chat/MessageContent.tsx
+++ b/src/inspect_ai/_view/www/src/samples/chat/MessageContent.tsx
@@ -104,6 +104,9 @@ const messageRenderers: Record<string, MessageRenderer> = {
   reasoning: {
     render: (key, content, isLast) => {
       const r = content as ContentReasoning;
+      if (!r.reasoning && !r.redacted) {
+        return undefined;
+      }
       return (
         <Fragment key={key}>
           <div


### PR DESCRIPTION
This will prevent a 'Reasoning' header from appearing in the message view when the reasoning is empty.


## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
