### PR TITLE
Agent Bridge: Don't print serialization warnings when going from Pydantic -> JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Agent Bridge: Don't print serialization warnings when going from Pydantic -> JSON (as we use beta types that can cause warnings even though serialization works as intended).
+
 ## 0.3.152 (04 December 2025)
 
 - [Update Plan](https://inspect.aisi.org.uk/tools-standard.html#sec-update-plan) tool for tracking steps and progress across longer horizon tasks.

--- a/src/inspect_ai/agent/_bridge/sandbox/service.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/service.py
@@ -53,7 +53,7 @@ def generate_completions(
         if bridge.model is not None:
             json_data["model"] = bridge.model
         completion = await inspect_completions_api_request(json_data, bridge)
-        return completion.model_dump(mode="json")
+        return completion.model_dump(mode="json", warnings=False)
 
     return generate
 
@@ -69,7 +69,7 @@ def generate_responses(
         completion = await inspect_responses_api_request(
             json_data, web_search, code_execution, bridge
         )
-        return completion.model_dump(mode="json")
+        return completion.model_dump(mode="json", warnings=False)
 
     return generate
 
@@ -85,6 +85,6 @@ def generate_anthropic(
         completion = await inspect_anthropic_api_request(
             json_data, web_search, code_execution, bridge
         )
-        return completion.model_dump(mode="json")
+        return completion.model_dump(mode="json", warnings=False)
 
     return generate


### PR DESCRIPTION
We use beta types that can cause warnings even though serialization works as intended).
