### PR TITLE
fix(viewer): align FindBand ordering with structured tool output

### DIFF
--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -16751,10 +16751,16 @@ button._segment_mhb7y_9 {
 }
 
 /* CSS Custom Highlight for find-in-page matches.
-   This is visible regardless of which element has focus,
-   unlike a regular Selection highlight. */
-::highlight(find-match) {
+   Two-tier: all visible matches (yellow) + current match (orange).
+   find-match-current declared after find-match-all so it wins when ranges overlap. */
+::highlight(find-match-all) {
   background-color: #ffff00;
+  color: #000;
+}
+
+/* Current (navigation target) match — orange, higher priority */
+::highlight(find-match-current) {
+  background-color: #f97316;
   color: #000;
 }
 ._footer_14uod_1 {

--- a/src/inspect_ai/_view/www/dist/assets/index.css
+++ b/src/inspect_ai/_view/www/dist/assets/index.css
@@ -16749,6 +16749,14 @@ button._segment_mhb7y_9 {
   margin-top: -0.1rem;
   margin-bottom: -0.1rem;
 }
+
+/* CSS Custom Highlight for find-in-page matches.
+   This is visible regardless of which element has focus,
+   unlike a regular Selection highlight. */
+::highlight(find-match) {
+  background-color: #ffff00;
+  color: #000;
+}
 ._footer_14uod_1 {
   border-top: solid var(--bs-light-border-subtle) 1px;
   background: var(--bs-light-bg-subtle);

--- a/src/inspect_ai/_view/www/package.json
+++ b/src/inspect_ai/_view/www/package.json
@@ -130,5 +130,6 @@
     "postcss-url/minimatch": "^3.1.3",
     "@microsoft/api-extractor": "^7.57.6",
     "rollup": "^4.59.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/eventSearchText.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/eventSearchText.ts
@@ -29,6 +29,17 @@ export const eventSearchText = (node: EventNode): string[] => {
           }
         }
       }
+      // Model event error details (API errors, tracebacks)
+      if (event.error) {
+        if (typeof event.error === "string") {
+          texts.push(event.error);
+        } else if (event.error.message) {
+          texts.push(event.error.message);
+        }
+      }
+      if (event.traceback) {
+        texts.push(event.traceback);
+      }
       break;
     }
 
