### PR TITLE
Properly support empty lists of reducers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - ReAct Agent: Add submit tool content to assistant message (in addition to setting the `completion`).
 - Inspect View: Add support for filtering sample transcripts by event types. Be default, filter out `sample_init`, `sandbox`, `store`, and `state` events.
 - Bugfix: Fix error in reducing scores when all scores for a sample are NaN.
+- Metrics: Compute metrics when an empty list of reducers is provided (do not reduce the scores before computing metrics).
 
 ## 0.3.125 (25 August 2025)
 

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -623,7 +623,7 @@ async def _eval_async_inner(
             sample_shuffle=sample_shuffle,
             epochs=epochs.epochs if epochs else None,
             epochs_reducer=reducer_log_names(epochs_reducer)
-            if epochs_reducer
+            if epochs_reducer is not None
             else None,
             approval=config_from_approval_policies(approval) if approval else None,
             fail_on_error=fail_on_error,

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -287,10 +287,27 @@ def eval_with_reducer():
     return eval(task, model="mockllm/model", epochs=Epochs(5, max_score()))[0]
 
 
+def eval_no_reducer():
+    task = Task(dataset=[Sample(input="Say hello.", target="Hello")], scorer=match())
+    return eval(task, model="mockllm/model", epochs=Epochs(5, []))[0]
+
+
 def test_reducer_by_name():
     task = Task(dataset=[Sample(input="Say hello.", target="Hello")], scorer=match())
     log = eval(task, model="mockllm/model", epochs=Epochs(5, "at_least_2"))[0]
     assert log.eval.config.epochs_reducer == ["at_least_2"]
+
+
+def test_no_reducer():
+    task = Task(dataset=[Sample(input="Say hello.", target="Hello")], scorer=match())
+    log = eval(task, model="mockllm/model", epochs=Epochs(5, []))[0]
+    assert log.eval.config.epochs_reducer == []
+
+
+def test_default_reducer():
+    task = Task(dataset=[Sample(input="Say hello.", target="Hello")], scorer=match())
+    log = eval(task, model="mockllm/model", epochs=4)[0]
+    assert log.eval.config.epochs_reducer == ["mean"]
 
 
 def test_eval_reducer():
@@ -304,6 +321,11 @@ def test_score_reducer():
 
     log = score(eval_with_reducer(), match(), [mode_score(), mean_score()])
     assert log.eval.config.epochs_reducer == ["mode", "mean"]
+
+
+def test_score_no_reducer():
+    log = score(eval_no_reducer(), match())
+    assert log.eval.config.epochs_reducer == []
 
 
 def test_main_reducer():


### PR DESCRIPTION
Previously, when an empty reducer list was passed, no metrics would be computed. This change will now properly compute metrics without using a reducer. For example:

```python
    return Task(
        dataset=dataset,
        solver=[system_message(SYSTEM_MESSAGE), generate()],
        scorer=[match()],
        epochs=Epochs(2, reducer=[]),
    )
```

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
