### PR TITLE
docker: register samples for cleanup immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Scoring: Handle parsing unicode fractions when evaluating numeric input for `match()` scorer.
 - Scoring: Add `sample_metadata_as()` method to `SampleScore`.
 - Sandbox API: Added `user` parameter to `connection()` method for getting connection details for a given user.
+- Docker: Register samples for cleanup immediately (so they are still cleaned up even if interrupted during startup).
 - Docker: Support sample metadata interpolation for image names in compose files. 
 - Tool calling: Support for additional types (`datetime`, `date`, `time`, and `Set`)
 - Log API: Functions for reading/writing eval logs can now take a `Path`.

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -177,6 +177,9 @@ class DockerSandboxEnvironment(SandboxEnvironment):
             env=env,
         )
 
+        # note that the project is running
+        project_startup(project)
+
         try:
             # enumerate the services that will be created
             services = await compose_services(project)
@@ -193,9 +196,6 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                 raise RuntimeError(
                     f"No services started.\nCompose up stderr: {result.stderr}"
                 )
-
-            # note that the project is running
-            project_startup(project)
 
             # create sandbox environments for all running services
             default_service: str | None = None


### PR DESCRIPTION
This will ensrue that they are still cleaned up even if interrupted during startup.

