### PR TITLE
fix: return str instead of raising

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1019,12 +1019,6 @@ def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
                 match value:
                     case str():
                         value = BatchConfig.model_validate(resolve_args(value))
-                    case int():
-                        value = BatchConfig(size=value)
-                    case bool():
-                        value = BatchConfig()
-                    case _:
-                        raise ValueError(f"Invalid value for batch: {value}")
 
             config[key] = value  # type: ignore
     return config

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1016,7 +1016,15 @@ def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
                 if value is not None:
                     value = ResponseSchema.model_validate_json(value)
             if key == "batch":
-                value = BatchConfig.model_validate(resolve_args(value))
+                match value:
+                    case str():
+                        value = BatchConfig.model_validate(resolve_args(value))
+                    case int():
+                        value = BatchConfig(size=value)
+                    case bool():
+                        value = BatchConfig()
+                    case _:
+                        raise ValueError(f"Invalid value for batch: {value}")
 
             config[key] = value  # type: ignore
     return config

--- a/src/inspect_ai/_cli/util.py
+++ b/src/inspect_ai/_cli/util.py
@@ -100,9 +100,7 @@ def int_bool_or_str_flag_callback(
             try:
                 return int(value)
             except ValueError:
-                raise click.BadParameter(
-                    f"Expected 'true', 'false', an integer, or string for --{param.name}. Got: {value}"
-                )
+                return str(value)
 
     return callback
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

```
(modelscan-inspect) metr/modelscan-inspect » inspect eval modelscan/scan_malt --model anthropic/claude-sonnet-4-20250514,anthropic/claude-3-5-haiku-20241022,anthropic/claude-3-5-sonnet-20241022 --epochs 5 --batch 300 -T job_name=reward_hacking --temperature 1 --max-tokens 1000 --log-level info                                                                                                                                                                                        
Traceback (most recent call last):
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/bin/inspect", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/inspect_ai/_cli/main.py", line 56, in main
    inspect(auto_envvar_prefix="INSPECT")  # pylint: disable=no-value-for-parameter
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/inspect_ai/_cli/common.py", line 45, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ~~~~^^^^^^^^^^^^^^^^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/inspect_ai/_cli/common.py", line 110, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ~~~~^^^^^^^^^^^^^^^^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/inspect_ai/_cli/eval.py", line 502, in wrapper
    return cast(click.Context, func(*args, **kwargs))
                               ~~~~^^^^^^^^^^^^^^^^^
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/inspect_ai/_cli/eval.py", line 583, in eval_command
    config = config_from_locals(dict(locals()))
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/inspect_ai/_cli/eval.py", line 1019, in config_from_locals
    value = BatchConfig.model_validate(resolve_args(value))
  File "/Users/neev/repos/metr/modelscan-inspect/.venv/lib/python3.13/site-packages/pydantic/main.py", line 705, in model_validate
    return cls.__pydantic_validator__.validate_python(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        obj, strict=strict, from_attributes=from_attributes, context=context, by_alias=by_alias, by_name=by_name
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 1 validation error for BatchConfig
  Input should be a valid dictionary or instance of BatchConfig [type=model_type, input_value=300, input_type=int]
    For further information visit https://errors.pydantic.dev/2.11/v/model_type
```
and if I pass in a path to a yaml file:
```
(modelscan-inspect) metr/modelscan-inspect » inspect eval modelscan/scan_malt --model anthropic/claude-sonnet-4-20250514,anthropic/claude-3-5-haiku-20241022,anthropic/claude-3-5-sonnet-20241022 --epochs 5 --batch batch_config.yaml -T job_name=reward_hacking --temperature 1 --max-tokens 1000 --log-level info                                                                                                                                                                          
Usage: inspect eval [OPTIONS] [TASKS]...
Try 'inspect eval --help' for help.

Error: Invalid value for '--batch': Expected 'true', 'false', an integer, or string for --batch. Got: batch_config.yaml
```
### What is the new behavior?

batch works with int
```
(inspect-ai) repos/inspect_ai » inspect eval examples/hello_world.py --model anthropic/claude-3-5-haiku-20241022 --batch 2                                                                                                                                                                                                                                                 
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│hello_world (1 sample): anthropic/claude-3-5-haiku-20241022                                                                                                                                                                                  │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
batch: 2, dataset: (samples)                                                                                                                                                                                                                   
                                                                                                                                                                                                                                               
total time:                                                                                                         0:01:16                                                                                                                    
anthropic/claude-3-5-haiku-20241022                                                                                 17 tokens [I: 12, CW: 0, CR: 0, O: 5]                                                                                      
                                                                                                                                                                                                                                               
mean: 1.0  stderr: 0                                                                                                                                                                                                                           
                                                                                                                                                                                                                                               
Log: logs/2025-07-04T15-12-21-07-00_hello-world_REYDVsE5B5XjDDsBHUnjzp.eval                                                                                                                                                                    
                                                                             
```
![image](https://github.com/user-attachments/assets/988899ce-59fc-41eb-a201-2e2e6a74f6d4)

and path to config:

```
(inspect-ai) repos/inspect_ai » inspect eval examples/hello_world.py --model anthropic/claude-3-5-sonnet-20241022 --batch batch_config.yaml                                                                                                   
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│hello_world (1 sample): anthropic/claude-3-5-sonnet-20241022                                                                                                                                                                                 │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
batch: {...}, dataset: (samples)                                                                                                                                                                                                               
                                                                                                                                                                                                                                               
total time:                                                                                                          0:02:02                                                                                                                   
anthropic/claude-3-5-sonnet-20241022                                                                                 17 tokens [I: 12, CW: 0, CR: 0, O: 5]                                                                                     
                                                                                                                                                                                                                                               
mean: 1.0  stderr: 0                                                                                                                                                                                                                           
                                                                                                                                                                                                                                               
Log: logs/2025-07-04T15-13-38-07-00_hello-world_GWvL9VwNAdjhuR4mdRXrsm.eval                                                                                                                                                                    
                                                                                                                                                                                                                                             
```
![image](https://github.com/user-attachments/assets/340685bc-3af0-47ad-99c0-07d40abe78ef)



### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
