### PR TITLE
Make match(numeric=True) more lenient when it comes to markdown

### DIFF
--- a/src/inspect_ai/scorer/_common.py
+++ b/src/inspect_ai/scorer/_common.py
@@ -61,12 +61,15 @@ def match_str(
         t = strip_numeric_punctuation(t)
         # normalize as required
         t = normalize_number(t)
-        if location == "begin":
-            words = re.split(r"\s+", v)
-            v = first_number_normalized(words)
-        elif location == "end":
-            words = re.split(r"\s+", v)
-            words.reverse()
+
+        if location == "begin" or location == "end":
+            # strip markdown `__` and `**` clumps from ends of words
+            words = [
+                re.sub(r"^(?:\*\*|__)|(?:\*\*|__)$", "", word)
+                for word in re.split(r"\s+", v)
+            ]
+            if location == "end":
+                words.reverse()
             v = first_number_normalized(words)
         elif location == "exact":
             v = normalize_number(v)

--- a/tests/scorer/test_match.py
+++ b/tests/scorer/test_match.py
@@ -14,6 +14,17 @@ async def test_number_eol():
 
 
 @pytest.mark.anyio
+async def test_non_number_eol_markdown():
+    scorer = match(numeric=True)
+    state = simple_task_state(
+        model_output="**ANSWER: 28 + 32 = 60**\nThis solves the problem."
+    )
+    result = await scorer(state, Target(["60"]))
+
+    assert result.text == CORRECT
+
+
+@pytest.mark.anyio
 async def test_non_numeric_match():
     scorer = match(numeric=True, location="any")
     state = simple_task_state(model_output="28 + 32 = 60%\nThis solves the problem.")


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently match(numeric=True) doesn't ignore markdown. Newer models tend to output markdown, so it causes problems like [this issue in Inspect Evals](https://github.com/UKGovernmentBEIS/inspect_evals/issues/470). 

@jjallaire seemed to think that [the answer() scorer can be made more lenient on the Inspect slack](https://inspectcommunity.slack.com/archives/C07VD4R7A58/p1748095928884759?thread_ts=1747957221.408629&cid=C07VD4R7A58). I don't know if the opinion extends to `match()` as well, but I figured I'd submit a PR.  

### What is the new behavior?

Markdown clumps (`**` and `__`) are stripped from the beginnings or ends of words 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Not expecting breaking changes, but this will definitely make some answers that were not accepted to be accepted.

### Other information:
