### PR TITLE
Feature: Require correct submit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Inspect View: Supporting linking to events via `uuid` field (or `event_id` in analysis data frames).
 - Bugfix: Use the output filesystem when creating directories in `inspect log convert`
 - Bugfix: Strip smuggled `<think>` and `<internal>` tags from tool messages to prevent leakage in multi-agent scenarios where an _inner_ assistant message can be coerced into a tool message.
+- React: Require submit tool to have no errors before you exit the react loop.
 
 ## 0.3.113 (16 July 2025)
 

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -153,6 +153,8 @@ def react(
                 for result in tool_results
                 if isinstance(result, ChatMessageTool)
                 and result.function == submit_tool.name
+                # Require that the submit tool call has no error
+                and result.error is None
             ),
             None,
         )


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When the agent submits in the react loop, the episode ends - regardless of if the submit tool was executed correctly.

### What is the new behavior?

The react loop only stops when the agent submits, and the function does not raise an exception.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Potentially, if someone was relying on a broken submit tool. They would need to fix the tool so that the agent can submit still.