### PR TITLE
fix: add file size clamping to aiohttp server's /log-bytes endpoint

### DIFF
--- a/src/inspect_ai/_view/server.py
+++ b/src/inspect_ai/_view/server.py
@@ -119,7 +119,18 @@ def view_server(
             return web.HTTPBadRequest(reason="No 'end' query param")
         start = int(start_param)
         end = int(end_param)
-        body = await get_log_bytes(file, start, end)
+
+        # Get actual file size to clamp the requested range
+        file_size = await get_log_size(file)
+
+        if start >= file_size:
+            raise web.HTTPRequestRangeNotSatisfiable(
+                headers={"Content-Range": f"bytes */{file_size}"}
+            )
+
+        actual_end = min(end, file_size - 1)
+
+        body = await get_log_bytes(file, start, actual_end)
         return web.Response(
             body=body,
             headers={"Content-Length": str(len(body))},


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The aiohttp `server.py`'s `/api/log-bytes` endpoint passes the raw `start`/`end` query params directly to `get_log_bytes` without validating them against actual file size. This was fixed in `fastapi_server.py` in #2946 and #3258 but never ported to `server.py`.

### What is the new behavior?

- Clamps `end` to `min(end, file_size - 1)` to prevent requesting bytes beyond the file
- Returns HTTP 416 (Range Not Satisfiable) when `start >= file_size`

This brings `server.py` to parity with `fastapi_server.py`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information: