### PR TITLE
More flexible text editor

### DIFF
--- a/src/inspect_tool_support/pyproject.toml
+++ b/src/inspect_tool_support/pyproject.toml
@@ -66,7 +66,7 @@ ignore = ["W002", "W009"]
 
 [project]
 name = "inspect_tool_support"
-version = "0.1.8"
+version = "0.1.9"
 description = "Sandbox container tool code for inspect_ai"
 authors = [{ name = "UK AI Security Institute" }]
 readme = "README.md"

--- a/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/text_editor.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/text_editor.py
@@ -19,11 +19,6 @@ HistoryType = dict[Path, list[HistoryEntryType]]
 async def view(path_str: str, view_range: list[int] | None = None) -> str:
     path = _validated_path(path_str, "view")
     if path.is_dir():
-        if view_range:
-            raise ToolException(
-                "The `view_range` parameter is not allowed when `path` points to a directory."
-            )
-
         path_str = str(path).rstrip("/") + "/"
 
         _, stdout, stderr = await run(
@@ -55,9 +50,8 @@ async def view(path_str: str, view_range: list[int] | None = None) -> str:
                 f"Invalid `view_range`: {view_range}. Its first element `{init_line}` should be within the range of lines of the file: {[1, n_lines_file]}"
             )
         if final_line > n_lines_file:
-            raise ToolException(
-                f"Invalid `view_range`: {view_range}. Its second element `{final_line}` should be smaller than the number of lines in the file: `{n_lines_file}`"
-            )
+            # Final line was too big - just show to EOF
+            final_line = -1
         if final_line != -1 and final_line < init_line:
             raise ToolException(
                 f"Invalid `view_range`: {view_range}. Its second element `{final_line}` should be larger or equal than its first `{init_line}`"


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If an agent calls the text editor tool in view mode and specifies an end line number that's larger than number of lines in the file, it will get an error. If the agent tries to use the tool to view a directory and specifies line numbers, it will get an error.

### What is the new behavior?

To improve model performance, I believe it's better for us to just ignore these errors and instead show the model what it asked for - in the first case the contents of the file up to the end. In the second case, the contents of the directory.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

The current text_editor tool's view logic will fall apart if a model tries reading a binary file. Maybe not a big surprise given that it is a **text** editor, but perhaps something worth improving. It might also have issues with very long lines.

In the binary file case, converting to a hex dump and then showing the requested lines might work reasonably well.
