### PR TITLE
fix(google): include images from tool results for non-computer-use models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Task Execution: Defer loading full task states until samples actually execute, reduding sample memory usage from O(total_samples × epochs) to O(concurrent_samples).
 - Task Execution: Add `--max-dataset-memory` option to limit the size of datasets held in memory during execution. When exceeded, samples are paged to disk.
 - Inspect Score: Add support for an optional list of metrics when rescoring a log.
+- Google: Include images from tool results in API requests for non-computer-use models.
 - Bugfix: Handle dicts with numeric keys in json_changes.
 
 ## 0.3.189 (07 March 2026)

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -1140,16 +1140,24 @@ async def content(
                 if message.tool_call_id
                 else "computer"
             )
-            response_parts = await computer_tool_result_parts(message)
+            # Computer-use models support multimodal function responses.
+            fn_response_parts = await computer_tool_result_parts(message)
         else:
             response_name = message.function or ""
-            response_parts = None
+            fn_response_parts = None
         response = FunctionResponse(
             name=response_name,
             response=response_dict,
-            parts=response_parts,
+            parts=fn_response_parts,
         )
-        return Content(role="user", parts=[Part(function_response=response)])
+        parts: list[Part] = [Part(function_response=response)]
+        # For non-computer tools, include images as sibling content parts
+        # since most models don't support multimodal function responses.
+        if message.function != "computer" and isinstance(message.content, list):
+            for item in message.content:
+                if isinstance(item, ContentImage):
+                    parts.append(await content_part(client, item))
+        return Content(role="user", parts=parts)
 
 
 async def content_part(client: Client, content: InspectContent | str) -> Part:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When a tool returns a `ContentImage` (e.g. a camera tool returning a photo), the image data is discarded for non-computer-use Google models. Only the text portion of the tool result is sent in the `FunctionResponse`, so the model cannot see the image.

### What is the new behavior?

Images from tool results are included as sibling `Part` objects in the `Content` alongside the `FunctionResponse`. This avoids the "Multimodal function responses are not supported" error that occurs when using `FunctionResponse.parts` with standard models like `gemini-2.5-pro`, while still delivering the image to the model.

Computer-use models continue to use `FunctionResponse.parts` as before.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Tested with `google/gemini-2.5-pro` using a tool that returns a `ContentImage` of balloons.