### PR TITLE
Show the waiting for retry message when using display=plain or display=log

### DIFF
--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -14,6 +14,7 @@ from tenacity import (
 )
 from typing_extensions import Unpack
 
+from inspect_ai._display import display as display_manager
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import basename, filesystem
 from inspect_ai._util.notgiven import NOT_GIVEN, NotGiven
@@ -36,7 +37,11 @@ from inspect_ai.model import (
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.solver._solver import Solver, SolverSpec
 from inspect_ai.util import DisplayType, SandboxEnvironmentType
-from inspect_ai.util._display import display_type_initialized, init_display_type
+from inspect_ai.util._display import (
+    display_type_initialized,
+    display_type_plain,
+    init_display_type,
+)
 
 from .eval import eval, eval_init, eval_resolve_tasks
 from .loader import resolve_task_args
@@ -294,14 +299,17 @@ def eval_set(
         kwargs["max_connections"] = max_connections
 
         # print waiting status
-        nonlocal status
-        console.print("")
         msg = (
             f"Evals not complete, waiting {round(retry_state.upcoming_sleep)} "
             + "seconds before retrying...\n"
         )
-        status = console.status(status_msg(msg), spinner="clock")
-        status.start()
+        if display_type_plain():
+            display_manager().print(msg)
+        else:
+            nonlocal status
+            console.print("")
+            status = console.status(status_msg(msg), spinner="clock")
+            status.start()
 
     def before(retry_state: RetryCallState) -> None:
         # clear waiting status


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When running with display=plain or display=log the message about waiting for retry was not displayed.

### What is the new behavior?
The message is now displayed.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
I thought about adding a `status_message` method to the `Display` class, but decided that it was too much for something that is only used in one place.