### PR TITLE
Bugfix: retry on anthropic internal server errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - OpenAI: Support for tool calls returning images (requires v2.0 of `openai` package, which is now required).
+- Anthropic: Retry requests that get an error body payload with 'internal server error'
 - Agents: Improve overload return value typing for agent `run()` function.
 - Task display: Improved reporting of errors that occur during log initialization.
 - Event API: Created new `inspect_ai.event` module with event related tyeps and functions.

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -506,7 +506,7 @@ class AnthropicAPI(ModelAPI):
     def should_retry(self, ex: BaseException) -> bool:
         if isinstance(ex, APIStatusError):
             # when streaming, anthropic does not set status_code == 529
-            # for overloaded or internal server errors so we check for it explicitly
+            # for overloaded or internal server errors so we check for them explicitly
             if isinstance(ex.body, dict):
                 body_str = str(ex.body).lower()
                 if "overloaded" in body_str or "internal server error" in body_str:

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -506,9 +506,10 @@ class AnthropicAPI(ModelAPI):
     def should_retry(self, ex: BaseException) -> bool:
         if isinstance(ex, APIStatusError):
             # when streaming, anthropic does not set status_code == 529
-            # for overloaded errors so we check for it explicitly
+            # for overloaded or internal server errors so we check for it explicitly
             if isinstance(ex.body, dict):
-                if "overloaded" in str(ex.body).lower():
+                body_str = str(ex.body).lower()
+                if "overloaded" in body_str or "internal server error" in body_str:
                     return True
 
             # standard http status code checking


### PR DESCRIPTION
## This PR contains:
- [ ] Bug fixes

### What is the current behavior? (You can also link to an open issue here)
The anthropic `should_retry` [method](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/model/_providers/anthropic.py#L506) isn't catching this exception:
```anthropic.APIStatusError: {'type': 'error', 'error': {'details': None, 'type': 'api_error', 'message': 'Internal server error'}, 'request_id': 'req_011CTnpKCE4RQY4wHWtsK2Bv'}```
### What is the new behavior?
This patch adds a check for "internal server error" in the error body (in addition to the existing "overloaded" check) to ensure these transient errors are properly retried.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Other information:
N/A