### PR TITLE
Fix web browser bug (#1734) caused by not properly awaiting navigation on a submit operation.

### DIFF
--- a/src/inspect_tool_support/CHANGELOG.md
+++ b/src/inspect_tool_support/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v1.0.1 (29 April 2025)
+
+- Fix occasional "Execution context was destroyed, most likely because of a navigation" web browser bug. (#1781)
+
 ## v1.0.0 (29 April 2025)
 
 - Major version bump for `bash_session` tool to be terminal oriented rather than command oriented. (#1600)

--- a/src/inspect_tool_support/pyproject.toml
+++ b/src/inspect_tool_support/pyproject.toml
@@ -66,7 +66,7 @@ ignore = ["W002", "W009"]
 
 [project]
 name = "inspect_tool_support"
-version = "1.0.0"
+version = "1.0.1"
 description = "Sandbox container tool code for inspect_ai"
 authors = [{ name = "UK AI Security Institute" }]
 readme = "README.md"

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/controller.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/controller.py
@@ -87,8 +87,7 @@ class WebBrowserSessionController(SessionController[PlaywrightCrawler]):
         self, session_name: str, element_id: int, text: str
     ) -> CrawlerResult:
         async def handler(page: PageCrawler) -> None:
-            await page.clear(element_id)
-            await page.type(element_id, text + "\n")
+            await page.submit(element_id, text)
 
         return await self._execute_crawler_command(session_name, handler)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Web browser code properly waited for potential navigation triggered by a click action, but it neglected to wait when the action was a submit. 

### What is the new behavior?
It now waits with the same code on a submit.

`_click_and_await_navigation` was generalized to `_await_navigation_after_action` and is now shared between `click` and `submit`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
Fixes #1734 