### PR TITLE
Write file in environment with owner

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -319,8 +319,13 @@ class DockerSandboxEnvironment(SandboxEnvironment):
         return exec_result
 
     @override
-    async def write_file(self, file: str, contents: str | bytes) -> None:
-        # defualt timeout for write_file operations
+    async def write_file(
+        self,
+        file: str,
+        contents: str | bytes,
+        owner: str | None = None,
+    ) -> None:
+        # default timeout for write_file operations
         TIMEOUT = 180
 
         # resolve relative file paths
@@ -347,6 +352,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                 ],
                 input=contents,
                 timeout=TIMEOUT,
+                user=owner,
             )
         else:
             base64_contents = base64.b64encode(contents).decode("US-ASCII")
@@ -361,6 +367,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                 ],
                 input=base64_contents,
                 timeout=TIMEOUT,
+                user=owner,
             )
         if result.returncode != 0:
             if "permission denied" in result.stderr.casefold():

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -135,7 +135,12 @@ class SandboxEnvironment(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self,
+        file: str,
+        contents: str | bytes,
+        owner: str | None = None,
+    ) -> None:
         """Write a file into the sandbox environment.
 
         If the parent directories of the file path do not exist they
@@ -145,6 +150,8 @@ class SandboxEnvironment(abc.ABC):
           file: Path to file (relative file paths will resolve to the
             per-sample working directory).
           contents: Text or binary file contents.
+          owner: Optional username or UID that will be the file's owner.
+
 
         Raises:
           PermissionError: If the current user does not have permission to

--- a/src/inspect_ai/util/_sandbox/events.py
+++ b/src/inspect_ai/util/_sandbox/events.py
@@ -79,13 +79,18 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
         return result
 
     @override
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self,
+        file: str,
+        contents: str | bytes,
+        owner: str | None = None,
+    ) -> None:
         from inspect_ai.log._transcript import SandboxEvent, transcript
 
         timestamp = datetime.now()
 
         # make call
-        await self._sandbox.write_file(file, contents)
+        await self._sandbox.write_file(file, contents, owner)
 
         # yield event
         if self._events:

--- a/src/inspect_ai/util/_sandbox/local.py
+++ b/src/inspect_ai/util/_sandbox/local.py
@@ -1,3 +1,4 @@
+import shutil
 import tempfile
 import warnings
 from pathlib import Path
@@ -79,7 +80,12 @@ class LocalSandboxEnvironment(SandboxEnvironment):
         return result
 
     @override
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self,
+        file: str,
+        contents: str | bytes,
+        owner: str | None = None,
+    ) -> None:
         # resolve file and ensure the parent dir exists
         file = self._resolve_file(file)
         Path(file).parent.mkdir(parents=True, exist_ok=True)
@@ -90,6 +96,9 @@ class LocalSandboxEnvironment(SandboxEnvironment):
         else:
             with open(file, "wb") as f:
                 f.write(contents)
+
+        if owner is not None:
+            shutil.chown(file, owner)
 
     @overload
     async def read_file(self, file: str, text: Literal[True] = True) -> str: ...

--- a/tests/test_package/inspect_package/sandboxenv/podman.py
+++ b/tests/test_package/inspect_package/sandboxenv/podman.py
@@ -45,7 +45,12 @@ class PodmanSandboxEnvironment(SandboxEnvironment):
         return ExecResult(success=True, returncode=0, stdout="Hello!", stderr="")
 
     @override
-    async def write_file(self, file: str, contents: str | bytes) -> None:
+    async def write_file(
+        self,
+        file: str,
+        contents: str | bytes,
+        owner: str | None = None,
+    ) -> None:
         pass
 
     @overload


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`SandboxEnvironment.write_file()` always writes files as the default user.

### What is the new behavior?
`SandboxEnvironment.write_file()` can now optionally write files as another user.

This is very useful when customizing an environment, where you can now directly specify the owner of a file. It could of course be done by running `exec()` directly, but this addition seems like a logical extension.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.
