### PR TITLE
Render tool call if next event isn’t tool event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@
 - Mistral: Type updates for `ThinkChunk` and `AudioChunk` in package v1.9.3 (which is now the minimum required version).
 - Inspect View: Use MathJax rather than Katex for math rendering.
 - Inspect View: Fix issue with scores 'More...' link not being displayed in some configurations.
+- Inspect View: Fix issue displaying tool calls in transcript in some configurations.
 - Bugfix: Strip smuggled `<think>` and `<internal>` tags from tool messages to prevent leakage in multi-agent scenarios where an _inner_ assistant message can be coerced into a tool message.
 - Bugfix: Handle descriptions of nested `BaseModel` types in tool call schemas.
+
 
 ## 0.3.114 (17 July 2025)
 

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.tsx
@@ -29,6 +29,7 @@ import { EventNode } from "./types";
 interface ModelEventViewProps {
   eventNode: EventNode<ModelEvent>;
   className?: string | string[];
+  showToolCalls: boolean;
 }
 
 /**
@@ -36,6 +37,7 @@ interface ModelEventViewProps {
  */
 export const ModelEventView: FC<ModelEventViewProps> = ({
   eventNode,
+  showToolCalls,
   className,
 }) => {
   const event = eventNode.event;
@@ -81,7 +83,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
           id={`${eventNode.id}-model-output`}
           messages={[...userMessages, ...(outputMessages || [])]}
           numbered={false}
-          toolCallStyle="omit"
+          toolCallStyle={showToolCalls ? "complete" : "omit"}
         />
         {event.pending ? (
           <div className={clsx(styles.progress)}>

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptVirtualList.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptVirtualList.tsx
@@ -106,13 +106,14 @@ export const TranscriptVirtualList: FC<TranscriptVirtualListProps> = memo(
 
 interface RenderedEventNodeProps {
   node: EventNode;
+  next?: EventNode;
   className?: string | string[];
 }
 /**
  * Renders the event based on its type.
  */
 export const RenderedEventNode: FC<RenderedEventNodeProps> = memo(
-  ({ node, className }) => {
+  ({ node, next, className }) => {
     switch (node.event.event) {
       case "sample_init":
         return (
@@ -150,6 +151,7 @@ export const RenderedEventNode: FC<RenderedEventNodeProps> = memo(
         return (
           <ModelEventView
             eventNode={node as EventNode<ModelEvent>}
+            showToolCalls={next?.event.event !== "tool"}
             className={className}
           />
         );

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptVirtualListComponent.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptVirtualListComponent.tsx
@@ -76,6 +76,7 @@ export const TranscriptVirtualListComponent: FC<
         >
           <RenderedEventNode
             node={item}
+            next={next}
             className={clsx(attachedParentClass, attachedChildClass)}
           />
         </div>


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### 

We currently don't render tool calls in model events (transcript) b/c we're relying upon the next event being a tool event (and that rendering the tool call). This will look ahead to the next event and render the tool call if the next event isn't a tool event.
