### PR TITLE
anthropic: use required `caller` field for server tool uses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - [Code Execution](https://inspect.aisi.org.uk/tools-standard.html#sec-code-execution) tool for executing Python code in a stateless sandbox running on model provider servers. 
 - Anthropic: Support for new [Effort](https://platform.claude.com/docs/en/build-with-claude/effort) setting (`--effort`) for trading off between response thoroughness and token efficiency. 
 - Anthropic: Include native `web_fetch` tool as part of `web_search()` implementation (matching capability of other providers that have native web search).
+- Anthropic: Use required `caller` field for server tool uses (required by package version 0.75, which is now the minimum version).
 - OpenAI: Check for mismatches between specified model and Azure deployment URL.
 - Mistral: Use the new Conversation API by default (disable with `-M conversation_api=False`).
 - Mistral: Added support for native web_search and code_execution tools (executed server side).

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -69,6 +69,7 @@ from anthropic.types.beta import (
     BetaBashCodeExecutionToolResultBlock,
     BetaBashCodeExecutionToolResultBlockParam,
     BetaCodeExecutionTool20250825Param,
+    BetaDirectCaller,
     BetaMCPToolResultBlock,
     BetaMCPToolUseBlock,
     BetaMCPToolUseBlockParam,
@@ -1320,7 +1321,16 @@ async def assistant_message_blocks(message: ChatMessageAssistant) -> list[Messag
         elif block_param["type"] == "tool_use":
             blocks.append(ToolUseBlock.model_validate(block_param))
         elif block_param["type"] == "server_tool_use":
-            blocks.append(BetaServerToolUseBlock.model_validate(block_param))
+            blocks.append(
+                BetaServerToolUseBlock(
+                    id=block_param["id"],
+                    caller=BetaDirectCaller(type="direct"),
+                    input=block_param["input"],
+                    name=block_param["name"],
+                    type=block_param["type"],
+                )
+            )
+
         elif block_param["type"] == "web_search_tool_result":
             blocks.append(WebSearchToolResultBlock.model_validate(block_param))
         elif block_param["type"] == "bash_code_execution_tool_result":

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -313,7 +313,7 @@ def validate_openai_client(feature: str) -> None:
 
 def validate_anthropic_client(feature: str) -> None:
     PACKAGE = "anthropic"
-    MIN_VERSION = "0.69.0"
+    MIN_VERSION = "0.75.0"
 
     # verify we have the package
     try:


### PR DESCRIPTION
Required by package version 0.75, which is now the minimum version.
