### PR TITLE
Model API: Normalize handling of cached tokens in `ModelUsage`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Model API: Add SageMaker provider for invoking models hosted on AWS SageMaker endpoints.
+- Model API: Normalize handling of cached tokens in `ModelUsage` (input tokens now excludes cached tokens whereas previously it included them for some providers).
 - OpenAI: Warn user when reasoning options are passed to non-reasoning model.
 - OpenAI: Pass through `phase` for gpt-5.3-codex models.
 - OpenAI Compatible: Re-create closed httpx client after disconnect.

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -15,7 +15,12 @@ class ModelUsage(BaseModel):
     """Token usage for completion."""
 
     input_tokens: int = Field(default=0)
-    """Total input tokens used."""
+    """Input tokens charged at full rate (excludes cached tokens).
+
+    This count excludes tokens reported in input_tokens_cache_read and
+    input_tokens_cache_write. The true total input token count is:
+    input_tokens + (input_tokens_cache_read or 0) + (input_tokens_cache_write or 0).
+    """
 
     output_tokens: int = Field(default=0)
     """Total output tokens used."""

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -760,7 +760,13 @@ def model_output_from_openai(
         choices=choices,
         usage=(
             ModelUsage(
-                input_tokens=completion.usage.prompt_tokens,
+                input_tokens=completion.usage.prompt_tokens
+                - (
+                    completion.usage.prompt_tokens_details.cached_tokens
+                    if completion.usage.prompt_tokens_details is not None
+                    and completion.usage.prompt_tokens_details.cached_tokens is not None
+                    else 0
+                ),
                 output_tokens=completion.usage.completion_tokens,
                 input_tokens_cache_read=(
                     completion.usage.prompt_tokens_details.cached_tokens

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -535,8 +535,9 @@ def _logprobs_from_grok_logprobs(grok_logprobs: chat_pb2.LogProbs) -> Logprobs |
 
 
 def _model_usage_from_sampling_usage(usage: usage_pb2.SamplingUsage) -> ModelUsage:
+    cached = usage.cached_prompt_text_tokens or 0
     return ModelUsage(
-        input_tokens=usage.prompt_tokens,
+        input_tokens=usage.prompt_tokens - cached,
         output_tokens=usage.completion_tokens,
         total_tokens=usage.total_tokens,
         input_tokens_cache_read=usage.cached_prompt_text_tokens,

--- a/src/inspect_ai/model/_providers/openai_o1.py
+++ b/src/inspect_ai/model/_providers/openai_o1.py
@@ -66,7 +66,13 @@ async def generate_o1(
         model=completion.model,
         choices=chat_choices_from_response(completion, tools, handler),
         usage=ModelUsage(
-            input_tokens=completion.usage.prompt_tokens,
+            input_tokens=completion.usage.prompt_tokens
+            - (
+                completion.usage.prompt_tokens_details.cached_tokens
+                if completion.usage.prompt_tokens_details is not None
+                and completion.usage.prompt_tokens_details.cached_tokens is not None
+                else 0
+            ),
             output_tokens=completion.usage.completion_tokens,
             input_tokens_cache_read=(
                 completion.usage.prompt_tokens_details.cached_tokens

--- a/src/inspect_ai/model/_providers/openai_responses.py
+++ b/src/inspect_ai/model/_providers/openai_responses.py
@@ -186,18 +186,22 @@ async def generate_responses(
 
 
 def model_usage_from_response(model_response: Response) -> ModelUsage | None:
-    return (
-        ModelUsage(
-            input_tokens=model_response.usage.input_tokens,
-            output_tokens=model_response.usage.output_tokens,
-            input_tokens_cache_read=(
-                model_response.usage.input_tokens_details.cached_tokens
-            ),
-            reasoning_tokens=model_response.usage.output_tokens_details.reasoning_tokens,
-            total_tokens=model_response.usage.total_tokens,
-        )
-        if model_response.usage
-        else None
+    if model_response.usage is None:
+        return None
+    cached_tokens = (
+        model_response.usage.input_tokens_details.cached_tokens
+        if model_response.usage.input_tokens_details is not None
+        and model_response.usage.input_tokens_details.cached_tokens is not None
+        else 0
+    )
+    return ModelUsage(
+        input_tokens=model_response.usage.input_tokens - cached_tokens,
+        output_tokens=model_response.usage.output_tokens,
+        input_tokens_cache_read=cached_tokens if cached_tokens > 0 else None,
+        reasoning_tokens=model_response.usage.output_tokens_details.reasoning_tokens
+        if model_response.usage.output_tokens_details is not None
+        else None,
+        total_tokens=model_response.usage.total_tokens,
     )
 
 


### PR DESCRIPTION
Input tokens now excludes cached tokens whereas previously it included them for some providers.

