### PR TITLE
Fix use of text editor tool with Claude 3.5 Sonnet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Ignore OSError that occurs while rotating trace files.
 - Bugfix: Ensure that "init" span is exited in the same async context when sandbox connection errors occur.
 - Bugfix: Protect against no `thought` argument being passed to `think()` tool.
+- Bugfix: Correct handling of `text_editor()` tool for Claude Sonnet 3.5.
 
 ## v0.3.94 (06 May 2025)
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -28,6 +28,7 @@ from anthropic.types import (
     ThinkingBlockParam,
     ToolParam,
     ToolResultBlockParam,
+    ToolTextEditor20241022Param,
     ToolTextEditor20250124Param,
     ToolUseBlock,
     ToolUseBlockParam,
@@ -570,8 +571,14 @@ class AnthropicAPI(ModelAPI):
                 ]
             )
         ):
-            return ToolTextEditor20250124Param(
-                type="text_editor_20250124", name="str_replace_editor"
+            return (
+                ToolTextEditor20241022Param(
+                    type="text_editor_20241022", name="str_replace_editor"
+                )
+                if self.is_claude_3_5()
+                else ToolTextEditor20250124Param(
+                    type="text_editor_20250124", name="str_replace_editor"
+                )
             )
         # not a text_editor tool
         else:
@@ -853,6 +860,7 @@ def _names_for_tool_call(
     """
     mappings = (
         (INTERNAL_COMPUTER_TOOL_NAME, "computer_20250124", "computer"),
+        ("str_replace_editor", "text_editor_20241022", "text_editor"),
         ("str_replace_editor", "text_editor_20250124", "text_editor"),
         ("bash", "bash_20250124", "bash_session"),
     )

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -28,13 +28,15 @@ from anthropic.types import (
     ThinkingBlockParam,
     ToolParam,
     ToolResultBlockParam,
-    ToolTextEditor20241022Param,
     ToolTextEditor20250124Param,
     ToolUseBlock,
     ToolUseBlockParam,
     message_create_params,
 )
-from anthropic.types.beta import BetaToolComputerUse20250124Param
+from anthropic.types.beta import (
+    BetaToolComputerUse20250124Param,
+    BetaToolTextEditor20241022Param,
+)
 from pydantic import JsonValue
 from typing_extensions import override
 
@@ -219,6 +221,8 @@ class AnthropicAPI(ModelAPI):
                 # tools are generally available for Claude 3.5 Sonnet (new) as well and
                 # can be used without the computer use beta header.
                 betas.append("computer-use-2025-01-24")
+            if any("20241022" in str(tool.get("type", "")) for tool in tools_param):
+                betas.append("computer-use-2024-10-22")
             if len(betas) > 0:
                 extra_headers["anthropic-beta"] = ",".join(betas)
 
@@ -555,7 +559,7 @@ class AnthropicAPI(ModelAPI):
 
     def text_editor_tool_param(
         self, tool: ToolInfo
-    ) -> Optional[ToolTextEditor20250124Param]:
+    ) -> ToolTextEditor20250124Param | BetaToolTextEditor20241022Param | None:
         # check for compatible 'text editor' tool
         if tool.name == "text_editor" and (
             sorted(tool.parameters.properties.keys())
@@ -572,7 +576,7 @@ class AnthropicAPI(ModelAPI):
             )
         ):
             return (
-                ToolTextEditor20241022Param(
+                BetaToolTextEditor20241022Param(
                     type="text_editor_20241022", name="str_replace_editor"
                 )
                 if self.is_claude_3_5()
@@ -587,7 +591,10 @@ class AnthropicAPI(ModelAPI):
 
 # tools can be either a stock tool param or a special Anthropic native use tool param
 ToolParamDef = (
-    ToolParam | BetaToolComputerUse20250124Param | ToolTextEditor20250124Param
+    ToolParam
+    | BetaToolComputerUse20250124Param
+    | ToolTextEditor20250124Param
+    | BetaToolTextEditor20241022Param
 )
 
 
@@ -596,6 +603,7 @@ def add_cache_control(
     | ToolParam
     | BetaToolComputerUse20250124Param
     | ToolTextEditor20250124Param
+    | BetaToolTextEditor20241022Param
     | dict[str, Any],
 ) -> None:
     cast(dict[str, Any], param)["cache_control"] = {"type": "ephemeral"}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`RuntimeError: BadRequestError('Error code: 400 - {\'type\': \'error\', \'error\': {\'type\': \'invalid_request_error\', \'message\': "\'claude-3-5-sonnet-20240620\' does not support tool types: text_editor_20250124."}}'`

This is because Anthropic uses slightly different tool schema names between 3.5 and 3.7.

> Anthropic’s text editor tool is only available for Claude 3.5 Sonnet and Claude 3.7 Sonnet:
>
> - Claude 3.7 Sonnet: text_editor_20250124
> - Claude 3.5 Sonnet: text_editor_20241022

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
