### PR TITLE
Update _task_state.py

### DIFF
--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -138,7 +138,7 @@ class TaskState:
     The `TaskState` represents the internal state of the `Task` being run for a single `Sample`.
 
     The `TaskState` is passed to and returned from each solver during a sample's
-    evaluation. It allows us to manipulated the message history, the tools
+    evaluation. It allows us to maintain the manipulated the message history, the tools
     available to the model, the final output of the model, and whether the task
     is completed or has hit a limit.
     """


### PR DESCRIPTION
Slightly changed the 'TaskState' docstring to improve grammar.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [X] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
"""The TaskState is passed to and returned from each solver during a sample's
    evaluation. It allows us to manipulated the message history, the tools
    available to the model, the final output of the model, and whether the task
    is completed or has hit a limit."""

### What is the new behavior?
"""The TaskState is passed to and returned from each solver during a sample's
    evaluation. It allows us to **maintain the** manipulated the message history, the tools
    available to the model, the final output of the model, and whether the task
    is completed or has hit a limit."""

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Nope

### Other information:
Very small change to grammar made to doctstring. - It could be that 'track' might be a better word than 'maintain'.
