### PR TITLE
feat(hooks): add eval-set start hook

### DIFF
--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -49,6 +49,8 @@ from .task import Epochs
 from .task.resolved import ResolvedTask
 from .task.task import PreviousTask
 from .task.tasks import Tasks
+from inspect_ai.hooks._hooks import emit_eval_set_start
+import anyio
 
 logger = logging.getLogger(__name__)
 
@@ -288,6 +290,8 @@ def eval_set(
     # ensure log_dir
     fs = filesystem(log_dir)
     fs.mkdir(log_dir, exist_ok=True)
+
+    anyio.run(emit_eval_set_start, log_dir)
 
     # resolve some parameters
     retry_connections = retry_connections or 1.0

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -17,6 +17,13 @@ from inspect_ai.model._model_output import ModelUsage
 
 logger = getLogger(__name__)
 
+@dataclass(frozen=True)
+class EvalSetStart:
+    """Eval-set start hook event data."""
+
+    log_dir: str
+    """The log dir to which eval-set logs will be written"""
+
 
 @dataclass(frozen=True)
 class RunStart:
@@ -139,6 +146,17 @@ class Hooks:
         expensive.
         """
         return True
+
+    async def on_eval_set_start(self, data: EvalSetStart) -> None:
+        """On eval-set start
+
+        An eval-set is a single invocation of `eval_set()`, which will run an eval
+        with automated retries in a variety of failure cases
+
+        Args:
+            data: Eval-set start data
+        """
+        pass
 
     async def on_run_start(self, data: RunStart) -> None:
         """On run start.
@@ -264,6 +282,10 @@ def hooks(name: str, description: str) -> Callable[..., Type[T]]:
         return hook_type
 
     return wrapper
+
+async def emit_eval_set_start(log_dir: str) -> None:
+    data = EvalSetStart(log_dir=log_dir)
+    await _emit_to_all(lambda hook: hook.on_eval_set_start(data))
 
 
 async def emit_run_start(run_id: str, tasks: list[ResolvedTask]) -> None:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Right now, it's near impossible to tell from the data passed to the hooks whether the Inspect run is eval-set or eval. This makes it hard during a eval-set run to group statistics across the entire eval-set via the hooks, particularly in failure cases. For example, for eval-set, we'd like to know the log dir in the hooks because this allows us to gracefully handle error cases where the eval-set is cancelled and rerun.

### What is the new behavior?

This PR solves both problems by adding a new hook that runs on eval set start, and passes the log_dir to the hooks. If the hook isn't called, it's not an eval set run.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:

I think it's plausible that other data might be interesting to pass to this hook, but log dir seems sufficient for now.
