### PR TITLE
improved sample interruption for operator and working time limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+- Task display: Sample cancel button now works immediately (no longer needs to wait for a cooperative check).
+- Limits: Sample working limit is now enforced even during long running generations and sandbox operations.
+- Bugfix: `background()` task is now scoped to the sample lifetime in the presence of `retry_on_error`.
+
 ## 0.3.118 (02 August 2025)
 
 - Remove support for `vertex` provider as the google-cloud-aiplatform package has [deprecated](https://pypi.org/project/google-cloud-aiplatform/) its support for Vertex generative models. Vertex can still be used via the native `google` and `anthropic` providers.

--- a/src/inspect_ai/_display/core/results.py
+++ b/src/inspect_ai/_display/core/results.py
@@ -68,7 +68,7 @@ def task_results(profile: TaskProfile, success: TaskSuccess) -> RenderableType:
     if success.samples_completed < profile.samples:
         sample_errors = profile.samples - success.samples_completed
         sample_error_pct = int(float(sample_errors) / float(profile.samples) * 100)
-        message = f"\n[{theme.warning}]WARNING: {sample_errors} of {profile.samples} samples ({sample_error_pct}%) had errors and were not scored.[/{theme.warning}]"
+        message = f"\n[{theme.warning}]WARNING: {sample_errors} of {profile.samples} samples ({sample_error_pct}%) had errors and were not scored.[/{theme.warning}]\n"
         return Group(grid, message)
     else:
         return grid

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -693,9 +693,6 @@ async def task_run_sample(
                     start_time = time.monotonic()
                     init_sample_working_time(start_time)
 
-                    # monitor working limit in the background
-                    monitor_working_limit()
-
                     # run sample w/ optional limits
                     with (
                         state._token_limit,
@@ -721,6 +718,9 @@ async def task_run_sample(
                             await emit_sample_start(
                                 run_id, task_id, state.uuid, sample_summary
                             )
+
+                        # monitor working limit in the background
+                        monitor_working_limit()
 
                         # set progress for plan then run it
                         async with span("solvers"):

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -4,7 +4,6 @@ import sys
 import time
 from copy import copy, deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime
 from logging import getLogger
 from pathlib import PurePath
 from typing import Callable, Literal
@@ -322,51 +321,34 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
                 async def run_sample(
                     sample: Sample, state: TaskState
                 ) -> dict[str, SampleScore] | None:
-                    result: dict[str, SampleScore] | None = None
-
-                    async def run(tg: TaskGroup) -> None:
-                        try:
-                            nonlocal result
-                            result = await task_run_sample(
-                                tg=tg,
-                                task_name=task.name,
-                                log_location=profile.log_location,
-                                sample=sample,
-                                state=state,
-                                sandbox=sandbox,
-                                max_sandboxes=config.max_sandboxes,
-                                sandbox_cleanup=sandbox_cleanup,
-                                plan=plan,
-                                scorers=scorers,
-                                generate=generate,
-                                progress=progress,
-                                logger=logger if log_samples else None,
-                                log_images=log_images,
-                                sample_source=sample_source,
-                                sample_error=sample_error_handler,
-                                sample_complete=sample_complete,
-                                fails_on_error=(
-                                    config.fail_on_error is None
-                                    or config.fail_on_error is True
-                                ),
-                                retry_on_error=config.retry_on_error or 0,
-                                error_retries=[],
-                                time_limit=config.time_limit,
-                                working_limit=config.working_limit,
-                                semaphore=sample_semaphore,
-                                run_id=logger.eval.run_id,
-                                task_id=logger.eval.eval_id,
-                            )
-                        finally:
-                            tg.cancel_scope.cancel()
-
-                    try:
-                        async with anyio.create_task_group() as tg:
-                            tg.start_soon(run, tg)
-                    except Exception as ex:
-                        raise inner_exception(ex)
-
-                    return result
+                    return await task_run_sample(
+                        task_name=task.name,
+                        log_location=profile.log_location,
+                        sample=sample,
+                        state=state,
+                        sandbox=sandbox,
+                        max_sandboxes=config.max_sandboxes,
+                        sandbox_cleanup=sandbox_cleanup,
+                        plan=plan,
+                        scorers=scorers,
+                        generate=generate,
+                        progress=progress,
+                        logger=logger if log_samples else None,
+                        log_images=log_images,
+                        sample_source=sample_source,
+                        sample_error=sample_error_handler,
+                        sample_complete=sample_complete,
+                        fails_on_error=(
+                            config.fail_on_error is None or config.fail_on_error is True
+                        ),
+                        retry_on_error=config.retry_on_error or 0,
+                        error_retries=[],
+                        time_limit=config.time_limit,
+                        working_limit=config.working_limit,
+                        semaphore=sample_semaphore,
+                        run_id=logger.eval.run_id,
+                        task_id=logger.eval.eval_id,
+                    )
 
                 sample_results = await tg_collect(
                     [
@@ -533,7 +515,6 @@ def update_metrics_display_fn(
 
 async def task_run_sample(
     *,
-    tg: TaskGroup,
     task_name: str,
     log_location: str,
     sample: Sample,
@@ -657,7 +638,6 @@ async def task_run_sample(
             working_limit=working_limit,
             fails_on_error=fails_on_error or (retry_on_error > 0),
             transcript=sample_transcript,
-            tg=tg,
         ) as active,
     ):
         start_time: float | None = None
@@ -700,31 +680,96 @@ async def task_run_sample(
                         create_time_limit(time_limit),
                         create_working_limit(working_limit),
                     ):
-                        # mark started
-                        active.started = datetime.now().timestamp()
 
-                        # emit/log sample start
-                        sample_summary = EvalSampleSummary(
-                            id=sample_id,
-                            epoch=state.epoch,
-                            input=sample.input,
-                            target=sample.target,
-                            metadata=sample.metadata or {},
-                        )
-                        if logger is not None:
-                            await logger.start_sample(sample_summary)
-                        # only emit the sample start once: not on retries
-                        if not error_retries:
-                            await emit_sample_start(
-                                run_id, task_id, state.uuid, sample_summary
-                            )
+                        async def run(tg: TaskGroup) -> None:
+                            # access to state, limit, and errors
+                            nonlocal state, limit, error, raise_error
 
-                        # monitor working limit in the background
-                        monitor_working_limit()
+                            try:
+                                # start the sample
+                                active.start(tg)
 
-                        # set progress for plan then run it
-                        async with span("solvers"):
-                            state = await plan(state, generate)
+                                # monitor working limit in the background
+                                monitor_working_limit()
+
+                                # emit/log sample start
+                                sample_summary = EvalSampleSummary(
+                                    id=sample_id,
+                                    epoch=state.epoch,
+                                    input=sample.input,
+                                    target=sample.target,
+                                    metadata=sample.metadata or {},
+                                )
+                                if logger is not None:
+                                    await logger.start_sample(sample_summary)
+                                # only emit the sample start once: not on retries
+                                if not error_retries:
+                                    await emit_sample_start(
+                                        run_id, task_id, state.uuid, sample_summary
+                                    )
+
+                                # set progress for plan then run it
+                                async with span("solvers"):
+                                    state = await plan(state, generate)
+
+                            # some 'cancel' exceptions are actually user interrupts or the
+                            # result of monitor_working_limit() - for these exceptions we
+                            # want to intercept them and apply the appropriate control flow
+                            # so they can continue on and be scored.
+                            except anyio.get_cancelled_exc_class() as ex:
+                                if active.interrupt_action:
+                                    # record event
+                                    transcript()._event(
+                                        SampleLimitEvent(
+                                            type="operator",
+                                            message="Sample completed: interrupted by operator",
+                                        )
+                                    )
+
+                                    # handle the action
+                                    match active.interrupt_action:
+                                        case "score":
+                                            # continue to scoring (capture the most recent state)
+                                            state = sample_state() or state
+                                            limit = EvalSampleLimit(
+                                                type="operator", limit=1
+                                            )
+                                        case "error":
+                                            # default error handling
+                                            error, raise_error = handle_error(ex)
+
+                                elif active.limit_exceeded_error:
+                                    # record event
+                                    transcript()._event(
+                                        SampleLimitEvent(
+                                            type="working",
+                                            message=active.limit_exceeded_error.message,
+                                            limit=active.limit_exceeded_error.limit,
+                                        )
+                                    )
+
+                                    # capture most recent state for scoring
+                                    state = sample_state() or state
+                                    limit = EvalSampleLimit(
+                                        type=active.limit_exceeded_error.type,
+                                        limit=active.limit_exceeded_error.limit
+                                        if active.limit_exceeded_error.limit is not None
+                                        else -1,
+                                    )
+
+                                # this was not a user interrupt or working time limit so propagate
+                                else:
+                                    raise
+                            finally:
+                                # ensures that monitor_working_limit() and any coroutines
+                                # created w/ background() are cancelled
+                                tg.cancel_scope.cancel()
+
+                        try:
+                            async with anyio.create_task_group() as tg:
+                                tg.start_soon(run, tg)
+                        except Exception as ex:
+                            raise inner_exception(ex)
 
                 except TimeoutError:
                     # Scoped time limits manifest themselves as LimitExceededError, not
@@ -736,39 +781,6 @@ async def task_run_sample(
                     # capture most recent state for scoring
                     state = sample_state() or state
 
-                except anyio.get_cancelled_exc_class() as ex:
-                    if active.interrupt_action:
-                        # record event
-                        transcript()._event(
-                            SampleLimitEvent(
-                                type="operator",
-                                message="Sample completed: interrupted by operator",
-                            )
-                        )
-
-                        # handle the action
-                        match active.interrupt_action:
-                            case "score":
-                                # continue to scoring (capture the most recent state)
-                                state = sample_state() or state
-                            case "error":
-                                # default error handling
-                                error, raise_error = handle_error(ex)
-                    elif active.limit_exceeded_error:
-                        # capture most recent state for scoring
-                        state = sample_state() or state
-                        limit = EvalSampleLimit(
-                            type=active.limit_exceeded_error.type,
-                            limit=active.limit_exceeded_error.limit
-                            if active.limit_exceeded_error.limit is not None
-                            else -1,
-                        )
-
-                    else:
-                        # task group provided by tg_collect will automatically
-                        # handle the cancel exception
-                        raise
-
                 except LimitExceededError as ex:
                     # capture most recent state for scoring
                     state = sample_state() or state
@@ -776,7 +788,12 @@ async def task_run_sample(
                         type=ex.type, limit=ex.limit if ex.limit is not None else -1
                     )
 
-                except TerminateSampleError:
+                except TerminateSampleError as ex:
+                    # emit event
+                    transcript()._event(
+                        SampleLimitEvent(type="operator", limit=1, message=ex.reason)
+                    )
+
                     # capture most recent state for scoring
                     state = sample_state() or state
                     limit = EvalSampleLimit(type="operator", limit=1)
@@ -929,7 +946,6 @@ async def task_run_sample(
             time_limit=time_limit,
             working_limit=working_limit,
             semaphore=semaphore,
-            tg=tg,
             run_id=run_id,
             task_id=task_id,
         )

--- a/src/inspect_ai/_util/working.py
+++ b/src/inspect_ai/_util/working.py
@@ -1,7 +1,7 @@
 import time
 from contextvars import ContextVar
 
-from inspect_ai.util._limit import check_working_limit, record_waiting_time
+from inspect_ai.util._limit import record_waiting_time
 
 
 def init_sample_working_time(start_time: float) -> None:
@@ -20,7 +20,6 @@ def sample_working_time() -> float:
 def report_sample_waiting_time(waiting_time: float) -> None:
     # record and check for scoped limits
     record_waiting_time(waiting_time)
-    check_working_limit()
 
     # record sample-level limits
     _sample_waiting_time.set(_sample_waiting_time.get() + waiting_time)

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -352,7 +352,7 @@ async def call_tool(
     conversation: list[ChatMessage],
 ) -> tuple[ToolResult, list[ChatMessage], ModelOutput | None, str | None]:
     from inspect_ai.agent._handoff import AgentTool
-    from inspect_ai.log._transcript import SampleLimitEvent, ToolEvent, transcript
+    from inspect_ai.log._transcript import ToolEvent, transcript
 
     # dodge circular import
     assert isinstance(event, ToolEvent)
@@ -383,9 +383,6 @@ async def call_tool(
     if not approved:
         if approval and approval.decision == "terminate":
             message = "Tool call approver requested termination."
-            transcript()._event(
-                SampleLimitEvent(type="operator", limit=1, message=message)
-            )
             raise TerminateSampleError(message)
         else:
             raise ToolApprovalError(approval.explanation if approval else None)

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -58,7 +58,6 @@ from inspect_ai.util import concurrency
 from inspect_ai.util._limit import (
     check_message_limit,
     check_token_limit,
-    check_working_limit,
     record_model_usage,
 )
 
@@ -583,8 +582,6 @@ class Model:
         async def generate() -> tuple[ModelOutput, BaseModel]:
             # type-checker can't see that we made sure tool_choice is not none in the outer frame
             assert tool_choice is not None
-
-            check_working_limit()
 
             cache_entry: CacheEntry | None
             if cache:

--- a/src/inspect_ai/solver/_plan.py
+++ b/src/inspect_ai/solver/_plan.py
@@ -11,7 +11,6 @@ from inspect_ai._util.registry import (
     registry_name,
     registry_tag,
 )
-from inspect_ai.util._limit import check_working_limit
 
 from ._solver import Generate, Solver
 from ._task_state import TaskState
@@ -116,14 +115,12 @@ class Plan(Solver):
                 async with solver_transcript(self.finish, state) as st:
                     state = await self.finish(state, generate)
                     st.complete(state)
-                check_working_limit()
 
         finally:
             # always do cleanup if we have one
             if self.cleanup:
                 try:
                     await self.cleanup(state)
-                    check_working_limit()
                 except Exception as ex:
                     logger.warning(
                         f"Exception occurred during plan cleanup: {ex}", exc_info=ex

--- a/src/inspect_ai/solver/_solver.py
+++ b/src/inspect_ai/solver/_solver.py
@@ -26,7 +26,6 @@ from inspect_ai._util.registry import (
 from inspect_ai.agent._agent import Agent, is_agent
 from inspect_ai.agent._as_solver import as_solver
 from inspect_ai.model import CachePolicy, GenerateConfigArgs
-from inspect_ai.util._limit import check_working_limit
 
 from ._task_state import TaskState, set_sample_state
 
@@ -211,7 +210,6 @@ def solver(
                     state: TaskState, generate: Generate
                 ) -> TaskState:
                     state = await original_call(state, generate)
-                    check_working_limit()
                     set_sample_state(state)
                     return state
 
@@ -227,7 +225,6 @@ def solver(
                     state: TaskState, generate: Generate
                 ) -> TaskState:
                     state = await solver(state, generate)
-                    check_working_limit()
                     set_sample_state(state)
                     return state
 

--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -25,7 +25,6 @@ from inspect_ai.tool._tool_def import ToolDef
 from inspect_ai.util._limit import (
     check_message_limit,
     check_token_limit,
-    check_working_limit,
 )
 from inspect_ai.util._limit import message_limit as create_message_limit
 from inspect_ai.util._limit import token_limit as create_token_limit
@@ -364,7 +363,6 @@ class TaskState:
         if self._completed:
             return True
         else:
-            check_working_limit()
             return self._completed
 
     @completed.setter

--- a/src/inspect_ai/util/_background.py
+++ b/src/inspect_ai/util/_background.py
@@ -51,6 +51,10 @@ def background(
         raise RuntimeError(
             "background() function must be called from a running sample."
         )
+    if sample.tg is None:
+        raise RuntimeError(
+            "background() function must be called after sample has been started."
+        )
 
     # handle and log background exceptions
     async def run() -> None:

--- a/src/inspect_ai/util/_limit.py
+++ b/src/inspect_ai/util/_limit.py
@@ -369,6 +369,11 @@ def monitor_working_limit(interval: float = 1) -> None:
     async def run() -> None:
         while True:
             await anyio.sleep(interval)
+
+            # don't continue after the sample is completed
+            if sample.completed:
+                return
+
             error = working_limit_exceeded()
             if error is not None:
                 # record event
@@ -377,8 +382,9 @@ def monitor_working_limit(interval: float = 1) -> None:
                         type="working", message=error.message, limit=error.limit
                     )
                 )
-                # interrupt sample
+                # interrupt sample and stop monitoring
                 sample.limit_exceeded(error)
+                return
 
     # kick it off
     sample.tg.start_soon(run)

--- a/src/inspect_ai/util/_limit.py
+++ b/src/inspect_ai/util/_limit.py
@@ -356,13 +356,16 @@ def check_working_limit() -> None:
 
 def monitor_working_limit(interval: float = 1) -> None:
     from inspect_ai.log._samples import sample_active
-    from inspect_ai.log._transcript import SampleLimitEvent, transcript
 
     # get the active sample
     sample = sample_active()
     if sample is None:
         raise RuntimeError(
             "monitor_working_limit() must be called from a running sample."
+        )
+    if sample.tg is None:
+        raise RuntimeError(
+            "monitor_working_limit() must be called after sample has been started."
         )
 
     # check every second
@@ -376,13 +379,6 @@ def monitor_working_limit(interval: float = 1) -> None:
 
             error = working_limit_exceeded()
             if error is not None:
-                # record event
-                transcript()._event(
-                    SampleLimitEvent(
-                        type="working", message=error.message, limit=error.limit
-                    )
-                )
-                # interrupt sample and stop monitoring
                 sample.limit_exceeded(error)
                 return
 


### PR DESCRIPTION
- Task display: Sample cancel button now works immediately (no longer needs to wait for a cooperative check).
- Limits: Sample working limit is now enforced even during long running generations and sandbox operations.
- Bugfix: `background()` task is now scoped to the sample lifetime in the presence of `retry_on_error`.

@epatey This is a major improvement in our "responsiveness" to operator and working time limits but required some anyio gymnastics. Let's review together realtime on Monday.
