### PR TITLE
Fix crash when determining tool_param based on type hint of Any in Python 3.10 w/Pydantic 2.12.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Bugfix: Honor `resolve_attachments` in score command when `stream=True`.
 - Bugfix: Allow cancellation errors to propagate when `fail_on_error=False`.
 - Bugfix: text_editor tool now supports relative file paths.
+- Bugfix: Fix crash when determining tool_param based on type hint of Any in Python 3.10 w/Pydantic 2.12.0.
 
 ## 0.3.136 (02 October 2025)
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -1,6 +1,7 @@
 import inspect
 import json
 import types
+import typing
 from copy import copy, deepcopy
 from dataclasses import is_dataclass
 from datetime import date, datetime, time
@@ -657,7 +658,9 @@ def tool_param(type_hint: Type[Any], input: Any) -> Any:
     args = get_args(type_hint)
 
     if origin is None:
-        if type_hint in [int, str, float, bool]:
+        if type_hint == typing.Any:
+            return input
+        elif type_hint in [int, str, float, bool]:
             try:
                 return type_hint(input)
             except (ValueError, TypeError):


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

This was a long standing bug in our code that was masked by Pydantic's customization of `issubclass` via implementations of `__subclasscheck__` and `__instancecheck__`. They fundamentally changed their implementation in `v2.12.0`. See: https://github.com/pydantic/pydantic/compare/v2.11.10...v2.12.0