### PR TITLE
Fix Google batch API JSONL serialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Inspect View: Make samples in task detail sortable, inline epoch filter, show sample status.
 - Bugfix: Shield sandbox cleanup after cancelled exception.
 - Bugfix: Protect against leading zero-width characters when printing tool output to the terminal.
+- Bugfix: Google batch JSONL serialization now correctly nests generation config fields (e.g. `thinking_config`) under `generation_config` in the REST schema.
+- Bugfix: Google batch polling no longer hangs forever when a batch job reaches `EXPIRED` or `PARTIALLY_SUCCEEDED` state.
 
 ## 0.3.179 (12 February 2026)
 

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -92,7 +92,7 @@ from inspect_ai.model._chat_message import ChatMessageSystem
 from inspect_ai.model._generate_config import normalized_batch_config
 from inspect_ai.model._model import log_model_retry
 from inspect_ai.model._model_call import ModelCall
-from inspect_ai.model._providers._google_batch import GoogleBatcher
+from inspect_ai.model._providers._google_batch import GoogleBatcher, batch_request_dict
 from inspect_ai.model._providers._google_citations import (
     distribute_citations_to_text_parts,
     get_candidate_citations,
@@ -344,13 +344,7 @@ class GoogleGenAIAPI(ModelAPI):
                 while tool_calling_attempts < 3:
                     if self._batcher:
                         response = await self._batcher.generate_for_request(
-                            {
-                                "contents": [
-                                    content.model_dump(exclude_none=True)
-                                    for content in gemini_contents
-                                ],
-                                **parameters.model_dump(exclude_none=True),
-                            }
+                            batch_request_dict(parameters, gemini_contents)
                         )
                     elif self.streaming:
                         response = await self._stream_generate_content(


### PR DESCRIPTION
## Summary

Fixes #3257 - batch API rejection of `thinking_config` (and potentially other generation config fields) when using the JSONL file-based batch approach with Gemini models.

## Problem

The Gemini batch API supports two approaches: inline requests and JSONL file uploads. The JSONL file format expects the raw REST `GenerateContentRequest` schema, where generation parameters (`temperature`, `thinking_config`, etc.) must be nested under `generationConfig`.

The Python SDK's `GenerateContentConfig` type flattens all fields to the top level. When using the **inline** batch approach, the SDK handles this mapping internally. However, the **JSONL file** approach has no such affordance — we serialize the dict directly into the file.

Previously we dumped `GenerateContentConfig` flat into the JSONL request body. This happened to work for most fields since the batch API is lenient, but `thinking_config` is rejected with `"no such field: 'thinking_config'"` because it only exists under `generationConfig` in the REST schema.

## Fix

- Add `_batch_request_dict()` to properly separate `GenerateContentConfig` fields into:
  - **Top-level `GenerateContentRequest` fields**: `safety_settings`, `tools`, `tool_config`, `system_instruction`, `cached_content`
  - **SDK-only fields** (stripped): `http_options`, `automatic_function_calling`, `should_return_http_response`, `labels`
  - **Everything else** nested under `generation_config`: `temperature`, `thinking_config`, `top_p`, etc.
- Simplify `_jsonl_line_for_request` since the dict now arrives in the correct shape.

## Additional fix: infinite polling on unhandled terminal JobStates

`_check_batch` only handled `SUCCEEDED`, `FAILED`, and `CANCELLED`. The terminal states `EXPIRED` and `PARTIALLY_SUCCEEDED` fell through to the `else` branch, returning `completed_count=0, failed_count=0, completion_info=None`. This meant the batch was never removed from `_inflight_batches`, causing the polling loop to run forever.

- Added `JOB_STATE_EXPIRED` to the failure states (alongside `FAILED`/`CANCELLED`)
- Added `JOB_STATE_PARTIALLY_SUCCEEDED` to the success states (alongside `SUCCEEDED`) since it has results to process
- Added parameterized tests covering all `JobState` values