### PR TITLE
Draft of read_eval_log skipping validation and using multiple process…

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+tests/log/test_eval_log/long_log.eval filter=lfs diff=lfs merge=lfs -text

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ convention = "google"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-rA --doctest-modules --color=yes"
+addopts = "-rA --doctest-modules --color=yes -m 'not benchmark'"
 testpaths = ["tests"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
 norecursedirs = [
@@ -66,6 +66,9 @@ norecursedirs = [
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 log_level = "WARNING"
+markers = [
+    "benchmark: performance comparison tests (excluded by default)",
+]
 
 [tool.mypy]
 exclude = [
@@ -188,6 +191,8 @@ dev = [
 dev-mcp-tests = ["mcp-server-fetch", "mcp_server_git"]
 doc = ["quarto-cli==1.7.32", "jupyter", "panflute", "markdown", "griffe"]
 dist = ["twine", "build"]
+
+dev-benchmarks = ["pytest-benchmark"]
 
 [tool.typos.default.extend-words]
 ba = "ba"

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -240,6 +240,7 @@ def read_eval_log(
     header_only: bool = False,
     resolve_attachments: bool = False,
     format: Literal["eval", "json", "auto"] = "auto",
+    skip_sample_validation: bool = False,
 ) -> EvalLog:
     """Read an evaluation log.
 
@@ -265,10 +266,7 @@ def read_eval_log(
     # flow, so force the use of asyncio
     return run_coroutine(
         read_eval_log_async(
-            log_file,
-            header_only,
-            resolve_attachments,
-            format,
+            log_file, header_only, resolve_attachments, format, skip_sample_validation
         )
     )
 
@@ -278,6 +276,7 @@ async def read_eval_log_async(
     header_only: bool = False,
     resolve_attachments: bool = False,
     format: Literal["eval", "json", "auto"] = "auto",
+    skip_sample_validation: bool = False,
 ) -> EvalLog:
     """Read an evaluation log.
 
@@ -308,7 +307,7 @@ async def read_eval_log_async(
         recorder_type = recorder_type_for_location(log_file)
     else:
         recorder_type = recorder_type_for_format(format)
-    log = await recorder_type.read_log(log_file, header_only)
+    log = await recorder_type.read_log(log_file, header_only, skip_sample_validation)
 
     # resolve attachement if requested
     if resolve_attachments and log.samples:

--- a/tests/log/test_eval_log/long_log.eval
+++ b/tests/log/test_eval_log/long_log.eval
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:be29138c9e35a3c3cba212e3d79f9bad53855913da92ea5d49d14bd0d18c6a11
+size 514557

--- a/tests/log/test_log_validate_samples.py
+++ b/tests/log/test_log_validate_samples.py
@@ -1,0 +1,17 @@
+from functools import partial
+from pathlib import Path
+
+import pytest
+
+from inspect_ai.log import read_eval_log
+
+long_log_path = Path(__file__).parent / "test_eval_log" / "long_log.eval"
+
+
+@pytest.mark.benchmark
+@pytest.mark.parametrize("skip_sample_validation", [True, False])
+def test_read_eval_logs_skip_sample_validation(benchmark, skip_sample_validation: bool):
+    read_eval_log_partial = partial(
+        read_eval_log, long_log_path, skip_sample_validation=skip_sample_validation
+    )
+    result = benchmark(read_eval_log_partial)


### PR DESCRIPTION
Hey Ekin! I have played around with this today, love it and would speed up my main workflow a lot!

My only suggestion is that we go bigger and aim to give `read_eval_logs` a  `skip_sample_validation` field so that users can get an `EvalLog` back. This is important to me because I have lots of analysis code that take `EvalLog`s, `EvalSample`s, `List[ChatMessage]` as input, and I would probably cast to these types before downstream analysis in the future.  

Here's a suggestion of how we could adapt the approach you've taken to do this:
- Use `model_construct` rather than `model_validate` to populate `EvalSample` with the JSON dict.
- Use multiprocessing to parallelise reading the samples from disk. It is annoying that the GIL prevents us from sharing the single ZipFile here, but that's life.
- Update the `Recorder` ABC to feature `skip_sample_validation` flag. There's a todo here - I haven't made a call about what we do with the `JSONRecorder`, which straightforwardly loads everything from JSON. I suggest we skip validation for all fields in this case, and detail this in the docs. 

I've included a benchmarking test that measures execution time on a realistic (for me!) log file of 5 samples, a few hundred messages each, lots of big messages and events. The average speedup was x2.5. I expect this to be bigger for more and longer samples, and potentially slightly sub-1 for logs with a handful of short samples.

<img width="1558" height="90" alt="Screenshot 2025-08-07 at 09 33 01" src="https://github.com/user-attachments/assets/e0ba0910-55e6-4fa3-936a-d2116641ec6e" />


Let me know what you think! Can then add in tests and docs. It could also be that we include some logic so that multiprocessing is only used if there are more than k samples, since for smaller logs I suspect the start-up overhead isn't worth it.