### PR TITLE
Fix Mypy error with mistralai update

### DIFF
--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from mistralai import (
     ContentChunk,
     DocumentURLChunk,
+    FileChunk,
     FunctionCall,
     FunctionName,
     ImageURL,
@@ -491,6 +492,8 @@ def completion_content(content: str | list[ContentChunk]) -> str | list[Content]
 
 
 def completion_content_chunks(content: ContentChunk) -> list[Content]:
+    if isinstance(content, FileChunk):
+        raise TypeError("FileChunk content is not supported by Inspect.")
     if isinstance(content, ReferenceChunk):
         raise TypeError("ReferenceChunk content is not supported by Inspect.")
     elif isinstance(content, TextChunk):

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -157,7 +157,7 @@ def cf() -> type[ModelAPI]:
 def mistral() -> type[ModelAPI]:
     FEATURE = "Mistral API"
     PACKAGE = "mistralai"
-    MIN_VERSION = "1.8.2"
+    MIN_VERSION = "1.9.1"
 
     # verify we have the package
     try:


### PR DESCRIPTION
The latest version of `mistralai` is causing a Mypy error.

```
src/inspect_ai/model/_providers/mistral.py:508: error: Item "FileChunk" of "ImageURLChunk | FileChunk" has no attribute "image_url"  [union-attr]
src/inspect_ai/model/_providers/mistral.py:509: error: Item "FileChunk" of "ImageURLChunk | FileChunk" has no attribute "image_url"  [union-attr]
src/inspect_ai/model/_providers/mistral.py:511: error: Item "FileChunk" of "ImageURLChunk | FileChunk" has no attribute "image_url"  [union-attr]
src/inspect_ai/model/_providers/mistral.py:513: error: Item "FileChunk" of "ImageURLChunk | FileChunk" has no attribute "image_url"  [union-attr]
src/inspect_ai/model/_providers/mistral.py:516: error: Item "FileChunk" of "ImageURLChunk | FileChunk" has no attribute "image_url"  [union-attr]
```

Hard to pin down their exact change, but notice here that FileChunk is new as of yesterday.
https://github.com/mistralai/client-python/blame/main/docs/models/contentchunk.md