### PR TITLE
Docs: fix broken links due to incorrect markdown formatting

### DIFF
--- a/docs/interactivity.qmd
+++ b/docs/interactivity.qmd
@@ -107,7 +107,7 @@ You can also use the [Layout](#sec-layout) primitives (columns, panels, and tabl
 
 ## Formatting
 
-The `console.print()` method supports [formatting]((https://rich.readthedocs.io/en/stable/console.html)) using simple markup. For example:
+The `console.print()` method supports [formatting](https://rich.readthedocs.io/en/stable/console.html) using simple markup. For example:
 
 ``` python
 with input_screen() as console:

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -443,7 +443,7 @@ from inspect_ai.tool import code_execution
 def code_execution_task():
     return Task(
         dataset=[Sample("Add 435678 + 23457")],
-        solver=react(tools=[code_execution())
+        solver=react(tools=[code_execution()])
     )
 ```
 
@@ -691,7 +691,7 @@ def intercode_ctf():
 
 ### Tool Description
 
-In the original [think tool article]((https://www.anthropic.com/engineering/claude-think-tool)) (which was based on experimenting with Claude) they found that providing clear instructions on when and how to use the `think()` tool for the particular problem domain it is being used within could sometimes be helpful. For example, here's the prompt they used with SWE-Bench:
+In the original [think tool article](https://www.anthropic.com/engineering/claude-think-tool) (which was based on experimenting with Claude) they found that providing clear instructions on when and how to use the `think()` tool for the particular problem domain it is being used within could sometimes be helpful. For example, here's the prompt they used with SWE-Bench:
 
 ``` python
 from textwrap import dedent


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Links in the docs are broken on both the Interactivity page and the Standard Tools page.

### What is the new behavior?
Fixed links in the docs!

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Also fixed a code sample in the tools-standard.qmd that was missing a closing square bracket (`]`).