### PR TITLE
Fix combobox's missing current value from accessibility tree.

### DIFF
--- a/src/inspect_tool_support/CHANGELOG.md
+++ b/src/inspect_tool_support/CHANGELOG.md
@@ -1,4 +1,4 @@
-## Unreleased
+## v1.1.1 (2025-06-09)
 
 -   Fixed https://github.com/UKGovernmentBEIS/inspect_ai/issues/1964 by including current value in combobox accessibility tree info.
 
@@ -28,7 +28,6 @@
             session_name, lambda page: page.go_to_url(url)
         )
     ```
-
 
 ## v1.0.1 (29 April 2025)
 

--- a/src/inspect_tool_support/CHANGELOG.md
+++ b/src/inspect_tool_support/CHANGELOG.md
@@ -1,48 +1,52 @@
-v1.1.0 (2025-05-02)
+## Unreleased
+
+-   Fixed https://github.com/UKGovernmentBEIS/inspect_ai/issues/1964 by including current value in combobox accessibility tree info.
+
+## v1.1.0 (2025-05-02)
 
 ### minor
 
-- Update installation of `inspect-tool-support` in container to use `pipx` instead of `pip`.
+-   Update installation of `inspect-tool-support` in container to use `pipx` instead of `pip`.
 
 ### patch
 
-- Cleaned up code that needlessly created named functions when a lambda would have been sufficient. e.g.
+-   Cleaned up code that needlessly created named functions when a lambda would have been sufficient. e.g.
 
-  ```python
-  async def go_to_url(self, session_name: str, url: str) -> CrawlerResult:
-      async def handler(page: PageCrawler) -> None:
-          await page.go_to_url(url)
+    ```python
+    async def go_to_url(self, session_name: str, url: str) -> CrawlerResult:
+        async def handler(page: PageCrawler) -> None:
+            await page.go_to_url(url)
 
-      return await self._execute_crawler_command(session_name, handler)
-  ```
+        return await self._execute_crawler_command(session_name, handler)
+    ```
 
-  became
+    became
 
-  ```python
-  async def go_to_url(self, session_name: str, url: str) -> CrawlerResult:
-      return await self._execute_crawler_command(
-          session_name, lambda page: page.go_to_url(url)
-      )
-  ```
+    ```python
+    async def go_to_url(self, session_name: str, url: str) -> CrawlerResult:
+        return await self._execute_crawler_command(
+            session_name, lambda page: page.go_to_url(url)
+        )
+    ```
 
 
 ## v1.0.1 (29 April 2025)
 
-- Fix occasional "Execution context was destroyed, most likely because of a navigation" web browser bug. (#1781)
+-   Fix occasional "Execution context was destroyed, most likely because of a navigation" web browser bug. (#1781)
 
 ## v1.0.0 (29 April 2025)
 
-- Major version bump for `bash_session` tool to be terminal oriented rather than command oriented. (#1600)
+-   Major version bump for `bash_session` tool to be terminal oriented rather than command oriented. (#1600)
 
 ## v0.1.19 (25 April 2025)
 
-- Make text editor interface more flexible (#1742)
+-   Make text editor interface more flexible (#1742)
 
 ## v0.1.18 (18 April 2025)
 
-- Added support for sandboxed Model Context Protocol (MCP) servers.
+-   Added support for sandboxed Model Context Protocol (MCP) servers.
 
 ## v0.1.17 (19 March 2025)
 
-- Fixed `bash_session` handling of commands whose `stdout` output do not include a trailing newline.
-- Include container side exception details in JSON RPC error response so that they appear in eval logs.
+-   Fixed `bash_session` handling of commands whose `stdout` output do not include a trailing newline.
+-   Include container side exception details in JSON RPC error response so that they appear in eval logs.

--- a/src/inspect_tool_support/pyproject.toml
+++ b/src/inspect_tool_support/pyproject.toml
@@ -66,7 +66,7 @@ ignore = ["W002", "W009"]
 
 [project]
 name = "inspect_tool_support"
-version = "1.1.0"
+version = "1.1.1"
 description = "Sandbox container tool code for inspect_ai"
 authors = [{ name = "UK AI Security Institute" }]
 readme = "README.md"

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/accessibility_tree_node.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_web_browser/accessibility_tree_node.py
@@ -92,7 +92,7 @@ class AccessibilityTreeNode:
                 else None
             )
 
-        if node_has_property(ax_node, "editable"):
+        if node_has_property(ax_node, "editable") or self.role == "combobox":
             # Sometimes a node will have it's input stored as 'value' other times we
             # need to go looking through the DOM tree to find its matching string.
             self._input = (


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Addresses #1964

### What is the current behavior? (You can also link to an open issue here)

The accessibility information made available to models for comboboxes does not include the currently selected value in the combobox. After selecting an item from the combobox, this accessibility tree info looks like:

`[11] combobox  [invalid: false, focusable: True, focused: True, hasPopup: menu, expanded]`

### What is the new behavior?
The currently selected value is included. Here is what the accessibility tree node for the combobox looks like now.

`[11] combobox Current input: \"February\"  [invalid: false, focusable: True, focused: True, hasPopup: menu, expanded]`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
