### PR TITLE
[bugfix] Adapt to latest transformers versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- vllm: Support models that don't provide a chat template (e.g. meta-llama/Llama-3.1-8B)
+
 ## v0.3.92 (26 April 2025)
 
 - OpenAI: In responses API, don't pass back assistant output that wasn't part of the output included in the server response (e.g. output generated from a call to a `submit()` tool).

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -150,12 +150,17 @@ class VLLMAPI(ModelAPI):
         # convert to chat template input format
         chat_messages = chat_api_input(messages, tools, ChatAPIHandler(self.model_name))
         # apply chat template
-        chat = self.tokenizer.apply_chat_template(
-            chat_messages,
-            add_generation_prompt=True,
-            tokenize=False,
-            chat_template=self.chat_template,
-        )
+        if self.tokenizer.chat_template is not None:
+            chat = self.tokenizer.apply_chat_template(
+                chat_messages,
+                add_generation_prompt=True,
+                tokenize=False,
+                chat_template=self.chat_template,
+            )
+        else:
+            chat = ""
+            for message in chat_messages:
+                chat += f"{message['role']}: {message['content']}\n"
         return cast(str, chat)
 
     @override


### PR DESCRIPTION
namely the absence of a default chat template

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Models failing to provide a chat template would not be executed through vllm (because of latest changes to the transformers library) in inspect_ai 3.92.

### What is the new behavior?
Models failing to provide a chat template can be executed through vllm (by applying a default chat templating in the very same fashion as : #1108 ) in inspect_ai 3.92.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
**This PR will not be merged because of the changes brought as of version 3.93 on inspect_ai, which moved from a python based vllm to the CLI version.**
Feel free to close it. Whenever #1809 is addressed, and if there is a need, I can port it to the new vllm wrapping solution.