### PR TITLE
Support username with `bash_session` and `text_editor` tools

### DIFF
--- a/src/inspect_ai/tool/_tools/_bash_session.py
+++ b/src/inspect_ai/tool/_tools/_bash_session.py
@@ -82,6 +82,7 @@ def bash_session(
     timeout: int | None = None,  # default is max_wait + 5 seconds
     wait_for_output: int | None = None,  # default is 30 seconds
     instance: str | None = None,
+    user: str = "root",
 ) -> Tool:
     """Interactive bash shell session tool.
 
@@ -102,6 +103,8 @@ def bash_session(
           empty string. The model may need to make multiple tool calls to obtain
           all output from a given command.
       instance: Instance id (each unique instance id has its own bash process)
+      user: Username to run commands as. Note user is ignored (defaulting to root) in
+          inspect_tool_support prior to v1.1.1.
 
     Returns:
       String with output from the shell.
@@ -196,7 +199,7 @@ def bash_session(
                 await exec_model_request(
                     sandbox,
                     "bash_session_new_session",
-                    {},
+                    {"user": user},
                     NewSessionResult,
                     TRANSPORT_TIMEOUT,
                 )

--- a/src/inspect_ai/tool/_tools/_text_editor.py
+++ b/src/inspect_ai/tool/_tools/_text_editor.py
@@ -18,6 +18,7 @@ from .._tool import Tool, tool
 
 class BaseParams(BaseModel):
     path: str
+    user: str = "root"
 
 
 class ViewParams(BaseParams):
@@ -61,7 +62,7 @@ TextEditorResult = str
 
 
 @tool()
-def text_editor(timeout: int | None = None, user: str | None = None) -> Tool:
+def text_editor(timeout: int | None = None, user: str = "root") -> Tool:
     """Custom editing tool for viewing, creating and editing files.
 
     Perform text editor operations using a sandbox environment (e.g. "docker").
@@ -110,6 +111,8 @@ def text_editor(timeout: int | None = None, user: str | None = None) -> Tool:
             for k, v in locals().items()
             if k in inspect.signature(execute).parameters
         }
+
+        params["user"] = user
 
         return await exec_scalar_request(
             sandbox=sandbox,

--- a/src/inspect_tool_support/Dockerfile.dev
+++ b/src/inspect_tool_support/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM aisiuk/inspect-tool-support
+
+COPY . /app
+
+RUN pip install --no-cache-dir /app \
+    && inspect-tool-support post-install
+
+CMD ["tail", "-f", "/dev/null"]

--- a/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/json_rpc_methods.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/json_rpc_methods.py
@@ -19,13 +19,15 @@ from inspect_tool_support._util.json_rpc_helpers import validated_json_rpc_metho
 @validated_json_rpc_method(TextEditorParams)
 async def text_editor(params: TextEditorParams) -> str:
     match params.root:
-        case ViewParams(path=path, view_range=view_range):
-            return await view(path, view_range)
-        case CreateParams(path=path, file_text=file_text):
-            return await create(path, file_text)
-        case StrReplaceParams(path=path, old_str=old_str, new_str=new_str):
-            return await str_replace(path, old_str, new_str)
-        case InsertParams(path=path, insert_line=insert_line, new_str=new_str):
-            return await insert(path, insert_line, new_str)
-        case UndoEditParams(path=path):
-            return await undo_edit(path)
+        case ViewParams(path=path, view_range=view_range, user=user):
+            return await view(path, view_range, user)
+        case CreateParams(path=path, file_text=file_text, user=user):
+            return await create(path, file_text, user)
+        case StrReplaceParams(path=path, old_str=old_str, new_str=new_str, user=user):
+            return await str_replace(path, old_str, new_str, user)
+        case InsertParams(
+            path=path, insert_line=insert_line, new_str=new_str, user=user
+        ):
+            return await insert(path, insert_line, new_str, user)
+        case UndoEditParams(path=path, user=user):
+            return await undo_edit(path, user)

--- a/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/tool_types.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/tool_types.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Discriminator, RootModel
 
 class BaseParams(BaseModel):
     path: str
+    user: str = "root"
 
 
 class ViewParams(BaseParams):

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/_controller.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/_controller.py
@@ -1,3 +1,5 @@
+from functools import partial
+
 from ..._util.session_controller import SessionController
 from ._session import Session
 from .tool_types import BashRestartResult, InteractResult
@@ -8,8 +10,10 @@ DEFAULT_SESSION_NAME = "BashSession"
 class Controller(SessionController[Session]):
     """BashSessionController provides support for isolated inspect subtask sessions."""
 
-    async def new_session(self) -> str:
-        return await self.create_new_session(DEFAULT_SESSION_NAME, Session.create)
+    async def new_session(self, user) -> str:
+        return await self.create_new_session(
+            DEFAULT_SESSION_NAME, partial(Session.create, user)
+        )
 
     async def interact(
         self,

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/_session.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/_session.py
@@ -6,8 +6,8 @@ from .tool_types import BashRestartResult, InteractResult
 
 class Session:
     @classmethod
-    async def create(cls) -> "Session":
-        return cls(await Process.create())
+    async def create(cls, user: str) -> "Session":
+        return cls(await Process.create(user=user))
 
     def __init__(self, process: Process) -> None:
         self._process = process

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/json_rpc_methods.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/json_rpc_methods.py
@@ -1,10 +1,11 @@
-from ..._util.json_rpc_helpers import NoParams, validated_json_rpc_method
+from ..._util.json_rpc_helpers import validated_json_rpc_method
 from ._controller import Controller
 from .tool_types import (
     BashParams,
     BashRestartResult,
     InteractParams,
     InteractResult,
+    NewSessionParams,
     NewSessionResult,
     RestartParams,
 )
@@ -12,9 +13,9 @@ from .tool_types import (
 controller = Controller()
 
 
-@validated_json_rpc_method(NoParams)
-async def bash_session_new_session(_: NoParams) -> NewSessionResult:
-    return NewSessionResult(session_name=await controller.new_session())
+@validated_json_rpc_method(NewSessionParams)
+async def bash_session_new_session(params: NewSessionParams) -> NewSessionResult:
+    return NewSessionResult(session_name=await controller.new_session(params.user))
 
 
 @validated_json_rpc_method(BashParams)

--- a/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/tool_types.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_remote_tools/_bash_session/tool_types.py
@@ -26,6 +26,10 @@ class BashParams(RootModel[InteractParams | RestartParams]):
     pass
 
 
+class NewSessionParams(BaseModel):
+    user: str = "root"
+
+
 class NewSessionResult(BaseModel):
     session_name: str
 

--- a/src/inspect_tool_support/unreleased_changes/2005.patch.md
+++ b/src/inspect_tool_support/unreleased_changes/2005.patch.md
@@ -1,0 +1,1 @@
+Enforce the specified username for the text editor tool.

--- a/src/inspect_tool_support/unreleased_changes/2006.minor.md
+++ b/src/inspect_tool_support/unreleased_changes/2006.minor.md
@@ -1,0 +1,1 @@
+Add support for running as a specified user with the bash session tool.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,17 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runapi", action="store_true", default=False, help="run API tests"
     )
+    parser.addoption(
+        "--local-inspect-tools",
+        action="store_true",
+        default=False,
+        help="If set, run inspect tools from local source instead of pulling from Docker Hub",
+    )
+
+
+@pytest.fixture(scope="session")
+def local_inspect_tools(request):
+    return request.config.getoption("--local-inspect-tools")
 
 
 def pytest_configure(config):

--- a/tests/tools/test_inspect_tool_support.from_source.yaml
+++ b/tests/tools/test_inspect_tool_support.from_source.yaml
@@ -1,0 +1,9 @@
+services:
+  default:
+    image: "python:3.12-bookworm"
+    init: true
+    command: "tail -f /dev/null"
+  web_browser:
+    build:
+      context: ../../src/inspect_tool_support
+      dockerfile: Dockerfile.dev

--- a/tests/tools/test_inspect_tool_support.py
+++ b/tests/tools/test_inspect_tool_support.py
@@ -232,3 +232,58 @@ def test_bash_session_missing_user(inspect_tool_support_sandbox):
     assert isinstance(response.error, ValueError), (
         f"Expected ValueError as user foo is missing, but got {type(response.error)}"
     )
+
+
+@pytest.mark.slow
+def test_text_editor_user(inspect_tool_support_sandbox):
+    task = Task(
+        dataset=[
+            Sample(
+                input="Create a file /flag only readable by root. Then read it with the text editor",
+            )
+        ],
+        solver=[
+            use_tools([bash_session(user="root"), text_editor(user="nobody")]),
+            generate(),
+        ],
+        scorer=match(),
+        sandbox=inspect_tool_support_sandbox,
+    )
+    flag = "this_is_it"
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="bash_session",
+                tool_arguments={
+                    "action": "type_submit",
+                    "input": f"echo {flag} > /flag && chmod 400 /flag; ls -al /flag && cat /flag",
+                },
+            ),
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="text_editor",
+                tool_arguments={"command": "view", "path": "/flag"},
+            ),
+            ModelOutput.from_content(model="mockllm/model", content="All done."),
+        ],
+    )
+    log = eval(task, model=model)[0]
+
+    assert log.status == "success"
+    assert log.samples
+    messages = log.samples[0].messages
+
+    bash_tool_call = get_tool_call(messages, "bash_session")
+    bash_response = get_tool_response(messages, bash_tool_call)
+    editor_tool_call = get_tool_call(messages, "text_editor")
+    editor_response = get_tool_response(messages, editor_tool_call)
+
+    assert "-r--------" in bash_response.content  # Expect read only flag
+    assert "root root" in bash_response.content  # Expect flag owned by root
+
+    assert editor_response
+    assert flag not in editor_response.content
+
+    print(editor_response)

