### PR TITLE
Fix error message for non-absolute path check

### DIFF
--- a/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/text_editor.py
+++ b/src/inspect_tool_support/src/inspect_tool_support/_in_process_tools/_text_editor/text_editor.py
@@ -183,7 +183,7 @@ def _validated_path(path_str: str, command: str) -> Path:
     # Check if its an absolute path
     if not path.is_absolute():
         raise ToolException(
-            f"The path {path} is not an absolute path, it should start with `/`. Maybe you meant {Path('') / path}?"
+            f"The path {path} is not an absolute path, it should start with `/`. Maybe you meant {Path.cwd() / path}?"
         )
     # Check if path exists
     if not path.exists() and command != "create":


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

The tool call error message will look like:
> The path src/README.md is not an absolute path, it should start with `/`. Maybe you meant src/README.md?

### What is the new behavior?

> The path src/README.md is not an absolute path, it should start with `/`. Maybe you meant /home/agent/src/README.md?

/home/agent or whatever the cwd is

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No
