### PR TITLE
Support streaming conversion

### DIFF
--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -10,6 +10,7 @@ from pydantic_core import to_jsonable_python
 from typing_extensions import Unpack
 
 from inspect_ai._cli.common import CommonOptions, common_options, process_common_options
+from inspect_ai._cli.util import int_or_bool_flag_callback
 from inspect_ai._util.constants import PKG_PATH
 from inspect_ai.log import list_eval_logs
 from inspect_ai.log._convert import convert_eval_logs
@@ -161,11 +162,24 @@ def dump_command(path: str, header_only: bool, resolve_attachments: bool) -> Non
     default=False,
     help="Overwrite files in the output directory.",
 )
+@click.option(
+    "--stream",
+    flag_value="true",
+    type=str,
+    is_flag=False,
+    default=False,
+    callback=int_or_bool_flag_callback(True, false_value=False, is_one_true=False),
+    help="Stream the samples through the conversion process instead of reading the entire log into memory. Useful for large logs. Set to an integer to limit the number of concurrent samples being converted.",
+)
 def convert_command(
-    path: str, to: Literal["eval", "json"], output_dir: str, overwrite: bool
+    path: str,
+    to: Literal["eval", "json"],
+    output_dir: str,
+    overwrite: bool,
+    stream: int | bool = False,
 ) -> None:
     """Convert between log file formats."""
-    convert_eval_logs(path, to, output_dir, overwrite)
+    convert_eval_logs(path, to, output_dir, overwrite, stream)
 
 
 @log_command.command("headers", hidden=True)

--- a/src/inspect_ai/_cli/score.py
+++ b/src/inspect_ai/_cli/score.py
@@ -150,16 +150,7 @@ async def score(
 
     read_sample = None
     if stream:
-        sample_map = sorted(
-            (
-                (x.id, x.epoch)
-                for x in await recorder.read_log_sample_summaries(log_file)
-            ),
-            key=lambda x: (
-                x[1],
-                (x[0] if isinstance(x[0], str) else str(x[0]).zfill(20)),
-            ),
-        )
+        sample_map = await recorder.read_log_sample_ids(log_file)
         semaphore = anyio.Semaphore(len(sample_map) if stream is True else stream)
 
         @contextlib.asynccontextmanager

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -70,6 +70,19 @@ class Recorder(abc.ABC):
     ) -> list[EvalSampleSummary]: ...
 
     @classmethod
+    async def read_log_sample_ids(cls, location: str) -> list[tuple[str | int, int]]:
+        return sorted(
+            (
+                (sample_summary.id, sample_summary.epoch)
+                for sample_summary in await cls.read_log_sample_summaries(location)
+            ),
+            key=lambda x: (
+                x[1],
+                (x[0] if isinstance(x[0], str) else str(x[0]).zfill(20)),
+            ),
+        )
+
+    @classmethod
     @abc.abstractmethod
     async def write_log(
         cls, location: str, log: EvalLog, if_match_etag: str | None = None

--- a/tests/log/test_convert.py
+++ b/tests/log/test_convert.py
@@ -1,0 +1,46 @@
+import pathlib
+from typing import Literal
+
+import pytest
+
+from inspect_ai.log._convert import convert_eval_logs
+from inspect_ai.log._file import read_eval_log
+from inspect_ai.log._log import EvalLog
+
+_TESTS_DIR = pathlib.Path(__file__).resolve().parent
+
+
+@pytest.mark.parametrize(
+    "stream", [True, False, 3], ids=["stream", "no-stream", "stream-3"]
+)
+@pytest.mark.parametrize("to", ["eval", "json"])
+@pytest.mark.parametrize(
+    "resolve_attachments",
+    [True, False],
+    ids=["resolve-attachments", "no-resolve-attachments"],
+)
+def test_convert_eval_logs(
+    tmp_path: pathlib.Path,
+    stream: bool | int,
+    to: Literal["eval", "json"],
+    resolve_attachments: bool,
+):
+    input_file = (
+        _TESTS_DIR
+        / "test_list_logs/2024-11-05T13-32-37-05-00_input-task_hxs4q9azL3ySGkjJirypKZ.eval"
+    )
+
+    convert_eval_logs(
+        str(input_file),
+        to,
+        str(tmp_path),
+        resolve_attachments=resolve_attachments,
+        stream=stream,
+    )
+
+    output_file = (tmp_path / input_file.name).with_suffix(f".{to}")
+    assert output_file.exists()
+    assert isinstance(
+        read_eval_log(str(output_file), resolve_attachments=resolve_attachments),
+        EvalLog,
+    )


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)
You have to read the entire file into memory when converting (e.g. when round-tripping for migrations)

### What is the new behavior?
`inspect log convert --stream`, following example in #2388 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
Nope, should be backwards compatible

### Other information:
