### PR TITLE
Fix tab issue in vscode

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -42613,7 +42613,9 @@ Please change the parent <Route path="${parentPath}"> to <Route path="${parentPa
           }
         }
         if (foundTabId && tabIdIndex > 0) {
-          const logPath = pathSegments.slice(0, tabIdIndex).join("/");
+          const pathSlice = pathSegments.slice(0, tabIdIndex);
+          const firstSegment = pathSlice[0];
+          const logPath = (firstSegment == null ? void 0 : firstSegment.endsWith(":")) && !firstSegment.includes("://") ? firstSegment + (firstSegment === "file:" ? "///" : "//") + pathSlice.slice(1).join("/") : pathSlice.join("/");
           return {
             logPath: decodeUrlParam(logPath),
             tabId: foundTabId,
@@ -91998,6 +92000,7 @@ Supported expressions:
       const clearInitialState = useStore(
         (state) => state.appActions.clearInitialState
       );
+      const evalSpec = useEvalSpec();
       const setSampleTab = useStore((state) => state.appActions.setSampleTab);
       const setShowingSampleDialog = useStore(
         (state) => state.appActions.setShowingSampleDialog
@@ -92020,7 +92023,7 @@ Supported expressions:
       const totalSampleCount = useTotalSampleCount();
       const navigate = useNavigate();
       reactExports.useEffect(() => {
-        if (initialState2) {
+        if (initialState2 && !evalSpec) {
           const url = baseUrl(
             initialState2.log,
             initialState2.sample_id,
@@ -92029,7 +92032,7 @@ Supported expressions:
           clearInitialState();
           navigate(url);
         }
-      }, [initialState2]);
+      }, [initialState2, evalSpec]);
       const prevLogPath = usePrevious(logPath);
       reactExports.useEffect(() => {
         const loadLogFromPath = async () => {

--- a/src/inspect_ai/_view/www/src/app/log-view/LogViewContainer.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-view/LogViewContainer.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { kLogViewSamplesTabId } from "../../constants";
 import {
+  useEvalSpec,
   useFilteredSamples,
   usePrevious,
   useTotalSampleCount,
@@ -20,6 +21,7 @@ export const LogViewContainer: FC = () => {
   const clearInitialState = useStore(
     (state) => state.appActions.clearInitialState,
   );
+  const evalSpec = useEvalSpec();
   const setSampleTab = useStore((state) => state.appActions.setSampleTab);
   const setShowingSampleDialog = useStore(
     (state) => state.appActions.setShowingSampleDialog,
@@ -47,7 +49,7 @@ export const LogViewContainer: FC = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (initialState) {
+    if (initialState && !evalSpec) {
       const url = baseUrl(
         initialState.log,
         initialState.sample_id,
@@ -56,7 +58,7 @@ export const LogViewContainer: FC = () => {
       clearInitialState();
       navigate(url);
     }
-  }, [initialState]);
+  }, [initialState, evalSpec]);
 
   const prevLogPath = usePrevious<string | undefined>(logPath);
 

--- a/src/inspect_ai/_view/www/src/app/routing/url.ts
+++ b/src/inspect_ai/_view/www/src/app/routing/url.ts
@@ -154,7 +154,14 @@ export const useLogRouteParams = () => {
 
     if (foundTabId && tabIdIndex > 0) {
       // Found a valid tab ID, split the path there
-      const logPath = pathSegments.slice(0, tabIdIndex).join("/");
+      const pathSlice = pathSegments.slice(0, tabIdIndex);
+      const firstSegment = pathSlice[0];
+      const logPath =
+        firstSegment?.endsWith(":") && !firstSegment.includes("://")
+          ? firstSegment +
+            (firstSegment === "file:" ? "///" : "//") +
+            pathSlice.slice(1).join("/")
+          : pathSlice.join("/");
 
       return {
         logPath: decodeUrlParam(logPath),


### PR DESCRIPTION
Eval tabs are broken in vscode- two things are happening:

1) the file path is being computed from the url incorrectly with mismatching slashes, causing an unexpected reload.

2) initial state is being restored even though an eval is loaded.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
