### PR TITLE
Follow symlinks when reading files from docker sandbox

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -96,7 +96,7 @@ async def compose_cp(
     output_limit: int | None = None,
 ) -> None:
     result = await compose_command(
-        ["cp", "--", src, dest],
+        ["cp", "-L", "--", src, dest],
         project=project,
         timeout=120,  # 2-minute timeout for file copies
         cwd=cwd,

--- a/tests/util/sandbox/sandbox_setup_symlink.sh
+++ b/tests/util/sandbox/sandbox_setup_symlink.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+# Base file
+echo "hello world" > foo.txt
+
+# Simple relative symlink from current dir
+ln -s foo.txt link_simple
+
+# Explicit “./” prefix
+ln -s ./foo.txt link_dot_slash
+
+# Create a nested directory and symlink via “..”
+mkdir -p nested/inner
+# from nested/, go up one level to find foo.txt
+ln -s ../foo.txt nested/link_up_one
+# from nested/inner/, go up two levels to find foo.txt
+ln -s ../../foo.txt nested/inner/link_up_two
+
+# Absolute symlink for comparison
+ln -s "$(pwd)/foo.txt" link_absolute
+
+
+# Simple relative symlink from current dir
+ln -s missing missing_simple
+
+# Explicit “./” prefix
+ln -s ./missing missing_dot_slash
+
+# from nested/, go up one level to find foo.txt
+ln -s ../missing nested/missing_up_one
+# from nested/inner/, go up two levels to find foo.txt
+ln -s ../../missing nested/inner/missing_up_two
+
+# Absolute symlink for comparison
+ln -s "$(pwd)/missing" missing_absolute
+

--- a/tests/util/sandbox/test_sandbox_setup.py
+++ b/tests/util/sandbox/test_sandbox_setup.py
@@ -25,7 +25,7 @@ NOT_FOUND = "MISSING"
 
 
 @solver
-def check_file(expected_content: str = None) -> Solver:
+def check_file(expected_content: str | None = None) -> Solver:
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         """
         Check if a file exists, and if it contains the expected_content.

--- a/tests/util/sandbox/test_sandbox_setup.py
+++ b/tests/util/sandbox/test_sandbox_setup.py
@@ -13,19 +13,37 @@ from inspect_ai.util._sandbox.docker.config import is_dockerfile
 
 SANDBOX_SETUP_FILE = (Path(__file__).parent / "sandbox_setup.sh").as_posix()
 SANDBOX_SETUP_ERROR_FILE = (Path(__file__).parent / "sandbox_setup_error.sh").as_posix()
+SANDBOX_SETUP_SYMLINK_FILE = (
+    Path(__file__).parent / "sandbox_setup_symlink.sh"
+).as_posix()
 
 with open(SANDBOX_SETUP_FILE, "r") as f:
     sandbox_setup = f.read()
 
+SUCCESS = "FOUND"
+NOT_FOUND = "MISSING"
+
 
 @solver
-def check_foo() -> Solver:
+def check_file(expected_content: str = None) -> Solver:
     async def solve(state: TaskState, generate: Generate) -> TaskState:
+        """
+        Check if a file exists, and if it contains the expected_content.
+
+        Returns SUCCESS if the file exists with expected content. Otherwise
+        returns NOT_FOUND if file is missing or the mismatched set of strings
+        if expected_content doesn't match actual content.
+        """
         try:
-            await sandbox().read_file(state.metadata["file"])
-            completion = "Yes"
+            value = await sandbox().read_file(state.metadata["file"])
+            # Strip before comparing values to avoid trailing newline mismatches
+            if not expected_content or expected_content.strip() == value.strip():
+                completion = SUCCESS
+            else:
+                # Unexpected contents,
+                completion = f"{repr(value)} != {repr(expected_content)}"
         except FileNotFoundError:
-            completion = "No"
+            completion = NOT_FOUND
 
         state.output = ModelOutput.from_content("mockllm/model", completion)
 
@@ -39,22 +57,22 @@ def check_foo() -> Solver:
 def test_docker_sandbox_setup():
     def sample(file: str, target: str, setup: str) -> Sample:
         return Sample(
-            input=f"Does the file '{file}' exist? Answer Yes or No",
+            input=f"Does the file '{file}' exist? Answer {SUCCESS} or {NOT_FOUND}",
             target=target,
             metadata={"file": file},
             setup=setup,
         )
 
     dataset = [
-        sample("foo.txt", "Yes", sandbox_setup),
-        sample("bar.txt", "No", sandbox_setup),
-        sample("foo.txt", "Yes", SANDBOX_SETUP_FILE),
-        sample("bar.txt", "No", SANDBOX_SETUP_FILE),
+        sample("foo.txt", SUCCESS, sandbox_setup),
+        sample("bar.txt", NOT_FOUND, sandbox_setup),
+        sample("foo.txt", SUCCESS, SANDBOX_SETUP_FILE),
+        sample("bar.txt", NOT_FOUND, SANDBOX_SETUP_FILE),
     ]
 
     task = Task(
         dataset=dataset,
-        solver=check_foo(),
+        solver=check_file(),
         scorer=includes(),
         sandbox="docker",
     )
@@ -64,6 +82,46 @@ def test_docker_sandbox_setup():
     assert log.samples
     for sample in log.samples:
         assert sample.scores["includes"].value == CORRECT
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_docker_sandbox_setup_symlink():
+    def sample(file: str, target: str, setup: str) -> Sample:
+        return Sample(
+            input=f"Does the file '{file}' exist? Answer {SUCCESS} or {NOT_FOUND}",
+            target=target,
+            metadata={"file": file},
+            setup=setup,
+        )
+
+    dataset = [
+        sample("link_simple", SUCCESS, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("link_dot_slash", SUCCESS, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("nested/link_up_one", SUCCESS, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("nested/inner/link_up_two", SUCCESS, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("link_absolute", SUCCESS, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("missing_simple", NOT_FOUND, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("missing_dot_slash", NOT_FOUND, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("nested/missing_up_one", NOT_FOUND, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("nested/inner/missing_up_two", NOT_FOUND, SANDBOX_SETUP_SYMLINK_FILE),
+        sample("missing_absolute", NOT_FOUND, SANDBOX_SETUP_SYMLINK_FILE),
+    ]
+
+    task = Task(
+        dataset=dataset,
+        solver=check_file(expected_content="hello world"),
+        scorer=includes(),
+        sandbox="docker",
+    )
+
+    log = eval(task, model="mockllm/model")[0]
+
+    assert log.samples
+    for sample in log.samples:
+        assert sample.scores["includes"].value == CORRECT, (
+            f"Failure for '{sample.metadata['file']}': {sample.scores['includes'].answer}'"
+        )
 
 
 @skip_if_no_docker


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Trying to read a symlink from within a docker sandbox will raise a RuntimeError, even though the file exists. E.g.,

```
┌───────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────┐
│ /home/dev/git/inspect_ai/src/inspect_ai/_eval/task/run.py:667 in task_run_sample                                     │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/solver/_plan.py:106 in __call__                                              │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/agent/_as_solver.py:56 in solve                                              │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/agent/_react.py:189 in execute                                               │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/model/_call_tools.py:334 in execute_tools                                    │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/model/_call_tools.py:146 in call_tool_task                                   │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/model/_call_tools.py:140 in call_tool_task                                   │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/model/_call_tools.py:396 in call_tool                                        │
│                                                                                                                      │
│ /my_file_read_tool.py in open_file                                                                                                            │
│                                                                                                                      │
│ >  71 │   │   │   file_content = await sandbox().read_file(path, text=True)                                          │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/util/_sandbox/events.py:116 in read_file                                     │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/util/_sandbox/docker/docker.py:420 in read_file                              │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/util/_sandbox/docker/docker.py:397 in read_file                              │
│                                                                                                                      │
│ /home/dev/git/inspect_ai/src/inspect_ai/util/_sandbox/docker/compose.py:107 in compose_cp                            │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
RuntimeError: Failed to copy file from 'agent:/etc/apache2/sites-enabled/000-default.conf' to '000-default.conf':  inspect-cybench-imyzwml-agent-1 copy
inspect-cybench-imyzwml-agent-1:/etc/apache2/sites-enabled/000-default.conf to 000-default.conf Copying
invalid symlink "/tmp/tmpsu3tkhri/000-default.conf" -> "../sites-available/000-default.conf"
```

### What is the new behavior?

Symlinks will be followed, resulting in the file contents being read for valid symlinks. If the symlink is invalid, a FileNotFoundError will be raised instead.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)


### Other information:

Added a new test to validate this behavior. Prior to the fix commit it will fail, after it will pass.

Symlinks can sometimes get scary from a security perspective - blindly following them is often a bad idea. I think in this case it's okay -  a sandbox is already untrusted and can write whatever data it wants into files. By following symlinks we don't ever change where Inspect places files on a host system, we just change what bytes are read. So I think this is still safe.