### PR TITLE
Agent: Support custom implementation of submit tool with react agent

### DIFF
--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -110,7 +110,7 @@ def react(
 
     # submission tool
     @tool
-    def submit_tool() -> Tool:
+    def default_submit_tool() -> Tool:
         async def execute(answer: str) -> ToolResult:
             """Submit an answer for evaluation.
 
@@ -135,7 +135,10 @@ def react(
 
     # resolve tools
     tools = list(tools) if tools is not None else []
-    tools.append(tool_with(submit_tool(), submit.name, submit.description))
+    submit_tool: Tool = (
+        submit.implementation if submit.implementation else default_submit_tool()
+    )
+    tools.append(tool_with(submit_tool, submit.name, submit.description))
 
     async def execute(state: AgentState) -> AgentState:
         async with mcp_connection(tools):

--- a/src/inspect_ai/agent/_types.py
+++ b/src/inspect_ai/agent/_types.py
@@ -1,7 +1,8 @@
-from typing import Awaitable, Callable, NamedTuple, TypeAlias
+from typing import Awaitable, Callable, NamedTuple, Optional, TypeAlias
 
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.scorer._metric import Score, ValueToFloat, value_to_float
+from inspect_ai.tool._tool import Tool
 
 DEFAULT_HANDOFF_PROMPT = """
 You are part of a multi-agent system designed to make agent coordination and
@@ -85,3 +86,6 @@ class AgentSubmit(NamedTuple):
 
     description: str = "Submit an answer for evaluation."
     """Description of submit tool."""
+
+    implementation: Optional[Tool] = None
+    """Implementation of submit tool."""


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

A user can specify a custom submit implementation as part of an AgentContinue.

Example:

```py
@tool
def custom_submit() -> Tool:
    async def submit(file_path: str = None):
        """
        Call this tool when you have created a file as per the task description.

        Args:
            file_path (str): Required string argument.

        Returns:
            result(str): Output from testing your solution.
        """
        
        # My custom submission validation goes here
        result = ...
        # If task is solved, call `store().set("result", True)` which is later check in `on_continue` and in a custom scorer.
        return result
    return submit


@agent
def my_agent(...):
    ...
    return react(..., submit=AgentSubmit(implementation=custom_submit()))`
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

Now that AgentSubmit has a name, description, and implementation, is it ultimately the same as a tool? If so, perhaps it would make sense to drop the `AgentSubmit` type entirely and update the signature of the react agent to replace `submit: AgentSubmit` to with `submit: Optional[Tool]` with a default of the current submit tool. Let me know if such an implementation would be preferred. I still haven't figured out how `Tool` are implemented so I might be missing something there.