### PR TITLE
Change more list types to sequence

### DIFF
--- a/src/inspect_ai/analysis/beta/_dataframe/evals/table.py
+++ b/src/inspect_ai/analysis/beta/_dataframe/evals/table.py
@@ -31,7 +31,7 @@ EVAL_SUFFIX = "_eval"
 @overload
 def evals_df(
     logs: LogPaths = list_eval_logs(),
-    columns: list[Column] = EvalColumns,
+    columns: Sequence[Column] = EvalColumns,
     strict: Literal[True] = True,
 ) -> "pd.DataFrame": ...
 
@@ -39,16 +39,16 @@ def evals_df(
 @overload
 def evals_df(
     logs: LogPaths = list_eval_logs(),
-    columns: list[Column] = EvalColumns,
+    columns: Sequence[Column] = EvalColumns,
     strict: Literal[False] = False,
-) -> tuple["pd.DataFrame", list[ColumnError]]: ...
+) -> tuple["pd.DataFrame", Sequence[ColumnError]]: ...
 
 
 def evals_df(
     logs: LogPaths = list_eval_logs(),
     columns: Sequence[Column] = EvalColumns,
     strict: bool = True,
-) -> "pd.DataFrame" | tuple["pd.DataFrame", list[ColumnError]]:
+) -> "pd.DataFrame" | tuple["pd.DataFrame", Sequence[ColumnError]]:
     """Read a dataframe containing evals.
 
     Args:
@@ -82,30 +82,30 @@ def evals_df(
 
 @overload
 def _read_evals_df(
-    log_paths: list[str],
+    log_paths: Sequence[str],
     columns: Sequence[Column],
     strict: Literal[True],
     progress: Callable[[], None],
-) -> tuple["pd.DataFrame", list[EvalLog], int]: ...
+) -> tuple["pd.DataFrame", Sequence[EvalLog], int]: ...
 
 
 @overload
 def _read_evals_df(
-    log_paths: list[str],
+    log_paths: Sequence[str],
     columns: Sequence[Column],
     strict: Literal[False],
     progress: Callable[[], None],
-) -> tuple["pd.DataFrame", list[EvalLog], list[ColumnError], int]: ...
+) -> tuple["pd.DataFrame", Sequence[EvalLog], Sequence[ColumnError], int]: ...
 
 
 def _read_evals_df(
-    log_paths: list[str],
+    log_paths: Sequence[str],
     columns: Sequence[Column],
     strict: bool,
     progress: Callable[[], None],
 ) -> (
-    tuple["pd.DataFrame", list[EvalLog], int]
-    | tuple["pd.DataFrame", list[EvalLog], list[ColumnError], int]
+    tuple["pd.DataFrame", Sequence[EvalLog], int]
+    | tuple["pd.DataFrame", Sequence[EvalLog], Sequence[ColumnError], int]
 ):
     verify_prerequisites()
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
This was done partially in #1867 but some were missed. The important ones are the overloads of `evals_df` -- without those I can't pass `evals_df` a list that includes subtypes of `Column`. But I didn't see a downside to changing all of them to sequence.