### PR TITLE
Do not use instance cache for S3FileSystem in the async_filesystem context manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Batch Processing: Improve batch processing scalability when handling very large concurrent batch counts.
 - Batch Processing: Add retry attempt logging.
 - Batch Processing: Move batch retry logic to base class to reduce logic duplication and simplify provider implementations.
+- Inspect View: Do not use instance cache for S3FileSystem (eliminates some errors with large eval sets)
 - Bugfix: Correct mapping for organization and model name in `model_info()` operation.
 
 ## 0.3.116 (27 July 2025)

--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -493,6 +493,7 @@ async def async_fileystem(
     options.update(fs_options)
 
     if protocol == "s3":
+        options["skip_instance_cache"] = True
         s3 = S3FileSystem(asynchronous=True, **options)
         session = await s3.set_session()
         try:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When calling `inspect view --log-dir=s3://...` with a large eval set log, the session gets closed too early resulting in this error:

```
$ uv run inspect view --log-dir=s3://...
======== Running on http://127.0.0.1:7575 ========
(Press CTRL+C to quit)
[07/29/25 14:05:28] ERROR    Error handling request from 127.0.0.1                                                                                                   web_protocol.py:451
                             Traceback (most recent call last):                                                                                                                         
                               File "/home/faber/src/metr/inspect-action/.venv/lib/python3.13/site-packages/aiobotocore/httpsession.py", line 222, in send                              
                                 response = await session.request(                                                                                                                      
                                            ^^^^^^^^^^^^^^^^^^^^^^                                                                                                                      
                                 ...<7 lines>...                                                                                                                                        
                                 )                                                                                                                                                      
                                 ^                                                                                                                                                      
                               File "/home/faber/src/metr/inspect-action/.venv/lib/python3.13/site-packages/aiohttp/client.py", line 703, in _request                                   
                                 conn = await self._connector.connect(                                                                                                                  
                                              ^^^^^^^^^^^^^^^^^^^^^^^                                                                                                                   
                             AttributeError: 'NoneType' object has no attribute 'connect' 
```
([Slack](https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1753793743602449))

### What is the new behavior?

We allocate a new `S3FileSystem` to avoid the session getting closed too early.
