### PR TITLE
Fix parameter passing bug that prevented the backward compatibility code for the web browser tool from working properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Inspect View: Render messages in `user` and `assistant` solver events.
 - Inspect View: Improved support for display of nested arrays.
 - Bugfix: Handle process lookup errors that can occur during timeout race conditions.
+- Bugfix: Correct handling of backward compatiblity for inspect-web-browser-tool image.
 
 ## v0.3.81 (30 March 2025)
 

--- a/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
@@ -363,7 +363,9 @@ async def _web_browser_cmd(tool_name: str, params: dict[str, object]) -> ToolRes
         # The user may have the old, incompatible, sandbox. If so, use that and
         # execute the old compatible code.
         try:
-            return await old_web_browser_cmd(tool_name, *params)
+            return await old_web_browser_cmd(
+                tool_name, *(str(value) for value in params.values())
+            )
         except PrerequisiteError:
             raise e
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When current versions of the Inspect web browser tool are executed against the old/deprecated Docker image, it fails because the tool call parameters are not passed through the `docker exec` properly.

### What is the new behavior?
They are now passed properly. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
