### PR TITLE
VLLM and SGLang: 5 second retry policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - [Code execution](https://inspect.aisi.org.uk/tools-standard.html#sec-code-execution) tool for executing Python code in a stateless sandbox running on model provider servers. 
+- VLLM and SGLang: Default to 5 second retry policy when server rejects requests due to saturated GPU (customize with model arg `retry_delay`).
 
 ## 0.3.151 (30 November 2025)
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -623,7 +623,7 @@ vLLM is generally much faster than the Hugging Face provider as the library is d
 
 ### Batching
 
-vLLM automatically handles batching, so you generally don't have to worry about selecting the optimal batch size. However, you can still use the `max_connections` option to control the number of concurrent requests which defaults to 32.
+vLLM automatically handles batching, so you generally don't have to worry about selecting the optimal batch size. However, you can still use the `max_connections` option to control the number of concurrent requests which defaults to 32. If the server has saturated the GPU it may reject requests---these are by default retried after 5 seconds (you can customize this using the `retry_delay` model args, e.g. `-M retry_delay=3`).
 
 ### Device
 
@@ -699,6 +699,11 @@ $ inspect eval arc.py --model sglang/meta-llama/Meta-Llama-3-8B-Instruct --model
 ### Tool Use and Reasoning
 
 SGLang supports tool use and reasoning; however, the usage is often model dependant and requires additional configuration. See the [Tool Use](https://docs.sglang.ai/backend/function_calling.html) and [Reasoning](https://docs.sglang.ai/backend/separate_reasoning.html) sections of the SGLang documentation for details.
+
+### Batching
+
+SGLang automatically handles batching, so you generally don't have to worry about selecting the optimal batch size. However, you can still use the `max_connections` option to control the number of concurrent requests which defaults to 32. If the server has saturated the GPU it may reject requests---these are by default retried after 5 seconds (you can customize this using the `retry_delay` model args, e.g. `-M retry_delay=3`).
+
 
 ## TransformerLens {#transformer-lens}
 

--- a/src/inspect_ai/_util/local_server.py
+++ b/src/inspect_ai/_util/local_server.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 # Global dictionary to keep track of process -> reserved port mappings
 process_socket_map: dict[subprocess.Popen[str], socket.socket] = {}
 
+DEFAULT_RETRY_DELAY = 5
 
 DEFAULT_TIMEOUT = 60 * 10  # fairly conservative default timeout of 10 minutes
 

--- a/src/inspect_ai/model/_providers/sglang.py
+++ b/src/inspect_ai/model/_providers/sglang.py
@@ -4,10 +4,12 @@ from subprocess import Popen
 from typing import Any
 
 from openai import APIStatusError
+from tenacity.wait import WaitBaseT, wait_fixed
 from typing_extensions import override
 
 from inspect_ai._util.error import PrerequisiteError, pip_dependency_error
 from inspect_ai._util.local_server import (
+    DEFAULT_RETRY_DELAY,
     configure_devices,
     merge_env_server_args,
     start_local_server,
@@ -56,6 +58,7 @@ class SGLangAPI(OpenAICompatibleAPI):
         port: int | None = None,
         api_key: str | None = None,
         config: GenerateConfig = GenerateConfig(),
+        retry_delay: int | None = None,
         **server_args: Any,
     ) -> None:
         # Validate inputs
@@ -63,6 +66,9 @@ class SGLangAPI(OpenAICompatibleAPI):
             raise ValueError("base_url and port cannot both be provided.")
         if port:
             base_url = f"http://localhost:{port}/v1"
+
+        # save retry delay
+        self.retry_delay = retry_delay or DEFAULT_RETRY_DELAY
 
         # Initialize server process and port variables
         self.server_process: Popen[str] | None = None
@@ -178,6 +184,10 @@ class SGLangAPI(OpenAICompatibleAPI):
     @override
     def collapse_assistant_messages(self) -> bool:
         return True
+
+    @override
+    def retry_wait(self) -> WaitBaseT | None:
+        return wait_fixed(self.retry_delay)
 
     def _cleanup_server(self) -> None:
         """Cleanup method to terminate server process when Python exits."""


### PR DESCRIPTION
Default to 5 second retry policy when server rejects requests due to saturated GPU

Customize with model arg `retry_delay`.
