### PR TITLE
Fix: handoff limits when agent handed off to multiple times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Inspect View: Add support for displaying citations for web searches in the transcript.
 - Inspect View: Correctly update browser URL when navigation between samples.
 - Bugfix: Properly honor `responses_api=False` when pass as an OpenAI model config arg.
+- Bugfix: Limits passed to handoffs can be used multiple times (if agent is handed off to multiple times).
 
 ## v0.3.103 (06 June 2025)
 

--- a/src/inspect_ai/agent/_handoff.py
+++ b/src/inspect_ai/agent/_handoff.py
@@ -37,9 +37,9 @@ def handoff(
             Use the built-in `last_message` filter to return only the last message
             or alternatively specify a custom `MessageFilter` function.
         tool_name: Alternate tool name (defaults to `transfer_to_{agent_name}`)
-        limits: List of limits to apply to the agent. Should a limit be exceeded,
-            the agent stops and a user message is appended explaining that a limit was
-            exceeded.
+        limits: List of limits to apply to the agent. Limits are scoped to each
+            handoff to the agent. Should a limit be exceeded, the agent stops and a user
+            message is appended explaining that a limit was exceeded.
         **agent_kwargs: Arguments to curry to `Agent` function (arguments provided here
             will not be presented to the model as part of the tool interface).
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -1,7 +1,7 @@
 import inspect
 import json
 import types
-from copy import copy
+from copy import copy, deepcopy
 from dataclasses import is_dataclass
 from datetime import date, datetime, time
 from enum import EnumMeta
@@ -478,7 +478,9 @@ async def agent_handoff(
     limit_error: LimitExceededError | None = None
     agent_state = AgentState(messages=copy(agent_conversation))
     try:
-        with apply_limits(agent_tool.limits):
+        # The agent_tool's limits will be applied multiple times if the agent is handed
+        # off to multiple times which is not supported, so create a copy of each limit.
+        with apply_limits(deepcopy(agent_tool.limits)):
             async with span(name=agent_name, type="agent"):
                 agent_state = await agent_tool.agent(agent_state, **arguments)
     except LimitExceededError as ex:

--- a/tests/agent/test_agent_execute.py
+++ b/tests/agent/test_agent_execute.py
@@ -287,6 +287,28 @@ def test_agent_handoff_respects_limits():
     check_limit_event(log, "message")
 
 
+def test_agent_handoff_does_not_reuse_limits():
+    agent_tool = handoff(looping_agent(), limits=[message_limit(10)])
+
+    log = eval(
+        Task(
+            solver=[
+                use_tools(agent_tool),
+                call_looping_agent("transfer_to_looping_agent", arguments={}),
+                call_looping_agent("transfer_to_looping_agent", arguments={}),
+            ]
+        )
+    )[0]
+
+    assert log.status == "success"
+    assert log.samples
+    assert (
+        log.samples[0].messages[-1].content
+        == "The looping_agent exceeded its message limit of 10."
+    )
+    check_limit_event(log, "message")
+
+
 def test_agent_handoff_respects_sample_limits():
     agent_tool = handoff(looping_agent())
 


### PR DESCRIPTION
Thanks to Charles for spotting this.

Limit context managers do not support being re-used. However, we store the limits passed to `handoff()` in `AgentTool` which can be reused across multiple calls to `agent_handoff()`.

I now take a copy of the limit instances in `agent_handoff()`, and clearly document that the limits passed to `handoff()` are per handoff (i.e. not per handoff definition). By this I mean that if you define `handoff(..., limits=[token_limit(500)])`, you get 500 tokens _each time_ you call the tool.

Added a test which failed before these changes.