### PR TITLE
Improve missing Model API error nessage

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -976,6 +976,7 @@ def get_model(
 
     # split model into api name and model name if necessary
     api_name = None
+    original_model = model
     parts = model.split("/")
     if len(parts) > 1:
         api_name = parts[0]
@@ -1011,8 +1012,14 @@ def get_model(
             _models[model_cache_key] = m
         return m
     else:
-        from_api = f" from {api_name}" if api_name else ""
-        raise ValueError(f"Model name {model}{from_api} not recognized.")
+        if api_name is None:
+            raise ValueError(
+                f"Model name {original_model!r} should be in the format of <api_name>/<model_name>."
+            )
+        else:
+            raise ValueError(
+                f"Model API {api_name} of model {original_model!r} not recognized."
+            )
 
 
 # cache for memoization of get_model


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If you mystype a model name, the error message is confusing

`ValueError: Model name {model}{from_api} not recognized.`

The actual error is in the from_api part. The name of the model is irrelevant.

### What is the new behavior?

`ValueError: Model API openapi of model 'openapi/o3-mini' not recognized.`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
