### PR TITLE
anthropic: mark second-to-last content block for cache lookback

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1130,6 +1130,18 @@ class AnthropicAPI(ModelAPI):
             # tools
             if tools_params:
                 add_cache_control(tools_params[-1])
+            # last user message: if content was deliberately split into blocks,
+            # mark the penultimate one. auto-cache will mark content[-1]; when
+            # that block is a changing suffix (RAG query, scorer criterion,
+            # etc.), lookback walks back from it and finds this write. for the
+            # append-only case (agentic loops, tool results) this is a harmless
+            # extra write that lookback never reads.
+            for msg in reversed(message_params):
+                if msg["role"] == "user":
+                    content = msg["content"]
+                    if isinstance(content, list) and len(content) >= 2:
+                        add_cache_control(cast(dict[str, Any], content[-2]))
+                    break
 
         # return chat input
         return (

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -349,3 +349,93 @@ async def test_anthropic_prompt_caching_content_blocks() -> None:
     response2 = await model.generate(input=turn2_messages)
     assert response2.usage is not None
     assert (response2.usage.input_tokens_cache_read or 0) > 0
+
+
+@pytest.mark.anyio
+async def test_anthropic_cache_marks_penultimate_block() -> None:
+    """Verify the penultimate content block gets an explicit cache marker.
+
+    When the last user message has multiple content blocks, content[-2] should
+    get an explicit cache_control marker (in addition to the auto-cache marker
+    the API places on content[-1]). This gives the 20-block lookback a write
+    to find when only the last block changes.
+    """
+    api = create_autospec(AnthropicAPI, instance=True)
+    api.service_model_name.return_value = "claude-sonnet-4-6"
+    api.partition_tools.return_value = ([], [])
+    api.resolve_chat_input = types.MethodType(AnthropicAPI.resolve_chat_input, api)
+
+    blocks: list[Content] = [
+        ContentText(text="header"),
+        ContentText(text="body 1"),
+        ContentText(text="body 2"),
+        ContentText(text="suffix"),
+    ]
+
+    _, _, _, msgs, cache_prompt = await api.resolve_chat_input(
+        input=[ChatMessageUser(content=blocks)],
+        tools=[],
+        config=GenerateConfig(cache_prompt=True),
+    )
+
+    assert cache_prompt is True
+    content = msgs[0]["content"]
+    assert isinstance(content, list)
+    cc = [i for i, b in enumerate(content) if "cache_control" in b]
+    assert cc == [2], f"expected marker on content[-2] only, got indices {cc}"
+
+    # single-block content should not get a marker
+    _, _, _, msgs, _ = await api.resolve_chat_input(
+        input=[ChatMessageUser(content=[ContentText(text="only block")])],
+        tools=[],
+        config=GenerateConfig(cache_prompt=True),
+    )
+    content = msgs[0]["content"]
+    assert isinstance(content, list)
+    assert not any("cache_control" in b for b in content)
+
+    # cache_prompt=False should not mark anything
+    _, _, _, msgs, cache_prompt = await api.resolve_chat_input(
+        input=[ChatMessageUser(content=blocks)],
+        tools=[],
+        config=GenerateConfig(cache_prompt=False),
+    )
+    assert cache_prompt is False
+    content = msgs[0]["content"]
+    assert isinstance(content, list)
+    assert not any("cache_control" in b for b in content)
+
+
+@pytest.mark.anyio
+@skip_if_no_anthropic
+async def test_anthropic_prompt_caching_changing_suffix() -> None:
+    """Verify caching when only the last content block changes.
+
+    Builds a user message with several stable blocks plus a final block that
+    differs between calls. The penultimate-block marker should give the
+    auto-cache lookback a write to fall back to.
+    """
+    model = get_model(
+        "anthropic/claude-sonnet-4-6",
+        config=GenerateConfig(max_tokens=50, temperature=0.0, cache_prompt=True),
+    )
+
+    # stable prefix blocks totalling >2048 tokens
+    paragraph = "The quick brown fox jumps over the lazy dog. " * 50
+    stable: list[Content] = [
+        ContentText(text=f"Section {i}: {paragraph}") for i in range(5)
+    ]
+
+    msgs1: list[ChatMessage] = [
+        ChatMessageUser(content=stable + [ContentText(text="Question one?")]),
+    ]
+    msgs2: list[ChatMessage] = [
+        ChatMessageUser(content=stable + [ContentText(text="Question two?")]),
+    ]
+
+    response1 = await model.generate(input=msgs1)
+    assert response1.usage is not None
+
+    response2 = await model.generate(input=msgs2)
+    assert response2.usage is not None
+    assert (response2.usage.input_tokens_cache_read or 0) > 0


### PR DESCRIPTION
## Summary

Follow-up to #3656. Auto-cache places its marker on the last content block, which is optimal for append-only growth (agentic loops, multi-turn) but misses entirely for the stable-prefix-with-changing-suffix pattern — RAG, scorers, approvers, few-shot.

Per [Anthropic's docs](https://platform.claude.com/docs/en/build-with-claude/prompt-caching), the cache lookback walks backward up to 20 blocks looking for **prior writes** — not stable content. When the last block is replaced (not appended), the marker stays at the same depth, and lookback walks through positions that were never written to. Result: zero cache reads even when 95% of the prompt is unchanged.

This adds an explicit marker on `content[-2]` of the last user message when that message has multiple content blocks. Auto-cache and explicit markers compose by design (the docs show this exact combination); the auto marker on `content[-1]` still handles append-only, and when `content[-1]` changes the lookback walks back one block and finds this write.

The signal is the user passing `list[Content]` rather than `str` — that's a deliberate choice to leverage block boundaries. Single-block messages are unaffected.

**Marker budget:** system + tools + this + auto = 4, exactly Anthropic's limit.

## Empirical results

Same conversation prefix, only the last block differs (`claude-haiku-4-5`):

| | cache_write | cache_read |
|---|---|---|
| **before** (auto only) | 5384 | **0** |
| **after** (auto + content[-2]) | 139 | **5503** |

Conversation grows + suffix changes (the realistic case):

| call | cache_write | cache_read |
|---|---|---|
| cold | 5642 | 0 |
| suffix changed | 139 | 5503 |
| +1 turn, new suffix | 381 | 5503 |
| suffix changed | 139 | 5745 |
| +1 turn, new suffix | 396 | 5745 |
| suffix changed | 139 | 6002 |

Prefix grows incrementally, suffix changes never bust it.

## Test plan

- [x] Unit test for marker placement (no API)
- [x] Integration test for changing-suffix cache hit
- [x] Existing caching tests still pass (`test_anthropic_prompt_caching`, `test_anthropic_prompt_caching_content_blocks`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)