### PR TITLE
refactor: extract load_json_exclude streaming utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -274,6 +274,7 @@
 - Testing: Run `--runtrio` as trio-only in a separate process to prevent cross-backend global state contamination; convert batch tests from asyncio to anyio.
 - Bugfix: Strip surrounding quotes from S3 ETag in `.eval` header-only reads so it is consistent with full reads.
 - Inspect View: Presigned URL support for S3 log files, enabling direct browser-to-S3 byte-range fetches with parallel chunk downloads and a determinate progress bar for large samples.
+- Eval Logs: Extract reusable `aload_json_exclude()` async streaming JSON utility for efficient partial log reads.
 
 ## 0.3.183 (24 February 2026)
 

--- a/src/inspect_ai/_util/json.py
+++ b/src/inspect_ai/_util/json.py
@@ -52,6 +52,25 @@ def is_ijson_nan_inf_error(
     )
 
 
+def _get_ijson_backend() -> Any:
+    """Return an ijson module compatible with the current async backend.
+
+    The default yajl2_c C backend uses asyncio-specific yields, so we
+    fall back to the pure-Python backend when running under trio.
+    """
+    import ijson  # type: ignore[import-untyped]
+    import sniffio
+
+    try:
+        if sniffio.current_async_library() == "trio":
+            import ijson.backends.python as ijson_py  # type: ignore[import-untyped]
+
+            return ijson_py
+    except sniffio.AsyncLibraryNotFoundError:
+        pass
+    return ijson
+
+
 async def aload_json_exclude(
     async_reader: "AsyncBytesReader",
     exclude_fields: set[str],
@@ -73,13 +92,13 @@ async def aload_json_exclude(
             full member content for the NaN/Inf fallback path.  If ``None``
             the NaN/Inf error is re-raised.
     """
-    import ijson  # type: ignore
-    from ijson import IncompleteJSONError
+    from ijson import IncompleteJSONError  # type: ignore[import-untyped]
     from ijson.backends.python import (  # type: ignore[import-untyped]
         UnexpectedSymbol,
     )
 
     try:
+        ijson = _get_ijson_backend()
         parser = ijson.parse_async(async_reader, use_float=True)
         events = parser.__aiter__()
         _, event, _ = await events.__anext__()

--- a/src/inspect_ai/_util/json.py
+++ b/src/inspect_ai/_util/json.py
@@ -1,4 +1,6 @@
+import json
 import re
+from collections.abc import AsyncIterator
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
@@ -46,6 +48,110 @@ def is_ijson_nan_inf_error(
         or "invalid char in json text" in error_msg
         or "unexpected symbol" in error_msg
     )
+
+
+async def aload_json_exclude(
+    async_reader: Any, exclude_fields: set[str], full_content_fallback: Any = None
+) -> dict[str, Any]:
+    """Async-load a JSON object, skipping excluded top-level fields.
+
+    Uses ``ijson.parse_async`` for streaming parse so excluded fields
+    (e.g. large ``events`` arrays) are never materialised.
+
+    Falls back to ``json.loads`` on the full content when ijson encounters
+    NaN/Inf values it cannot handle.
+
+    Args:
+        async_reader: Async file-like object with ``read(size)`` method
+            (e.g. from ``adapt_to_reader``).
+        exclude_fields: Top-level keys whose values should be skipped.
+        full_content_fallback: An async callable returning ``bytes`` of the
+            full member content for the NaN/Inf fallback path.  If ``None``
+            the NaN/Inf error is re-raised.
+    """
+    import ijson  # type: ignore
+    from ijson import IncompleteJSONError
+    from ijson.backends.python import (  # type: ignore[import-untyped]
+        UnexpectedSymbol,
+    )
+
+    try:
+        parser = ijson.parse_async(async_reader, use_float=True)
+        events = parser.__aiter__()
+        _, event, _ = await events.__anext__()
+        if event != "start_map":
+            raise ValueError(f"Expected start_map event at root, got: {event}")
+
+        data: dict[str, Any] = {}
+        async for _, event, value in events:
+            if event == "end_map":
+                break
+            if event != "map_key":
+                raise ValueError(f"Expected map_key event, got: {event}")
+            key = value
+            if key in exclude_fields:
+                await _askip_json_value(events)
+            else:
+                _, next_event, next_value = await events.__anext__()
+                data[key] = await _abuild_json_value(next_event, next_value, events)
+    except (
+        ValueError,
+        IncompleteJSONError,
+        UnexpectedSymbol,
+    ) as ex:
+        if is_ijson_nan_inf_error(ex) and full_content_fallback is not None:
+            raw = await full_content_fallback()
+            data = json.loads(raw)
+            for field in exclude_fields:
+                data.pop(field, None)
+        else:
+            raise
+    return data
+
+
+async def _askip_json_value(
+    events: AsyncIterator[tuple[str, str, Any]],
+) -> None:
+    """Skip the next JSON value from an async ijson parse stream."""
+    _, event, _ = await events.__anext__()
+    if event in ("null", "boolean", "number", "string"):
+        return
+    depth = 1
+    async for _, event, _ in events:
+        if event in ("start_map", "start_array"):
+            depth += 1
+        elif event in ("end_map", "end_array"):
+            depth -= 1
+            if depth == 0:
+                return
+    raise ValueError("Truncated JSON: unexpected end of stream while skipping value")
+
+
+async def _abuild_json_value(
+    event: str, value: Any, events: AsyncIterator[tuple[str, str, Any]]
+) -> Any:
+    """Build a Python value from an async ijson parse stream."""
+    if event in ("null", "boolean", "number", "string"):
+        return value
+    elif event == "start_array":
+        arr: list[Any] = []
+        async for _, ev, val in events:
+            if ev == "end_array":
+                return arr
+            arr.append(await _abuild_json_value(ev, val, events))
+        raise ValueError("Unterminated JSON array")
+    elif event == "start_map":
+        obj: dict[str, Any] = {}
+        async for _, ev, val in events:
+            if ev == "end_map":
+                return obj
+            if ev != "map_key":
+                raise ValueError(f"Expected map_key event, got: {ev}")
+            key = val
+            _, next_ev, next_val = await events.__anext__()
+            obj[key] = await _abuild_json_value(next_ev, next_val, events)
+        raise ValueError("Unterminated JSON object")
+    raise ValueError(f"Unexpected ijson event: {event}")
 
 
 JSONType = Literal["string", "integer", "number", "boolean", "array", "object", "null"]

--- a/src/inspect_ai/_util/json.py
+++ b/src/inspect_ai/_util/json.py
@@ -1,6 +1,6 @@
 import json
 import re
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from copy import deepcopy
 from typing import (
     TYPE_CHECKING,
@@ -15,6 +15,8 @@ import jsonpatch
 if TYPE_CHECKING:
     from ijson import IncompleteJSONError  # type: ignore[import-untyped]
     from ijson.backends.python import UnexpectedSymbol  # type: ignore[import-untyped]
+
+    from inspect_ai._util.async_bytes_reader import AsyncBytesReader
 from jsonpointer import (  # type: ignore  # jsonpointer is already a dependency of jsonpatch
     JsonPointerException,
     resolve_pointer,
@@ -51,7 +53,9 @@ def is_ijson_nan_inf_error(
 
 
 async def aload_json_exclude(
-    async_reader: Any, exclude_fields: set[str], full_content_fallback: Any = None
+    async_reader: "AsyncBytesReader",
+    exclude_fields: set[str],
+    full_content_fallback: Callable[[], Awaitable[bytes]] | None = None,
 ) -> dict[str, Any]:
     """Async-load a JSON object, skipping excluded top-level fields.
 

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -31,7 +31,7 @@ from inspect_ai._util.constants import (
 )
 from inspect_ai._util.error import EvalError, WriteConflictError
 from inspect_ai._util.file import FileSystem, dirname, filesystem, local_path
-from inspect_ai._util.json import is_ijson_nan_inf_error, to_json_safe
+from inspect_ai._util.json import aload_json_exclude, to_json_safe
 from inspect_ai._util.trace import trace_action
 from inspect_ai._util.zip_common import ZipEntry
 from inspect_ai._util.zipfile import zipfile_compress_kwargs
@@ -315,71 +315,18 @@ class EvalRecorder(FileRecorder):
                 id = sample.id
                 epoch = sample.epoch
 
+            filename = _sample_filename(id, epoch)
             if exclude_fields:
-                # Stream the sample JSON using low-level parse events.
-                # An ObjectBuilder accumulates events only for included fields;
-                # excluded fields are read as raw events and never allocated
-                # as Python objects, keeping peak memory proportional to the
-                # data we actually keep.
-                import ijson  # type: ignore
-                from ijson import IncompleteJSONError, ObjectBuilder
-                from ijson.backends.python import (  # type: ignore[import-untyped]
-                    UnexpectedSymbol,
-                )
-
-                try:
-                    data: dict[str, Any] = {}
-                    async with await reader.open_member(
-                        _sample_filename(id, epoch)
-                    ) as f:
-                        depth = 0
-                        current_key: str = ""
-                        builder: ObjectBuilder | None = None
-                        async for prefix, event, value in ijson.parse_async(
-                            adapt_to_reader(f), use_float=True
-                        ):
-                            # Depth must be updated before the completion check
-                            # so that a closing bracket that returns depth to 1
-                            # is recognised as completing the current value.
-                            if event in ("start_map", "start_array"):
-                                depth += 1
-                            elif event in ("end_map", "end_array"):
-                                depth -= 1
-
-                            if depth == 1 and event == "map_key":
-                                current_key = value
-                                builder = (
-                                    None
-                                    if current_key in exclude_fields
-                                    else ObjectBuilder()
-                                )
-                            elif builder is not None:
-                                builder.event(event, value)
-                                # Depth 1 means we have returned to the top-level
-                                # object, so the current field's value is complete.
-                                if depth == 1:
-                                    data[current_key] = builder.value
-                                    builder = None
-                except (
-                    ValueError,
-                    IncompleteJSONError,
-                    UnexpectedSymbol,
-                ) as ex:
-                    # ijson doesn't support NaN/Inf which are valid in
-                    # Python's JSON. Fall back to standard json.load
-                    # and manually remove excluded fields.
-                    if is_ijson_nan_inf_error(ex):
-                        data = json.loads(
-                            await reader.read_member_fully(_sample_filename(id, epoch))
-                        )
-                        for field in exclude_fields:
-                            data.pop(field, None)
-                    else:
-                        raise
+                async with await reader.open_member(filename) as f:
+                    data = await aload_json_exclude(
+                        adapt_to_reader(f),
+                        exclude_fields,
+                        full_content_fallback=lambda: reader.read_member_fully(
+                            filename
+                        ),
+                    )
             else:
-                data = json.loads(
-                    await reader.read_member_fully(_sample_filename(id, epoch))
-                )
+                data = json.loads(await reader.read_member_fully(filename))
             return EvalSample.model_validate(data, context=get_deserializing_context())
         except KeyError:
             raise IndexError(

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -148,6 +148,31 @@ def test_read_sample_with_exclude_fields():
     assert not sample.events
 
 
+def test_read_sample_exclude_fields():
+    log_file = os.path.join("tests", "log", "test_eval_log", "log_formats.json")
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        log = read_eval_log(log_file)
+        eval_log_path = os.path.join(tmpdirname, "new_log.eval")
+        write_eval_log(log, eval_log_path)
+
+        full_sample = read_eval_log_sample(eval_log_path, 1, 1)
+        assert len(full_sample.events) > 0, (
+            "Fixture must have events for this test to be meaningful"
+        )
+
+        sample = read_eval_log_sample(
+            eval_log_path, 1, 1, exclude_fields={"events", "attachments", "store"}
+        )
+        assert sample.events == []
+        assert sample.attachments == {}
+        assert sample.store == {}
+        assert sample.target == " Yes"
+        assert sample.input == full_sample.input
+        assert sample.target == full_sample.target
+        assert sample.id == full_sample.id
+        assert sample.epoch == full_sample.epoch
+
+
 def test_log_location():
     json_log_file = os.path.join("tests", "log", "test_eval_log", "log_formats.json")
     check_log_location(json_log_file)

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -1,6 +1,16 @@
+import io
 import json
+import math
 
-from inspect_ai._util.json import json_changes, to_json_str_safe
+import pytest
+
+from inspect_ai._util.json import (
+    _abuild_json_value,
+    _askip_json_value,
+    aload_json_exclude,
+    json_changes,
+    to_json_str_safe,
+)
 from inspect_ai.dataset._sources.json import (
     json_dataset_reader,
     jsonlines_dataset_reader,
@@ -339,3 +349,100 @@ def test_json_dataset_reader_kwargs(tmp_path):
     assert result == [
         {"x": None, "y": float("inf"), "z": float("-inf"), "a": "5", "b": 5}
     ]
+
+
+class _AsyncBytesIO:
+    """Minimal async reader wrapping BytesIO, for testing."""
+
+    def __init__(self, data: bytes) -> None:
+        self._buf = io.BytesIO(data)
+
+    async def read(self, size: int) -> bytes:
+        return self._buf.read(size)
+
+
+@pytest.mark.parametrize(
+    "json_str,expected",
+    [
+        ("42", 42),
+        ('"hello"', "hello"),
+        ("null", None),
+        ("true", True),
+        ("[]", []),
+        ("{}", {}),
+        ("[1, 2, 3]", [1, 2, 3]),
+        ('{"a": 1, "b": [2, 3]}', {"a": 1, "b": [2, 3]}),
+        ('{"nested": {"deep": [{"x": 1}]}}', {"nested": {"deep": [{"x": 1}]}}),
+    ],
+)
+@pytest.mark.anyio
+async def test_build_json_value(json_str: str, expected: object) -> None:
+    import ijson  # type: ignore
+
+    events = ijson.parse_async(_AsyncBytesIO(json_str.encode()), use_float=True)
+    it = events.__aiter__()
+    _, event, value = await it.__anext__()
+    result = await _abuild_json_value(event, value, it)
+    assert result == expected
+
+
+@pytest.mark.anyio
+async def test_skip_json_value() -> None:
+    import ijson
+
+    data = b'{"skip": {"nested": [1,2,3]}, "keep": 42}'
+    events = ijson.parse_async(_AsyncBytesIO(data), use_float=True)
+    it = events.__aiter__()
+    _, ev, _ = await it.__anext__()
+    assert ev == "start_map"
+    _, ev, key1 = await it.__anext__()
+    assert key1 == "skip"
+    await _askip_json_value(it)
+    _, ev, key2 = await it.__anext__()
+    assert key2 == "keep"
+    _, ev2, val2 = await it.__anext__()
+    result = await _abuild_json_value(ev2, val2, it)
+    assert result == 42
+
+
+@pytest.mark.parametrize(
+    "json_bytes,exclude,expected",
+    [
+        (b'{"a": 1, "b": [2, 3], "c": "hello"}', {"b"}, {"a": 1, "c": "hello"}),
+        (b'{"a": 1, "b": 2, "c": 3, "d": 4}', {"b", "d"}, {"a": 1, "c": 3}),
+        (
+            b'{"keep": "yes", "skip": {"deep": {"nested": [1, 2, {"x": true}]}}}',
+            {"skip"},
+            {"keep": "yes"},
+        ),
+        (b'{"a": 1, "b": 2}', set(), {"a": 1, "b": 2}),
+        (b'{"a": 1, "b": 2}', {"a", "b"}, {}),
+        (b'{"a": 1}', {"nonexistent"}, {"a": 1}),
+    ],
+)
+@pytest.mark.anyio
+async def test_load_json_exclude(
+    json_bytes: bytes, exclude: set[str], expected: dict[str, object]
+) -> None:
+    result = await aload_json_exclude(_AsyncBytesIO(json_bytes), exclude)
+    assert result == expected
+
+
+@pytest.mark.anyio
+async def test_load_json_exclude_nan_inf_fallback():
+    data = b'{"a": NaN, "b": 2, "skip": [1, 2, 3]}'
+
+    async def fallback() -> bytes:
+        return data
+
+    result = await aload_json_exclude(_AsyncBytesIO(data), {"skip"}, fallback)
+    assert math.isnan(result["a"])
+    assert result["b"] == 2
+    assert "skip" not in result
+
+
+@pytest.mark.anyio
+async def test_load_json_exclude_non_object_root():
+    data = b"[1, 2, 3]"
+    with pytest.raises(ValueError, match="Expected start_map"):
+        await aload_json_exclude(_AsyncBytesIO(data), {"x"})

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -3,6 +3,7 @@ import json
 import math
 
 import pytest
+from test_helpers.utils import skip_if_trio
 
 from inspect_ai._util.json import (
     _abuild_json_value,
@@ -360,6 +361,15 @@ class _AsyncBytesIO:
     async def read(self, size: int) -> bytes:
         return self._buf.read(size)
 
+    async def aclose(self) -> None:
+        pass
+
+    async def __aenter__(self) -> "_AsyncBytesIO":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
 
 @pytest.mark.parametrize(
     "json_str,expected",
@@ -376,6 +386,7 @@ class _AsyncBytesIO:
     ],
 )
 @pytest.mark.anyio
+@skip_if_trio
 async def test_build_json_value(json_str: str, expected: object) -> None:
     import ijson  # type: ignore
 
@@ -387,6 +398,7 @@ async def test_build_json_value(json_str: str, expected: object) -> None:
 
 
 @pytest.mark.anyio
+@skip_if_trio
 async def test_skip_json_value() -> None:
     import ijson
 
@@ -421,6 +433,7 @@ async def test_skip_json_value() -> None:
     ],
 )
 @pytest.mark.anyio
+@skip_if_trio
 async def test_load_json_exclude(
     json_bytes: bytes, exclude: set[str], expected: dict[str, object]
 ) -> None:
@@ -429,6 +442,7 @@ async def test_load_json_exclude(
 
 
 @pytest.mark.anyio
+@skip_if_trio
 async def test_load_json_exclude_nan_inf_fallback():
     data = b'{"a": NaN, "b": 2, "skip": [1, 2, 3]}'
 
@@ -442,6 +456,7 @@ async def test_load_json_exclude_nan_inf_fallback():
 
 
 @pytest.mark.anyio
+@skip_if_trio
 async def test_load_json_exclude_non_object_root():
     data = b"[1, 2, 3]"
     with pytest.raises(ValueError, match="Expected start_map"):

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -3,11 +3,11 @@ import json
 import math
 
 import pytest
-from test_helpers.utils import skip_if_trio
 
 from inspect_ai._util.json import (
     _abuild_json_value,
     _askip_json_value,
+    _get_ijson_backend,
     aload_json_exclude,
     json_changes,
     to_json_str_safe,
@@ -386,10 +386,8 @@ class _AsyncBytesIO:
     ],
 )
 @pytest.mark.anyio
-@skip_if_trio
 async def test_build_json_value(json_str: str, expected: object) -> None:
-    import ijson  # type: ignore
-
+    ijson = _get_ijson_backend()
     events = ijson.parse_async(_AsyncBytesIO(json_str.encode()), use_float=True)
     it = events.__aiter__()
     _, event, value = await it.__anext__()
@@ -398,10 +396,8 @@ async def test_build_json_value(json_str: str, expected: object) -> None:
 
 
 @pytest.mark.anyio
-@skip_if_trio
 async def test_skip_json_value() -> None:
-    import ijson
-
+    ijson = _get_ijson_backend()
     data = b'{"skip": {"nested": [1,2,3]}, "keep": 42}'
     events = ijson.parse_async(_AsyncBytesIO(data), use_float=True)
     it = events.__aiter__()
@@ -433,7 +429,6 @@ async def test_skip_json_value() -> None:
     ],
 )
 @pytest.mark.anyio
-@skip_if_trio
 async def test_load_json_exclude(
     json_bytes: bytes, exclude: set[str], expected: dict[str, object]
 ) -> None:
@@ -442,7 +437,6 @@ async def test_load_json_exclude(
 
 
 @pytest.mark.anyio
-@skip_if_trio
 async def test_load_json_exclude_nan_inf_fallback():
     data = b'{"a": NaN, "b": 2, "skip": [1, 2, 3]}'
 
@@ -456,7 +450,6 @@ async def test_load_json_exclude_nan_inf_fallback():
 
 
 @pytest.mark.anyio
-@skip_if_trio
 async def test_load_json_exclude_non_object_root():
     data = b"[1, 2, 3]"
     with pytest.raises(ValueError, match="Expected start_map"):


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The `read_log_sample` method in `eval.py` contains ~30 lines of inline ijson streaming logic for skipping excluded fields when reading samples. This logic is not reusable and mixes low-level JSON parsing with the recorder's responsibilities. It also materializes the full structure in memory only to throw the excluded fields away afterwards, which may be a problem with large eval files in memory-constrained environments.

### What is the new behavior?

- Extracts `aload_json_exclude()` into `_util/json.py` as a reusable streaming JSON utility.
- Have it fully skip parsing the skipped sub-fields

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Extracted from #3213.