### PR TITLE
Support OpenAI prompt_cache_retention model arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Anthropic: Support for [Structured Output](https://inspect.aisi.org.uk/structured.html) for Sonnet 4.5 and Opus 4.1.
 - Anthropic: Don't insert "(no content)" when replaying empty assistant messages with tool calls.
+- OpenAI: Add `prompt_cache_retention` custom model arg (bump required version of `openai` package to v2.8.0).
 
 ## 0.3.146 (15 November 2025)
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -38,6 +38,7 @@ The `openai` provider supports the following custom model args (other model args
 | `background` | Execute generate requests asynchronously, polling response objects to check status over time. Defaults to `True` for `gpt-5-pro` and `deep-research` and `False` for other models.  |
 | `safety_identifier` | A stable identifier used to help detect users of your application. |
 | `prompt_cache_key` | Used by OpenAI to cache responses for similar requests. |
+| `prompt_cache_retention` | Retention policy for the prompt cache. |
 | `http_client` | Custom instance of `httpx.AsyncClient` for handling requests. |
 
 : {tbl-colwidths=\[35,65\]}

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -80,6 +80,11 @@ class OpenAIAPI(ModelAPI):
             "prompt_cache_key", NOT_GIVEN
         )
 
+        # extract prompt_cache_retention model arg if provided
+        self.prompt_cache_retention: str | NotGiven = model_args.pop(
+            "prompt_cache_retention", NOT_GIVEN
+        )
+
         # extract safety_identifier model arg if provided
         self.safety_identifier: str | NotGiven = model_args.pop(
             "safety_identifier", NOT_GIVEN
@@ -366,6 +371,7 @@ class OpenAIAPI(ModelAPI):
                 background=self.background,
                 service_tier=self.service_tier,
                 prompt_cache_key=self.prompt_cache_key,
+                prompt_cache_retention=self.prompt_cache_retention,
                 safety_identifier=self.safety_identifier,
                 responses_store=self.responses_store,
                 model_info=self,
@@ -381,6 +387,7 @@ class OpenAIAPI(ModelAPI):
                 tool_choice=tool_choice,
                 config=config,
                 prompt_cache_key=self.prompt_cache_key,
+                prompt_cache_retention=self.prompt_cache_retention,
                 safety_identifier=self.safety_identifier,
                 openai_api=self,
                 batcher=self._completions_batcher,

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -156,6 +156,7 @@ class OpenAICompatibleAPI(ModelAPI):
                 background=False,
                 service_tier=None,
                 prompt_cache_key=NOT_GIVEN,
+                prompt_cache_retention=NOT_GIVEN,
                 safety_identifier=NOT_GIVEN,
                 responses_store=self.responses_store,
                 model_info=ModelInfo(),

--- a/src/inspect_ai/model/_providers/openai_completions.py
+++ b/src/inspect_ai/model/_providers/openai_completions.py
@@ -46,6 +46,7 @@ async def generate_completions(
     tool_choice: ToolChoice,
     config: GenerateConfig,
     prompt_cache_key: str | NotGiven,
+    prompt_cache_retention: str | NotGiven,
     safety_identifier: str | NotGiven,
     openai_api: "OpenAIAPI",
     batcher: OpenAIBatcher[ChatCompletion] | None,
@@ -98,6 +99,8 @@ async def generate_completions(
     )
     if isinstance(prompt_cache_key, str):
         request["prompt_cache_key"] = prompt_cache_key
+    if isinstance(prompt_cache_retention, str):
+        request["prompt_cache_retention"] = prompt_cache_retention
     if isinstance(safety_identifier, str):
         request["safety_identifier"] = safety_identifier
 

--- a/src/inspect_ai/model/_providers/openai_responses.py
+++ b/src/inspect_ai/model/_providers/openai_responses.py
@@ -57,6 +57,7 @@ async def generate_responses(
     background: bool | None,
     service_tier: str | None,
     prompt_cache_key: str | NotGiven,
+    prompt_cache_retention: str | NotGiven,
     safety_identifier: str | NotGiven,
     responses_store: bool | None,
     model_info: ResponsesModelInfo,
@@ -107,6 +108,7 @@ async def generate_responses(
             config=config,
             service_tier=service_tier,
             prompt_cache_key=prompt_cache_key,
+            prompt_cache_retention=prompt_cache_retention,
             safety_identifier=safety_identifier,
             responses_store=responses_store,
             tools=len(tools) > 0,
@@ -210,6 +212,7 @@ def completion_params_responses(
     config: GenerateConfig,
     service_tier: str | None,
     prompt_cache_key: str | NotGiven,
+    prompt_cache_retention: str | NotGiven,
     safety_identifier: str | NotGiven,
     responses_store: bool | None,
     tools: bool,
@@ -227,6 +230,8 @@ def completion_params_responses(
         params["service_tier"] = service_tier
     if isinstance(prompt_cache_key, str):
         params["prompt_cache_key"] = prompt_cache_key
+    if isinstance(prompt_cache_retention, str):
+        params["prompt_cache_retention"] = prompt_cache_retention
     if isinstance(safety_identifier, str):
         params["safety_identifier"] = safety_identifier
     if model_info.is_computer_use_preview():

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -309,7 +309,7 @@ def hf_inference_providers() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "2.0.0"
+    MIN_VERSION = "2.8.0"
 
     # verify we have the package
     try:

--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -93,6 +93,7 @@ def check_openai_responses_log_json(log_json: str, tools: bool):
     assert r'"max_tool_calls": 5' in log_json
     assert r'"foo": "bar"' in log_json
     assert r'"prompt_cache_key": "42"' in log_json
+    assert r'"prompt_cache_retention": "24h"' in log_json
     assert r'"safety_identifier": "42"' in log_json
     assert r'"truncation": "auto"' in log_json
     if tools:
@@ -161,6 +162,7 @@ def responses_agent(tools: bool) -> Agent:
                 max_tool_calls=5,
                 metadata={"foo": "bar"},
                 prompt_cache_key="42",
+                prompt_cache_retention="24h",
                 safety_identifier="42",
                 truncation="auto",
             )


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When making OpenAI chat completions and Responses API calls, it isn't possible to set the new `prompt_cache_retention` flag.

### What is the new behavior?

Passing `prompt_cache_retention="in_memory"` or `prompt_cache_retention="24h"` to `get_model` will add it to subsequent chat completions or Responses API call. This is similar to how `prompt_cache_key` works.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, it requires users to upgrade the `openai` Python library to a version that supports `prompt_cache_retention`.

Also, this a new argument in the middle of the arguments list of some functions in `src/inspect_ai/model/_providers`. Since the directory is `_providers`, I don't think it's part of Inspect's public API.

### Other information:

I used this script to test that the flag works:

```py
import asyncio

import inspect_ai.log
import inspect_ai.model


async def main():
    model = inspect_ai.model.get_model("openai/gpt-5.1", prompt_cache_retention="24h")
    await model.generate("What is the capital of France?" * 1024)

    transcript = inspect_ai.log.transcript()
    model_event = next(e for e in transcript.events if e.event == "model")
    assert model_event.call is not None
    assert model_event.call.request["prompt_cache_retention"] == "24h"


if __name__ == "__main__":
    asyncio.run(main())
```