### PR TITLE
Bugfix: Fix sqlite row value misused exceptions

### DIFF
--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -206,23 +206,27 @@ class SampleBufferDatabase(SampleBuffer):
         with self._get_connection(write=True) as conn:
             cursor = conn.cursor()
             try:
-                # create placeholders for the IN clause
-                placeholders = ",".join(["(?,?)"] * len(samples))
+                # Build a query using individual column comparisons instead of row values
+                placeholders = " OR ".join(
+                    ["(sample_id=? AND sample_epoch=?)" for _ in samples]
+                )
 
-                # flatten the list of tuples for SQLite parameter binding
+                # Flatten parameters for binding
                 parameters = [item for tup in samples for item in tup]
 
-                # Delete associated events first due to foreign key constraint
+                # Delete associated events first
                 events_query = f"""
                     DELETE FROM events
-                    WHERE (sample_id, sample_epoch) IN ({placeholders})
+                    WHERE {placeholders}
                 """
                 cursor.execute(events_query, parameters)
 
-                # Then delete the samples
+                # Then delete the samples using the same approach
+                placeholders = " OR ".join(["(id=? AND epoch=?)" for _ in samples])
+
                 samples_query = f"""
                     DELETE FROM samples
-                    WHERE (id, epoch) IN ({placeholders})
+                    WHERE {placeholders}
                 """
                 cursor.execute(samples_query, parameters)
             finally:
@@ -263,7 +267,7 @@ class SampleBufferDatabase(SampleBuffer):
 
                 # fetch data
                 return Samples(
-                    samples=list(self._get_samples(conn, True)),
+                    samples=list(self._get_samples(conn)),
                     metrics=task_data.metrics,
                     refresh=self.update_interval,
                     etag=str(task_data.version),

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -267,7 +267,7 @@ class SampleBufferDatabase(SampleBuffer):
 
                 # fetch data
                 return Samples(
-                    samples=list(self._get_samples(conn)),
+                    samples=list(self._get_samples(conn, True)),
                     metrics=task_data.metrics,
                     refresh=self.update_interval,
                     etag=str(task_data.version),


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)


https://inspectcommunity.slack.com/archives/C080K7SQ4SG/p1744204399673029


```
╭──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Cleaning up Docker environments (please do not interrupt this operation!):                                                           │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
╭─ run_eval_with_single_mode (473 samples): anthropic/claude-3-5-sonnet-latest ────────────────────────────────────────────────────────╮
│ ╭───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────╮             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/_util/_async.py:57 in tg_collect             │             │
│ │                                                                                                                      │             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py:772 in __aexit__            │             │
│ │                                                                                                                      │             │
│ │    769 │   │   │   │   │   # added to self._exceptions so it's ok to break exception                                 │             │
│ │    770 │   │   │   │   │   # chaining and avoid adding a "During handling of above..."                               │             │
│ │    771 │   │   │   │   │   # for each nesting level.                                                                 │             │
│ │ ❱  772 │   │   │   │   │   raise BaseExceptionGroup(                                                                 │             │
│ │    773 │   │   │   │   │   │   "unhandled errors in a TaskGroup", self._exceptions                                   │             │
│ │    774 │   │   │   │   │   ) from None                                                                               │             │
│ │    775 │   │   │   │   elif exc_val:                                                                                 │             │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯             │
│ ExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)                                                                    │
│                                                                                                                                      │
│ During handling of the above exception, another exception occurred:                                                                  │
│                                                                                                                                      │
│ ╭───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────╮             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:312 in task_run            │             │
│ │                                                                                                                      │             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/_util/_async.py:72 in tg_collect             │             │
│ │                                                                                                                      │             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/_util/_async.py:60 in run_task               │             │
│ │                                                                                                                      │             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:834 in task_run_sample     │             │
│ │                                                                                                                      │             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py:910 in log_sample          │             │
│ │                                                                                                                      │             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/log.py:221 in complete_sample     │             │
│ │                                                                                                                      │             │
│ │ /workspaces/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/log/_recorders/buffer/database.py:216 in     │             │
│ │ remove_samples                                                                                                       │             │
│ ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯             │
│ OperationalError: row value misused                                                                                                  │
│                                                                                                                                      │
│ Task interrupted (9 of 473 total samples logged before interruption). Resume task with:                                              │
│                                                                                                                                      │
│ inspect eval-retry logs/2025-04-09T10-55-30+00-00_run-eval-with-single-mode_PmaMXtnHjS6vPEByx9DLMq.eval                              │
│                                                                                                                                      │
│ Log: logs/2025-04-09T10-55-30+00-00_run-eval-with-single-mode_PmaMXtnHjS6vPEByx9DLMq.eval                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
```


### What is the new behavior?

No exception raised


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
