### PR TITLE
anthropic:`streaming` model argument to control whether streaming API is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [read_eval_log_sample_summaries()](https://inspect.aisi.org.uk/eval-logs.html#summaries) function for reading sample summaries (including scoring) from eval logs.
 - Updated [vLLM](https://inspect.aisi.org.uk/providers.html#vllm) provider to use local server rather than in process `vllm` package (improved concurrency and resource utilization).
 - New [SGLang](https://inspect.aisi.org.uk/providers.html#sglang) provider (using similar local server architecture as vLLM provider).
+- Anthropic: Added `streaming` model argument to control whether streaming API is used (by default, streams when using extended thinking).
 - `--sample-id` option can now include task prefixes (e.g. `--sample-id=popularity:10,security:5)`).
 - Improved write performance for realtime event logging.
 - `--no-log-realtime` option for disabling realtime event logging (live viewing of logs is disabled when this is specified).

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -95,7 +95,14 @@ The `max_tokens` for any given request is determined as follows:
 1.  If you only specify `reasoning_tokens`, then the `max_tokens` will be set to `4096 + reasoning_tokens` (as 4096 is the standard Inspect default for Anthropic max tokens).
 2.  If you explicitly specify a `max_tokens`, that value will be used as the max tokens without modification (so should accomodate sufficient space for both your `reasoning_tokens` and normal output).
 
-Inspect will automatically use [response streaming](https://docs.anthropic.com/en/api/messages-streaming) whenever extended thinking is enabled to mitigate against networking issue that can occur for long running requests.
+Inspect will automatically use [response streaming](https://docs.anthropic.com/en/api/messages-streaming) whenever extended thinking is enabled to mitigate against networking issue that can occur for long running requests. You can overide the default behavior using the `streaming` model argument. For example:
+
+``` bash
+inspect eval math.py \
+  --model anthropic/claude-3-7-sonnet-latest \
+  --reasoning-tokens 4096 \
+  -M streaming=false
+```
 
 #### History
 


### PR DESCRIPTION
By default, streams when using extended thinking.

