### PR TITLE
Ensure old log files with `output_limit` can be loaded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `--no-log-realtime` option for disabling realtime event logging (live viewing of logs is disabled when this is specified).
 - Packaging: Exclude `_resources` directories from package (reduces pressure on path lengths for Windows).
 - Inspect View: Split info tab into task, models, and info for improved layout.
+- Bugfix: Avoid validation errors when loading old log files which contain "output_limit" tool errors.
 
 ## v0.3.92 (26 April 2025)
 

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -4850,7 +4850,8 @@
             "is_a_directory",
             "limit",
             "approval",
-            "unknown"
+            "unknown",
+            "output_limit"
           ],
           "title": "Type",
           "type": "string"

--- a/src/inspect_ai/_view/www/src/@types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/@types/log.d.ts
@@ -265,7 +265,8 @@ export type Type9 =
   | "is_a_directory"
   | "limit"
   | "approval"
-  | "unknown";
+  | "unknown"
+  | "output_limit";
 export type Message1 = string;
 export type Choices = string[] | null;
 export type Target = string | string[];

--- a/src/inspect_ai/tool/_tool_call.py
+++ b/src/inspect_ai/tool/_tool_call.py
@@ -71,6 +71,9 @@ class ToolCallError:
         "limit",
         "approval",
         "unknown",
+        # Retained for backward compatibility when loading logs created with an older
+        # version of inspect.
+        "output_limit",
     ]
     """Error type."""
 

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -177,6 +177,13 @@ def test_can_round_trip_serialize_subtask_event():
     assert original == deserialized
 
 
+def test_can_load_log_with_all_tool_call_errors():
+    # Log file contains all supported tool call errors.
+    log_file = os.path.join("tests", "log", "test_eval_log", "log_tool_call_error.json")
+
+    read_eval_log(log_file)
+
+
 def check_log_location(log_file: str):
     location = filesystem(log_file).info(log_file).name
     log = read_eval_log(location)

--- a/tests/log/test_eval_log/log_tool_call_error.json
+++ b/tests/log/test_eval_log/log_tool_call_error.json
@@ -1,0 +1,206 @@
+{
+    "version": 2,
+    "status": "success",
+    "eval": {
+        "run_id": "...",
+        "created": "2025-02-07T00:00:00+00:00",
+        "task": "...",
+        "task_id": "...",
+        "task_version": 0,
+        "task_file": "...",
+        "task_attribs": {
+            "lite": true
+        },
+        "task_args": {},
+        "dataset": {
+            "name": "...",
+            "location": ".",
+            "samples": 1,
+            "sample_ids": [
+                1
+            ],
+            "shuffled": false
+        },
+        "sandbox": {
+            "type": "docker",
+            "config": "compose.yaml"
+        },
+        "model": "...",
+        "model_generate_config": {},
+        "model_args": {},
+        "config": {},
+        "revision": {
+            "type": "git",
+            "origin": "...",
+            "commit": "..."
+        },
+        "packages": {
+            "inspect_ai": "0.3.58.dev9002"
+        }
+    },
+    "plan": {
+        "name": "plan",
+        "steps": [
+            {
+                "solver": "...",
+                "params": {}
+            }
+        ]
+    },
+    "results": {
+        "total_samples": 4,
+        "completed_samples": 4,
+        "scores": [
+            {
+                "name": "includes",
+                "scorer": "includes",
+                "params": {},
+                "metrics": {
+                    "accuracy": {
+                        "name": "accuracy",
+                        "value": 1.0,
+                        "params": {}
+                    },
+                    "stderr": {
+                        "name": "stderr",
+                        "value": 0.0,
+                        "params": {}
+                    }
+                }
+            }
+        ]
+    },
+    "stats": {
+        "started_at": "2025-02-07T00:00:00+00:00",
+        "completed_at": "2025-02-07T00:00:00+00:00",
+        "model_usage": {
+            "...": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "total_tokens": 1
+            }
+        }
+    },
+    "samples": [
+        {
+            "id": 1,
+            "epoch": 4,
+            "input": "...",
+            "target": "...",
+            "files": [],
+            "setup": "...",
+            "messages": [
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_1",
+                    "function": "bash",
+                    "error": {
+                        "type": "parsing",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_2",
+                    "function": "bash",
+                    "error": {
+                        "type": "timeout",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_3",
+                    "function": "bash",
+                    "error": {
+                        "type": "parsing",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_4",
+                    "function": "bash",
+                    "error": {
+                        "type": "unicode_decode",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_5",
+                    "function": "bash",
+                    "error": {
+                        "type": "permission",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_6",
+                    "function": "bash",
+                    "error": {
+                        "type": "file_not_found",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_7",
+                    "function": "bash",
+                    "error": {
+                        "type": "is_a_directory",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_8",
+                    "function": "bash",
+                    "error": {
+                        "type": "limit",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_9",
+                    "function": "bash",
+                    "error": {
+                        "type": "approval",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "...",
+                    "role": "tool",
+                    "tool_call_id": "bash_10",
+                    "function": "bash",
+                    "error": {
+                        "type": "unknown",
+                        "message": "..."
+                    }
+                },
+                {
+                    "content": "\nThe output of your call to bash was too long to be displayed.\nHere is a truncated version:\n<START_TOOL_OUTPUT>\n...\n<END_TOOL_OUTPUT>\n",
+                    "role": "tool",
+                    "tool_call_id": "bash_11",
+                    "function": "bash",
+                    "error": {
+                        "type": "output_limit",
+                        "message": "The tool output limit of 10 MiB was exceeded."
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #1777 

This issue was introduced in #1737

I've added a regression test to prevent this sort of issue in future.