### PR TITLE
Events: Rename `EventNode` to `EventTreeNode` and `SpanNode` to `EventTreeSpan`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Sandboxes: New `exec_remote()` method for async execution of long-running commands.
 - Limits: New `cost_limit()` context manager for scoped application of cost limits.
 - Performance: Disable expensive per-sample options when running high-throughput workloads.
+- Events: Rename `EventNode` to `EventTreeNode` and `SpanNode` to `EventTreeSpan` (old type names will still work at runtime with a deprecation warning).
 - Inspect View: Make samples in task detail sortable, inline epoch filter.
 - Bugfix: Shield sandbox cleanup after cancelled exception.
 

--- a/docs/reference/inspect_ai.event.qmd
+++ b/docs/reference/inspect_ai.event.qmd
@@ -20,8 +20,8 @@ title: "inspect_ai.event"
 ### event_tree
 ### event_sequence
 ### EventTree
-### EventNode
-### SpanNode
+### EventTreeSpan
+### EventTreeNode
 
 ## Eval Events
 

--- a/examples/repro.py
+++ b/examples/repro.py
@@ -1,0 +1,35 @@
+from inspect_ai import Task, task
+from inspect_ai.agent import react
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import match
+from inspect_ai.tool import bash
+
+
+@task
+def binary_repro_react():
+    return Task(
+        dataset=[
+            Sample(
+                input=(
+                    "Do these steps in order:\n\n"
+                    "Step 1: Run: echo $((2+2))\n"
+                    "Step 2: Run: cat /bin/ls | head -c 5000\n"
+                    "Step 3: Run: cat /bin/cat | head -c 5000\n"
+                    "Step 4: Run: cat /bin/cp | head -c 5000\n"
+                    "Step 5: Run: cat /bin/mv | head -c 5000\n"
+                    "Step 6: Run: cat /bin/rm | head -c 5000\n"
+                    "Step 7: Run: cat /bin/chmod | head -c 5000\n"
+                    "Step 8: Run: cat /bin/chown | head -c 5000\n"
+                    "Step 9: Run: cat /bin/mkdir | head -c 5000\n"
+                    "Step 10: Run: cat /usr/bin/head | head -c 5000\n"
+                    "Step 11: Run: cat /usr/bin/tail | head -c 5000\n"
+                    "\nAfter each command, briefly describe what you see. "
+                    "Do all 11 steps, do not skip any."
+                ),
+                target="irrelevant",
+            )
+        ],
+        solver=react(tools=[bash()]),
+        scorer=match(),
+        sandbox="docker",
+    )

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -29,7 +29,12 @@ from inspect_ai._util.platform import platform_init, running_in_notebook
 from inspect_ai._util.registry import registry_create, registry_unqualified_name
 from inspect_ai.event._event import Event
 from inspect_ai.event._score import ScoreEvent
-from inspect_ai.event._tree import SpanNode, event_sequence, event_tree, walk_node_spans
+from inspect_ai.event._tree import (
+    EventTreeSpan,
+    event_sequence,
+    event_tree,
+    walk_node_spans,
+)
 from inspect_ai.log import (
     EvalLog,
 )
