### PR TITLE
Return `hook_type` (i.e. class) rather than instance from decorator wrapper

### DIFF
--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -266,7 +266,7 @@ def hooks(name: str, description: str) -> Callable[..., Type[T]]:
                 type="hooks", name=hook_name, metadata={"description": description}
             ),
         )
-        return cast(Type[T], hook_instance)
+        return cast(Type[T], hook_type)
 
     return wrapper
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -264,6 +264,16 @@ def test_hooks_name_and_description(mock_hooks: MockHooks) -> None:
     assert info.metadata["description"] == "test_hooks-description"
 
 
+def test_hooks_decorator_returns_class() -> None:
+    @hooks(name="test_hooks_class", description="test")
+    class TestHooksClass(Hooks):
+        pass
+
+    assert isinstance(TestHooksClass, type)
+    instance = TestHooksClass()
+    assert isinstance(instance, Hooks)
+
+
 T = TypeVar("T", bound=Hooks)
 
 


### PR DESCRIPTION
I was incorrectly returning the instance rather than the class. This meant that if you did

``` py
@hooks(...)
class MyHooks(Hooks):
    pass

# TypeError: 'TelemetryHooks' object is not callable
instance = MyHooks()
```

