### PR TITLE
message history truncation for model context overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,13 @@
 
 - [Model Roles](https://inspect.aisi.org.uk/models.html#model-roles) for creating aliases to models used in a task (e.g. "grader", "red_team", "blue_team", etc.)
 - New [openai-api](https://inspect.aisi.org.uk/providers.html#openai-api) model provider for interfacing with arbitrary services that have Open AI API compatible endpoints.
+- ReAct Agent: [truncation](https://inspect.aisi.org.uk/agents.html#truncation) option to trim conversation messages when the model context window is exceeded.
+- ReAct Agent: Improve default `on_continue` message, including using a dynamic name for the submit tool.
 - Added `default` argument to `get_model()` to explicitly specify a fallback model if the specified model isn't found.
 - Approval: Approvers now take `history` argument (rather than `TaskState`) to better handle agent conversation state.
 - Anthropic: Update string matching to correctly handle BadRequestErrors related to prompt + max_tokens being too long.
 - CloudFlare: Use OpenAI compatible REST endpoint for interface to models.
 - Model API: Improved detection of context window overflow for Grok, Groq, and CloudFlare.
-- React Agent: Improve default `on_continue()` message, including using a dynamic name for the submit tool.
 - Registry: Exported `registry_create()` function for dynamic creation of registry objects (e.g. `@task`, `@solver`, etc.).
 - Remove `chdir` option from `@task` (tasks can no longer change their working directory during execution).
 - `INSPECT_EVAL_LOG_FILE_PATTERN` environment variable for setting the eval log file pattern.

--- a/docs/agent-custom.qmd
+++ b/docs/agent-custom.qmd
@@ -94,16 +94,22 @@ def my_agent(tools: list[Tool]):
 You might then further tailor the behaviour of this loop. For example, you might want to:
 
 1.  Add another termination condition for the output satisfying some criteria.
-
 2.  Add a critique / reflection step between tool calling and generate.
-
 3.  Urge the model to keep going after it decides to stop calling tools.
-
-4.  Handle context window overflow (`stop_reason=="model_length"`) by truncating or summarizing the `messages`.
-
+4.  Handle context window overflow (`stop_reason=="model_length"`) by truncating or summarising the `messages`.
 5.  Examine and possibly filter the tool calls before invoking `execute_tools()`
 
+For example, you might implement automatic context window truncation in response to context window overflow:
 
+``` python
+# check for context window overflow
+if state.output.stop_reason == "model_length":
+    if overflow is not None:
+        state.messages = trim_messages(state.messages)
+        continue
+```
+
+Note that the standard `react()` agent provides some of these agent loop enhancements (urging the model to continue and handling context window overflow).
 
 ## Sample Store {#agent-store}
 

--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -23,7 +23,6 @@ The Inspect `Agent` protocol enables the creation of agent components that can b
 3.  Delegated to in a multi-agent architecture.
 4.  Provided as a standard `Tool` to a model
 
-
 The agents module includes a flexible, general-purpose [react agent](#react-agent), which can be used standalone or to orchestrate a [multi agent](#multi-agent) system.
 
 ### Example
@@ -66,7 +65,6 @@ This agent can be used in the following ways:
     print(f"The most popular movies were: {state.output.completion}")
     ```
 
-
 3.  It can participate in a multi-agent system where the conversation history is shared across agents. Use the `handoff()` function to create a tool that enables handing off the conversation from one agent to another:
 
     ``` python
@@ -100,7 +98,6 @@ This agent can be used in the following ways:
     ```
 
     The difference between `handoff()` and `as_tool()` is that `handoff()` forwards the entire conversation history to the agent (and enables the agent to add entries to it) whereas `as_tool()` provides a simple string in, string out interface to the agent.
-
 
 ## ReAct Agent {#react-agent}
 
@@ -158,12 +155,11 @@ task = Task(
 eval(task, model="openai/gpt-4o")
 ```
 
-
 ### Prompt
 
 In the examples above we provide a `prompt` to the agent. This prompt is layered with other default prompt(s) to compose the final system prompt. This includes an `asssistant` prompt and a `handoff` prompt (used only when a multi-agent system with `handoff()` is running). Here is the default `assistant` prompt:
 
-```python
+``` python
 DEFAULT_ASSISTANT_PROMPT = """
 You are a helpful assistant attempting to submit the best possible answer.
 You have several tools available to help with finding the answer. You will
@@ -179,7 +175,7 @@ tool to report it.
 
 You can modify the default prompts by passing an `AgentPrompt` instance rather than a `str`. For example:
 
-```python
+``` python
 react(
     description="Expert at completing cybersecurity challenges.",
     prompt=AgentPrompt(
@@ -191,12 +187,11 @@ react(
 )
 ```
 
-
 ### Attempts
 
 By default the `react()` agent is allowed a single attempt at calling the `submit()` function. If you want to give it multiple attempts, pass another value to `attempts`:
 
-```python
+``` python
 react(
     ...
     attempts=3,
@@ -207,22 +202,43 @@ Submissions are evaluated using the task's main scorer, with value of 1.0 indica
 
 ### Continuation
 
-In some cases models in a tool use loop will simply fail to call a tool (or just talk about calling the `submit()` tool but not actually call it!). This is typically an oversight, and models simply need to be encouraged to call `submit()` or alternatively continue if they haven't yet completed the task. 
+In some cases models in a tool use loop will simply fail to call a tool (or just talk about calling the `submit()` tool but not actually call it!). This is typically an oversight, and models simply need to be encouraged to call `submit()` or alternatively continue if they haven't yet completed the task.
 
 This behavior is controlled by the `on_continue` parameter, which by default yields the following user message to the model:
 
-```default
-If you believe you have completed the task, please call the 
-`submit()` tool with your answer.
+``` default
+Please proceed to the next step using your best judgement. If you believe you
+have completed the task, please call the `submit()` tool."
 ```
 
 You can pass a different continuation message, or alternative pass an `AgentContinue` function that can dynamically determine both whether to continue and what the message is.
+
+### Truncation
+
+::: callout-note
+The `truncation` option described below is available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+If your agent runs for long enough, it may end up filling the entire model context window. By default, this will cause the agent to termiante (with a log message indicating the reason). Alternatively, you can specify that the conversation should be truncated and the agent loop continue.
+
+This behavior is controlled by the `truncation` parameter (which is `"disabled"` by default, doing no truncation). To perform truncation, specify either `"auto"` (which reduces conversation size by roughly 30%) or pass a custom `MessageFilter` function. For example:
+
+``` python
+react(... truncation="auto")
+react(..., truncation=custom_truncation)
+```
+
+The default `"auto"` truncation scheme calls the `trim_messages()` function with a `preserve` ratio of 0.7.
 
 ### Model
 
 The `model` parameter to `react()` agent lets you specify an alternate model to use for the agent loop (if not specified then the default model for the evaluation is used). In some cases you might want to do something fancier than just call a model (e.g. do a "best of n" sampling an pick the best response). Pass a `Agent` as the `model` parameter to implement this type of custom scheme. For example:
 
-```python
+``` python
 @agent
 def best_of_n(n: int, discriminator: str | Model):
 
@@ -240,7 +256,6 @@ def best_of_n(n: int, discriminator: str | Model):
 
 Note that when you pass an `Agent` as the `model` it must include a `tools` parameter so that the ReAct agent can forward its tools.
 
-
 ## Learning More
 
 See these additioanl articles to learn more about creating agent evaluations with Inspect:
@@ -253,4 +268,4 @@ See these additioanl articles to learn more about creating agent evaluations wit
 
 -   [Human Agent](human-agent.qmd) is a solver that enables human baselining on computing tasks.
 
--   [Sandboxing](sandboxing.qmd) enables you to isolate code generated by models as well as set up more complex computing environments for tasks. 
+-   [Sandboxing](sandboxing.qmd) enables you to isolate code generated by models as well as set up more complex computing environments for tasks.

--- a/docs/reference/_sidebar.yml
+++ b/docs/reference/_sidebar.yml
@@ -252,6 +252,8 @@ website:
           href: reference/inspect_ai.model.qmd#chatmessageassistant
         - text: ChatMessageTool
           href: reference/inspect_ai.model.qmd#chatmessagetool
+        - text: trim_messages
+          href: reference/inspect_ai.model.qmd#trim_messages
         - text: Content
           href: reference/inspect_ai.model.qmd#content
         - text: ContentText

--- a/docs/reference/inspect_ai.model.qmd
+++ b/docs/reference/inspect_ai.model.qmd
@@ -24,6 +24,7 @@ title: "inspect_ai.model"
 ### ChatMessageUser
 ### ChatMessageAssistant
 ### ChatMessageTool
+### trim_messages
 
 ## Content
 

--- a/src/inspect_ai/agent/_as_tool.py
+++ b/src/inspect_ai/agent/_as_tool.py
@@ -42,7 +42,7 @@ def as_tool(agent: Agent, description: str | None = None, **agent_kwargs: Any) -
 
     async def execute(input: str, *args: Any, **kwargs: Any) -> ToolResult:
         # prepare state and call agent
-        state = AgentState(messages=[ChatMessageUser(content=input)])
+        state = AgentState(messages=[ChatMessageUser(content=input, source="input")])
         state = await agent(state, *args, **(agent_kwargs | kwargs))
 
         # find assistant message to read content from (prefer output)

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -1,4 +1,5 @@
 from logging import getLogger
+from typing import Literal, cast
 
 from inspect_ai._util._async import is_callable_coroutine
 from inspect_ai.model._call_tools import execute_tools
@@ -8,6 +9,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageUser,
 )
 from inspect_ai.model._model import Model, get_model
+from inspect_ai.model._trim import trim_messages
 from inspect_ai.scorer._score import score
 from inspect_ai.tool._tool import Tool, ToolResult, tool
 from inspect_ai.tool._tool_call import ToolCall
@@ -15,6 +17,7 @@ from inspect_ai.tool._tool_info import parse_tool_info
 from inspect_ai.tool._tool_with import tool_with
 
 from ._agent import Agent, AgentState, agent, agent_with
+from ._filter import MessageFilter
 from ._handoff import has_handoff
 from ._types import (
     DEFAULT_CONTINUE_PROMPT,
@@ -38,6 +41,7 @@ def react(
     attempts: int | AgentAttempts = 1,
     submit: AgentSubmit = AgentSubmit(),
     on_continue: str | AgentContinue | None = None,
+    truncation: Literal["auto", "disabled"] | MessageFilter = "disabled",
 ) -> Agent:
     """Extensible ReAct agent based on the paper [ReAct: Synergizing Reasoning and Acting in Language Models](https://arxiv.org/abs/2210.03629).
 
@@ -75,6 +79,10 @@ def react(
           is called on _every_ iteration of the loop so if you only want to send
           a message back when the model fails to call tools you need to code
           that behavior explicitly.
+       truncation: Truncate the conversation history in the event of a context
+          window overflow. Defaults to "disabled" which does no truncation. Pass
+          "auto" to use `trim_messages()` to reduce the context size. Pass a
+          `MessageFilter` function to do custom truncation.
 
     Returns:
         ReAct agent.
@@ -143,6 +151,14 @@ def react(
         if system_message:
             state.messages.insert(0, system_message)
 
+        # resolve overflow handling
+        if truncation == "auto":
+            overflow = cast(MessageFilter | None, trim_messages)
+        elif truncation == "disabled":
+            overflow = None
+        else:
+            overflow = truncation
+
         # track attempts
         attempt_count = 0
 
@@ -156,8 +172,12 @@ def react(
             if state.output.stop_reason == "model_length":
                 from inspect_ai.log._transcript import transcript
 
-                transcript().info("Agent terminated: model context window exceeded")
-                break
+                if overflow is not None:
+                    state.messages = await overflow(state.messages)
+                    continue
+                else:
+                    transcript().info("Agent terminated: model context window exceeded")
+                    break
 
             # check for a submission
             answer = submitted_answer(state.output.message.tool_calls)

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -173,7 +173,10 @@ def react(
                 from inspect_ai.log._transcript import transcript
 
                 if overflow is not None:
-                    state.messages = await overflow(state.messages)
+                    state.messages = await overflow(state.messages[:-1])
+                    transcript().info(
+                        "Agent exceeded model context window, truncating messages and continuing."
+                    )
                     continue
                 else:
                     transcript().info("Agent terminated: model context window exceeded")

--- a/src/inspect_ai/agent/_run.py
+++ b/src/inspect_ai/agent/_run.py
@@ -27,10 +27,21 @@ async def run(
 
     # resolve str
     if isinstance(input, str):
-        input = [ChatMessageUser(content=input)]
+        input_messages: list[ChatMessage] = [
+            ChatMessageUser(content=input, source="input")
+        ]
+    elif isinstance(input, list):
+        input_messages = [
+            message.model_copy(update=dict(source="input")) for message in input
+        ]
+    else:
+        input_messages = [
+            message.model_copy(update=dict(source="input"))
+            for message in input.messages
+        ]
 
     # create state
-    state = AgentState(messages=input) if isinstance(input, list) else input
+    state = AgentState(messages=input_messages)
 
     # run the agent
     return await agent(state, **agent_kwargs)

--- a/src/inspect_ai/model/__init__.py
+++ b/src/inspect_ai/model/__init__.py
@@ -47,6 +47,7 @@ from ._model_output import (
 )
 from ._providers.providers import *
 from ._registry import modelapi
+from ._trim import trim_messages
 
 __all__ = [
     "GenerateConfig",
@@ -80,6 +81,7 @@ __all__ = [
     "call_tools",
     "execute_tools",
     "ExecuteToolsResult",
+    "trim_messages",
     "cache_clear",
     "cache_list_expired",
     "cache_path",

--- a/src/inspect_ai/model/_trim.py
+++ b/src/inspect_ai/model/_trim.py
@@ -1,23 +1,74 @@
+from typing import NamedTuple
+
 from ._chat_message import ChatMessage
 
 
 def trim_messages(
     messages: list[ChatMessage], preserve: float = 0.7
 ) -> list[ChatMessage]:
-    """Trim messages to fit within the model context window.
+    """Trim message list to fit within model context.
+
+    ::: callout-note
+    The `trim_messages()` function is available only in the development version of Inspect.
+    To install the development version from GitHub:
+
+    ``` bash
+    pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+    ```
+    :::
 
     Trim the list of messages by:
-    - Keeping system messages
-    - Keeping the 'input' messages from the sample.
-    - Keeping a proportion of the remaining messages (`preserve=0.7` by default)
+    - Retaining all system messages.
+    - Retaining the 'input' messages from the sample.
+    - Preserving a proportion of the remaining messages (`preserve=0.7` by default).
     - Ensuring that all assistant tool calls have corresponding tool messages.
 
     Args:
-        messages: List of messages to trim
-        preserve: Ratio of original messages to preserve
+        messages: List of messages to trim.
+        preserve: Ratio of converation messages to preserve
            (defaults to 0.7)
 
     Returns:
         Trimmed messages.
     """
-    return messages
+    # partition messages
+    system_messages, input_messages, conversation_messages = _partition_messages(
+        messages
+    )
+
+    # determine how many of the conversation messages we want to keep
+    keep_messages = preserve * len(conversation_messages)
+
+    # peel tool messages off of the end (as we have to )
+
+    # return trimmed messages
+    return system_messages + input_messages + conversation_messages
+
+
+class PartitionedMessages(NamedTuple):
+    system: list[ChatMessage] = []
+    input: list[ChatMessage] = []
+    conversation: list[ChatMessage] = []
+
+
+def _partition_messages(messages: list[ChatMessage]) -> PartitionedMessages:
+    # first pass at partitioning
+    partitioned = PartitionedMessages()
+    for message in messages:
+        if message.role == "system":
+            partitioned.system.append(message)
+        elif message.source == "input":
+            partitioned.input.append(message)
+        else:
+            partitioned.conversation.append(message)
+
+    # if there are no input messages then take up to the first user message
+    if len(partitioned.input) == 0:
+        while partitioned.conversation:
+            message = partitioned.conversation.pop(0)
+            partitioned.input.append(message)
+            if message.role == "user":
+                break
+
+    # all done!
+    return partitioned

--- a/src/inspect_ai/model/_trim.py
+++ b/src/inspect_ai/model/_trim.py
@@ -41,7 +41,7 @@ def trim_messages(
     # one last step: many model apis require tool messages to have a parent assistant
     # message with a corresponding tool_call_id. to ensure this, we build the
     # final list of conversation messages by filtering out tool messages for which
-    # we haven't seen a corresponding assistatn message with their id
+    # we haven't seen a corresponding assistant message with their id
     conversation_messages: list[ChatMessage] = []
     active_tool_ids = set()
     for message in preserved_messages:

--- a/src/inspect_ai/model/_trim.py
+++ b/src/inspect_ai/model/_trim.py
@@ -1,0 +1,23 @@
+from ._chat_message import ChatMessage
+
+
+def trim_messages(
+    messages: list[ChatMessage], preserve: float = 0.7
+) -> list[ChatMessage]:
+    """Trim messages to fit within the model context window.
+
+    Trim the list of messages by:
+    - Keeping system messages
+    - Keeping the 'input' messages from the sample.
+    - Keeping a proportion of the remaining messages (`preserve=0.7` by default)
+    - Ensuring that all assistant tool calls have corresponding tool messages.
+
+    Args:
+        messages: List of messages to trim
+        preserve: Ratio of original messages to preserve
+           (defaults to 0.7)
+
+    Returns:
+        Trimmed messages.
+    """
+    return messages

--- a/tests/model/test_trim_messages.py
+++ b/tests/model/test_trim_messages.py
@@ -1,3 +1,5 @@
+import pytest
+
 from inspect_ai.model import (
     ChatMessage,
     ChatMessageAssistant,
@@ -6,7 +8,31 @@ from inspect_ai.model import (
     ChatMessageUser,
     trim_messages,
 )
+from inspect_ai.model._trim import PartitionedMessages, _partition_messages
 from inspect_ai.tool import ToolCall
+
+
+@pytest.fixture
+def tool_call() -> ToolCall:
+    return ToolCall(
+        id="tool1", function="get_weather", arguments={"location": "London"}
+    )
+
+
+@pytest.fixture
+def assistant_with_tool_call(tool_call: ToolCall) -> ChatMessageAssistant:
+    return ChatMessageAssistant(
+        content="Let me check the weather for you.", tool_calls=[tool_call]
+    )
+
+
+@pytest.fixture
+def tool_response() -> ChatMessageTool:
+    return ChatMessageTool(
+        content='{"temperature": 22, "condition": "sunny"}',
+        tool_call_id="tool1",
+        function="get_weather",
+    )
 
 
 # Tests for the trim_messages function
@@ -23,6 +49,15 @@ def test_simple_conversation() -> None:
         ChatMessageAssistant(content="How can I help you today?"),
     ]
     # With default preserve=0.7, all messages should be retained
+    assert trim_messages(messages) == messages
+
+
+def test_no_system_messages() -> None:
+    """Test trimming a conversation with no system messages."""
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="Hello!"),
+        ChatMessageAssistant(content="How can I help you today?"),
+    ]
     assert trim_messages(messages) == messages
 
 
@@ -62,6 +97,70 @@ def test_tool_message_without_assistant() -> None:
     trimmed = trim_messages(messages)
     assert tool_message not in trimmed
     assert user_message in trimmed
+
+
+def test_tool_calls(
+    assistant_with_tool_call: ChatMessageAssistant,
+    tool_response: ChatMessageTool,
+) -> None:
+    """Test trimming with tool calls."""
+    messages: list[ChatMessage] = [
+        ChatMessageSystem(content="You are a helpful assistant."),
+        ChatMessageUser(content="Hello!"),
+        ChatMessageAssistant(content="Hi there"),
+        ChatMessageUser(content="How can you help me today?"),
+        assistant_with_tool_call,
+        tool_response,
+        ChatMessageUser(content="Thanks for the weather info!"),
+    ]
+    trimmed = trim_messages(messages, preserve=1)
+    # All messages should be retained
+    assert trimmed == messages
+
+    # Now test with a higher trim rate
+    trimmed = trim_messages(messages, preserve=0.5)
+    # Even with high trim, tool_response should be kept because assistant_with_tool_call is kept
+    assert assistant_with_tool_call in trimmed
+    assert tool_response in trimmed
+
+
+def test_orphaned_tool_responses(
+    assistant_with_tool_call: ChatMessageAssistant,
+    tool_response: ChatMessageTool,
+) -> None:
+    """Test handling of orphaned tool responses."""
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    user_message = ChatMessageUser(content="Hello!")
+    # Create a scenario with a tool response without a corresponding assistant message
+    messages: list[ChatMessage] = [
+        system_message,
+        user_message,
+        ChatMessageTool(
+            content='{"error": "No corresponding assistant"}',
+            tool_call_id="orphaned_tool",
+            function="unknown_function",
+        ),
+        assistant_with_tool_call,
+        tool_response,
+    ]
+
+    trimmed = trim_messages(messages)
+
+    # The orphaned tool message should be removed
+    assert (
+        len(
+            [
+                m
+                for m in trimmed
+                if m.role == "tool" and m.tool_call_id == "orphaned_tool"
+            ]
+        )
+        == 0
+    )
+    # The valid tool message should be kept
+    assert (
+        len([m for m in trimmed if m.role == "tool" and m.tool_call_id == "tool1"]) == 1
+    )
 
 
 def test_user_message_resets_tool_ids() -> None:
@@ -113,6 +212,24 @@ def test_input_source() -> None:
     assert conversation_assistant not in trimmed
 
 
+def test_first_user_as_input() -> None:
+    """Test that the first user message is treated as input if no input source is specified."""
+    # When no source="input" is specified, the first user message becomes input
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    user1 = ChatMessageUser(content="First user")
+    assistant1 = ChatMessageAssistant(content="First assistant")
+    user2 = ChatMessageUser(content="Second user")
+    assistant2 = ChatMessageAssistant(content="Second assistant")
+
+    messages: list[ChatMessage] = [system_message, user1, assistant1, user2, assistant2]
+
+    # With preserve=0, only system and input (first user) should be kept
+    trimmed = trim_messages(messages, preserve=0)
+    assert system_message in trimmed
+    assert user1 in trimmed
+    assert assistant1 not in trimmed
+
+
 def test_preserve_edge_cases() -> None:
     """Test edge cases of the preserve parameter."""
     # Create a longer conversation
@@ -141,3 +258,164 @@ def test_preserve_edge_cases() -> None:
     trimmed = trim_messages(messages, preserve=-0.5)
     assert len(trimmed) == 2
     assert trimmed[0] == system_message
+
+
+def test_consecutive_assistant_tool_chains() -> None:
+    """Test with multiple consecutive assistant-tool chains."""
+    # Test with multiple assistant-tool chains
+    assistant1 = ChatMessageAssistant(
+        content="First tool call",
+        tool_calls=[ToolCall(id="tool1", function="func1", arguments={})],
+    )
+    tool1 = ChatMessageTool(
+        content='{"result": "result1"}', tool_call_id="tool1", function="func1"
+    )
+
+    assistant2 = ChatMessageAssistant(
+        content="Second tool call",
+        tool_calls=[ToolCall(id="tool2", function="func2", arguments={})],
+    )
+    tool2 = ChatMessageTool(
+        content='{"result": "result2"}', tool_call_id="tool2", function="func2"
+    )
+
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="Can you help?"),
+        assistant1,
+        tool1,
+        assistant2,
+        tool2,
+    ]
+
+    # With preserve=0.5, we should keep the second assistant-tool chain
+    trimmed = trim_messages(messages, preserve=0.5)
+    assert assistant1 not in trimmed
+    assert tool1 not in trimmed
+    assert assistant2 in trimmed
+    assert tool2 in trimmed
+
+
+def test_preserve_assistant_tool_sequence() -> None:
+    """Test preserving assistant-tool sequences."""
+    # Create a longer conversation with tool calls
+    messages: list[ChatMessage] = []
+    for i in range(5):
+        messages.append(ChatMessageUser(content=f"User message {i}"))
+        assistant = ChatMessageAssistant(
+            content=f"Assistant message {i}",
+            tool_calls=[ToolCall(id=f"tool{i}", function=f"func{i}", arguments={})],
+        )
+        messages.append(assistant)
+        messages.append(
+            ChatMessageTool(
+                content=f'{{"result": "result{i}"}}',
+                tool_call_id=f"tool{i}",
+                function=f"func{i}",
+            )
+        )
+
+    # With preserve=0.4, we should keep 2 out of 5 assistant-tool sequences
+    trimmed = trim_messages(messages, preserve=0.4)
+
+    # Check that we have exactly 2 assistant-tool sequences
+    assistant_count = len([m for m in trimmed if m.role == "assistant"])
+    tool_count = len([m for m in trimmed if m.role == "tool"])
+    assert assistant_count == 2
+    assert tool_count == 2
+
+    # Check that the tool messages correspond to the assistant messages
+    assistant_ids = set()
+    for msg in trimmed:
+        if msg.role == "assistant" and msg.tool_calls:
+            for tc in msg.tool_calls:
+                assistant_ids.add(tc.id)
+
+    tool_ids = set()
+    for msg in trimmed:
+        if msg.role == "tool":
+            tool_ids.add(msg.tool_call_id)
+
+    # All tool IDs should correspond to assistant tool calls
+    assert tool_ids.issubset(assistant_ids)
+
+
+def test_alternating_conversation() -> None:
+    """Test with alternating user-assistant pairs."""
+    # Create a conversation with alternating user-assistant pairs
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    messages: list[ChatMessage] = [system_message]
+    for i in range(10):
+        messages.append(ChatMessageUser(content=f"User message {i}"))
+        messages.append(ChatMessageAssistant(content=f"Assistant message {i}"))
+
+    # With preserve=0.5, we should keep 5 out of 10 user-assistant pairs
+    trimmed = trim_messages(messages, preserve=0.5)
+
+    # Check that we have the right number of each type of message
+    system_count = len([m for m in trimmed if m.role == "system"])
+    user_count = len([m for m in trimmed if m.role == "user"])
+    assistant_count = len([m for m in trimmed if m.role == "assistant"])
+
+    assert system_count == 1
+    assert user_count == 6
+    assert assistant_count == 5
+
+    # The conversation should start with "User message 0"
+    first_user_idx = next(i for i, m in enumerate(trimmed) if m.role == "user")
+    assert trimmed[first_user_idx].content == "User message 0"
+
+
+# Tests for the _partition_messages helper function
+def test_partition_messages() -> None:
+    """Test basic message partitioning."""
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    input_user = ChatMessageUser(content="User input", source="input")
+    conversation_user = ChatMessageUser(content="User conversation")
+    conversation_assistant = ChatMessageAssistant(content="Assistant conversation")
+
+    messages: list[ChatMessage] = [
+        system_message,
+        input_user,
+        conversation_user,
+        conversation_assistant,
+    ]
+
+    partitioned = _partition_messages(messages)
+
+    assert partitioned.system == [system_message]
+    assert partitioned.input == [input_user]
+    assert partitioned.conversation == [conversation_user, conversation_assistant]
+
+
+def test_partition_no_input_messages() -> None:
+    """Test partitioning when no messages have source='input'."""
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    user1 = ChatMessageUser(content="First user")
+    assistant1 = ChatMessageAssistant(content="First assistant")
+    user2 = ChatMessageUser(content="Second user")
+
+    messages: list[ChatMessage] = [system_message, user1, assistant1, user2]
+
+    partitioned = _partition_messages(messages)
+
+    assert partitioned.system == [system_message]
+    # When no input source is specified, messages up to first user become input
+    assert partitioned.input == [user1]
+    assert partitioned.conversation == [assistant1, user2]
+
+
+def test_partition_edge_cases() -> None:
+    """Test edge cases for partitioning."""
+    # Test with empty list
+    assert _partition_messages([]) == PartitionedMessages()
+
+    # Test with only system messages
+    system = ChatMessageSystem(content="System message")
+    assert _partition_messages([system]) == PartitionedMessages(system=[system])
+
+    # Test with no user messages
+    assistant = ChatMessageAssistant(content="Assistant message")
+    partitioned = _partition_messages([assistant])
+    # Without any user messages, all non-system become input
+    assert partitioned.input == [assistant]
+    assert partitioned.conversation == []

--- a/tests/model/test_trim_messages.py
+++ b/tests/model/test_trim_messages.py
@@ -1,0 +1,143 @@
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+    trim_messages,
+)
+from inspect_ai.tool import ToolCall
+
+
+# Tests for the trim_messages function
+def test_empty_list() -> None:
+    """Test trimming an empty list of messages."""
+    assert trim_messages([]) == []
+
+
+def test_simple_conversation() -> None:
+    """Test trimming a simple conversation."""
+    messages: list[ChatMessage] = [
+        ChatMessageSystem(content="You are a helpful assistant."),
+        ChatMessageUser(content="Hello!"),
+        ChatMessageAssistant(content="How can I help you today?"),
+    ]
+    # With default preserve=0.7, all messages should be retained
+    assert trim_messages(messages) == messages
+
+
+def test_preserve_ratio() -> None:
+    """Test preserving a specific ratio of messages."""
+    # Create a longer conversation
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    messages: list[ChatMessage] = [system_message]
+    for i in range(10):
+        messages.append(ChatMessageUser(content=f"User message {i}"))
+        messages.append(ChatMessageAssistant(content=f"Assistant message {i}"))
+
+    # With preserve=0.5, we should keep 50% of the conversation messages (plus the first user and system message)
+    trimmed = trim_messages(messages, preserve=0.5)
+
+    # System message + user message + 10 preserved conversation messages (5 user-assistant pairs)
+    assert len(trimmed) == 2 + 10
+    # The system message should be the first one
+    assert trimmed[0] == system_message
+    assert trimmed[1].content == "User message 0"
+    assert trimmed[2].content == "User message 5"
+
+
+def test_tool_message_without_assistant() -> None:
+    """Test a tool message without a corresponding assistant message."""
+    # A tool message without a corresponding assistant message should be excluded
+    tool_message = ChatMessageTool(
+        content='{"result": "orphaned"}',
+        tool_call_id="orphaned",
+        function="orphaned_function",
+    )
+    user_message = ChatMessageUser(content="User message")
+
+    messages: list[ChatMessage] = [user_message, tool_message]
+
+    # The tool message should be excluded
+    trimmed = trim_messages(messages)
+    assert tool_message not in trimmed
+    assert user_message in trimmed
+
+
+def test_user_message_resets_tool_ids() -> None:
+    """Test that a user message resets the active tool IDs."""
+    assistant1 = ChatMessageAssistant(
+        content="First tool call",
+        tool_calls=[ToolCall(id="tool1", function="func1", arguments={})],
+    )
+
+    user = ChatMessageUser(content="User interruption")
+
+    tool1 = ChatMessageTool(
+        content='{"result": "result1"}', tool_call_id="tool1", function="func1"
+    )
+
+    messages: list[ChatMessage] = [assistant1, user, tool1]
+
+    # The tool message should be excluded since active_tool_ids is reset by the user message
+    trimmed = trim_messages(messages)
+    assert assistant1 in trimmed
+    assert user in trimmed
+    assert tool1 not in trimmed
+
+
+def test_input_source() -> None:
+    """Test handling of messages with source='input'."""
+    # Test with messages explicitly marked as input
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    input_user = ChatMessageUser(content="User input", source="input")
+    input_assistant = ChatMessageAssistant(content="Assistant input", source="input")
+    conversation_user = ChatMessageUser(content="User conversation")
+    conversation_assistant = ChatMessageAssistant(content="Assistant conversation")
+
+    messages: list[ChatMessage] = [
+        system_message,
+        input_user,
+        input_assistant,
+        conversation_user,
+        conversation_assistant,
+    ]
+
+    # Even with preserve=0, input messages should be kept
+    trimmed = trim_messages(messages, preserve=0)
+    assert system_message in trimmed
+    assert input_user in trimmed
+    assert input_assistant in trimmed
+    # But conversation messages should be trimmed
+    assert conversation_user not in trimmed
+    assert conversation_assistant not in trimmed
+
+
+def test_preserve_edge_cases() -> None:
+    """Test edge cases of the preserve parameter."""
+    # Create a longer conversation
+    system_message = ChatMessageSystem(content="You are a helpful assistant.")
+    messages: list[ChatMessage] = [system_message]
+    for i in range(10):
+        messages.append(ChatMessageUser(content=f"User message {i}"))
+        messages.append(ChatMessageAssistant(content=f"Assistant message {i}"))
+
+    # Test with preserve=0
+    trimmed = trim_messages(messages, preserve=0)
+    # Only system message and first user message should remain
+    assert len(trimmed) == 2
+    assert trimmed[0] == system_message
+
+    # Test with preserve=1
+    trimmed = trim_messages(messages, preserve=1)
+    # All messages should be preserved
+    assert trimmed == messages
+
+    # Test with preserve > 1 (should be treated as 1)
+    trimmed = trim_messages(messages, preserve=1.5)
+    assert trimmed == messages
+
+    # Test with preserve < 0 (should be treated as 0)
+    trimmed = trim_messages(messages, preserve=-0.5)
+    assert len(trimmed) == 2
+    assert trimmed[0] == system_message


### PR DESCRIPTION
- ReAct Agent: `truncation` option to trim messages when the model context window is exceeded.
- `trim_messages()` function for use in custom truncation schemes.

The react agent `truncation` parameter is `"disabled"` by default, doing no truncation. To perform truncation, specify either `"auto"` (which reduces conversation size by roughly 30%) or pass a custom `MessageFilter` function. For example:

``` python
react(... truncation="auto")
react(..., truncation=custom_truncation)
```

The default `"auto"` truncation scheme calls the `trim_messages()` function with a `preserve` ratio of 0.7.
