### PR TITLE
View fastapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ click>=8.1.3,!=8.2.0
 debugpy
 docstring-parser>=0.16
 exceptiongroup>=1.0.2; python_version < '3.11'
+fastapi==0.116.1
 fsspec>=2023.1.0,<=2025.3.0 # align with hf datasets to prevent pip errors
 httpx
 ijson>=3.2.0
@@ -30,4 +31,5 @@ sniffio
 tenacity
 textual>=0.86.2,<v3.0.0 # https://github.com/UKGovernmentBEIS/inspect_ai/issues/1891
 typing_extensions>=4.9.0
+uvicorn>=0.30.0
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability

--- a/src/inspect_ai/_cli/info.py
+++ b/src/inspect_ai/_cli/info.py
@@ -4,7 +4,7 @@ import click
 
 from inspect_ai import __version__
 from inspect_ai._util.constants import PKG_PATH
-from inspect_ai._view.server import resolve_header_only
+from inspect_ai._view.utils import resolve_header_only
 from inspect_ai.log._file import eval_log_json_str, read_eval_log
 
 from .log import headers, schema, types

--- a/src/inspect_ai/_view/routes.py
+++ b/src/inspect_ai/_view/routes.py
@@ -1,0 +1,184 @@
+import urllib.parse
+from typing import Any, Callable, Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi.responses import JSONResponse, Response
+
+from inspect_ai._util.file import filesystem
+from inspect_ai.log._recorders.buffer.buffer import sample_buffer
+
+from .notify import view_last_eval_time
+from .utils import (
+    list_eval_logs_async,
+    log_bytes_response,
+    log_delete_response,
+    log_file_response,
+    log_headers_response,
+    log_listing_response,
+    log_size_response,
+    normalize_uri,
+)
+
+
+def create_inspect_view_router(
+    log_dir: str,
+    recursive: bool = True,
+    fs_options: dict[str, Any] = {},
+    auth_callback: Optional[Callable[[Request], bool]] = None,
+) -> APIRouter:
+    router = APIRouter(prefix="/api")
+
+    fs = filesystem(log_dir)
+    if not fs.exists(log_dir):
+        fs.mkdir(log_dir, True)
+    log_dir = fs.info(log_dir).name
+
+    def validate_log_file_request(log_file: str) -> None:
+        if not auth_callback and (not log_file.startswith(log_dir) or ".." in log_file):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    def check_auth(request: Request) -> None:
+        if auth_callback and not auth_callback(request):
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED)
+
+    @router.get("/logs/{log}")
+    async def api_log(
+        request: Request,
+        log: str,
+        header_only: Optional[str] = Query(None, alias="header-only"),
+    ) -> Response:
+        check_auth(request)
+        file = normalize_uri(log)
+        validate_log_file_request(file)
+        return await log_file_response(file, header_only)
+
+    @router.get("/log-size/{log}")
+    async def api_log_size(request: Request, log: str) -> int:
+        check_auth(request)
+        file = normalize_uri(log)
+        validate_log_file_request(file)
+        return await log_size_response(file)
+
+    @router.get("/log-delete/{log}")
+    async def api_log_delete(request: Request, log: str) -> bool:
+        check_auth(request)
+        file = normalize_uri(log)
+        validate_log_file_request(file)
+        return await log_delete_response(file)
+
+    @router.get("/log-bytes/{log}")
+    async def api_log_bytes(
+        request: Request, log: str, start: int = Query(...), end: int = Query(...)
+    ) -> Response:
+        check_auth(request)
+        file = normalize_uri(log)
+        validate_log_file_request(file)
+        return await log_bytes_response(file, start, end)
+
+    @router.get("/logs")
+    async def api_logs(
+        request: Request, log_dir_param: Optional[str] = Query(None, alias="log_dir")
+    ) -> dict[str, Any]:
+        check_auth(request)
+        if auth_callback:
+            request_log_dir = normalize_uri(log_dir_param) if log_dir_param else log_dir
+        else:
+            request_log_dir = log_dir
+
+        logs = await list_eval_logs_async(
+            log_dir=request_log_dir, recursive=recursive, fs_options=fs_options
+        )
+        return log_listing_response(logs, request_log_dir)
+
+    @router.get("/log-headers")
+    async def api_log_headers(
+        request: Request, file: list[str] = Query(...)
+    ) -> dict[str, Any]:
+        check_auth(request)
+        files = [normalize_uri(f) for f in file]
+        for f in files:
+            validate_log_file_request(f)
+        return await log_headers_response(files)
+
+    @router.get("/events")
+    async def api_events(
+        request: Request, last_eval_time: Optional[str] = None
+    ) -> JSONResponse:
+        check_auth(request)
+        actions = (
+            ["refresh-evals"]
+            if last_eval_time and view_last_eval_time() > int(last_eval_time)
+            else []
+        )
+        return JSONResponse(actions)
+
+    @router.get("/pending-samples")
+    async def api_pending_samples(request: Request, log: str) -> Response:
+        check_auth(request)
+        file = urllib.parse.unquote(log)
+        validate_log_file_request(file)
+
+        client_etag = request.headers.get("If-None-Match")
+
+        buffer = sample_buffer(file)
+        samples = buffer.get_samples(client_etag)
+        if samples == "NotModified":
+            return Response(status_code=304)
+        elif samples is None:
+            return Response(status_code=404)
+        else:
+            return Response(
+                content=samples.model_dump_json(),
+                media_type="application/json",
+                headers={"ETag": samples.etag},
+            )
+
+    @router.get("/log-message")
+    async def api_log_message(
+        request: Request, log_file: str, message: str
+    ) -> Response:
+        check_auth(request)
+        file = urllib.parse.unquote(log_file)
+        validate_log_file_request(file)
+
+        import logging
+
+        logger = logging.getLogger(__name__)
+        logger.warning(f"[CLIENT MESSAGE] ({file}): {message}")
+
+        return Response(status_code=204)
+
+    @router.get("/pending-sample-data")
+    async def api_sample_events(
+        request: Request,
+        log: str,
+        id: str,
+        epoch: int,
+        last_event_id: Optional[int] = Query(None, alias="last-event-id"),
+        after_attachment_id: Optional[int] = Query(None, alias="after-attachment-id"),
+    ) -> Response:
+        check_auth(request)
+        file = urllib.parse.unquote(log)
+        validate_log_file_request(file)
+
+        buffer = sample_buffer(file)
+        sample_data = buffer.get_sample_data(
+            id=id,
+            epoch=epoch,
+            after_event_id=last_event_id,
+            after_attachment_id=after_attachment_id,
+        )
+
+        if sample_data is None:
+            return Response(status_code=404)
+        else:
+            return Response(
+                content=sample_data.model_dump_json(), media_type="application/json"
+            )
+
+    return router
+
+
+inspect_view_router = create_inspect_view_router
+
+__all__ = ["create_inspect_view_router", "inspect_view_router"]

