### PR TITLE
Fix InterCode CTF full source code link

### DIFF
--- a/docs/tutorial.qmd
+++ b/docs/tutorial.qmd
@@ -528,7 +528,7 @@ The [InterCode CTF](https://intercode-benchmark.github.io/#ctf) dataset contains
 
 The definition of the task calls out to a couple of helper functions that do most of the heavy lifting:
 
-1) `read_dataset()`, which reads samples from the file system. Note that samples include both instructions and files to copy into the secure sandbox. See the [full source code](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/gdm_capabilities/intercode_ctf) of this example for details.
+1) `read_dataset()`, which reads samples from the file system. Note that samples include both instructions and files to copy into the secure sandbox. See the [full source code](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/gdm_intercode_ctf) of this example for details.
 
 2. `ctf_agent()`, which defines an agent that will be use as the task's solver. The agent consists principally of using `bash()` and `python()` tools in a loop until the flag is discovered. We'll describe this function in more detail below.
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The [current link](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/gdm_capabilities/intercode_ctf) 404s

### What is the new behavior?

This [new link](https://github.com/UKGovernmentBEIS/inspect_evals/tree/main/src/inspect_evals/gdm_intercode_ctf) works!

### Other information:

It looks like this moved in https://github.com/UKGovernmentBEIS/inspect_evals/pull/917
