### PR TITLE
Address flakiness in slow tests.

### DIFF
--- a/tests/agent/test_agent_handoff.py
+++ b/tests/agent/test_agent_handoff.py
@@ -1,3 +1,4 @@
+import pytest
 from test_helpers.tool_call_utils import find_tool_call, get_tool_event
 from test_helpers.tools import addition
 from test_helpers.utils import skip_if_no_openai
@@ -60,17 +61,23 @@ def check_agent_handoff(
     assert str(max_searches) in assistant_message.text
 
 
+# These tests are flaky because, occasionally, the model will call the with a max_searches parameter
+
+
 @skip_if_no_openai
+@pytest.mark.flaky
 def test_agent_handoff_tool():
     check_agent_handoff()
 
 
 @skip_if_no_openai
+@pytest.mark.flaky
 def test_agent_handoff_tool_arg():
     check_agent_handoff(10)
 
 
 @skip_if_no_openai
+@pytest.mark.flaky
 def test_agent_handoff_tool_curry():
     check_agent_handoff(15, handoff(searcher(), max_searches=15))
 
@@ -93,6 +100,7 @@ def searcher2() -> Agent:
 
 
 @skip_if_no_openai
+@pytest.mark.flaky
 def test_agent_handoff_user_message():
     log = eval(
         Task(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,9 @@ def pytest_addoption(parser):
         "--runapi", action="store_true", default=False, help="run API tests"
     )
     parser.addoption(
+        "--runflaky", action="store_true", default=False, help="run flaky tests"
+    )
+    parser.addoption(
         "--local-inspect-tools",
         action="store_true",
         default=False,
@@ -36,6 +39,7 @@ def local_inspect_tools(request):
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "api: mark test as requiring API access")
+    config.addinivalue_line("markers", "flaky: mark test as flaky/unreliable")
 
 
 def pytest_collection_modifyitems(config, items):
@@ -50,6 +54,12 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "api" in item.keywords:
                 item.add_marker(skip_api)
+
+    if not config.getoption("--runflaky"):
+        skip_flaky = pytest.mark.skip(reason="need --runflaky option to run")
+        for item in items:
+            if "flaky" in item.keywords:
+                item.add_marker(skip_flaky)
 
 
 @pytest.fixture(scope="module")

--- a/tests/model/test_model_roles.py
+++ b/tests/model/test_model_roles.py
@@ -31,7 +31,12 @@ def role_task():
     return Task(solver=role_solver())
 
 
+# skip_if_no_openai is needed on the below tests because of RED_TEAM_DEFAULT
+# which is "openai/gpt-4o"
+
+
 @skip_if_no_google
+@skip_if_no_openai
 def test_model_role() -> None:
     log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_20})[0]
     assert log.eval.model_roles
@@ -46,6 +51,7 @@ def test_model_role_default() -> None:
 
 
 @skip_if_no_google
+@skip_if_no_openai
 def test_model_role_retry() -> None:
     log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_20})[0]
     log.status = "cancelled"
@@ -63,6 +69,7 @@ def role_task_init():
 
 
 @skip_if_no_google
+@skip_if_no_openai
 def test_model_role_task_init():
     log = eval(role_task_init, model_roles={RED_TEAM: GEMINI_FLASH_20})[0]
     assert log.eval.model_roles
@@ -71,6 +78,7 @@ def test_model_role_task_init():
 
 
 @skip_if_no_google
+@skip_if_no_openai
 def test_model_role_eval_set() -> None:
     dataset: list[Sample] = []
     for _ in range(0, 10):

--- a/tests/model/test_reasoning_google.py
+++ b/tests/model/test_reasoning_google.py
@@ -25,5 +25,11 @@ def test_google_reasoning():
 
     # confirm we captured the reasoning content block
     content = output.message.content
-    assert isinstance(content, list)
-    assert isinstance(content[0], ContentReasoning)
+    if isinstance(content, ContentReasoning):
+        pass
+    elif isinstance(content, list):
+        assert any(isinstance(item, ContentReasoning) for item in content), (
+            "List should contain at least one ContentReasoning object"
+        )
+    else:
+        assert False, f"Content should be ContentReasoning or list, got {type(content)}"


### PR DESCRIPTION
- `test_google_reasoning` failed improperly on occasion because of a lack of flexibility in result assertions.
- Marked some agent handoff tests as flaky.