### PR TITLE
Handle Anthropic prefill rejection in handle_bad_request

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1033,8 +1033,14 @@ class AnthropicAPI(ModelAPI):
         elif "content filtering" in error:
             content = "Sorry, but I am unable to help with that request."
             stop_reason = "content_filter"
+        elif "prefill" in error:
+            # Models that don't support assistant message prefill reject
+            # requests ending with an assistant message. Return an empty
+            # response so the caller can continue rather than crashing.
+            content = ""
+            stop_reason = "stop"
 
-        if content and stop_reason:
+        if content is not None and stop_reason:
             return ModelOutput.from_content(
                 model=self.service_model_name(),
                 content=content,

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -135,6 +135,45 @@ def test_anthropic_should_retry():
     model.api.should_retry(ex)
 
 
+def test_anthropic_handle_bad_request_prefill_error() -> None:
+    """handle_bad_request returns a graceful ModelOutput for prefill errors.
+
+    When the API rejects a request because the conversation ends with an
+    assistant message (prefill not supported), the provider should return
+    an empty ModelOutput instead of propagating the exception.
+    """
+    import httpx
+    from anthropic import BadRequestError
+
+    api = AnthropicAPI(model_name="claude-sonnet-4-6", api_key="test-key")
+    response = httpx.Response(
+        status_code=400, request=httpx.Request("POST", "https://example.com")
+    )
+    ex = BadRequestError(
+        "This model does not support assistant message prefill. "
+        "The conversation must end with a user message.",
+        response=response,
+        body={
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": (
+                    "This model does not support assistant message prefill. "
+                    "The conversation must end with a user message."
+                ),
+            },
+        },
+    )
+
+    result = api.handle_bad_request(ex)
+    # Should return ModelOutput, not the exception
+    from inspect_ai.model import ModelOutput
+
+    assert isinstance(result, ModelOutput)
+    assert result.stop_reason == "stop"
+    assert result.error is not None
+
+
 @skip_if_no_anthropic
 async def test_anthropic_count_tokens_single_tool_call() -> None:
     """Test counting tokens for a single assistant message with one tool call."""


### PR DESCRIPTION
## Summary

- Catch "assistant message prefill" 400 errors in the Anthropic provider's `handle_bad_request`, returning an empty `ModelOutput` with `stop_reason="stop"` instead of crashing the sample.
- Fix `if content and stop_reason:` → `if content is not None and stop_reason:` so empty-string content is accepted.

## Context

Some Anthropic models reject requests where the conversation ends with an assistant message. This can happen when a multi-turn solver calls `generate()` without appending a user message between turns (e.g. due to an empty turn in the eval dataset). The primary fix for the case we hit belongs in `inspect_evals`, but this change makes the provider resilient to it.

## Test plan

- [x] Added `test_anthropic_handle_bad_request_prefill_error`
- [x] Existing anthropic tests pass
- [x] Ran BFCL multi-turn composite category (which triggers this path) — 20 samples, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)