### PR TITLE
fix: log warning for Google image generation null inline_data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - OpenAI: Store readable reasoning text in `summary` when both text and encrypted reasoning content are provided.
 - Eval Logs: Replace '+' with '-' in eval log filenames.
+- Google: Log warning when image generation returns inline_data with null data (intermittent API issue).
 
 ## 0.3.197 (16 March 2026)
 

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -1354,6 +1354,12 @@ def completion_choice_from_candidate(
                                 )
                                 continue
                             content.append(ContentAudio(audio=data_uri, format=fmt))
+                    else:
+                        logger.warning(
+                            f"Received inline_data part with mime_type "
+                            f"'{blob.mime_type}' but data was None — "
+                            f"content dropped (intermittent API issue)."
+                        )
                 continue  # Skip other non-text/non-executable_code parts
 
             if part.code_execution_result is not None:

--- a/tests/model/test_multimodal_output.py
+++ b/tests/model/test_multimodal_output.py
@@ -104,6 +104,7 @@ async def test_openai_responses_image_generation_gpt5_with_options():
 
 @pytest.mark.slow
 @skip_if_no_google
+@flaky_retry(max_retries=3)
 async def test_google_image_generation():
     model = get_model("google/gemini-3.1-flash-image-preview")
     output = await model.generate(


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

The Google API intermittently returns `inline_data` parts with `data=None` during image generation. When this happens, image content is silently dropped and `test_google_image_generation` fails with `assert isinstance('', list)`.

### What is the new behavior?

- Logs a warning when `inline_data.data` is `None`, making the silent drop visible.
- Adds `@flaky_retry(max_retries=3)` to `test_google_image_generation` to handle known API-side flakiness (matching `test_google_image_replay` which already uses this).

### Does this PR introduce a breaking change?

No.

### Other information:

This is a known intermittent issue with the Google `generate_content` API where image responses occasionally have a null `data` field in `inline_data`.