### PR TITLE
Fix `test_message_limit_*` tests

### DIFF
--- a/tests/test_sample_limits.py
+++ b/tests/test_sample_limits.py
@@ -65,11 +65,11 @@ def appending_solver():
 
 
 @solver
-def overwriting_solver(messages: int):
+def overwriting_solver():
     async def solve(state: TaskState, generate: Generate):
-        state.messages = [
-            ChatMessageUser(content="message") for _ in range(0, messages)
-        ]
+        # keep overwriting with an increasing number of messages until we hit a limit
+        while True:
+            state.messages = state.messages + [ChatMessageUser(content="message")]
 
         return state
 
@@ -91,7 +91,7 @@ def check_message_limit(solver: Solver):
     message_limit = randint(1, 3) * 2
     task = Task(
         dataset=[Sample(input="Say Hello", target="Hello")],
-        solver=looping_solver(),
+        solver=solver,
         scorer=match(),
         message_limit=message_limit,
     )
@@ -111,7 +111,7 @@ def test_message_limit_append():
 
 
 def test_message_limit_overwrite():
-    check_message_limit(overwriting_solver(10))
+    check_message_limit(overwriting_solver())
 
 
 @skip_if_no_openai


### PR DESCRIPTION
The `solver` parameter to `check_message_limit()` was unused which I think is unintentional as currently `test_message_limit_generate`, `test_message_limit_append`, `test_message_limit_overwrite` run exactly the same eval.

Once the passed solver is correctly used, `test_message_limit_overwrite` fails because it is "blocked" from overwriting the `TaskState.messages: ChatMessageList` with a list longer than `message_limit`. So `assert len(messages) == message_limit` fails e.g. `1 != 6`. I've adapted the solver to overwrite incrementally, but lmk if this was not the intention of the test!