### PR TITLE
Limit concurrent compose_command calls

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -306,7 +306,7 @@ async def compose_command(
 
     # set a concurrency limit for docker CLI invocations.
     # this should help with running more containers in parallel while avoiding hangs on some systems
-    DEFAULT_CLI_CONCURRENCY = min((os.cpu_count() or 1) * 2, 4)
+    DEFAULT_CLI_CONCURRENCY = max((os.cpu_count() or 1) * 2, 4)
     docker_cli_concurrency = int(
         os.environ.get("INSPECT_DOCKER_CLI_CONCURRENCY", DEFAULT_CLI_CONCURRENCY)
     )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

See the [Slack thread with an MRE](https://inspectcommunity.slack.com/archives/C080K7SQ4SG/p1746190208128689)

Copying the OP:

> I continue to run into rare issues with my evals hanging for hours on some container command, ignoring my bash timeout and max sample time limit. The commands that cause it are always something that either takes a lot of CPU or has a lot of output (e.g. ls -R . or grep -r "query" /). The eval then hangs, with just that one sample left around for hours, despite me having configured (1) the bash timeout (30 seconds) and (2) sample time limit (10 minutes). ~~So far, I've failed to reproduce it in a controlled setup.~~ Is there any hardening we can do to ensure the bash timeout and/or the sample timeout are always respected, even if e.g. the container is not responding?

### What is the new behavior?

Set a concurrency limit for the number of concurrent `docker compose` invocations, overridable with an environment variable. This limits how many `exec()` calls will be concurrently made, while still allowing a high number of concurrent _containers_ — helpful when your evaluation samples are mostly model-bottlenecked.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

If users were relying on a higher CLI concurrency than the current default (`max((os.cpu_count or 1) * 2, 4)`), they would need to bump `INSPECT_DOCKER_CLI_CONCURRENCY`.

### Other information:

This change seems sufficient to unblock me, but ideally, we'd allow a higher number of concurrent commands. According to `o3`, this would require switching away from executing commands via `docker compose` to directly calling the docker daemon via `docker exec`, but AFAIR we moved in the other direction in the past for related reasons. Would love for someone to look into a better fix.