### PR TITLE
Fix infinite recursion edge case in _flatten_exception.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 - Inspect View: Properly wrap log configuration values in evaluation header.
 - Inspect View: Support for displaying and navigating directories of evaluation logs.
 - Bugfix: Prevent concurrent accesses of eval event database from raising lock errors.
-- Docs: Correct shared documentation snippet that describes Dockerfile customization for Inspect Tool Support. 
+- Docs: Correct shared documentation snippet that describes Dockerfile customization for Inspect Tool Support.
+- Bugfix: Fix infinite recursion edge case in _flatten_exception.
 
 ## 0.3.108 (25 June 2025)
 

--- a/tests/util/test_anyio.py
+++ b/tests/util/test_anyio.py
@@ -70,3 +70,68 @@ def _construct_mcp_exception(use_from: bool) -> Exception:
             raise ExceptionGroup("Outer Group", [e])
     except Exception as wow:
         return wow
+
+
+def test_circular_exception_context():
+    """Test that _flatten_exception handles circular exception references without infinite recursion."""
+    # Create two exceptions that reference each other circularly
+    exc1 = ValueError("first exception")
+    exc2 = TypeError("second exception")
+
+    # Create a circular reference: exc1.__context__ -> exc2 -> exc1
+    exc1.__context__ = exc2
+    exc2.__context__ = exc1
+
+    # This should not cause infinite recursion
+    flattened = _flatten_exception(exc1)
+
+    # Should get both exceptions, but not infinitely
+    assert len(flattened) == 2
+    assert any(
+        isinstance(e, ValueError) and str(e) == "first exception" for e in flattened
+    )
+    assert any(
+        isinstance(e, TypeError) and str(e) == "second exception" for e in flattened
+    )
+
+
+def test_circular_exception_group():
+    """Test that _flatten_exception handles circular ExceptionGroup references."""
+    if sys.version_info < (3, 11):
+        # Skip this test on older Python versions
+        return
+
+    # Create a circular reference in exception groups
+    exc1 = ValueError("value error")
+    exc2 = TypeError("type error")
+
+    # Create groups that would create a cycle
+    group1 = ExceptionGroup("group1", [exc1])
+    group2 = ExceptionGroup("group2", [exc2])
+
+    # Make group1 contain group2, and group2's context point back to group1
+    group1 = ExceptionGroup("group1", [exc1, group2])
+    group2.__context__ = group1
+
+    # This should not cause infinite recursion
+    flattened = _flatten_exception(group1)
+
+    # Should contain the actual exceptions, not the groups
+    assert len(flattened) >= 2  # At least the two base exceptions
+    assert any(isinstance(e, ValueError) and str(e) == "value error" for e in flattened)
+    assert any(isinstance(e, TypeError) and str(e) == "type error" for e in flattened)
+
+
+def test_self_referencing_exception():
+    """Test that _flatten_exception handles an exception that references itself."""
+    exc = RuntimeError("self-referencing exception")
+    # Make the exception reference itself
+    exc.__context__ = exc
+
+    # This should not cause infinite recursion
+    flattened = _flatten_exception(exc)
+
+    # Should get the exception exactly once
+    assert len(flattened) == 1
+    assert isinstance(flattened[0], RuntimeError)
+    assert str(flattened[0]) == "self-referencing exception"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

In the right circumstances, `_flatten_exception` can recurse infinitely. This was made evident in [this thread](https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1750875773323909?thread_ts=1750875767.512639&cid=C0805HJTK8U). 

### What is the new behavior?
Failing unit test was added.
The defect was repaired by maintaining a global set of exceptions that have already been visited.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
