### PR TITLE
Preserve query params when copying links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Inspect View: Improve display of OpenAI Codex tool calls in transcript and messages.
+- Inspect View: Preserve query parameters in log viewer URLs when copying links.
 
 ## 0.3.135 (29 September 2025)
 

--- a/src/inspect_ai/_view/www/src/app/routing/url.ts
+++ b/src/inspect_ai/_view/www/src/app/routing/url.ts
@@ -364,5 +364,5 @@ export const supportsLinking = () => {
 };
 
 export const toFullUrl = (path: string) => {
-  return `${window.location.origin}${window.location.pathname}#${path}`;
+  return `${window.location.origin}${window.location.pathname}${window.location.search}#${path}`;
 };


### PR DESCRIPTION
We were dropping query params when forming urls for the clipboard

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
