### PR TITLE
Fix resolve-attachments while log convert --stream

### DIFF
--- a/src/inspect_ai/log/_convert.py
+++ b/src/inspect_ai/log/_convert.py
@@ -6,6 +6,7 @@ import anyio
 from inspect_ai._util._async import configured_async_backend
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import exists, filesystem
+from inspect_ai.log import resolve_sample_attachments
 from inspect_ai.log._file import (
     log_files_from_ls,
     read_eval_log,
@@ -128,9 +129,12 @@ async def _stream_convert_file(
 
     async def _convert_sample(sample_id: str | int, epoch: int) -> None:
         async with semaphore:
+            sample = await input_recorder.read_log_sample(input_file, sample_id, epoch)
+            if resolve_attachments:
+                sample = resolve_sample_attachments(sample)
             await output_recorder.log_sample(
                 log_header.eval,
-                await input_recorder.read_log_sample(input_file, sample_id, epoch),
+                sample,
             )
 
     log_header = await read_eval_log_async(

--- a/tests/log/test_convert.py
+++ b/tests/log/test_convert.py
@@ -3,6 +3,7 @@ from typing import Literal
 
 import pytest
 
+from inspect_ai.event import SampleInitEvent
 from inspect_ai.log._convert import convert_eval_logs
 from inspect_ai.log._file import read_eval_log
 from inspect_ai.log._log import EvalLog
@@ -45,7 +46,12 @@ def test_convert_eval_logs(
         log,
         EvalLog,
     )
+    assert log.samples
+    assert log.samples[0].events
+    sample_init_event = log.samples[0].events[0]
+    assert isinstance(sample_init_event, SampleInitEvent)
+    assert isinstance(sample_init_event.sample.input, str)
     if resolve_attachments:
-        assert not log.samples[0].events[0].sample.input.startswith("attachment:")
+        assert not sample_init_event.sample.input.startswith("attachment:")
     else:
-        assert log.samples[0].events[0].sample.input.startswith("attachment:")
+        assert sample_init_event.sample.input.startswith("attachment:")

--- a/tests/log/test_convert.py
+++ b/tests/log/test_convert.py
@@ -40,7 +40,12 @@ def test_convert_eval_logs(
 
     output_file = (tmp_path / input_file.name).with_suffix(f".{to}")
     assert output_file.exists()
+    log = read_eval_log(str(output_file))
     assert isinstance(
-        read_eval_log(str(output_file), resolve_attachments=resolve_attachments),
+        log,
         EvalLog,
     )
+    if resolve_attachments:
+        assert not log.samples[0].events[0].sample.input.startswith("attachment:")
+    else:
+        assert log.samples[0].events[0].sample.input.startswith("attachment:")


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If you run `inspect log convert` with both `--resolve-attachments` (#2465) and `--stream` (#2496), `resolve_attachments` is ignored.

### What is the new behavior?

Attachments are resolved.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Note that the unit test was "cheating": it resolved attachments while reading the log back in.
