### PR TITLE
Fix link in tools-standard.qmd

### DIFF
--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -261,7 +261,7 @@ Note that we provide a `timeout` for the bash session and text editor tools (thi
 
 ### Tool Binding
 
-The schema for the `text_editor()` tool is based on the standard Anthropic [text editor tool type](https://docs.anthropic.com/en/docs/agents-and-tools/computer-use#text-editor-tool). The `text_editor()` works with all models that support tool calling, but when using Claude, the text editor tool will automatically bind to the native Claude tool definition.
+The schema for the `text_editor()` tool is based on the standard Anthropic [text editor tool type](https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/text-editor-tool). The `text_editor()` works with all models that support tool calling, but when using Claude, the text editor tool will automatically bind to the native Claude tool definition.
 
 ## Web Browser {#sec-web-browser}
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [X] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Text editor tool links to computer use tool

### What is the new behavior?

Links to text editor tool

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
