### PR TITLE
fix: Handle maps and lists in registry_kwargs()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Bash Session: Increase bash session transport timeout and make new session timeouts fatal.
 - Inspect View: Timestamps for USER and ASSISTANT transcript of model events, `yyyy-mm-dd hh:mm:ss` format (keep local time zone).
 - Bugfix: Include type field in JSON Schema for Literal and Enum types.
+- Bugfix: Handle maps and lists in registry_kwargs().
 
 ## 0.3.163 (21 January 2026)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

registry_kwargs does not correctly handle lists and dicts. This is a problem for example if an agent takes a list of tools as an arg.

### What is the new behavior?

registry_kwargs works recursively to create nested registry objects.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

no

### Other information:
