### PR TITLE
Rename AZUREAI_OPENAI_BASE_URL to AZUREAI_BASE_URL in Docs

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -105,7 +105,7 @@ The `openai` provider supports OpenAI models deployed on the [Azure AI Foundry](
 | Variable | Description |
 |---------------------------|---------------------------------------------|
 | `AZUREAI_OPENAI_API_KEY` | API key credentials (optional). |
-| `AZUREAI_OPENAI_BASE_URL` | Base URL for requests (required) |
+| `AZUREAI_BASE_URL` | Base URL for requests (required) |
 | `AZUREAI_OPENAI_API_VERSION` | OpenAI API version (optional) |
 | `AZUREAI_AUDIENCE` | Azure resource URI that the access token is intended for when using managed identity (optional, defaults to `https://cognitiveservices.azure.com/.default`) |
 
@@ -113,7 +113,7 @@ You can then use the normal `openai` provider with the `azure` qualifier and the
 
 ``` bash
 export AZUREAI_OPENAI_API_KEY=your-api-key
-export AZUREAI_OPENAI_BASE_URL=https://your-url-at.azure.com
+export AZUREAI_BASE_URL=https://your-url-at.azure.com
 export AZUREAI_OPENAI_API_VERSION=2025-03-01-preview
 inspect eval math.py --model openai/azure/gpt-4o-mini
 ```
@@ -122,7 +122,7 @@ If using managed identity for authentication, install the `azure-identity` packa
 
 ``` bash
 pip install azure-identity
-export AZUREAI_OPENAI_BASE_URL=https://your-url-at.azure.com
+export AZUREAI_BASE_URL=https://your-url-at.azure.com
 export AZUREAI_AUDIENCE=https://cognitiveservices.azure.com/.default
 export AZUREAI_OPENAI_API_VERSION=2025-03-01-preview
 inspect eval math.py --model openai/azure/gpt-4o-mini


### PR DESCRIPTION
Code seems to expect a different environment variable.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [X] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Execution complains that AZUREAI_BASE_URL environment variable is missing. Changing AZUREAI_OPENAI_BASE_URL to AZUREAI_BASE_URL resolves issues. 

### What is the new behavior?
Correct docs to match codebase expectation

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
