### PR TITLE
Add list_by_prefix method to KVStore

### DIFF
--- a/src/inspect_ai/_util/kvstore.py
+++ b/src/inspect_ai/_util/kvstore.py
@@ -63,6 +63,15 @@ class KVStore(AbstractContextManager["KVStore"]):
         self.conn.commit()
         return cursor.rowcount > 0
 
+    def list_by_prefix(self, prefix: str) -> list[tuple[str, str]]:
+        """Return all (key, value) pairs whose key starts with prefix, newest first."""
+        escaped = prefix.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+        cursor = self.conn.execute(
+            "SELECT key, value FROM kv_store WHERE key LIKE ? ESCAPE '\\' ORDER BY created_at DESC",
+            (escaped + "%",),
+        )
+        return cursor.fetchall()
+
     def count(self) -> int:
         cursor = self.conn.execute("SELECT COUNT(*) FROM kv_store")
         return cast(int, cursor.fetchone()[0])

--- a/tests/util/test_kvstore.py
+++ b/tests/util/test_kvstore.py
@@ -135,6 +135,36 @@ def test_kvstore_multiple_rotations(db_path: Path) -> None:
         assert store.get("key4") == "value4"
 
 
+def test_kvstore_list_by_prefix(store: KVStore) -> None:
+    with store:
+        store.put("a:1", "v1")
+        store.put("a:2", "v2")
+        store.put("b:1", "v3")
+
+        results = store.list_by_prefix("a:")
+        assert len(results) == 2
+        assert {k for k, _ in results} == {"a:1", "a:2"}
+        # Should not include "b:1"
+        assert all(k.startswith("a:") for k, _ in results)
+
+
+def test_kvstore_list_by_prefix_empty(store: KVStore) -> None:
+    with store:
+        store.put("a:1", "v1")
+        assert store.list_by_prefix("z:") == []
+
+
+def test_kvstore_list_by_prefix_special_chars(store: KVStore) -> None:
+    with store:
+        store.put("100%_done:1", "v1")
+        store.put("100%_done:2", "v2")
+        store.put("100x:1", "v3")
+
+        results = store.list_by_prefix("100%_done:")
+        assert len(results) == 2
+        assert {k for k, _ in results} == {"100%_done:1", "100%_done:2"}
+
+
 def test_kvstore_using_store_without_context_manager() -> None:
     with pytest.raises(AttributeError):
         store = KVStore("test.db")


### PR DESCRIPTION
`KVStore` currently provides basic methods like `get` and `put`. In Scout, we want to use it to persist saved searches, and part of that functionality is that we want to be able to retrieve a list of searches for a given transcript. 

The plan is to structure the keys such that the transcript dir and id are composed into the key prefix, and the other search parameters are hashed to form the suffix. That way, we can use this new `list_by_prefix` method to give us a list of saved searches for a given transcript.

We implement this by escaping all wildcard values in the provided `prefix` and then appending `%` to the escaped value. 