### PR TITLE
update to `fsspec` 2025.9.0 to match upper bound of HF datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Dependencies: Update to fsspec 2025.9.0 to match upper bound of HF datasets.
+
 ## 0.3.136 (02 October 2025)
 
 - Google: Manage Google client lifetime to scope of call to `generate()`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ click>=8.1.3,!=8.2.0
 debugpy
 docstring-parser>=0.16
 exceptiongroup>=1.0.2; python_version < '3.11'
-fsspec>=2023.1.0,<=2025.3.0 # align with hf datasets to prevent pip errors
+fsspec>=2023.1.0,<=2025.9.0 # align with hf datasets to prevent pip errors
 httpx
 ijson>=3.2.0
 jsonlines>=3.0.0

--- a/uv.lock
+++ b/uv.lock
@@ -1649,7 +1649,7 @@ requires-dist = [
     { name = "debugpy" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.2" },
-    { name = "fsspec", specifier = ">=2023.1.0,<=2025.3.0" },
+    { name = "fsspec", specifier = ">=2023.1.0,<=2025.9.0" },
     { name = "google-genai", marker = "extra == 'dev'" },
     { name = "griffe", marker = "extra == 'dev'" },
     { name = "griffe", marker = "extra == 'doc'" },


### PR DESCRIPTION
This is the most recent version of fsspec -- HF datasets upper bounds b/c they've experienced breakage in the past so we match that behavior to prevent pip errors from occurring when you install `datasets` alongside `inspect_ai`.