### PR TITLE
Add tests for `read_eval_log_sample_summaries`

### DIFF
--- a/tests/log/test_log_summaries.py
+++ b/tests/log/test_log_summaries.py
@@ -31,6 +31,19 @@ def test_sample_summaries_thin_metadata() -> None:
     assert "dict" not in summaries[0].metadata
     assert len(summaries[0].metadata["long"]) <= 1024
 
+def test_metadata_summary() -> None:
+    # XXX: The test logs have no metadata - this test isn't really checking anything
+    logs = list_eval_logs(
+        join(dirname(file), "test_list_logs"), formats=["eval", "json"]
+    )
+    for log in logs:
+        summary_samples = read_eval_log_sample_summaries(log)
+        full_samples = read_eval_log_samples(log)
+
+        for summary, full in zip(summary_samples, full_samples):
+            assert(summary.metadata == full.metadata)
+
+
 def test_model_usage() -> None:
     logs = list_eval_logs(
         join(dirname(file), "test_list_logs"), formats=["eval", "json"]

--- a/tests/log/test_log_summaries.py
+++ b/tests/log/test_log_summaries.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
-from inspect_ai.log import list_eval_logs, read_eval_log_sample_summaries
+from inspect_ai.log import list_eval_logs, read_eval_log_sample_summaries, read_eval_log_samples
 
 file = Path(__file__)
 
@@ -30,3 +30,14 @@ def test_sample_summaries_thin_metadata() -> None:
     assert len(summaries) > 0
     assert "dict" not in summaries[0].metadata
     assert len(summaries[0].metadata["long"]) <= 1024
+
+def test_model_usage() -> None:
+    logs = list_eval_logs(
+        join(dirname(file), "test_list_logs"), formats=["eval", "json"]
+    )
+    for log in logs:
+        summary_samples = read_eval_log_sample_summaries(log)
+        full_samples = read_eval_log_samples(log)
+
+        for summary, full in zip(summary_samples, full_samples):
+            assert(summary.model_usage == full.model_usage)


### PR DESCRIPTION
## This PR contains:
2 new tests for `read_eval_log_sample_summaries`, one fails and the other is a work in progress. Hoping this can provide a starting point for a fix for the failure.

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
How are the files in `test_list_logs/` generated? Can I regenerate these to add some metadata?
