### PR TITLE
Tweak read_eval_log() docs

### DIFF
--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -201,7 +201,7 @@ Eval log files can get quite large (multiple GB) so it is often useful to read o
 log_header = read_eval_log(log_file, header_only=True)
 ```
 
-The log header is a standard `EvalLog` object without the `samples` and `reductions` fields.
+The log header is a standard `EvalLog` object without the `samples` fields. The `reductions` field is included for `eval` log files and not for `json` log files.
 
 ### Summaries
 


### PR DESCRIPTION
Correct documentation for `read_eval_log()` with note regarding `reductions` being present in `eval` formatted log files.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [] Bug fixes
- [ ] Code refactor

### 
