### PR TITLE
make changes so ETag always matches content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - OpenAI Compatible: Add support for using Responses API via `responses_api` model arg.
+- Bugfix: Ensure ETags always match content when reading S3 logs to prevent write conflicts.
 
 ## 0.3.129 (03 September 2025)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When `read_eval_log()` reads an entire log file in S3, the content and ETag do not match if the file is changed before `read_eval_log()` gets the ETag.

### What is the new behavior?

When `read_eval_log()` reads an entire log file in S3, it reads the content and ETag at the same time, so they always match.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:
