### PR TITLE
Allow running `human_cli` as non-default user

### DIFF
--- a/docs/_sandboxenv-interface.md
+++ b/docs/_sandboxenv-interface.md
@@ -53,7 +53,7 @@ class SandboxEnvironment:
         """
         ...
 
-    async def connection(self) -> SandboxConnection:
+    async def connection(self, user: str | None = None) -> SandboxConnection:
         """
         Raises:
            NotImplementedError: For sandboxes that don't provide connections

--- a/examples/human/Dockerfile
+++ b/examples/human/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:24.04
+
+# Update the package lists
+RUN apt-get update -y && apt-get upgrade -y
+
+# Install any necessary packages
+RUN apt-get install -y curl python3 python3-pip python3-dev python3-venv
+
+# Create a non-root user
+RUN useradd -m nonroot
+
+# Specify the command to run when the container starts
+CMD ["/bin/bash"]

--- a/examples/human/Dockerfile
+++ b/examples/human/Dockerfile
@@ -1,13 +1,15 @@
 FROM ubuntu:24.04
 
-# Update the package lists
-RUN apt-get update -y && apt-get upgrade -y
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        curl \
+        python3 \
+        python3-pip \
+        python3-dev \
+        python3-venv && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
-# Install any necessary packages
-RUN apt-get install -y curl python3 python3-pip python3-dev python3-venv
-
-# Create a non-root user
 RUN useradd -m nonroot
 
-# Specify the command to run when the container starts
-CMD ["/bin/bash"]
+CMD ["tail", "-f", "/dev/null"]

--- a/examples/human/compose.yaml
+++ b/examples/human/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  default:
+    build: .
+    command: tail -f /dev/null
+    cpus: 1.0
+    mem_limit: 2.0gb
+    network_mode: bridge

--- a/examples/human/compose.yaml
+++ b/examples/human/compose.yaml
@@ -2,6 +2,3 @@ services:
   default:
     build: .
     command: tail -f /dev/null
-    cpus: 1.0
-    mem_limit: 2.0gb
-    network_mode: bridge

--- a/examples/human/human.py
+++ b/examples/human/human.py
@@ -1,0 +1,10 @@
+from inspect_ai import Task, task
+from inspect_ai.solver._human_agent import human_agent
+
+
+@task
+def human() -> Task:
+    return Task(
+        solver=human_agent(user="nonroot"),
+        sandbox=("docker", "compose.yaml"),
+    )

--- a/examples/human/human.py
+++ b/examples/human/human.py
@@ -5,6 +5,6 @@ from inspect_ai.solver._human_agent import human_agent
 @task
 def human() -> Task:
     return Task(
-        solver=human_agent(user="nonroot"),
+        solver=human_agent(),
         sandbox=("docker", "compose.yaml"),
     )

--- a/src/inspect_ai/agent/_human/agent.py
+++ b/src/inspect_ai/agent/_human/agent.py
@@ -18,6 +18,7 @@ def human_cli(
     answer: bool | str = True,
     intermediate_scoring: bool = False,
     record_session: bool = True,
+    user: str | None = None,
 ) -> Agent:
     """Human CLI agent for tasks that run in a sandbox.
 
@@ -37,6 +38,7 @@ def human_cli(
           that the answer matches the expected format.
        intermediate_scoring: Allow the human agent to check their score while working.
        record_session: Record all user commands and outputs in the sandbox bash session.
+       user: User to login as. Defaults to the sandbox environment's default user.
 
     Returns:
        Agent: Human CLI agent.
@@ -48,7 +50,7 @@ def human_cli(
         async with agent_lock:
             # ensure that we have a sandbox to work with
             try:
-                connection = await sandbox().connection()
+                connection = await sandbox().connection(user=user)
             except ProcessLookupError:
                 raise RuntimeError("Human agent must run in a task with a sandbox.")
             except NotImplementedError:
@@ -66,13 +68,13 @@ def human_cli(
                     )
 
                     # install agent tools
-                    await install_human_agent(commands, record_session)
+                    await install_human_agent(user, commands, record_session)
 
                     # hookup the view ui
                     view.connect(connection)
 
                     # run sandbox service
-                    return await run_human_agent_service(state, commands, view)
+                    return await run_human_agent_service(user, state, commands, view)
 
             # support both fullscreen ui and fallback
             if display_type() == "full":

--- a/src/inspect_ai/agent/_human/install.py
+++ b/src/inspect_ai/agent/_human/install.py
@@ -192,7 +192,7 @@ def human_agent_bashrc(commands: list[HumanAgentCommand], record_session: bool) 
     return "\n".join([TERMINAL_CHECK, COMMANDS, RECORDING, INSTRUCTIONS, CLOCK])
 
 
-def human_agent_install_sh(user: str) -> str:
+def human_agent_install_sh(user: str | None) -> str:
     return dedent(f"""
     #!/usr/bin/env bash
 
