### PR TITLE
Fix broken viewer navigation in vscode

### DIFF
--- a/src/inspect_ai/_view/www/src/app/samples/list/SampleList.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/list/SampleList.tsx
@@ -167,6 +167,13 @@ export const SampleList: FC<SampleListProps> = memo((props) => {
               item.data.id,
               item.data.epoch,
             )}
+            showSample={() => {
+              sampleNavigation.showSample(
+                item.index,
+                item.data.id,
+                item.data.epoch,
+              );
+            }}
           />
         );
       } else if (item.type === "separator") {

--- a/src/inspect_ai/_view/www/src/app/samples/list/SampleRow.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/list/SampleRow.tsx
@@ -5,6 +5,7 @@ import { MarkdownDiv } from "../../../components/MarkdownDiv";
 import { PulsingDots } from "../../../components/PulsingDots";
 import { useStore } from "../../../state/store";
 import { arrayToString, inputString } from "../../../utils/format";
+import { isVscode } from "../../../utils/vscode";
 import { SampleErrorView } from "../error/SampleErrorView";
 import styles from "./SampleRow.module.css";
 
@@ -17,6 +18,7 @@ interface SampleRowProps {
   scoreRendered: ReactNode;
   gridColumnsTemplate: string;
   height: number;
+  showSample: () => void;
   sampleUrl?: string;
 }
 
@@ -29,6 +31,7 @@ export const SampleRow: FC<SampleRowProps> = ({
   scoreRendered,
   gridColumnsTemplate,
   height,
+  showSample,
   sampleUrl,
 }) => {
   const streamSampleData = useStore(
@@ -122,6 +125,15 @@ export const SampleRow: FC<SampleRowProps> = ({
   // If no sample URL available or not viewable, render as div
   if (!sampleUrl || !isViewable) {
     return <div className={styles.disabledRow}>{rowContent}</div>;
+  }
+
+  // VS code doesn't support navigating links
+  if (isVscode()) {
+    return (
+      <div onClick={showSample} className={styles.sampleLink}>
+        {rowContent}
+      </div>
+    );
   }
 
   // Render as a proper link


### PR DESCRIPTION
vscode doesn’t support navigating urls so we need to support old school click handling for this case.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
