### PR TITLE
code_viewer: handle non-string arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Task display: Sample cancel button now works immediately (no longer needs to wait for a cooperative check).
 - Limits: Sample working limit is now enforced even during long running generations and sandbox operations.
 - Store: Support for serializing complex nested types (e.g. to read in an offline scorer).
+- Tools: Code viewer now handles function calls with `list[str]` rather than `str` without crashing.
 - Tests: Improve sandbox self_check to handle test failure via `with pytest.raises`, add test for env vars.
 - Tests: Improve sandbox self_check to handle test failure via `with pytest.raises`, add test for env vars.
 - Tests: Added the ability to provide a generator like callback function for `MockLLM`.

--- a/src/inspect_ai/tool/_tools/_execute.py
+++ b/src/inspect_ai/tool/_tools/_execute.py
@@ -8,7 +8,7 @@ from .._tool_call import ToolCall, ToolCallContent, ToolCallView, ToolCallViewer
 def code_viewer(language: str, code_param: str) -> ToolCallViewer:
     def viewer(tool_call: ToolCall) -> ToolCallView:
         code = tool_call.arguments.get(code_param, None)
-        code = (code or tool_call.function).strip()
+        code = str(code or tool_call.function).strip()
         call = ToolCallContent(
             title=language,
             format="markdown",


### PR DESCRIPTION
Sometimes models call functions with incorrect argument types. (This is particularly notable in the newly-released gpt-oss, which has a strong tendency to pass a list of strings rather than a single string to the bash command.)

The actual function call logic handles this gracefully by returning a string describing the argument parsing error, so the model can correct it.

But the viewer was crashing when the argument type was incorrect. Instead of crashing, it now converts whatever it gets to a string using `str`.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When a model calls `bash` or `python` with an incorrect type for the `cmd` argument (eg `cmd=["echo", "hello", "world"]` rather than `cmd="echo hello world"`), the code viewer crashes.

### What is the new behavior?

Instead of crashing, the code viewer renders the argument as a string.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
