### PR TITLE
Add content filter handling to grok

### DIFF
--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -46,6 +46,21 @@ class GrokAPI(OpenAICompatibleAPI):
                 )
             else:
                 return ex
+        elif ex.status_code == 403:
+            # extract message
+            if isinstance(ex.body, dict) and "message" in ex.body.keys():
+                content = str(ex.body.get("message"))
+            else:
+                content = ex.message
+            
+            if 'Content violates usage guidelines' in content:
+                return ModelOutput.from_content(
+                    model=self.model_name,
+                    content=content,
+                    stop_reason="content_filter",
+                )
+            else:
+                return ex
         else:
             return ex
 


### PR DESCRIPTION
Not sure if there's a better way to check the error type. Have only seen a biology content filter so far. Here's a redacted sample error message captured by the code:
`Error code: 403 - {'code': 'The caller does not have permission to execute the specified operation', 'error': 'Content violates usage guidelines. Team: [REDACTED], API key ID: [REDACTED], Model: grok-4-0709, Failed check: SAFETY_CHECK_TYPE_BIO'}`