### PR TITLE
Fix call_tools: ensure result_exception is always set

### DIFF
--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -264,6 +264,7 @@ async def execute_tools(
                 tuple[ExecuteToolsResult, ToolEvent, Exception | None]
             ]()
 
+            result_exception = None
             async with anyio.create_task_group() as tg:
                 tg.start_soon(call_tool_task, call, messages, send_stream)
                 event._set_cancel_fn(tg.cancel_scope.cancel)


### PR DESCRIPTION
Fixes #1674

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

#1674

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
