### PR TITLE
Fix `check-schema-and-types` GitHub CI job.

### DIFF
--- a/.github/workflows/log_viewer.yml
+++ b/.github/workflows/log_viewer.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           node-version: "22.x"
       - name: Install Node.js dependencies
+        working-directory: src/inspect_ai/_view/www
         run: yarn install --frozen-lockfile
 
       - name: Update schema and types

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ nest_asyncio
 numpy
 platformdirs>=2.3.0
 psutil
-pydantic>=2
+pydantic>=2.11.4
 python-dotenv>=0.16.0
 pyyaml
 rich>=13.3.3,<14.0.0 # https://github.com/Textualize/rich/issues/3682

--- a/src/inspect_ai/_view/schema.py
+++ b/src/inspect_ai/_view/schema.py
@@ -45,9 +45,10 @@ def sync_view_schema() -> None:
                 "false",
             ],
             cwd=WWW_DIR,
+            check=True,
         )
 
-        subprocess.run(["yarn", "prettier:write"], cwd=types_path.parent)
+        subprocess.run(["yarn", "prettier:write"], cwd=types_path.parent, check=True)
 
         shutil.copyfile(types_path, vs_code_types_path)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The new job introduced with #1897, failed for any PR that actually changed the schema. cc @tbroadley 

### What is the new behavior?
- Properly sets the working directory before doing `yarn install`
- `schema.py` now properly checks the subprocess result results from the calls to `json2ts` and `prettier`
- Bumps the required version of `pydantic` to avoid differences in the generated schema between local machines and GitHub (despite being within the same major version `pydantic` effectively made a breaking change causing generated schemas to differ).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
