### PR TITLE
fix: make event header text searchable via cmd-F

### DIFF
--- a/src/inspect_ai/_view/www/src/app/samples/transcript/eventSearchText.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/eventSearchText.ts
@@ -164,9 +164,7 @@ export const eventSearchText = (node: EventNode): string[] => {
 
     case "score": {
       const scoreEvent = event as ScoreEvent;
-      texts.push(
-        (scoreEvent.intermediate ? "Intermediate " : "") + "Score",
-      );
+      texts.push((scoreEvent.intermediate ? "Intermediate " : "") + "Score");
       if (scoreEvent.score.answer) {
         texts.push(scoreEvent.score.answer);
       }
@@ -232,9 +230,7 @@ export const eventSearchText = (node: EventNode): string[] => {
         working: "Execution Time Limit Exceeded",
         cost: "Cost Limit Exceeded",
       };
-      texts.push(
-        limitTitles[sampleLimitEvent.type] ?? sampleLimitEvent.type,
-      );
+      texts.push(limitTitles[sampleLimitEvent.type] ?? sampleLimitEvent.type);
       if (sampleLimitEvent.message) {
         texts.push(sampleLimitEvent.message);
       }

--- a/src/inspect_ai/_view/www/src/tests/transcript/eventSearchText.test.ts
+++ b/src/inspect_ai/_view/www/src/tests/transcript/eventSearchText.test.ts
@@ -212,7 +212,11 @@ describe("eventSearchText", () => {
     const texts = eventSearchText(
       makeNode({
         event: "logger",
-        message: { level: "WARNING", message: "disk space low", filename: "main.py" },
+        message: {
+          level: "WARNING",
+          message: "disk space low",
+          filename: "main.py",
+        },
         timestamp: "2024-01-01T00:00:00Z",
       }),
     );


### PR DESCRIPTION
## Summary

- Add search text extraction for 7 missing event types (`score`, `score_edit`, `sample_init`, `sample_limit`, `input`, `approval`, `sandbox`) to the custom find-in-page system
- Include rendered title strings in all existing event handlers (e.g. "Model Call (assistant): gpt-4", "Tool: search", "Intermediate Score") so cmd-F matches what users see on screen
- Add 21 unit tests covering all event types

## Context

The transcript viewer uses a custom find-in-page system when virtualization is active (>100 events). The `eventSearchText()` function is the sole source of searchable text for this system. It was missing handlers for 7 event types and wasn't including the rendered title strings for existing handlers, causing cmd-F to fail to find visible text like "Intermediate Score".

## Test plan

- [x] All 21 new unit tests pass
- [x] TypeScript type check passes (`yarn tsc`)
- [x] ESLint passes (`yarn lint`)
- [x] Full test suite passes (153 tests, 8 suites)
- [ ] Manual: Open a transcript with >100 events, use cmd-F to search for "Intermediate", "Score", "Model Call", etc.

Closes PLT-617