### PR TITLE
Fix human_agent initial clock event action

### DIFF
--- a/src/inspect_ai/agent/_human/commands/clock.py
+++ b/src/inspect_ai/agent/_human/commands/clock.py
@@ -62,7 +62,9 @@ class StopCommand(HumanAgentCommand):
         return stop
 
 
-def clock_action_event(action: str, state: HumanAgentState) -> None:
+def clock_action_event(
+    action: Literal["start", "stop"], state: HumanAgentState
+) -> None:
     from inspect_ai.log._transcript import transcript
 
     transcript().info(

--- a/src/inspect_ai/agent/_human/service.py
+++ b/src/inspect_ai/agent/_human/service.py
@@ -16,8 +16,8 @@ async def run_human_agent_service(
     instructions = "\n\n".join([message.text for message in state.messages]).strip()
     agent_state = HumanAgentState(instructions=instructions)
 
-    # record that clock is paused
-    clock_action_event("pause", agent_state)
+    # record that clock is stopped
+    clock_action_event("stop", agent_state)
 
     # extract service methods from commands
     methods = {


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

#1592 contained a bug: The initial event it records has an action of `pause` when it should be `stop`, to match the other actions it records.

### What is the new behavior?

`human_agent` now uses an action of `stop`, as it should.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

N/A
