### PR TITLE
Fix flaky `test_df` failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 - Task Execution: Cancelled samples are now logged in the same fashion as samples with errors.
 - Limits: New `cost_limit()` context manager for scoped application of cost limits (can also be applied directly samples or agents).
 - Inspect View: Make samples in task detail sortable, inline epoch filter.
-- Bugfix: Fix non-deterministic test failures in `test_df.py` caused by platform-dependent ordering of `list_eval_logs()`.
 
 ## 0.3.178 (11 February 2026)
 


### PR DESCRIPTION
- Single-log tests in `test_df.py` used `list_eval_logs()[0]`, which depends on filesystem ordering
- Two log files share the same timestamp prefix (`2025-05-12T20-28-13-04-00`), so their relative order differs between Linux (CI) and macOS (local dev)
- Tests now reference `security-guide.json` by path instead of relying on list ordering

### Why CI passed

`list_eval_logs()` sorts by file modification time. In CI, a fresh `git clone` sets all file mtimes to the checkout time, so ties are broken by the filesystem's inode/directory ordering — which happened to put `security-guide.json` first. Locally, file mtimes reflect when the files were actually last written which can vary depending on how long the clone existed, when the files were created, etc.