### PR TITLE
Wrap sandbox utils injection failures in `SandboxInjectionError` so that they're not treated as errors coming from the invocation of an actual tool.

### DIFF
--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -39,6 +39,24 @@ logger = getLogger(__name__)
 
 TRACE_SANDBOX_TOOLS = "Sandbox Tools"
 
+
+class SandboxInjectionError(Exception):
+    """Exception raised when sandbox tools injection fails.
+
+    This error wraps any exception that occurs during the injection process
+    to provide a clear signal that the failure was specifically during injection.
+    This is required because SandboxInjection happens as a side effect of making
+    a tool call. We need to make sure that injection errors are not interpreted
+    and handled specially (e.g. give to the model) as exceptions throw from tool
+    calls are.
+    """
+
+    def __init__(self, message: str, cause: Exception | None = None) -> None:
+        super().__init__(message)
+        self.cause = cause
+        self.__cause__ = cause
+
+
 InstallState = Literal["pypi", "clean", "edited"]
 """Represents the state of the inspect-ai installation.
 
@@ -75,13 +93,18 @@ async def sandbox_with_injected_tools(
 
 
 async def _inject_container_tools_code(sandbox: SandboxEnvironment) -> None:
-    info = await detect_sandbox_os(sandbox)
+    try:
+        info = await detect_sandbox_os(sandbox)
 
-    async with _open_executable_for_arch(info["architecture"]) as (_, f):
-        # TODO: The first tuple member, filename, isn't currently used, but it will be
-        await sandbox.write_file(SANDBOX_TOOLS_CLI, f.read())
-        # .write_file used `tee` which dropped execute permissions
-        await sandbox.exec(["chmod", "+x", SANDBOX_TOOLS_CLI])
+        async with _open_executable_for_arch(info["architecture"]) as (_, f):
+            # TODO: The first tuple member, filename, isn't currently used, but it will be
+            await sandbox.write_file(SANDBOX_TOOLS_CLI, f.read())
+            # .write_file used `tee` which dropped execute permissions
+            await sandbox.exec(["chmod", "+x", SANDBOX_TOOLS_CLI])
+    except Exception as e:
+        raise SandboxInjectionError(
+            f"Failed to inject sandbox tools into sandbox: {e}", cause=e
+        ) from e
 
 
 @asynccontextmanager


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`_inject_container_tools_code` allows any exception to propagate directly. Since sandbox injection happens as a side effect of making a tool call, uncaught exceptions could be interpreted and handled as tool execution errors—potentially even being passed to the model. This created ambiguity about the source of failures and could lead to incorrect error handling.

### What is the new behavior?

Exceptions propagated through `_inject_container_tools_code` will now be wrapped in a `SandboxInjectionError`. This prevents any special handling if they were interpreted as _tool_ errors.

Evals will now properly fail with something like:
```
SandboxInjectionError: Failed to inject sandbox tools into sandbox: Permission was denied. Error details: tee: /opt/inspect-sandbox-tools: Permission denied
```
cc @jacobmdsit 