### PR TITLE
View Log Link in Task Progress

### DIFF
--- a/src/inspect_ai/_display/textual/widgets/task_detail.py
+++ b/src/inspect_ai/_display/textual/widgets/task_detail.py
@@ -221,12 +221,11 @@ class TaskMetrics(Widget):
             self.recompute_grid()
 
     def on_mount(self) -> None:
-        self.recompute_grid()
+        self.recompute_grid(True)
 
-    def recompute_grid(self) -> None:
-        if not self.is_mounted:
+    def recompute_grid(self, force: bool = False) -> None:
+        if not self.is_mounted and not force:
             return
-
         grid = self.query_one(f"#{self.grid_id()}")
 
         grid.remove_children()

--- a/src/inspect_ai/_display/textual/widgets/task_detail.py
+++ b/src/inspect_ai/_display/textual/widgets/task_detail.py
@@ -6,14 +6,9 @@ from textual.app import ComposeResult
 from textual.containers import Center, Grid, Horizontal
 from textual.reactive import Reactive, reactive
 from textual.widget import Widget
-from textual.widgets import Link, Static
+from textual.widgets import Static
 
-from inspect_ai._display.core.display import TaskDisplayMetric, TaskProfile
-from inspect_ai._util.vscode import (
-    VSCodeCommand,
-    can_execute_vscode_commands,
-    execute_vscode_commands,
-)
+from inspect_ai._display.core.display import TaskDisplayMetric
 
 OPEN_VIEWER_LINK_ID = "open-log-viewer"
 
@@ -163,7 +158,7 @@ class TaskMetrics(Widget):
         grid-gutter: 0 3;
         padding: 0 2 0 2;
     }
