### PR TITLE
Approval: Approvers now take `history` argument (rather than `TaskState`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - [Model Roles](https://inspect.aisi.org.uk/models.html#model-roles) for creating aliases to models used in a task (e.g. "grader", "red_team", "blue_team", etc.)
 - Added `default` argument to `get_model()` to explicitly specify a fallback model if the specified model isn't found.
+- Approval: Approvers now take `history` argument (rather than `TaskState`) to better handle agent conversation state.
 - Bugfix: Correctly resolve approvers in the same source file as tasks. 
 
 ## v0.3.88 (11 April 2025)

--- a/docs/approval.qmd
+++ b/docs/approval.qmd
@@ -123,7 +123,7 @@ def auto_approver(decision: ApprovalDecision = "approve") -> Approver:
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         return Approval(decision=decision, explanation="Automatic decision.")
 
@@ -156,7 +156,7 @@ def bash_allowlist(
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
 
         # Make approval decision

--- a/docs/extensions.qmd
+++ b/docs/extensions.qmd
@@ -296,7 +296,7 @@ def auto_approver(decision: ApprovalDecision = "approve") -> Approver:
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         return Approval(
             decision=decision, 

--- a/examples/approval/approval.py
+++ b/examples/approval/approval.py
@@ -7,7 +7,7 @@ from inspect_ai import Task, task
 from inspect_ai.agent import react
 from inspect_ai.approval import Approval, Approver, approver
 from inspect_ai.dataset import Sample
-from inspect_ai.solver import TaskState
+from inspect_ai.model import ChatMessage
 from inspect_ai.tool import ToolCall, ToolCallView, bash, python
 
 
@@ -56,7 +56,7 @@ def bash_allowlist(
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         # evaluate the first argument no matter its name (for compatiblity
         # with a broader range of bash command executing tools)
@@ -153,7 +153,7 @@ def python_allowlist(
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         # evaluate the first argument no matter its name (for compatiblity
         # with a broader range of python code executing tools)

--- a/src/inspect_ai/approval/_apply.py
+++ b/src/inspect_ai/approval/_apply.py
@@ -2,6 +2,7 @@ from contextvars import ContextVar
 
 from inspect_ai._util.format import format_function_call
 from inspect_ai.approval._approval import Approval
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import (
     ToolCall,
     ToolCallContent,
@@ -14,10 +15,11 @@ from ._policy import ApprovalPolicy, policy_approver
 
 
 async def apply_tool_approval(
-    message: str, call: ToolCall, viewer: ToolCallViewer | None
+    message: str,
+    call: ToolCall,
+    viewer: ToolCallViewer | None,
+    history: list[ChatMessage],
 ) -> tuple[bool, Approval | None]:
-    from inspect_ai.solver._task_state import sample_state
-
     approver = _tool_approver.get(None)
     if approver:
         # resolve view
@@ -28,15 +30,12 @@ async def apply_tool_approval(
         else:
             view = default_tool_call_viewer(call)
 
-        # current sample state
-        state = sample_state()
-
         # call approver
         approval = await approver(
             message=message,
             call=call,
             view=view,
-            state=state,
+            history=history,
         )
 
         # process decision

--- a/src/inspect_ai/approval/_approver.py
+++ b/src/inspect_ai/approval/_approver.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from inspect_ai.solver._task_state import TaskState
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
 
 from ._approval import Approval
@@ -14,7 +14,7 @@ class Approver(Protocol):
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         """
         Approve or reject a tool call.
@@ -23,7 +23,7 @@ class Approver(Protocol):
             message: Message genreated by the model along with the tool call.
             call: The tool call to be approved.
             view: Custom rendering of tool context and call.
-            state: The current task state, if available.
+            history: The current conversation history.
 
         Returns:
             Approval: An Approval object containing the decision and explanation.

--- a/src/inspect_ai/approval/_auto.py
+++ b/src/inspect_ai/approval/_auto.py
@@ -1,4 +1,4 @@
-from inspect_ai.solver._task_state import TaskState
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
 
 from ._approval import Approval, ApprovalDecision
@@ -21,7 +21,7 @@ def auto_approver(decision: ApprovalDecision = "approve") -> Approver:
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         return Approval(decision=decision, explanation="Automatic decision.")
 

--- a/src/inspect_ai/approval/_call.py
+++ b/src/inspect_ai/approval/_call.py
@@ -1,9 +1,15 @@
+import inspect
+from logging import getLogger
+
+from inspect_ai._util.logger import warn_once
 from inspect_ai._util.registry import registry_log_name
-from inspect_ai.solver._task_state import TaskState
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
 
 from ._approval import Approval
 from ._approver import Approver
+
+logger = getLogger(__name__)
 
 
 async def call_approver(
@@ -11,10 +17,20 @@ async def call_approver(
     message: str,
     call: ToolCall,
     view: ToolCallView,
-    state: TaskState | None = None,
+    history: list[ChatMessage],
 ) -> Approval:
-    # run approver
-    approval = await approver(message, call, view, state)
+    # run approver (if the approval is still using state then
+    # provide that but issue a warning)
+    signature = inspect.signature(approver)
+    if "state" in signature.parameters.keys():
+        from inspect_ai.solver._task_state import sample_state
+
+        warn_once(
+            logger, "Approver 'state' parameter is deprecated (use 'history' instead)"
+        )
+        approval = await approver(message, call, view, sample_state())  # type: ignore[arg-type]
+    else:
+        approval = await approver(message, call, view, history)
 
     # record
     record_approval(registry_log_name(approver), message, call, view, approval)

--- a/src/inspect_ai/approval/_human/approver.py
+++ b/src/inspect_ai/approval/_human/approver.py
@@ -1,4 +1,4 @@
-from inspect_ai.solver._task_state import TaskState
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
 
 from .._approval import Approval, ApprovalDecision
@@ -25,11 +25,11 @@ def human_approver(
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         # try to use the panel approval (available in fullscreen display)
         try:
-            return await panel_approval(message, call, view, state, choices)
+            return await panel_approval(message, call, view, history, choices)
 
         # fallback to plain console approval (available in all displays)
         except NotImplementedError:

--- a/src/inspect_ai/approval/_human/manager.py
+++ b/src/inspect_ai/approval/_human/manager.py
@@ -3,7 +3,7 @@ from contextvars import ContextVar
 from typing import Callable, Literal, NamedTuple
 
 from inspect_ai._util.future import Future
-from inspect_ai.solver._task_state import TaskState
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
 
 from .._approval import Approval, ApprovalDecision
@@ -13,7 +13,7 @@ class ApprovalRequest(NamedTuple):
     message: str
     call: ToolCall
     view: ToolCallView
-    state: TaskState | None
+    history: list[ChatMessage]
     choices: list[ApprovalDecision]
 
 

--- a/src/inspect_ai/approval/_human/panel.py
+++ b/src/inspect_ai/approval/_human/panel.py
@@ -10,7 +10,7 @@ from textual.widgets import Button, Static
 from typing_extensions import override
 
 from inspect_ai._util.registry import registry_unqualified_name
-from inspect_ai.solver._task_state import TaskState
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
 from inspect_ai.util._panel import InputPanel, input_panel
 
@@ -29,7 +29,7 @@ async def panel_approval(
     message: str,
     call: ToolCall,
     view: ToolCallView,
-    state: TaskState | None,
+    history: list[ChatMessage],
     choices: list[ApprovalDecision],
 ) -> Approval:
     # ensure the approvals panel is shown
@@ -39,7 +39,7 @@ async def panel_approval(
     approvals = human_approval_manager()
     id = approvals.request_approval(
         ApprovalRequest(
-            message=message, call=call, view=view, state=state, choices=choices
+            message=message, call=call, view=view, history=history, choices=choices
         )
     )
     try:

--- a/src/inspect_ai/approval/_policy.py
+++ b/src/inspect_ai/approval/_policy.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field, model_validator
 from inspect_ai._util.config import read_config_object
 from inspect_ai._util.format import format_function_call
 from inspect_ai._util.registry import registry_create, registry_lookup
-from inspect_ai.solver._task_state import TaskState
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.tool._tool_call import ToolCall, ToolCallView
 from inspect_ai.util._resource import resource
 
@@ -59,13 +59,13 @@ def policy_approver(policies: str | list[ApprovalPolicy]) -> Approver:
         message: str,
         call: ToolCall,
         view: ToolCallView,
-        state: TaskState | None = None,
+        history: list[ChatMessage],
     ) -> Approval:
         # process approvers for this tool call (continue loop on "escalate")
         has_approver = False
         for approver in tool_approvers(call):
             has_approver = True
-            approval = await call_approver(approver, message, call, view, state)
+            approval = await call_approver(approver, message, call, view, history)
             if approval.decision != "escalate":
                 return approval
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -348,7 +348,9 @@ async def call_tool(
     # if we have a tool approver, apply it now
     from inspect_ai.approval._apply import apply_tool_approval
 
-    approved, approval = await apply_tool_approval(message, call, tool_def.viewer)
+    approved, approval = await apply_tool_approval(
+        message, call, tool_def.viewer, conversation
+    )
     if not approved:
         if approval and approval.decision == "terminate":
             from inspect_ai.solver._limit import SampleLimitExceededError


### PR DESCRIPTION
This enables approvers to get the full conversation history for sub-agents
