### PR TITLE
Enrich retry log messages with task/sample/model context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Model API: Log model retries at WARNING when backoff >= 60s.
+- Model API: Enrich retry log messages with task/sample/model context and error summary.
 
 ## 0.3.207 (16 April 2026)
 

--- a/src/inspect_ai/_eval/context.py
+++ b/src/inspect_ai/_eval/context.py
@@ -3,6 +3,7 @@ from anyio.abc import TaskGroup
 from inspect_ai._util.background import set_background_task_group
 from inspect_ai._util.dotenv import init_dotenv
 from inspect_ai._util.logger import init_logger
+from inspect_ai._util.retry import install_sample_context_logging
 from inspect_ai.approval._apply import have_tool_approval, init_tool_approval
 from inspect_ai.approval._human.manager import init_human_approval_manager
 from inspect_ai.approval._policy import ApprovalPolicy
@@ -40,6 +41,7 @@ def init_eval_context(
     init_active_samples()
     init_human_approval_manager()
     set_background_task_group(task_group)
+    install_sample_context_logging()
 
 
 def init_model_context(

--- a/src/inspect_ai/_util/httpx.py
+++ b/src/inspect_ai/_util/httpx.py
@@ -36,9 +36,12 @@ def httpx_should_retry(ex: BaseException) -> bool:
 
 def log_httpx_retry_attempt(context: str) -> Callable[[RetryCallState], None]:
     def log_attempt(retry_state: RetryCallState) -> None:
+        from inspect_ai._util.retry import sample_context_prefix
+
+        prefix = sample_context_prefix()
         logger.log(
             HTTP,
-            f"{context} connection retry {retry_state.attempt_number} (retrying in {retry_state.upcoming_sleep:,.0f} seconds)",
+            f"{prefix}{context} connection retry {retry_state.attempt_number} (retrying in {retry_state.upcoming_sleep:,.0f} seconds)",
         )
 
     return log_attempt

--- a/src/inspect_ai/_util/retry.py
+++ b/src/inspect_ai/_util/retry.py
@@ -1,3 +1,10 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tenacity import RetryCallState
+
 _http_retries_count: int = 0
 
 
@@ -14,3 +21,52 @@ def report_http_retry() -> None:
 
 def http_retries_count() -> int:
     return _http_retries_count
+
+
+def sample_context_prefix() -> str:
+    """Build a compact context prefix from the active sample.
+
+    Returns a string like "[Abc12xY mmlu/42/1 openai/gpt-4o] " or "" if
+    no sample is active.
+    """
+    from inspect_ai.log._samples import sample_active
+
+    active = sample_active()
+    if active is None:
+        return ""
+    return (
+        f"[{active.id} {active.task}/{active.sample.id}/{active.epoch} {active.model}] "
+    )
+
+
+def retry_error_summary(retry_state: RetryCallState) -> str:
+    """Build a compact error summary from a tenacity RetryCallState.
+
+    Returns a string like " [RateLimitError 429 rate_limit_exceeded]" or ""
+    if no exception is available. Never includes full error messages (could
+    leak prompt content or API keys).
+    """
+    if retry_state.outcome is None:
+        return ""
+    ex = retry_state.outcome.exception()
+    if ex is None:
+        return ""
+
+    type_name = type(ex).__name__
+
+    # HTTP status code — on the exception itself or on ex.response
+    status: int | None = getattr(ex, "status_code", None)
+    if status is None:
+        response = getattr(ex, "response", None)
+        if response is not None:
+            status = getattr(response, "status_code", None)
+
+    # API error code (e.g. "rate_limit_exceeded", "server_error")
+    code: str | None = getattr(ex, "code", None)
+
+    parts = [type_name]
+    if status is not None:
+        parts.append(str(status))
+    if code is not None:
+        parts.append(code)
+    return f" [{' '.join(parts)}]"

--- a/src/inspect_ai/_util/retry.py
+++ b/src/inspect_ai/_util/retry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -62,7 +63,8 @@ def retry_error_summary(retry_state: RetryCallState) -> str:
             status = getattr(response, "status_code", None)
 
     # API error code (e.g. "rate_limit_exceeded", "server_error")
-    code: str | None = getattr(ex, "code", None)
+    raw_code = getattr(ex, "code", None)
+    code: str | None = str(raw_code) if raw_code is not None else None
 
     parts = [type_name]
     if status is not None:
@@ -70,3 +72,53 @@ def retry_error_summary(retry_state: RetryCallState) -> str:
     if code is not None:
         parts.append(code)
     return f" [{' '.join(parts)}]"
+
+
+class SampleContextFilter(logging.Filter):
+    """Logging filter that enriches log records with active sample context.
+
+    Prepends a compact prefix to record.msg for plain text formatters and
+    sets structured attributes on the record for JSON/structured formatters.
+    Passes records through unchanged when no active sample exists.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        from inspect_ai.log._samples import sample_active
+
+        active = sample_active()
+        if active is not None:
+            prefix = (
+                f"[{active.id} {active.task}/{active.sample.id}/{active.epoch} "
+                f"{active.model}] "
+            )
+            record.msg = f"{prefix}{record.getMessage()}"
+            record.args = None
+            record.sample_uuid = active.id  # type: ignore[attr-defined]
+            record.sample_task = active.task  # type: ignore[attr-defined]
+            record.sample_id = active.sample.id  # type: ignore[attr-defined]
+            record.sample_epoch = active.epoch  # type: ignore[attr-defined]
+            record.sample_model = active.model  # type: ignore[attr-defined]
+        return True
+
+
+_sample_context_logging_installed = False
+
+
+_SDK_LOGGERS = ("openai._base_client",)
+
+
+def install_sample_context_logging() -> None:
+    """Install SampleContextFilter on SDK loggers.
+
+    Attaches the filter to the actual emitting loggers (not parent loggers)
+    so that retry messages from the OpenAI SDK are enriched with active
+    sample context. Safe to call multiple times — installs at most once.
+    """
+    global _sample_context_logging_installed
+    if _sample_context_logging_installed:
+        return
+    _sample_context_logging_installed = True
+
+    sample_filter = SampleContextFilter()
+    for name in _SDK_LOGGERS:
+        logging.getLogger(name).addFilter(sample_filter)

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1903,10 +1903,15 @@ def combine_messages(
 
 
 def log_model_retry(model_name: str, retry_state: RetryCallState) -> None:
+    from inspect_ai._util.retry import retry_error_summary, sample_context_prefix
+
+    prefix = sample_context_prefix()
+    error = retry_error_summary(retry_state)
     level = logging.WARNING if retry_state.upcoming_sleep >= 60 else HTTP
     logger.log(
         level,
-        f"-> {model_name} retry {retry_state.attempt_number} (retrying in {retry_state.upcoming_sleep:,.0f} seconds)",
+        f"{prefix}-> {model_name} retry {retry_state.attempt_number} "
+        f"(retrying in {retry_state.upcoming_sleep:,.0f} seconds){error}",
     )
 
 

--- a/tests/util/test_retry_logging.py
+++ b/tests/util/test_retry_logging.py
@@ -1,0 +1,158 @@
+"""Tests for retry log enrichment helpers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inspect_ai._util.constants import HTTP
+from inspect_ai._util.retry import retry_error_summary, sample_context_prefix
+
+
+def _make_mock_sample(
+    *,
+    uuid: str = "Abc12xY",
+    task: str = "mmlu",
+    sample_id: int | str | None = 42,
+    epoch: int = 1,
+    model: str = "openai/gpt-4o",
+) -> MagicMock:
+    """Create a mock ActiveSample with the given fields."""
+    active = MagicMock()
+    active.id = uuid
+    active.task = task
+    active.sample.id = sample_id
+    active.epoch = epoch
+    active.model = model
+    return active
+
+
+class TestSampleContextPrefix:
+    def test_returns_prefix_with_active_sample(self) -> None:
+        mock = _make_mock_sample()
+        with patch("inspect_ai.log._samples.sample_active", return_value=mock):
+            result = sample_context_prefix()
+        assert result == "[Abc12xY mmlu/42/1 openai/gpt-4o] "
+
+    def test_returns_empty_string_when_no_active_sample(self) -> None:
+        with patch("inspect_ai.log._samples.sample_active", return_value=None):
+            result = sample_context_prefix()
+        assert result == ""
+
+    def test_handles_string_sample_id(self) -> None:
+        mock = _make_mock_sample(sample_id="q_123")
+        with patch("inspect_ai.log._samples.sample_active", return_value=mock):
+            result = sample_context_prefix()
+        assert result == "[Abc12xY mmlu/q_123/1 openai/gpt-4o] "
+
+    def test_handles_none_sample_id(self) -> None:
+        mock = _make_mock_sample(sample_id=None)
+        with patch("inspect_ai.log._samples.sample_active", return_value=mock):
+            result = sample_context_prefix()
+        assert result == "[Abc12xY mmlu/None/1 openai/gpt-4o] "
+
+
+def _make_retry_state(exception: BaseException | None = None) -> MagicMock:
+    """Create a mock RetryCallState with the given exception."""
+    state = MagicMock()
+    if exception is not None:
+        state.outcome.exception.return_value = exception
+    else:
+        state.outcome = None
+    return state
+
+
+class TestRetryErrorSummary:
+    def test_with_status_code_and_error_code(self) -> None:
+        ex = Exception("rate limited")
+        ex.status_code = 429  # type: ignore[attr-defined]
+        ex.code = "rate_limit_exceeded"  # type: ignore[attr-defined]
+        state = _make_retry_state(ex)
+        assert retry_error_summary(state) == " [Exception 429 rate_limit_exceeded]"
+
+    def test_with_status_code_only(self) -> None:
+        ex = Exception("server error")
+        ex.status_code = 503  # type: ignore[attr-defined]
+        state = _make_retry_state(ex)
+        assert retry_error_summary(state) == " [Exception 503]"
+
+    def test_with_error_code_only(self) -> None:
+        ex = Exception("bad")
+        ex.code = "server_error"  # type: ignore[attr-defined]
+        state = _make_retry_state(ex)
+        assert retry_error_summary(state) == " [Exception server_error]"
+
+    def test_with_status_on_response_object(self) -> None:
+        """Some SDKs put status_code on ex.response, not ex directly."""
+        ex = Exception("error")
+        response = MagicMock()
+        response.status_code = 502
+        ex.response = response  # type: ignore[attr-defined]
+        state = _make_retry_state(ex)
+        assert retry_error_summary(state) == " [Exception 502]"
+
+    def test_plain_exception(self) -> None:
+        ex = ConnectionError("refused")
+        state = _make_retry_state(ex)
+        assert retry_error_summary(state) == " [ConnectionError]"
+
+    def test_no_outcome(self) -> None:
+        state = _make_retry_state(exception=None)
+        assert retry_error_summary(state) == ""
+
+    def test_outcome_with_no_exception(self) -> None:
+        state = MagicMock()
+        state.outcome.exception.return_value = None
+        assert retry_error_summary(state) == ""
+
+    def test_uses_specific_exception_class_name(self) -> None:
+        """Verify we get 'TimeoutError' not 'Exception'."""
+        ex = TimeoutError("timed out")
+        state = _make_retry_state(ex)
+        assert retry_error_summary(state) == " [TimeoutError]"
+
+
+class TestLogModelRetry:
+    def test_includes_sample_context_and_error_summary(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from inspect_ai.model._model import log_model_retry
+
+        mock_sample = _make_mock_sample()
+        ex = Exception("rate limited")
+        ex.status_code = 429  # type: ignore[attr-defined]
+        ex.code = "rate_limit_exceeded"  # type: ignore[attr-defined]
+        state = _make_retry_state(ex)
+        state.attempt_number = 2
+        state.upcoming_sleep = 6.0
+
+        with (
+            caplog.at_level(HTTP),
+            patch("inspect_ai.log._samples.sample_active", return_value=mock_sample),
+        ):
+            log_model_retry("openai/gpt-4o", state)
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "[Abc12xY mmlu/42/1 openai/gpt-4o]" in msg
+        assert "openai/gpt-4o retry 2" in msg
+        assert "[Exception 429 rate_limit_exceeded]" in msg
+
+    def test_no_sample_context_when_inactive(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from inspect_ai.model._model import log_model_retry
+
+        state = _make_retry_state(ConnectionError("refused"))
+        state.attempt_number = 1
+        state.upcoming_sleep = 3.0
+
+        with (
+            caplog.at_level(HTTP),
+            patch("inspect_ai.log._samples.sample_active", return_value=None),
+        ):
+            log_model_retry("openai/gpt-4o", state)
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert msg.startswith("-> openai/gpt-4o retry 1")
+        assert "[ConnectionError]" in msg

--- a/tests/util/test_retry_logging.py
+++ b/tests/util/test_retry_logging.py
@@ -1,11 +1,23 @@
 """Tests for retry log enrichment helpers."""
 
+import logging
+from typing import Iterator
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 from inspect_ai._util.constants import HTTP
 from inspect_ai._util.retry import retry_error_summary, sample_context_prefix
+
+
+@pytest.fixture(autouse=True)
+def _ensure_log_propagation() -> Iterator[None]:
+    """Counter init_logger() setting propagate=False on inspect_ai logger."""
+    lgr = logging.getLogger("inspect_ai")
+    old_propagate = lgr.propagate
+    lgr.propagate = True
+    yield
+    lgr.propagate = old_propagate
 
 
 def _make_mock_sample(
@@ -156,3 +168,233 @@ class TestLogModelRetry:
         msg = caplog.records[0].message
         assert msg.startswith("-> openai/gpt-4o retry 1")
         assert "[ConnectionError]" in msg
+
+
+class TestLogHttpxRetryAttempt:
+    def test_includes_sample_context(self, caplog: pytest.LogCaptureFixture) -> None:
+        from inspect_ai._util.httpx import log_httpx_retry_attempt
+
+        mock_sample = _make_mock_sample()
+        state = _make_retry_state(ConnectionError("refused"))
+        state.attempt_number = 1
+        state.upcoming_sleep = 3.0
+
+        log_fn = log_httpx_retry_attempt("https://api.example.com/search")
+        with (
+            caplog.at_level(HTTP),
+            patch("inspect_ai.log._samples.sample_active", return_value=mock_sample),
+        ):
+            log_fn(state)
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert "[Abc12xY mmlu/42/1 openai/gpt-4o]" in msg
+        assert "https://api.example.com/search connection retry 1" in msg
+
+    def test_no_prefix_when_no_sample(self, caplog: pytest.LogCaptureFixture) -> None:
+        from inspect_ai._util.httpx import log_httpx_retry_attempt
+
+        state = _make_retry_state(ConnectionError("refused"))
+        state.attempt_number = 2
+        state.upcoming_sleep = 6.0
+
+        log_fn = log_httpx_retry_attempt("https://api.example.com/search")
+        with (
+            caplog.at_level(HTTP),
+            patch("inspect_ai.log._samples.sample_active", return_value=None),
+        ):
+            log_fn(state)
+
+        assert len(caplog.records) == 1
+        msg = caplog.records[0].message
+        assert msg.startswith("https://api.example.com/search connection retry 2")
+
+
+class TestSampleContextFilter:
+    def test_enriches_record_with_active_sample(self) -> None:
+        from inspect_ai._util.retry import SampleContextFilter
+
+        mock_sample = _make_mock_sample()
+        filt = SampleContextFilter()
+        record = logging.LogRecord(
+            name="openai._base_client",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Retrying request to /responses in 0.4 seconds",
+            args=None,
+            exc_info=None,
+        )
+        with patch("inspect_ai.log._samples.sample_active", return_value=mock_sample):
+            result = filt.filter(record)
+
+        assert result is True
+        assert record.getMessage().startswith("[Abc12xY mmlu/42/1 openai/gpt-4o]")
+        assert "Retrying request to /responses" in record.getMessage()
+        # Structured fields for JSON formatters
+        assert record.sample_uuid == "Abc12xY"  # type: ignore[attr-defined]
+        assert record.sample_task == "mmlu"  # type: ignore[attr-defined]
+        assert record.sample_id == 42  # type: ignore[attr-defined]
+        assert record.sample_epoch == 1  # type: ignore[attr-defined]
+        assert record.sample_model == "openai/gpt-4o"  # type: ignore[attr-defined]
+
+    def test_passes_through_when_no_active_sample(self) -> None:
+        from inspect_ai._util.retry import SampleContextFilter
+
+        filt = SampleContextFilter()
+        record = logging.LogRecord(
+            name="openai._base_client",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Retrying request to /responses in 0.4 seconds",
+            args=None,
+            exc_info=None,
+        )
+        with patch("inspect_ai.log._samples.sample_active", return_value=None):
+            result = filt.filter(record)
+
+        assert result is True
+        assert record.getMessage() == "Retrying request to /responses in 0.4 seconds"
+        assert not hasattr(record, "sample_uuid")
+
+    def test_handles_format_args_in_msg(self) -> None:
+        """The OpenAI SDK uses % formatting: log.info('Retrying request to %s in %f seconds', url, timeout)"""
+        from inspect_ai._util.retry import SampleContextFilter
+
+        mock_sample = _make_mock_sample()
+        filt = SampleContextFilter()
+        record = logging.LogRecord(
+            name="openai._base_client",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="Retrying request to %s in %f seconds",
+            args=("/responses", 0.396765),
+            exc_info=None,
+        )
+        with patch("inspect_ai.log._samples.sample_active", return_value=mock_sample):
+            result = filt.filter(record)
+
+        assert result is True
+        full_msg = record.getMessage()
+        assert "[Abc12xY mmlu/42/1 openai/gpt-4o]" in full_msg
+        assert "/responses" in full_msg
+
+
+class TestSampleContextFilterOnChildLogger:
+    """Verify filter intercepts records from the actual SDK emitting logger.
+
+    Python logging filters on a parent logger don't run for child logger
+    records during propagation. The OpenAI SDK logs from 'openai._base_client',
+    so the filter must be installed on the actual emitting logger, not 'openai'.
+    """
+
+    def test_filter_intercepts_child_logger_records(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        import inspect_ai._util.retry as retry_module
+        from inspect_ai._util.retry import (
+            SampleContextFilter,
+            install_sample_context_logging,
+        )
+
+        retry_module._sample_context_logging_installed = False
+        for logger_name in ("openai", "openai._base_client"):
+            lgr = logging.getLogger(logger_name)
+            lgr.filters = [
+                f for f in lgr.filters if not isinstance(f, SampleContextFilter)
+            ]
+
+        install_sample_context_logging()
+
+        mock_sample = _make_mock_sample()
+        child_logger = logging.getLogger("openai._base_client")
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch("inspect_ai.log._samples.sample_active", return_value=mock_sample),
+        ):
+            child_logger.info(
+                "Retrying request to %s in %f seconds", "/responses", 0.396765
+            )
+
+        assert len(caplog.records) >= 1
+        msg = caplog.records[-1].getMessage()
+        assert "[Abc12xY mmlu/42/1 openai/gpt-4o]" in msg, (
+            f"Filter did not intercept openai._base_client record. Got: {msg}"
+        )
+
+        for logger_name in ("openai", "openai._base_client"):
+            lgr = logging.getLogger(logger_name)
+            lgr.filters = [
+                f for f in lgr.filters if not isinstance(f, SampleContextFilter)
+            ]
+        retry_module._sample_context_logging_installed = False
+
+
+class TestRetryErrorSummaryEdgeCases:
+    def test_integer_code_does_not_crash(self) -> None:
+        ex = Exception("error")
+        ex.code = 429  # type: ignore[attr-defined]
+        state = _make_retry_state(ex)
+        result = retry_error_summary(state)
+        assert "429" in result
+
+    def test_percent_in_task_name_does_not_break_formatting(self) -> None:
+        mock = _make_mock_sample(task="100%_accuracy", sample_id="item%20foo")
+        with patch("inspect_ai.log._samples.sample_active", return_value=mock):
+            prefix = sample_context_prefix()
+        assert "100%_accuracy" in prefix
+        assert "item%20foo" in prefix
+
+
+class TestInstallSampleContextLogging:
+    def test_installs_filter_on_sdk_logger(self) -> None:
+        import inspect_ai._util.retry as retry_module
+        from inspect_ai._util.retry import (
+            SampleContextFilter,
+            install_sample_context_logging,
+        )
+
+        retry_module._sample_context_logging_installed = False
+
+        sdk_logger = logging.getLogger("openai._base_client")
+        sdk_logger.filters = [
+            f for f in sdk_logger.filters if not isinstance(f, SampleContextFilter)
+        ]
+        original_count = len(sdk_logger.filters)
+
+        install_sample_context_logging()
+
+        assert len(sdk_logger.filters) == original_count + 1
+        assert isinstance(sdk_logger.filters[-1], SampleContextFilter)
+
+        sdk_logger.removeFilter(sdk_logger.filters[-1])
+        retry_module._sample_context_logging_installed = False
+
+    def test_is_idempotent(self) -> None:
+        import inspect_ai._util.retry as retry_module
+        from inspect_ai._util.retry import (
+            SampleContextFilter,
+            install_sample_context_logging,
+        )
+
+        retry_module._sample_context_logging_installed = False
+
+        sdk_logger = logging.getLogger("openai._base_client")
+        sdk_logger.filters = [
+            f for f in sdk_logger.filters if not isinstance(f, SampleContextFilter)
+        ]
+
+        install_sample_context_logging()
+        install_sample_context_logging()
+
+        new_filters = [
+            f for f in sdk_logger.filters if isinstance(f, SampleContextFilter)
+        ]
+        assert len(new_filters) == 1
+
+        for f in new_filters:
+            sdk_logger.removeFilter(f)
+        retry_module._sample_context_logging_installed = False


### PR DESCRIPTION
## Summary

When inspect retries failed model requests, log messages like `Retrying request to /responses in 0.396765 seconds` lack context about which task, sample, and provider triggered the retry. In a concurrent runner processing many samples across many tasks, this makes debugging difficult.

This PR enriches all retry log messages with a compact context prefix and error summary:

```
[EeDA74nwfs3uirgyprfa4b hello_world/1/1 openai/gpt-4o-mini] Retrying request to /chat/completions in 1.000000 seconds
```

```
[Abc12xY mmlu/42/1 openai/gpt-4o] -> openai/gpt-4o retry 2 (retrying in 6 seconds) [RateLimitError 429 rate_limit_exceeded]
```

Format: `[{sample_uuid} {task}/{sample_id}/{epoch} {model}]`

## What changed

**New helpers in `src/inspect_ai/_util/retry.py`:**
- `sample_context_prefix()` — builds the compact prefix from `sample_active()` ContextVar
- `retry_error_summary()` — extracts exception type/status/code without leaking message content
- `SampleContextFilter` — `logging.Filter` for SDK loggers, adds both inline prefix and structured fields
- `install_sample_context_logging()` — attaches filter at eval startup

**Enriched existing loggers:**
- `log_model_retry()` in `model/_model.py` — prefix + error summary
- `log_httpx_retry_attempt()` in `_util/httpx.py` — prefix

**Wired into startup:**
- `init_eval_context()` in `_eval/context.py` calls `install_sample_context_logging()`

## Evidence of working

### E2E: Real `inspect eval` against mock 429 server

Ran `inspect eval examples/hello_world.py` against a local mock server returning 429s:

```
[02/13/26 20:24:32] HTTP     POST                                   hooks.py:123
                             http://localhost:8765/v1/chat/completi
                             ons "HTTP/1.0 429 Too Many Requests"
                    INFO     [EeDA74nwfs3uirgyprfa4b        _base_client.py:1693
                             hello_world/1/1
                             openai/gpt-4o-mini] Retrying
                             request to /chat/completions
                             in 1.000000 seconds
```

The prefix `[EeDA74nwfs3uirgyprfa4b hello_world/1/1 openai/gpt-4o-mini]` appears on the SDK's own retry message — confirming the `SampleContextFilter` on `openai._base_client` works.

### Structured JSON logging

When using a JSON log formatter (e.g. `python-json-logger`), the structured fields appear as top-level keys:

```json
{
  "message": "[Abc12xY mmlu/42/1 openai/gpt-4o] Retrying request to /responses in 0.396765 seconds",
  "name": "openai._base_client",
  "levelname": "INFO",
  "sample_uuid": "Abc12xY",
  "sample_task": "mmlu",
  "sample_id": 42,
  "sample_epoch": 1,
  "sample_model": "openai/gpt-4o"
}
```

### Unit tests: 24 passing

```
tests/util/test_retry_logging.py  24 passed
tests/test_retry.py               12 passed, 1 skipped
tests/test_retry_on_error.py       5 passed
```

## Review-driven fixes

Code review caught three issues, all fixed with regression tests added before the fix:

| Issue | Fix |
|---|---|
| **Filter on wrong logger** — installed on `openai` but SDK logs from `openai._base_client`; parent logger filters don't run for child records during propagation | Target `openai._base_client` directly |
| **`TypeError` on non-string `.code`** — `getattr(ex, "code")` can return int, crashing `' '.join()` | `str(raw_code)` cast |
| **`%` in prefix breaks formatting** — mutating `record.msg` with `%` chars would corrupt `msg % args` | Call `record.getMessage()` first, then set resolved msg and clear args |

Linear: ENG-594