### PR TITLE
Pin beautifulsoup4 version >= 4.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 aiohttp>=3.9.0
 anyio>=4.8.0
-beautifulsoup4
+beautifulsoup4>=4.10.0
 click>=8.1.3,!=8.2.0
 debugpy
 docstring-parser>=0.16


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
In the Inspect Evals repo a CI jobs are failing [because bs4's version gets resolved to an older one](https://github.com/UKGovernmentBEIS/inspect_evals/actions/runs/16890884507/job/47850106868).

<img width="1036" height="648" alt="image" src="https://github.com/user-attachments/assets/f7533f92-d09b-4592-bbd0-27ee98576e89" />


### What is the new behavior?
It's a bit tricky to reproduce CI failures in that repo, so I cannot tell you the exact behaviour. However, my understanding is that resolver will stop trying to install an older version that's no longer support by the modern toolchain.  

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
To my best understanding, no. It was impossible to install an older BS4 version anyway.  

### Other information:
