### PR TITLE
Retry on 429 response from google provider

### DIFF
--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -275,6 +275,9 @@ class GoogleGenAIAPI(ModelAPI):
         ):
             return is_retryable_http_status(int(ex.status))
 
+        elif isinstance(ex, APIError) and ex.code is not None:
+            return is_retryable_http_status(ex.code)
+
         # low-level requests exceptions
         elif isinstance(ex, requests.exceptions.RequestException):
             return isinstance(

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -94,7 +94,7 @@ def vertex() -> type[ModelAPI]:
 def google() -> type[ModelAPI]:
     FEATURE = "Google API"
     PACKAGE = "google-genai"
-    MIN_VERSION = "1.2.0"
+    MIN_VERSION = "1.8.0"
 
     # workaround log spam
     # https://github.com/ray-project/ray/issues/24917

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1,9 +1,7 @@
-from google.genai.types import Candidate, Content, FinishReason  # type: ignore
 from test_helpers.utils import skip_if_no_google, skip_if_trio
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
-from inspect_ai.model._providers.google import completion_choice_from_candidate
 from inspect_ai.scorer import includes
 
 
@@ -48,6 +46,10 @@ def test_google_block_reason():
 
 
 def test_completion_choice_malformed_function_call():
+    from google.genai.types import Candidate, Content, FinishReason  # type: ignore
+
+    from inspect_ai.model._providers.google import completion_choice_from_candidate
+
     # Copied from the ``Candidate`` object actually returned by the Google API
     candidate = Candidate(
         content=Content(parts=None, role=None),

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1,6 +1,6 @@
 import unittest.mock as mock
 
-from test_helpers.utils import skip_if_no_google, skip_if_trio
+from test_helpers.utils import skip_if_no_google, skip_if_no_google_genai, skip_if_trio
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
@@ -47,6 +47,7 @@ def test_google_block_reason():
     # assert log.samples[0].output.stop_reason == "content_filter"
 
 
+@skip_if_no_google_genai
 def test_completion_choice_malformed_function_call():
     from google.genai.types import Candidate, Content, FinishReason  # type: ignore
 

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -77,6 +77,7 @@ def test_completion_choice_malformed_function_call():
     )  # No tool calls for malformed function calls
 
 
+@skip_if_no_google_genai
 def test_429_response_is_retried():
     error_response_json = {
         "error": {
@@ -114,16 +115,15 @@ def test_429_response_is_retried():
             ],
         }
     }
-
-    import requests  # type: ignore
+    import httpx
     from google.genai.errors import ClientError  # type: ignore
 
     from inspect_ai.model._providers.google import GoogleGenAIAPI
 
-    mock_response = mock.MagicMock(spec=requests.Response)
+    mock_response = mock.MagicMock(spec=httpx.Response)
     mock_response.status_code = 429
     mock_response.json.return_value = error_response_json
-    error = ClientError(429, mock_response)
+    error = ClientError(429, error_response_json, mock_response)
 
     api = GoogleGenAIAPI(model_name="gemini-1.0-pro", base_url=None, api_key="fake-key")
 

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -83,6 +83,10 @@ def skip_if_no_google(func):
     return pytest.mark.api(skip_if_env_var("GOOGLE_API_KEY", exists=False)(func))
 
 
+def skip_if_no_google_genai(func):
+    return skip_if_no_package("google.genai")(func)
+
+
 def skip_if_no_mistral(func):
     return pytest.mark.api(skip_if_env_var("MISTRAL_API_KEY", exists=False)(func))
 


### PR DESCRIPTION
This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When using the "google/gemini-2.0-flash-thinking-exp-01-21" model, responses with code=429 and status="RESOURCE_EXHAUSTED" are being treated as not retryable (see details in included test).

The current implementation of `GoogleGenAIAPI.should_retry` expects `status` to be a integer-formatted string like `"429"` but that is not what is observed in the current case. I'm not sure if this is version-specific, model-specific, or under what conditions the current implementation is correct.

### What is the new behavior?

Raised `ClientErrors` with an integer `code` are checked and retried.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking changes

### Other information:

Included a test with a copy of the logged error response. Personally I find this kind of record of errors observed in the wild very valuable as documentation, but understand if you'd prefer to keep things cleaner and remove the parts not essential for the test.

Pytest was erroring when trying to collect the project's tests if `google-genai` was not installed, even if no `GOOGLE_API_KEY` was set so `skip_if_no_google` would skip the google tests anyway. This seemed like undesired behaviour so the `google.genai`  imports were moved inside the tests, and this allowed the tests to be collected without error. Happy to revert this if it should just be expected that all dev dependencies are installed.