### PR TITLE
AzureAI: Don't include `tools` or `tool_choice` in requests when emulating tool calling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - React agent: Use of `submit()` tool is now [optional](https://inspect.aisi.org.uk/agent.html#submit-tool).
 - Anthropic: Show warning when generation config incompatible with extended thinking is used (affects `temperature`, `top_p`, and `top_k`).
+- AzureAI: Don't include `tools` or `tool_choice` in  requests when emulating tool calling (avoiding a 400 error).
 
 
 ## v0.3.96 (13 May 2025)


### PR DESCRIPTION
Newer versions of vllm reject requests with tools or tool_choice if the server hasn't been started explicitly with the `--tool-call-parser` and  `--enable-auto-tool-choice` flags
