### PR TITLE
improvements to react agent submit and continue handling

### DIFF
--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -6,6 +6,7 @@ from inspect_ai.model._call_tools import execute_tools
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageSystem,
+    ChatMessageTool,
     ChatMessageUser,
 )
 from inspect_ai.model._model import Model, get_model
@@ -102,23 +103,6 @@ def react(
     else:
         system_message = None
 
-    # resolve on_continue
-    on_continue = on_continue or DEFAULT_CONTINUE_PROMPT
-    if isinstance(on_continue, str):
-        no_tools_continue_message = on_continue
-
-        async def no_tools_continue(state: AgentState) -> bool | str:
-            if state.output is None or not state.output.message.tool_calls:
-                return no_tools_continue_message.format(submit=submit.name)
-            else:
-                return True
-
-        on_continue = no_tools_continue
-
-    # validate that on_continue is async
-    if not is_callable_coroutine(on_continue):
-        raise ValueError("The on_continue function must be async.")
-
     # resolve attempts
     attempts = AgentAttempts(attempts) if isinstance(attempts, int) else attempts
 
@@ -135,12 +119,17 @@ def react(
 
         return execute
 
-    # helper to see if there is a submit tool call
-    def submitted_answer(tool_calls: list[ToolCall] | None) -> str | None:
-        for tool_call in tool_calls or []:
-            if tool_call.function == submit.name and tool_call.parse_error is None:
-                return str(tool_call.arguments["answer"])
-        return None
+    # helper to extract a submitted answer
+    def submission(tool_results: list[ChatMessage]) -> str | None:
+        return next(
+            (
+                result.text
+                for result in tool_results
+                if isinstance(result, ChatMessageTool)
+                and result.function == submit.name
+            ),
+            None,
+        )
 
     # resolve tools
     tools = tools or []
@@ -185,55 +174,81 @@ def react(
                 transcript().info("Agent terminated: model context window exceeded")
                 break
 
-            # check for a submission
-            answer = submitted_answer(state.output.message.tool_calls)
-            if answer is not None:
-                # remove the tool call and set the output to the answer for scoring
-                state.output.message.tool_calls = None
-                state.output.completion = (
-                    f"{state.output.completion}\n\n{answer}".strip()
-                )
+            # resolve tool calls (if any)
+            if state.output.message.tool_calls:
+                # call tool functions
+                messages, output = await execute_tools(state.messages, tools)
+                state.messages.extend(messages)
+                if output:
+                    state.output = output
 
-                # exit if we are at max_attempts
-                attempt_count += 1
-                if attempt_count >= attempts.attempts:
-                    break
+                # check for a submission
+                answer = submission(messages)
+                if answer is not None:
+                    # set the output to the answer for scoring
+                    state.output.completion = (
+                        f"{state.output.completion}\n\n{answer}".strip()
+                    )
 
-                # exit if the submission is successful
-                answer_scores = await score(state)
-                if attempts.score_value(answer_scores[0].value) == 1.0:
-                    break
+                    # exit if we are at max_attempts
+                    attempt_count += 1
+                    if attempt_count >= attempts.attempts:
+                        break
 
-                # otherwise notify the model that it was incorrect and continue
-                else:
-                    if callable(attempts.incorrect_message):
-                        if not is_callable_coroutine(attempts.incorrect_message):
-                            raise ValueError(
-                                "The incorrect_message function must be async."
-                            )
-                        response_message: str = await attempts.incorrect_message(
-                            state, answer_scores
-                        )
+                    # exit if the submission is successful
+                    answer_scores = await score(state)
+                    if attempts.score_value(answer_scores[0].value) == 1.0:
+                        break
+
+                    # otherwise notify the model that it was incorrect and continue
                     else:
-                        response_message = attempts.incorrect_message
+                        if callable(attempts.incorrect_message):
+                            if not is_callable_coroutine(attempts.incorrect_message):
+                                raise ValueError(
+                                    "The incorrect_message function must be async."
+                                )
+                            response_message: str = await attempts.incorrect_message(
+                                state, answer_scores
+                            )
+                        else:
+                            response_message = attempts.incorrect_message
 
-                    state.messages.append(ChatMessageUser(content=response_message))
+                        state.messages.append(ChatMessageUser(content=response_message))
 
-            # no submitted answer, call tools and evaluate whether we should continue
-            else:
-                if state.output.message.tool_calls:
-                    # call tool functions
-                    messages, output = await execute_tools(state.messages, tools)
-                    state.messages.extend(messages)
-                    if output:
-                        state.output = output
+                # call the on_continue hook (if any)
+                if callable(on_continue):
+                    if not is_callable_coroutine(on_continue):
+                        raise ValueError("The on_continue function must be async.")
+                    do_continue = await cast(AgentContinue, on_continue)(state)
+                    if do_continue is True:
+                        # if there were no tool calls we need to send back a user message
+                        if not state.output.message.tool_calls:
+                            state.messages.append(
+                                ChatMessageUser(
+                                    content=DEFAULT_CONTINUE_PROMPT.format(
+                                        submit=submit.name
+                                    )
+                                )
+                            )
+                    elif isinstance(do_continue, str):
+                        state.messages.append(
+                            ChatMessageUser(
+                                content=do_continue.format(submit=submit.name)
+                            )
+                        )
+                    else:  # do_continue is False
+                        break
 
-                # check if we should continue....
-                do_continue = await on_continue(state)
-                if isinstance(do_continue, str):
-                    state.messages.append(ChatMessageUser(content=do_continue))
-                elif do_continue is False:
-                    break
+                # if there is no on_continue hook then add a user message if there were no tool calls
+                elif not state.output.message.tool_calls:
+                    continue_msg = (
+                        DEFAULT_CONTINUE_PROMPT
+                        if on_continue is None
+                        else str(on_continue)
+                    )
+                    state.messages.append(
+                        ChatMessageUser(content=continue_msg.format(submit=submit.name))
+                    )
 
         return state
 

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -266,10 +266,11 @@ def test_react_agent_on_continue_str():
                     "mockllm/model", "addition", {"x": 1, "y": 1}
                 ),
                 ModelOutput.from_content("mockllm/model", "I give up!"),
-                ModelOutput.for_tool_call("mockllm/model", "submit", {"answer": 2}),
+                ModelOutput.for_tool_call("mockllm/model", "submit", {"answer": "2"}),
             ],
         ),
     )[0]
+    assert log.status == "success"
     assert log.samples
     messages = log.samples[0].messages
     assert messages[-2].text == on_continue.format(submit="submit")
@@ -291,6 +292,7 @@ def test_react_agent_on_continue_func():
         message_limit=30,
     )
     log = eval(addition_task, mockllm_model_with_outputs(["5", "1", "2"]))[0]
+    assert log.status == "success"
     assert log.samples
     messages = log.samples[0].messages
     assert (


### PR DESCRIPTION
- Keep `submit()` tool invocations in the history presented to model (so that it doesn't think it can answer w/o the `submit()` tool)
- Remove `submit()` tool invocations in messages yielded from agent at the end of the loop (so that parent agents aren't confused by `submit()` executed in child agents)
- When `on_continue` returns `True` and there were no tool calls, automatically include the default continue message (otherwise the message history is invalid b/c it ends with an assistant message)
