### PR TITLE
change Task.metrics type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - OpenAI: Automatically switch to the completions API when `--num-choices` is specified.
 - Model APIs: Improve legibility/clarify of error messages when updated versions of anthropic or openai packages are required.
 - Sandbox tools: Rewrite `inspect-ai` package installation type detection code.
+- Task: Support mixed metrics (both direct metrics and dict groupings in the same list), matching the flexibility of the @scorer decorator.
 - Inspect View: Fix regression sorting folder and logs in list (folders should sort to the front of the list)
 - Inspect View: Properly reset page when navigating between folders.
 - Score Editing: New `edit_score()` and `recompute_metrics()` functions for modifying evaluation scores with provenance tracking and metric recomputation.

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -69,7 +69,7 @@ def eval_results(
     scores: list[dict[str, SampleScore]],
     reducers: ScoreReducer | list[ScoreReducer] | None,
     scorers: list[Scorer] | None,
-    metrics: list[Metric] | dict[str, list[Metric]] | None,
+    metrics: list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]] | None,
 ) -> Tuple[EvalResults, list[EvalSampleReductions] | None]:
     # initialise results
     results = EvalResults(total_samples=samples, completed_samples=len(scores))
@@ -87,15 +87,7 @@ def eval_results(
 
                 # resolve the task scores
                 if metrics is not None:
-                    scorer_info.metrics = cast(
-                        list[
-                            MetricProtocol
-                            | MetricDeprecated
-                            | dict[str, list[MetricProtocol | MetricDeprecated]]
-                        ]
-                        | dict[str, list[MetricProtocol | MetricDeprecated]],
-                        metrics,
-                    )
+                    scorer_info.metrics = metrics
 
                 # capture the scorer information
                 scorers_info.append(scorer_info)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -484,7 +484,7 @@ def update_metrics_display_fn(
         list[dict[str, SampleScore]],
         list[Scorer] | None,
         ScoreReducer | list[ScoreReducer] | None,
-        list[Metric] | dict[str, list[Metric]] | None,
+        list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]] | None,
     ],
     None,
 ]:
@@ -495,7 +495,9 @@ def update_metrics_display_fn(
         sample_scores: list[dict[str, SampleScore]],
         scorers: list[Scorer] | None,
         reducers: ScoreReducer | list[ScoreReducer] | None,
-        metrics: list[Metric] | dict[str, list[Metric]] | None,
+        metrics: list[Metric | dict[str, list[Metric]]]
+        | dict[str, list[Metric]]
+        | None,
     ) -> None:
         # Don't compute metrics if they are not being displayed
         if not display_metrics:

--- a/src/inspect_ai/_eval/task/task.py
+++ b/src/inspect_ai/_eval/task/task.py
@@ -57,7 +57,9 @@ class Task:
         solver: Solver | Agent | list[Solver] = generate(),
         cleanup: Callable[[TaskState], Awaitable[None]] | None = None,
         scorer: Scorer | list[Scorer] | None = None,
-        metrics: list[Metric] | dict[str, list[Metric]] | None = None,
+        metrics: list[Metric | dict[str, list[Metric]]]
+        | dict[str, list[Metric]]
+        | None = None,
         model: str | Model | None = None,
         config: GenerateConfig = GenerateConfig(),
         model_roles: dict[str, str | Model] | None = None,
@@ -207,7 +209,10 @@ def task_with(
     solver: Solver | list[Solver] | NotGiven = NOT_GIVEN,
     cleanup: Callable[[TaskState], Awaitable[None]] | None | NotGiven = NOT_GIVEN,
     scorer: Scorer | list[Scorer] | None | NotGiven = NOT_GIVEN,
-    metrics: list[Metric] | dict[str, list[Metric]] | None | NotGiven = NOT_GIVEN,
+    metrics: list[Metric | dict[str, list[Metric]]]
+    | dict[str, list[Metric]]
+    | None
+    | NotGiven = NOT_GIVEN,
     model: str | Model | NotGiven = NOT_GIVEN,
     config: GenerateConfig | NotGiven = NOT_GIVEN,
     model_roles: dict[str, str | Model] | NotGiven = NOT_GIVEN,
@@ -422,7 +427,8 @@ def resolve_scorer(scorer: Scorer | list[Scorer] | None) -> list[Scorer] | None:
 
 
 def resolve_scorer_metrics(
-    scorers: list[Scorer] | None, metrics: list[Metric] | dict[str, list[Metric]] | None
+    scorers: list[Scorer] | None,
+    metrics: list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]] | None,
 ) -> list[Scorer] | None:
     if scorers is not None and metrics is not None:
         for scorer in scorers:

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -3121,7 +3121,20 @@
           "anyOf": [
             {
               "items": {
-                "$ref": "#/$defs/EvalMetricDefinition"
+                "anyOf": [
+                  {
+                    "$ref": "#/$defs/EvalMetricDefinition"
+                  },
+                  {
+                    "additionalProperties": {
+                      "items": {
+                        "$ref": "#/$defs/EvalMetricDefinition"
+                      },
+                      "type": "array"
+                    },
+                    "type": "object"
+                  }
+                ]
               },
               "type": "array"
             },

--- a/src/inspect_ai/_view/www/src/@types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/@types/log.d.ts
@@ -149,7 +149,12 @@ export type Metadata1 = {
   [k: string]: unknown;
 } | null;
 export type Metrics1 =
-  | EvalMetricDefinition[]
+  | (
+      | EvalMetricDefinition
+      | {
+          [k: string]: EvalMetricDefinition[];
+        }
+    )[]
   | {
       [k: string]: EvalMetricDefinition[];
     }

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -795,7 +795,9 @@ class EvalSpec(BaseModel):
     """Scorers and args for this eval"""
 
     metrics: (
-        list[EvalMetricDefinition] | dict[str, list[EvalMetricDefinition]] | None
+        list[EvalMetricDefinition | dict[str, list[EvalMetricDefinition]]]
+        | dict[str, list[EvalMetricDefinition]]
+        | None
     ) = Field(default=None)
     """metrics and args for this eval"""
 

--- a/src/inspect_ai/scorer/_metric.py
+++ b/src/inspect_ai/scorer/_metric.py
@@ -537,10 +537,23 @@ def metric_create(name: str, **kwargs: Any) -> Metric:
 
 
 def to_metric_specs(
-    metrics: list[Metric] | dict[str, list[Metric]],
-) -> list[MetricSpec] | dict[str, list[MetricSpec]]:
+    metrics: list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]],
+) -> list[MetricSpec | dict[str, list[MetricSpec]]] | dict[str, list[MetricSpec]]:
     if isinstance(metrics, list):
-        return [as_metric_spec(m) for m in metrics]
+        result: list[MetricSpec | dict[str, list[MetricSpec]]] = []
+        for metric_item in metrics:
+            if isinstance(metric_item, dict):
+                # It's a dict of metric groups
+                result.append(
+                    {
+                        k: [as_metric_spec(v) for v in metric_list]
+                        for k, metric_list in metric_item.items()
+                    }
+                )
+            else:
+                # It's a direct metric
+                result.append(as_metric_spec(metric_item))
+        return result
     else:
         return {
             k: [as_metric_spec(v) for v in metric_list]


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`Task.__init__()` cannot take a list that's a mix of `Metric` and `dict[str, list[Metric]]` values for the `metrics` param.

### What is the new behavior?

It can take a list that's a mix of `Metric` and `dict[str, list[Metric]]` values for the `metrics` param.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

There's a use case where it'd be useful to pass a list that's a mix of `Metric` and `dict[str, list[Metric]]` values.