### PR TITLE
Agent bridge: enhance automatic state tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Agent bridge: Enhance automatic state tracking by ignoring shorter sub-agent generations.
 - Eval logs: Option to resolve attachments for `convert_eval_logs()`.
 - Model grading: `model_graded_qa()`, `model_graded_fact()`) now look for the "grader" model-role by default.
 - Human agent: Enable installation even when default tool user is not root.

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -120,9 +120,8 @@ async def inspect_anthropic_api_request_impl(
 
     debug_log("INSPECT OUTPUT", output.message)
 
-    # update state
-    bridge.state.messages = messages + [output.message]
-    bridge.state.output = output
+    # update state if we have more messages than the last generation
+    bridge._track_state(messages, output)
 
     # return message
     message = Message(

--- a/src/inspect_ai/agent/_bridge/completions.py
+++ b/src/inspect_ai/agent/_bridge/completions.py
@@ -84,9 +84,8 @@ async def inspect_completions_api_request(
     # if there is a bridge filter give it a shot first
     output = await bridge_generate(bridge, model, input, tools, tool_choice, config)
 
-    # update state
-    bridge.state.messages = input + [output.message]
-    bridge.state.output = output
+    # update state if we have more messages than the last generation
+    bridge._track_state(input, output)
 
     # inspect completion to openai completion
     return ChatCompletion(

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -183,9 +183,8 @@ async def inspect_responses_api_request_impl(
 
     debug_log("INSPECT OUTPUT", output.message)
 
-    # update state
-    bridge.state.messages = messages + [output.message]
-    bridge.state.output = output
+    # update state if we have more messages than the last generation
+    bridge._track_state(messages, output)
 
     # return response
     response = Response(

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -8,6 +8,7 @@ from inspect_ai._util.json import to_json_str_safe
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._model import GenerateFilter
+from inspect_ai.model._model_output import ModelOutput
 
 
 class AgentBridge:
@@ -17,6 +18,7 @@ class AgentBridge:
         self.state = state
         self.filter = filter
         self._message_ids = {}
+        self._last_message_count = 0
 
     state: AgentState
     """State updated from messages traveling over the bridge."""
@@ -54,6 +56,22 @@ class AgentBridge:
         return message_id
 
     _message_ids: dict[str, list[str]]
+
+    def _track_state(self, input: list[ChatMessage], output: ModelOutput) -> None:
+        # automatically track agent state based on observing generations made through
+        # the bridge. we need to distinguish between the "main" thread of generation
+        # and various types of side / sub-agent calls to the model (e.g. claude code
+        # does bash path detection using a side call). our heuristic is to keep the
+        # number of messages that were in the _last_ generation, and to update the
+        # state whenever the total messages exceeds it. this should pick up normal
+        # agent loops that keep appending, while at the same time discarding side model
+        # calls that tend to be shorter. finally, this should handle recovering from
+        # history compaction, which will shorten the message history considerably
+        messages = input + [output.message]
+        if len(messages) > self._last_message_count:
+            self.state.messages = messages
+            self.state.output = output
+        self._last_message_count = len(messages)
 
 
 @lru_cache(maxsize=100)


### PR DESCRIPTION
Automatically track agent state based on observing generations made through the bridge. We need to distinguish between the "main" thread of generation and various types of side / sub-agent calls to the model (e.g. claude code does bash path detection using a side call).

Our heuristic is to keep the number of messages that were in the _last_ generation, and to update the state whenever the total messages exceeds it. This should pick up normal agent loops that keep appending, while at the same time discarding side model calls that tend to be shorter. Finally, this should handle recovering from history compaction, which can shorten the message history considerably.
