### PR TITLE
Add metric decorator to grouped

### DIFF
--- a/src/inspect_ai/scorer/_metrics/grouped.py
+++ b/src/inspect_ai/scorer/_metrics/grouped.py
@@ -8,10 +8,12 @@ from inspect_ai.scorer._metric import (
     SampleScore,
     Value,
     ValueToFloat,
+    metric,
     value_to_float,
 )
 
 
+@metric
 def grouped(
     metric: Metric,
     group_key: str,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

I think there is a missing decorator from the grouped metric. Minimal failing example:

```python
from inspect_ai import Task, task
from inspect_ai.dataset import example_dataset, FieldSpec
from inspect_ai.scorer import model_graded_fact
from inspect_ai.solver import chain_of_thought, generate
from inspect_ai.scorer import Scorer, scorer, grouped, accuracy

@task
def biology_qa():
    dataset = example_dataset("biology_qa",
                              FieldSpec("question", "answer"))
    
    for sample in dataset:
        sample.metadata = {"group_label": sample.id in ("q1", "q2", "q3")}

    return Task(
        dataset=dataset,
        solver=[chain_of_thought(), generate()],
        scorer=grouped_model_graded_fact()
    )

@scorer(metrics=[grouped(accuracy(), "group_label")])
def grouped_model_graded_fact() -> Scorer:
    return model_graded_fact()
```

Returns:

```
The metric grouped_metric was not created by a function decorated with @metric so cannot be recorded.
```

If instead of using an existing scorer (which already has metrics) you write a scorer from scratch, there is a similar error:

```
ValueError: Object 'grouped_metric' does not have registry info. Did you forget to add a decorator somewhere?
```

### What is the new behavior?

`grouped` is given a `@metric` decorator. I think this is the desired behaviour (otherwise you have to manually decorate your new metric every time you used `grouped`) and matches how I interpret intended usage in #1568. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
