### PR TITLE
Fix unintentional breaking change in `web_search` caused by removing a default value.

### DIFF
--- a/src/inspect_ai/tool/_tools/_web_search/_web_search.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_web_search.py
@@ -9,7 +9,7 @@ from ._tavily import tavily_search_provider
 
 @tool
 def web_search(
-    provider: Literal["tavily", "google"] | None,
+    provider: Literal["tavily", "google"] | None = None,
     num_results: int = 3,
     max_provider_calls: int = 3,
     max_connections: int = 10,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Prior to #1817, `web_search` had a default value for `provider`. Despite writing backward compatibility code, I mistakenly removed the default value.

### What is the new behavior?
The default value is now `None`. This will allow old code to continue to build without error, and it will do runtime checks to see if it's likely that "google" was the intended provider.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
