### PR TITLE
string to float conversion now extracts the first valid float from the string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - OpenAI: Use types from latest SDK (v1.99.7) and make that the minimum required version of the `openai` package.
 - OpenAI: Automatically use background-mode for deep research models.
 - Scoring: NaN values returned from scorers will be excluded from reductions when reducing epochs.
+- Scoring: String to float conversion now extracts the first valid float from the string (ignoring trailing characters that are invalid for floats).
 - Eval logs: Add `if_match_etag` parameter for `write_eval_log()` and `etag` field to `EvalLog` for safe concurrent log modification.
 - ModelOutput: Setting the `completion` property now does not affect the underlying `message` content.
 - Inspect View: Improved handling of scores and messages with large or complex metadata.

--- a/src/inspect_ai/_util/text.py
+++ b/src/inspect_ai/_util/text.py
@@ -191,6 +191,12 @@ def str_to_float(s: str) -> float:
     base_value = 0.0
 
     if base_part:
+        # find the first valid float (LLMs may include additional spurious output)
+        match = re.match(r"^([+-]?\d+(?:\.\d+)?)", base_part)
+        if match is None:
+            raise ValueError(f"Value could not be parsed as a float: {s}")
+        base_part = match.group(1)
+
         try:
             base_value = float(base_part)
         except ValueError:

--- a/tests/util/test_str_to_float.py
+++ b/tests/util/test_str_to_float.py
@@ -48,15 +48,10 @@ def test_str_to_float_invalid_input():
     with pytest.raises(ValueError):
         str_to_float("")
     with pytest.raises(ValueError):
-        str_to_float("2^3")
-    with pytest.raises(ValueError):
         str_to_float("⁺²")  # Unsupported superscript characters
 
 
 def test_str_to_float_edge_cases():
-    # Exponent with unsupported characters
-    with pytest.raises(ValueError):
-        str_to_float("2⁻³")
     # Base with unsupported characters
     with pytest.raises(ValueError):
         str_to_float("a²")
@@ -117,6 +112,41 @@ def test_str_to_float_fraction_invalid_input():
     with pytest.raises(ValueError):
         str_to_float("a½")
 
-    # Invalid character between number and fraction
-    with pytest.raises(ValueError):
-        str_to_float("2a½")
+
+def test_str_to_float_trailing_decimal_groups():
+    # Test the original case with many trailing decimal groups
+    assert (
+        str_to_float(
+            "31800.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.00.0"
+        )
+        == 31800.00
+    )
+
+    # Test simpler cases with trailing decimal groups
+    assert str_to_float("100.00.00") == 100.00
+    assert str_to_float("42.5.5.5") == 42.5
+    assert str_to_float("3.14159.265") == 3.14159
+
+    # Test with trailing text after valid float
+    assert str_to_float("123.45abc") == 123.45
+    assert str_to_float("99.99xyz123") == 99.99
+    assert str_to_float("0.5hello") == 0.5
+
+    # Test negative numbers with trailing content
+    assert str_to_float("-50.25.25") == -50.25
+    assert str_to_float("-100.00.00.00") == -100.00
+    assert str_to_float("-3.14extra") == -3.14
+
+    # Test integers with trailing content
+    assert str_to_float("42garbage") == 42.0
+    assert str_to_float("100abc123") == 100.0
+    assert str_to_float("-75text") == -75.0
+
+    # Test edge cases
+    assert str_to_float("0.0.0.0") == 0.0
+    assert str_to_float("1.") == 1.0  # Valid float with trailing dot
+    # Note: .5extra doesn't match the regex pattern ^([+-]?\d+(?:\.\d+)?)
+
+    # Test with signs
+    assert str_to_float("+123.45.67") == 123.45
+    assert str_to_float("-987.65.43") == -987.65


### PR DESCRIPTION
Ignores trailing characters that are invalid for floats

