### PR TITLE
Fix log polling refresh when eval completes quickly

### DIFF
--- a/src/inspect_ai/_view/www/src/state/logPolling.ts
+++ b/src/inspect_ai/_view/www/src/state/logPolling.ts
@@ -129,24 +129,14 @@ export function createLogPolling(
           // Continue polling
           return true;
         } else if (pendingSamples.status === "NotFound") {
-          // NotFound can mean either:
-          // 1. The eval completed (buffer cleaned up)
-          // 2. The sample buffer isn't ready yet (eval just started)
-          // Only stop polling if the eval is no longer running.
-          const currentStatus = get().log.selectedLogDetails?.status;
-          if (currentStatus === "started") {
-            log.debug(
-              `NotFound but eval still running, continuing to poll: ${logFileName}`,
-            );
-            // Refresh log details to pick up any status changes
-            await refreshLog(logFileName, false);
-            return true;
-          }
-
+          // The eval has completed (no more events/pending samples will be delivered)
           log.debug(`Stop polling running samples: ${logFileName}`);
 
           // Clear pending summaries and refresh in one transaction
-          if (loadedPendingSamples) {
+          if (
+            loadedPendingSamples ||
+            get().log.selectedLogDetails?.status === "started"
+          ) {
             log.debug(`Refresh log: ${logFileName}`);
             await refreshLog(logFileName, true);
           }


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When an eval completes before the poller has loaded any pending samples, the `NotFound` handler skips the final `refreshLog` call, leaving stale sample summaries on screen.

The old code tried to distinguish "eval completed" from "buffer not ready yet" by continuing to poll when `status === "started"`, but this meant a fast-completing eval could leave the viewer showing outdated data.

### What is the new behavior?

Always stop polling on `NotFound`, but ensure a final `refreshLog(logFileName, true)` happens when the eval status was still `"started"`, so the viewer picks up the completed results.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Related to #3325 (stale sample display fix) — both address cases where the Inspect View shows outdated data.