### PR TITLE
add executed_tools from Groq api

### DIFF
--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -156,6 +156,8 @@ class GroqAPI(ModelAPI):
                     "completion_time": completion.usage.completion_time,
                     "total_time": completion.usage.total_time,
                 }
+            if completion.choices[0].message.executed_tools:
+                metadata["executed_tools"] = completion.choices[0].message.executed_tools
 
             # extract output
             choices = self._chat_choices_from_response(completion, tools)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? 
The `executed_tools` field in groq api cannot be accessed as it doesn't exist in the inspect ai structure. This causes the metadata to be missing or potentially throw errors when the field is accessed for evaluation.  [Groq `executed_tools` Documentation](https://console.groq.com/docs/agentic-tooling#executed-tools)

### What is the new behavior?
Correctly extract `executed_tools` from where it actually exists in the Groq API response.

### Does this PR introduce a breaking change? 
No, this is a bug fix that ensures the `executed_tools` metadata is properly captured without breaking existing functionality.