### PR TITLE
Handle closed http_client in OpenAIAPI

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -224,6 +224,10 @@ class OpenAIAPI(ModelAPI):
 
     def initialize(self) -> None:
         super().initialize()
+
+        if self.http_client.is_closed:
+            self.http_client = OpenAIAsyncHttpxClient()
+
         self.client = self._create_client()
 
         # TODO: Although we could enhance OpenAIBatcher to support requests with


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The refresh token functionality fails with OpenAIAPI:
When an authentication failure is detected, `_model.before_retry()` [calls](https://github.com/UKGovernmentBEIS/inspect_ai/blob/9f2561bd7e7bf650b06ecfe41648dce8bbc21f3a/src/inspect_ai/model/_model.py#L844-L846) `self.api.aclose()` before calling `self.api.initialize().

But the `OpenAIAPI.aclose()` method closes the `http_client`, and the `initialize()` method does not reopen it. This causes subsequent calls to fail.

### What is the new behavior?

We test whether the `http_client` is closed during `initialize()` and if it is, we create a new one.

There is some complexity here with the possibility to create the OpenAIAPI provider with a custom http_client. This http_client will be overridden if we retry. Another option would be to detect that the http_client is a custom one, and not close the inner client in that case.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
