### PR TITLE
Refactor stream conversion to use run_coroutine

### DIFF
--- a/src/inspect_ai/log/_convert.py
+++ b/src/inspect_ai/log/_convert.py
@@ -3,7 +3,7 @@ from typing import Literal
 
 import anyio
 
-from inspect_ai._util._async import configured_async_backend, run_coroutine
+from inspect_ai._util._async import run_coroutine
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.file import exists, filesystem
 from inspect_ai.log import resolve_sample_attachments


### PR DESCRIPTION
> Another possible bug in convert_eval_logs: When setting stream=True and running it in a notebook, `I get RuntimeError: Already running asyncio in this thread. Traceback in :thread: 

```
---------------------------------------------------------------------------
Cell In[3], line 40, in migrate_log(log_path)
     38 print(f"Migrating to {output_dir}\n")
     39 s3_log_path = convert_to_s3_path(log_path)
---> 40 convert_eval_logs(path=s3_log_path, to="eval", output_dir=s3_output_dir, stream=1)
     41 gc.collect()

File .venv/lib/python3.12/site-packages/inspect_ai/log/_convert.py:103, in convert_eval_logs(path, to, output_dir, overwrite, resolve_attachments, stream)
     97         write_eval_log(
     98             read_eval_log(input_file, resolve_attachments=resolve_attachments),
     99             output_file,
    100         )
    102 if fs.info(path).type == "file":
--> 103     convert_file(path)
    104 else:
    105     root_dir = fs.info(path).name

File .venv/lib/python3.12/site-packages/inspect_ai/log/_convert.py:87, in convert_eval_logs.<locals>.convert_file(input_file)
     85 # do a full read/write (normalized deprecated constructs and adds sample summaries)
     86 if stream:
---> 87     anyio.run(
     88         _stream_convert_file,
     89         input_file,
     90         output_file,
     91         output_dir,
     92         resolve_attachments,
     93         stream,
     94         backend=configured_async_backend(),
     95     )
     96 else:
     97     write_eval_log(
     98         read_eval_log(input_file, resolve_attachments=resolve_attachments),
     99         output_file,
    100     )

File .venv/lib/python3.12/site-packages/anyio/_core/_eventloop.py:59, in run(func, backend, backend_options, *args)
     57     pass
     58 else:
---> 59     raise RuntimeError(f"Already running {asynclib_name} in this thread")
     61 try:
     62     async_backend = get_async_backend(backend)
RuntimeError: Already running asyncio in this thread
```