### PR TITLE
Add callbacks for customizing batch status rendering and log output during batch processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Agent Bridge: Don't print serialization warnings when going from Pydantic -> JSON (as we use beta types that can cause warnings even though serialization works as intended).
+- Batch Processing: Enable customizing of batch status rendering.
 
 ## 0.3.152 (04 December 2025)
 

--- a/src/inspect_ai/model/_providers/util/batch_log.py
+++ b/src/inspect_ai/model/_providers/util/batch_log.py
@@ -1,5 +1,56 @@
 """Logging utilities for batch operations."""
 
+import dataclasses
+import time
+from collections.abc import Callable
+
+from inspect_ai._util.format import format_progress_time
+
+
+@dataclasses.dataclass(frozen=True)
+class BatchStatus:
+    """Immutable status of batch processing."""
+
+    batch_count: int
+    pending_requests: int
+    completed_requests: int
+    failed_requests: int
+    oldest_created_at: int | None
+    """unix timestamp in seconds - or None if batch_count is 0"""
+
+
+BatchStatusCallback = Callable[[BatchStatus], None]
+BatchLogCallback = Callable[[str], None]
+
+_batch_status_callback: BatchStatusCallback | None = None
+_batch_log_callback: BatchLogCallback | None = None
+
+
+def set_batch_status_callback(callback: BatchStatusCallback | None) -> None:
+    global _batch_status_callback
+    _batch_status_callback = callback
+
+
+def set_batch_log_callback(callback: BatchLogCallback | None) -> None:
+    global _batch_log_callback
+    _batch_log_callback = callback
+
+
+def _default_batch_status_callback(status: BatchStatus) -> None:
+    oldest_age = (
+        int(time.time() - status.oldest_created_at) if status.oldest_created_at else 0
+    )
+    log_batch(
+        f"Current batches: {status.batch_count}, "
+        f"requests (pending/completed/failed): {status.pending_requests}/{status.completed_requests}/{status.failed_requests}, "
+        f"oldest batch age: {format_progress_time(oldest_age, False)}"
+    )
+
+
+def emit_batch_status(status: BatchStatus) -> None:
+    """Emit batch status to callback or default handler."""
+    (_batch_status_callback or _default_batch_status_callback)(status)
+
 
 def log_batch(message: str) -> None:
     """Log batch operation messages.
@@ -10,4 +61,4 @@ def log_batch(message: str) -> None:
     Args:
         message: The message to log
     """
-    print(message)
+    (_batch_log_callback or print)(message)


### PR DESCRIPTION
- `set_batch_status_callback(callback)` - custom status rendering
- `set_batch_log_callback(callback)` - custom log output