### PR TITLE
Shield critical shutdown code from cancel scope.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Analysis: More forgiving column reading (use Pandas default reader rather than PyArrow).
 - Inspect View: Properly wrap log configuration values in evaluation header.
 - Inspect View: Support for displaying and navigating directories of evaluation logs.
+- Bugfix: Shield critical shutdown code from cancel scope.
 - Bugfix: Prevent concurrent accesses of eval event database from raising lock errors.
 
 ## v0.3.106 (21 June 2025)

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -522,15 +522,16 @@ async def startup_sandbox_environments(
 
     # return shutdown method
     async def shutdown() -> None:
-        for cleanup_jobs in cleanups:
-            try:
-                cleanup_fn, config, task_run_dir = cleanup_jobs
-                with chdir(task_run_dir):
-                    await cleanup_fn("shutdown", config, cleanup)
-            except BaseException as ex:
-                log.warning(
-                    f"Error occurred shutting down sandbox environments: {exception_message(ex)}"
-                )
+        with anyio.CancelScope(shield=True):
+            for cleanup_jobs in cleanups:
+                try:
+                    cleanup_fn, config, task_run_dir = cleanup_jobs
+                    with chdir(task_run_dir):
+                        await cleanup_fn("shutdown", config, cleanup)
+                except BaseException as ex:
+                    log.warning(
+                        f"Error occurred shutting down sandbox environments: {exception_message(ex)}"
+                    )
 
     return shutdown
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When the user cancels an eval (via Ctrl-C), sandbox cleanup code is no longer executed.

#2025 introduced a new task group when executing an eval. An AnyIO task group carries with it a `CancelScope`. When a task group has been cancelled, the cancellation is propagated _down_ to all child task groups. This includes any new task group that is create. It will immediately be cancelled. Beyond that, any _wait_ done in the context of a cancelled task group will induced a `CancelledError` exception.

Sandbox cleanup must be done even if the user has used Ctrl-C. Because of the behavior described above, the cleanup is immediately terminated.

### What is the new behavior?

AnyIO provides an affordance for altering the behavior described above. An inner `CancelScope` can be created with `shield=True`. This causes code that waits within that inner scope to continue - ignoring the parent's cancelled state.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
