### PR TITLE
Task file can be not present

### DIFF
--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -35,10 +35,7 @@ from inspect_ai.log._file import (
 )
 from inspect_ai.log._log import EvalConfig
 from inspect_ai.log._model import model_roles_to_model_roles_config
-from inspect_ai.model import (
-    GenerateConfigArgs,
-    Model,
-)
+from inspect_ai.model import GenerateConfigArgs, Model
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model import ModelName
 from inspect_ai.solver._solver import Solver, SolverSpec
@@ -761,7 +758,7 @@ def status_msg(msg: str) -> str:
 class EvalSetTask(BaseModel):
     name: str | None
     task_id: str
-    task_file: str | None
+    task_file: str | None = None
     task_args: dict[str, Any]
     model: str
     model_args: dict[str, Any]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When I read from eval-set.json it's missing the `task_file` key. I see that it can be `None` when writing -
https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/_eval/evalset.py#L790

```
  File "/Users/mish/dev/inspect-action/hawk/api/eval_log_server.py", line 223, in eval_set
    eval_set = inspect_ai._eval.evalset.read_eval_set_info(
        _to_s3_uri(log_dir), fs_options={}
    )
  File "/Users/mish/dev/inspect-action/.venv/lib/python3.13/site-packages/inspect_ai/_eval/evalset.py", line 839, in read_eval_set_info
    return EvalSet.model_validate_json(eval_set_json)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/Users/mish/dev/inspect-action/.venv/lib/python3.13/site-packages/pydantic/main.py", line 746, in model_validate_json
    return cls.__pydantic_validator__.validate_json(
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        json_data, strict=strict, context=context, by_alias=by_alias, by_name=by_name
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
pydantic_core._pydantic_core.ValidationError: 2 validation errors for EvalSet
tasks.0.task_file
  Field required [type=missing, input_value={'name': 'inspect_evals/m...rgs': {}, 'sequence': 0}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
tasks.1.task_file
  Field required [type=missing, input_value={'name': 'inspect_evals/c...rgs': {}, 'sequence': 1}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.11/v/missing
```

### What is the new behavior?

Making the key optional, not just explicit None/null

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
