### PR TITLE
Conform to OpenAI SDK 1.99.2 breaking changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Bugfix: Correct forwarding of `reasoning_effort` and `reasoning_tokens` for OpenRouter provider.
 - Bugfix: `bridge()` no longer causes a recursion error when running a large number of samples with openai models
 - Bugfix: Ensure that `sample_shuffle` is `None` (rather than 0) when not specified on the command line.
+- Bugfix: Conform to breaking changes in `openai` package (1.99.2).
 
 
 ## 0.3.119 (04 August 2025)

--- a/src/inspect_ai/agent/_bridge/patch.py
+++ b/src/inspect_ai/agent/_bridge/patch.py
@@ -115,6 +115,7 @@ async def inspect_model_request(
     tools: list[ChatCompletionToolParam] = json_data.get("tools", [])
     inspect_tools: list[ToolInfo] = []
     for tool in tools:
+        assert tool["type"] == "function", '"custom" tool calls are not supported'
         function = tool["function"].copy()
         inspect_tools.append(
             ToolInfo(
@@ -136,6 +137,9 @@ async def inspect_model_request(
             case "required":
                 inspect_tool_choice = "any"
             case _:
+                assert tool_choice["type"] == "function", (
+                    '"custom" tool calls are not supported'
+                )
                 inspect_tool_choice = ToolFunction(name=tool_choice["function"]["name"])
 
     output = await model.generate(

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -439,6 +439,9 @@ def chat_messages_from_openai(
             if "tool_calls" in message:
                 tool_calls: list[ToolCall] = []
                 for call in message["tool_calls"]:
+                    # TODO: For now, we don't yet support "custom" tool calls
+                    if call["type"] != "function":
+                        continue
                     tool_calls.append(tool_call_from_openai(call))
                     tool_names[call["id"]] = call["function"]["name"]
 
@@ -482,6 +485,7 @@ def chat_messages_from_openai(
 
 
 def tool_call_from_openai(tool_call: ChatCompletionMessageToolCallParam) -> ToolCall:
+    assert tool_call["type"] == "function", '"custom" tool calls are not supported'
     return parse_tool_call(
         tool_call["id"],
         tool_call["function"]["name"],

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -352,6 +352,8 @@ def chat_tool_calls_from_openai(
         return [
             parse_tool_call(call.id, call.function.name, call.function.arguments, tools)
             for call in message.tool_calls
+            # TODO: For now, we don't yet support "custom" tool calls
+            if call.type == "function"
         ]
     else:
         return None

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -24,6 +24,7 @@ from openai.types.chat import (
     ChatCompletionContentPartTextParam,
     ChatCompletionDeveloperMessageParam,
     ChatCompletionMessage,
+    ChatCompletionMessageFunctionToolCall,
     ChatCompletionMessageParam,
     ChatCompletionMessageToolCall,
     ChatCompletionMessageToolCallParam,
@@ -81,7 +82,7 @@ class OpenAIResponseError(OpenAIError):
 
 
 def openai_chat_tool_call(tool_call: ToolCall) -> ChatCompletionMessageToolCall:
-    return ChatCompletionMessageToolCall(
+    return ChatCompletionMessageFunctionToolCall(
         type="function",
         id=tool_call.id,
         function=Function(

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -23,6 +23,7 @@ from openai.types.chat import (
     ChatCompletionContentPartRefusalParam,
     ChatCompletionContentPartTextParam,
     ChatCompletionDeveloperMessageParam,
+    ChatCompletionFunctionToolParam,
     ChatCompletionMessage,
     ChatCompletionMessageFunctionToolCall,
     ChatCompletionMessageFunctionToolCallParam,
@@ -323,7 +324,7 @@ def openai_chat_tool_param(tool: ToolInfo) -> ChatCompletionToolParam:
         description=tool.description,
         parameters=tool.parameters.model_dump(exclude_none=True),
     )
-    return ChatCompletionToolParam(type="function", function=function)
+    return ChatCompletionFunctionToolParam(type="function", function=function)
 
 
 def openai_chat_tools(tools: list[ToolInfo]) -> list[ChatCompletionToolParam]:

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -25,6 +25,7 @@ from openai.types.chat import (
     ChatCompletionDeveloperMessageParam,
     ChatCompletionMessage,
     ChatCompletionMessageFunctionToolCall,
+    ChatCompletionMessageFunctionToolCallParam,
     ChatCompletionMessageParam,
     ChatCompletionMessageToolCall,
     ChatCompletionMessageToolCallParam,
@@ -36,7 +37,7 @@ from openai.types.chat import (
     ChatCompletionUserMessageParam,
 )
 from openai.types.chat.chat_completion import Choice, ChoiceLogprobs
-from openai.types.chat.chat_completion_message_tool_call import Function
+from openai.types.chat.chat_completion_message_function_tool_call import Function
 from openai.types.completion_usage import CompletionUsage
 from openai.types.shared_params.function_definition import FunctionDefinition
 from pydantic import JsonValue
@@ -94,7 +95,7 @@ def openai_chat_tool_call(tool_call: ToolCall) -> ChatCompletionMessageToolCall:
 def openai_chat_tool_call_param(
     tool_call: ToolCall,
 ) -> ChatCompletionMessageToolCallParam:
-    return ChatCompletionMessageToolCallParam(
+    return ChatCompletionMessageFunctionToolCallParam(
         id=tool_call.id,
         function=dict(
             name=tool_call.function, arguments=json.dumps(tool_call.arguments)

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -320,7 +320,7 @@ def goodfire() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "1.98.0"
+    MIN_VERSION = "1.99.2"
 
     # verify we have the package
     try:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

OpenAI introduced a new type of tool call named "custom". This caused breaking changes in the API. This PR does not add support for custom tools, but it does update the typing to conform to the changes.

Roughly speaking, `ChatCompletionMessageToolCall` became a union of `ChatCompletionMessageFunctionToolCall | ChatCompletionMessageCustomToolCall`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
