### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ dev = [
   "moto[server]",
   "mypy>=1.17.0",
   "nbformat",
-  "openai",
+  "openai<=1.99.6",
   "pandas>=2.0.0",
   "panflute",
   "pip",


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Importing `inspect_ai.model._openai` fails with `ImportError: cannot import name 'ChatCompletionMessageToolCall' from 'openai.types.chat'` with the latest main and OpenAI >= 1.99.7, can reproduce with 
```
uv venv
uv pip install git+ssh://git@github.com/UKGovernmentBEIS/inspect_ai.git
uv pip install openai
uv run python -c "import inspect_ai.model._openai"
```

### What is the new behavior?

This hotfix updates Inspect's dependencies to restrict `openai` to version <= 1.99.7, with the effect that importing the openai model module succeeds. It's intended as an interim fix, with the real fix being updating the module to regain compatability with the latest `openai` version (welcome volunteers for this as it's a busy week for me!).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.
