### PR TITLE
Fix occasional subprocess deadlock (timeout + large output)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [sandbox_service()](https://inspect.aisi.org.uk/agent-custom.html#sandbox-service) function for making available methods to a sandbox for calling back into the main Inspect process.
 - Agent handoff: Ensure that handoff tool call responses immediately follow the call.
 - Agent handoff: Only print handoff agent prefix if there is assistant message content.
+- Subprocess: Ensure that streams are drained when a cancellation occurs (prevent hanging on calls with large output payloads).
 
 ## v0.3.104 (12 June 2025)
 

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -168,9 +168,9 @@ async def subprocess(
                     stdout=stdout if capture_output else bytes(),
                     stderr=stderr if capture_output else bytes(),
                 )
-        # Handle cancellation before aclose() is called (which can result in deadlock).
+        # Handle cancellation before aclose() is called to avoid deadlock.
         except anyio.get_cancelled_exc_class():
-            await gracefully_terminate_cancelled_subprocesses(process)
+            await gracefully_terminate_cancelled_subprocess(process)
             raise
         finally:
             try:
@@ -184,13 +184,11 @@ async def subprocess(
 
     # wrapper for run command that implements timeout
     async def run_command_timeout() -> Union[ExecResult[str], ExecResult[bytes]]:
-        # await result wrapped in timeout handler if requested
+        # wrap in timeout handler if requested
         if timeout is not None:
             with anyio.fail_after(timeout):
                 # run_command() handles terminating the process if it is cancelled.
                 return await run_command()
-
-        # await result without timeout
         else:
             return await run_command()
 
@@ -213,15 +211,8 @@ def default_max_subprocesses() -> int:
     return cpus if cpus else 1
 
 
-async def gracefully_terminate_cancelled_subprocesses(process: Process) -> None:
+async def gracefully_terminate_cancelled_subprocess(process: Process) -> None:
     with anyio.CancelScope(shield=True):
-        # With anyio's asyncio backend, process.aclose() calls process.wait() which can
-        # deadlock if the process generates so much output that it blocks waiting for
-        # the OS pipe buffer to accept more data. See
-        # https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.wait
-        # Therefore, we need to ensure that the process's stdout and stderr streams are
-        # drained before we call process.wait() in aclose().
-
         try:
             # Terminate timed out process -- try for graceful termination then kill if
             # required.
@@ -229,7 +220,12 @@ async def gracefully_terminate_cancelled_subprocesses(process: Process) -> None:
             await anyio.sleep(2)
             if process.returncode is None:
                 process.kill()
-            # Drain the streams to avoid deadlocks when calling process.wait().
+            # With anyio's asyncio backend, process.aclose() calls process.wait() which
+            # can deadlock if the process generates so much output that it blocks
+            # waiting for the OS pipe buffer to accept more data. See
+            # https://docs.python.org/3/library/asyncio-subprocess.html#asyncio.subprocess.Process.wait
+            # Therefore, we need to ensure that the process's stdout and stderr streams
+            # are drained before we call process.wait() in aclose().
             async with create_task_group() as tg:
                 tg.start_soon(drain_stream, process.stdout)
                 tg.start_soon(drain_stream, process.stderr)

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -2,17 +2,16 @@ import functools
 import io
 import os
 import shlex
-from contextlib import aclosing
 from contextvars import ContextVar
 from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
 from subprocess import DEVNULL, PIPE
-from typing import AsyncGenerator, Generic, Literal, TypeVar, Union, cast, overload
+from typing import Generic, Literal, TypeVar, Union, overload
 
 import anyio
-from anyio import open_process
-from anyio.abc import ByteReceiveStream, Process
+from anyio import ClosedResourceError, create_task_group, open_process
+from anyio.abc import ByteReceiveStream
 
 from inspect_ai._util._async import tg_collect
 from inspect_ai._util.trace import trace_action
@@ -114,9 +113,7 @@ async def subprocess(
         else None
     )
 
-    async def run_command() -> AsyncGenerator[
-        Union[Process, ExecResult[str], ExecResult[bytes]], None
-    ]:
+    async def run_command() -> Union[ExecResult[str], ExecResult[bytes]]:
         process = await open_process(
             args,
             stdin=PIPE if input else DEVNULL,
@@ -126,9 +123,6 @@ async def subprocess(
             env={**os.environ, **env},
         )
         try:
-            # yield the process so the caller has a handle to it
-            yield process
-
             # write to stdin (convert input to bytes)
             if process.stdin and input:
                 await process.stdin.send(input)
@@ -161,14 +155,14 @@ async def subprocess(
             returncode = await process.wait()
             success = returncode == 0
             if text:
-                yield ExecResult[str](
+                return ExecResult[str](
                     success=success,
                     returncode=returncode,
                     stdout=stdout.decode() if capture_output else "",
                     stderr=stderr.decode() if capture_output else "",
                 )
             else:
-                yield ExecResult[bytes](
+                return ExecResult[bytes](
                     success=success,
                     returncode=returncode,
                     stdout=stdout if capture_output else bytes(),
@@ -176,7 +170,14 @@ async def subprocess(
                 )
         finally:
             try:
-                await process.aclose()
+                with anyio.CancelScope(shield=True):
+                    # With asyncio, aclose() can deadlock if the process generates so
+                    # much output that it fills the pipe buffers, waiting on the OS pipe
+                    # buffer to accept more data. Drain the streams.
+                    async with create_task_group() as tg:
+                        tg.start_soon(drain_stream, process.stdout)
+                        tg.start_soon(drain_stream, process.stderr)
+                    await process.aclose()
             except ProcessLookupError:
                 # the anyio ansycio backend calls process.kill() from within
                 # its aclose() method without an enclosing exception handler
@@ -186,33 +187,15 @@ async def subprocess(
 
     # wrapper for run command that implements timeout
     async def run_command_timeout() -> Union[ExecResult[str], ExecResult[bytes]]:
-        # run the command and capture the process handle
-        async with aclosing(run_command()) as rc:
-            proc = cast(Process, await anext(rc))
+        # await result wrapped in timeout handler if requested
+        if timeout is not None:
+            with anyio.fail_after(timeout):
+                # run_command()'s finally block handles killing the process.
+                return await run_command()
 
-            # await result wrapped in timeout handler if requested
-            if timeout is not None:
-                try:
-                    with anyio.fail_after(timeout):
-                        result = await anext(rc)
-                        return cast(Union[ExecResult[str], ExecResult[bytes]], result)
-                except TimeoutError:
-                    # terminate timed out process -- try for graceful termination
-                    # then be more forceful if requied
-                    with anyio.CancelScope(shield=True):
-                        try:
-                            proc.terminate()
-                            await anyio.sleep(2)
-                            if proc.returncode is None:
-                                proc.kill()
-                        except Exception:
-                            pass
-                    raise
-
-            # await result without timeout
-            else:
-                result = await anext(rc)
-                return cast(Union[ExecResult[str], ExecResult[bytes]], result)
+        # await result without timeout
+        else:
+            return await run_command()
 
     # run command
     async with concurrency("subprocesses", max_subprocesses_context_var.get()):
@@ -231,6 +214,16 @@ def init_max_subprocesses(max_subprocesses: int | None = None) -> None:
 def default_max_subprocesses() -> int:
     cpus = os.cpu_count()
     return cpus if cpus else 1
+
+
+async def drain_stream(stream: ByteReceiveStream | None) -> None:
+    if stream is None:
+        return
+    try:
+        async for _ in stream:
+            pass
+    except ClosedResourceError:
+        pass
 
 
 max_subprocesses_context_var = ContextVar[int](


### PR DESCRIPTION
This fixes an occasional issue which was primarily observed when executing commands in Docker sandboxes. This issue exists with _any_ call to `inspect_ai.util.subprocess` which:
* has a timeout parameter which is hit
* produces large amounts of stdout/stderr (e.g. `cat large_file.txt`) [regardless of whether the `output_limit` is hit]
* is using asyncio as the anyio backend

The call to `await process.aclose()` within the `finally` block of `subprocess().run_command()` was deadlocking because the child process produced so much output that it was blocking on the OS pipe buffer accepting more data, but we were no longer attempting to read any of this data from stdout or stderr (because we'd cancelled the reading of the streams).

The `finally` block of `run_command()` calls `process.aclose()` which in turn calls `process.wait()`, which will only return once the process has exited. Therefore, handling terminating the subprocess in the `TimeoutError` block of `run_command_timeout()` was redundant - because to have gotten past the finally block of `run_command()` the process had to have exited.

The solution is to handle the cancellation within `run_command()` before the finally block which calls `aclose()`. We call terminate (+ kill if necessary) and drain the output pipes.

There are some repro scripts as comments.

See Slack thread https://inspectcommunity.slack.com/archives/C080K7SQ4SG/p1746190208128689