### PR TITLE
Omit `None`'s when creating ContentToolUse objects.

### DIFF
--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -532,7 +532,7 @@ def web_search_to_tool_use(output: ResponseFunctionWebSearch) -> ContentToolUse:
         tool_type="web_search",
         id=output.id,
         name=output.action.type,
-        arguments=output.action.to_json(),
+        arguments=output.action.to_json(exclude_none=True),
         result="",
         error="failed" if output.status == "failed" else None,
     )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
OpenAI chokes when Inspect plays back a `web_search_call` like this:
```json
    {
      "id": "ws_68b836b34c708194a7905f8a97b9ecd10c44c6f42d3f5c79",
      "action": {
        "query": "How to submit answer using functions.submit tool in Inspect AI",
        "type": "search",
        "sources": null
      },
      "status": "completed",
      "type": "web_search_call"
    }
```

```python
BadRequestError('Error code: 400 - {\'error\': {\'message\': "Unknown parameter: 
\'input[8].action.sources\'.", \'type\': \'invalid_request_error\', \'param\': \'input[8].action.sources\', 
\'code\': \'unknown_parameter\'}}')
```

### What is the new behavior?

We strip the `None` so that a `null` will not show up in the json.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
