### PR TITLE
Fix API key being empty string, not None

### DIFF
--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -113,7 +113,7 @@ class AzureAIAPI(ModelAPI):
         # resolve api_key or managed identity (for Azure)
         self.token_provider = None
         self.api_key = os.environ.get(
-            AZURE_API_KEY, os.environ.get(AZUREAI_API_KEY, "")
+            AZURE_API_KEY, os.environ.get(AZUREAI_API_KEY, None)
         )
         if not self.api_key:
             # try managed identity (Microsoft Entra ID)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
When not setting an API Key for the Azure AI provider, the `self.api_key` falls back to an empty string, thus passing the later `self.api_key is not None` check, failing to use Managed Identity (which will be tried when no api key can be found)

### What is the new behavior?
API key falls back to None, triggering the Managed Identity flow when needed

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
