### PR TITLE
Suppress link click behavior in vscode links

### DIFF
--- a/src/inspect_ai/_display/textual/widgets/vscode.py
+++ b/src/inspect_ai/_display/textual/widgets/vscode.py
@@ -42,3 +42,7 @@ class VSCodeLink(Link):
 
     def on_click(self) -> None:
         execute_vscode_commands(self.commands)
+
+    def action_open_link(self) -> None:
+        # Workaround to prevent the default action of opening the link in a browser
+        return None


### PR DESCRIPTION
This prevents link clicks resulting in an open browser window (seen intermittently on linux and windows)

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