-    TaskMetric Center { 
+    TaskMetric Center {
         width: auto;
     }
     TaskMetrics Center Static {
@@ -281,30 +276,3 @@ def valid_id(identifier: str) -> str:
 
     # If the string is empty return a default valid identifier
     return valid_part or "default_identifier"
-
-
-class VSCodeLink(Link):
-    def __init__(
-        self,
-        text: str,
-        *,
-        url: str | None = None,
-        tooltip: str | None = None,
-        name: str | None = None,
-        id: str | None = None,
-        classes: str | None = None,
-        disabled: bool = False,
-    ) -> None:
-        super().__init__(
-            text,
-            url=url,
-            tooltip=tooltip,
-            name=name,
-            id=id,
-            classes=classes,
-            disabled=disabled,
-        )
-        self.commands: list[VSCodeCommand] = []
-
-    def on_click(self) -> None:
-        execute_vscode_commands(self.commands)

--- a/src/inspect_ai/_display/textual/widgets/task_detail.py
+++ b/src/inspect_ai/_display/textual/widgets/task_detail.py
@@ -10,8 +10,6 @@ from textual.widgets import Static
 
 from inspect_ai._display.core.display import TaskDisplayMetric
 
-OPEN_VIEWER_LINK_ID = "open-log-viewer"
-
 
 @dataclass
 class TaskMetric:
@@ -32,12 +30,6 @@ class TaskDetail(Widget):
         width: 100%;
         height: auto;
         grid-gutter: 1 3;
-    }
-    TaskDetail .section_title {
-        text-style: bold underline;
-    }
-    TaskDetail .inset {
-        padding: 0 0 1 2;
     }
     """
 

--- a/src/inspect_ai/_display/textual/widgets/task_detail.py
+++ b/src/inspect_ai/_display/textual/widgets/task_detail.py
@@ -49,28 +49,16 @@ class TaskDetail(Widget):
     def __init__(
         self,
         *,
-        profile: TaskProfile,
         hidden: bool = True,
         id: str | None = None,
         classes: str | None = None,
     ) -> None:
         super().__init__(id=id, classes=classes)
-        print(profile.log_location)
         self.hidden = hidden
         self.existing_metrics: dict[str, TaskMetrics] = {}
         self.grid = Grid()
         self.by_reducer: dict[str | None, dict[str, list[TaskMetric]]] = {}
         self.metrics: list[TaskDisplayMetric] = []
-        self.profile = profile
-        self.link = VSCodeLink(
-            "Open Log Viewer", id=OPEN_VIEWER_LINK_ID, classes="inset"
-        )
-        self.link.commands = [
-            VSCodeCommand(
-                command="inspect.openLogViewer",
-                args=[profile.log_location] if profile.log_location else [],
-            )
-        ]
 
     def watch_hidden(self, hidden: bool) -> None:
         """React to changes in the `visible` property."""
@@ -80,9 +68,6 @@ class TaskDetail(Widget):
             self.remove_class("hidden")
 
     def compose(self) -> ComposeResult:
-        if can_execute_vscode_commands():
-            yield self.link
-        yield Static("Metrics", classes="section_title inset")
         yield self.grid
 
     def on_mount(self) -> None:

--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -17,6 +17,12 @@ from inspect_ai._display.core.results import task_metric
 from inspect_ai._display.textual.widgets.clock import Clock
 from inspect_ai._display.textual.widgets.task_detail import TaskDetail
 from inspect_ai._display.textual.widgets.toggle import Toggle
+from inspect_ai._display.textual.widgets.vscode import conditional_vscode_link
+from inspect_ai._util.file import to_uri
+from inspect_ai._util.vscode import (
+    VSCodeCommand,
+    can_execute_vscode_commands,
+)
 
 from ...core.display import (
     Progress,
@@ -151,7 +157,7 @@ class TaskProgressView(Widget):
         height: auto;
         width: 1fr;
         layout: grid;
-        grid-size: 8 2;
+        grid-size: 9 2;
         grid-columns: auto auto auto auto 1fr auto auto auto;
         grid-rows: auto auto;
         grid-gutter: 0 1;
@@ -200,6 +206,17 @@ class TaskProgressView(Widget):
 
         self.sample_count_width: int = sample_count_width
         self.display_metrics = display_metrics
+        self.view_log_link = conditional_vscode_link(
+            "[View Log]",
+            [
+                VSCodeCommand(
+                    command="inspect.openLogViewer",
+                    args=[to_uri(task.profile.log_location)]
+                    if task.profile.log_location
+                    else [],
+                )
+            ],
+        )
 
     metrics: reactive[list[TaskDisplayMetric] | None] = reactive(None)
     metrics_width: reactive[int | None] = reactive(None)
@@ -222,6 +239,8 @@ class TaskProgressView(Widget):
         yield self.count_display
         yield self.metrics_display
         yield Clock()
+        yield self.view_log_link if can_execute_vscode_commands() else Static()
+
         yield self.task_detail
 
     @on(Toggle.Toggled)

--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -196,9 +196,7 @@ class TaskProgressView(Widget):
         self.task_progress = TaskProgress(self.progress_bar)
 
         self.toggle = Toggle()
-        self.task_detail = TaskDetail(
-            id="task-detail", classes="hidden", profile=task.profile
-        )
+        self.task_detail = TaskDetail(id="task-detail", classes="hidden")
 
         self.sample_count_width: int = sample_count_width
         self.display_metrics = display_metrics

--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -21,7 +21,6 @@ from inspect_ai._display.textual.widgets.vscode import conditional_vscode_link
 from inspect_ai._util.file import to_uri
 from inspect_ai._util.vscode import (
     VSCodeCommand,
-    can_execute_vscode_commands,
 )
 
 from ...core.display import (
@@ -208,14 +207,12 @@ class TaskProgressView(Widget):
         self.display_metrics = display_metrics
         self.view_log_link = conditional_vscode_link(
             "[View Log]",
-            [
-                VSCodeCommand(
-                    command="inspect.openLogViewer",
-                    args=[to_uri(task.profile.log_location)]
-                    if task.profile.log_location
-                    else [],
-                )
-            ],
+            VSCodeCommand(
+                command="inspect.openLogViewer",
+                args=[to_uri(task.profile.log_location)]
+                if task.profile.log_location
+                else [],
+            ),
         )
 
     metrics: reactive[list[TaskDisplayMetric] | None] = reactive(None)
@@ -239,7 +236,7 @@ class TaskProgressView(Widget):
         yield self.count_display
         yield self.metrics_display
         yield Clock()
-        yield self.view_log_link if can_execute_vscode_commands() else Static()
+        yield self.view_log_link
 
         yield self.task_detail
 

--- a/src/inspect_ai/_display/textual/widgets/tasks.py
+++ b/src/inspect_ai/_display/textual/widgets/tasks.py
@@ -196,7 +196,9 @@ class TaskProgressView(Widget):
         self.task_progress = TaskProgress(self.progress_bar)
 
         self.toggle = Toggle()
-        self.task_detail = TaskDetail(id="task-detail", classes="hidden")
+        self.task_detail = TaskDetail(
+            id="task-detail", classes="hidden", profile=task.profile
+        )
 
         self.sample_count_width: int = sample_count_width
         self.display_metrics = display_metrics

--- a/src/inspect_ai/_display/textual/widgets/vscode.py
+++ b/src/inspect_ai/_display/textual/widgets/vscode.py
@@ -1,0 +1,44 @@
+from textual.widget import Widget
+from textual.widgets import Link, Static
+
+from inspect_ai._util.vscode import (
+    VSCodeCommand,
+    can_execute_vscode_commands,
+    execute_vscode_commands,
+)
+
+
+def conditional_vscode_link(text: str, commands: list[VSCodeCommand]) -> Widget:
+    if can_execute_vscode_commands():
+        vscode_link = VSCodeLink(text)
+        vscode_link.commands = commands
+        return vscode_link
+    else:
+        return Static()
+
+
+class VSCodeLink(Link):
+    def __init__(
+        self,
+        text: str,
+        *,
+        url: str | None = None,
+        tooltip: str | None = None,
+        name: str | None = None,
+        id: str | None = None,
+        classes: str | None = None,
+        disabled: bool = False,
+    ) -> None:
+        super().__init__(
+            text,
+            url=url,
+            tooltip=tooltip,
+            name=name,
+            id=id,
+            classes=classes,
+            disabled=disabled,
+        )
+        self.commands: list[VSCodeCommand] = []
+
+    def on_click(self) -> None:
+        execute_vscode_commands(self.commands)

--- a/src/inspect_ai/_display/textual/widgets/vscode.py
+++ b/src/inspect_ai/_display/textual/widgets/vscode.py
@@ -3,15 +3,15 @@ from textual.widgets import Link, Static
 
 from inspect_ai._util.vscode import (
     VSCodeCommand,
-    can_execute_vscode_commands,
+    can_execute_vscode_command,
     execute_vscode_commands,
 )
 
 
-def conditional_vscode_link(text: str, commands: list[VSCodeCommand]) -> Widget:
-    if can_execute_vscode_commands():
+def conditional_vscode_link(text: str, command: VSCodeCommand) -> Widget:
+    if can_execute_vscode_command(command.command):
         vscode_link = VSCodeLink(text)
-        vscode_link.commands = commands
+        vscode_link.commands = [command]
         return vscode_link
     else:
         return Static()

--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -322,6 +322,19 @@ def absolute_file_path(file: str) -> str:
     return file
 
 
+def to_uri(path_or_uri: str) -> str:
+    # Check if it's already a URI
+    parsed = urlparse(path_or_uri)
+
+    if parsed.scheme:
+        # Already has a scheme, return as is
+        return path_or_uri
+
+    # It's a file path, convert to URI
+    path_obj = Path(path_or_uri).absolute()
+    return path_obj.as_uri()
+
+
 def default_fs_options(file: str) -> dict[str, Any]:
     scheme = urlparse(file).scheme
     if (

--- a/src/inspect_ai/_util/vscode.py
+++ b/src/inspect_ai/_util/vscode.py
@@ -1,12 +1,18 @@
 import os
+from logging import getLogger
 from pathlib import Path
 from typing import Any
 
 from pydantic import BaseModel, Field
 from pydantic_core import to_json
+from semver import Version
 from shortuuid import uuid
 
 from .appdirs import inspect_data_dir
+
+logger = getLogger(__name__)
+
+EXTENSION_COMMAND_VERSIONS = {"inspect.openLogViewer": Version(0, 3, 60)}
 
 
 class VSCodeCommand(BaseModel):
@@ -34,6 +40,25 @@ def can_execute_vscode_commands() -> bool:
     return vs_code_commands_dir() is not None
 
 
+def can_execute_vscode_command(command: str) -> bool:
+    if not can_execute_vscode_commands():
+        return False
+
+    required_version = EXTENSION_COMMAND_VERSIONS.get(command)
+    if required_version is None:
+        return True
+    else:
+        return has_vscode_version(required_version)
+
+
+def has_vscode_version(required_version: Version) -> bool:
+    current_version = vscode_extension_version()
+    if current_version is None:
+        return False
+    else:
+        return current_version.is_compatible(required_version)
+
+
 def vs_code_commands_dir() -> Path | None:
     workspace_id = vscode_workspace_id()
     if workspace_id:
@@ -49,3 +74,15 @@ def vs_code_commands_dir() -> Path | None:
 
 def vscode_workspace_id() -> str | None:
     return os.environ.get("INSPECT_WORKSPACE_ID", None)
+
+
+def vscode_extension_version() -> Version | None:
+    version = os.environ.get("INSPECT_VSCODE_EXT_VERSION", None)
+    if version is not None:
+        try:
+            return Version.parse(version)
+        except Exception:
+            logger.warning(f"Invalid Inspect vscode extension version: {version}")
+            return None
+    else:
+        return None

--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -25,7 +25,7 @@ from inspect_ai.log._file import (
     read_eval_log_async,
     read_eval_log_headers_async,
 )
-from inspect_ai.log._recorders.buffer.buffer import running_tasks, sample_buffer
+from inspect_ai.log._recorders.buffer.buffer import sample_buffer
 
 from .notify import view_last_eval_time
 
@@ -186,22 +186,6 @@ def view_server(
         else:
             return web.Response(body=sample_data.model_dump_json())
 
-    @routes.get("/api/running-tasks")
-    async def api_running_tasks(request: web.Request) -> web.Response:
-        # log dir can optionally be overridden by the request
-        if authorization:
-            request_log_dir = request.query.getone("log_dir", None)
-            if request_log_dir:
-                request_log_dir = normalize_uri(request_log_dir)
-            else:
-                request_log_dir = log_dir
-        else:
-            request_log_dir = log_dir
-
-        # list running tasks
-        tasks = running_tasks(request_log_dir)
-        return await running_task_response(tasks, request_log_dir)
-
     # optional auth middleware
     @web.middleware
     async def authorize(
@@ -339,11 +323,6 @@ async def log_bytes_response(log_file: str, start: int, end: int) -> web.Respons
 async def log_headers_response(files: list[str]) -> web.Response:
     headers = await read_eval_log_headers_async(files)
     return web.json_response(to_jsonable_python(headers, exclude_none=True))
-
-
-async def running_task_response(files: list[str], log_dir: str) -> web.Response:
-    response = dict(log_dir=aliased_path(log_dir), tasks=files)
-    return web.json_response(response)
 
 
 class WWWResource(web.StaticResource):

--- a/tools/vscode/src/providers/openlog.ts
+++ b/tools/vscode/src/providers/openlog.ts
@@ -11,7 +11,8 @@ export function activateOpenLog(
   viewManager: InspectViewManager
 ) {
 
-  context.subscriptions.push(commands.registerCommand('inspect.openLogViewer', async (uri: Uri) => {
+  context.subscriptions.push(commands.registerCommand('inspect.openLogViewer', async (uri: Uri | string) => {
+    uri = typeof uri === "string" ? Uri.parse(uri) : uri;
 
     // function to open using defualt editor in preview mode
     const openLogViewer = async () => {


### PR DESCRIPTION
This PR introduces a new link in the task progress display (when running in VSCode) which will open the log file for a running log (requires version 0.3.60 of the VSCode extension):

<img width="983" alt="Screenshot 2025-04-04 at 2 00 00 PM" src="https://github.com/user-attachments/assets/0dc21426-6f2f-46b6-97cf-19f78c2387cc" />


When clicked, opens the selected log with live updating as the eval runs:

<img width="1719" alt="Screenshot 2025-04-04 at 1 58 23 PM" src="https://github.com/user-attachments/assets/67cdbe4a-999a-4c55-8fb3-1801e8a15fdd" />

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
