### PR TITLE
Don't enforce sample `working_limit` after sovlers have completed executing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Don't enforce sample `working_limit` after sovlers have completed executing (matching behavior of other sample limits).
+
 ## v0.3.94 (06 May 2025)
 
 - [span()](https://inspect.aisi.org.uk/agent-custom.html#grouping-with-spans) function for grouping transcript events.

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -35,6 +35,7 @@ from inspect_ai._util.registry import (
     registry_unqualified_name,
 )
 from inspect_ai._util.working import (
+    end_sample_working_limit,
     init_sample_working_limit,
     sample_waiting_time,
 )
@@ -673,6 +674,9 @@ async def task_run_sample(
 
                         # set progress for plan then run it
                         state = await plan(state, generate)
+
+                    # disable sample working limit after execution
+                    end_sample_working_limit()
 
                 except TimeoutError:
                     if time_limit is not None:

--- a/src/inspect_ai/_util/working.py
+++ b/src/inspect_ai/_util/working.py
@@ -10,6 +10,10 @@ def init_sample_working_limit(start_time: float, working_limit: float | None) ->
     _sample_waiting_time.set(0)
 
 
+def end_sample_working_limit() -> None:
+    _sample_working_limit.set(None)
+
+
 def sample_waiting_time() -> float:
     return _sample_waiting_time.get()
 


### PR DESCRIPTION
Now matches behavior of other sample limits.
