### PR TITLE
Improve types for scorer decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Hooks: Emit `on_run_end()` even when the eval is cancelled.
 - Scoring: Allow scorers to return `None` to indicate that they did not score the sample. Such samples are excluded from reductions and metrics.
 - Scoring: Resolve task metrics on to scores returned by solvers.
+- Scoring: Use `Sequence` and `Mapping` types for metrics on scorer decorator.
 - Scoring: Properly make sample events available in the transcript during re-scoring an eval log.
 - Inspect View: Display pending tasks in eval sets (tasks that have not yet started running)
 - Inspect View: Fine tune status appearance to improve legibility

--- a/src/inspect_ai/scorer/_scorer.py
+++ b/src/inspect_ai/scorer/_scorer.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass, field
 from functools import wraps
@@ -121,7 +122,8 @@ def scorer_create(name: str, **kwargs: Any) -> Scorer:
 
 
 def scorer(
-    metrics: list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]],
+    metrics: Sequence[Metric | Mapping[str, Sequence[Metric]]]
+    | Mapping[str, Sequence[Metric]],
     name: str | None = None,
     **metadata: Any,
 ) -> Callable[[Callable[P, Scorer]], Callable[P, Scorer]]:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [X] Code refactor

### What is the current behavior? (You can also link to an open issue here)
https://github.com/UKGovernmentBEIS/inspect_ai/issues/2467

### What is the new behavior?
The `scorer` decorator now accepts `metrics` of type `list[Metric]`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
I initially wanted to replace all instances of `list` and `dict`, but I realized some of the Inspect AI code uses `.items` so `dict` is required. Therefore, I did the minimal change that can close https://github.com/UKGovernmentBEIS/inspect_ai/issues/2467