### PR TITLE
Fix `store_as` examples, document `inspect_ai.scorer.score`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## Unreleased
 
 - Analysis: More forgiving column reading (use Pandas default reader rather than PyArrow).
+- Fix store_as examples, document inspect_ai.scorer.score
+- Docs: Correct shared documentation snippet that describes Dockerfile customization for Inspect Tool Support.
 - Inspect View: Properly wrap log configuration values in evaluation header.
 - Inspect View: Support for displaying and navigating directories of evaluation logs.
 - Bugfix: Prevent concurrent accesses of eval event database from raising lock errors.
-- Docs: Correct shared documentation snippet that describes Dockerfile customization for Inspect Tool Support.
 - Bugfix: Fix infinite recursion edge case in _flatten_exception.
 
 ## 0.3.108 (25 June 2025)

--- a/docs/agent-custom.qmd
+++ b/docs/agent-custom.qmd
@@ -171,7 +171,8 @@ class WebSurferState(StoreModel):
     messages: list[ChatMessage] = Field(default_factory=list)
 
 @agent
-def web_surfer(instance: str | None = uuid()) -> Agent:
+def web_surfer(instance: str | None = None) -> Agent:
+    instance = instance if instance is not None else uuid()
     
     async def execute(state: AgentState) -> AgentState:
 

--- a/docs/reference/_sidebar.yml
+++ b/docs/reference/_sidebar.yml
@@ -233,6 +233,8 @@ website:
           href: reference/inspect_ai.scorer.qmd#metric
         - text: score_reducer
           href: reference/inspect_ai.scorer.qmd#score_reducer
+        - text: score
+          href: reference/inspect_ai.scorer.qmd#score
       - section: inspect_ai.model
         href: reference/inspect_ai.model.qmd
         contents:

--- a/docs/reference/inspect_ai.scorer.qmd
+++ b/docs/reference/inspect_ai.scorer.qmd
@@ -49,4 +49,6 @@ title: "inspect_ai.scorer"
 ### metric
 ### score_reducer
 
+## Intermediate Scoring
 
+### score

--- a/docs/tools-custom.qmd
+++ b/docs/tools-custom.qmd
@@ -121,7 +121,7 @@ class WebSurferState(StoreModel):
     messages: list[ChatMessage] = Field(default_factory=list)
 
 @tool
-def web_surfer(instance: str | None = uuid()) -> Tool:
+def web_surfer(instance: str | None = None) -> Tool:
     """Web surfer tool for researching topics.
 
     The web_surfer tool builds on the web_browser tool to complete
@@ -129,6 +129,8 @@ def web_surfer(instance: str | None = uuid()) -> Tool:
     Input can either be requests to do research or questions about 
     previous research.
     """
+
+    instance = instance if instance is not None else uuid()
 
     async def execute(input: str, clear_history: bool = False) -> str:
         """Use the web to research a topic.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

- `store_as` examples don't work as expected. Python doesn't regenerate the value of argument defaults each time the function is called. Therefore, each sample gets the same `instance` UUID.
- `inspect_ai.scorer.score` isn't documented

### What is the new behavior?

This PR:

- Changes the `store_as` examples to generate new `instance` values for each `web_surfer` invocation
- Adds `inspect_ai.scorer.score` to the docs

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

N/A