### PR TITLE
Improve Handling of Large / Complex Message or Score Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Bugfix: Update `inspect-tool-support` reference container to support executing tool code with non-root accounts.
 - Bugfix: Correct forwarding of `reasoning_effort` and `reasoning_tokens` for OpenRouter provider.
 - Bugfix: `bridge()` no longer causes a recursion error when running a large number of samples with openai models
+- Inspect View: Improved handling of scores and messages with large or complex metadata.
 
 ## 0.3.120 (07 August 2025)
 

--- a/src/inspect_ai/_view/www/src/app/content/RecordTree.tsx
+++ b/src/inspect_ai/_view/www/src/app/content/RecordTree.tsx
@@ -63,11 +63,12 @@ export const RecordTree: FC<RecordTreeProps> = ({
 
   // Tree-ify the record (creates a flat lsit of items with depth property)
   const items = useMemo(() => {
-    return toTreeItems(
+    const items = toTreeItems(
       record,
       collapsedIds || {},
       processStore ? [resolveStoreKeys] : [],
     );
+    return items;
   }, [record, collapsedIds, processStore]);
 
   // If collapsedIds is not set, we need to set it to the default state
@@ -76,15 +77,15 @@ export const RecordTree: FC<RecordTreeProps> = ({
       return;
     }
 
-    const defaultCollapsedIds = items.reduce((prev, item) => {
-      if (item.depth >= defaultExpandLevel && item.hasChildren) {
-        return {
-          ...prev,
-          [item.id]: true,
-        };
-      }
-      return prev;
-    }, {});
+    const defaultCollapsedIds = items.reduce(
+      (prev, item) => {
+        if (item.depth >= defaultExpandLevel && item.hasChildren) {
+          prev[item.id] = true;
+        }
+        return prev;
+      },
+      {} as Record<string, true>,
+    );
     setCollapsedIds(id, defaultCollapsedIds);
   }, [collapsedIds, items]);
 

--- a/src/inspect_ai/_view/www/src/app/content/RecordTree.tsx
+++ b/src/inspect_ai/_view/www/src/app/content/RecordTree.tsx
@@ -205,6 +205,11 @@ export const RecordTree: FC<RecordTreeProps> = ({
     );
   };
 
+  // Don't render until collapsedIds is initialized to avoid flash of all items
+  if (!collapsedIds) {
+    return null;
+  }
+
   if (!scrollRef) {
     // No virtualization - render directly
     return (

--- a/src/inspect_ai/_view/www/src/app/samples/chat/ChatMessage.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/ChatMessage.tsx
@@ -88,7 +88,7 @@ export const ChatMessage: FC<ChatMessageProps> = ({
             <RecordTree
               record={message.metadata}
               id={`${id}-metadata`}
-              defaultExpandLevel={1}
+              defaultExpandLevel={0}
             />
           </LabeledValue>
         ) : (

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ScoreEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ScoreEventView.tsx
@@ -7,6 +7,7 @@ import { MetaDataGrid } from "../../content/MetaDataGrid";
 import { EventPanel } from "./event/EventPanel";
 
 import clsx from "clsx";
+import { RecordTree } from "../../content/RecordTree";
 import styles from "./ScoreEventView.module.css";
 import { EventNode } from "./types";
 
@@ -68,9 +69,11 @@ export const ScoreEventView: FC<ScoreEventViewProps> = ({
       </div>
       {event.score.metadata ? (
         <div data-name="Metadata">
-          <MetaDataGrid
-            entries={event.score.metadata}
-            className={styles.metadata}
+          <RecordTree
+            id={`${eventNode.id}-score-metadata`}
+            record={event.score.metadata}
+            className={styles.metadataTree}
+            defaultExpandLevel={0}
           />
         </div>
       ) : undefined}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/SpanEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/SpanEventView.tsx
@@ -25,7 +25,7 @@ export const SpanEventView: FC<SpanEventViewProps> = ({
   const title =
     descriptor.name ||
     `${event.type ? event.type + ": " : "Step: "}${event.name}`;
-  
+
   const text = useMemo(() => summarize(children), [children]);
   const childIds = useMemo(() => children.map((child) => child.id), [children]);
 

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/SpanEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/SpanEventView.tsx
@@ -1,5 +1,5 @@
 import clsx from "clsx";
-import { FC } from "react";
+import { FC, useMemo } from "react";
 import { SpanBeginEvent } from "../../../@types/log";
 import { formatDateTime } from "../../../utils/format";
 import { EventPanel } from "./event/EventPanel";
@@ -25,13 +25,15 @@ export const SpanEventView: FC<SpanEventViewProps> = ({
   const title =
     descriptor.name ||
     `${event.type ? event.type + ": " : "Step: "}${event.name}`;
-  const text = summarize(children);
+  
+  const text = useMemo(() => summarize(children), [children]);
+  const childIds = useMemo(() => children.map((child) => child.id), [children]);
 
   return (
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      childIds={children.map((child) => child.id)}
+      childIds={childIds}
       className={clsx("transcript-span", className)}
       title={title}
       subTitle={formatDateTime(new Date(event.timestamp))}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Fixes #2249

There were a number of issues conspiring together to cause horrible perf and viewer crashes. There is no issue related to sandbox events, all related to Metadata. Specifically:

- Score event was rendering with a non-virtualized metadata viewer. Switch to visualized viewer.
- RecordTree (the virtualized metadata viewer) had a _very_ inefficient implementation of computing collapsed state which results in tons of objects copies.
- RecordTree would attempt to render all items while is computed collapsed state of items.

These together conspired to terrible perf. 
