### PR TITLE
Optional no-copy arg for scoring

### DIFF
--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -154,6 +154,7 @@ async def score_async(
     epochs_reducer: ScoreReducers | None = None,
     action: ScoreAction | None = None,
     display: DisplayType | None = None,
+    copy: bool = True,
 ) -> EvalLog:
     """Score an evaluation log.
 
@@ -165,20 +166,24 @@ async def score_async(
          Defaults to previously used reducer(s).
        action: Whether to append or overwrite this score
        display: Progress/status display
+       copy: Whether to deepcopy the log before scoring.
 
     Returns:
        Log with scores yielded by scorer.
     """
-    # init display if necessary
+    if log.samples is None or len(log.samples) == 0:
+        raise ValueError("There are no samples to score in the log.")
+
     if not display_type_initialized():
         init_display_type(display or "plain")
 
-    # deepcopy so we don't mutate the passed log
-    log = deepcopy(log)
+    if copy:
+        # deepcopy so we don't mutate the passed log
+        log = deepcopy(log)
 
-    # confirm we have samples
-    if log.samples is None or len(log.samples) == 0:
-        raise ValueError("There are no samples to score in the log.")
+    assert (
+        log.samples is not None  # make the type checker happy after re-assignment above
+    )
 
     # prime the scoring tasks
     states = [


### PR DESCRIPTION
Deepcopy-ing takes a really long time and is not always needed. It would be nice to be able to skip it. I will also have a follow-up PR that makes the CLI `inspect score` re-use `score_async`, which will make use of this option.