### PR TITLE
Allow dirty log_dir during eval_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Bugifx: Properly handle surrogates in JSON serialization.
 - Bugfix: Enable use of custom reducers with `eval-retry` by delaying their creation until after task creation.
 - Bugfix: Fix custom json schema generation code for `CitationBase` so that it no longer leads to an invalid schema.
+- Eval set: You can now run eval sets in log dirs containing unrelated eval log files using the `--log-dir-allow-dirty` option.
 
 ## 0.3.123 (16 August 2025)
 

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -688,6 +688,12 @@ def eval_command(
     is_flag=True,
     help="Overwrite existing bundle dir.",
 )
+@click.option(
+    "--allow-dirty-log-dir",
+    type=str,
+    is_flag=True,
+    help="Do not fail if the log-dir contains files that are not part of the eval set.",
+)
 @eval_options
 @click.pass_context
 def eval_set_command(
@@ -765,6 +771,7 @@ def eval_set_command(
     no_score_display: bool | None,
     bundle_dir: str | None,
     bundle_overwrite: bool | None,
+    allow_dirty_log_dir: bool | None,
     log_format: Literal["eval", "json"] | None,
     log_level_transcript: str,
     **common: Unpack[CommonOptions],
@@ -833,6 +840,7 @@ def eval_set_command(
         retry_cleanup=not no_retry_cleanup,
         bundle_dir=bundle_dir,
         bundle_overwrite=True if bundle_overwrite else False,
+        allow_dirty_log_dir=allow_dirty_log_dir,
         **config,
     )
 
@@ -893,6 +901,7 @@ def eval_exec(
     retry_cleanup: bool | None = None,
     bundle_dir: str | None = None,
     bundle_overwrite: bool = False,
+    allow_dirty_log_dir: bool | None = None,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> bool:
     # parse task, solver, and model args
@@ -1001,6 +1010,7 @@ def eval_exec(
         params["retry_cleanup"] = retry_cleanup
         params["bundle_dir"] = bundle_dir
         params["bundle_overwrite"] = bundle_overwrite
+        params["allow_dirty_log_dir"] = allow_dirty_log_dir
         success, _ = eval_set(**params)
         return success
     else:

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -689,8 +689,8 @@ def eval_command(
     help="Overwrite existing bundle dir.",
 )
 @click.option(
-    "--allow-dirty-log-dir",
-    type=str,
+    "--log-dir-allow-dirty",
+    type=bool,
     is_flag=True,
     help="Do not fail if the log-dir contains files that are not part of the eval set.",
 )
@@ -771,7 +771,7 @@ def eval_set_command(
     no_score_display: bool | None,
     bundle_dir: str | None,
     bundle_overwrite: bool | None,
-    allow_dirty_log_dir: bool | None,
+    log_dir_allow_dirty: bool | None,
     log_format: Literal["eval", "json"] | None,
     log_level_transcript: str,
     **common: Unpack[CommonOptions],
@@ -840,7 +840,7 @@ def eval_set_command(
         retry_cleanup=not no_retry_cleanup,
         bundle_dir=bundle_dir,
         bundle_overwrite=True if bundle_overwrite else False,
-        allow_dirty_log_dir=allow_dirty_log_dir,
+        log_dir_allow_dirty=log_dir_allow_dirty,
         **config,
     )
 
@@ -901,7 +901,7 @@ def eval_exec(
     retry_cleanup: bool | None = None,
     bundle_dir: str | None = None,
     bundle_overwrite: bool = False,
-    allow_dirty_log_dir: bool | None = None,
+    log_dir_allow_dirty: bool | None = None,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> bool:
     # parse task, solver, and model args
@@ -1010,7 +1010,7 @@ def eval_exec(
         params["retry_cleanup"] = retry_cleanup
         params["bundle_dir"] = bundle_dir
         params["bundle_overwrite"] = bundle_overwrite
-        params["allow_dirty_log_dir"] = allow_dirty_log_dir
+        params["log_dir_allow_dirty"] = log_dir_allow_dirty
         success, _ = eval_set(**params)
         return success
     else:

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -590,7 +590,8 @@ def validate_eval_set_prerequisites(
                 raise PrerequisiteError(
                     f"[bold]ERROR[/bold]: Existing log file '{basename(log.info.name)}' in log_dir is not "
                     + "associated with a task passed to eval_set (you must run eval_set "
-                    + "in a fresh log directory)"
+                    + "in a fresh log directory). You can use the `--log-dir-allow-dirty` option to allow "
+                    + "logs from other eval sets to be present in the log directory."
                 )
         return all_logs
 

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -290,6 +290,7 @@ def eval_set(
     retry_cleanup = retry_cleanup is not False
     max_connections = starting_max_connections(models, GenerateConfig(**kwargs))
     max_tasks = max_tasks if max_tasks is not None else max(len(models), 4)
+    allow_dirty_log_dir = allow_dirty_log_dir is True
 
     # prepare console/status
     console = rich.get_console()

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -105,7 +105,7 @@ def eval_set(
     log_shared: bool | int | None = None,
     bundle_dir: str | None = None,
     bundle_overwrite: bool = False,
-    allow_dirty_log_dir: bool | None = None,
+    log_dir_allow_dirty: bool | None = None,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> tuple[bool, list[EvalLog]]:
     r"""Evaluate a set of tasks.
@@ -195,7 +195,7 @@ def eval_set(
             by this eval set will be bundled into this directory.
         bundle_overwrite: Whether to overwrite files in the bundle_dir.
             (defaults to False).
-        allow_dirty_log_dir: If True, allow the log directory to contain
+        log_dir_allow_dirty: If True, allow the log directory to contain
             unrelated logs. If False, ensure that the log directory only contains logs
             for tasks in this eval set (defaults to False).
         **kwargs: Model generation options.
@@ -290,7 +290,7 @@ def eval_set(
     retry_cleanup = retry_cleanup is not False
     max_connections = starting_max_connections(models, GenerateConfig(**kwargs))
     max_tasks = max_tasks if max_tasks is not None else max(len(models), 4)
-    allow_dirty_log_dir = allow_dirty_log_dir is True
+    log_dir_allow_dirty = log_dir_allow_dirty is True
 
     # prepare console/status
     console = rich.get_console()
@@ -350,7 +350,7 @@ def eval_set(
         #  (1) All tasks have a unique identifier
         #  (2) All logs have identifiers that map to tasks
         all_logs = validate_eval_set_prerequisites(
-            resolved_tasks, all_logs, allow_dirty_log_dir
+            resolved_tasks, all_logs, log_dir_allow_dirty
         )
 
         # see which tasks are yet to run (to complete successfully we need
@@ -568,7 +568,7 @@ def latest_completed_task_eval_logs(
 def validate_eval_set_prerequisites(
     resolved_tasks: list[ResolvedTask],
     all_logs: list[Log],
-    allow_dirty_log_dir: bool,
+    log_dir_allow_dirty: bool,
 ) -> list[Log]:
     # do all resolved tasks have unique identfiers?
     task_identifiers: Set[str] = set()
@@ -582,7 +582,7 @@ def validate_eval_set_prerequisites(
             task_identifiers.add(identifier)
 
     # do all logs in the log directory correspond to task identifiers?
-    if allow_dirty_log_dir:
+    if log_dir_allow_dirty:
         return [log for log in all_logs if log.task_identifier in task_identifiers]
     else:
         for log in all_logs:

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -419,7 +419,8 @@ def eval_set(
 
     # final sweep to remove failed log files
     if retry_cleanup:
-        cleanup_older_eval_logs(log_dir)
+        task_ids = {result.eval.task_id for result in results}
+        cleanup_older_eval_logs(log_dir, task_ids)
 
     # report final status
     success = all_evals_succeeded(results)
@@ -510,10 +511,13 @@ def list_latest_eval_logs(
 
 
 # cleanup logs that aren't the latest
-def cleanup_older_eval_logs(log_dir: str) -> None:
-    latest_completed_task_eval_logs(
-        logs=list_all_eval_logs(log_dir), cleanup_older=True
-    )
+def cleanup_older_eval_logs(log_dir: str, task_ids: set[str]) -> None:
+    logs = [
+        log
+        for log in list_all_eval_logs(log_dir)
+        if log.header.eval.task_id in task_ids
+    ]
+    latest_completed_task_eval_logs(logs=logs, cleanup_older=True)
 
 
 def latest_completed_task_eval_logs(

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -168,7 +168,7 @@ def test_validate_eval_set_prerequisites_ok() -> None:
     )
 
     all_logs = validate_eval_set_prerequisites(
-        resolved_tasks=resolved_tasks, all_logs=all_logs, allow_dirty_log_dir=False
+        resolved_tasks=resolved_tasks, all_logs=all_logs, log_dir_allow_dirty=False
     )
     assert len(all_logs) == 2
 
@@ -185,11 +185,11 @@ def test_validate_eval_set_prerequisites_mismatch() -> None:
 
     with pytest.raises(PrerequisiteError):
         validate_eval_set_prerequisites(
-            resolved_tasks=resolved_tasks, all_logs=all_logs, allow_dirty_log_dir=False
+            resolved_tasks=resolved_tasks, all_logs=all_logs, log_dir_allow_dirty=False
         )
 
 
-def test_validate_eval_set_prerequisites_mismatch_allow_dirty_log_dir() -> None:
+def test_validate_eval_set_prerequisites_mismatch_log_dir_allow_dirty() -> None:
     # cleanup previous tests
     TEST_EVAL_SET_PATH = Path("tests/test_eval_set")
 
@@ -200,7 +200,7 @@ def test_validate_eval_set_prerequisites_mismatch_allow_dirty_log_dir() -> None:
     )
 
     all_logs = validate_eval_set_prerequisites(
-        resolved_tasks=resolved_tasks, all_logs=all_logs, allow_dirty_log_dir=True
+        resolved_tasks=resolved_tasks, all_logs=all_logs, log_dir_allow_dirty=True
     )
     assert len(all_logs) == 0
 

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -18,7 +18,10 @@ from inspect_ai._eval.evalset import (
     eval_set,
     latest_completed_task_eval_logs,
     list_all_eval_logs,
+    validate_eval_set_prerequisites,
 )
+from inspect_ai._eval.loader import resolve_tasks
+from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.dataset import Sample
 from inspect_ai.log._file import list_eval_logs, read_eval_log, write_eval_log
 from inspect_ai.model import get_model
@@ -152,6 +155,54 @@ def test_latest_completed_task_eval_logs() -> None:
         assert len(list_eval_logs(clean_dir.as_posix())) == 1
     finally:
         shutil.rmtree(clean_dir, ignore_errors=True)
+
+
+def test_validate_eval_set_prerequisites_ok() -> None:
+    # cleanup previous tests
+    TEST_EVAL_SET_PATH = Path("tests/test_eval_set")
+
+    # verify we correctly select only the most recent log
+    all_logs = list_all_eval_logs(TEST_EVAL_SET_PATH.as_posix())
+    resolved_tasks = resolve_tasks(
+        "examples/popularity.py", {}, get_model("mockllm/model"), None, None, None
+    )
+
+    all_logs = validate_eval_set_prerequisites(
+        resolved_tasks=resolved_tasks, all_logs=all_logs, allow_dirty_log_dir=False
+    )
+    assert len(all_logs) == 2
+
+
+def test_validate_eval_set_prerequisites_mismatch() -> None:
+    # cleanup previous tests
+    TEST_EVAL_SET_PATH = Path("tests/test_eval_set")
+
+    # verify we correctly select only the most recent log
+    all_logs = list_all_eval_logs(TEST_EVAL_SET_PATH.as_posix())
+    resolved_tasks = resolve_tasks(
+        "examples/hello_world.py", {}, get_model("mockllm/model"), None, None, None
+    )
+
+    with pytest.raises(PrerequisiteError):
+        validate_eval_set_prerequisites(
+            resolved_tasks=resolved_tasks, all_logs=all_logs, allow_dirty_log_dir=False
+        )
+
+
+def test_validate_eval_set_prerequisites_mismatch_allow_dirty_log_dir() -> None:
+    # cleanup previous tests
+    TEST_EVAL_SET_PATH = Path("tests/test_eval_set")
+
+    # verify we correctly select only the most recent log
+    all_logs = list_all_eval_logs(TEST_EVAL_SET_PATH.as_posix())
+    resolved_tasks = resolve_tasks(
+        "examples/hello_world.py", {}, get_model("mockllm/model"), None, None, None
+    )
+
+    all_logs = validate_eval_set_prerequisites(
+        resolved_tasks=resolved_tasks, all_logs=all_logs, allow_dirty_log_dir=True
+    )
+    assert len(all_logs) == 0
 
 
 @pytest.mark.slow

--- a/tests/test_eval_set/2024-08-29T15-11-17+00-00_popularity_5EAmX6wjMFqea6WY7XHzZp.json
+++ b/tests/test_eval_set/2024-08-29T15-11-17+00-00_popularity_5EAmX6wjMFqea6WY7XHzZp.json
@@ -16,9 +16,7 @@
     },
     "model": "mockllm/model",
     "task_attribs": {},
-    "task_args": {
-      "model": null
-    },
+    "task_args": {},
     "model_args": {},
     "config": {
       "limit": 1

--- a/tests/test_eval_set/2024-08-29T15-11-18+00-00_popularity_5EAmX6wjMFqea6WY7XHzZp.json
+++ b/tests/test_eval_set/2024-08-29T15-11-18+00-00_popularity_5EAmX6wjMFqea6WY7XHzZp.json
@@ -16,9 +16,7 @@
     },
     "model": "mockllm/model",
     "task_attribs": {},
-    "task_args": {
-      "model": null
-    },
+    "task_args": {},
     "model_args": {},
     "config": {
       "limit": 1


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When changing the included tasks in an eval-set, you cannot rerun it in the same `log_dir`. If you want to reuse some of the successful earlier runs, you need to manually copy them.

### What is the new behavior?
This PR adds a new `--log-dir-allow-dirty` flag, that allows you to run the eval set in a `log_dir` with eval-files from earlier runs that are no longer in the eval set (or from a completely different run).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
[Slack thread](https://inspectcommunity.slack.com/archives/C080K7SQ4SG/p1755545184752159)