### PR TITLE
Fix task return order in `run_multiple`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Exported `view()` function for running Inspect View from Python.
+- Always return tasks in the same order they were passed to `eval()` or `eval_set()`.
 - Google: Updated required version of `google-genai` to 1.16.1 (which includes support for reasoning summaries and is now compatible with the trio async backend).
 
 ## v0.3.98 (18 May 2025)

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -301,7 +301,7 @@ async def run_multiple(tasks: list[TaskRunOptions], parallel: int) -> list[EvalL
     results: list[tuple[int, EvalLog]] = []
     tasks_completed = 0
     total_tasks = len(tasks)
-    
+
     # Create a mapping from task to its original index
     task_to_original_index = {id(task): i for i, task in enumerate(tasks)}
 
@@ -435,6 +435,7 @@ async def run_multiple(tasks: list[TaskRunOptions], parallel: int) -> list[EvalL
 
         # Sort results by original index and return just the values
         return [r for _, r in sorted(results)]
+
 
 def resolve_task_sample_ids(
     task: str, sample_id: str | int | list[str] | list[int] | list[str | int] | None


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`run_multiple` will return tasks in the order they finish.

### What is the new behavior?

`run_multiple` will return tasks in the order they are passed in

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
