### PR TITLE
Include default values in resolved task args

### DIFF
--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -583,18 +583,20 @@ def task_identifier(task: ResolvedTask | EvalLog) -> str:
         model_roles = task.eval.model_roles or {}
 
     # hash for task args
+    cleaned_task_args = {k: v for k, v in task_args.items() if v is not None}
     task_args_hash = hashlib.sha256(
-        to_json(task_args, exclude_none=True, fallback=lambda _x: None)
+        to_json(cleaned_task_args, fallback=lambda _x: None)
     ).hexdigest()
 
     # hash for model roles
     if len(model_roles):
+        cleaned_model_roles = {k: v for k, v in model_roles.items() if v is not None}
         model = (
             model
             + "/"
             + hashlib.sha256(
-                to_json(model_roles, exclude_none=True, fallback=lambda _x: None)
-            ).hexdigest()
+            to_json(cleaned_model_roles, fallback=lambda _x: None)
+        ).hexdigest()
         )
 
     if task_file:

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -39,7 +39,7 @@ from inspect_ai.util._sandbox.registry import registry_find_sandboxenv
 from .list import task_files
 from .registry import task_create
 from .task import PreviousTask, Task, TaskInfo
-from .task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
+from .task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR, TASK_ALL_PARAMS_ATTR
 from .task.run import eval_log_sample_source
 from .task.tasks import Tasks
 
@@ -148,6 +148,11 @@ def resolve_tasks(
 
 
 def resolve_task_args(task: Task) -> dict[str, Any]:
+    # If the task has been properly instantiated via the registry,
+    # it will have its TASK_ALL_PARAMS_ATTR attribute set.
+    task_args = getattr(task, TASK_ALL_PARAMS_ATTR, None)
+    if task_args is not None:
+        return task_args
     # was the task instantiated via the registry or a decorator?
     # if so then we can get the task_args from the registry.
     try:
@@ -155,7 +160,7 @@ def resolve_task_args(task: Task) -> dict[str, Any]:
         return task_args
 
     # if it wasn't instantiated via the registry or a decorator
-    # then it will not be in the registy and not have formal
+    # then it will not be in the registry and not have formal
     # task args (as it was simply synthesized via ad-hoc code)
     except ValueError:
         return {}

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -209,9 +209,7 @@ async def eval_run(
                     metrics=eval_metrics,
                     sandbox=resolved_task.sandbox,
                     task_attribs=task.attribs,
-                    task_args=getattr(
-                        task, TASK_ALL_PARAMS_ATTR, resolved_task.task_args
-                    ),
+                    task_args=resolved_task.task_args,
                     task_args_passed=resolved_task.task_args,
                     model_args=resolved_task.model.model_args,
                     eval_config=task_eval_config,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

In #1976 the eval-file header was changed to also include default task arguments. But resolved tasks still just uses the provided task args. That means that the `task_identifier`s are no longer calculated on the same values when tasks have default arguments.

### What is the current behavior? (You can also link to an open issue here)
When you run an evalset fix a task with default arguments, the task_args are not correctly validated against the task_args in the .eval-file causing an error like:

```
ERROR: Existing log file '2025-06-17T07-52-18+00-00_xxx_Vq7LEiypYtvWQLot22hjSG.eval' in log_dir is not associated with a task passed to eval_set (you must run eval_set in a fresh log directory)
```

### What is the new behavior?
The evalset is correctly detected as being the same.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
When generating the data for the task_args (and model_roles) hash the code called Pydantic `to_json()` with `exclude_none=True`. But the input to `to_json()` was a `dict`. `exclude_none` only works on Pydantic types, so the None values was included anyway.

I changed that to conform with what I think the code was supposed to do, but that means that eval-files with None task_args now gets a different hash.

Alternatively, we can just retain the old behavior.

### Other information:
