### PR TITLE
open ai: filter assistant output messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- OpenAI: In responses API, don't pass back assistant output that wasn't part of the output included in the server response (e.g. output generated from a call to a `submit()` tool).
 - Bugfix: Correctly pass tool arguments back to model for OpenAI responses API.
 
 ## v0.3.91 (26 April 2025)

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -307,6 +307,14 @@ def _openai_input_items_from_chat_message_assistant(
     """
     (output_message_id, tool_message_ids) = _ids_from_assistant_internal(message)
 
+    # we want to prevent yielding output messages in the case where we have an
+    # 'internal' field (so the message came from the model API as opposed to
+    # being user synthesized) AND there is no output_message_id (indicating that
+    # when reading the message from the server we didn't find output). this could
+    # happen e.g. when a react() agent sets the output.completion in response
+    # to a submit() tool call
+    suppress_output_message = message.internal is not None and output_message_id is None
+
     # if we are not storing messages on the server then blank these out
     if not store:
         output_message_id = None
@@ -342,6 +350,9 @@ def _openai_input_items_from_chat_message_assistant(
                         )
                     )
             case ContentText(text=text, refusal=refusal):
+                if suppress_output_message:
+                    continue
+
                 new_content = (
                     ResponseOutputRefusalParam(type="refusal", refusal=text)
                     if refusal


### PR DESCRIPTION
OpenAI: In responses API, don't pass back assistant output that wasn't part of the output included in the server response (e.g. output generated from a call to a `submit()` tool).