### PR TITLE
add `concurrency` option to sandbox exec() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Agent Bridge: Don't use `concurrency()` for agent bridge interactions (not required for long-running proxy server or cheap polling requests).
+- Sandboxes: Add `concurrency` parameter to `exec()` to advise whether the execution should be subject to local process concurrency limits.
+
 ## 0.3.128 (02 September 2025)
 
 - Agent Bridge: Correctly dispatch LimitExceededError which occurs during proxied model calls.

--- a/docs/_sandboxenv-interface.md
+++ b/docs/_sandboxenv-interface.md
@@ -10,7 +10,8 @@ class SandboxEnvironment:
         env: dict[str, str] = {},
         user: str | None = None,
         timeout: int | None = None,
-        timeout_retry: bool = True
+        timeout_retry: bool = True,
+        concurrency: bool = True
     ) -> ExecResult[str]:
         """
         Raises:

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -120,7 +120,7 @@ async def run_model_proxy(
         )
 
     # run the model proxy script
-    result = await sandbox.exec([MODEL_PROXY_PY, str(port)])
+    result = await sandbox.exec([MODEL_PROXY_PY, str(port)], concurrency=False)
     if not result.success:
         raise RuntimeError(
             f"Error running model proxy script for agent bridge: {result.stderr}"

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -282,6 +282,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
         user: str | None = None,
         timeout: int | None = None,
         timeout_retry: bool = True,
+        concurrency: bool = True,
     ) -> ExecResult[str]:
         # additional args
         args = []
@@ -311,6 +312,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
             timeout_retry=timeout_retry,
             input=input,
             output_limit=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+            concurrency=concurrency,
         )
         verify_exec_result_size(exec_result)
         if exec_result.returncode == 126 and "permission denied" in exec_result.stdout:

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -98,6 +98,7 @@ class SandboxEnvironment(abc.ABC):
         user: str | None = None,
         timeout: int | None = None,
         timeout_retry: bool = True,
+        concurrency: bool = True,
     ) -> ExecResult[str]:
         """Execute a command within a sandbox environment.
 
@@ -117,7 +118,8 @@ class SandboxEnvironment(abc.ABC):
           timeout_retry: Retry the command in the case that it times out.
             Commands will be retried up to twice, with a timeout of no greater
             than 60 seconds for the first retry and 30 for the second.
-
+          concurrency: For sandboxes that run locally, request that the `concurrency()`
+            function be used to throttle concurrent subprocesses.
 
         Returns:
           Execution result (status code, stderr/stdout, etc.)

--- a/src/inspect_ai/util/_sandbox/local.py
+++ b/src/inspect_ai/util/_sandbox/local.py
@@ -56,6 +56,7 @@ class LocalSandboxEnvironment(SandboxEnvironment):
         user: str | None = None,
         timeout: int | None = None,
         timeout_retry: bool = True,
+        concurrency: bool = True,
     ) -> ExecResult[str]:
         if user is not None:
             warnings.warn(
@@ -74,6 +75,7 @@ class LocalSandboxEnvironment(SandboxEnvironment):
             env=env,
             timeout=timeout,
             output_limit=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE,
+            concurrency=concurrency,
         )
         verify_exec_result_size(result)
         return result

--- a/src/inspect_ai/util/_sandbox/service.py
+++ b/src/inspect_ai/util/_sandbox/service.py
@@ -341,7 +341,7 @@ class SandboxService:
     async def _exec(self, cmd: list[str], input: str | None = None) -> ExecResult[str]:
         try:
             return await self._sandbox.exec(
-                cmd, user=self._user, input=input, timeout=30
+                cmd, user=self._user, input=input, timeout=30, concurrency=False
             )
         except TimeoutError:
             raise RuntimeError(
@@ -422,7 +422,7 @@ async def validate_sandbox_python(
     service_name: str, sandbox: SandboxEnvironment, user: str | None = None
 ) -> None:
     # validate python in sandbox
-    result = await sandbox.exec(["which", "python3"], user=user)
+    result = await sandbox.exec(["which", "python3"], user=user, concurrency=False)
     if not result.success:
         raise PrerequisiteError(
             f"The {service_name} requires that Python be installed in the sandbox."

--- a/tests/test_package/inspect_package/sandboxenv/podman.py
+++ b/tests/test_package/inspect_package/sandboxenv/podman.py
@@ -41,6 +41,7 @@ class PodmanSandboxEnvironment(SandboxEnvironment):
         user: str | None = None,
         timeout: int | None = None,
         timeout_retry: bool = True,
+        concurrency: bool = True,
     ) -> ExecResult[str]:
         return ExecResult(success=True, returncode=0, stdout="Hello!", stderr="")
 


### PR DESCRIPTION
use concurrency=False for long-running / cheap polling requests
