### PR TITLE
openai: support for new reasoning models + reasoning summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Future
+
+- [reasoning_summary](https://inspect.aisi.org.uk/reasoning.html#reasoning-summary) generation option for OpenAI reasoning models.
+
 ## Unreleased
 
 - [Model Roles](https://inspect.aisi.org.uk/models.html#model-roles) for creating aliases to models used in a task (e.g. "grader", "red_team", "blue_team", etc.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-- [reasoning_summary](https://inspect.aisi.org.uk/reasoning.html#reasoning-summary) generation option for OpenAI reasoning models.
+- OpenAI: [reasoning_summary](https://inspect.aisi.org.uk/reasoning.html#reasoning-summary) generation option for reasoning models.
+- OpenAI: Responses API is now used by default for all reasoning models.
 
 ## v0.3.89 (17 April 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
 
-- OpenAI: [reasoning_summary](https://inspect.aisi.org.uk/reasoning.html#reasoning-summary) generation option for reasoning models.
 - OpenAI: Responses API is now used by default for all reasoning models.
+- OpenAI: [reasoning_summary](https://inspect.aisi.org.uk/reasoning.html#reasoning-summary) generation option for reasoning models.
+- OpenAI: New `responses_store` model argument to control whether the `store` option is enabled (it is enabled by default for reasoning models to support reasoning playback).
 
 ## v0.3.89 (17 April 2025)
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -31,15 +31,23 @@ The following environment variables are supported by the OpenAI provider
 
 ### Responses API
 
-By default, Inspect uses the standard OpenAI Chat Completions API. However, if you use features that require the new [Responses API](https://platform.openai.com/docs/api-reference/responses) Inspect will use that instead. 
+By default, Inspect uses the standard OpenAI Chat Completions API for gpt-series models and the new [Responses API](https://platform.openai.com/docs/api-reference/responses) for o-series models and the `computer_use_preview` model.
 
-Currently, the only feature that requires the Responses API is [o1-pro](https://platform.openai.com/docs/models/o1-pro). In the near future, Inspect will add support for OpenAI's built-in computer and web search tools, which will also require the Responses API.
-
-If you want to manually switch to the Responses API you can use the `responses_api` model argument. For example:
+If you want to manually enable or disable the Responses API you can use the `responses_api` model argument. For example:
 
 ```bash
 inspect eval math.py --model openai/gpt-4o -M responses_api=true
 ```
+
+Note that certain models including `o1-pro` and `computer_use_preview` _require_ the use of the Responses API. Check the Open AI [models documentation](https://platform.openai.com/docs/models) for details on which models are supported by the respective APIs.
+
+When using o-series models, Inspect also automatically enables the [store](https://platform.openai.com/docs/api-reference/responses/create#responses-create-store) option so that reasoning blocks can be retrieved by the model from the conversation history. To control this behavior explicitly use the `responses_store` model argument. For example:
+
+```bash
+inspect eval math.py --model openai/o4-mini -M responses_store=false
+```
+
+For example, you might need to do this if you have a non-logging interface to OpenAI models (as `store` is incompatible with non-logging interfaces).
 
 ### OpenAI on Azure {#openai-on-azure}
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -41,14 +41,6 @@ inspect eval math.py --model openai/gpt-4o -M responses_api=true
 
 Note that certain models including `o1-pro` and `computer_use_preview` _require_ the use of the Responses API. Check the Open AI [models documentation](https://platform.openai.com/docs/models) for details on which models are supported by the respective APIs.
 
-When using o-series models, Inspect also automatically enables the [store](https://platform.openai.com/docs/api-reference/responses/create#responses-create-store) option so that reasoning blocks can be retrieved by the model from the conversation history. To control this behavior explicitly use the `responses_store` model argument. For example:
-
-```bash
-inspect eval math.py --model openai/o4-mini -M responses_store=false
-```
-
-For example, you might need to do this if you have a non-logging interface to OpenAI models (as `store` is incompatible with non-logging interfaces).
-
 ### OpenAI on Azure {#openai-on-azure}
 
 The `openai` provider supports OpenAI models deployed on the [Azure AI Foundary](https://ai.azure.com/). To use OpenAI models on Azure AI, specify the following environment variables:

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -45,31 +45,46 @@ As you can see from above, models have different means of specifying the tokens 
 
 The `reasoning_history` option lets you control how much of the model's previous reasoning is presented in the message history sent to `generate()`. The default is `auto`, which uses a provider-specific recommended default (normally `all`). Use `last` to not let the reasoning overwhelm the context window.
 
-## OpenAI o1/o3
+## OpenAI o-series
 
-OpenAI has several reasoning models available including the o1 and o3 series (`openai/o1`, `openai/o1-mini`, and `openai/o3-mini`). Learn more about the specific models available in the [OpenAI Models](https://platform.openai.com/docs/models) documentation.
+OpenAI has several reasoning models available including the o1, o3, and o4 famillies of models. Learn more about the specific models available in the [OpenAI Models](https://platform.openai.com/docs/models) documentation.
 
 #### Reasoning Effort
 
-You can condition the amount of reasoning done via the [`reasoning_effort`](https://platform.openai.com/docs/guides/reasoning#reasoning-effort) option, which can be set to `low`, `medium`, or `high` (the default is `medium` if not specified).
+You can condition the amount of reasoning done via the [`reasoning_effort`](https://platform.openai.com/docs/guides/reasoning#reasoning-effort) option, which can be set to `low`, `medium`, or `high` (the default is `medium` if not specified). For example:
 
-#### Reasoning Summary
+``` bash
+inspect eval math.py --model openai/o3 --reasoning-effort high
+```
+
+#### Reasoning History
 
 ::: callout-note
-The `reasoning_summary` option described below is available only in the development version of Inspect. To install the development version from GitHub:
+The `reasoning_summary` and `responses_store` options described below are available only in the development version of Inspect. To install the development version from GitHub:
 
 ``` bash
 pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
 ```
 :::
 
-You can see a summary of the model's reasoning by specifying the [`reasoning_summary`](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries) option. Availablle options are `concise`, `detailed`, and `auto` (`auto` is recommended to access the most detailed summarizer available for the current model).
+You can see a summary of the model's reasoning by specifying the [`reasoning_summary`](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries) option. Availablle options are `concise`, `detailed`, and `auto` (`auto` is recommended to access the most detailed summarizer available for the current model). For example:
+
+``` bash
+inspect eval math.py --model openai/o3 --reasoning-summary auto
+```
 
 ::: {.callout-warning appearance="minimal"}
 
 Before using summarizers with the latest OpenAI reasoning models, you may need to complete [organization verification](https://help.openai.com/en/articles/10910291-api-organization-verification).
 :::
 
+When using o-series models, Inspect automatically enables the [store](https://platform.openai.com/docs/api-reference/responses/create#responses-create-store) option so that reasoning blocks can be retrieved by the model from the conversation history. To control this behavior explicitly use the `responses_store` model argument. For example:
+
+```bash
+inspect eval math.py --model openai/o4-mini -M responses_store=false
+```
+
+For example, you might need to do this if you have a non-logging interface to OpenAI models (as `store` is incompatible with non-logging interfaces).
 
 ## Claude 3.7 Sonnet
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -22,11 +22,14 @@ In addition, some models (currently OpenAI and Anthropic) make available `reason
 
 The following reasoning options are available from the CLI and within `GenerateConfig`:
 
-| Option              | Description                                                                           | Default  | Models       |
-|------------------|--------------------|------------------|------------------|
-| `reasoning_effort`  | Constrains effort on reasoning for reasoning models (`low`, `medium`, or `high`)      | `medium` | OpenAI o1/o3 |
-| `reasoning_tokens`  | Maximum number of tokens to use for reasoning.                                        | (none)   | Claude 3.7   |
-| `reasoning_history` | Include reasoning in message history sent to model (`none`, `all`, `last`, or `auto`) | `auto`   | All models   |
+| Option              | Description                                                                                                                                            | Default  | Models          |
+|------------------|-------------------|------------------|------------------|
+| `reasoning_effort`  | Constrains effort on reasoning for reasoning models (`low`, `medium`, or `high`)                                                                       | `medium` | OpenAI o-series |
+| `reasoning_tokens`  | Maximum number of tokens to use for reasoning.                                                                                                         | (none)   | Claude 3.7      |
+| `reasoning_summary` | Provide summary of reasoning steps (`concise`, `detailed`, `auto`). Use "auto" to access the most detailed summarizer available for the current model. | (none)   | OpenAI o-series |
+| `reasoning_history` | Include reasoning in message history sent to model (`none`, `all`, `last`, or `auto`)                                                                  | `auto`   | All models      |
+
+: {tbl-colwidths=\[25,40,15,20\]}
 
 As you can see from above, models have different means of specifying the tokens to allocate for reasoning (`reasoning_effort` and `reasoning_tokens`). The two options don't map precisely into each other, so if you are doing an evaluation with multiple reasoning models you should specify both. For example:
 
@@ -34,8 +37,9 @@ As you can see from above, models have different means of specifying the tokens 
  eval(
     task,
     model=["openai/o3-mini","anthropic/anthropic/claude-3-7-sonnet-20250219"],
-    reasoning_effort="medium",
-    reasoning_tokens=4096
+    reasoning_effort="medium",  # openai specific
+    reasoning_summary="auto",   # openai specific
+    reasoning_tokens=4096       # anthropic specific
  )
 ```
 
@@ -45,9 +49,27 @@ The `reasoning_history` option lets you control how much of the model's previous
 
 OpenAI has several reasoning models available including the o1 and o3 series (`openai/o1`, `openai/o1-mini`, and `openai/o3-mini`). Learn more about the specific models available in the [OpenAI Models](https://platform.openai.com/docs/models) documentation.
 
+#### Reasoning Effort
+
 You can condition the amount of reasoning done via the [`reasoning_effort`](https://platform.openai.com/docs/guides/reasoning#reasoning-effort) option, which can be set to `low`, `medium`, or `high` (the default is `medium` if not specified).
 
-OpenAI models currently do not have provision for displaying reasoning content or replaying it to the model.
+#### Reasoning Summary
+
+::: callout-note
+The `reasoning_summary` option described below is available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+You can see a summary of the model's reasoning by specifying the [`reasoning_summary`](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries) option. Availablle options are `concise`, `detailed`, and `auto` (`auto` is recommended to access the most detailed summarizer available for the current model).
+
+::: {.callout-warning appearance="minimal"}
+
+Before using summarizers with the latest OpenAI reasoning models, you may need to complete [organization verification](https://help.openai.com/en/articles/10910291-api-organization-verification).
+:::
+
 
 ## Claude 3.7 Sonnet
 
@@ -63,11 +85,10 @@ inspect eval math.py \
 
 The `max_tokens` for any given request is determined as follows:
 
-1. If you only specify `reasoning_tokens`, then the `max_tokens` will be set to `4096 + reasoning_tokens` (as 4096 is the standard Inspect default for Anthropic max tokens).
-2. If you explicitly specify a `max_tokens`, that value will be used as the max tokens without modification (so should accomodate sufficient space for both your `reasoning_tokens` and normal output).
+1.  If you only specify `reasoning_tokens`, then the `max_tokens` will be set to `4096 + reasoning_tokens` (as 4096 is the standard Inspect default for Anthropic max tokens).
+2.  If you explicitly specify a `max_tokens`, that value will be used as the max tokens without modification (so should accomodate sufficient space for both your `reasoning_tokens` and normal output).
 
 Inspect will automatically use [response streaming](https://docs.anthropic.com/en/api/messages-streaming) whenever extended thinking is enabled to mitigate against networking issue that can occur for long running requests.
-
 
 #### History
 
@@ -92,7 +113,7 @@ Inspect captures reasoning blocks from Gemini using the "Final Answer: " delimit
 DeepSeek models can be accessed directly using their [OpenAI interface](https://api-docs.deepseek.com/). Further, a number of model hosting providers supported by Inspect make DeepSeek available, for example:
 
 | Provider                                 | Model                                                                                   |
-|-------------------------|-----------------------------------------------|
+|-------------------------|----------------------------------------------|
 | [Together AI](providers.qmd#together-ai) | `together/deepseek-ai/DeepSeek-R1` ([docs](https://www.together.ai/models/deepseek-r1)) |
 | [Groq](providers.qmd#groq)               | `groq/deepseek-r1-distill-llama-70b` ([docs](https://console.groq.com/docs/reasoning))  |
 | [Ollama](providers.qmd#ollama)           | `ollama/deepseek-r1:<tag>` ([docs](https://ollama.com/library/deepseek-r1))             |

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -429,6 +429,12 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         envvar="INSPECT_EVAL_REASONING_TOKENS",
     )
     @click.option(
+        "--reasoning-summary",
+        type=click.Choice(["concise", "detailed", "auto"]),
+        help="Provide summary of reasoning steps (defaults to no summary). Use 'auto' to access the most detailed summarizer available for the current model. OpenAI reasoning models only.",
+        envvar="INSPECT_EVAL_REASONING_SUMMARY",
+    )
+    @click.option(
         "--reasoning-history",
         type=click.Choice(["none", "all", "last", "auto"]),
         help='Include reasoning in chat message history sent to generate (defaults to "auto", which uses the recommended default for each provider)',
@@ -512,6 +518,7 @@ def eval_command(
     cache_prompt: str | None,
     reasoning_effort: str | None,
     reasoning_tokens: int | None,
+    reasoning_summary: Literal["concise", "detailed", "auto"] | None,
     reasoning_history: Literal["none", "all", "last", "auto"] | None,
     response_schema: ResponseSchema | None,
     message_limit: int | None,
@@ -683,6 +690,7 @@ def eval_set_command(
     cache_prompt: str | None,
     reasoning_effort: str | None,
     reasoning_tokens: int | None,
+    reasoning_summary: Literal["concise", "detailed", "auto"] | None,
     reasoning_history: Literal["none", "all", "last", "auto"] | None,
     response_schema: ResponseSchema | None,
     message_limit: int | None,

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -97,6 +97,9 @@ class GenerateConfigArgs(TypedDict, total=False):
     reasoning_tokens: int | None
     """Maximum number of tokens to use for reasoning. Anthropic Claude models only."""
 
+    reasoning_summary: Literal["concise", "detailed", "auto"] | None
+    """Provide summary of reasoning steps (defaults to no summary). Use 'auto' to access the most detailed summarizer available for the current model. OpenAI reasoning models only."""
+
     reasoning_history: Literal["none", "all", "last", "auto"] | None
     """Include reasoning in chat message history sent to generate."""
 
@@ -175,6 +178,11 @@ class GenerateConfig(BaseModel):
 
     reasoning_tokens: int | None = Field(default=None)
     """Maximum number of tokens to use for reasoning. Anthropic Claude models only."""
+
+    reasoning_summary: Literal["concise", "detailed", "auto"] | None = Field(
+        default=None
+    )
+    """Provide summary of reasoning steps (defaults to no summary). Use 'auto' to access the most detailed summarizer available for the current model. OpenAI reasoning models only."""
 
     reasoning_history: Literal["none", "all", "last", "auto"] | None = Field(
         default=None

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -82,16 +82,16 @@ def is_o_series(name: str) -> bool:
         return not is_gpt(name) and bool(re.search(r"o\d+", name))
 
 
-def is_o1_pro(name: str) -> bool:
-    return "o1-pro" in name
+def is_o1(name: str) -> bool:
+    return "o1" in name and not is_o1_early(name)
 
 
-def is_o1_mini(name: str) -> bool:
-    return "o1-mini" in name
+def is_o1_early(name: str) -> bool:
+    return "o1-mini" in name or "o1-preview" in name
 
 
-def is_o1_preview(name: str) -> bool:
-    return "o1-preview" in name
+def is_o3_mini(name: str) -> bool:
+    return "o3-mini" in name
 
 
 def is_computer_use_preview(name: str) -> bool:

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -252,10 +252,10 @@ def _chat_message_assistant_from_openai_response(
                     ]
                 )
             case ResponseReasoningItem(summary=summary, id=id):
-                assert internal["reasoning_id"] is None, "Multiple reasoning items"
-                internal["reasoning_id"] = id
                 message_content.append(
-                    ContentReasoning(reasoning="\n".join([s.text for s in summary]))
+                    ContentReasoning(
+                        reasoning="\n".join([s.text for s in summary]), signature=id
+                    )
                 )
             case _:
                 stop_reason = "tool_calls"
@@ -316,11 +316,12 @@ def _openai_input_items_from_chat_message_assistant(
     ):
         match content:
             case ContentReasoning(reasoning=reasoning):
-                assert reasoning_item is None, "Multiple reasoning items"
-                assert reasoning_id is not None, "Must find reasoning id"
+                assert content.signature is not None, (
+                    "reasoning_id must be saved in signature"
+                )
                 reasoning_item = ResponseReasoningItemParam(
                     type="reasoning",
-                    id=reasoning_id,
+                    id=content.signature,
                     summary=[Summary(type="summary_text", text=reasoning)],
                 )
             case ContentText(text=text, refusal=refusal):

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -29,9 +29,9 @@ from .._openai import (
     OpenAIAsyncHttpxClient,
     is_computer_use_preview,
     is_gpt,
-    is_o1_mini,
-    is_o1_preview,
-    is_o1_pro,
+    is_o1,
+    is_o1_early,
+    is_o3_mini,
     is_o_series,
     model_output_from_openai,
     openai_chat_messages,
@@ -84,7 +84,9 @@ class OpenAIAPI(ModelAPI):
 
         # note whether we are forcing the responses_api
         self.responses_api = (
-            responses_api or self.is_o1_pro() or self.is_computer_use_preview()
+            responses_api
+            or (self.is_o_series() and not self.is_o1_early())
+            or self.is_computer_use_preview()
         )
 
         # resolve api_key
@@ -159,14 +161,14 @@ class OpenAIAPI(ModelAPI):
     def is_o_series(self) -> bool:
         return is_o_series(self.service_model_name())
 
-    def is_o1_pro(self) -> bool:
-        return is_o1_pro(self.service_model_name())
+    def is_o1(self) -> bool:
+        return is_o1(self.service_model_name())
 
-    def is_o1_mini(self) -> bool:
-        return is_o1_mini(self.service_model_name())
+    def is_o1_early(self) -> bool:
+        return is_o1_early(self.service_model_name())
 
-    def is_o1_preview(self) -> bool:
-        return is_o1_preview(self.service_model_name())
+    def is_o3_mini(self) -> bool:
+        return is_o3_mini(self.service_model_name())
 
     def is_computer_use_preview(self) -> bool:
         return is_computer_use_preview(self.service_model_name())
@@ -184,8 +186,18 @@ class OpenAIAPI(ModelAPI):
 
     @override
     def tool_result_images(self) -> bool:
-        # o1-pro, o1, and computer_use_preview support image inputs (but we're not strictly supporting o1)
-        return self.is_o1_pro() or self.is_computer_use_preview()
+        # o1-pro, o1, and computer_use_preview support image inputs
+        if self.is_computer_use_preview():
+            return True
+        elif self.is_o_series():
+            if self.is_o1_early():
+                return False
+            elif self.is_o3_mini():
+                return False
+            else:
+                return True
+        else:
+            return False
 
     @override
     def disable_computer_screenshot_truncation(self) -> bool:
@@ -203,7 +215,7 @@ class OpenAIAPI(ModelAPI):
         config: GenerateConfig,
     ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
         # short-circuit to call o1- models that are text only
-        if self.is_o1_preview() or self.is_o1_mini():
+        if self.is_o1_early():
             return await generate_o1(
                 client=self.client,
                 input=input,
@@ -248,7 +260,7 @@ class OpenAIAPI(ModelAPI):
         # determine system role
         # o1-mini does not support developer or system messages
         # (see Dec 17, 2024 changelog: https://platform.openai.com/docs/changelog)
-        if self.is_o1_mini():
+        if self.is_o1_early():
             system_role: Literal["user", "system", "developer"] = "user"
         # other o-series models use 'developer' rather than 'system' messages
         # https://platform.openai.com/docs/guides/reasoning#advice-on-prompting
@@ -329,7 +341,7 @@ class OpenAIAPI(ModelAPI):
 
         # remove reasoning_effort if not supported
         if "reasoning_effort" in params.keys() and (
-            self.is_gpt() or self.is_o1_mini() or self.is_o1_preview()
+            self.is_gpt() or self.is_o1_early()
         ):
             del params["reasoning_effort"]
 

--- a/src/inspect_ai/model/_providers/openai_responses.py
+++ b/src/inspect_ai/model/_providers/openai_responses.py
@@ -152,9 +152,13 @@ def completion_params_responses(
     if tools and config.parallel_tool_calls is not None and not is_o_series(model_name):
         params["parallel_tool_calls"] = config.parallel_tool_calls
     if is_o_series(model_name) and not is_o1_early(model_name):
-        # TODO: this actually needs to be fully opt-in as "auto" will cause an error for some orgs
-        reasoning_effort = config.reasoning_effort or "medium"
-        params["reasoning"] = dict(effort=reasoning_effort, summary="auto")
+        reasoning: dict[str, str] = {}
+        if config.reasoning_effort is not None:
+            reasoning["effort"] = config.reasoning_effort
+        if config.reasoning_summary is not None:
+            reasoning["summary"] = config.reasoning_summary
+        if len(reasoning) > 0:
+            params["reasoning"] = reasoning
     if config.response_schema is not None:
         params["text"] = dict(
             format=ResponseFormatTextJSONSchemaConfigParam(

--- a/tests/model/providers/test_openai_responses.py
+++ b/tests/model/providers/test_openai_responses.py
@@ -51,3 +51,11 @@ def test_openai_responses_o1_pro():
         model="openai/o1-pro",
     )[0]
     assert log.status == "success"
+
+
+@skip_if_no_openai
+def test_openai_responses_no_store():
+    log = eval(Task(), model="openai/o4-mini", model_args=dict(responses_store=False))[
+        0
+    ]
+    assert log.status == "success"

--- a/tests/model/test_reasoning_openai.py
+++ b/tests/model/test_reasoning_openai.py
@@ -1,0 +1,56 @@
+from test_helpers.utils import skip_if_no_openai, skip_if_no_openai_reasoning_summaries
+
+from inspect_ai import Task, eval
+from inspect_ai.agent import react
+from inspect_ai.dataset import Sample
+from inspect_ai.model import ContentReasoning
+from inspect_ai.tool import Tool, tool
+
+
+@skip_if_no_openai
+@skip_if_no_openai_reasoning_summaries
+def test_openai_reasoning_summary():
+    log = eval(
+        Task(dataset=[Sample(input="Solve 3*x^3-5*x=1")]),
+        model="openai/o4-mini",
+        reasoning_summary="auto",
+    )[0]
+    assert log.status == "success"
+    assert log.samples
+    content = log.samples[0].output.message.content
+    assert isinstance(content, list)
+    assert isinstance(content[0], ContentReasoning)
+
+
+@skip_if_no_openai
+@skip_if_no_openai_reasoning_summaries
+def test_openai_reasoning_summary_playback():
+    @tool
+    def validate() -> Tool:
+        async def execute(answer: str) -> bool:
+            """Validate the answer to a mathematical question.
+
+            Args:
+                answer: Answer to validate
+            """
+            return True
+
+        return execute
+
+    log = eval(
+        Task(
+            dataset=[
+                Sample(
+                    input="Solve 3*x^3-5*x=1, then call the validate() tool validate your answer. Then after that, solve x^2 - 5x + 6 = 0 and once again call the validate() tool to validate your answer."
+                )
+            ],
+            solver=react(tools=[validate()]),
+        ),
+        model="openai/o4-mini",
+        reasoning_summary="auto",
+    )[0]
+    assert log.status == "success"
+    assert log.samples
+    content = log.samples[0].output.message.content
+    assert isinstance(content, list)
+    assert isinstance(content[0], ContentReasoning)

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -80,6 +80,12 @@ def skip_if_no_openai_package(func):
     return skip_if_no_package("openai")(func)
 
 
+def skip_if_no_openai_reasoning_summaries(func):
+    return pytest.mark.api(
+        skip_if_env_var("ENABLE_OPENAI_REASONING_SUMMARIES", exists=False)(func)
+    )
+
+
 def skip_if_no_anthropic(func):
     return pytest.mark.api(skip_if_env_var("ANTHROPIC_API_KEY", exists=False)(func))
 


### PR DESCRIPTION
- Responses API is now used by default for all reasoning models.
- `reasoning_summary` generation option for reasoning models.
- `responses_store` model argument to control whether the `store` option is enabled (it is enabled by default for reasoning models to support reasoning playback).

