### PR TITLE
Fix `web_search` backward compatibility issue by making new "required" parameter optional.

### DIFF
--- a/src/inspect_ai/tool/_tools/_web_search/_web_search.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_web_search.py
@@ -14,7 +14,7 @@ from inspect_ai._util.deprecation import deprecation_warning
 from inspect_ai.tool._tool_def import ToolDef
 
 from ..._tool import Tool, ToolResult, tool
-from ._google import GoogleOptions, google_search_provider, maybe_get_google_api_keys
+from ._google import GoogleOptions, google_search_provider
 from ._tavily import TavilyOptions, tavily_search_provider
 
 Provider: TypeAlias = Literal["openai", "tavily", "google"]  # , "gemini", "anthropic"
@@ -83,6 +83,8 @@ def web_search(
         supports several formats based on either a `str` specifying a provider or
         a `dict` whose keys are the provider names and whose values are the
         provider-specific options. A single value or a list of these can be passed.
+        This arg is optional just for backwards compatibility. New code should
+        always provide this argument.
 
         Single provider:
         ```
@@ -167,10 +169,10 @@ def _normalize_config(
     #     ValueError
     # 2. Neither deprecated_provider nor providers is set
     #     act as if they passed provider="google"
-    # - Only providers is set
+    # 3. Only providers is set
     #     if any of the other deprecated parameters is set, then ValueError
     #     else Happy path
-    # - Only deprecated_provider is set
+    # 4. Only deprecated_provider is set
     #     convert to new config format - including processing old other params
 
     deprecated_provider = deprecated.get("provider", None)

--- a/src/inspect_ai/tool/_tools/_web_search/_web_search.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_web_search.py
@@ -45,7 +45,7 @@ class WebSearchDeprecatedArgs(TypedDict, total=False):
 
 @tool
 def web_search(
-    providers: Provider | Providers | list[Provider | Providers],
+    providers: Provider | Providers | list[Provider | Providers] | None = None,
     **deprecated: Unpack[WebSearchDeprecatedArgs],
 ) -> Tool:
     """Web search tool.
@@ -166,8 +166,7 @@ def _normalize_config(
     # 1. Both deprecated_provider and providers are set
     #     ValueError
     # 2. Neither deprecated_provider nor providers is set
-    #     Do the google_none_hack.
-    #     if deprecated_provider is still none ValueError
+    #     act as if they passed provider="google"
     # - Only providers is set
     #     if any of the other deprecated parameters is set, then ValueError
     #     else Happy path
@@ -180,12 +179,8 @@ def _normalize_config(
         raise ValueError("`provider` is deprecated. Please only specify `providers`.")
 
     # Case 2.
-    if (
-        providers is None
-        and deprecated_provider is None
-        and (deprecated_provider := _google_none_hack()) is None
-    ):
-        raise ValueError("`providers` must be specified.")
+    if providers is None and deprecated_provider is None:
+        deprecated_provider = "google"
 
     num_results = deprecated.get("num_results", None)
     max_provider_calls = deprecated.get("max_provider_calls", None)
@@ -215,19 +210,6 @@ def _normalize_config(
                     raise ValueError(f"Invalid provider: '{key}'")
                 normalized[key] = value  # type: ignore
     return normalized
-
-
-def _google_none_hack() -> Literal["google"]:
-    """If no config nor provider was set, infer 'google' if the API keys are set."""
-    if maybe_get_google_api_keys():
-        deprecation_warning(
-            "The `google` `web_search` provider was inferred based on the presence of environment variables. Please specify the provider explicitly to avoid this warning."
-        )
-        return "google"
-    else:
-        raise ValueError(
-            "Omitting `provider` is no longer supported. Please specify a `web_search` config explicitly to avoid this error."
-        )
 
 
 def _get_config_via_back_compat(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Recent updates (#1838) to `web_search` erroneously assumed that it could use a backward compatibility strategy that would induce static analysis (e.g. `mypy`) errors but still function properly at runtime. With this in mind, the new `providers` parameter was required.

Not only did old code that failed to pass `providers` induce `mypy` errors as expected, the code also failed at runtime.

This approach was based on a misunderstanding of how much runtime validation Python does when making function calls. The assumption was that it was like JavaScript - making no checks. In fact, Python uses introspection to ensure that something is passed for all required arguments.

### What is the new behavior?

Despite being semantically required, the new `providers` argument is now actually optional.

This PR adds a suit of unit tests _at the appropriate level_ to validate the expected behavior.

This PR additionally updates the heuristic code that inferred `"google"` as the provider when no explicit provider was specified. Previously, it would choose `"google"` if the required Google API keys were present, and raise an error otherwise. It now chooses `"google"` without respect to the presence of the API keys.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
Although there were extensive unit tests validating the argument normalization process, they missed the bug because they tested the workhorse helper method used by `web_search` rather than testing calls `web_search` directly.
