### PR TITLE
add sudo back to Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
   instances.
 - Bugfix: Fix `JSONRecorder` returning condensed `ModelEvent.input` (empty list) when `eval()` uses `log_format="json"`.
 - Bugfix: Include LoRA adapter in logged vLLM model name.
+- Computer Use: Restore `sudo` package to computer tool Docker image.
 
 ## 0.3.205 (04 April 2026)
 

--- a/src/inspect_ai/tool/_tools/_computer/_resources/Dockerfile
+++ b/src/inspect_ai/tool/_tools/_computer/_resources/Dockerfile
@@ -28,7 +28,8 @@ RUN apt-get update && \
       # A command-line tool for taking screenshots.
       scrot \
       # A suite for image manipulation — needed for scaling images.
-      imagemagick && \
+      imagemagick \
+      sudo && \
     apt-get clean
 
 # Userland apt-get'able apps


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The Dockerfile that builds the `aisiuk/inspect-computer-tool` image does not install `sudo`.

### What is the new behavior?

It installs `sudo`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

We should update the image at https://hub.docker.com/r/aisiuk/inspect-computer-tool/.

I found this bug when I ran OSWorld, and for some samples, the inspect_evals code needed to execute commands with `sudo`, but `sudo` wasn't found.

The line in the Dockerfile to install `sudo` was removed in #1170.