### PR TITLE
add mechanisms to allow docker containers to be reused

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -154,6 +154,11 @@ class DockerSandboxEnvironment(SandboxEnvironment):
         return {}
 
     @override
+    def project_name(self) -> str:
+        """Get the project name of the current sandbox. (Only applicable to docker compose based sandboxes.)"""
+        return self._project.name
+
+    @override
     @classmethod
     async def sample_init(
         cls,

--- a/src/inspect_ai/util/_sandbox/docker/docker_reuse.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker_reuse.py
@@ -1,0 +1,27 @@
+from typing import Any
+
+from typing_extensions import override
+
+from pydantic import BaseModel
+
+from ..registry import sandboxenv
+from .docker import DockerSandboxEnvironment
+
+class DockerReuseConfig(BaseModel, frozen=True):
+    reuse : str
+
+@sandboxenv(name="docker.reuse")
+class DockerReuseSandboxEnvironment(DockerSandboxEnvironment):
+    @override
+    @classmethod
+    def is_reuse_sandbox(cls) -> bool:
+        return True
+
+    @override
+    @classmethod
+    def get_compose_project_name(cls, config, task_name) -> str:
+        return config.reuse
+
+    @classmethod
+    def config_deserialize(cls, config: dict[str, Any]) -> BaseModel:
+        return DockerReuseConfig(reuse=config["reuse"])

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -334,6 +334,10 @@ class SandboxEnvironment(abc.ABC):
         """Standard config files for this provider (used for automatic discovery)"""
         return []
 
+    def project_name(self) -> str:
+        """Get the project name of the current sandbox. (Only applicable to docker compose based sandboxes.)"""
+        raise NotImplementedError("This type of sandbox doesn't have a project name.")
+
     @classmethod
     def config_deserialize(cls, config: dict[str, Any]) -> BaseModel:
         """Deserialize a sandbox-specific configuration model from a dict.

--- a/src/inspect_ai/util/_sandbox/events.py
+++ b/src/inspect_ai/util/_sandbox/events.py
@@ -164,6 +164,11 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
     ) -> None:
         pass
 
+    @override
+    def project_name(self) -> str:
+        """Get the project name of the current sandbox. (Only applicable to docker compose based sandboxes.)"""
+        return self._sandbox.project_name()
+
 
 def content_display(content: str | bytes) -> str:
     if isinstance(content, str):


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

You can prevent containers from being deleted, and delete them later if you want, but each new execution of a particular sample will always create a new container for that sample.

### What is the new behavior?

In some cases, it might be beneficial to reuse the container for sample, in a subsequent run (if for instance we are saving and replaying the history across multiple runs in a test of an agent). This patch suggests one way to do this, by:

1. adding a way to identify the container (well, compose project name) for a sample, using `sandbox().project_name()`
2. adding a new sandbox environment, called "docker.reuse", which must be accompanied by a config dict of the form `{"reuse": "<compose project name>"}`

This no doubt has other implications that haven't been covered yet, but the intent of this PR currently is more akin to a RFC or something. In particular, more work will probably need to be done for tests and ensuring that the system can't be easily used incorrectly (i.e. should the container reuse be limited to samples only, and should it force sequential execution of samples, so you don't have two samples trying to use the same container at the same time?)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

This patch isn't intended to affect the behaviour of tasks/samples/evals already using `sandbox="docker"`. It should just add new functionality, accessed using `sandbox="docker.reuse"`.