### PR TITLE
Claude 3.5 has a 8192 max output token limit

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -468,9 +468,9 @@ class AnthropicAPI(ModelAPI):
         # Claude 4 models currently have maxes of 32k (Opus 4 and 4.1) or
         # 64k (Sonnet 4 and 4.5 and Haiku 4.5). Claude 3 models max at 4k or
         # 8k, w/ 3.7 Sonnet being capable of 128k w/ a special header).
-        # Therefore, we use 4k as the default for Claude 3 and 32,000 as the
+        # Therefore, we use 4k as the default for Claude 3 and 3.5 and 32,000 as the
         # default for everything else.
-        if self.is_claude_3():
+        if self.is_claude_3() or self.is_claude_3_5():
             return 4096
         else:
             return 32000


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
#2675 increased the default `max_tokens` for Claude 4 models to 32000 (thanks!), but also increased the limit for Claude 3.5. Claude 3.5 has a max of 8192, so the default fails. 

### What is the new behavior?
Keep Claude 3.5 at the old default of 4096.

Note that Claude 3.7 also gets the 32000 limit, but that is supported.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
