### PR TITLE
perf(viewer): add immutable cache headers for hashed static assets

### DIFF
--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -482,15 +482,21 @@ class WWWResource(web.StaticResource):
         # call super
         response = await super()._handle(request)
 
-        # disable caching as this is only ever served locally
-        # and w/ caching sometimes we get stale assets
-        response.headers.update(
-            {
-                "Expires": "Fri, 01 Jan 1990 00:00:00 GMT",
-                "Pragma": "no-cache",
-                "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
-            }
-        )
+        # Cache policy: hashed assets are immutable, index.html always revalidates
+        if filename and "/assets/" in request.path:
+            response.headers.update(
+                {
+                    "Cache-Control": "public, max-age=31536000, immutable",
+                }
+            )
+        else:
+            response.headers.update(
+                {
+                    "Expires": "Fri, 01 Jan 1990 00:00:00 GMT",
+                    "Pragma": "no-cache",
+                    "Cache-Control": "no-cache, no-store, max-age=0, must-revalidate",
+                }
+            )
 
         # return response
         return response


### PR DESCRIPTION
## Summary

The aiohttp server's `WWWResource` was setting `Cache-Control: no-cache, no-store` on ALL static assets, including Vite-built bundles with content hashes in their filenames. This forced browsers to re-download ~2MB of JavaScript on every page reload.

Now differentiates between:
- **Hashed assets** in `/assets/` → `Cache-Control: public, max-age=31536000, immutable`
- **`index.html`** and other root files → `Cache-Control: no-cache, no-store` (always revalidate)

## Changes

- `server.py`: Check request path for `/assets/` prefix and apply appropriate cache headers