### PR TITLE
Fix handing of shuffle_choices parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Inspect View: Display sample id & epoch in sample dialog title bar.
 - Inspect View: Don't open sample dialog when simply navigating the sample list.
+- Bugfix: Ensure that dataset shuffle_choices=True always uses a distinct random seed.
 
 ## v0.3.100 (01 June 2025)
 

--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -14,7 +14,7 @@ from .._dataset import (
     MemoryDataset,
     RecordToSample,
 )
-from .._util import data_to_samples, record_to_sample_fn
+from .._util import data_to_samples, record_to_sample_fn, shuffle_choices_if_requested
 
 
 def csv_dataset(
@@ -88,11 +88,7 @@ def csv_dataset(
         if shuffle:
             dataset.shuffle(seed=seed)
 
-        # shuffle choices, if requested
-        if isinstance(shuffle_choices, int):
-            dataset.shuffle_choices(seed=shuffle_choices)
-        elif shuffle_choices is True:
-            dataset.shuffle_choices()
+        shuffle_choices_if_requested(dataset, shuffle_choices)
 
         # limit if requested
         if limit:

--- a/src/inspect_ai/dataset/_sources/hf.py
+++ b/src/inspect_ai/dataset/_sources/hf.py
@@ -16,7 +16,7 @@ from .._dataset import (
     MemoryDataset,
     RecordToSample,
 )
-from .._util import data_to_samples, record_to_sample_fn
+from .._util import data_to_samples, record_to_sample_fn, shuffle_choices_if_requested
 
 
 def hf_dataset(
@@ -125,10 +125,6 @@ def hf_dataset(
         location=path,
     )
 
-    # maybe shuffle the choices
-    if isinstance(shuffle_choices, int):
-        memory_dataset.shuffle_choices(seed=shuffle_choices)
-    elif shuffle_choices is True:
-        memory_dataset.shuffle_choices()
+    shuffle_choices_if_requested(memory_dataset, shuffle_choices)
 
     return memory_dataset

--- a/src/inspect_ai/dataset/_sources/json.py
+++ b/src/inspect_ai/dataset/_sources/json.py
@@ -15,7 +15,7 @@ from .._dataset import (
     MemoryDataset,
     RecordToSample,
 )
-from .._util import data_to_samples, record_to_sample_fn
+from .._util import data_to_samples, record_to_sample_fn, shuffle_choices_if_requested
 from .util import resolve_sample_files
 
 
@@ -88,11 +88,7 @@ def json_dataset(
         if shuffle:
             dataset.shuffle(seed=seed)
 
-        # shuffle choices, if requested
-        if isinstance(shuffle_choices, int):
-            dataset.shuffle_choices(seed=shuffle_choices)
-        elif shuffle_choices is True:
-            dataset.shuffle_choices()
+        shuffle_choices_if_requested(dataset, shuffle_choices)
 
         # limit if requested
         if limit:

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -13,6 +13,7 @@ from inspect_ai.model import (
 from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
 from ._dataset import (
+    Dataset,
     DatasetRecord,
     FieldSpec,
     RecordToSample,
@@ -225,3 +226,24 @@ def read_files(files: Any | None) -> dict[str, str] | None:
         raise ValueError(f"Unexpected type for 'files' field: {type(files)}")
     else:
         return None
+
+
+def shuffle_choices_if_requested(
+    dataset: Dataset, shuffle_choices: bool | int | None
+) -> None:
+    """
+    Shuffle the choices in the dataset if requested.
+
+    The `shuffle_choices` parameter passed to `Dataset.shuffle_choices` can be
+    a boolean, an integer, or `None`. If it is a boolean, it will shuffle the choices
+    if the value is `True` and do nothing if it is `False`. If it is an integer, it will
+    shuffle the choices using the integer as the seed.
+    """
+    # Note that `isinstance(x, int)` returns True if x is True or False,
+    # so we need to check for both explicitly
+    if shuffle_choices is True:
+        dataset.shuffle_choices()
+    elif shuffle_choices is False:
+        pass
+    elif isinstance(shuffle_choices, int):
+        dataset.shuffle_choices(seed=shuffle_choices)

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -234,10 +234,11 @@ def shuffle_choices_if_requested(
     """
     Shuffle the choices in the dataset if requested.
 
-    The `shuffle_choices` parameter passed to `Dataset.shuffle_choices` can be
-    a boolean, an integer, or `None`. If it is a boolean, it will shuffle the choices
-    if the value is `True` and do nothing if it is `False`. If it is an integer, it will
-    shuffle the choices using the integer as the seed.
+    The `shuffle_choices` parameter passed to `json_dataset`, `csv_dataset`, and `hf_dataset` can be
+    a boolean, an integer, or `None`.
+    If it is a boolean, it will shuffle the choices
+    if the value is `True` and do nothing if it is `False`.
+    If it is an integer, it will shuffle the choices using the integer as the seed.
     """
     # Note that `isinstance(x, int)` returns True if x is True or False,
     # so we need to check for both explicitly

--- a/src/inspect_ai/dataset/_util.py
+++ b/src/inspect_ai/dataset/_util.py
@@ -234,10 +234,10 @@ def shuffle_choices_if_requested(
     """
     Shuffle the choices in the dataset if requested.
 
-    The `shuffle_choices` parameter passed to `json_dataset`, `csv_dataset`, and `hf_dataset` can be
-    a boolean, an integer, or `None`.
-    If it is a boolean, it will shuffle the choices
-    if the value is `True` and do nothing if it is `False`.
+    The `shuffle_choices` parameter passed to `json_dataset`, `csv_dataset`,
+    and `hf_dataset` can be a boolean, an integer, or `None` (default).
+    If it is a boolean, it will shuffle the choices if the value is `True`,
+    and do nothing if it is `False`.
     If it is an integer, it will shuffle the choices using the integer as the seed.
     """
     # Note that `isinstance(x, int)` returns True if x is True or False,

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -133,14 +133,20 @@ def test_dataset_metadata_pydantic(type: Type[T_ds], file: str) -> None:
 @pytest.mark.parametrize("type,file", dataset_mcq_params)
 def test_dataset_shuffle_choices_true_uses_no_seed(type: Type[T_ds], file: str) -> None:
     dataset_1, dataset_2 = [
-        type.__call__(
-            dataset_path(file),
-            sample_fields=FieldSpec(input="input", target="target", choices="choices"),
-            shuffle_choices=True,
-        )
-        for _ in range(2)
+        type.__call__(dataset_path(file), shuffle_choices=True) for _ in range(2)
     ]
     assert dataset_1[0].choices != dataset_2[0].choices
+
+
+# test explicitly not shuffling choices
+@pytest.mark.parametrize("type,file", dataset_mcq_params)
+def test_dataset_shuffle_choices_false_does_not_shuffle(
+    type: Type[T_ds], file: str
+) -> None:
+    dataset_1, dataset_2 = [
+        type.__call__(dataset_path(file), shuffle_choices=False) for _ in range(2)
+    ]
+    assert dataset_1[0].choices == dataset_2[0].choices
 
 
 @skip_if_github_action

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -30,6 +30,10 @@ dataset_md_params = [
     (param[0], param[1].replace(".", "-md.")) for param in dataset_params
 ]
 
+dataset_mcq_params = [
+    (param[0], param[1].replace(".", "-mcq.")) for param in dataset_params
+]
+
 
 # test reading a dataset using default configuration
 @pytest.mark.parametrize("type,file", dataset_params)
@@ -123,6 +127,20 @@ def test_dataset_metadata_pydantic(type: Type[T_ds], file: str) -> None:
         dataset = type.__call__(
             dataset_path(file), sample_fields=FieldSpec(metadata=MetadataNotFrozen)
         )
+
+
+# test shuffling choices
+@pytest.mark.parametrize("type,file", dataset_mcq_params)
+def test_dataset_shuffle_choices_true_uses_no_seed(type: Type[T_ds], file: str) -> None:
+    dataset_1, dataset_2 = [
+        type.__call__(
+            dataset_path(file),
+            sample_fields=FieldSpec(input="input", target="target", choices="choices"),
+            shuffle_choices=True,
+        )
+        for _ in range(2)
+    ]
+    assert dataset_1[0].choices != dataset_2[0].choices
 
 
 @skip_if_github_action

--- a/tests/dataset/test_dataset/samples-mcq.csv
+++ b/tests/dataset/test_dataset/samples-mcq.csv
@@ -1,0 +1,2 @@
+input,target,choices
+"Which is the smallest number?",A,"1,2,3,4,5,6,7,8,9,10"

--- a/tests/dataset/test_dataset/samples-mcq.json
+++ b/tests/dataset/test_dataset/samples-mcq.json
@@ -1,0 +1,18 @@
+[
+  {
+    "input": "Which is the smallest number?",
+    "target": "A",
+    "choices": [
+      "1",
+      "2",
+      "3",
+      "4",
+      "5",
+      "6",
+      "7",
+      "8",
+      "9",
+      "10"
+    ]
+  }
+]

--- a/tests/dataset/test_dataset/samples-mcq.jsonl
+++ b/tests/dataset/test_dataset/samples-mcq.jsonl
@@ -1,0 +1,1 @@
+{"input": "Which is the smallest number?", "target": "A", "choices": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Passing `shuffle_choices=True` or `shuffle_choices=False` to `hf_dataset`, `json_dataset`, or `csv_dataset` incorrectly interprets the boolean as an integer and uses it as a seed for the random number generator, which is not the intended behaviour.

Fixes #1921 

### What is the new behavior?
Passing `shuffle_choices=False` does not shuffle choices, and passing `shuffle_choices=True` shuffles choices without setting a seed value i.e. produces a different result each time.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking changes, but any datasets constructed with `shuffle_choices=True` will now have differently-ordered choices on each run, which is the intended behaviour.

### Other information:
-