### PR TITLE
Binding port reservation on MacOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 
 - Model Context Protocol: Upgrade sandbox client to typing changes made in v1.8.0 of `mcp` package.
+- vLLM/SGLang: Fix dynamic port binding for local server on Mac OS X.
 
 ## v0.3.95 (10 May 2025)
 


### PR DESCRIPTION
Use system to identify a free port.
Don't reserve it.

Closes  #1809

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Connection to vllm server fails on MacOS from version 3.93.

### What is the new behavior?
Connection to vllm server succeeds on MacOS.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
From the doc:
```
        # On macOS, let the OS pick a free port but not open it
        # It leads to a small racode condition window until the port
        # is actually opened by the llm server
        with socket.socket(socket.AF_INET, socket
```