### PR TITLE
fix: apply flaky_retry to all parametrized test variants

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -124,7 +124,6 @@ def pytest_collection_modifyitems(config, items):
         if getattr(fn, "_needs_flaky_retry", False) and not getattr(
             fn, "_flaky_retry", False
         ):
-            fn._flaky_retry = True  # prevent re-wrap for parametrized variants
             item.obj = _retry(fn)
 
 


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

`flaky_retry(max_retries=3)` is only applied to the first parametrized variant of each test (typically `[asyncio]`). The `[trio]` variant runs without retries because `pytest_collection_modifyitems` sets `_flaky_retry=True` on the shared original function object, causing the guard condition to skip all subsequent variants.

This caused `test_anthropic_prompt_caching[trio]` to fail in CI — the flaky cache behavior was tolerated by retries on `[asyncio]` but not on `[trio]`.

### What is the new behavior?

Each parametrized item gets its own retry wrapper. The existing `_flaky_retry` check on `item.obj` still prevents double-wrapping since the wrapper function returned by `flaky_retry` already sets `_flaky_retry=True` on itself.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

One-line fix: removes `fn._flaky_retry = True` which was guarding the shared function object rather than the per-item wrapper.