### PR TITLE
Export `ModelCall` in `inspect_ai.model`

### DIFF
--- a/src/inspect_ai/model/__init__.py
+++ b/src/inspect_ai/model/__init__.py
@@ -35,6 +35,7 @@ from ._model import (
     ModelName,
     get_model,
 )
+from ._model_call import ModelCall
 from ._model_output import (
     ChatCompletionChoice,
     Logprob,
@@ -65,6 +66,7 @@ __all__ = [
     "ChatMessageAssistant",
     "ChatMessageTool",
     "ChatCompletionChoice",
+    "ModelCall",
     "ModelOutput",
     "ModelConversation",
     "Logprobs",


### PR DESCRIPTION
This type is required for implementing `ModelAPI.generate()` so should be public as plugins can define their own model providers.

`generate()` signature:
```py
    async def generate(
        self,
        input: list[ChatMessage],
        tools: list[ToolInfo],
        tool_choice: ToolChoice,
        config: GenerateConfig,
    ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
```
https://github.com/UKGovernmentBEIS/inspect_ai/blob/c2b3b77653956482ba3b7fd91982dedc070d369d/src/inspect_ai/model/_model.py#L145