@@ -204,7 +204,11 @@ def human_agent_install_sh(user: str) -> str:
     cp {TASK_PY} $HUMAN_AGENT
 
     # get user's home directory
-    USER_HOME=$(getent passwd {user} | cut -d: -f6)
+    USER="{user or ""}"
+    if [ -z "$USER" ]; then
+        USER=$(whoami)
+    fi
+    USER_HOME=$(getent passwd $USER | cut -d: -f6)
 
     # append to user's .bashrc
     cat {BASHRC} >> $USER_HOME/{BASHRC}

--- a/src/inspect_ai/agent/_human/install.py
+++ b/src/inspect_ai/agent/_human/install.py
@@ -179,8 +179,8 @@ def human_agent_bashrc(commands: list[HumanAgentCommand], record_session: bool) 
     INSTRUCTIONS = dedent("""
     if [ -z "$INSTRUCTIONS_SHOWN" ]; then
         export INSTRUCTIONS_SHOWN=1
-        task instructions > instructions.txt
-        cat instructions.txt
+        task instructions > ~/instructions.txt
+        cat ~/instructions.txt
     fi
     """).lstrip()
 

--- a/src/inspect_ai/agent/_human/service.py
+++ b/src/inspect_ai/agent/_human/service.py
@@ -10,7 +10,10 @@ from .view import HumanAgentView
 
 
 async def run_human_agent_service(
-    state: AgentState, commands: list[HumanAgentCommand], view: HumanAgentView | None
+    user: str | None,
+    state: AgentState,
+    commands: list[HumanAgentCommand],
+    view: HumanAgentView | None,
 ) -> AgentState:
     # initialise agent state
     instructions = "\n\n".join([message.text for message in state.messages]).strip()
@@ -39,6 +42,7 @@ async def run_human_agent_service(
         methods=methods,
         until=task_is_completed,
         sandbox=sandbox(),
+        user=user,
     )
 
     # set the answer if we have one

--- a/src/inspect_ai/solver/_human_agent.py
+++ b/src/inspect_ai/solver/_human_agent.py
@@ -13,6 +13,7 @@ def human_agent(
     answer: bool | str = True,
     intermediate_scoring: bool = False,
     record_session: bool = True,
+    user: str | None = None,
 ) -> Solver:
     """Human solver for agentic tasks that run in a Linux environment.
 
@@ -32,6 +33,7 @@ def human_agent(
           that the answer matches the expected format.
        intermediate_scoring: Allow the human agent to check their score while working.
        record_session: Record all user commands and outputs in the sandbox bash session.
+       user: User to login as. Defaults to the sandbox environment's default user.
 
     Returns:
        Solver: Human agent solver.
@@ -48,5 +50,6 @@ def human_agent(
             answer=answer,
             intermediate_scoring=intermediate_scoring,
             record_session=record_session,
+            user=user,
         )
     )

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -425,7 +425,15 @@ class DockerSandboxEnvironment(SandboxEnvironment):
             return SandboxConnection(
                 type="docker",
                 command=shlex.join(
-                    ["docker", "exec", "-it", "--user", user, container, "bash", "-l"]
+                    [
+                        "docker",
+                        "exec",
+                        "-it",
+                        *(["--user", user] if user else []),
+                        container,
+                        "bash",
+                        "-l",
+                    ]
                 ),
                 vscode_command=[
                     "remote-containers.attachToRunningContainer",

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -187,11 +187,14 @@ class SandboxEnvironment(abc.ABC):
         """
         ...
 
