### PR TITLE
Replace deprecated user with safety_identifier and prompt_cache_key

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -76,6 +76,11 @@ class OpenAIAPI(ModelAPI):
         else:
             self.service = None
 
+        # extract prompt_cache_key model arg if provided
+        self.prompt_cache_key: str | NotGiven = model_args.pop(
+            "prompt_cache_key", NOT_GIVEN
+        )
+
         # extract safety_identifier model arg if provided
         self.safety_identifier: str | NotGiven = model_args.pop(
             "safety_identifier", NOT_GIVEN
@@ -301,6 +306,7 @@ class OpenAIAPI(ModelAPI):
                 tool_choice=tool_choice,
                 config=config,
                 service_tier=self.service_tier,
+                prompt_cache_key=self.prompt_cache_key,
                 safety_identifier=self.safety_identifier,
                 openai_api=self,
                 batcher=self._responses_batcher,
@@ -314,6 +320,7 @@ class OpenAIAPI(ModelAPI):
                 tools=tools,
                 tool_choice=tool_choice,
                 config=config,
+                prompt_cache_key=self.prompt_cache_key,
                 safety_identifier=self.safety_identifier,
                 openai_api=self,
                 batcher=self._completions_batcher,

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -76,8 +76,10 @@ class OpenAIAPI(ModelAPI):
         else:
             self.service = None
 
-        # extract user model arg if provided
-        self.user: str | NotGiven = model_args.pop("user", NOT_GIVEN)
+        # extract safety_identifier model arg if provided
+        self.safety_identifier: str | NotGiven = model_args.pop(
+            "safety_identifier", NOT_GIVEN
+        )
 
         # call super
         super().__init__(
@@ -299,7 +301,7 @@ class OpenAIAPI(ModelAPI):
                 tool_choice=tool_choice,
                 config=config,
                 service_tier=self.service_tier,
-                user=self.user,
+                safety_identifier=self.safety_identifier,
                 openai_api=self,
                 batcher=self._responses_batcher,
             )
@@ -312,7 +314,7 @@ class OpenAIAPI(ModelAPI):
                 tools=tools,
                 tool_choice=tool_choice,
                 config=config,
-                user=self.user,
+                safety_identifier=self.safety_identifier,
                 openai_api=self,
                 batcher=self._completions_batcher,
             )

--- a/src/inspect_ai/model/_providers/openai_completions.py
+++ b/src/inspect_ai/model/_providers/openai_completions.py
@@ -45,6 +45,7 @@ async def generate_completions(
     tools: list[ToolInfo],
     tool_choice: ToolChoice,
     config: GenerateConfig,
+    prompt_cache_key: str | NotGiven,
     safety_identifier: str | NotGiven,
     openai_api: "OpenAIAPI",
     batcher: OpenAIBatcher[ChatCompletion] | None,
@@ -93,6 +94,7 @@ async def generate_completions(
         if len(tools) > 0
         else NOT_GIVEN,
         extra_headers={HttpxHooks.REQUEST_ID_HEADER: request_id},
+        prompt_cache_key=prompt_cache_key,
         safety_identifier=safety_identifier,
         **completion_params_completions(openai_api, config, len(tools) > 0),
     )

--- a/src/inspect_ai/model/_providers/openai_completions.py
+++ b/src/inspect_ai/model/_providers/openai_completions.py
@@ -45,7 +45,7 @@ async def generate_completions(
     tools: list[ToolInfo],
     tool_choice: ToolChoice,
     config: GenerateConfig,
-    user: str | NotGiven,
+    safety_identifier: str | NotGiven,
     openai_api: "OpenAIAPI",
     batcher: OpenAIBatcher[ChatCompletion] | None,
 ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
@@ -93,7 +93,7 @@ async def generate_completions(
         if len(tools) > 0
         else NOT_GIVEN,
         extra_headers={HttpxHooks.REQUEST_ID_HEADER: request_id},
-        user=user,
+        safety_identifier=safety_identifier,
         **completion_params_completions(openai_api, config, len(tools) > 0),
     )
 

--- a/src/inspect_ai/model/_providers/openai_responses.py
+++ b/src/inspect_ai/model/_providers/openai_responses.py
@@ -41,6 +41,7 @@ async def generate_responses(
     tool_choice: ToolChoice,
     config: GenerateConfig,
     service_tier: str | None,
+    prompt_cache_key: str | NotGiven,
     safety_identifier: str | NotGiven,
     openai_api: "OpenAIAPI",
     batcher: OpenAIBatcher[Response] | None,
@@ -75,6 +76,7 @@ async def generate_responses(
         else NOT_GIVEN,
         truncation="auto" if openai_api.is_computer_use_preview() else NOT_GIVEN,
         extra_headers={HttpxHooks.REQUEST_ID_HEADER: request_id},
+        prompt_cache_key=prompt_cache_key,
         safety_identifier=safety_identifier,
         **completion_params_responses(
             model_name,

--- a/src/inspect_ai/model/_providers/openai_responses.py
+++ b/src/inspect_ai/model/_providers/openai_responses.py
@@ -41,7 +41,7 @@ async def generate_responses(
     tool_choice: ToolChoice,
     config: GenerateConfig,
     service_tier: str | None,
-    user: str | NotGiven,
+    safety_identifier: str | NotGiven,
     openai_api: "OpenAIAPI",
     batcher: OpenAIBatcher[Response] | None,
 ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
@@ -75,7 +75,7 @@ async def generate_responses(
         else NOT_GIVEN,
         truncation="auto" if openai_api.is_computer_use_preview() else NOT_GIVEN,
         extra_headers={HttpxHooks.REQUEST_ID_HEADER: request_id},
-        user=user,
+        safety_identifier=safety_identifier,
         **completion_params_responses(
             model_name,
             openai_api=openai_api,


### PR DESCRIPTION
The functionality of the user field has been deprecated and split into two arguments. safety_identifier is used for additional safeguards. prompt_cache_key is used for enhanced caching. See: https://platform.openai.com/docs/api-reference/responses/create#responses_create-user