### PR TITLE
add evals in eval example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Anthropic: Protect against signature not being replayed (can occur for agent bridge) by saving a side list of signatures.
 - Memory tool: Added `memory()` tool and bound it to native definitions for providers that support it (currently only Anthropic).
 - Sandboxes: For "local" and "docker" sandbox providers, treat `output_limit` as a cap enforced with a circular buffer (rather than a limit that results in killing the process and raising).
+- Sandboxes: Added `evals_in_eval` example for running Inspect evaluations inside other evaluations.
 - Model API: Enable model providers to have custom retry wait strategies (use 5 second fixed wait for vllm).
 - Prevent querying of local timezone and forbid naïve `datetime`'s via DTZ lint rule. 
 - Dependencies: Change jsonpath-ng requirement to >=1.6.0 (formerly required >= 1.7.0).

--- a/examples/evals_in_eval/Dockerfile
+++ b/examples/evals_in_eval/Dockerfile
@@ -1,0 +1,28 @@
+FROM node:20-slim
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Python 3 + pip, make `python` point to python3; useful basics
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip python-is-python3 \
+    git ca-certificates curl procps gnupg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install official Docker CLI (required for nested evals with Docker sandboxes)
+RUN install -m 0755 -d /etc/apt/keyrings \
+    && curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg \
+    && chmod a+r /etc/apt/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian bookworm stable" > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin docker-buildx-plugin \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Inspect AI and Anthropic SDK
+RUN pip install --no-cache-dir --break-system-packages inspect-ai anthropic
+
+# Install Claude Code globally (available to all users)
+RUN npm install -g @anthropic-ai/claude-code && npm cache clean --force
+
+WORKDIR /workspace
+
+CMD ["/bin/bash"]

