### PR TITLE
Feature/bundle scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,7 @@
 - Eval Log: Protect against removing excessive numbers of samples at once from realtime database.
 - Hooks: Provide full `EvalSample` (rather than only the summary) to `on_sample_end()` hook.
 - Inspect View: Compatiblility for sites published to GitHub Pages for `inspect view bundle`.
-- Batching: Add robust retry logic using existing retry configuration specified for the model.
-- Batching: Added insight into batch processing progress via the console.
+- Inspect View: The bundle produced for deployment now includes a much more compact manifest, improving support for bundling large numbers of files.
 - Bugfix: Fix failure to allow Anthropic native web search for some model names such as `claude-3-7-sonnet-latest`.
 - Bugfix: Fix Anthropic citation support code when it encounters citations created by external search providers such as Tavily.
 - Bugfix: Break after finding final assistant message when implementing fallback for `AgentState` `output` field.
@@ -122,7 +121,6 @@
 - Task display: Wrap scorers and scores in the task detail display.
 - Inspect View: Add support for displaying citations for web searches in the transcript.
 - Inspect View: Correctly update browser URL when navigation between samples.
-- Inspect View Bundle: The bundle produced for deployment now includes a much more compact manifest, improving support for bundling large numbers of files.
 - Bugfix: Properly honor `responses_api=False` when pass as an OpenAI model config arg.
 - Bugfix: Limits passed to handoffs can be used multiple times (if agent is handed off to multiple times).
 - Bugfix: Replace invalid surrogate characters when serializing strings to JSON.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
 - Task display: Wrap scorers and scores in the task detail display.
 - Inspect View: Add support for displaying citations for web searches in the transcript.
 - Inspect View: Correctly update browser URL when navigation between samples.
