### PR TITLE
Display Sample Retries in Viewer

### DIFF
--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -205,6 +205,9 @@ class TaskLogger:
                 scores=sample.scores,
                 error=sample.error.message if sample.error is not None else None,
                 limit=f"{sample.limit.type}" if sample.limit is not None else None,
+                retries=len(sample.error_retries)
+                if sample.error_retries is not None
+                else None,
             )
         )
 

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -20088,7 +20088,7 @@ span.ap-marker-container:hover span.ap-marker {
 ._message_5y0hl_15 {
   width: 300px;
 }
-._grid_1oibv_1 {
+._grid_185sx_1 {
   display: grid;
   padding-top: 1em;
   padding-bottom: 1em;
@@ -20100,40 +20100,45 @@ span.ap-marker-container:hover span.ap-marker {
   padding-right: 1rem;
 }
 
-._selected_1oibv_13 {
+._selected_185sx_13 {
   box-shadow: inset 0 0 0px 2px var(--bs-focus-ring-color);
 }
 
-._sampleRowLink_1oibv_17 {
+._sampleRowLink_185sx_17 {
   text-decoration: none;
   color: inherit;
   display: block;
 }
 
-._disabled_1oibv_23 {
+._disabled_185sx_23 {
   cursor: not-allowed;
   opacity: 0.7;
 }
 
-._cell_1oibv_28 {
+._cell_185sx_28 {
   padding-left: 0;
   padding-right: 0;
 }
 
-._wrapAnywhere_1oibv_33 {
+._wrapAnywhere_185sx_33 {
   word-wrap: anywhere;
 }
 
-._noLeft_1oibv_37 {
+._noLeft_185sx_37 {
   padding-left: 0;
 }
 
-._score_1oibv_41 {
+._score_185sx_41 {
   display: flex;
   justify-self: center;
 }
 
-._spinner_1oibv_46 {
+._centered_185sx_46 {
+  display: flex;
+  justify-content: center;
+}
+
+._spinner_185sx_51 {
   height: 1.4em;
   width: 1.4em;
   color: var(--bs-focus-ring-color);

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -23965,6 +23965,7 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
       play: "bi bi-play-fill",
       previous: "bi bi-chevron-left",
       refresh: "bi bi-arrow-clockwise",
+      retry: "bi bi-arrow-repeat",
       role: {
         user: "bi bi-person",
         system: "bi bi-cpu",
@@ -39331,7 +39332,7 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
           const score2 = selectedScore ? evalDescriptor.score(current2, selectedScore) : void 0;
           const scoreValue = score2 == null ? void 0 : score2.value;
           const scoreText = scoreValue ? String(scoreValue) : current2.error ? String(current2.error) : "";
-          previous[0] = Math.min(Math.max(previous[0], text2.length), 300);
+          previous[0] = Math.min(Math.max(previous[0], text2.length), 200);
           previous[1] = Math.min(
             Math.max(previous[1], arrayToString(current2.target).length),
             300
@@ -39348,10 +39349,17 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
             50
           );
           previous[4] = Math.min(
-            Math.max(previous[4], String(current2.id).length),
+            Math.max(
+              previous[4],
+              current2.retries ? String(current2.retries).length : 0
+            ),
+            50
+          );
+          previous[5] = Math.min(
+            Math.max(previous[5], String(current2.id).length),
             10
           );
-          previous[5] = Math.min(Math.max(previous[5], scoreText.length), 30);
+          previous[6] = Math.min(Math.max(previous[6], scoreText.length), 30);
           return previous;
         },
         [0, 0, 0, 0, 0, 0]
@@ -39361,24 +39369,27 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
         target: Math.min(sizes[1], 300),
         answer: Math.min(sizes[2], 300),
         limit: Math.min(sizes[3], 50),
-        id: Math.min(sizes[4], 10),
-        score: Math.min(sizes[5], 30)
+        retries: Math.min(sizes[4], 50),
+        id: Math.min(sizes[5], 10),
+        score: Math.min(sizes[6], 30)
       };
-      const base2 = maxSizes.input + maxSizes.target + maxSizes.answer + maxSizes.limit + maxSizes.id + maxSizes.score || 1;
+      const base2 = maxSizes.input + maxSizes.target + maxSizes.answer + maxSizes.limit + maxSizes.retries + maxSizes.id + maxSizes.score || 1;
       const messageShape = {
         raw: {
           input: sizes[0],
           target: sizes[1],
           answer: sizes[2],
           limit: sizes[3],
-          id: sizes[4],
-          score: sizes[5]
+          retries: sizes[4],
+          id: sizes[5],
+          score: sizes[6]
         },
         normalized: {
           input: maxSizes.input / base2,
           target: maxSizes.target / base2,
           answer: maxSizes.answer / base2,
           limit: maxSizes.limit / base2,
+          retries: maxSizes.retries / base2,
           id: maxSizes.id / base2,
           score: maxSizes.score / base2
         }
@@ -50764,10 +50775,10 @@ self.onmessage = function (e) {
       value
     };
     function isEvalSample(sample2) {
-      return "choices" in sample2 && Array.isArray(sample2.choices);
+      return "store" in sample2;
     }
     const resolveSample = (sample2, sampleDescriptor) => {
-      var _a2, _b2, _c;
+      var _a2, _b2, _c, _d;
       const input2 = inputString(sample2.input);
       if (isEvalSample(sample2) && sample2.choices && sample2.choices.length > 0) {
         input2.push("");
@@ -50783,12 +50794,14 @@ self.onmessage = function (e) {
       const working_time = isEvalSample(sample2) ? sample2.working_time : void 0;
       const total_time = isEvalSample(sample2) ? sample2.total_time : void 0;
       const error2 = isEvalSample(sample2) ? (_c = sample2.error) == null ? void 0 : _c.message : void 0;
+      const retries = isEvalSample(sample2) ? (_d = sample2.error_retries) == null ? void 0 : _d.length : sample2.retries;
       return {
         id: sample2.id,
         input: input2,
         target: target2,
         answer: answer2,
         limit,
+        retries,
         working_time,
         total_time,
         error: error2
@@ -50809,7 +50822,7 @@ self.onmessage = function (e) {
       const target2 = (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.normalized.target) > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.target) : 0;
       const answer2 = (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.normalized.answer) > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.answer) : 0;
       const limitSize = (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.normalized.limit) > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.limit) : 0;
-      const timeSize = fields.working_time || fields.total_time ? 0.15 : 0;
+      const retrySize = (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.normalized.retries) > 0 ? 6 : 0;
       const idSize = Math.max(
         2,
         Math.min(10, sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.raw.id)
@@ -50850,7 +50863,7 @@ self.onmessage = function (e) {
               className: clsx("no-last-para-padding", styles$x.answer)
             }
           ) : "",
-          size: `${answer2}fr`,
+          size: `${Math.max(answer2, 20)}fr`,
           clamp: true
         });
       }
@@ -50864,7 +50877,7 @@ self.onmessage = function (e) {
         columns.push({
           label: "Time",
           value: formatTime$1(fields.total_time),
-          size: `${timeSize}fr`,
+          size: `fit-content(10rem)`,
           center: true,
           title: toolTip(fields.working_time)
         });
@@ -50873,14 +50886,22 @@ self.onmessage = function (e) {
         columns.push({
           label: "Limit",
           value: fields.limit,
-          size: `${limitSize}fr`,
+          size: `fit-content(10rem)`,
+          center: true
+        });
+      }
+      if ((fields == null ? void 0 : fields.retries) && retrySize > 0) {
+        columns.push({
+          label: "Retries",
+          value: fields.retries,
+          size: `${retrySize}rem`,
           center: true
         });
       }
       columns.push({
         label: "Score",
         value: fields.error ? /* @__PURE__ */ jsxRuntimeExports.jsx(FlatSampleError, { message: fields.error }) : ((_a2 = sampleDescriptor == null ? void 0 : sampleDescriptor.evalDescriptor.score(sample2, currentScore)) == null ? void 0 : _a2.render()) || "",
-        size: "minmax(2em, 30em)",
+        size: "fit-content(15em)",
         center: true
       });
       return /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -60112,7 +60133,7 @@ ${events}
     );
     const SampleDisplay = ({ id, scrollRef }) => {
       const baseId = `sample-dialog`;
-      const sampleSummaries = useSampleSummaries();
+      const filteredSamples = useFilteredSamples();
       const selectedSampleIndex = useStore(
         (state) => state.log.selectedSampleIndex
       );
@@ -60124,7 +60145,7 @@ ${events}
       const { sampleTabId } = useParams();
       const effectiveSelectedTab = sampleTabId || selectedTab;
       const navigate = useNavigate();
-      const sampleSummary = sampleSummaries[selectedSampleIndex];
+      const sampleSummary = filteredSamples[selectedSampleIndex];
       const sampleEvents = (sample2 == null ? void 0 : sample2.events) || runningSampleData;
       const sampleMessages = reactExports.useMemo(() => {
         if (sample2 == null ? void 0 : sample2.messages) {
@@ -81422,13 +81443,14 @@ Supported expressions:
         /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: styles$6.message, style: ApplicationStyles.lineClamp(2), children: errorType(message2) })
       ] });
     };
-    const grid = "_grid_1oibv_1";
-    const selected = "_selected_1oibv_13";
-    const disabled = "_disabled_1oibv_23";
-    const cell = "_cell_1oibv_28";
-    const wrapAnywhere = "_wrapAnywhere_1oibv_33";
-    const noLeft = "_noLeft_1oibv_37";
-    const score = "_score_1oibv_41";
+    const grid = "_grid_185sx_1";
+    const selected = "_selected_185sx_13";
+    const disabled = "_disabled_185sx_23";
+    const cell = "_cell_185sx_28";
+    const wrapAnywhere = "_wrapAnywhere_185sx_33";
+    const noLeft = "_noLeft_185sx_37";
+    const score = "_score_185sx_41";
+    const centered = "_centered_185sx_46";
     const styles$5 = {
       grid,
       selected,
@@ -81436,7 +81458,8 @@ Supported expressions:
       cell,
       wrapAnywhere,
       noLeft,
-      score
+      score,
+      centered
     };
     const SampleRow = ({
       id,
@@ -81512,6 +81535,19 @@ Supported expressions:
                 children: sample2.limit
               }
             ),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "div",
+              {
+                className: clsx(
+                  "sample-retries",
+                  "text-size-small",
+                  "three-line-clamp",
+                  styles$5.cell,
+                  styles$5.centered
+                ),
+                children: sample2.retries && sample2.retries > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: clsx(ApplicationIcons.retry) }) : void 0
+              }
+            ),
             /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx("text-size-small", styles$5.cell, styles$5.score), children: sample2.error ? /* @__PURE__ */ jsxRuntimeExports.jsx(SampleErrorView, { message: sample2.error }) : completed ? scoreRendered : /* @__PURE__ */ jsxRuntimeExports.jsx(PulsingDots, {}) })
           ]
         }
@@ -81584,6 +81620,7 @@ Supported expressions:
       target: target2 = true,
       answer: answer2 = true,
       limit = true,
+      retries = false,
       score: score2 = true,
       gridColumnsTemplate
     }) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -81602,6 +81639,7 @@ Supported expressions:
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: target2 ? "Target" : "" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: answer2 ? "Answer" : "" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: limit ? "Limit" : "" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: retries ? "Retried" : "" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: styles$2.center, children: score2 ? "Score" : "" })
         ]
       }
