### PR TITLE
Fix typo in solvers.qmd

### DIFF
--- a/docs/solvers.qmd
+++ b/docs/solvers.qmd
@@ -191,7 +191,7 @@ Here is the task definition:
 @task
 def mmlu():
     # read the dataset
-    dataset = csv_dataset(
+    task_dataset = csv_dataset(
         "mmlu.csv", 
         sample_fields=record_to_sample
     )


### PR DESCRIPTION
I (hopefully) fixed a typo. As far as I can tell, dataset should be task_dataset here.

## This PR contains:
- [x] Docs


### What is the current behavior? (You can also link to an open issue here)
Code throws an error as task_dataset is not defined.

### What is the new behavior?
Works

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
None, since it is the doc.

### Other information:
This is my first ever PR, would be glad for feedback!