+- Inspect View Bundle: The bundle produced for deployment now includes a much more compact manifest, improving support for bundling large numbers of files.
 - Bugfix: Properly honor `responses_api=False` when pass as an OpenAI model config arg.
 - Bugfix: Limits passed to handoffs can be used multiple times (if agent is handed off to multiple times).
 - Bugfix: Replace invalid surrogate characters when serializing strings to JSON.

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -54113,7 +54113,7 @@ self.onmessage = function (e) {
     };
     const fetchManifest = async (log_dir) => {
       const logs = await fetchFile(
-        log_dir + "/logs.json",
+        log_dir + "/overview.json",
         async (text2) => {
           const parsed = await asyncJsonParse(text2);
           return {

--- a/src/inspect_ai/_view/www/dist/assets/index.js
+++ b/src/inspect_ai/_view/www/dist/assets/index.js
@@ -54060,7 +54060,7 @@ self.onmessage = function (e) {
             }
           }
           throw new Error(
-            `Failed to load a manifest files using the directory: ${log_dir}. Please be sure you have deployed a manifest file (logs.json).`
+            `Failed to load a listing file using the directory: ${log_dir}. Please be sure you have deployed a manifest file (listing.json).`
           );
         },
         download_file: download_file$1,
@@ -54113,7 +54113,7 @@ self.onmessage = function (e) {
     };
     const fetchManifest = async (log_dir) => {
       const logs = await fetchFile(
-        log_dir + "/overview.json",
+        log_dir + "/listing.json",
         async (text2) => {
           const parsed = await asyncJsonParse(text2);
           return {

--- a/src/inspect_ai/_view/www/src/app/log-list/LogItem.ts
+++ b/src/inspect_ai/_view/www/src/app/log-list/LogItem.ts
@@ -1,4 +1,4 @@
-import { EvalLogHeader, LogFile } from "../../client/api/types";
+import { LogFile, LogOverview } from "../../client/api/types";
 
 export interface LogItem {
   id: string;
@@ -14,5 +14,5 @@ export interface FolderLogItem extends LogItem {
 export interface FileLogItem extends LogItem {
   type: "file";
   logFile: LogFile;
-  header?: EvalLogHeader;
+  logOverview?: LogOverview;
 }

--- a/src/inspect_ai/_view/www/src/app/log-list/LogsPanel.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/LogsPanel.tsx
@@ -35,8 +35,8 @@ export const LogsPanel: FC<LogsPanelProps> = () => {
 
   const { loadLogs } = useLogs();
   const logs = useStore((state) => state.logs.logs);
-  const logHeaders = useStore((state) => state.logs.logHeaders);
-  const headersLoading = useStore((state) => state.logs.headersLoading);
+  const logHeaders = useStore((state) => state.logs.logOverviews);
+  const headersLoading = useStore((state) => state.logs.logOverviewsLoading);
   const watchedLogs = useStore((state) => state.logs.listing.watchedLogs);
 
   // Unload the load when this is mounted. This prevents the old log
@@ -117,7 +117,7 @@ export const LogsPanel: FC<LogsPanelProps> = () => {
           type: "file",
           url: logUrl(path, logs.log_dir),
           logFile: logFile,
-          header: logHeaders[logFile.name],
+          logOverview: logHeaders[logFile.name],
         });
       } else if (name.startsWith(currentDir)) {
         // This is file that is next level (or deeper) child

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/LogListGrid.tsx
@@ -44,11 +44,11 @@ export const LogListGrid: FC<LogListGridProps> = ({ items }) => {
     kLogsPaginationId,
     kDefaultPageSize,
   );
-  const headersLoading = useStore((state) => state.logs.headersLoading);
+  const headersLoading = useStore((state) => state.logs.logOverviewsLoading);
   const loading = useStore((state) => state.app.status.loading);
   const setWatchedLogs = useStore((state) => state.logsActions.setWatchedLogs);
 
-  const logHeaders = useStore((state) => state.logs.logHeaders);
+  const logHeaders = useStore((state) => state.logs.logOverviews);
   const sortingRef = useRef(sorting);
 
   // Load all headers when needed (store handles deduplication)

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/columns/CompletedDate.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/columns/CompletedDate.tsx
@@ -60,5 +60,5 @@ export const completedDateColumn = () => {
 
 const itemCompletedAt = (item: FileLogItem | FolderLogItem) => {
   if (item.type !== "file") return undefined;
-  return item.header?.stats?.completed_at;
+  return item.logOverview?.completed_at;
 };

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Model.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Model.tsx
@@ -7,20 +7,18 @@ export const modelColumn = () => {
   return columnHelper.accessor(
     (row) => {
       if (row.type !== "file") return "";
-      return row.header?.eval?.model || "";
+      return row.logOverview?.model || "";
     },
     {
       id: "model",
       header: "Model",
       cell: (info) => {
         const item = info.row.original;
-        if (item.type !== "file" || item.header?.eval.model === undefined) {
+        if (item.type !== "file" || item.logOverview?.model === undefined) {
           return <EmptyCell />;
         }
         return (
-          <div className={styles.modelCell}>
-            {item.header?.eval.model || ""}
-          </div>
+          <div className={styles.modelCell}>{item.logOverview.model || ""}</div>
         );
       },
       enableSorting: true,

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Score.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Score.tsx
@@ -1,4 +1,3 @@
-import { firstMetric } from "../../../../scoring/metrics";
 import { formatPrettyDecimal } from "../../../../utils/format";
 import { FileLogItem, FolderLogItem } from "../../LogItem";
 import { columnHelper } from "./columns";
@@ -56,6 +55,5 @@ const itemMetric = (item: FileLogItem | FolderLogItem) => {
     return undefined;
   }
 
-  const header = item.header;
-  return header?.results ? firstMetric(header.results) : undefined;
+  return item.logOverview?.primary_metric;
 };

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Status.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Status.tsx
@@ -73,7 +73,7 @@ const itemStatus = (item: FileLogItem | FolderLogItem) => {
   if (item.type !== "file") {
     return undefined;
   }
-  const header = item.header;
+  const header = item.logOverview;
   return header?.status;
 };
 

--- a/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Task.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/grid/columns/Task.tsx
@@ -44,7 +44,7 @@ export const taskColumn = () => {
 const itemName = (item: FileLogItem | FolderLogItem) => {
   let value = item.name;
   if (item.type === "file") {
-    return item.header?.eval?.task || parseLogFileName(item.name).name;
+    return item.logOverview?.task || parseLogFileName(item.name).name;
   }
   return value;
 };

--- a/src/inspect_ai/_view/www/src/app/types.ts
+++ b/src/inspect_ai/_view/www/src/app/types.ts
@@ -29,6 +29,7 @@ import {
   EventData,
   LogFile,
   LogFiles,
+  LogOverview,
   PendingSamples,
   SampleSummary,
 } from "../client/api/types";
@@ -62,8 +63,8 @@ export interface AppState {
 
 export interface LogsState {
   logs: LogFiles;
-  logHeaders: Record<string, EvalLogHeader>;
-  headersLoading: boolean;
+  logOverviews: Record<string, LogOverview>;
+  logOverviewsLoading: boolean;
   selectedLogIndex: number;
   selectedLogFile?: string;
   listing: LogsListing;

--- a/src/inspect_ai/_view/www/src/client/api/api-browser.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-browser.ts
@@ -310,7 +310,7 @@ const browserApi: LogViewAPI = {
   eval_log,
   eval_log_size,
   eval_log_bytes,
-  eval_log_headers,
+  eval_log_overviews: eval_log_headers,
   log_message,
   download_file,
 

--- a/src/inspect_ai/_view/www/src/client/api/api-http.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-http.ts
@@ -218,7 +218,7 @@ const fetchManifest = async (
   log_dir: string,
 ): Promise<LogFilesFetchResponse | undefined> => {
   const logs = await fetchFile<LogFilesFetchResponse>(
-    log_dir + "/logs.json",
+    log_dir + "/overview.json",
     async (text) => {
       const parsed = await asyncJsonParse(text);
       return {

--- a/src/inspect_ai/_view/www/src/client/api/api-http.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-http.ts
@@ -5,10 +5,10 @@ import { fetchRange, fetchSize } from "../remote/remoteZipFile";
 import { download_file } from "./api-shared";
 import {
   Capabilities,
-  EvalHeader,
   LogContents,
   LogFiles,
   LogFilesFetchResponse,
+  LogOverview,
   LogViewAPI,
 } from "./types";
 
@@ -40,11 +40,11 @@ export default function simpleHttpApi(
  */
 function simpleHttpAPI(logInfo: LogInfo): LogViewAPI {
   const log_dir = logInfo.log_dir;
-  let manifest: Record<string, EvalHeader> | undefined = undefined;
-  let manifestPromise: Promise<Record<string, EvalHeader>> | undefined =
+  let manifest: Record<string, LogOverview> | undefined = undefined;
+  let manifestPromise: Promise<Record<string, LogOverview>> | undefined =
     undefined;
 
-  const getManifest = async (): Promise<Record<string, EvalHeader>> => {
+  const getManifest = async (): Promise<Record<string, LogOverview>> => {
     if (!manifest && log_dir) {
       if (!manifestPromise) {
         manifestPromise = fetchManifest(log_dir).then((manifestRaw) => {
@@ -74,8 +74,8 @@ function simpleHttpAPI(logInfo: LogInfo): LogViewAPI {
           const logs = Object.keys(manifest).map((key) => {
             return {
               name: joinURI(log_dir, key),
-              task: manifest[key].eval.task,
-              task_id: manifest[key].eval.task_id,
+              task: manifest[key].task,
+              task_id: manifest[key].task_id,
             };
           });
           return Promise.resolve({
@@ -108,10 +108,10 @@ function simpleHttpAPI(logInfo: LogInfo): LogViewAPI {
     eval_log_bytes: async (log_file: string, start: number, end: number) => {
       return await fetchRange(log_file, start, end);
     },
-    eval_log_header: async (log_file: string) => {
+    eval_log_overview: async (log_file: string) => {
       const manifest = await getManifest();
       if (manifest) {
-        const manifestAbs: Record<string, EvalHeader> = {};
+        const manifestAbs: Record<string, LogOverview> = {};
         Object.keys(manifest).forEach((key) => {
           manifestAbs[joinURI(log_dir || "", key)] = manifest[key];
         });
@@ -122,7 +122,7 @@ function simpleHttpAPI(logInfo: LogInfo): LogViewAPI {
       }
       throw new Error(`Unable to load eval log header for ${log_file}`);
     },
-    eval_log_headers: async (files: string[]) => {
+    eval_log_overviews: async (files: string[]) => {
       if (files.length === 0) {
         return [];
       }
@@ -131,7 +131,7 @@ function simpleHttpAPI(logInfo: LogInfo): LogViewAPI {
         const manifest = await getManifest();
         if (manifest) {
           const keys = Object.keys(manifest);
-          const result: EvalLog[] = [];
+          const result: LogOverview[] = [];
           files.forEach((file) => {
             const fileKey = keys.find((key) => {
               return file.endsWith(key);

--- a/src/inspect_ai/_view/www/src/client/api/api-http.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-http.ts
@@ -146,7 +146,7 @@ function simpleHttpAPI(logInfo: LogInfo): LogViewAPI {
 
       // No log.json could be found, and there isn't a log file,
       throw new Error(
-        `Failed to load a manifest files using the directory: ${log_dir}. Please be sure you have deployed a manifest file (logs.json).`,
+        `Failed to load a listing file using the directory: ${log_dir}. Please be sure you have deployed a manifest file (listing.json).`,
       );
     },
     download_file,
@@ -218,7 +218,7 @@ const fetchManifest = async (
   log_dir: string,
 ): Promise<LogFilesFetchResponse | undefined> => {
   const logs = await fetchFile<LogFilesFetchResponse>(
-    log_dir + "/overview.json",
+    log_dir + "/listing.json",
     async (text) => {
       const parsed = await asyncJsonParse(text);
       return {

--- a/src/inspect_ai/_view/www/src/client/api/api-vscode.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-vscode.ts
@@ -78,7 +78,7 @@ async function eval_log_bytes(log_file: string, start: number, end: number) {
   return await vscodeClient(kMethodEvalLogBytes, [log_file, start, end]);
 }
 
-async function eval_log_headers(files: string[]) {
+async function eval_log_overviews(files: string[]) {
   const response = await vscodeClient(kMethodEvalLogHeaders, [files]);
   if (response) {
     return JSON5.parse(response);
@@ -171,7 +171,7 @@ const api: LogViewAPI = {
   eval_log,
   eval_log_size,
   eval_log_bytes,
-  eval_log_headers,
+  eval_log_overviews,
   log_message,
   download_file,
   open_log_file,

--- a/src/inspect_ai/_view/www/src/client/api/types.ts
+++ b/src/inspect_ai/_view/www/src/client/api/types.ts
@@ -1,7 +1,10 @@
 import {
   ApprovalEvent,
+  CompletedAt,
   EvalError,
+  EvalId,
   EvalLog,
+  EvalMetric,
   EvalPlan,
   EvalResults,
   EvalSample,
@@ -10,18 +13,24 @@ import {
   InfoEvent,
   Input,
   LoggerEvent,
+  Model,
   ModelEvent,
+  RunId,
   SampleInitEvent,
   SampleLimitEvent,
   SandboxEvent,
   ScoreEvent,
   Scores1,
+  StartedAt,
   StateEvent,
   Status,
   StepEvent,
   StoreEvent,
   SubtaskEvent,
   Target,
+  Task,
+  TaskId,
+  TaskVersion,
   ToolEvent,
   Version,
 } from "../../@types/log";
@@ -149,8 +158,8 @@ export interface LogViewAPI {
     start: number,
     end: number,
   ) => Promise<Uint8Array>;
-  eval_log_header?: (log_file: string) => Promise<EvalHeader>;
-  eval_log_headers: (log_files: string[]) => Promise<EvalLog[]>;
+  eval_log_overview?: (log_file: string) => Promise<LogOverview>;
+  eval_log_overviews: (log_files: string[]) => Promise<LogOverview[]>;
   log_message: (log_file: string, message: string) => Promise<void>;
   download_file: (
     filename: string,
@@ -173,7 +182,7 @@ export interface LogViewAPI {
 export interface ClientAPI {
   client_events: () => Promise<string[]>;
   get_log_paths: () => Promise<LogFiles>;
-  get_log_headers: (log_files: string[]) => Promise<EvalLog[]>;
+  get_log_overviews: (log_files: string[]) => Promise<LogOverview[]>;
   get_log_summary: (log_file: string) => Promise<EvalSummary>;
   get_log_sample: (
     log_file: string,
@@ -221,6 +230,26 @@ export interface EvalHeader {
   error?: EvalError | null;
 }
 
+export interface LogOverview {
+  eval_id: EvalId;
+  run_id: RunId;
+
+  task: Task;
+  task_id: TaskId;
+  task_version: TaskVersion;
+
+  version?: Version;
+  status?: Status;
+  error?: EvalError | null;
+
+  model: Model;
+
+  started_at?: StartedAt;
+  completed_at?: CompletedAt;
+
+  primary_metric?: EvalMetric;
+}
+
 export interface LogFiles {
   files: LogFile[];
   log_dir?: string;
@@ -239,7 +268,7 @@ export interface LogContents {
 
 export interface LogFilesFetchResponse {
   raw: string;
-  parsed: Record<string, EvalHeader>;
+  parsed: Record<string, LogOverview>;
 }
 
 export interface UpdateStateMessage {

--- a/src/inspect_ai/_view/www/src/client/remote/remoteLogFile.ts
+++ b/src/inspect_ai/_view/www/src/client/remote/remoteLogFile.ts
@@ -4,9 +4,11 @@ import { AsyncQueue } from "../../utils/queue";
 import {
   EvalHeader,
   EvalSummary,
+  LogOverview,
   LogViewAPI,
   SampleSummary,
 } from "../api/types";
+import { toBasicInfo } from "../utils/type-utils";
 import {
   CentralDirectoryEntry,
   FileSizeLimitError,
@@ -31,7 +33,7 @@ export class SampleNotFoundError extends Error {
   }
 }
 export interface RemoteLogFile {
-  readHeader: () => Promise<EvalHeader>;
+  readEvalBasicInfo: () => Promise<LogOverview>;
   readLogSummary: () => Promise<EvalSummary>;
   readSample: (sampleId: string, epoch: number) => Promise<EvalSample>;
   readCompleteLog: () => Promise<EvalLog>;
@@ -163,6 +165,11 @@ export const openRemoteLogFile = async (
     }
   };
 
+  const readEvalBasicInfo = async (): Promise<LogOverview> => {
+    const header = await readHeader();
+    return toBasicInfo(header);
+  };
+
   /**
    * Reads individual summary files when summaries.json is not available.
    */
@@ -215,7 +222,7 @@ export const openRemoteLogFile = async (
   };
 
   return {
-    readHeader,
+    readEvalBasicInfo,
     readLogSummary: async () => {
       const [header, sampleSummaries] = await Promise.all([
         readHeader(),

--- a/src/inspect_ai/_view/www/src/client/utils/type-utils.ts
+++ b/src/inspect_ai/_view/www/src/client/utils/type-utils.ts
@@ -1,0 +1,37 @@
+import { EvalMetric, EvalResults } from "../../@types/log";
+import { EvalHeader, EvalSummary, LogOverview } from "../api/types";
+
+export const toBasicInfo = (header: EvalHeader | EvalSummary): LogOverview => {
+  return {
+    eval_id: header.eval.eval_id,
+    run_id: header.eval.run_id,
+
+    task: header.eval.task,
+    task_id: header.eval.task_id,
+    task_version: header.eval.task_version,
+
+    version: header.version,
+    status: header.status,
+    error: header.error,
+
+    model: header.eval.model,
+
+    started_at: header.stats?.started_at,
+    completed_at: header.stats?.completed_at,
+
+    primary_metric: primaryMetric(header.results),
+  };
+};
+
+const primaryMetric = (
+  evalResults?: EvalResults | null,
+): EvalMetric | undefined => {
+  if (evalResults?.scores && evalResults?.scores.length > 0) {
+    const evalMetrics = evalResults.scores[0].metrics;
+    const metrics = Object.values(evalMetrics);
+    if (metrics.length > 0) {
+      return metrics[0];
+    }
+  }
+  return undefined;
+};

--- a/src/inspect_ai/_view/www/src/state/clientEvents.ts
+++ b/src/inspect_ai/_view/www/src/state/clientEvents.ts
@@ -9,7 +9,7 @@ const log = createLogger("Client-Events");
 
 export function useClientEvents() {
   const refreshLogs = useStore((state) => state.logsActions.refreshLogs);
-  const logHeaders = useStore((state) => state.logs.logHeaders);
+  const logHeaders = useStore((state) => state.logs.logOverviews);
   const api = useStore((state) => state.api);
   const { loadHeaders } = useLogs();
 

--- a/src/inspect_ai/_view/www/src/state/hooks.ts
+++ b/src/inspect_ai/_view/www/src/state/hooks.ts
@@ -577,8 +577,10 @@ export const useLogs = () => {
   }, [load, setLogs, setStatus]);
 
   // Loading headers
-  const storeLoadHeaders = useStore((state) => state.logsActions.loadHeaders);
-  const existingHeaders = useStore((state) => state.logs.logHeaders);
+  const storeLoadHeaders = useStore(
+    (state) => state.logsActions.loadLogOverviews,
+  );
+  const existingHeaders = useStore((state) => state.logs.logOverviews);
   const allLogFiles = useStore((state) => state.logs.logs.files);
 
   const loadHeaders = useCallback(

--- a/src/inspect_ai/_view/www/src/state/logSlice.ts
+++ b/src/inspect_ai/_view/www/src/state/logSlice.ts
@@ -1,5 +1,6 @@
 import { FilterError, LogState, ScoreLabel } from "../app/types";
 import { EvalSummary, PendingSamples } from "../client/api/types";
+import { toBasicInfo } from "../client/utils/type-utils";
 import { kDefaultSort, kLogViewInfoTabId } from "../constants";
 import { createLogger } from "../utils/logger";
 import { createLogPolling } from "./logPolling";
@@ -175,19 +176,10 @@ export const createLogSlice = (
 
           // Push the updated header information up
           const header = {
-            [logFileName]: {
-              version: logContents.version,
-              status: logContents.status,
-              eval: logContents.eval,
-              plan: logContents.plan,
-              results:
-                logContents.results !== null ? logContents.results : undefined,
-              stats: logContents.stats,
-              error: logContents.error !== null ? logContents.error : undefined,
-            },
+            [logFileName]: toBasicInfo(logContents),
           };
 
-          state.logsActions.updateLogHeaders(header);
+          state.logsActions.updateLogOverviews(header);
           set((state) => {
             state.log.loadedLog = logFileName;
           });

--- a/src/inspect_ai/log/_bundle.py
+++ b/src/inspect_ai/log/_bundle.py
@@ -72,13 +72,9 @@ def bundle_log_dir(
             # Copy the logs to the log dir
             copy_log_files(log_dir, view_logs_dir, p.update, fs_options)
 
-            # Always regenerate the manifest
-            write_log_dir_manifest(view_logs_dir)
-            p.update(15)
-
-            # Write the log overviews
+            # Always write the log overviews
             write_log_overviews(view_logs_dir)
-            p.update(10)
+            p.update(25)
 
             # update the index html to embed the log_dir
             inject_configuration(

--- a/src/inspect_ai/log/_bundle.py
+++ b/src/inspect_ai/log/_bundle.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Iterator
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import filesystem
 
-from ._file import log_files_from_ls, write_log_dir_manifest
+from ._file import log_files_from_ls, write_log_dir_manifest, write_log_overviews
 
 # INSPECT_VIEW_BUNDLE_OUT_DIR
 
@@ -74,7 +74,11 @@ def bundle_log_dir(
 
             # Always regenerate the manifest
             write_log_dir_manifest(view_logs_dir)
-            p.update(25)
+            p.update(15)
+
+            # Write the log overviews
+            write_log_overviews(view_logs_dir)
+            p.update(10)
 
             # update the index html to embed the log_dir
             inject_configuration(

--- a/src/inspect_ai/log/_bundle.py
+++ b/src/inspect_ai/log/_bundle.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Iterator
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import filesystem
 
-from ._file import log_files_from_ls, write_log_dir_manifest, write_log_listing
+from ._file import log_files_from_ls, write_log_listing
 
 # INSPECT_VIEW_BUNDLE_OUT_DIR
 

--- a/src/inspect_ai/log/_bundle.py
+++ b/src/inspect_ai/log/_bundle.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Iterator
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import filesystem
 
-from ._file import log_files_from_ls, write_log_dir_manifest, write_log_overviews
+from ._file import log_files_from_ls, write_log_dir_manifest, write_log_listing
 
 # INSPECT_VIEW_BUNDLE_OUT_DIR
 
@@ -73,7 +73,7 @@ def bundle_log_dir(
             copy_log_files(log_dir, view_logs_dir, p.update, fs_options)
 
             # Always write the log overviews
-            write_log_overviews(view_logs_dir)
+            write_log_listing(view_logs_dir)
             p.update(25)
 
             # update the index html to embed the log_dir

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -651,16 +651,16 @@ def eval_log_json_str(log: EvalLog) -> str:
     return eval_log_json(log).decode()
 
 
-def write_log_overviews(
+def write_log_listing(
     log_dir: str,
     *,
-    filename: str = "overview.json",
+    filename: str = "listing.json",
     output_dir: str | None = None,
     fs_options: dict[str, Any] = {},
 ) -> None:
-    """Write a an overview file for a log directory.
+    """Write a listing file for a log directory.
 
-    A log directory overview is a thinned manifest summarizing the logs in the directory (but with much less information than the full manifest).
+    A listing file is a thinned manifest summarizing the logs in the directory (but with much less information than a full manifest of headers).
 
     Args:
       log_dir (str): Log directory to write overview for.

--- a/tests/view/test_bundle.py
+++ b/tests/view/test_bundle.py
@@ -40,7 +40,7 @@ def test_s3_bundle(mock_s3) -> None:
         "assets/index.js",
         "assets/index.css",
         "logs",
-        "logs/logs.json",
+        "logs/listing.json",
     ]
 
     for exp in expected:
@@ -74,13 +74,13 @@ def test_bundle() -> None:
             "assets/index.js",
             "assets/index.css",
             "logs",
-            "logs/logs.json",
+            "logs/listing.json",
         ]
         for exp in expected:
             abs = os.path.join(output_dir, exp)
             assert os.path.exists(abs)
 
-        # ensure there is a non-logs.json log file present in logs
+        # ensure there is a non-listing.json log file present in logs
         non_manifest_logs = [
             f
             for f in os.listdir(os.path.join(output_dir, "logs"))


### PR DESCRIPTION
When bundling log files with a viewer for deployment to a static web server, the bundle also includes a `logs.json` file which contained a list of all the headers for the logs in the directory. When thousands of files were bundled, the header size in this file could add up, making it unwieldy (e.g. 100+MB) and hanging the viewer as it attempted to download and parse huge JSON files.

This removes the `logs.json` file and replaces it with a purpose built `listing.json` file which contains the minimal information necessary to render the listing pages (rather than the complete headers for each log). In local testing, this purpose built schema reduced the overall file size to approximately .15% of the original file size (e.g. 120MB -> 150KB).

The viewer has been updated to read a `listing.json` file.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
