### PR TITLE
Anthropic: Increase default `max_tokens` to 32,000 for Claude 4 models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - OpenAI: Use `responses_store=false` by default (handling reasoning via the "reasoning.encrypted_content" include option).
+- Anthropic: Increase default `max_tokens` to 32,000 for Claude 4 models.
 - OpenRouter: Classify `JSONDecodeError` as a retry-able infrastructure error.
 - Remove Goodfire model provider (as the goodfire package has been archived/deprecated).
 - Inspect View: Display copy button for model events api request and response JSON.

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -463,11 +463,17 @@ class AnthropicAPI(ModelAPI):
 
     @override
     def max_tokens(self) -> int | None:
-        # anthropic requires you to explicitly specify max_tokens (most others
+        # Anthropic requires you to explicitly specify max_tokens (most others
         # set it to the maximum allowable output tokens for the model).
-        # set to 4096 which is the highest possible for claude 3 (claude 3.5
-        # allows up to 8192)
-        return 4096
+        # Claude 4 models currently have maxes of 32k (Opus 4 and 4.1) or
+        # 64k (Sonnet 4 and 4.5 and Haiku 4.5). Claude 3 models max at 4k or
+        # 8k, w/ 3.7 Sonnet being capable of 128k w/ a special header).
+        # Therefore, we use 4k as the default for Claude 3 and 32,000 as the
+        # default for everything else.
+        if self.is_claude_3():
+            return 4096
+        else:
+            return 32000
 
     @override
     def max_tokens_for_config(self, config: GenerateConfig) -> int | None:


### PR DESCRIPTION
Anthropic requires you to explicitly specify max_tokens (most others set it to the maximum allowable output tokens for the model). Claude 4 models currently have maxes of 32k (Opus 4 and 4.1) or 64k (Sonnet 4 and 4.5 and Haiku 4.5). Claude 3 models max at 4k or 8k, w/ 3.7 Sonnet being capable of128k w/ a special header).

Therefore, we use 4k as the default for Claude 3 and 32,000 as the default for everything else.
