### PR TITLE
only pass `user` parameter on to sandboxes if is not `None`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-- Don't enforce sample `working_limit` after sovlers have completed executing (matching behavior of other sample limits).
+- Only pass `user` parameter on to sandboxes if is not `None` (eases compatibility with older sandbox providers).
+- Don't enforce sample `working_limit` after solvers have completed executing (matching behavior of other sample limits).
 
 ## v0.3.94 (06 May 2025)
 

--- a/src/inspect_ai/util/_sandbox/events.py
+++ b/src/inspect_ai/util/_sandbox/events.py
@@ -1,7 +1,7 @@
 import contextlib
 import shlex
 from datetime import datetime
-from typing import Iterator, Literal, Type, Union, overload
+from typing import Any, Iterator, Literal, Type, Union, overload
 
 from pydantic import JsonValue
 from pydantic_core import to_jsonable_python
@@ -134,7 +134,8 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
 
     @override
     async def connection(self, *, user: str | None = None) -> SandboxConnection:
-        return await self._sandbox.connection(user=user)
+        params: dict[str, Any] = {"user": user} if user is not None else {}
+        return await self._sandbox.connection(**params)
 
     @override
     def as_type(self, sandbox_cls: Type[ST]) -> ST:


### PR DESCRIPTION
eases compatibility with older sandbox providers

