### PR TITLE
revert changes to react on_continue

### DIFF
--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -246,13 +246,12 @@ def react(
                                 )
                             )
                     elif isinstance(do_continue, str):
-                        # if there were no tool calls we need to send back the user message
-                        if not state.output.message.tool_calls:
-                            state.messages.append(
-                                ChatMessageUser(
-                                    content=do_continue.format(submit=submit_tool.name)
-                                )
+                        # send back the user message
+                        state.messages.append(
+                            ChatMessageUser(
+                                content=do_continue.format(submit=submit_tool.name)
                             )
+                        )
                     else:  # do_continue is False
                         break
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The react agent will only output a user message when there are no tool calls made by the agent.

### What is the new behavior?
It depends what is passed to `on_continue`.

- `None`: a default user message will be output only when there are no tool calls made by the agent
- `str`: the str will be appended as a user message when there are no tool calls
- `Callable`: the function passed can return one of
  - `True`: in which case nothing happens - the agent loop continues
  - `False`: the agent loop is exited early
  - `str`: the agent loop continues and the `str` will be appended as a user message regardless of whether a tool call was made in the previous assistant message

This reverts changes made in 8e44fca making the user responsible for deciding when a user message is appended by optionally outputting a `str` from their `AgentContinue` function. If `str` is passed directly it will only be appended if there are no tool calls which is slightly inconsistent with what one might expect given the behaviour of the `AgentContinue` function. This is because some models do not allow the Assistant=>Tool=>User message sequence and having `str` always result in an assistant message is likely to break some workflows.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