@@ -81714,7 +81752,7 @@ Supported expressions:
         },
         [gridColumnsTemplate]
       );
-      const { input: input2, limit, answer: answer2, target: target2 } = gridColumns(samplesDescriptor);
+      const { input: input2, limit, answer: answer2, target: target2, retries } = gridColumns(samplesDescriptor);
       const sampleCount = items == null ? void 0 : items.reduce((prev, current2) => {
         if (current2.type === "sample") {
           return prev + 1;
@@ -81754,6 +81792,7 @@ Supported expressions:
             target: target2 !== "0",
             answer: answer2 !== "0",
             limit: limit !== "0",
+            retries: retries !== "0em",
             gridColumnsTemplate
           }
         ),
@@ -81794,14 +81833,15 @@ Supported expressions:
       ] });
     });
     const gridColumnsValue = (sampleDescriptor) => {
-      const { input: input2, target: target2, answer: answer2, limit, id, score: score2 } = gridColumns(sampleDescriptor);
-      return `${id} ${input2} ${target2} ${answer2} ${limit} ${score2}`;
+      const { input: input2, target: target2, answer: answer2, limit, retries, id, score: score2 } = gridColumns(sampleDescriptor);
+      return `${id} ${input2} ${target2} ${answer2} ${limit} ${retries} ${score2}`;
     };
     const gridColumns = (sampleDescriptor) => {
       const input2 = sampleDescriptor && sampleDescriptor.messageShape.normalized.input > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.input) : 0;
       const target2 = sampleDescriptor && sampleDescriptor.messageShape.normalized.target > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.target) : 0;
       const answer2 = sampleDescriptor && sampleDescriptor.messageShape.normalized.answer > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.answer) : 0;
       const limit = sampleDescriptor && sampleDescriptor.messageShape.normalized.limit > 0 ? Math.max(0.15, sampleDescriptor.messageShape.normalized.limit) : 0;
