### PR TITLE
fix: use exec test -r for lightweight file existence check in _is_file_readable

### DIFF
--- a/src/inspect_ai/util/_sandbox/context.py
+++ b/src/inspect_ai/util/_sandbox/context.py
@@ -124,6 +124,8 @@ async def _is_file_readable(environment: SandboxEnvironment, file: str) -> bool:
         if result.success:
             return True
     except Exception:
+        # Catch broadly because sandbox providers may raise a variety of
+        # provider-specific exceptions that we can't predict here.
         pass
 
     # Fallback: read the file. Cross-platform but transfers full contents.


### PR DESCRIPTION
## Problem

`_is_file_readable` checks whether a file exists by reading its entire contents:

```python
# TODO: This is gross. We actually read the file contents just to see if it's readable.
await environment.read_file(file, False)
```

On sandbox providers where the file transfer mechanism has size limits (e.g. the Proxmox QEMU guest agent, which drops connections on files >~15 MiB), this causes the injection check to fail even when the file was written successfully.

## Change

Try `exec(["test", "-r", file])` first — no file contents transferred. Fall back to `read_file` if `test` isn't available (e.g. Windows), preserving existing behaviour on all platforms.
