### PR TITLE
Fix completion alias mutating last message

### DIFF
--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -441,7 +441,7 @@ async def _agent_generate(
 def _model_generate(model: str | Model | None) -> Agent:
     async def generate(state: AgentState, tools: list[Tool]) -> AgentState:
         state.output = await get_model(model).generate(state.messages, tools)
-        state.messages.append(state.output.message)
+        state.messages.append(state.output.message.model_copy())
         return state
 
     return generate


### PR DESCRIPTION
This PR fixes a subtle bug where assigning to state.output.completion unintentionally mutated the last message in the message history, due to both referencing the same object.

## This PR contains:
- [ ] Bug fixes

### What is the current behavior? (You can also link to an open issue here)
Before, line 199 (state.output.completion = answer) would modify the last message because the completion and the last message pointed to the same thing.

### What is the new behavior?
Now, the code copies the message so that they're decoupled from each other

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Encountered when using Control Arena