### PR TITLE
Add environment parameter to preserve env vars in eval-retry (#3312)

### DIFF
--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -96,6 +96,7 @@ def eval(
     solver: Solver | SolverSpec | Agent | list[Solver] | None = None,
     tags: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
+    environment: dict[str, str] | None = None,
     trace: bool | None = None,
     display: DisplayType | None = None,
     approval: str | list[ApprovalPolicy] | ApprovalPolicyConfig | None = None,
@@ -156,6 +157,8 @@ def eval(
             Optional (uses task solver by default).
         tags: Tags to associate with this evaluation run.
         metadata: Metadata to associate with this evaluation run.
+        environment: Environment variables to preserve for eval retry.
+            Specify as a dict mapping variable names to values
         trace: Trace message interactions with evaluated model to terminal.
         display: Task display type (defaults to 'full').
         approval: Tool use approval policies.
@@ -246,6 +249,7 @@ def eval(
                 solver=solver,
                 tags=tags,
                 metadata=metadata,
+                environment=environment,
                 approval=approval,
                 log_level=log_level,
                 log_level_transcript=log_level_transcript,
@@ -307,6 +311,7 @@ async def eval_async(
     solver: Solver | SolverSpec | Agent | list[Solver] | None = None,
     tags: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
+    environment: dict[str, str] | None = None,
     approval: str | list[ApprovalPolicy] | ApprovalPolicyConfig | None = None,
     log_level: str | None = None,
     log_level_transcript: str | None = None,
@@ -359,6 +364,8 @@ async def eval_async(
         solver: Alternative solver for task(s).  Optional (uses task solver by default).
         tags: Tags to associate with this evaluation run.
         metadata: Metadata to associate with this evaluation run.
+        environment: Environment variables to preserve for eval retry.
+            Specify as a dict mapping variable names to values.
         approval: Tool use approval policies.
           Either a path to an approval policy config file, an ApprovalPolicyConfig, or a list of approval policies.
           Defaults to no approval policy.
@@ -432,6 +439,7 @@ async def eval_async(
                 solver=solver,
                 tags=tags,
                 metadata=metadata,
+                environment=environment,
                 approval=approval,
                 log_level=log_level,
                 log_level_transcript=log_level_transcript,
@@ -498,6 +506,7 @@ async def _eval_async_inner(
     solver: Solver | SolverSpec | Agent | list[Solver] | None = None,
     tags: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
+    environment: dict[str, str] | None = None,
     approval: str | list[ApprovalPolicy] | ApprovalPolicyConfig | None = None,
     log_level: str | None = None,
     log_level_transcript: str | None = None,
@@ -721,6 +730,7 @@ async def _eval_async_inner(
                         solver=solver,
                         tags=tags,
                         metadata=metadata,
+                        environment=environment,
                         run_samples=run_samples,
                         score=score,
                         debug_errors=debug_errors is True,
@@ -749,6 +759,7 @@ async def _eval_async_inner(
                 solver=solver,
                 tags=tags,
                 metadata=metadata,
+                environment=environment,
                 run_samples=run_samples,
                 score=score,
                 **kwargs,
@@ -1044,6 +1055,11 @@ async def eval_retry_async(
         task_args = eval_log.eval.task_args_passed
         tags = eval_log.eval.tags
         metadata = eval_log.eval.metadata
+        environment = eval_log.eval.environment
+        if environment:
+            for key, value in environment.items():
+                os.environ[key] = value
+
         limit = eval_log.eval.config.limit
         # try to match log format of retried log
         if log_format is None and eval_log.location:
@@ -1155,6 +1171,7 @@ async def eval_retry_async(
                 solver=solver,
                 tags=tags,
                 metadata=metadata,
+                environment=environment,
                 approval=approval,
                 log_level=log_level,
                 log_level_transcript=log_level_transcript,

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -69,6 +69,7 @@ async def eval_run(
     solver: Solver | SolverSpec | None = None,
     tags: list[str] | None = None,
     metadata: dict[str, Any] | None = None,
+    environment: dict[str, str] | None = None,
     debug_errors: bool = False,
     run_samples: bool = True,
     score: bool = True,
@@ -231,6 +232,7 @@ async def eval_run(
                     model_args=resolved_task.model.model_args,
                     eval_config=task_eval_config,
                     metadata=((metadata or {}) | (task.metadata or {})) or None,
+                    environment=environment,
                     recorder=recorder,
                     header_only=header_only,
                 )

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -137,6 +137,7 @@ class TaskLogger:
         model_args: dict[str, Any],
         eval_config: EvalConfig,
         metadata: dict[str, Any] | None,
+        environment: dict[str, str] | None,
         recorder: Recorder,
         header_only: bool,
     ) -> None:
@@ -232,6 +233,7 @@ class TaskLogger:
             revision=revision,
             packages=packages,
             metadata=metadata,
+            environment=environment,
         )
 
         # stack recorder and location

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -3560,6 +3560,21 @@
           "default": null,
           "title": "Metadata"
         },
+        "environment": {
+          "anyOf": [
+            {
+              "additionalProperties": {
+                "type": "string"
+              },
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Environment"
+        },
         "scorers": {
           "anyOf": [
             {
@@ -3642,6 +3657,7 @@
         "revision",
         "packages",
         "metadata",
+        "environment",
         "scorers",
         "metrics"
       ],

--- a/src/inspect_ai/_view/www/src/@types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/@types/log.d.ts
@@ -152,6 +152,9 @@ export type Dirty = boolean | null;
 export type Metadata = {
   [k: string]: unknown;
 } | null;
+export type Environment = {
+  [k: string]: string;
+} | null;
 export type Scorers = EvalScorer[] | null;
 export type Name3 = string;
 export type Options = {
@@ -934,6 +937,7 @@ export interface EvalSpec {
   revision: EvalRevision | null;
   packages: Packages;
   metadata: Metadata;
+  environment: Environment;
   scorers: Scorers;
   metrics: Metrics1;
 }

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -846,6 +846,9 @@ class EvalSpec(BaseModel):
     metadata: dict[str, Any] | None = Field(default=None)
     """Additional eval metadata."""
 
+    environment: dict[str, str] | None = Field(default=None)
+    """Environment variables to preserve for eval retry."""
+
     scorers: list[EvalScorer] | None = Field(default=None)
     """Scorers and args for this eval"""
 

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -275,3 +275,55 @@ def test_eval_retry_token_usage_multi_retry():
     assert log3.status == "success"
     tokens3 = get_tokens(log3)
     assert tokens3 > tokens2
+
+
+def test_eval_retry_preserves_environment_variables():
+    import os
+    import tempfile
+
+    @solver
+    def env_dependent_solver():
+        async def solve(state: TaskState, generate) -> TaskState:
+            custom_value = os.environ.get("TEST_EVAL_RETRY_VAR")
+            state.metadata["env_var_value"] = custom_value
+            if custom_value:
+                state.output.completion = f"Value: {custom_value}"
+            else:
+                state.output.completion = "Value: NOT_FOUND"
+            return state
+
+        return solve
+
+    @task
+    def env_task():
+        return Task(
+            dataset=[Sample(input="Test", target="Value: test123")],
+            solver=[env_dependent_solver()],
+            scorer=exact(),
+        )
+
+    with tempfile.TemporaryDirectory() as log_dir:
+        os.environ["TEST_EVAL_RETRY_VAR"] = "test123"
+
+        log1 = eval(
+            env_task(),
+            model="mockllm/model",
+            log_dir=log_dir,
+            environment={"TEST_EVAL_RETRY_VAR": os.environ["TEST_EVAL_RETRY_VAR"]},
+        )[0]
+
+        assert log1.status == "success"
+        assert log1.eval.environment == {"TEST_EVAL_RETRY_VAR": "test123"}
+        assert log1.samples[0].metadata["env_var_value"] == "test123"
+
+        del os.environ["TEST_EVAL_RETRY_VAR"]
+        assert os.environ.get("TEST_EVAL_RETRY_VAR") is None
+
+        log2 = eval_retry(log1)[0]
+
+        assert log2.status == "success"
+        assert log2.samples[0].metadata["env_var_value"] == "test123"
+        assert os.environ.get("TEST_EVAL_RETRY_VAR") == "test123"
+
+        if "TEST_EVAL_RETRY_VAR" in os.environ:
+            del os.environ["TEST_EVAL_RETRY_VAR"]


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Fixes #3312. Environment variables set during an eval run are not recorded in the eval log. When `inspect eval-retry` replays a failed eval, it reconstructs the task, model config, sandbox settings, and other parameters from `EvalSpec`, but environment variables are lost because they were never serialized.

This causes `eval-retry` to behave differently from the original run when the eval depends on environment variables. For example, if an eval uses `os.environ.get("MY_CUSTOM_SETTING")` to configure sandbox behavior, the retry will fail or behave incorrectly when that variable is not present in the environment.

There is currently no way to pass environment variables through `eval()` or `eval_set()` such that they are persisted in the log and recovered on retry.

### What is the new behavior?

Adds an explicit `environment` parameter to the `eval()` function that allows users to specify which environment variables should be preserved for retry.

**Usage:**

```python
import os
from inspect_ai import eval, eval_retry

log = eval(
    my_task(),
    model="openai/gpt-4",
    environment={
        "MY_CUSTOM_SETTING": os.environ["MY_CUSTOM_SETTING"],
        "ANOTHER_VAR": "some_value"
    }
)
```

## Does this PR introduce a breaking change?

No. The environment parameter is optional and defaults to None.