### PR TITLE
Fix file info on filesystem without mtime

### DIFF
--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -269,7 +269,7 @@ class FileSystem:
         # if we don't yet have an mtime key then fetch created explicitly
         # note: S3 doesn't give you a directory modification time
         if "mtime" not in file.keys() and file["type"] == "file":
-            file["mtime"] = self.fs.created(file).timestamp()
+            file["mtime"] = self.fs.created(file["name"]).timestamp()
 
         # adjust mtime to be milliseconds
         if "mtime" in file.keys():

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -1,4 +1,4 @@
-from inspect_ai._util.file import basename
+from inspect_ai._util.file import basename, filesystem
 
 
 def test_basename():
@@ -14,3 +14,11 @@ def test_basename():
     assert basename(f"/opt/files/{MYDIR}/") == MYDIR
     assert basename(f"C:\\Documents\\{MYDIR}") == MYDIR
     assert basename(f"C:\\Documents\\{MYDIR}\\") == MYDIR
+
+
+def test_filesystem_file_info():
+    memory_filesystem = filesystem("memory://")
+    memory_filesystem.touch("test_file")
+    info = memory_filesystem.info("test_file")
+    assert info.name == "memory:///test_file"
+    assert info.size == 0


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`FileSystem._file_info()` crashes when used on a filesystem without `mtime`.

### What is the new behavior?
It works, which is useful for tests.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
