### PR TITLE
Update `inspect-tool-support` dockerfile to allow use by all users.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Tests: Improve sandbox self_check to handle test failure via `with pytest.raises`, add test for env vars.
+- Bugfix: Update `inspect-tool-support` reference container to support executing tool code with non-root accounts.
 
 ## 0.3.119 (04 August 2025)
 

--- a/docs/_sandbox-dockerfile.md
+++ b/docs/_sandbox-dockerfile.md
@@ -2,8 +2,10 @@ You should add the following to your sandbox `Dockerfile` in order to use this t
 
 ``` dockerfile
 RUN apt-get update && apt-get install -y pipx && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    pipx ensurepath
-ENV PATH="$PATH:/root/.local/bin"
-RUN pipx install inspect-tool-support && inspect-tool-support post-install
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+ENV PATH="$PATH:/opt/inspect/bin"
+RUN PIPX_HOME=/opt/inspect/pipx PIPX_BIN_DIR=/opt/inspect/bin PIPX_VENV_DIR=/opt/inspect/pipx/venvs \
+    pipx install inspect-tool-support && \
+    chmod -R 755 /opt/inspect && \
+    inspect-tool-support post-install
 ```

--- a/src/inspect_tool_support/Dockerfile
+++ b/src/inspect_tool_support/Dockerfile
@@ -4,12 +4,15 @@
 
 FROM python:3.12-bookworm
 
-# Install pipx to manage Python applications in isolated environments and add
-# its installation directory to PATH
+# Install pipx to manage Python applications in isolated environments
 RUN apt-get update && apt-get install -y pipx && \
-    apt-get clean && rm -rf /var/lib/apt/lists/* && \
-    pipx ensurepath
-ENV PATH="$PATH:/root/.local/bin"
-RUN pipx install inspect-tool-support && inspect-tool-support post-install
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install inspect-tool-support to a custom location that's on the path and has permissions granting access to all users
+ENV PATH="$PATH:/opt/inspect/bin"
+RUN PIPX_HOME=/opt/inspect/pipx PIPX_BIN_DIR=/opt/inspect/bin PIPX_VENV_DIR=/opt/inspect/pipx/venvs \
+    pipx install inspect-tool-support && \
+    chmod -R 755 /opt/inspect && \
+    inspect-tool-support post-install
 
 CMD ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

The current Dockerfile installed `inspect-tool-support` using `pipx` with default settings, which placed the installation in `/root/.local/bin`. This caused permission issues when the Docker container was used by non-root users, as they couldn't access the tools installed in the root user's private directory.

### What is the new behavior?
Solution
- **Relocate installation**: Use custom `PIPX_HOME`, `PIPX_BIN_DIR`, and `PIPX_VENV_DIR` environment variables to install `inspect-tool-support` in `/opt/inspect/` instead of `/root/.local/`
- **Set proper permissions**: Add `chmod -R 755 /opt/inspect` to ensure all users can read and execute the installed tools
- **Update PATH**: Change the `PATH` environment variable to point to the shared `/opt/inspect/bin` directory


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
