### PR TITLE
takeover vscode storage serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Inspect View: Improved display of sample input, target, answer, and scoring information (improve column width behavior).
 - Inspect View: Add support for linking to logs, specific log tabs, individual samples, and sample tabs within samples.
 - Inspect View: Collapse sample init view by default.
+- Inspect: Properly store and restore NaN values when viewing logs in VSCode.
 - Documentation: Update tutorial to use HuggingFaceH4/MATH-500 as math dataset.
 - Documetnation: Add scorer.py example that uses the expression_equivalence custom scorer from the tutorial.
 - Bugfix: Correct parsing of `CUDA_VISIBLE_DEVICES` environment variable for vLLM provider

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -82777,11 +82777,13 @@ Supported expressions:
         return {
           getItem: (_name) => {
             const state = vscodeApi2.getState();
-            return state;
+            const deserialized = lib$1.parse(state);
+            return deserialized;
           },
           setItem: (_name, value2) => {
             const valObj = value2;
-            vscodeApi2.setState(valObj);
+            const serialized = lib$1.stringify(valObj);
+            vscodeApi2.setState(serialized);
           },
           removeItem: (_name) => {
             vscodeApi2.setState(null);

--- a/src/inspect_ai/_view/www/src/client/storage/index.ts
+++ b/src/inspect_ai/_view/www/src/client/storage/index.ts
@@ -1,3 +1,4 @@
+import JSON5 from "json5";
 import { PersistedState } from "../../state/store";
 import { getVscodeApi } from "../../utils/vscode";
 import { ClientStorage } from "../api/types";
@@ -7,13 +8,18 @@ const resolveStorage = (): ClientStorage | undefined => {
   if (vscodeApi) {
     return {
       getItem: (_name: string) => {
-        const state = vscodeApi.getState() as PersistedState;
-        return state;
+        const state = vscodeApi.getState() as string;
+        const deserialized = JSON5.parse(state) as {
+          state: PersistedState;
+          version: number;
+        };
+        return deserialized;
       },
       setItem: (_name: string, value: unknown) => {
         // TODO: This is pretty gnarly type hijinks
         const valObj = value as { state: PersistedState; version: number };
-        vscodeApi.setState(valObj);
+        const serialized = JSON5.stringify(valObj);
+        vscodeApi.setState(serialized);
       },
       removeItem: (_name: string) => {
         vscodeApi.setState(null);


### PR DESCRIPTION
It uses JSON serialization internally which can’t deal with Nan, so take over serialization and use JSON5 as we do everywhere else.

Fixes #1747

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
