### PR TITLE
feat: Add Forge as LLM provider

### DIFF
--- a/docs/_model-providers.md
+++ b/docs/_model-providers.md
@@ -3,7 +3,7 @@
 |------------------------------------|------------------------------------|
 | Lab APIs | [OpenAI](providers.qmd#openai), [Anthropic](providers.qmd#anthropic), [Google](providers.qmd#google), [Grok](providers.qmd#grok), [Mistral](providers.qmd#mistral), [DeepSeek](providers.qmd#deepseek), [Perplexity](providers.qmd#perplexity) |
 | Cloud APIs | [AWS Bedrock](providers.qmd#aws-bedrock), [AWS SageMaker](providers.qmd#aws-sagemaker), and [Azure AI](providers.qmd#azure-ai) |
-| Open (Hosted) | [Groq](providers.qmd#groq), [Together AI](providers.qmd#together-ai), [Fireworks AI](providers.qmd#fireworks-ai), [Cloudflare](providers.qmd#cloudflare), [HF Inference Providers](providers.qmd#hf-inference-providers), [SambaNova](providers.qmd#sambanova) |
+| Open (Hosted) | [Groq](providers.qmd#groq), [Together AI](providers.qmd#together-ai), [Fireworks AI](providers.qmd#fireworks-ai), [Cloudflare](providers.qmd#cloudflare), [HF Inference Providers](providers.qmd#hf-inference-providers), [SambaNova](providers.qmd#sambanova), [Forge](providers.qmd#forge) |
 | Open (Local) | [Hugging Face](providers.qmd#hugging-face), [vLLM](providers.qmd#vllm), [Ollama](providers.qmd#ollama), [Lllama-cpp-python](providers.qmd#llama-cpp-python), [SGLang](providers.qmd#sglang), [TransformerLens](providers.qmd#transformer-lens), [nnterp](providers.qmd#nnterp) |
 
 <br/>

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1085,6 +1085,25 @@ You can enable the use of the streaming with the `openai-api` provider by passin
 $ inspect eval arc.py --model openai-api/<provider>/<model> -M stream=true
 ```
 
+## Forge
+
+To use the [Forge](https://forge.tensorblock.co) provider, install the `openai` package (which Forge provides a compatible backend for), set your credentials, and specify a model using the `--model` option:
+
+``` bash
+pip install openai
+export FORGE_API_KEY=your-forge-api-key
+inspect eval arc.py --model forge/OpenAI/gpt-4o-mini
+```
+
+Forge models use the `Provider/model-name` format (for example `OpenAI/gpt-4o-mini`) and are fully OpenAI compatible.
+
+The following environment variables are supported by the Forge provider
+
+| Variable | Description |
+|----------------------------|--------------------------------------------|
+| `FORGE_API_KEY` | API key credentials (required). |
+| `FORGE_API_BASE` | Base URL for requests (optional, defaults to `https://api.forge.tensorblock.co/v1`). |
+
 ## OpenRouter
 
 To use the [OpenRouter](https://openrouter.ai/) provider, install the `openai` package (which the OpenRouter service provides a compatible backend for), set your credentials, and specify a model using the `--model` option:

--- a/src/inspect_ai/model/_providers/forge.py
+++ b/src/inspect_ai/model/_providers/forge.py
@@ -1,0 +1,38 @@
+from typing_extensions import override
+
+from .._generate_config import GenerateConfig
+from .openai_compatible import OpenAICompatibleAPI
+from .util import model_base_url
+
+FORGE_API_BASE = "FORGE_API_BASE"
+FORGE_BASE_URL = "FORGE_BASE_URL"
+
+
+class ForgeAPI(OpenAICompatibleAPI):
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        emulate_tools: bool = False,
+    ) -> None:
+        resolved_base_url = model_base_url(base_url, [FORGE_API_BASE, FORGE_BASE_URL])
+        super().__init__(
+            model_name=model_name,
+            base_url=resolved_base_url,
+            api_key=api_key,
+            config=config,
+            service="Forge",
+            service_base_url="https://api.forge.tensorblock.co/v1",
+            emulate_tools=emulate_tools,
+        )
+
+    @override
+    def canonical_name(self) -> str:
+        """Canonical model name for model info database lookup.
+
+        Forge uses a Provider/model-name format. We preserve the provider prefix
+        to match model info entries when available.
+        """
+        return self.service_model_name()

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -197,6 +197,17 @@ def openrouter() -> type[ModelAPI]:
     return OpenRouterAPI
 
 
+@modelapi(name="forge")
+def forge() -> type[ModelAPI]:
+    # validate
+    validate_openai_client("Forge API")
+
+    # in the clear
+    from .forge import ForgeAPI
+
+    return ForgeAPI
+
+
 @modelapi(name="perplexity")
 def perplexity() -> type[ModelAPI]:
     # validate


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?
`inspect_ai` does not support Forge as a model provider.

### What is the new behavior?
Adds Forge as a new model provider by implementing `ForgeAPI` extending `OpenAICompatibleAPI`, following the same pattern as OpenRouter and Together AI providers.

### Changes
- `src/inspect_ai/model/_providers/forge.py`: New `ForgeAPI` class extending `OpenAICompatibleAPI` with Forge base URL and model name resolution
- `src/inspect_ai/model/_providers/providers.py`: Register `forge` model API provider
- `docs/providers.qmd`: Documentation for Forge provider setup and usage
- `docs/_model-providers.md`: Add Forge to supported providers table

### Usage
```bash
# Set environment variable
export FORGE_API_KEY="your-forge-api-key"

# Use with inspect eval
inspect eval --model forge/OpenAI/gpt-4o-mini
```

### Does this PR introduce a breaking change?
No. Existing functionality is unaffected.

I work at TensorBlock and will help maintain this integration.

---

## About Forge

[Forge](https://github.com/TensorBlock/forge) is an open-source middleware service for unified AI model provider management. It routes requests across 40+ AI providers with access to thousands of models through a single OpenAI-compatible API.

- Repo: https://github.com/TensorBlock/forge
- Docs: https://www.tensorblock.co/api-docs/overview