### PR TITLE
Better deal with non-range request servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Inspect View: Live updates to running evaluation logs.
 - Inspect View: Fallback to content range request if inital HEAD request fails.
+- Inspect View: Improve error message when view bundles are server from incompatible servers.
 
 ## v0.3.79 (26 March 2025)
 

--- a/docs/log-viewer.qmd
+++ b/docs/log-viewer.qmd
@@ -240,3 +240,5 @@ Deploy this folder to a static webserver to publish the log viewer.
     ```
 
 -   The bundled output directory includes a `robots.txt` file to prevent indexing by web crawlers. If you deploy this folder outside of the root of your website then you would need to update your root `robots.txt` accordingly to exclude the folder from indexing (this is required because web crawlers only read `robots.txt` from the root of the website not subdirectories).
+
+-   The Inspect log viewer uses HTTP range requests to efficiently read the log files being served in the bundle. Please be sure to use a server which supports HTTP range requests to server the statically bundled files. Most HTTP servers do support this, but notably, Python's built in `http.server` does not. 

--- a/src/inspect_ai/_view/www/src/logfile/remoteZipFile.ts
+++ b/src/inspect_ai/_view/www/src/logfile/remoteZipFile.ts
@@ -67,7 +67,15 @@ export const openRemoteZipFile = async (
 
   // Check signature to make sure we found the EOCD record
   if (eocdrView.getUint32(0, true) !== 0x06054b50) {
-    throw new Error("End of central directory record not found");
+    if (eocdrBuffer.length !== 22) {
+      // The range request seems like it was ignored because more bytes than
+      // were requested were returned.
+      throw new Error(
+        "Unexpected central directory size - does the HTTP server serving this file support HTTP range requests?",
+      );
+    } else {
+      throw new Error("End of central directory record not found");
+    }
   }
 
   let centralDirOffset = eocdrView.getUint32(16, true);


### PR DESCRIPTION
Improve the documentation and error message when the statically bundled viewer is served from a server which is ignoring the HTTP range requests that we are making.

Addresses #1557

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
