### PR TITLE
Update o1 provider tool call regex patterns

### DIFF
--- a/src/inspect_ai/model/_providers/openai_o1.py
+++ b/src/inspect_ai/model/_providers/openai_o1.py
@@ -211,8 +211,15 @@ class O1PreviewChatAPIHandler(ChatAPIHandler):
         This method has an interdependency with `input_with_tools()` (as that is the
         prompt that asks the model to use the <tool_call>...</tool_call> syntax)
         """
-        # extract tool calls
+        # define regex patterns
+        # NOTE: If you change either of these regex patterns, please update the other
+        # tool_call_regex extracts the JSON content (in curly braces) between tool call tags
         tool_call_regex = rf"<{TOOL_CALL}>\s*(\{{[\s\S]*?\}})\s*</{TOOL_CALL}>"
+        # tool_call_content_regex matches the entire tool call block including tags for extracting
+        # the content outside of the tool call tags
+        tool_call_content_regex = rf"<{TOOL_CALL}>\s*\{{[\s\S]*?\}}\s*</{TOOL_CALL}>"
+
+        # extract tool calls
         tool_calls_content: list[str] = re.findall(tool_call_regex, response)
 
         # if there are tool calls proceed with parsing

--- a/src/inspect_ai/model/_providers/openai_o1.py
+++ b/src/inspect_ai/model/_providers/openai_o1.py
@@ -233,7 +233,6 @@ class O1PreviewChatAPIHandler(ChatAPIHandler):
             ]
 
             # find other content that exists outside tool calls
-            tool_call_content_regex = rf"<{TOOL_CALL}>(?:.|\n)*?</{TOOL_CALL}>"
             other_content = re.split(tool_call_content_regex, response, flags=re.DOTALL)
             other_content = [
                 str(content).strip()

--- a/tests/model/providers/test_openai_o1.py
+++ b/tests/model/providers/test_openai_o1.py
@@ -61,6 +61,7 @@ def test_openai_o1_tool_call_parsing_no_arguments() -> None:
     assert resp.tool_calls[0].function == "unknown"
     assert resp.tool_calls[0].parse_error is not None
 
+
 def test_openai_o1_tool_call_parsing_model_mentions_tool_call_tag() -> None:
     from inspect_ai.model._providers.openai_o1 import O1PreviewChatAPIHandler
 
@@ -80,4 +81,7 @@ def test_openai_o1_tool_call_parsing_model_mentions_tool_call_tag() -> None:
         "element_id": 11399,
         "text": "hilarious cat videos",
     }
-    assert resp.content == "I will use the <tool_call> tags to enter the search term into the search box and submit the search."
+    assert (
+        resp.content
+        == "I will use the <tool_call> tags to enter the search term into the search box and submit the search."
+    )

--- a/tests/model/providers/test_openai_o1.py
+++ b/tests/model/providers/test_openai_o1.py
@@ -60,3 +60,24 @@ def test_openai_o1_tool_call_parsing_no_arguments() -> None:
     assert len(resp.tool_calls) == 1
     assert resp.tool_calls[0].function == "unknown"
     assert resp.tool_calls[0].parse_error is not None
+
+def test_openai_o1_tool_call_parsing_model_mentions_tool_call_tag() -> None:
+    from inspect_ai.model._providers.openai_o1 import O1PreviewChatAPIHandler
+
+    handler = O1PreviewChatAPIHandler("")
+
+    resp: ChatMessageAssistant = handler.parse_assistant_response(
+        response="""I will use the <tool_call> tags to enter the search term into the search box and submit the search.
+
+<tool_call>{"name": "web_browser_type_submit", "arguments": {"element_id": 11399, "text": "hilarious cat videos"}}</tool_call>""",
+        tools=[],
+    )
+
+    assert resp.tool_calls is not None
+    assert len(resp.tool_calls) == 1
+    assert resp.tool_calls[0].function == "web_browser_type_submit"
+    assert resp.tool_calls[0].arguments == {
+        "element_id": 11399,
+        "text": "hilarious cat videos",
+    }
+    assert resp.content == "I will use the <tool_call> tags to enter the search term into the search box and submit the search."


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

* Update tool_call_content_regex pattern in o1 provider to be symmetric to tool_call_regex
* Update comments to attempt to avoid future decoupling 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
