### PR TITLE
Correct typo to satisfy pre-commit action

### DIFF
--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -29,7 +29,7 @@ web_search("tavily")
 # internal provider and fallback
 web_search(["openai", "tavily"])
 
-# multiple interal providers and fallback
+# multiple internal providers and fallback
 web_search(["openai", "anthropic", "gemini", "tavily"])
 
 # provider with specific options


### PR DESCRIPTION
The typo was causing the pre-commit GitHub action to [fail](https://github.com/UKGovernmentBEIS/inspect_ai/actions/runs/15630989960/job/44035079042) in other PRs.

```
typos....................................................................Failed
- hook id: typos
- exit code: 2

error: `interal` should be `internal`, `interval`, `integral`
  --> docs/tools-standard.qmd:32:12
   |
32 | # multiple interal providers and fallback
   |            ^^^^^^^
   |
```