### PR TITLE
OpenAI Compatible: Always pass function definitions with `strict=True`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- OpenAI Compatible: Always pass function definitions with `strict=True`. This is required by HF Inference Providers and Fireworks (and possibly others).
+
 ## 0.3.160 (09 January 2026)
 
 - Agent Bridge: Consolidate bridged tools implementation into the existing sandbox model proxy service (eliminate Python requirement for using bridged tools).

--- a/src/inspect_ai/model/_providers/hf_inference_providers.py
+++ b/src/inspect_ai/model/_providers/hf_inference_providers.py
@@ -1,11 +1,7 @@
 import os
 from typing import Any
 
-from openai.types.chat import ChatCompletionToolParam
 from typing_extensions import override
-
-from inspect_ai.model._openai import openai_chat_tools
-from inspect_ai.tool._tool_info import ToolInfo
 
 from .._generate_config import GenerateConfig
 from .openai_compatible import OpenAICompatibleAPI
@@ -59,11 +55,3 @@ class HFInferenceProvidersAPI(OpenAICompatibleAPI):
             name = name.split(":")[0]
 
         return name
-
-    @override
-    def tools_to_openai(self, tools: list[ToolInfo]) -> list[ChatCompletionToolParam]:
-        # hf inference providers requires "strict" for tools
-        openai_tools = openai_chat_tools(tools)
-        for tool in openai_tools:
-            tool["function"]["strict"] = True
-        return openai_tools

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -305,8 +305,11 @@ class OpenAICompatibleAPI(ModelAPI):
         return False
 
     def tools_to_openai(self, tools: list[ToolInfo]) -> list[ChatCompletionToolParam]:
-        """Hook for subclasses to do custom tools processing"""
-        return openai_chat_tools(tools)
+        # some inference platforms (e.g. hf-inference) require strict=True
+        openai_tools = openai_chat_tools(tools)
+        for tool in openai_tools:
+            tool["function"]["strict"] = True
+        return openai_tools
 
     async def messages_to_openai(
         self, input: list[ChatMessage]


### PR DESCRIPTION
This is required by HF Inference Providers and Fireworks (and possibly others).

