### PR TITLE
add type alias for status literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Eval Logs: Add `EvalStatus` type alias for evaluation status literals (`"started"`, `"success"`, `"cancelled"`, `"error"`).
 - Bugfix: raise PrerequisiteError when bundling to a subdirectory of the log dir (instead of deleting the logs from the log dir).
 
 ## 0.3.167 (29 January 2026)

--- a/docs/reference/_sidebar.yml
+++ b/docs/reference/_sidebar.yml
@@ -489,6 +489,8 @@ website:
           href: reference/inspect_ai.log.qmd#uninvalidate_samples
         - text: ProvenanceData
           href: reference/inspect_ai.log.qmd#provenancedata
+        - text: EvalStatus
+          href: reference/inspect_ai.log.qmd#evalstatus
         - text: EvalLog
           href: reference/inspect_ai.log.qmd#evallog
         - text: EvalSpec

--- a/docs/reference/inspect_ai.log.qmd
+++ b/docs/reference/inspect_ai.log.qmd
@@ -25,6 +25,7 @@ title: "inspect_ai.log"
 
 ## Eval Log API
 
+### EvalStatus
 ### EvalLog
 ### EvalSpec
 ### EvalDataset

--- a/src/inspect_ai/_cli/list.py
+++ b/src/inspect_ai/_cli/list.py
@@ -1,5 +1,4 @@
 from json import dumps
-from typing import Literal
 
 import click
 from pydantic_core import to_jsonable_python
@@ -10,6 +9,7 @@ from inspect_ai._cli.log import list_logs_options, log_list
 from inspect_ai._cli.util import parse_cli_args
 from inspect_ai._eval.list import list_tasks
 from inspect_ai._eval.task import TaskInfo
+from inspect_ai.log import EvalStatus
 
 
 @click.group("list")
