### PR TITLE
Don’t throw error if we’re unable to synthesize a comparable object f…

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -71192,7 +71192,15 @@ ${events}
         return summarizeChanges(event.changes);
       }, [event.changes]);
       const [before, after] = reactExports.useMemo(() => {
-        return synthesizeComparable(event.changes);
+        try {
+          return synthesizeComparable(event.changes);
+        } catch (e) {
+          console.error(
+            "Unable to synthesize comparable object to display state diffs.",
+            e
+          );
+          return [{}, {}];
+        }
       }, [event.changes]);
       const changePreview = reactExports.useMemo(() => {
         return generatePreview(event.changes, structuredClone(after), isStore);

--- a/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventView.tsx
+++ b/src/inspect_ai/_view/www/src/samples/transcript/state/StateEventView.tsx
@@ -41,7 +41,15 @@ export const StateEventView: FC<StateEventViewProps> = ({
 
   // Synthesize objects for comparison
   const [before, after] = useMemo(() => {
-    return synthesizeComparable(event.changes);
+    try {
+      return synthesizeComparable(event.changes);
+    } catch (e) {
+      console.error(
+        "Unable to synthesize comparable object to display state diffs.",
+        e,
+      );
+      return [{}, {}];
+    }
   }, [event.changes]);
 
   // This clone is important since the state is used by react as potential values that are rendered


### PR DESCRIPTION
…or diff generation

This will result in failures to generate diffable objects to no longer throw errors (instead just logging and error to the console).

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
