### PR TITLE
Increase sandbox/proxy timeouts and improve proxy error logging

### DIFF
--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -216,10 +216,16 @@ async def _monitor_proxy(proxy: ExecRemoteProcess) -> None:
     async for event in proxy:
         if isinstance(event, ExecStderr):
             stderr.append(event.data)
+            logger.debug("model_proxy stderr: %s", event.data.rstrip())
         if isinstance(event, ExecCompleted):
             if not event.success:
                 raise RuntimeError(
                     f"Model proxy process exited unexpectedly with failure: {''.join(stderr)}."
+                )
+            if stderr:
+                logger.warning(
+                    "model_proxy stderr output on clean exit:\n%s",
+                    "".join(stderr).rstrip(),
                 )
             return
     # Stream ended without ExecCompleted

--- a/src/inspect_ai/agent/_bridge/sandbox/proxy.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/proxy.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import time
+import traceback
 from email.utils import formatdate
 from http import HTTPStatus
 from typing import (
@@ -29,8 +30,8 @@ MethodRoutes: TypeAlias = dict[str, RouteMap]
 # ---------- Limits / Defaults ----------
 MAX_HEADER_BYTES = 64 * 1024
 MAX_BODY_BYTES = 50 * 1024 * 1024
-READ_TIMEOUT_S = 60
-WRITE_TIMEOUT_S = 60
+READ_TIMEOUT_S = 300
+WRITE_TIMEOUT_S = 300
 STREAM_CHUNK = 8192
 
 HOP_BY_HOP = {
@@ -1842,7 +1843,8 @@ async def run_model_proxy_server(port: int) -> None:
     try:
         await server.start()
     except Exception as ex:
-        sys.stderr.write(f"Unexpected error running model proxy: {ex}")
+        sys.stderr.write(f"Unexpected error running model proxy: {ex}\n")
+        sys.stderr.write(traceback.format_exc())
         sys.stderr.flush()
         os._exit(1)
 
@@ -1862,7 +1864,8 @@ def _handle_model_proxy_error(ex: Exception) -> None:
     # returning 500 to the proxied agent. This is because we are in a
     # hard failure anyway so we need the user to see the error message
     # and have the task fail (the 500 error would just result in retries)
-    sys.stderr.write(f"Unexpected error during model proxy call: {ex}")
+    sys.stderr.write(f"Unexpected error during model proxy call: {ex}\n")
+    sys.stderr.write(traceback.format_exc())
     sys.stderr.flush()
 
 

--- a/src/inspect_ai/util/_sandbox/context.py
+++ b/src/inspect_ai/util/_sandbox/context.py
@@ -339,7 +339,7 @@ async def setup_sandbox_environment(
     # execute and then remove setup script (don't retry it on timeout
     # in case it is not idempotent)
     try:
-        await env.exec(["chmod", "+x", setup_file], timeout=30)
+        await env.exec(["chmod", "+x", setup_file], timeout=120)
         timeout = int(
             os.environ.get("INSPECT_SANDBOX_SETUP_TIMEOUT", SANDBOX_SETUP_TIMEOUT)
         )
@@ -350,7 +350,7 @@ async def setup_sandbox_environment(
             raise RuntimeError(
                 f"Failed to execute setup script for sample: {result.stderr}"
             )
-        await env.exec(["rm", setup_file], timeout=30)
+        await env.exec(["rm", setup_file], timeout=120)
     except TimeoutError:
         raise RuntimeError("Timed out executing setup command in sandbox")
 

--- a/src/inspect_ai/util/_sandbox/docker/compose.py
+++ b/src/inspect_ai/util/_sandbox/docker/compose.py
@@ -25,7 +25,7 @@ from .util import TRACE_DOCKER, ComposeProject, is_inspect_project
 logger = getLogger(__name__)
 
 # How long to wait for compose environment to pass a health check
-COMPOSE_WAIT = 120
+COMPOSE_WAIT = 600
 
 
 async def compose_up(
@@ -63,8 +63,7 @@ async def compose_down(project: ComposeProject, quiet: bool = True) -> None:
 
     # shut down docker containers. default internal timeout is 10 seconds
     # but we've seen reports of this handing, so add a proess timeout
-    # of 60 seconds for belt and suspenders
-    TIMEOUT = 60
+    TIMEOUT = 300
     try:
         result = await compose_command(
             ["down", "--volumes"],
@@ -102,7 +101,7 @@ async def compose_cp(
     result = await compose_command(
         ["cp", "-L", "--", src, dest],
         project=project,
-        timeout=120,  # 2-minute timeout for file copies
+        timeout=600,  # 10-minute timeout for file copies
         cwd=cwd,
         output_limit=output_limit,
     )
@@ -146,7 +145,7 @@ async def compose_ps(
         command.append("--all")
     if status:
         command = command + ["--status", status]
-    result = await compose_command(command, project=project, timeout=60)
+    result = await compose_command(command, project=project, timeout=300)
     if not result.success:
         msg = f"Error querying for running services: {result.stderr}"
         raise RuntimeError(msg)
@@ -208,7 +207,7 @@ async def compose_exec(
 
 
 async def compose_services(project: ComposeProject) -> dict[str, ComposeService]:
-    result = await compose_command(["config"], project=project, timeout=60)
+    result = await compose_command(["config"], project=project, timeout=300)
     if not result.success:
         raise RuntimeError(f"Error reading docker config: {result.stderr}")
     return cast(dict[str, ComposeService], yaml.safe_load(result.stdout)["services"])

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -90,7 +90,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
             await compose_build(project)
 
             # cleanup images created during build
-            await compose_cleanup_images(project, timeout=60)
+            await compose_cleanup_images(project, timeout=300)
 
             services = await compose_services(project)
             for name, service in services.items():
@@ -325,7 +325,7 @@ class DockerSandboxEnvironment(SandboxEnvironment):
     @override
     async def write_file(self, file: str, contents: str | bytes) -> None:
         # defualt timeout for write_file operations
-        TIMEOUT = 180
+        TIMEOUT = 600
 
         # resolve relative file paths
         file = self.container_file(file)

--- a/src/inspect_ai/util/_sandbox/recon.py
+++ b/src/inspect_ai/util/_sandbox/recon.py
@@ -45,7 +45,7 @@ fi
 
 async def _sandbox_exec(sandbox: SandboxEnvironment, command: str) -> str:
     """Execute a command in the container and return the output."""
-    result = await sandbox.exec(["sh", "-c", command], timeout=30)
+    result = await sandbox.exec(["sh", "-c", command], timeout=120)
     if not result.success:
         raise RuntimeError(
             f"Error executing command {' '.join(command)}: {result.stderr}"

--- a/src/inspect_ai/util/_sandbox/service.py
+++ b/src/inspect_ai/util/_sandbox/service.py
@@ -388,7 +388,7 @@ class SandboxService:
     async def _exec(self, cmd: list[str], input: str | None = None) -> ExecResult[str]:
         try:
             return await self._sandbox.exec(
-                cmd, user=self._user, input=input, timeout=120, concurrency=False
+                cmd, user=self._user, input=input, timeout=600, concurrency=False
             )
         except TimeoutError:
             raise RuntimeError(

--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_agent_bridge/proxy.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_agent_bridge/proxy.py
@@ -8,6 +8,7 @@ import os
 import re
 import sys
 import time
+import traceback
 from email.utils import formatdate
 from http import HTTPStatus
 from typing import (
@@ -29,8 +30,8 @@ MethodRoutes: TypeAlias = dict[str, RouteMap]
 # ---------- Limits / Defaults ----------
 MAX_HEADER_BYTES = 64 * 1024
 MAX_BODY_BYTES = 50 * 1024 * 1024
-READ_TIMEOUT_S = 60
-WRITE_TIMEOUT_S = 60
+READ_TIMEOUT_S = 300
+WRITE_TIMEOUT_S = 300
 STREAM_CHUNK = 8192
 
 HOP_BY_HOP = {
@@ -1919,7 +1920,8 @@ async def run_model_proxy_server() -> None:
     try:
         await server.start()
     except Exception as ex:
-        sys.stderr.write(f"Unexpected error running model proxy: {ex}")
+        sys.stderr.write(f"Unexpected error running model proxy: {ex}\n")
+        sys.stderr.write(traceback.format_exc())
         sys.stderr.flush()
         os._exit(1)
 
@@ -1939,7 +1941,8 @@ def _handle_model_proxy_error(ex: Exception) -> None:
     # returning 500 to the proxied agent. This is because we are in a
     # hard failure anyway so we need the user to see the error message
     # and have the task fail (the 500 error would just result in retries)
-    sys.stderr.write(f"Unexpected error during model proxy call: {ex}")
+    sys.stderr.write(f"Unexpected error during model proxy call: {ex}\n")
+    sys.stderr.write(traceback.format_exc())
     sys.stderr.flush()
 
 

--- a/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_cli/main.py
+++ b/src/inspect_sandbox_tools/src/inspect_sandbox_tools/_cli/main.py
@@ -104,7 +104,7 @@ def _ensure_server_is_running() -> None:
     )
 
     # Wait for socket to become available
-    for _ in range(1200):  # Wait up to 120 seconds
+    for _ in range(6000):  # Wait up to 600 seconds
         if _can_connect_to_socket():
             return
         # Detect early crash — no point waiting 20s if the process already exited


### PR DESCRIPTION
## Summary

- Bumps timeouts across the sandbox stack (compose up/down/cp/ps, sandbox exec, setup scripts, service RPCs, `write_file`, proxy read/write, and CLI socket startup wait) to more generous values for slower infrastructure (e.g. SWE-bench via inspect-swe with Docker Compose).
- Adds full `traceback.format_exc()` to model proxy stderr error handlers in both the `inspect_ai` and `inspect_sandbox_tools` proxy copies.
- Logs `model_proxy` stderr at `debug` level as it arrives, plus a `warning` on clean exit when any stderr was collected, making sandbox proxy debugging easier.

## Timeout changes

| Location | Old | New |
|----------|-----|-----|
| Proxy `READ_TIMEOUT_S` / `WRITE_TIMEOUT_S` | 60s | 300s |
| `COMPOSE_WAIT` (health check) | 120s | 600s |
| `compose_down` | 60s | 300s |
| `compose_cp` | 120s | 600s |
| `compose_ps` / `compose_services` / `compose_config` | 60s | 300s |
| `compose_cleanup_images` | 60s | 300s |
| `write_file` | 180s | 600s |
| Sandbox setup `chmod`/`rm` | 30s | 120s |
| `_sandbox_exec` (recon) | 30s | 120s |
| `SandboxService._exec` | 120s | 600s |
| CLI socket startup wait | 120s | 600s |

## Test plan

- [ ] Run an eval with Docker Compose sandbox to verify no regressions
- [ ] Confirm proxy errors now show full tracebacks in stderr