### PR TITLE
Google: Updated required version of `google-genai` to 1.16.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Exported `view()` function for running Inspect View from Python.
+- Google: Updated required version of `google-genai` to 1.16.1 (which includes support for reasoning summaries and is now compatible with the trio async backend).
 
 ## v0.3.98 (18 May 2025)
 

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -307,8 +307,7 @@ Note that there are some features of Inspect that do not yet work when using Tri
 
 2. Interaction with AWS S3 (e.g. for log storage) uses the [s3fs](https://s3fs.readthedocs.io/en/latest/) package, which currently works only with asyncio.
 
-3. The [Google](providers.qmd#google) and [Bedrock](providers.qmd#aws-bedrock) providers both depend on asyncio so cannot be used with the Trio backend.
-
+3. The [Bedrock](providers.qmd#aws-bedrock) provider depends on asyncio so cannot be used with the Trio backend.
 
 ### Portable Async
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -116,9 +116,9 @@ When using tools, you should read Anthropic's documentation on [extended thinkin
 
 Google currently makes available several Gemini reasoning models, the most recent of which are:
 
-- [Gemini 2.5 Flash](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash): `google/gemini-2.5-flash-preview-04-17`
+- [Gemini 2.5 Flash](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-flash): `google/gemini-2.5-flash-preview-05-20`
 
-- [Gemini 2.5 Pro](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro):  `google/gemini-2.5-pro-preview-03-25`
+- [Gemini 2.5 Pro](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/2-5-pro):  `google/gemini-2.5-pro-preview-05-06`
 
 You can use the `--reasoning-tokens` option to control the amount of reasoning used by these models. For example:
 
@@ -128,7 +128,7 @@ inspect eval math.py \
   --reasoning-tokens 4096
 ```
 
-The Gemini API includes support for including reasoning in model output, however this feature is not yet enabled for any of their deployed reasoning models.
+The most recent Gemini models also include support for including a reasoning summary in model output.
 
 ## Grok
 

--- a/src/inspect_ai/_util/_async.py
+++ b/src/inspect_ai/_util/_async.py
@@ -136,7 +136,7 @@ def current_async_backend() -> Literal["asyncio", "trio"] | None:
 
 
 def configured_async_backend() -> Literal["asyncio", "trio"]:
-    backend = os.environ.get("INSPECT_ASYNC_BACKEND", "asyncio").lower()
+    backend = os.environ.get("INSPECT_ASYNC_BACKEND", "asyncio").lower() or "asyncio"
     return _validate_backend(backend)
 
 

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -105,7 +105,7 @@ def vertex() -> type[ModelAPI]:
 def google() -> type[ModelAPI]:
     FEATURE = "Google API"
     PACKAGE = "google-genai"
-    MIN_VERSION = "1.12.1"
+    MIN_VERSION = "1.16.1"
 
     # verify we have the package
     try:

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -8,7 +8,6 @@ from inspect_ai.scorer import includes
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_google_safety_settings():
     safety_settings = dict(
         dangerous_content="medium_and_above",
@@ -27,7 +26,6 @@ def test_google_safety_settings():
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_google_block_reason():
     safety_settings = dict(harassment="low")
     eval(

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1,5 +1,5 @@
 from google.genai.types import Candidate, Content, FinishReason
-from test_helpers.utils import skip_if_no_google, skip_if_trio
+from test_helpers.utils import skip_if_no_google
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample

--- a/tests/model/test_api_key.py
+++ b/tests/model/test_api_key.py
@@ -9,7 +9,6 @@ from test_helpers.utils import (
     skip_if_no_mistral,
     skip_if_no_openai,
     skip_if_no_together,
-    skip_if_trio,
 )
 
 from inspect_ai.model import get_model

--- a/tests/model/test_api_key.py
+++ b/tests/model/test_api_key.py
@@ -54,7 +54,6 @@ async def test_anthropic_api_key():
 
 @pytest.mark.anyio
 @skip_if_no_google
-@skip_if_trio
 async def test_google_api_key():
     await check_explicit_api_key("google/gemini-1.5-pro", "GOOGLE_API_KEY")
 

--- a/tests/model/test_structured_output.py
+++ b/tests/model/test_structured_output.py
@@ -148,7 +148,6 @@ def test_openai_responses_structured_output():
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_google_structured_output():
     check_color_structured_output("google/gemini-2.0-flash")
     check_nested_pydantic_output("google/gemini-2.0-flash")

--- a/tests/model/test_structured_output.py
+++ b/tests/model/test_structured_output.py
@@ -3,7 +3,6 @@ from test_helpers.utils import (
     skip_if_no_google,
     skip_if_no_mistral,
     skip_if_no_openai,
-    skip_if_trio,
 )
 
 from inspect_ai import Task, eval, task

--- a/tests/tools/test_tool_images.py
+++ b/tests/tools/test_tool_images.py
@@ -58,7 +58,6 @@ def test_openai_responses_tool_image_result():
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_google_tool_image_result():
     check_tool_image_result("google/gemini-1.5-pro")
 

--- a/tests/tools/test_tool_images.py
+++ b/tests/tools/test_tool_images.py
@@ -2,7 +2,6 @@ from test_helpers.utils import (
     skip_if_no_anthropic,
     skip_if_no_google,
     skip_if_no_openai,
-    skip_if_trio,
 )
 
 from inspect_ai import Task, eval, task

--- a/tests/tools/test_tool_types.py
+++ b/tests/tools/test_tool_types.py
@@ -282,7 +282,6 @@ def test_anthropoic_tool_types() -> None:
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_google_tool_types() -> None:
     check_tool_types("google/gemini-1.5-pro")
 

--- a/tests/tools/test_tool_types.py
+++ b/tests/tools/test_tool_types.py
@@ -9,7 +9,6 @@ from test_helpers.utils import (
     skip_if_no_mistral,
     skip_if_no_openai,
     skip_if_no_vertex,
-    skip_if_trio,
 )
 
 from inspect_ai import Task, eval

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -190,7 +190,6 @@ def test_mistral_tools():
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_google_tools():
     check_tools("google/gemini-1.5-pro")
 

--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -13,7 +13,6 @@ from test_helpers.utils import (
     skip_if_no_mistral,
     skip_if_no_openai,
     skip_if_no_vertex,
-    skip_if_trio,
 )
 
 from inspect_ai import Task, eval

--- a/tests/util/test_images.py
+++ b/tests/util/test_images.py
@@ -7,7 +7,6 @@ from test_helpers.utils import (
     skip_if_no_mistral,
     skip_if_no_openai,
     skip_if_no_vertex,
-    skip_if_trio,
 )
 
 from inspect_ai import Task, eval, task

--- a/tests/util/test_images.py
+++ b/tests/util/test_images.py
@@ -37,7 +37,6 @@ def check_images(model):
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_google_images():
     check_images("google/gemini-1.5-flash")
 

--- a/tests/util/test_media.py
+++ b/tests/util/test_media.py
@@ -4,7 +4,6 @@ from test_helpers.utils import (
     skip_if_no_google,
     skip_if_no_openai,
     skip_if_no_vertex,
-    skip_if_trio,
 )
 
 from inspect_ai import Task, eval, task

--- a/tests/util/test_media.py
+++ b/tests/util/test_media.py
@@ -46,13 +46,11 @@ def check_video(model):
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_media_google_audio():
     check_audio("google/gemini-1.5-flash")
 
 
 @skip_if_no_google
-@skip_if_trio
 def test_media_google_video():
     check_video("google/gemini-1.5-flash")
 


### PR DESCRIPTION
Includes support for reasoning summaries and is now compatible with the trio async backend
