### PR TITLE
feat: Pass event to TaskState

### DIFF
--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -281,6 +281,7 @@ async def _run_score_task(
         target=target,
         choices=sample.choices,
         messages=sample.messages,
+        events=sample.events,
         output=sample.output,
         completed=True,
         metadata=sample.metadata,

--- a/src/inspect_ai/solver/_task_state.py
+++ b/src/inspect_ai/solver/_task_state.py
@@ -10,6 +10,7 @@ from shortuuid import uuid
 
 from inspect_ai._util.metadata import MT, metadata_as
 from inspect_ai.dataset._dataset import Sample
+from inspect_ai.log._transcript import Event
 from inspect_ai.model import (
     ChatMessage,
     ChatMessageUser,
@@ -151,6 +152,7 @@ class TaskState:
         epoch: int,
         input: str | list[ChatMessage],
         messages: list[ChatMessage],
+        events: list[Event] = [],
         target: Target = Target(""),
         choices: list[str] | None = [],
         output: ModelOutput | None = None,
@@ -168,6 +170,7 @@ class TaskState:
         self._target = target
         self._metadata = metadata
         self._messages: list[ChatMessage] = ChatMessageList(messages)
+        self._events: list[Event] = events
         self._tools: list[Tool] = []
         self._output = output if output else ModelOutput(model=str(model))
         self._message_limit = create_message_limit(message_limit)
@@ -264,6 +267,15 @@ class TaskState:
     @messages.setter
     def messages(self, messages: list[ChatMessage]) -> None:
         self._messages = ChatMessageList(messages)
+
+    @property
+    def events(self) -> list[Event]:
+        """Events that have occurred during the sample run."""
+        return self._events
+
+    @events.setter
+    def events(self, events: list[Event]) -> None:
+        self._events = events
 
     @property
     def output(self) -> ModelOutput:


### PR DESCRIPTION
## This PR contains:
- [x] New features

### What is the current behavior? (You can also link to an open issue here)

Currently there is no way to access the events when scoring. You can see in [this pr](https://github.com/METR/inspect-agents/pull/14) this forced me to read the log directly at sha [1c1d418](https://github.com/METR/inspect-agents/pull/14/commits/1c1d418aa62a95e196dc5c7d5708d7db5f3f067d).

### What is the new behavior?

After this PR the events can be obtained from the state and I could simplify my scorer in [e19d253](https://github.com/METR/inspect-agents/pull/14/commits/e19d25331b5c6a3ce30fe29cd39432ad93325df0).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:
