### PR TITLE
improvements for openai web search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- OpenAI: Enable native `web_search()` tool for GPT-5.
+- OpenAI: Convert "web_search" tool choice to native "web_search_preview" type.
+
 ## 0.3.121 (10 August 2025)
 
 - [SambaNova](https://inspect.aisi.org.uk/providers.html#sambanova) model provider.

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -168,6 +168,9 @@ def openai_responses_tool_choice(
                 ToolChoiceTypesParam(type="computer_use_preview")
                 if tool_choice.name == "computer"
                 and any(tool["type"] == "computer_use_preview" for tool in tools)
+                else ToolChoiceTypesParam(type="web_search_preview")
+                if tool_choice.name == "web_search"
+                and any(tool["type"] == "web_search_preview" for tool in tools)
                 else ToolChoiceFunctionParam(type="function", name=tool_choice.name)
             )
 

--- a/src/inspect_ai/model/_providers/_openai_web_search.py
+++ b/src/inspect_ai/model/_providers/_openai_web_search.py
@@ -4,7 +4,7 @@ from openai.types.responses import WebSearchTool, WebSearchToolParam
 
 from inspect_ai.tool._tool_info import ToolInfo
 
-COMPATIBLE_MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "o3", "o4-mini"]
+COMPATIBLE_MODELS = ["gpt-4o", "gpt-4o-mini", "gpt-4.1", "o3", "o4-mini", "gpt-5"]
 
 
 def maybe_web_search_tool(model_name: str, tool: ToolInfo) -> WebSearchToolParam | None:


### PR DESCRIPTION
- Enable native `web_search()` tool for GPT-5.
- Convert "web_search" tool choice to native "web_search_preview" type.
