### PR TITLE
Add sandbox test for env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## Unreleased
+
+- Tests: Improve sandbox self_check to handle test failure via `with pytest.raises`, add test for env vars.
+
 ## 0.3.119 (04 August 2025)
 
 - Analysis functions are out of beta (`inspect_ai.analysis.beta` is deprecated in favor of `inspect_ai.analysis`).
 - Scoring: Provide access to sample `store` for scorers run on existing log files.
-- Tests: Improve sandbox self_check to handle test failure via `with pytest.raises`, add test for env vars.
 
 ## 0.3.118 (02 August 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Analysis functions are out of beta (`inspect_ai.analysis.beta` is deprecated in favor of `inspect_ai.analysis`).
+- Tests: sandbox self_check: Improve check_test_fn to handle test failure via `with pytest.raises`, add test for env vars.
 
 ## 0.3.118 (02 August 2025)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Sandbox tests don't check env vars are passed correctly

### What is the new behavior?

I added another test to the self_check suite

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

It might break people's tests if they have written a custom sandbox that violates the spec, but that would be a good outcome

### Other information:
