### PR TITLE
fix(viewer): show running sample detail for in-progress evals

### DIFF
--- a/src/inspect_ai/_view/www/src/app/samples/SampleDetailComponent.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDetailComponent.tsx
@@ -95,8 +95,11 @@ export const SampleDetailComponent: FC<SampleDetailComponentProps> = ({
 
   // Check if the loaded sample matches the requested sample from URL params
   // This prevents showing old sample data while a new sample is loading
+  // When sample is null but we have sampleId/epoch, it's a running sample —
+  // allow rendering so the downstream SampleDisplay can show runningEvents
   const sampleMatchesRequest = useMemo(() => {
-    if (!sample || !sampleId || !epoch) return false;
+    if (!sampleId || !epoch) return false;
+    if (!sample) return true; // running sample: render via runningEvents path
     return (
       String(sample.id) === sampleId && sample.epoch === parseInt(epoch, 10)
     );
@@ -226,7 +229,7 @@ export const SampleDetailComponent: FC<SampleDetailComponentProps> = ({
           </div>
         </ApplicationNavbar>
 
-        {sampleStatus !== "loading" && sample && sampleMatchesRequest && (
+        {sampleStatus !== "loading" && sampleMatchesRequest && (
           <InlineSampleComponent
             showActivity={false}
             className={styles.panel}

--- a/src/inspect_ai/_view/www/src/state/useLoadSample.ts
+++ b/src/inspect_ai/_view/www/src/state/useLoadSample.ts
@@ -117,6 +117,7 @@ export function useLoadSample() {
           // Clear the previous sample so component uses runningEvents instead
           // of old sample.events. Polling will be started by useSamplePolling.
           sampleActions.clearSampleForPolling(logFile, id, epoch);
+          sampleActions.setSampleStatus("streaming");
           getSamplePolling().stopPolling();
         }
       } catch (e) {


### PR DESCRIPTION
## Summary

Fixes blank sample detail panel when viewing in-progress evaluations. The sample list renders correctly but clicking any sample shows an empty page.

## Root Cause

Two bugs introduced by 63f9f99f ("Fix Inspect View showing stale sample data #3325"):

1. **`SampleDetailComponent.tsx`**: `sampleMatchesRequest` returned `false` when `sample` was `null`. Running samples intentionally have no `sample` object — they render via `runningEvents` in `SampleDisplay`. The `null` check should allow rendering, not block it.

2. **`useLoadSample.ts`**: `prepareForSampleLoad()` sets `sampleStatus = "loading"`, but the running sample code path (`completed === false`) never transitions it away. The render guard `sampleStatus !== "loading"` stays blocked forever. The completed path correctly calls `setSampleStatus("ok")` but the running path was missing an equivalent call.

## Fix

- `SampleDetailComponent.tsx`: Split the guard so `!sample` returns `true` (allow rendering for running samples) while `!sampleId || !epoch` returns `false`.
- `useLoadSample.ts`: Call `setSampleStatus("streaming")` after `clearSampleForPolling()` so the render guard unblocks.
- Rebuilt `dist/assets/index.js` with the fix.