### PR TITLE
Prefer most recent log item in collapseLogItems()

### DIFF
--- a/src/inspect_ai/_view/www/src/app/log-list/LogsPanel.tsx
+++ b/src/inspect_ai/_view/www/src/app/log-list/LogsPanel.tsx
@@ -313,7 +313,9 @@ export const collapseLogItems = (
     let bestItem = items[0];
     for (const item of items) {
       const currentStatus = item.logPreview?.status;
+      const currentMtime = item.log.mtime ?? 0;
       const bestStatus = bestItem.logPreview?.status;
+      const bestMtime = bestItem.log.mtime ?? 0;
 
       // Prefer started over everything
       if (currentStatus === "started" && bestStatus !== "started") {
@@ -325,8 +327,8 @@ export const collapseLogItems = (
         bestItem = item;
       }
 
-      // If same status or current is error, prefer the last one (most recent)
-      else if (currentStatus === bestStatus) {
+      // If same status or current is error, prefer most recent
+      else if (currentStatus === bestStatus && currentMtime > bestMtime) {
         bestItem = item;
       }
     }


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`collapseLogItems()` is supposed to prefer the most recent item, but the list is no longer sorted, so the last item might not be the most recent.

### What is the new behavior?

`collapseLogItems()` uses `mtime` to decide which item is most recent.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:
