### PR TITLE
Fix test_human_agent_state_time_accumulation

### DIFF
--- a/src/inspect_ai/agent/_human/state.py
+++ b/src/inspect_ai/agent/_human/state.py
@@ -1,4 +1,4 @@
-from time import time as current_time
+import time as python_time
 
 from pydantic import BaseModel, Field
 
@@ -25,7 +25,7 @@ class HumanAgentState(StoreModel):
         """Set current running state."""
         # if we are flipping to running mode then update started running
         if not self.running_state and running:
-            self.started_running = current_time()
+            self.started_running = python_time.time()
 
         # if we are exiting running mode then update accumulated time
         if self.running_state and not running:
@@ -37,7 +37,7 @@ class HumanAgentState(StoreModel):
     @property
     def time(self) -> float:
         """Total time spend on task."""
-        running_time = current_time() - self.started_running if self.running else 0
+        running_time = python_time.time() - self.started_running if self.running else 0
         return self.accumulated_time + running_time
 
     scorings: list[IntermediateScoring] = Field(default_factory=list)
@@ -51,5 +51,5 @@ class HumanAgentState(StoreModel):
 
     # internal state variables used by running and time properties
     running_state: bool = Field(default=False)
-    started_running: float = Field(default_factory=current_time)
+    started_running: float = Field(default_factory=python_time.time)
     accumulated_time: float = Field(default=0.0)

--- a/tests/agent/_human/test_state.py
+++ b/tests/agent/_human/test_state.py
@@ -1,27 +1,23 @@
-# import time
+from unittest import mock
 
-# import numpy as np
-
-# from inspect_ai.agent._human.state import HumanAgentState
+from inspect_ai.agent._human.state import HumanAgentState
 
 
-def test_human_agent_state_time_accumulation():
-    # mysteriously started failing in CI
-    # https://github.com/UKGovernmentBEIS/inspect_ai/actions/runs/14237922878/job/39900932495
-    pass
+@mock.patch("time.time", autospec=True)
+def test_human_agent_state_time_accumulation(mock_time):
+    mock_time.return_value = 12345.0
 
-    # state = HumanAgentState(instructions="test instructions")
-    # assert state.time == 0.0, "Initial time should be 0"
+    state = HumanAgentState(instructions="test instructions")
+    assert state.time == 0.0, "Initial time should be 0"
 
-    # for i in range(1, 3):
-    #     state.running = True
-    #     time.sleep(0.1)
-    #     assert np.isclose(state.time, 0.1 * i, atol=0.0 * i), (
-    #         f"Time should accumulate while running (i={i})"
-    #     )
+    periods = [2, 4.5, 10]
+    expected_times = [2, 6.5, 16.5]
 
-    #     state.running = False
-    #     time.sleep(0.1)
-    #     assert np.isclose(state.time, 0.1 * i, atol=0.01 * i), (
-    #         f"Time should not increase while stopped (i={i})"
-    #     )
+    for period, expected_time in zip(periods, expected_times):
+        state.running = True
+        mock_time.return_value += period
+        assert state.time == expected_time, "Time should accumulate while running"
+
+        state.running = False
+        mock_time.return_value += period
+        assert state.time == expected_time, "Time should not accumulate while stopped"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`test_human_agent_state_time_accumulation` fails at least occasionally in CI: https://github.com/UKGovernmentBEIS/inspect_ai/actions/runs/14237922878/job/39900932495

### What is the new behavior?

This PR changes the test not to use `time.sleep` to advance the clock, but instead to mock `time.time`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

None.