### PR TITLE
Fix error reducing NaN scores when all scores for a sample are NaN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Fix error in reducing scores when all scores for a sample are NaN.
+
 ## 0.3.125 (25 August 2025)
 
 - Scoring: Refactor `inspect score` to call same underlying code as `score()`.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

An error

### What is the new behavior?

If all scores for a sample are NaN, we now return NaN as the final score (rather than calling the reducers at all).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