--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -50,46 +50,12 @@ def view_server(
         app,
         host=host,
         port=port,
-        log_config={
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {
-                "default": {
-                    "()": "uvicorn.logging.DefaultFormatter",
-                    "fmt": "%(asctime)s %(levelname)s %(message)s",
-                    "use_colors": None,
-                },
-                "access": {
-                    "()": "uvicorn.logging.AccessFormatter",
-                    "fmt": '%(asctime)s %(levelname)s %(client_addr)s - "%(request_line)s" %(status_code)s',
-                },
-            },
-            "handlers": {
-                "default": {
-                    "formatter": "default",
-                    "class": "logging.StreamHandler",
-                    "stream": "ext://sys.stdout",
-                },
-                "access": {
-                    "formatter": "access",
-                    "class": "logging.StreamHandler",
-                    "stream": "ext://sys.stdout",
-                },
-            },
-            "loggers": {
-                "uvicorn": {"handlers": ["default"], "level": "INFO"},
-                "uvicorn.error": {"level": "INFO"},
-                "uvicorn.access": {
-                    "handlers": ["access"],
-                    "level": "INFO",
-                    "propagate": False,
-                },
-            },
-        },
     )
 
 
 def filter_uvicorn_log() -> None:
+    """Filter out noisy /api/events requests from access logs."""
+
     class RequestFilter(logging.Filter):
         def filter(self, record: LogRecord) -> bool:
             return "/api/events" not in record.getMessage()

--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -1,33 +1,17 @@
-import asyncio
-import contextlib
 import logging
 import os
-import urllib.parse
 from logging import LogRecord, getLogger
 from pathlib import Path
-from typing import Any, AsyncIterator, Awaitable, Callable, Literal, TypeVar, cast
+from typing import Any
 
-import fsspec  # type: ignore
-from aiohttp import web
-from fsspec.asyn import AsyncFileSystem  # type: ignore
-from fsspec.core import split_protocol  # type: ignore
-from pydantic_core import to_jsonable_python
-from s3fs import S3FileSystem  # type: ignore
+import uvicorn
+from fastapi import FastAPI, Request
+from fastapi.staticfiles import StaticFiles
 
 from inspect_ai._display import display
 from inspect_ai._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
-from inspect_ai._util.file import default_fs_options, filesystem, size_in_mb
-from inspect_ai.log._file import (
-    EvalLogInfo,
-    eval_log_json,
-    list_eval_logs,
-    log_files_from_ls,
-    read_eval_log_async,
-    read_eval_log_headers_async,
-)
-from inspect_ai.log._recorders.buffer.buffer import sample_buffer
 
-from .notify import view_last_eval_time
+from .routes import create_inspect_view_router
 
 logger = getLogger(__name__)
 
@@ -40,523 +24,79 @@ def view_server(
     authorization: str | None = None,
     fs_options: dict[str, Any] = {},
 ) -> None:
