### PR TITLE
anthropic: protect against signature not being replayed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Grok: Correctly reconstruct assistant tool calls when replaying messages to API.
 - Grok: Round trip encrypted reasoning (made available in v1.4.0 of `xai_sdk`, which is now required).
+- Anthropic: Protect against signature not being replayed (can occur for agent bridge) by saving a side list of signatures.
 - Memory tool: Added `memory()` tool and bound it to native definitions for providers that support it (currently only Anthropic).
 - Sandboxes: For "local" and "docker" sandbox providers, treat `output_limit` as a cap enforced with a circular buffer (rather than a limit that results in killing the process and raising).
 - Prevent querying of local timezone and forbid naïve `datetime`'s via DTZ lint rule. 


### PR DESCRIPTION
this can occur for agent bridge -- as a mitigation we save a side list of signatures
