### PR TITLE
Cleanup partially initialized sandbox on init fail

### DIFF
--- a/src/inspect_ai/util/_sandbox/context.py
+++ b/src/inspect_ai/util/_sandbox/context.py
@@ -180,6 +180,16 @@ async def init_sandbox_environments_sample(
         raise ex
 
 
+async def cleanup_sandbox_failed_init(
+    type: str,
+    task_name: str,
+    config: SandboxEnvironmentConfigType | None,
+) -> None:
+    sandboxenv_type = registry_find_sandboxenv(type)
+    sample_cleanup = cast(SampleCleanup, getattr(sandboxenv_type, "sample_cleanup"))
+    await sample_cleanup(task_name, config, {}, True)
+
+
 async def cleanup_sandbox_environments_sample(
     type: str,
     task_name: str,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [✅] Bug fixes
- [✅] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When a sandbox environment fails to fully initialize, the partially-initialized sandbox isn't completely cleaned.

### What is the new behavior?

Partially-initialized sandboxes are completely cleaned.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

Proof-of-concept:

`task.py`:

```
from inspect_ai import task, Task
from inspect_ai.dataset import Sample
from inspect_ai.scorer import includes
from inspect_ai.solver import generate

dataset = [
    Sample(
        input='Is there a file named "bar.txt" ' 
               + 'in the current directory?',
        target="Yes",
        files={"bar.txt": "hello"},
    ),
    Sample(
        input='Is there a file named "bar.txt" '
               + 'in the current directory?',
        target="Yes",
        files={"bar.txt": "hello"},
    )
]

@task
def some_task():
    return Task(
        dataset=dataset,
        solver=[
            generate()
        ],
        sandbox="docker",
        scorer=includes(),
    )
```

`compose.yaml`:

```
networks:
  default:
    driver: bridge
    ipam:
      config:
        - subnet: 192.168.177.0/24
services:
  default:
    image: alpine
    init: true
    cpus: 1.0
    mem_limit: 0.5gb
    command: tail -f /dev/null
  victim:
    image: alpine
    cpus: 1.0
    mem_limit: 0.5gb
    networks:
      default:
        ipv4_address: 192.168.177.2
    command: tail -f /dev/null
```

```
watch -n 1 docker network ls
```

```
watch -n 1 docker ps
```

```
inspect eval task.py --model=openai/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B --limit 2
 | ...
│ RuntimeError: No services started.                                                        │
│ Compose up stderr:  Network inspect-some_task-ifpxhdu_default  Creating                   │
│  Network inspect-some_task-ifpxhdu_default  Error                                         │
│ failed to create network inspect-some_task-ifpxhdu_default: Error response from daemon:   │
│ invalid pool request: Pool overlaps with other one on this address space                  │
│                                                                                           │
│                                                                                           │
│ Task interrupted (no samples completed before interruption)                               │
│                                                                                           │
│ Log: logs/2025-04-21T07-02-05-07-00_some-task_Rp3wg3Rx2dXjGLBfdYKo4N.eval
```

And one of the docker networks and containers is still hanging around.