### PR TITLE
agent bridge: respect reference vs. value semantics of agent caller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased 
 
 - Agent Bridge: Correctly dispatch LimitExceededError which occurs during proxied model calls.
+- Agent Bridge: Respect reference vs. value semantics of agent caller (enables preservation of messages when agent is run via `as_solver()`).
 - Mistral: Support for updated use of `ThinkChunk` types in mistralai v1.9.10.
 - Scoring: Use fallback unicode numeric string parser when default `str_to_float()` fails.
 

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -71,7 +71,7 @@ async def agent_bridge(
     web_search = resolve_web_search_providers(web_search)
 
     # create a state value that will be used to track mesages going over the bridge
-    state = AgentState(messages=state.messages.copy() if state else [])
+    state = state or AgentState(messages=[])
 
     # create the bridge
     bridge = AgentBridge(state)

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -72,7 +72,7 @@ async def sandbox_agent_bridge(
     web_search = web_search or internal_web_search_providers()
 
     # create a state value that will be used to track mesages going over the bridge
-    state = AgentState(messages=state.messages.copy() if state else [])
+    state = state or AgentState(messages=[])
 
     try:
         async with anyio.create_task_group() as tg:


### PR DESCRIPTION
enables preservation of messages when agent is run via `as_solver()`

