### PR TITLE
Properly initialize column sizes

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -39361,7 +39361,7 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
           previous[6] = Math.min(Math.max(previous[6], scoreText.length), 30);
           return previous;
         },
-        [0, 0, 0, 0, 0, 0]
+        [0, 0, 0, 0, 0, 0, 0]
       );
       const maxSizes = {
         input: Math.min(sizes[0], 300),

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -22731,13 +22731,17 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
             });
           },
           setShowingSampleDialog: (showing) => {
-            set2((state) => {
-              state.app.dialogs.sample = showing;
+            const state = get2();
+            const isShowing = state.app.dialogs.sample;
+            if (showing === isShowing) {
+              return;
+            }
+            set2((state2) => {
+              state2.app.dialogs.sample = showing;
             });
             if (!showing) {
-              const state = get2();
-              state.appActions.clearSampleTab();
-              state.sampleActions.clearSelectedSample();
+              const state2 = get2();
+              state2.appActions.clearSampleTab();
             }
           },
           setWorkspaceTab: (tab2) => {
@@ -82413,6 +82417,7 @@ Supported expressions:
       const selectSample = useStore((state) => state.logActions.selectSample);
       const setSampleTab = useStore((state) => state.appActions.setSampleTab);
       const filteredSamples = useFilteredSamples();
+      const totalSampleCount = useTotalSampleCount();
       const setStatus = useStore((state) => state.appActions.setStatus);
       const setSelectedLogIndex = useStore(
         (state) => state.logsActions.setSelectedLogIndex
@@ -82496,14 +82501,17 @@ Supported expressions:
             }
           }
         } else {
-          clearSample();
           setShowingSampleDialog(false);
+          if (totalSampleCount > 1) {
+            clearSample();
+          }
         }
       }, [
         sampleId,
         epoch,
         sampleTabId,
         filteredSamples,
+        totalSampleCount,
         selectSample,
         setSampleTab,
         setShowingSampleDialog,

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -42375,9 +42375,11 @@ categories: ${categories.join(" ")}`;
       const selectedLogFile = useStore(
         (state) => state.logsActions.getSelectedLogFile()
       );
+      const loadedLog = useStore((state) => state.log.loadedLog);
       return reactExports.useMemo(() => {
         return {
           logFile: selectedLogFile,
+          loadedLog,
           sample: selectedSampleSummary
         };
       }, [selectedLogFile, selectedSampleSummary]);
@@ -60504,17 +60506,17 @@ ${events}
       const prevCompleted = usePrevious(
         ((_a2 = logSelection.sample) == null ? void 0 : _a2.completed) !== void 0 ? logSelection.sample.completed : true
       );
-      const prevLogFile = usePrevious(logSelection.logFile);
+      const prevLogFile = usePrevious(logSelection.loadedLog);
       reactExports.useEffect(() => {
         var _a3, _b3, _c2;
         if (logSelection.logFile && logSelection.sample) {
           const currentSampleCompleted = ((_a3 = logSelection.sample) == null ? void 0 : _a3.completed) !== void 0 ? logSelection.sample.completed : true;
-          if (prevLogFile !== void 0 && prevLogFile !== logSelection.logFile || ((_b3 = sampleData.sample) == null ? void 0 : _b3.id) !== logSelection.sample.id || ((_c2 = sampleData.sample) == null ? void 0 : _c2.epoch) !== logSelection.sample.epoch || prevCompleted !== void 0 && currentSampleCompleted !== prevCompleted) {
+          if (prevLogFile !== void 0 && prevLogFile !== logSelection.loadedLog || ((_b3 = sampleData.sample) == null ? void 0 : _b3.id) !== logSelection.sample.id || ((_c2 = sampleData.sample) == null ? void 0 : _c2.epoch) !== logSelection.sample.epoch || prevCompleted !== void 0 && currentSampleCompleted !== prevCompleted) {
             loadSample(logSelection.logFile, logSelection.sample);
           }
         }
       }, [
-        logSelection.logFile,
+        logSelection.loadedLog,
         (_b2 = logSelection.sample) == null ? void 0 : _b2.id,
         (_c = logSelection.sample) == null ? void 0 : _c.epoch,
         (_d = logSelection.sample) == null ? void 0 : _d.completed,

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -60287,7 +60287,7 @@ ${events}
                   children: sampleMetadatas.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: clsx(styles$z.metadataPanel), children: sampleMetadatas }) : /* @__PURE__ */ jsxRuntimeExports.jsx(NoContentsPanel, { text: "No metadata" })
                 }
               ),
-              (sample2 == null ? void 0 : sample2.error) || (sample2 == null ? void 0 : sample2.error_retries) ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+              (sample2 == null ? void 0 : sample2.error) || (sample2 == null ? void 0 : sample2.error_retries) && (sample2 == null ? void 0 : sample2.error_retries.length) > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
                 TabPanel,
                 {
                   id: kSampleErrorTabId,

--- a/src/inspect_ai/_view/www/src/app/log-view/LogViewContainer.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-view/LogViewContainer.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import { kLogViewSamplesTabId } from "../../constants";
-import { useFilteredSamples } from "../../state/hooks";
+import { useFilteredSamples, useTotalSampleCount } from "../../state/hooks";
 import { useStore } from "../../state/store";
 import { baseUrl } from "../routing/url";
 import { LogViewLayout } from "./LogViewLayout";
@@ -26,6 +26,7 @@ export const LogViewContainer: FC = () => {
   const selectSample = useStore((state) => state.logActions.selectSample);
   const setSampleTab = useStore((state) => state.appActions.setSampleTab);
   const filteredSamples = useFilteredSamples();
+  const totalSampleCount = useTotalSampleCount();
   const setStatus = useStore((state) => state.appActions.setStatus);
   const setSelectedLogIndex = useStore(
     (state) => state.logsActions.setSelectedLogIndex,
@@ -137,14 +138,17 @@ export const LogViewContainer: FC = () => {
     } else {
       // If we don't have sample params in the URL but the dialog is showing, close it
       // This handles the case when user navigates back from a sample
-      clearSample();
       setShowingSampleDialog(false);
+      if (totalSampleCount > 1) {
+        clearSample();
+      }
     }
   }, [
     sampleId,
     epoch,
     sampleTabId,
     filteredSamples,
+    totalSampleCount,
     selectSample,
     setSampleTab,
     setShowingSampleDialog,

--- a/src/inspect_ai/_view/www/src/app/samples/InlineSampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/InlineSampleDisplay.tsx
@@ -30,7 +30,7 @@ export const InlineSampleDisplay: FC = () => {
       ? logSelection.sample.completed
       : true,
   );
-  const prevLogFile = usePrevious<string | undefined>(logSelection.logFile);
+  const prevLogFile = usePrevious<string | undefined>(logSelection.loadedLog);
   useEffect(() => {
     if (logSelection.logFile && logSelection.sample) {
       const currentSampleCompleted =
@@ -39,7 +39,7 @@ export const InlineSampleDisplay: FC = () => {
           : true;
 
       if (
-        (prevLogFile !== undefined && prevLogFile !== logSelection.logFile) ||
+        (prevLogFile !== undefined && prevLogFile !== logSelection.loadedLog) ||
         sampleData.sample?.id !== logSelection.sample.id ||
         sampleData.sample?.epoch !== logSelection.sample.epoch ||
         (prevCompleted !== undefined &&
@@ -49,7 +49,7 @@ export const InlineSampleDisplay: FC = () => {
       }
     }
   }, [
-    logSelection.logFile,
+    logSelection.loadedLog,
     logSelection.sample?.id,
     logSelection.sample?.epoch,
     logSelection.sample?.completed,

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -226,7 +226,8 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({ id, scrollRef }) => {
             <NoContentsPanel text="No metadata" />
           )}
         </TabPanel>
-        {sample?.error || sample?.error_retries ? (
+        {sample?.error ||
+        (sample?.error_retries && sample?.error_retries.length > 0) ? (
           <TabPanel
             id={kSampleErrorTabId}
             className="sample-tab"

--- a/src/inspect_ai/_view/www/src/app/samples/descriptor/samplesDescriptor.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/descriptor/samplesDescriptor.tsx
@@ -332,7 +332,7 @@ export const createSamplesDescriptor = (
 
       return previous;
     },
-    [0, 0, 0, 0, 0, 0],
+    [0, 0, 0, 0, 0, 0, 0],
   );
 
   // normalize to base 1

--- a/src/inspect_ai/_view/www/src/state/appSlice.ts
+++ b/src/inspect_ai/_view/www/src/state/appSlice.ts
@@ -117,13 +117,19 @@ export const createAppSlice = (
         });
       },
       setShowingSampleDialog: (showing: boolean) => {
+        const state = get();
+        const isShowing = state.app.dialogs.sample;
+
+        if (showing === isShowing) {
+          return;
+        }
+
         set((state) => {
           state.app.dialogs.sample = showing;
         });
         if (!showing) {
           const state = get();
           state.appActions.clearSampleTab();
-          state.sampleActions.clearSelectedSample();
         }
       },
       setWorkspaceTab: (tab: string) => {

--- a/src/inspect_ai/_view/www/src/state/hooks.ts
+++ b/src/inspect_ai/_view/www/src/state/hooks.ts
@@ -229,10 +229,12 @@ export const useLogSelection = () => {
   const selectedLogFile = useStore((state) =>
     state.logsActions.getSelectedLogFile(),
   );
+  const loadedLog = useStore((state) => state.log.loadedLog);
 
   return useMemo(() => {
     return {
       logFile: selectedLogFile,
+      loadedLog: loadedLog,
       sample: selectedSampleSummary,
     };
   }, [selectedLogFile, selectedSampleSummary]);


### PR DESCRIPTION
- Improved layout for samples- failure to initialize can cause column layout issues. Introduced today when adding retries column.
- Don't unintentionally show the errors tab when there are no errors or retries
- Fix flash of error when switching from single sample log to multiple sample log
- Fix excessive sample loading (wouldn't be apparent, but wasteful) when viewing a single sample eval using the log route.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
