### PR TITLE
Remove sample list from DOM when showing sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - ReAct Agent: Add submit tool content to assistant message (in addition to setting the `completion`).
 - Metrics: Compute metrics when an empty list of reducers is provided (do not reduce the scores before computing metrics). Add `--no-epochs-reducer` CLI flag for specifying no reducers.
 - Inspect View: Add support for filtering sample transcripts by event types. Be default, filter out `sample_init`, `sandbox`, `store`, and `state` events.
+- Inspect View: Remove sample list / title content when sample is displaying (prevents find from matching content behind the sample detail).
 - Bugfix: Fix error in reducing scores when all scores for a sample are NaN.
 
 

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -14352,7 +14352,7 @@ a:hover {
 }
 
 .modal {
-  --bs-modal-margin: 0.5rem;
+  --bs-modal-margin: 0.25rem;
 }
 
 .modal-backdrop {
@@ -20286,11 +20286,11 @@ span.ap-marker-container:hover span.ap-marker {
   height: 100%;
   position: relative;
 }
-._title_yj2nt_1 {
+._title_1hch3_1 {
   flex: 1 1 auto;
 }
 
-._detail_yj2nt_5 {
+._detail_1hch3_5 {
   margin-left: auto;
   margin-right: auto;
   display: flex;
@@ -20298,12 +20298,12 @@ span.ap-marker-container:hover span.ap-marker {
   justify-content: center;
 }
 
-._detailText_yj2nt_13 {
+._detailText_1hch3_13 {
   display: flex;
   align-items: center;
 }
 
-._close_yj2nt_18 {
+._close_1hch3_18 {
   border-width: 0px;
   font-weight: 300;
   padding: 0em 0.5em;
@@ -20311,31 +20311,32 @@ span.ap-marker-container:hover span.ap-marker {
   text-align: right;
 }
 
-._modal_yj2nt_26 {
+._modal_1hch3_26 {
   border-radius: var(--bs-border-radius);
   display: block;
 }
 
-._hidden_yj2nt_31 {
+._hidden_1hch3_31 {
   display: none;
 }
 
-._modalBody_yj2nt_35 {
+._modalBody_1hch3_35 {
   max-width: 100%;
   margin-left: var(--bs-modal-margin);
   margin-right: var(--bs-modal-margin);
 }
 
-._content_yj2nt_41 {
+._content_1hch3_41 {
   height: 100%;
 }
 
-._header_yj2nt_45 {
+._header_1hch3_45 {
   padding: 0 0 0 1em;
   display: flex;
+  background-color: var(--bs-light);
 }
 
-._titleTool_yj2nt_50 {
+._titleTool_1hch3_51 {
   padding-top: 0;
   padding-bottom: 0;
   border: none;

--- a/src/inspect_ai/_view/www/src/app/App.css
+++ b/src/inspect_ai/_view/www/src/app/App.css
@@ -65,7 +65,7 @@ a:hover {
 }
 
 .modal {
-  --bs-modal-margin: 0.5rem;
+  --bs-modal-margin: 0.25rem;
 }
 
 .modal-backdrop {

--- a/src/inspect_ai/_view/www/src/app/log-view/tabs/SamplesTab.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-view/tabs/SamplesTab.tsx
@@ -210,7 +210,7 @@ export const SamplesTab: FC<SamplesTabProps> = ({ running }) => {
         {samplesDescriptor && totalSampleCount === 1 ? (
           <InlineSampleDisplay />
         ) : undefined}
-        {samplesDescriptor && totalSampleCount > 1 ? (
+        {samplesDescriptor && totalSampleCount > 1 && !showingSampleDialog ? (
           <SampleList
             listHandle={sampleListHandle}
             items={items}

--- a/src/inspect_ai/_view/www/src/app/log-view/title-view/TitleView.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-view/title-view/TitleView.tsx
@@ -9,6 +9,7 @@ import {
 } from "../../../@types/log";
 import { RunningMetric } from "../../../client/api/types";
 import { useTotalSampleCount } from "../../../state/hooks";
+import { useStore } from "../../../state/store";
 import { PrimaryBar } from "./PrimaryBar";
 import { SecondaryBar } from "./SecondaryBar";
 import styles from "./TitleView.module.css";
@@ -34,6 +35,11 @@ export const TitleView: FC<TitleViewProps> = ({
   runningMetrics,
 }) => {
   const totalSampleCount = useTotalSampleCount();
+  const showingSampleDialog = useStore((state) => state.app.dialogs.sample);
+  if (showingSampleDialog) {
+    return null;
+  }
+
   return (
     <nav className={clsx("navbar", "sticky-top", styles.navbarWrapper)}>
       <PrimaryBar

--- a/src/inspect_ai/_view/www/src/components/LargeModal.module.css
+++ b/src/inspect_ai/_view/www/src/components/LargeModal.module.css
@@ -45,6 +45,7 @@
 .header {
   padding: 0 0 0 1em;
   display: flex;
+  background-color: var(--bs-light);
 }
 
 .titleTool {


### PR DESCRIPTION
Find will match contents not visible in the sample detail since they are in the DOM behind the sample dialog. Instead, when the sample dialog is shown, remove such content.

Fixes #2307

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
