### PR TITLE
vertex: Ignore types to workaround update that removes type information from some of their sub-packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Analysis: More forgiving column reading (use Pandas default reader rather than PyArrow).
 - Fix store_as examples, document inspect_ai.scorer.score
+- Vertex: Ignore types to workaround update that removes type information from some of their sub-packages (tests still pass).
 - Docs: Correct docs for `web_browser()` and `bash_session()` to indicate that you must pass an `instance` explicitly to get distinct processes. 
 - Docs: Correct shared documentation snippet that describes Dockerfile customization for Inspect Tool Support.
 - Inspect View: Properly wrap log configuration values in evaluation header.

--- a/src/inspect_ai/model/_providers/vertex.py
+++ b/src/inspect_ai/model/_providers/vertex.py
@@ -1,3 +1,5 @@
+# type: ignore
+
 import functools
 import json
 from copy import copy

--- a/tests/model/providers/test_vertex.py
+++ b/tests/model/providers/test_vertex.py
@@ -11,11 +11,11 @@ from inspect_ai.model import (
 from inspect_ai.scorer import includes
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 @skip_if_no_vertex
 async def test_vertex_api() -> None:
     model = get_model(
-        "vertex/gemini-1.5-flash",
+        "vertex/gemini-2.0-flash",
         config=GenerateConfig(
             frequency_penalty=0.0,
             stop_seqs=None,
@@ -52,6 +52,6 @@ def test_vertex_safety_settings():
             dataset=[Sample(input="What is 1 + 1?", target=["2", "2.0", "Two"])],
             scorer=includes(),
         ),
-        model="vertex/gemini-1.5-flash",
+        model="vertex/gemini-2.0-flash",
         safety_settings=safety_settings,
     )


### PR DESCRIPTION
all vertex tests still pass
