### PR TITLE
fix(google): handle AttributeError when API returns non-dict error body

### DIFF
--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -411,6 +411,23 @@ class GoogleGenAIAPI(ModelAPI):
                     http_hooks.end_request(request_id),
                 )
                 return self.handle_client_error(ex), model_call
+            except AttributeError as ex:
+                # The google-genai SDK raises AttributeError when the API returns an
+                # error response whose body is a plain string rather than a JSON object.
+                # In that case ClientError.__init__ calls response_json.get(...) on a
+                # str and crashes before the ClientError is ever constructed, so the
+                # real HTTP error message is lost. Surface it as a RuntimeError instead.
+                message = (
+                    f"Google API returned an error response that could not be parsed "
+                    f"(the response body may not be a JSON object). "
+                    f"This can happen when the model name is not recognised by the "
+                    f"endpoint. Detail: {ex}"
+                )
+                model_call.set_error(
+                    {"error": {"message": message}},
+                    http_hooks.end_request(request_id),
+                )
+                return RuntimeError(message), model_call
 
             assert response is not None  # mypy confused by retry loop
 


### PR DESCRIPTION
## Summary

When a Google/Gemini API endpoint returns an error response whose body is a **plain string** rather than a JSON object (e.g. a proxy returning `"model not found"`), the `google-genai` SDK crashes inside `ClientError.__init__` before the exception object is ever constructed:

```python
# google/genai/errors.py
def _get_message(self, response_json):
    return response_json.get('error', {}).get('message', None)
    #      ^^^^^^^^^^^^^^^^ AttributeError if response_json is a str
```

Because `ClientError` is never constructed, the `except ClientError` handler in `google.py` never fires. Instead, the `AttributeError` propagates up through two layers of tenacity retries and an anyio `ExceptionGroup`, completely burying the original HTTP error. The user sees:

```
AttributeError: 'str' object has no attribute 'get'
```

…with no indication of what model failed or why.

## Fix

Catch `AttributeError` alongside `ClientError` in the `generate` method and convert it to a descriptive `RuntimeError` that mentions the likely cause (unrecognised model name / non-JSON error body from endpoint).

## Testing

Reproduces when using any OpenAI-compatible proxy in front of the Google API that returns a plain-string error body for unknown model names (rather than the expected `{"error": {"message": "..."}}`).