### PR TITLE
Update `inspect-tool-support` Dockerfile and documentation to put tool directory at the end of the path rather than the front.

### DIFF
--- a/docs/_sandbox-dockerfile.md
+++ b/docs/_sandbox-dockerfile.md
@@ -1,9 +1,8 @@
 You should add the following to your sandbox `Dockerfile` in order to use this tool:
 
 ``` dockerfile
-RUN python -m venv /opt/inspect_tool_support
-ENV PATH="/opt/inspect_tool_support/bin:$PATH"
-
-RUN pip install inspect-tool-support
-RUN inspect-tool-support post-install
+ENV PATH="$PATH:/opt/inspect_tool_support/bin"
+RUN python -m venv /opt/inspect_tool_support && \
+    /opt/inspect_tool_support/bin/pip install inspect-tool-support && \
+    /opt/inspect_tool_support/bin/inspect-tool-support post-install
 ```

--- a/src/inspect_ai/tool/_tool_support_helpers.py
+++ b/src/inspect_ai/tool/_tool_support_helpers.py
@@ -128,10 +128,10 @@ async def tool_container_sandbox(tool_name: str) -> SandboxEnvironment:
 
                 Alternatively, you can include the service into your own Dockerfile:
 
-                RUN python -m venv /opt/inspect_tool_support
-                ENV PATH="/opt/inspect_tool_support/bin:$PATH"
-                RUN pip install inspect-tool-support
-                RUN inspect-tool-support post-install
+                ENV PATH="$PATH:/opt/inspect_tool_support/bin"
+                RUN python -m venv /opt/inspect_tool_support && \
+                    /opt/inspect_tool_support/bin/pip install inspect-tool-support && \
+                    /opt/inspect_tool_support/bin/inspect-tool-support post-install
                 """).strip()
         raise PrerequisiteError(msg)
 

--- a/src/inspect_tool_support/Dockerfile
+++ b/src/inspect_tool_support/Dockerfile
@@ -8,13 +8,12 @@ FROM python:3.12-bookworm
 # RUN apt-get update && apt-get install -y python3 python3-pip python3-venv
 
 # create and install into a venv
-RUN python -m venv /opt/inspect_tool_support
-ENV PATH="/opt/inspect_tool_support/bin:$PATH"
-
-# install inspect-tool-support
+# install inspect-tool-support 
 # (on platforms where Playwright is not supported, add --no-web-browser to the post-install command)
-RUN pip install inspect-tool-support
-RUN inspect-tool-support post-install
+ENV PATH="$PATH:/opt/inspect_tool_support/bin"
+RUN python -m venv /opt/inspect_tool_support && \
+    /opt/inspect_tool_support/bin/pip install inspect-tool-support && \
+    /opt/inspect_tool_support/bin/inspect-tool-support post-install
 
 # run forever
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When using the suggested `Dockerfile` commands for `inspect-tool-support`, the image's default Python environment is overridden with the `inspect-tool-support`'s virtual env. This is because the directory is put at the front of `PATH` instead of at the end.

### What is the new behavior?
It's not put at the end.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
