### PR TITLE
Fix Slow Test: Correct score editing final order

### DIFF
--- a/tests/_cli/test_score.py
+++ b/tests/_cli/test_score.py
@@ -49,8 +49,8 @@ LOG_UNSCORED = (
             "append",
             ("f1", ("stop_words=[woah]",)),
             {
-                "f1": {"num_metrics": 2, "stop_words": ["woah"]},
                 "match": {"num_metrics": 2},
+                "f1": {"num_metrics": 2, "stop_words": ["woah"]},
             },
             id="scored-append",
         ),


### PR DESCRIPTION
The latest changes to score editing append results, so the new results appear at the end of the of results list. This seems strictly correct, so updating the test to expect this.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
