### PR TITLE
Add support for Hugging Face Inference Providers

### DIFF
--- a/docs/_model-providers.md
+++ b/docs/_model-providers.md
@@ -3,7 +3,7 @@
 |------------------------------------|------------------------------------|
 | Lab APIs | [OpenAI](providers.qmd#openai), [Anthropic](providers.qmd#anthropic), [Google](providers.qmd#google), [Grok](providers.qmd#grok), [Mistral](providers.qmd#mistral), [DeepSeek](providers.qmd#deepseek), [Perplexity](providers.qmd#perplexity) |
 | Cloud APIs | [AWS Bedrock](providers.qmd#aws-bedrock) and [Azure AI](providers.qmd#azure-ai) |
-| Open (Hosted) | [Groq](providers.qmd#groq), [Together AI](providers.qmd#together-ai), [Fireworks AI](providers.qmd#fireworks-ai), [Cloudflare](providers.qmd#cloudflare) | [SambaNova](providers.qmd#sambanova) | [Goodfire](providers.qmd#goodfire) |
+| Open (Hosted) | [Groq](providers.qmd#groq), [Together AI](providers.qmd#together-ai), [Fireworks AI](providers.qmd#fireworks-ai), [Cloudflare](providers.qmd#cloudflare), [HF Inference Providers](providers.qmd#hf-inference-providers), [SambaNova](providers.qmd#sambanova), [Goodfire](providers.qmd#goodfire) |
 | Open (Local) | [Hugging Face](providers.qmd#hugging-face), [vLLM](providers.qmd#vllm), [Ollama](providers.qmd#ollama), [Lllama-cpp-python](providers.qmd#llama-cpp-python), [SGLang](providers.qmd#sglang), [TransformerLens](providers.qmd#transformer-lens) |
 
 <br/>

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -882,6 +882,32 @@ The following environment variables are supported by the OpenRouter AI provider
 | `OPENROUTER_API_KEY` | API key credentials (required). |
 | `OPENROUTER_BASE_URL` | Base URL for requests (optional, defaults to `https://openrouter.ai/api/v1`) |
 
+## Hugging Face Inference Providers
+
+To use [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers), install the `openai` package (which provides the compatibility layer), set your Hugging Face token, and specify a model using the `--model` option:
+
+``` bash
+pip install openai
+export HF_TOKEN=your-huggingface-token
+inspect eval arc.py --model hf-inference-providers/openai/gpt-oss-120b
+```
+
+The above will automatically select the provider for you. If you want to use a specific provider you can append `:` followed by the provider name. To use cerebras for example, you would do the following:
+
+``` bash
+pip install openai
+export HF_TOKEN=your-huggingface-token
+inspect eval arc.py --model hf-inference-providers/openai/gpt-oss-120b:cerebras
+```
+
+HF Inference Providers provides unified access to hundreds of machine learning models through multiple world-class inference providers (Cerebras, Groq, Together AI, etc.) with automatic provider routing and failover.
+
+The following environment variables are supported by the HF Inference Providers:
+
+| Variable | Description |
+|----------------------------|--------------------------------------------|
+| `HF_TOKEN` | Hugging Face token with appropriate permissions (required). |
+
 ## Custom Models
 
 If you want to support another model hosting service or local model source, you can add a custom model API. See the documentation on [Model API Extensions](extensions.qmd#sec-model-api-extensions) for additional details.

--- a/src/inspect_ai/model/_providers/hf_inference_providers.py
+++ b/src/inspect_ai/model/_providers/hf_inference_providers.py
@@ -1,0 +1,38 @@
+import os
+from typing import Any
+from typing_extensions import override
+
+from .._generate_config import GenerateConfig
+from .openai_compatible import OpenAICompatibleAPI
+from .util import environment_prerequisite_error
+
+HF_TOKEN = "HF_TOKEN"
+
+
+class HFInferenceProvidersAPI(OpenAICompatibleAPI):
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args: Any,
+    ) -> None:
+        # Handle API key before calling super() to avoid the automatic key generation
+        if not api_key:
+            api_key = os.environ.get(HF_TOKEN, None)
+            if not api_key:
+                raise environment_prerequisite_error(
+                    "HF Inference Providers",
+                    [HF_TOKEN],
+                )
+        
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url or "https://router.huggingface.co/v1",
+            api_key=api_key,
+            config=config,
+            service="HF Inference Providers",
+            service_base_url="https://router.huggingface.co/v1",
+            **model_args,
+        )

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -307,6 +307,17 @@ def goodfire() -> type[ModelAPI]:
     return GoodfireAPI  # type: ignore[no-any-return]
 
 
+@modelapi(name="hf-inference-providers")
+def hf_inference_providers() -> type[ModelAPI]:
+    # validate
+    validate_openai_client("HF Inference Providers API")
+
+    # in the clear
+    from .hf_inference_providers import HFInferenceProvidersAPI
+
+    return HFInferenceProvidersAPI
+
+
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"

--- a/tests/model/test_hf_inference_providers.py
+++ b/tests/model/test_hf_inference_providers.py
@@ -1,0 +1,40 @@
+import pytest
+from test_helpers.utils import skip_if_no_openai_package, skip_if_trio
+
+from inspect_ai.model import GenerateConfig, get_model
+
+
+@pytest.mark.anyio
+@skip_if_no_openai_package
+@skip_if_trio
+async def test_hf_inference_providers_model_creation():
+    """Test that HF Inference Providers models can be created."""
+    model = get_model("hf-inference-providers/openai/gpt-oss-20b")
+
+    # Verify the model was created successfully
+    assert model is not None
+    assert model.model_name == "openai/gpt-oss-20b"
+
+
+@pytest.mark.anyio
+@skip_if_no_openai_package
+@skip_if_trio
+async def test_hf_inference_providers_with_config():
+    """Test HF Inference Providers model with custom config."""
+    config = GenerateConfig(temperature=0.7, max_tokens=100)
+    model = get_model("hf-inference-providers/openai/gpt-oss-20b", config=config)
+
+    assert model is not None
+    assert model.model_name == "openai/gpt-oss-20b"
+
+
+@pytest.mark.anyio
+@skip_if_no_openai_package
+@skip_if_trio
+async def test_hf_inference_providers_caching():
+    """Test that HF Inference Providers models are cached properly."""
+    model1 = get_model("hf-inference-providers/openai/gpt-oss-20b")
+    model2 = get_model("hf-inference-providers/openai/gpt-oss-20b")
+
+    # Verify we got the same cached instance
+    assert model1 is model2


### PR DESCRIPTION
Congrats on the library, it's fantastic!

We'd love to add [HF Inference Providers](https://huggingface.co/docs/inference-providers/index) so users can benchmark +4K open models from the Hub.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? 

Inspect AI supports many model providers (OpenAI, Anthropic, Google, etc.) but does not directly integrate with Hugging Face Inference Providers. Thus, it offers unified access to thousands of open models across multiple inference providers.

### What is the new behavior?

This PR adds a new `hf-inference-providers` model provider through Hugging Face's Inference Providers. The integration provides:

- Unified access to models from multiple providers (Cerebras, Groq, Together AI, etc.)
- Automatic provider routing and failover
- OpenAI-compatible API interface
- Simple authentication via `HF_TOKEN` environment variable

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking changes. This is purely additive functionality.

### Other information:

**Usage:**
Provider is auto-selected
```bash
export HF_TOKEN=your-huggingface-token
inspect eval arc.py --model hf-inference-providers/openai/gpt-oss-120b
```
Or specified by the user:
```bash
export HF_TOKEN=your-huggingface-token
inspect eval arc.py --model hf-inference-providers/openai/gpt-oss-120b:cerebras
```