@@ -139,11 +144,11 @@ def _get_updated_events(
         return [*sample.events, *new_events]
 
     (new_scorers_tree,) = event_tree(new_events)
-    assert isinstance(new_scorers_tree, SpanNode)
+    assert isinstance(new_scorers_tree, EventTreeSpan)
     if action == "append":
         # Add the new score nodes to the existing scorer node's children
         for child in new_scorers_tree.children:
-            if isinstance(child, SpanNode):
+            if isinstance(child, EventTreeSpan):
                 child.parent_id = final_scorers_node.id
         final_scorers_node.children.extend(new_scorers_tree.children)
     else:

--- a/src/inspect_ai/event/__init__.py
+++ b/src/inspect_ai/event/__init__.py
@@ -1,3 +1,5 @@
+from inspect_ai._util.deprecation import relocated_module_attribute
+
 from ._approval import ApprovalEvent
 from ._compaction import CompactionEvent
 from ._error import ErrorEvent
@@ -17,7 +19,7 @@ from ._step import StepEvent
 from ._store import StoreEvent
 from ._subtask import SubtaskEvent
 from ._tool import ToolEvent
-from ._tree import EventNode, EventTree, SpanNode, event_sequence, event_tree
+from ._tree import EventTree, EventTreeNode, EventTreeSpan, event_sequence, event_tree
 
 __all__ = [
     "Event",
@@ -45,6 +47,23 @@ __all__ = [
     "event_tree",
     "event_sequence",
     "EventTree",
-    "EventNode",
-    "SpanNode",
+    "EventTreeSpan",
+    "EventTreeNode",
 ]
+
+_EVENT_TREE_VERSION_0_3_180 = "0.3.180"
+_REMOVED_IN = "0.4"
+
+relocated_module_attribute(
+    "EventNode",
+    "inspect_ai.event.EventTreeNode",
+    _EVENT_TREE_VERSION_0_3_180,
+    _REMOVED_IN,
+)
+
+relocated_module_attribute(
+    "SpanNode",
+    "inspect_ai.event.EventTreeSpan",
+    _EVENT_TREE_VERSION_0_3_180,
+    _REMOVED_IN,
+)

--- a/src/inspect_ai/log/_score.py
+++ b/src/inspect_ai/log/_score.py
@@ -1,7 +1,7 @@
 """Score editing functionality."""
 
 from inspect_ai.event._score_edit import ScoreEditEvent
-from inspect_ai.event._tree import EventTree, SpanNode, event_tree, walk_node_spans
+from inspect_ai.event._tree import EventTree, EventTreeSpan, event_tree, walk_node_spans
 from inspect_ai.scorer._metric import Score, ScoreEdit
 
 from ._log import EvalLog
@@ -123,7 +123,7 @@ def edit_score(
         _recompute_metrics(log)
 
 
-def _find_scorers_span(tree: EventTree) -> SpanNode | None:
+def _find_scorers_span(tree: EventTree) -> EventTreeSpan | None:
     last_scorers_node = None
     for node in walk_node_spans(tree):
         if node.type == "scorers" and node.name == "scorers":

--- a/src/inspect_ai/util/_store.py
+++ b/src/inspect_ai/util/_store.py
@@ -154,14 +154,14 @@ def store_from_events(events: list["Event"]) -> Store:
         Store: A new Store with reconstructed state.
     """
     from inspect_ai.event._store import StoreEvent
-    from inspect_ai.event._tree import SpanNode, event_tree
+    from inspect_ai.event._tree import EventTreeSpan, event_tree
 
     tree = event_tree(events)
     data: dict[str, Any] = {}
 
     # Process only root-level items
     for node in tree:
-        if isinstance(node, SpanNode):
+        if isinstance(node, EventTreeSpan):
             # Find StoreEvents that are direct children (not nested in child spans)
             for child in node.children:
                 if isinstance(child, StoreEvent):

--- a/tests/log/test_event_tree.py
+++ b/tests/log/test_event_tree.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timezone
 
 from inspect_ai.event import (
-    SpanNode,
+    EventTreeSpan,
     event_sequence,
     event_tree,
 )
@@ -30,7 +30,7 @@ def test_single_span():
 
     # Verify tree structure
     assert len(tree) == 1
-    assert isinstance(tree[0], SpanNode)
+    assert isinstance(tree[0], EventTreeSpan)
     assert tree[0].id == "span1"
     assert tree[0].begin == span_begin
     assert tree[0].end == span_end
@@ -65,7 +65,7 @@ def test_nested_spans():
     # Verify parent node
     assert len(tree) == 1
     parent_node = tree[0]
-    assert isinstance(parent_node, SpanNode)
+    assert isinstance(parent_node, EventTreeSpan)
     assert parent_node.id == "parent"
     assert parent_node.begin == parent_begin
     assert parent_node.end == parent_end
@@ -73,7 +73,7 @@ def test_nested_spans():
     # Verify child node is inside parent
     assert len(parent_node.children) == 2  # child span and log event
     child_span = next(
-        child for child in parent_node.children if isinstance(child, SpanNode)
+        child for child in parent_node.children if isinstance(child, EventTreeSpan)
     )
     assert child_span.id == "child"
     assert len(child_span.children) == 1
@@ -115,7 +115,7 @@ def test_events_outside_spans():
 
     assert len(tree) == 3
     assert tree[0] == log1
-    assert isinstance(tree[1], SpanNode)
+    assert isinstance(tree[1], EventTreeSpan)
     assert tree[2] == log3
 
     sequence = list(event_sequence(tree))
@@ -131,7 +131,7 @@ def test_missing_span_end():
     tree = event_tree(events)
 
     assert len(tree) == 1
-    assert isinstance(tree[0], SpanNode)
+    assert isinstance(tree[0], EventTreeSpan)
     assert tree[0].end is None
 
     sequence = list(event_sequence(tree))


### PR DESCRIPTION
(old type names will still work at runtime with a deprecation warning)