### PR TITLE
enable model providers to have custom retry wait strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Anthropic: Protect against signature not being replayed (can occur for agent bridge) by saving a side list of signatures.
 - Memory tool: Added `memory()` tool and bound it to native definitions for providers that support it (currently only Anthropic).
 - Sandboxes: For "local" and "docker" sandbox providers, treat `output_limit` as a cap enforced with a circular buffer (rather than a limit that results in killing the process and raising).
+- Model API: Enable model providers to have custom retry wait strategies (use 5 second fixed wait for vllm).
 - Prevent querying of local timezone and forbid naïve `datetime`'s via DTZ lint rule. 
 - Dependencies: Move from unmaintained `nest_asyncio`, which is fundamentally incompatible with Python 3.14, to `nest_asyncio2`, which has explicit 3.14 compatibility.
 - Inspect View: Improve markdown rendering performance.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -29,6 +29,7 @@ from tenacity import (
     RetryCallState,
     retry,
 )
+from tenacity.wait import WaitBaseT
 
 from inspect_ai._util.constants import (
     DEFAULT_MAX_CONNECTIONS,
@@ -263,6 +264,9 @@ class ModelAPI(abc.ABC):
            ex: Exception to check for retry
         """
         return False
+
+    def retry_wait(self) -> WaitBaseT | None:
+        return None
 
     def is_auth_failure(self, ex: Exception) -> bool:
         """Check if this exception indicates an authentication failure.
@@ -670,6 +674,7 @@ class Model:
                 self.should_retry,
                 self.before_retry,
                 log_model_retry,
+                self.api.retry_wait(),
             )
         )
         async def generate() -> tuple[ModelOutput, BaseModel]:

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -6,6 +6,7 @@ from subprocess import Popen
 from typing import Any
 
 from openai import APIStatusError
+from tenacity.wait import WaitBaseT, wait_fixed
 from typing_extensions import override
 
 from inspect_ai._util.content import (
@@ -212,6 +213,10 @@ class VLLMAPI(OpenAICompatibleAPI):
     @override
     def collapse_assistant_messages(self) -> bool:
         return True
+
+    @override
+    def retry_wait(self) -> WaitBaseT | None:
+        return wait_fixed(5)
 
     def _cleanup_server(self) -> None:
         """Cleanup method to terminate server process when Python exits."""


### PR DESCRIPTION
use 5 second fixed wait for vllm
