### PR TITLE
Fix release_date for Claude 3.5 sonnet

### DIFF
--- a/src/inspect_ai/model/_model_data/anthropic.yml
+++ b/src/inspect_ai/model/_model_data/anthropic.yml
@@ -107,6 +107,7 @@ anthropic:
             - anthropic.claude-3-5-sonnet-20241022-v2:0
             - claude-3-5-sonnet-v2@20241022
         claude-3-5-sonnet-20240620:
+          release_date: 2024-06-20
           snapshot: "20240620"
           aliases:
             - anthropic.claude-3-5-sonnet-20240620-v1:0


### PR DESCRIPTION
The original Claude 3.5 Sonnet was released on 2024-06-20, but the version entry used by the `model_info` metadata was missing a release_date and incorrectly inheriting 2024-10-22 from the base claude-3-5-sonnet model (which uses the v2/3.6 release date).

🤖 Generated with [Claude Code](https://claude.com/claude-code), but I reviewed this and believe the change is correct.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Looking up the release date of claude-3-5-sonnet-20240620 returns `2024-10-22` (incorrect).

### What is the new behavior?
Looking up the release date of claude-3-5-sonnet-20240620 returns `2024-06-20` (correct)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

Minimal example to demonstrate the issue:
```py
from inspect_ai.analysis import model_info, prepare
import pandas as pd

df = pd.DataFrame({
          'model': [
              'anthropic/anthropic.claude-3-5-sonnet-20240620-v1:0',
              'anthropic/anthropic.claude-3-5-sonnet-20241022-v2:0',
          ]
      })

df = prepare(df, model_info())
print(df[['model', 'model_display_name', 'model_release_date']].to_string())
```

Without the fix, the code produces incorrect dates:
```
                                                 model model_display_name model_release_date
0  anthropic/anthropic.claude-3-5-sonnet-20240620-v1:0  Claude Sonnet 3.5         2024-10-22
1  anthropic/anthropic.claude-3-5-sonnet-20241022-v2:0  Claude Sonnet 3.6         2024-10-22
```

With this fix, the code produces correct dates:
```
                                                 model model_display_name model_release_date
0  anthropic/anthropic.claude-3-5-sonnet-20240620-v1:0  Claude Sonnet 3.5         2024-06-20
1  anthropic/anthropic.claude-3-5-sonnet-20241022-v2:0  Claude Sonnet 3.6         2024-10-22
```