### PR TITLE
WIP - Enable OpenTelemetry integration with existing span and hook architecture

### DIFF
--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -648,6 +648,12 @@ async def task_run_sample(
         else contextlib.nullcontext()
     )
 
+    # establish OpenTelemetry trace context for this sample
+    # (all spans within this sample will share the same trace_id)
+    from inspect_ai.telemetry import otel_trace_context
+
+    otel_trace_cm = otel_trace_context(f"sample-{sample_id}")
+
     # helper to handle exceptions (will throw if we've exceeded the limit)
     def handle_error(ex: BaseException) -> tuple[EvalError, BaseException | None]:
         # helper to log sample error
@@ -671,6 +677,7 @@ async def task_run_sample(
 
     # solver loop
     async with (
+        otel_trace_cm,
         semaphore_cm,
         active_sample(
             task=task_name,

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -227,6 +227,15 @@ class AnthropicAPI(ModelAPI):
         super().initialize()
         self.client = self._create_client()
         self._http_hooks = HttpxHooks(self.client._client)
+
+        # Register OpenTelemetry hook if enabled
+        from inspect_ai.telemetry import is_otel_enabled
+
+        if is_otel_enabled():
+            from inspect_ai.telemetry._httpx_hook import register_otel_hook
+
+            register_otel_hook(self.client._client)
+
         self._batcher: AnthropicBatcher | None = None
 
     @override

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -244,6 +244,14 @@ class OpenAIAPI(ModelAPI):
         self._responses_batcher: OpenAIBatcher[Response] | None = None
         self._http_hooks = HttpxHooks(self.client._client)
 
+        # Register OpenTelemetry hook if enabled
+        from inspect_ai.telemetry import is_otel_enabled
+
+        if is_otel_enabled():
+            from inspect_ai.telemetry._httpx_hook import register_otel_hook
+
+            register_otel_hook(self.client._client)
+
     def is_azure(self) -> bool:
         return self.service == "azure"
 

--- a/src/inspect_ai/model/_providers/util/hooks.py
+++ b/src/inspect_ai/model/_providers/util/hooks.py
@@ -116,9 +116,44 @@ class HttpxHooks(HttpHooks):
         if request_id:
             self.update_request_time(request_id)
 
+        # inject OpenTelemetry trace context for distributed tracing
+        self._inject_otel_context(request)
+
     async def response_hook(self, response: httpx.Response) -> None:
         message = f'{response.request.method} {response.request.url} "{response.http_version} {response.status_code} {response.reason_phrase}" '
         logger.log(HTTP, message)
+
+    def _inject_otel_context(self, request: httpx.Request) -> None:
+        """Inject OpenTelemetry trace context into HTTP request headers.
+
+        This enables distributed tracing by propagating the current trace context
+        to external services via W3C Trace Context headers (traceparent, tracestate).
+
+        Args:
+            request: The httpx.Request to inject context into.
+        """
+        try:
+            from opentelemetry import trace
+            from opentelemetry.propagate import inject
+
+            # get current active OpenTelemetry span
+            current_span = trace.get_current_span()
+            if current_span and current_span.is_recording():
+                # inject W3C Trace Context headers into request
+                # this adds traceparent and tracestate headers
+                carrier = dict(request.headers)
+                inject(carrier)
+
+                # update request headers with injected trace context
+                for key, value in carrier.items():
+                    if key.lower() not in request.headers:
+                        request.headers[key] = value
+
+        except ImportError:
+            # OpenTelemetry not installed, skip
+            pass
+        except Exception as e:
+            logger.debug(f"Failed to inject OpenTelemetry context: {e}")
 
 
 def urllib3_hooks() -> HttpHooks:

--- a/src/inspect_ai/telemetry/__init__.py
+++ b/src/inspect_ai/telemetry/__init__.py
@@ -1,0 +1,17 @@
+"""OpenTelemetry integration for distributed tracing."""
+
+from ._otel import (
+    configure_opentelemetry,
+    get_otel_trace_context,
+    get_tracer,
+    is_otel_enabled,
+    otel_trace_context,
+)
+
+__all__ = [
+    "configure_opentelemetry",
+    "get_tracer",
+    "is_otel_enabled",
+    "otel_trace_context",
+    "get_otel_trace_context",
+]

--- a/src/inspect_ai/telemetry/_httpx_hook.py
+++ b/src/inspect_ai/telemetry/_httpx_hook.py
@@ -1,0 +1,106 @@
+"""HttpX hooks for OpenTelemetry trace context propagation."""
+
+from logging import getLogger
+
+import httpx
+
+logger = getLogger(__name__)
+
+
+class OTelHttpxHook:
+    """HttpX event hook for injecting OpenTelemetry trace context into HTTP requests.
+
+    This hook automatically injects W3C Trace Context headers (traceparent, tracestate)
+    into outgoing HTTP requests when an active OpenTelemetry span exists. This enables
+    distributed tracing across service boundaries.
+
+    The hook is registered on httpx.AsyncClient's request event and will be called
+    for every outgoing request.
+
+    Example:
+        ```python
+        import httpx
+        from inspect_ai.telemetry import configure_opentelemetry
+        from inspect_ai.telemetry._httpx_hook import OTelHttpxHook
+
+        # Configure OTel
+        configure_opentelemetry(enabled=True)
+
+        # Create client and register hook
+        client = httpx.AsyncClient()
+        OTelHttpxHook(client)
+
+        # Requests will now include trace context headers
+        await client.get("https://api.example.com")
+        ```
+    """
+
+    def __init__(self, client: httpx.AsyncClient):
+        """Initialize the hook and register it with the httpx client.
+
+        Args:
+            client: The httpx.AsyncClient to attach the hook to.
+        """
+        # Register our hook alongside any existing hooks
+        client.event_hooks["request"].append(self.request_hook)
+        logger.debug("Registered OTel httpx hook for trace context propagation")
+
+    async def request_hook(self, request: httpx.Request) -> None:
+        """Inject OpenTelemetry trace context into HTTP request headers.
+
+        This hook is called automatically by httpx for each request. It checks
+        if there's an active OpenTelemetry span, and if so, injects the trace
+        context into the request headers using W3C Trace Context format.
+
+        Args:
+            request: The httpx.Request being prepared for sending.
+        """
+        try:
+            from opentelemetry import trace
+            from opentelemetry.propagate import inject
+
+            # Get current active OpenTelemetry span
+            current_span = trace.get_current_span()
+            if current_span and current_span.is_recording():
+                # Inject W3C Trace Context headers into request
+                # This adds traceparent (required) and tracestate (optional, vendor-specific)
+                carrier = dict(request.headers)
+                inject(carrier)
+
+                # Update request headers with injected trace context
+                for key, value in carrier.items():
+                    if key.lower() not in request.headers:
+                        request.headers[key] = value
+
+                logger.debug(
+                    f"Injected OTel trace context into request: {request.method} {request.url}"
+                )
+
+        except ImportError:
+            # OpenTelemetry not installed, skip (logged once at module level)
+            pass
+        except Exception as e:
+            # Don't fail requests due to tracing issues
+            logger.debug(f"Failed to inject OpenTelemetry context: {e}")
+
+
+def register_otel_hook(client: httpx.AsyncClient) -> None:
+    """Register OpenTelemetry trace propagation hook on an httpx client.
+
+    This is a convenience function that creates and registers an OTelHttpxHook
+    on the given client. It's safe to call even if OpenTelemetry is not enabled
+    or not installed - the hook will simply be a no-op in those cases.
+
+    Args:
+        client: The httpx.AsyncClient to attach the hook to.
+
+    Example:
+        ```python
+        import httpx
+        from inspect_ai.telemetry._httpx_hook import register_otel_hook
+
+        client = httpx.AsyncClient()
+        register_otel_hook(client)
+        ```
+    """
+    OTelHttpxHook(client)

--- a/src/inspect_ai/telemetry/_otel.py
+++ b/src/inspect_ai/telemetry/_otel.py
@@ -4,7 +4,7 @@ import contextlib
 import os
 from contextvars import ContextVar
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, AsyncIterator
+from typing import TYPE_CHECKING, AsyncIterator
 
 if TYPE_CHECKING:
     from opentelemetry.context import Context
@@ -139,7 +139,9 @@ def configure_opentelemetry(
                 )
 
             elif exporter == "jaeger":
-                from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # type: ignore[import-not-found]
+                from opentelemetry.exporter.jaeger.thrift import (
+                    JaegerExporter,  # type: ignore[import-not-found]
+                )
 
                 jaeger_exporter = JaegerExporter(
                     agent_host_name="localhost",

--- a/src/inspect_ai/telemetry/_otel.py
+++ b/src/inspect_ai/telemetry/_otel.py
@@ -1,0 +1,302 @@
+"""OpenTelemetry integration implementation."""
+
+import contextlib
+import os
+from contextvars import ContextVar
+from logging import getLogger
+from typing import TYPE_CHECKING, Any, AsyncIterator
+
+if TYPE_CHECKING:
+    from opentelemetry.context import Context
+    from opentelemetry.trace import Tracer
+
+logger = getLogger(__name__)
+
+
+def configure_opentelemetry(
+    *,
+    enabled: bool = True,
+    service_name: str | None = None,
+    exporter: str | None = None,
+    endpoint: str | None = None,
+    tracer: "Tracer | None" = None,
+) -> None:
+    """Configure OpenTelemetry integration for distributed tracing.
+
+    When enabled, inspect_ai spans will create active OpenTelemetry spans that
+    propagate trace context to external services via HTTP headers. This enables
+    end-to-end distributed tracing across inspect_ai evaluations and external
+    APIs (model providers, tools, etc.).
+
+    Args:
+        enabled: Enable or disable OpenTelemetry integration.
+        service_name: Service name for traces. Defaults to "inspect_ai" or
+            the value of OTEL_SERVICE_NAME environment variable.
+        exporter: Exporter type. Supported values:
+            - "console": Console output (for debugging)
+            - "otlp": OTLP gRPC exporter (default)
+            - "jaeger": Jaeger exporter
+            If None, uses "otlp".
+        endpoint: Exporter endpoint URL. Defaults to "http://localhost:4317"
+            or the value of OTEL_EXPORTER_OTLP_ENDPOINT environment variable.
+        tracer: Custom OpenTelemetry Tracer instance. If provided, overrides
+            service_name, exporter, and endpoint parameters.
+
+    Examples:
+        Basic OTLP export to localhost:
+        ```python
+        from inspect_ai.telemetry import configure_opentelemetry
+
+        configure_opentelemetry(
+            enabled=True,
+            service_name="my-evaluation",
+        )
+        ```
+
+        Export to custom Jaeger instance:
+        ```python
+        configure_opentelemetry(
+            enabled=True,
+            service_name="my-evaluation",
+            exporter="jaeger",
+        )
+        ```
+
+        Use custom tracer:
+        ```python
+        from opentelemetry import trace
+        from opentelemetry.sdk.trace import TracerProvider
+
+        provider = TracerProvider()
+        # ... configure provider ...
+
+        configure_opentelemetry(
+            enabled=True,
+            tracer=provider.get_tracer("inspect_ai"),
+        )
+        ```
+
+        Configure via environment variables:
+        ```bash
+        export OTEL_SERVICE_NAME="my-evaluation"
+        export OTEL_EXPORTER_OTLP_ENDPOINT="http://jaeger:4317"
+        ```
+        ```python
+        # Auto-detects from environment
+        configure_opentelemetry(enabled=True)
+        ```
+    """
+    if not enabled:
+        _otel_enabled.set(False)
+        _otel_tracer.set(None)
+        logger.info("OpenTelemetry integration disabled")
+        return
+
+    # Auto-configure from environment variables if not provided
+    if service_name is None:
+        service_name = os.getenv("OTEL_SERVICE_NAME", "inspect_ai")
+
+    if endpoint is None:
+        endpoint = os.getenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+
+    if exporter is None:
+        exporter = "otlp"
+
+    # Use provided tracer or create one
+    if tracer is None:
+        try:
+            from opentelemetry import trace
+            from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+            from opentelemetry.sdk.trace import TracerProvider
+            from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+            # Create resource with service name
+            resource = Resource(attributes={
+                SERVICE_NAME: service_name
+            })
+
+            # Create provider with resource
+            provider = TracerProvider(resource=resource)
+
+            # Configure exporter based on type
+            if exporter == "console":
+                from opentelemetry.sdk.trace.export import ConsoleSpanExporter
+
+                processor = BatchSpanProcessor(ConsoleSpanExporter())
+                provider.add_span_processor(processor)
+                logger.info(
+                    f"OpenTelemetry configured with console exporter (service: {service_name})"
+                )
+
+            elif exporter == "otlp":
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                    OTLPSpanExporter,
+                )
+
+                otlp_exporter = OTLPSpanExporter(endpoint=endpoint)
+                processor = BatchSpanProcessor(otlp_exporter)
+                provider.add_span_processor(processor)
+                logger.info(
+                    f"OpenTelemetry configured with OTLP exporter (service: {service_name}, endpoint: {endpoint})"
+                )
+
+            elif exporter == "jaeger":
+                from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+
+                jaeger_exporter = JaegerExporter(
+                    agent_host_name="localhost",
+                    agent_port=6831,
+                )
+                processor = BatchSpanProcessor(jaeger_exporter)
+                provider.add_span_processor(processor)
+                logger.info(
+                    f"OpenTelemetry configured with Jaeger exporter (service: {service_name})"
+                )
+
+            else:
+                raise ValueError(
+                    f"Unsupported exporter type: {exporter}. "
+                    f"Supported types: console, otlp, jaeger"
+                )
+
+            # Set as global provider
+            trace.set_tracer_provider(provider)
+            tracer = provider.get_tracer(service_name)
+
+        except ImportError as e:
+            logger.error(
+                f"Failed to import OpenTelemetry dependencies: {e}. "
+                f"Install with: pip install opentelemetry-api opentelemetry-sdk opentelemetry-exporter-otlp"
+            )
+            _otel_enabled.set(False)
+            _otel_tracer.set(None)
+            return
+        except Exception as e:
+            logger.error(f"Failed to configure OpenTelemetry: {e}")
+            _otel_enabled.set(False)
+            _otel_tracer.set(None)
+            return
+
+    # Store configuration in context variables
+    _otel_enabled.set(True)
+    _otel_tracer.set(tracer)
+    logger.info(f"OpenTelemetry integration enabled (service: {service_name})")
+
+
+def get_tracer() -> "Tracer | None":
+    """Get the currently configured OpenTelemetry tracer.
+
+    Returns:
+        The configured Tracer instance, or None if OpenTelemetry
+        integration is not enabled.
+    """
+    return _otel_tracer.get()
+
+
+def is_otel_enabled() -> bool:
+    """Check if OpenTelemetry integration is enabled.
+
+    Returns:
+        True if OpenTelemetry integration is enabled, False otherwise.
+    """
+    return _otel_enabled.get()
+
+
+# Context variables for OpenTelemetry configuration
+_otel_enabled: ContextVar[bool] = ContextVar("_otel_enabled", default=False)
+_otel_tracer: ContextVar[Any] = ContextVar("_otel_tracer", default=None)
+_otel_trace_context: ContextVar["Context | None"] = ContextVar(
+    "_otel_trace_context", default=None
+)
+
+
+@contextlib.asynccontextmanager
+async def otel_trace_context(name: str) -> AsyncIterator[None]:
+    """Establish a root OpenTelemetry trace context.
+
+    This creates a root span that establishes a trace ID. All subsequent
+    spans created within this context will share the same trace ID,
+    creating a unified trace in observability tools like Jaeger.
+
+    Typically used to wrap sample execution so that all spans within a
+    sample (solvers, scorers, tools, etc.) appear under one trace.
+
+    Args:
+        name: Name for the root span (e.g., "sample-1", "evaluation").
+
+    Example:
+        ```python
+        from inspect_ai.telemetry import otel_trace_context
+        from inspect_ai.util import span
+
+        async with otel_trace_context("sample-1"):
+            # All spans here share the same trace_id
+            async with span("solver"):
+                async with span("tool_call"):
+                    pass
+        ```
+    """
+    if not _otel_enabled.get():
+        yield
+        return
+
+    otel_tracer = _otel_tracer.get()
+    if not otel_tracer:
+        yield
+        return
+
+    try:
+        from opentelemetry import context, trace
+        from opentelemetry.trace import Status, StatusCode
+
+        # Start a root span that establishes the trace context
+        root_span = otel_tracer.start_span(name)
+        root_span.set_attribute("inspect.root", True)
+        root_span.set_attribute("inspect.trace_name", name)
+
+        # Set this span as the current context
+        otel_context = trace.set_span_in_context(root_span)
+        token = context.attach(otel_context)
+
+        # Store in context variable for child spans to access
+        ctx_token = _otel_trace_context.set(otel_context)
+
+        exception_occurred = False
+        try:
+            yield
+        except Exception as ex:
+            # Record exception on the root span
+            exception_occurred = True
+            try:
+                root_span.record_exception(ex)
+                root_span.set_status(Status(StatusCode.ERROR, description=str(ex)))
+            except Exception as e:
+                logger.debug(f"Failed to record exception on root span: {e}")
+            raise
+        finally:
+            # Set status to OK if no exception occurred
+            if not exception_occurred:
+                try:
+                    root_span.set_status(Status(StatusCode.OK))
+                except Exception as e:
+                    logger.debug(f"Failed to set span status: {e}")
+
+            # End the root span
+            root_span.end()
+
+            # Restore previous context
+            _otel_trace_context.reset(ctx_token)
+            context.detach(token)
+
+    except Exception as e:
+        logger.debug(f"Failed to establish OTel trace context: {e}")
+        yield
+
+
+def get_otel_trace_context() -> "Context | None":
+    """Get the current OpenTelemetry trace context.
+
+    Returns:
+        The active trace context, or None if not established.
+    """
+    return _otel_trace_context.get()

--- a/src/inspect_ai/telemetry/_otel.py
+++ b/src/inspect_ai/telemetry/_otel.py
@@ -111,9 +111,7 @@ def configure_opentelemetry(
             from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
             # Create resource with service name
-            resource = Resource(attributes={
-                SERVICE_NAME: service_name
-            })
+            resource = Resource(attributes={SERVICE_NAME: service_name})
 
             # Create provider with resource
             provider = TracerProvider(resource=resource)
@@ -129,7 +127,7 @@ def configure_opentelemetry(
                 )
 
             elif exporter == "otlp":
-                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
+                from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (  # type: ignore[import-not-found]
                     OTLPSpanExporter,
                 )
 
@@ -141,7 +139,7 @@ def configure_opentelemetry(
                 )
 
             elif exporter == "jaeger":
-                from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+                from opentelemetry.exporter.jaeger.thrift import JaegerExporter  # type: ignore[import-not-found]
 
                 jaeger_exporter = JaegerExporter(
                     agent_host_name="localhost",
@@ -204,7 +202,7 @@ def is_otel_enabled() -> bool:
 
 # Context variables for OpenTelemetry configuration
 _otel_enabled: ContextVar[bool] = ContextVar("_otel_enabled", default=False)
-_otel_tracer: ContextVar[Any] = ContextVar("_otel_tracer", default=None)
+_otel_tracer: ContextVar["Tracer | None"] = ContextVar("_otel_tracer", default=None)
 _otel_trace_context: ContextVar["Context | None"] = ContextVar(
     "_otel_trace_context", default=None
 )

--- a/src/inspect_ai/telemetry/_otel.py
+++ b/src/inspect_ai/telemetry/_otel.py
@@ -139,8 +139,8 @@ def configure_opentelemetry(
                 )
 
             elif exporter == "jaeger":
-                from opentelemetry.exporter.jaeger.thrift import (
-                    JaegerExporter,  # type: ignore[import-not-found]
+                from opentelemetry.exporter.jaeger.thrift import (  # type: ignore[import-not-found]
+                    JaegerExporter,
                 )
 
                 jaeger_exporter = JaegerExporter(

--- a/src/inspect_ai/util/_span.py
+++ b/src/inspect_ai/util/_span.py
@@ -113,6 +113,7 @@ async def span(name: str, *, type: str | None = None) -> AsyncIterator[None]:
                 # if no exception occurred, mark span as OK
                 if not exception_occurred:
                     from opentelemetry.trace import Status, StatusCode
+
                     otel_span.set_status(Status(StatusCode.OK))
 
                 otel_span.end()

--- a/src/inspect_ai/util/_span.py
+++ b/src/inspect_ai/util/_span.py
@@ -2,7 +2,7 @@ import contextlib
 import inspect
 from contextvars import ContextVar
 from logging import getLogger
-from typing import AsyncIterator
+from typing import Any, AsyncIterator
 from uuid import uuid4
 
 logger = getLogger(__name__)
@@ -11,6 +11,11 @@ logger = getLogger(__name__)
 @contextlib.asynccontextmanager
 async def span(name: str, *, type: str | None = None) -> AsyncIterator[None]:
     """Context manager for establishing a transcript span.
+
+    When OpenTelemetry integration is enabled (via `configure_opentelemetry()`),
+    this also creates an active OpenTelemetry span for distributed tracing. The
+    OpenTelemetry span will propagate trace context to external services via
+    HTTP headers.
 
     Args:
         name (str): Step name.
@@ -22,7 +27,7 @@ async def span(name: str, *, type: str | None = None) -> AsyncIterator[None]:
         transcript,
     )
 
-    # span id
+    # generate inspect_ai span id
     id = uuid4().hex
 
     # capture parent id
@@ -31,9 +36,40 @@ async def span(name: str, *, type: str | None = None) -> AsyncIterator[None]:
     # set new current span (reset at the end)
     token = _current_span_id.set(id)
 
+    # optionally create active OpenTelemetry span
+    otel_span = None
+    otel_context_token = None
+    if _get_otel_enabled():
+        otel_tracer = _get_otel_tracer()
+        if otel_tracer:
+            try:
+                # import OpenTelemetry only when needed (optional dependency)
+                from opentelemetry import context, trace
+
+                # start span (will inherit trace_id from parent context if set)
+                otel_span = otel_tracer.start_span(name)
+
+                # link inspect_ai span id to OpenTelemetry span
+                otel_span.set_attribute("inspect.span_id", id)
+                otel_span.set_attribute("inspect.type", type or name)
+                if parent_id:
+                    otel_span.set_attribute("inspect.parent_id", parent_id)
+
+                # make this span active in OpenTelemetry context
+                # (enables automatic trace propagation in HTTP requests)
+                # Note: If we're already within an otel_trace_context, this span
+                # will automatically inherit the trace_id and appear as a child
+                otel_context_token = context.attach(
+                    trace.set_span_in_context(otel_span)
+                )
+
+            except Exception as e:
+                logger.debug(f"Failed to create OpenTelemetry span: {e}")
+
     # run the span
+    exception_occurred = False
     try:
-        # span begin event
+        # emit inspect_ai span begin event
         transcript()._event(
             SpanBeginEvent(
                 id=id,
@@ -45,12 +81,54 @@ async def span(name: str, *, type: str | None = None) -> AsyncIterator[None]:
 
         # run span w/ store change events
         with track_store_changes():
-            yield
+            try:
+                yield
+            except Exception as ex:
+                # record exception on OpenTelemetry span
+                exception_occurred = True
+                if otel_span:
+                    try:
+                        from opentelemetry.trace import Status, StatusCode
+
+                        # record the exception with full details
+                        otel_span.record_exception(ex)
+
+                        # set span status to ERROR
+                        otel_span.set_status(
+                            Status(StatusCode.ERROR, description=str(ex))
+                        )
+                    except Exception as e:
+                        logger.debug(f"Failed to record exception on OTel span: {e}")
+
+                # re-raise the exception to maintain normal flow
+                raise
 
     finally:
-        # send end event
+        # emit inspect_ai span end event
         transcript()._event(SpanEndEvent(id=id))
 
+        # end OpenTelemetry span if created
+        if otel_span:
+            try:
+                # if no exception occurred, mark span as OK
+                if not exception_occurred:
+                    from opentelemetry.trace import Status, StatusCode
+                    otel_span.set_status(Status(StatusCode.OK))
+
+                otel_span.end()
+            except Exception as e:
+                logger.debug(f"Failed to end OpenTelemetry span: {e}")
+
+        # detach OpenTelemetry context
+        if otel_context_token is not None:
+            try:
+                from opentelemetry import context
+
+                context.detach(otel_context_token)
+            except Exception as e:
+                logger.debug(f"Failed to detach OpenTelemetry context: {e}")
+
+        # reset inspect_ai span context
         try:
             _current_span_id.reset(token)
         except ValueError:
@@ -60,7 +138,33 @@ async def span(name: str, *, type: str | None = None) -> AsyncIterator[None]:
 
 
 def current_span_id() -> str | None:
+    """Get the current inspect_ai span ID.
+
+    Returns:
+        The current span ID, or None if not within a span.
+    """
     return _current_span_id.get()
 
 
+# Context variable for inspect_ai span tracking
 _current_span_id: ContextVar[str | None] = ContextVar("_current_span_id", default=None)
+
+
+def _get_otel_enabled() -> bool:
+    """Check if OpenTelemetry integration is enabled."""
+    try:
+        from inspect_ai.telemetry._otel import _otel_enabled
+
+        return _otel_enabled.get()
+    except ImportError:
+        return False
+
+
+def _get_otel_tracer() -> Any:
+    """Get the configured OpenTelemetry tracer."""
+    try:
+        from inspect_ai.telemetry._otel import _otel_tracer
+
+        return _otel_tracer.get()
+    except ImportError:
+        return None

--- a/tests/util/test_telemetry.py
+++ b/tests/util/test_telemetry.py
@@ -1,0 +1,35 @@
+"""Tests for OpenTelemetry integration."""
+
+import pytest
+
+from inspect_ai.telemetry import configure_opentelemetry, get_tracer, is_otel_enabled
+
+
+def test_telemetry_disabled_by_default() -> None:
+    """Test that OpenTelemetry is disabled by default."""
+    assert not is_otel_enabled()
+    assert get_tracer() is None
+
+
+def test_telemetry_can_be_disabled() -> None:
+    """Test that OpenTelemetry can be explicitly disabled."""
+    configure_opentelemetry(enabled=False)
+    assert not is_otel_enabled()
+    assert get_tracer() is None
+
+
+@pytest.mark.skipif(
+    True,
+    reason="OpenTelemetry dependencies not required for core tests",
+)
+def test_telemetry_configuration() -> None:
+    """Test OpenTelemetry configuration with console exporter."""
+    configure_opentelemetry(
+        enabled=True,
+        service_name="test-service",
+        exporter="console",
+    )
+
+    assert is_otel_enabled()
+    tracer = get_tracer()
+    assert tracer is not None


### PR DESCRIPTION
This is a first draft of enabling opentelemetry integration with inspect spans, and using inspect hooks to propagate those to model calls (or across other system boundaries). Opentelemetry is the dominant provider for distributed tracing - see screenshots below for examples of how it can be useful. We actually use AWS X-Ray within AISI, but they are compatible and otel is an open standard.

This creates one otel 'trace' per sample, and each inspect span within that will become an otel 'span'. Looking at the output in jaeger, you get something like the following:

<img width="1940" height="899" alt="image" src="https://github.com/user-attachments/assets/2ac5a79e-0135-465c-a6f3-ed174ce4bf15" />

These are all traces.

Clicking into a trace gives you more detailed info:

<img width="1941" height="517" alt="image" src="https://github.com/user-attachments/assets/d5997a7e-4fe3-4714-8917-76e664aa3440" />

The solver which produced this has a few custom inspect spans which you can see above translated into otel spans:

```python
    # Define a custom solver that creates nested spans
    @solver
    def custom_solver():
        async def solve(state: TaskState, generate: Generate) -> TaskState:
            # Create a custom span to demonstrate nesting
            async with span("custom_processing", type="processing"):
                # Add some metadata
                state.metadata["processed"] = True

                # Create another nested span
                async with span("validation", type="validation"):
                    state.metadata["validated"] = True

            return state

        return solve
```

Trace visualisation is also useful for surfacing errors:

<img width="1944" height="631" alt="image" src="https://github.com/user-attachments/assets/8e7b4b60-593a-4106-928b-c43170c79ab1" />

From:

```python
    # Define a solver that intentionally raises an exception
    @solver
    def error_solver():
        async def solve(state: TaskState, generate: Generate) -> TaskState:
            async with span("before_error", type="processing"):
                state.metadata["before"] = True

            # This span will have an exception recorded
            async with span("error_span", type="processing"):
                state.metadata["about_to_fail"] = True
                raise ValueError("Intentional test error!")

            # This won't be reached
            async with span("after_error", type="processing"):
                state.metadata["after"] = True

            return state

        return solve
```

I've validated that this does successfully insert otel headers in httpx requests. These look like `traceparent=00-6e94d6fe73078499fe0ab315cb7ea7d0-95d43b4b053d0c23-01`, which can be explained like:

```raw
  00-6e94d6fe73078499fe0ab315cb7ea7d0-95d43b4b053d0c23-01
  │  │                                │                │
  │  │                                │                └─ flags: 01 (sampled/recorded)
  │  │                                └─ parent_span_id: 95d43b4b053d0c23
  │  └─ trace_id: 6e94d6fe73078499fe0ab315cb7ea7d0
  └─ version: 00 (W3C Trace Context v1.0)
```

This allows propagating trace info **across system boundaries** so, assuming i'm collecting the emitted data from both systems, I can view correlated activity in a single place.

I'm quite excited about this because it allows linking span-level inspect info with network-level activity from a platform point of view. For example, it will make it far easier to separate and group network activity from different agents. In the future it would be interesting to think about propagating this trace info into sandboxes.

I'm sure there's loads of things i've missed with this implementation, but please let me know if you think this is a direction worth pursuing. All feedback very welcome. 

### Setup Notes

A common pattern with tracing is to have a local process (or sidecar etc) acting as a collector, which ships trace data elsewhere. For example to create the above, I ran the following docker compose:

```yaml
version: '3.8'

services:
  jaeger:
    image: jaegertracing/all-in-one:latest
    container_name: jaeger
    ports:
      - "16686:16686"  # Jaeger UI
      - "14250:14250"  # Jaeger gRPC
    environment:
      - COLLECTOR_OTLP_ENABLED=true
    restart: unless-stopped

  otel-collector:
    image: otel/opentelemetry-collector:latest
    container_name: otel-collector
    command: ["--config=/etc/otel-collector-config.yml"]
    volumes:
      - ./otel-collector-config.yml:/etc/otel-collector-config.yml
    ports:
      - "4317:4317"   # OTLP gRPC receiver
      - "4318:4318"   # OTLP HTTP receiver
      - "13133:13133" # health_check extension
    depends_on:
      - jaeger
    restart: unless-stopped
```

and configured inspect via:

```python
    configure_opentelemetry(
        enabled=True,
        service_name="inspect_ai_test",
        exporter="otlp",
        endpoint="http://localhost:4317",
    )
```

Before running the eval. 

These requests are on localhost (very normal for a trace collector) so they should be fast. You can see we're also using `BatchSpanProcessor` so I think the performance implications of this should be minimal. 

'Recording' (sending to a collector) is actually independent of trace ID generation and propagation; **I fully expect most users will never care about this and will not enable recording**. However, within AISI (and I think probably other places with model proxies and centralised platforms like METR hawk) it would still be super valuable to have a trace ID injected into our platform systems (where we _are_ recording) which can be correlated with eval logs. 