+      const retries = sampleDescriptor && sampleDescriptor.messageShape.normalized.retries > 0 ? 4 : 0;
       const id = Math.max(
         2,
         Math.min(10, (sampleDescriptor == null ? void 0 : sampleDescriptor.messageShape.raw.id) || 0)
@@ -81822,6 +81862,7 @@ Supported expressions:
         target: frSize(target2),
         answer: frSize(answer2),
         limit: frSize(limit),
+        retries: `${retries}em`,
         id: `${id}rem`,
         score: `${score2}rem`
       };

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -41864,7 +41864,8 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
     };
     const sampleVariables = (sample2) => {
       return {
-        has_error: !!sample2.error
+        has_error: !!sample2.error,
+        has_retries: sample2.retries !== void 0 && sample2.retries > 0
       };
     };
     const scoreFilterItems = (evalDescriptor) => {
@@ -41952,7 +41953,8 @@ categories: ${categories.join(" ")}`;
         };
         const resolveVariable = (name2, get2) => {
           if (name2 in mySampleVariables) {
-            return get2(name2);
+            const value2 = get2(name2);
+            return value2;
           }
           return sample2.error ? void 0 : get2(name2);
         };
@@ -80659,7 +80661,8 @@ ${events}
       ["log10", "Base 10 logarithm"]
     ];
     const SAMPLE_VARIABLES = [
-      ["has_error", "Checks if the sample has an error"]
+      ["has_error", "Checks if the sample has an error"],
+      ["has_retries", "Checks if the sample has been retried"]
     ];
     const SAMPLE_FUNCTIONS = [
       ["input_contains", "Checks if input contains a regular expression"],
@@ -80963,6 +80966,7 @@ Filter samples by:
   • Scores
   • Samples with errors: has_error
   • Input, target and error regex search: input_contains, target_contains, error_contains
+  • Samples that have been retried: has_retries
 
 Supported expressions:
   • Arithmetic: +, -, *, /, mod, ^

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -22658,6 +22658,7 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
     const kSampleScoringTabId = `scoring`;
     const kSampleMetdataTabId = `metadata`;
     const kSampleErrorTabId = `error`;
+    const kSampleErrorRetriesTabId = `retry-errors`;
     const kSampleJsonTabId = `json`;
     const kScoreTypePassFail = "passfail";
     const kScoreTypeCategorical = "categorical";
@@ -23965,7 +23966,6 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
       play: "bi bi-play-fill",
       previous: "bi bi-chevron-left",
       refresh: "bi bi-arrow-clockwise",
-      retry: "bi bi-arrow-repeat",
       role: {
         user: "bi bi-person",
         system: "bi bi-cpu",
@@ -60301,6 +60301,32 @@ ${events}
                   ) })
                 }
               ) : null,
+              (sample2 == null ? void 0 : sample2.error_retries) ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+                TabPanel,
+                {
+                  id: kSampleErrorRetriesTabId,
+                  className: "sample-tab",
+                  title: "Errors",
+                  onSelected: onSelectedTab,
+                  selected: effectiveSelectedTab === kSampleErrorRetriesTabId,
+                  children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx(styles$z.padded), children: sample2.error_retries.map((retry, index2) => {
+                    return /* @__PURE__ */ jsxRuntimeExports.jsxs(Card, { children: [
+                      /* @__PURE__ */ jsxRuntimeExports.jsx(CardHeader, { label: `Attempt ${index2 + 1}` }),
+                      /* @__PURE__ */ jsxRuntimeExports.jsx(CardBody, { children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+                        ANSIDisplay,
+                        {
+                          output: retry.traceback_ansi,
+                          className: clsx("text-size-small", styles$z.ansi),
+                          style: {
+                            fontSize: "clamp(0.4rem, calc(0.15em + 1vw), 0.8rem)",
+                            margin: "0.5em 0"
+                          }
+                        }
+                      ) })
+                    ] }, `sample-retry-error-${index2}`);
+                  }) })
+                }
+              ) : null,
               /* @__PURE__ */ jsxRuntimeExports.jsx(
                 TabPanel,
                 {
@@ -81549,7 +81575,7 @@ Supported expressions:
                   styles$5.cell,
                   styles$5.centered
                 ),
-                children: sample2.retries && sample2.retries > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("i", { className: clsx(ApplicationIcons.retry) }) : void 0
+                children: sample2.retries && sample2.retries > 0 ? sample2.retries : void 0
               }
             ),
             /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx("text-size-small", styles$5.cell, styles$5.score), children: sample2.error ? /* @__PURE__ */ jsxRuntimeExports.jsx(SampleErrorView, { message: sample2.error }) : completed ? scoreRendered : /* @__PURE__ */ jsxRuntimeExports.jsx(PulsingDots, {}) })
@@ -81643,7 +81669,7 @@ Supported expressions:
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: target2 ? "Target" : "" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: answer2 ? "Answer" : "" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: limit ? "Limit" : "" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: retries ? "Retried" : "" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: retries ? "Retries" : "" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: styles$2.center, children: score2 ? "Score" : "" })
         ]
       }

--- a/src/inspect_ai/_view/www/src/app/appearance/icons.ts
+++ b/src/inspect_ai/_view/www/src/app/appearance/icons.ts
@@ -76,6 +76,7 @@ export const ApplicationIcons = {
   play: "bi bi-play-fill",
   previous: "bi bi-chevron-left",
   refresh: "bi bi-arrow-clockwise",
+  retry: "bi bi-arrow-repeat",
   role: {
     user: "bi bi-person",
     system: "bi bi-cpu",

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -24,6 +24,7 @@ import { Card, CardBody, CardHeader } from "../../components/Card";
 import { JSONPanel } from "../../components/JsonPanel";
 import { NoContentsPanel } from "../../components/NoContentsPanel";
 import {
+  kSampleErrorRetriesTabId,
   kSampleErrorTabId,
   kSampleJsonTabId,
   kSampleMessagesTabId,
@@ -239,6 +240,35 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({ id, scrollRef }) => {
                 output={sample.error.traceback_ansi}
                 className={clsx("text-size-small", styles.ansi)}
               />
+            </div>
+          </TabPanel>
+        ) : null}
+        {sample?.error_retries ? (
+          <TabPanel
+            id={kSampleErrorRetriesTabId}
+            className="sample-tab"
+            title="Errors"
+            onSelected={onSelectedTab}
+            selected={effectiveSelectedTab === kSampleErrorRetriesTabId}
+          >
+            <div className={clsx(styles.padded)}>
+              {sample.error_retries.map((retry, index) => {
+                return (
+                  <Card key={`sample-retry-error-${index}`}>
+                    <CardHeader label={`Attempt ${index + 1}`} />
+                    <CardBody>
+                      <ANSIDisplay
+                        output={retry.traceback_ansi}
+                        className={clsx("text-size-small", styles.ansi)}
+                        style={{
+                          fontSize: "clamp(0.4rem, calc(0.15em + 1vw), 0.8rem)",
+                          margin: "0.5em 0",
+                        }}
+                      />
+                    </CardBody>
+                  </Card>
+                );
+              })}
             </div>
           </TabPanel>
         ) : null}

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -31,7 +31,7 @@ import {
   kSampleScoringTabId,
   kSampleTranscriptTabId,
 } from "../../constants";
-import { useSampleData, useSampleSummaries } from "../../state/hooks";
+import { useFilteredSamples, useSampleData } from "../../state/hooks";
 import { useStore } from "../../state/store";
 import { formatTime } from "../../utils/format";
 import { printHeadingHtml, printHtml } from "../../utils/print";
@@ -55,7 +55,7 @@ interface SampleDisplayProps {
 export const SampleDisplay: FC<SampleDisplayProps> = ({ id, scrollRef }) => {
   // Tab ids
   const baseId = `sample-dialog`;
-  const sampleSummaries = useSampleSummaries();
+  const filteredSamples = useFilteredSamples();
   const selectedSampleIndex = useStore(
     (state) => state.log.selectedSampleIndex,
   );
@@ -77,7 +77,7 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({ id, scrollRef }) => {
   // Navigation hook for URL updates
   const navigate = useNavigate();
 
-  const sampleSummary = sampleSummaries[selectedSampleIndex];
+  const sampleSummary = filteredSamples[selectedSampleIndex];
 
   // Consolidate the events and messages into the proper list
   // whether running or not

--- a/src/inspect_ai/_view/www/src/app/samples/SampleSummaryView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleSummaryView.tsx
@@ -30,6 +30,7 @@ interface SampleFields {
   target: Target;
   answer?: string;
   limit?: string;
+  retries?: number;
   working_time?: WorkingTime;
   total_time?: TotalTime;
   error?: string;
@@ -38,7 +39,7 @@ interface SampleFields {
 function isEvalSample(
   sample: SampleSummary | EvalSample,
 ): sample is EvalSample {
-  return "choices" in sample && Array.isArray((sample as EvalSample).choices);
+  return "store" in sample;
 }
 
 const resolveSample = (
@@ -64,6 +65,9 @@ const resolveSample = (
   const working_time = isEvalSample(sample) ? sample.working_time : undefined;
   const total_time = isEvalSample(sample) ? sample.total_time : undefined;
   const error = isEvalSample(sample) ? sample.error?.message : undefined;
+  const retries = isEvalSample(sample)
+    ? sample.error_retries?.length
+    : sample.retries;
 
   return {
     id: sample.id,
@@ -71,6 +75,7 @@ const resolveSample = (
     target,
     answer,
     limit,
+    retries,
     working_time,
     total_time,
     error,
@@ -107,7 +112,8 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
     sampleDescriptor?.messageShape.normalized.limit > 0
       ? Math.max(0.15, sampleDescriptor.messageShape.normalized.limit)
       : 0;
-  const timeSize = fields.working_time || fields.total_time ? 0.15 : 0;
+  const retrySize =
+    sampleDescriptor?.messageShape.normalized.retries > 0 ? 6 : 0;
   const idSize = Math.max(
     2,
     Math.min(10, sampleDescriptor?.messageShape.raw.id),
@@ -153,7 +159,7 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
       ) : (
         ""
       ),
-      size: `${answer}fr`,
+      size: `${Math.max(answer, 20)}fr`,
       clamp: true,
     });
   }
@@ -169,7 +175,7 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
     columns.push({
       label: "Time",
       value: formatTime(fields.total_time),
-      size: `${timeSize}fr`,
+      size: `fit-content(10rem)`,
       center: true,
       title: toolTip(fields.working_time),
     });
@@ -179,7 +185,16 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
     columns.push({
       label: "Limit",
       value: fields.limit,
-      size: `${limitSize}fr`,
+      size: `fit-content(10rem)`,
+      center: true,
+    });
+  }
+
+  if (fields?.retries && retrySize > 0) {
+    columns.push({
+      label: "Retries",
+      value: fields.retries,
+      size: `${retrySize}rem`,
       center: true,
     });
   }
@@ -192,7 +207,7 @@ export const SampleSummaryView: FC<SampleSummaryViewProps> = ({
       sampleDescriptor?.evalDescriptor.score(sample, currentScore)?.render() ||
       ""
     ),
-    size: "minmax(2em, 30em)",
+    size: "fit-content(15em)",
     center: true,
   });
 

--- a/src/inspect_ai/_view/www/src/app/samples/descriptor/samplesDescriptor.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/descriptor/samplesDescriptor.tsx
@@ -298,11 +298,12 @@ export const createSamplesDescriptor = (
         : current.error
           ? String(current.error)
           : "";
-      previous[0] = Math.min(Math.max(previous[0], text.length), 300);
+      previous[0] = Math.min(Math.max(previous[0], text.length), 200);
       previous[1] = Math.min(
         Math.max(previous[1], arrayToString(current.target).length),
         300,
       );
+
       previous[2] = Math.min(
         Math.max(
           previous[2],
@@ -317,10 +318,17 @@ export const createSamplesDescriptor = (
         50,
       );
       previous[4] = Math.min(
-        Math.max(previous[4], String(current.id).length),
+        Math.max(
+          previous[4],
+          current.retries ? String(current.retries).length : 0,
+        ),
+        50,
+      );
+      previous[5] = Math.min(
+        Math.max(previous[5], String(current.id).length),
         10,
       );
-      previous[5] = Math.min(Math.max(previous[5], scoreText.length), 30);
+      previous[6] = Math.min(Math.max(previous[6], scoreText.length), 30);
 
       return previous;
     },
@@ -333,14 +341,16 @@ export const createSamplesDescriptor = (
     target: Math.min(sizes[1], 300),
     answer: Math.min(sizes[2], 300),
     limit: Math.min(sizes[3], 50),
-    id: Math.min(sizes[4], 10),
-    score: Math.min(sizes[5], 30),
+    retries: Math.min(sizes[4], 50),
+    id: Math.min(sizes[5], 10),
+    score: Math.min(sizes[6], 30),
   };
   const base =
     maxSizes.input +
       maxSizes.target +
       maxSizes.answer +
       maxSizes.limit +
+      maxSizes.retries +
       maxSizes.id +
       maxSizes.score || 1;
   const messageShape = {
@@ -349,14 +359,16 @@ export const createSamplesDescriptor = (
       target: sizes[1],
       answer: sizes[2],
       limit: sizes[3],
-      id: sizes[4],
-      score: sizes[5],
+      retries: sizes[4],
+      id: sizes[5],
+      score: sizes[6],
     },
     normalized: {
       input: maxSizes.input / base,
       target: maxSizes.target / base,
       answer: maxSizes.answer / base,
       limit: maxSizes.limit / base,
+      retries: maxSizes.retries / base,
       id: maxSizes.id / base,
       score: maxSizes.score / base,
     },

--- a/src/inspect_ai/_view/www/src/app/samples/descriptor/types.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/descriptor/types.ts
@@ -52,5 +52,6 @@ export interface MessageShapeData {
   target: number;
   answer: number;
   limit: number;
+  retries: number;
   score: number;
 }

--- a/src/inspect_ai/_view/www/src/app/samples/list/SampleHeader.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/list/SampleHeader.tsx
@@ -3,6 +3,7 @@ interface SampleHeaderProps {
   target?: boolean;
   answer?: boolean;
   limit?: boolean;
+  retries?: boolean;
   score?: boolean;
   gridColumnsTemplate: string;
 }
@@ -15,6 +16,7 @@ export const SampleHeader: FC<SampleHeaderProps> = ({
   target = true,
   answer = true,
   limit = true,
+  retries = false,
   score = true,
   gridColumnsTemplate,
 }) => (
@@ -32,6 +34,7 @@ export const SampleHeader: FC<SampleHeaderProps> = ({
     <div>{target ? "Target" : ""}</div>
     <div>{answer ? "Answer" : ""}</div>
     <div>{limit ? "Limit" : ""}</div>
+    <div>{retries ? "Retries" : ""}</div>
     <div className={styles.center}>{score ? "Score" : ""}</div>
   </div>
 );

--- a/src/inspect_ai/_view/www/src/app/samples/list/SampleList.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/list/SampleList.tsx
@@ -157,7 +157,8 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
     [gridColumnsTemplate],
   );
 
-  const { input, limit, answer, target } = gridColumns(samplesDescriptor);
+  const { input, limit, answer, target, retries } =
+    gridColumns(samplesDescriptor);
 
   const sampleCount = items?.reduce((prev, current) => {
     if (current.type === "sample") {
@@ -208,6 +209,7 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
         target={target !== "0"}
         answer={answer !== "0"}
         limit={limit !== "0"}
+        retries={retries !== "0em"}
         gridColumnsTemplate={gridColumnsTemplate}
       />
       <Virtuoso
@@ -243,9 +245,9 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
 });
 
 const gridColumnsValue = (sampleDescriptor?: SamplesDescriptor) => {
-  const { input, target, answer, limit, id, score } =
+  const { input, target, answer, limit, retries, id, score } =
     gridColumns(sampleDescriptor);
-  return `${id} ${input} ${target} ${answer} ${limit} ${score}`;
+  return `${id} ${input} ${target} ${answer} ${limit} ${retries} ${score}`;
 };
 
 const gridColumns = (sampleDescriptor?: SamplesDescriptor) => {
@@ -265,6 +267,11 @@ const gridColumns = (sampleDescriptor?: SamplesDescriptor) => {
     sampleDescriptor && sampleDescriptor.messageShape.normalized.limit > 0
       ? Math.max(0.15, sampleDescriptor.messageShape.normalized.limit)
       : 0;
+  const retries =
+    sampleDescriptor && sampleDescriptor.messageShape.normalized.retries > 0
+      ? 4
+      : 0;
+
   const id = Math.max(
     2,
     Math.min(10, sampleDescriptor?.messageShape.raw.id || 0),
@@ -287,6 +294,7 @@ const gridColumns = (sampleDescriptor?: SamplesDescriptor) => {
     target: frSize(target),
     answer: frSize(answer),
     limit: frSize(limit),
+    retries: `${retries}em`,
     id: `${id}rem`,
     score: `${score}rem`,
   };

--- a/src/inspect_ai/_view/www/src/app/samples/list/SampleRow.module.css
+++ b/src/inspect_ai/_view/www/src/app/samples/list/SampleRow.module.css
@@ -43,6 +43,11 @@
   justify-self: center;
 }
 
+.centered {
+  display: flex;
+  justify-content: center;
+}
+
 .spinner {
   height: 1.4em;
   width: 1.4em;

--- a/src/inspect_ai/_view/www/src/app/samples/list/SampleRow.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/list/SampleRow.tsx
@@ -103,7 +103,17 @@ export const SampleRow: FC<SampleRowProps> = ({
       >
         {sample.limit}
       </div>
-
+      <div
+        className={clsx(
+          "sample-retries",
+          "text-size-small",
+          "three-line-clamp",
+          styles.cell,
+          styles.centered,
+        )}
+      >
+        {sample.retries && sample.retries > 0 ? sample.retries : undefined}
+      </div>
       <div className={clsx("text-size-small", styles.cell, styles.score)}>
         {sample.error ? (
           <SampleErrorView message={sample.error} />

--- a/src/inspect_ai/_view/www/src/app/samples/sample-tools/filters.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/sample-tools/filters.ts
@@ -110,6 +110,7 @@ const scoreVariables = (
 const sampleVariables = (sample: SampleSummary): Record<string, unknown> => {
   return {
     has_error: !!sample.error,
+    has_retries: sample.retries !== undefined && sample.retries > 0,
   };
 };
 
@@ -220,7 +221,8 @@ export const filterExpression = (
     const resolveVariable = (name: string, get: (name: string) => any) => {
       // Sample variables (like has_error) always exist.
       if (name in mySampleVariables) {
-        return get(name);
+        const value = get(name);
+        return value;
       }
       // Score variables exist only if the sample completed successfully.
       return sample.error ? undefined : get(name);

--- a/src/inspect_ai/_view/www/src/app/samples/sample-tools/sample-filter/SampleFilter.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/sample-tools/sample-filter/SampleFilter.tsx
@@ -16,9 +16,9 @@ import clsx from "clsx";
 import { EditorView, minimalSetup } from "codemirror";
 import { FC, useEffect, useMemo, useRef, useState } from "react";
 
+import { ScoreFilter } from "../../../../app/types";
 import { SampleSummary } from "../../../../client/api/types";
 import { useEvalDescriptor } from "../../../../state/hooks";
-import { ScoreFilter } from "../../../../app/types";
 import { EvalDescriptor } from "../../descriptor/types";
 import { FilterError, filterSamples, scoreFilterItems } from "../filters";
 import { getCompletions } from "./completions";
@@ -43,6 +43,7 @@ Filter samples by:
   • Scores
   • Samples with errors: has_error
   • Input, target and error regex search: input_contains, target_contains, error_contains
+  • Samples that have been retried: has_retries
 
 Supported expressions:
   • Arithmetic: +, -, *, /, mod, ^

--- a/src/inspect_ai/_view/www/src/app/samples/sample-tools/sample-filter/language.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/sample-tools/sample-filter/language.ts
@@ -15,6 +15,7 @@ export const MATH_FUNCTIONS: [string, string][] = [
 
 export const SAMPLE_VARIABLES: [string, string][] = [
   ["has_error", "Checks if the sample has an error"],
+  ["has_retries", "Checks if the sample has been retried"],
 ];
 
 export const SAMPLE_FUNCTIONS: [string, string][] = [

--- a/src/inspect_ai/_view/www/src/client/api/types.ts
+++ b/src/inspect_ai/_view/www/src/client/api/types.ts
@@ -116,6 +116,7 @@ export interface SampleSummary {
   error?: string;
   limit?: string;
   completed?: boolean;
+  retries?: number;
 }
 
 export interface BasicSampleData {

--- a/src/inspect_ai/_view/www/src/constants.ts
+++ b/src/inspect_ai/_view/www/src/constants.ts
@@ -12,6 +12,7 @@ export const kSampleTranscriptTabId = `transcript`;
 export const kSampleScoringTabId = `scoring`;
 export const kSampleMetdataTabId = `metadata`;
 export const kSampleErrorTabId = `error`;
+export const kSampleErrorRetriesTabId = `retry-errors`;
 export const kSampleJsonTabId = `json`;
 
 // Scoring constants

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -329,6 +329,9 @@ class ZipLogFile:
                         limit=f"{sample.limit.type}"
                         if sample.limit is not None
                         else None,
+                        retries=len(sample.error_retries)
+                        if sample.error_retries is not None
+                        else None,
                     )
                 )
             self._samples.clear()

--- a/src/inspect_ai/log/_recorders/types.py
+++ b/src/inspect_ai/log/_recorders/types.py
@@ -20,6 +20,7 @@ class SampleSummary(BaseModel):
     scores: dict[str, Score] | None = Field(default=None)
     error: str | None = Field(default=None)
     limit: str | None = Field(default=None)
+    retries: int | None = Field(default=None)
 
     @model_validator(mode="after")
     def thin_scores(self) -> "SampleSummary":


### PR DESCRIPTION
Support for displaying sample retries in the viewer, including display in the sample list, sample summary, and a new errors tab for displaying the errors that caused the retries. Filter to samples with retries using `has_retries` (or the opposite using `not has_retries`).

### Sample List

<img width="1094" alt="Screenshot 2025-04-22 at 11 04 15 AM" src="https://github.com/user-attachments/assets/1dc4ea67-9d6a-4cd6-a293-d4e6851ad990" />

### Sample Retry Errors

<img width="1094" alt="Screenshot 2025-04-22 at 11 02 54 AM" src="https://github.com/user-attachments/assets/525a9d34-4aa3-457a-ad80-e8ac8b003961" />

### Filtering to Retries

<img width="1094" alt="Screenshot 2025-04-22 at 11 07 18 AM" src="https://github.com/user-attachments/assets/46366cb8-eec5-4d1a-a223-16ecb18e8fa5" />

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
