### PR TITLE
Resume inflight batches from unfinished samples

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1244,6 +1244,14 @@ def parse_comma_separated(value: str | None) -> list[str] | None:
     envvar="INSPECT_LOG_LEVEL_TRANSCRIPT",
     help=f"Set the log level of the transcript (defaults to '{DEFAULT_LOG_LEVEL_TRANSCRIPT}')",
 )
+@click.option(
+    "--resume-batches",
+    type=bool,
+    default=False,
+    is_flag=True,
+    help="Resume any old inflight batches. Completed batches are added to the cache.",
+    envvar="INSPECT_EVAL_RESUME_BATCHES",
+)
 @common_options
 def eval_retry_command(
     log_files: tuple[str, ...],
@@ -1268,6 +1276,7 @@ def eval_retry_command(
     max_retries: int | None,
     timeout: int | None,
     log_level_transcript: str,
+    resume_batches: bool,
     **common: Unpack[CommonOptions],
 ) -> None:
     """Retry failed evaluation(s)"""
@@ -1323,4 +1332,5 @@ def eval_retry_command(
         max_retries=max_retries,
         timeout=timeout,
         max_connections=max_connections,
+        resume_batches=resume_batches,
     )

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -1303,17 +1303,6 @@ async def batch_to_cache(batch_id: str, batch: Any, eval_log: EvalLog) -> None:
         batcher = model.api._batcher
 
     if not batcher:
-        print(f"No batcher found for model {model.name}, skipping batch {batch_id}")
-        print(f"API class: {type(model.api)}")
-        print(f"Attributes: {dir(model.api)}")
-        print(
-            f"model.api._completions_batcher: {hasattr(model.api, '_completions_batcher')}"
-        )
-        print(f"model.api.completions_batcher: {model.api._completions_batcher}")
-        print(
-            f"model.api._responses_batcher: {hasattr(model.api, '_responses_batcher')}"
-        )
-        print(f"model.api.completions_batcher: {model.api._responses_batcher}")
         # No batcher available or batch mode not being used
         return
 
@@ -1471,12 +1460,7 @@ async def batch_to_cache(batch_id: str, batch: Any, eval_log: EvalLog) -> None:
 
             # Set what epoch the batch was from
             epoch.set(batch_request.epoch)
-            log.warning(
-                f"Caching result for batch request {custom_id} (model: {cache_entry.model})\n messages: {messages}\ncache_key: {_cache_key(cache_entry)}\nmodel_output: {model_output}"
-            )
-            log.warning(
-                f"cache_entry:\nbase_url: {cache_entry.base_url}\nconfig: {cache_entry.config}\ninput: {cache_entry.input}\nmodel: {cache_entry.model}\npolicy_expiry: {cache_entry.policy.expiry}\npolicy_per_epoch: {cache_entry.policy.per_epoch}\npolicy_scopes: {cache_entry.policy.scopes}\ntool_choice {cache_entry.tool_choice}\ntools: {cache_entry.tools}"
-            )
+            log.warning(f"Caching result for batch request {custom_id}")
 
             # Store in cache
             cache_store(cache_entry, model_output)

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -1316,6 +1316,7 @@ async def batch_to_cache(batch_id: str, batch: Any, eval_log: EvalLog) -> None:
                 request=req["request"],
                 result_stream=req["result_stream"],
                 custom_id=req["custom_id"],
+                epoch=req["epoch"],
             )
         batch_object = Batch(
             id=batch["id"],

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -1470,8 +1470,7 @@ async def batch_to_cache(batch_id: str, batch: Any, eval_log: EvalLog) -> None:
             )
 
             # Set what epoch the batch was from
-            # TODO: This should be recorded in the batch data but currently isn't so just assume epoch 1 for now
-            epoch.set(eval_log.model_config.get("epoch", 1))
+            epoch.set(batch_request.epoch)
             log.warning(
                 f"Caching result for batch request {custom_id} (model: {cache_entry.model})\n messages: {messages}\ncache_key: {_cache_key(cache_entry)}\nmodel_output: {model_output}"
             )

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -770,6 +770,7 @@ def eval_retry(
     max_retries: int | None = None,
     timeout: int | None = None,
     max_connections: int | None = None,
+    resume_batches: bool = False,
 ) -> list[EvalLog]:
     """Retry a previously failed evaluation task.
 
@@ -858,6 +859,7 @@ def eval_retry(
             max_retries=max_retries,
             timeout=timeout,
             max_connections=max_connections,
+            resume_batches=resume_batches,
         )
 
     return task_display().run_task_app(run_task_app)
@@ -888,6 +890,7 @@ async def eval_retry_async(
     max_retries: int | None = None,
     timeout: int | None = None,
     max_connections: int | None = None,
+    resume_batches: bool = False,
 ) -> list[EvalLog]:
     """Retry a previously failed evaluation task.
 
