### PR TITLE
Attachment warning

### DIFF
--- a/src/inspect_ai/_view/www/src/client/api/api-browser.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-browser.ts
@@ -113,11 +113,11 @@ async function eval_log_sample_data(
   params.append("log", log_file);
   params.append("id", String(id));
   params.append("epoch", String(epoch));
-  if (last_event) {
+  if (last_event !== undefined) {
     params.append("last-event-id", String(last_event));
   }
 
-  if (last_attachment) {
+  if (last_attachment !== undefined) {
     params.append("after-attachment-id", String(last_attachment));
   }
 

--- a/src/inspect_ai/_view/www/src/state/samplePolling.ts
+++ b/src/inspect_ai/_view/www/src/state/samplePolling.ts
@@ -283,6 +283,14 @@ function processEvents(sampleData: SampleData, pollingState: PollingState) {
     const resolvedEvent = resolveAttachments<Event>(
       eventData.event,
       pollingState.attachments,
+      (attachmentId: string) => {
+        const snapshot = {
+          eventId: eventData.event_id,
+          attachmentId,
+          available_attachments: Object.keys(pollingState.attachments),
+        };
+        console.warn(`Unable to resolve attachment ${attachmentId}`, snapshot);
+      },
     );
 
     if (existingIndex) {

--- a/src/inspect_ai/_view/www/src/utils/attachments.ts
+++ b/src/inspect_ai/_view/www/src/utils/attachments.ts
@@ -1,6 +1,7 @@
 export const resolveAttachments = <T>(
   value: T,
   attachments: Record<string, string>,
+  onFailedResolve?: (attachmentId: string) => void,
 ): T => {
   const CONTENT_PROTOCOL = "tc://";
   const ATTACHMENT_PROTOCOL = "attachment://";
@@ -56,6 +57,9 @@ export const resolveAttachments = <T>(
         const attachment = attachments[attachmentId];
 
         // Return the attachment content if it exists, otherwise return the original string
+        if (attachment === undefined && onFailedResolve) {
+          onFailedResolve(attachmentId);
+        }
         return (attachment !== undefined ? attachment : value) as unknown as T;
       }
 
@@ -66,6 +70,9 @@ export const resolveAttachments = <T>(
     if (value.startsWith(ATTACHMENT_PROTOCOL)) {
       const attachmentId = value.slice(ATTACHMENT_PROTOCOL.length);
       const attachment = attachments[attachmentId];
+      if (attachment === undefined && onFailedResolve) {
+        onFailedResolve(attachmentId);
+      }
 
       // Return the attachment content if it exists, otherwise return the original string
       return (attachment !== undefined ? attachment : value) as unknown as T;


### PR DESCRIPTION
Add an optional handler to deal with attachments that fail to resolve. Add a sample polling handler that will log polling state to the console as a warning when this happens.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor


