### PR TITLE
Auto-apply flaky_retry to external-service tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -114,6 +114,19 @@ def pytest_collection_modifyitems(config, items):
             if "flaky" in item.keywords:
                 item.add_marker(skip_flaky)
 
+    # Auto-apply flaky_retry(max_retries=3) to tests that hit external services
+    # (model providers or Docker). Decorators opt in via func._needs_flaky_retry.
+    from test_helpers.utils import flaky_retry
+
+    _retry = flaky_retry(max_retries=3)
+    for item in items:
+        fn = item.obj
+        if getattr(fn, "_needs_flaky_retry", False) and not getattr(
+            fn, "_flaky_retry", False
+        ):
+            fn._flaky_retry = True  # prevent re-wrap for parametrized variants
+            item.obj = _retry(fn)
+
 
 @pytest.fixture(scope="module")
 def mock_s3():

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -98,6 +98,7 @@ def flaky_retry(max_retries: int) -> Callable[[F], F]:
                             continue
                         raise last_exception
 
+            async_wrapper._flaky_retry = True  # type: ignore[attr-defined]
             return async_wrapper  # type: ignore
 
         @functools.wraps(func)
@@ -113,6 +114,7 @@ def flaky_retry(max_retries: int) -> Callable[[F], F]:
                         continue
                     raise last_exception
 
+        wrapper._flaky_retry = True  # type: ignore[attr-defined]
         return wrapper  # type: ignore
 
     return decorator
@@ -133,6 +135,7 @@ def skip_if_env_var(var: str, exists=True):
 
 
 def skip_if_no_groq(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("GROQ_API_KEY", exists=False)(func))
 
 
