### PR TITLE
Submodule guard for ts-mono migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Inspect View: Move log viewer frontend from `src/inspect_ai/_view/www/` into `ts-mono/apps/inspect/` monorepo (pnpm + Vite + Jest). Built assets are copied to `src/inspect_ai/_view/dist/` via a Vite plugin. No user-facing changes.
 - Approval: New `read_approval_policies()` function for reading approval policies from a config file.
 - Cache results of `parse_tool_info()` to improve performance when there are many tools defined.
 - Cache Pydantic TypeAdapters in condense_events for performance.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The web UI lives in a git submodule at `src/inspect_ai/_view/ts-mono/`. **These 
 
 Initialize the submodule and install dependencies — see the [one-time setup guide](src/inspect_ai/_view/ts-mono/docs/submodule-guide.md#one-time-setup).
 
-***
+### Documentation
 
 To work on the Inspect documentation, install the optional `[doc]` dependencies with the `-e` flag and build the docs:
 

--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -253,15 +253,28 @@ def types() -> None:
     print(view_type_resource("log.d.ts"))
 
 
+_TS_MONO_APP = PKG_PATH / "_view" / "ts-mono" / "apps" / "inspect"
+
+_SUBMODULE_MSG = (
+    "ts-mono submodule not initialized. "
+    "Run 'git submodule update --init' to set it up."
+)
+
+
+def _require_submodule() -> None:
+    if not (_TS_MONO_APP / "src").exists():
+        raise RuntimeError(_SUBMODULE_MSG)
+
+
 def view_resource(file: str) -> str:
-    resource = PKG_PATH / "_view" / "ts-mono" / "apps" / "inspect" / file
+    _require_submodule()
+    resource = _TS_MONO_APP / file
     with open(resource, "r", encoding="utf-8") as f:
         return f.read()
 
 
 def view_type_resource(file: str) -> str:
-    resource = (
-        PKG_PATH / "_view" / "ts-mono" / "apps" / "inspect" / "src" / "@types" / file
-    )
+    _require_submodule()
+    resource = _TS_MONO_APP / "src" / "@types" / file
     with open(resource, "r", encoding="utf-8") as f:
         return f.read()

--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -256,8 +256,7 @@ def types() -> None:
 _TS_MONO_APP = PKG_PATH / "_view" / "ts-mono" / "apps" / "inspect"
 
 _SUBMODULE_MSG = (
-    "ts-mono submodule not initialized. "
-    "Run 'git submodule update --init' to set it up."
+    "ts-mono submodule not initialized. Run 'git submodule update --init' to set it up."
 )
 
 

--- a/tests/cli/test_log.py
+++ b/tests/cli/test_log.py
@@ -1,6 +1,11 @@
-from inspect_ai._cli.log import view_type_resource
+import pytest
+
+from inspect_ai._cli.log import _TS_MONO_APP, view_type_resource
+
+_submodule_missing = not (_TS_MONO_APP / "src").exists()
 
 
+@pytest.mark.skipif(_submodule_missing, reason="ts-mono submodule not initialized")
 def test_view_type_resource():
     ts_types = view_type_resource("log.d.ts")
     assert isinstance(ts_types, str)


### PR DESCRIPTION
## Summary
Follow-up to #3567 (move `www/` into `ts-mono` monorepo).

- `view_resource` / `view_type_resource` raise `RuntimeError` with setup instructions when ts-mono submodule is missing
- `test_view_type_resource` skips when submodule not initialized

## Behavior after this change
- **CI**: continues to run the test — it pulls the submodule
- **Python-only devs**: no longer need the submodule to run tests
- **Runtime without submodule**: `inspect log types` raises a clear `RuntimeError` with `git submodule update --init` instructions instead of a raw `FileNotFoundError`