### PR TITLE
openai-api model provider for interfacing with arbitrary services that have Open AI API compatible endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [Model Roles](https://inspect.aisi.org.uk/models.html#model-roles) for creating aliases to models used in a task (e.g. "grader", "red_team", "blue_team", etc.)
+- New [openai-api](https://inspect.aisi.org.uk/providers.html#openai-api) model provider for interfacing with arbitrary services that have Open AI API compatible endpoints.
 - Added `default` argument to `get_model()` to explicitly specify a fallback model if the specified model isn't found.
 - Approval: Approvers now take `history` argument (rather than `TaskState`) to better handle agent conversation state.
 - Bugfix: Correctly resolve approvers in the same source file as tasks. 

--- a/docs/_model-providers.md
+++ b/docs/_model-providers.md
@@ -10,8 +10,9 @@
 
 If the provider you are using is not listed above, you may still be able to use it if:
 
-1. It is available via OpenRouter (see the docs on using [OpenRouter](providers.qmd#openrouter) with Inspect).
+1. It provides an OpenAI compatible API endpoint. In this scenario, use the Inspect [OpenAI Compatible API](providers.qmd#openai-api) interface.
 
-2. It provides an OpenAI compatible API endpoint. In this scenario, use the Inspect [OpenAI](providers.qmd#openai) interface and set the `OPENAI_BASE_URL` environment variable to the apprpriate value for your provider.
+2. It is available via OpenRouter (see the docs on using [OpenRouter](providers.qmd#openrouter) with Inspect).
+
 
 You can also create [Model API Extensions](extensions.qmd#model-apis) to add model providers using their native interface.

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -482,12 +482,13 @@ $ inspect eval arc.py --model vllm/local -M model_path=./my-model
 
 ### vLLM Server
 
-vLLM provides an HTTP server that implements OpenAI’s Chat API. To use this with Inspect, use the `openai` provider rather than the `vllm` provider, setting the model base URL to point to the vLLM server rather than OpenAI. For example:
+vLLM provides an HTTP server that implements OpenAI’s Chat API. To use this with Inspect, use the `openai-api` provider rather than the `vllm` provider, setting the model base URL to point to the vLLM server. For example:
 
 ``` bash
-$ export OPENAI_BASE_URL=http://localhost:8080/v1
-$ export OPENAI_API_KEY=<your-server-api-key>
-$ inspect eval arc.py --model openai/meta-llama/Meta-Llama-3-8B-Instruct
+$ export VLLM_BASE_URL=http://localhost:8080/v1
+$ export VLLM_API_KEY=<your-server-api-key>
+$ inspect eval arc.py \
+    --model openai-api/vllm/meta-llama/Meta-Llama-3-8B-Instruct
 ```
 
 See the vLLM documentation on [Server Mode](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html) for additional details.
@@ -525,6 +526,41 @@ The following environment variables are supported by the llama-cpp-python provid
 | Variable | Description |
 |----------------------------|--------------------------------------------|
 | `LLAMA_CPP_PYTHON_BASE_URL` | Base URL for requests (optional, defaults to `http://localhost:8000/v1`) |
+
+## OpenAI Compatible {#openai-api}
+
+::: callout-note
+The `openai-api` provider described below is available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+If your model provider makes an OpenAI API compatible endpoint available, you can use it with Inspect via the `openai-api` provider, which uses the following model naming convention:
+
+```
+openai-api/<provider-name>/<model-name>
+```
+
+Inspect will read environment variables corresponding to the api key and base url of your provider using the following convention (note that the provider name is capitalized):
+
+```
+<PROVIDER-NAME>_API_KEY
+<PROVIDER-NAME>_BASE_URL
+```
+
+### Example
+
+Together already has it's own Inspect provider but is still useful for purposes of demonstrating the `openai-api` provider since it implements an OpenAI compatible endpoint. Here's how you would interface with Together using the `openai-api` provider:
+
+```bash
+TOGETHER_API_KEY=<your-together-api-key>
+TOGETHER_BASE_URL=https://api.together.xyz/v1
+inspect eval arc.py \
+   --model openai-api/together/deepseek-ai/DeepSeek-R1
+```
+
 
 ## OpenRouter
 

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -53,7 +53,7 @@ def bridge(agent: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]]) -> Agen
 
     async def execute(state: AgentState) -> AgentState:
         # create input (use standard gpt-4 message encoding -- i.e. no 'developer' messages)
-        messages = await openai_chat_messages(state.messages, model="gpt-4")
+        messages = await openai_chat_messages(state.messages)
         input = BridgeInput(messages=messages, input=messages)
 
         # run target function

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -1,9 +1,18 @@
 import json
 import re
+import socket
 from copy import copy
-from typing import Literal
+from typing import Any, Literal
 
-from openai import APIStatusError, OpenAIError
+import httpx
+from openai import (
+    DEFAULT_CONNECTION_LIMITS,
+    DEFAULT_TIMEOUT,
+    APIStatusError,
+    APITimeoutError,
+    OpenAIError,
+    RateLimitError,
+)
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionAssistantMessageParam,
@@ -38,9 +47,11 @@ from inspect_ai._util.content import (
     ContentReasoning,
     ContentText,
 )
+from inspect_ai._util.http import is_retryable_http_status
 from inspect_ai._util.images import file_as_data_uri
 from inspect_ai._util.url import is_http_url
 from inspect_ai.model._call_tools import parse_tool_call
+from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ChatCompletionChoice, Logprobs
 from inspect_ai.model._reasoning import parse_content_with_reasoning
 from inspect_ai.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo
@@ -146,24 +157,20 @@ async def openai_chat_completion_part(
 
 
 async def openai_chat_message(
-    message: ChatMessage, model: str
+    message: ChatMessage, system_role: Literal["user", "system", "developer"] = "system"
 ) -> ChatCompletionMessageParam:
     if message.role == "system":
-        # o1-mini does not support developer or system messages
-        # (see Dec 17, 2024 changelog: https://platform.openai.com/docs/changelog)
-        if is_o1_mini(model):
-            return ChatCompletionUserMessageParam(role="user", content=message.text)
-        # other o-series models use 'developer' rather than 'system' messages
-        # https://platform.openai.com/docs/guides/reasoning#advice-on-prompting
-        elif is_o_series(model):
-            return ChatCompletionDeveloperMessageParam(
-                role="developer", content=message.text
-            )
-        # gpt models use standard 'system' messages
-        else:
-            return ChatCompletionSystemMessageParam(
-                role=message.role, content=message.text
-            )
+        match system_role:
+            case "user":
+                return ChatCompletionUserMessageParam(role="user", content=message.text)
+            case "system":
+                return ChatCompletionSystemMessageParam(
+                    role=message.role, content=message.text
+                )
+            case "developer":
+                return ChatCompletionDeveloperMessageParam(
+                    role="developer", content=message.text
+                )
     elif message.role == "user":
         return ChatCompletionUserMessageParam(
             role=message.role,
@@ -202,9 +209,54 @@ async def openai_chat_message(
 
 
 async def openai_chat_messages(
-    messages: list[ChatMessage], model: str
+    messages: list[ChatMessage],
+    system_role: Literal["user", "system", "developer"] = "system",
 ) -> list[ChatCompletionMessageParam]:
-    return [await openai_chat_message(message, model) for message in messages]
+    return [await openai_chat_message(message, system_role) for message in messages]
+
+
+def openai_completion_params(
+    model: str, config: GenerateConfig, tools: bool
+) -> dict[str, Any]:
+    params: dict[str, Any] = dict(model=model)
+    if config.max_tokens is not None:
+        params["max_tokens"] = config.max_tokens
+    if config.frequency_penalty is not None:
+        params["frequency_penalty"] = config.frequency_penalty
+    if config.stop_seqs is not None:
+        params["stop"] = config.stop_seqs
+    if config.presence_penalty is not None:
+        params["presence_penalty"] = config.presence_penalty
+    if config.logit_bias is not None:
+        params["logit_bias"] = config.logit_bias
+    if config.seed is not None:
+        params["seed"] = config.seed
+    if config.temperature is not None:
+        params["temperature"] = config.temperature
+    if config.top_p is not None:
+        params["top_p"] = config.top_p
+    if config.num_choices is not None:
+        params["n"] = config.num_choices
+    if config.logprobs is not None:
+        params["logprobs"] = config.logprobs
+    if config.top_logprobs is not None:
+        params["top_logprobs"] = config.top_logprobs
+    if tools and config.parallel_tool_calls is not None:
+        params["parallel_tool_calls"] = config.parallel_tool_calls
+    if config.reasoning_effort is not None:
+        params["reasoning_effort"] = config.reasoning_effort
+    if config.response_schema is not None:
+        params["response_format"] = dict(
+            type="json_schema",
+            json_schema=dict(
+                name=config.response_schema.name,
+                schema=config.response_schema.json_schema.model_dump(exclude_none=True),
+                description=config.response_schema.description,
+                strict=config.response_schema.strict,
+            ),
+        )
+
+    return params
 
 
 def openai_assistant_content(message: ChatMessageAssistant) -> str:
@@ -496,6 +548,35 @@ def chat_message_assistant_from_openai(
     )
 
 
+def model_output_from_openai(
+    completion: ChatCompletion,
+    choices: list[ChatCompletionChoice],
+) -> ModelOutput:
+    return ModelOutput(
+        model=completion.model,
+        choices=choices,
+        usage=(
+            ModelUsage(
+                input_tokens=completion.usage.prompt_tokens,
+                output_tokens=completion.usage.completion_tokens,
+                input_tokens_cache_read=(
+                    completion.usage.prompt_tokens_details.cached_tokens
+                    if completion.usage.prompt_tokens_details is not None
+                    else None  # openai only have cache read stats/pricing.
+                ),
+                reasoning_tokens=(
+                    completion.usage.completion_tokens_details.reasoning_tokens
+                    if completion.usage.completion_tokens_details is not None
+                    else None
+                ),
+                total_tokens=completion.usage.total_tokens,
+            )
+            if completion.usage
+            else None
+        ),
+    )
+
+
 def chat_choices_from_openai(
     response: ChatCompletion, tools: list[ToolInfo]
 ) -> list[ChatCompletionChoice]:
@@ -515,6 +596,19 @@ def chat_choices_from_openai(
         )
         for choice in choices
     ]
+
+
+def openai_should_retry(ex: Exception) -> bool:
+    if isinstance(ex, RateLimitError):
+        return True
+    elif isinstance(ex, APIStatusError):
+        return is_retryable_http_status(ex.status_code)
+    elif isinstance(ex, OpenAIResponseError):
+        return ex.code in ["rate_limit_exceeded", "server_error"]
+    elif isinstance(ex, APITimeoutError):
+        return True
+    else:
+        return False
 
 
 def openai_handle_bad_request(
@@ -559,3 +653,39 @@ def openai_media_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
         value = copy(value)
         value.update(data=BASE_64_DATA_REMOVED)
     return value
+
+
+class OpenAIAsyncHttpxClient(httpx.AsyncClient):
+    """Custom async client that deals better with long running Async requests.
+
+    Based on Anthropic DefaultAsyncHttpClient implementation that they
+    released along with Claude 3.7 as well as the OpenAI DefaultAsyncHttpxClient
+
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        # This is based on the openai DefaultAsyncHttpxClient:
+        # https://github.com/openai/openai-python/commit/347363ed67a6a1611346427bb9ebe4becce53f7e
+        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
+        kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
+        kwargs.setdefault("follow_redirects", True)
+
+        # This is based on the anthrpopic changes for claude 3.7:
+        # https://github.com/anthropics/anthropic-sdk-python/commit/c5387e69e799f14e44006ea4e54fdf32f2f74393#diff-3acba71f89118b06b03f2ba9f782c49ceed5bb9f68d62727d929f1841b61d12bR1387-R1403
+
+        # set socket options to deal with long running reasoning requests
+        socket_options = [
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, True),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 60),
+            (socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 5),
+        ]
+        TCP_KEEPIDLE = getattr(socket, "TCP_KEEPIDLE", None)
+        if TCP_KEEPIDLE is not None:
+            socket_options.append((socket.IPPROTO_TCP, TCP_KEEPIDLE, 60))
+
+        kwargs["transport"] = httpx.AsyncHTTPTransport(
+            limits=DEFAULT_CONNECTION_LIMITS,
+            socket_options=socket_options,
+        )
+
+        super().__init__(**kwargs)

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -1,15 +1,8 @@
-import os
-
-from inspect_ai.model._providers.util import model_base_url
-from inspect_ai.model._providers.util.util import environment_prerequisite_error
-
 from .._generate_config import GenerateConfig
-from .openai import OpenAIAPI
-
-GROK_API_KEY = "GROK_API_KEY"
+from .openai_compatible import OpenAICompatibleAPI
 
 
-class GrokAPI(OpenAIAPI):
+class GrokAPI(OpenAICompatibleAPI):
     def __init__(
         self,
         model_name: str,
@@ -17,19 +10,11 @@ class GrokAPI(OpenAIAPI):
         api_key: str | None = None,
         config: GenerateConfig = GenerateConfig(),
     ) -> None:
-        # resolve base url
-        base_url = model_base_url(base_url, "GROK_BASE_URL")
-        base_url = base_url or "https://api.x.ai/v1"
-
-        # resolve api key
-        api_key = api_key or os.environ.get(GROK_API_KEY, None)
-        if api_key is None:
-            raise environment_prerequisite_error("Grok", GROK_API_KEY)
-
-        # call super
         super().__init__(
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
             config=config,
+            service="Grok",
+            service_base_url="https://api.x.ai/v1",
         )

--- a/src/inspect_ai/model/_providers/llama_cpp_python.py
+++ b/src/inspect_ai/model/_providers/llama_cpp_python.py
@@ -1,10 +1,8 @@
-from inspect_ai.model._providers.util import model_base_url
-
 from .._generate_config import GenerateConfig
-from .openai import OpenAIAPI
+from .openai_compatible import OpenAICompatibleAPI
 
 
-class LlamaCppPythonAPI(OpenAIAPI):
+class LlamaCppPythonAPI(OpenAICompatibleAPI):
     def __init__(
         self,
         model_name: str,
@@ -12,10 +10,11 @@ class LlamaCppPythonAPI(OpenAIAPI):
         api_key: str | None = None,
         config: GenerateConfig = GenerateConfig(),
     ) -> None:
-        base_url = model_base_url(base_url, "LLAMA_CPP_PYTHON_BASE_URL")
-        base_url = base_url if base_url else "http://localhost:8000/v1"
-        if not api_key:
-            api_key = "llama-cpp-python"
         super().__init__(
-            model_name=model_name, base_url=base_url, api_key=api_key, config=config
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key or "llama-cpp-python",
+            config=config,
+            service="llama_cpp_python",
+            service_base_url="http://localhost:8000/v1",
         )

--- a/src/inspect_ai/model/_providers/ollama.py
+++ b/src/inspect_ai/model/_providers/ollama.py
@@ -1,10 +1,8 @@
-from inspect_ai.model._providers.util import model_base_url
-
 from .._generate_config import GenerateConfig
-from .openai import OpenAIAPI
+from .openai_compatible import OpenAICompatibleAPI
 
 
-class OllamaAPI(OpenAIAPI):
+class OllamaAPI(OpenAICompatibleAPI):
     def __init__(
         self,
         model_name: str,
@@ -12,10 +10,11 @@ class OllamaAPI(OpenAIAPI):
         api_key: str | None = None,
         config: GenerateConfig = GenerateConfig(),
     ) -> None:
-        base_url = model_base_url(base_url, "OLLAMA_BASE_URL")
-        base_url = base_url if base_url else "http://localhost:11434/v1"
-        if not api_key:
-            api_key = "ollama"
         super().__init__(
-            model_name=model_name, base_url=base_url, api_key=api_key, config=config
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key or "ollama",
+            config=config,
+            service="Ollama",
+            service_base_url="http://localhost:11434/v1",
         )

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -1,0 +1,194 @@
+import os
+from logging import getLogger
+from typing import Any
+
+from openai import (
+    APIStatusError,
+    AsyncOpenAI,
+    BadRequestError,
+    UnprocessableEntityError,
+)
+from openai._types import NOT_GIVEN
+from openai.types.chat import ChatCompletion
+from typing_extensions import override
+
+from inspect_ai.model._openai import chat_choices_from_openai
+from inspect_ai.model._providers.util.hooks import HttpxHooks
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+from .._chat_message import ChatMessage
+from .._generate_config import GenerateConfig
+from .._model import ModelAPI
+from .._model_call import ModelCall
+from .._model_output import ChatCompletionChoice, ModelOutput
+from .._openai import (
+    OpenAIAsyncHttpxClient,
+    model_output_from_openai,
+    openai_chat_messages,
+    openai_chat_tool_choice,
+    openai_chat_tools,
+    openai_completion_params,
+    openai_handle_bad_request,
+    openai_media_filter,
+    openai_should_retry,
+)
+from .util import environment_prerequisite_error, model_base_url
+
+logger = getLogger(__name__)
+
+
+class OpenAICompatibleAPI(ModelAPI):
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        service: str | None = None,
+        service_base_url: str | None = None,
+        **model_args: Any,
+    ) -> None:
+        # extract service prefix from model name if not specified
+        if service is None:
+            parts = model_name.split("/")
+            if len(parts) == 1:
+                raise ValueError(
+                    "openai-api model names must include a service prefix (e.g. 'openai-api/service/model')"
+                )
+            self.service = parts[0]
+        else:
+            self.service = service
+
+        # compute api key
+        api_key_var = f"{self.service.upper()}_API_KEY"
+
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            api_key_vars=[api_key_var],
+            config=config,
+        )
+
+        # use service prefix to lookup api_key
+        if not self.api_key:
+            self.api_key = os.environ.get(api_key_var, None)
+            if not self.api_key:
+                raise environment_prerequisite_error(
+                    self.service,
+                    [api_key_var],
+                )
+
+        # use service prefix to lookup base_url
+        if not self.base_url:
+            base_url_var = f"{self.service.upper()}_BASE_URL"
+            self.base_url = model_base_url(base_url, [base_url_var]) or service_base_url
+            if not self.base_url:
+                raise environment_prerequisite_error(
+                    self.service,
+                    [base_url_var],
+                )
+
+        # create async http client
+        http_client = OpenAIAsyncHttpxClient()
+        self.client = AsyncOpenAI(
+            api_key=self.api_key,
+            base_url=self.base_url,
+            http_client=http_client,
+            **model_args,
+        )
+
+        # create time tracker
+        self._http_hooks = HttpxHooks(self.client._client)
+
+    @override
+    async def aclose(self) -> None:
+        await self.client.close()
+
+    async def generate(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
+        # allocate request_id (so we can see it from ModelCall)
+        request_id = self._http_hooks.start_request()
+
+        # setup request and response for ModelCall
+        request: dict[str, Any] = {}
+        response: dict[str, Any] = {}
+
+        def model_call() -> ModelCall:
+            return ModelCall.create(
+                request=request,
+                response=response,
+                filter=openai_media_filter,
+                time=self._http_hooks.end_request(request_id),
+            )
+
+        # get completion params (slice off service from model name)
+        completion_params = self.completion_params(
+            config=config,
+            tools=len(tools) > 0,
+        )
+
+        # prepare request (we do this so we can log the ModelCall)
+        request = dict(
+            messages=await openai_chat_messages(input),
+            tools=openai_chat_tools(tools) if len(tools) > 0 else NOT_GIVEN,
+            tool_choice=openai_chat_tool_choice(tool_choice)
+            if len(tools) > 0
+            else NOT_GIVEN,
+            extra_headers={HttpxHooks.REQUEST_ID_HEADER: request_id},
+            **completion_params,
+        )
+
+        try:
+            # generate completion and save response for model call
+            completion: ChatCompletion = await self.client.chat.completions.create(
+                **request
+            )
+            response = completion.model_dump()
+            self.on_response(response)
+
+            # return output and call
+            choices = self.chat_choices_from_completion(completion, tools)
+            return model_output_from_openai(completion, choices), model_call()
+
+        except (BadRequestError, UnprocessableEntityError) as ex:
+            return self.handle_bad_request(ex), model_call()
+
+    def service_model_name(self) -> str:
+        """Model name without any service prefix."""
+        return self.model_name.replace(f"{self.service}/", "", 1)
+
+    @override
+    def should_retry(self, ex: Exception) -> bool:
+        return openai_should_retry(ex)
+
+    @override
+    def connection_key(self) -> str:
+        """Scope for enforcing max_connections (could also use endpoint)."""
+        return str(self.api_key)
+
+    def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        return openai_completion_params(
+            model=self.service_model_name(),
+            config=config,
+            tools=tools,
+        )
+
+    def on_response(self, response: dict[str, Any]) -> None:
+        """Hook for subclasses to do custom response handling."""
+        pass
+
+    def chat_choices_from_completion(
+        self, completion: ChatCompletion, tools: list[ToolInfo]
+    ) -> list[ChatCompletionChoice]:
+        """Hook for subclasses to do custom chat choice processing."""
+        return chat_choices_from_openai(completion, tools)
+
+    def handle_bad_request(self, ex: APIStatusError) -> ModelOutput | Exception:
+        """Hook for subclasses to do bad request handling"""
+        return openai_handle_bad_request(self.service_model_name(), ex)

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -1,16 +1,13 @@
 import json
-import os
 from typing import Any, TypedDict
 
 from typing_extensions import NotRequired, override
 
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.model._openai import OpenAIResponseError
-from inspect_ai.model._providers.util import model_base_url
-from inspect_ai.model._providers.util.util import environment_prerequisite_error
 
 from .._generate_config import GenerateConfig
-from .openai import OpenAIAPI
+from .openai_compatible import OpenAICompatibleAPI
 
 OPENROUTER_API_KEY = "OPENROUTER_API_KEY"
 
@@ -37,7 +34,7 @@ class OpenRouterError(Exception):
         )
 
 
-class OpenRouterAPI(OpenAIAPI):
+class OpenRouterAPI(OpenAICompatibleAPI):
     def __init__(
         self,
         model_name: str,
@@ -46,16 +43,6 @@ class OpenRouterAPI(OpenAIAPI):
         config: GenerateConfig = GenerateConfig(),
         **model_args: Any,
     ) -> None:
-        # api_key
-        if not api_key:
-            api_key = os.environ.get(OPENROUTER_API_KEY, None)
-            if not api_key:
-                raise environment_prerequisite_error("OpenRouter", OPENROUTER_API_KEY)
-
-        # base_url
-        base_url = model_base_url(base_url, "OPENROUTER_BASE_URL")
-        base_url = base_url if base_url else "https://openrouter.ai/api/v1"
-
         # collect known model args that we forward to generate
         def collect_model_arg(name: str) -> Any | None:
             nonlocal model_args
@@ -88,6 +75,8 @@ class OpenRouterAPI(OpenAIAPI):
             base_url=base_url,
             api_key=api_key,
             config=config,
+            service="OpenRouter",
+            service_base_url="https://openrouter.ai/api/v1",
             **model_args,
         )
 

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -44,6 +44,17 @@ def openai() -> type[ModelAPI]:
     return OpenAIAPI
 
 
+@modelapi(name="openai-api")
+def openai_api() -> type[ModelAPI]:
+    # validate
+    validate_openai_client("OpenAI Compatible API")
+
+    # in the clear
+    from .openai_compatible import OpenAICompatibleAPI
+
+    return OpenAICompatibleAPI
+
+
 @modelapi(name="anthropic")
 def anthropic() -> type[ModelAPI]:
     FEATURE = "Anthropic API"

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -1,0 +1,31 @@
+import pytest
+from test_helpers.utils import skip_if_no_together, skip_if_no_together_base_url
+
+from inspect_ai.model import (
+    ChatMessageUser,
+    GenerateConfig,
+    get_model,
+)
+
+
+@pytest.mark.asyncio
+@skip_if_no_together
+@skip_if_no_together_base_url
+async def test_openai_compatible() -> None:
+    model = get_model(
+        "openai-api/together/meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+        config=GenerateConfig(
+            frequency_penalty=0.0,
+            stop_seqs=None,
+            max_tokens=50,
+            presence_penalty=0.0,
+            logit_bias=dict([(42, 10), (43, -10)]),
+            seed=None,
+            temperature=0.0,
+            top_p=1.0,
+        ),
+    )
+
+    message = ChatMessageUser(content="This is a test string. What are you?")
+    response = await model.generate(input=[message])
+    assert len(response.completion) >= 1

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -99,6 +99,10 @@ def skip_if_no_together(func):
     return pytest.mark.api(skip_if_env_var("TOGETHER_API_KEY", exists=False)(func))
 
 
+def skip_if_no_together_base_url(func):
+    return pytest.mark.api(skip_if_env_var("TOGETHER_BASE_URL", exists=False)(func))
+
+
 def skip_if_no_azureai(func):
     return pytest.mark.api(skip_if_env_var("AZUREAI_API_KEY", exists=False)(func))
 


### PR DESCRIPTION

If your model provider makes an OpenAI API compatible endpoint available, you can use it with Inspect via the `openai-api` provider, which uses the following model naming convention:

```
openai-api/<provider-name>/<model-name>
```

Inspect will read environment variables corresponding to the api key and base url of your provider using the following convention (note that the provider name is capitalized):

```
<PROVIDER-NAME>_API_KEY
<PROVIDER-NAME>_BASE_URL
```

### Example

Together already has it's own Inspect provider but is still useful for purposes of demonstrating the `openai-api` provider since it implements an OpenAI compatible endpoint. Here's how you would interface with Together using the `openai-api` provider:

```bash
TOGETHER_API_KEY=<your-together-api-key>
TOGETHER_BASE_URL=https://api.together.xyz/v1
inspect eval arc.py \
   --model openai-api/together/deepseek-ai/DeepSeek-R1
```
