### PR TITLE
Add .qmd to .editorconfig to specify rules for QMD files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,7 +8,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[*.md]
+[*.{md,qmd}]
 indent_size = 4
 trim_trailing_whitespace = false
 insert_final_newline = false


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Currently, `.qmd` files have their trailing whitespace trimmed, but `.md` files don't. It seems like they should be treated the same way since `.qmd` files are basically just fancy markdown files. 

### What is the new behavior?
`.qmd` files now have the same rules as `.md` files in the `.editorconfig`, so they'll be treated exactly like `.md` files.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
I'm not 100% sure QMD files should be given the exact same rules as Markdown files, but it seems logical. If they need any different rules, I'm happy to break them into their own category.