### PR TITLE
Fix virtual list search: FindBand preserves selection and scroll position when no results found

### DIFF
--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -279,22 +279,27 @@ export const FindBand: FC<FindBandProps> = () => {
 
     document.addEventListener("keydown", handleGlobalKeydown, true); // Use capture phase
 
+    // Capture ref values for cleanup
+    const mutatedPanels = mutatedPanelsRef.current;
+    const scrollTimeout = scrollTimeoutRef.current;
+    const focusTimeout = focusTimeoutRef.current;
+
     return () => {
       document.removeEventListener("keydown", handleGlobalKeydown, true);
-      if (scrollTimeoutRef.current !== null) {
-        window.clearTimeout(scrollTimeoutRef.current);
+      if (scrollTimeout !== null) {
+        window.clearTimeout(scrollTimeout);
       }
-      if (focusTimeoutRef.current !== null) {
-        window.clearTimeout(focusTimeoutRef.current);
+      if (focusTimeout !== null) {
+        window.clearTimeout(focusTimeout);
       }
       // Restore original styles on mutated expandable panels
-      mutatedPanelsRef.current.forEach((originalStyles, panel) => {
+      mutatedPanels.forEach((originalStyles, panel) => {
         panel.style.display = originalStyles.display;
         panel.style.maxHeight = originalStyles.maxHeight;
         panel.style.webkitLineClamp = originalStyles.webkitLineClamp;
         panel.style.webkitBoxOrient = originalStyles.webkitBoxOrient;
       });
-      mutatedPanelsRef.current.clear();
+      mutatedPanels.clear();
     };
   }, [handleSearch]);
 
@@ -405,7 +410,9 @@ export const FindBand: FC<FindBandProps> = () => {
         onBeforeInput={handleBeforeInput}
         onChange={handleInputChange}
       />
-      <span id="inspect-find-no-results" aria-hidden="true">No results</span>
+      <span id="inspect-find-no-results" aria-hidden="true">
+        No results
+      </span>
       <button
         type="button"
         title="Previous match"


### PR DESCRIPTION
More fixes for searching in virtual list mode:

- Add direction-aware no-result caching (forward/backward search independent)
- Save and restore selection when search finds no new matches
- Save and restore scroll position when search finds no new matches
- Improve scroll-into-view for matches in large elements (use selection rect)
- Restore expandable panel styles on FindBand unmount
- Handle race conditions in async searches
- Fix Ctrl+G search direction
- Add aria-hidden for accessibility and automated testing

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

There were many small mistakes when searching in a virtualized view: search results were not visible, CTRL-f + typing worked differently than normal search, CTRL-G was inverted. Pressing next and/or previous after reaching the final result worked strangely.

### What is the new behavior?

The mistakes I was able to find now works correctly.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
