### PR TITLE
Modify openai_api to allow for passing in of api_version argument

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -128,10 +128,14 @@ class OpenAIAPI(ModelAPI):
                 )
 
             # resolve version
-            api_version = os.environ.get(
-                "AZUREAI_OPENAI_API_VERSION",
-                os.environ.get("OPENAI_API_VERSION", "2025-02-01-preview"),
-            )
+            if model_args.get("api_version") is not None:
+                # use slightly complicated logic to allow for "api_version" to be removed
+                api_version = model_args.pop("api_version")
+            else:
+                api_version = os.environ.get(
+                    "AZUREAI_OPENAI_API_VERSION",
+                    os.environ.get("OPENAI_API_VERSION", "2025-02-01-preview"),
+                )
 
             self.client: AsyncAzureOpenAI | AsyncOpenAI = AsyncAzureOpenAI(
                 api_key=self.api_key,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When api_version is passed in as an argument and is different from `AZUREAI_OPENAI_API_VERSION` it will cause an error, when running
```python
self.client: AsyncAzureOpenAI | AsyncOpenAI = AsyncAzureOpenAI(
                api_key=self.api_key,
                api_version=api_version,
                azure_endpoint=base_url,
                http_client=http_client,
                **model_args,
            )
```

### What is the new behavior?
If api_version is passed it is removed from `model_args` and passed in directly.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
