### PR TITLE
Make strict schema in tools into a settable model arg for openai-api

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -948,6 +948,20 @@ inspect eval ctf.py --model openai-api/<provider>/<model> -M emulate_tools=true
 
 Tool calling emulation works by encoding tool JSON schema in an XML tag and asking the model to make tool calls using another XML tag. This works with varying degrees of efficacy depending on the model and the complexity of the tool schema. Before using tool emulation you should always check if your provider implements native support for tool calling on the model you are using, as that will generally work better.
 
+### Strict Tool Schemas
+
+By default, Inspect sets `"strict": true` on tool function schemas for the `openai-api` provider. This preserves compatibility with providers that require strict tool schemas. You can override this using the `strict_tools` model arg:
+
+``` bash
+inspect eval arc.py --model openai-api/<provider>/<model> -M strict_tools=false
+```
+
+Or using the `eval()` function:
+
+``` python
+eval("arc.py", model="openai-api/<provider>/<model>", model_args=dict(strict_tools=False))
+```
+
 ### Streaming {#streaming-openai-compatible}
 
 You can enable the use of the streaming with the `openai-api` provider by passing the `stream` model arg. For example:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -65,6 +65,7 @@ class OpenAICompatibleAPI(ModelAPI):
         responses_api: bool | None = None,
         responses_store: bool | None = None,
         stream: bool | None = None,
+        strict_tools: bool = True,
         **model_args: Any,
     ) -> None:
         # extract service prefix from model name if not specified
@@ -118,6 +119,7 @@ class OpenAICompatibleAPI(ModelAPI):
                 "emulate_tools is not compatible with using the responses_api"
             )
         self.stream = False if stream is None else stream
+        self.strict_tools = strict_tools
 
         # store http_client and model_args for reinitialization
         self.http_client = model_args.pop("http_client", OpenAIAsyncHttpxClient())
@@ -313,7 +315,7 @@ class OpenAICompatibleAPI(ModelAPI):
         # some inference platforms (e.g. hf-inference) require strict=True
         openai_tools = openai_chat_tools(tools)
         for tool in openai_tools:
-            tool["function"]["strict"] = True
+            tool["function"]["strict"] = self.strict_tools
         return openai_tools
 
     async def messages_to_openai(

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -16,6 +16,7 @@ from inspect_ai.model import (
     get_model,
 )
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.tool import ToolInfo
 
 
 @pytest.mark.asyncio
@@ -39,6 +40,30 @@ async def test_openai_compatible() -> None:
     message = ChatMessageUser(content="This is a test string. What are you?")
     response = await model.generate(input=[message])
     assert len(response.completion) >= 1
+
+
+@pytest.mark.parametrize("strict_tools", [True, False])
+def test_strict_tools_model_arg(strict_tools: bool) -> None:
+    api = OpenAICompatibleAPI(
+        model_name="openai-api/openai/gpt-5",
+        api_key="test",
+        base_url="https://example.com",
+        strict_tools=strict_tools,
+    )
+
+    tools = api.tools_to_openai([ToolInfo(name="test_tool", description="Test tool")])
+    assert tools[0]["function"]["strict"] is strict_tools
+
+
+def test_strict_tools_default_true() -> None:
+    api = OpenAICompatibleAPI(
+        model_name="openai-api/openai/gpt-5",
+        api_key="test",
+        base_url="https://example.com",
+    )
+
+    tools = api.tools_to_openai([ToolInfo(name="test_tool", description="Test tool")])
+    assert tools[0]["function"]["strict"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The default behavior remains for it to be set to true, but this allows the strict field in tool schema to be set to false, if necessary.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

In `openai-api/*` models, the tools always have `strict: true` on the JSON Schema, which requires all of the input parameters to be included in the `required` list in the tool spec to the LLM. However, this will cause the schema validation to fail if a tool-source doesn't do this, because the code adding this doesn't check if the tool can be strict.

### What is the new behavior?

The new behavior allows a new model arg `-M strict_tools=false` (default: `true`) to be specified which will disable the force-setting of `strict` in the tool schema.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, it preserves the existing behavior unless the caller specifically sets the new model argument to `false`
