### PR TITLE
Fix Google Gemini 2.5 function calling configuration error when using native search tool.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Bugfix: Fix Google Gemini 2.5 function calling configuration error when using native search tools.
+
+
 ## 0.3.132 (12 September 2025)
 
 - Anthropic: Support for images with mime type image/bmp.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

Fixes #2462. 

The fix addresses Gemini 2.5's stricter validation by conditionally applying `tool_config` only when using function declaration tools, not native search tools. This resolves the "Function calling config is set without function_declarations" error.