### PR TITLE
Make TimeoutError more descriptive

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -354,14 +354,16 @@ async def compose_command(
                     timeout if retries == 0 else (min(timeout, 60) // retries), 1
                 )
                 return await run_command(command_timeout)
-            except TimeoutError:
+            except TimeoutError as e:
                 retries += 1
                 if timeout_retry and (retries <= MAX_RETRIES):
                     logger.info(
                         f"Retrying docker compose command: {shlex.join(compose_command)}"
                     )
                 else:
-                    raise
+                    raise TimeoutError(
+                        f"Docker compose command {command} timed out after {timeout} seconds"
+                    ) from e
 
     else:
         return await run_command(timeout)

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -362,7 +362,7 @@ async def compose_command(
                     )
                 else:
                     raise TimeoutError(
-                        f"Docker compose command {command} timed out after {timeout} seconds"
+                        f"Docker compose command '{command}' timed out after {timeout} seconds"
                     ) from e
 
     else:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)
EvalLog shows TimeoutError but doesn't show which command timed out

<details><summary>Example error</summary>
<p>

```
Traceback (most recent call last):
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/anyio/_core/_tasks.py", line 115, in fail_after
    yield cancel_scope
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_subprocess.py", line 191, in run_command_timeout
    return await run_command()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_subprocess.py", line 148, in run_command
    stdout, stderr = await tg_collect(
                     ^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/_util/_async.py", line 59, in tg_collect
    async with anyio.create_task_group() as tg:
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 776, in __aexit__
    raise exc_val
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/anyio/_backends/_asyncio.py", line 744, in __aexit__
    await self._on_completed_fut
asyncio.exceptions.CancelledError: Cancelled by cancel scope 7d855d1a5e50

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/run.py", line 680, in task_run_sample
    async with sandboxenv_cm:
  File "/usr/lib/python3.12/contextlib.py", line 210, in __aenter__
    return await anext(self.gen)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/_eval/task/sandbox.py", line 97, in sandboxenv_context
    environments = await init_sandbox_environments_sample(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_sandbox/context.py", line 152, in init_sandbox_environments_sample
    environments = await sample_init(task_name, config, metadata)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_sandbox/docker/docker.py", line 234, in sample_init
    raise ex
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_sandbox/docker/docker.py", line 188, in sample_init
    result = await compose_up(project, services)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_sandbox/docker/compose.py", line 53, in compose_up
    result = await compose_command(up_command, project=project, timeout=timeout)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_sandbox/docker/compose.py", line 346, in compose_command
    return await run_command(command_timeout)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_sandbox/docker/compose.py", line 317, in run_command
    result = await subprocess(
             ^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_subprocess.py", line 199, in subprocess
    return await run_command_timeout()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/inspect_ai/util/_subprocess.py", line 189, in run_command_timeout
    with anyio.fail_after(timeout):
  File "/usr/lib/python3.12/contextlib.py", line 158, in __exit__
    self.gen.throw(value)
  File "/home/ubuntu/apex/.venv/lib/python3.12/site-packages/anyio/_core/_tasks.py", line 118, in fail_after
    raise TimeoutError
TimeoutError
```

</p>
</details> 

### What is the new behavior?
Command and timeout duration are included in the error message

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
