### PR TITLE
Option to override Vertex base uri with environment variable

### DIFF
--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -215,6 +215,9 @@ class GoogleGenAIAPI(ModelAPI):
                         + "or the 'location' custom model arg (-M) when running against vertex."
                     )
 
+            # custom base_url
+            self.base_url = model_base_url(self.base_url, "VERTEX_BASE_URL")
+
         # normal google endpoint
         else:
             # read api key from env


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Most (perhaps all) other model provider API URLs can be overridden both through arguments and through environment variables, but there is no environment variable for overriding the Google Vertex API URL.

### What is the new behavior?
The Vertex base API URL can be overridden using `VERTEX_BASE_URI`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
