### PR TITLE
Added high-level diagrams

### DIFF
--- a/.codeboarding/Agent_Solver_Framework.md
+++ b/.codeboarding/Agent_Solver_Framework.md
@@ -1,0 +1,291 @@
+```mermaid
+
+graph LR
+
+    Agent_Core["Agent Core"]
+
+    Solver_Core["Solver Core"]
+
+    Task_State_Management["Task State Management"]
+
+    ReAct_Agent_Strategy["ReAct Agent Strategy"]
+
+    Human_in_the_Loop_Agent["Human-in-the-Loop Agent"]
+
+    Chained_Solver_Strategy["Chained Solver Strategy"]
+
+    Planning_Solver_Strategy["Planning Solver Strategy"]
+
+    Tool_Usage_Integration["Tool Usage Integration"]
+
+    Agent_Solver_Bridge["Agent-Solver Bridge"]
+
+    Agent_Tool_Bridge["Agent-Tool Bridge"]
+
+    ReAct_Agent_Strategy -- "extends" --> Agent_Core
+
+    Human_in_the_Loop_Agent -- "extends" --> Agent_Core
+
+    Agent_Solver_Bridge -- "uses" --> Agent_Core
+
+    Agent_Tool_Bridge -- "uses" --> Agent_Core
+
+    Chained_Solver_Strategy -- "uses" --> Agent_Core
+
+    Chained_Solver_Strategy -- "extends" --> Solver_Core
+
+    Planning_Solver_Strategy -- "extends" --> Solver_Core
+
+    Solver_Core -- "interacts with" --> Agent_Core
+
+    Tool_Usage_Integration -- "uses" --> Solver_Core
+
+    Agent_Solver_Bridge -- "uses" --> Solver_Core
+
+    Task_State_Management -- "manages" --> Agent_Core
+
+    Agent_Solver_Bridge -- "uses" --> Task_State_Management
+
+    Chained_Solver_Strategy -- "uses" --> Task_State_Management
+
+    Planning_Solver_Strategy -- "uses" --> Task_State_Management
+
+    Tool_Usage_Integration -- "uses" --> Task_State_Management
+
+    Human_in_the_Loop_Agent -- "uses" --> Task_State_Management
+
+    ReAct_Agent_Strategy -- "extends" --> Agent_Core
+
+    ReAct_Agent_Strategy -- "uses" --> Tool_Usage_Integration
+
+    Human_in_the_Loop_Agent -- "extends" --> Agent_Core
+
+    Human_in_the_Loop_Agent -- "interacts with" --> Task_State_Management
+
+    Chained_Solver_Strategy -- "extends" --> Solver_Core
+
+    Chained_Solver_Strategy -- "uses" --> Agent_Core
+
+    Chained_Solver_Strategy -- "uses" --> Solver_Core
+
+    Chained_Solver_Strategy -- "uses" --> Task_State_Management
+
+    Planning_Solver_Strategy -- "extends" --> Solver_Core
+
+    Planning_Solver_Strategy -- "uses" --> Task_State_Management
+
+    Solver_Core -- "used by" --> Tool_Usage_Integration
+
+    ReAct_Agent_Strategy -- "used by" --> Tool_Usage_Integration
+
+    Tool_Usage_Integration -- "interacts with" --> Task_State_Management
+
+    Agent_Solver_Bridge -- "adapts" --> Agent_Core
+
+    Agent_Solver_Bridge -- "implements" --> Solver_Core
+
+    Agent_Tool_Bridge -- "adapts" --> Agent_Core
+
+    Agent_Tool_Bridge -- "uses" --> Tool_Usage_Integration
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Agent & Solver Framework` subsystem is the core orchestrator for how LLMs and agents approach and resolve evaluation tasks within the `inspect_ai` framework. It provides a flexible and extensible architecture for defining various agent behaviors and task-solving strategies, managing their execution, and integrating external capabilities like tool usage and human intervention.
+
+
+
+### Agent Core
+
+This component defines the fundamental `Agent` interface and provides base functionalities for all LLM agents within the framework. It manages the agent's internal state (`AgentState`) and its interaction with the conversation history, serving as the blueprint for specific agent implementations. It is fundamental as it establishes the common contract for all agents, enabling extensibility and consistent interaction patterns.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/agent/_agent.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.agent._agent` (1:1)</a>
+
+
+
+
+
+### Solver Core
+
+This component establishes the abstract `Solver` interface, which dictates how an LLM or an agent approaches and resolves an evaluation task. It forms the foundational layer for various task-solving strategies, ensuring a consistent approach across different problem-solving methodologies. It is fundamental as it provides the high-level strategy for task completion, allowing for diverse problem-solving patterns.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_solver.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._solver` (1:1)</a>
+
+
+
+
+
+### Task State Management
+
+This is a critical, central component responsible for maintaining the complete and current state of an ongoing evaluation task. This includes the conversation history, outputs from models, records of tool calls, scoring metrics, and adherence to various operational limits (e.g., token limits, time limits). It acts as the single source of truth and shared context for all agents and solvers involved in a task. It is fundamental for ensuring data consistency, enabling complex multi-turn interactions, and providing a comprehensive audit trail for evaluations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_task_state.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._task_state` (1:1)</a>
+
+
+
+
+
+### ReAct Agent Strategy
+
+This component implements the ReAct (Reasoning and Acting) agent strategy, a common pattern where LLMs iteratively reason about a task and interact with external tools. It handles the parsing of model outputs to identify and execute tool calls, and manages the agent's internal thought process. It is fundamental as it provides a concrete and widely adopted pattern for intelligent agent behavior, crucial for complex LLM evaluations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/agent/_react.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.agent._react` (1:1)</a>
+
+
+
+
+
+### Human-in-the-Loop Agent
+
+This component provides the necessary framework for human-assisted agents, enabling human evaluators to intervene, provide instructions, or submit scores during an evaluation. It includes sub-components for processing human commands, displaying interactive UI panels, and managing the state of human interactions. It is fundamental for incorporating human judgment and oversight, which is essential for qualitative evaluation in an LLM framework.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.agent._human` (1:1)
+
+
+
+
+
+### Chained Solver Strategy
+
+This component implements a solver strategy that allows for the sequential execution of multiple agents or solvers. This enables the creation of complex, multi-step evaluation workflows where the output of one step feeds into the next. It is fundamental for building sophisticated evaluation pipelines that require a sequence of distinct problem-solving steps.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_chain.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._chain` (1:1)</a>
+
+
+
+
+
+### Planning Solver Strategy
+
+This component implements a solver strategy where the LLM or agent first generates a detailed plan to solve the task before executing any steps. It manages the planning process and the subsequent execution of the planned actions. It is fundamental for evaluating LLMs' ability to strategize and execute multi-step plans, a key aspect of complex problem-solving.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_plan.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._plan` (1:1)</a>
+
+
+
+
+
+### Tool Usage Integration
+
+This component provides the essential mechanism for solvers to interact with and effectively utilize external tools. It acts as a bridge, connecting the solver's decision-making logic with the secure tool execution environment. It is fundamental for enabling LLMs to perform actions beyond pure text generation, allowing for realistic evaluation scenarios involving external systems.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_use_tools.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._use_tools` (1:1)</a>
+
+
+
+
+
+### Agent-Solver Bridge
+
+This component acts as an adapter, enabling an `Agent` to be seamlessly integrated and used as a `Solver`. This flexibility allows agent-based logic to be incorporated directly into the broader solver framework, promoting reusability and modularity. It is fundamental for maximizing the reusability of agent implementations within the solver framework, fostering a more modular architecture.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/agent/_as_solver.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.agent._as_solver` (1:1)</a>
+
+
+
+
+
+### Agent-Tool Bridge
+
+This component provides an adapter that allows an `Agent` to be exposed and utilized as a `Tool` within the system. This means that other agents or models can invoke an agent's capabilities as if it were a standard tool, enhancing the composability of the framework. It is fundamental for enabling advanced composability, where agents can leverage the capabilities of other agents as if they were simple tools.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/agent/_handoff.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.agent._handoff` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Data_Analysis.md
+++ b/.codeboarding/Data_Analysis.md
@@ -1,0 +1,279 @@
+```mermaid
+
+graph LR
+
+    DataFrame_Core["DataFrame Core"]
+
+    Evaluation_Log_Reader["Evaluation Log Reader"]
+
+    Record_Processing_Utility["Record Processing Utility"]
+
+    Data_Validation_Utility["Data Validation Utility"]
+
+    Progress_Reporting_Utility["Progress Reporting Utility"]
+
+    Sample_DataFrame_Manager["Sample DataFrame Manager"]
+
+    Message_DataFrame_Manager["Message DataFrame Manager"]
+
+    Event_DataFrame_Manager["Event DataFrame Manager"]
+
+    Evaluation_DataFrame_Manager["Evaluation DataFrame Manager"]
+
+    Evaluation_Log_Reader -- "Provides raw log data" --> Record_Processing_Utility
+
+    Record_Processing_Utility -- "Transforms data for" --> Sample_DataFrame_Manager
+
+    Record_Processing_Utility -- "Transforms data for" --> Message_DataFrame_Manager
+
+    Record_Processing_Utility -- "Transforms data for" --> Event_DataFrame_Manager
+
+    Record_Processing_Utility -- "Transforms data for" --> Evaluation_DataFrame_Manager
+
+    DataFrame_Core -- "Provides base structures/utilities" --> Sample_DataFrame_Manager
+
+    DataFrame_Core -- "Provides base structures/utilities" --> Message_DataFrame_Manager
+
+    DataFrame_Core -- "Provides base structures/utilities" --> Event_DataFrame_Manager
+
+    DataFrame_Core -- "Provides base structures/utilities" --> Evaluation_DataFrame_Manager
+
+    Data_Validation_Utility -- "Validates data for" --> Record_Processing_Utility
+
+    Sample_DataFrame_Manager -- "Reports progress to" --> Progress_Reporting_Utility
+
+    Message_DataFrame_Manager -- "Reports progress to" --> Progress_Reporting_Utility
+
+    Event_DataFrame_Manager -- "Reports progress to" --> Progress_Reporting_Utility
+
+    Evaluation_DataFrame_Manager -- "Reports progress to" --> Progress_Reporting_Utility
+
+    Sample_DataFrame_Manager -- "Utilizes" --> DataFrame_Core
+
+    Message_DataFrame_Manager -- "Utilizes" --> DataFrame_Core
+
+    Event_DataFrame_Manager -- "Utilizes" --> DataFrame_Core
+
+    Evaluation_DataFrame_Manager -- "Utilizes" --> DataFrame_Core
+
+    Sample_DataFrame_Manager -- "Utilizes" --> Evaluation_Log_Reader
+
+    Message_DataFrame_Manager -- "Utilizes" --> Evaluation_Log_Reader
+
+    Event_DataFrame_Manager -- "Utilizes" --> Evaluation_Log_Reader
+
+    Evaluation_DataFrame_Manager -- "Utilizes" --> Evaluation_Log_Reader
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Data Analysis` subsystem, primarily centered around `inspect_ai.analysis.beta._dataframe`, is designed to transform raw evaluation logs into structured, queryable dataframes (e.g., Pandas DataFrames). This enables advanced statistical analysis, filtering, and custom reporting of LLM evaluation results. It adheres to the project's data-driven design and modular architecture, providing clear contracts for data transformation and access.
+
+
+
+### DataFrame Core
+
+This is the foundational layer for data manipulation and analysis within the subsystem. It defines the base `Column` structure and provides common utilities for creating, validating, and processing dataframes from evaluation logs. It acts as a central hub for shared data transformation tasks, including JSONPath extraction and type coercion.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.analysis.beta._dataframe` (0:0)
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/columns.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.columns` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/extract.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.extract` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/util.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.util` (0:0)</a>
+
+
+
+
+
+### Evaluation Log Reader
+
+Responsible for reading raw evaluation log files from the file system. It serves as the primary data source, providing the raw log entries that are subsequently processed and transformed by other components.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/log/_file.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.log._file` (0:0)</a>
+
+
+
+
+
+### Record Processing Utility
+
+Handles the conversion of raw log entries into structured records suitable for DataFrame creation. This includes logic for resolving values, performing type coercion (e.g., string to boolean/int), and managing duplicate columns during the import process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/record.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.record` (0:0)</a>
+
+
+
+
+
+### Data Validation Utility
+
+Ensures the structural and type correctness of data, particularly for JSONPath expressions used in column definitions. It prevents malformed data from corrupting the analysis and ensures data integrity.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/validate.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.validate` (0:0)</a>
+
+
+
+
+
+### Progress Reporting Utility
+
+Provides mechanisms for displaying progress during potentially long-running data import operations, enhancing user experience by giving feedback on the loading process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/progress.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.progress` (0:0)</a>
+
+
+
+
+
+### Sample DataFrame Manager
+
+Specializes in loading, processing, and managing DataFrames for individual evaluation samples. It orchestrates the reading of raw log data, converting it into a structured DataFrame, and ensuring data integrity for individual evaluation samples.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.analysis.beta._dataframe.samples` (0:0)
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/samples/columns.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.samples.columns` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/samples/extract.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.samples.extract` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/samples/table.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.samples.table` (0:0)</a>
+
+
+
+
+
+### Message DataFrame Manager
+
+Specializes in creating and managing DataFrames specifically for chat messages extracted from evaluation logs. This allows for detailed analysis of conversational turns and model outputs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.analysis.beta._dataframe.messages` (0:0)
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/messages/columns.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.messages.columns` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/messages/extract.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.messages.extract` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/messages/table.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.messages.table` (0:0)</a>
+
+
+
+
+
+### Event DataFrame Manager
+
+Specializes in creating and managing DataFrames for events recorded during the evaluation process (e.g., model calls, tool executions). This provides a granular timeline of the evaluation flow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.analysis.beta._dataframe.events` (0:0)
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/events/columns.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.events.columns` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/events/extract.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.events.extract` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/events/table.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.events.table` (0:0)</a>
+
+
+
+
+
+### Evaluation DataFrame Manager
+
+Specializes in creating and managing DataFrames for overall evaluation summaries and metadata, providing a high-level view of evaluation runs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.analysis.beta._dataframe.evals` (0:0)
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/evals/columns.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.evals.columns` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/evals/extract.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.evals.extract` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/analysis/beta/_dataframe/evals/table.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.analysis.beta._dataframe.evals.table` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Dataset_Management.md
+++ b/.codeboarding/Dataset_Management.md
@@ -1,0 +1,137 @@
+```mermaid
+
+graph LR
+
+    Dataset_Abstraction["Dataset Abstraction"]
+
+    In_Memory_Dataset_Task_Definition["In-Memory Dataset & Task Definition"]
+
+    Data_Sample["Data Sample"]
+
+    Data_Source_Adapters["Data Source Adapters"]
+
+    Data_Source_Utilities["Data Source Utilities"]
+
+    Data_Source_Adapters -- "provides data to" --> In_Memory_Dataset_Task_Definition
+
+    In_Memory_Dataset_Task_Definition -- "is a type of" --> Dataset_Abstraction
+
+    Dataset_Abstraction -- "contains" --> Data_Sample
+
+    Data_Source_Utilities -- "assists" --> Data_Source_Adapters
+
+    In_Memory_Dataset_Task_Definition -- "defines" --> Evaluation_Core
+
+    Data_Sample -- "is processed by" --> Evaluation_Core
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Dataset Management` component is central to `inspect_ai`'s data-driven evaluation framework, ensuring that diverse input data is consistently prepared for evaluation tasks. It achieves this through a well-defined structure of abstract and concrete dataset representations, coupled with robust data source adapters and utilities.
+
+
+
+### Dataset Abstraction
+
+This is the abstract base class that defines the fundamental structure and interface for all datasets within the `inspect_ai` framework. It establishes the contract for how evaluation data is represented and accessed, ensuring consistency across different data sources.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/dataset/_dataset.py#L129-L205" target="_blank" rel="noopener noreferrer">`inspect_ai.dataset._dataset.Dataset` (129:205)</a>
+
+
+
+
+
+### In-Memory Dataset & Task Definition
+
+A concrete implementation of `Dataset` that holds evaluation data in memory. Its significance lies in its dual role: it not only represents a dataset but also inherits from `inspect_ai._eval.task.task.Task`, meaning a dataset can directly define an evaluation task. This is a core aspect of the framework's data-driven design, where the data itself dictates the evaluation structure.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/dataset/_dataset.py#L241-L363" target="_blank" rel="noopener noreferrer">`inspect_ai.dataset._dataset.MemoryDataset` (241:363)</a>
+
+
+
+
+
+### Data Sample
+
+Represents a single, immutable entry or row within a dataset. Each `Sample` contains the input data for a specific evaluation instance, and it can also store metadata and results as the evaluation progresses.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/dataset/_dataset.py#L29-L106" target="_blank" rel="noopener noreferrer">`inspect_ai.dataset._dataset.Sample` (29:106)</a>
+
+
+
+
+
+### Data Source Adapters
+
+This package (and its sub-modules like `_csv`, `_json`, `_hf`, `_file`, `_example`) provides the specific logic and adapters required to load and parse evaluation data from diverse external sources (CSV, JSONL, Hugging Face datasets, etc.). Each sub-module handles a particular data format.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.dataset._sources` (0:0)
+
+
+
+
+
+### Data Source Utilities
+
+This utility module provides common functions for processing and transforming data originating from the various sources. It ensures data consistency, performs necessary transformations (e.g., converting to chat message format), and potentially interacts with the sandbox environment for secure or complex data preparation steps.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/dataset/_sources/util.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.dataset._sources.util` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Evaluation_Orchestrator.md
+++ b/.codeboarding/Evaluation_Orchestrator.md
@@ -1,0 +1,269 @@
+```mermaid
+
+graph LR
+
+    Eval_Core["Eval Core"]
+
+    Evaluation_Runner["Evaluation Runner"]
+
+    Evaluation_Loader["Evaluation Loader"]
+
+    Evaluation_Task_Definition["Evaluation Task Definition"]
+
+    Evaluation_Context_Manager["Evaluation Context Manager"]
+
+    Evaluation_Scoring_Integration["Evaluation Scoring Integration"]
+
+    Model_Integration["Model Integration"]
+
+    Solver_Core["Solver Core"]
+
+    Logging_and_Transcript["Logging and Transcript"]
+
+    Registry_Service["Registry Service"]
+
+    Dataset["Dataset"]
+
+    Eval_Core -- "uses" --> Evaluation_Loader
+
+    Eval_Core -- "uses" --> Evaluation_Runner
+
+    Eval_Core -- "uses" --> Evaluation_Context_Manager
+
+    Eval_Core -- "uses" --> Evaluation_Scoring_Integration
+
+    Evaluation_Runner -- "interacts with" --> Evaluation_Task_Definition
+
+    Evaluation_Runner -- "communicates with" --> Logging_and_Transcript
+
+    Evaluation_Loader -- "relies on" --> Registry_Service
+
+    Evaluation_Task_Definition -- "is implemented by" --> Dataset
+
+    Evaluation_Task_Definition -- "is implemented by" --> Solver_Core
+
+    Solver_Core -- "uses" --> Model_Integration
+
+    Evaluation_Runner -- "sends data to" --> Logging_and_Transcript
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+One paragraph explaining the functionality which is represented by this graph. What the main flow is and what is its purpose.
+
+
+
+### Eval Core
+
+The primary module responsible for initiating and coordinating the overall evaluation process. It acts as the central hub, bringing together task loading, configuration resolution, execution, and result handling. This is the "brain" of the orchestrator.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/eval.py#L73-L255" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.eval` (73:255)</a>
+
+
+
+
+
+### Evaluation Runner
+
+Manages the execution lifecycle of individual evaluation runs. It handles the actual dispatching of tasks, manages concurrency, and integrates with display and logging mechanisms. This is the "executor" that makes the evaluation happen.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/run.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.run` (1:1)</a>
+
+
+
+
+
+### Evaluation Loader
+
+Responsible for discovering, loading, and resolving evaluation tasks and their associated configurations (models, solvers, scorers, datasets). It ensures all necessary components are correctly identified and prepared for an evaluation run. This is the "setup crew."
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/loader.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.loader` (1:1)</a>
+
+
+
+
+
+### Evaluation Task Definition
+
+Defines the fundamental structure and properties of an evaluation task. This includes specifying datasets, models, solvers, and scoring criteria. It serves as the blueprint for what an evaluation entails. This is the "blueprint" for any evaluation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/task/task.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.task.task` (1:1)</a>
+
+
+
+
+
+### Evaluation Context Manager
+
+Provides and manages the operational context for an evaluation run, including environment variables, hooks, and logging configurations. It ensures a consistent and controlled environment for evaluation execution. This is the "environment controller."
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/context.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.context` (1:1)</a>
+
+
+
+
+
+### Evaluation Scoring Integration
+
+Handles the integration and application of scoring mechanisms within the overall evaluation flow. It processes evaluation results and applies defined scorers to generate metrics and outcomes, effectively acting as the scoring engine. This is the "results processor and scoring engine."
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_score.py#L11-L62" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._score.score` (11:62)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_scorer.py#L32-L59" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._scorer.Scorer` (32:59)</a>
+
+
+
+
+
+### Model Integration
+
+Provides an abstraction layer for interacting with various LLMs. It handles model loading, inference calls, and manages model-specific configurations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_model.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.model._model` (1:1)</a>
+
+
+
+
+
+### Solver Core
+
+Represents the logic or "agent" that interacts with the LLM to perform tasks within an evaluation. This could be a simple prompt, a chain of prompts, or a more complex agentic workflow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_solver.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._solver` (1:1)</a>
+
+
+
+
+
+### Logging and Transcript
+
+Manages the recording of all events, interactions, and results during an evaluation run. It provides detailed logs and transcripts for analysis and debugging.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/log/_transcript.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.log._transcript` (1:1)</a>
+
+
+
+
+
+### Registry Service
+
+A centralized service for registering and discovering various components like models, datasets, and scorers. It acts as a lookup mechanism for the Evaluation Loader.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/registry.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.registry` (1:1)</a>
+
+
+
+
+
+### Dataset
+
+A component providing datasets for evaluation tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/dataset/_dataset.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.dataset._dataset` (1:1)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/LLM_Integration_Layer.md
+++ b/.codeboarding/LLM_Integration_Layer.md
@@ -1,0 +1,201 @@
+```mermaid
+
+graph LR
+
+    LLM_Integration_Layer["LLM Integration Layer"]
+
+    Model["Model"]
+
+    ModelAPI["ModelAPI"]
+
+    ChatMessage["ChatMessage"]
+
+    GenerateConfig["GenerateConfig"]
+
+    ModelOutput["ModelOutput"]
+
+    Cache["Cache"]
+
+    Tool_Execution_Handler["Tool Execution Handler"]
+
+    Evaluation_Core -- "uses" --> Model
+
+    Model -- "uses" --> ModelAPI
+
+    ModelAPI -- "implemented by" --> Concrete_LLM_Providers
+
+    Model -- "uses" --> ChatMessage
+
+    Model -- "uses" --> GenerateConfig
+
+    Model -- "produces" --> ModelOutput
+
+    Model -- "uses" --> Cache
+
+    Model -- "uses" --> Tool_Execution_Handler
+
+    Tool_Execution_Handler -- "communicates with" --> Tool_Execution_Sandbox
+
+    Model -- "interacts with" --> Logging_and_Reporting
+
+    click LLM_Integration_Layer href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//LLM_Integration_Layer.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Overview of abstract components and their relationships within the inspect_ai framework's LLM integration layer.
+
+
+
+### LLM Integration Layer [[Expand]](./LLM_Integration_Layer.md)
+
+A crucial component within the `inspect_ai` framework, acting as an abstraction over various Large Language Models. Its primary purpose is to provide a unified interface for interacting with different LLM providers, handling the complexities of message formatting, API calls, response parsing, and managing model-specific configurations and caching. This ensures that the core evaluation logic of `inspect_ai` remains decoupled from the specific implementations of individual LLM APIs.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Model
+
+This is the core class representing an LLM within the `inspect_ai` framework. It provides a high-level, unified interface for LLM interaction, handling common concerns such as caching, concurrency, retry mechanisms, and orchestrating tool execution loops. It acts as the primary entry point for the `LLM Integration Layer` for external components like the `Evaluation Core`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_model.py#L257-L816" target="_blank" rel="noopener noreferrer">`inspect_ai.model._model.Model` (257:816)</a>
+
+
+
+
+
+### ModelAPI
+
+An abstract base class that defines the low-level interface for specific LLM provider integrations. Concrete implementations (e.g., for OpenAI, Anthropic, Google) inherit from `ModelAPI` and are responsible for handling the actual API calls, request/response translation, and model-specific behaviors. The `Model` component utilizes an instance of `ModelAPI` to perform the underlying LLM generation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_model.py#L97-L254" target="_blank" rel="noopener noreferrer">`inspect_ai.model._model.ModelAPI` (97:254)</a>
+
+
+
+
+
+### ChatMessage
+
+This component defines the structure for messages exchanged with LLMs. It includes various types of messages like `ChatMessageUser`, `ChatMessageAssistant`, `ChatMessageSystem`, and `ChatMessageTool`, ensuring consistent message formatting across different LLM APIs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_chat_message.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.model._chat_message.ChatMessage` (1:1)</a>
+
+
+
+
+
+### GenerateConfig
+
+This class encapsulates configuration parameters for generating responses from LLMs, such as temperature, max tokens, and response schema. It allows for fine-grained control over the LLM's behavior during generation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_generate_config.py#L112-L233" target="_blank" rel="noopener noreferrer">`inspect_ai.model._generate_config.GenerateConfig` (112:233)</a>
+
+
+
+
+
+### ModelOutput
+
+Represents the structured output received from an LLM after a generation call. It includes the generated text, usage statistics (e.g., token counts), and potentially other metadata like citations or tool calls.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_model_output.py#L130-L267" target="_blank" rel="noopener noreferrer">`inspect_ai.model._model_output.ModelOutput` (130:267)</a>
+
+
+
+
+
+### Cache
+
+This component is responsible for caching LLM responses to avoid redundant API calls, especially during repeated evaluations or development cycles. It helps in speeding up evaluations and reducing costs.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_cache.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.model._cache.Cache` (1:1)</a>
+
+
+
+
+
+### Tool Execution Handler
+
+This component, primarily represented by the `execute_tools` function, facilitates the invocation and execution of external tools by the LLM. It processes tool calls made by the LLM, executes the corresponding tool functions, and formats their results back into messages for the LLM.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_call_tools.py#L96-L342" target="_blank" rel="noopener noreferrer">`inspect_ai.model._call_tools.execute_tools` (96:342)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Scoring_Metrics_Engine.md
+++ b/.codeboarding/Scoring_Metrics_Engine.md
@@ -1,0 +1,357 @@
+```mermaid
+
+graph LR
+
+    inspect_ai_scorer__scorer_Scorer["inspect_ai.scorer._scorer.Scorer"]
+
+    inspect_ai_scorer__metric_Metric["inspect_ai.scorer._metric.Metric"]
+
+    inspect_ai_scorer__model_ModelScorer["inspect_ai.scorer._model.ModelScorer"]
+
+    inspect_ai_scorer__reducer_Reducer["inspect_ai.scorer._reducer.Reducer"]
+
+    inspect_ai_scorer__score_score["inspect_ai.scorer._score.score"]
+
+    inspect_ai_log__log_EvalSampleScore["inspect_ai.log._log.EvalSampleScore"]
+
+    inspect_ai_log__transcript_ScoreEvent["inspect_ai.log._transcript.ScoreEvent"]
+
+    inspect_ai_log__recorders_eval_EvalRecorder["inspect_ai.log._recorders.eval.EvalRecorder"]
+
+    inspect_ai_log__recorders_buffer_database_SampleBufferDatabase["inspect_ai.log._recorders.buffer.database.SampleBufferDatabase"]
+
+    inspect_ai_log__recorders_buffer_filestore_SampleBufferFilestore["inspect_ai.log._recorders.buffer.filestore.SampleBufferFilestore"]
+
+    Solver_Core["Solver Core"]
+
+    Model_Integration["Model Integration"]
+
+    Registry_Service["Registry Service"]
+
+    Evaluation_Plan_Manager["Evaluation Plan Manager"]
+
+    Logging_and_Transcript["Logging and Transcript"]
+
+    inspect_ai_scorer__metric_Score["inspect_ai.scorer._metric.Score"]
+
+    Solver_Core -- "invokes" --> inspect_ai_scorer__scorer_Scorer
+
+    Solver_Core -- "invokes" --> inspect_ai_scorer__metric_Metric
+
+    inspect_ai_scorer__model_ModelScorer -- "depends on" --> Model_Integration
+
+    inspect_ai_scorer__score_score -- "sends to" --> Logging_and_Transcript
+
+    inspect_ai_scorer__reducer_Reducer -- "sends to" --> Logging_and_Transcript
+
+    Registry_Service -- "used by" --> inspect_ai_scorer__scorer_Scorer
+
+    Registry_Service -- "used by" --> inspect_ai_scorer__metric_Metric
+
+    Registry_Service -- "used by" --> inspect_ai_scorer__reducer_Reducer
+
+    Evaluation_Plan_Manager -- "defines plan for" --> inspect_ai_scorer__scorer_Scorer
+
+    Evaluation_Plan_Manager -- "defines plan for" --> inspect_ai_scorer__metric_Metric
+
+    Solver_Core -- "orchestrates" --> inspect_ai_scorer__score_score
+
+    Solver_Core -- "passes output to" --> inspect_ai_scorer__score_score
+
+    inspect_ai_scorer__score_score -- "uses" --> inspect_ai_scorer__scorer_Scorer
+
+    inspect_ai_scorer__scorer_Scorer -- "uses" --> inspect_ai_scorer__metric_Metric
+
+    inspect_ai_scorer__scorer_Scorer -- "uses" --> inspect_ai_scorer__model_ModelScorer
+
+    inspect_ai_scorer__score_score -- "passes scores to" --> inspect_ai_scorer__reducer_Reducer
+
+    inspect_ai_log__log_EvalSampleScore -- "is a" --> inspect_ai_scorer__metric_Score
+
+    inspect_ai_log__transcript_ScoreEvent -- "contains" --> inspect_ai_log__log_EvalSampleScore
+
+    inspect_ai_log__recorders_eval_EvalRecorder -- "uses" --> inspect_ai_log__log_EvalSampleScore
+
+    inspect_ai_log__recorders_buffer_database_SampleBufferDatabase -- "uses" --> inspect_ai_log__log_EvalSampleScore
+
+    inspect_ai_log__recorders_buffer_filestore_SampleBufferFilestore -- "uses" --> inspect_ai_log__log_EvalSampleScore
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Scoring & Metrics Engine is a crucial component within the LLM Evaluation Framework, responsible for quantitatively assessing the performance and quality of LLM outputs. It provides a flexible and extensible mechanism for defining, applying, and aggregating various evaluation metrics.
+
+
+
+### inspect_ai.scorer._scorer.Scorer
+
+This is the foundational component for defining and registering scoring functions. It acts as a decorator, transforming a standard Python function into a callable scorer that can be seamlessly integrated into the evaluation pipeline. It orchestrates the execution of individual metrics and ensures they operate within the correct evaluation context.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_scorer.py#L32-L59" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._scorer.Scorer` (32:59)</a>
+
+
+
+
+
+### inspect_ai.scorer._metric.Metric
+
+Represents a single, atomic metric used for evaluation. This class serves as the base for all specific metric types (e.g., accuracy, F1-score, mean squared error). It defines the essential interface for how a metric is calculated and how its results are structured, ensuring consistency across different evaluation criteria.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_metric.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._metric.Metric` (0:0)</a>
+
+
+
+
+
+### inspect_ai.scorer._model.ModelScorer
+
+A specialized `Scorer` that leverages an LLM to perform evaluations. This enables "model-graded evaluations," where one LLM assesses the quality of another LLM's output based on predefined criteria or rubrics. It interacts with the `Model Integration` component to utilize LLMs for the scoring process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_model.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._model.ModelScorer` (0:0)</a>
+
+
+
+
+
+### inspect_ai.scorer._reducer.Reducer
+
+Responsible for aggregating scores from individual samples or metrics into a final, summarized result. This is essential for providing overall performance insights (e.g., average accuracy, standard deviation, aggregated F1-score across a dataset). It defines how raw scores are processed and combined to yield meaningful evaluation summaries.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_reducer/reducer.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._reducer.Reducer` (0:0)</a>
+
+
+
+
+
+### inspect_ai.scorer._score.score
+
+A utility function or decorator that applies a `Scorer` to a given evaluation sample. It orchestrates the process of taking an LLM output and computing its score using the defined metrics and scorers. It acts as a bridge between the evaluation execution and the scoring logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_score.py#L11-L62" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._score.score` (11:62)</a>
+
+
+
+
+
+### inspect_ai.log._log.EvalSampleScore
+
+Represents the structured output of a scoring operation for a single evaluation sample. It inherits from `inspect_ai.scorer._metric.Score`, indicating that it holds the result of a metric calculation. This component is crucial for logging and reporting, ensuring that detailed scoring results are captured and made available for analysis.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/log/_log.py#L502-L506" target="_blank" rel="noopener noreferrer">`inspect_ai.log._log.EvalSampleScore` (502:506)</a>
+
+
+
+
+
+### inspect_ai.log._transcript.ScoreEvent
+
+An event type within the evaluation transcript that specifically records the outcome of a scoring operation. It contains an `EvalSampleScore` object, providing a timestamped record of when a score was computed and what its value was. This is part of the broader logging and observability framework.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/log/_transcript.py#L406-L423" target="_blank" rel="noopener noreferrer">`inspect_ai.log._transcript.ScoreEvent` (406:423)</a>
+
+
+
+
+
+### inspect_ai.log._recorders.eval.EvalRecorder
+
+A specialized recorder responsible for capturing and persisting evaluation-related data, including scores. It extends `inspect_ai.log._recorders.file.FileRecorder`, suggesting it writes evaluation logs to files. This component is essential for long-term storage and retrieval of evaluation results.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/log/_recorders/eval.py#L58-L237" target="_blank" rel="noopener noreferrer">`inspect_ai.log._recorders.eval.EvalRecorder` (58:237)</a>
+
+
+
+
+
+### inspect_ai.log._recorders.buffer.database.SampleBufferDatabase
+
+Manages a buffer of evaluation samples and their associated data, including scores, before they are fully processed or written to a permanent log. It acts as a temporary storage mechanism, inheriting from `inspect_ai.log._recorders.buffer.types.SampleBuffer` and `inspect_ai._eval.task.log.TaskLogger`.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/log/_recorders/buffer/database.py#L56-L571" target="_blank" rel="noopener noreferrer">`inspect_ai.log._recorders.buffer.database.SampleBufferDatabase` (56:571)</a>
+
+
+
+
+
+### inspect_ai.log._recorders.buffer.filestore.SampleBufferFilestore
+
+A concrete implementation of a sample buffer that stores evaluation data, including scores, in a file-based system. It inherits from `inspect_ai.log._recorders.buffer.types.SampleBuffer`, indicating its role in managing temporary storage of evaluation data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/log/_recorders/buffer/filestore.py#L48-L204" target="_blank" rel="noopener noreferrer">`inspect_ai.log._recorders.buffer.filestore.SampleBufferFilestore` (48:204)</a>
+
+
+
+
+
+### Solver Core
+
+The core component responsible for orchestrating the evaluation process.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Model Integration
+
+Component responsible for integrating and interacting with LLMs.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Registry Service
+
+A service for registering and discovering various components within the framework.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Evaluation Plan Manager
+
+Manages and defines the evaluation plan, specifying which scorers and metrics to use.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Logging and Transcript
+
+The component responsible for logging and recording evaluation events and results.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### inspect_ai.scorer._metric.Score
+
+A base class or data structure representing the result of a metric calculation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_metric.py#L55-L109" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._metric.Score` (55:109)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Tool_Sandbox_Environment.md
+++ b/.codeboarding/Tool_Sandbox_Environment.md
@@ -1,0 +1,181 @@
+```mermaid
+
+graph LR
+
+    Tool_Definition_and_Registry["Tool Definition and Registry"]
+
+    Tool_Invocation_and_Communication_Protocol_MCP_["Tool Invocation and Communication Protocol (MCP)"]
+
+    Sandbox_Environment_Management["Sandbox Environment Management"]
+
+    Tool_Approval_System["Tool Approval System"]
+
+    Built_in_Tools_Library["Built-in Tools Library"]
+
+    Tool_Definition_and_Registry -- "defines tools for" --> Built_in_Tools_Library
+
+    Tool_Definition_and_Registry -- "provides metadata to" --> Tool_Invocation_and_Communication_Protocol_MCP_
+
+    Tool_Invocation_and_Communication_Protocol_MCP_ -- "requests execution from" --> Sandbox_Environment_Management
+
+    Tool_Invocation_and_Communication_Protocol_MCP_ -- "sends tool calls to" --> Tool_Approval_System
+
+    Sandbox_Environment_Management -- "executes tools for" --> Tool_Invocation_and_Communication_Protocol_MCP_
+
+    Tool_Approval_System -- "intercepts tool calls from" --> Tool_Invocation_and_Communication_Protocol_MCP_
+
+    Tool_Approval_System -- "grants/denies execution to" --> Sandbox_Environment_Management
+
+    Built_in_Tools_Library -- "implements tools using definitions from" --> Tool_Definition_and_Registry
+
+    Built_in_Tools_Library -- "is executed within" --> Sandbox_Environment_Management
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+This subsystem enables LLMs and agents to interact with external functionalities and environments through defined tools. It encompasses tool definition, invocation, result processing, and provides a secure, isolated execution environment (sandbox), including an approval system for sensitive tool calls.
+
+
+
+### Tool Definition and Registry
+
+This component is responsible for defining, registering, and managing the metadata of tools that LLM agents can utilize. It provides mechanisms to expose Python functions as callable tools, automatically extracting essential information such as descriptions, parameters, and usage instructions. This metadata is crucial for LLMs to understand and correctly invoke the tools.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool.py#L152-L152" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool.tool` (152:152)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool_def.py#L35-L167" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool_def.ToolDef` (35:167)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool_info.py#L55-L122" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool_info.parse_tool_info` (55:122)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool.py#L88-L113" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool.Tool` (88:113)</a>
+
+
+
+
+
+### Tool Invocation and Communication Protocol (MCP)
+
+This component manages the entire process of invoking a tool, from receiving an LLM's tool request to executing it and transmitting the results back. It utilizes a Multi-Component Protocol (MCP) built on JSON-RPC for robust and reliable inter-process communication between the main `inspect_ai` process and the isolated sandbox environment.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool_call.py#L36-L56" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool_call.ToolCall` (36:56)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_json_rpc_helpers.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._json_rpc_helpers` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_mcp/_mcp.py#L43-L75" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._mcp._mcp.MCPServerImpl` (43:75)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_mcp/connection.py#L45-L59" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._mcp.connection.MCPServerConnection` (45:59)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool_support_helpers.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool_support_helpers.ToolSupportSandboxTransport` (0:0)</a>
+
+
+
+
+
+### Sandbox Environment Management
+
+This component provides and manages secure, isolated execution environments for tools. It abstracts the underlying sandboxing technology (e.g., Docker containers), ensuring that tool execution is contained, preventing malicious code or unintended side effects from impacting the main evaluation process. It handles the setup, execution, and teardown of these isolated environments.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/util/_sandbox/context.py#L52-L114" target="_blank" rel="noopener noreferrer">`inspect_ai.util._sandbox.context.sandbox_with` (52:114)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/util/_sandbox/environment.py#L83-L353" target="_blank" rel="noopener noreferrer">`inspect_ai.util._sandbox.environment.SandboxEnvironment` (83:353)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/util/_sandbox/local.py#L21-L115" target="_blank" rel="noopener noreferrer">`inspect_ai.util._sandbox.local.LocalSandboxEnvironment` (21:115)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/util/_sandbox/service.py#L90-L356" target="_blank" rel="noopener noreferrer">`inspect_ai.util._sandbox.service.SandboxService` (90:356)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/util/_sandbox/environment.py#L64-L80" target="_blank" rel="noopener noreferrer">`inspect_ai.util._sandbox.environment.SandboxConnection` (64:80)</a>
+
+
+
+
+
+### Tool Approval System
+
+This component implements a robust, policy-driven approval mechanism for sensitive or potentially risky tool calls. It allows for human intervention or automated policy checks before a tool is executed within the sandbox, adding a crucial layer of security and control to the evaluation process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/approval/_policy.py#L31-L80" target="_blank" rel="noopener noreferrer">`inspect_ai.approval._policy.policy_approver` (31:80)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/approval/_approver.py#L8-L30" target="_blank" rel="noopener noreferrer">`inspect_ai.approval._approver.Approver` (8:30)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/approval/_apply.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.approval._apply` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/approval/_human/approver.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.approval._human.approver` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/approval/_human/manager.py#L11-L16" target="_blank" rel="noopener noreferrer">`inspect_ai.approval._human.manager.ApprovalRequest` (11:16)</a>
+
+
+
+
+
+### Built-in Tools Library
+
+This package contains a collection of pre-defined, ready-to-use tools that demonstrate the framework's capabilities and provide common functionalities for LLMs, such as interacting with the shell (`bash`), executing Python code, performing web searches, or simulating web browsing. These tools serve as examples and extend the LLM's operational scope.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tools/__init__.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tools.__init__.py` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tools/_bash_session.py#L31-L33" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tools._bash_session.BashSessionStore` (31:33)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tools/_computer/_computer.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tools._computer._computer.py` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tools/_web_search/_web_search.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tools._web_search._web_search.py` (0:0)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tools/_web_browser/_web_browser.py#L0-L0" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tools._web_browser._web_browser.py` (0:0)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,241 @@
+```mermaid
+
+graph LR
+
+    Evaluation_Orchestrator["Evaluation Orchestrator"]
+
+    Dataset_Management["Dataset Management"]
+
+    Agent_Solver_Framework["Agent & Solver Framework"]
+
+    LLM_Integration_Layer["LLM Integration Layer"]
+
+    Tool_Sandbox_Environment["Tool & Sandbox Environment"]
+
+    Scoring_Metrics_Engine["Scoring & Metrics Engine"]
+
+    Data_Analysis["Data Analysis"]
+
+    Evaluation_Orchestrator -- "interacts with" --> Dataset_Management
+
+    Evaluation_Orchestrator -- "orchestrates" --> Agent_Solver_Framework
+
+    Scoring_Metrics_Engine -- "provides to" --> Evaluation_Orchestrator
+
+    Evaluation_Orchestrator -- "provides to" --> Data_Analysis
+
+    Dataset_Management -- "provides to" --> Evaluation_Orchestrator
+
+    Dataset_Management -- "provides to" --> Data_Analysis
+
+    Agent_Solver_Framework -- "interacts with" --> Evaluation_Orchestrator
+
+    Agent_Solver_Framework -- "interacts with" --> LLM_Integration_Layer
+
+    Agent_Solver_Framework -- "interacts with" --> Tool_Sandbox_Environment
+
+    Agent_Solver_Framework -- "provides to" --> Scoring_Metrics_Engine
+
+    LLM_Integration_Layer -- "interacts with" --> Agent_Solver_Framework
+
+    LLM_Integration_Layer -- "interacts with" --> Tool_Sandbox_Environment
+
+    Scoring_Metrics_Engine -- "uses" --> LLM_Integration_Layer
+
+    Tool_Sandbox_Environment -- "interacts with" --> Agent_Solver_Framework
+
+    Tool_Sandbox_Environment -- "interacts with" --> LLM_Integration_Layer
+
+    click Evaluation_Orchestrator href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//Evaluation_Orchestrator.md" "Details"
+
+    click Dataset_Management href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//Dataset_Management.md" "Details"
+
+    click Agent_Solver_Framework href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//Agent_Solver_Framework.md" "Details"
+
+    click LLM_Integration_Layer href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//LLM_Integration_Layer.md" "Details"
+
+    click Tool_Sandbox_Environment href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//Tool_Sandbox_Environment.md" "Details"
+
+    click Scoring_Metrics_Engine href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//Scoring_Metrics_Engine.md" "Details"
+
+    click Data_Analysis href "https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/.codeboarding//Data_Analysis.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+High-level data flow overview of the `inspect_ai` architecture, focusing on its core components and their interactions, aligned with typical LLM Evaluation Framework patterns.
+
+
+
+### Evaluation Orchestrator [[Expand]](./Evaluation_Orchestrator.md)
+
+The central control plane managing the entire evaluation lifecycle. It loads evaluation tasks, resolves configurations (models, solvers, scorers, datasets), orchestrates the execution of evaluation runs, and manages the overall flow, including concurrency and error handling.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/eval.py#L73-L255" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.eval` (73:255)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/run.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.run` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/loader.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.loader` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/_eval/task/task.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai._eval.task.task` (1:1)</a>
+
+
+
+
+
+### Dataset Management [[Expand]](./Dataset_Management.md)
+
+Manages the loading, processing, and transformation of evaluation datasets from diverse sources (e.g., JSONL, CSV, Hugging Face datasets). It ensures that input data is prepared in a consistent format for evaluation tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/dataset/_dataset.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.dataset._dataset` (1:1)</a>
+
+
+
+
+
+### Agent & Solver Framework [[Expand]](./Agent_Solver_Framework.md)
+
+Provides a flexible framework for implementing and running different types of LLM agents (e.g., ReAct agents, human-in-the-loop agents). It defines high-level strategies, manages task state, and chains multiple steps for how an LLM or agent approaches and solves a given evaluation task.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/agent/_agent.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.agent._agent` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/agent/_react.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.agent._react` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_solver.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._solver` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_plan.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._plan` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/solver/_chain.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.solver._chain` (1:1)</a>
+
+
+
+
+
+### LLM Integration Layer [[Expand]](./LLM_Integration_Layer.md)
+
+Offers a unified, abstract interface for interacting with various Large Language Models (LLMs) from different providers (e.g., OpenAI, Anthropic, Google, Hugging Face). It handles message formatting, API calls, response parsing, and manages model-specific configurations and caching.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_model.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.model._model` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_chat_message.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.model._chat_message` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_generate_config.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.model._generate_config` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/model/_call_tools.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.model._call_tools` (1:1)</a>
+
+
+
+
+
+### Tool & Sandbox Environment [[Expand]](./Tool_Sandbox_Environment.md)
+
+Enables LLMs and agents to interact with external functionalities and environments through defined tools. It handles tool definition, invocation, result processing, and provides a secure, isolated execution environment (sandbox), including an approval system for sensitive tool calls.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool_def.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool_def` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_tool_call.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.tool._tool_call` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/util/_sandbox/context.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.util._sandbox.context` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/approval/_policy.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.approval._policy` (1:1)</a>
+
+
+
+
+
+### Scoring & Metrics Engine [[Expand]](./Scoring_Metrics_Engine.md)
+
+Defines and applies various scoring methodologies and metrics to evaluate the quality and performance of LLM outputs. It supports different metric types (e.g., accuracy, F1, model-graded evaluations) and provides mechanisms for aggregating scores.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_scorer.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._scorer` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_metric.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._metric` (1:1)</a>
+
+- <a href="https://github.com/UKGovernmentBEIS/inspect_ai/src/inspect_ai/scorer/_model.py#L1-L1" target="_blank" rel="noopener noreferrer">`inspect_ai.scorer._model` (1:1)</a>
+
+
+
+
+
+### Data Analysis [[Expand]](./Data_Analysis.md)
+
+Provides tools and utilities for loading and transforming raw evaluation results (logs) into structured dataframes (e.g., Pandas DataFrames). This facilitates advanced statistical analysis, filtering, and custom reporting of evaluation results.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `inspect_ai.analysis.beta._dataframe` (1:1)
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Not Related.

### What is the new behavior?

I am adding a diagram representation of the codebase. I see that you already have quite a complete documentation in the `/doc` part of the project. What I am adding a new documentation rendering the codebase as a diagram - showing to new contributors what the main components are and how they interact with each other. You can see how the change renders here: https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/inspect_ai/on_boarding.md

The idea is that with it a new contirbutor can immediately get a high-level understanding. Then deepen that knowledge by looking into the component of interest. With this high-level understanding of what the main pieces are and how they interact now the new contributor can start their first task and dive deeper in your documentation for the relevant things they do!

I would love to hear your opinion on diagram first documentaiton. If you like what you see I'd be happy to properly integrate it within your `/docs`. We also have a free github action which will update the diagram with new changes.

Any feedback is more than welcome! Thanks for taking a look, I'd usually open a discussion first, but they aren't enabled for this repo.

Full disclosure: we're trying to turn this into a startup, but we're still in a very early stage and figuring out what will actually be useful for people.


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
