### PR TITLE
Conform to Mistral breaking change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Analysis: Include `order` field in `messages_df()` and `events_df()`.
 - Logging: Improvements to `--display=log` (improved task info formatting, ability to disable rich logging)
 - Task Display: Limit console to a maximum of 100 lines to prevent rendering performance problems.
+- Bugfix: Conform to breaking changes in `mistralai` package (1.9.1).
 
 ## 0.3.111 (29 June 2025)
 

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -6,6 +6,7 @@ from typing import Any, Literal
 from mistralai import (
     ContentChunk,
     DocumentURLChunk,
+    FileChunk,
     FunctionCall,
     FunctionName,
     ImageURL,
@@ -504,6 +505,8 @@ def completion_content_chunks(content: ContentChunk) -> list[Content]:
             return [ContentText(text=content.text)]
     elif isinstance(content, DocumentURLChunk):
         return [ContentText(text=content.document_url)]
+    elif isinstance(content, FileChunk):
+        return [ContentText(text=f"file: {content.file_id}")]
     else:
         if isinstance(content.image_url, str):
             return [ContentImage(image=content.image_url)]

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -157,7 +157,7 @@ def cf() -> type[ModelAPI]:
 def mistral() -> type[ModelAPI]:
     FEATURE = "Mistral API"
     PACKAGE = "mistralai"
-    MIN_VERSION = "1.8.2"
+    MIN_VERSION = "1.9.1"
 
     # verify we have the package
     try:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

This PR updates the Mistral provider to align with breaking changes in mistralai v1.9.1 by bumping the minimum supported version and adding support for the new FileChunk type in content chunk handling.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
