### PR TITLE
Fix ContentDocument typo in documentation.

### DIFF
--- a/docs/multimodal.qmd
+++ b/docs/multimodal.qmd
@@ -191,7 +191,7 @@ If you are constructing chat messages programmatically, then the equivalent to t
 input = [
     ChatMessageUser(content=[
          ContentText(text="Please describe the contents of the attached PDF."),
-        ContentDocument(video="attention.pdf")
+        ContentDocument(document="attention.pdf")
     ])
 ]
 ```


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Very small fix. There was just a typo in the documentation about how to use ContentDocument.
