### PR TITLE
Only use semver tags for versioning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 dependencies = { file = ["requirements.txt"] }
 
 [tool.setuptools_scm]
+git_describe_command = "git describe --dirty --tags --long  --match '[0-9]*.[0-9]*.[0-9]*' --exclude '*-*'"
 
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`pip install .` would produce a package versioned `1.2.1.dev5+gbf37709bd` because the most recent tag was [inspect-tool-support-1.2.0](https://github.com/UKGovernmentBEIS/inspect_ai/releases/tag/inspect-tool-support-1.2.0).  

I suspect this is the culprit of the [build failing in the Inspect Evals](https://github.com/UKGovernmentBEIS/inspect_evals/actions/runs/16890884507/job/47858840750?pr=454).  The `inspect-cyber` package has a requirement `dependencies = ["inspect-ai>=0.3.86,<0.4"]` that 1.2.1.dev5 doesn't match, so we end up in a resolution mess. This is currently hard to test because my fork doesn't contain the tags. 

### What is the new behavior?

`pip install .` produces a package versioned `inspect_ai-0.3.123.dev24+g29ef0b02`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, it only filters out some tags and versions dev builds properly. 

### Other information:
