### PR TITLE
inspect view bundle: preserve mtime-ordering in the output log directory

### DIFF
--- a/src/inspect_ai/log/_bundle.py
+++ b/src/inspect_ai/log/_bundle.py
@@ -201,8 +201,10 @@ def move_output(
                 output_fs.mkdir(dir_path)
             tick()
 
-            # Copy the files
-            for working_file in files:
+            # Copy the files, preserving relative mtime ordering
+            for _, working_file in sorted(
+                (os.stat(os.path.join(root, f)).st_mtime, f) for f in files
+            ):
                 target_path = (
                     os.path.join(relative_dir, working_file)
                     if relative_dir != "."


### PR DESCRIPTION
Fixes #1904

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When `inspect view bundle` copies log files from the input directory to the output directory, it changes their relative mtime-ordering. This has the effect of scrambling the ordering of experiments in the sidebar in certain (maybe unusual!) conditions. See #1904 for a full description.

### What is the new behavior?

The relative mtime-ordering is now preserved.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
