### PR TITLE
truncate task config to prevent overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Added native OpenAI web search to [web_search()](https://inspect.aisi.org.uk/tools-standard.html#sec-web-search) tool.
 - Limit `docker compose` concurrency to 2 * os.cpu_count() by default (override with `INSPECT_DOCKER_CLI_CONCURRENCY`).
 - Task display: Simplify task display for `plain` mode (no outline, don't expand tables to console width).
+- Task display: Truncate task config to prevent overflow (collapse dicts, limit individual values to 50 chars, limit overall output to 500 chars).
 - Inspect View: Outline view for transcript which enables high level navigation to solvers, agents, scorers, etc.
 
 ## v0.3.99 (22 May 2025)

--- a/src/inspect_ai/_display/core/config.py
+++ b/src/inspect_ai/_display/core/config.py
@@ -1,4 +1,8 @@
+from rich.console import RenderableType
+from rich.text import Text
+
 from inspect_ai._util.registry import is_model_dict, is_registry_dict
+from inspect_ai._util.text import truncate_text
 from inspect_ai.log._log import eval_config_defaults
 
 from .display import TaskProfile
@@ -6,7 +10,7 @@ from .display import TaskProfile
 
 def task_config(
     profile: TaskProfile, generate_config: bool = True, style: str = ""
-) -> str:
+) -> RenderableType:
     # merge config
     # wind params back for display
     task_args = dict(profile.task_args)
@@ -39,15 +43,17 @@ def task_config(
         elif name not in ["limit", "model", "response_schema", "log_shared"]:
             if isinstance(value, list):
                 value = ",".join([str(v) for v in value])
+            elif isinstance(value, dict):
+                value = "{...}"
             if isinstance(value, str):
+                value = truncate_text(value, 50)
                 value = value.replace("[", "\\[")
             config_print.append(f"{name}: {value}")
     values = ", ".join(config_print)
     if values:
-        if style:
-            return f"[{style}]{values}[/{style}]"
-        else:
-            return values
+        values_text = Text(values, style=style)
+        values_text.truncate(500, overflow="ellipsis")
+        return values_text
     else:
         return ""
 

--- a/src/inspect_ai/_display/rich/display.py
+++ b/src/inspect_ai/_display/rich/display.py
@@ -341,8 +341,6 @@ def tasks_live_status(
 
     # get config
     config = task_config(tasks[0].profile, generate_config=False, style=theme.light)
-    if config:
-        config += "\n"
 
     # build footer table
     footer_table = Table.grid(expand=True)
@@ -356,6 +354,8 @@ def tasks_live_status(
     layout_table = Table.grid(expand=True)
     layout_table.add_column()
     layout_table.add_row(config)
+    if config:
+        layout_table.add_row("")
     layout_table.add_row(progress)
     layout_table.add_row(footer_table)
 

--- a/src/inspect_ai/_util/text.py
+++ b/src/inspect_ai/_util/text.py
@@ -1,10 +1,17 @@
 import random
 import re
 import string
+import textwrap
 from logging import getLogger
 from typing import List, NamedTuple
 
 logger = getLogger(__name__)
+
+
+def truncate_text(text: str, max_length: int) -> str:
+    if len(text) <= max_length:
+        return text
+    return textwrap.shorten(text, width=max_length, placeholder="...")
 
 
 def strip_punctuation(s: str) -> str:


### PR DESCRIPTION
- collapse dicts
- limit individual values to 50 chars
- limit overall output to 500 chars
