### PR TITLE
Disable Gemini reasoning when reasoning_tokens is set to zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Google: Disable reasoning when `reasoning_tokens` is set to 0.
 - Temporarily pin to textual < 3.0.0 to work around event loop breakage.
 
 ## v0.3.97 (16 May 2025)

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -350,6 +350,12 @@ class GoogleGenAIAPI(ModelAPI):
             self.is_gemini() and not self.is_gemini_1_5() and not self.is_gemini_2_0()
         )
         if has_thinking_config:
+            if config.reasoning_tokens == 0:
+                # When reasoning_tokens is set to zero, we disable reasoning and return None.
+                # We cannot return a ThinkingConfig with reasoning_tokens set to 0,
+                # as this will cause the Gemini API to return a 400 INVALID_ARGUMENT error.
+                return None
+
             return ThinkingConfig(
                 include_thoughts=True, thinking_budget=config.reasoning_tokens
             )


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When a Google Gemini models that supports thinking is called via Vertex AI with `--reasoning-tokens 0`, this results in the following error:
```
ClientError: 400 INVALID_ARGUMENT. {'error': {'code': 400, 'message': 'Unable to submit request because Thinking_config.include_thoughts 
is only enabled when thinking is enabled.. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini', 
'status': 'INVALID_ARGUMENT'}}
``` 

You can reproduce this error using the following command:
```
inspect eval examples/hello_world.py --model google/vertex/gemini-2.5-flash-preview-04-17 --reasoning-tokens 0
```

### What is the new behavior?
When `--reasoning-tokens 0` is passed, we explicitly disable thinking in a way that does not result in an error. Running the command above no longer results in an error. Instead, it results in a successful run that looks like this:
<img width="182" alt="image" src="https://github.com/user-attachments/assets/c66c4222-1e9c-4f75-b2cb-88871222de68" />

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.