### PR TITLE
Handle tools with datetime, date, time, Set, or Any arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - OpenAI: New `responses_store` model argument to control whether the `store` option is enabled (it is enabled by default for reasoning models to support reasoning playback).
 - OpenAI: Support for [flex processing](https://inspect.aisi.org.uk/providers.html#flex-processing), which provides lower inference costs in exchange for slower response times and occasional resource unavailability (added in v1.75.0, which is now required).
 - Google: Support for `reasoning_tokens` option for Gemini 2.5 models.
+- Tool calling: Support for additional types (`datetime`, `date`, `time`, and `Set`)
 - Inspect View: Improved display of reasoning blocks.
 - Inspect View: Add support for linking to logs, specific log tabs, individual samples, and sample tabs within samples. 
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -3,7 +3,7 @@ import json
 import types
 from copy import copy
 from dataclasses import is_dataclass
-from datetime import datetime, date, time
+from datetime import date, datetime, time
 from logging import getLogger
 from textwrap import dedent
 from types import UnionType
@@ -603,7 +603,7 @@ def tool_param(type_hint: Type[Any], input: Any) -> Any:
         elif type_hint == datetime:
             if input.endswith("Z"):
                 # convert trailing Z to +00:00
-                input = s[:-1] + "+00:00"
+                input = input[:-1] + "+00:00"
             return datetime.fromisoformat(input)
         elif type_hint == date:
             return date.fromisoformat(input)

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -3,6 +3,7 @@ import json
 import types
 from copy import copy
 from dataclasses import is_dataclass
+from datetime import datetime, date, time
 from logging import getLogger
 from textwrap import dedent
 from types import UnionType
@@ -14,6 +15,7 @@ from typing import (
     NamedTuple,
     Optional,
     Sequence,
+    Set,
     Tuple,
     Type,
     Union,
@@ -391,7 +393,6 @@ async def call_tool(
 
         # normal tool call
         else:
-            arguments = tool_params(call.arguments, tool_def.tool)
             result: ToolResult = await tool_def.tool(**arguments)
             return result, [], None, None
 
@@ -599,6 +600,15 @@ def tool_param(type_hint: Type[Any], input: Any) -> Any:
                 raise ToolParsingError(
                     f"Unable to convert '{input}' to {type_hint.__name__}"
                 )
+        elif type_hint == datetime:
+            if input.endswith("Z"):
+                # convert trailing Z to +00:00
+                input = s[:-1] + "+00:00"
+            return datetime.fromisoformat(input)
+        elif type_hint == date:
+            return date.fromisoformat(input)
+        elif type_hint == time:
+            return time.fromisoformat(input)
         elif is_typeddict(type_hint):
             typeddict_data: dict[str, Any] = {}
             annotations = get_type_hints(type_hint)
@@ -620,6 +630,11 @@ def tool_param(type_hint: Type[Any], input: Any) -> Any:
             return [tool_param(args[0], x) for x in input]
         else:
             return input
+    elif origin is set or origin is Set:
+        if args:
+            return {tool_param(args[0], x) for x in input}
+        else:
+            return set(input)
     elif origin is tuple or origin is Tuple:
         if args:
             return tuple([tool_param(args[0], x) for x in input])

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -532,6 +532,27 @@ def schema_from_param(
             type=Type.BOOLEAN, description=param.description, nullable=nullable
         )
     elif param.type == "string":
+        if param.format == "date-time":
+            return Schema(
+                type=Type.STRING,
+                description=param.description,
+                format="^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$",
+                nullable=nullable,
+            )
+        elif param.format == "date":
+            return Schema(
+                type=Type.STRING,
+                description=param.description,
+                format="^[0-9]{4}-[0-9]{2}-[0-9]{2}$",
+                nullable=nullable,
+            )
+        elif param.format == "time":
+            return Schema(
+                type=Type.STRING,
+                description=param.description,
+                format="^[0-9]{2}:[0-9]{2}:[0-9]{2}$",
+                nullable=nullable,
+            )
         return Schema(
             type=Type.STRING, description=param.description, nullable=nullable
         )

--- a/src/inspect_ai/tool/_tool_def.py
+++ b/src/inspect_ai/tool/_tool_def.py
@@ -264,7 +264,5 @@ def validate_tool_parameters(tool_name: str, parameters: dict[str, ToolParam]) -
                 f"{context} provided for parameter '{bound_name}' of function '{tool_name}'."
             )
 
-        if param.type is None and not param.anyOf and not param.enum:
-            raise_not_provided_error("Unsupported type or type annotation")
-        elif not param.description:
+        if not param.description:
             raise_not_provided_error("Description not")

--- a/src/inspect_ai/util/_json.py
+++ b/src/inspect_ai/util/_json.py
@@ -32,6 +32,9 @@ class JSONSchema(BaseModel):
     type: JSONType | None = Field(default=None)
     """JSON type of tool parameter."""
 
+    format: str | None = Field(default=None)
+    """Format of the parameter (e.g. date-time)."""
+
     description: str | None = Field(default=None)
     """Parameter description."""
 

--- a/src/inspect_ai/util/_json.py
+++ b/src/inspect_ai/util/_json.py
@@ -2,12 +2,14 @@ import types
 import typing
 from copy import deepcopy
 from dataclasses import is_dataclass
+from datetime import datetime, date, time
 from typing import (
     Any,
     Dict,
     List,
     Literal,
     Optional,
+    Set,
     Tuple,
     Type,
     Union,
@@ -80,7 +82,13 @@ def json_schema(t: Type[Any]) -> JSONSchema:
             return JSONSchema(type="string")
         elif t is bool:
             return JSONSchema(type="boolean")
-        elif t is list:
+        elif t is datetime:
+            return JSONSchema(type="string", format="date-time")
+        elif t is date:
+            return JSONSchema(type="string", format="date")
+        elif t is time:
+            return JSONSchema(type="string", format="time")
+        elif t is list or t is set:
             return JSONSchema(type="array", items=JSONSchema())
         elif t is dict:
             return JSONSchema(type="object", additionalProperties=JSONSchema())
@@ -94,7 +102,7 @@ def json_schema(t: Type[Any]) -> JSONSchema:
             return JSONSchema(type="null")
         else:
             return JSONSchema()
-    elif origin is list or origin is List or origin is tuple or origin is Tuple:
+    elif origin is list or origin is List or origin is tuple or origin is Tuple or origin is set or origin is Set:
         return JSONSchema(
             type="array", items=json_schema(args[0]) if args else JSONSchema()
         )

--- a/src/inspect_ai/util/_json.py
+++ b/src/inspect_ai/util/_json.py
@@ -2,7 +2,7 @@ import types
 import typing
 from copy import deepcopy
 from dataclasses import is_dataclass
-from datetime import datetime, date, time
+from datetime import date, datetime, time
 from typing import (
     Any,
     Dict,
@@ -102,7 +102,14 @@ def json_schema(t: Type[Any]) -> JSONSchema:
             return JSONSchema(type="null")
         else:
             return JSONSchema()
-    elif origin is list or origin is List or origin is tuple or origin is Tuple or origin is set or origin is Set:
+    elif (
+        origin is list
+        or origin is List
+        or origin is tuple
+        or origin is Tuple
+        or origin is set
+        or origin is Set
+    ):
         return JSONSchema(
             type="array", items=json_schema(args[0]) if args else JSONSchema()
         )

--- a/tests/tools/test_call_tools.py
+++ b/tests/tools/test_call_tools.py
@@ -1,0 +1,199 @@
+from dataclasses import dataclass
+from datetime import datetime, date, time
+from typing import List, Tuple, Dict, Optional, Union, TypedDict, Any, Set
+
+import pytest
+from inspect_ai.model._call_tools import call_tool
+from inspect_ai.tool import Tool, tool
+from inspect_ai.tool._tool_call import ToolCall
+from inspect_ai.tool._tool_def import ToolDef
+from pydantic import BaseModel
+
+
+# --- Helpers ---------------------------------------------------------------
+
+def make_call(function_name, args):
+    return ToolCall(id="test", function=function_name, arguments=args or {}, parse_error=None)
+
+
+# --- Simple tool -------------------------------------------------
+
+@tool
+def incr() -> Tool:
+    async def incr(x: int) -> int:
+        """
+        Increment an integer by 1.
+
+        Args:
+            x (int): The integer to increment.
+
+        Returns:
+            int: The incremented result.
+        """
+        return x + 1
+
+    return incr
+
+
+# --- Complex tool ----------------------------------------------
+
+class MyTypedDict(TypedDict):
+    count: int
+    label: str
+
+
+@dataclass
+class MyDataClass:
+    value: float
+    flag: bool
+
+
+class MyPydanticModel(BaseModel):
+    name: str
+    id: int
+
+
+@tool
+def complex_tool() -> Tool:
+    async def complex_tool(
+            text: str,
+            count: int,
+            ratio: float,
+            active: bool,
+            numbers: List[int],
+            strings: Set[str],
+            tags: Tuple[str, ...],
+            mapping: Dict[str, int],
+            optional_text: Optional[str],
+            either: Union[int, str],
+            td: MyTypedDict,
+            dc: MyDataClass,
+            pm: MyPydanticModel,
+            timestamp: datetime,
+            the_date: date,
+            the_time: time,
+            anything: Any
+    ) -> dict:
+        """
+        Echo back diverse parameters of various types.
+
+        Args:
+            text (str): A simple text string.
+            count (int): An integer count.
+            ratio (float): A floating-point ratio.
+            active (bool): A boolean flag.
+            numbers (List[int]): A list of integers.
+            strings (Set[str]): A set of strings.
+            tags (Tuple[str, ...]): A tuple of strings.
+            mapping (Dict[str, int]): A dict mapping strings to integers.
+            optional_text (Optional[str]): An optional string value.
+            either (Union[int, str]): A value that can be int or str.
+            td (MyTypedDict): A TypedDict with 'count' and 'label'.
+            dc (MyDataClass): A dataclass with 'value' and 'flag'.
+            pm (MyPydanticModel): A Pydantic model with 'name' and 'id'.
+            timestamp (datetime): A datetime object.
+            the_date (date): A date object.
+            the_time (time): A time object.
+            anything (Any): Any arbitrary data.
+
+        Returns:
+            dict: A dictionary echoing all inputs.
+        """
+        return {
+            "text": text,
+            "count": count,
+            "ratio": ratio,
+            "active": active,
+            "numbers": numbers,
+            "strings": strings,
+            "tags": tags,
+            "mapping": mapping,
+            "optional_text": optional_text,
+            "either": either,
+            "td": td,
+            "dc": {"value": dc.value, "flag": dc.flag},
+            "pm": pm.dict(),
+            "timestamp": timestamp,
+            "the_date": the_date,
+            "the_time": the_time,
+            "anything": anything,
+        }
+
+    return complex_tool
+
+
+# --- Positive tests -------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_incr_simple_positive():
+    """Calling incr(0) should return 1."""
+    tool_def = ToolDef(incr())
+    call = make_call("incr", {"x": 0})
+    result, messages, output, agent = await call_tool([
+        tool_def
+    ], message="", call=call, conversation=[])
+    assert result == 1
+    assert messages == []
+    assert output is None
+    assert agent is None
+
+
+@pytest.mark.asyncio
+async def test_complex_tool_all_params():
+    """Exercise every parameter type in one call."""
+    args = {
+        "text": "hello",
+        "count": 10,
+        "ratio": 0.75,
+        "active": False,
+        "numbers": [5, 10, 15],
+        "strings": ["a", "b", "c"],
+        "tags": ["x", "y", "z"],
+        "mapping": {"a": 1, "b": 2},
+        "optional_text": "opt",
+        "either": 123,
+        "td": {"count": 1, "label": "one"},
+        "dc": {"value": 2.5, "flag": True},
+        "pm": {"name": "test", "id": 42},
+        "timestamp": "2025-04-17T12:00:00",
+        "the_date": "2025-04-17",
+        "the_time": "12:00:00",
+        "anything": {"complex": ["structure", 123]},
+    }
+    tool_def = ToolDef(complex_tool())
+    call = make_call("complex_tool", args)
+    result, messages, output, agent = await call_tool([
+        tool_def
+    ], message="", call=call, conversation=[])
+
+    # primitives
+    assert result["text"] == "hello"
+    assert result["count"] == 10
+    assert abs(result["ratio"] - 0.75) < 1e-9
+    assert result["active"] is False
+
+    # collections
+    assert result["numbers"] == [5, 10, 15]
+    assert result["strings"] == {"a", "b", "c"}
+    assert result["tags"] == ("x", "y", "z")
+    assert result["mapping"] == {"a": 1, "b": 2}
+
+    # Optional and Union
+    assert result["optional_text"] == "opt"
+    assert result["either"] == 123
+
+    # TypedDict, dataclass, Pydantic
+    assert result["td"] == {"count": 1, "label": "one"}
+    assert result["dc"] == {"value": 2.5, "flag": True}
+    assert result["pm"] == {"name": "test", "id": 42}
+
+    # date/time/any
+    assert result["timestamp"] == datetime(2025, 4, 17, 12, 0, 0)
+    assert result["the_date"] == date(2025, 4, 17)
+    assert result["the_time"] == time(12, 0, 0)
+    assert result["anything"] == {"complex": ["structure", 123]}
+
+    # no side‑effects or agent handoff
+    assert messages == []
+    assert output is None
+    assert agent is None

--- a/tests/tools/test_call_tools.py
+++ b/tests/tools/test_call_tools.py
@@ -1,22 +1,26 @@
 from dataclasses import dataclass
-from datetime import datetime, date, time
-from typing import List, Tuple, Dict, Optional, Union, TypedDict, Any, Set
+from datetime import date, datetime, time
+from typing import Any, Dict, List, Optional, Set, Tuple, TypedDict, Union
 
 import pytest
+from pydantic import BaseModel
+
 from inspect_ai.model._call_tools import call_tool
 from inspect_ai.tool import Tool, tool
 from inspect_ai.tool._tool_call import ToolCall
 from inspect_ai.tool._tool_def import ToolDef
-from pydantic import BaseModel
-
 
 # --- Helpers ---------------------------------------------------------------
 
+
 def make_call(function_name, args):
-    return ToolCall(id="test", function=function_name, arguments=args or {}, parse_error=None)
+    return ToolCall(
+        id="test", function=function_name, arguments=args or {}, parse_error=None
+    )
 
 
 # --- Simple tool -------------------------------------------------
+
 
 @tool
 def incr() -> Tool:
@@ -37,6 +41,7 @@ def incr() -> Tool:
 
 # --- Complex tool ----------------------------------------------
 
+
 class MyTypedDict(TypedDict):
     count: int
     label: str
@@ -56,23 +61,23 @@ class MyPydanticModel(BaseModel):
 @tool
 def complex_tool() -> Tool:
     async def complex_tool(
-            text: str,
-            count: int,
-            ratio: float,
-            active: bool,
-            numbers: List[int],
-            strings: Set[str],
-            tags: Tuple[str, ...],
-            mapping: Dict[str, int],
-            optional_text: Optional[str],
-            either: Union[int, str],
-            td: MyTypedDict,
-            dc: MyDataClass,
-            pm: MyPydanticModel,
-            timestamp: datetime,
-            the_date: date,
-            the_time: time,
-            anything: Any
+        text: str,
+        count: int,
+        ratio: float,
+        active: bool,
+        numbers: List[int],
+        strings: Set[str],
+        tags: Tuple[str, ...],
+        mapping: Dict[str, int],
+        optional_text: Optional[str],
+        either: Union[int, str],
+        td: MyTypedDict,
+        dc: MyDataClass,
+        pm: MyPydanticModel,
+        timestamp: datetime,
+        the_date: date,
+        the_time: time,
+        anything: Any,
     ) -> dict:
         """
         Echo back diverse parameters of various types.
@@ -124,14 +129,15 @@ def complex_tool() -> Tool:
 
 # --- Positive tests -------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_incr_simple_positive():
     """Calling incr(0) should return 1."""
     tool_def = ToolDef(incr())
     call = make_call("incr", {"x": 0})
-    result, messages, output, agent = await call_tool([
-        tool_def
-    ], message="", call=call, conversation=[])
+    result, messages, output, agent = await call_tool(
+        [tool_def], message="", call=call, conversation=[]
+    )
     assert result == 1
     assert messages == []
     assert output is None
@@ -162,9 +168,9 @@ async def test_complex_tool_all_params():
     }
     tool_def = ToolDef(complex_tool())
     call = make_call("complex_tool", args)
-    result, messages, output, agent = await call_tool([
-        tool_def
-    ], message="", call=call, conversation=[])
+    result, messages, output, agent = await call_tool(
+        [tool_def], message="", call=call, conversation=[]
+    )
 
     # primitives
     assert result["text"] == "hello"

--- a/tests/tools/test_call_tools.py
+++ b/tests/tools/test_call_tools.py
@@ -23,7 +23,7 @@ def make_call(function_name, args):
 
 
 @tool
-def incr() -> Tool:
+def incr():
     async def incr(x: int) -> int:
         """
         Increment an integer by 1.
@@ -59,7 +59,7 @@ class MyPydanticModel(BaseModel):
 
 
 @tool
-def complex_tool() -> Tool:
+def complex_tool():
     async def complex_tool(
         text: str,
         count: int,

--- a/tests/tools/test_call_tools.py
+++ b/tests/tools/test_call_tools.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import BaseModel
 
 from inspect_ai.model._call_tools import call_tool
-from inspect_ai.tool import Tool, tool
+from inspect_ai.tool import tool
 from inspect_ai.tool._tool_call import ToolCall
 from inspect_ai.tool._tool_def import ToolDef
 

--- a/tests/tools/test_tool_parse.py
+++ b/tests/tools/test_tool_parse.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, TypedDict, Union
+from datetime import datetime, date, time
+from typing import Any, Dict, List, Optional, TypedDict, Union, Set
 
 from pydantic import BaseModel, Field
 
@@ -16,9 +17,15 @@ def test_json_schema():
     assert json_schema(float) == JSONSchema(type="number")
     assert json_schema(str) == JSONSchema(type="string")
     assert json_schema(bool) == JSONSchema(type="boolean")
+    assert json_schema(datetime) == JSONSchema(type="string", format="date-time")
+    assert json_schema(date) == JSONSchema(type="string", format="date")
+    assert json_schema(time) == JSONSchema(type="string", format="time")
     assert json_schema(Any) == JSONSchema()
     assert json_schema(List[int]) == JSONSchema(
         type="array", items=JSONSchema(type="integer")
+    )
+    assert json_schema(Set[str]) == JSONSchema(
+        type="array", items=JSONSchema(type="string")
     )
     assert json_schema(Dict[str, int]) == JSONSchema(
         type="object", additionalProperties=JSONSchema(type="integer")

--- a/tests/tools/test_tool_parse.py
+++ b/tests/tools/test_tool_parse.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
-from datetime import datetime, date, time
-from typing import Any, Dict, List, Optional, TypedDict, Union, Set
+from datetime import date, datetime, time
+from typing import Any, Dict, List, Optional, Set, TypedDict, Union
 
 from pydantic import BaseModel, Field
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Currently tools with `datetime`, `date`, `time`, `set`/`Set`, or `Any` arguments are first all translated to an empty JSONSchema spec (which is correct for `Any`, but loses a lot of information for the other three argument types). A little bit later in the flow they are then all rejected without any good reason.

### What is the new behavior?

Translates `datetime`, `date`, and `time` into string arguments with date-time/date/time format specifiers.

`Set` is translated into an array.

Allows the empty JSONSchema for `Any` and unknown types.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

It should only allow some tools than weren't previously allowed.