--- a/examples/evals_in_eval/README.md
+++ b/examples/evals_in_eval/README.md
@@ -1,0 +1,22 @@
+## Evals Inside An Eval
+
+This example demonstrates running Inspect evals (in Docker containers) inside an Inspect eval. The example involves installing Inspect AI itself in a container and instructing [Claude Code](https://docs.anthropic.com/en/docs/claude-code) as an Inspect agent to run evals.
+
+> [!NOTE] The correct way to run an eval in an eval is to shell out a subprocess that has the eval you want to run. That protects many error conditions you would run into if you tried to run an eval in an eval. This is global state, background tasks (e.g. batch jobs), and contention for the UI.
+
+The example includes the following source files:
+
+| File | Description |
+|------|-------------|
+| [task.py](task.py) | Evaluation task which uses the claude code agent. |
+| [file_probe.py](file_probe.py) | Evaluation task which uses the `list_files()` tool. |
+| [bash_task.py](bash_task.py) | Evaluation task which uses the `bash()` tool. |
+| [claude.py](claude.py) | Claude code agent (invokes the claude CLI within the sandbox). |
+| [compose.yaml](compose.yaml) | Docker-in-Docker compose config with dind sidecar. |
+| [Dockerfile](Dockerfile) | Dockerfile which installs Docker, Inspect AI, and Claude Code. |
+
+You can run the example by evaluating the `task.py` file:
+
+```bash
+inspect eval task.py --model anthropic/claude-3-7-sonnet-latest
+```

--- a/examples/evals_in_eval/bash_task.py
+++ b/examples/evals_in_eval/bash_task.py
@@ -1,0 +1,20 @@
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, use_tools
+from inspect_ai.tool import bash
+
+
+@task
+def bash_task():
+    return Task(
+        dataset=[
+            Sample(
+                input="Use the bash tool to print 'hello world'.",
+                target="hello world",
+            ),
+        ],
+        solver=[use_tools([bash()]), generate()],
+        scorer=includes(),
+        sandbox="docker",
+    )

--- a/examples/evals_in_eval/claude.py
+++ b/examples/evals_in_eval/claude.py
@@ -1,0 +1,67 @@
+# NOTE: This example is intended as a demonstration of the basic mechanics of using the
+# sandbox agent bridge. For a more feature-rich implementation of a Claude Code agent
+# for Inspect see <https://meridianlabs-ai.github.io/inspect_swe/>.
+
+from inspect_ai.agent import (
+    Agent,
+    AgentState,
+    agent,
+    sandbox_agent_bridge,
+)
+from inspect_ai.model import ChatMessageSystem, ChatMessageUser, get_model
+from inspect_ai.util import sandbox
+
+
+@agent
+def claude_code() -> Agent:
+    async def execute(state: AgentState) -> AgentState:
+        async with sandbox_agent_bridge(state, model="inspect") as bridge:
+            # base options
+            cmd = [
+                "claude",
+                "--print",  # run without interactions
+                "--dangerously-skip-permissions",
+                "--model",  # use current inspect model
+                "inspect",
+            ]
+
+            # system message
+            system_message = "\n\n".join(
+                [m.text for m in state.messages if isinstance(m, ChatMessageSystem)]
+            )
+            if system_message:
+                cmd.extend(["--append-system-prompt", system_message])
+
+            # user prompt
+            prompt = "\n\n".join(
+                [m.text for m in state.messages if isinstance(m, ChatMessageUser)]
+            )
+            cmd.append(prompt)
+
+            # execute the agent
+            result = await sandbox().exec(
+                cmd=cmd,
+                env={
+                    "ANTHROPIC_BASE_URL": f"http://localhost:{bridge.port}",
+                    "ANTHROPIC_API_KEY": "sk-ant-api03-DOq5tyLPrk9M4hPE",
+                    "ANTHROPIC_MODEL": "inspect",
+                    "ANTHROPIC_DEFAULT_OPUS_MODEL": "inspect",
+                    "ANTHROPIC_DEFAULT_SONNET_MODEL": "inspect",
+                    "CLAUDE_CODE_SUBAGENT_MODEL": "inspect",
+                    "ANTHROPIC_DEFAULT_HAIKU_MODEL": "inspect",
+                    "ANTHROPIC_SMALL_FAST_MODEL": "inspect",
+                    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+                    "IS_SANDBOX": "1",
+                    # set the environment variable so Claude Code doesn't need to pass the --model argument
+                    "INSPECT_EVAL_MODEL": str(get_model()),
+                },
+            )
+
+        if result.success:
+            return bridge.state
+        else:
+            raise RuntimeError(
+                f"Error executing claude code agent: {result.stdout}\n{result.stderr}"
+            )
+
+    return execute

--- a/examples/evals_in_eval/compose.yaml
+++ b/examples/evals_in_eval/compose.yaml
@@ -1,0 +1,27 @@
+services:
+  default:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      # Connect to the dind sidecar's Docker daemon
+      - DOCKER_HOST=tcp://docker:2375
+    working_dir: /workspace
+    command: tail -f /dev/null
+    depends_on:
+      docker:
+        condition: service_healthy
+
+  docker:
+    image: docker:dind
+    privileged: true
+    environment:
+      # Disable TLS for simplicity (internal network only)
+      - DOCKER_TLS_CERTDIR=
+    healthcheck:
+      test: ["CMD", "docker", "info"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+    # Expose Docker daemon on port 2375
+    command: ["dockerd", "--host=tcp://0.0.0.0:2375", "--host=unix:///var/run/docker.sock"]

--- a/examples/evals_in_eval/file_probe.py
+++ b/examples/evals_in_eval/file_probe.py
@@ -1,0 +1,42 @@
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, use_tools
+from inspect_ai.tool import ToolError, tool
+from inspect_ai.util import sandbox
+
+
+@tool
+def list_files():
+    async def execute(dir: str):
+        """List the files in a directory.
+
+        Args:
+            dir: Directory
+
+        Returns:
+            File listing of the directory
+        """
+        result = await sandbox().exec(["ls", dir])
+        if result.success:
+            return result.stdout
+        else:
+            raise ToolError(result.stderr)
+
+    return execute
+
+
+@task
+def file_probe():
+    return Task(
+        dataset=[
+            Sample(
+                input='Is there a file named "foo.txt" in the current directory?',
+                target="Yes",
+                files={"foo.txt": "hello"},
+            ),
+        ],
+        solver=[use_tools([list_files()]), generate()],
+        scorer=includes(),
+        sandbox="docker",
+    )

--- a/examples/evals_in_eval/task.py
+++ b/examples/evals_in_eval/task.py
@@ -1,0 +1,23 @@
+from claude import claude_code
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import MemoryDataset, Sample
+
+
+@task
+def evals_in_eval() -> Task:
+    return Task(
+        dataset=MemoryDataset(
+            [
+                Sample(
+                    input="Run two evaluations using the inspect CLI:\n1. 'inspect eval file_probe.py'\n2. 'inspect eval bash_task.py'\n\nAfter running both, report the accuracy scores from each evaluation.",
+                    files={
+                        "file_probe.py": "file_probe.py",
+                        "bash_task.py": "bash_task.py",
+                    },
+                )
+            ]
+        ),
+        solver=claude_code(),
+        sandbox=("docker", "compose.yaml"),
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Researchers can't refer to examples of running Inspect evals (in Docker containers) inside of an Inspect eval.

### What is the new behavior?

They can refer to `examples/evals_in_eval`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Users have tried to build an Inspect eval that involves installing Inspect AI and instructing Claude Code in a container to run evals (in Docker containers), but have seen the error at https://github.com/UKGovernmentBEIS/inspect_ai/blob/deec1b7a8e8ecb90a5caef8adb476d6fbc0d18ae/src/inspect_ai/_eval/eval.py#L519.

I ran `inspect eval task.py --model anthropic/claude-3-7-sonnet-latest`.