### PR TITLE
Feature/react submit tooldef

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Inspect View: Update document titles when viewing a sample, log, or log dir to better disambiguate tabs or windows. Use reverse pyramid to place details at the head of the title.
 - Bugifx: Properly handle surrogates in JSON serialization.
 - Bugfix: Enable use of custom reducers with `eval-retry` by delaying their creation until after task creation.
+- React: Allow for a ToolDef to be passed to an AgentSubmit type.
 
 ## 0.3.123 (16 August 2025)
 

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -137,7 +137,7 @@ def react(
         submit.tool or default_submit_tool(),
         name=submit.name,
         description=submit.description,
-    )
+    ) if not isinstance(submit.tool, ToolDef) else submit.tool
     tools.append(submit_tool)
 
     # resolve prompt / system message

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -133,11 +133,15 @@ def react(
     tools = list(tools) if tools is not None else []
 
     # resolve submit tool
-    submit_tool = ToolDef(
-        submit.tool or default_submit_tool(),
-        name=submit.name,
-        description=submit.description,
-    ) if not isinstance(submit.tool, ToolDef) else submit.tool
+    submit_tool = (
+        ToolDef(
+            submit.tool or default_submit_tool(),
+            name=submit.name,
+            description=submit.description,
+        )
+        if not isinstance(submit.tool, ToolDef)
+        else submit.tool
+    )
     tools.append(submit_tool)
 
     # resolve prompt / system message

--- a/src/inspect_ai/agent/_types.py
+++ b/src/inspect_ai/agent/_types.py
@@ -4,6 +4,8 @@ from inspect_ai.agent._agent import AgentState
 from inspect_ai.scorer._metric import Score, ValueToFloat, value_to_float
 from inspect_ai.tool._tool import Tool
 
+from src.inspect_ai.tool._tool_def import ToolDef
+
 DEFAULT_HANDOFF_PROMPT = """
 You are part of a multi-agent system designed to make agent coordination and
 execution easy. Agents uses two primary abstraction: **Agents** and **Handoffs**.
@@ -104,7 +106,7 @@ class AgentSubmit(NamedTuple):
     description: str | None = None
     """Description of submit tool (defaults to 'Submit an answer for evaluation')."""
 
-    tool: Tool | None = None
+    tool: Tool | ToolDef | None = None
     """Alternate implementation for submit tool.
 
     The tool can provide its `name` and `description` internally,

--- a/src/inspect_ai/agent/_types.py
+++ b/src/inspect_ai/agent/_types.py
@@ -3,8 +3,7 @@ from typing import Awaitable, Callable, NamedTuple, TypeAlias
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.scorer._metric import Score, ValueToFloat, value_to_float
 from inspect_ai.tool._tool import Tool
-
-from src.inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tool_def import ToolDef
 
 DEFAULT_HANDOFF_PROMPT = """
 You are part of a multi-agent system designed to make agent coordination and

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -96,17 +96,20 @@ def run_react_agent(
         scorer=includes(),
         message_limit=message_limit,
     )
-
+    # breakpoint()
     model = get_model(
         "mockllm/model",
         custom_outputs=[
             ModelOutput.for_tool_call(
                 model="mockllm/model",
-                tool_name=submit.name or submit.tool.name
-                if isinstance(submit.tool, ToolDef)
-                else ToolDef(submit.tool).name
-                if submit.tool
-                else AGENT_SUBMIT_TOOL_NAME,
+                tool_name=submit.name
+                or (
+                    submit.tool.name
+                    if isinstance(submit.tool, ToolDef)
+                    else ToolDef(submit.tool).name
+                    if submit.tool
+                    else AGENT_SUBMIT_TOOL_NAME
+                ),
                 tool_arguments={"answer": "2"},
             )
         ],

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -102,7 +102,9 @@ def run_react_agent(
         custom_outputs=[
             ModelOutput.for_tool_call(
                 model="mockllm/model",
-                tool_name=submit.name or ToolDef(submit.tool).name
+                tool_name=submit.name or submit.tool.name
+                if isinstance(submit.tool, ToolDef)
+                else ToolDef(submit.tool).name
                 if submit.tool
                 else AGENT_SUBMIT_TOOL_NAME,
                 tool_arguments={"answer": "2"},


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

AgentSubmit type takes a `submit` tool. This cannot be a `ToolDef`. The `react` agent then converts this into a `ToolDef`. If you want to pass a `ToolDef`, you need to use `as_tool` to convert it to a tool, then it will be converted back in the react agent.

In ControlArena, we want to subclass the `ToolDef` type to add more fields to the registry. However this behavior is lost if you convert the `ToolDef` to a `Tool`, and then back to a `ToolDef`

### What is the new behavior?

If you pass an `AgentSubmit` with a  tool which is a `ToolDef`, the `ToolDef` is directly used.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

There might be some typing issues if people are using custom agents. They would need to add in handling for the case where the `AgentSubmit.tool` is a `ToolDef` instead of a `Tool`.
