### PR TITLE
Fix typo in WBHooks.on_sample_end sample code

### DIFF
--- a/docs/extensions.qmd
+++ b/docs/extensions.qmd
@@ -1,5 +1,5 @@
 ---
-title: Extensions 
+title: Extensions
 ---
 
 ## Overview
@@ -25,7 +25,7 @@ You can add a model provider by deriving a new class from `ModelAPI` and then cr
 ``` {.python filename="custom.py"}
 class CustomModelAPI(ModelAPI):
     def __init__(
-        self, 
+        self,
         model_name: str,
         base_url: str | None = None,
         api_key: str | None = None,
@@ -34,7 +34,7 @@ class CustomModelAPI(ModelAPI):
         **model_args: Any
     ) -> None:
         super().__init__(model_name, base_url, api_key, api_key_vars, config)
-  
+
     async def generate(
         self,
         input: list[ChatMessage],
@@ -146,9 +146,9 @@ class PodmanSandboxEnvironment(SandboxEnvironment):
 
     @classmethod
     async def sample_init(
-        cls, 
-        task_name: str, 
-        config: SandboxEnvironmentConfigType | None, 
+        cls,
+        task_name: str,
+        config: SandboxEnvironmentConfigType | None,
         metadata: dict[str, str]
     ) -> dict[str, SandboxEnvironment]:
         ...
@@ -307,7 +307,7 @@ Approvers can be implemented in Python packages and the referred to by package a
 ``` {.python filename="approvers.py"}
 @approver
 def auto_approver(decision: ApprovalDecision = "approve") -> Approver:
-    
+
     async def approve(
         message: str,
         call: ToolCall,
@@ -315,7 +315,7 @@ def auto_approver(decision: ApprovalDecision = "approve") -> Approver:
         history: list[ChatMessage],
     ) -> Approval:
         return Approval(
-            decision=decision, 
+            decision=decision,
             explanation="Automatic decision."
         )
 
@@ -328,7 +328,7 @@ If you are publishing an approver within a Python package, you should register a
 
 For example, let's say your package is named `evaltools` and has this structure:
 
-```         
+```
 evaltools/
   approvers.py
   _registry.py
@@ -478,11 +478,12 @@ class WBHooks(Hooks):
         wandb.finish()
 
     async def on_sample_end(self, data: SampleEnd) -> None:
-        scores = {k: v.value for k, v in data.summary.scores.items()}
-        wandb.log({
-            "sample_id": data.sample_id,
-            "scores": scores
-        })
+    if data.sample.scores:
+          scores = {k: v.value for k, v in data.sample.scores.items()}
+          wandb.log({
+              "sample_id": data.sample_id,
+              "scores": scores
+          })
 ```
 
 See the `Hooks` class for more documentation and the full list of available hook events.
@@ -506,7 +507,7 @@ Packages that provide hooks should register an `inspect_ai` [setuptools entry po
 
 For example, let's say your package is named `evaltools` and has this structure:
 
-```         
+```
 evaltools/
   wandb.py
   _registry.py


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The code in doesn't work because [`SampleEnd`](https://inspect.aisi.org.uk/reference/inspect_ai.hooks.html#sampleend
) doesn't have `summary` field.

### What is the new behavior?
It works now.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.