### PR TITLE
fix(view): dedupe CodeMirror packages in library build

### DIFF
--- a/src/inspect_ai/_view/www/vite.config.js
+++ b/src/inspect_ai/_view/www/vite.config.js
@@ -16,7 +16,13 @@ export default defineConfig(({ mode }) => {
       }),
     ],
     resolve: {
-      dedupe: ["react", "react-dom"],
+      dedupe: [
+        "react",
+        "react-dom",
+        "@codemirror/state",
+        "@codemirror/view",
+        "@codemirror/language",
+      ],
     },
     define: {
       __DEV_WATCH__: JSON.stringify(process.env.DEV_LOGGING === "true"),


### PR DESCRIPTION
## Summary

Adds `@codemirror/state`, `@codemirror/view`, and `@codemirror/language` to `resolve.dedupe` in the viewer's Vite config, preventing the library build from bundling duplicate CodeMirror instances.

## Problem

PR #3073 upgraded `@codemirror/state` from 6.5.2 to 6.5.3, but `@codemirror/language` still resolves its own nested copy of `@codemirror/state` at the older version. When the viewer is built as a library (`yarn build:lib`), Vite bundles both copies into `lib/index.js`, causing a runtime error in consumers:

```
Error: Unrecognized extension value in extension set ([object Object]).
This sometimes happens because multiple instances of @codemirror/state
are loaded, breaking instanceof checks.
```

The existing `resolve.dedupe` only covered `react` and `react-dom`, so Vite had no instruction to deduplicate the CodeMirror packages.

## Fix

Add the CodeMirror packages to `resolve.dedupe` so Vite always resolves them to a single copy during the library build, regardless of `node_modules` layout.