### PR TITLE
add documentation for inspect_modal_sandbox

### DIFF
--- a/docs/extensions/extensions.yml
+++ b/docs/extensions/extensions.yml
@@ -82,6 +82,12 @@
   author: "[UK AISI](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox)"
   categories: ["Sandbox"]
 
+- name: "[Modal Sandbox](https://github.com/anthonyduong9/inspect_modal_sandbox)"
+  description: |
+    Python package that provides a Modal container sandbox environment for Inspect.
+  author: "[Anthony Duong](https://github.com/anthonyduong9)"
+  categories: ["Sandbox"]
+
 - name: "[Proxmox Sandbox](https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox)"
   description: Use virtual machines, running within a [Proxmox](https://www.proxmox.com/en/products/proxmox-virtual-environment/overview) instance, as Inspect sandboxes.
   author: "[UK AISI](https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox)"

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -22,7 +22,7 @@ Inspect can be used for a broad range of evaluations that measure coding, agenti
 -   Extensive tooling, including a web-based Inspect View tool for monitoring and visualizing evaluations and a VS Code Extension that assists with authoring and debugging.
 -   Flexible support for tool calling---custom and MCP tools, as well as built-in bash, python, text editing, web search, web browsing, and computer tools.
 -   Support for agent evaluations, including flexible built-in agents, multi-agent primitives, the ability to run arbitrary external agents like Claude Code and Codex CLI.
--   A sandboxing system that supports running untrusted model code in Docker, Kubernetes, Proxmox, and other systems via an extension API.
+-   A sandboxing system that supports running untrusted model code in Docker, Kubernetes, Modal, Proxmox, and other systems via an extension API.
 :::
 
 We'll walk through a fairly trivial "Hello, Inspect" example below. Read on to learn the basics, then read the documentation on [Datasets](datasets.qmd), [Solvers](solvers.qmd), [Scorers](scorers.qmd), [Tools](tools.qmd), and [Agents](agents.qmd) to learn how to create more advanced evaluations.

--- a/docs/sandboxing.qmd
+++ b/docs/sandboxing.qmd
@@ -88,7 +88,7 @@ The sandbox is also available to custom scorers.
 
 ## Environment Binding
 
-There are two sandbox environments built in to Inspect and three available as external packages:
+There are two sandbox environments built in to Inspect and four available as external packages:
 
 | Environment Type | Description |
 |---------------------------|---------------------------------------------|
@@ -96,6 +96,7 @@ There are two sandbox environments built in to Inspect and three available as ex
 | `docker` | Run `sandbox()` methods within a Docker container (see the [Docker Configuration](#sec-docker-configuration) section below for additional details). |
 | `k8s` | Run `sandbox()` methods within a Kubernetes cluster (see the [K8s Sandbox](https://k8s-sandbox.aisi.org.uk/) package documentation for additional details). |
 | `ec2` | Run `sandbox()` methods on an AWS EC2 virtual machine (see the [EC2 Sandbox](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox) package documentation for additional details). |
+| `modal` | Run `sandbox()` methods within a Modal container (see the [Modal Sandbox](https://github.com/anthonyduong9/inspect_modal_sandbox) package documentation for additional details). |
 | `proxmox` | Run `sandbox()` methods within a virtual machine (see the [Proxmox Sandbox](https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox) package documentation for additional details). |
 
 Sandbox environment definitions can be bound at the `Sample`, `Task`, or `eval()` level. Binding precedence goes from `eval()`, to `Task` to `Sample`, however sandbox config files defined on the `Sample` always take precedence when the sandbox type for the `Sample` is the same as the enclosing `Task` or `eval()`.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The documentation at https://inspect.aisi.org.uk/extensions/ and https://inspect.aisi.org.uk/sandboxing.html does not list the Modal sandbox.

### What is the new behavior?

It lists the Modal sandbox.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

I ran `cd docs` and then `quarto preview`.