### PR TITLE
Support username with `bash_session` and `text_editor` tools

### DIFF
--- a/src/inspect_ai/tool/_tools/_bash_session.py
+++ b/src/inspect_ai/tool/_tools/_bash_session.py
@@ -81,6 +81,7 @@ def bash_session(
     *,
     timeout: int | None = None,  # default is max_wait + 5 seconds
     wait_for_output: int | None = None,  # default is 30 seconds
+    user: str | None = None,
     instance: str | None = None,
 ) -> Tool:
     """Interactive bash shell session tool.
@@ -101,6 +102,7 @@ def bash_session(
           output is received within this period, the function will return an
           empty string. The model may need to make multiple tool calls to obtain
           all output from a given command.
+      user: Username to run commands as
       instance: Instance id (each unique instance id has its own bash process)
 
     Returns:
@@ -199,6 +201,7 @@ def bash_session(
                     {},
                     NewSessionResult,
                     TRANSPORT_TIMEOUT,
+                    user=user,
                 )
             ).session_name
 
@@ -220,6 +223,7 @@ def bash_session(
             {"session_name": store.session_id, **(action_specific[action])},
             str,
             timeout,
+            user=user,
         )
 
         # Return the appropriate response

--- a/src/inspect_ai/tool/_tools/_text_editor.py
+++ b/src/inspect_ai/tool/_tools/_text_editor.py
@@ -117,6 +117,7 @@ def text_editor(timeout: int | None = None, user: str | None = None) -> Tool:
             params=params,
             result_type=TextEditorResult,
             timeout=timeout,
+            user=user,
         )
 
     return execute

--- a/src/inspect_tool_support/Dockerfile.dev
+++ b/src/inspect_tool_support/Dockerfile.dev
@@ -1,0 +1,8 @@
+FROM aisiuk/inspect-tool-support
+
+COPY . /app
+
+RUN pip install --no-cache-dir /app \
+    && inspect-tool-support post-install
+
+CMD ["tail", "-f", "/dev/null"]

--- a/src/inspect_tool_support/README.md
+++ b/src/inspect_tool_support/README.md
@@ -75,3 +75,11 @@ When it's time to make a release:
    - Tags the commit with the new version number `inspect-tool-support-1.1.0`
 
 All changelog items are consumed during the release process and converted into entries in the `CHANGELOG.md` file. After the release, the `unreleased_changes/` directory will be empty, ready to collect changes for the next release cycle.
+
+
+## Testing
+When running `pytest` with inspect to test interactions with this package, you may wish to test your _local_ version of the `inspect_tool_support` code instead of the latest published package. Passing the flag `--local-inspect-tools` to pytest when running tests from `test_inspect_tool_support.py` will build and install the package from source, for example:
+
+```sh
+pytest tests/tools/test_inspect_tool_support.py --runslow --local-inspect-tools
+```

--- a/src/inspect_tool_support/src/inspect_tool_support/_cli/main.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_cli/main.py
@@ -47,8 +47,6 @@ def main() -> None:
 # {"jsonrpc": "2.0", "method": "editor", "id": 666, "params": {"command": "view", "path": "/tmp"}}
 # {"jsonrpc": "2.0", "method": "bash", "id": 666, "params": {"command": "ls ~/Downloads"}}
 async def _exec(request: str | None) -> None:
-    _ensure_server_is_running()
-
     in_process_tools = load_tools("inspect_tool_support._in_process_tools")
 
     request_json_str = request or sys.stdin.read().strip()
@@ -69,6 +67,7 @@ async def _dispatch_local_method(request_json_str: str) -> JSONRPCResponseJSON:
 
 
 async def _dispatch_remote_method(request_json_str: str) -> JSONRPCResponseJSON:
+    _ensure_server_is_running()
     return await json_rpc_http_call(_SERVER_URL, request_json_str)
 
 

--- a/src/inspect_tool_support/unreleased_changes/+718f270e.minor.md
+++ b/src/inspect_tool_support/unreleased_changes/+718f270e.minor.md
@@ -1,0 +1,1 @@
+Do not start server until it is needed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,17 @@ def pytest_addoption(parser):
     parser.addoption(
         "--runapi", action="store_true", default=False, help="run API tests"
     )
+    parser.addoption(
+        "--local-inspect-tools",
+        action="store_true",
+        default=False,
+        help="If set, run inspect tools from local source instead of pulling from Docker Hub",
+    )
+
+
+@pytest.fixture(scope="session")
+def local_inspect_tools(request):
+    return request.config.getoption("--local-inspect-tools")
 
 
 def pytest_configure(config):

--- a/tests/tools/test_inspect_tool_support.from_source.yaml
+++ b/tests/tools/test_inspect_tool_support.from_source.yaml
@@ -1,0 +1,9 @@
+services:
+  default:
+    image: "python:3.12-bookworm"
+    init: true
+    command: "tail -f /dev/null"
+  web_browser:
+    build:
+      context: ../../src/inspect_tool_support
+      dockerfile: Dockerfile.dev

--- a/tests/tools/test_inspect_tool_support.py
+++ b/tests/tools/test_inspect_tool_support.py
@@ -226,3 +226,56 @@ def test_bash_session_missing_user(inspect_tool_support_sandbox):
     # Note that the sandbox exec helper doesn't log anything about the user being
     # the cause of this error, so there's unfortunately nothing more precise for us to check
     assert log.status == "error"
+
+
+@pytest.mark.slow
+def test_text_editor_user(inspect_tool_support_sandbox):
+    task = Task(
+        dataset=[
+            Sample(
+                input="Create a file /flag only readable by root. Then read it with the text editor",
+            )
+        ],
+        solver=[
+            use_tools([bash_session(user="root"), text_editor(user="nobody")]),
+            generate(),
+        ],
+        scorer=match(),
+        sandbox=inspect_tool_support_sandbox,
+    )
+    flag = "this_is_it"
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="bash_session",
+                tool_arguments={
+                    "action": "type_submit",
+                    "input": f"echo {flag} > /flag && chmod 400 /flag; ls -al /flag && cat /flag",
+                },
+            ),
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="text_editor",
+                tool_arguments={"command": "view", "path": "/flag"},
+            ),
+            ModelOutput.from_content(model="mockllm/model", content="All done."),
+        ],
+    )
+    log = eval(task, model=model)[0]
+
+    assert log.status == "success"
+    assert log.samples
+    messages = log.samples[0].messages
+
+    bash_tool_call = get_tool_call(messages, "bash_session")
+    bash_response = get_tool_response(messages, bash_tool_call)
+    editor_tool_call = get_tool_call(messages, "text_editor")
+    editor_response = get_tool_response(messages, editor_tool_call)
+
+    assert "-r--------" in bash_response.content  # Expect read only flag
+    assert "root root" in bash_response.content  # Expect flag owned by root
+
+    assert editor_response
+    assert flag not in editor_response.content


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)
These two tools always run as a sandbox's default user, and cannot be configured differently. The existing `user` argument for the `text_editor` tool is simply ignored while the `bash_session` tool does not expose this argument.

FIXES #2005 
FIXES #2006 

### What is the new behavior?
The specified username in these tools will be passed through to the sandbox exec call. This PR also adds some test (and improves how `inspect_tool_support` can be tested).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

When using inspect with these changes and the updated version of inspect_tool_support, these tools will run as the specified user. If either package is outdated, the username will continue to be ignored.

| Inspect_ai version    | Inspect_tool_support version | result |
| -------- | ------- | ------- |
| New | New | Username can be set, tools run as specified user |
| Old  | Old    | Username cannot be set, tools run as default user |
| New | Old    | Username can be set, tools run as default user |
| Old | New | Username cannot be set, tools run as default user (Could maybe add a warning for this case?) |

### Other information:
1) This is an updated version of #2083 after talking it through with @epatey and realizing there was a more lightweight fix
2) The way the `inspect_tool_support` server runs in a sandbox is still somewhat confusing when thinking about multiple users and could potentially lead to confusing unexpected behavior, e.g., if the persistent server is launched as one user but then a different tool tries running as another. The design in #2083 assumed that the server would always run as root, which had other downsides and was a bit more complicated, but it might be worth re-visiting this in the future.