### PR TITLE
Bug: Don't try to format all prompts in react agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [background()](https://inspect.aisi.org.uk/agent-custom.html#background) function for executing work in the background of the current sample.
 - [sandbox_service()](https://inspect.aisi.org.uk/agent-custom.html#sandbox-service) function for making available methods to a sandbox for calling back into the main Inspect process.
 - [sample_limits()](https://inspect.aisi.org.uk/errors-and-limits.html#query-usage) function for determining the current status of sample limits.
+- React agent: Only do substitution on parts of the prompt that may contain a {submit} reference.
 - Agent handoff: Ensure that handoff tool call responses immediately follow the call.
 - Agent handoff: Only print handoff agent prefix if there is assistant message content.
 - Subprocess: Ensure that streams are drained when a cancellation occurs (prevent hanging on calls with large output payloads).

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -361,13 +361,13 @@ def _prompt_to_system_message(
                 and ("{submit}" not in prompt.assistant_prompt)
                 and prompt.submit_prompt
             ):
-                assistant_prompt = f"{prompt.assistant_prompt}\n{prompt.submit_prompt}"
+                assistant_prompt = f"{prompt.assistant_prompt}\n{prompt.submit_prompt.format(submit=submit_tool)}"
             else:
-                assistant_prompt = prompt.assistant_prompt
+                assistant_prompt = prompt.assistant_prompt.format(
+                    submit=submit_tool or "submit"
+                )
             prompt_lines.append(assistant_prompt)
-        prompt_content = "\n\n".join(prompt_lines).format(
-            submit=submit_tool or "submit"
-        )
+        prompt_content = "\n\n".join(prompt_lines)
         system_message: ChatMessage | None = ChatMessageSystem(content=prompt_content)
     else:
         system_message = None


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If you pass in a string to the react prompt which has some curly brackets in it, an error is thrown when the react code tries to format it as an fstring.

```
│ /home/ubuntu/control-arena/control_arena/control_solver.py:46 in solve                                               │
│                                                                                                                      │
│   43 │   │   state.tools = tools(state)                                                                              │
│   44 │   │   protocol = protocol_builder(state.metadata_as(ControlTaskMetadata))                                     │
│   45 │   │                                                                                                           │
│ > 46 │   │   agent = react(                                                                                          │
│   47 │   │   │   prompt=system_prompt.format_map(                                                                    │
│   48 │   │   │   │   state.metadata_as(ControlTaskMetadata).model_dump()                                             │
│   49 │   │   │   ),                                                                                                  │
│                                                                                                                      │
│ /home/ubuntu/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/agent/_agent.py:169 in agent_wrapper        │
│                                                                                                                      │
│ /home/ubuntu/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/agent/_react.py:145 in react                │
│                                                                                                                      │
│ /home/ubuntu/control-arena/.venv/lib/python3.12/site-packages/inspect_ai/agent/_react.py:368 in                      │
│ _prompt_to_system_message                                                                                            │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
KeyError: 'ENVIRONMENT'
```

This is annoying because my system prompt contains content like `"Restrict your actions to 'prometheus-${ENVIRONMENT}'..."` where I do not want "{ENVIRONMENT}" to be interpreted as an f string. 

More generally I wouldn't expect my system prompt to be interpreted as an fstring.

### What is the new behavior?

This is no longer raised. The react agent loop code only tries to format the parts of the prompt with the submit tool rather than applying `format` to the whole prompt.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No