### PR TITLE
Perplexity configurable with web search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - OpenAI: Use prefix matching when detecting compatible models for `web_search()`.
 - Groq: Capture `executed_tools` field as model output metadata.
 - ReAct agent: Always send `str` returned from `on_continue` to the model (formerly this was only done if there were no tool calls).
+- Web Search: Added provider for Perplexity's internal web search tool.
 - Eval: Wrap eval execution in TaskGroup.
 
 ## v0.3.105 (17 June 2025)

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -12,7 +12,7 @@ tbl-colwidths: [40,60]
 
 The `web_search()` tool provides models the ability to enhance their context window by performing a search. Web searches are executed using a provider. Providers are split into two categories:
 
--   Internal providers: `"openai"`, `"anthropic"`, and `"gemini"` - these use the model's built-in search capability and do not require separate API keys. These work only for their respective model provider (e.g. the "openai" search provider works only for `openai/*` models).
+-   Internal providers: `"openai"`, `"anthropic"`, `"gemini"`, and `"perplexity"` - these use the model's built-in search capability and do not require separate API keys. These work only for their respective model provider (e.g. the "openai" search provider works only for `openai/*` models).
 
 -   External providers: `"tavily"`, `"exa"`, and `"google"`. These are external services that work with any model and require separate accounts and API keys. Note that "google" is different from "gemini" - "google" refers to Google's Programmable Search Engine service, while "gemini" refers to Google's built-in search capability for Gemini models.
 
@@ -30,7 +30,7 @@ web_search("tavily")
 web_search(["openai", "tavily"])
 
 # multiple internal providers and fallback
-web_search(["openai", "anthropic", "gemini", "tavily"])
+web_search(["openai", "anthropic", "gemini", "perplexity", "tavily"])
 
 # provider with specific options
 web_search({"tavily": {"max_results": 5}})
@@ -72,6 +72,14 @@ Note that when using the "gemini" provider, you should also specify a fallback e
 ::: callout-warning
 Google's search grounding does not currently support use with other tools. Attempting to use `web_search("gemini")` alongside other tools will result in an error.
 :::
+
+### Perplexity Options
+
+The `web_search()` tool can use Perplexity's built-in search capability when running on Perplexity models. This provider does not require any API keys beyond what's needed for the model itself. Search parameters can be passed using the `perplexity` provider options and will be forwarded to the model API.
+
+For more details, see [Perplexity API Documentation](https://docs.perplexity.ai/api-reference/chat-completions-post).
+
+Note that when using the "perplexity" provider, you should also specify a fallback external provider (like "tavily", "exa", or "google") if you are also running the evaluation with non-Perplexity models.
 
 ### Tavily Options
 

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -157,7 +157,9 @@ class GroqAPI(ModelAPI):
                     "total_time": completion.usage.total_time,
                 }
             if completion.choices[0].message.executed_tools:
-                metadata["executed_tools"] = completion.choices[0].message.executed_tools
+                metadata["executed_tools"] = completion.choices[
+                    0
+                ].message.executed_tools
 
             # extract output
             choices = self._chat_choices_from_response(completion, tools)

--- a/src/inspect_ai/model/_providers/perplexity.py
+++ b/src/inspect_ai/model/_providers/perplexity.py
@@ -67,7 +67,9 @@ class PerplexityAPI(OpenAICompatibleAPI):
                             f"Expected a dictionary or True for perplexity_options, got {type(maybe_opts)}"
                         )
             else:
-                raise ValueError("Perplexity does not support tools other than web_search with perplexity options")
+                raise ValueError(
+                    "Perplexity does not support tools other than web_search with perplexity options"
+                )
 
         if search_options:
             extra_body = {**(config.extra_body or {}), **search_options}

--- a/src/inspect_ai/tool/_tools/_web_search/_web_search.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_web_search.py
@@ -18,7 +18,7 @@ from ._tavily import TavilyOptions, tavily_search_provider
 from ._web_search_provider import SearchProvider
 
 Provider: TypeAlias = Literal[
-    "gemini", "openai", "anthropic", "tavily", "google", "exa"
+    "gemini", "openai", "anthropic", "perplexity", "tavily", "google", "exa"
 ]
 valid_providers = set(get_args(Provider))
 
@@ -35,6 +35,7 @@ class Providers(TypedDict, total=False):
     openai: dict[str, Any] | Literal[True]
     anthropic: dict[str, Any] | Literal[True]
     gemini: dict[str, Any] | Literal[True]
+    perplexity: dict[str, Any] | Literal[True]
     tavily: dict[str, Any] | Literal[True]
     google: dict[str, Any] | Literal[True]
     exa: dict[str, Any] | Literal[True]
@@ -44,6 +45,7 @@ class _NormalizedProviders(TypedDict, total=False):
     openai: dict[str, Any]
     anthropic: dict[str, Any]
     gemini: dict[str, Any]
+    perplexity: dict[str, Any]
     tavily: dict[str, Any]
     google: dict[str, Any]
     exa: dict[str, Any]
