### PR TITLE
add a test

### DIFF
--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -683,12 +683,16 @@ async def _eval_async_inner(
         # cleanup sample buffers if required
         cleanup_sample_buffers(log_dir)
 
-    finally:
         try:
             await emit_run_end(run_id, logs)
         except UnboundLocalError:
             await emit_run_end(run_id, EvalLogs([]))
         _eval_async_running = False
+
+    except Exception as e:
+        await emit_run_end(run_id, EvalLogs([]), e)
+        _eval_async_running = False
+        raise e
 
     # return logs
     return logs

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -34,6 +34,9 @@ class RunEnd:
 
     run_id: str
     """The globally unique identifier for the run."""
+    exception: Exception | None
+    """The exception that occurred during the run, if any. If None, the run completed
+    successfully."""
     logs: EvalLogs
     """All eval logs generated during the run. Can be headers only if the run was an
     `eval_set()`."""
@@ -268,8 +271,10 @@ async def emit_run_start(run_id: str, tasks: list[ResolvedTask]) -> None:
     await _emit_to_all(lambda hook: hook.on_run_start(data))
 
 
-async def emit_run_end(run_id: str, logs: EvalLogs) -> None:
-    data = RunEnd(run_id=run_id, logs=logs)
+async def emit_run_end(
+    run_id: str, logs: EvalLogs, exception: Exception | None = None
+) -> None:
+    data = RunEnd(run_id=run_id, logs=logs, exception=exception)
     await _emit_to_all(lambda hook: hook.on_run_end(data))
 
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -231,12 +231,11 @@ def test_hooks_with_error_passes_exception_to_run_end(mock_hooks: MockHooks) -> 
     with pytest.raises(RuntimeError, match="test"):
         with patch("inspect_ai._eval.eval.eval_init", side_effect=RuntimeError("test")):
             eval(
-                Task(dataset=[Sample("sample_1")], solver=_fail_n_times_solver(2)),
+                Task(dataset=[Sample("sample_1")], solver=_fail_n_times_solver(1)),
                 model="mockllm/model",
                 retry_on_error=0,
             )
 
-    # Will fail on first attempt without any retries.
     assert len(mock_hooks.run_end_events) == 1
     assert mock_hooks.run_end_events[0].exception is not None
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -227,6 +227,20 @@ def test_hooks_with_error_and_no_retries(mock_hooks: MockHooks) -> None:
     assert len(mock_hooks.sample_end_events) == 1
 
 
+def test_hooks_with_error_passes_exception_to_run_end(mock_hooks: MockHooks) -> None:
+    with pytest.raises(RuntimeError, match="test"):
+        with patch("inspect_ai._eval.eval.eval_init", side_effect=RuntimeError("test")):
+            eval(
+                Task(dataset=[Sample("sample_1")], solver=_fail_n_times_solver(2)),
+                model="mockllm/model",
+                retry_on_error=0,
+            )
+
+    # Will fail on first attempt without any retries.
+    assert len(mock_hooks.run_end_events) == 1
+    assert mock_hooks.run_end_events[0].exception is not None
+
+
 def test_hooks_do_not_need_to_subscribe_to_all_events(
     hooks_minimal: MockMinimalHooks,
 ) -> None:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently, if an Inspect run fails in an unhandled manner, the `on_run_end` hook doesn't get run. This means that integrations built on hooks don't get a chance to handle the error (for example, the integration might want to register an error state elsewhere)

### What is the new behavior?
Added an optional exception argument to the `RunEnd` object. If an unhandled exception occurs during a run, this exception is passed to `on_run_end` for any hooks to react to the exception before reraising.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No, since the new argument to `emit_run_end` is optional

### Other information:
