### PR TITLE
Add MLflow tracking hook

### DIFF
--- a/examples/hooks/mlflow_tracking.py
+++ b/examples/hooks/mlflow_tracking.py
@@ -1,0 +1,335 @@
+"""MLflow Tracking hook for Inspect AI.
+
+Logs evaluation runs, task configurations, sample scores, and model usage
+to an MLflow tracking server. Creates a parent run per eval run with nested
+child runs per task.
+
+To enable, set MLFLOW_TRACKING_URI (and optionally MLFLOW_EXPERIMENT_NAME):
+
+    export MLFLOW_TRACKING_URI="http://localhost:5000"
+    export MLFLOW_EXPERIMENT_NAME="inspect-evals"  # defaults to "inspect_ai"
+
+Then import this module before running evals:
+
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks  # noqa: F401
+
+    inspect eval my_task.py
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+import mlflow
+
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._tool import ToolEvent
+from inspect_ai.hooks import (
+    Hooks,
+    ModelUsageData,
+    RunEnd,
+    RunStart,
+    SampleEnd,
+    SampleEvent,
+    TaskEnd,
+    TaskStart,
+    hooks,
+)
+from inspect_ai.log import EvalSpec
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_log_params(params: dict[str, Any]) -> None:
+    """Log params, truncating values that exceed MLflow's 500-char limit."""
+    for key, value in params.items():
+        str_val = str(value)
+        if len(str_val) > 500:
+            str_val = str_val[:497] + "..."
+        try:
+            mlflow.log_param(key, str_val)
+        except Exception:
+            pass
+
+
+def _score_to_numeric(value: Any) -> float | None:
+    """Convert a Score value to a numeric value for MLflow metrics."""
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        # Common patterns: "C" for correct, "I" for incorrect, "P" for partial
+        mapping = {"C": 1.0, "I": 0.0, "P": 0.5, "correct": 1.0, "incorrect": 0.0}
+        return mapping.get(value)
+    return None
+
+
+@hooks(name="mlflow_tracking", description="MLflow Tracking")
+class MlflowTrackingHooks(Hooks):
+    """MLflow Tracking Hooks.
+
+    Tracks Inspect AI evaluations in MLflow with a hierarchical structure:
+    one parent run per eval invocation, with nested child runs per task.
+
+    Logs task configuration as parameters, per-sample scores as metrics,
+    and model token usage.
+
+    To enable, set MLFLOW_TRACKING_URI and optionally MLFLOW_EXPERIMENT_NAME.
+    """
+
+    def __init__(self) -> None:
+        self._parent_run: mlflow.ActiveRun | None = None
+        self._task_runs: dict[str, mlflow.ActiveRun] = {}
+        self._tasks: dict[str, EvalSpec] = {}
+        self._sample_counts: dict[str, int] = {}
+        self._model_usage: dict[str, dict[str, float]] = {}
+        self._event_counts: dict[str, dict[str, int]] = {}
+
+    def enabled(self) -> bool:
+        return os.getenv("MLFLOW_TRACKING_URI") is not None
+
+    async def on_run_start(self, data: RunStart) -> None:
+        experiment_name = os.getenv("MLFLOW_EXPERIMENT_NAME", "inspect_ai")
+        mlflow.set_experiment(experiment_name)
+
+        self._parent_run = mlflow.start_run(
+            run_name=f"inspect-{data.run_id[:8]}",
+            tags={
+                "inspect.run_id": data.run_id,
+                "inspect.task_count": str(len(data.task_names)),
+                "inspect.tasks": ", ".join(data.task_names),
+            },
+        )
+
+    async def on_run_end(self, data: RunEnd) -> None:
+        # End any remaining task runs (shouldn't happen normally)
+        for eval_id in list(self._task_runs.keys()):
+            mlflow.end_run()
+            self._task_runs.pop(eval_id, None)
+
+        # Log run-level summary on parent
+        if self._parent_run:
+            status = "FAILED" if data.exception else "FINISHED"
+            mlflow.end_run(status=status)
+            self._parent_run = None
+
+        self._tasks.clear()
+        self._sample_counts.clear()
+        self._model_usage.clear()
+        self._event_counts.clear()
+
+    async def on_task_start(self, data: TaskStart) -> None:
+        self._tasks[data.eval_id] = data.spec
+        self._sample_counts[data.eval_id] = 0
+
+        if not self._parent_run:
+            return
+
+        # Start a nested child run for this task
+        task_run = mlflow.start_run(
+            run_name=data.spec.task,
+            nested=True,
+            tags={
+                "inspect.eval_id": data.eval_id,
+                "inspect.run_id": data.run_id,
+                "inspect.task": data.spec.task,
+                "inspect.model": data.spec.model,
+            },
+        )
+        self._task_runs[data.eval_id] = task_run
+
+        # Log task configuration as parameters
+        _safe_log_params(
+            {
+                "task": data.spec.task,
+                "model": data.spec.model,
+                "task_version": str(data.spec.task_version),
+                "dataset.name": data.spec.dataset.name or "",
+                "dataset.samples": str(data.spec.dataset.samples or ""),
+                "solver": data.spec.solver or "",
+            }
+        )
+
+        # Log task args (user-provided)
+        if data.spec.task_args_passed:
+            _safe_log_params(
+                {f"task_arg.{k}": v for k, v in data.spec.task_args_passed.items()}
+            )
+
+        # Log generate config
+        config = data.spec.model_generate_config
+        gen_params: dict[str, Any] = {}
+        if config.temperature is not None:
+            gen_params["temperature"] = config.temperature
+        if config.top_p is not None:
+            gen_params["top_p"] = config.top_p
+        if config.max_tokens is not None:
+            gen_params["max_tokens"] = config.max_tokens
+        if gen_params:
+            _safe_log_params(gen_params)
+
+        # Log tags if present
+        if data.spec.tags:
+            _safe_log_params({"tags": ", ".join(data.spec.tags)})
+
+    async def on_task_end(self, data: TaskEnd) -> None:
+        eval_id = data.eval_id
+        task_run = self._task_runs.get(eval_id)
+        if not task_run:
+            return
+
+        log = data.log
+
+        # Log aggregate results
+        if log.results and log.results.scores:
+            for eval_score in log.results.scores:
+                scorer_name = eval_score.name
+                for metric_name, metric in eval_score.metrics.items():
+                    metric_key = f"{scorer_name}/{metric_name}"
+                    if isinstance(metric.value, (int, float)):
+                        try:
+                            mlflow.log_metric(metric_key, float(metric.value))
+                        except Exception:
+                            pass
+
+        # Log completion stats
+        if log.results:
+            try:
+                mlflow.log_metric("total_samples", log.results.total_samples)
+                mlflow.log_metric("completed_samples", log.results.completed_samples)
+            except Exception:
+                pass
+
+        # Log aggregate model usage from stats
+        if log.stats and log.stats.model_usage:
+            for model_name, usage in log.stats.model_usage.items():
+                prefix = f"usage/{model_name}"
+                try:
+                    mlflow.log_metric(f"{prefix}/input_tokens", usage.input_tokens)
+                    mlflow.log_metric(f"{prefix}/output_tokens", usage.output_tokens)
+                    mlflow.log_metric(f"{prefix}/total_tokens", usage.total_tokens)
+                except Exception:
+                    pass
+
+        # Log event counts
+        event_counts = self._event_counts.get(eval_id, {})
+        if event_counts:
+            try:
+                mlflow.log_metric(
+                    "total_model_calls", event_counts.get("model_calls", 0)
+                )
+                mlflow.log_metric(
+                    "total_tool_calls", event_counts.get("tool_calls", 0)
+                )
+            except Exception:
+                pass
+
+        # Log eval status
+        status = "FINISHED" if log.status == "success" else "FAILED"
+        mlflow.end_run(status=status)
+        self._task_runs.pop(eval_id, None)
+        self._tasks.pop(eval_id, None)
+        self._event_counts.pop(eval_id, None)
+
+    async def on_sample_end(self, data: SampleEnd) -> None:
+        eval_id = data.eval_id
+        if eval_id not in self._task_runs:
+            return
+
+        # Increment sample counter
+        sample_idx = self._sample_counts.get(eval_id, 0)
+        self._sample_counts[eval_id] = sample_idx + 1
+
+        sample = data.sample
+
+        # Log per-sample scores as step metrics
+        if sample.scores:
+            for scorer_name, score in sample.scores.items():
+                numeric = _score_to_numeric(score.value)
+                if numeric is not None:
+                    try:
+                        mlflow.log_metric(
+                            f"sample/{scorer_name}",
+                            numeric,
+                            step=sample_idx,
+                        )
+                    except Exception:
+                        pass
+
+        # Log sample timing
+        if sample.total_time is not None:
+            try:
+                mlflow.log_metric(
+                    "sample/total_time", sample.total_time, step=sample_idx
+                )
+            except Exception:
+                pass
+
+    async def on_sample_event(self, data: SampleEvent) -> None:
+        eval_id = data.eval_id
+        if eval_id not in self._task_runs:
+            return
+
+        # Initialize per-task event counters
+        if eval_id not in self._event_counts:
+            self._event_counts[eval_id] = {"model_calls": 0, "tool_calls": 0}
+
+        event = data.event
+        counters = self._event_counts[eval_id]
+
+        if isinstance(event, ModelEvent):
+            step = counters["model_calls"]
+            counters["model_calls"] += 1
+            try:
+                mlflow.log_metric("event/model_call", step, step=step)
+                if event.output and event.output.usage:
+                    usage = event.output.usage
+                    mlflow.log_metric(
+                        "event/input_tokens", usage.input_tokens, step=step
+                    )
+                    mlflow.log_metric(
+                        "event/output_tokens", usage.output_tokens, step=step
+                    )
+                if event.working_time is not None:
+                    mlflow.log_metric(
+                        "event/model_time", event.working_time, step=step
+                    )
+            except Exception:
+                pass
+
+        elif isinstance(event, ToolEvent):
+            step = counters["tool_calls"]
+            counters["tool_calls"] += 1
+            try:
+                mlflow.log_metric("event/tool_call", step, step=step)
+                mlflow.log_param(
+                    f"tool_call.{step}.function", event.function[:500]
+                )
+                if event.error:
+                    mlflow.log_metric("event/tool_error", 1, step=step)
+                if event.working_time is not None:
+                    mlflow.log_metric(
+                        "event/tool_time", event.working_time, step=step
+                    )
+            except Exception:
+                pass
+
+    async def on_model_usage(self, data: ModelUsageData) -> None:
+        # Accumulate model usage for the current context
+        model = data.model_name
+        if model not in self._model_usage:
+            self._model_usage[model] = {
+                "calls": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "total_duration": 0.0,
+            }
+
+        stats = self._model_usage[model]
+        stats["calls"] += 1
+        stats["input_tokens"] += data.usage.input_tokens
+        stats["output_tokens"] += data.usage.output_tokens
+        stats["total_tokens"] += data.usage.total_tokens
+        stats["total_duration"] += data.call_duration

--- a/tests/hooks/test_mlflow_tracking.py
+++ b/tests/hooks/test_mlflow_tracking.py
@@ -1,0 +1,551 @@
+"""Tests for the MLflow tracking hook."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from inspect_ai.hooks._hooks import (
+    ModelUsageData,
+    RunEnd,
+    RunStart,
+    SampleEnd,
+    SampleEvent,
+    TaskEnd,
+    TaskStart,
+)
+from inspect_ai.log._log import (
+    EvalConfig,
+    EvalDataset,
+    EvalLog,
+    EvalMetric,
+    EvalResults,
+    EvalSample,
+    EvalScore,
+    EvalSpec,
+    EvalStats,
+)
+from inspect_ai.model._model_output import ModelOutput, ModelUsage
+from inspect_ai.scorer._metric import Score
+
+
+def _make_eval_spec(
+    task: str = "test_task",
+    model: str = "openai/gpt-4",
+    eval_id: str = "eval-001",
+    run_id: str = "run-001",
+) -> EvalSpec:
+    return EvalSpec(
+        eval_id=eval_id,
+        run_id=run_id,
+        created="2026-03-06T00:00:00Z",
+        task=task,
+        model=model,
+        dataset=EvalDataset(name="test_dataset", location="test.jsonl"),
+        config=EvalConfig(),
+    )
+
+
+def _make_sample(
+    sample_id: int = 1,
+    scores: dict[str, Score] | None = None,
+    total_time: float = 1.5,
+) -> EvalSample:
+    return EvalSample(
+        id=sample_id,
+        epoch=1,
+        input="What is 2+2?",
+        target="4",
+        output=ModelOutput(),
+        scores=scores,
+        total_time=total_time,
+    )
+
+
+@pytest.fixture
+def mlflow_env(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_NAME", "test-experiment")
+
+
+def test_enabled_requires_tracking_uri(monkeypatch: pytest.MonkeyPatch):
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    assert hook.enabled() is False
+
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
+    assert hook.enabled() is True
+
+
+@pytest.mark.anyio
+async def test_run_lifecycle(mlflow_env):
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+
+    mock_run = MagicMock()
+    with patch("examples.hooks.mlflow_tracking.mlflow") as mock_mlflow:
+        mock_mlflow.start_run.return_value = mock_run
+
+        await hook.on_run_start(
+            RunStart(
+                eval_set_id=None,
+                run_id="run-abc123",
+                task_names=["task_a", "task_b"],
+            )
+        )
+
+        mock_mlflow.set_experiment.assert_called_once_with("test-experiment")
+        mock_mlflow.start_run.assert_called_once()
+        start_kwargs = mock_mlflow.start_run.call_args
+        assert "inspect-run-abc1" in start_kwargs.kwargs["run_name"]
+        assert start_kwargs.kwargs["tags"]["inspect.run_id"] == "run-abc123"
+
+        await hook.on_run_end(
+            RunEnd(
+                eval_set_id=None,
+                run_id="run-abc123",
+                exception=None,
+                logs=[],
+            )
+        )
+
+        mock_mlflow.end_run.assert_called_with(status="FINISHED")
+
+
+@pytest.mark.anyio
+async def test_run_end_with_exception(mlflow_env):
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+
+    with patch("examples.hooks.mlflow_tracking.mlflow") as mock_mlflow:
+        mock_mlflow.start_run.return_value = MagicMock()
+
+        await hook.on_run_start(
+            RunStart(eval_set_id=None, run_id="run-fail", task_names=["task_a"])
+        )
+
+        await hook.on_run_end(
+            RunEnd(
+                eval_set_id=None,
+                run_id="run-fail",
+                exception=RuntimeError("boom"),
+                logs=[],
+            )
+        )
+
+        mock_mlflow.end_run.assert_called_with(status="FAILED")
+
+
+@pytest.mark.anyio
+async def test_task_lifecycle(mlflow_env):
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+    spec = _make_eval_spec()
+
+    with patch("examples.hooks.mlflow_tracking.mlflow") as mock_mlflow:
+        mock_mlflow.start_run.return_value = MagicMock()
+
+        await hook.on_run_start(
+            RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
+        )
+
+        await hook.on_task_start(
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+            )
+        )
+
+        assert mock_mlflow.start_run.call_count == 2
+        nested_call = mock_mlflow.start_run.call_args_list[1]
+        assert nested_call.kwargs["nested"] is True
+        assert nested_call.kwargs["run_name"] == "test_task"
+
+        mock_mlflow.log_param.assert_any_call("task", "test_task")
+        mock_mlflow.log_param.assert_any_call("model", "openai/gpt-4")
+
+        results = EvalResults(
+            total_samples=10,
+            completed_samples=10,
+            scores=[
+                EvalScore(
+                    name="accuracy",
+                    scorer="accuracy",
+                    metrics={"accuracy": EvalMetric(name="accuracy", value=0.85)},
+                )
+            ],
+        )
+        log = EvalLog(
+            eval=spec,
+            status="success",
+            results=results,
+            stats=EvalStats(
+                started_at="2026-03-06T00:00:00Z",
+                completed_at="2026-03-06T00:01:00Z",
+                model_usage={
+                    "openai/gpt-4": ModelUsage(
+                        input_tokens=5000, output_tokens=1000, total_tokens=6000
+                    )
+                },
+            ),
+        )
+        await hook.on_task_end(
+            TaskEnd(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                log=log,
+            )
+        )
+
+        mock_mlflow.log_metric.assert_any_call("accuracy/accuracy", 0.85)
+        mock_mlflow.log_metric.assert_any_call("total_samples", 10)
+        mock_mlflow.log_metric.assert_any_call("completed_samples", 10)
+        mock_mlflow.log_metric.assert_any_call(
+            "usage/openai/gpt-4/input_tokens", 5000
+        )
+        mock_mlflow.log_metric.assert_any_call(
+            "usage/openai/gpt-4/output_tokens", 1000
+        )
+        mock_mlflow.end_run.assert_called_with(status="FINISHED")
+
+
+@pytest.mark.anyio
+async def test_sample_scores_logged_as_step_metrics(mlflow_env):
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+    spec = _make_eval_spec()
+
+    with patch("examples.hooks.mlflow_tracking.mlflow") as mock_mlflow:
+        mock_mlflow.start_run.return_value = MagicMock()
+
+        await hook.on_run_start(
+            RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
+        )
+        await hook.on_task_start(
+            TaskStart(
+                eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec
+            )
+        )
+
+        sample_0 = _make_sample(
+            sample_id=1,
+            scores={"accuracy": Score(value=1.0)},
+            total_time=2.0,
+        )
+        await hook.on_sample_end(
+            SampleEnd(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                sample_id="sample-0",
+                sample=sample_0,
+            )
+        )
+
+        mock_mlflow.log_metric.assert_any_call("sample/accuracy", 1.0, step=0)
+        mock_mlflow.log_metric.assert_any_call("sample/total_time", 2.0, step=0)
+
+        sample_1 = _make_sample(
+            sample_id=2,
+            scores={"accuracy": Score(value=0.0)},
+            total_time=1.0,
+        )
+        await hook.on_sample_end(
+            SampleEnd(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                sample_id="sample-1",
+                sample=sample_1,
+            )
+        )
+
+        mock_mlflow.log_metric.assert_any_call("sample/accuracy", 0.0, step=1)
+        mock_mlflow.log_metric.assert_any_call("sample/total_time", 1.0, step=1)
+
+
+def test_score_to_numeric_conversion():
+    from examples.hooks.mlflow_tracking import _score_to_numeric
+
+    assert _score_to_numeric(0.85) == 0.85
+    assert _score_to_numeric(1) == 1.0
+    assert _score_to_numeric("C") == 1.0
+    assert _score_to_numeric("I") == 0.0
+    assert _score_to_numeric("correct") == 1.0
+    assert _score_to_numeric("incorrect") == 0.0
+    assert _score_to_numeric("unknown_value") is None
+    assert _score_to_numeric(None) is None
+
+
+@pytest.mark.anyio
+async def test_model_usage_accumulation():
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+
+    await hook.on_model_usage(
+        ModelUsageData(
+            model_name="gpt-4",
+            usage=ModelUsage(input_tokens=100, output_tokens=50, total_tokens=150),
+            call_duration=0.5,
+        )
+    )
+    await hook.on_model_usage(
+        ModelUsageData(
+            model_name="gpt-4",
+            usage=ModelUsage(input_tokens=200, output_tokens=100, total_tokens=300),
+            call_duration=1.0,
+        )
+    )
+
+    assert hook._model_usage["gpt-4"]["calls"] == 2
+    assert hook._model_usage["gpt-4"]["input_tokens"] == 300
+    assert hook._model_usage["gpt-4"]["output_tokens"] == 150
+    assert hook._model_usage["gpt-4"]["total_tokens"] == 450
+    assert hook._model_usage["gpt-4"]["total_duration"] == 1.5
+
+
+@pytest.mark.anyio
+async def test_sample_without_active_task_is_ignored():
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+
+    sample = _make_sample(scores={"accuracy": Score(value=1.0)})
+
+    await hook.on_sample_end(
+        SampleEnd(
+            eval_set_id=None,
+            run_id="run-001",
+            eval_id="eval-999",
+            sample_id="sample-0",
+            sample=sample,
+        )
+    )
+
+
+@pytest.mark.anyio
+async def test_sample_event_model_call(mlflow_env):
+    from inspect_ai.event._model import ModelEvent
+    from inspect_ai.model._generate_config import GenerateConfig
+    from inspect_ai.model._model_output import ModelOutput, ModelUsage
+
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+    spec = _make_eval_spec()
+
+    with patch("examples.hooks.mlflow_tracking.mlflow") as mock_mlflow:
+        mock_mlflow.start_run.return_value = MagicMock()
+
+        await hook.on_run_start(
+            RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
+        )
+        await hook.on_task_start(
+            TaskStart(
+                eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec
+            )
+        )
+
+        model_event = ModelEvent(
+            model="openai/gpt-4",
+            input=[],
+            tools=[],
+            tool_choice="auto",
+            config=GenerateConfig(),
+            output=ModelOutput(
+                usage=ModelUsage(
+                    input_tokens=150, output_tokens=50, total_tokens=200
+                )
+            ),
+            working_time=0.8,
+        )
+
+        await hook.on_sample_event(
+            SampleEvent(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                sample_id="sample-0",
+                event=model_event,
+            )
+        )
+
+        mock_mlflow.log_metric.assert_any_call("event/model_call", 0, step=0)
+        mock_mlflow.log_metric.assert_any_call("event/input_tokens", 150, step=0)
+        mock_mlflow.log_metric.assert_any_call("event/output_tokens", 50, step=0)
+        mock_mlflow.log_metric.assert_any_call("event/model_time", 0.8, step=0)
+
+        assert hook._event_counts["eval-001"]["model_calls"] == 1
+
+
+@pytest.mark.anyio
+async def test_sample_event_tool_call(mlflow_env):
+    from inspect_ai.event._tool import ToolEvent
+
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+    spec = _make_eval_spec()
+
+    with patch("examples.hooks.mlflow_tracking.mlflow") as mock_mlflow:
+        mock_mlflow.start_run.return_value = MagicMock()
+
+        await hook.on_run_start(
+            RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
+        )
+        await hook.on_task_start(
+            TaskStart(
+                eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec
+            )
+        )
+
+        tool_event = ToolEvent(
+            id="call-001",
+            function="web_search",
+            arguments={"query": "test"},
+            working_time=1.2,
+        )
+
+        await hook.on_sample_event(
+            SampleEvent(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                sample_id="sample-0",
+                event=tool_event,
+            )
+        )
+
+        mock_mlflow.log_metric.assert_any_call("event/tool_call", 0, step=0)
+        mock_mlflow.log_param.assert_any_call("tool_call.0.function", "web_search")
+        mock_mlflow.log_metric.assert_any_call("event/tool_time", 1.2, step=0)
+
+        assert hook._event_counts["eval-001"]["tool_calls"] == 1
+
+
+@pytest.mark.anyio
+async def test_sample_event_without_active_task_is_ignored():
+    from inspect_ai.event._model import ModelEvent
+    from inspect_ai.model._generate_config import GenerateConfig
+    from inspect_ai.model._model_output import ModelOutput
+
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+
+    model_event = ModelEvent(
+        model="openai/gpt-4",
+        input=[],
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput(),
+    )
+
+    # Should not raise even with no active task
+    await hook.on_sample_event(
+        SampleEvent(
+            eval_set_id=None,
+            run_id="run-001",
+            eval_id="eval-999",
+            sample_id="sample-0",
+            event=model_event,
+        )
+    )
+
+    assert "eval-999" not in hook._event_counts
+
+
+@pytest.mark.anyio
+async def test_event_counts_logged_on_task_end(mlflow_env):
+    from inspect_ai.event._model import ModelEvent
+    from inspect_ai.event._tool import ToolEvent
+    from inspect_ai.model._generate_config import GenerateConfig
+    from inspect_ai.model._model_output import ModelOutput
+
+    from examples.hooks.mlflow_tracking import MlflowTrackingHooks
+
+    hook = MlflowTrackingHooks()
+    spec = _make_eval_spec()
+
+    with patch("examples.hooks.mlflow_tracking.mlflow") as mock_mlflow:
+        mock_mlflow.start_run.return_value = MagicMock()
+
+        await hook.on_run_start(
+            RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
+        )
+        await hook.on_task_start(
+            TaskStart(
+                eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec
+            )
+        )
+
+        # Send 2 model events and 1 tool event
+        for _ in range(2):
+            await hook.on_sample_event(
+                SampleEvent(
+                    eval_set_id=None,
+                    run_id="run-001",
+                    eval_id="eval-001",
+                    sample_id="sample-0",
+                    event=ModelEvent(
+                        model="openai/gpt-4",
+                        input=[],
+                        tools=[],
+                        tool_choice="auto",
+                        config=GenerateConfig(),
+                        output=ModelOutput(),
+                    ),
+                )
+            )
+
+        await hook.on_sample_event(
+            SampleEvent(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                sample_id="sample-0",
+                event=ToolEvent(
+                    id="call-001",
+                    function="bash",
+                    arguments={"cmd": "ls"},
+                ),
+            )
+        )
+
+        log = EvalLog(
+            eval=spec,
+            status="success",
+            results=EvalResults(total_samples=1, completed_samples=1),
+            stats=EvalStats(
+                started_at="2026-03-06T00:00:00Z",
+                completed_at="2026-03-06T00:01:00Z",
+            ),
+        )
+
+        await hook.on_task_end(
+            TaskEnd(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                log=log,
+            )
+        )
+
+        mock_mlflow.log_metric.assert_any_call("total_model_calls", 2)
+        mock_mlflow.log_metric.assert_any_call("total_tool_calls", 1)
+
+        # Event counts cleaned up after task end
+        assert "eval-001" not in hook._event_counts


### PR DESCRIPTION
Resolves #3417

Adds an MLflow tracking hook that logs Inspect evaluations as MLflow experiments. Follows the same `examples/hooks/` pattern as the existing W&B/Weave hook.

**Run hierarchy:**
- Parent MLflow run per `eval()` call
- Nested child run per task
- Step metrics per sample (scores, timing)
- Real-time event metrics via `on_sample_event` (model calls, tool usage)

## Usage

Set `MLFLOW_TRACKING_URI` and import the hook:

```python
import os
os.environ["MLFLOW_TRACKING_URI"] = "http://localhost:5000"

from examples.hooks.mlflow_tracking import MlflowTrackingHooks  # noqa: F401

from inspect_ai import Task, eval
from inspect_ai.dataset import Sample
from inspect_ai.scorer import match
from inspect_ai.solver import generate

task = Task(
    dataset=[
        Sample(input="What is 2+2? Reply with just the number.", target="4"),
        Sample(input="What is 7*8? Reply with just the number.", target="56"),
    ],
    solver=generate(),
    scorer=match(),
    name="math_arithmetic",
)

logs = eval(task, model="openai/gpt-4o-mini")
```

The hook activates automatically when `MLFLOW_TRACKING_URI` is set. Optional `MLFLOW_EXPERIMENT_NAME` defaults to `"inspect_ai"`.

## What gets logged

| Inspect event | MLflow action |
|---|---|
| `on_run_start` | Create parent run with eval metadata tags |
| `on_task_start` | Create nested child run, log task params (model, dataset, solver, scorer) |
| `on_sample_end` | Log per-sample scores as step metrics |
| `on_sample_event` | Log real-time model call tokens/timing and tool call details as step metrics |
| `on_model_usage` | Accumulate token usage across model calls |
| `on_task_end` | Log aggregate scores, total token usage, event counts; close child run |
| `on_run_end` | Close parent run with FINISHED/FAILED status |

The `on_sample_event` integration tracks `ModelEvent` (input/output tokens, call duration) and `ToolEvent` (function name, error flag, duration) as they happen during evaluation, giving step-by-step visibility into model and tool behavior in the MLflow UI.

## Screenshots

Tested locally against a real MLflow server with `openai/gpt-4o-mini` (2 tasks, 8 samples).

**Task run overview** showing metrics (scores, token usage, event counts) and tags (task name, model, dataset size):


<img width="1440" height="900" alt="02-math-run-overview" src="https://github.com/user-attachments/assets/c9bc3bf0-36c7-4600-83d1-aa15a6a0807f" />


**Model metrics tab** showing real-time step charts from `on_sample_event` (input/output tokens per model call, call duration):
<img width="1440" height="900" alt="04-math-model-metrics" src="https://github.com/user-attachments/assets/9ed455d7-1823-472f-9204-2f508e6e3f0a" />


**Parent run** with nested child runs per task:

<img width="1440" height="900" alt="08-parent-run" src="https://github.com/user-attachments/assets/1617a0b6-be6e-43fc-8507-1f260153c832" />


## Testing

12 unit tests covering the full lifecycle, event handling, score conversion, and edge cases:

```
PASSED test_enabled_requires_tracking_uri
PASSED test_run_lifecycle
PASSED test_run_end_with_exception
PASSED test_task_lifecycle
PASSED test_sample_scores_logged_as_step_metrics
PASSED test_model_usage_accumulation
PASSED test_sample_without_active_task_is_ignored
PASSED test_sample_event_model_call
PASSED test_sample_event_tool_call
PASSED test_sample_event_without_active_task_is_ignored
PASSED test_event_counts_logged_on_task_end
PASSED test_score_to_numeric_conversion
```

All 27 existing hooks tests continue to pass.