### PR TITLE
Remove AudioURLChunk dropped in mistralai 2.0.1

### DIFF
--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -10,7 +10,6 @@ from mistralai.client.models import (
 )
 from mistralai.client.models import (
     AudioChunk,
-    AudioURLChunk,
     ContentChunk,
     DocumentURLChunk,
     FileChunk,
@@ -584,7 +583,7 @@ def completion_content_chunks(content: ContentChunk) -> list[Content]:
                 )
             )
         ]
-    elif isinstance(content, AudioChunk | AudioURLChunk | UnknownContentChunk):
+    elif isinstance(content, AudioChunk | UnknownContentChunk):
         raise TypeError(f"{type(content)} content is not supported by Inspect.")
 
 

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -110,7 +110,7 @@ def cf() -> type[ModelAPI]:
 def mistral() -> type[ModelAPI]:
     FEATURE = "Mistral API"
     PACKAGE = "mistralai"
-    MIN_VERSION = "2.0.0"
+    MIN_VERSION = "2.0.1"
 
     # verify we have the package
     try:


### PR DESCRIPTION
## Summary
- Remove `AudioURLChunk` import — dropped in mistralai 2.0.1 (merged into `AudioChunk`)
- Bump MIN_VERSION to 2.0.1