### PR TITLE
Added lint check to catch (among other things) late binding closure bugs and fixed two extant bugs.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,12 +24,13 @@ select = [
     "F",      # flake8
     "D",      # pydocstyle
     "I",      # isort
+    "B",      # flake8-bugbear
     "SIM101", # duplicate isinstance
     "UP038",  # non-pep604-isinstance
     # "RET", # flake8-return
     # "RUF", # ruff rules
 ]
-ignore = ["E203", "E501", "D10", "D212", "D415"]
+ignore = ["E203", "E501", "D10", "D212", "D415","B006", "B007", "B008","B009","B010", "B011", "B017", "B027", "B028", "B039", "B904", "B905"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"

--- a/src/inspect_ai/tool/_tool_def.py
+++ b/src/inspect_ai/tool/_tool_def.py
@@ -234,9 +234,15 @@ def validate_tool_parameters(tool_name: str, parameters: dict[str, ToolParam]) -
     # validate that we have types/descriptions for paramters
     for param_name, param in parameters.items():
 
-        def raise_not_provided_error(context: str) -> None:
+        def raise_not_provided_error(
+            context: str,
+            # Use the default value trick to avoid Python's late binding of
+            # closures issue.
+            # see: https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result
+            bound_name: str = param_name,
+        ) -> None:
             raise ValueError(
-                f"{context} provided for parameter '{param_name}' of function '{tool_name}'."
+                f"{context} provided for parameter '{bound_name}' of function '{tool_name}'."
             )
 
         if param.type is None and not param.anyOf and not param.enum:

--- a/src/inspect_tool_support/pyproject.toml
+++ b/src/inspect_tool_support/pyproject.toml
@@ -21,6 +21,7 @@ select = [
     "F",      # flake8
     "D",      # pydocstyle
     "I",      # isort
+    "B",      # flake8-bugbear
     "SIM101", # duplicate isinstance
     "UP038",  # non-pep604-isinstance
     # "RET", # flake8-return
@@ -103,6 +104,7 @@ inspect-tool-support = "inspect_tool_support._cli.main:main"
 
 [project.optional-dependencies]
 dev = [
+    "ruff==0.9.6", # match version specified in .pre-commit-config.yaml
     "types-psutil"
 ]
 

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/cdp/dom_snapshot.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/cdp/dom_snapshot.py
@@ -293,5 +293,7 @@ def _dict_for_rare_string_data(
     """Creates a dictionary from a RareStringData object enabling lookups given a node index."""
     return {
         NodeIndex(index): value
-        for index, value in zip(rare_string_data.index, rare_string_data.value)
+        for index, value in zip(
+            rare_string_data.index, rare_string_data.value, strict=True
+        )
     }

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/playwright_page_crawler.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/playwright_page_crawler.py
@@ -292,6 +292,3 @@ class PageCrawler:
         except (asyncio.TimeoutError, TimeoutError):
             # No navigation occurred within the timeout period
             pass
-        except (asyncio.TimeoutError, TimeoutError):
-            # No navigation occurred within the timeout period
-            pass


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor


Introduces a lint check to catch issues, including late binding closure bugs and resolves two existing bugs in the codebase.

I added the entire [flake8-bugbear](https://github.com/PyCQA/flake8-bugbear?tab=readme-ov-file#list-of-warnings) class of rules to our ruff configuration. I then opted out of noisy/marginal rules.


See:
- [Late binding closures](https://docs.python-guide.org/writing/gotchas/#late-binding-closures)
- [Why do lambdas defined in a loop with different values all return the same result?](https://docs.python.org/3/faq/programming.html#why-do-lambdas-defined-in-a-loop-with-different-values-all-return-the-same-result)