### PR TITLE
Fix truncation of messages in react agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Agent bridge: Workaround Codex CLI not passing `detail` along with images.
 - Inspect View: Fix regression sorting folder and logs in list (folders should sort to the front of the list)
 - Inspect View: Properly reset page when navigating between folders.
+- Bugfix: Fix "auto" message truncation in react agent.
 
 ## 0.3.133 (22 September 2025)
 

--- a/src/inspect_ai/model/_trim.py
+++ b/src/inspect_ai/model/_trim.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from ._chat_message import ChatMessage
 
 
-def trim_messages(
+async def trim_messages(
     messages: list[ChatMessage], preserve: float = 0.7
 ) -> list[ChatMessage]:
     """Trim message list to fit within model context.

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -1,8 +1,11 @@
 import re
+from typing import Literal
 
+import pytest
 from inspect_ai import Task, eval
 from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai.agent._agent import Agent, AgentState, agent
+from inspect_ai.agent._filter import MessageFilter
 from inspect_ai.agent._handoff import handoff
 from inspect_ai.agent._react import react
 from inspect_ai.agent._types import (
@@ -18,6 +21,7 @@ from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
     ChatMessageSystem,
+    ChatMessageTool,
 )
 from inspect_ai.scorer import Score, Target, accuracy, includes, scorer
 from inspect_ai.solver import Generate, Solver, TaskState, solver
@@ -558,3 +562,61 @@ def test_remove_submit_tool_filters_reasoning_content():
         "Reasoning content should remain when no submit tool call is filtered"
     )
     assert reasoning_content[0].reasoning == "This reasoning should stay"
+
+
+@pytest.mark.parametrize(
+    ("truncation", "expected_message_count", "expected_submit"),
+    [
+        pytest.param("auto", 142, True, id="with_auto_truncation"),  # sys msg + 0.7 * 200
+        pytest.param("disabled", 201, False, id="with_disabled_truncation"),  # no submit (agent terminates)
+    ],
+)
+def test_react_agent_truncation(
+    truncation: Literal["auto", "disabled"] | MessageFilter,
+    expected_message_count: int,
+    expected_submit: bool,
+):
+    """Test the react agent with different truncation settings"""
+    task = Task(
+        dataset=[Sample(input="What is the capital of Denmark?", target="Copenhagen")],
+        solver=react(truncation=truncation),
+        scorer=includes(),
+    )
+
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            *(
+                [
+                    ModelOutput.from_content(
+                        model="mockllm/model",
+                        content="This is a repeated message",
+                    )
+                ] * 99
+            ),
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Final message with stop_reason=model_length",
+                stop_reason="model_length",
+            ),
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": "Copenhagen"},
+            ),
+        ],
+    )
+
+    log = eval(task, model=model)[0]
+
+    assert log.samples
+    sample = log.samples[0]
+    assert len(sample.messages) == expected_message_count
+    last_message = sample.messages[-1]
+    assert (
+        last_message.content == "tool call for tool submit\n\nCopenhagen"
+    ) == expected_submit
+
+    assert sample.scores and len(sample.scores) == 1
+    assert (score := sample.scores["includes"])
+    assert score.value == "C" if expected_submit else "I"

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -2,6 +2,7 @@ import re
 from typing import Literal
 
 import pytest
+
 from inspect_ai import Task, eval
 from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai.agent._agent import Agent, AgentState, agent
@@ -21,7 +22,6 @@ from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
     ChatMessageSystem,
-    ChatMessageTool,
 )
 from inspect_ai.scorer import Score, Target, accuracy, includes, scorer
 from inspect_ai.solver import Generate, Solver, TaskState, solver
@@ -567,8 +567,12 @@ def test_remove_submit_tool_filters_reasoning_content():
 @pytest.mark.parametrize(
     ("truncation", "expected_message_count", "expected_submit"),
     [
-        pytest.param("auto", 142, True, id="with_auto_truncation"),  # sys msg + 0.7 * 200
-        pytest.param("disabled", 201, False, id="with_disabled_truncation"),  # no submit (agent terminates)
+        pytest.param(
+            "auto", 142, True, id="with_auto_truncation"
+        ),  # sys msg + 0.7 * 200
+        pytest.param(
+            "disabled", 201, False, id="with_disabled_truncation"
+        ),  # no submit (agent terminates)
     ],
 )
 def test_react_agent_truncation(
@@ -592,7 +596,8 @@ def test_react_agent_truncation(
                         model="mockllm/model",
                         content="This is a repeated message",
                     )
-                ] * 99
+                ]
+                * 99
             ),
             ModelOutput.from_content(
                 model="mockllm/model",

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -608,9 +608,9 @@ def test_react_agent_truncation(
     )
 
     log = eval(task, model=model)[0]
+    assert log.results
 
-    assert log.samples
-    sample = log.samples[0]
+    assert log.samples and (sample := log.samples[0])
     assert len(sample.messages) == expected_message_count
     last_message = sample.messages[-1]
     assert (


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The react agent crashes if the model context window length is exceeded and truncation is set to `auto` (see #2505).

### What is the new behavior?

Truncation now behaves as expected.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No (fix should bring behavior in line with [documented behavior](https://inspect.aisi.org.uk/react-agent.html#truncation)).
