### PR TITLE
Google: Use parameters_json_schema for function declarations

### DIFF
--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -783,7 +783,12 @@ class GoogleGenAIAPI(ModelAPI):
                     FunctionDeclaration(
                         name=tool.name,
                         description=tool.description,
-                        parameters=schema_from_param(tool.parameters)
+                        # Use parameters_json_schema to preserve full JSON Schema
+                        # including anyOf types, which Gemini 3+ handles correctly
+                        # but the Schema format (via schema_from_param) loses
+                        parameters_json_schema=tool.parameters.model_dump(
+                            exclude_none=True
+                        )
                         if len(tool.parameters.properties) > 0
                         else None,
                     )


### PR DESCRIPTION
Gemini 3 started rejecting function schemas containing `TYPE_UNSPECIFIED` (previous Gemini models accepted them).

This PR uses parameters_json_schema instead of parameters (with schema_from_param conversion) for FunctionDeclaration. This preserves the full JSON Schema including anyOf types, which Gemini 3+ handles correctly but the Schema format loses by converting to TYPE_UNSPECIFIED.

We could also do the same for response schema, then `schema_from_param` altogether https://github.com/UKGovernmentBEIS/inspect_ai/commit/a6d990c3da45e4945210862f196d1e7a0dde5ce2 does that, -93 LOC. Not sure if we want to include it too?

```diff
-                parameters.response_schema = schema_from_param(
-                    config.response_schema.json_schema, nullable=None
+                parameters.response_schema_json_schema = (
+                    config.response_schema.json_schema.model_dump(exclude_none=True)
```


## This PR contains:
- Bug fixes

### What is the current behavior? (You can also link to an open issue here)

Gemini 3 returns `MALFORMED_FUNCTION_CALL` error for functions with union / anyof types

### What is the new behavior?

Pass the full json schema to `parameters_json_schema`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Maybe schemas with invalid content of an `anyOf` would previously work for Gemini <3, but now will fail with 400 from Gemini API?

### Other information:

#### Curl Repro of issue:

```bash
curl -X POST "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-pro-preview:generateContent?key=$DEFAULT_GOOGLE_API_KEY" \
    -H "Content-Type: application/json" \
    -d '{
    "contents": [{"role": "user", "parts": [{"text": "Run: ls -la"}]}],
    "tools": [{
      "functionDeclarations": [{
        "name": "bash",
        "description": "Execute a bash command",
        "parameters": {
          "type": "OBJECT",
          "properties": {
            "cmd": {
              "description": "The command to run",
              "type": "TYPE_UNSPECIFIED"
            }
          },
          "required": ["cmd"]
        }
      }]
    }],
    "tool_config": {"functionCallingConfig": {"mode": "ANY"}}
  }'
{
  "candidates": [
    {
      "content": {},
      "finishReason": "MALFORMED_FUNCTION_CALL",
      "index": 0,
      "finishMessage": "Malformed function call: "
    }
  ],...}
```