### PR TITLE
Add process for automating changelog generation and release commit creation.

### DIFF
--- a/src/inspect_tool_support/.bumpversion.cfg
+++ b/src/inspect_tool_support/.bumpversion.cfg
@@ -1,0 +1,12 @@
+[bumpversion]
+current_version = 1.0.1
+parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
+serialize = {major}.{minor}.{patch}
+commit = True
+message = Bump inspect-tool-support version: {current_version} → {new_version}
+tag = True
+tag_name = inspect-tool-support-{new_version}
+
+[bumpversion:file:pyproject.toml]
+search = version = "{current_version}"
+replace = version = "{new_version}"

--- a/src/inspect_tool_support/README.md
+++ b/src/inspect_tool_support/README.md
@@ -1,6 +1,6 @@
 # Design
 
-![diagram](https://raw.githubusercontent.com/UKGovernmentBEIS/inspect_ai/refs/heads/feature/stateful-bash/src/inspect_tool_support/shared_tool_container_design.svg)
+![diagram](https://raw.githubusercontent.com/UKGovernmentBEIS/inspect_ai/refs/heads/main/src/inspect_tool_support/shared_tool_container_design.svg)
 
 Inspect calls into the sandboxed image are done statelessly via `docker exec inspect-tool-support`.
 
@@ -14,7 +14,7 @@ Each stateful tool should have its own subdirectory that contains the following 
 
 - `json_rpc_methods.py`
 
-  This module contains all of the JSON RPC `@method` functions — one for each tool (e.g. the web browser tool is actually a set of distinct tools). It is responsible for unpacking the JSON RPC request and forwarding the call to a transport-agnostic, strongly typed, stateful controller.
+  This module contains all of the JSON RPC `@method` functions — one for each tool (e.g. the web browser tool is actually a set of distinct tools). It is responsible for unpacking the JSON RPC request and forwarding the call to a transport-agnostic, strongly typed, stateful controller.
 
 - `tool_types.py`
 
@@ -23,3 +23,55 @@ Each stateful tool should have its own subdirectory that contains the following 
 - `controller.py`
 
   This is transport-agnostic, strongly typed code that manages the tool specific in-process state and performs requested commands.
+
+## Release Process
+
+### Overview
+
+The release process for this project separates code commits from package publishing. While developers can make frequent commits to the repository, package releases are performed on a different tempo, typically when enough meaningful changes have accumulated. This approach allows for continuous development while providing stable, well-documented releases.
+
+Pending changelog items in the `unreleased_changes/` directory serve two key purposes:
+
+1. They document all changes that will be included in the next release
+2. They determine what type of semantic version bump (major, minor, or patch) will be needed when publishing these pending changes
+
+This system ensures that version numbers accurately reflect the nature of changes between releases according to semantic versioning principles.
+
+### Documenting Changes
+
+All changes should be documented using [`towncrier`](https://towncrier.readthedocs.io/). When making changes to the codebase, developers should create pending changelog items that will be used to update the changelog at release time:
+
+1. Use `towncrier create` to create a new pending changelog item:
+
+   This will interactively prompt you for:
+
+   - The (optional) related issue
+   - The type of semantic version change (major, minor, or patch)
+   - A description of your change (supporting markdown)
+
+   Alternatively, all options can be provided directly on the command line:
+
+   ```
+   towncrier create <issue-number>.[major|minor|patch].md
+   ```
+
+   For more details on `towncrier`'s command line options, refer to the [`towncrier` documentation](https://towncrier.readthedocs.io/en/latest/cli.html).
+
+2. Pending changelog items are stored in the `unreleased_changes/` directory and accumulate until the next release.
+
+### Creating a Release
+
+When it's time to make a release:
+
+1. Ensure all changes are committed.
+
+2. Run the `make-release-commit` script:
+
+3. The script automatically:
+   - Determines the version bump type (major, minor, or patch) based on the pending changelog items
+   - Runs `towncrier build` to incorporate all pending changelog items into `CHANGELOG.md`
+   - Updates the version in `pyproject.toml` using `bump2version`
+   - Commits the changes into a commit with a message like `Bump inspect-tool-support version: 1.0.2 → 1.1.0`
+   - Tags the commit with the new version number `inspect-tool-support-1.1.0`
+
+All changelog items are consumed during the release process and converted into entries in the `CHANGELOG.md` file. After the release, the `unreleased_changes/` directory will be empty, ready to collect changes for the next release cycle.

--- a/src/inspect_tool_support/make-release-commit
+++ b/src/inspect_tool_support/make-release-commit
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+import os
+import subprocess
+
+
+def determine_version_bump_type(fragment_dir: str) -> str:
+    files = os.listdir(fragment_dir)
+
+    has_breaking = any(f.endswith(".major.md") for f in files)
+    has_feature = any(f.endswith(".minor.md") for f in files)
+
+    if has_breaking:
+        return "major"
+    elif has_feature:
+        return "minor"
+    else:
+        return "patch"
+
+
+current_dir = os.getcwd()
+print(f"Current directory: {current_dir}")
+
+# Get the directory where this script is located
+script_dir = os.path.dirname(os.path.abspath(__file__))
+# The unreleased_changes directory is at the peer level of the script
+news_dir = os.path.join(script_dir, "unreleased_changes")
+
+print(f"Looking for unreleased_changes at: {news_dir}")
+
+# Determine which part to bump
+if not os.path.isdir(news_dir):
+    raise FileNotFoundError(
+        f"Cannot determine version bump: unreleased_changes directory not found at {news_dir}"
+    )
+bump_type = determine_version_bump_type(news_dir)
+print(f"Determined bump type: {bump_type}")
+
+try:
+    new_version = next(
+        (
+            line.split("=")[1]
+            for line in subprocess.run(
+                ["bump2version", bump_type, "--dry-run", "--list"],
+                capture_output=True,
+                text=True,
+                check=True,
+            ).stdout.splitlines()
+            if line.startswith("new_version=")
+        ),
+        None,
+    )
+except subprocess.CalledProcessError as e:
+    print(f"Error running bump2version: {e.stderr}")
+    raise
+
+if not new_version:
+    raise ValueError("Failed to determine new version from bump2version output")
+
+print(f"New version determined: {new_version}")
+
+subprocess.run(["towncrier", "build", "--version", new_version, "--yes"], check=True)
+
+# --allow-dirty is needed since towncrier updated the change log
+subprocess.run(["bump2version", "--allow-dirty", bump_type], check=True)

--- a/src/inspect_tool_support/pyproject.toml
+++ b/src/inspect_tool_support/pyproject.toml
@@ -107,8 +107,26 @@ inspect-tool-support = "inspect_tool_support._cli.main:main"
 
 [project.optional-dependencies]
 dev = [
+    "bump2version",
     "ruff==0.9.6", # match version specified in .pre-commit-config.yaml
+    "towncrier",
     "types-psutil"
 ]
 
 dist = ["twine", "build"]
+
+[tool.towncrier]
+directory = "unreleased_changes"
+filename = "CHANGELOG.md"
+package = "inspect_tool_support"
+package_dir = "src"
+title_format = "v{version} ({project_date})"
+# Define the types of changes that match semantic versioning
+type = [
+    {name = "major", directory = "major", showcontent = true},
+    {name = "minor", directory = "minor", showcontent = true},
+    {name = "patch", directory = "patch", showcontent = true},
+    {name = "doc", directory = "doc", showcontent = true},
+    {name = "chore", directory = "chore", showcontent = true}
+]
+


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

This PR automates the changelog generation and release commit creation process by adding configuration for towncrier and a release script.

- Added towncrier configuration in pyproject.toml to manage changelog entries.
- Introduced the make-release-commit Python script to determine version bumps, build the changelog, and update the version using bump2version.
- Updated README.md to document the new release process.
