### PR TITLE
`read_eval_log_sample_summaries()` function for reading sample summaries from eval logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Future
+
+- [read_eval_log_sample_summaries()](https://inspect.aisi.org.uk/eval-logs.html#summaries) function for reading sample summaries (including scoring) from eval logs.
+
 ## Unreleased
 
 - Support for using tools from [Model Context Protocol](https://inspect.aisi.org.uk/tools-mcp.html) providers.

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -219,9 +219,18 @@ It may also be useful to read only the summary level information about samples (
 summaries = read_eval_log_sample_summaries(log_file)
 ```
 
-The `summaries` are a list of `EvalSampleSummary` objects, one for each sample.
+The `summaries` are a list of `EvalSampleSummary` objects, one for each sample. Reading only sample summaries will take orders of magnitude less time than reading all of the samples one-by-one, so if you only need access to summary level data, always prefer this function to reading the entire log file.
 
+You can also use `read_eval_log_sample_summaries()` as means of filtering which samples you want to read in full. For example, imagine you only want to read samples that include errors:
 
+```python
+errors: list[EvalSample] = []
+for sample in read_eval_log_sample_summaries(log_file):
+    if sample.error is not None
+        errors.append(
+            read_eval_log_sample(log_file, sample.id, sample.epoch)
+        )
+``` 
 
 ### Streaming
 

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -219,7 +219,11 @@ It may also be useful to read only the summary level information about samples (
 summaries = read_eval_log_sample_summaries(log_file)
 ```
 
-The `summaries` are a list of `EvalSampleSummary` objects, one for each sample. Reading only sample summaries will take orders of magnitude less time than reading all of the samples one-by-one, so if you only need access to summary level data, always prefer this function to reading the entire log file.
+The `summaries` are a list of `EvalSampleSummary` objects, one for each sample. Some sample data is "thinned" in the interest of keeping the summaries small: images are removed from `input`, `metadata` is restricted to scalar values (with strings truncated to 1k), and scores include only their `value`.
+
+Reading only sample summaries will take orders of magnitude less time than reading all of the samples one-by-one, so if you only need access to summary level data, always prefer this function to reading the entire log file.
+
+#### Filtering
 
 You can also use `read_eval_log_sample_summaries()` as means of filtering which samples you want to read in full. For example, imagine you only want to read samples that include errors:
 

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -174,6 +174,7 @@ You can enumerate, read, and write `EvalLog` objects using the following helper 
 | `read_eval_log` | Read an `EvalLog` from a log file path (pass `header_only` to not read samples). |
 | `read_eval_log_sample` | Read a single `EvalSample` from a log file |
 | `read_eval_log_samples` | Read all samples incrementally (returns a generator that yields samples one at a time). |
+| `read_eval_log_sample_summaries` | Read a summary of all samples (including scoring for each sample). |
 | `write_eval_log` | Write an `EvalLog` to a log file path. |
 
 A common workflow is to define an `INSPECT_LOG_DIR` for running a set of evaluations, then calling `list_eval_logs()` to analyse the results when all the work is done:
@@ -191,6 +192,36 @@ logs = list_eval_logs()
 ```
 
 Note that `list_eval_logs()` lists log files recursively. Pass `recursive=False` to list only the log files at the root level.
+
+### Log Headers
+
+Eval log files can get quite large (multiple GB) so it is often useful to read only the header, which contains metadata and aggregated scores. Use the `header_only` option to read only the header of a log file:
+
+```python
+log_header = read_eval_log(log_file, header_only=True)
+```
+
+The log header is a standard `EvalLog` object without the `samples` and `reductions` fields.
+
+### Summaries
+
+::: callout-note
+The `read_eval_log_sample_summaries()` function described below is available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+It may also be useful to read only the summary level information about samples (input, target, error status, and scoring). To do this, use the `read_eval_log_sample_summaries()` function:
+
+```python
+summaries = read_eval_log_sample_summaries(log_file)
+```
+
+The `summaries` are a list of `EvalSampleSummary` objects, one for each sample.
+
+
 
 ### Streaming
 
@@ -222,6 +253,7 @@ Note that `read_eval_log_samples()` will raise an error if you pass it a log tha
 for sample in read_eval_log_samples(log_file, all_samples_required=False):
     ...
 ```
+
 
 ### Attachments
 

--- a/docs/reference/_sidebar.yml
+++ b/docs/reference/_sidebar.yml
@@ -359,6 +359,8 @@ website:
           href: reference/inspect_ai.log.qmd#read_eval_log_sample
         - text: read_eval_log_samples
           href: reference/inspect_ai.log.qmd#read_eval_log_samples
+        - text: read_eval_log_sample_summaries
+          href: reference/inspect_ai.log.qmd#read_eval_log_sample_summaries
         - text: convert_eval_logs
           href: reference/inspect_ai.log.qmd#convert_eval_logs
         - text: bundle_log_dir
@@ -399,6 +401,8 @@ website:
           href: reference/inspect_ai.log.qmd#evalerror
         - text: EvalSample
           href: reference/inspect_ai.log.qmd#evalsample
+        - text: EvalSampleSummary
+          href: reference/inspect_ai.log.qmd#evalsamplesummary
         - text: EvalSampleLimit
           href: reference/inspect_ai.log.qmd#evalsamplelimit
         - text: EvalSampleReductions

--- a/docs/reference/inspect_ai.log.qmd
+++ b/docs/reference/inspect_ai.log.qmd
@@ -11,6 +11,7 @@ title: "inspect_ai.log"
 ### read_eval_log_async
 ### read_eval_log_sample
 ### read_eval_log_samples
+### read_eval_log_sample_summaries
 ### convert_eval_logs
 ### bundle_log_dir
 ### write_log_dir_manifest
@@ -34,6 +35,7 @@ title: "inspect_ai.log"
 ### EvalStats
 ### EvalError
 ### EvalSample
+### EvalSampleSummary
 ### EvalSampleLimit
 ### EvalSampleReductions
 ### EvalSampleScore

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -196,25 +196,7 @@ class TaskLogger:
         await self.recorder.log_sample(self.eval, sample)
 
         # mark complete
-        self._buffer_db.complete_sample(
-            EvalSampleSummary(
-                id=sample.id,
-                epoch=sample.epoch,
-                input=sample.input,
-                target=sample.target,
-                completed=True,
-                scores=sample.scores,
-                model_usage=sample.model_usage,
-                total_time=sample.total_time,
-                working_time=sample.working_time,
-                uuid=sample.uuid,
-                error=sample.error.message if sample.error is not None else None,
-                limit=f"{sample.limit.type}" if sample.limit is not None else None,
-                retries=len(sample.error_retries)
-                if sample.error_retries is not None
-                else None,
-            )
-        )
+        self._buffer_db.complete_sample(sample.summary())
 
         # flush if requested
         if flush:

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -36,7 +36,7 @@ from inspect_ai.log._log import (
 from inspect_ai.log._model import model_args_for_log, model_roles_to_model_roles_config
 from inspect_ai.log._recorders import Recorder
 from inspect_ai.log._recorders.buffer import SampleBufferDatabase
-from inspect_ai.log._recorders.types import SampleEvent, SampleSummary
+from inspect_ai.log._recorders.types import EvalSampleSummary, SampleEvent
 from inspect_ai.log._transcript import Event
 from inspect_ai.model import (
     GenerateConfig,
@@ -180,7 +180,7 @@ class TaskLogger:
         await self.recorder.log_start(self.eval, plan)
         await self.recorder.flush(self.eval)
 
-    async def start_sample(self, sample: SampleSummary) -> None:
+    async def start_sample(self, sample: EvalSampleSummary) -> None:
         self._buffer_db.start_sample(sample)
 
     def log_sample_event(self, id: str | int, epoch: int, event: Event) -> None:
@@ -196,7 +196,7 @@ class TaskLogger:
 
         # mark complete
         self._buffer_db.complete_sample(
-            SampleSummary(
+            EvalSampleSummary(
                 id=sample.id,
                 epoch=sample.epoch,
                 input=sample.input,

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -30,13 +30,14 @@ from inspect_ai.log._log import (
     EvalLog,
     EvalMetricDefinition,
     EvalSampleReductions,
+    EvalSampleSummary,
     EvalScorer,
     eval_config_defaults,
 )
 from inspect_ai.log._model import model_args_for_log, model_roles_to_model_roles_config
 from inspect_ai.log._recorders import Recorder
 from inspect_ai.log._recorders.buffer import SampleBufferDatabase
-from inspect_ai.log._recorders.types import EvalSampleSummary, SampleEvent
+from inspect_ai.log._recorders.types import SampleEvent
 from inspect_ai.log._transcript import Event
 from inspect_ai.model import (
     GenerateConfig,
@@ -203,6 +204,10 @@ class TaskLogger:
                 target=sample.target,
                 completed=True,
                 scores=sample.scores,
+                model_usage=sample.model_usage,
+                total_time=sample.total_time,
+                working_time=sample.working_time,
+                uuid=sample.uuid,
                 error=sample.error.message if sample.error is not None else None,
                 limit=f"{sample.limit.type}" if sample.limit is not None else None,
                 retries=len(sample.error_retries)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -52,7 +52,7 @@ from inspect_ai.log import (
 from inspect_ai.log._condense import condense_sample
 from inspect_ai.log._file import eval_log_json_str
 from inspect_ai.log._log import EvalSampleLimit, EvalSampleReductions, eval_error
-from inspect_ai.log._recorders.types import SampleSummary
+from inspect_ai.log._recorders.types import EvalSampleSummary
 from inspect_ai.log._samples import (
     active_sample,
 )
@@ -655,7 +655,7 @@ async def task_run_sample(
 
                         if logger is not None:
                             await logger.start_sample(
-                                SampleSummary(
+                                EvalSampleSummary(
                                     id=sample_id,
                                     epoch=state.epoch,
                                     input=sample.input,

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -51,8 +51,12 @@ from inspect_ai.log import (
 )
 from inspect_ai.log._condense import condense_sample
 from inspect_ai.log._file import eval_log_json_str
-from inspect_ai.log._log import EvalSampleLimit, EvalSampleReductions, eval_error
-from inspect_ai.log._recorders.types import EvalSampleSummary
+from inspect_ai.log._log import (
+    EvalSampleLimit,
+    EvalSampleReductions,
+    EvalSampleSummary,
+    eval_error,
+)
 from inspect_ai.log._samples import (
     active_sample,
 )

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -664,6 +664,7 @@ async def task_run_sample(
                                     epoch=state.epoch,
                                     input=sample.input,
                                     target=sample.target,
+                                    metadata=sample.metadata or {},
                                 )
                             )
 
@@ -933,7 +934,7 @@ async def log_sample(
         input=sample.input,
         choices=sample.choices,
         target=sample.target,
-        metadata=state.metadata if state.metadata else {},
+        metadata=sample.metadata or {},
         sandbox=sample.sandbox,
         files=list(sample.files.keys()) if sample.files else None,
         setup=sample.setup,

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -9,6 +9,7 @@ from ._file import (
     read_eval_log,
     read_eval_log_async,
     read_eval_log_sample,
+    read_eval_log_sample_summaries,
     read_eval_log_samples,
     write_eval_log,
     write_eval_log_async,
@@ -33,6 +34,7 @@ from ._log import (
     EvalStats,
 )
 from ._message import LoggingLevel, LoggingMessage
+from ._recorders import EvalSampleSummary
 from ._retry import retryable_eval_logs
 from ._transcript import (
     ApprovalEvent,
@@ -70,6 +72,7 @@ __all__ = [
     "EvalSampleLimit",
     "EvalSampleScore",
     "EvalSampleReductions",
+    "EvalSampleSummary",
     "EvalScore",
     "EvalSpec",
     "EvalStats",
@@ -100,6 +103,7 @@ __all__ = [
     "read_eval_log_async",
     "read_eval_log_sample",
     "read_eval_log_samples",
+    "read_eval_log_sample_summaries",
     "condense_sample",
     "resolve_sample_attachments",
     "write_eval_log",

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -29,12 +29,12 @@ from ._log import (
     EvalSampleLimit,
     EvalSampleReductions,
     EvalSampleScore,
+    EvalSampleSummary,
     EvalScore,
     EvalSpec,
     EvalStats,
 )
 from ._message import LoggingLevel, LoggingMessage
-from ._log import EvalSampleSummary
 from ._retry import retryable_eval_logs
 from ._transcript import (
     ApprovalEvent,

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -34,7 +34,7 @@ from ._log import (
     EvalStats,
 )
 from ._message import LoggingLevel, LoggingMessage
-from ._recorders import EvalSampleSummary
+from ._log import EvalSampleSummary
 from ._retry import retryable_eval_logs
 from ._transcript import (
     ApprovalEvent,

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -16,7 +16,7 @@ from inspect_ai._util.file import (
 )
 from inspect_ai._util.json import jsonable_python
 from inspect_ai.log._condense import resolve_sample_attachments
-from inspect_ai.log._recorders.types import EvalSampleSummary
+from inspect_ai.log._log import EvalSampleSummary
 
 from ._log import EvalLog, EvalSample
 from ._recorders import recorder_type_for_format, recorder_type_for_location

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -161,6 +161,60 @@ class EvalSampleLimit(BaseModel):
     """The limit value"""
 
 
+class EvalSampleSummary(BaseModel):
+    """Summary information (including scoring) for a sample."""
+
+    id: int | str
+    """Unique id for sample."""
+
+    epoch: int
+    """Epoch number for sample."""
+
+    input: str | list[ChatMessage]
+    """Sample input."""
+
+    target: str | list[str]
+    """Sample target value(s)"""
+
+    scores: dict[str, Score] | None = Field(default=None)
+    """Scores for sample."""
+
+    model_usage: dict[str, ModelUsage] = Field(default_factory=dict)
+    """Model token usage for sample."""
+
+    total_time: float | None = Field(default=None)
+    """Total time that the sample was running."""
+
+    working_time: float | None = Field(default=None)
+    """Time spent working (model generation, sandbox calls, etc.)"""
+
+    uuid: str | None = Field(default=None)
+    """Globally unique identifier for sample run (exists for samples created in Inspect >= 0.3.70)"""
+
+    error: str | None = Field(default=None)
+    """Error that halted sample."""
+
+    limit: str | None = Field(default=None)
+    """Limit that halted the sample"""
+
+    retries: int | None = Field(default=None)
+    """Number of retries for the sample."""
+
+    completed: bool = Field(default=False)
+    """Is the sample complete."""
+
+    @model_validator(mode="after")
+    def thin_scores(self) -> "EvalSampleSummary":
+        if self.scores is not None:
+            self.scores = {
+                key: Score(value=score.value) for key, score in self.scores.items()
+            }
+        return self
+
+    # allow field model_usage
+    model_config = ConfigDict(protected_namespaces=())
+
+
 class EvalSample(BaseModel):
     """Sample from evaluation task."""
 

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -30,6 +30,7 @@ from inspect_ai.util._store import Store
 from inspect_ai.util._store_model import SMT
 
 from ._transcript import Event
+from ._util import text_inputs
 
 logger = getLogger(__name__)
 
@@ -324,6 +325,34 @@ class EvalSample(BaseModel):
 
     limit: EvalSampleLimit | None = Field(default=None)
     """The limit that halted the sample"""
+
+    def summary(self) -> EvalSampleSummary:
+        """Summary of sample.
+
+        The summary excludes potentially large fields like messages, output,
+        events, store, and metadata so that it is always fast to load.
+
+        If there are images, audio, or video in the input, they are
+        replaced with a placeholder.
+
+        Returns:
+           Summary of sample.
+        """
+        return EvalSampleSummary(
+            id=self.id,
+            epoch=self.epoch,
+            input=text_inputs(self.input),
+            target=self.target,
+            scores=self.scores,
+            model_usage=self.model_usage,
+            total_time=self.total_time,
+            working_time=self.working_time,
+            uuid=self.uuid,
+            error=self.error.message if self.error is not None else None,
+            limit=f"{self.limit.type}" if self.limit is not None else None,
+            retries=len(self.error_retries) if self.error_retries is not None else None,
+            completed=True,
+        )
 
     # deprecated properties
 

--- a/src/inspect_ai/log/_recorders/__init__.py
+++ b/src/inspect_ai/log/_recorders/__init__.py
@@ -1,3 +1,4 @@
+from .._log import EvalSampleSummary
 from .create import (
     create_recorder_for_format,
     create_recorder_for_location,
@@ -5,7 +6,6 @@ from .create import (
     recorder_type_for_location,
 )
 from .recorder import Recorder
-from .._log import EvalSampleSummary
 
 __all__ = [
     "EvalSampleSummary",

--- a/src/inspect_ai/log/_recorders/__init__.py
+++ b/src/inspect_ai/log/_recorders/__init__.py
@@ -5,7 +5,7 @@ from .create import (
     recorder_type_for_location,
 )
 from .recorder import Recorder
-from .types import EvalSampleSummary
+from .._log import EvalSampleSummary
 
 __all__ = [
     "EvalSampleSummary",

--- a/src/inspect_ai/log/_recorders/__init__.py
+++ b/src/inspect_ai/log/_recorders/__init__.py
@@ -5,8 +5,10 @@ from .create import (
     recorder_type_for_location,
 )
 from .recorder import Recorder
+from .types import EvalSampleSummary
 
 __all__ = [
+    "EvalSampleSummary",
     "Recorder",
     "create_recorder_for_format",
     "create_recorder_for_location",

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -26,7 +26,7 @@ from ..._condense import (
     walk_input,
     walk_json_dict,
 )
-from ..types import SampleEvent, SampleSummary
+from ..types import EvalSampleSummary, SampleEvent
 from .filestore import (
     Manifest,
     SampleBufferFilestore,
@@ -141,7 +141,7 @@ class SampleBufferDatabase(SampleBuffer):
         )
         self._sync_time = time.monotonic()
 
-    def start_sample(self, sample: SampleSummary) -> None:
+    def start_sample(self, sample: EvalSampleSummary) -> None:
         with self._get_connection(write=True) as conn:
             sample = self._consense_sample(conn, sample)
             conn.execute(
@@ -177,7 +177,7 @@ class SampleBufferDatabase(SampleBuffer):
             # Insert all rows
             conn.execute(sql, values)
 
-    def complete_sample(self, summary: SampleSummary) -> None:
+    def complete_sample(self, summary: EvalSampleSummary) -> None:
         with self._get_connection(write=True) as conn:
             summary = self._consense_sample(conn, summary)
             conn.execute(
@@ -359,7 +359,7 @@ class SampleBufferDatabase(SampleBuffer):
 
     def _get_samples(
         self, conn: Connection, resolve_attachments: bool = False
-    ) -> Iterator[SampleSummary]:
+    ) -> Iterator[EvalSampleSummary]:
         cursor = conn.execute(
             """
             SELECT s.data as sample_data
@@ -369,7 +369,7 @@ class SampleBufferDatabase(SampleBuffer):
         )
 
         for row in cursor:
-            summary = SampleSummary.model_validate_json(row["sample_data"])
+            summary = EvalSampleSummary.model_validate_json(row["sample_data"])
             if resolve_attachments:
                 summary = self._resolve_sample_attachments(conn, summary)
             yield summary
@@ -437,8 +437,8 @@ class SampleBufferDatabase(SampleBuffer):
             )
 
     def _consense_sample(
-        self, conn: Connection, sample: SampleSummary
-    ) -> SampleSummary:
+        self, conn: Connection, sample: EvalSampleSummary
+    ) -> EvalSampleSummary:
         # alias attachments
         attachments: dict[str, str] = {}
         sample = sample.model_copy(
@@ -456,8 +456,8 @@ class SampleBufferDatabase(SampleBuffer):
         return sample
 
     def _resolve_sample_attachments(
-        self, conn: Connection, sample: SampleSummary
-    ) -> SampleSummary:
+        self, conn: Connection, sample: EvalSampleSummary
+    ) -> EvalSampleSummary:
         return sample.model_copy(
             update={
                 "input": walk_input(

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -18,6 +18,7 @@ from inspect_ai._util.appdirs import inspect_data_dir
 from inspect_ai._util.file import basename, dirname, filesystem
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.trace import trace_action
+from ..._log import EvalSampleSummary
 
 from ..._condense import (
     ATTACHMENT_PROTOCOL,
@@ -26,7 +27,7 @@ from ..._condense import (
     walk_input,
     walk_json_dict,
 )
-from ..types import EvalSampleSummary, SampleEvent
+from ..types import SampleEvent
 from .filestore import (
     Manifest,
     SampleBufferFilestore,

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -18,7 +18,6 @@ from inspect_ai._util.appdirs import inspect_data_dir
 from inspect_ai._util.file import basename, dirname, filesystem
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.trace import trace_action
-from ..._log import EvalSampleSummary
 
 from ..._condense import (
     ATTACHMENT_PROTOCOL,
@@ -27,6 +26,7 @@ from ..._condense import (
     walk_input,
     walk_json_dict,
 )
+from ..._log import EvalSampleSummary
 from ..types import SampleEvent
 from .filestore import (
     Manifest,

--- a/src/inspect_ai/log/_recorders/buffer/filestore.py
+++ b/src/inspect_ai/log/_recorders/buffer/filestore.py
@@ -14,7 +14,7 @@ from inspect_ai._util.file import FileSystem, basename, dirname, file, filesyste
 from inspect_ai._util.json import to_json_safe, to_json_str_safe
 from inspect_ai.log._file import read_eval_log
 
-from ..types import SampleSummary
+from ..types import EvalSampleSummary
 from .types import SampleBuffer, SampleData, Samples
 
 logger = getLogger(__name__)
@@ -33,7 +33,7 @@ class SegmentFile(BaseModel):
 
 
 class SampleManifest(BaseModel):
-    summary: SampleSummary
+    summary: EvalSampleSummary
     segments: list[int] = Field(default_factory=list)
 
 

--- a/src/inspect_ai/log/_recorders/buffer/filestore.py
+++ b/src/inspect_ai/log/_recorders/buffer/filestore.py
@@ -14,7 +14,7 @@ from inspect_ai._util.file import FileSystem, basename, dirname, file, filesyste
 from inspect_ai._util.json import to_json_safe, to_json_str_safe
 from inspect_ai.log._file import read_eval_log
 
-from ..types import EvalSampleSummary
+from ..._log import EvalSampleSummary
 from .types import SampleBuffer, SampleData, Samples
 
 logger = getLogger(__name__)

--- a/src/inspect_ai/log/_recorders/buffer/types.py
+++ b/src/inspect_ai/log/_recorders/buffer/types.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, JsonValue
 
 from inspect_ai._display.core.display import TaskDisplayMetric
 
-from ..types import EvalSampleSummary
+from ..._log import EvalSampleSummary
 
 JsonData: TypeAlias = dict[str, JsonValue]
 

--- a/src/inspect_ai/log/_recorders/buffer/types.py
+++ b/src/inspect_ai/log/_recorders/buffer/types.py
@@ -5,13 +5,13 @@ from pydantic import BaseModel, JsonValue
 
 from inspect_ai._display.core.display import TaskDisplayMetric
 
-from ..types import SampleSummary
+from ..types import EvalSampleSummary
 
 JsonData: TypeAlias = dict[str, JsonValue]
 
 
 class Samples(BaseModel):
-    samples: list[SampleSummary]
+    samples: list[EvalSampleSummary]
     metrics: list[TaskDisplayMetric]
     refresh: int
     etag: str

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -30,12 +30,12 @@ from .._log import (
     EvalResults,
     EvalSample,
     EvalSampleReductions,
+    EvalSampleSummary,
     EvalSpec,
     EvalStats,
     sort_samples,
 )
 from .file import FileRecorder
-from .types import EvalSampleSummary
 
 logger = getLogger(__name__)
 
@@ -282,6 +282,7 @@ class ZipLogFile:
 
     def __init__(self, file: str) -> None:
         self._file = file
+        self._zip = None
         self._fs = filesystem(file)
         self._lock = anyio.Lock()
         self._temp_file = tempfile.TemporaryFile()

--- a/src/inspect_ai/log/_recorders/file.py
+++ b/src/inspect_ai/log/_recorders/file.py
@@ -8,9 +8,8 @@ from inspect_ai._util.constants import MODEL_NONE
 from inspect_ai._util.file import filesystem
 from inspect_ai._util.registry import registry_unqualified_name
 
-from .._log import EvalLog, EvalSample, EvalSpec
+from .._log import EvalLog, EvalSample, EvalSampleSummary, EvalSpec
 from .recorder import Recorder
-from .types import EvalSampleSummary
 
 logger = getLogger(__name__)
 

--- a/src/inspect_ai/log/_recorders/file.py
+++ b/src/inspect_ai/log/_recorders/file.py
@@ -74,20 +74,7 @@ class FileRecorder(Recorder):
 
         summaries: list[EvalSampleSummary] = []
         for sample in eval_log.samples:
-            summaries.append(
-                EvalSampleSummary(
-                    id=sample.id,
-                    epoch=sample.epoch,
-                    input=sample.input,
-                    target=sample.target,
-                    scores=sample.scores,
-                    error=sample.error.message if sample.error else None,
-                    limit=sample.limit.type if sample.limit else None,
-                    retries=len(sample.error_retries)
-                    if sample.error_retries is not None
-                    else None,
-                )
-            )
+            summaries.append(sample.summary())
 
         return summaries
 

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -11,6 +11,7 @@ from inspect_ai.log._log import (
     EvalSpec,
     EvalStats,
 )
+from inspect_ai.log._recorders.types import EvalSampleSummary
 
 
 class Recorder(abc.ABC):
@@ -56,6 +57,12 @@ class Recorder(abc.ABC):
     async def read_log_sample(
         cls, location: str, id: str | int, epoch: int = 1
     ) -> EvalSample: ...
+
+    @classmethod
+    @abc.abstractmethod
+    async def read_log_sample_summaries(
+        cls, location: str
+    ) -> list[EvalSampleSummary]: ...
 
     @classmethod
     @abc.abstractmethod

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -8,10 +8,10 @@ from inspect_ai.log._log import (
     EvalResults,
     EvalSample,
     EvalSampleReductions,
+    EvalSampleSummary,
     EvalSpec,
     EvalStats,
 )
-from inspect_ai.log._log import EvalSampleSummary
 
 
 class Recorder(abc.ABC):

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -11,7 +11,7 @@ from inspect_ai.log._log import (
     EvalSpec,
     EvalStats,
 )
-from inspect_ai.log._recorders.types import EvalSampleSummary
+from inspect_ai.log._log import EvalSampleSummary
 
 
 class Recorder(abc.ABC):

--- a/src/inspect_ai/log/_recorders/types.py
+++ b/src/inspect_ai/log/_recorders/types.py
@@ -1,50 +1,9 @@
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel
 
 from inspect_ai.log._transcript import Event
-from inspect_ai.model._chat_message import ChatMessage
-from inspect_ai.scorer._metric import Score
 
 
 class SampleEvent(BaseModel):
     id: str | int
     epoch: int
     event: Event
-
-
-class EvalSampleSummary(BaseModel):
-    """Summary information (including scoring) for a sample."""
-
-    id: int | str
-    """Unique id for sample."""
-
-    epoch: int
-    """Epoch number for sample."""
-
-    input: str | list[ChatMessage]
-    """Sample input."""
-
-    target: str | list[str]
-    """Sample target value(s)"""
-
-    scores: dict[str, Score] | None = Field(default=None)
-    """Scores for sample."""
-
-    error: str | None = Field(default=None)
-    """Error that halted sample."""
-
-    limit: str | None = Field(default=None)
-    """Limit that halted the sample"""
-
-    retries: int | None = Field(default=None)
-    """Number of retries for the sample."""
-
-    completed: bool = Field(default=False)
-    """Is the sample complete."""
-
-    @model_validator(mode="after")
-    def thin_scores(self) -> "EvalSampleSummary":
-        if self.scores is not None:
-            self.scores = {
-                key: Score(value=score.value) for key, score in self.scores.items()
-            }
-        return self

--- a/src/inspect_ai/log/_recorders/types.py
+++ b/src/inspect_ai/log/_recorders/types.py
@@ -11,19 +11,38 @@ class SampleEvent(BaseModel):
     event: Event
 
 
-class SampleSummary(BaseModel):
+class EvalSampleSummary(BaseModel):
+    """Summary information (including scoring) for a sample."""
+
     id: int | str
+    """Unique id for sample."""
+
     epoch: int
+    """Epoch number for sample."""
+
     input: str | list[ChatMessage]
+    """Sample input."""
+
     target: str | list[str]
-    completed: bool = Field(default=False)
+    """Sample target value(s)"""
+
     scores: dict[str, Score] | None = Field(default=None)
+    """Scores for sample."""
+
     error: str | None = Field(default=None)
+    """Error that halted sample."""
+
     limit: str | None = Field(default=None)
+    """Limit that halted the sample"""
+
     retries: int | None = Field(default=None)
+    """Number of retries for the sample."""
+
+    completed: bool = Field(default=False)
+    """Is the sample complete."""
 
     @model_validator(mode="after")
-    def thin_scores(self) -> "SampleSummary":
+    def thin_scores(self) -> "EvalSampleSummary":
         if self.scores is not None:
             self.scores = {
                 key: Score(value=score.value) for key, score in self.scores.items()

--- a/src/inspect_ai/log/_transcript.py
+++ b/src/inspect_ai/log/_transcript.py
@@ -14,7 +14,13 @@ from typing import (
     Union,
 )
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue, field_serializer
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    JsonValue,
+    field_serializer,
+)
 from shortuuid import uuid
 
 from inspect_ai._util.constants import SAMPLE_SUBTASK

--- a/src/inspect_ai/log/_util.py
+++ b/src/inspect_ai/log/_util.py
@@ -1,3 +1,7 @@
+import textwrap
+from datetime import date, datetime, time
+from typing import Any
+
 from inspect_ai._util.content import (
     ContentAudio,
     ContentImage,
@@ -8,7 +12,7 @@ from inspect_ai._util.content import (
 from inspect_ai.model._chat_message import ChatMessage
 
 
-def text_inputs(inputs: str | list[ChatMessage]) -> str | list[ChatMessage]:
+def text_input_only(inputs: str | list[ChatMessage]) -> str | list[ChatMessage]:
     # Clean the input of any images
     if isinstance(inputs, list):
         input: list[ChatMessage] = []
@@ -36,3 +40,13 @@ def text_inputs(inputs: str | list[ChatMessage]) -> str | list[ChatMessage]:
         return input
     else:
         return inputs
+
+
+def thin_metadata(metadata: dict[str, Any]) -> dict[str, Any]:
+    thinned: dict[str, Any] = {}
+    for key, value in metadata.items():
+        if isinstance(value, int | float | bool | date | time | datetime):
+            thinned[key] = value
+        elif isinstance(value, str):
+            thinned[key] = textwrap.shorten(value, width=1024, placeholder="...")
+    return thinned

--- a/src/inspect_ai/log/_util.py
+++ b/src/inspect_ai/log/_util.py
@@ -1,0 +1,38 @@
+from inspect_ai._util.content import (
+    ContentAudio,
+    ContentImage,
+    ContentReasoning,
+    ContentText,
+    ContentVideo,
+)
+from inspect_ai.model._chat_message import ChatMessage
+
+
+def text_inputs(inputs: str | list[ChatMessage]) -> str | list[ChatMessage]:
+    # Clean the input of any images
+    if isinstance(inputs, list):
+        input: list[ChatMessage] = []
+        for message in inputs:
+            if not isinstance(message.content, str):
+                filtered_content: list[
+                    ContentText
+                    | ContentReasoning
+                    | ContentImage
+                    | ContentAudio
+                    | ContentVideo
+                ] = []
+                for content in message.content:
+                    if content.type == "text":
+                        filtered_content.append(content)
+                    else:
+                        filtered_content.append(
+                            ContentText(text=f"({content.type.capitalize()})")
+                        )
+                message.content = filtered_content
+                input.append(message)
+            else:
+                input.append(message)
+
+        return input
+    else:
+        return inputs

--- a/tests/log/test_log_eventdb.py
+++ b/tests/log/test_log_eventdb.py
@@ -8,11 +8,12 @@ from typing import Any, Generator, Iterator, cast
 
 import pytest
 
+from inspect_ai.log._log import EvalSampleSummary
 from inspect_ai.log._recorders.buffer import SampleBufferDatabase
 from inspect_ai.log._recorders.buffer.database import sync_to_filestore
 from inspect_ai.log._recorders.buffer.filestore import SampleBufferFilestore
 from inspect_ai.log._recorders.buffer.types import Samples
-from inspect_ai.log._recorders.types import EvalSampleSummary, SampleEvent
+from inspect_ai.log._recorders.types import SampleEvent
 from inspect_ai.log._transcript import Event, InfoEvent
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
 

--- a/tests/log/test_log_eventdb.py
+++ b/tests/log/test_log_eventdb.py
@@ -12,7 +12,7 @@ from inspect_ai.log._recorders.buffer import SampleBufferDatabase
 from inspect_ai.log._recorders.buffer.database import sync_to_filestore
 from inspect_ai.log._recorders.buffer.filestore import SampleBufferFilestore
 from inspect_ai.log._recorders.buffer.types import Samples
-from inspect_ai.log._recorders.types import SampleEvent, SampleSummary
+from inspect_ai.log._recorders.types import EvalSampleSummary, SampleEvent
 from inspect_ai.log._transcript import Event, InfoEvent
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
 
@@ -27,8 +27,10 @@ def db() -> Generator[SampleBufferDatabase, None, None]:
 
 
 @pytest.fixture
-def sample() -> Generator[SampleSummary, None, None]:
-    yield SampleSummary(id="sample1", epoch=1, input="test input", target="test target")
+def sample() -> Generator[EvalSampleSummary, None, None]:
+    yield EvalSampleSummary(
+        id="sample1", epoch=1, input="test input", target="test target"
+    )
 
 
 def get_samples(db: SampleBufferDatabase) -> Samples:
@@ -43,7 +45,7 @@ def test_database_initialization(db: SampleBufferDatabase) -> None:
     assert bool(re.search(r"test_location\.\d+\.db$", db.db_path.as_posix()))
 
 
-def test_start_sample(db: SampleBufferDatabase, sample: SampleSummary) -> None:
+def test_start_sample(db: SampleBufferDatabase, sample: EvalSampleSummary) -> None:
     """Test starting a new sample."""
     db.start_sample(sample=sample)
 
@@ -53,7 +55,7 @@ def test_start_sample(db: SampleBufferDatabase, sample: SampleSummary) -> None:
     assert samples[0] == sample
 
 
-def test_log_events(db: SampleBufferDatabase, sample: SampleSummary) -> None:
+def test_log_events(db: SampleBufferDatabase, sample: EvalSampleSummary) -> None:
     """Test logging events for a sample."""
     # First create a sample
     db.start_sample(sample=sample)
@@ -68,13 +70,13 @@ def test_log_events(db: SampleBufferDatabase, sample: SampleSummary) -> None:
     assert len(logged_events) == 2
 
 
-def test_complete_sample(db: SampleBufferDatabase, sample: SampleSummary) -> None:
+def test_complete_sample(db: SampleBufferDatabase, sample: EvalSampleSummary) -> None:
     """Test completing a sample with a summary."""
     # Create sample
     db.start_sample(sample=sample)
 
     # Complete sample
-    summary = SampleSummary(
+    summary = EvalSampleSummary(
         id=sample.id, epoch=sample.epoch, input=sample.input, target=sample.target
     )
     db.complete_sample(summary=summary)
@@ -88,8 +90,12 @@ def test_complete_sample(db: SampleBufferDatabase, sample: SampleSummary) -> Non
 def test_get_events_with_filters(db: SampleBufferDatabase) -> None:
     """Test getting events with various filters."""
     # Create two samples with events
-    sample1 = SampleSummary(id="sample1", epoch=1, input="test1", target="test target")
-    sample2 = SampleSummary(id="sample2", epoch=1, input="test2", target="test target")
+    sample1 = EvalSampleSummary(
+        id="sample1", epoch=1, input="test1", target="test target"
+    )
+    sample2 = EvalSampleSummary(
+        id="sample2", epoch=1, input="test2", target="test target"
+    )
     db.start_sample(sample=sample1)
     db.start_sample(sample=sample2)
 
@@ -119,10 +125,10 @@ def test_get_events_with_filters(db: SampleBufferDatabase) -> None:
 def test_concurrent_samples(db: SampleBufferDatabase) -> None:
     """Test handling multiple samples concurrently."""
     # Create multiple samples
-    samples: list[SampleSummary] = [
-        SampleSummary(id="sample1", epoch=1, input="test1", target="target"),
-        SampleSummary(id="sample1", epoch=2, input="test1_v2", target="target"),
-        SampleSummary(id="sample2", epoch=1, input="test2", target="target"),
+    samples: list[EvalSampleSummary] = [
+        EvalSampleSummary(id="sample1", epoch=1, input="test1", target="target"),
+        EvalSampleSummary(id="sample1", epoch=2, input="test1_v2", target="target"),
+        EvalSampleSummary(id="sample2", epoch=1, input="test2", target="target"),
     ]
 
     for sample in samples:
@@ -153,10 +159,10 @@ def test_concurrent_samples(db: SampleBufferDatabase) -> None:
 def test_remove_samples(db: SampleBufferDatabase) -> None:
     """Test removing samples and their associated events."""
     # Create multiple samples with events
-    samples: list[SampleSummary] = [
-        SampleSummary(id="sample1", epoch=1, input="test1", target="target"),
-        SampleSummary(id="sample1", epoch=2, input="test1_v2", target="target"),
-        SampleSummary(id="sample2", epoch=1, input="test2", target="target"),
+    samples: list[EvalSampleSummary] = [
+        EvalSampleSummary(id="sample1", epoch=1, input="test1", target="target"),
+        EvalSampleSummary(id="sample1", epoch=2, input="test1_v2", target="target"),
+        EvalSampleSummary(id="sample2", epoch=1, input="test2", target="target"),
     ]
 
     # Start all samples
@@ -245,7 +251,7 @@ def test_large_input_attachment_handling(db: SampleBufferDatabase) -> None:
     """Test that large inputs are automatically converted to attachments."""
     # Create a sample with input larger than 100 characters
     large_input = ChatMessageUser(content="x" * 150)
-    sample = SampleSummary(
+    sample = EvalSampleSummary(
         id="large_sample",
         epoch=1,
         input=[large_input],
@@ -293,7 +299,7 @@ def test_large_input_attachment_handling(db: SampleBufferDatabase) -> None:
 def test_large_event_attachment_handling(db: SampleBufferDatabase) -> None:
     """Test that events with large data fields are automatically converted to attachments."""
     # Create a normal sample
-    sample = SampleSummary(
+    sample = EvalSampleSummary(
         id="event_test", epoch=1, input="test input", target="test target"
     )
     db.start_sample(sample=sample)
@@ -346,7 +352,7 @@ def test_multiple_attachments_same_content(db: SampleBufferDatabase) -> None:
 
     # Create two samples with the same large input
     samples = [
-        SampleSummary(id=f"sample{i}", epoch=1, input=large_input, target="test")
+        EvalSampleSummary(id=f"sample{i}", epoch=1, input=large_input, target="test")
         for i in range(2)
     ]
 
@@ -373,7 +379,7 @@ def test_mixed_content_sizes(db: SampleBufferDatabase) -> None:
     large_data = "y" * 150
 
     # Create sample with large input
-    sample = SampleSummary(
+    sample = EvalSampleSummary(
         id="mixed_test", epoch=1, input=large_input, target="test target"
     )
     db.start_sample(sample=sample)
@@ -409,7 +415,7 @@ def test_version_increments_on_write_operations(db: SampleBufferDatabase):
         task_data = db._get_task_data(conn)
 
     # Test write operation
-    sample = SampleSummary(id="test1", epoch=1, input="foo", target="bar")
+    sample = EvalSampleSummary(id="test1", epoch=1, input="foo", target="bar")
     db.start_sample(sample)
 
     with db._get_connection() as conn:
@@ -419,7 +425,7 @@ def test_version_increments_on_write_operations(db: SampleBufferDatabase):
 
 
 def test_version_unchanged_on_read_operations(
-    db: SampleBufferDatabase, sample: SampleSummary
+    db: SampleBufferDatabase, sample: EvalSampleSummary
 ):
     """Test that read operations don't change the version."""
     # First add a sample so we have something to read
@@ -447,7 +453,7 @@ def test_version_in_samples_etag(db: SampleBufferDatabase):
     assert samples.etag == str(task_data.version)
 
 
-def test_cleanup(db: SampleBufferDatabase, sample: SampleSummary) -> None:
+def test_cleanup(db: SampleBufferDatabase, sample: EvalSampleSummary) -> None:
     """Test database cleanup."""
     # Create some data
     db.start_sample(sample=sample)
@@ -479,7 +485,7 @@ def test_running_tasks():
 
             try:
                 # some test data
-                s1 = SampleSummary(id="inc", epoch=1, input="foo", target="bar")
+                s1 = EvalSampleSummary(id="inc", epoch=1, input="foo", target="bar")
                 test_db.start_sample(s1)
 
                 # First batch

--- a/tests/log/test_log_eventdb_sync.py
+++ b/tests/log/test_log_eventdb_sync.py
@@ -3,13 +3,14 @@ from pathlib import Path
 
 import pytest
 
+from inspect_ai.log._log import EvalSampleSummary
 from inspect_ai.log._recorders.buffer.database import (
     SampleBufferDatabase,
     sync_to_filestore,
 )
 from inspect_ai.log._recorders.buffer.filestore import SampleBufferFilestore
 from inspect_ai.log._recorders.buffer.types import Samples
-from inspect_ai.log._recorders.types import EvalSampleSummary, SampleEvent
+from inspect_ai.log._recorders.types import SampleEvent
 from inspect_ai.log._transcript import InfoEvent
 
 

--- a/tests/log/test_log_eventdb_sync.py
+++ b/tests/log/test_log_eventdb_sync.py
@@ -9,7 +9,7 @@ from inspect_ai.log._recorders.buffer.database import (
 )
 from inspect_ai.log._recorders.buffer.filestore import SampleBufferFilestore
 from inspect_ai.log._recorders.buffer.types import Samples
-from inspect_ai.log._recorders.types import SampleEvent, SampleSummary
+from inspect_ai.log._recorders.types import EvalSampleSummary, SampleEvent
 from inspect_ai.log._transcript import InfoEvent
 
 
@@ -62,7 +62,7 @@ def test_sync_one_sample(
     db, filestore = db_and_filestore
 
     # 1) Start a sample in the DB
-    sample = SampleSummary(id="s1", epoch=1, input="Hello", target="World")
+    sample = EvalSampleSummary(id="s1", epoch=1, input="Hello", target="World")
     db.start_sample(sample)
 
     # 2) Log a couple of events
@@ -107,8 +107,8 @@ def test_sync_multiple_samples(
     db, filestore = db_and_filestore
 
     # Create two samples
-    s1 = SampleSummary(id="A", epoch=1, input="inputA", target="targetA")
-    s2 = SampleSummary(id="B", epoch=1, input="inputB", target="targetB")
+    s1 = EvalSampleSummary(id="A", epoch=1, input="inputA", target="targetA")
+    s2 = EvalSampleSummary(id="B", epoch=1, input="inputB", target="targetB")
     db.start_sample(s1)
     db.start_sample(s2)
 
@@ -145,8 +145,8 @@ def test_sync_removed_sample(
     db, filestore = db_and_filestore
 
     # Create two samples
-    s1 = SampleSummary(id="keep", epoch=1, input="x", target="y")
-    s2 = SampleSummary(id="remove", epoch=1, input="xx", target="yy")
+    s1 = EvalSampleSummary(id="keep", epoch=1, input="x", target="y")
+    s2 = EvalSampleSummary(id="remove", epoch=1, input="xx", target="yy")
     db.start_sample(s1)
     db.start_sample(s2)
 
@@ -179,7 +179,7 @@ def test_sync_incremental(
     """Demonstrate incremental sync. First, create a sample and log events; sync. Then log more events and sync again, ensuring a second segment is created containing only the new events."""
     db, filestore = db_and_filestore
 
-    s1 = SampleSummary(id="inc", epoch=1, input="foo", target="bar")
+    s1 = EvalSampleSummary(id="inc", epoch=1, input="foo", target="bar")
     db.start_sample(s1)
 
     # First batch

--- a/tests/log/test_log_summaries.py
+++ b/tests/log/test_log_summaries.py
@@ -1,0 +1,17 @@
+from os.path import dirname, join
+from pathlib import Path
+
+from inspect_ai.log import list_eval_logs
+from inspect_ai.log._file import read_eval_log_sample_summaries
+
+file = Path(__file__)
+
+
+def test_sample_summaries():
+    logs = list_eval_logs(
+        join(dirname(file), "test_list_logs"), formats=["eval", "json"]
+    )
+
+    for log in logs:
+        summaries = read_eval_log_sample_summaries(log)
+        assert len(summaries) > 0

--- a/tests/log/test_log_summaries.py
+++ b/tests/log/test_log_summaries.py
@@ -1,13 +1,14 @@
 from os.path import dirname, join
 from pathlib import Path
 
-from inspect_ai.log import list_eval_logs
-from inspect_ai.log._file import read_eval_log_sample_summaries
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
+from inspect_ai.log import list_eval_logs, read_eval_log_sample_summaries
 
 file = Path(__file__)
 
 
-def test_sample_summaries():
+def test_sample_summaries() -> None:
     logs = list_eval_logs(
         join(dirname(file), "test_list_logs"), formats=["eval", "json"]
     )
@@ -15,3 +16,17 @@ def test_sample_summaries():
     for log in logs:
         summaries = read_eval_log_sample_summaries(log)
         assert len(summaries) > 0
+
+
+def test_sample_summaries_thin_metadata() -> None:
+    task = Task(
+        dataset=[
+            Sample(input="Say hello.", metadata={"dict": dict(), "long": "a" * 2000})
+        ]
+    )
+    log = eval(task, model="mockllm/model")[0]
+
+    summaries = read_eval_log_sample_summaries(log.location)
+    assert len(summaries) > 0
+    assert "dict" not in summaries[0].metadata
+    assert len(summaries[0].metadata["long"]) <= 1024


### PR DESCRIPTION
`read_eval_log_sample_summaries()` enables reading summary level information about samples (input, target, error status, and scoring) from a log file.  This will be considerably higher performance than reading the entire log.

For example:

```python
from inspect_ai.log import read_eval_log_sample_summaries

summaries = read_eval_log_sample_summaries(log_file)
```

Some sample data is "thinned" in the interest of keeping the summaries small: images are removed from `input`, `metadata` is restricted to scalar values (with strings truncated to 1k), and scores include only their `value`.

Reading only sample summaries will take orders of magnitude less time than reading all of the samples one-by-one, so if you only need access to summary level data, always prefer this function to reading the entire log file.

The `summaries` are a list of `EvalSampleSummary` objects, one for each sample:

```python
class EvalSampleSummary(BaseModel):
    """Summary information (including scoring) for a sample."""

    id: int | str
    """Unique id for sample."""

    epoch: int
    """Epoch number for sample."""

    input: str | list[ChatMessage]
    """Sample input (text inputs only)."""

    target: str | list[str]
    """Sample target value(s)"""

    metadata: dict[str, Any] = Field(default_factory=dict)
    """Sample metadata (scalar types only, strings truncated to 1k)."""

    scores: dict[str, Score] | None = Field(default=None)
    """Scores for sample (score values only, no answers, explanations, or metadata)."""

    model_usage: dict[str, ModelUsage] = Field(default_factory=dict)
    """Model token usage for sample."""

    total_time: float | None = Field(default=None)
    """Total time that the sample was running."""

    working_time: float | None = Field(default=None)
    """Time spent working (model generation, sandbox calls, etc.)"""

    uuid: str | None = Field(default=None)
    """Globally unique identifier for sample run (exists for samples created in Inspect >= 0.3.70)"""

    error: str | None = Field(default=None)
    """Error that halted sample."""

    limit: str | None = Field(default=None)
    """Limit that halted the sample"""

    retries: int | None = Field(default=None)
    """Number of retries for the sample."""
```


### Filtering

You can also use `read_eval_log_sample_summaries()` as means of filtering which samples you want to read in full. For example, imagine you only want to read samples that include errors:

```python
errors: list[EvalSample] = []
for sample in read_eval_log_sample_summaries(log_file):
    if sample.error is not None
        errors.append(
            read_eval_log_sample(log_file, sample.id, sample.epoch)
        )
``` 
