### PR TITLE
Provide a fake request in the fake response when creating an Anthropic error object (such as APIStatusError) when an individual batch entry fails.

### DIFF
--- a/src/inspect_ai/model/_providers/_anthropic_batch.py
+++ b/src/inspect_ai/model/_providers/_anthropic_batch.py
@@ -147,7 +147,14 @@ def _get_individual_result(
                 error_class = anthropic.InternalServerError
         response = error_class(
             message=message,
-            response=httpx.Response(status_code=500, text=message),
+            response=httpx.Response(
+                status_code=500,
+                text=message,
+                request=httpx.Request(
+                    method="POST",
+                    url="https://api.anthropic.com/v1/messages/batches",
+                ),
+            ),
             body=None,
         )
         response.response.status_code = response.status_code


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

https://inspectcommunity.slack.com/archives/D094WU17RPD/p1752345821817559

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
