### PR TITLE
Backport Mistral message folding behavior into Azure provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [time_limit()](https://inspect.aisi.org.uk/errors-and-limits.html#time-limit) and [working_limit()](https://inspect.aisi.org.uk/errors-and-limits.html#working-limit) context managers for scoped application of time limits.
 - Added native OpenAI web search to [web_search()](https://inspect.aisi.org.uk/tools-standard.html#sec-web-search) tool.
 - Limit `docker compose` concurrency to 2 * os.cpu_count() by default (override with `INSPECT_DOCKER_CLI_CONCURRENCY`).
+- AzureAI: Automatically fold user and tool messages for Mistral models.
 - Task display: Simplify task display for `plain` mode (no outline, don't expand tables to console width).
 - Task display: Truncate task config to prevent overflow (collapse dicts, limit individual values to 50 chars, limit overall output to 500 chars).
 - Task display: Always show the sample init event in the task transcript display.

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -298,10 +298,7 @@ def mistral_message_reducer(
     messages: list[ChatRequestMessage],
     message: ChatRequestMessage,
 ) -> list[ChatRequestMessage]:
-    """
-    Fold any user messages found immediately after tool messages
-    into the last tool message.
-    """
+    """Fold any user messages found immediately after tool messages into the last tool message."""
     if (
         len(messages) > 0
         and isinstance(messages[-1], ToolMessage)
@@ -320,7 +317,7 @@ def fold_user_message_into_tool_message(
 ) -> ToolMessage:
     def convert_content_items_to_string(list_content: list[ContentItem]) -> str:
         if not all(
-            isinstance(item, (TextContentItem, ImageContentItem))
+            isinstance(item, (TextContentItem | ImageContentItem))
             for item in list_content
         ):
             raise TypeError(

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -323,7 +323,9 @@ def fold_user_message_into_tool_message(
             isinstance(item, (TextContentItem, ImageContentItem))
             for item in list_content
         ):
-            raise TypeError("Expected all items to be TextContentItem or ImageContentItem")
+            raise TypeError(
+                "Expected all items to be TextContentItem or ImageContentItem"
+            )
 
         parts = []
         for item in list_content:
@@ -333,7 +335,7 @@ def fold_user_message_into_tool_message(
                 parts.append(f"[Image: {item.image_url.url}]")
             else:
                 raise ValueError("Unexpected content item type")
-        return ''.join(parts)
+        return "".join(parts)
 
     def normalise_content(
         content: str | list[ContentItem] | None,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

Addresses #1813 

### What is the current behavior? (You can also link to an open issue here)
Right now, the Mistral provider has this behavior included, however the Azure provider (necessary for Azure Mistral inference recently, there has been some regression) does not have the behaviour. 

### What is the new behavior?
For Mistral models, we perform folding of user messages into tool messages when there is a user message immediately following the tool message.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
This should not introduce a breaking change.
### Other information:
### Test Plan
1. Install my local modified copy of Inspect
2. Rerun my test eval (below) to see that it no longer breaks the provider.
3. Verify that reverting to the PyPI inspect causes the breakage again.

```python
from inspect_ai import Task, task
from inspect_ai.dataset import Sample
from inspect_ai.scorer import includes
from inspect_ai.solver import basic_agent
from inspect_ai.tool import Tool, tool


@tool
def get_answer() -> Tool:
    async def execute():
        """Gets the answer."""
        return "tool-used"

    return execute


@task
def basic_tool_task() -> Task:
    return Task(
        dataset=[
            Sample(
                input="Use the get_answer tool and use the submit tool to submit one wrong answer before submitting the correct answer. Ensure to use tool calls correctly, ESPECIALLY FOR THE SUBMIT TOOL.",
                target="tool-used",
            )
        ],
        solver=basic_agent(
            tools=[get_answer()],
            max_attempts=3,
            message_limit=30,
        ),
        scorer=includes(),
    )
```