### PR TITLE
MCP: Support for `mcp_server_streamablehttp()` (

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - [SambaNova](https://inspect.aisi.org.uk/providers.html#sambanova) model provider.
 - [Goodfire](https://inspect.aisi.org.uk/providers.html#goodfire) model provider.
 - Google: Pass `timeout` generation config option through to API `Client`.
+- MCP: Support for `mcp_server_streamablehttp()` (which replaces the deprecated SSE server mode).
 - Task display: Sample cancel button now works immediately (no longer needs to wait for a cooperative check).
 - Limits: Sample working limit is now enforced even during long running generations and sandbox operations.
 - Store: Support for serializing complex nested types (e.g. to read in an offline scorer).

--- a/docs/reference/inspect_ai.tool.qmd
+++ b/docs/reference/inspect_ai.tool.qmd
@@ -17,8 +17,9 @@ title: "inspect_ai.tool"
 
 ### mcp_connection
 ### mcp_server_stdio
-### mcp_server_sse
+### mcp_server_streamablehttp
 ### mcp_server_sandbox
+### mcp_server_sse
 ### mcp_tools
 ### MCPServer
 

--- a/docs/tools-mcp.qmd
+++ b/docs/tools-mcp.qmd
@@ -51,8 +51,9 @@ You can use the following functions to create interfaces to the various types of
 |                        |                                                                                           |
 |------------------------------------|------------------------------------|
 | `mcp_server_stdio()`   | Stdio interface to MCP server. Use this for MCP servers that run locally.                 |
-| `mcp_server_sse()`     | SSE interface to MCP server. Use this for MCP servers available via a URL endpoint.       |
+| `mcp_server_streamablehttp()` | Streamable interface to MCP server. Use this for MCP servers available via a URL endpoint.
 | `mcp_server_sandbox()` | Sandbox interface to MCP server. Use this for MCP servers that run in an Inspect sandbox. |
+| `mcp_server_sse()`     | SSE interface to MCP server (NOTE: The SSE interface has been [deprecated](https://mcp-framework.com/docs/Transports/sse/))       |
 
 : {tbl-colwidths=\[40,60\]}
 

--- a/src/inspect_ai/tool/__init__.py
+++ b/src/inspect_ai/tool/__init__.py
@@ -22,6 +22,7 @@ from ._mcp import (
     mcp_server_sandbox,
     mcp_server_sse,
     mcp_server_stdio,
+    mcp_server_streamablehttp,
     mcp_tools,
 )
 from ._tool import Tool, ToolError, ToolResult, ToolSource, tool
@@ -66,6 +67,7 @@ __all__ = [
     "mcp_connection",
     "mcp_server_stdio",
     "mcp_server_sse",
+    "mcp_server_streamablehttp",
     "mcp_server_sandbox",
     "MCPServer",
     "Content",

--- a/src/inspect_ai/tool/_mcp/__init__.py
+++ b/src/inspect_ai/tool/_mcp/__init__.py
@@ -1,6 +1,11 @@
 from ._types import MCPServer
 from .connection import mcp_connection
-from .server import mcp_server_sandbox, mcp_server_sse, mcp_server_stdio
+from .server import (
+    mcp_server_sandbox,
+    mcp_server_sse,
+    mcp_server_stdio,
+    mcp_server_streamablehttp,
+)
 from .tools import mcp_tools
 
 __all__ = [
@@ -8,6 +13,7 @@ __all__ = [
     "mcp_server_stdio",
     "mcp_server_sse",
     "mcp_server_sandbox",
+    "mcp_server_streamablehttp",
     "mcp_connection",
     "MCPServer",
 ]

--- a/src/inspect_ai/tool/_mcp/_context.py
+++ b/src/inspect_ai/tool/_mcp/_context.py
@@ -1,5 +1,5 @@
 from contextlib import _AsyncGeneratorContextManager
-from typing import TypeAlias
+from typing import Callable, TypeAlias
 
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp.shared.message import SessionMessage
@@ -8,5 +8,6 @@ MCPServerContext: TypeAlias = _AsyncGeneratorContextManager[
     tuple[
         MemoryObjectReceiveStream[SessionMessage | Exception],
         MemoryObjectSendStream[SessionMessage],
+        Callable[[], str | None],
     ],
 ]

--- a/src/inspect_ai/tool/_mcp/server.py
+++ b/src/inspect_ai/tool/_mcp/server.py
@@ -21,6 +21,9 @@ def mcp_server_sse(
 
     SSE interface to MCP server.  Use this for MCP servers available via a URL endpoint.
 
+    NOTE: The SEE interface has been [deprecated](https://mcp-framework.com/docs/Transports/sse/)
+    in favor of `mcp_server_streamablehttp()` for MCP servers at URL endpoints.
+
     Args:
         url: URL to remote server
         headers: Headers to send server (typically authorization is included here)
@@ -35,6 +38,33 @@ def mcp_server_sse(
     from ._mcp import create_server_sse
 
     return create_server_sse(url, headers, timeout, sse_read_timeout)
+
+
+def mcp_server_streamablehttp(
+    *,
+    url: str,
+    headers: dict[str, Any] | None = None,
+    timeout: float = 5,
+    sse_read_timeout: float = 60 * 5,
+) -> MCPServer:
+    """MCP Server (SSE).
+
+    Streamable HTTP interface to MCP server. Use this for MCP servers available via a URL endpoint.
+
+    Args:
+        url: URL to remote server
+        headers: Headers to send server (typically authorization is included here)
+        timeout: Timeout for HTTP operations
+        sse_read_timeout: How long (in seconds) the client will wait for a new
+            event before disconnecting.
+
+    Returns:
+        McpClient: Client for MCP Server
+    """
+    verfify_mcp_package()
+    from ._mcp import create_server_streamablehttp
+
+    return create_server_streamablehttp(url, headers, timeout, sse_read_timeout)
 
 
 def mcp_server_stdio(
@@ -102,7 +132,7 @@ def mcp_server_sandbox(
 def verfify_mcp_package() -> None:
     FEATURE = "MCP tools"
     PACKAGE = "mcp"
-    MIN_VERSION = "1.9.4"
+    MIN_VERSION = "1.12.3"
 
     # verify we have the package
     try:

--- a/src/inspect_ai/tool/_mcp/tools.py
+++ b/src/inspect_ai/tool/_mcp/tools.py
@@ -12,7 +12,8 @@ def mcp_tools(
     """Tools from MCP server.
 
     Args:
-       server: MCP server created with `mcp_server_stdio()` or `mcp_server_sse()`
+       server: MCP server created with `mcp_server_stdio()` or `mcp_server_streamablehttp()`
+          or `mcp_server_sandbox()`.
        tools: List of tool names (or globs) (defaults to "all")
           which returns all tools.
 

--- a/tests/tools/test_mcp_tools.py
+++ b/tests/tools/test_mcp_tools.py
@@ -70,13 +70,18 @@ def fetch_task():
 
 
 # to run this test:
-# git clone https://github.com/modelcontextprotocol/python-sdk
-# cd pip install python-sdk/examples/servers/simple-tool/
-# mcp-simple-tool --transport sse --port 8000
-#
-# async def test_mcp_server_sse():
-#     async with mcp_server_sse(url="http://localhost:8000/sse") as server:
-#         await check_fetch_server(server)
+# - git clone https://github.com/modelcontextprotocol/python-sdk
+# - pip install python-sdk/examples/servers/simple-tool/
+# - mcp-simple-tool --transport sse --port 8000
+# - comment out the skip decorator below
+
+
+@pytest.mark.skip
+async def test_mcp_server_sse():
+    from inspect_ai.tool import mcp_server_sse
+
+    server = mcp_server_sse(url="http://localhost:8000/sse")
+    await check_fetch_server(server)
 
 
 async def check_fetch_server(server: MCPServer) -> None:
@@ -85,6 +90,25 @@ async def check_fetch_server(server: MCPServer) -> None:
         tools=server,
     )
     assert "example.com" in output.completion
+
+
+# to run this test
+# - git clone https://github.com/modelcontextprotocol/python-sdk
+# - uv run python-sdk/examples/snippets/servers/streamable_config.py
+# - comment out the skip decorator below
+
+
+@pytest.mark.skip
+async def test_mcp_server_streamablehttp():
+    from inspect_ai.tool import mcp_server_streamablehttp
+
+    server = mcp_server_streamablehttp(url="http://localhost:8000/mcp")
+
+    _, output = await get_model("openai/gpt-4o").generate_loop(
+        "Please call the greet() tool with the name 'Bob'",
+        tools=server,
+    )
+    assert "bob" in output.completion.lower()
 
 
 @task


### PR DESCRIPTION
Replaces the deprecated SSE server mode
