### PR TITLE
Fix typo: 'varible' -> 'variable'

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1362,7 +1362,7 @@ def get_model(
             model = model.split(",")[0]
         else:
             raise ValueError(
-                "No model specified (and no model environment varible defined)"
+                "No model specified (and no model environment variable defined)"
             )
 
     # see if we can return a memoized model instance

--- a/src/inspect_ai/model/_providers/none.py
+++ b/src/inspect_ai/model/_providers/none.py
@@ -27,5 +27,5 @@ class NoModel(ModelAPI):
         config: GenerateConfig,
     ) -> ModelOutput:
         raise PrerequisiteError(
-            "No model specified (and no model environment varible defined)"
+            "No model specified (and no model environment variable defined)"
         )


### PR DESCRIPTION
Small typo fix in error message ('varible' -> 'variable').
No behavior change.