### PR TITLE
React agent: `answer_only` and `answer_delimiter` options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [collect()](https://inspect.aisi.org.uk/agent-custom.html#grouping-with-spans) function for enclosing parallel tasks in spans.
 - [Event tree](https://inspect.aisi.org.uk/reference/inspect_ai.log.html#event-tree) functions for organising transcript events into a tree of spans.
 - `inspect convert` now always fully re-writes log files even of the same format (so that e.g. sample summaries always exist in the converted logs).
+- React agent: `answer_only` and `answer_delimiter` to control how submitted answers are reflected in the assistant message content. 
 - Task display: Realtime display of events that occur within tool calls and subtasks.
 - Bugfix: Ensure that each MCP server gets its own cached tool list.
 

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -195,9 +195,10 @@ def react(
                     answer = submission(messages)
                     if answer is not None:
                         # set the output to the answer for scoring
-                        state.output.completion = (
-                            f"{state.output.completion}\n\n{answer}".strip()
-                        )
+                        if submit.answer_only:
+                            state.output.completion = answer
+                        else:
+                            state.output.completion = f"{state.output.completion}{submit.answer_delimiter}{answer}".strip()
 
                         # exit if we are at max_attempts
                         attempt_count += 1

--- a/src/inspect_ai/agent/_types.py
+++ b/src/inspect_ai/agent/_types.py
@@ -96,3 +96,12 @@ class AgentSubmit(NamedTuple):
 
     The tool should return the `answer` provided to it for scoring.
     """
+
+    answer_only: bool = False
+    """Set the completion to only the answer provided by the submit tool.
+
+    By default, the answer is appended (with `answer_delimiter`) to whatever
+    other content the model generated along with the call to `submit()`."""
+
+    answer_delimiter: str = "\n\n"
+    """Delimter used when appending submit tool answer to other content the model generated along with the call to `submit()`."""


### PR DESCRIPTION
Used to control how submitted answers are reflected in the assistant message content.
