### PR TITLE
docs: add Inspect Harbor to extensions listing

### DIFF
--- a/docs/extensions/extensions.yml
+++ b/docs/extensions/extensions.yml
@@ -99,3 +99,9 @@
     over command execution and file I/O without modifying core sandbox backends.
   author: "[Arnab Mitra](https://github.com/Dedulus)"
   categories: ["Sandbox"]
+
+- name: "[Inspect Harbor](https://github.com/meridianlabs-ai/inspect_harbor)"
+  description: |
+    Run Harbor RL tasks with Inspect AI, with access to 40+ registry datasets including terminal-bench, replicationbench, and compilebench.
+  author: "[Meridian](https://github.com/meridianlabs-ai/inspect_harbor)"
+  categories: ["Framework"]


### PR DESCRIPTION
Adds [Inspect Harbor](https://github.com/meridianlabs-ai/inspect_harbor) to the Inspect Extensions table: Inspect Harbor enables running Harbor RL tasks with Inspect AI, with access to 40+ registry datasets including terminal-bench, replicationbench, and compilebench.

🤖 Generated with [Claude Code](https://claude.com/claude-code)