### PR TITLE
Always show the sample init event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Limit `docker compose` concurrency to 2 * os.cpu_count() by default (override with `INSPECT_DOCKER_CLI_CONCURRENCY`).
 - Task display: Simplify task display for `plain` mode (no outline, don't expand tables to console width).
 - Task display: Truncate task config to prevent overflow (collapse dicts, limit individual values to 50 chars, limit overall output to 500 chars).
+- Task display: Always show the sample init event in the task transcript display.
 - Inspect View: Outline view for transcript which enables high level navigation to solvers, agents, scorers, etc.
 - Inspect View: Fix an issue that prevented the display of the viewer in VSCode when the viewer tab was moved to the background.
 


### PR DESCRIPTION
when truncating the transcript events, always show the sample init event as the first event.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

