### PR TITLE
pass retry_on_error from eval_set() to eval()

### DIFF
--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -218,6 +218,7 @@ def eval_set(
             sample_id=sample_id,
             epochs=epochs,
             fail_on_error=fail_on_error,
+            retry_on_error=retry_on_error,
             debug_errors=debug_errors,
             message_limit=message_limit,
             token_limit=token_limit,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`retry_on_error` is not used when using the `eval_set()` function. So by default `eval_set` cannot set the number of per-sample retry attempts.

### What is the new behavior?

This passes `retry_on_error` to `eval()` so that you can set the number of per-sample retries.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

n/a

### Other information:
