### PR TITLE
feat(anthropic): add fast mode support (speed="fast") for Opus 4.6

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -533,6 +533,12 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         envvar="INSPECT_EVAL_EFFORT",
     )
     @click.option(
+        "--speed",
+        type=click.Choice(["fast"]),
+        help="Enable fast mode for higher output token generation speed at premium pricing (6x standard rates). Anthropic Claude Opus 4.6 only (research preview).",
+        envvar="INSPECT_EVAL_SPEED",
+    )
+    @click.option(
         "--reasoning-effort",
         type=click.Choice(["none", "minimal", "low", "medium", "high", "xhigh"]),
         help="Constrains effort on reasoning. Defaults vary by provider and model and not all models support all values (please consult provider documentation for details).",
@@ -656,6 +662,7 @@ def eval_command(
     cache_prompt: str | None,
     verbosity: Literal["low", "medium", "high"] | None,
     effort: Literal["low", "medium", "high"] | None,
+    speed: Literal["fast"] | None,
     reasoning_effort: str | None,
     reasoning_tokens: int | None,
     reasoning_summary: Literal["none", "concise", "detailed", "auto"] | None,
@@ -864,6 +871,7 @@ def eval_set_command(
     cache_prompt: str | None,
     verbosity: Literal["low", "medium", "high"] | None,
     effort: Literal["low", "medium", "high"] | None,
+    speed: Literal["fast"] | None,
     reasoning_effort: str | None,
     reasoning_tokens: int | None,
     reasoning_summary: Literal["none", "concise", "detailed", "auto"] | None,

--- a/src/inspect_ai/_view/www/log-schema.json
+++ b/src/inspect_ai/_view/www/log-schema.json
@@ -2422,6 +2422,7 @@
             "cache_prompt": null,
             "verbosity": null,
             "effort": null,
+            "speed": null,
             "reasoning_effort": null,
             "reasoning_tokens": null,
             "reasoning_summary": null,
@@ -4027,6 +4028,19 @@
           "default": null,
           "title": "Effort"
         },
+        "speed": {
+          "anyOf": [
+            {
+              "const": "fast",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speed"
+        },
         "reasoning_effort": {
           "anyOf": [
             {
@@ -4195,6 +4209,7 @@
         "cache_prompt",
         "verbosity",
         "effort",
+        "speed",
         "reasoning_effort",
         "reasoning_tokens",
         "reasoning_summary",
@@ -5343,6 +5358,18 @@
           ],
           "default": null,
           "title": "Total Cost"
+        },
+        "speed": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Speed"
         }
       },
       "title": "ModelUsage",
@@ -5354,7 +5381,8 @@
         "input_tokens_cache_write",
         "input_tokens_cache_read",
         "reasoning_tokens",
-        "total_cost"
+        "total_cost",
+        "speed"
       ],
       "additionalProperties": false
     },
@@ -7355,6 +7383,18 @@
           "title": "Utility",
           "type": "boolean"
         },
+        "agent_result": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Agent Result"
+        },
         "outline": {
           "anyOf": [
             {
@@ -7376,6 +7416,7 @@
         "branches",
         "description",
         "utility",
+        "agent_result",
         "outline"
       ],
       "title": "TimelineSpan",

--- a/src/inspect_ai/_view/www/src/@types/log.d.ts
+++ b/src/inspect_ai/_view/www/src/@types/log.d.ts
@@ -58,6 +58,7 @@ export type MaxToolOutput = number | null;
 export type CachePrompt = "auto" | boolean | null;
 export type Verbosity = ("low" | "medium" | "high") | null;
 export type Effort = ("low" | "medium" | "high" | "max") | null;
+export type Speed = "fast" | null;
 export type ReasoningEffort =
   | ("none" | "minimal" | "low" | "medium" | "high" | "xhigh")
   | null;
@@ -227,6 +228,7 @@ export type InputTokensCacheWrite = number | null;
 export type InputTokensCacheRead = number | null;
 export type ReasoningTokens1 = number | null;
 export type TotalCost = number | null;
+export type Speed1 = string | null;
 export type Message = string;
 export type Traceback = string;
 export type TracebackAnsi = string;
@@ -836,6 +838,7 @@ export type Content7 = (TimelineEvent | TimelineSpan)[];
 export type Branches = TimelineBranch[];
 export type Description4 = string | null;
 export type Utility = boolean;
+export type AgentResult = string | null;
 export type Event20 = string;
 export type Children = OutlineNode[];
 export type Nodes = OutlineNode[];
@@ -997,6 +1000,7 @@ export interface GenerateConfig {
   cache_prompt: CachePrompt;
   verbosity: Verbosity;
   effort: Effort;
+  speed: Speed;
   reasoning_effort: ReasoningEffort;
   reasoning_tokens: ReasoningTokens;
   reasoning_summary: ReasoningSummary;
@@ -1202,6 +1206,7 @@ export interface GenerateConfig1 {
   cache_prompt: CachePrompt;
   verbosity: Verbosity;
   effort: Effort;
+  speed: Speed;
   reasoning_effort: ReasoningEffort;
   reasoning_tokens: ReasoningTokens;
   reasoning_summary: ReasoningSummary;
@@ -1296,6 +1301,7 @@ export interface ModelUsage1 {
   input_tokens_cache_read: InputTokensCacheRead;
   reasoning_tokens: ReasoningTokens1;
   total_cost: TotalCost;
+  speed: Speed1;
 }
 export interface RoleUsage {
   [k: string]: ModelUsage1;
@@ -2068,6 +2074,7 @@ export interface TimelineSpan {
   branches: Branches;
   description: Description4;
   utility: Utility;
+  agent_result: AgentResult;
   outline: Outline | null;
 }
 /**

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -128,6 +128,9 @@ class GenerateConfigArgs(TypedDict, total=False):
     effort: Literal["low", "medium", "high", "max"] | None
     """Control how many tokens are used for a response, trading off between response thoroughness and token efficiency. Anthropic Claude Opus 4.5 and 4.6 only (`max` only supported on 4.6)."""
 
+    speed: Literal["fast"] | None
+    """Enable fast mode for higher output token generation speed at premium pricing. Anthropic Claude Opus 4.6 only (research preview)."""
+
     reasoning_effort: (
         Literal["none", "minimal", "low", "medium", "high", "xhigh"] | None
     )
@@ -232,6 +235,9 @@ class GenerateConfig(BaseModel):
 
     effort: Literal["low", "medium", "high", "max"] | None = Field(default=None)
     """Control how many tokens are used for a response, trading off between response thoroughness and token efficiency. Anthropic Claude Opus 4.5 and 4.6 only (`max` only supported on 4.6)."""
+
+    speed: Literal["fast"] | None = Field(default=None)
+    """Enable fast mode for higher output token generation speed at premium pricing. Anthropic Claude Opus 4.6 only (research preview)."""
 
     reasoning_effort: (
         Literal["none", "minimal", "low", "medium", "high", "xhigh"] | None

--- a/src/inspect_ai/model/_model_output.py
+++ b/src/inspect_ai/model/_model_output.py
@@ -40,6 +40,9 @@ class ModelUsage(BaseModel):
     total_cost: float | None = Field(default=None)
     """Total cost in dollars for this usage."""
 
+    speed: str | None = Field(default=None)
+    """Speed mode used for this response ('fast' or 'standard'). Anthropic Opus 4.6 only."""
+
     def __add__(self, other: "ModelUsage") -> "ModelUsage":
         def optional_sum(a: _T | None, b: _T | None) -> _T | None:
             if a is not None and b is not None:

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -434,8 +434,17 @@ class AnthropicAPI(ModelAPI):
             if _request_has_edit_compaction(request):
                 betas.append("compact-2026-01-12")
 
-            # resolve betas and extra headers
+            # resolve betas and extra headers — preserve any client default
+            # betas (e.g. oauth-2025-04-20 set via ANTHROPIC_AUTH_TOKEN)
             if len(betas) > 0:
+                client_beta = getattr(self.client, "_custom_headers", {}).get(
+                    "anthropic-beta", ""
+                )
+                if client_beta:
+                    for b in client_beta.split(","):
+                        b = b.strip()
+                        if b and b not in betas:
+                            betas.insert(0, b)
                 betas = list(dict.fromkeys(betas))  # remove duplicates
                 extra_headers["anthropic-beta"] = ",".join(betas)
             request["extra_headers"] = extra_headers
@@ -739,6 +748,17 @@ class AnthropicAPI(ModelAPI):
             if effort == "max" and not self.is_claude_4_6():
                 effort = "high"
             params["output_config"] = OutputConfigParam(effort=effort)
+
+        # fast mode (research preview) — Opus 4.6 only
+        if config.speed == "fast":
+            if not self.is_claude_4_6():
+                warn_once(
+                    logger,
+                    "Fast mode is only supported on Claude Opus 4.6. Ignoring speed='fast'.",
+                )
+            else:
+                betas.append("fast-mode-2026-02-01")
+                extra_body["speed"] = "fast"
 
         # some thinking-only stuff
         if self.is_using_thinking(config):
@@ -1963,6 +1983,7 @@ async def model_output_from_message(
                 input_tokens_cache_write=input_tokens_cache_write,
                 input_tokens_cache_read=input_tokens_cache_read,
                 reasoning_tokens=reasoning_tokens if reasoning_tokens > 0 else None,
+                speed=usage.get("speed", None),
             ),
         ),
         pause_turn,
@@ -2938,4 +2959,4 @@ def is_image_type(media_type: str) -> bool:
 
 
 def anthropic_extra_body_fields() -> list[str]:
-    return ["metadata", "service_tier"]
+    return ["metadata", "service_tier", "speed"]

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -1,4 +1,5 @@
 import types
+from typing import Any
 from unittest.mock import AsyncMock, create_autospec
 
 import pytest
@@ -45,6 +46,47 @@ def test_anthropic_effort() -> None:
         effort="low",
     )[0]
     assert log.status == "success"
+
+
+def test_anthropic_fast_mode_config_opus_4_6() -> None:
+    """Test that speed='fast' produces correct request params for Opus 4.6."""
+    import os
+
+    os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-dummy")
+    model = get_model("anthropic/claude-opus-4-6")
+    api: Any = model.api
+    config = GenerateConfig(speed="fast", max_tokens=64)
+    params, extra_body, _headers, betas = api.completion_config(config)
+    assert extra_body.get("speed") == "fast"
+    assert "fast-mode-2026-02-01" in betas
+
+
+def test_anthropic_fast_mode_config_non_4_6_ignored() -> None:
+    """Test that speed='fast' is silently ignored on non-4.6 models."""
+    import os
+
+    os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-dummy")
+    model = get_model("anthropic/claude-sonnet-4-5")
+    api: Any = model.api
+    config = GenerateConfig(speed="fast", max_tokens=64)
+    params, extra_body, _headers, betas = api.completion_config(config)
+    assert "speed" not in extra_body
+    assert "fast-mode-2026-02-01" not in betas
+
+
+def test_anthropic_fast_mode_with_effort() -> None:
+    """Test that speed='fast' and effort='low' coexist correctly."""
+    import os
+
+    os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test-dummy")
+    model = get_model("anthropic/claude-opus-4-6")
+    api: Any = model.api
+    config = GenerateConfig(speed="fast", effort="low", max_tokens=64)
+    params, extra_body, _headers, betas = api.completion_config(config)
+    assert extra_body.get("speed") == "fast"
+    assert "fast-mode-2026-02-01" in betas
+    assert "effort-2025-11-24" in betas
+    assert params.get("output_config") == {"effort": "low"}
 
 
 @skip_if_no_anthropic


### PR DESCRIPTION
## Summary

Adds support for Anthropic's [Fast Mode](https://platform.claude.com/docs/en/build-with-claude/fast-mode) (research preview), which provides 2.5x faster output token generation for Claude Opus 4.6 at premium pricing (6x standard rates).

> **Depends on #3424** (OAuth beta header fix) — should be merged first or together.

- Adds `speed: Literal["fast"] | None` to `GenerateConfig` / `GenerateConfigArgs`
- Adds `--speed [fast]` CLI option to `eval_options`
- Handles `config.speed` in `AnthropicAPI.completion_config()` — validates Opus 4.6 only, adds `fast-mode-2026-02-01` beta header + `speed: "fast"` via `extra_body`
- Surfaces `response.usage.speed` in `ModelUsage` for log inspection
- Adds `"speed"` to `anthropic_extra_body_fields()` whitelist

### Usage

```bash
inspect eval task.py --model anthropic/claude-opus-4-6 --speed fast
inspect eval task.py --model anthropic/claude-opus-4-6 --speed fast --effort low  # combine both
```

### Tests

3 unit tests added (no API key required):
- `test_anthropic_fast_mode_config_opus_4_6` — verifies correct request params
- `test_anthropic_fast_mode_config_non_4_6_ignored` — verifies graceful warning on unsupported models
- `test_anthropic_fast_mode_with_effort` — verifies speed + effort coexistence

### References

- [Anthropic Fast Mode docs](https://platform.claude.com/docs/en/build-with-claude/fast-mode)
- API: `speed: "fast"` body param + `anthropic-beta: fast-mode-2026-02-01` header
- Opus 4.6 only, not available with Batch API or Priority Tier