### PR TITLE
Docs: pretty involved language ->  natural, nuanced language

### DIFF
--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -141,7 +141,7 @@ def theory_of_mind():
 
 2.  In this example we are chaining together three standard solver components. It's also possible to create a more complex custom solver that manages state and interactions internally.
 
-3.  Since the output is likely to have pretty involved language, we use a model for scoring.
+3.  Since the output is likely to have natural, nuanced language, we use a model for scoring.
 
 Note that you can provide a *single* solver or multiple solvers chained together as we did here.
 


### PR DESCRIPTION
Suggested improvement. `pretty involved language` sounded a bit weird to me, so suggesting a change. 
This is subjective, so no hurt feelings if the initial text seems more fitting.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [X] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
text change only for a code comment

### What is the new behavior?
<img width="2112" height="906" alt="CleanShot 2025-10-19 at 12 24 02@2x" src="https://github.com/user-attachments/assets/92f81e00-c805-4b87-bc16-59d51d22bff1" />


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
no, docs only update

### Other information:
