### PR TITLE
correct `instance` docs for `web_browser()` and `bash_session()` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Analysis: More forgiving column reading (use Pandas default reader rather than PyArrow).
 - Fix store_as examples, document inspect_ai.scorer.score
+- Docs: Correct docs for `web_browser()` and `bash_session()` to indicate that you must pass an `instance` explicitly to get distinct processes. 
 - Docs: Correct shared documentation snippet that describes Dockerfile customization for Inspect Tool Support.
 - Inspect View: Properly wrap log configuration values in evaluation header.
 - Inspect View: Support for displaying and navigating directories of evaluation logs.

--- a/docs/agent-custom.qmd
+++ b/docs/agent-custom.qmd
@@ -157,7 +157,7 @@ activity = store_as(Activity)
 
 ### Agent Instances
 
-If you want an agent to have a store-per-instance by default, add an `instance` parameter to your `@agent` function and default it to `uuid()`. Then, forward the `instance` on to `store_as()` as well as any tools you call that are also stateful (e.g. `web_browser()`). For example:
+If you want an agent to have a store-per-instance by default, add an `instance` parameter to your `@agent` function and pass it a unique value. Then, forward the `instance` on to `store_as()` as well as any tools you call that are also stateful (e.g. `web_browser()`). For example:
 
 ``` python
 from pydantic import Field
@@ -172,7 +172,6 @@ class WebSurferState(StoreModel):
 
 @agent
 def web_surfer(instance: str | None = None) -> Agent:
-    instance = instance if instance is not None else uuid()
     
     async def execute(state: AgentState) -> AgentState:
 
@@ -185,6 +184,14 @@ def web_surfer(instance: str | None = None) -> Agent:
         messages, state.output = await get_model().generate_loop(
             state.messages, tools=web_browser(instance=instance)
         )
+```
+
+Then, pass a unique id as the `instance`:
+
+```{python}
+from shortuuid import uuid
+
+react(..., tools=[web_surfer(instance=uuid())])
 ```
 
 This enables you to have multiple instances of the `web_surfer()` agent, each with their own state and web browser.

--- a/docs/tools-custom.qmd
+++ b/docs/tools-custom.qmd
@@ -129,9 +129,6 @@ def web_surfer(instance: str | None = None) -> Tool:
     Input can either be requests to do research or questions about 
     previous research.
     """
-
-    instance = instance if instance is not None else uuid()
-
     async def execute(input: str, clear_history: bool = False) -> str:
         """Use the web to research a topic.
 
@@ -191,7 +188,15 @@ def web_surfer(instance: str | None = None) -> Tool:
     return execute
 ```
 
-Note that we use an `instance` parameter (which defaults to `uuid()`) to ensure that each call to the `web_surfer()` function creates its own instance of the tool. We then pass this `instance` to the `store_as()` function (to store our own tool's message history) and the `web_browser()` function (so that we also provision a unique browser for the web surfer session).
+Note that we make available an `instance` parameter that enables creation of multiple instances of the `web_surfer()` tool. We then pass this `instance` to the `store_as()` function (to store our own tool's message history) and the `web_browser()` function (so that we also provision a unique browser for the web surfer session).
+
+For example, this creates a distinct instance of the `web_surfer()` with its own state and browser:
+
+```{python}
+from shortuuid import uuid
+
+react(..., tools=[web_surfer(instance=uuid())])
+```
 
 
 ## Tool Choice

--- a/src/inspect_ai/tool/_tools/_bash_session.py
+++ b/src/inspect_ai/tool/_tools/_bash_session.py
@@ -3,7 +3,6 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, Discriminator, Field, RootModel
 from semver import Version
-from shortuuid import uuid
 
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.tool import ToolResult
@@ -82,7 +81,7 @@ def bash_session(
     *,
     timeout: int | None = None,  # default is max_wait + 5 seconds
     wait_for_output: int | None = None,  # default is 30 seconds
-    instance: str | None = uuid(),
+    instance: str | None = None,
 ) -> Tool:
     """Interactive bash shell session tool.
 
@@ -91,10 +90,8 @@ def bash_session(
     which could be a command followed by a newline character or any other input
     text such as the response to a password prompt.
 
-    By default, a separate bash process is created within the sandbox for each
-    call to `bash_session()`. You can modify this behavior by passing
-    `instance=None` (which will result in a single bash process for the entire
-    sample) or use other `instance` values that implement another scheme).
+    To create a separate bash process for each
+    call to `bash_session()`, pass a unique value for `instance`
 
     See complete documentation at <https://inspect.aisi.org.uk/tools-standard.html#sec-bash-session>.
 

--- a/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
+++ b/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py
@@ -1,7 +1,6 @@
 import re
 
 from pydantic import BaseModel, Field
-from shortuuid import uuid
 
 from inspect_ai._util.content import ContentText
 from inspect_ai._util.error import PrerequisiteError
@@ -32,15 +31,11 @@ class CrawlerResult(BaseModel):
     error: str | None = None
 
 
-def web_browser(
-    *, interactive: bool = True, instance: str | None = uuid()
-) -> list[Tool]:
+def web_browser(*, interactive: bool = True, instance: str | None = None) -> list[Tool]:
     """Tools used for web browser navigation.
 
-    By default, a separate web browser process is created within the sandbox for each
-    call to `web_browser()`. You can modify this behavior by passing `instance=None`
-    (which will result in a single web browser for the entire sample) or use other
-    `instance` values that implement another scheme).
+    To create a separate web browser process for each
+    call to `web_browser()`, pass a unique value for `instance`.
 
     See complete documentation at <https://inspect.aisi.org.uk/tools-standard.html#sec-web-browser>.
 


### PR DESCRIPTION
indicate that you must pass an `instance` explicitly to get distinct processes