-    # route table
-    routes = web.RouteTableDef()
+    def auth_callback(request: Request) -> bool:
+        if not authorization:
+            return True
+        return request.headers.get("Authorization") == authorization
 
-    # get filesystem and resolve log_dir to full path
-    fs = filesystem(log_dir)
-    if not fs.exists(log_dir):
-        fs.mkdir(log_dir, True)
-    log_dir = fs.info(log_dir).name
+    app = FastAPI()
 
-    # validate log file requests (must be in the log_dir
-    # unless authorization has been provided)
-    def validate_log_file_request(log_file: str) -> None:
-        if not authorization and (not log_file.startswith(log_dir) or ".." in log_file):
-            raise web.HTTPUnauthorized()
+    router = create_inspect_view_router(
+        log_dir=log_dir,
+        recursive=recursive,
+        fs_options=fs_options,
+        auth_callback=auth_callback if authorization else None,
+    )
 
-    @routes.get("/api/logs/{log}")
-    async def api_log(request: web.Request) -> web.Response:
-        # log file requested
-        file = normalize_uri(request.match_info["log"])
-        validate_log_file_request(file)
+    app.include_router(router)
 
-        # header_only is based on a size threshold
-        header_only = request.query.get("header-only", None)
-        return await log_file_response(file, header_only)
+    www_path = os.path.abspath((Path(__file__).parent / "www" / "dist").as_posix())
+    app.mount("/", StaticFiles(directory=www_path, html=True), name="static")
 
-    @routes.get("/api/log-size/{log}")
-    async def api_log_size(request: web.Request) -> web.Response:
-        # log file requested
-        file = normalize_uri(request.match_info["log"])
-        validate_log_file_request(file)
+    filter_uvicorn_log()
 
-        return await log_size_response(file)
-
-    @routes.get("/api/log-delete/{log}")
-    async def api_log_delete(request: web.Request) -> web.Response:
-        # log file requested
-        file = normalize_uri(request.match_info["log"])
-        validate_log_file_request(file)
-
-        return await log_delete_response(file)
-
-    @routes.get("/api/log-bytes/{log}")
-    async def api_log_bytes(request: web.Request) -> web.Response:
-        # log file requested
-        file = normalize_uri(request.match_info["log"])
-        validate_log_file_request(file)
-
-        # header_only is based on a size threshold
-        start = request.query.get("start", None)
-        if start is None:
-            return web.HTTPBadRequest(reason="No 'start' query param.")
-        end = request.query.get("end", None)
-        if end is None:
-            return web.HTTPBadRequest(reason="No 'end' query param")
-
-        return await log_bytes_response(file, int(start), int(end))
-
-    @routes.get("/api/logs")
-    async def api_logs(request: web.Request) -> web.Response:
-        # log dir can optionally be overridden by the request
-        if authorization:
-            request_log_dir = request.query.getone("log_dir", None)
-            if request_log_dir:
-                request_log_dir = normalize_uri(request_log_dir)
-            else:
-                request_log_dir = log_dir
-        else:
-            request_log_dir = log_dir
-
-        # list logs
-        logs = await list_eval_logs_async(
-            log_dir=request_log_dir, recursive=recursive, fs_options=fs_options
-        )
-        return log_listing_response(logs, request_log_dir)
-
-    @routes.get("/api/log-headers")
-    async def api_log_headers(request: web.Request) -> web.Response:
-        files = request.query.getall("file", [])
-        files = [normalize_uri(file) for file in files]
-        map(validate_log_file_request, files)
-        return await log_headers_response(files)
-
-    @routes.get("/api/events")
-    async def api_events(request: web.Request) -> web.Response:
-        last_eval_time = request.query.get("last_eval_time", None)
-        actions = (
-            ["refresh-evals"]
-            if last_eval_time and view_last_eval_time() > int(last_eval_time)
-            else []
-        )
-        return web.json_response(actions)
-
-    @routes.get("/api/pending-samples")
-    async def api_pending_samples(request: web.Request) -> web.Response:
-        # log file requested
-        file = query_param_required("log", request, str)
-
-        file = urllib.parse.unquote(file)
-        validate_log_file_request(file)
-
-        # see if there is an etag
-        client_etag = request.headers.get("If-None-Match")
-
-        # get samples and respond
-        buffer = sample_buffer(file)
-        samples = buffer.get_samples(client_etag)
-        if samples == "NotModified":
-            return web.Response(status=304)
-        elif samples is None:
-            return web.Response(status=404)
-        else:
-            return web.Response(
-                body=samples.model_dump_json(), headers={"ETag": samples.etag}
-            )
-
-    @routes.get("/api/log-message")
-    async def api_log_message(request: web.Request) -> web.Response:
-        # log file requested
-        file = query_param_required("log_file", request, str)
-
-        file = urllib.parse.unquote(file)
-        validate_log_file_request(file)
-
-        # message to log
-        message = query_param_required("message", request, str)
-
-        # log the message
-        logger.warning(f"[CLIENT MESSAGE] ({file}): {message}")
-
-        # respond
-        return web.Response(status=204)
-
-    @routes.get("/api/pending-sample-data")
-    async def api_sample_events(request: web.Request) -> web.Response:
-        # log file requested
-        file = query_param_required("log", request, str)
-
-        file = urllib.parse.unquote(file)
-        validate_log_file_request(file)
-
-        # sample id information
-        id = query_param_required("id", request, str)
-        epoch = query_param_required("epoch", request, int)
-
-        # get sync info
-        after_event_id = query_param_optional("last-event-id", request, int)
-        after_attachment_id = query_param_optional("after-attachment-id", request, int)
-
-        # get samples and responsd
-        buffer = sample_buffer(file)
-        sample_data = buffer.get_sample_data(
-            id=id,
-            epoch=epoch,
-            after_event_id=after_event_id,
-            after_attachment_id=after_attachment_id,
-        )
-
-        # respond
-        if sample_data is None:
-            return web.Response(status=404)
-        else:
-            return web.Response(body=sample_data.model_dump_json())
-
-    # optional auth middleware
-    @web.middleware
-    async def authorize(
-        request: web.Request,
-        handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
-    ) -> web.StreamResponse:
-        if request.headers.get("Authorization", None) != authorization:
-            return web.HTTPUnauthorized()
-        else:
-            return await handler(request)
-
-    # setup server
-    app = web.Application(middlewares=[authorize] if authorization else [])
-    app.router.add_routes(routes)
-    app.router.register_resource(WWWResource())
-
-    # filter request log (remove /api/events)
-    filter_aiohttp_log()
-
-    # run app
     display().print(f"Inspect View: {log_dir}")
