### PR TITLE
Update test for pytest 8.4 compatibility

### DIFF
--- a/tests/solver/test_bridge.py
+++ b/tests/solver/test_bridge.py
@@ -47,7 +47,7 @@ def agent(tools: bool):
             ),
         )
         if tools:
-            params["tools"] = openai_chat_tools([testing_tool_info()])
+            params["tools"] = openai_chat_tools([get_testing_tool_info()])
             params["tool_choice"] = "auto"
         else:
             params["logprobs"] = True
@@ -180,7 +180,7 @@ def test_bridged_agent_context():
             check_anthropic_log_json(log_json)
 
 
-def testing_tool_info() -> ToolInfo:
+def get_testing_tool_info() -> ToolInfo:
     return ToolInfo(
         name="testing_tool",
         description="This is a testing tool.",


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Builds are [failing in CI](https://github.com/UKGovernmentBEIS/inspect_ai/actions/runs/15400576569/job/43341730906?pr=1953#step:6:5448).

pytest v8.4.0 shows a failure if a test function returns something other than `None`, and the `testing_tool_info()` utility function in `tests/solver/test_bridge.py` is getting picked up as a test function due to its name.

### What is the new behavior?
Function is renamed to avoid getting collected as a test function.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
-