### PR TITLE
Docker: `write_file()` function now gracefully handles larger input file sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Eval Set: Resolve tasks before each pass (ensure that each pass runs against an entirely new task instance).
 - Eval Retry: Ability to retry any task in the registry, even if it has a custom `name` (save `registry_name` separately).
 - Typed Store: Raise error if attempting to embed a `StoreModel` within another `StoreModel`.
+- Docker: `write_file()` function now gracefully handles larger input file sizes (was failing on files > 2MB).
 - Inspect View: Live updates to running evaluation logs.
 - Inspect View: Fallback to content range request if inital HEAD request fails.
 - Inspect View: Improve error message when view bundles are server from incompatible servers.

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -310,7 +310,14 @@ class DockerSandboxEnvironment(SandboxEnvironment):
         # write the file
         if isinstance(contents, str):
             result = await self.exec(
-                ["sh", "-e", "-c", 'tee -- "$1"', "write_file_script", file],
+                [
+                    "sh",
+                    "-e",
+                    "-c",
+                    'tee -- "$1" > /dev/null',
+                    "write_file_script",
+                    file,
+                ],
                 input=contents,
                 timeout=TIMEOUT,
             )


### PR DESCRIPTION
Was failing on files > 2MB due to stdout interleaving with stdin. Fix was to redirect `tee` to `/dev/null` (as is already done for binary files). 

A broader fix would be to enhance `run_command()` to interleave stdin and stdout but this is riskier, more intrusive change so not pursuing this for the time being.

