### PR TITLE
`--sample-id` option can now include task prefixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [read_eval_log_sample_summaries()](https://inspect.aisi.org.uk/eval-logs.html#summaries) function for reading sample summaries (including scoring) from eval logs.
 - Updated [vLLM](https://inspect.aisi.org.uk/providers.html#vllm) provider to use local server rather than in process `vllm` package (improved concurrency and resource utilization).
 - New [SGLang](https://inspect.aisi.org.uk/providers.html#sglang) provider (using similar local server architecture as vLLM provider).
+- `--sample-id` option can now include task prefixes (e.g. `--sample-id=popularity:10,security:5)`).
 - Improved write performance for realtime event logging.
 - `--no-log-realtime` option for disabling realtime event logging (live viewing of logs is disabled when this is specified).
 - Packaging: Exclude `_resources` directories from package (reduces pressure on path lengths for Windows).

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -146,7 +146,7 @@ def eval(
             to "eval", the native high-performance format).
         limit: Limit evaluated samples
             (defaults to all samples).
-        sample_id: Evaluate specific sample(s) from the dataset.
+        sample_id: Evaluate specific sample(s) from the dataset. Use plain ids or preface with task names as required to disambiguate ids across tasks (e.g. `popularity:10`).
         epochs: Epochs to repeat samples for and optional score
             reducer function(s) used to combine sample scores (defaults to "mean")
         fail_on_error: `True` to fail on first sample error
@@ -318,7 +318,7 @@ async def eval_async(
         log_dir: Output path for logging results (defaults to file log in ./logs directory).
         log_format: Format for writing log files (defaults to "eval", the native high-performance format).
         limit: Limit evaluated samples (defaults to all samples).
-        sample_id: Evaluate specific sample(s) from the dataset.
+        sample_id: Evaluate specific sample(s) from the dataset. Use plain ids or preface with task names as required to disambiguate ids across tasks (e.g. `popularity:10`).
         epochs: Epochs to repeat samples for and optional score
             reducer function(s) used to combine sample scores (defaults to "mean")
         fail_on_error: `True` to fail on first sample error

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -148,7 +148,7 @@ def eval_set(
             log files (defaults to "eval", the native high-performance format).
         limit: Limit evaluated samples
             (defaults to all samples).
-        sample_id: Evaluate specific sample(s) from the dataset.
+        sample_id: Evaluate specific sample(s) from the dataset. Use plain ids or preface with task names as required to disambiguate ids across tasks (e.g. `popularity:10`).
         epochs: Epochs to repeat samples for and optional score
             reducer function(s) used to combine sample scores (defaults to "mean")
         fail_on_error: `True` to fail on first sample error

--- a/tests/test_sample_id.py
+++ b/tests/test_sample_id.py
@@ -5,10 +5,12 @@ from inspect_ai.dataset import Sample
 def test_sample_id():
     task = Task(dataset=[Sample(id=id, input=f"Input for {id}") for id in range(0, 10)])
     log = eval(task, sample_id=5, model="mockllm/model")[0]
+    assert log.samples
     assert len(log.samples) == 1
     assert log.samples[0].id == 5
 
     log = eval(task, sample_id=[5, 9], model="mockllm/model")[0]
+    assert log.samples
     assert len(log.samples) == 2
     assert log.samples[0].id == 5
     assert log.samples[1].id == 9
@@ -19,10 +21,58 @@ def test_sample_id():
         ]
     )
     log = eval(task, sample_id="sample-5", model="mockllm/model")[0]
+    assert log.samples
     assert len(log.samples) == 1
     assert log.samples[0].id == "sample-5"
 
     log = eval(task, sample_id=["sample-5", "sample-6"], model="mockllm/model")[0]
+    assert log.samples
     assert len(log.samples) == 2
     assert log.samples[0].id == "sample-5"
     assert log.samples[1].id == "sample-6"
+
+
+def test_sample_id_task_preface():
+    task = Task(
+        name="foo",
+        dataset=[Sample(id=id, input=f"Input for {id}") for id in range(0, 10)],
+    )
+    # qualifier
+    log = eval(task, sample_id="foo:5", model="mockllm/model")[0]
+    assert log.samples
+    assert len(log.samples) == 1
+
+    # two qualifiers
+    log = eval(task, sample_id=["foo:5", "foo:6"], model="mockllm/model")[0]
+    assert log.samples
+    assert len(log.samples) == 2
+
+    # one hit one miss
+    log = eval(task, sample_id=["foo:5", "bar:6"], model="mockllm/model")[0]
+    assert log.samples
+    assert len(log.samples) == 1
+    assert log.samples[0].id == 5
+
+    # two misses
+    log = eval(task, sample_id=["bar:5", "bar:6"], model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 0
+
+
+def test_sample_id_task_preface_multiple():
+    task1 = Task(
+        name="foo",
+        dataset=[Sample(id=id, input=f"Input for {id}") for id in range(0, 10)],
+    )
+    task2 = Task(
+        name="bar",
+        dataset=[Sample(id=id, input=f"Input for {id}") for id in range(0, 10)],
+    )
+    logs = eval([task1, task2], sample_id=["foo:5", "bar:6"], model="mockllm/model")
+    assert logs[0].samples
+    assert len(logs[0].samples) == 1
+    assert logs[0].samples[0].id == 5
+
+    assert logs[1].samples
+    assert len(logs[1].samples) == 1
+    assert logs[1].samples[0].id == 6


### PR DESCRIPTION
e.g. `--sample-id=popularity:10,security:5`

