### PR TITLE
Server privilege separation for sandbox tools

### DIFF
--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -70,17 +70,22 @@ async def sandbox_with_injected_tools(
     *,
     sandbox_name: str | None = None,
     sandbox: SandboxEnvironment | None = None,
+    server_user: str | None = None,
 ) -> SandboxEnvironment:
     """Create a sandbox environment with sandbox tools injection.
 
     Args:
         sandbox_name: Optional name for the sandbox environment.
         sandbox: Optional sandbox instance to inject into directly.
+        server_user: User to run the CLI/server as. When set (e.g. "root"),
+            the transport executes CLI commands as this user, and the server
+            drops privileges to the original user for child processes.
+            When None, uses the default sandbox user (backward compatible).
 
     Returns:
         A sandbox environment with container tools injected.
     """
-    return await sandbox_with_injection(
+    result = await sandbox_with_injection(
         SandboxInjectable(
             sandbox_file_detector(SANDBOX_CLI),
             _inject_container_tools_code,
@@ -88,6 +93,9 @@ async def sandbox_with_injected_tools(
         name=sandbox_name,
         target=sandbox,
     )
+    if server_user is not None:
+        result._server_user = server_user
+    return result
 
 
 async def _inject_container_tools_code(sandbox: SandboxEnvironment) -> None:

--- a/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
+++ b/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
@@ -57,11 +57,19 @@ class SandboxJSONRPCTransport(JSONRPCTransport):
         Raises:
             RuntimeError: If the sandbox execution fails.
         """
+        original_user: str | None = transport_extra_args.get("user", None)
+        server_user = self.sandbox._server_user
+
+        # When server_user is set, run the CLI as that user (e.g. root) so the
+        # server process is protected from agent kills. Otherwise use the
+        # caller's user as before.
+        exec_user = server_user or original_user
+
         exec_result = await self.sandbox.exec(
             [self.cli, "exec"],
             input=create_json_rpc_request(method, params, is_notification),
             timeout=transport_extra_args.get("timeout", None),
-            user=transport_extra_args.get("user", None),
+            user=exec_user,
             concurrency=transport_extra_args.get("concurrency", True),
         )
 

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -99,6 +99,7 @@ class SandboxEnvironment(abc.ABC):
     def __init__(self) -> None:
         self._tools_injected = False
         self._inject_lock = anyio.Lock()
+        self._server_user: str | None = None
 
     @abc.abstractmethod
     async def exec(

--- a/src/inspect_ai/util/_sandbox/exec_remote.py
+++ b/src/inspect_ai/util/_sandbox/exec_remote.py
@@ -298,6 +298,8 @@ class ExecRemoteProcess:
             params["env"] = self._options.env
         if self._options.cwd:
             params["cwd"] = self._options.cwd
+        if self._options.user:
+            params["user"] = self._options.user
 
         result = await self._rpc("exec_remote_start", params, _StartResult)
         self._pid = result.pid

--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/_controller.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/_controller.py
@@ -21,6 +21,7 @@ class Controller:
         stdin_open: bool = False,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
+        user: str | None = None,
     ) -> int:
         """Create a new job and return its PID.
 
@@ -30,9 +31,10 @@ class Controller:
             stdin_open: If True, keep stdin open for later writes.
             env: Additional environment variables (merged with current env).
             cwd: Working directory for command execution.
+            user: Target user to drop privileges to before exec.
         """
         job = await Job.create(
-            command, input=input, stdin_open=stdin_open, env=env, cwd=cwd
+            command, input=input, stdin_open=stdin_open, env=env, cwd=cwd, user=user
         )
         self._jobs[job.pid] = job
         return job.pid

--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/_job.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/_job.py
@@ -1,12 +1,56 @@
 import asyncio
 import os
+import pwd
 import signal
 from asyncio.subprocess import Process as AsyncIOProcess
+from collections.abc import Callable
 from typing import Literal
 
 from inspect_sandbox_tools._util.common_types import ToolException
 
 from .tool_types import PollResult
+
+
+def _make_preexec_fn(user: str | None) -> Callable[[], None]:
+    """Create a preexec_fn that sets OOM score and optionally drops privileges.
+
+    Called in the child process after fork() but before exec(). Sets
+    oom_score_adj to make child the preferred OOM target, and when running
+    as root with a target user, drops privileges so the child runs as that user.
+
+    Args:
+        user: Target user to drop privileges to. If None or not running as
+            root, only OOM score adjustment is performed.
+    """
+
+    def preexec() -> None:
+        # Make child the preferred OOM-kill target
+        try:
+            with open("/proc/self/oom_score_adj", "w") as f:
+                f.write("1000")
+        except OSError:
+            pass
+
+        # Drop privileges if running as root and a target user is specified
+        if user and os.getuid() == 0:
+            try:
+                pw = pwd.getpwnam(user)
+                os.setgid(pw.pw_gid)
+                os.initgroups(user, pw.pw_gid)
+                os.environ["HOME"] = pw.pw_dir
+                os.environ["USER"] = user
+                os.environ["LOGNAME"] = user
+                os.setuid(pw.pw_uid)
+            except (KeyError, OSError) as e:
+                # Never run a child as root when a user was explicitly
+                # requested. A partial setgid/setuid leaves the process in
+                # an inconsistent state, so fail hard.
+                os.write(
+                    2, f"inspect: privilege drop failed for '{user}': {e}\n".encode()
+                )
+                os._exit(126)
+
+    return preexec
 
 
 class Job:
@@ -26,6 +70,7 @@ class Job:
         stdin_open: bool = False,
         env: dict[str, str] | None = None,
         cwd: str | None = None,
+        user: str | None = None,
     ) -> "Job":
         """Create and start a new Job for the given command.
 
@@ -40,6 +85,7 @@ class Job:
                 for later write_stdin()/close_stdin() calls.
             env: Additional environment variables (merged with current env).
             cwd: Working directory for command execution.
+            user: Target user to drop privileges to before exec.
         """
         # Use stdin=PIPE if we have input to send or if stdin should stay open
         stdin = asyncio.subprocess.PIPE if (input is not None or stdin_open) else None
@@ -55,19 +101,25 @@ class Job:
             start_new_session=True,
             env=subprocess_env,
             cwd=cwd,
+            preexec_fn=_make_preexec_fn(user),
         )
 
         job = cls(process)
 
-        # Write initial input if provided
-        if input is not None and process.stdin is not None:
-            process.stdin.write(input.encode("utf-8"))
-            await process.stdin.drain()
+        # Write initial input if provided. The write can fail with
+        # BrokenPipeError if the child died in preexec_fn (e.g. privilege
+        # drop failure). That's fine — the caller will see the exit code.
+        try:
+            if input is not None and process.stdin is not None:
+                process.stdin.write(input.encode("utf-8"))
+                await process.stdin.drain()
 
-        # Close stdin unless caller wants it kept open
-        if not stdin_open and process.stdin is not None:
-            process.stdin.close()
-            await process.stdin.wait_closed()
+            # Close stdin unless caller wants it kept open
+            if not stdin_open and process.stdin is not None:
+                process.stdin.close()
+                await process.stdin.wait_closed()
+        except (BrokenPipeError, ConnectionResetError, OSError):
+            pass
 
         return job
 

--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/json_rpc_methods.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/json_rpc_methods.py
@@ -25,6 +25,7 @@ async def exec_remote_start(params: SubmitParams) -> SubmitResult:
         stdin_open=params.stdin_open,
         env=params.env,
         cwd=params.cwd,
+        user=params.user,
     )
     return SubmitResult(pid=pid)
 

--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/tool_types.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_remote_tools/_exec_remote/tool_types.py
@@ -15,6 +15,9 @@ class SubmitParams(BaseModel):
     """Additional environment variables (merged with the current environment)."""
     cwd: str | None = None
     """Working directory for command execution."""
+    user: str | None = None
+    """User to run the command as. When the server runs as root, it drops
+    privileges to this user before exec. Ignored when server is not root."""
     model_config = {"extra": "forbid"}
 
 

--- a/src/inspect_sandbox_tools/tests/test_job_preexec.py
+++ b/src/inspect_sandbox_tools/tests/test_job_preexec.py
@@ -1,0 +1,65 @@
+from unittest.mock import MagicMock, patch
+
+from inspect_sandbox_tools._remote_tools._exec_remote._job import _make_preexec_fn
+
+
+def test_make_preexec_fn_no_user_still_sets_oom():
+    """When user is None, preexec_fn only sets oom_score_adj."""
+    fn = _make_preexec_fn(None)
+    with patch("builtins.open", MagicMock()):
+        with patch("os.getuid", return_value=0):
+            fn()  # should not call setuid/setgid
+
+
+def test_make_preexec_fn_with_user_when_root():
+    """When user is set and we're root, preexec_fn drops privileges and sets env."""
+    fn = _make_preexec_fn("testuser")
+    mock_pw = MagicMock()
+    mock_pw.pw_uid = 1000
+    mock_pw.pw_gid = 1000
+    mock_pw.pw_dir = "/home/testuser"
+    mock_environ = {"HOME": "/root", "USER": "root", "LOGNAME": "root"}
+    with patch("builtins.open", MagicMock()):
+        with patch("os.getuid", return_value=0):
+            with patch("pwd.getpwnam", return_value=mock_pw) as mock_getpw:
+                with patch("os.setgid") as mock_setgid:
+                    with patch("os.initgroups") as mock_initgroups:
+                        with patch("os.setuid") as mock_setuid:
+                            with patch.dict("os.environ", mock_environ):
+                                fn()
+                                mock_getpw.assert_called_once_with("testuser")
+                                mock_setgid.assert_called_once_with(1000)
+                                mock_initgroups.assert_called_once_with(
+                                    "testuser", 1000
+                                )
+                                mock_setuid.assert_called_once_with(1000)
+                                import os
+
+                                assert os.environ["HOME"] == "/home/testuser"
+                                assert os.environ["USER"] == "testuser"
+                                assert os.environ["LOGNAME"] == "testuser"
+
+
+def test_make_preexec_fn_user_not_found_exits_with_message():
+    """When target user doesn't exist, preexec_fn writes stderr and calls os._exit."""
+    fn = _make_preexec_fn("nonexistent")
+    with patch("builtins.open", MagicMock()):
+        with patch("os.getuid", return_value=0):
+            with patch("pwd.getpwnam", side_effect=KeyError("nonexistent")):
+                with patch("os._exit") as mock_exit:
+                    with patch("os.write") as mock_write:
+                        fn()
+                        mock_write.assert_called_once()
+                        assert mock_write.call_args[0][0] == 2  # stderr fd
+                        assert b"nonexistent" in mock_write.call_args[0][1]
+                        mock_exit.assert_called_once_with(126)
+
+
+def test_make_preexec_fn_with_user_when_not_root():
+    """When user is set but we're not root, preexec_fn skips privilege drop."""
+    fn = _make_preexec_fn("testuser")
+    with patch("builtins.open", MagicMock()):
+        with patch("os.getuid", return_value=1000):
+            with patch("os.setuid") as mock_setuid:
+                fn()
+                mock_setuid.assert_not_called()

--- a/tests/util/sandbox/test_server_user.py
+++ b/tests/util/sandbox/test_server_user.py
@@ -1,0 +1,72 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+from inspect_ai.util._sandbox._json_rpc_transport import SandboxJSONRPCTransport
+
+
+async def test_transport_uses_server_user_for_exec():
+    """When server_user is set, CLI runs as server_user."""
+    sandbox = MagicMock()
+    sandbox._server_user = "root"
+    sandbox.exec = AsyncMock(
+        return_value=MagicMock(
+            success=True, stdout='{"jsonrpc":"2.0","id":1,"result":{}}'
+        )
+    )
+
+    transport = SandboxJSONRPCTransport(sandbox, "/opt/inspect-sandbox-tools")
+    await transport(
+        method="test_method",
+        params={"command": "echo hello"},
+        is_notification=False,
+        user="agent_user",
+    )
+
+    call_kwargs = sandbox.exec.call_args
+    assert call_kwargs.kwargs.get("user") == "root"
+
+
+async def test_transport_does_not_inject_user_into_params():
+    """Transport must not add user to RPC params (methods have extra=forbid)."""
+    sandbox = MagicMock()
+    sandbox._server_user = "root"
+    sandbox.exec = AsyncMock(
+        return_value=MagicMock(
+            success=True, stdout='{"jsonrpc":"2.0","id":1,"result":{}}'
+        )
+    )
+
+    transport = SandboxJSONRPCTransport(sandbox, "/opt/inspect-sandbox-tools")
+    await transport(
+        method="bash_session_interact",
+        params={"session_name": "default", "input": "ls"},
+        is_notification=False,
+        user="agent_user",
+    )
+
+    call_kwargs = sandbox.exec.call_args
+    rpc_input = call_kwargs.kwargs.get("input")
+    rpc_body = json.loads(rpc_input)
+    assert "user" not in rpc_body["params"]
+
+
+async def test_transport_no_server_user_backward_compat():
+    """Without server_user, transport behaves as before."""
+    sandbox = MagicMock()
+    sandbox._server_user = None
+    sandbox.exec = AsyncMock(
+        return_value=MagicMock(
+            success=True, stdout='{"jsonrpc":"2.0","id":1,"result":{}}'
+        )
+    )
+
+    transport = SandboxJSONRPCTransport(sandbox, "/opt/inspect-sandbox-tools")
+    await transport(
+        method="test_method",
+        params={"command": "echo hello"},
+        is_notification=False,
+        user="agent_user",
+    )
+
+    call_kwargs = sandbox.exec.call_args
+    assert call_kwargs.kwargs.get("user") == "agent_user"


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The sandbox tools server (`inspect-sandbox-tools`) runs as the same user as agent-spawned processes. An agent can discover and kill the server process by scanning `/proc/*/fd` for socket inodes and sending `kill -9` to the owning PIDs. Once the server is killed, all stateful tools (bash sessions, exec_remote) stop working.

### What is the new behavior?

Adds privilege separation so the server can run as a different (privileged) user while child processes run as the original (unprivileged) user:

**Host side (`inspect_ai`):**
- `sandbox_with_injected_tools()` accepts a `server_user` parameter, stored on the sandbox as `_server_user`
- Transport layer (`SandboxJSONRPCTransport`) uses `server_user` for the `exec_user` (who runs the CLI/server), without injecting `user` into RPC params (which would break methods with `extra="forbid"`)
- `ExecRemoteProcess._start()` includes `user` in the `exec_remote_start` params, so the server knows which user to drop to for child processes

**Server side (`inspect_sandbox_tools`):**
- `SubmitParams` has a new optional `user` field, threaded through Controller to Job
- `_make_preexec_fn(user)` runs after `fork()` / before `exec()`:
  - Sets `oom_score_adj=1000` (child is preferred OOM-kill target)
  - When running as root with a target user: drops privileges via `setgid` → `initgroups` → env vars (`HOME`/`USER`/`LOGNAME`) → `setuid`
  - On failure: writes diagnostic to stderr and calls `os._exit(126)` (never runs a child as root when a user was requested)
- Stdin writes wrapped in `try/except` for `BrokenPipeError` (child can die in `preexec_fn` before parent writes)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The `server_user` parameter defaults to `None`, which preserves existing behavior. The `user` field in `SubmitParams` is optional with a default of `None`. No existing callers need changes.

### Other information:

**Test coverage:**
- `tests/util/sandbox/test_server_user.py`: 3 transport-level tests (server_user for exec, no user injection into params, backward compat)
- `src/inspect_sandbox_tools/tests/test_job_preexec.py`: 4 unit tests for `_make_preexec_fn` (OOM-only, privilege drop, user not found, non-root skip)

**Architecture note:** There are two distinct "user" concepts:
1. `exec_user` (transport level): who runs the CLI process — controlled by `server_user`
2. `params.user` (method level): who the server drops privileges to for child processes — set by `_start()`

These are kept deliberately separate to avoid leaking user info into RPC methods that don't expect it.