### PR TITLE
fix edit_score() for multiple epochs case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - Bugfix: Ensure that calls to generate always sync the cache state to the current sample's epoch.
 - Bugfix: Don't use default values for `list` and `dict` parameters (rather use `None` and initialize on use).
 - Bugfix: When reading log files, tolerate `SubtaskEvent.input` values that aren't of the required `dict` type.
+- Bugfix: Fix `edit_score()` silently editing only first epoch in multi-epoch evaluations (now requires explicit `epoch` parameter).
 
 ## 0.3.137 (07 October 2025)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`edit_score()` edits the score for the first sample found with the ID passed to `sample_id`.

### What is the new behavior?

If there are multiple epochs, and the user does not pass a valid value to the `epoch` param, `edit_score()` raises an exception. If the user passes a valid value, `edit_score()` edits the score for the sample with the ID and epoch number.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes. Users need to make changes to pass the sample's epoch number for the score they want to edit, to `epoch`, when they call `edit_score()`, if there are multiple epochs.

### Other information:
