### PR TITLE
Update OpenAI SDK and work around "find_in_page" breaking change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Agent Bridge: Respect reference vs. value semantics of agent caller (enables preservation of messages when agent is run via `as_solver()`).
 - Mistral: Support for updated use of `ThinkChunk` types in mistralai v1.9.10.
 - Scoring: Use fallback unicode numeric string parser when default `str_to_float()` fails.
+- Bugfix: Work around OpenAI breaking change that renamed "find" web search action to "find_in_page".
 
 ## 0.3.127 (01 September 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Agent Bridge: Respect reference vs. value semantics of agent caller (enables preservation of messages when agent is run via `as_solver()`).
 - Mistral: Support for updated use of `ThinkChunk` types in mistralai v1.9.10.
 - Scoring: Use fallback unicode numeric string parser when default `str_to_float()` fails.
-- Bugfix: Work around OpenAI breaking change that renamed "find" web search action to "find_in_page".
+- Bugfix: Work around OpenAI breaking change that renamed "find" web search action to "find_in_page" (bump required version of `openai` package to v1.104.0).
 
 ## 0.3.127 (01 September 2025)
 

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -458,6 +458,11 @@ def messages_from_responses_input(
                 elif is_response_reasoning_item(param):
                     content.append(reasoning_from_responses_reasoning(param))
                 elif is_response_web_search_call(param):
+                    # Workaround for OpenAI server implementation change
+                    # https://github.com/openai/openai-java/issues/526
+                    action = param["action"]
+                    if action["type"] == "find_in_page":  # type: ignore[comparison-overlap]
+                        action["type"] = "find"
                     web_search = ResponseFunctionWebSearch.model_validate(param)
                     content.append(web_search_to_tool_use(web_search))
                 elif is_response_mcp_list_tools(param):

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -249,7 +249,7 @@ def openai_responses_tool_choice(
                 and any(tool["type"] == "computer_use_preview" for tool in tools)
                 else ToolChoiceTypesParam(type="web_search_preview")
                 if tool_choice.name == "web_search"
-                and any(tool["type"] == "web_search_preview" for tool in tools)
+                and any(tool["type"] == "web_search" for tool in tools)
                 else ToolChoiceFunctionParam(type="function", name=tool_choice.name)
             )
 
@@ -996,10 +996,7 @@ def is_function_tool_param(tool_param: ToolParam) -> TypeGuard[FunctionToolParam
 
 
 def is_web_search_tool_param(tool_param: ToolParam) -> TypeGuard[WebSearchToolParam]:
-    return tool_param.get("type") in [
-        "web_search_preview",
-        "web_search_preview_2025_03_11",
-    ]
+    return tool_param.get("type") in ["web_search", "web_search_2025_08_26"]
 
 
 def is_mcp_tool_param(tool_param: ToolParam) -> TypeGuard[Mcp]:

--- a/src/inspect_ai/model/_providers/_openai_web_search.py
+++ b/src/inspect_ai/model/_providers/_openai_web_search.py
@@ -28,11 +28,9 @@ def _web_search_tool(maybe_openai_options: object) -> WebSearchToolParam:
             f"Expected a dictionary for openai_options, got {type(maybe_openai_options)}"
         )
     openai_options = (
-        WebSearchTool.model_validate(
-            {"type": "web_search_preview", **maybe_openai_options}
-        )
+        WebSearchTool.model_validate({"type": "web_search", **maybe_openai_options})
         if maybe_openai_options
-        else WebSearchTool(type="web_search_preview")
+        else WebSearchTool(type="web_search")
     )
 
     return cast(WebSearchToolParam, openai_options.model_dump(exclude_none=True))

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -310,7 +310,7 @@ def goodfire() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "1.103.0"
+    MIN_VERSION = "1.104.0"
 
     # verify we have the package
     try:

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -310,7 +310,7 @@ def goodfire() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "1.99.7"
+    MIN_VERSION = "1.103.0"
 
     # verify we have the package
     try:

--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -153,7 +153,7 @@ def responses_web_search_agent() -> Agent:
                 model="inspect",
                 tools=[
                     {
-                        "type": "web_search_preview",
+                        "type": "web_search",
                         "search_context_size": "low",
                     }
                 ],

--- a/tests/model/providers/test_openai_web_search.py
+++ b/tests/model/providers/test_openai_web_search.py
@@ -57,7 +57,7 @@ class TestOpenAIWebSearch:
                 description="A web search tool",
                 options={"openai": {"key": "value"}},
             ),
-        ) == {"type": "web_search_preview", "key": "value"}
+        ) == {"type": "web_search", "key": "value"}
 
     def test_web_search_tool_raises_type_error(self):
         with pytest.raises(TypeError) as excinfo:
@@ -73,24 +73,22 @@ class TestOpenAIWebSearch:
         ) as mock_validate:
             mock_tool = MagicMock()
             mock_tool.model_dump.return_value = {
-                "type": "web_search_preview",
+                "type": "web_search",
                 **options,
             }
             mock_validate.return_value = mock_tool
 
             result = _web_search_tool(options)
 
-            mock_validate.assert_called_once_with(
-                {"type": "web_search_preview", **options}
-            )
+            mock_validate.assert_called_once_with({"type": "web_search", **options})
             assert result == {
-                "type": "web_search_preview",
+                "type": "web_search",
                 "key1": "value1",
                 "key2": "value2",
             }
 
     def test_web_search_tool_with_empty_options(self):
-        assert _web_search_tool({}) == {"type": "web_search_preview"}
+        assert _web_search_tool({}) == {"type": "web_search"}
 
     def test_web_search_tool_with_none(self):
-        assert _web_search_tool(None) == {"type": "web_search_preview"}
+        assert _web_search_tool(None) == {"type": "web_search"}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

OpenAI deployed a breaking change by changing `.action.type == "find"` to `.action.type == "find_in_page"`. They did not, however, update their client SDK to match that server change.

### What is the new behavior?

Conformed to the change.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
