### PR TITLE
Update workaround of OpenAI reasoning issue to retain only the last (rather than the first) in a run of consecutive reasoning items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Inspect View: Fix issue displaying tool calls in transcript in some configurations.
 - Bugfix: Strip smuggled `<think>` and `<internal>` tags from tool messages to prevent leakage in multi-agent scenarios where an _inner_ assistant message can be coerced into a tool message.
 - Bugfix: Handle descriptions of nested `BaseModel` types in tool call schemas.
+- Bugfix: Update workaround of OpenAI reasoning issue to retain only the last (rather than the first) in a run of consecutive reasoning items.
 
 
 ## 0.3.114 (17 July 2025)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Some OpenAI reasoning models return multiple consecutive `reasoning` items in a row. Our current `_filter_consecutive_reasoning_blocks` drops all but the first in each consecutive run. This leads to `400` errors from OpenAI when we play that back to them.

### What is the new behavior?

`_filter_consecutive_reasoning_blocks` has been updated to drop all but the _last_ reasoning item instead, and that fixed the bug.

Note that we're updating a heuristic work-around of an issue with the OpenAI API. Though unlikely, it's possible that, in some cases, this fix will break previously functioning scenarios.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