@@ -176,6 +179,7 @@ def skip_if_no_nnterp(func):
 
 
 def skip_if_no_openai(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(
         pytest.mark.skipif(
             importlib.util.find_spec("openai") is None
@@ -186,6 +190,7 @@ def skip_if_no_openai(func):
 
 
 def skip_if_no_openai_azure(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.skipif(
         importlib.util.find_spec("openai") is None
         or os.environ.get("AZUREAI_OPENAI_API_KEY") is None
@@ -195,6 +200,7 @@ def skip_if_no_openai_azure(func):
 
 
 def skip_if_no_mistral_azure(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.skipif(
         importlib.util.find_spec("mistral") is None
         or os.environ.get("AZUREAI_MISTRAL_BASE_URL") is None,
@@ -207,20 +213,24 @@ def skip_if_no_openai_package(func):
 
 
 def skip_if_no_openai_reasoning_summaries(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(
         skip_if_env_var("ENABLE_OPENAI_REASONING_SUMMARIES", exists=False)(func)
     )
 
 
 def skip_if_no_anthropic(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("ANTHROPIC_API_KEY", exists=False)(func))
 
 
 def skip_if_no_google(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("GOOGLE_API_KEY", exists=False)(func))
 
 
 def skip_if_no_mistral(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("MISTRAL_API_KEY", exists=False)(func))
 
 
@@ -230,36 +240,44 @@ def skip_if_no_mistral_package(func):
 
 def skip_if_no_grok(func):
     # gRPC is asyncio-only, so always skip under trio
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(
         skip_if_env_var("GROK_API_KEY", exists=False)(skip_if_trio(func))
     )
 
 
 def skip_if_no_cloudflare(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("CLOUDFLARE_API_KEY", exists=False)(func))
 
 
 def skip_if_no_together(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("TOGETHER_API_KEY", exists=False)(func))
 
 
 def skip_if_no_openrouter(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("OPENROUTER_API_KEY", exists=False)(func))
 
 
 def skip_if_no_together_base_url(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("TOGETHER_BASE_URL", exists=False)(func))
 
 
 def skip_if_no_fireworks(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("FIREWORKS_API_KEY", exists=False)(func))
 
 
 def skip_if_no_sambanova(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("SAMBANOVA_API_KEY", exists=False)(func))
 
 
 def skip_if_no_perplexity(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     missing_requirements = []
     if importlib.util.find_spec("openai") is None:
         missing_requirements.append("openai package")
@@ -279,24 +297,29 @@ def skip_if_no_perplexity_package(func):
 
 
 def skip_if_no_azureai(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("AZUREAI_API_KEY", exists=False)(func))
 
 
 def skip_if_no_llama_cpp_python(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(
         skip_if_env_var("ENABLE_LLAMA_CPP_PYTHON_TESTS", exists=False)(func)
     )
 
 
 def skip_if_no_bedrock(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("ENABLE_BEDROCK_TESTS", exists=False)(func))
 
 
 def skip_if_no_vertex(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("ENABLE_VERTEX_TESTS", exists=False)(func))
 
 
 def skip_if_no_hf_token(func):
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.api(skip_if_env_var("HF_TOKEN", exists=False)(func))
 
 
@@ -318,6 +341,7 @@ def skip_if_no_docker(func):
     except FileNotFoundError:
         is_docker_installed = False
 
+    func._needs_flaky_retry = True  # type: ignore[attr-defined]
     return pytest.mark.skipif(
         not is_docker_installed, reason="Test doesn't work without Docker installed."
     )(func)

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -135,7 +135,7 @@ def skip_if_env_var(var: str, exists=True):
 
 
 def skip_if_no_groq(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("GROQ_API_KEY", exists=False)(func))
 
 
@@ -179,7 +179,7 @@ def skip_if_no_nnterp(func):
 
 
 def skip_if_no_openai(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(
         pytest.mark.skipif(
             importlib.util.find_spec("openai") is None
@@ -190,7 +190,7 @@ def skip_if_no_openai(func):
 
 
 def skip_if_no_openai_azure(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.skipif(
         importlib.util.find_spec("openai") is None
         or os.environ.get("AZUREAI_OPENAI_API_KEY") is None
@@ -200,7 +200,7 @@ def skip_if_no_openai_azure(func):
 
 
 def skip_if_no_mistral_azure(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.skipif(
         importlib.util.find_spec("mistral") is None
         or os.environ.get("AZUREAI_MISTRAL_BASE_URL") is None,
@@ -213,24 +213,24 @@ def skip_if_no_openai_package(func):
 
 
 def skip_if_no_openai_reasoning_summaries(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(
         skip_if_env_var("ENABLE_OPENAI_REASONING_SUMMARIES", exists=False)(func)
     )
 
 
 def skip_if_no_anthropic(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("ANTHROPIC_API_KEY", exists=False)(func))
 
 
 def skip_if_no_google(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("GOOGLE_API_KEY", exists=False)(func))
 
 
 def skip_if_no_mistral(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("MISTRAL_API_KEY", exists=False)(func))
 
 
@@ -240,44 +240,44 @@ def skip_if_no_mistral_package(func):
 
 def skip_if_no_grok(func):
     # gRPC is asyncio-only, so always skip under trio
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(
         skip_if_env_var("GROK_API_KEY", exists=False)(skip_if_trio(func))
     )
 
 
 def skip_if_no_cloudflare(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("CLOUDFLARE_API_KEY", exists=False)(func))
 
 
 def skip_if_no_together(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("TOGETHER_API_KEY", exists=False)(func))
 
 
 def skip_if_no_openrouter(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("OPENROUTER_API_KEY", exists=False)(func))
 
 
 def skip_if_no_together_base_url(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("TOGETHER_BASE_URL", exists=False)(func))
 
 
 def skip_if_no_fireworks(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("FIREWORKS_API_KEY", exists=False)(func))
 
 
 def skip_if_no_sambanova(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("SAMBANOVA_API_KEY", exists=False)(func))
 
 
 def skip_if_no_perplexity(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     missing_requirements = []
     if importlib.util.find_spec("openai") is None:
         missing_requirements.append("openai package")
@@ -297,29 +297,29 @@ def skip_if_no_perplexity_package(func):
 
 
 def skip_if_no_azureai(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("AZUREAI_API_KEY", exists=False)(func))
 
 
 def skip_if_no_llama_cpp_python(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(
         skip_if_env_var("ENABLE_LLAMA_CPP_PYTHON_TESTS", exists=False)(func)
     )
 
 
 def skip_if_no_bedrock(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("ENABLE_BEDROCK_TESTS", exists=False)(func))
 
 
 def skip_if_no_vertex(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("ENABLE_VERTEX_TESTS", exists=False)(func))
 
 
 def skip_if_no_hf_token(func):
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.api(skip_if_env_var("HF_TOKEN", exists=False)(func))
 
 
@@ -341,7 +341,7 @@ def skip_if_no_docker(func):
     except FileNotFoundError:
         is_docker_installed = False
 
-    func._needs_flaky_retry = True  # type: ignore[attr-defined]
+    func._needs_flaky_retry = True
     return pytest.mark.skipif(
         not is_docker_installed, reason="Test doesn't work without Docker installed."
     )(func)


### PR DESCRIPTION
## Summary
- Each `skip_if_no_*` decorator for model providers and docker now sets `_needs_flaky_retry` on the test function
- `conftest.py` auto-wraps those tests with `flaky_retry(max_retries=3)` at collection time
- Tests with explicit `@flaky_retry` are not double-wrapped (sentinel attribute guard)

## Motivation
We've been chasing one-off flaky failures from model/docker stuff forever — API timeouts, Docker Hub 502s, etc. We already have `skip_if_no_*` decorators on every test that hits an external service, and we already have `flaky_retry`. This composes them so any test declaring an external dependency automatically gets retry support.