### PR TITLE
OpenAI: Support for tool calls returning images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- OpenAI: Support for tool calls returning images (requires v2.0 of `openai` package, which is now required).
 - Agents: Improve overload return value typing for agent `run()` function.
 - Dependencies: Update to fsspec 2025.9.0 to match upper bound of HF datasets.
 - Dependencies: Allow any version of `rich` > 13.3.3 save for 14.0.0 (which had an infinite recursion bug affecting stack traces with exception groups).

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -6,6 +6,7 @@ from typing import Any, Set, cast
 from openai.types.responses import (
     Response,
     ResponseComputerToolCall,
+    ResponseFunctionCallOutputItemListParam,
     ResponseFunctionToolCall,
     ResponseFunctionWebSearch,
     ResponseInputContentParam,
@@ -530,7 +531,7 @@ def messages_from_responses_input(
                 ChatMessageTool(
                     tool_call_id=item["call_id"],
                     function=function_calls_by_id.get(item["call_id"]),
-                    content=[ContentText(text=str(item["output"]))],
+                    content=_tool_content_from_openai_tool_output(item["output"]),
                 )
             )
         elif is_computer_call_output(item):
@@ -560,6 +561,27 @@ def messages_from_responses_input(
     collect_pending_assistant_message()
 
     return messages
+
+
+def _tool_content_from_openai_tool_output(
+    output: str | ResponseFunctionCallOutputItemListParam,
+) -> str | list[Content]:
+    if isinstance(output, str):
+        return output
+    else:
+        content: list[Content] = []
+        for o in output:
+            if o["type"] == "input_text":
+                content.append(ContentText(text=o["text"]))
+            elif o["type"] == "input_image" and "image_url" in o:
+                content.append(
+                    ContentImage(
+                        image=o.get("image_url", "") or "",
+                        detail=o.get("detail", "auto") or "auto",
+                    )
+                )
+
+        return content
 
 
 # some scaffolds (e.g. codex) can present duplciate assistant messages

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -715,6 +715,10 @@ def openai_media_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
     if key == "output" and isinstance(value, dict) and "image_url" in value:
         value = copy(value)
         value.update(image_url=BASE_64_DATA_REMOVED)
+    if key == "output" and isinstance(value, list):
+        for v in value:
+            if isinstance(v, dict) and "image_url" in v:
+                v.update(image_url=BASE_64_DATA_REMOVED)
     if key == "image_url" and isinstance(value, dict) and "url" in value:
         url = str(value.get("url"))
         if url.startswith("data:"):

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -10,6 +10,7 @@ from openai.types.responses import (
     FunctionToolParam,
     ResponseComputerToolCall,
     ResponseComputerToolCallParam,
+    ResponseFunctionCallOutputItemListParam,
     ResponseFunctionToolCall,
     ResponseFunctionToolCallParam,
     ResponseFunctionWebSearch,
@@ -43,6 +44,9 @@ from openai.types.responses.response_function_web_search_param import (
     Action,
     ActionSearch,
 )
+from openai.types.responses.response_input_image_content_param import (
+    ResponseInputImageContentParam,
+)
 from openai.types.responses.response_input_item_param import (
     ComputerCallOutput,
     FunctionCallOutput,
@@ -54,6 +58,9 @@ from openai.types.responses.response_input_item_param import (
 )
 from openai.types.responses.response_input_item_param import (
     McpListToolsTool as McpListToolsToolParam,
+)
+from openai.types.responses.response_input_text_content_param import (
+    ResponseInputTextContentParam,
 )
 from openai.types.responses.response_output_item import (
     McpCall,
@@ -98,6 +105,7 @@ from inspect_ai.model._call_tools import parse_tool_call
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
+    ChatMessageTool,
 )
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ChatCompletionChoice, ModelUsage, StopReason
@@ -177,12 +185,39 @@ async def _openai_input_item_from_chat_message(
                 call_id=message.tool_call_id or str(message.function),
                 output=message.error.message
                 if message.error is not None
-                else message.text,
+                else await _openai_responses_function_call_output(message),
             )
         ]
 
     else:
         raise ValueError(f"Unexpected message role '{message.role}'")
+
+
+async def _openai_responses_function_call_output(
+    message: ChatMessageTool,
+) -> str | ResponseFunctionCallOutputItemListParam:
+    if isinstance(message.content, str):
+        return message.content
+    else:
+        outputs: ResponseFunctionCallOutputItemListParam = []
+        for c in message.content:
+            if isinstance(c, ContentText):
+                outputs.append(
+                    ResponseInputTextContentParam(type="input_text", text=c.text)
+                )
+            elif isinstance(c, ContentImage):
+                outputs.append(
+                    ResponseInputImageContentParam(
+                        type="input_image",
+                        detail=c.detail,
+                        image_url=(
+                            c.image
+                            if is_http_url(c.image)
+                            else await file_as_data_uri(c.image)
+                        ),
+                    )
+                )
+        return outputs
 
 
 async def _openai_responses_content_list_param(
@@ -347,9 +382,8 @@ def content_from_response_input_content_param(
     if is_input_text(input):
         return ContentText(text=input["text"])
     elif is_input_image(input):
-        assert input["image_url"]
         return ContentImage(
-            image=input["image_url"], detail=input.get("detail", "auto")
+            image=input.get("image_url", "") or "", detail=input.get("detail", "auto")
         )
     elif is_input_file(input):
         return ContentDocument(document=input["file_data"], filename=input["filename"])

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -290,7 +290,7 @@ class OpenAIAPI(ModelAPI):
     @override
     def tool_result_images(self) -> bool:
         # computer_use_preview supports tool calls returning images
-        if self.is_computer_use_preview():
+        if self.is_computer_use_preview() or self.responses_api:
             return True
         else:
             return False

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -310,7 +310,7 @@ def goodfire() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "1.104.1"
+    MIN_VERSION = "2.0.0"
 
     # verify we have the package
     try:


### PR DESCRIPTION
Requires v2.0 of `openai` package, which is now required.