@@ -81,7 +81,7 @@ def tasks(
 @list_command.command("logs", hidden=True)
 @list_logs_options
 def list_logs_command(
-    status: Literal["started", "success", "cancelled", "error"] | None,
+    status: EvalStatus | None,
     absolute: bool,
     json: bool,
     no_recursive: bool | None,

--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -12,7 +12,7 @@ from typing_extensions import Unpack
 from inspect_ai._cli.common import CommonOptions, common_options, process_common_options
 from inspect_ai._cli.util import int_or_bool_flag_callback
 from inspect_ai._util.constants import PKG_PATH
-from inspect_ai.log import list_eval_logs
+from inspect_ai.log import EvalStatus, list_eval_logs
 from inspect_ai.log._convert import convert_eval_logs
 from inspect_ai.log._file import (
     eval_log_json_str,
@@ -73,7 +73,7 @@ def list_logs_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 
 
 def log_list(
-    status: Literal["started", "success", "cancelled", "error"] | None,
+    status: EvalStatus | None,
     absolute: bool,
     json: bool,
     no_recursive: bool | None,
@@ -125,7 +125,7 @@ def resolve_attachments_callback(
 @log_command.command("list")
 @list_logs_options
 def list_command(
-    status: Literal["started", "success", "cancelled", "error"] | None,
+    status: EvalStatus | None,
     absolute: bool,
     json: bool,
     no_recursive: bool | None,

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from importlib import metadata as importlib_metadata
-from typing import Any, Literal, cast
+from typing import Any, cast
 
 from shortuuid import uuid
 
@@ -29,6 +29,7 @@ from inspect_ai.log import (
     EvalSample,
     EvalSpec,
     EvalStats,
+    EvalStatus,
 )
 from inspect_ai.log._log import (
     EvalLog,
@@ -289,7 +290,7 @@ class TaskLogger:
 
     async def log_finish(
         self,
-        status: Literal["started", "success", "cancelled", "error"],
+        status: EvalStatus,
         stats: EvalStats,
         results: EvalResults | None = None,
         reductions: list[EvalSampleReductions] | None = None,

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -38,6 +38,7 @@ from ._log import (
     EvalScore,
     EvalSpec,
     EvalStats,
+    EvalStatus,
 )
 from ._metric import recompute_metrics
 from ._retry import retryable_eval_logs
@@ -66,6 +67,7 @@ __all__ = [
     "EvalScore",
     "EvalSpec",
     "EvalStats",
+    "EvalStatus",
     "EvalLogInfo",
     "Transcript",
     "transcript",

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -22,7 +22,7 @@ from inspect_ai._util.json import to_json_safe
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.log._log import EvalSampleSummary
 
-from ._log import EvalLog, EvalMetric, EvalSample
+from ._log import EvalLog, EvalMetric, EvalSample, EvalStatus
 from ._recorders import (
     recorder_type_for_bytes,
     recorder_type_for_format,
@@ -68,7 +68,7 @@ class LogOverview(BaseModel):
     task_version: int | str
 
     version: int
-    status: Literal["started", "success", "cancelled", "error"]
+    status: EvalStatus
     invalidated: bool = Field(default=False)
     error: EvalError | None = Field(default=None)
 

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -36,6 +36,9 @@ from ._util import thin_input, thin_metadata, thin_target, thin_text
 
 logger = getLogger(__name__)
 
+EvalStatus = Literal["started", "success", "cancelled", "error"]
+"""Status of an evaluation run."""
+
 SCORER_PLACEHOLDER = "88F74D2C"
 
 
@@ -928,9 +931,7 @@ class EvalLog(BaseModel):
     version: int = Field(default=2)
     """Eval log file format version."""
 
-    status: Literal["started", "success", "cancelled", "error"] = Field(
-        default="started"
-    )
+    status: EvalStatus = Field(default="started")
     """Status of evaluation (did it succeed or fail)."""
 
     eval: EvalSpec

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -4,7 +4,7 @@ import math
 import os
 import tempfile
 from logging import getLogger
-from typing import IO, Any, BinaryIO, Literal, cast
+from typing import IO, Any, BinaryIO, cast
 from zipfile import ZIP_DEFLATED, ZipFile
 
 import anyio
@@ -26,6 +26,7 @@ from .._log import (
     EvalSampleSummary,
     EvalSpec,
     EvalStats,
+    EvalStatus,
     sort_samples,
 )
 from .file import FileRecorder
@@ -40,7 +41,7 @@ class LogStart(BaseModel):
 
 
 class LogResults(BaseModel):
-    status: Literal["started", "success", "cancelled", "error"]
+    status: EvalStatus
     stats: EvalStats
     results: EvalResults | None = Field(default=None)
     error: EvalError | None = Field(default=None)
@@ -136,7 +137,7 @@ class EvalRecorder(FileRecorder):
     async def log_finish(
         self,
         eval: EvalSpec,
-        status: Literal["started", "success", "cancelled", "error"],
+        status: EvalStatus,
         stats: EvalStats,
         results: EvalResults | None,
         reductions: list[EvalSampleReductions] | None,

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -1,5 +1,5 @@
 from logging import getLogger
-from typing import IO, Any, Literal, get_args
+from typing import IO, Any, get_args
 
 import ijson  # type: ignore
 from ijson import IncompleteJSONError
@@ -22,6 +22,7 @@ from .._log import (
     EvalSampleReductions,
     EvalSpec,
     EvalStats,
+    EvalStatus,
     sort_samples,
 )
 from .eval import _s3_bucket_and_key, _write_s3_conditional
@@ -102,7 +103,7 @@ class JSONRecorder(FileRecorder):
     async def log_finish(
         self,
         eval: EvalSpec,
-        status: Literal["started", "success", "cancelled", "error"],
+        status: EvalStatus,
         stats: EvalStats,
         results: EvalResults | None,
         reductions: list[EvalSampleReductions] | None,
@@ -303,7 +304,7 @@ def _read_header_streaming(log_file: str) -> EvalLog:
 
         # Parse the log file, stopping before parsing samples
         invalidated = False
-        status: Literal["started", "success", "cancelled", "error"] | None = None
+        status: EvalStatus | None = None
         eval: EvalSpec | None = None
         plan: EvalPlan | None = None
         results: EvalResults | None = None
@@ -311,9 +312,7 @@ def _read_header_streaming(log_file: str) -> EvalLog:
         error: EvalError | None = None
         for k, v in ijson.kvitems(f, ""):
             if k == "status":
-                assert v in get_args(
-                    Literal["started", "success", "cancelled", "error"]
-                )
+                assert v in get_args(EvalStatus)
                 status = v
             elif k == "invalidated":
                 invalidated = v

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -1,5 +1,5 @@
 import abc
-from typing import IO, Literal
+from typing import IO
 
 from inspect_ai._util.error import EvalError
 from inspect_ai.log._log import (
@@ -11,6 +11,7 @@ from inspect_ai.log._log import (
     EvalSampleSummary,
     EvalSpec,
     EvalStats,
+    EvalStatus,
 )
 
 
@@ -45,7 +46,7 @@ class Recorder(abc.ABC):
     async def log_finish(
         self,
         eval: EvalSpec,
-        status: Literal["started", "success", "cancelled", "error"],
+        status: EvalStatus,
         stats: EvalStats,
         results: EvalResults | None,
         reductions: list[EvalSampleReductions] | None,


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Users read `Literal["started", "success", "cancelled", "error"]` in many places in the code, and cannot import this into their code.

### What is the new behavior?

Users read `EvalStatus` and can import this into their code.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

I ran `cd docs` and then `quarto render`.