### PR TITLE
bugfix: eval set now correctly handles retries for tasks with defaulted args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Inspect View: Increase transcript outline font size.
 - Inspect View: Add support for filtering by sample id, sample metadata.
 - Eval: Wrap eval execution in TaskGroup.
+- Bugfix: Eval set now correctly handles retries for tasks with defaulted args (regressed in v0.3.104).
 - Bugfix: Use correct bindings for Claude v4 native `text_editor` tool; don't use native tool definition for Haiku 3.5 or Opus 3.0.  
 - Bugfix: Restore preservation of `ContentReasoning` blocks for Gemini (regressed in v0.3.104). 
 - Bugfix: Dataset shuffling now works correctly with `seed` of 0.

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -578,7 +578,7 @@ def task_identifier(task: ResolvedTask | EvalLog) -> str:
     else:
         task_file = task.eval.task_file or ""
         task_name = task.eval.task
-        task_args = task.eval.task_args
+        task_args = task.eval.task_args_passed
         model = str(task.eval.model)
         model_roles = task.eval.model_roles or {}
 


### PR DESCRIPTION
Regressed in v0.3.104

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
