### PR TITLE
Fix bug in multiple_choice solver answer parsing (#2216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,11 @@
 - Tests: Improve sandbox self_check to handle test failure via `with pytest.raises`, add test for env vars.
 - Tests: Improve sandbox self_check to handle test failure via `with pytest.raises`, add test for env vars.
 - Tests: Added the ability to provide a generator like callback function for `MockLLM`.
+- Scoring: Improve multiple_choice answer parsing, making it more strict in interpreting answers like `ANSWER: None of the above`. Allow answers to end with full stop (`.`).
 - Bugfix: `background()` task is now scoped to the sample lifetime in the presence of `retry_on_error`.
 - Bugfix: Correct recording of `waiting_time` from within coroutines spawned from the main sample coroutine.
 - Bugfix: Update `inspect-tool-support` reference container to support executing tool code with non-root accounts.
-- Scoring: Improve multiple_choice answer parsing, making it more strict in interpreting answers like `ANSWER: None of the above`. Allow answers to end with full stop (`.`).
+
 
 ## 0.3.119 (04 August 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Bugfix: `background()` task is now scoped to the sample lifetime in the presence of `retry_on_error`.
 - Bugfix: Correct recording of `waiting_time` from within coroutines spawned from the main sample coroutine.
 - Bugfix: Update `inspect-tool-support` reference container to support executing tool code with non-root accounts.
+- Scoring: Improve multiple_choice answer parsing, making it more strict in interpreting answers like `ANSWER: None of the above`. Allow answers to end with full stop (`.`).
 
 ## 0.3.119 (04 August 2025)
 

--- a/src/inspect_ai/solver/_multiple_choice.py
+++ b/src/inspect_ai/solver/_multiple_choice.py
@@ -143,6 +143,8 @@ def parse_answers(state: TaskState, multiple_correct: bool) -> set[str]:
             answers = {matched}
             return answers
 
+    return set()
+
 
 def set_choices_based_on_generated_response(
     state: TaskState, answers: set[str]

--- a/src/inspect_ai/solver/_multiple_choice.py
+++ b/src/inspect_ai/solver/_multiple_choice.py
@@ -80,7 +80,7 @@ def prompt(question: str, choices: Choices, template: str) -> str:
     )
 
 
-def parse_answers(state: TaskState) -> Match[str] | None:
+def parse_answers(state: TaskState, multiple_correct: bool) -> set[str]:
     """
     Convenience function for extracting answers from the state output.
 
@@ -93,9 +93,9 @@ def parse_answers(state: TaskState) -> Match[str] | None:
     """
     # First check whether the string strictly ends with the expected answer
     # In this case, we're looking for a single line which contains the expected
-    # ANSWER: B,C string with only whitespace after it
+    # ANSWER: <answer> string with only whitespace or a period/full stop at the end.
     match = re.search(
-        r"(?i)^ANSWER\s*:\s*([A-Za-z\d ,]+)\s*(?:$|\n)",
+        r"(?i)^ANSWER\s*:\s*([A-Za-z\d ,]+)\s*(?:$|\n|\.)",
         state.output.completion,
         flags=re.MULTILINE,
     )
@@ -103,14 +103,47 @@ def parse_answers(state: TaskState) -> Match[str] | None:
     # If we couldn't match the strict version, we can try the less strict
     # version for backward compatibility
     if match is None:
-        return re.search(
-            r"(?i)ANSWER\s*:\s*([A-Za-z\d ,]+)(?:[^\w]|\n|$)", state.output.completion
+        match = re.search(
+            r"(?i)ANSWER\s*:\s*([A-Za-z\d ,]+)(?:[^\w]|\n|$|\.)", state.output.completion
         )
+
+    if match is None:
+        return set()
+
+    matched = match.group(1)
+
+    # Strip trailing period / full stop
+    matched = matched.strip()
+    matched = matched.rstrip(".")
+
+    allowed_options = set(answer_character(i) for i in range(len(state.choices)))
+
+    if multiple_correct:
+        # Match must contain only the allowed choices
+        # (may be separated by commas, spaces, the word 'and', or nothing at all)
+
+        matched = matched.replace(" and ", "")
+
+        matched = matched.replace(" ", "")
+
+        split_comma = set(matched.split(","))
+        if split_comma.issubset(allowed_options):
+            answers = split_comma
+            return answers
+
+        split_nothing = set(matched)
+        if split_nothing.issubset(allowed_options):
+            answers = split_nothing
+            return answers
+
     else:
-        return match
+        # Match must contain a single letter in the allowed choices
+        if matched in allowed_options:
+            answers = {matched}
+            return answers
 
 
-def set_choices_based_on_generated_response(state: TaskState, answers: str) -> None:
+def set_choices_based_on_generated_response(state: TaskState, answers: set[str]) -> None:
     true_answers = [answer_index(letter) for letter in answers]
 
     for i in range(len(state.choices)):
@@ -287,13 +320,12 @@ def multiple_choice(
 
         state = await generate(state, max_tokens=max_tokens)
 
-        answers = parse_answers(state)
-        if answers and answers.group(1):
+        answers = parse_answers(state, multiple_correct)
+        if answers:
             # If we've found answers, update the state appropriately
             set_choices_based_on_generated_response(
-                state=state, answers=answers.group(1)
+                state=state, answers=answers,
             )
-
             if shuffle:
                 pretend_we_didnt_shuffle(
                     state=state,

--- a/src/inspect_ai/solver/_multiple_choice.py
+++ b/src/inspect_ai/solver/_multiple_choice.py
@@ -2,7 +2,7 @@ import logging
 import re
 from enum import Enum
 from random import Random
-from typing import Match, TypedDict
+from typing import TypedDict
 
 from typing_extensions import Unpack
 
@@ -104,7 +104,8 @@ def parse_answers(state: TaskState, multiple_correct: bool) -> set[str]:
     # version for backward compatibility
     if match is None:
         match = re.search(
-            r"(?i)ANSWER\s*:\s*([A-Za-z\d ,]+)(?:[^\w]|\n|$|\.)", state.output.completion
+            r"(?i)ANSWER\s*:\s*([A-Za-z\d ,]+)(?:[^\w]|\n|$|\.)",
+            state.output.completion,
         )
 
     if match is None:
@@ -143,7 +144,9 @@ def parse_answers(state: TaskState, multiple_correct: bool) -> set[str]:
             return answers
 
 
-def set_choices_based_on_generated_response(state: TaskState, answers: set[str]) -> None:
+def set_choices_based_on_generated_response(
+    state: TaskState, answers: set[str]
+) -> None:
     true_answers = [answer_index(letter) for letter in answers]
 
     for i in range(len(state.choices)):
@@ -324,7 +327,8 @@ def multiple_choice(
         if answers:
             # If we've found answers, update the state appropriately
             set_choices_based_on_generated_response(
-                state=state, answers=answers,
+                state=state,
+                answers=answers,
             )
             if shuffle:
                 pretend_we_didnt_shuffle(

--- a/tests/solver/test_multiple_choice.py
+++ b/tests/solver/test_multiple_choice.py
@@ -371,3 +371,69 @@ async def test_cot_complex_text():
 
     assert result.value == CORRECT
     assert result.answer == "D"
+
+def choices_marked_correct(choices: list[Choice]) -> set[str]:
+    """Helper function"""
+    return set([choice.value for choice in choices if choice.correct])
+
+@pytest.mark.anyio
+@pytest.mark.xfail(reason="'ANSWER: None of the above' incorrectly parsed as options A,B")
+async def test_none_of_the_above_should_not_mark_choices():
+    async def generate_none_of_above(state: TaskState, **kwargs: Any) -> TaskState:
+        content = "ANSWER: None of the above"
+        state.messages.append(ChatMessageAssistant(content=content))
+        state.output = ModelOutput.from_content(model="model", content=content)
+        return state
+
+    solver = multiple_choice()
+    state = simple_task_state(
+        choices=["Option A", "Option B", "Option C", "Option D"],
+        messages=[ChatMessageUser(content="What's the answer?", source="input")],
+    )
+
+    new_state = await solver(state=state, generate=generate_none_of_above)
+
+    assert choices_marked_correct(new_state.choices) == set()
+
+@pytest.mark.anyio
+@pytest.mark.xfail(reason="Bug: 'Don't know' incorrectly parsed as option D")
+async def test_dont_know_should_not_mark_choices():
+    async def generate_dont_know(state: TaskState, **kwargs: Any) -> TaskState:
+        content = "ANSWER: Don't know"
+        state.messages.append(ChatMessageAssistant(content=content))
+        state.output = ModelOutput.from_content(model="model", content=content)
+        return state
+
+    solver = multiple_choice()
+    state = simple_task_state(
+        choices=["Option A", "Option B", "Option C", "Option D"],
+        messages=[ChatMessageUser(content="What's the answer?", source="input")],
+    )
+
+    new_state = await solver(state=state, generate=generate_dont_know)
+
+    assert choices_marked_correct(new_state.choices) == set()
+
+    # No false positives when scoring
+    scorer = choice()
+    result = await scorer(new_state, Target("D"))
+    assert result.value != CORRECT  # Should not be marked as correct
+
+@pytest.mark.anyio
+@pytest.mark.xfail(reason="Bug: 'ANSWER: I don't know' maked as options I, D")
+async def test_i_dont_know_should_not_mark_choices():
+    async def generate_i_dont_know(state: TaskState, **kwargs: Any) -> TaskState:
+        content = "ANSWER: I don't know"
+        state.messages.append(ChatMessageAssistant(content=content))
+        state.output = ModelOutput.from_content(model="model", content=content)
+        return state
+
+    solver = multiple_choice()
+    state = simple_task_state(
+        choices=["Option A", "Option B", "Option C", "Option D", "Option E", "Option F", "Option G", "Option H", "Option I"],
+        messages=[ChatMessageUser(content="What's the answer?", source="input")],
+    )
+
+    new_state = await solver(state=state, generate=generate_i_dont_know)
+
+    assert choices_marked_correct(new_state.choices) == set()

--- a/tests/solver/test_multiple_choice.py
+++ b/tests/solver/test_multiple_choice.py
@@ -125,7 +125,9 @@ async def test_custom_template():
 
 @pytest.mark.anyio
 async def test_trailing_punctuation_whitespace():
-    async def generate_trailing_punctuation(state: TaskState, **kwargs: Any) -> TaskState:
+    async def generate_trailing_punctuation(
+        state: TaskState, **kwargs: Any
+    ) -> TaskState:
         state.messages.append(ChatMessageAssistant(content="ANSWER: A. \n"))
         state.output = ModelOutput.from_content(model="model", content="ANSWER: A. \n")
         return state
@@ -134,7 +136,6 @@ async def test_trailing_punctuation_whitespace():
     state = simple_task_state(
         choices=["choice 1", "choice 2", "choice 3"],
         messages=[ChatMessageUser(content="What's the answer?", source="input")],
-
     )
     new_state = await solver(state=state, generate=generate_trailing_punctuation)
 
@@ -146,19 +147,22 @@ async def test_trailing_punctuation_whitespace():
 async def test_multiple_trailing_punctuation_whitespace():
     async def generate_1(state: TaskState, **kwargs: Any) -> TaskState:
         state.messages.append(ChatMessageAssistant(content="ANSWER: A, C. \n"))
-        state.output = ModelOutput.from_content(model="model", content="ANSWER: A, C. \n")
+        state.output = ModelOutput.from_content(
+            model="model", content="ANSWER: A, C. \n"
+        )
         return state
 
     async def generate_2(state: TaskState, **kwargs: Any) -> TaskState:
         state.messages.append(ChatMessageAssistant(content="ANSWER: A and C. \n"))
-        state.output = ModelOutput.from_content(model="model", content="ANSWER: A and C. \n")
+        state.output = ModelOutput.from_content(
+            model="model", content="ANSWER: A and C. \n"
+        )
         return state
 
     solver = multiple_choice(multiple_correct=True)
     state = simple_task_state(
         choices=["choice 1", "choice 2", "choice 3"],
         messages=[ChatMessageUser(content="What's the answer?", source="input")],
-
     )
     new_state1 = await solver(state=state, generate=generate_1)
     new_state2 = await solver(state=state, generate=generate_2)
@@ -416,9 +420,11 @@ async def test_cot_complex_text():
     assert result.value == CORRECT
     assert result.answer == "D"
 
+
 def choices_marked_correct(choices: list[Choice]) -> set[str]:
     """Helper function"""
     return set([choice.value for choice in choices if choice.correct])
+
 
 @pytest.mark.anyio
 async def test_none_of_the_above_should_not_mark_choices():
@@ -437,6 +443,7 @@ async def test_none_of_the_above_should_not_mark_choices():
     new_state = await solver(state=state, generate=generate_none_of_above)
 
     assert choices_marked_correct(new_state.choices) == set()
+
 
 @pytest.mark.anyio
 async def test_dont_know_should_not_mark_choices():
@@ -461,6 +468,7 @@ async def test_dont_know_should_not_mark_choices():
     result = await scorer(new_state, Target("D"))
     assert result.value != CORRECT  # Should not be marked as correct
 
+
 @pytest.mark.anyio
 async def test_i_dont_know_should_not_mark_choices():
     async def generate_i_dont_know(state: TaskState, **kwargs: Any) -> TaskState:
@@ -471,7 +479,17 @@ async def test_i_dont_know_should_not_mark_choices():
 
     solver = multiple_choice()
     state = simple_task_state(
-        choices=["Option A", "Option B", "Option C", "Option D", "Option E", "Option F", "Option G", "Option H", "Option I"],
+        choices=[
+            "Option A",
+            "Option B",
+            "Option C",
+            "Option D",
+            "Option E",
+            "Option F",
+            "Option G",
+            "Option H",
+            "Option I",
+        ],
         messages=[ChatMessageUser(content="What's the answer?", source="input")],
     )
 


### PR DESCRIPTION
My attempt at fixing https://github.com/UKGovernmentBEIS/inspect_ai/issues/2216. 

The `parse_answers` function is now much stricter. It only parses out answers that are actually valid choices, instead of any character in `[A-Za-z\d ,]`. It now takes in `multiple_correct`, and allows only one answer if it's False. It now returns the parsed answers as `set[str]`.

(I also now allow the answer line to end in a full stop like, `ANSWER: A, B.`, which is more permissive than the previous behaviour. Previously we didn't catch such answers at all).

Full backward compatibility would require preserving the bug, which seems like a shame. I can't think of a reason anyone would be relying on it. If full backward compatibility is desired, I can put this behaviour behind a flag that defaults to False.