### PR TITLE
Fix inspect_sandbox_tools tests

### DIFF
--- a/src/inspect_sandbox_tools/pyproject.toml
+++ b/src/inspect_sandbox_tools/pyproject.toml
@@ -65,6 +65,9 @@ disallow_untyped_decorators = true
 extra_checks = true
 disable_error_code = "unused-ignore"
 
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+
 [tool.check-wheel-contents]
 ignore = ["W002", "W009"]
 
@@ -115,6 +118,8 @@ dev = [
     "towncrier",
     "types-psutil",
     "pytest",
+    "pytest-asyncio",
+    "pytest-dotenv",
 ]
 
 dist = ["twine", "build"]

--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_in_process_tools/_version/json_rpc_methods.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_in_process_tools/_version/json_rpc_methods.py
@@ -1,9 +1,8 @@
-import os
-import sys
+from inspect_sandbox_tools import __version__
 
 from ..._util.json_rpc_helpers import NoParams, validated_json_rpc_method
 
 
 @validated_json_rpc_method(NoParams)
 async def version(_: NoParams) -> str:
-    return f"Client: {sys.argv[0]} ({os.getpid()})"
+    return __version__


### PR DESCRIPTION
## Summary
- Fix the `version` JSON-RPC method to return the actual package version instead of a debug string with the process name and PID
- Add missing test dependencies (`pytest-asyncio`, `pytest-dotenv`) to `pyproject.toml`
- Configure `asyncio_mode = "auto"` for pytest so async tests work without per-test markers