### PR TITLE
Add continuous batching infrastructure for HuggingFace provider

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -626,6 +626,43 @@ Concurrency for REST API based models is managed using the `max_connections` opt
 
 The default batch size for Hugging Face is 32, but you should tune your `max_connections` to maximise performance and ensure that batches don't exceed available GPU memory. The [Pipeline Batching](https://huggingface.co/docs/transformers/main_classes/pipelines#pipeline-batching) section of the transformers documentation is a helpful guide to the ways batch size and performance interact.
 
+### Continuous Batching (Experimental)
+
+::: {.callout-note}
+## Status: In Development
+
+Continuous batching support is planned but not yet fully implemented. This section documents the intended API for when the feature is complete.
+:::
+
+For improved memory efficiency and dynamic request handling, you can enable continuous batching with the `continuous_batching` model argument:
+
+``` bash
+inspect eval task.py \
+  --model hf/meta-llama/Llama-3.1-8B-Instruct \
+  -M continuous_batching=true \
+  -M num_blocks=2048 \
+  -M max_batch_tokens=4096
+```
+
+**Benefits:**
+- Shared KV cache across requests (lower memory usage)
+- Dynamic scheduling (add/remove requests on-the-fly)
+- Better GPU utilization
+- Prefix sharing for common prompts
+
+**Requirements:**
+- transformers >= 4.38.0
+- Model must support paged attention
+- GPU recommended (CPU supported but slower)
+
+**Configuration:**
+- `continuous_batching`: Enable feature (default: False)
+- `num_blocks`: Number of cache blocks (auto-detected if not specified)
+- `max_batch_tokens`: Total token budget across all requests
+- `scheduler`: "fifo" or "prefill_first" scheduling policy
+
+**Note:** This feature uses transformers' `generate_batch()` API with `PagedAttentionCache`. Not all models support this feature. For now, the standard batching implementation will be used when enabled.
+
 ### Device
 
 The PyTorch `cuda` device will be used automatically if CUDA is available (as will the Mac OS `mps` device). If you want to override the device used, use the `device` model argument. For example:

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -100,6 +100,12 @@ class HuggingFaceAPI(ModelAPI):
             self.tokenizer_call_args = {}
         self.hidden_states = collect_model_arg("hidden_states")
 
+        # continuous batching parameters
+        self.continuous_batching = collect_model_arg("continuous_batching") or False
+        self.num_blocks = collect_model_arg("num_blocks")
+        self.max_batch_tokens = collect_model_arg("max_batch_tokens")
+        self.scheduler = collect_model_arg("scheduler") or "fifo"
+
         # device
         if device:
             self.device = device
@@ -133,6 +139,20 @@ class HuggingFaceAPI(ModelAPI):
         # LLMs generally don't have a pad token and we need one for batching
         self.tokenizer.pad_token = self.tokenizer.eos_token
         self.tokenizer.padding_side = "left"
+
+        # Setup continuous batching if enabled
+        if self.continuous_batching:
+            logger.warning(
+                "continuous_batching is enabled but not yet fully implemented. "
+                "This feature requires transformers' generate_batch() API with "
+                "paged attention. For now, falling back to standard batching. "
+                "Track progress at: https://github.com/UKGovernmentBEIS/inspect_ai/issues/[TBD]"
+            )
+            # TODO: Implement continuous batching with:
+            # 1. Load model with attn_implementation="paged|sdpa" or "paged|flash_attention_2"
+            # 2. Set up GenerationConfig with max_batch_tokens and num_blocks
+            # 3. Replace batched_generate to use model.generate_batch()
+            # 4. Handle PagedAttentionCache initialization and management
 
     @override
     def close(self) -> None:

--- a/tests/model/providers/test_hf.py
+++ b/tests/model/providers/test_hf.py
@@ -101,3 +101,27 @@ def test_hf_disable_chat_template() -> None:
     message = ChatMessageUser(content="Lorem ipsum dolor")
     chat = model.api.hf_chat([message], [])  # type: ignore[attr-defined]
     assert chat == "user: Lorem ipsum dolor\n"
