### PR TITLE
Fix breakage of sample_id task prefix

### DIFF
--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -475,7 +475,10 @@ async def startup_sandbox_environments(
     sandboxenvs: Set[TaskSandboxEnvironment] = set()
     for task in tasks:
         # resolve each sample and add to sandboxenvs
-        dataset = slice_dataset(task.task.dataset, config.limit, config.sample_id)
+        resolved_task_sample_ids = resolve_task_sample_ids(
+            task.task.name, config.sample_id
+        )
+        dataset = slice_dataset(task.task.dataset, config.limit, resolved_task_sample_ids)
         for sample in dataset:
             sandbox = await resolve_sandbox_for_task_and_sample(
                 eval_sandbox, task.task, sample

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -478,7 +478,9 @@ async def startup_sandbox_environments(
         resolved_task_sample_ids = resolve_task_sample_ids(
             task.task.name, config.sample_id
         )
-        dataset = slice_dataset(task.task.dataset, config.limit, resolved_task_sample_ids)
+        dataset = slice_dataset(
+            task.task.dataset, config.limit, resolved_task_sample_ids
+        )
         for sample in dataset:
             sandbox = await resolve_sandbox_for_task_and_sample(
                 eval_sandbox, task.task, sample

--- a/tests/test_sample_id.py
+++ b/tests/test_sample_id.py
@@ -55,6 +55,18 @@ def test_sample_id_task_preface():
         log = eval(task, sample_id=["bar:5", "bar:6"], model="mockllm/model")[0]
 
 
+def test_sample_id_task_preface_with_sandbox():
+    task = Task(
+        name="foo",
+        dataset=[Sample(id="sample", input=f"Input for sample")],
+        sandbox="local",
+    )
+    # qualifier
+    log = eval(task, sample_id="foo:sample", model="mockllm/model")[0]
+    assert log.samples
+    assert len(log.samples) == 1
+
+
 def test_sample_id_task_preface_multiple():
     task1 = Task(
         name="foo",

--- a/tests/test_sample_id.py
+++ b/tests/test_sample_id.py
@@ -58,7 +58,7 @@ def test_sample_id_task_preface():
 def test_sample_id_task_preface_with_sandbox():
     task = Task(
         name="foo",
-        dataset=[Sample(id="sample", input=f"Input for sample")],
+        dataset=[Sample(id="sample", input="Input for sample")],
         sandbox="local",
     )
     # qualifier


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

#1865 broke passing sample_ids with a task prefix (i.e. `sample_id=task:sample` from #1782)

When setting up the sandboxes in `eval_run()`, `startup_sandbox_environments()` passes the unresolved sample_ids to slice_dataset, which breaks it. I guess the sandbox might have gotten empty sample_ids when using sample_id task prefixes earlier as well, but it didn't cause an error before.

### What is the new behavior?

You can use sample_ids with task prefixes again

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

