### PR TITLE
Deduplicate messages when deserializing

### DIFF
--- a/src/inspect_ai/_util/constants.py
+++ b/src/inspect_ai/_util/constants.py
@@ -44,4 +44,7 @@ MODEL_NONE = "none/none"
 DEFAULT_BATCH_SIZE = 100
 
 DESERIALIZING = "deserializing"
-DESERIALIZING_CONTEXT = {DESERIALIZING: True}
+
+
+def get_deserializing_context():
+    return {DESERIALIZING: True, "message_cache": {}}

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -11,7 +11,7 @@ import anyio
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
-from inspect_ai._util.constants import DESERIALIZING_CONTEXT, LOG_SCHEMA_VERSION
+from inspect_ai._util.constants import LOG_SCHEMA_VERSION, get_deserializing_context
 from inspect_ai._util.error import EvalError, WriteConflictError
 from inspect_ai._util.file import FileSystem, dirname, file, filesystem
 from inspect_ai._util.json import to_json_safe
@@ -250,7 +250,7 @@ class EvalRecorder(FileRecorder):
 
                     with zip.open(_sample_filename(id, epoch), "r") as f:
                         return EvalSample.model_validate(
-                            json.load(f), context=DESERIALIZING_CONTEXT
+                            json.load(f), context=get_deserializing_context()
                         )
                 except KeyError:
                     raise IndexError(
@@ -537,7 +537,7 @@ def _read_log(log: BinaryIO, location: str, header_only: bool = False) -> EvalLo
             with zip.open(REDUCTIONS_JSON, "r") as f:
                 reductions = [
                     EvalSampleReductions.model_validate(
-                        reduction, context=DESERIALIZING_CONTEXT
+                        reduction, context=get_deserializing_context()
                     )
                     for reduction in json.load(f)
                 ]
@@ -552,7 +552,7 @@ def _read_log(log: BinaryIO, location: str, header_only: bool = False) -> EvalLo
                     with zip.open(name, "r") as f:
                         samples.append(
                             EvalSample.model_validate(
-                                json.load(f), context=DESERIALIZING_CONTEXT
+                                json.load(f), context=get_deserializing_context()
                             ),
                         )
             sort_samples(samples)
@@ -588,7 +588,9 @@ def _read_all_summaries(zip: ZipFile, count: int) -> list[EvalSampleSummary]:
         summaries_raw = _read_json(zip, SUMMARIES_JSON)
         if isinstance(summaries_raw, list):
             return [
-                EvalSampleSummary.model_validate(value, context=DESERIALIZING_CONTEXT)
+                EvalSampleSummary.model_validate(
+                    value, context=get_deserializing_context()
+                )
                 for value in summaries_raw
             ]
         else:
@@ -605,7 +607,7 @@ def _read_all_summaries(zip: ZipFile, count: int) -> list[EvalSampleSummary]:
                 summaries.extend(
                     [
                         EvalSampleSummary.model_validate(
-                            value, context=DESERIALIZING_CONTEXT
+                            value, context=get_deserializing_context()
                         )
                         for value in summary
                     ]
@@ -621,12 +623,16 @@ def _read_header(zip: ZipFile, location: str) -> EvalLog:
     # first see if the header is here
     if HEADER_JSON in zip.namelist():
         with zip.open(HEADER_JSON, "r") as f:
-            log = EvalLog.model_validate(json.load(f), context=DESERIALIZING_CONTEXT)
+            log = EvalLog.model_validate(
+                json.load(f), context=get_deserializing_context()
+            )
             log.location = location
             return log
     else:
         with zip.open(_journal_path(START_JSON), "r") as f:
-            start = LogStart.model_validate(json.load(f), context=DESERIALIZING_CONTEXT)
+            start = LogStart.model_validate(
+                json.load(f), context=get_deserializing_context()
+            )
         return EvalLog(
             version=start.version, eval=start.eval, plan=start.plan, location=location
         )

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel
 from pydantic_core import from_json
 from typing_extensions import override
 
-from inspect_ai._util.constants import DESERIALIZING_CONTEXT, LOG_SCHEMA_VERSION
+from inspect_ai._util.constants import LOG_SCHEMA_VERSION, get_deserializing_context
 from inspect_ai._util.error import EvalError
 from inspect_ai._util.file import FileSystem, absolute_file_path, file, filesystem
 from inspect_ai._util.trace import trace_action
@@ -160,7 +160,7 @@ class JSONRecorder(FileRecorder):
                 raw_data = from_json(f.read())
             etag = None
 
-        log = EvalLog.model_validate(raw_data, context=DESERIALIZING_CONTEXT)
+        log = EvalLog.model_validate(raw_data, context=get_deserializing_context())
         log.location = location
         if etag:
             log.etag = etag

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -280,3 +280,23 @@ def test_unicode_surrogates_are_escaped():
     sample = log.samples[0]
     assert sample.output.message.text == "\\udc00\\udc00\\udc00"
     assert sample.scores["exact"].answer == "\\udc00\\udc00\\udc00"
+
+
+def test_message_deduplication():
+    log_file = os.path.join("tests", "log", "test_eval_log", "log_read_sample.json")
+
+    sample = read_eval_log_sample(log_file, id=1, epoch=1, resolve_attachments=True)
+
+    messages_by_id = {}
+    for message in sample.messages:
+        if message.id not in messages_by_id:
+            messages_by_id[message.id] = message
+        else:
+            assert message is messages_by_id[message.id]
+    for event in sample.events:
+        if isinstance(event, ModelEvent):
+            for message in event.input:
+                if message.id not in messages_by_id:
+                    messages_by_id[message.id] = message
+                else:
+                    assert message is messages_by_id[message.id]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [X] Code refactor

### What is the current behavior? (You can also link to an open issue here)

While deserializing the sample logs, repeated references to the same logical message are not preserved. Each occurrence is turned into a new model instance, so messages that referred to the same entity during serialization end up as different instances.

This causes severe memory blowup for long sample runs since the length of the messages in the model events typically grow linearly (and total memory usage thus grows quadratically).

### What is the new behavior?

During deserialization we cache messages by id and reuse object instances.


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

See also Slack thread.