### PR TITLE
Fix event filtering error when restoring from the background in vscode

### DIFF
--- a/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptFilter.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptFilter.tsx
@@ -27,6 +27,8 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
     arrangedEventTypes,
   } = useTranscriptFilter();
 
+  console.log("filtered", filtered);
+
   return (
     <PopOver
       id={`transcript-filter-popover`}
@@ -65,12 +67,12 @@ export const TranscriptFilterPopover: FC<TranscriptFilterProps> = ({
               key={eventType}
               className={clsx(styles.row)}
               onClick={() => {
-                filterEventType(eventType, filtered.has(eventType));
+                filterEventType(eventType, filtered.includes(eventType));
               }}
             >
               <input
                 type="checkbox"
-                checked={!filtered.has(eventType)}
+                checked={!filtered.includes(eventType)}
                 onChange={(e) => {
                   filterEventType(eventType, e.target.checked);
                 }}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptPanel.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/TranscriptPanel.tsx
@@ -33,11 +33,11 @@ export const TranscriptPanel: FC<TranscriptPanelProps> = memo((props) => {
 
   // Apply the filter
   const filteredEvents = useMemo(() => {
-    if (filteredEventTypes.size === 0) {
+    if (filteredEventTypes.length === 0) {
       return events;
     }
     return events.filter((event) => {
-      return !filteredEventTypes.has(event.event);
+      return !filteredEventTypes.includes(event.event);
     });
   }, [events, filteredEventTypes]);
 

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/hooks.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/hooks.ts
@@ -15,7 +15,7 @@ import {
   Event8,
   Event9,
 } from "../../../@types/log";
-import { kDefaultExcludeSet } from "../../../state/sampleSlice";
+import { kDefaultExcludeEvents } from "../../../state/sampleSlice";
 import { useStore } from "../../../state/store";
 
 export type AllEventTypes =
@@ -65,28 +65,28 @@ export const useTranscriptFilter = () => {
       } else {
         newFiltered.add(type);
       }
-      setFilteredEventTypes(newFiltered);
+      setFilteredEventTypes(Array.from(newFiltered));
     },
     [filtered],
   );
 
   const setDebugFilter = useCallback(() => {
-    setFilteredEventTypes(new Set<string>());
+    setFilteredEventTypes([]);
   }, [setFilteredEventTypes]);
 
   const setDefaultFilter = useCallback(() => {
-    setFilteredEventTypes(new Set(kDefaultExcludeSet));
+    setFilteredEventTypes([...kDefaultExcludeEvents]);
   }, [setFilteredEventTypes]);
 
   const isDefaultFilter = useMemo(() => {
     return (
-      filtered.size === kDefaultExcludeSet.size &&
-      [...filtered].every((type) => kDefaultExcludeSet.has(type))
+      filtered.length === kDefaultExcludeEvents.length &&
+      [...filtered].every((type) => kDefaultExcludeEvents.includes(type))
     );
   }, [filtered]);
 
   const isDebugFilter = useMemo(() => {
-    return filtered.size === 0;
+    return filtered.length === 0;
   }, [filtered]);
 
   const arrangedEventTypes = useCallback((columns: number = 1) => {
@@ -94,8 +94,8 @@ export const useTranscriptFilter = () => {
 
     // Sort keys alphabetically with default disabled keys at the end
     const sortedKeys = keys.sort((a, b) => {
-      const aIsDefault = kDefaultExcludeSet.has(a);
-      const bIsDefault = kDefaultExcludeSet.has(b);
+      const aIsDefault = kDefaultExcludeEvents.includes(a);
+      const bIsDefault = kDefaultExcludeEvents.includes(b);
 
       // If one is in default exclude set and the other isn't, default goes to end
       if (aIsDefault && !bIsDefault) return 1;

--- a/src/inspect_ai/_view/www/src/app/types.ts
+++ b/src/inspect_ai/_view/www/src/app/types.ts
@@ -109,7 +109,7 @@ export type SampleIdentifier = {
 };
 
 export interface EventFilter {
-  filteredTypes: Set<string>;
+  filteredTypes: string[];
 }
 
 export interface SampleState {

--- a/src/inspect_ai/_view/www/src/state/sampleSlice.ts
+++ b/src/inspect_ai/_view/www/src/state/sampleSlice.ts
@@ -15,12 +15,12 @@ let selectedSampleRef: { current: EvalSample | undefined } = {
   current: undefined,
 };
 
-export const kDefaultExcludeSet = new Set([
+export const kDefaultExcludeEvents = [
   "sample_init",
   "sandbox",
   "state",
   "store",
-]);
+];
 
 export interface SampleSlice {
   sample: SampleState;
@@ -44,7 +44,7 @@ export interface SampleSlice {
     collapseId: (key: string, id: string, collapsed: boolean) => void;
     clearCollapsedIds: (key: string) => void;
 
-    setFilteredEventTypes: (types: Set<string>) => void;
+    setFilteredEventTypes: (types: string[]) => void;
 
     setVisiblePopover: (id: string) => void;
     clearVisiblePopover: () => void;
@@ -84,7 +84,7 @@ const initialState: SampleState = {
   runningEvents: [],
   collapsedEvents: null,
   eventFilter: {
-    filteredTypes: new Set<string>(kDefaultExcludeSet),
+    filteredTypes: [...kDefaultExcludeEvents],
   },
 
   collapsedIdBuckets: {},
@@ -211,7 +211,7 @@ export const createSampleSlice = (
           delete state.sample.collapsedIdBuckets[key];
         });
       },
-      setFilteredEventTypes: (types: Set<string>) => {
+      setFilteredEventTypes: (types: string[]) => {
         set((state) => {
           state.sample.eventFilter.filteredTypes = types;
         });


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Restoring the viewer from the backgrounding vscode will result in an error.

### What is the new behavior?

There is no error

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
