### PR TITLE
call model api aclose() method before re-initialization

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -832,6 +832,9 @@ class Model:
 
     async def before_retry(self, ex: BaseException) -> None:
         if isinstance(ex, Exception) and self.api.is_auth_failure(ex):
+            # close existing model instance
+            await self.api.aclose()
+            # re-initialize
             self.api.initialize()
 
     # function to verify that its okay to call model apis


### PR DESCRIPTION
for models that need some explicit resource cleanup this does it eagerly rather than rely on garbage collection (or not have cleanup happen at all)
