### PR TITLE
Fix to make inspect ai mlx compatible

### DIFF
--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -594,7 +594,7 @@ def chat_choices_from_openai(
             stop_reason=as_stop_reason(choice.finish_reason),
             logprobs=(
                 Logprobs(**choice.logprobs.model_dump())
-                if choice.logprobs is not None
+                if choice.logprobs and choice.logprobs.content is not None
                 else None
             ),
         )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`inspect eval biology_qa.py --model openai/mlx_community/Llama-3.1-8B-Instruct --model-base-url=http://10.0.0.100:8001/v1` 
which accesses local mlx server running on 10.0.0.100 like `python -m mlx_lm server --model mlx-community/Llama-3.1-8B-Instruct --host 0.0.0.0 --port 8001` 

crashed with
```
│ │ ❱  253 │   │   validated_self = self.__pydantic_validator__.validate_python(data, self_instance                      │                  │
│ │    254 │   │   if self is not validated_self:                                                                        │                  │
│ │    255 │   │   │   warnings.warn(                                                                                    │                  │
│ │    256 │   │   │   │   'A custom validator is returning a value other than `self`.\n' 
```

### What is the new behavior?
`inspect eval biology_qa.py --model openai/mlx_community/Llama-3.1-8B-Instruct --model-base-url=http://10.0.0.100:8001/v1` passes using local llm served via mlx server

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
