### PR TITLE
Fix agent decorator to work with imported annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added `default` argument to `get_model()` to explicitly specify a fallback model if the specified model isn't found.
 - Approval: Approvers now take `history` argument (rather than `TaskState`) to better handle agent conversation state.
 - Bugfix: Correctly resolve approvers in the same source file as tasks. 
+- Bugfix: Ensure agent decorator resolves string annotations from `__future__` as needed.
 
 ## v0.3.88 (11 April 2025)
 

--- a/src/inspect_ai/agent/_agent.py
+++ b/src/inspect_ai/agent/_agent.py
@@ -1,5 +1,6 @@
 from copy import copy, deepcopy
 from functools import wraps
+from inspect import signature
 from typing import (
     Any,
     Callable,
@@ -7,6 +8,7 @@ from typing import (
     Protocol,
     TypeGuard,
     cast,
+    get_type_hints,
     overload,
     runtime_checkable,
 )
@@ -188,6 +190,16 @@ def agent(
                 **kwargs,
             )
             return agent
+
+        # If a user's code runs "from __future__ import annotations", all type annotations are stored as strings,
+        # which can break introspection-based mechanisms (like inspecting a function’s signature).
+        # The following two lines resolve these string annotations using the original function's globals,
+        # ensuring that any forward references (e.g., "Agent") are evaluated to their actual types,
+        # and then reassign the original function's signature to the wrapper.
+        agent_wrapper.__annotations__ = get_type_hints(
+            agent_wrapper, agent_type.__globals__
+        )
+        agent_wrapper.__signature__ = signature(agent_type)  # type: ignore[attr-defined]
 
         # register
         return agent_register(cast(Callable[P, Agent], agent_wrapper), agent_name)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Running `inspect eval mytask.py --solver mysolver.py` with the following two files produces an error
`TypeError: object function can't be used in 'await' expression `


mytask.py:
```py
from inspect_ai import Task, task
from inspect_ai.dataset import Sample
from inspect_ai.solver import generate

@task
def test_agent_react_ctf():
    task = Task(
        dataset=[Sample(input="Submit the flag 'hello'.")],
        solver=generate(),
        sandbox="docker",
        max_messages=5,
    )
    return task
```

mysolver.py:
```py
from __future__ import annotations # XXX Remove this line and the error goes away
from inspect_ai.agent import Agent, agent, react

@agent
def ctf_agent(attempts=1) -> Agent:
    return react(
        description="Expert at completing cybersecurity challenges.",
        prompt="Submit any flag",
        tools=[],
        attempts=attempts,
    )
```


### What is the new behavior?

The agent decorator will still work even if annotations are imported.


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

I learned a lot about annotations tracking this issue down, it seems like the import modifies how the type signature stores information, changing what's normally stored as an object into a string. It might be reasonable to broadly recommend against importing annotations into any file that defines inspect tasks and agents if there are other places where this will cause issues. Would appreciate feedback on the bigger picture situation from someone with a better understanding of python annotations!