@@ -36,15 +47,11 @@ export const eventSearchText = (node: EventNode): string[] => {
       if (event.function) {
         texts.push(event.function);
       }
-      if (event.arguments) {
-        texts.push(JSON.stringify(event.arguments));
+      if (event.arguments && typeof event.arguments === "string") {
+        texts.push(event.arguments);
       }
-      if (event.result) {
-        if (typeof event.result === "string") {
-          texts.push(event.result);
-        } else {
-          texts.push(JSON.stringify(event.result));
-        }
+      if (event.result && typeof event.result === "string") {
+        texts.push(event.result);
       }
       if (event.error?.message) {
         texts.push(event.error.message);
@@ -80,12 +87,8 @@ export const eventSearchText = (node: EventNode): string[] => {
     }
 
     case "info": {
-      if (event.data) {
-        if (typeof event.data === "string") {
-          texts.push(event.data);
-        } else {
-          texts.push(JSON.stringify(event.data));
-        }
+      if (event.data && typeof event.data === "string") {
+        texts.push(event.data);
       }
       break;
     }
@@ -94,16 +97,15 @@ export const eventSearchText = (node: EventNode): string[] => {
       if (event.source) {
         texts.push(event.source);
       }
-      texts.push(JSON.stringify(event));
       break;
     }
 
     case "subtask": {
-      if (event.input) {
-        texts.push(JSON.stringify(event.input));
+      if (event.input && typeof event.input === "string") {
+        texts.push(event.input);
       }
-      if (event.result) {
-        texts.push(JSON.stringify(event.result));
+      if (event.result && typeof event.result === "string") {
+        texts.push(event.result);
       }
       break;
     }
@@ -226,8 +228,8 @@ const extractContentText = (content: Content): string[] => {
         if (item.name) {
           texts.push(item.name);
         }
-        if (item.arguments) {
-          texts.push(JSON.stringify(item.arguments));
+        if (item.arguments && typeof item.arguments === "string") {
+          texts.push(item.arguments);
         }
         break;
       }

--- a/src/inspect_ai/_view/www/src/components/FindBand.css
+++ b/src/inspect_ai/_view/www/src/components/FindBand.css
@@ -60,9 +60,15 @@
 }
 
 /* CSS Custom Highlight for find-in-page matches.
-   This is visible regardless of which element has focus,
-   unlike a regular Selection highlight. */
-::highlight(find-match) {
+   Two-tier: all visible matches (yellow) + current match (orange).
+   find-match-current declared after find-match-all so it wins when ranges overlap. */
+::highlight(find-match-all) {
   background-color: #ffff00;
+  color: #000;
+}
+
+/* Current (navigation target) match — orange, higher priority */
+::highlight(find-match-current) {
+  background-color: #f97316;
   color: #000;
 }

--- a/src/inspect_ai/_view/www/src/components/FindBand.css
+++ b/src/inspect_ai/_view/www/src/components/FindBand.css
@@ -58,3 +58,11 @@
   margin-top: -0.1rem;
   margin-bottom: -0.1rem;
 }
+
+/* CSS Custom Highlight for find-in-page matches.
+   This is visible regardless of which element has focus,
+   unlike a regular Selection highlight. */
+::highlight(find-match) {
+  background-color: #ffff00;
+  color: #000;
+}

--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -102,7 +102,6 @@ export const FindBand: FC = () => {
 
       const focusedElement = document.activeElement as HTMLElement;
 
-      // Navigate to the target match (scroll + highlight)
       await goToMatch(searchTerm, newIndex);
 
       if (searchIdRef.current !== thisSearchId) return;

--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -10,7 +10,8 @@ import {
 import { useStore } from "../state/store";
 import { debounce } from "../utils/sync";
 import { useExtendedFind } from "./ExtendedFindContext";
-import { FindBandUI } from "./FindBandUI";
+import clsx from "clsx";
+import { ApplicationIcons } from "../app/appearance/icons";
 
 export const FindBand: FC = () => {
   const searchBoxRef = useRef<HTMLInputElement>(null);
@@ -245,7 +246,11 @@ export const FindBand: FC = () => {
     };
   }, [handleSearch, restoreCursor]);
 
-  const hasHighlightAPI = !!(typeof CSS !== "undefined" && CSS?.highlights && typeof Highlight !== "undefined");
+  const hasHighlightAPI = !!(
+    typeof CSS !== "undefined" &&
+    CSS?.highlights &&
+    typeof Highlight !== "undefined"
+  );
 
   const matchCountLabel = useMemo(() => {
     if (matchCount === null) return null;

--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -8,21 +8,17 @@ import {
   useState,
 } from "react";
 import { useStore } from "../state/store";
-import { scrollRangeToCenter } from "../utils/dom";
 import { debounce } from "../utils/sync";
 import { useExtendedFind } from "./ExtendedFindContext";
 import { FindBandUI } from "./FindBandUI";
 
-interface FindBandProps {}
-
-export const FindBand: FC<FindBandProps> = () => {
+export const FindBand: FC = () => {
   const searchBoxRef = useRef<HTMLInputElement>(null);
   const storeHideFind = useStore((state) => state.appActions.hideFind);
   const { countAllMatches, goToMatch } = useExtendedFind();
   const currentSearchTerm = useRef<string>("");
   const matchIndexRef = useRef(0);
   const needsCursorRestoreRef = useRef<boolean>(false);
-  const scrollTimeoutRef = useRef<number | null>(null);
   const focusTimeoutRef = useRef<number | null>(null);
   const searchIdRef = useRef(0);
   const cachedCount = useRef<{ term: string; count: number }>({
@@ -44,23 +40,6 @@ export const FindBand: FC<FindBandProps> = () => {
   const [matchCount, setMatchCount] = useState<number | null>(null);
   const [currentMatchIndex, setCurrentMatchIndex] = useState(0);
 
-  const getParentExpandablePanel = useCallback(
-    (selection: Selection): HTMLElement | undefined => {
-      let node = selection.anchorNode;
-      while (node) {
-        if (
-          node instanceof HTMLElement &&
-          node.hasAttribute("data-expandable-panel")
-        ) {
-          return node;
-        }
-        node = node.parentElement;
-      }
-      return undefined;
-    },
-    [],
-  );
-
   const handleSearch = useCallback(
     async (back = false) => {
       const thisSearchId = ++searchIdRef.current;
@@ -69,7 +48,8 @@ export const FindBand: FC<FindBandProps> = () => {
       if (!searchTerm) {
         // Clear CSS highlight when search term is emptied
         if (CSS?.highlights) {
-          CSS.highlights.delete("find-match");
+          CSS.highlights.delete("find-match-all");
+          CSS.highlights.delete("find-match-current");
         }
         setMatchCount(null);
         setCurrentMatchIndex(0);
@@ -91,7 +71,8 @@ export const FindBand: FC<FindBandProps> = () => {
       if (total === 0) {
         // Clear CSS highlight when search returns 0 results
         if (CSS?.highlights) {
-          CSS.highlights.delete("find-match");
+          CSS.highlights.delete("find-match-all");
+          CSS.highlights.delete("find-match-current");
         }
         setCurrentMatchIndex(0);
         matchIndexRef.current = 0;
@@ -122,48 +103,13 @@ export const FindBand: FC<FindBandProps> = () => {
       const focusedElement = document.activeElement as HTMLElement;
 
       // Navigate to the target match (scroll + highlight)
-      const found = await goToMatch(searchTerm, newIndex);
+      await goToMatch(searchTerm, newIndex);
 
       if (searchIdRef.current !== thisSearchId) return;
 
-      if (found) {
-        const selection = window.getSelection();
-        if (selection && selection.rangeCount > 0) {
-          const range = selection.getRangeAt(0);
-
-          // Expand collapsed panels containing the match
-          const parentPanel = getParentExpandablePanel(selection);
-          if (parentPanel) {
-            if (!mutatedPanelsRef.current.has(parentPanel)) {
-              mutatedPanelsRef.current.set(parentPanel, {
-                display: parentPanel.style.display,
-                maxHeight: parentPanel.style.maxHeight,
-                webkitLineClamp: parentPanel.style.webkitLineClamp,
-                webkitBoxOrient: parentPanel.style.webkitBoxOrient,
-              });
-            }
-            parentPanel.style.display = "block";
-            parentPanel.style.maxHeight = "none";
-            parentPanel.style.webkitLineClamp = "";
-            parentPanel.style.webkitBoxOrient = "";
-          }
-
-          if (scrollTimeoutRef.current !== null) {
-            window.clearTimeout(scrollTimeoutRef.current);
-          }
-          scrollTimeoutRef.current = window.setTimeout(() => {
-            scrollRangeToCenter(range);
-            // Clear selection so CSS Custom Highlight (yellow ::highlight) is visible.
-            // The selection (blue ::selection) visually overrides ::highlight when both
-            // exist on the same range. We only needed it for scrollRangeToCenter.
-            window.getSelection()?.removeAllRanges();
-          }, 100);
-        }
-      }
-
       focusedElement?.focus();
     },
-    [getParentExpandablePanel, countAllMatches, goToMatch],
+    [countAllMatches, goToMatch],
   );
 
   useEffect(() => {
@@ -173,13 +119,9 @@ export const FindBand: FC<FindBandProps> = () => {
     }, 10);
 
     const mutatedPanels = mutatedPanelsRef.current;
-    const scrollTimeout = scrollTimeoutRef.current;
     const focusTimeout = focusTimeoutRef.current;
 
     return () => {
-      if (scrollTimeout !== null) {
-        window.clearTimeout(scrollTimeout);
-      }
       if (focusTimeout !== null) {
         window.clearTimeout(focusTimeout);
       }
@@ -193,7 +135,8 @@ export const FindBand: FC<FindBandProps> = () => {
       mutatedPanels.clear();
       // Clear the CSS Custom Highlight
       if (CSS?.highlights) {
-        CSS.highlights.delete("find-match");
+        CSS.highlights.delete("find-match-all");
+        CSS.highlights.delete("find-match-current");
       }
     };
   }, []);

--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -8,31 +8,19 @@ import {
   useState,
 } from "react";
 import { useStore } from "../state/store";
-import { findScrollableParent, scrollRangeToCenter } from "../utils/dom";
+import { scrollRangeToCenter } from "../utils/dom";
 import { debounce } from "../utils/sync";
 import { useExtendedFind } from "./ExtendedFindContext";
 import { FindBandUI } from "./FindBandUI";
 
 interface FindBandProps {}
 
-const findConfig = {
-  caseSensitive: false,
-  wrapAround: false,
-  wholeWord: false,
-  searchInFrames: false,
-  showDialog: false,
-};
-
 export const FindBand: FC<FindBandProps> = () => {
   const searchBoxRef = useRef<HTMLInputElement>(null);
   const storeHideFind = useStore((state) => state.appActions.hideFind);
-  const { extendedFindTerm, countAllMatches } = useExtendedFind();
-  const lastFoundItem = useRef<{
-    text: string;
-    offset: number;
-    parentElement: Element;
-  } | null>(null);
+  const { countAllMatches, goToMatch } = useExtendedFind();
   const currentSearchTerm = useRef<string>("");
+  const matchIndexRef = useRef(0);
   const needsCursorRestoreRef = useRef<boolean>(false);
   const scrollTimeoutRef = useRef<number | null>(null);
   const focusTimeoutRef = useRef<number | null>(null);
@@ -79,17 +67,18 @@ export const FindBand: FC<FindBandProps> = () => {
 
       const searchTerm = searchBoxRef.current?.value ?? "";
       if (!searchTerm) {
+        // Clear CSS highlight when search term is emptied
+        if (CSS?.highlights) {
+          CSS.highlights.delete("find-match");
+        }
         setMatchCount(null);
         setCurrentMatchIndex(0);
+        matchIndexRef.current = 0;
+        currentSearchTerm.current = "";
         return;
       }
 
-      if (currentSearchTerm.current !== searchTerm) {
-        lastFoundItem.current = null;
-        currentSearchTerm.current = searchTerm;
-        setCurrentMatchIndex(0);
-      }
-
+      // Count total matches (data-level)
       let total: number;
       if (cachedCount.current.term === searchTerm) {
         total = cachedCount.current.count;
@@ -100,69 +89,49 @@ export const FindBand: FC<FindBandProps> = () => {
       setMatchCount(total);
 
       if (total === 0) {
+        // Clear CSS highlight when search returns 0 results
+        if (CSS?.highlights) {
+          CSS.highlights.delete("find-match");
+        }
         setCurrentMatchIndex(0);
+        matchIndexRef.current = 0;
+        currentSearchTerm.current = searchTerm;
         return;
       }
+
+      // Compute the target match index
+      const isNewTerm = currentSearchTerm.current !== searchTerm;
+      let newIndex: number;
+
+      if (isNewTerm) {
+        currentSearchTerm.current = searchTerm;
+        newIndex = 1;
+      } else if (back) {
+        newIndex =
+          matchIndexRef.current <= 1 ? total : matchIndexRef.current - 1;
+      } else {
+        newIndex =
+          matchIndexRef.current >= total ? 1 : matchIndexRef.current + 1;
+      }
+
+      matchIndexRef.current = newIndex;
+      setCurrentMatchIndex(newIndex);
+
+      if (searchIdRef.current !== thisSearchId) return;
 
       const focusedElement = document.activeElement as HTMLElement;
 
-      const selection = window.getSelection();
-      let savedRange: Range | null = null;
-      if (selection && selection.rangeCount > 0) {
-        savedRange = selection.getRangeAt(0).cloneRange();
-      }
+      // Navigate to the target match (scroll + highlight)
+      const found = await goToMatch(searchTerm, newIndex);
 
-      const savedScrollParent = savedRange
-        ? findScrollableParent(savedRange.startContainer.parentElement)
-        : null;
-      const savedScrollTop = savedScrollParent?.scrollTop ?? 0;
+      if (searchIdRef.current !== thisSearchId) return;
 
-      const result = await findExtendedInDOM(
-        searchTerm,
-        back,
-        lastFoundItem.current,
-        extendedFindTerm,
-      );
-
-      if (searchIdRef.current !== thisSearchId) {
-        return;
-      }
-
-      if (!result && savedRange) {
-        const sel = window.getSelection();
-        if (sel) {
-          sel.removeAllRanges();
-          sel.addRange(savedRange);
-        }
-        if (savedScrollParent) {
-          savedScrollParent.scrollTop = savedScrollTop;
-        }
-      }
-
-      if (result) {
+      if (found) {
         const selection = window.getSelection();
         if (selection && selection.rangeCount > 0) {
           const range = selection.getRangeAt(0);
-          const parentElement =
-            range.startContainer.parentElement ||
-            (range.commonAncestorContainer as Element);
-          const isNewMatch = !isLastFoundItem(range, lastFoundItem.current);
-          lastFoundItem.current = {
-            text: range.toString(),
-            offset: range.startOffset,
-            parentElement,
-          };
 
-          if (isNewMatch) {
-            setCurrentMatchIndex((prev) => {
-              if (back) {
-                return prev <= 1 ? total : prev - 1;
-              } else {
-                return prev >= total ? 1 : prev + 1;
-              }
-            });
-          }
-
+          // Expand collapsed panels containing the match
           const parentPanel = getParentExpandablePanel(selection);
           if (parentPanel) {
             if (!mutatedPanelsRef.current.has(parentPanel)) {
@@ -190,7 +159,7 @@ export const FindBand: FC<FindBandProps> = () => {
 
       focusedElement?.focus();
     },
-    [getParentExpandablePanel, extendedFindTerm, countAllMatches],
+    [getParentExpandablePanel, countAllMatches, goToMatch],
   );
 
   useEffect(() => {
@@ -218,6 +187,10 @@ export const FindBand: FC<FindBandProps> = () => {
         panel.style.webkitBoxOrient = originalStyles.webkitBoxOrient;
       });
       mutatedPanels.clear();
+      // Clear the CSS Custom Highlight
+      if (CSS?.highlights) {
+        CSS.highlights.delete("find-match");
+      }
     };
   }, []);
 
@@ -263,7 +236,7 @@ export const FindBand: FC<FindBandProps> = () => {
         await handleSearch(false);
         // Mark for cursor restore on next keypress (keeps find highlight visible)
         needsCursorRestoreRef.current = true;
-      }, 300),
+      }, 100),
     [handleSearch],
   );
 
@@ -272,14 +245,10 @@ export const FindBand: FC<FindBandProps> = () => {
   }, [debouncedSearch]);
 
   const handleBeforeInput = useCallback(() => {
-    const input = searchBoxRef.current;
-    if (input) {
-      const hasSelection = input.selectionStart !== input.selectionEnd;
-      if (!hasSelection) {
-        restoreCursor();
-      }
-    }
-  }, [restoreCursor]);
+    // Clear the restore flag — the user is actively editing,
+    // so the cursor is already where they want it.
+    needsCursorRestoreRef.current = false;
+  }, []);
 
   // Consolidated global keyboard handler
   useEffect(() => {
@@ -316,12 +285,10 @@ export const FindBand: FC<FindBandProps> = () => {
       const input = searchBoxRef.current;
       if (!input) return;
 
-      const hasSelection = input.selectionStart !== input.selectionEnd;
-      if (!hasSelection) {
-        restoreCursor();
-      }
-
+      // Only restore cursor and focus if the input doesn't already have focus.
+      // If the user is actively editing in the input, don't move their cursor.
       if (document.activeElement !== input) {
+        restoreCursor();
         input.focus();
       }
     };
@@ -332,225 +299,63 @@ export const FindBand: FC<FindBandProps> = () => {
     };
   }, [handleSearch, restoreCursor]);
 
+  const hasHighlightAPI = !!(typeof CSS !== "undefined" && CSS?.highlights && typeof Highlight !== "undefined");
+
+  const matchCountLabel = useMemo(() => {
+    if (matchCount === null) return null;
+    if (matchCount === 0) return "No results";
+    return `${currentMatchIndex} of ${matchCount}`;
+  }, [matchCount, currentMatchIndex]);
+
   return (
-    <FindBandUI
-      inputRef={searchBoxRef}
-      onClose={storeHideFind}
-      onNext={findNext}
-      onPrevious={findPrevious}
-      onKeyDown={handleKeyDown}
-      onBeforeInput={handleBeforeInput}
-      onChange={handleInputChange}
-      noResults={matchCount !== null && matchCount === 0}
-      matchCount={matchCount ?? undefined}
-      matchIndex={
-        matchCount !== null && matchCount > 0
-          ? currentMatchIndex - 1
-          : undefined
-      }
-    />
+    <div data-unsearchable="true" className={clsx("findBand")}>
+      <input
+        type="text"
+        ref={searchBoxRef}
+        placeholder="Find"
+        onKeyDown={handleKeyDown}
+        onBeforeInput={handleBeforeInput}
+        onChange={handleInputChange}
+      />
+      {!hasHighlightAPI && (
+        <span className="findBand-no-results">
+          Search requires Chrome 105+, Firefox 140+, or Safari 17.2+
+        </span>
+      )}
+      {matchCountLabel !== null && (
+        <span
+          className={clsx(
+            "findBand-match-count",
+            matchCount === 0 && "findBand-no-results",
+          )}
+        >
+          {matchCountLabel}
+        </span>
+      )}
+      <button
+        type="button"
+        title="Previous match"
+        className="btn next"
+        onClick={findPrevious}
+      >
+        <i className={ApplicationIcons.arrows.up} />
+      </button>
+      <button
+        type="button"
+        title="Next match"
+        className="btn prev"
+        onClick={findNext}
+      >
+        <i className={ApplicationIcons.arrows.down} />
+      </button>
+      <button
+        type="button"
+        title="Close"
+        className="btn close"
+        onClick={storeHideFind}
+      >
+        <i className={ApplicationIcons.close} />
+      </button>
+    </div>
   );
 };
-function windowFind(searchTerm: string, back: boolean): boolean {
-  // @ts-expect-error: `Window.find` is non-standard
-  return window.find(
-    searchTerm,
-    findConfig.caseSensitive,
-    back,
-    findConfig.wrapAround,
-    findConfig.wholeWord,
-    findConfig.searchInFrames,
-    findConfig.showDialog,
-  ) as boolean;
-}
-
-function positionSelectionForWrap(back: boolean): void {
-  if (!back) return;
-  const sel = window.getSelection();
-  if (sel) {
-    const range = document.createRange();
-    range.selectNodeContents(document.body);
-    range.collapse(false);
-    sel.removeAllRanges();
-    sel.addRange(range);
-  }
-}
-
-async function findExtendedInDOM(
-  searchTerm: string,
-  back: boolean,
-  lastFoundItem: {
-    text: string;
-    offset: number;
-    parentElement: Element;
-  } | null,
-  extendedFindTerm: (
-    term: string,
-    direction: "forward" | "backward",
-  ) => Promise<boolean>,
-) {
-  let result = false;
-  let hasTriedExtendedSearch = false;
-  let extendedSearchSucceeded = false;
-  const maxAttempts = 25;
-
-  for (let attempts = 0; attempts < maxAttempts; attempts++) {
-    result = windowFind(searchTerm, back);
-
-    if (result) {
-      const selection = window.getSelection();
-      if (selection && selection.rangeCount > 0) {
-        const range = selection.getRangeAt(0);
-        const isUnsearchable = inUnsearchableElement(range);
-        const isSameAsLast = isLastFoundItem(range, lastFoundItem);
-
-        if (!isUnsearchable && !isSameAsLast) {
-          break;
-        }
-
-        if (isSameAsLast) {
-          if (!hasTriedExtendedSearch) {
-            hasTriedExtendedSearch = true;
-            window.getSelection()?.removeAllRanges();
-
-            const foundInVirtual = await extendedFindTerm(
-              searchTerm,
-              back ? "backward" : "forward",
-            );
-
-            if (foundInVirtual) {
-              extendedSearchSucceeded = true;
-              continue;
-            }
-          }
-
-          if (extendedSearchSucceeded) {
-            // Extended search scrolled to new content but old match is still in DOM.
-            // Collapse past it so windowFind advances to the new match.
-            const sel = window.getSelection();
-            if (sel?.rangeCount) {
-              sel.getRangeAt(0).collapse(!back);
-            }
-          } else {
-            window.getSelection()?.removeAllRanges();
-            positionSelectionForWrap(back);
-          }
-
-          result = windowFind(searchTerm, back);
-          if (result) {
-            const sel = window.getSelection();
-            if (sel && sel.rangeCount > 0) {
-              const r = sel.getRangeAt(0);
-              if (inUnsearchableElement(r)) {
-                continue;
-              }
-            }
-          }
-          break;
-        }
-      }
-    } else if (!hasTriedExtendedSearch) {
-      hasTriedExtendedSearch = true;
-      window.getSelection()?.removeAllRanges();
-
-      const foundInVirtual = await extendedFindTerm(
-        searchTerm,
-        back ? "backward" : "forward",
-      );
-
-      if (foundInVirtual) {
-        extendedSearchSucceeded = true;
-        continue;
-      }
-
-      positionSelectionForWrap(back);
-      result = windowFind(searchTerm, back);
-      if (result) {
-        const sel = window.getSelection();
-        if (sel && sel.rangeCount > 0) {
-          const r = sel.getRangeAt(0);
-          if (inUnsearchableElement(r)) {
-            continue;
-          }
-        }
-      }
-      break;
-    } else {
-      break;
-    }
-  }
-
-  if (result) {
-    const sel = window.getSelection();
-    if (sel?.rangeCount && inUnsearchableElement(sel.getRangeAt(0))) {
-      sel.removeAllRanges();
-      result = false;
-    }
-  }
-
-  return result;
-}
-
-function isLastFoundItem(
-  range: Range,
-  lastFoundItem: {
-    text: string;
-    offset: number;
-    parentElement: Element;
-  } | null,
-) {
-  if (!lastFoundItem) return false;
-
-  const currentText = range.toString();
-  const currentOffset = range.startOffset;
-  const currentParentElement =
-    range.startContainer.parentElement ||
-    (range.commonAncestorContainer as Element);
-
-  return (
-    currentText === lastFoundItem.text &&
-    currentOffset === lastFoundItem.offset &&
-    currentParentElement === lastFoundItem.parentElement
-  );
-}
-
-function inUnsearchableElement(range: Range) {
-  let element: Element | null = selectionParentElement(range);
-
-  // Check if this match is inside an unsearchable element
-  let isUnsearchable = false;
-  while (element) {
-    if (
-      element.hasAttribute("data-unsearchable") ||
-      getComputedStyle(element).userSelect === "none"
-    ) {
-      isUnsearchable = true;
-      break;
-    }
-    element = element.parentElement;
-  }
-  return isUnsearchable;
-}
-
-function selectionParentElement(range: Range) {
-  let element: Element | null = null;
-
-  if (range.startContainer.nodeType === Node.ELEMENT_NODE) {
-    // This is a direct element
-    element = range.startContainer as Element;
-  } else {
-    // This isn't an element, try its parent
-    element = range.startContainer.parentElement;
-  }
-
-  // Still not found, try the common ancestor container
-  if (
-    !element &&
-    range.commonAncestorContainer.nodeType === Node.ELEMENT_NODE
-  ) {
-    element = range.commonAncestorContainer as Element;
-  } else if (!element && range.commonAncestorContainer.parentElement) {
-    element = range.commonAncestorContainer.parentElement;
-  }
-  return element;
-}

--- a/src/inspect_ai/_view/www/src/components/FindBand.tsx
+++ b/src/inspect_ai/_view/www/src/components/FindBand.tsx
@@ -153,6 +153,10 @@ export const FindBand: FC<FindBandProps> = () => {
           }
           scrollTimeoutRef.current = window.setTimeout(() => {
             scrollRangeToCenter(range);
+            // Clear selection so CSS Custom Highlight (yellow ::highlight) is visible.
+            // The selection (blue ::selection) visually overrides ::highlight when both
+            // exist on the same range. We only needed it for scrollRangeToCenter.
+            window.getSelection()?.removeAllRanges();
           }, 100);
         }
       }

--- a/src/inspect_ai/_view/www/src/components/LiveVirtualList.tsx
+++ b/src/inspect_ai/_view/www/src/components/LiveVirtualList.tsx
@@ -74,7 +74,10 @@ function countMatchesInPanel(panelId: string, term: string): number {
 function expandParentExpandablePanel(selection: Selection): void {
   let node = selection.anchorNode;
   while (node) {
-    if (node instanceof HTMLElement && node.hasAttribute("data-expandable-panel")) {
+    if (
+      node instanceof HTMLElement &&
+      node.hasAttribute("data-expandable-panel")
+    ) {
       node.style.display = "block";
       node.style.maxHeight = "none";
       node.style.webkitLineClamp = "";
@@ -141,10 +144,7 @@ export const LiveVirtualList = <T,>({
   const { getRestoreState, isScrolling, visibleRange, setVisibleRange } =
     useVirtuosoState(listHandle, `live-virtual-list-${id}`);
 
-  const {
-    registerMatchCounter,
-    registerGoToMatch,
-  } = useExtendedFind();
+  const { registerMatchCounter, registerGoToMatch } = useExtendedFind();
   const pendingTargetRef = useRef<{
     index: number;
     resolve: () => void;
@@ -298,7 +298,10 @@ export const LiveVirtualList = <T,>({
     (index: number): Promise<void> => {
       return new Promise((resolve) => {
         const currentRange = visibleRangeRef.current;
-        if (index >= currentRange.startIndex && index <= currentRange.endIndex) {
+        if (
+          index >= currentRange.startIndex &&
+          index <= currentRange.endIndex
+        ) {
           requestAnimationFrame(() => resolve());
           return;
         }
@@ -353,7 +356,11 @@ export const LiveVirtualList = <T,>({
       if (!term || typeof Highlight === "undefined" || !CSS?.highlights) return;
       const allRanges: StaticRange[] = [];
       const range = visibleRangeRef.current;
-      for (let i = range.startIndex; i <= range.endIndex && i < data.length; i++) {
+      for (
+        let i = range.startIndex;
+        i <= range.endIndex && i < data.length;
+        i++
+      ) {
         const nodeId = (data[i] as { id?: string }).id;
         if (!nodeId) continue;
         const panelId = "event-panel-" + nodeId;
@@ -370,7 +377,6 @@ export const LiveVirtualList = <T,>({
     },
     [data],
   );
-
 
   // Navigate to the nth match (1-based). Uses data-level counts to locate
   // the target item WITHOUT scrolling, then scrolls to ONLY that item and
@@ -571,7 +577,11 @@ export const LiveVirtualList = <T,>({
                 window.getSelection()?.removeAllRanges();
               }
             }
-            rebuildVisibleHighlights(term, highlight?.occurrence, highlight?.panelId);
+            rebuildVisibleHighlights(
+              term,
+              highlight?.occurrence,
+              highlight?.panelId,
+            );
           });
         }
       }}

--- a/src/inspect_ai/_view/www/src/components/searchUtils.ts
+++ b/src/inspect_ai/_view/www/src/components/searchUtils.ts
@@ -232,3 +232,35 @@ export function createMatchRange(
 
   return { range, staticRange };
 }
+
+/**
+ * Get all StaticRanges for every occurrence of a search term in a panel element.
+ * Used for the "find-match-all" CSS Custom Highlight (yellow background on all visible matches).
+ *
+ * @param panelId The DOM element id of the panel to search
+ * @param term The search term (case-insensitive)
+ * @param excludeOccurrence 1-based occurrence number to exclude (the current match, highlighted separately)
+ * @returns Array of StaticRanges for all matches (except the excluded one)
+ */
+export function getAllMatchRangesInPanel(
+  panelId: string,
+  term: string,
+  excludeOccurrence?: number,
+): StaticRange[] {
+  const panelEl = document.getElementById(panelId);
+  if (!panelEl) return [];
+  const { text, nodes, offsets } = buildSearchableText(panelEl);
+  const lowerTerm = term.toLowerCase();
+  const ranges: StaticRange[] = [];
+  let n = 1;
+  while (true) {
+    const match = findNthMatch(text, lowerTerm, n);
+    if (!match) break;
+    if (n !== excludeOccurrence) {
+      const result = createMatchRange(nodes, offsets, match);
+      if (result) ranges.push(result.staticRange);
+    }
+    n++;
+  }
+  return ranges;
+}

--- a/src/inspect_ai/_view/www/src/components/searchUtils.ts
+++ b/src/inspect_ai/_view/www/src/components/searchUtils.ts
@@ -1,0 +1,234 @@
+/**
+ * Pure DOM utility functions for cross-node text matching in FindBand search.
+ * Zero React imports. Handles text nodes split across multiple DOM elements.
+ */
+
+/**
+ * Build a searchable text string from a DOM subtree, tracking node boundaries.
+ * Skips text nodes inside elements with data-unsearchable or user-select:none.
+ * Inserts '\n' separators at unsearchable boundaries to prevent false cross-boundary matches.
+ *
+ * @param root The root element to search within
+ * @returns Object with concatenated lowercase text, parallel arrays of nodes and their offsets
+ */
+export function buildSearchableText(root: Element): {
+  text: string;
+  nodes: Text[];
+  offsets: number[];
+} {
+  const nodes: Text[] = [];
+  const offsets: number[] = [];
+  let text = "";
+
+  // Cache for computed styles to avoid repeated getComputedStyle calls
+  const styleCache = new WeakMap<Element, boolean>();
+
+  /**
+   * Check if an element or any ancestor is unsearchable.
+   * Uses element.closest() for fast path, then getComputedStyle with caching.
+   */
+  function isUnsearchable(node: Node): boolean {
+    let el: Element | null =
+      node.nodeType === Node.ELEMENT_NODE
+        ? (node as Element)
+        : node.parentElement;
+
+    if (!el) return false;
+
+    // Fast path: check for data-unsearchable attribute
+    if (el.closest("[data-unsearchable]")) {
+      return true;
+    }
+
+    // Check ancestors for user-select: none with caching
+    let current: Element | null = el;
+    while (current) {
+      if (styleCache.has(current)) {
+        if (styleCache.get(current)) {
+          return true;
+        }
+      } else {
+        const isNone = getComputedStyle(current).userSelect === "none";
+        styleCache.set(current, isNone);
+        if (isNone) {
+          return true;
+        }
+      }
+      current = current.parentElement;
+    }
+
+    return false;
+  }
+
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
+  let textNode: Node | null;
+
+  while ((textNode = walker.nextNode())) {
+    if (isUnsearchable(textNode)) {
+      // Insert separator to prevent false matches bridging across unsearchable regions
+      text += "\n";
+    } else {
+      // Record the offset where this node's text starts
+      offsets.push(text.length);
+      nodes.push(textNode as Text);
+
+      // Append the node's text (lowercase for case-insensitive matching)
+      const nodeText = textNode.textContent ?? "";
+      text += nodeText.toLowerCase();
+    }
+  }
+
+  return { text, nodes, offsets };
+}
+
+/**
+ * Count the number of occurrences of a search term in searchable text.
+ * Case-insensitive.
+ *
+ * @param searchableText The concatenated lowercase text from buildSearchableText
+ * @param term The search term (will be lowercased)
+ * @returns Number of matches found
+ */
+export function countMatches(searchableText: string, term: string): number {
+  let count = 0;
+  let pos = 0;
+  const lower = term.toLowerCase();
+
+  while ((pos = searchableText.indexOf(lower, pos)) !== -1) {
+    count++;
+    pos += lower.length;
+  }
+
+  return count;
+}
+
+/**
+ * Find the nth occurrence (1-based) of a search term in searchable text.
+ *
+ * @param text The concatenated lowercase text from buildSearchableText
+ * @param term The search term (will be lowercased)
+ * @param n The occurrence number (1-based)
+ * @returns Object with globalStart and globalEnd offsets, or null if fewer than n matches exist
+ */
+export function findNthMatch(
+  text: string,
+  term: string,
+  n: number,
+): { globalStart: number; globalEnd: number } | null {
+  let count = 0;
+  let pos = 0;
+  const lower = term.toLowerCase();
+
+  while ((pos = text.indexOf(lower, pos)) !== -1) {
+    count++;
+    if (count === n) {
+      return {
+        globalStart: pos,
+        globalEnd: pos + lower.length,
+      };
+    }
+    pos += lower.length;
+  }
+
+  return null;
+}
+
+/**
+ * Map a global offset in the concatenated text to a specific text node and offset within that node.
+ * Uses binary search through the offsets array.
+ *
+ * @param nodes Parallel array of Text nodes from buildSearchableText
+ * @param offsets Parallel array of offsets from buildSearchableText
+ * @param globalOffset The offset in the concatenated text
+ * @returns Object with the text node and offset within that node, or null if not found
+ */
+export function mapOffsetToNode(
+  nodes: Text[],
+  offsets: number[],
+  globalOffset: number,
+): { node: Text; offset: number } | null {
+  if (nodes.length === 0 || offsets.length === 0) {
+    return null;
+  }
+
+  // Binary search to find the node containing this offset
+  let left = 0;
+  let right = offsets.length - 1;
+
+  while (left <= right) {
+    const mid = Math.floor((left + right) / 2);
+    const nodeStart = offsets[mid];
+    const nodeEnd = mid + 1 < offsets.length ? offsets[mid + 1] : Infinity;
+
+    if (globalOffset >= nodeStart && globalOffset < nodeEnd) {
+      return {
+        node: nodes[mid],
+        offset: globalOffset - nodeStart,
+      };
+    }
+
+    if (globalOffset < nodeStart) {
+      right = mid - 1;
+    } else {
+      left = mid + 1;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Create a Range and StaticRange for a match spanning potentially multiple text nodes.
+ * Validates that the range is connected and not collapsed.
+ *
+ * @param nodes Parallel array of Text nodes from buildSearchableText
+ * @param offsets Parallel array of offsets from buildSearchableText
+ * @param match Object with globalStart and globalEnd from findNthMatch
+ * @returns Object with both Range and StaticRange, or null if range is invalid
+ */
+export function createMatchRange(
+  nodes: Text[],
+  offsets: number[],
+  match: { globalStart: number; globalEnd: number },
+): { range: Range; staticRange: StaticRange } | null {
+  const startMapping = mapOffsetToNode(nodes, offsets, match.globalStart);
+  const endMapping = mapOffsetToNode(nodes, offsets, match.globalEnd);
+
+  if (!startMapping || !endMapping) {
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        "createMatchRange: Could not map match offsets to nodes",
+        match,
+      );
+    }
+    return null;
+  }
+
+  const range = document.createRange();
+  range.setStart(startMapping.node, startMapping.offset);
+  range.setEnd(endMapping.node, endMapping.offset);
+
+  // Validate the range
+  if (
+    range.collapsed ||
+    !range.startContainer.isConnected ||
+    !range.endContainer.isConnected
+  ) {
+    if (typeof console !== "undefined" && console.warn) {
+      console.warn(
+        "createMatchRange: Range is collapsed or disconnected",
+        range,
+      );
+    }
+    return null;
+  }
+
+  const staticRange = new StaticRange({
+    startContainer: startMapping.node,
+    startOffset: startMapping.offset,
+    endContainer: endMapping.node,
+    endOffset: endMapping.offset,
+  });
+
+  return { range, staticRange };
+}

--- a/src/inspect_ai/_view/www/src/tests/transcript/eventSearchText.test.ts
+++ b/src/inspect_ai/_view/www/src/tests/transcript/eventSearchText.test.ts
@@ -196,6 +196,38 @@ describe("eventSearchText", () => {
     expect(texts).toContain("search");
   });
 
+  test("tool: extracts searchable text from structured result content", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "tool",
+        function: "browser",
+        view: { title: "Browser" },
+        arguments: { action: "get_page_text" },
+        result: [
+          { type: "text", text: "Revenue Recognition in policy docs" },
+          {
+            type: "tool",
+            content: [
+              { type: "text", text: "Revenue Recognition in extracted page" },
+            ],
+          },
+          { type: "image", image: "data:image/png;base64,abc123" },
+        ],
+        error: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+
+    expect(texts).toContain('{"action":"get_page_text"}');
+    expect(texts).toContain("Revenue Recognition in policy docs");
+    expect(texts).toContain("Revenue Recognition in extracted page");
+    expect(texts.join("\n")).not.toContain("data:image/png;base64");
+
+    const revenueCount = (texts.join("\n").match(/Revenue Recognition/g) || [])
+      .length;
+    expect(revenueCount).toBe(2);
+  });
+
   test("error: includes 'Error' title", () => {
     const texts = eventSearchText(
       makeNode({


### PR DESCRIPTION
## Summary
- align FindBand match indexing with visible transcript and tool content by refining eventSearchText extraction
- include structured tool result text (including nested content) in search indexing while excluding inline data image payloads
- add a regression test for structured tool result extraction to prevent Revenue Recognition count and navigation drift

## Verification
- yarn tsc
- yarn test src/tests/transcript/eventSearchText.test.ts
- yarn test
- pytest perf-harness/src/test_findband.py -q --tb=short
- pytest perf-harness/src/test_findband_properties.py -q --tb=short