### PR TITLE
Track idealized token usage in addition to actual

### DIFF
--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -44,7 +44,7 @@ from inspect_ai.model import (
     Model,
     ModelName,
 )
-from inspect_ai.model._model import model_usage
+from inspect_ai.model._model import model_usage, idealized_model_usage
 from inspect_ai.scorer._metric import MetricSpec
 from inspect_ai.scorer._scorer import ScorerSpec
 from inspect_ai.solver._plan import Plan
@@ -280,6 +280,7 @@ def collect_eval_data(stats: EvalStats) -> None:
     # collect stats
     stats.completed_at = iso_now()
     stats.model_usage = model_usage()
+    stats.idealized_model_usage = idealized_model_usage()
 
 
 def resolve_eval_metrics(

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -902,6 +902,9 @@ class EvalStats(BaseModel):
     model_usage: dict[str, ModelUsage] = Field(default_factory=dict)
     """Model token usage for evaluation."""
 
+    idealized_model_usage: dict[str, ModelUsage] = Field(default_factory=dict)
+    """Theoretical model token usage if provider perfectly cached all prompts."""
+
     # allow field model_usage
     model_config = ConfigDict(protected_namespaces=())
 

--- a/src/inspect_ai/model/__init__.py
+++ b/src/inspect_ai/model/__init__.py
@@ -55,6 +55,7 @@ from ._model_output import (
     Logprobs,
     ModelOutput,
     ModelUsage,
+    IdealizedModelUsage,
     StopReason,
     TopLogprob,
 )
@@ -88,6 +89,7 @@ __all__ = [
     "Logprobs",
     "Logprob",
     "TopLogprob",
+    "IdealizedModelUsage",
     "Model",
     "ModelAPI",
     "ModelName",

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1,9 +1,11 @@
 import abc
 import contextlib
 import functools
+import hashlib
 import json
 import logging
 import os
+import struct
 import time
 from contextvars import ContextVar
 from copy import copy, deepcopy
@@ -93,9 +95,37 @@ from ._generate_config import (
     set_active_generate_config,
 )
 from ._model_call import ModelCall
-from ._model_output import ModelOutput, ModelUsage
+from ._model_output import (
+    IdealizedModelUsage,
+    ModelOutput,
+    ModelUsage,
+)
 
 logger = logging.getLogger(__name__)
+
+
+class _TrieNode(dict):
+    __slots__ = ("tokens",)
+
+    def __init__(self):
+        super().__init__()
+        self.tokens: int | None = None
+
+
+def _message_signature(msg: ChatMessage) -> int:
+    """64-bit signature mapping role|name|content to uint64"""
+    role = getattr(msg, "role", "")
+    name = getattr(msg, "name", "")
+    data = f"{role}|{name}|{msg.text}".encode("utf8")
+
+    for content in [x for x in msg.content if not isinstance(x, str)]:
+        # Not yet implemented - signatures for non-text messages.
+        # Avoiding private import from inspect_ai._util.content import Content
+        if content.type != "text":
+            logger.warning("Ignoring signature for msg of type %s", content.type)
+
+    digest = hashlib.blake2b(data, digest_size=8).digest()
+    return struct.unpack("!Q", digest)[0]
 
 
 class ModelAPI(abc.ABC):
@@ -297,9 +327,18 @@ class Model:
         self._context_bound = False
         self._closed = False
 
+        # state for modeling the model usage if a provider was using an ideal cache
+        self._prefix_root = _TrieNode()
+        self._ideal_usage = IdealizedModelUsage(input_tokens_cache_write=0)
+
         # if using the Model API standalone in a notebook this will
         # get hit before score() or eval() so we activate nest_asyncio
         platform_init()
+
+    @property
+    def idealized_model_usage(self) -> IdealizedModelUsage:
+        """Cumulative *theoretical* usage of a perfect cache for this Model instance."""
+        return self._ideal_usage
 
     def __enter__(self: "Model") -> "Model":
         self._context_bound = True
@@ -611,6 +650,11 @@ class Model:
                 )
                 existing = cache_fetch(cache_entry)
                 if isinstance(existing, ModelOutput):
+                    # Update idealized-cache counters
+                    self._update_idealized_model_model_usage(
+                        messages=input,
+                        usage=existing.usage,
+                    )
                     _, event = self._record_model_interaction(
                         input=input,
                         tools=tools_info,
@@ -686,6 +730,9 @@ class Model:
             # record usage
             if output.usage:
                 # record usage
+                self._update_idealized_model_model_usage(
+                    messages=input, usage=output.usage
+                )
                 record_and_check_model_usage(f"{self}", output.usage)
 
                 # send telemetry to hooks
@@ -736,6 +783,53 @@ class Model:
 
         # no retry
         return False
+
+    def _update_idealized_model_model_usage(
+        self,
+        messages: list[ChatMessage],
+        usage: ModelUsage,
+    ) -> None:
+        total_in = (
+            (usage.input_tokens or 0)
+            + (usage.input_tokens_cache_write or 0)
+            + (usage.input_tokens_cache_read or 0)
+        )
+
+        # find longest cached prefix
+        node = self._prefix_root
+        longest_prefix_tokens = 0
+        path: list[_TrieNode] = [node]
+
+        for sig in map(_message_signature, messages):
+            nxt = node.get(sig)
+            if nxt is None:
+                break  # cache miss from here onward
+            node = nxt
+            path.append(node)
+            if node.tokens is not None:
+                longest_prefix_tokens = node.tokens
+
+        billed_new_tokens = max(total_in - longest_prefix_tokens, 0)
+
+        # update idealised counters
+        self._ideal_usage.input_tokens += total_in
+        self._ideal_usage.input_tokens_cache_write += billed_new_tokens
+        self._ideal_usage.output_tokens += usage.output_tokens or 0
+
+        # insert missing nodes & store this prefix’s token count
+        for sig in map(_message_signature, messages[len(path) - 1 :]):  # only the new tail
+            new_node = _TrieNode()
+            path[-1][sig] = new_node
+            path.append(new_node)
+
+        path[-1].tokens = total_in  # mark full prompt
+
+        delta = IdealizedModelUsage(
+            input_tokens=total_in,
+            input_tokens_cache_write=billed_new_tokens,
+            output_tokens=usage.output_tokens or 0,
+        )
+        record_idealized_model_usage(str(self), delta)
 
     # function to verify that its okay to call model apis
     def verify_model_apis(self) -> None:
@@ -1463,10 +1557,12 @@ def set_total_messages(input: str | list[ChatMessage]) -> None:
 
 def init_model_usage() -> None:
     model_usage_context_var.set({})
+    idealized_model_usage_context_var.set({})
 
 
 def init_sample_model_usage() -> None:
     sample_model_usage_context_var.set({})
+    sample_idealized_model_usage_context_var.set({})
 
 
 def record_and_check_model_usage(model: str, usage: ModelUsage) -> None:
@@ -1508,11 +1604,58 @@ def sample_model_usage() -> dict[str, ModelUsage]:
     return sample_model_usage_context_var.get()
 
 
+sample_model_usage_context_var: ContextVar[dict[str, ModelUsage]] = ContextVar(
+    "sample_model_usage", default={}
+)
+
+
 def sample_total_tokens() -> int:
     total_tokens = [usage.total_tokens for usage in iter(sample_model_usage().values())]
     return sum(total_tokens)
 
 
-sample_model_usage_context_var: ContextVar[dict[str, ModelUsage]] = ContextVar(
-    "sample_model_usage", default={}
+def idealized_model_usage() -> dict[str, IdealizedModelUsage]:
+    return idealized_model_usage_context_var.get()
+
+
+idealized_model_usage_context_var: ContextVar[dict[str, IdealizedModelUsage]] = ContextVar(
+    "idealized_model_usage", default={}
 )
+
+
+def sample_idealized_model_usage() -> dict[str, IdealizedModelUsage]:
+    return sample_idealized_model_usage_context_var.get()
+
+
+sample_idealized_model_usage_context_var: ContextVar[dict[str, IdealizedModelUsage]] = (
+    ContextVar("sample_idealized_model_usage", default={})
+)
+
+
+def record_idealized_model_usage(model: str, delta: IdealizedModelUsage) -> None:
+    """
+    Push *delta* into the two task-local accumulators.
+
+    We copy the delta for the 2nd accumulator to avoid mutating the same
+    IdealizedModelUsage instance twice.
+    """
+    _accumulate_idealized_model(model, delta, idealized_model_usage_context_var)
+
+    _accumulate_idealized_model(
+        model, delta.model_copy(), sample_idealized_model_usage_context_var
+    )
+
+
+def _accumulate_idealized_model(
+    model: str, delta: IdealizedModelUsage, var: ContextVar[dict[str, IdealizedModelUsage]]
+) -> None:
+    store = var.get(None)
+    if store is None:
+        store = {}
+        var.set(store)
+
+    current = store.get(model)
+    if current is None:
+        store[model] = delta
+    else:
+        current += delta

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -32,13 +32,9 @@ class ModelUsage(BaseModel):
 
     def __add__(self, other: "ModelUsage") -> "ModelUsage":
         def optional_sum(a: int | None, b: int | None) -> int | None:
-            if a is not None and b is not None:
-                return a + b
-            if a is not None:
-                return a
-            if b is not None:
-                return b
-            return None
+            if a is None and b is None:
+                return None
+            return (a or 0) + (b or 0)
 
         return ModelUsage(
             input_tokens=self.input_tokens + other.input_tokens,

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -51,6 +51,48 @@ class ModelUsage(BaseModel):
             ),
         )
 
+class IdealizedModelUsage(ModelUsage):
+    """
+    Theoretical model usage, tracked as if a provider perfectly cached all inputs.
+
+    IdealizedModelUsage counts reads from the local inspect cache as contributing to
+    the tracked usage.
+
+    NOTE only a subset of ModelUsage fields are used in this class:
+    * input_tokens_cache_write stores the total number of unique tokens
+    * input_tokens stores the total input tokens used
+    * output tokens stores the total output tokens produced
+
+    Unique tokens are defined as unique suffixes when looking across all prior inputs
+    sent to a given model. When each prompt is sent to the model it will be matched
+    against the longest previous prefix sent to that model, and only the new text since
+    the match (or all text in the case of no match) will be counted as unique tokens.
+
+    Partial matches will not be counted, only entire prefixes (e.g., a turn based agent);
+    we assume caching happens at a prompt granularity. This assumption allows us to
+    use provider-reported token usage stats to understand the number of tokens (as defined
+    by any provider) in the suffix.
+
+    For example, consider the following sequence of prompts (one prompt per line). Underlined
+    text is considered unique:
+
+        part1
+        _____
+
+        part1part2
+             _____
+
+        part1part3
+             _____
+
+        part1part2part4
+                  _____
+
+        part5
+        _____
+    """
+    pass
+
 
 StopReason = Literal[
     "stop",

--- a/tests/test_idealized_usage.py
+++ b/tests/test_idealized_usage.py
@@ -1,0 +1,273 @@
+# tests/test_idealized_model_usage.py
+from __future__ import annotations
+
+from contextvars import Token
+from datetime import datetime
+
+import pprint
+import pytest
+
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
+from inspect_ai.log import ModelEvent
+from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
+from inspect_ai.model._model import (
+    get_model,
+    idealized_model_usage,
+    idealized_model_usage_context_var,
+)
+from inspect_ai.model._model_output import ModelOutput, ModelUsage
+from inspect_ai.solver import generate
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# helpers
+# ────────────────────────────────────────────────────────────────────────────
+def simulate_out(*, write: int, read: int, output: int | None) -> ModelOutput:
+    """
+    Fabricate a ModelOutput 
+    """
+    mo = ModelOutput.from_content("mockllm/model", "A (stub)")
+
+    if output is not None:
+        mo.usage = ModelUsage(
+            input_tokens_cache_write=write,
+            input_tokens_cache_read=read,
+            output_tokens=output,
+        )
+    else:  # usage missing
+        mo.usage = None
+    return mo
+
+
+def sig(msgs: list[ChatMessage]) -> str:
+    """Tiny dump for debugging output inside failing assert reports"""
+    return " | ".join(m.content for m in msgs)
+
+def dump_state(step: str, msgs: list[ChatMessage], usage) -> None:
+    """Pretty-print conversation and counters for debugging."""
+    print(f"\n===== {step} =====")
+    for i, m in enumerate(msgs, 1):
+        role = getattr(m, "role", m.__class__.__name__).upper()
+        # collapse ContentText / ContentReasoning if present
+        if isinstance(m.content, list):
+            text = "".join(
+                getattr(c, "text", getattr(c, "reasoning", str(c))) for c in m.content
+            )
+        else:
+            text = m.content
+        print(f"{i:02d} {role:<10}: {text}")
+    print("idealised-usage:", pprint.pformat(usage.model_dump(), compact=True))
+    print("=" * 60)
+
+
+
+# ────────────────────────────────────────────────────────────────────────────
+# 1. Instance-level perfect-cache accounting
+# ────────────────────────────────────────────────────────────────────────────
+test_matrix_instance = [
+    (
+        "simple prefix growth",
+        [
+            simulate_out(write=4, read=0, output=3),  # U1
+            simulate_out(write=8, read=4, output=5),  # U1 A1 U2
+            simulate_out(write=11, read=12, output=2),  # U1 A1 U2 A2 U3
+        ],
+        [
+            (["U1"], 4, 4, 3),
+            (["U1", "A1", "U2"], 16, 12, 8),
+            (["U1", "A1", "U2", "U3"], 39, 23, 10),
+        ],
+    ),
+    (
+        "repeat identical prompt (full hit)",
+        [
+            simulate_out(write=4, read=0, output=1),
+            simulate_out(write=0, read=4, output=1),
+        ],
+        [
+            (["U1"], 4, 4, 1),
+            (["U1"], 8, 4, 2),
+        ],
+    ),
+    (
+        "shorter prompt - prefix miss",
+        [
+            simulate_out(write=10, read=0, output=2),  # U1 U2 U3
+            simulate_out(write=4, read=0, output=2),  # U1
+        ],
+        [
+            (["1", "2", "3"], 10, 10, 2),
+            (["1"], 14, 14, 4),
+        ],
+    ),
+]
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize("desc,custom_outputs,steps", test_matrix_instance)
+async def test_idealized_model_usage_instance(desc, custom_outputs, steps):
+    """Validate *per-instance* IdealizedModelUsage numbers for various scenarios."""
+    async with get_model("mockllm/model", custom_outputs=custom_outputs) as model:
+        msgs: list[ChatMessage] = []
+        for prompt, exp_I, exp_U, exp_O in steps:
+            # rebuild conversation up to 'prompt'
+            msgs = [ChatMessageUser(content=p) for p in prompt]
+            await model.generate(msgs)
+
+            ideal = model.idealized_model_usage
+            assert (
+                ideal.input_tokens,
+                ideal.input_tokens_cache_write,
+                ideal.output_tokens,
+            ) == (
+                exp_I,
+                exp_U,
+                exp_O,
+            ), f"{desc} / prompt=[{sig(msgs)}]"
+
+@pytest.mark.anyio
+async def test_idealised_usage_four_turns_with_cache(capsys) -> None:
+    """
+    Test of a 4 turn conversation with caching
+
+    Conversation we simulate             provider reports
+    ───────────────────────────────────────────────────────────────
+    call-1  U1                → write 4  read 0   out 3
+    call-2  U1 A1 U2          → write 8  read 4   out 5
+    call-3  U1 A1 U2 A2 U3    → write 11 read 12  out 2
+
+    call-4  U1 A1 U4          → write 10  read 4   out 5. Note U1 A1 were previously sent, but _with U2_ which we've now dropped - the best prefix we can find in the cache is just U1
+
+    Ideal cache charges     4 + 8 + 11 = 23 prompt tokens
+    Completions               3 + 5 + 2  = 10 tokens
+    """
+    custom_outputs = [
+        simulate_out(write=4, read=0, output=3),  # U1
+        simulate_out(write=8, read=4, output=5),  # U1 A1 U2
+        simulate_out(write=11, read=12, output=2),  # U1 A1 U2 A2 U3
+        simulate_out(write=10, read=4, output=5),  # U1 A1 U4
+    ]
+
+    async with get_model("mockllm/model", custom_outputs=custom_outputs) as model:
+        # ── call-1 ─────────────────────────────────────────────────────────
+        msgs: list[ChatMessage] = [ChatMessageUser(content="U1: 4 unique tokens")]
+        out1 = await model.generate(msgs)
+        msgs.append(out1.choices[0].message)  # A1
+        dump_state("after call-1", msgs, model.idealized_model_usage)
+
+        # ── call-2 ─────────────────────────────────────────────────────────
+        msgs.append(ChatMessageUser(content="U2: 5 unique tokens"))
+        out2 = await model.generate(msgs)
+        msgs.append(out2.choices[0].message)  # A2
+        dump_state("after call-2", msgs, model.idealized_model_usage)
+
+        # ── call-3 ─────────────────────────────────────────────────────────
+        msgs.append(ChatMessageUser(content="U3: 6 unique tokens"))
+        await model.generate(msgs)
+        dump_state("after call-3", msgs, model.idealized_model_usage)
+
+        ideal = model.idealized_model_usage
+        assert ideal.input_tokens == 39  # 4 + 8+4 + 11+12
+        assert ideal.input_tokens_cache_write == 23  # total unique tokens
+        assert ideal.output_tokens == 10  # 3 + 5 + 2
+
+        new_msgs = msgs[:2].copy()
+        new_msgs.append(ChatMessageUser(content="U4: 7 unique tokens"))
+        await model.generate(new_msgs)
+        dump_state("after call-4", new_msgs, model.idealized_model_usage)
+
+        ideal = model.idealized_model_usage
+        assert ideal.input_tokens == 53  # 4 + 8+4 + 11+12 + 10+4
+        assert ideal.input_tokens_cache_write == 33  # total unique tokens
+        assert ideal.output_tokens == 15  # 3 + 5 + 2 + 5
+
+# ────────────────────────────────────────────────────────────────────────────
+# 2. ContextVar aggregation
+# ────────────────────────────────────────────────────────────────────────────
+@pytest.mark.anyio
+async def test_ideal_usage_contextvar() -> None:
+    """
+    Validate relevant ContextVars are configured as expected.
+
+    Ensures that record_idealized_model_usage() populates the task-local
+    ContextVar exactly once per provider call.
+    """
+    # 2 calls, different models => two independent entries
+    outputs_A = [simulate_out(write=5, read=0, output=1)]
+    outputs_B = [simulate_out(write=3, read=0, output=2)]
+
+    async with (
+        get_model("mockllm/A", custom_outputs=outputs_A) as model_A,
+        get_model("mockllm/B", custom_outputs=outputs_B) as model_B,
+    ):
+        await model_A.generate([ChatMessageUser(content="foo")])
+        await model_B.generate([ChatMessageUser(content="bar")])
+
+        store = idealized_model_usage()
+
+        assert set(store.keys()) == {str(model_A), str(model_B)}
+
+        ua = store[str(model_A)]
+        ub = store[str(model_B)]
+
+        assert (
+            ua.input_tokens == 5
+            and ua.input_tokens_cache_write == 5
+            and ua.output_tokens == 1
+        )
+        assert (
+            ub.input_tokens == 3
+            and ub.input_tokens_cache_write == 3
+            and ub.output_tokens == 2
+        )
+
+
+def sample_cache_hit(sample) -> bool:
+    return any(isinstance(e, ModelEvent) and e.cache == "read" for e in sample.events)
+
+
+def test_eval_populates_idealized_model_usage():
+    """
+    Ensure perfect cache usage is updated even when the local cache is used.
+
+    First eval populates the inspect cache (MISS), second eval is served
+    from it (HIT) but must still update perfect-cache accounting.
+    """
+    timestamp = str(datetime.now())
+
+    custom_outputs = [simulate_out(write=4, read=0, output=1)]
+
+    log1 = eval(
+        Task(
+            dataset=[Sample(input=f"What is the timestamp: {timestamp}")],
+            solver=[generate(cache=True)],
+        ),
+        model="mockllm/model",
+        model_args={"custom_outputs": custom_outputs},
+    )[0]
+
+    assert log1.samples and not sample_cache_hit(log1.samples[0])
+    assert log1.stats.model_usage
+    assert log1.stats.idealized_model_usage
+
+    # ---- run #2  (cache hit) --------------------------------------------
+    log2 = eval(
+        Task(
+            dataset=[Sample(input=f"What is the timestamp: {timestamp}")],
+            solver=[generate(cache=True)],
+        ),
+        model="mockllm/model",
+        model_args={"custom_outputs": custom_outputs},
+    )[0]
+    assert log2.samples and sample_cache_hit(log2.samples[0])
+    assert (
+        not log2.stats.model_usage
+    )  # No expected usage, should have loaded from inspect cache
+    assert log2.stats.idealized_model_usage
+
+    # Simulated cache usage _should_ match, even though local inspect cache was used for second request
+    assert (
+        log1.stats.idealized_model_usage["mockllm/model"]
+        == log2.stats.idealized_model_usage["mockllm/model"]
+    )


### PR DESCRIPTION
## This PR contains:
- [x] New features

### What is the current behavior? (You can also link to an open issue here)
Token usage is only tracked based on what is reported by a provider and responses from the local inspect cache are treated as free. The existing usage information is helpful for tracking actual costs spent on an eval, but suboptimal for comparing token-normalized performance when treating cached and uncached tokens differently, as different providers may implement different caching strategies or variable load on their systems could different cache performance at different times.

### What is the new behavior?
A new usage metric is tracked with each sample, "IdealizedModelUsage" which assumes providers have implemented a perfect cache that stores every previously-sent prompt from all turns within the execution of a sample. Within this ModelUsage instance, unique input tokens are counted in `input_tokens_cache_write` and total input/output tokens are stored in their respective fields. Tokens read from the local inspect cache *are counted*.

By tracking token usage across all prompts and the history of all prompts sent within a sample, we're able to simulate the ideal cache without needing to re-implement any tokenization.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
I'm not positive I can add new information to the log like this while maintaining backwards compatibility.

### Other information:
Our approach to model comparison is to think about ideal usage instead of actual so that we're fairly comparing models. Getting this information added to inspect would enable us to subsequently upstream some other budgeting and usage tracking logic of ours and fully switch over to the standard inspect react agent. For example:
* Weighted token budget - support a budget based on weighting cached, uncached, and output tokens with different weights
* Theoretical dollar budget (I'm thinking I'd want to rewrite #1930 to support this idealized usage - the current version is halfway between this and an actual budget and that's why it got so messy).