-    web.run_app(
-        app=app,
+    uvicorn.run(
+        app,
         host=host,
         port=port,
-        print=display().print,
-        access_log_format='%a %t "%r" %s %b (%Tf)',
-        shutdown_timeout=1,
+        log_config={
+            "version": 1,
+            "disable_existing_loggers": False,
+            "formatters": {
+                "default": {
+                    "()": "uvicorn.logging.DefaultFormatter",
+                    "fmt": "%(asctime)s %(levelname)s %(message)s",
+                    "use_colors": None,
+                },
+                "access": {
+                    "()": "uvicorn.logging.AccessFormatter",
+                    "fmt": '%(asctime)s %(levelname)s %(client_addr)s - "%(request_line)s" %(status_code)s',
+                },
+            },
+            "handlers": {
+                "default": {
+                    "formatter": "default",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                },
+                "access": {
+                    "formatter": "access",
+                    "class": "logging.StreamHandler",
+                    "stream": "ext://sys.stdout",
+                },
+            },
+            "loggers": {
+                "uvicorn": {"handlers": ["default"], "level": "INFO"},
+                "uvicorn.error": {"level": "INFO"},
+                "uvicorn.access": {
+                    "handlers": ["access"],
+                    "level": "INFO",
+                    "propagate": False,
+                },
+            },
+        },
     )
 
 
-def normalize_uri(uri: str) -> str:
-    """Normalize incoming URIs to a consistent format."""
-    # Decode any URL-encoded characters
-    parsed = urllib.parse.urlparse(urllib.parse.unquote(uri))
-
-    if parsed.scheme != "file":
-        # If this isn't a file uri, just unquote it
-        return urllib.parse.unquote(uri)
-
-    else:
-        # If this is a file uri, see whether we should process triple slashes
-        # down to double slashes
-        path = parsed.path
-
-        # Detect and normalize Windows-style file URIs
-        if path.startswith("/") and len(path) > 3 and path[2] == ":":
-            # Strip leading `/` before drive letter
-            path = path[1:]
-
-        return f"file://{path}"
-
-
-def log_listing_response(logs: list[EvalLogInfo], log_dir: str) -> web.Response:
-    response = dict(
-        log_dir=aliased_path(log_dir),
-        files=[
-            dict(
-                name=log.name,
-                size=log.size,
-                mtime=log.mtime,
-                task=log.task,
-                task_id=log.task_id,
-            )
-            for log in logs
-        ],
-    )
-    return web.json_response(response)
-
-
-async def log_file_response(file: str, header_only_param: str | None) -> web.Response:
-    # resolve header_only
-    header_only_mb = int(header_only_param) if header_only_param is not None else None
-    header_only = resolve_header_only(file, header_only_mb)
-
-    try:
-        contents: bytes | None = None
-        if header_only:
-            try:
-                log = await read_eval_log_async(file, header_only=True)
-                contents = eval_log_json(log)
-            except ValueError as ex:
-                logger.info(
-                    f"Unable to read headers from log file {file}: {ex}. "
-                    + "The file may include a NaN or Inf value. Falling back to reading entire file."
-                )
-
-        if contents is None:  # normal read
-            log = await read_eval_log_async(file, header_only=False)
-            contents = eval_log_json(log)
-
-        return web.Response(body=contents, content_type="application/json")
-
-    except Exception as error:
-        logger.exception(error)
-        return web.Response(status=500, reason="File not found")
-
-
-async def log_size_response(log_file: str) -> web.Response:
-    fs = filesystem(log_file)
-    if fs.is_async():
-        info = fs._file_info(await async_connection(log_file)._info(log_file))
-    else:
-        info = fs.info(log_file)
-    return web.json_response(info.size)
-
-
-async def log_delete_response(log_file: str) -> web.Response:
-    fs = filesystem(log_file)
-    fs.rm(log_file)
-    return web.json_response(True)
-
-
-async def log_bytes_response(log_file: str, start: int, end: int) -> web.Response:
-    # build headers
-    content_length = end - start + 1
-    headers = {
-        "Content-Type": "application/octet-stream",
-        "Content-Length": str(content_length),
-    }
-
-    # fetch bytes
-    fs = filesystem(log_file)
-    if fs.is_async():
-        bytes = await async_connection(log_file)._cat_file(
-            log_file, start=start, end=end + 1
-        )
-    else:
-        bytes = fs.read_bytes(log_file, start, end + 1)
-
-    # return response
-    return web.Response(status=200, body=bytes, headers=headers)
-
-
-async def log_headers_response(files: list[str]) -> web.Response:
-    headers = await read_eval_log_headers_async(files)
-    return web.json_response(to_jsonable_python(headers, exclude_none=True))
-
-
-class WWWResource(web.StaticResource):
-    def __init__(self) -> None:
-        super().__init__(
-            "", os.path.abspath((Path(__file__).parent / "www" / "dist").as_posix())
-        )
-
-    async def _handle(self, request: web.Request) -> web.StreamResponse:
-        # serve /index.html for /
-        filename = request.match_info["filename"]
-        if not filename:
-            request.match_info["filename"] = "index.html"
-
-        # call super
-        response = await super()._handle(request)
-
-        # disable caching as this is only ever served locally
-        # and w/ caching sometimes we get stale assets
-        response.headers.update(
-            {
-                "Expires": "Fri, 01 Jan 1990 00:00:00 GMT",
-                "Pragma": "no-cache",
-                "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-            }
-        )
-
-        # return response
-        return response
-
-
-def aliased_path(path: str) -> str:
-    home_dir = os.path.expanduser("~")
-    if path.startswith(home_dir):
-        return path.replace(home_dir, "~", 1)
-    else:
-        return path
-
-
-def resolve_header_only(path: str, header_only: int | None) -> bool:
-    # if there is a max_size passed, respect that and switch to
-    # header_only mode if the file is too large
-    if header_only == 0:
-        return True
-    if header_only is not None and size_in_mb(path) > int(header_only):
-        return True
-    else:
-        return False
-
-
-async def list_eval_logs_async(
-    log_dir: str = os.environ.get("INSPECT_LOG_DIR", "./logs"),
-    formats: list[Literal["eval", "json"]] | None = None,
-    recursive: bool = True,
-    descending: bool = True,
-    fs_options: dict[str, Any] = {},
-) -> list[EvalLogInfo]:
-    """List all eval logs in a directory.
-
-    Will be async for filesystem providers that support async (e.g. s3, gcs, etc.)
-    otherwise will fallback to sync implementation.
-
-    Args:
-      log_dir (str): Log directory (defaults to INSPECT_LOG_DIR)
-      formats (Literal["eval", "json"]): Formats to list (default
-        to listing all formats)
-      recursive (bool): List log files recursively (defaults to True).
-      descending (bool): List in descending order.
-      fs_options (dict[str, Any]): Optional. Additional arguments to pass through
-          to the filesystem provider (e.g. `S3FileSystem`).
-
-    Returns:
-       List of EvalLog Info.
-    """
-    # async filesystem if we can
-    fs = filesystem(log_dir, fs_options)
-    if fs.is_async():
-        async with async_fileystem(log_dir, fs_options=fs_options) as async_fs:
-            if await async_fs._exists(log_dir):
-                # prevent caching of listings
-                async_fs.invalidate_cache(log_dir)
-                # list logs
-                if recursive:
-                    files: list[dict[str, Any]] = []
-                    async for _, _, filenames in async_fs._walk(log_dir, detail=True):
-                        files.extend(filenames.values())
-                else:
-                    files = cast(
-                        list[dict[str, Any]],
-                        await async_fs._ls(log_dir, detail=True),
-                    )
-                logs = [fs._file_info(file) for file in files]
-                # resolve to eval logs
-                return log_files_from_ls(logs, formats, descending)
-            else:
-                return []
-    else:
-        return list_eval_logs(
-            log_dir=log_dir,
-            formats=formats,
-            recursive=recursive,
-            descending=descending,
-            fs_options=fs_options,
-        )
-
-
-def filter_aiohttp_log() -> None:
-    #  filter overly chatty /api/events messages
+def filter_uvicorn_log() -> None:
     class RequestFilter(logging.Filter):
         def filter(self, record: LogRecord) -> bool:
             return "/api/events" not in record.getMessage()
 
-    # don't add if we already have
-    access_logger = getLogger("aiohttp.access")
+    access_logger = getLogger("uvicorn.access")
     for existing_filter in access_logger.filters:
         if isinstance(existing_filter, RequestFilter):
             return
 
-    # add the filter
     access_logger.addFilter(RequestFilter())
-
-
-_async_connections: dict[str, AsyncFileSystem] = {}
-
-
-def async_connection(log_file: str) -> AsyncFileSystem:
-    # determine protocol
-    protocol, _ = split_protocol(log_file)
-    protocol = protocol or "file"
-
-    # create connection if required
-    if protocol not in _async_connections.keys():
-        _async_connections[protocol] = fsspec.filesystem(
-            protocol, asynchronous=True, loop=asyncio.get_event_loop()
-        )
-
-    # return async file-system
-    return _async_connections.get(protocol)
-
-
-@contextlib.asynccontextmanager
-async def async_fileystem(
-    location: str, fs_options: dict[str, Any] = {}
-) -> AsyncIterator[AsyncFileSystem]:
-    # determine protocol
-    protocol, _ = split_protocol(location)
-    protocol = protocol or "file"
-
-    # build options
-    options = default_fs_options(location)
-    options.update(fs_options)
-
-    if protocol == "s3":
-        options["skip_instance_cache"] = True
-        s3 = S3FileSystem(asynchronous=True, **options)
-        session = await s3.set_session()
-        try:
-            yield s3
-        finally:
-            await session.close()
-    else:
-        options.update({"asynchronous": True, "loop": asyncio.get_event_loop()})
-        yield fsspec.filesystem(protocol, **options)
-
-
-T = TypeVar("T")  # Define type variable
-
-
-def query_param_required(
-    key: str, request: web.Request, converter: Callable[[str], T]
-) -> T:
-    """
-    Generic parameter validation function.
-
-    Args:
-        key: Parameter key to look up
-        request: aiohttp Request object
-        converter: Function to convert the string parameter to type T
-
-    Returns:
-        Converted parameter value of type T
-
-    Raises:
-        HTTPBadRequest: If parameter is missing or invalid
-    """
-    value = request.query.get(key)
-    if value is None:
-        raise web.HTTPBadRequest(text=f"Missing parameter {key}")
-
-    try:
-        return converter(value)
-    except ValueError:
-        raise web.HTTPBadRequest(text=f"Invalid value {value} for {key}")
-
-
-def query_param_optional(
-    key: str, request: web.Request, converter: Callable[[str], T]
-) -> T | None:
-    """
-    Generic parameter validation function.
-
-    Args:
-        key: Parameter key to look up
-        request: aiohttp Request object
-        converter: Function to convert the string parameter to type T
-
-    Returns:
-        Converted parameter value of type T
-
-    Raises:
-        HTTPBadRequest: If parameter is missing or invalid
-    """
-    value = request.query.get(key)
-    if value is None:
-        return None
-
-    try:
-        return converter(value)
-    except ValueError:
-        raise web.HTTPBadRequest(text=f"Invalid value {value} for {key}")

--- a/src/inspect_ai/_view/utils.py
+++ b/src/inspect_ai/_view/utils.py
@@ -1,0 +1,234 @@
+import asyncio
+import contextlib
+import os
+import urllib.parse
+from logging import getLogger
+from typing import Any, AsyncIterator, Literal, cast
+
+import fsspec  # type: ignore
+from fastapi.responses import Response
+from fsspec.asyn import AsyncFileSystem  # type: ignore
+from fsspec.core import split_protocol  # type: ignore
+from pydantic_core import to_jsonable_python
+from s3fs import S3FileSystem  # type: ignore
+
+from inspect_ai._util.file import default_fs_options, filesystem, size_in_mb
+from inspect_ai.log._file import (
+    EvalLogInfo,
+    eval_log_json,
+    list_eval_logs,
+    log_files_from_ls,
+    read_eval_log_async,
+    read_eval_log_headers_async,
+)
+
+logger = getLogger(__name__)
+
+
+def normalize_uri(uri: str) -> str:
+    """Normalize incoming URIs to a consistent format."""
+    parsed = urllib.parse.urlparse(urllib.parse.unquote(uri))
+
+    if parsed.scheme != "file":
+        return urllib.parse.unquote(uri)
+    else:
+        path = parsed.path
+        if path.startswith("/") and len(path) > 3 and path[2] == ":":
+            path = path[1:]
+        return f"file://{path}"
+
+
+def log_listing_response(logs: list[EvalLogInfo], log_dir: str) -> dict[str, Any]:
+    response: dict[str, Any] = dict(
+        log_dir=aliased_path(log_dir),
+        files=[
+            dict(
+                name=log.name,
+                size=log.size,
+                mtime=log.mtime,
+                task=log.task,
+                task_id=log.task_id,
+            )
+            for log in logs
+        ],
+    )
+    return response
+
+
+async def log_file_response(file: str, header_only_param: str | None) -> Response:
+    header_only_mb = int(header_only_param) if header_only_param is not None else None
+    header_only = resolve_header_only(file, header_only_mb)
+
+    try:
+        contents: bytes | None = None
+        if header_only:
+            try:
+                log = await read_eval_log_async(file, header_only=True)
+                contents = eval_log_json(log)
+            except ValueError as ex:
+                logger.info(
+                    f"Unable to read headers from log file {file}: {ex}. "
+                    + "The file may include a NaN or Inf value. Falling back to reading entire file."
+                )
+
+        if contents is None:
+            log = await read_eval_log_async(file, header_only=False)
+            contents = eval_log_json(log)
+
+        return Response(content=contents, media_type="application/json")
+
+    except Exception as error:
+        logger.exception(error)
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=500, detail="File not found")
+
+
+async def log_size_response(log_file: str) -> int:
+    fs = filesystem(log_file)
+    if fs.is_async():
+        info = fs._file_info(await async_connection(log_file)._info(log_file))
+    else:
+        info = fs.info(log_file)
+    return info.size
+
+
+async def log_delete_response(log_file: str) -> bool:
+    fs = filesystem(log_file)
+    fs.rm(log_file)
+    return True
+
+
+async def log_bytes_response(log_file: str, start: int, end: int) -> Response:
+    content_length = end - start + 1
+    headers = {
+        "Content-Type": "application/octet-stream",
+        "Content-Length": str(content_length),
+    }
+
+    fs = filesystem(log_file)
+    if fs.is_async():
+        bytes_content = await async_connection(log_file)._cat_file(
+            log_file, start=start, end=end + 1
+        )
+    else:
+        bytes_content = fs.read_bytes(log_file, start, end + 1)
+
+    return Response(content=bytes_content, headers=headers)
+
+
+async def log_headers_response(files: list[str]) -> dict[str, Any]:
+    headers = await read_eval_log_headers_async(files)
+    return to_jsonable_python(headers, exclude_none=True)  # type: ignore[no-any-return]
+
+
+def aliased_path(path: str) -> str:
+    home_dir = os.path.expanduser("~")
+    if path.startswith(home_dir):
+        return path.replace(home_dir, "~", 1)
+    else:
+        return path
+
+
+def resolve_header_only(path: str, header_only: int | None) -> bool:
+    if header_only == 0:
+        return True
+    if header_only is not None and size_in_mb(path) > int(header_only):
+        return True
+    else:
+        return False
+
+
+async def list_eval_logs_async(
+    log_dir: str = os.environ.get("INSPECT_LOG_DIR", "./logs"),
+    formats: list[Literal["eval", "json"]] | None = None,
+    recursive: bool = True,
+    descending: bool = True,
+    fs_options: dict[str, Any] = {},
+) -> list[EvalLogInfo]:
+    """List all eval logs in a directory.
+
+    Will be async for filesystem providers that support async (e.g. s3, gcs, etc.)
+    otherwise will fallback to sync implementation.
+
+    Args:
+      log_dir (str): Log directory (defaults to INSPECT_LOG_DIR)
+      formats (Literal["eval", "json"]): Formats to list (default
+        to listing all formats)
+      recursive (bool): List log files recursively (defaults to True).
+      descending (bool): List in descending order.
+      fs_options (dict[str, Any]): Optional. Additional arguments to pass through
+          to the filesystem provider (e.g. `S3FileSystem`).
+
+    Returns:
+       List of EvalLog Info.
+    """
+    fs = filesystem(log_dir, fs_options)
+    if fs.is_async():
+        async with async_fileystem(log_dir, fs_options=fs_options) as async_fs:
+            if await async_fs._exists(log_dir):
+                async_fs.invalidate_cache(log_dir)
+                if recursive:
+                    files: list[dict[str, Any]] = []
+                    async for path, dirs, filenames in async_fs._walk(
+                        log_dir, detail=True
+                    ):
+                        if isinstance(filenames, dict):
+                            files.extend(filenames.values())
+                        else:
+                            files.extend(filenames)
+                else:
+                    files = cast(
+                        list[dict[str, Any]],
+                        await async_fs._ls(log_dir, detail=True),
+                    )
+                logs = [fs._file_info(file) for file in files]
+                return log_files_from_ls(logs, formats, descending)
+            else:
+                return []
+    else:
+        return list_eval_logs(
+            log_dir=log_dir,
+            formats=formats,
+            recursive=recursive,
+            descending=descending,
+            fs_options=fs_options,
+        )
+
+
+_async_connections: dict[str, AsyncFileSystem] = {}
+
+
+def async_connection(log_file: str) -> AsyncFileSystem:
+    protocol, _ = split_protocol(log_file)
+    protocol = protocol or "file"
+
+    if protocol not in _async_connections.keys():
+        _async_connections[protocol] = fsspec.filesystem(
+            protocol, asynchronous=True, loop=asyncio.get_event_loop()
+        )
+
+    return _async_connections[protocol]
+
+
+@contextlib.asynccontextmanager
+async def async_fileystem(
+    location: str, fs_options: dict[str, Any] = {}
+) -> AsyncIterator[AsyncFileSystem]:
+    protocol, _ = split_protocol(location)
+    protocol = protocol or "file"
+
+    options = default_fs_options(location)
+    options.update(fs_options)
+
+    if protocol == "s3":
+        options["skip_instance_cache"] = True
+        s3 = S3FileSystem(asynchronous=True, **options)
+        session = await s3.set_session()
+        try:
+            yield s3
+        finally:
+            await session.close()
+    else:
+        options.update({"asynchronous": True, "loop": asyncio.get_event_loop()})
+        yield fsspec.filesystem(protocol, **options)

--- a/uv.lock
+++ b/uv.lock
@@ -1052,6 +1052,20 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.116.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/d7/6c8b3bfe33eeffa208183ec037fee0cce9f7f024089ab1c5d12ef04bd27c/fastapi-0.116.1.tar.gz", hash = "sha256:ed52cbf946abfd70c5a0dccb24673f0670deeb517a88b3544d03c2a6bf283143", size = 296485, upload-time = "2025-07-11T16:22:32.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/47/d63c60f59a59467fda0f93f46335c9d18526d7071f025cb5b89d5353ea42/fastapi-0.116.1-py3-none-any.whl", hash = "sha256:c46ac7c312df840f0c9e220f7964bada936781bc4e2e6eb71f1c4d7553786565", size = 95631, upload-time = "2025-07-11T16:22:30.485Z" },
+]
+
+[[package]]
 name = "fastjsonschema"
 version = "2.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1539,6 +1553,7 @@ dependencies = [
     { name = "debugpy" },
     { name = "docstring-parser" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "fastapi" },
     { name = "fsspec" },
     { name = "httpx" },
     { name = "ijson" },
