### PR TITLE
Add `--no-log-realtime` option to `eval_retry_command`

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1087,6 +1087,13 @@ def parse_comma_separated(value: str | None) -> list[str] | None:
     envvar="INSPECT_EVAL_LOG_SAMPLES",
 )
 @click.option(
+    "--no-log-realtime",
+    type=bool,
+    is_flag=True,
+    help=NO_LOG_REALTIME_HELP,
+    envvar="INSPECT_EVAL_LOG_REALTIME",
+)
+@click.option(
     "--log-images/--no-log-images",
     type=bool,
     default=True,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Calling `eval retry` from the command line throws an error

```txt
inspect eval-retry logs/2025-04-29T16-20-17+10-00_cybench_iEuY7tm6PYZvLZB8C5taB5.eval
Traceback (most recent call last):
  File "/Users/matt/Developer/inspect_ai/inspect_evals_scoring/.venv/bin/inspect", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/matt/Developer/inspect_ai/inspect_ai/src/inspect_ai/_cli/main.py", line 56, in main
    inspect(auto_envvar_prefix="INSPECT")  # pylint: disable=no-value-for-parameter
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matt/Developer/inspect_ai/inspect_evals_scoring/.venv/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/matt/Developer/inspect_ai/inspect_evals_scoring/.venv/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/matt/Developer/inspect_ai/inspect_evals_scoring/.venv/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/matt/Developer/inspect_ai/inspect_evals_scoring/.venv/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/matt/Developer/inspect_ai/inspect_evals_scoring/.venv/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/matt/Developer/inspect_ai/inspect_ai/src/inspect_ai/_cli/common.py", line 45, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ~~~~^^^^^^^^^^^^^^^^^
  File "/Users/matt/Developer/inspect_ai/inspect_ai/src/inspect_ai/_cli/common.py", line 109, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ~~~~^^^^^^^^^^^^^^^^^
TypeError: eval_retry_command() missing 1 required positional argument: 'no_log_realtime'
```


### What is the new behavior?
Calling `eval retry` from the command line works as expected

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
