### PR TITLE
Catch `NotADirectoryError` when locating sandbox tools binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Google: Include images from tool results in API requests for non-computer-use models.
 - Bugfix: Handle dicts with numeric keys in json_changes.
 - Bugfix: Raise error when computer use is requested with an incompatible model/bridge combination.
+- Bugfix: Catch `NotADirectoryError` when locating sandbox tools binary so S3 download/build fallbacks run on Python < 3.13.
 
 ## 0.3.190 (11 March 2026)
 

--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -162,7 +162,7 @@ async def _open_executable_for_arch(
                 trace_message(logger, TRACE_SANDBOX_TOOLS, f"found {executable_name}")
                 yield executable_name, f
                 return
-        except (FileNotFoundError, ModuleNotFoundError):
+        except (FileNotFoundError, ModuleNotFoundError, NotADirectoryError):
             if install_state == "pypi":
                 msg = f"Tool support executable {executable_name} is missing from the PyPI package installation. This indicates a problem with the package. Please reinstall inspect_ai."
                 # TODO: once we get the github CI/CD actions robust, this should be fatal


### PR DESCRIPTION
## Summary

When `binaries/` doesn't exist (expected for a git install), `resources.path("inspect_ai.binaries", ...)` should raise `ModuleNotFoundError`, which we catch and fall back to downloading from S3 or building locally.

However, on Python < 3.13, `importlib.resources` can raise `NotADirectoryError` instead (via `MultiplexedPath`). We don't catch that exception, so the fallback logic never runs.

This appears to require `inspect_ai.binaries` having been imported earlier as a namespace package with a cached path that later becomes invalid (e.g., if the `binaries/` directory existed briefly and was then removed). I could only reproduce the error by artificially creating and then deleting the directory — I'm not sure what sequence of events causes it in normal usage.

The fix treats `NotADirectoryError` the same as `ModuleNotFoundError` and `FileNotFoundError`, since all three mean the binary isn't locally available and we should fall through to download/build.