### PR TITLE
Update: Add new params to grouped metric

### DIFF
--- a/src/inspect_ai/scorer/_metrics/grouped.py
+++ b/src/inspect_ai/scorer/_metrics/grouped.py
@@ -2,6 +2,7 @@ from typing import Literal, cast
 
 import numpy as np
 
+from inspect_ai._util.registry import registry_info
 from inspect_ai.scorer._metric import (
     Metric,
     MetricProtocol,
@@ -10,10 +11,6 @@ from inspect_ai.scorer._metric import (
     ValueToFloat,
     metric,
     value_to_float,
-)
-
-from inspect_ai._util.registry import (
-    registry_info
 )
 
 
@@ -26,7 +23,7 @@ def grouped(
     all_label: str = "all",
     value_to_float: ValueToFloat = value_to_float(),
     verbose: bool = True,
-    add_metric_name_to_group: bool = True,
+    add_metric_name_to_group: bool = False,
 ) -> Metric:
     """
     Creates a grouped metric that applies the given metric to subgroups of samples.
@@ -69,7 +66,9 @@ def grouped(
 
         # Compute the per group metric
         grouped_scores = {
-            f'{group_name}_{registry_info(metric).name.split('/')[-1]}' if add_metric_name_to_group else group_name: metric_protocol(values)
+            f"{group_name}_{registry_info(metric).name.split('/')[-1]}"
+            if add_metric_name_to_group
+            else group_name: metric_protocol(values)
             for group_name, values in scores_dict.items()
         }
 

--- a/tests/scorer/test_metric.py
+++ b/tests/scorer/test_metric.py
@@ -418,6 +418,42 @@ def test_grouped_mean_multiple():
     assert result["all"] == 4.0
 
 
+def test_grouped_mean_multiple_not_verbose():
+    metric = grouped(mean(), group_key="group", verbose=False)
+    result = metric(
+        [
+            SampleScore(score=Score(value=1), sample_metadata={"group": "A"}),
+            SampleScore(score=Score(value=1), sample_metadata={"group": "A"}),
+            SampleScore(score=Score(value=4), sample_metadata={"group": "A"}),
+            SampleScore(score=Score(value=2), sample_metadata={"group": "B"}),
+            SampleScore(score=Score(value=6), sample_metadata={"group": "B"}),
+            SampleScore(score=Score(value=10), sample_metadata={"group": "B"}),
+        ]
+    )
+    assert result.get("A") is None
+    assert result.get("B") is None
+    assert result["all"] == 4.0
+
+
+def test_grouped_mean_multiple_add_metric_name_to_group():
+    metric = grouped(mean(), group_key="group", add_metric_name_to_group=True)
+    result = metric(
+        [
+            SampleScore(score=Score(value=1), sample_metadata={"group": "A"}),
+            SampleScore(score=Score(value=1), sample_metadata={"group": "A"}),
+            SampleScore(score=Score(value=4), sample_metadata={"group": "A"}),
+            SampleScore(score=Score(value=2), sample_metadata={"group": "B"}),
+            SampleScore(score=Score(value=6), sample_metadata={"group": "B"}),
+            SampleScore(score=Score(value=10), sample_metadata={"group": "B"}),
+        ]
+    )
+    assert result["A_mean"] == 2.0
+    assert result["B_mean"] == 6.0
+    assert result.get("A") is None
+    assert result.get("B") is None
+    assert result["all"] == 4.0
+
+
 def test_grouped_mean_error():
     metric = grouped(mean(), group_key="group")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The existing grouped metric will output all the groups and the aggregate "all" metrics if specified. However there are cases where you may only want to report the aggregate metrics or toggle off the group metrics.
The existing implementation will also add a number to the name of the group if the grouped metric is used on the same field for two different metrics. I.e. accuracy and stderr are used, so it outputs 96[pass_at_1] for accuracy and 96_2[pass_at_1] for stderr. It is not easy to tell what metric is what with the current implementation.

### What is the new behavior?

This PR introduces two new params to the grouped metric to handle these cases.

      verbose - bool, defaults to True: show or hide metrics for each group in order to handle when "all" metrics are only useful to report.
      add_metric_name_to_group - bool, defaults to False: Adjust reported group name to include the metric used. Important if the grouped function is used multiple times on the same field in the metadata for different metrics i.e. accuracy and stderr

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

This should not introduce a breaking change as existing defaults have been maintained

### Other information:

Added test cases to cover these new metric params.
This update to grouped was identified through an implementation being completed for inspect_evals, and will be immediately useful once that eval is merged into inspect_evals