@@ -67,7 +69,7 @@ def web_search(
     Web searches are executed using a provider. Providers are split
     into two categories:
 
-    - Internal providers: "openai", "anthropic" - these use the model's built-in
+    - Internal providers: "openai", "anthropic", "gemini", "perplexity" - these use the model's built-in
       search capability and do not require separate API keys. These work only for
       their respective model provider (e.g. the "openai" search provider
       works only for `openai/*` models).
@@ -84,7 +86,7 @@ def web_search(
 
     Args:
       providers: Configuration for the search providers to use. Currently supported
-        providers are "openai", "anthropic", "tavily", "google", and "exa". The
+        providers are "openai", "anthropic", "perplexity", "tavily", "google", and "exa". The
         `providers` parameter supports several formats based on either a `str`
         specifying a provider or a `dict` whose keys are the provider names and
         whose values are the provider-specific options. A single value or a list
@@ -120,6 +122,9 @@ def web_search(
 
         - anthropic: Supports Anthropic's web search parameters.
           See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool#tool-definition
+
+        - perplexity: Supports Perplexity's web search parameters.
+          See https://docs.perplexity.ai/api-reference/chat-completions-post
 
         - tavily: Supports options like `max_results`, `search_depth`, etc.
           See https://docs.tavily.com/documentation/api-reference/endpoint/search

--- a/tests/model/providers/test_perplexity.py
+++ b/tests/model/providers/test_perplexity.py
@@ -14,6 +14,7 @@ from inspect_ai.model import (
 from inspect_ai.model._model_output import ChatCompletionChoice
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
 from inspect_ai.model._providers.perplexity import PerplexityAPI
+from inspect_ai.tool._tool_info import ToolInfo
 
 
 @pytest.mark.anyio
@@ -29,6 +30,10 @@ async def test_perplexity_api() -> None:
             seed=None,
             temperature=0.0,
             top_p=1.0,
+            extra_body={
+                "search_mode": "academic",
+                "web_search_options": {"search_context_size": "low"}
+            }
         ),
     )
 
@@ -57,8 +62,8 @@ async def test_perplexity_api() -> None:
     assert response.metadata is not None
     if "search_context_size" in response.metadata:
         context_size = response.metadata["search_context_size"]
-        # Updated based on actual API response values
-        assert context_size in ["low", "medium", "high"]
+        # Since we explicitly requested "low", verify it matches
+        assert context_size == "low"
     if "citation_tokens" in response.metadata:
         citation_tokens = response.metadata["citation_tokens"]
         assert citation_tokens >= 0
@@ -145,3 +150,37 @@ async def test_perplexity_citation_mapping(monkeypatch) -> None:
     assert result.usage.reasoning_tokens == 1
     assert result.metadata is not None
     assert result.metadata["search_context_size"] == "low"
+
+
+@pytest.mark.anyio
+async def test_perplexity_web_search_options(monkeypatch) -> None:
+    captured = {}
+
+    async def fake_generate(self, input, tools, tool_choice, config):
+        captured["tools"] = tools
+        captured["config"] = config
+        return (
+            ModelOutput(model="perplexity/sonar", choices=[]),
+            ModelCall.create({}, {})
+        )
+
+    provider = PerplexityAPI(model_name="perplexity/sonar", api_key="sk-test")
+    monkeypatch.setattr(OpenAICompatibleAPI, "generate", fake_generate)
+
+    tool = ToolInfo(
+        name="web_search",
+        description="",
+        options={
+            "perplexity": {
+                "search_mode": "academic",
+                "web_search_options": {"search_context_size": "low"}
+            }
+        }
+    )
+    await provider.generate([], [tool], "none", GenerateConfig())
+
+    assert captured["tools"] == []
+    assert captured["config"].extra_body == {
+        "search_mode": "academic",
+        "web_search_options": {"search_context_size": "low"}
+    }

--- a/tests/model/providers/test_perplexity.py
+++ b/tests/model/providers/test_perplexity.py
@@ -32,8 +32,8 @@ async def test_perplexity_api() -> None:
             top_p=1.0,
             extra_body={
                 "search_mode": "academic",
-                "web_search_options": {"search_context_size": "low"}
-            }
+                "web_search_options": {"search_context_size": "low"},
+            },
         ),
     )
 
@@ -161,7 +161,7 @@ async def test_perplexity_web_search_options(monkeypatch) -> None:
         captured["config"] = config
         return (
             ModelOutput(model="perplexity/sonar", choices=[]),
-            ModelCall.create({}, {})
+            ModelCall.create({}, {}),
         )
 
     provider = PerplexityAPI(model_name="perplexity/sonar", api_key="sk-test")
@@ -173,14 +173,14 @@ async def test_perplexity_web_search_options(monkeypatch) -> None:
         options={
             "perplexity": {
                 "search_mode": "academic",
-                "web_search_options": {"search_context_size": "low"}
+                "web_search_options": {"search_context_size": "low"},
             }
-        }
+        },
     )
     await provider.generate([], [tool], "none", GenerateConfig())
 
     assert captured["tools"] == []
     assert captured["config"].extra_body == {
         "search_mode": "academic",
-        "web_search_options": {"search_context_size": "low"}
+        "web_search_options": {"search_context_size": "low"},
     }


### PR DESCRIPTION
## This PR contains:
- [ X ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Perplexity is a provider but is not configurable with the web search tool

### What is the new behavior?
Perplexity is configurable with the web search tool, like other "native" provider search tools

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Resolves https://github.com/UKGovernmentBEIS/inspect_ai/issues/1975