### PR TITLE
Resolve Task Metrics Immediately

### DIFF
--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -15,6 +15,7 @@ import anyio
 from inspect_ai._display import display as display_manager
 from inspect_ai._eval.context import init_task_context
 from inspect_ai._eval.loader import scorer_from_spec
+from inspect_ai._eval.task.task import resolve_scorer_metrics
 from inspect_ai._util._async import configured_async_backend, run_coroutine, tg_collect
 from inspect_ai._util.platform import platform_init, running_in_notebook
 from inspect_ai._util.registry import registry_create, registry_unqualified_name
@@ -247,6 +248,9 @@ async def score_async(
         # that will be taken care of in eval_results)
         log_metrics = metrics_from_log_header(log)
 
+        # resolve the scorer metrics onto the scorers
+        scorers = resolve_scorer_metrics(scorers, log_metrics) or []
+
         # override epochs_reducer if specified
         epochs_reducer = create_reducers(epochs_reducer)
         if epochs_reducer:
@@ -260,7 +264,6 @@ async def score_async(
             list(filter(None, scores)),
             epochs_reducer,
             scorers,
-            log_metrics,
         )
 
     return log

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -69,7 +69,6 @@ def eval_results(
     scores: list[dict[str, SampleScore]],
     reducers: ScoreReducer | list[ScoreReducer] | None,
     scorers: list[Scorer] | None,
-    metrics: list[Metric] | dict[str, list[Metric]] | None,
 ) -> Tuple[EvalResults, list[EvalSampleReductions] | None]:
     # initialise results
     results = EvalResults(total_samples=samples, completed_samples=len(scores))
@@ -105,11 +104,9 @@ def eval_results(
             if len(reducers) == 0:
                 # Compute metrics without reduction since no reducers were
                 # explicitly specified
-                targets = metrics if metrics is not None else scorer_info.metrics
-
                 eval_scores = compute_eval_scores(
                     resolved_scores,
-                    targets,
+                    scorer_info.metrics,
                     scorer_name,
                     scorer_info,
                     None,
@@ -135,11 +132,9 @@ def eval_results(
                     sample_reductions.append(reduced_samples)
 
                     # Compute metrics for this scorer
-                    targets = metrics if metrics is not None else scorer_info.metrics
-
                     eval_scores = compute_eval_scores(
                         reduced_scores,
-                        targets,
+                        scorer_info.metrics,
                         scorer_name,
                         scorer_info,
                         reducer_display_nm,

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -77,7 +77,7 @@ from inspect_ai.model import (
 )
 from inspect_ai.model._model import init_sample_model_usage, sample_model_usage
 from inspect_ai.scorer import Scorer, Target
-from inspect_ai.scorer._metric import Metric, SampleScore
+from inspect_ai.scorer._metric import SampleScore
 from inspect_ai.scorer._reducer.types import ScoreReducer
 from inspect_ai.scorer._score import init_scoring_context
 from inspect_ai.scorer._scorer import unique_scorer_name
@@ -311,7 +311,6 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
                         progress_results,
                         scorers,
                         task.epochs_reducer,
-                        task.metrics,
                     )
 
                 # initial progress
@@ -323,7 +322,6 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
                     progress_results,
                     scorers,
                     task.epochs_reducer,
-                    task.metrics,
                 )
 
                 async def run_sample(
@@ -383,7 +381,6 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
                     scores=completed_scores,
                     reducers=task.epochs_reducer,
                     scorers=scorers,
-                    metrics=task.metrics,
                 )
 
             # collect eval data
@@ -477,7 +474,6 @@ def update_metrics_display_fn(
         list[dict[str, SampleScore]],
         list[Scorer] | None,
         ScoreReducer | list[ScoreReducer] | None,
-        list[Metric] | dict[str, list[Metric]] | None,
     ],
     None,
 ]:
@@ -488,7 +484,6 @@ def update_metrics_display_fn(
         sample_scores: list[dict[str, SampleScore]],
         scorers: list[Scorer] | None,
         reducers: ScoreReducer | list[ScoreReducer] | None,
-        metrics: list[Metric] | dict[str, list[Metric]] | None,
     ) -> None:
         # Don't compute metrics if they are not being displayed
         if not display_metrics:
@@ -503,7 +498,6 @@ def update_metrics_display_fn(
                 scores=sample_scores,
                 reducers=reducers,
                 scorers=scorers,
-                metrics=metrics,
             )
 
             # Name, reducer, value


### PR DESCRIPTION
Rather than pass task metrics thorugh to results computation, resolve the task metrics immediately onto the scorers and simply use those when computing results.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
