### PR TITLE
Fix: Kimi K2.5 reasoning_content support for multi-turn tool calls

### DIFF
--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -221,14 +221,20 @@ async def openai_chat_message(
 async def messages_to_openai(
     messages: list[ChatMessage],
     system_role: Literal["user", "system", "developer"] = "system",
+    reasoning_handler: Callable[[ContentReasoning], dict[str, JsonValue] | str]
+    | None = None,
 ) -> list[ChatCompletionMessageParam]:
     """Convert messages to OpenAI Completions API compatible messages.
 
     Args:
        messages: List of messages to convert
        system_role: Role to use for system messages (newer OpenAI models use "developer" rather than "system").
+       reasoning_handler: Optional handler to convert ContentReasoning to API-specific format.
     """
-    return [await openai_chat_message(message, system_role) for message in messages]
+    return [
+        await openai_chat_message(message, system_role, reasoning_handler)
+        for message in messages
+    ]
 
 
 def openai_completion_params(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Kimi K2.5 (Moonshot AI) requires reasoning_content to be echoed back in messages when thinking mode is enabled. Without this, multi-turn tool calls fail with:
```
Error code: 400 - 'thinking is enabled but reasoning_content is missing in assistant tool call message at index N'
```

### What is the new behavior?
- Add reasoning_handler parameter to messages_to_openai() to support provider-specific reasoning serialization
- For Kimi models, return {"reasoning_content": ...} instead of converting to <think> tags

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
