### PR TITLE
README: show how to build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,15 @@ make test
 ```
 
 If you use VS Code, you should be sure to have installed the recommended extensions (Python, Ruff, and MyPy). Note that you'll be prompted to install these when you open the project in VS Code.
+
+***
+
+To work on the Inspect documentation, install the optional `[doc]` dependencies with the `-e` flag and build the docs:
+
+```
+pip install -e ".[doc]"
+cd docs
+quarto render # or 'quarto preview'
+```
+
+If you intend to work on the docs iteratively, you'll want to install the Quarto extension in VS Code.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
#2611 shows that people want to know how to build the docs.

### What is the new behavior?
This adds a section to the README that explains how to build the docs.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. Just docs!

### Other information:
None