### PR TITLE
Support viewing single files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - OpenAI Compatible: Add support for using Responses API via `responses_api` model arg.
 - Eval Set: Add `eval_set_id` to log file (unique id for eval set across invocations for the same `log_dir`).
 - Hooks: New `EvalSetStart` and `EvalSetEnd` hook methods.
-- `inspect score` supports streaming using the `--stream` argument.
+- Scoring: `inspect score` now supports streaming via the `--stream` argument.
 - Inspect View: Starting the view server with a path to a specific log file will automatically open that log file (if it exists) rather than showing the log list.
 - Bugfix: Ensure ETags always match content when reading S3 logs to prevent write conflicts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Inspect View: Starting the view server with a path to a specific log file will automatically open that log file (if it exists) rather than showing the log list.
+
 ## 0.3.128 (02 September 2025)
 
 - Agent Bridge: Correctly dispatch LimitExceededError which occurs during proxied model calls.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,8 @@
 - OpenAI Compatible: Add support for using Responses API via `responses_api` model arg.
 - Eval Set: Add `eval_set_id` to log file (unique id for eval set across invocations for the same `log_dir`).
 - Hooks: New `EvalSetStart` and `EvalSetEnd` hook methods.
-- Bugfix: Ensure ETags always match content when reading S3 logs to prevent write conflicts.
 - Inspect View: Starting the view server with a path to a specific log file will automatically open that log file (if it exists) rather than showing the log list.
-
+- Bugfix: Ensure ETags always match content when reading S3 logs to prevent write conflicts.
 
 ## 0.3.129 (03 September 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - OpenAI Compatible: Add support for using Responses API via `responses_api` model arg.
 - Eval Set: Add `eval_set_id` to log file (unique id for eval set across invocations for the same `log_dir`).
 - Hooks: New `EvalSetStart` and `EvalSetEnd` hook methods.
+- `inspect score` supports streaming using the `--stream` argument.
 - Inspect View: Starting the view server with a path to a specific log file will automatically open that log file (if it exists) rather than showing the log list.
 - Bugfix: Ensure ETags always match content when reading S3 logs to prevent write conflicts.
 

--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -17,7 +17,6 @@ from s3fs import S3FileSystem  # type: ignore
 from inspect_ai._display import display
 from inspect_ai._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
 from inspect_ai._util.file import (
-    basename,
     default_fs_options,
     dirname,
     filesystem,

--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -120,11 +120,11 @@ def view_server(
         # if the log_dir contains the path to a specific file
         # then just return that file
         if is_log_file(request_log_dir, [".json"]):
-            file_name = basename(request_log_dir)
-            request_log_dir = dirname(request_log_dir)
-            file_info = await eval_log_info_async(request_log_dir, file_name)
+            file_info = await eval_log_info_async(request_log_dir)
             if file_info is not None:
-                return log_listing_response(logs=[file_info], log_dir=request_log_dir)
+                return log_listing_response(
+                    logs=[file_info], log_dir=dirname(request_log_dir)
+                )
             else:
                 return web.Response(status=404, reason="File not found")
 
@@ -410,24 +410,21 @@ def resolve_header_only(path: str, header_only: int | None) -> bool:
 
 
 async def eval_log_info_async(
-    log_dir: str,
     log_file: str,
     fs_options: dict[str, Any] = {},
 ) -> EvalLogInfo | None:
     """Get EvalLogInfo for a specific log file asynchronously.
 
     Args:
-        log_dir (str): The log directory
-        log_file (str): The log file name
+        log_file (str): The complete path to the log file
         fs_options (dict[str, Any]): Optional. Additional arguments to pass through
 
     Returns:
         EvalLogInfo or None: The EvalLogInfo object if the file exists and is valid, otherwise None.
     """
-    file_path = os.path.join(log_dir, log_file)
-    fs = filesystem(log_dir, fs_options)
-    if fs.exists(file_path):
-        info = fs.info(file_path)
+    fs = filesystem(log_file, fs_options)
+    if fs.exists(log_file):
+        info = fs.info(log_file)
         return log_file_info(info)
     else:
         return None

--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -16,11 +16,19 @@ from s3fs import S3FileSystem  # type: ignore
 
 from inspect_ai._display import display
 from inspect_ai._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
-from inspect_ai._util.file import default_fs_options, filesystem, size_in_mb
+from inspect_ai._util.file import (
+    basename,
+    default_fs_options,
+    dirname,
+    filesystem,
+    size_in_mb,
+)
 from inspect_ai.log._file import (
     EvalLogInfo,
     eval_log_json,
+    is_log_file,
     list_eval_logs,
+    log_file_info,
     log_files_from_ls,
     read_eval_log_async,
     read_eval_log_headers_async,
@@ -108,6 +116,17 @@ def view_server(
                 request_log_dir = log_dir
         else:
             request_log_dir = log_dir
+
+        # if the log_dir contains the path to a specific file
+        # then just return that file
+        if is_log_file(request_log_dir, [".json"]):
+            file_name = basename(request_log_dir)
+            request_log_dir = dirname(request_log_dir)
+            file_info = await eval_log_info_async(request_log_dir, file_name)
+            if file_info is not None:
+                return log_listing_response(logs=[file_info], log_dir=request_log_dir)
+            else:
+                return web.Response(status=404, reason="File not found")
 
         # list logs
         logs = await list_eval_logs_async(
@@ -388,6 +407,30 @@ def resolve_header_only(path: str, header_only: int | None) -> bool:
         return True
     else:
         return False
+
+
+async def eval_log_info_async(
+    log_dir: str,
+    log_file: str,
+    fs_options: dict[str, Any] = {},
+) -> EvalLogInfo | None:
+    """Get EvalLogInfo for a specific log file asynchronously.
+
+    Args:
+        log_dir (str): The log directory
+        log_file (str): The log file name
+        fs_options (dict[str, Any]): Optional. Additional arguments to pass through
+
+    Returns:
+        EvalLogInfo or None: The EvalLogInfo object if the file exists and is valid, otherwise None.
+    """
+    file_path = os.path.join(log_dir, log_file)
+    fs = filesystem(log_dir, fs_options)
+    if fs.exists(file_path):
+        info = fs.info(file_path)
+        return log_file_info(info)
+    else:
+        return None
 
 
 async def list_eval_logs_async(

--- a/src/inspect_ai/_view/www/src/app/log-list/LogsPanel.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/LogsPanel.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import { FC, useEffect, useMemo, useRef } from "react";
 
+import { useNavigate } from "react-router-dom";
 import { ProgressBar } from "../../components/ProgressBar";
 import { useClientEvents } from "../../state/clientEvents";
 import { useDocumentTitle, useLogs } from "../../state/hooks";
@@ -27,9 +28,11 @@ const rootName = (relativePath: string) => {
 export const kLogsPaginationId = "logs-list-pagination";
 export const kDefaultPageSize = 30;
 
-interface LogsPanelProps {}
+interface LogsPanelProps {
+  maybeShowSingleLog?: boolean;
+}
 
-export const LogsPanel: FC<LogsPanelProps> = () => {
+export const LogsPanel: FC<LogsPanelProps> = ({ maybeShowSingleLog }) => {
   // Get the logs from the store
   const loading = useStore((state) => state.app.status.loading);
 
@@ -38,6 +41,7 @@ export const LogsPanel: FC<LogsPanelProps> = () => {
   const logHeaders = useStore((state) => state.logs.logOverviews);
   const headersLoading = useStore((state) => state.logs.logOverviewsLoading);
   const watchedLogs = useStore((state) => state.logs.listing.watchedLogs);
+  const navigate = useNavigate();
 
   // Unload the load when this is mounted. This prevents the old log
   // data from being displayed when navigating back to the logs panel
@@ -162,6 +166,13 @@ export const LogsPanel: FC<LogsPanelProps> = () => {
     };
     exec();
   }, [loadLogs]);
+
+  useEffect(() => {
+    if (maybeShowSingleLog && logItems.length === 1) {
+      const onlyItem = logItems[0];
+      navigate(onlyItem.url);
+    }
+  }, [logItems, maybeShowSingleLog]);
 
   return (
     <div className={clsx(styles.panel)}>

--- a/src/inspect_ai/_view/www/src/app/routing/AppRouter.tsx
+++ b/src/inspect_ai/_view/www/src/app/routing/AppRouter.tsx
@@ -58,7 +58,7 @@ export const AppRouter = createHashRouter(
       children: [
         {
           index: true, // This will match exactly the "/" path
-          element: <LogsPanel />,
+          element: <LogsPanel maybeShowSingleLog={true} />,
         },
         {
           path: kLogsRouteUrlPattern,


### PR DESCRIPTION
- The view server will check the log_dir to see whether it is a file. If it is, it will provide the proper info to the viewer when responding to the initial logs request (the single file and the log_dir).

- When launching a log viewer where there is only a single file in the log_dir, the viewer will initially load the log view directly, skipping the listing view.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