+
+
+@skip_if_no_transformers
+@skip_if_no_accelerate
+def test_hf_continuous_batching_arguments() -> None:
+    """Test that continuous batching model arguments are accepted."""
+    model = get_model(
+        "hf/EleutherAI/pythia-70m",
+        config=GenerateConfig(
+            max_tokens=1,
+            seed=42,
+            temperature=0.01,
+        ),
+        chat_template="{% for message in messages %}{{ message.content }}{% endfor %}",
+        continuous_batching=True,
+        num_blocks=100,
+        max_batch_tokens=2048,
+        scheduler="fifo",
+    )
+    # Verify the model was created successfully with the arguments
+    assert model.api.continuous_batching is True  # type: ignore[attr-defined]
+    assert model.api.num_blocks == 100  # type: ignore[attr-defined]
+    assert model.api.max_batch_tokens == 2048  # type: ignore[attr-defined]
+    assert model.api.scheduler == "fifo"  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

This PR adds infrastructure and documentation for continuous batching support in the HuggingFace model provider. This is a **foundation/placeholder PR** that sets up the API and documents the intended functionality for maintainer review before proceeding with full implementation.

## Motivation

Continuous batching using transformers' `generate_batch()` API with `PagedAttentionCache` offers significant benefits:
- **Memory efficiency**: Shared KV cache across requests vs separate cache per sequence
- **Dynamic scheduling**: Add/remove sequences on-the-fly vs static padded batches
- **Better throughput**: Reduced memory overhead allows larger effective batch sizes

## Changes

### Code (`src/inspect_ai/model/_providers/hf.py`)
- Added 4 new model arguments:
  - `continuous_batching` (bool): Enable continuous batching (default: False)
  - `num_blocks` (int): KV cache blocks for PagedAttention
  - `max_batch_tokens` (int): Max tokens per batch
  - `scheduler` (str): Scheduling policy ("fifo" or "prefill_first")
- Added placeholder implementation that currently displays a warning message
- Includes TODO comments outlining full implementation steps

### Documentation (`docs/providers.qmd`)
- Added new "Continuous Batching (Experimental)" section
- Documented benefits, requirements, and configuration parameters
- Includes usage examples for when feature is complete
- Clear "In Development" notice

### Tests (`tests/model/providers/test_hf.py`)
- Added `test_hf_continuous_batching_arguments()` to verify model arguments are accepted

## Design Decisions

1. **Opt-in feature**: Default `continuous_batching=False` maintains backward compatibility
2. **Placeholder implementation**: Current version warns users that full implementation is pending
3. **Infrastructure first**: This PR establishes the API surface for maintainer feedback before investing in full implementation

## Why Placeholder?

Full implementation requires:
- Loading models with `attn_implementation="paged|sdpa"` or `"paged|flash_attention_2"`
- Complete refactor of `batched_generate()` to use `generate_batch()`
- `PagedAttentionCache` and `GenerationConfig` setup
- Model capability detection and graceful fallbacks

This PR provides a foundation for discussion about:
- Is this the right API design?
- Are there concerns about this approach?
- Should we proceed with full implementation?

## Testing

- All linting/formatting checks pass (`ruff`, `mypy`, `pylint`)
- New test verifies model arguments are accepted
- Backward compatibility maintained (existing tests unaffected)

## Next Steps (if approved)

1. Implement full `generate_batch()` integration
2. Add model capability detection
3. Implement graceful fallbacks for unsupported models
4. Add comprehensive tests with actual continuous batching
5. Performance benchmarking vs current batching

## Questions for Maintainers

1. Does this API design align with Inspect AI's architecture?
2. Any concerns about adding this as an opt-in feature?
3. Should we proceed with full implementation or adjust the approach?

---

Looking forward to feedback on this approach! Happy to make any adjustments or proceed with full implementation if the design looks good.