### PR TITLE
Bug: Keep description when resolving schema references

### DIFF
--- a/src/inspect_ai/util/_json.py
+++ b/src/inspect_ai/util/_json.py
@@ -202,12 +202,12 @@ def resolve_schema_references(schema: dict[str, Any]) -> dict[str, Any]:
     def _resolve_refs(obj: Any) -> Any:
         if isinstance(obj, dict):
             if "$ref" in obj and obj["$ref"].startswith("#/$defs/"):
-                ref_key = obj["$ref"].split("/")[-1]
+                ref_key = obj.pop("$ref").split("/")[-1]
                 if ref_key in definitions:
                     # Replace with a deep copy of the definition
                     resolved = deepcopy(definitions[ref_key])
                     # Process any nested references in the definition
-                    return _resolve_refs(resolved)
+                    return _resolve_refs(resolved) | obj
 
             # Process all entries in the dictionary
             return {k: _resolve_refs(v) for k, v in obj.items()}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The descriptions of fields in nested pydantic classes are ignored. E.g. with this MRE:

```mre.py
"""Submission type definitions for the data poisoning setting."""

from inspect_ai.tool import Tool, ToolDef, tool
from pydantic import BaseModel, Field


class Foo(BaseModel):
    foo: str = Field(description="Foo description")


class FooWDescription(BaseModel):
    """FooWDescription's description"""

    foo: str = Field(description="Foo description")


class Bar(BaseModel):
    foo_a: Foo = Field(description="Bar's description for foo_a")
    foo_b: Foo = Field(description="Bar's description for foo_b")
    foo_c: FooWDescription = Field(description="Bar's description for foo_c")


@tool
def bar_tool() -> Tool:
    async def impl(bar: Bar) -> str:
        """Submit a pair of responses from two models for evaluation.

        Args:
            bar: Bar!

        Returns:
            str: Confirmation message indicating successful submission.
        """
        # Here you would typically handle the submission logic, e.g., saving to a database
        return "Response pair submitted successfully."

    return impl


if __name__ == "__main__":
    bar = bar_tool()
    tool_def = ToolDef(bar)
    foo_a_desc = tool_def.parameters.properties["bar"].properties["foo_a"].description
    foo_b_desc = tool_def.parameters.properties["bar"].properties["foo_b"].description
    foo_c_desc = tool_def.parameters.properties["bar"].properties["foo_c"].description

    print(
        f"Foo a Description: {foo_a_desc}\n"
        f"Foo b Description: {foo_b_desc}\n"
        f"Foo c Description: {foo_c_desc}\n"
    )
```

the response is:

```bash
(.venv) ubuntu@kraft27club:~/control-arena$ uv run mre.py 
Foo a Description: None
Foo b Description: None
Foo c Description: FooWDescription's description
```

### What is the new behavior?

The response with the example above is:

```bash
(.venv) ubuntu@kraft27club:~/inspect_ai$ python mre.py 
Foo a Description: Bar's description for foo_a
Foo b Description: Bar's description for foo_b
Foo c Description: Bar's description for foo_c
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Potentially, if people are relying on the old logic.