@@ -1563,6 +1578,7 @@ dependencies = [
     { name = "tenacity" },
     { name = "textual" },
     { name = "typing-extensions" },
+    { name = "uvicorn" },
     { name = "zipp" },
 ]
 
@@ -1649,6 +1665,7 @@ requires-dist = [
     { name = "debugpy" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.2" },
+    { name = "fastapi", specifier = "==0.116.1" },
     { name = "fsspec", specifier = ">=2023.1.0,<=2025.3.0" },
     { name = "google-genai", marker = "extra == 'dev'" },
     { name = "griffe", marker = "extra == 'dev'" },
@@ -1724,6 +1741,7 @@ requires-dist = [
     { name = "types-python-dateutil", marker = "extra == 'dev'" },
     { name = "types-pyyaml", marker = "extra == 'dev'" },
     { name = "typing-extensions", specifier = ">=4.9.0" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
     { name = "zipp", specifier = ">=3.19.1" },
 ]
 provides-extras = ["dev", "dev-mcp-tests", "doc", "dist"]


### PR DESCRIPTION
(Previous discussion can be found in https://github.com/UKGovernmentBEIS/inspect_ai/pull/2342)

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

View API routes are not reusable in other applications and use aiohttp.

### What is the new behavior?

Creating a FastAPI APIRouter to make the API routes reusable and able to be added to existing FastAPI servers.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No behavior should change.

### Other information:

Is there some namespace we can export it from that isn't private-looking like `_view`?

#### Example usage

```py
from fastapi import FastAPI

from inspect_ai._view.routes import create_inspect_view_router

# Example: Using the inspect view routes in another FastAPI app


def create_custom_app_with_inspect_view(log_dir: str = "./logs") -> FastAPI:
    app = FastAPI(title="Custom App with Inspect View")

    # Add your custom routes here
    @app.get("/health")
    async def health_check():
        return {"status": "healthy"}

    # Custom authentication example
    def custom_auth_callback(request):
        # Example: Check for API key in headers
        api_key = request.headers.get("X-API-Key")
        return api_key == "your-secret-key"  # Replace with real auth logic

    # Include the inspect view router with custom auth
    inspect_router = create_inspect_view_router(
        log_dir=log_dir,
        auth_callback=custom_auth_callback,  # Optional custom auth
    )
    app.include_router(inspect_router)

    # Add more custom routes after
    @app.get("/custom-endpoint")
    async def custom_endpoint():
        return {"message": "This is a custom endpoint"}

    return app


# Example usage:
if __name__ == "__main__":
    import uvicorn

    app = create_custom_app_with_inspect_view()
    uvicorn.run(app, host="0.0.0.0", port=8000)
```