### PR TITLE
Retry specific samples

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1145,6 +1145,12 @@ def parse_comma_separated(value: str | None) -> list[str] | None:
     help=NO_SANDBOX_CLEANUP_HELP,
 )
 @click.option(
+    "--sample-id",
+    type=str,
+    help="Evaluate specific sample(s) (comma separated list of ids)",
+    envvar="INSPECT_EVAL_SAMPLE_ID",
+)
+@click.option(
     "--trace",
     type=bool,
     is_flag=True,
@@ -1267,6 +1273,7 @@ def eval_retry_command(
     max_subprocesses: int | None,
     max_sandboxes: int | None,
     no_sandbox_cleanup: bool | None,
+    sample_id: str | None,
     trace: bool | None,
     fail_on_error: bool | float | None,
     no_fail_on_error: bool | None,
@@ -1313,12 +1320,16 @@ def eval_retry_command(
         log_file_info(filesystem(log_file).info(log_file)) for log_file in log_files
     ]
 
+    # parse sample_id
+    eval_sample_id = parse_sample_id(sample_id)
+
     # retry
     eval_retry(
         retry_log_files,
         log_level=common["log_level"],
         log_level_transcript=log_level_transcript,
         log_dir=common["log_dir"],
+        sample_id=eval_sample_id,
         max_samples=max_samples,
         max_tasks=max_tasks,
         max_subprocesses=max_subprocesses,

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -740,6 +740,7 @@ def eval_retry(
     log_level_transcript: str | None = None,
     log_dir: str | None = None,
     log_format: Literal["eval", "json"] | None = None,
+    sample_id: str | int | list[str] | list[int] | list[str | int] | None = None,
     max_samples: int | None = None,
     max_tasks: int | None = None,
     max_subprocesses: int | None = None,
@@ -774,6 +775,9 @@ def eval_retry(
             (defaults to file log in ./logs directory).
         log_format: Format for writing log files (defaults
             to "eval", the native high-performance format).
+        sample_id: Evaluate specific sample(s) from the dataset. If provided,
+            overrides the sample_id from the original evaluation log, allowing
+            you to rerun specific samples even if they previously succeeded.
         max_samples: Maximum number of samples to run in parallel
             (default is max_connections)
         max_tasks: Maximum number of tasks to run in parallel
@@ -833,6 +837,7 @@ def eval_retry(
             log_level_transcript=log_level_transcript,
             log_dir=log_dir,
             log_format=log_format,
+            sample_id=sample_id,
             max_samples=max_samples,
             max_tasks=max_tasks,
             max_subprocesses=max_subprocesses,
@@ -864,6 +869,7 @@ async def eval_retry_async(
     log_level_transcript: str | None = None,
     log_dir: str | None = None,
     log_format: Literal["eval", "json"] | None = None,
+    sample_id: str | int | list[str] | list[int] | list[str | int] | None = None,
     max_samples: int | None = None,
     max_tasks: int | None = None,
     max_subprocesses: int | None = None,
@@ -894,6 +900,9 @@ async def eval_retry_async(
         log_level_transcript: Level for logging to the log file (defaults to "info")
         log_dir: Output path for logging results (defaults to file log in ./logs directory).
         log_format: Format for writing log files (defaults to "eval", the native high-performance format).
+        sample_id: Evaluate specific sample(s) from the dataset. If provided,
+            overrides the sample_id from the original evaluation log, allowing
+            you to rerun specific samples even if they previously succeeded.
         max_samples: Maximum number of samples to run in parallel
            (default is max_connections)
         max_tasks: Maximum number of tasks to run in parallel (default is 1)
@@ -1007,7 +1016,7 @@ async def eval_retry_async(
                     log_format = "eval"
                 case ".json":
                     log_format = "json"
-        sample_id = eval_log.eval.config.sample_id
+        sample_id = sample_id if sample_id is not None else eval_log.eval.config.sample_id
         sample_shuffle = eval_log.eval.config.sample_shuffle
         epochs = (
             Epochs(eval_log.eval.config.epochs, eval_log.eval.config.epochs_reducer)

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,8 +1,10 @@
 import tempfile
 
+import pytest
 from test_helpers.utils import failing_task
 
 from inspect_ai import Task, eval, eval_retry, task
+from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.dataset import Sample
 from inspect_ai.log import list_eval_logs, retryable_eval_logs
 from inspect_ai.model import GenerateConfig, get_model
@@ -89,3 +91,354 @@ def test_eval_retry_with_model_generate_config():
     log = eval_retry(log)[0]
     assert log.status == "success"
     assert log.eval.model_generate_config == generate_config
+
+
+# Tests for eval_retry with sample_id argument
+
+
+def test_eval_retry_sample_id_single_integer():
+    """Test retry with single integer sample_id reruns that specific sample."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def sample_id_test_task():
+        return Task(
+            dataset=[
+                Sample(id=i, input=f"Input {i}", target=f"target {i}") for i in range(5)
+            ],
+            solver=[
+                failing_solver_deterministic([False, False, True, False, False]),
+                generate(),
+            ],
+            scorer=exact(),
+        )
+
+    # Initial eval
+    log = eval(sample_id_test_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 5
+    failed_samples = [s for s in log.samples if s.error is not None]
+    assert len(failed_samples) == 1
+    assert failed_samples[0].id == 2
+
+    # Retry with sample_id=1 (a successful sample)
+    retry_log = eval_retry(log, sample_id=1)[0]
+
+    # Verify only sample 1 was rerun
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 1
+    assert retry_log.samples[0].id == 1
+    assert retry_log.samples[0].error is None
+
+
+def test_eval_retry_sample_id_multiple_integers():
+    """Test retry with multiple integer sample_ids."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def multiple_samples_task():
+        should_fail = [i in [3, 7] for i in range(10)]
+        return Task(
+            dataset=[
+                Sample(id=i, input=f"Input {i}", target=f"target {i}") for i in range(10)
+            ],
+            solver=[failing_solver_deterministic(should_fail), generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval
+    log = eval(multiple_samples_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 10
+
+    # Retry with sample_id=[1, 3, 5] (mix of successful and failed)
+    retry_log = eval_retry(log, sample_id=[1, 3, 5])[0]
+
+    # Verify exactly 3 samples were rerun
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 3
+    sample_ids = {s.id for s in retry_log.samples}
+    assert sample_ids == {1, 3, 5}
+
+
+def test_eval_retry_sample_id_string_ids():
+    """Test retry with single string sample_id."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def string_ids_task():
+        sample_ids = ["sample-a", "sample-b", "sample-c"]
+        return Task(
+            dataset=[
+                Sample(id=sid, input=f"Input {sid}", target=f"target {sid}")
+                for sid in sample_ids
+            ],
+            solver=[failing_solver_deterministic([False, True, False]), generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval where "sample-b" fails
+    log = eval(string_ids_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 3
+    failed_samples = [s for s in log.samples if s.error is not None]
+    assert len(failed_samples) == 1
+    assert failed_samples[0].id == "sample-b"
+
+    # Retry with sample_id="sample-a" (a successful sample)
+    retry_log = eval_retry(log, sample_id="sample-a")[0]
+
+    # Verify only "sample-a" was rerun
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 1
+    assert retry_log.samples[0].id == "sample-a"
+
+
+def test_eval_retry_sample_id_string_list():
+    """Test retry with list of string sample_ids."""
+
+    @task
+    def string_list_task():
+        sample_ids = ["sample-a", "sample-b", "sample-c", "sample-d"]
+        return Task(
+            dataset=[
+                Sample(id=sid, input=f"Input {sid}", target=f"target {sid}")
+                for sid in sample_ids
+            ],
+            solver=[generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval
+    log = eval(string_list_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 4
+
+    # Retry with sample_id=["sample-a", "sample-c"]
+    retry_log = eval_retry(log, sample_id=["sample-a", "sample-c"])[0]
+
+    # Verify both samples were rerun
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 2
+    sample_ids_result = {s.id for s in retry_log.samples}
+    assert sample_ids_result == {"sample-a", "sample-c"}
+
+
+def test_eval_retry_sample_id_pattern_brackets():
+    """Test retry with bracket pattern matching."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def pattern_brackets_task():
+        sample_ids = [f"sample-{i}" for i in range(10)]
+        should_fail = [i in [3, 7] for i in range(10)]
+        return Task(
+            dataset=[
+                Sample(id=sid, input=f"Input {sid}", target=f"target {sid}")
+                for sid in sample_ids
+            ],
+            solver=[failing_solver_deterministic(should_fail), generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval where samples 3 and 7 fail
+    log = eval(pattern_brackets_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 10
+
+    # Retry with sample_id=["sample-[56]"] (should match sample-5 and sample-6)
+    retry_log = eval_retry(log, sample_id=["sample-[56]"])[0]
+
+    # Verify samples 5 and 6 were rerun (even though they didn't fail)
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 2
+    sample_ids_result = {s.id for s in retry_log.samples}
+    assert sample_ids_result == {"sample-5", "sample-6"}
+
+
+def test_eval_retry_sample_id_wildcard():
+    """Test retry with wildcard pattern matching."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def wildcard_task():
+        sample_ids = ["a-1", "a-2", "b-1", "b-2"]
+        should_fail = [False, True, False, False]
+        return Task(
+            dataset=[
+                Sample(id=sid, input=f"Input {sid}", target=f"target {sid}")
+                for sid in sample_ids
+            ],
+            solver=[failing_solver_deterministic(should_fail), generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval where "a-2" fails
+    log = eval(wildcard_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 4
+
+    # Retry with sample_id=["a-*"] (should match a-1 and a-2)
+    retry_log = eval_retry(log, sample_id=["a-*"])[0]
+
+    # Verify both a-1 and a-2 were rerun
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 2
+    sample_ids_result = {s.id for s in retry_log.samples}
+    assert sample_ids_result == {"a-1", "a-2"}
+
+
+def test_eval_retry_reruns_completed_samples_with_sample_id():
+    """Test that completed samples ARE rerun when sample_id is provided."""
+
+    @task
+    def completed_samples_task():
+        return Task(
+            dataset=[
+                Sample(id=i, input=f"Input {i}", target=f"target {i}") for i in range(3)
+            ],
+            solver=[generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval - all succeed
+    log = eval(completed_samples_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 3
+    assert all(s.error is None for s in log.samples)
+
+    # Retry with sample_id=1 (a successful sample)
+    retry_log = eval_retry(log, sample_id=1)[0]
+
+    # Verify sample 1 was RERUN (not reused)
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 1
+    retry_sample_1 = retry_log.samples[0]
+    assert retry_sample_1.id == 1
+
+    # The sample should have new events (indicating it was rerun, not reused)
+    assert len(retry_sample_1.events) > 0
+
+
+def test_eval_retry_preserves_completed_without_sample_id():
+    """Test that completed samples are NOT rerun when sample_id is NOT provided."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def preserve_completed_task():
+        should_fail = [False, False, True, False, False]
+        return Task(
+            dataset=[
+                Sample(id=i, input=f"Input {i}", target=f"target {i}") for i in range(5)
+            ],
+            solver=[failing_solver_deterministic(should_fail), generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval
+    log = eval(preserve_completed_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 5
+    failed_samples = [s for s in log.samples if s.error is not None]
+    assert len(failed_samples) == 1
+    assert failed_samples[0].id == 2
+
+    # Retry WITHOUT sample_id parameter
+    retry_log = eval_retry(log)[0]
+
+    # Verify only the failed sample (2) was rerun
+    # The successful samples should be reused from the previous log
+    assert retry_log.samples is not None
+    # In a retry without sample_id, successful samples are preserved
+    # so we should only see sample 2 being rerun
+    rerun_sample_ids = {s.id for s in retry_log.samples}
+    assert 2 in rerun_sample_ids
+
+
+def test_eval_retry_sample_id_overrides_failures():
+    """Test that sample_id overrides default retry behavior (which is to retry failures)."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def override_failures_task():
+        should_fail = [False, True, False, True, False]
+        return Task(
+            dataset=[
+                Sample(id=i, input=f"Input {i}", target=f"target {i}") for i in range(5)
+            ],
+            solver=[failing_solver_deterministic(should_fail), generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval where samples 1 and 3 fail
+    log = eval(override_failures_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 5
+    failed_samples = [s for s in log.samples if s.error is not None]
+    assert len(failed_samples) == 2
+    assert {s.id for s in failed_samples} == {1, 3}
+
+    # Retry with sample_id=2 (a successful sample, NOT the failures)
+    retry_log = eval_retry(log, sample_id=2)[0]
+
+    # Verify only sample 2 is in retry log
+    # Failed samples 1 and 3 are NOT retried
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 1
+    assert retry_log.samples[0].id == 2
+
+
+def test_eval_retry_sample_id_nonexistent():
+    """Test that retry with nonexistent sample_id raises an error."""
+
+    @task
+    def nonexistent_id_task():
+        return Task(
+            dataset=[
+                Sample(id=i, input=f"Input {i}", target=f"target {i}") for i in range(5)
+            ],
+            solver=[generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval
+    log = eval(nonexistent_id_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 5
+
+    # Retry with sample_id=99 (doesn't exist)
+    with pytest.raises(PrerequisiteError):
+        eval_retry(log, sample_id=99)
+
+
+def test_eval_retry_sample_id_mixed_success_and_failure():
+    """Test retry with mixed successful and failed samples."""
+    from test_helpers.utils import failing_solver_deterministic
+
+    @task
+    def mixed_samples_task():
+        should_fail = [i in [2, 5, 8] for i in range(10)]
+        return Task(
+            dataset=[
+                Sample(id=i, input=f"Input {i}", target=f"target {i}") for i in range(10)
+            ],
+            solver=[failing_solver_deterministic(should_fail), generate()],
+            scorer=exact(),
+        )
+
+    # Initial eval
+    log = eval(mixed_samples_task(), model="mockllm/model")[0]
+    assert log.samples is not None
+    assert len(log.samples) == 10
+    failed_samples = [s for s in log.samples if s.error is not None]
+    assert len(failed_samples) == 3
+    assert {s.id for s in failed_samples} == {2, 5, 8}
+
+    # Retry with sample_id=[1, 2, 5, 9] (2 successful, 2 failed)
+    retry_log = eval_retry(log, sample_id=[1, 2, 5, 9])[0]
+
+    # Verify all 4 samples were rerun
+    assert retry_log.samples is not None
+    assert len(retry_log.samples) == 4
+    sample_ids_result = {s.id for s in retry_log.samples}
+    assert sample_ids_result == {1, 2, 5, 9}


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently only eval accepts sample-ids as an argument.

### What is the new behavior?
Added sample-id as an argument to eval-retry, only retries the specific samples given and if those samples are already completed they will still be rerun. the final set of samples in the log file should be the union of any completed samples and the specified sample ids.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
I don't this this should effect anything else as the argument is optional and defaults to the original behaviour.

### Other information:
