### PR TITLE
Allow scorers to return None for unscored samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Hooks: Propagate LimitExceededError so that hooks can raise limit errors.
 - Bugfix: Fix Google Gemini 2.5 function calling configuration error when using native search tools.
 - Bugfix: Enable passing no reducers to `async_score` in eval score.
-
+- Scoring: Allow scorers to return `None` to indicate that they did not score the sample. Such samples are excluded from reductions and metrics.
 
 ## 0.3.132 (12 September 2025)
 

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -323,21 +323,22 @@ async def _run_score_task(
                     raise RuntimeError(
                         f"Scorer {scorer_name} has modified state.scores"
                     )
-                state.scores[scorer_name] = score_result
+                if score_result is not None:
+                    state.scores[scorer_name] = score_result
 
-                transcript()._event(
-                    ScoreEvent(
-                        score=score_result,
-                        target=target.target,
+                    transcript()._event(
+                        ScoreEvent(
+                            score=score_result,
+                            target=target.target,
+                        )
                     )
-                )
 
-                results[scorer_name] = SampleScore(
-                    score=score_result,
-                    sample_id=state.sample_id,
-                    sample_metadata=state.metadata,
-                    scorer=registry_unqualified_name(scorer),
-                )
+                    results[scorer_name] = SampleScore(
+                        score=score_result,
+                        sample_id=state.sample_id,
+                        sample_metadata=state.metadata,
+                        scorer=registry_unqualified_name(scorer),
+                    )
 
     sample.scores = _get_updated_scores(sample, results, action=action)
     sample.events = _get_updated_events(sample, transcript(), action=action)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -859,21 +859,24 @@ async def task_run_sample(
                                             raise RuntimeError(
                                                 f"Scorer {scorer_name} has modified state.scores"
                                             )
-                                        state.scores[scorer_name] = score_result
+                                        if score_result is not None:
+                                            state.scores[scorer_name] = score_result
 
-                                        transcript()._event(
-                                            ScoreEvent(
-                                                score=score_result,
-                                                target=sample.target,
+                                            transcript()._event(
+                                                ScoreEvent(
+                                                    score=score_result,
+                                                    target=sample.target,
+                                                )
                                             )
-                                        )
 
-                                        results[scorer_name] = SampleScore(
-                                            score=score_result,
-                                            sample_id=sample.id,
-                                            sample_metadata=sample.metadata,
-                                            scorer=registry_unqualified_name(scorer),
-                                        )
+                                            results[scorer_name] = SampleScore(
+                                                score=score_result,
+                                                sample_id=sample.id,
+                                                sample_metadata=sample.metadata,
+                                                scorer=registry_unqualified_name(
+                                                    scorer
+                                                ),
+                                            )
 
                                 for name in solver_score_names:
                                     score = state.scores[name]

--- a/src/inspect_ai/scorer/_multi.py
+++ b/src/inspect_ai/scorer/_multi.py
@@ -23,6 +23,8 @@ def multi_scorer(scorers: list[Scorer], reducer: str | ScoreReducer) -> Scorer:
         scores = await tg_collect(
             [functools.partial(_scorer, state, target) for _scorer in scorers]
         )
-        return reducer(scores)
+        # Filter out None values from scores list
+        resolved_scores = [score for score in scores if score is not None]
+        return reducer(resolved_scores)
 
     return score

--- a/src/inspect_ai/scorer/_score.py
+++ b/src/inspect_ai/scorer/_score.py
@@ -55,10 +55,11 @@ async def score(conversation: ModelConversation) -> list[Score]:
     scores: list[Score] = []
     for scorer in scorers:
         score = await scorer(state, target)
-        scores.append(score)
-        transcript()._event(
-            ScoreEvent(score=score, target=target.target, intermediate=True)
-        )
+        if score is not None:
+            scores.append(score)
+            transcript()._event(
+                ScoreEvent(score=score, target=target.target, intermediate=True)
+            )
 
     return scores
 

--- a/src/inspect_ai/scorer/_scorer.py
+++ b/src/inspect_ai/scorer/_scorer.py
@@ -35,7 +35,7 @@ class Scorer(Protocol):
         self,
         state: TaskState,
         target: Target,
-    ) -> Score:
+    ) -> Score | None:
         r"""Score model outputs.
 
         Evaluate the passed outputs and targets and return a

--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -388,7 +388,7 @@ async def test_score(
                 target: Target,
                 scorer_name: str = scorer_unresolved[0],
                 scorer_fn: Scorer = scorer_fn,
-            ) -> Score:
+            ) -> Score | None:
                 seen_scores[state.sample_id, scorer_name] = (state.scores or {}).copy()
                 return await scorer_fn(state, target)
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Scorers must always return a score with a value.

### What is the new behavior?

Scorers may return `None` to indicate that they did not score the sample.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes. Anyone calling scorers directly may receive `None` as a result. Internally, this is handled as we check for `None` and exclude the score as appropriate.

### Other information:
