### PR TITLE
Allow configuring API base URL

### DIFF
--- a/src/inspect_ai/_view/www/src/client/api/api-browser.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-browser.ts
@@ -8,6 +8,8 @@ import {
   SampleDataResponse,
 } from "./types";
 
+const API_BASE_URL = __API_URL__ || "";
+
 const loaded_time = Date.now();
 let last_eval_time = 0;
 
@@ -190,6 +192,9 @@ async function apiRequest<T>(
   path: string,
   request: Request<T>,
 ): Promise<{ raw: string; parsed: T }> {
+  const url = API_BASE_URL + path;
+  const isCrossOrigin = API_BASE_URL && new URL(API_BASE_URL).origin !== window.location.origin;
+
   // build headers
   const responseHeaders: HeadersInit = {
     Accept: "application/json",
@@ -203,10 +208,11 @@ async function apiRequest<T>(
   }
 
   // make request
-  const response = await fetch(`${path}`, {
+  const response = await fetch(url, {
     method,
     headers: responseHeaders,
     body: request.body,
+    credentials: isCrossOrigin ? "include" : "same-origin",
   });
   if (response.ok) {
     const text = await response.text();
@@ -241,6 +247,9 @@ async function api(
   headers?: Record<string, string>,
   body?: string,
 ) {
+  const url = API_BASE_URL + path;
+  const isCrossOrigin = API_BASE_URL && new URL(API_BASE_URL).origin !== window.location.origin;
+
   // build headers
   const responseHeaders: HeadersInit = {
     Accept: "application/json",
@@ -254,10 +263,11 @@ async function api(
   }
 
   // make request
-  const response = await fetch(`${path}`, {
+  const response = await fetch(url, {
     method,
     headers: responseHeaders,
     body,
+    credentials: isCrossOrigin ? "include" : "same-origin",
   });
   if (response.ok) {
     const text = await response.text();
@@ -278,6 +288,9 @@ async function api_bytes(
   method: "GET" | "POST" | "PUT" | "DELETE",
   path: string,
 ) {
+  const url = API_BASE_URL + path;
+  const isCrossOrigin = API_BASE_URL && new URL(API_BASE_URL).origin !== window.location.origin;
+
   // build headers
   const headers: HeadersInit = {
     Accept: "application/octet-stream",
@@ -287,7 +300,11 @@ async function api_bytes(
   };
 
   // make request
-  const response = await fetch(`${path}`, { method, headers });
+  const response = await fetch(url, {
+    method,
+    headers,
+    credentials: isCrossOrigin ? "include" : "same-origin",
+  });
   if (response.ok) {
     const buffer = await response.arrayBuffer();
     return new Uint8Array(buffer);

--- a/src/inspect_ai/_view/www/src/client/api/api-browser.ts
+++ b/src/inspect_ai/_view/www/src/client/api/api-browser.ts
@@ -8,6 +8,7 @@ import {
   SampleDataResponse,
 } from "./types";
 
+/* global __API_URL__ */
 const API_BASE_URL = __API_URL__ || "";
 const loaded_time = Date.now();
 let last_eval_time = 0;

--- a/src/inspect_ai/_view/www/src/vite-env.d.ts
+++ b/src/inspect_ai/_view/www/src/vite-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __API_URL__: string;

--- a/src/inspect_ai/_view/www/vite.config.js
+++ b/src/inspect_ai/_view/www/vite.config.js
@@ -29,5 +29,6 @@ export default defineConfig({
     __LOGGING_FILTER__: JSON.stringify(
       process.env.DEV_LOGGING_NAMESPACES || "*",
     ),
+    __API_URL__: JSON.stringify(process.env.API_URL || ""),
   },
 });


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

Allow configuring where the API server is for the viewer. Include credentials when hitting the API.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

Seems odd to me that dist/* is checked in but ok