### PR TITLE
Properly support list score display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - ModelOutput: Setting the `completion` property now does not affect the underlying `message` content.
 - Inspect View: Improved handling of scores and messages with large or complex metadata.
 - Inspect View: Web search and other server-side tool calls (e.g. remote MCP) are now shown in the transcript.
+- Inspect View: Properly display scores with list values.
 - Bugfix: Don't inspect stack in `span()` function until required for logging.
 
 ## 0.3.122 (11 August 2025)

--- a/src/inspect_ai/_view/www/src/app/samples/descriptor/score/ListScoreDescriptor.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/descriptor/score/ListScoreDescriptor.tsx
@@ -1,0 +1,40 @@
+import { Value2 } from "../../../../@types/log";
+import { kScoreTypeList } from "../../../../constants";
+import { formatPrettyDecimal } from "../../../../utils/format";
+import { isNumeric } from "../../../../utils/type";
+import { ScoreDescriptor, SelectedScore } from "../types";
+
+export const listScoreDescriptor = (_values: Value2[]): ScoreDescriptor => {
+  return {
+    scoreType: kScoreTypeList,
+    filterable: false,
+    compare: (a: SelectedScore, b: SelectedScore) => {
+      return (a.value as any as []).length - (b.value as any as []).length;
+    },
+    render: (score) => {
+      if (score === null || score === undefined) {
+        return "[null]";
+      }
+
+      const formattedScores: string[] = [];
+      (score as []).forEach((value) => {
+        if (!Array.isArray(score)) {
+          throw new Error(
+            "Unexpected use of list score descriptor for non-lisß object",
+          );
+        }
+        const formattedValue =
+          value && isNumeric(value)
+            ? formatPrettyDecimal(
+                typeof value === "number"
+                  ? value
+                  : parseFloat(value === true ? "1" : value),
+              )
+            : String(value);
+        formattedScores.push(formattedValue);
+      });
+
+      return <div key={`score-value`}>[{formattedScores.join(", ")}]</div>;
+    },
+  };
+};

--- a/src/inspect_ai/_view/www/src/app/samples/descriptor/score/ObjectScoreDescriptor.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/descriptor/score/ObjectScoreDescriptor.tsx
@@ -25,6 +25,7 @@ export const objectScoreDescriptor = (values: Value2[]): ScoreDescriptor => {
   return {
     scoreType: kScoreTypeObject,
     categories,
+    filterable: false,
     compare: () => {
       return 0;
     },
@@ -38,7 +39,7 @@ export const objectScoreDescriptor = (values: Value2[]): ScoreDescriptor => {
       keys.forEach((key) => {
         if (typeof score !== "object" || Array.isArray(score)) {
           throw new Error(
-            "Unexpected us of object score descriptor for non-score object",
+            "Unexpected use of object score descriptor for non-score object",
           );
         }
         const value = score[key];

--- a/src/inspect_ai/_view/www/src/app/samples/descriptor/score/ScoreDescriptor.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/descriptor/score/ScoreDescriptor.tsx
@@ -2,6 +2,7 @@ import { Value2 } from "../../../../@types/log";
 import { ScoreDescriptor } from "../types";
 import { booleanScoreDescriptor } from "./BooleanScoreDescriptor";
 import { categoricalScoreDescriptor } from "./CategoricalScoreDescriptor";
+import { listScoreDescriptor } from "./ListScoreDescriptor";
 import { numericScoreDescriptor } from "./NumericScoreDescriptor";
 import { objectScoreDescriptor } from "./ObjectScoreDescriptor";
 import { otherScoreDescriptor } from "./OtherScoreDescriptor";
@@ -87,7 +88,11 @@ const scoreCategorizers: ScoreCategorizer[] = [
   {
     describe: (values: Value2[], types?: ScorerTypes[]) => {
       if (types && types.length !== 0 && types[0] === "object") {
-        return objectScoreDescriptor(values);
+        if (values.length > 0 && Array.isArray(values[0])) {
+          return listScoreDescriptor(values);
+        } else {
+          return objectScoreDescriptor(values);
+        }
       }
     },
   },

--- a/src/inspect_ai/_view/www/src/app/samples/descriptor/types.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/descriptor/types.ts
@@ -32,6 +32,7 @@ export interface ScoreDescriptor {
   categories?: Array<Object>;
   min?: number;
   max?: number;
+  filterable?: boolean;
   compare: (a: SelectedScore, b: SelectedScore) => number;
   render: (score: Value2) => ReactNode;
 }

--- a/src/inspect_ai/_view/www/src/app/samples/sample-tools/filters.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/sample-tools/filters.ts
@@ -147,6 +147,12 @@ export const sampleFilterItems = (
       throw new Error("Unable to create a canonical name for a score");
     }
     const descriptor = evalDescriptor.scoreDescriptor(scoreLabel);
+
+    // This is not a filterable score
+    if (descriptor.filterable === false) {
+      return;
+    }
+
     const scoreType = descriptor?.scoreType;
     if (!descriptor) {
       items.push({

--- a/src/inspect_ai/_view/www/src/constants.ts
+++ b/src/inspect_ai/_view/www/src/constants.ts
@@ -42,6 +42,7 @@ export const kScoreTypeNumeric = "numeric";
 export const kScoreTypeOther = "other";
 export const kScoreTypeObject = "object";
 export const kScoreTypeBoolean = "boolean";
+export const kScoreTypeList = "list";
 
 // Sorting constants
 export const kSampleAscVal = "sample-asc";


### PR DESCRIPTION
- list scores will be displayed, but are not filterable.
- existing object scores are now properly not filterable.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
