### PR TITLE
feat: support for reasoning_effort with groq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Agent Bridge: Correctly dispatch LimitExceededError which occurs during proxied model calls.
 - Agent Bridge: Respect reference vs. value semantics of agent caller (enables preservation of messages when agent is run via `as_solver()`).
 - Mistral: Support for updated use of `ThinkChunk` types in mistralai v1.9.10.
+- Groq: Support for `--reasoning-effort` parameter (works w/ gpt-oss models).
 - Scoring: Use fallback unicode numeric string parser when default `str_to_float()` fails.
 
 ## 0.3.127 (01 September 2025)

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -202,6 +202,8 @@ class GroqAPI(ModelAPI):
             params["seed"] = config.seed
         if config.num_choices is not None:
             params["n"] = config.num_choices
+        if config.reasoning_effort is not None:
+            params["reasoning_effort"] = config.reasoning_effort
         if config.response_schema is not None:
             params["response_format"] = dict(
                 type="json_schema",


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Models provided by Groq ignore the --reasoning-effort flag.

### What is the new behavior?
reasoning_effort for supported Groq models (groq/openai/gpt-oss-20b and groq/openai/gpt-oss-120b) can now be specified with the --reasoning-effort flag. Groq models that do not support reasoning_effort, yet provided with the --reasoning-effort flag, will simply throw a 400 error.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
