### PR TITLE
docs: add Inspect Policy Sandbox to extensions page

### DIFF
--- a/docs/extensions/extensions.yml
+++ b/docs/extensions/extensions.yml
@@ -92,3 +92,10 @@
   description: Use virtual machines, running within a [Proxmox](https://www.proxmox.com/en/products/proxmox-virtual-environment/overview) instance, as Inspect sandboxes.
   author: "[UK AISI](https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox)"
   categories: ["Sandbox"]
+
+- name: "[Inspect Policy Sandbox](https://github.com/Dedulus/inspect-policy-sandbox)"
+  description: |
+    Policy enforced sandbox wrapper for Inspect AI that allows fine grained control
+    over command execution and file I/O without modifying core sandbox backends.
+  author: "[Arnab Mitra](https://github.com/Dedulus)"
+  categories: ["Sandbox"]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

The Inspect Policy Sandbox extension was not yet listed on the Inspect Extensions page.

### What is the new behavior?

The Inspect Policy Sandbox extension is now listed on the Extensions page with a short description and a link to its GitHub repository.

### Does this PR introduce a breaking change?

No. This change is related only to documentation.

### Other information

This follows on from the earlier discussion in #2995, where the extension was created as an external package.

Thanks again. Happy to adjust anything here if needed.
