### PR TITLE
Append `submit` tool output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Agent](https://inspect.aisi.org.uk/agent-protocol.html) protocol and [inspect_ai.agent](https://inspect.aisi.org.uk/reference/inspect_ai.agent.html) module with new system for creating, composing, and executing agents.
 - Scoring: New [grouped()](https://inspect.aisi.org.uk/scoring.html#metric-grouping) metric wrapper function, which applies a given metric to subgroups of samples defined by a key in sample metadata.
+- Basic Agent: New `submit_append` option to append the submit tool output to the completion rather than replacing the completion (note that the new `react()` agent appends by default).
 - Model API: New [execute_tools()](https://inspect.aisi.org.uk/reference/inspect_ai.model.html#execute_tools) function (replaces deprecated `call_tools()` function) which handles agent handoffs that occur during tool calling.
 - Model API: `generate_loop()` method for calling generate with a tool use loop.
 - Model API: Provide optional sync context manager for `Model` (works only with providers that don't require an async close).

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -161,7 +161,9 @@ def react(
             if answer is not None:
                 # remove the tool call and set the output to the answer for scoring
                 state.output.message.tool_calls = None
-                state.output.completion = answer
+                state.output.completion = (
+                    f"{state.output.completion}\n\n{answer}".strip()
+                )
 
                 # exit if we are at max_attempts
                 attempt_count += 1

--- a/src/inspect_ai/solver/_basic_agent.py
+++ b/src/inspect_ai/solver/_basic_agent.py
@@ -65,6 +65,7 @@ def basic_agent(
     continue_message: str = DEFAULT_CONTINUE_MESSAGE,
     submit_name: str = DEFAULT_SUBMIT_NAME,
     submit_description: str = DEFAULT_SUBMIT_DESCRIPTION,
+    submit_append: bool = False,
     **kwargs: Unpack[BasicAgentDeprecatedArgs],
 ) -> Solver:
     """Basic ReAct agent.
@@ -102,6 +103,9 @@ def basic_agent(
           (defaults to 'submit')
        submit_description: Description of submit tool (defaults to
           'Submit an answer for evaluation')
+       submit_append: Append the submit tool output to the model completion
+           text (defaults to `False`, which means the submission overwrites
+           the model completion).
        **kwargs: Deprecated arguments for backward compatibility.
 
     Returns:
@@ -205,8 +209,12 @@ def basic_agent(
                         # was an answer submitted?
                         answer = submission(tool_results)
                         if answer:
-                            # set the output to the answer for scoring
-                            state.output.completion = answer
+                            if submit_append:
+                                state.output.completion = (
+                                    f"{state.output.completion}\n\n{answer}".strip()
+                                )
+                            else:
+                                state.output.completion = answer
 
                             # exit if we are at max_attempts
                             attempts += 1

--- a/tests/solver/test_basic_agent.py
+++ b/tests/solver/test_basic_agent.py
@@ -4,6 +4,7 @@ from inspect_ai.log import EvalLog
 from inspect_ai.model import ChatMessageUser, ModelOutput, get_model
 from inspect_ai.scorer import Score, Target, accuracy, includes, scorer
 from inspect_ai.solver import Solver, TaskState, basic_agent, solver, system_message
+from inspect_ai.solver._solver import Generate
 from inspect_ai.tool import Tool, tool
 
 
@@ -188,6 +189,33 @@ def test_basic_agent_retries_with_custom_incorrect_message():
 
     check_task(custom_incorrect_message)
     check_task(async_custom_incorrect_message)
+
+
+def test_basic_agent_provide_answer():
+    @solver
+    def validate_answer() -> Solver:
+        async def execute(state: TaskState, generate: Generate) -> TaskState:
+            if state.output.completion == "2":
+                raise RuntimeError("Submitted answer not properly concatenated")
+            return state
+
+        return execute
+
+    task = Task(
+        dataset=[Sample(input="What is 1 + 1?", target=["2", "2.0", "Two"])],
+        solver=[
+            basic_agent(
+                tools=[addition()],
+                max_attempts=1,
+                message_limit=30,
+                submit_append=True,
+            ),
+            validate_answer(),
+        ],
+        scorer=includes(),
+    )
+    log = eval(task, mockllm_model(["2"]))[0]
+    assert log.results.scores[0].metrics["accuracy"].value == 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR addresses the same core issue in closed PR #1608.

Currently, when using the basic_agent, anytime the agent uses the submit tool to submit an answer, we overwrite the completion with the contents of the submit tool. This allows scorers to check the completion when determining whether to continue the agent. This also has the side effect of overwriting any other contents of the completion that the model may have included when calling the submit tool (for example thinking or analysis as context for the submit tool call).

This PR has two changes to address this:

1) The `react` agent will now always just append the submit tool to the completion text, preserving any model output that accompanied the tool call.

2) The `basic_agent` now has an option to append the submitted text to the completion rather than replacing the completion (`submit_append`). This defaults to `False` to preserve backward compatibility.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