--- a/tests/tools/test_inspect_tool_support.py
+++ b/tests/tools/test_inspect_tool_support.py
@@ -17,7 +17,7 @@ from inspect_ai.solver import (
     generate,
     use_tools,
 )
-from inspect_ai.tool import ToolCallError, text_editor
+from inspect_ai.tool import ToolCallError, bash_session, text_editor
 
 
 @pytest.fixture(scope="session")
@@ -108,4 +108,127 @@ def test_text_editor_read_missing(inspect_tool_support_sandbox):
     assert response.error  # Expect ToolError as file is missing
     assert isinstance(response.error, ToolCallError), (
         f"Expected ToolCallError, got {type(response.error)}"
+    )
+
+
+@pytest.mark.slow
+def test_bash_session_root(inspect_tool_support_sandbox):
+    task = Task(
+        dataset=[
+            Sample(
+                input='What is the output of running the command echo "start $(whoami) end"?'
+            )
+        ],
+        solver=[use_tools([bash_session()]), generate()],
+        scorer=match(),
+        sandbox=inspect_tool_support_sandbox,
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="bash_session",
+                tool_arguments={
+                    "action": "type_submit",
+                    "input": 'echo "start $(whoami) end"',
+                },
+            ),
+            ModelOutput.from_content(model="mockllm/model", content="All done."),
+        ],
+    )
+    log = eval(task, model=model)[0]
+
+    assert log.status == "success"
+    assert log.samples
+    messages = log.samples[0].messages
+    tool_call = get_tool_call(messages, "bash_session")
+    assert tool_call
+    response = get_tool_response(messages, tool_call)
+    assert response
+    assert response.error is None, f"Tool call returns error: {response.error}"
+    assert "start root end" in response.content, (
+        f"Unexpected output from whoami: {response.content}"
+    )
+
+
+@pytest.mark.slow
+def test_bash_session_non_root(inspect_tool_support_sandbox):
+    task = Task(
+        dataset=[
+            Sample(
+                input='What is the output of running the command echo "start $(whoami) end"?'
+            )
+        ],
+        solver=[use_tools([bash_session(user="nobody")]), generate()],
+        scorer=match(),
+        sandbox=inspect_tool_support_sandbox,
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="bash_session",
+                tool_arguments={
+                    "action": "type_submit",
+                    "input": 'echo "start $(whoami) end"',
+                },
+            ),
+            ModelOutput.from_content(model="mockllm/model", content="All done."),
+        ],
+    )
+    log = eval(task, model=model)[0]
+
+    assert log.status == "success"
+    assert log.samples
+    messages = log.samples[0].messages
+    tool_call = get_tool_call(messages, "bash_session")
+    assert tool_call
+    response = get_tool_response(messages, tool_call)
+    assert response
+    assert response.error is None, f"Tool call returns error: {response.error}"
+    assert "start nobody end" in response.content, (
+        f"Unexpected output from whoami: {response.content}"
+    )
+
+
+@pytest.mark.slow
+def test_bash_session_missing_user(inspect_tool_support_sandbox):
+    task = Task(
+        dataset=[
+            Sample(
+                input='What is the output of running the command echo "start $(whoami) end"?'
+            )
+        ],
+        solver=[use_tools([bash_session(user="foo")]), generate()],
+        scorer=match(),
+        sandbox=inspect_tool_support_sandbox,
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="bash_session",
+                tool_arguments={
+                    "action": "type_submit",
+                    "input": 'echo "start $(whoami) end"',
+                },
+            ),
+            ModelOutput.from_content(model="mockllm/model", content="All done."),
+        ],
+    )
+    log = eval(task, model=model)[0]
+
+    assert log.status == "success"
+    assert log.samples
+    messages = log.samples[0].messages
+    tool_call = get_tool_call(messages, "bash_session")
+    assert tool_call
+    response = get_tool_response(messages, tool_call)
+    assert response
+    assert response.error  # Expect ValueError as user foo doesn't exist
+    assert isinstance(response.error, ValueError), (
+        f"Expected ValueError as user foo is missing, but got {type(response.error)}"
     )


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [x]  Changes to dev-tools: new feature for unit tests

### What is the current behavior? (You can also link to an open issue here)
Fixes #2006

### What is the new behavior?
You can now specify a username. If the user doesn't exist, a Value error will be raised when the session is created.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

I expected this to cause issues when running with older versions of the inspect_tool_support package, but it seems to silently ignore it instead. If there'd be an easy way to add a warning message when this happens, that might be good, but things won't break if a user only updates inspect_ai or only inspect_tool_support.

### Other information:

The first commit here was required for testing these changes and I think is generally helpful - when running tests from `test_inspect_tool_support.py`, a user can now specify `--local-inspect-tools` as part of the pytest command to specify that the local code for inspect_tool_support should be used instead of the container from dockerhub.