### PR TITLE
Render document types

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -15957,6 +15957,31 @@ a._citationLink_t2k1z_9:hover {
 ._toolPanel_1792k_40 {
   display: contents;
 }
+._documentFrame_1576h_1 {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  row-gap: 0.5em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+
+._documentFrameTitle_1576h_9 {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.3em;
+  align-items: center;
+}
+
+._downloadLink_1576h_16:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+._imageDocument_1576h_21 {
+  max-width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+}
 ._toolCallView_16q6n_1 {
   display: grid;
   row-gap: 1em;

--- a/src/inspect_ai/_view/www/src/app/appearance/icons.ts
+++ b/src/inspect_ai/_view/www/src/app/appearance/icons.ts
@@ -8,6 +8,16 @@ const loggingIcons: Record<string, string> = {
   critical: "bi bi-fire",
 };
 
+export const iconForMimeType = (mimeType: string): string => {
+  if (mimeType === "application/pdf") {
+    return "bi bi-file-pdf";
+  } else if (mimeType.startsWith("image/")) {
+    return "bi bi-file-image";
+  } else {
+    return "bi bi-file-earmark";
+  }
+};
+
 export const ApplicationIcons = {
   agent: "bi bi-grid", // bi bi-x-diamond
   approve: "bi bi-shield",

--- a/src/inspect_ai/_view/www/src/app/samples/chat/MessageContent.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/MessageContent.tsx
@@ -23,6 +23,7 @@ import { MessagesContext } from "./MessageContents";
 import { ToolOutput } from "./tools/ToolOutput";
 import { Citation } from "./types";
 import { ServerToolCall } from "./server-tools/ServerToolCall";
+import { ContentDocumentView } from "./documents/ContentDocumentView";
 
 type ContentObject =
   | ContentText
@@ -226,6 +227,12 @@ const messageRenderers: Record<string, MessageRenderer> = {
     render: (key, content) => {
       const c = content as ContentData;
       return <ContentDataView id={key} contentData={c} />;
+    },
+  },
+  document: {
+    render: (key, content) => {
+      const c = content as ContentDocument;
+      return <ContentDocumentView id={key} document={c} />;
     },
   },
 };

--- a/src/inspect_ai/_view/www/src/app/samples/chat/documents/ContentDocumentView.module.css
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/documents/ContentDocumentView.module.css
@@ -1,0 +1,25 @@
+.documentFrame {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  row-gap: 0.5em;
+  padding-top: 1em;
+  padding-bottom: 1em;
+}
+
+.documentFrameTitle {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  column-gap: 0.3em;
+  align-items: center;
+}
+
+.downloadLink:hover {
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.imageDocument {
+  max-width: 100%;
+  max-height: 200px;
+  object-fit: cover;
+}

--- a/src/inspect_ai/_view/www/src/app/samples/chat/documents/ContentDocumentView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/documents/ContentDocumentView.tsx
@@ -1,0 +1,85 @@
+import { FC, ReactNode } from "react";
+import { ContentDocument } from "../../../../@types/log";
+import { isImage } from "../../../../utils/mime";
+
+import clsx from "clsx";
+import { iconForMimeType } from "../../../appearance/icons";
+
+import api from "../../../../client/api";
+import { useStore } from "../../../../state/store";
+import styles from "./ContentDocumentView.module.css";
+
+interface ContentDocumentProps {
+  id: string;
+  document: ContentDocument;
+}
+
+export const ContentDocumentView: FC<ContentDocumentProps> = ({
+  id,
+  document,
+}) => {
+  const canDownloadFiles = useStore(
+    (state) => state.capabilities.downloadFiles,
+  );
+
+  if (isImage(document.mime_type)) {
+    return (
+      <ContentDocumentFrame document={document} downloadable={canDownloadFiles}>
+        <img
+          className={clsx(styles.imageDocument)}
+          src={document.document}
+          alt={document.filename}
+          id={id}
+        />
+      </ContentDocumentFrame>
+    );
+  } else {
+    return (
+      <ContentDocumentFrame
+        document={document}
+        downloadable={canDownloadFiles}
+      />
+    );
+  }
+};
+
+interface ContentDocumentFrameProps {
+  children?: ReactNode;
+  document: ContentDocument;
+  downloadable: boolean;
+}
+
+const ContentDocumentFrame: FC<ContentDocumentFrameProps> = ({
+  document,
+  children,
+  downloadable,
+}) => {
+  return (
+    <div
+      className={clsx(
+        styles.documentFrame,
+        "text-size-small",
+        "text-style-secondary",
+      )}
+    >
+      <div className={clsx(styles.documentFrameTitle)}>
+        <i className={clsx(iconForMimeType(document.mime_type))} />
+        <div>
+          {downloadable ? (
+            <a
+              className={clsx(styles.downloadLink)}
+              onClick={() => {
+                api.download_file(document.filename, document.document);
+              }}
+            >
+              {document.filename}
+            </a>
+          ) : (
+            document.filename
+          )}
+        </div>
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/src/inspect_ai/_view/www/src/client/api/api-shared.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-shared.ts
@@ -5,11 +5,22 @@ export async function download_file(
   filename: string,
   filecontents: string | Blob | ArrayBuffer | ArrayBufferView,
 ): Promise<void> {
-  const blob = new Blob([filecontents], { type: "text/plain" });
+  let blob: Blob;
+
+  if (typeof filecontents === "string" && filecontents.startsWith("data:")) {
+    // Convert data URL to Blob
+    const response = await fetch(filecontents);
+    blob = await response.blob();
+  } else {
+    // Handle regular content
+    blob = new Blob([filecontents], { type: "text/plain" });
+  }
+
   const link = document.createElement("a");
   link.href = URL.createObjectURL(blob);
   link.download = filename;
   document.body.appendChild(link);
   link.click();
   document.body.removeChild(link);
+  URL.revokeObjectURL(link.href);
 }

--- a/src/inspect_ai/_view/www/src/utils/mime.ts
+++ b/src/inspect_ai/_view/www/src/utils/mime.ts
@@ -1,0 +1,3 @@
+export const isImage = (mimeType: string): boolean => {
+  return mimeType.startsWith("image/");
+};


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### Render document types

We have special handling for images (which show a small version of the image) otherwise all others files show filename and link.

<img width="816" height="129" alt="Screenshot 2025-08-13 at 10 51 24 PM" src="https://github.com/user-attachments/assets/686b1d3f-1609-446b-9f1d-9995e98900cf" />

<img width="816" height="290" alt="Screenshot 2025-08-13 at 10 51 17 PM" src="https://github.com/user-attachments/assets/6ccebcec-ee2b-4465-833c-450738575d33" />

Files are downloadable outside of VSCode.

