### PR TITLE
fix: update Terminal-Bench 2.0 docs link

### DIFF
--- a/docs/evals/evals.yml
+++ b/docs/evals/evals.yml
@@ -281,6 +281,9 @@
     It measures whether an agent can execute workflows that resemble real engineering,
     data, devops, and software-automation tasks, not just text generation.
 
+    This benchmark is now run via Inspect Harbor rather than the removed inspect_evals
+    implementation.
+
     '
   group: Coding
   metadata:
@@ -295,7 +298,7 @@
   tasks:
   - terminal_bench_2
   title: 'Terminal-Bench 2.0: Terminal Mastery Challenges'
-  url: https://ukgovernmentbeis.github.io/inspect_evals/evals/coding/terminal_bench_2
+  url: https://github.com/meridianlabs-ai/inspect_harbor
 - arxiv: https://arxiv.org/abs/2311.12983
   categories:
   - Assistants

--- a/docs/evals/import.py
+++ b/docs/evals/import.py
@@ -27,7 +27,10 @@ group_order = {
 records = sorted(records, key=lambda x: group_order.get(x["group"], float('inf')))    
 
 for record in records:
-    record["url"] = f'https://ukgovernmentbeis.github.io/inspect_evals/evals/{record["group"].lower()}/{record["path"].split("/")[-1]}'
+    record["url"] = record.get(
+        "url",
+        f'https://ukgovernmentbeis.github.io/inspect_evals/evals/{record["group"].lower()}/{record["path"].split("/")[-1]}',
+    )
     record["categories"] = [record["group"]]
     if "tags" in record:
         record["categories"].extend(record["tags"])

--- a/docs/evals/listing.yml
+++ b/docs/evals/listing.yml
@@ -1303,8 +1303,10 @@
   description: |
     A popular benchmark for measuring the capabilities of agents and language models to perform realistic, end-to-end challenges in containerized environments.
     It measures whether an agent can execute workflows that resemble real engineering, data, devops, and software-automation tasks, not just text generation.
+    This benchmark is now run via Inspect Harbor rather than the removed inspect_evals implementation.
   path: src/inspect_evals/terminal_bench_2
   arxiv: https://www.tbench.ai/
+  url: https://github.com/meridianlabs-ai/inspect_harbor
   group: Coding
   contributors: ["iphan"]
   tasks:


### PR DESCRIPTION
## Summary
- replace the dead Terminal-Bench 2.0 docs link with the Inspect Harbor repository
- note in the eval description that the old inspect_evals implementation was removed
- preserve explicit per-entry URLs in `docs/evals/import.py` so this override survives future regenerations

## Validation
- `git diff --check`
- inspected the updated `docs/evals/listing.yml`, generated `docs/evals/evals.yml`, and `docs/evals/import.py` changes for consistency

Fixes #3496