### PR TITLE
python tool: execute using a bash login shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Event tree](https://inspect.aisi.org.uk/reference/inspect_ai.log.html#event-tree) functions for organising transcript events into a tree of spans.
 - `inspect convert` now always fully re-writes log files even of the same format (so that e.g. sample summaries always exist in the converted logs).
 - React agent: `answer_only` and `answer_delimiter` to control how submitted answers are reflected in the assistant message content. 
+- Python tool: Execute using a bash login shell for consistency of Python versions across `bash()` and `python()` tools.
 - Task display: Realtime display of events that occur within tool calls and subtasks.
 - Multiple choice: Support for more than 26 choices.
 - Bugfix: Ensure that each MCP server gets its own cached tool list.

--- a/src/inspect_ai/tool/_tools/_execute.py
+++ b/src/inspect_ai/tool/_tools/_execute.py
@@ -96,7 +96,10 @@ def python(
           The output of the Python code.
         """
         result = await sandbox_env(sandbox).exec(
-            cmd=["python3"], input=code, timeout=timeout, user=user
+            cmd=["bash", "--login", "-c", "python3 -"],
+            input=code,
+            timeout=timeout,
+            user=user,
         )
         # return output (including stderr if any)
         output = ""


### PR DESCRIPTION
for consistency of python versions across `bash()` and `python()` tools
