### PR TITLE
prevent resources.path deprecation warning during tests

### DIFF
--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -1,5 +1,6 @@
 import subprocess
 import sys
+import warnings
 from contextlib import asynccontextmanager
 from importlib import resources
 from logging import getLogger
@@ -84,9 +85,11 @@ async def _inject_container_tools_code(sandbox: SandboxEnvironment) -> None:
 @asynccontextmanager
 async def _open_executable(executable: str) -> AsyncIterator[BinaryIO]:
     """Open the executable file from the binaries package."""
-    with resources.path("inspect_ai.binaries", executable) as executable_path:
-        with open(executable_path, "rb") as f:
-            yield f
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
+        with resources.path("inspect_ai.binaries", executable) as executable_path:
+            with open(executable_path, "rb") as f:
+                yield f
 
 
 def _prompt_user_action(message: str, executable_name: str, arch: Architecture) -> None:


### PR DESCRIPTION
without this we get the following when running tests:

```
/Users/jjallaire/ukinstitute/UKGovernmentBEIS/inspect_ai/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py:90:
DeprecationWarning: path is deprecated. Use files() instead. Refer to https://importlib-
resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.
    with resources.path("inspect_ai.binaries", executable) as executable_path:
```
