### PR TITLE
Remove correlated reasoning content items when removing submit tool calls from ChatMessageAssistant's in multi-agent scenarios.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - ReAct agent: Always send `str` returned from `on_continue` to the model (formerly this was only done if there were no tool calls).
 - Web Search: Added provider for Perplexity's internal web search tool.
 - Eval: Wrap eval execution in TaskGroup.
-- Bugfix: Remove correlated reasoning content items when removing submit tool calls from ChatMessageAssistant's in multi-agent scenarios.
+- Bugfix: Remove correlated reasoning content items when removing submit tool calls from ChatMessageAssistant instances in multi-agent scenarios.
 
 ## v0.3.105 (17 June 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ReAct agent: Always send `str` returned from `on_continue` to the model (formerly this was only done if there were no tool calls).
 - Web Search: Added provider for Perplexity's internal web search tool.
 - Eval: Wrap eval execution in TaskGroup.
+- Bugfix: Remove correlated reasoning content items when removing submit tool calls from ChatMessageAssistant's in multi-agent scenarios.
 
 ## v0.3.105 (17 June 2025)
 

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -480,11 +480,12 @@ def _remove_submit_tool(
 
             # If a submit tool call was removed, we need to update the message
             if len(new_tools_calls) < len(message.tool_calls):
-                # Some models (OpenAI) don't like to see the reasoning content item
-                # that led to the submit tool call, so we have to remove it too.
                 message = message.model_copy(
                     update=dict(
                         tool_calls=new_tools_calls,
+                        # Some models (OpenAI) don't like to see the reasoning
+                        # content item that led to the submit tool call, so we
+                        # have to remove it too.
                         content=(
                             [
                                 content


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

React agent removes tool calls to the submit tool. Depending on the model, this can leave reasoning content item that lead to the tool call dangling. OpenAI really doesn't like that.

See discussion [here](https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1750338183162969).

### What is the new behavior?
We remove reasoning content items from `ChatMessageAssistant`'s from which we removed the `submit` tool call.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
