### PR TITLE
Add unit tests and bug fixes for passing None for OpenAI and Tavily web search parameters.

### DIFF
--- a/src/inspect_ai/model/_openai_web_search.py
+++ b/src/inspect_ai/model/_openai_web_search.py
@@ -14,7 +14,9 @@ def maybe_web_search_tool(tool: ToolInfo) -> WebSearchToolParam | None:
 
 
 def _web_search_tool(maybe_openai_options: object) -> WebSearchToolParam:
-    if not isinstance(maybe_openai_options, dict):
+    if maybe_openai_options is None:
+        maybe_openai_options = {}
+    elif not isinstance(maybe_openai_options, dict):
         raise TypeError(
             f"Expected a dictionary for openai_options, got {type(maybe_openai_options)}"
         )
@@ -26,4 +28,4 @@ def _web_search_tool(maybe_openai_options: object) -> WebSearchToolParam:
         else WebSearchTool(type="web_search_preview")
     )
 
-    return cast(WebSearchToolParam, openai_options.model_dump())
+    return cast(WebSearchToolParam, openai_options.model_dump(exclude_none=True))

--- a/src/inspect_ai/tool/_tools/_web_search/_tavily.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_tavily.py
@@ -58,11 +58,7 @@ def tavily_search_provider(
     # options which will be passed in the request body
     max_connections = (options.max_connections if options else None) or 10
     api_options = (
-        {
-            k: v
-            for k, v in options.model_dump().items()
-            if v is not None and k != "max_connections"
-        }
+        options.model_dump(exclude={"max_connections"}, exclude_none=True)
         if options
         else {}
     )

--- a/src/inspect_ai/tool/_tools/_web_search/_web_search.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_web_search.py
@@ -270,10 +270,10 @@ def _get_config_via_back_compat(
 def _create_external_provider(
     providers: Providers,
 ) -> Callable[[str], Awaitable[str | None]]:
-    if tavily := providers.get("tavily", None):
-        return tavily_search_provider(tavily)
+    if "tavily" in providers:
+        return tavily_search_provider(providers.get("tavily", None))
 
-    if google := providers.get("google", None):
-        return google_search_provider(google)
+    if "google" in providers:
+        return google_search_provider(providers.get("google", None))
 
     raise ValueError("No valid provider found.")

--- a/tests/model/providers/test_openai_web_search.py
+++ b/tests/model/providers/test_openai_web_search.py
@@ -1,0 +1,96 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inspect_ai.model._openai_web_search import _web_search_tool, maybe_web_search_tool
+from inspect_ai.tool._tool_info import ToolInfo
+
+
+class TestOpenAIWebSearch:
+    """Tests for the _openai_web_search.py module."""
+
+    def test_maybe_web_search_tool_returns_none_for_non_web_search(self):
+        assert (
+            maybe_web_search_tool(
+                ToolInfo(
+                    name="not_web_search",
+                    description="Not a web search tool",
+                    options={"openai": {}},
+                )
+            )
+            is None
+        )
+
+    def test_maybe_web_search_tool_returns_none_for_no_options(self):
+        assert (
+            maybe_web_search_tool(
+                ToolInfo(
+                    name="web_search", description="A web search tool", options=None
+                )
+            )
+            is None
+        )
+
+    def test_maybe_web_search_tool_returns_none_for_no_openai_options(self):
+        assert (
+            maybe_web_search_tool(
+                ToolInfo(
+                    name="web_search",
+                    description="A web search tool",
+                    options={"not_openai": {}},
+                )
+            )
+            is None
+        )
+
+    def test_maybe_web_search_tool_returns_tool_param(self):
+        openai_options = {"key": "value"}
+
+        with patch("inspect_ai.model._openai_web_search._web_search_tool") as mock_tool:
+            mock_tool.return_value = {"type": "web_search_preview", "key": "value"}
+            result = maybe_web_search_tool(
+                ToolInfo(
+                    name="web_search",
+                    description="A web search tool",
+                    options={"openai": openai_options},
+                )
+            )
+
+            mock_tool.assert_called_once_with(openai_options)
+            assert result == {"type": "web_search_preview", "key": "value"}
+
+    def test_web_search_tool_raises_type_error(self):
+        with pytest.raises(TypeError) as excinfo:
+            _web_search_tool("not a dict")
+
+        assert "Expected a dictionary for openai_options" in str(excinfo.value)
+
+    def test_web_search_tool_with_options(self):
+        options = {"key1": "value1", "key2": "value2"}
+
+        with patch(
+            "openai.types.responses.WebSearchTool.model_validate"
+        ) as mock_validate:
+            mock_tool = MagicMock()
+            mock_tool.model_dump.return_value = {
+                "type": "web_search_preview",
+                **options,
+            }
+            mock_validate.return_value = mock_tool
+
+            result = _web_search_tool(options)
+
+            mock_validate.assert_called_once_with(
+                {"type": "web_search_preview", **options}
+            )
+            assert result == {
+                "type": "web_search_preview",
+                "key1": "value1",
+                "key2": "value2",
+            }
+
+    def test_web_search_tool_with_empty_options(self):
+        assert _web_search_tool({}) == {"type": "web_search_preview"}
+
+    def test_web_search_tool_with_none(self):
+        assert _web_search_tool(None) == {"type": "web_search_preview"}

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -168,13 +168,31 @@ class TestNormalizeConfig:
 
 
 class TestCreateExternalProvider:
-    def test_tavily_provider_with_normal_config(self) -> None:
+    @patch(
+        "os.environ.get",
+        side_effect=lambda key, default=None: "fake-key"
+        if key == "TAVILY_API_KEY"
+        else default,
+    )
+    def test_tavily_provider_with_normal_config(self, mock_environ_get) -> None:
         assert callable(_create_external_provider({"tavily": {"max_results": 5}}))
 
-    def test_tavily_provider_with_none(self) -> None:
+    @patch(
+        "os.environ.get",
+        side_effect=lambda key, default=None: "fake-key"
+        if key == "TAVILY_API_KEY"
+        else default,
+    )
+    def test_tavily_provider_with_none(self, mock_environ_get) -> None:
         assert callable(_create_external_provider({"tavily": None}))
 
-    def test_tavily_provider_with_bogus_config(self) -> None:
+    @patch(
+        "os.environ.get",
+        side_effect=lambda key, default=None: "fake-key"
+        if key == "TAVILY_API_KEY"
+        else default,
+    )
+    def test_tavily_provider_with_bogus_config(self, mock_environ_get) -> None:
         with pytest.raises(ValidationError):
             _create_external_provider({"tavily": {"max_results": "bogus"}})
 

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
 import pytest
+from pydantic import ValidationError
 
 from inspect_ai.tool._tools._web_search._web_search import (
     Providers,
+    _create_external_provider,
     _normalize_config,
 )
 
@@ -163,3 +165,29 @@ class TestNormalizeConfig:
             model=None,
         )
         assert result == {"google": {"num_results": 5}}
+
+
+class TestCreateExternalProvider:
+    def test_tavily_provider_with_normal_config(self) -> None:
+        assert callable(_create_external_provider({"tavily": {"max_results": 5}}))
+
+    def test_tavily_provider_with_none(self) -> None:
+        assert callable(_create_external_provider({"tavily": None}))
+
+    def test_tavily_provider_with_bogus_config(self) -> None:
+        with pytest.raises(ValidationError):
+            _create_external_provider({"tavily": {"max_results": "bogus"}})
+
+    @patch(
+        "inspect_ai.tool._tools._web_search._google.maybe_get_google_api_keys",
+        return_value=("fake-key", "fake-cse-id"),
+    )
+    def test_google_provider_with_normal_config(self, mock_google_api_keys) -> None:
+        assert callable(_create_external_provider({"google": {"max_results": 5}}))
+
+    @patch(
+        "inspect_ai.tool._tools._web_search._google.maybe_get_google_api_keys",
+        return_value=("fake-key", "fake-cse-id"),
+    )
+    def test_google_provider_with_none(self, mock_google_api_keys) -> None:
+        assert callable(_create_external_provider({"google": None}))


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Passing `None` for OpenAI internal web search params improperly raises an error.

### What is the new behavior?
`None` is now honored as the equivalent to `{}`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
