### PR TITLE
fix: include LoRA adapter in vLLM model name for eval logs/UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
   a loop, causing inconsistent reducer assignment across scorer       
   instances.
 - Bugfix: Fix `JSONRecorder` returning condensed `ModelEvent.input` (empty list) when `eval()` uses `log_format="json"`.
+- Bugfix: Include LoRA adapter in logged vLLM model name.
 
 ## 0.3.205 (04 April 2026)
 

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -138,7 +138,7 @@ class VLLMAPI(OpenAICompatibleAPI):
             raise ValueError("base_url and port cannot both be provided.")
 
         self.api_key = api_key or os.environ.get("VLLM_API_KEY", "inspectai")
-        self.model_name = self.base_model
+        self.model_name = model_name
         self.base_url: str | None = None
 
         # Store for deferred OpenAICompatibleAPI.__init__()

--- a/tests/model/providers/test_vllm_lora.py
+++ b/tests/model/providers/test_vllm_lora.py
@@ -135,7 +135,7 @@ class TestVLLMAPIInit:
         """model_name and base_url exist immediately (before _resolve_server)."""
         api = VLLMAPI("base-model:some-adapter")
 
-        assert api.model_name == "base-model"
+        assert api.model_name == "base-model:some-adapter"
         assert api.base_url is None
         assert api._server_resolved is False
 

--- a/tests/model/providers/test_vllm_lora.py
+++ b/tests/model/providers/test_vllm_lora.py
@@ -11,6 +11,7 @@ from inspect_ai.model._providers._vllm_lora import (
     VLLMServer,
     _normalize_api_base,
     _vllm_servers,
+    cleanup_servers,
     ensure_adapter_loaded,
     parse_vllm_model,
 )
@@ -20,10 +21,15 @@ from inspect_ai.solver import solver
 
 @pytest.fixture(autouse=True)
 def _clean_vllm_servers():
-    """Reset global server registry between tests."""
-    _vllm_servers.clear()
+    """Reset global server registry between tests.
+
+    Calls cleanup_servers() to terminate any running vLLM server
+    processes before clearing the registry.  Without this, orphaned
+    servers hold GPU memory and cause subsequent tests to OOM.
+    """
+    cleanup_servers()
     yield
-    _vllm_servers.clear()
+    cleanup_servers()
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- When using a LoRA adapter (`vllm/base-model:adapter`), the adapter suffix was stripped from `model_name` during `VLLMAPI.__init__`, so eval logs, the UI header, log filenames, and `model_usage` keys only showed the base model name
- One-line fix: keep the original `model_name` (with `:adapter` suffix) instead of replacing it with `base_model`
- The OpenAI client init and API routing are unaffected — they already use `self.base_model` and `service_model_name()` respectively

Fixes #3648

## Test plan
- [ ] Run eval with `vllm/base-model:adapter` syntax and verify the adapter name appears in the eval log header, UI, and log filename
- [ ] Run eval with plain `vllm/base-model` (no adapter) and verify no regression
- [ ] Run eval with multiple adapters on the same base model and verify each shows distinct model names in logs

🤖 Generated with [Claude Code](https://claude.ai/code)