### PR TITLE
Fix Build: Workaround Type Checker

### DIFF
--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -530,7 +530,7 @@ def messages_from_responses_input(
                 ChatMessageTool(
                     tool_call_id=item["call_id"],
                     function=function_calls_by_id.get(item["call_id"]),
-                    content=[ContentText(text=item["output"])],
+                    content=[ContentText(text=cast(str, item["output"]))],
                 )
             )
         elif is_computer_call_output(item):


### PR DESCRIPTION
function_call_output messages will always have a string value for `text` (either the message.text or an erorr message string if present).

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