@@ -1077,8 +1080,7 @@ async def eval_retry_async(
         # load any in-flight batches from the previous log
         # and add them to the cache if done
         in_flight_batches = eval_log.stats.in_flight_batches or {}
-        # TODO: this should also check if the useer wants to use the cache
-        if len(in_flight_batches) > 0:
+        if resume_batches and len(in_flight_batches) > 0:
             for batch_id, batch in in_flight_batches.items():
                 await batch_to_cache(batch_id, batch, eval_log)
 

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -823,6 +823,8 @@ def eval_retry(
             Request timeout (in seconds)
         max_connections:
             Maximum number of concurrent connections to Model API (default is per Model API)
+        resume_batches:
+            Resume batches in progress rather than starting from the beginning (defaults to False).
 
     Returns:
         List of EvalLog (one for each task)
@@ -932,6 +934,7 @@ async def eval_retry_async(
         max_retries: Maximum number of times to retry request.
         timeout: Request timeout (in seconds)
         max_connections: Maximum number of concurrent connections to Model API (default is per Model API)
+        resume_batches: Resume batches in progress rather than starting from the beginning (defaults to False).
 
     Returns:
         List of EvalLog (one for each task)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -58,6 +58,7 @@ from inspect_ai.log._log import (
 from inspect_ai.log._samples import (
     active_sample,
 )
+from inspect_ai.log._stats import set_active_eval_stats
 from inspect_ai.log._transcript import (
     ErrorEvent,
     SampleInitEvent,
@@ -179,6 +180,8 @@ async def task_run(options: TaskRunOptions) -> EvalLog:
     results: EvalResults | None = None
     reductions: list[EvalSampleReductions] | None = None
     stats = EvalStats(started_at=iso_now())
+
+    set_active_eval_stats(stats)
 
     # handle sample errors (raise as required)
     sample_error_handler = SampleErrorHandler(

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -36,6 +36,7 @@ from ._log import (
 )
 from ._message import LoggingLevel, LoggingMessage
 from ._retry import retryable_eval_logs
+from ._stats import active_eval_stats, set_active_eval_stats
 from ._transcript import (
     ApprovalEvent,
     ErrorEvent,
@@ -122,4 +123,6 @@ __all__ = [
     "EventTree",
     "EventNode",
     "SpanNode",
+    "active_eval_stats",
+    "set_active_eval_stats",
 ]

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -938,6 +938,9 @@ class EvalStats(BaseModel):
     # allow field model_usage
     model_config = ConfigDict(protected_namespaces=())
 
+    in_flight_batches: dict[str, Any] = Field(default_factory=dict)
+    """Batches that were being processed when the eval stopped."""
+
 
 class EvalLog(BaseModel):
     """Evaluation log."""

--- a/src/inspect_ai/log/_stats.py
+++ b/src/inspect_ai/log/_stats.py
@@ -1,0 +1,16 @@
+import contextlib
+from contextvars import ContextVar
+
+from inspect_ai.log._log import EvalStats
+
+_active_eval_stats: ContextVar[EvalStats | None] = ContextVar(
+    "_active_eval_stats", default=None
+)
+
+
+def active_eval_stats() -> EvalStats | None:
+    return _active_eval_stats.get(None)
+
+
+def set_active_eval_stats(stats: EvalStats) -> None:
+    _active_eval_stats.set(stats)

--- a/src/inspect_ai/model/_cache.py
+++ b/src/inspect_ai/model/_cache.py
@@ -161,7 +161,10 @@ def _cache_key(entry: CacheEntry) -> str:
             )
         ),
         ",".join(
-            [str(message.model_dump(exclude=set(["id"]))) for message in entry.input]
+            [
+                str(message.model_dump(exclude=set(["id", "source"])))
+                for message in entry.input
+            ]
         ),
         entry.base_url,
         entry.tool_choice,

--- a/src/inspect_ai/model/_providers/util/batch.py
+++ b/src/inspect_ai/model/_providers/util/batch.py
@@ -18,6 +18,7 @@ from inspect_ai._util.notgiven import sanitize_notgiven
 from inspect_ai.log._stats import active_eval_stats
 from inspect_ai.model._generate_config import BatchConfig
 from inspect_ai.model._retry import ModelRetryConfig
+from inspect_ai.model._cache import epoch
 
 from .batch_log import log_batch
 
@@ -43,6 +44,7 @@ class BatchRequest(Generic[ResponseT]):
 
     request: dict[str, Any]
     result_stream: anyio.abc.ObjectSendStream[ResponseT | Exception]
+    epoch: int
     custom_id: str = dataclasses.field(default_factory=lambda: str(uuid.uuid4()))
 
 
@@ -97,7 +99,7 @@ class Batcher(Generic[ResponseT, CompletedBatchInfoT]):
             ResponseT | Exception
         ](1)
         batch_request = BatchRequest[ResponseT](
-            request=request, result_stream=send_stream
+            request=request, result_stream=send_stream, epoch=epoch.get(1)
         )
         self._intake_queue.append(batch_request)
 


### PR DESCRIPTION
## This PR contains:
- [X] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently in batch mode, if an eval is stopped mid sample there will be batches that are inflight that are not resumed when the eval is retried. This means that we need to resend all of the requests when running the sample again.

### What is the new behavior?
Now the current set of inflight batches are saved in the eval stats of the eval log. When the log is retried it will check each of the inflight batches when the log was closed, each request from completed batches will be added into the cache, batches that are still in progress will be added to the current inflight batches. Adding completed requests to the cache will mean that when resuming the sample that request will be automatically filled without needing to create a new batch allowing whatever sample that was in progress to effectively resume from where it was (assuming the rest of the input is the same).

This was born out of a desire to run large batches asynchronously for simple 1 step evals such as big mcq datasets. The ideal use case would be run the eval, send off all the requests in a large batch, close the process, resume the next day and pick up the completed sample.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Changing the information stored in the logs might break something related to reading the logs but I have not checked.
As part of this change I removed the source field from cache key calculation. This will result in different keys compared to before meaning generate will need to be called again.

### Other information:

TODO:
1. plan how to resume batches that have not been completed 
-- The problem with this is how do we marry up the requests from a batch with a specific generate call in a sample?
-- we could do something like, if we would call generate with a given input, epoch, ect and there is an inflight batch with the same input, epoch, ect then we dont make a new request and instead just wait for that inflight batch to be done.
-- This approach sounds like it will have problems but I can't describe why yet. 