### PR TITLE
bump google-genai to 1.62.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,7 +161,7 @@ dev = [
   "azure-identity",
   "azure-ai-inference",
   "fastapi",
-  "google-genai>=1.56.0",
+  "google-genai>=1.62.0",
   "griffe<=1.14.0",
   "groq>=0.28.0",
   "huggingface_hub>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1765,7 +1765,7 @@ requires-dist = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.2" },
     { name = "fastapi", marker = "extra == 'dev'" },
     { name = "fsspec", specifier = ">=2023.1.0,<=2025.9.0" },
-    { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.56.0" },
+    { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.62.0" },
     { name = "griffe", marker = "extra == 'dev'", specifier = "<=1.14.0" },
     { name = "griffe", marker = "extra == 'doc'", specifier = "<=1.14.0" },
     { name = "groq", marker = "extra == 'dev'", specifier = ">=0.28.0" },


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behaviour? (You can also link to an open issue here)

When the Google API (or a proxy in front of it) returns a json string error body instead of a JSON object, google-genai ≤ 1.59 raises a cryptic `AttributeError: 'str' object has no attribute 'get'` instead of a useful error message. The original HTTP error e.g. "model not found" is lost.

See: https://github.com/googleapis/python-genai/blob/main/CHANGELOG.md#1620-2026-02-04

We encounter this at apollo as we use a proxy between us and the providers. I assume other users of GOOGLE_BASE_URL/GOOGLE_GEMINI_BASE_URL also could face this issue. We'll also look to changing our proxy return format but this looks sensible in any case.

### What is the new behaviour?

The google-genai versions equal to or above 1.62.0 wrap `_get_message` in try/except AttributeError so non-dicts are handled gracefully. The same error now surfaces as a proper ClientError with the full message from the proxy e.g. `ClientError: 404 None. {'error': 'no route found for model "X" for user "Y"'}.`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

AFAIK no, the changes in genai all seem additive. 
`uv run -m pytest tests/model/providers/test_google.py tests/model/test_google_convert.py tests/model/test_reasoning_google.py -v --runapi` doesn't fail

### Other information:

This looks to have been fixed for other reasons in google-genai but it fixes our usecase.

Also I did not add a test here as the dependency has it and the value here seems small but happy to add if thought needed.