### PR TITLE
Introduce 'Answer' 

### DIFF
--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -894,6 +894,7 @@ async def log_sample(
         setup=sample.setup,
         messages=state.messages,
         output=state.output,
+        answer=state.answer,
         scores={k: v.score for k, v in scores.items()},
         store=dict(state.store.items()),
         uuid=state.uuid,

--- a/src/inspect_ai/agent/_agent.py
+++ b/src/inspect_ai/agent/_agent.py
@@ -33,6 +33,7 @@ class AgentState:
     def __init__(self, *, messages: list[ChatMessage]) -> None:
         self._messages = messages
         self._output: ModelOutput | None = None
+        self._answer: str | None = None
 
     @property
     def messages(self) -> list[ChatMessage]:
@@ -73,13 +74,26 @@ class AgentState:
         """Set the model output."""
         self._output = output
 
+    @property
+    def answer(self) -> str:
+        if self._answer is not None:
+            return self._answer
+        else:
+            return self.output.completion
+
+    @answer.setter
+    def answer(self, answer: str | None) -> None:
+        self._answer = answer
+
     def __copy__(self) -> "AgentState":
         state = AgentState(messages=copy(self.messages))
+        state.answer = self.answer
         state.output = self.output.model_copy()
         return state
 
     def __deepcopy__(self, memo: dict[int, Any]) -> "AgentState":
         state = AgentState(messages=deepcopy(self.messages, memo))
+        state.answer = self.answer
         state.output = self.output.model_copy(deep=True)
         return state
 

--- a/src/inspect_ai/agent/_as_solver.py
+++ b/src/inspect_ai/agent/_as_solver.py
@@ -64,6 +64,9 @@ def as_solver(agent: Agent, **agent_kwargs: Any) -> Solver:
             if agent_state.output:
                 state.output = agent_state.output
 
+            # update answer
+            state.answer = agent_state.answer
+
             return state
 
         # return solver

--- a/src/inspect_ai/agent/_human/commands/score.py
+++ b/src/inspect_ai/agent/_human/commands/score.py
@@ -54,6 +54,7 @@ class ScoreCommand(HumanAgentCommand):
             if answer:
                 agent_state = deepcopy(self._state)
                 agent_state.output = ModelOutput.from_content("human_agent", answer)
+                agent_state.answer = agent_state.output.completion
                 result = await score(agent_state)
             else:
                 result = await score(self._state)

--- a/src/inspect_ai/agent/_human/service.py
+++ b/src/inspect_ai/agent/_human/service.py
@@ -44,6 +44,7 @@ async def run_human_agent_service(
     # set the answer if we have one
     if agent_state.answer is not None:
         state.output = ModelOutput.from_content("human_agent", agent_state.answer)
+        state.answer = agent_state.answer
 
     # return state
     return state

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -159,9 +159,16 @@ def react(
             # check for a submission
             answer = submitted_answer(state.output.message.tool_calls)
             if answer is not None:
-                # remove the tool call and set the output to the answer for scoring
+                # record the answer
+                state.answer = answer
+
+                # remove the tool call
                 state.output.message.tool_calls = None
-                state.output.completion = answer
+
+                # amend the completion with the submitted answer
+                state.output.completion = (
+                    f"{state.output.completion}\n\nsubmit: {answer}".strip()
+                )
 
                 # exit if we are at max_attempts
                 attempt_count += 1

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -189,6 +189,9 @@ class EvalSample(BaseModel):
     output: ModelOutput = Field(default_factory=ModelOutput)
     """Model output from sample."""
 
+    answer: str = Field(default_factory=str)
+    """Final answer."""
+
     scores: dict[str, Score] | None = Field(default=None)
     """Scores for sample."""
 

--- a/src/inspect_ai/model/_conversation.py
+++ b/src/inspect_ai/model/_conversation.py
@@ -16,3 +16,7 @@ class ModelConversation(Protocol):
     def output(self) -> ModelOutput:
         """Model output."""
         ...
+
+    @property
+    def answer(self) -> str:
+        """Final answer."""

--- a/src/inspect_ai/scorer/_classification.py
+++ b/src/inspect_ai/scorer/_classification.py
@@ -25,9 +25,7 @@ def f1(
 
     async def score(state: TaskState, target: Target) -> Score:
         # Get generated answer and extract relevant answer text
-        answer = (
-            answer_fn(state.output.completion) if answer_fn else state.output.completion
-        )
+        answer = answer_fn(state.answer) if answer_fn else state.answer
         targets = target.target
 
         f1_score = max_f1_score(answer, targets, stop_words=stop_words)
@@ -48,7 +46,7 @@ def exact() -> Scorer:
 
     async def score(state: TaskState, target: Target) -> Score:
         # Get generated answer and extract relevant answer text
-        answer = state.output.completion
+        answer = state.answer
         targets = target.target
 
         exact_score = max_exact_score(answer, targets)

--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -23,7 +23,7 @@ def str_match_scorer(match: Callable[[str, str], tuple[str, bool]]) -> Scorer:
     async def score(state: TaskState, target: Target) -> Score:
         answer: str | None = None
         for value in target:
-            answer, matched = match(state.output.completion, value)
+            answer, matched = match(state.answer, value)
             if matched:
                 return Score(
                     value=CORRECT, answer=answer, explanation=state.output.completion

--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -168,7 +168,7 @@ def _model_graded_qa_single(
         # format the scoring template
         score_prompt = grading_template.format(
             question=question,
-            answer=state.output.completion,
+            answer=state.answer,
             criterion=target.text,
             instructions=instructions,
             **metadata,
@@ -182,7 +182,7 @@ def _model_graded_qa_single(
         if match:
             return Score(
                 value=match.group(1),
-                answer=state.output.completion,
+                answer=state.answer,
                 explanation=result.completion,
                 metadata=dict(
                     grading=[

--- a/src/inspect_ai/scorer/_pattern.py
+++ b/src/inspect_ai/scorer/_pattern.py
@@ -65,9 +65,7 @@ def pattern(pattern: str, ignore_case: bool = True, match_all: bool = False) -> 
 
     async def score(state: TaskState, target: Target) -> Score:
         # extract the answer
-        match = re.search(
-            pattern, state.output.completion, re.IGNORECASE if ignore_case else 0
-        )
+        match = re.search(pattern, state.answer, re.IGNORECASE if ignore_case else 0)
 
         if match:
             groups = match.groups()

--- a/src/inspect_ai/scorer/_score.py
+++ b/src/inspect_ai/scorer/_score.py
@@ -43,6 +43,7 @@ async def score(conversation: ModelConversation) -> list[Score]:
         state = copy(current_state)
         state.messages = conversation.messages
         state.output = conversation.output
+        state.answer = conversation.answer
 
     # get current scorers and target
     scorers = _scorers.get(None)

--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -65,6 +65,7 @@ def basic_agent(
     continue_message: str = DEFAULT_CONTINUE_MESSAGE,
     submit_name: str = DEFAULT_SUBMIT_NAME,
     submit_description: str = DEFAULT_SUBMIT_DESCRIPTION,
+    provide_answer: bool = False,
     **kwargs: Unpack[BasicAgentDeprecatedArgs],
 ) -> Solver:
     """Basic ReAct agent.
@@ -102,6 +103,8 @@ def basic_agent(
           (defaults to 'submit')
        submit_description: Description of submit tool (defaults to
           'Submit an answer for evaluation')
+       provide_answer: Whether the agent should set the answer property when the model
+           uses the submit tool to submit an answer (defaults to False)
        **kwargs: Deprecated arguments for backward compatibility.
 
     Returns:
@@ -205,8 +208,12 @@ def basic_agent(
                         # was an answer submitted?
                         answer = submission(tool_results)
                         if answer:
-                            # set the output to the answer for scoring
-                            state.output.completion = answer
+                            # set the output to the answer for scoring (use the answer)
+                            # field if requested
+                            if provide_answer:
+                                state.answer = answer
+                            else:
+                                state.output.completion = answer
 
                             # exit if we are at max_attempts
                             attempts += 1

--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -162,6 +162,7 @@ class TaskState:
         self._messages: list[ChatMessage] = ChatMessageList(messages, self)
         self._tools: list[Tool] = []
         self._output = output if output else ModelOutput(model=str(model))
+        self._answer: str | None = None
         self._message_limit = message_limit
         self._token_limit = token_limit
         self._completed = completed
@@ -269,6 +270,17 @@ class TaskState:
     @output.setter
     def output(self, output: ModelOutput) -> None:
         self._output = output
+
+    @property
+    def answer(self) -> str:
+        if self._answer is not None:
+            return self._answer
+        else:
+            return self.output.completion
+
+    @answer.setter
+    def answer(self, answer: str | None) -> None:
+        self._answer = answer
 
     @property
     def store(self) -> Store:

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -301,10 +301,10 @@ def test_react_agent_on_continue_func():
 @scorer(metrics=[accuracy()])
 def compare_quantities():
     async def score(state: TaskState, target: Target) -> Score:
-        answer = float(state.output.completion)
+        answer = float(state.answer)
         target_value = float(target.text)
         if answer == target_value:
-            return Score(value=1.0, answer=state.output.completion)
+            return Score(value=1.0, answer=state.answer)
         elif answer > target_value:
             return Score(
                 value=0.0,

--- a/tests/scorer/test_multiscorer.py
+++ b/tests/scorer/test_multiscorer.py
@@ -9,7 +9,7 @@ from inspect_ai.solver import TaskState
 @scorer(metrics=[mean(), stderr()])
 def rand_score():
     async def score(state: TaskState, target: Target):
-        answer = state.output.completion
+        answer = state.answer
         return Score(value=random.randint(1, 100), answer=answer)
 
     return score
@@ -18,7 +18,7 @@ def rand_score():
 @scorer(metrics=[mean(), stderr()])
 def another_rand_score():
     async def score(state: TaskState, target: Target):
-        answer = state.output.completion
+        answer = state.answer
         return Score(value=random.randint(1, 100), answer=answer)
 
     return score
@@ -27,7 +27,7 @@ def another_rand_score():
 @scorer(metrics={"a_count": [mean(), stderr()], "e_count": [mean(), stderr()]})
 def letter_count():
     async def score(state: TaskState, target: Target):
-        answer = state.output.completion
+        answer = state.answer
         a_count = answer.count("a")
         e_count = answer.count("e")
         return Score(value={"a_count": a_count, "e_count": e_count}, answer=answer)

--- a/tests/scorer/test_scorer.py
+++ b/tests/scorer/test_scorer.py
@@ -13,11 +13,7 @@ from inspect_ai.solver import TaskState
 @scorer(metrics=[accuracy()], name="test_match")
 def match() -> Scorer:
     async def score(state: TaskState, target: Target) -> Score:
-        return (
-            Score(value="C")
-            if state.output.completion == target.text
-            else Score(value="I")
-        )
+        return Score(value="C") if state.answer == target.text else Score(value="I")
 
     return score
 

--- a/tests/test_package/inspect_package/score/scorer.py
+++ b/tests/test_package/inspect_package/score/scorer.py
@@ -14,7 +14,7 @@ from inspect_ai.solver import TaskState
 def simple_score(ignore_case: bool = True):
     async def score(state: TaskState, target: Target):
         # check for correct
-        answer = state.output.completion
+        answer = state.answer
         text = target.text
         if ignore_case:
             correct = answer.lower().rfind(text.lower()) != -1


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### The Problem

Currently, when using the `basic_agent`, anytime the agent uses the `submit` tool to submit an answer, we overwrite the completion with the contents of the submit tool. This allows scorers to check the completion when determining whether to continue the agent. This also has the side effect of overwriting any other contents of the completion that the model may have included when calling the submit tool (for example thinking or analysis as context for the `submit` tool call). 

Changing this behavior (for example, just concatenating the submitted answer to the existing completion) will break existing usage of `basic_agent` and scorers that rely upon the answer being the contents of the completion.

### What is the new behavior?

We introduce an `answer` field to both `TaskState` and the new `AgentState`. The answer field can be explicitly set, or if no explicitly set answer is provided, the completion will be considered the answer. This will allow us to do a couple of things:

1) The`react()` agent will now properly set the answer when the submit tool is called and leave the completion intact (it will append the answer to try to maximise compatibility and document that the model has provided the answer). 

2) `basic_agent()` will remain as is, setting the completion to the submitted answer, for backward compatibility.

3) Scorers should be updated not to use `state.output.completion`, but instead to use `state.answer`. This will mean that if an answer is provided, scoring will happen using that answer. If an answer is not provided, the `state.output.completion` value is returned and scoring happens against the completion (as it does today).

4) If possible, we will introduce a warning that occurs when scorers use `state.output.completion` for scoring rather than `state.answer` (so that scorers know to migrate to the new scheme).

The net effect of this change is that the new answer field will contain any explicitly set answer and should be used for scoring. All existing code will remain working as is, but scorers that want to work with the `react()` agent (or any other agent that sets the `state.answer` field) need to change to read from `state.answer` (which again will fall back to `state.output.completion` for backward compatibility.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Since the `react()` agent is new, we feel like this is a good time to consider a change like this which will be better in the longer term. Existing `basic_agent()` is left as is.


