### PR TITLE
Fix bug that failed to find sample db files.

### DIFF
--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -248,7 +248,7 @@ class SampleBufferDatabase(SampleBuffer):
         db_dir = resolve_db_dir() / log_subdir
 
         if db_dir.exists():
-            logs = [log.name.rsplit(".", 2)[0] for log in db_dir.glob("*.*.db")]
+            logs = [log.name.rsplit(".", 2)[0] for log in db_dir.rglob("*.*.db")]
             return logs
         else:
             return None
@@ -695,7 +695,7 @@ def maximum_ids(
 def cleanup_sample_buffer_databases(db_dir: Path | None = None) -> None:
     try:
         db_dir = resolve_db_dir(db_dir)
-        for db in db_dir.glob("*.*.db"):
+        for db in db_dir.rglob("*.*.db"):
             # this is a failsafe cleanup method for buffer db's leaked during
             # abnormal terminations. therefore, it's not critical that we clean
             # it up immediately. it's also possible that users are _sharing_
@@ -715,6 +715,12 @@ def cleanup_sample_buffer_databases(db_dir: Path | None = None) -> None:
 def cleanup_sample_buffer_db(path: Path) -> None:
     try:
         path.unlink(missing_ok=True)
+        try:
+            # Remove the directory if it's empty
+            path.parent.rmdir()
+        except OSError:
+            # Not empty or other error, which is fine
+            pass
     except Exception as ex:
         logger.warning(f"Error cleaning up sample buffer database at {path}: {ex}")
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Database cleanup code failed to located database files in subdirectories.

### What is the new behavior?

This PR fixes a bug where database cleanup code didn’t locate files in subdirectories by switching from `glob` to `rglob` and adds logic to remove empty directories after deleting a database file.

- Switched to recursive searches in running_tasks and cleanup_sample_buffer_databases.
- Added removal of parent directories when they become empty in cleanup_sample_buffer_db.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
