### PR TITLE
Increase sample size limit to 100MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Add `--continue-on-fail` option for `eval()` and `eval_set()`.
 - Inspect View: Convert samples in the sample list to use simple a tags for navigation. This allows typical user gestures like cmd+click to work correctly.
 - Inspect View: Update document titles when viewing a sample, log, or log dir to better disambiguate tabs or windows. Use reverse pyramid to place details at the head of the title.
+- Inspect View: Increase sample size limit to 100MB (samples larger than that are not browseable in the viewer).
 - Bugifx: Properly handle surrogates in JSON serialization.
 - Bugfix: Google and Mistral providers now generate unique tool call IDs to prevent collisions when calling the same tool multiple times.
 - Bugfix: Enable use of custom reducers with `eval-retry` by delaying their creation until after task creation.

--- a/src/inspect_ai/_view/www/src/client/remote/remoteLogFile.ts
+++ b/src/inspect_ai/_view/www/src/client/remote/remoteLogFile.ts
@@ -16,7 +16,7 @@ import {
 } from "./remoteZipFile";
 
 // don't try to load samples greater than 50mb
-const MAX_BYTES = 50 * 1024 * 1024;
+const MAX_BYTES = 100 * 1024 * 1024;
 const OPEN_RETRY_LIMIT = 5;
 
 interface SampleEntry {


### PR DESCRIPTION
I hven’t yet tried a sample of this size, but this will double our current limit.

- It started at 10MB
- then was raised to 50MB
- this raises it to 100MB

My guess is that 100MB will be ok and we’ll see degraded perf north of that. Still, I’d like to explore raising this further - we may now have done enough optimization that the slow deserialization could be an ok experience (e.g. background worker deserialization).

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
