### PR TITLE
Fix json schema generation of CitationBase.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Inspect View: Update document titles when viewing a sample, log, or log dir to better disambiguate tabs or windows. Use reverse pyramid to place details at the head of the title.
 - Bugifx: Properly handle surrogates in JSON serialization.
 - Bugfix: Enable use of custom reducers with `eval-retry` by delaying their creation until after task creation.
+- Bugfix: Fix custom json schema generation code for `CitationBase` so that it no longer leads to an invalid schema.
 
 ## 0.3.123 (16 August 2025)
 

--- a/src/inspect_ai/_util/citation.py
+++ b/src/inspect_ai/_util/citation.py
@@ -14,8 +14,7 @@ class CitationBase(BaseModel):
                 {"type": "string"},
                 {
                     "type": "array",
-                    "items": [{"type": "integer"}, {"type": "integer"}],
-                    "additionalItems": False,
+                    "items": {"type": "integer"},
                     "minItems": 2,
                     "maxItems": 2,
                 },

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -912,15 +912,9 @@
               "type": "string"
             },
             {
-              "additionalItems": false,
-              "items": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "integer"
-                }
-              ],
+              "items": {
+                "type": "integer"
+              },
               "maxItems": 2,
               "minItems": 2,
               "type": "array"
@@ -1367,15 +1361,9 @@
               "type": "string"
             },
             {
-              "additionalItems": false,
-              "items": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "integer"
-                }
-              ],
+              "items": {
+                "type": "integer"
+              },
               "maxItems": 2,
               "minItems": 2,
               "type": "array"
@@ -6916,15 +6904,9 @@
               "type": "string"
             },
             {
-              "additionalItems": false,
-              "items": [
-                {
-                  "type": "integer"
-                },
-                {
-                  "type": "integer"
-                }
-              ],
+              "items": {
+                "type": "integer"
+              },
               "maxItems": 2,
               "minItems": 2,
               "type": "array"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

OpenAPI schemas generated from Inspect types are not valid since #1919. 

### What is the new behavior?

We had a `json_schema_extra` in that class to ensure that it retained the proper typing when making its way to TypeScript. The issue was we were using some non-compliant functionality. Specifically,`additionalItems: False` is deprecated in JSON Schema Draft 2020-12 (which OpenAPI 3.1.0 uses).

The fix is to use `"items": {"type": "integer"}` instead of the tuple-style array schema, while keeping the `minItems: 2` and `maxItems: 2` constraints to ensure exactly 2 integers are required.