-    async def connection(self) -> SandboxConnection:
+    async def connection(self, user: str | None = None) -> SandboxConnection:
         """Information required to connect to sandbox environment.
 
+        Args:
+          user: User to login as.
+
         Returns:
-           SandboxConnection: connection information
+           SandboxConnection: connection information.
 
         Raises:
            NotImplementedError: For sandboxes that don't provide connections

--- a/src/inspect_ai/util/_sandbox/events.py
+++ b/src/inspect_ai/util/_sandbox/events.py
@@ -133,8 +133,8 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
         return output
 
     @override
-    async def connection(self) -> SandboxConnection:
-        return await self._sandbox.connection()
+    async def connection(self, user: str | None = None) -> SandboxConnection:
+        return await self._sandbox.connection(user)
 
     @override
     def as_type(self, sandbox_cls: Type[ST]) -> ST:

--- a/tests/agent/compose.human.yaml
+++ b/tests/agent/compose.human.yaml
@@ -1,0 +1,6 @@
+services:
+  default:
+    build:
+      context: .
+      dockerfile: human.Dockerfile
+    init: true

--- a/tests/agent/human.Dockerfile
+++ b/tests/agent/human.Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        curl \
+        python3 \
+        python3-pip \
+        python3-dev \
+        python3-venv && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m nonroot
+
+CMD ["tail", "-f", "/dev/null"]

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -1,3 +1,9 @@
+import concurrent.futures
+import re
+import subprocess
+import time
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
 
 import pytest
@@ -9,10 +15,49 @@ from inspect_ai.agent._human.agent import human_cli
 
 @pytest.mark.slow
 @skip_if_no_docker
-def test_human_cli():
+@pytest.mark.parametrize("user", ["root", "nonroot", None])
+def test_human_cli(user: str | None):
     task = Task(
-        solver=human_cli(),
-        sandbox=("docker", (Path(__file__).parent / "compose.yaml").as_posix()),
+        solver=human_cli(user=user),
+        sandbox=("docker", (Path(__file__).parent / "compose.human.yaml").as_posix()),
     )
-    log = eval(task, display="plain")[0]
-    assert log.status == "success"
+
+    stdout = StringIO()
+
+    def run_eval():
+        with redirect_stdout(stdout):
+            return eval(task, display="plain")[0]
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        future = executor.submit(run_eval)
+
+        while True:
+            if match := re.search(r"inspect-task-[^\s]+", stdout.getvalue()):
+                container_name = match.group(0)
+                assert container_name, "Expected to find task ID in docker exec command"
+                break
+            time.sleep(1)
+
+        docker_exec = [
+            "docker",
+            "exec",
+            "-it",
+            *(["-u", user] if user else []),
+            container_name,
+            "bash",
+            "-l",
+            "-c",
+        ]
+        subprocess.run(docker_exec + ["python3 /opt/human_agent/task.py start"])
+        subprocess.run(
+            docker_exec
+            + [
+                'echo -e "y\\n" | python3 /opt/human_agent/task.py submit "test"',
+            ],
+        )
+
+        concurrent.futures.wait([future])
+
+        log = future.result()
+        assert log.status == "success"
+        assert log.samples[0].output.choices[0].message.content == "test"

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+
+import pytest
+from test_helpers.utils import skip_if_no_docker
+
+from inspect_ai import Task, eval
+from inspect_ai.agent._human.agent import human_cli
+
+
+@pytest.mark.slow
+@skip_if_no_docker
+def test_human_cli():
+    task = Task(
+        solver=human_cli(),
+        sandbox=("docker", (Path(__file__).parent / "compose.yaml").as_posix()),
+    )
+    log = eval(task, display="plain")[0]
+    assert log.status == "success"

--- a/tests/agent/test_agent_human.py
+++ b/tests/agent/test_agent_human.py
@@ -28,61 +28,54 @@ def test_human_cli(capsys: pytest.CaptureFixture[str], user: str | None):
     with concurrent.futures.ThreadPoolExecutor() as executor:
         future = executor.submit(run_eval)
 
-        try:
-            out = ""
-            container_name = None
-            for _ in range(10):
-                out += capsys.readouterr().out
-                if match := re.search(r"inspect-task-\S+-default-1", out):
-                    container_name = match.group(0)
-                    break
-                time.sleep(1)
+        out = ""
+        container_name = None
+        for _ in range(10):
+            out += capsys.readouterr().out
+            if match := re.search(r"inspect-task-\S+-default-1", out):
+                container_name = match.group(0)
+                break
+            time.sleep(1)
 
-            if not container_name:
-                raise Exception("Failed to find container name")
+        if not container_name:
+            raise Exception("Failed to find container name")
 
-            docker_exec = [
-                "docker",
-                "exec",
-                *(["-u", user] if user else []),
-                container_name,
-                "bash",
-                "-l",
-                "-c",
-            ]
+        docker_exec = [
+            "docker",
+            "exec",
+            *(["-u", user] if user else []),
+            container_name,
+            "bash",
+            "-l",
+            "-c",
+        ]
 
-            human_agent_found = False
-            for _ in range(10):
-                result = subprocess.run(
-                    docker_exec
-                    + ["ls /var/tmp/sandbox-services/human_agent/human_agent.py"]
-                )
-                if result.returncode == 0:
-                    human_agent_found = True
-                    break
-                time.sleep(1)
-
-            if not human_agent_found:
-                raise Exception("Human agent not found")
-
-            subprocess.check_call(
-                docker_exec + ["python3 /opt/human_agent/task.py start"]
-            )
-            subprocess.check_call(
+        human_agent_found = False
+        for _ in range(10):
+            result = subprocess.run(
                 docker_exec
-                + [
-                    'echo -e "y\\n" | python3 /opt/human_agent/task.py submit "test"',
-                ],
+                + ["ls /var/tmp/sandbox-services/human_agent/human_agent.py"]
             )
+            if result.returncode == 0:
+                human_agent_found = True
+                break
+            time.sleep(1)
 
-            done, _ = concurrent.futures.wait([future], timeout=5)
-            if future in done:
-                log = future.result()
-                assert log.status == "success"
-                assert log.samples[0].output.choices[0].message.content == "test"
-            else:
-                raise Exception("eval() did not complete within timeout")
+        if not human_agent_found:
+            raise Exception("Human agent sandbox service not found")
 
-        except Exception:
-            concurrent.futures.wait([future], timeout=1)
-            raise
+        subprocess.check_call(docker_exec + ["python3 /opt/human_agent/task.py start"])
+        subprocess.check_call(
+            docker_exec
+            + [
+                'echo -e "y\\n" | python3 /opt/human_agent/task.py submit "test"',
+            ],
+        )
+
+        done, _ = concurrent.futures.wait([future], timeout=5)
+        if future in done:
+            log = future.result()
+            assert log.status == "success"
+            assert log.samples[0].output.choices[0].message.content == "test"
+        else:
+            raise Exception("eval() did not complete within timeout")

--- a/tests/util/sandbox/compose.sandbox-service.yaml
+++ b/tests/util/sandbox/compose.sandbox-service.yaml
@@ -1,0 +1,6 @@
+services:
+  default:
+    build:
+      context: .
+      dockerfile: sandbox-service.Dockerfile
+    init: true

--- a/tests/util/sandbox/sandbox-service.Dockerfile
+++ b/tests/util/sandbox/sandbox-service.Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.12-bookworm
+
+RUN useradd -m nonroot
+
+CMD ["tail", "-f", "/dev/null"]

--- a/tests/util/sandbox/sandbox-service.Dockerfile
+++ b/tests/util/sandbox/sandbox-service.Dockerfile
@@ -1,4 +1,14 @@
-FROM python:3.12-bookworm
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        curl \
+        python3 \
+        python3-pip \
+        python3-dev \
+        python3-venv && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN useradd -m nonroot
 

--- a/tests/util/sandbox/test_sandbox_service.py
+++ b/tests/util/sandbox/test_sandbox_service.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from textwrap import dedent
 
 import anyio
@@ -10,8 +11,16 @@ from inspect_ai.util._sandbox.service import sandbox_service
 
 
 @pytest.mark.slow
-def test_sandbox_service():
-    log = eval(Task(solver=math_service()), model="mockllm/model", sandbox="docker")[0]
+@pytest.mark.parametrize("user", ["root", "nonroot", None])
+def test_sandbox_service(user: str | None):
+    log = eval(
+        Task(solver=math_service(user)),
+        model="mockllm/model",
+        sandbox=(
+            "docker",
+            str(Path(__file__).parent / "compose.sandbox-service.yaml"),
+        ),
+    )[0]
     assert log.status == "success"
     assert log.samples
     sample = log.samples[0]
@@ -19,7 +28,7 @@ def test_sandbox_service():
 
 
 @solver
-def math_service() -> Solver:
+def math_service(user: str | None) -> Solver:
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         # generate a script that will exercise the service and copy it to the sandbox
         run_script = "run.py"
@@ -53,7 +62,7 @@ def math_service() -> Solver:
             async def run_service_script() -> None:
                 script_error = ""
                 try:
-                    result = await sandbox().exec(["python3", run_script])
+                    result = await sandbox().exec(["python3", run_script], user=user)
                     if not result.success:
                         script_error = (
                             f"Error running script '{run_script}': {result.stderr}"
@@ -64,7 +73,7 @@ def math_service() -> Solver:
                     print(script_error)
                     tg.cancel_scope.cancel()
 
-            tg.start_soon(run_math_service, state)
+            tg.start_soon(run_math_service, state, user)
             tg.start_soon(run_service_script)
 
         return state
@@ -72,7 +81,7 @@ def math_service() -> Solver:
     return solve
 
 
-async def run_math_service(state: TaskState) -> None:
+async def run_math_service(state: TaskState, user: str | None) -> None:
     finished = False
 
     async def add(x: int, y: int) -> int:
@@ -91,4 +100,5 @@ async def run_math_service(state: TaskState) -> None:
         methods=[add, subtract, finish],
         until=lambda: finished,
         sandbox=sandbox(),
+        user=user,
     )

--- a/tests/util/sandbox/test_sandbox_service.py
+++ b/tests/util/sandbox/test_sandbox_service.py
@@ -3,6 +3,7 @@ from textwrap import dedent
 
 import anyio
 import pytest
+from tests.test_helpers.utils import skip_if_no_docker
 
 from inspect_ai import Task, eval
 from inspect_ai.solver import Generate, Solver, TaskState, solver
@@ -11,6 +12,7 @@ from inspect_ai.util._sandbox.service import sandbox_service
 
 
 @pytest.mark.slow
+@skip_if_no_docker
 @pytest.mark.parametrize("user", ["root", "nonroot", None])
 def test_sandbox_service(user: str | None):
     log = eval(

--- a/tests/util/sandbox/test_sandbox_service.py
+++ b/tests/util/sandbox/test_sandbox_service.py
@@ -3,7 +3,7 @@ from textwrap import dedent
 
 import anyio
 import pytest
-from tests.test_helpers.utils import skip_if_no_docker
+from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai import Task, eval
 from inspect_ai.solver import Generate, Solver, TaskState, solver


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`human_cli` installs itself and runs as the default sandbox environment's default user. However, it could be useful to be able to run `human_cli` as a different user. The motivating example is a human baseline with a Kubernetes sandbox environment. The sandbox environment's default user must be root. Otherwise, it's difficult for the task code to run commands in the sandbox environment as root (`kubectl exec` will run as the default user and there's no way to run as a different user). However, we might want the human baseliner to access the sandbox environment as a non-root user.

### What is the new behavior?

This PR adds a `user` parameter to `human_cli` and `human_agent`. The agent will install and run itself as the specified user, or the default sandbox environment's default user if not specified.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

I don't believe so. The `user` parameter defaults to `None`, which is consistent with the current behaviour.

### Other information:

I've tested this manually using the example task in `examples/human`.
