### PR TITLE
allow any version of `rich` > 13.3.3 (save for 14.0.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Dependencies: Allow any version of `rich` > 13.3.3 save for 14.0.0 (which had an infinite recursion bug affecting stack traces with exception groups).
+
 ## 0.3.136 (02 October 2025)
 
 - Google: Manage Google client lifetime to scope of call to `generate()`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ psutil
 pydantic>=2.11.4
 python-dotenv>=0.16.0
 pyyaml
-rich>=13.3.3,<14.0.0 # https://github.com/Textualize/rich/issues/3682
+rich>=13.3.3,!=14.0.0
 s3fs>=2023
 semver>=3.0.0
 shortuuid

--- a/uv.lock
+++ b/uv.lock
@@ -1699,7 +1699,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=0.16.0" },
     { name = "pyyaml" },
     { name = "quarto-cli", marker = "extra == 'doc'", specifier = "==1.7.32" },
-    { name = "rich", specifier = ">=13.3.3,<14.0.0" },
+    { name = "rich", specifier = ">=13.3.3,!=14.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.9.6" },
     { name = "s3fs", specifier = ">=2023" },
     { name = "semver", specifier = ">=3.0.0" },


### PR DESCRIPTION
14.0.0 had this bug which was fixed in 14.1.0: https://github.com/Textualize/rich/issues/3682


