### PR TITLE
Bugfix: Preservation of `ContentReasoning` blocks for Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Inspect View: Increase transcript outline font size.
 - Inspect View: Add support for filtering by sample id, sample metadata.
 - Eval: Wrap eval execution in TaskGroup.
+- Bugfix: Restore preservation of `ContentReasoning` blocks for Gemini (regressed in v0.3.104). 
 - Bugfix: Dataset shuffling now works correctly with `seed` of 0.
 
 ## v0.3.104 (12 June 2025)

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -991,6 +991,10 @@ def _combine_text_parts(acc: list[Part], part: Part) -> list[Part]:
     """Combine adjacent text parts into a single part."""
     return (
         acc + [part]
-        if part.text is None or len(acc) == 0 or acc[-1].text is None
+        if part.text is None
+        or part.thought is not None
+        or len(acc) == 0
+        or acc[-1].text is None
+        or acc[-1].thought is not None
         else acc[:-1] + [Part(text=acc[-1].text + part.text)]
     )

--- a/tests/model/test_reasoning_google.py
+++ b/tests/model/test_reasoning_google.py
@@ -1,19 +1,29 @@
 from test_helpers.utils import skip_if_no_google
 
 from inspect_ai import Task, eval
+from inspect_ai._util.content import ContentReasoning
 from inspect_ai.dataset import Sample
 
 
 @skip_if_no_google
-def test_google_reasoning_tokens():
+def test_google_reasoning():
+    # run eval w/ reasoning tokens
     task = Task(dataset=[Sample(input="Solve 3*x^3-5*x=1")])
     log = eval(
         task,
-        model="google/gemini-2.5-flash-preview-04-17",
+        model="google/gemini-2.5-flash-preview-05-20",
         reasoning_tokens=1024,
     )[0]
     assert log.status == "success"
+
+    # confirm thinking budget was set and reasoning was done
     log_json = log.model_dump_json(indent=2)
     assert '"thinkingBudget": 1024' in log_json
     assert log.samples
-    assert log.samples[0].output.usage.reasoning_tokens > 0
+    output = log.samples[0].output
+    assert output.usage.reasoning_tokens > 0
+
+    # confirm we captured the reasoning content block
+    content = output.message.content
+    assert isinstance(content, list)
+    assert isinstance(content[0], ContentReasoning)


### PR DESCRIPTION
Regressed in v0.3.104 w/ `_combine_text_parts()` not doing special handling for `thought` blocks.

