### PR TITLE
Add --resolve-attachments to inspect log dump

### DIFF
--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -126,9 +126,18 @@ def list_command(
     default=False,
     help="Read and print only the header of the log file (i.e. no samples).",
 )
-def dump_command(path: str, header_only: bool) -> None:
+@click.option(
+    "--resolve-attachments",
+    type=bool,
+    is_flag=True,
+    default=False,
+    help="Resolve attachments (e.g. images) to their full content.",
+)
+def dump_command(path: str, header_only: bool, resolve_attachments: bool) -> None:
     """Print log file contents as JSON."""
-    log = read_eval_log(path, header_only=header_only)
+    log = read_eval_log(
+        path, header_only=header_only, resolve_attachments=resolve_attachments
+    )
     print(eval_log_json_str(log))
 
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Log dumps always include "attachment://..." strings.

### What is the new behavior?

Optionally, these can be resolved.

```
(breakpoint-control) ➜  breakpoint-control git:(master) ✗ uv run inspect log dump --resolve-attachments /home/adamn/single-file-refactoring-setting/logs/2025-08-20T20-46-39-07-00_single-file-backdoored-refactoring_c4CsQqsaE8jHbDjkqSnkAN.eval|wc  
 121192  763964 13332487
(breakpoint-control) ➜  breakpoint-control git:(master) ✗ uv run inspect log dump /home/adamn/single-file-refactoring-setting/logs/2025-08-20T20-46-39-07-00_single-file-backdoored-refactoring_c4CsQqsaE8jHbDjkqSnkAN.eval|wc           
 121224  278198 7622768
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

This brings the commandline in sync with the args of read_eval_log. 