### PR TITLE
Fix Error using `inspect_score` / `inspect score` on S3 logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Inspect View: Make message and event link affordances slightly more discoverable.
 - Inspect View: Preserve query parameters in log viewer URLs when copying links.
 - Inspect View: Fix issue where sometimes the incorrect log is displayed when new logs are added to a log directory while viewing a log.
+- Scoring: Fix regression in `inspect score` command (and `inspect_score` function) when scoring log files on S3.
 
 ## 0.3.135 (29 September 2025)
 


### PR DESCRIPTION
These paths may be S3 URIs, so shouldn’t use StrPath

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
