### PR TITLE
fix(viewer): Copy/Download Transcript copies event-derived messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,81 @@
 ## Unreleased
 
+- Model API: Add SageMaker provider for invoking models hosted on AWS SageMaker endpoints.
+- Model API: Normalize handling of cached tokens in `ModelUsage` (input tokens now excludes cached tokens whereas previously it included them for some providers).
+- Model API: Track model usage by model role in addition to globally.
+- OpenAI: Warn user when reasoning options are passed to non-reasoning model.
+- OpenAI: Pass through `phase` for gpt-5.3-codex models.
+- OpenAI Compatible: Re-create closed httpx client after disconnect.
+- Anthropic: Support ANTHROPIC_AUTH_TOKEN for OAuth Bearer authentication.
+- vLLM: Support for LoRA (Low-Rank Adaptation) via `--enable-lora` server option and LoRA-tuned server startup logic.
+- OpenRouter: Improved capture of reasoning summaries for Gemini models.
+- Agent Bridge: Only require `openai` package when bridging the openai completions or reaponses API.
+- Sandbox Tools: Increase server startup timeout from 20 seconds to 120 seconds.
+- Timelines: Improve agent detection logic in `timeline_build()`.
+- Performance: Share a single `AsyncFilesystem` via ContextVar within each async context, eliminating redundant S3 client creation and connection pool fragmentation.
+- Inspect View: Improve virtualized find in transcript by matching event titles as well as contents.
+- Testing: Migrate async tests from pytest-asyncio to anyio, enabling dual-backend (asyncio/trio) test execution via `--runtrio` flag.
+- Bugfix: Strip surrounding quotes from S3 ETag in `.eval` header-only reads so it is consistent with full reads.
+
+## 0.3.183 (24 February 2026)
+
+- Improved naming and typeinfo for `exec_remote()` output stream events.
+- Scoring: Don't use task level metric overrides when appending scores to an existing log.
+- Inspect View: Add support for downloading sample JSON.
+- Inspect View: Server returns correct content length for responses.
+
+## 0.3.182 (24 February 2026)
+
+- AzureAI: Pass `max_completion_tokens` to gpt-5 and o-series models.
+- Events: Add timeline functions for providing additional structure for event viewing and traversal.
+
+## 0.3.181 (23 February 2026)
+
+- Hooks: New `on_sample_init()` hook that fires before sandbox environments are created, enabling hooks to gate sandbox resource provisioning.
+- Model API: Add `content_list` property to `ChatMessage` for consistent access to content as a list.
+- OpenAI Compatible: Send `max_completion_tokens` when interacting with gpt-5 or o-series models.
+- Anthropic: Use `output_config` directly (rather than via `extra_body`) which is compatible with batch mode.
+- Google: Add latest Gemini models to model info database.
+- Sandboxes: Verify execute result size automatically for all sandbox exec calls.
+- Sandboxes: Export `exec_remote()` types from root namespace and add docs.
+- Eval Set: Add `TASK_IDENTIFIER_VERSION` to support persistence of task identifiers in inspect_flow.
+- Eval Retry: Don't retry with `model_base_url` unless it was explicitly specified by the user.
+- Agent Bridge: Add model_aliases to agent bridge and pass Model to GenerateFilter.
+- Dependencies: Update to nest-asyncio2 v1.7.2 to address anyio threading issue.
+- Inspect View: Display all non-undefined edited score values.
+- Bugfix: Don't reuse eval_set logs when `sample_shuffle` changes and `limit` constrains sample selection.
+- Bugfix: `eval_set` now correctly handles pending tasks and incomplete tasks (e.g. limit/epoch changes) in a single pass, instead of skipping incomplete tasks when new tasks were present.
+- Bugfix: Reuse S3 clients in log recorders to fix session leak.
+- Bugfix: Create eval set bundle even when all logs are already complete.
+- Bugfix: Fix `epochs_changed` false positives in `eval_set` caused by comparing reducer closure `__name__` instead of registry log name.
+- Bugfix: Fix async ZIP parser crash on valid `.eval` files whose compressed data contained a false ZIP64 EOCD Locator signature.
+- Bugfix: Skip non-JSON lines in MCP server stdout parsing,
+- Bugfix: Remove doubled MIME prefix in MCP content conversion.
+- Bugfix: Ensure that `eval()` specified `model_roles` override task-level roles.
+- Bugfix: Improve max sample size error.
+
+## 0.3.180 (20 February 2026)
+
 - Agent Bridge: Google Gemini API is now supported for in-process and sandbox bridges.
 - Task Execution: Cancelled samples are now logged in the same fashion as samples with errors.
+- Anthropic: Increase max_tokens caps for Claude 4.5 and 4.6 models.
+- Anthropic: Update to new sdk types released with Sonnet 4.6 (v0.80.0 of `anthropic` package is now required).
+- Anthropic: Remove uses of Sonnet 3.7 from tests (no longer available).
+- Hugging Face: More flexible control over application of chat templates (enables support for generation from base models).
+- VLLM: Don't retry when the error indicates that the VLLM server has crashed.
 - Analysis: Async reading of logs/samples in `samples_df()` (now 50x faster).
 - Sandboxes: Don't require Docker compatible sandboxes to implement `config_deserialize()`.
 - Sandboxes: New `exec_remote()` method for async execution of long-running commands.
 - Compaction: Add `type` field to `CompactionEvent` to record compaction type.
+- Web Search: Treat Tavily query character limits as ToolErrors.
 - Limits: New `cost_limit()` context manager for scoped application of cost limits.
 - Performance: Disable expensive per-sample options when running high-throughput workloads.
 - Events: Rename `EventNode` to `EventTreeNode` and `SpanNode` to `EventTreeSpan` (old type names will still work at runtime with a deprecation warning).
-- Inspect View: Make samples in task detail sortable, inline epoch filter.
+- Inspect View: Make samples in task detail sortable, inline epoch filter, show sample status.
 - Bugfix: Shield sandbox cleanup after cancelled exception.
+- Bugfix: Protect against leading zero-width characters when printing tool output to the terminal.
+- Bugfix: Google batch JSONL serialization now correctly nests generation config fields (e.g. `thinking_config`) under `generation_config` in the REST schema.
+- Bugfix: Google batch polling no longer hangs forever when a batch job reaches `EXPIRED` or `PARTIALLY_SUCCEEDED` state.
 
 ## 0.3.179 (12 February 2026)
 

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -21,7 +21,8 @@ import {
   useState,
 } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { EvalSample, Events } from "../../@types/log";
+import { EvalSample, Events, Messages } from "../../@types/log";
+import api from "../../client/api/index";
 import { SampleSummary } from "../../client/api/types";
 import { Card, CardBody, CardHeader } from "../../components/Card";
 import { JSONPanel } from "../../components/JsonPanel";
@@ -220,8 +221,30 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
 
   const { isDebugFilter, isDefaultFilter } = useTranscriptFilter();
 
+  const transcriptMessages = useMemo((): Messages => {
+    const events = sample?.events;
+    if (events && events.length > 0) {
+      const fromEvents = messagesFromEvents(events);
+      if (fromEvents.length > 0) {
+        return fromEvents;
+      }
+    }
+    return sample?.messages ?? [];
+  }, [sample?.events, sample?.messages]);
+
   const tools = [];
   const [icon, setIcon] = useState(ApplicationIcons.copy);
+
+  const flashCopyIcon = useCallback(() => {
+    setIcon(ApplicationIcons.confirm);
+    setTimeout(() => {
+      setIcon(ApplicationIcons.copy);
+    }, 1250);
+  }, []);
+
+  const canDownloadFiles = useStore(
+    (state) => state.capabilities.downloadFiles,
+  );
 
   tools.push(
     <ToolDropdownButton
@@ -232,24 +255,57 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
         UUID: () => {
           if (sample?.uuid) {
             navigator.clipboard.writeText(sample.uuid);
-            setIcon(ApplicationIcons.confirm);
-            setTimeout(() => {
-              setIcon(ApplicationIcons.copy);
-            }, 1250);
+            flashCopyIcon();
+          }
+        },
+        Messages: () => {
+          if (sample?.messages && sample.messages.length > 0) {
+            navigator.clipboard.writeText(messagesToStr(sample.messages));
+            flashCopyIcon();
           }
         },
         Transcript: () => {
-          if (sample?.messages) {
-            navigator.clipboard.writeText(messagesToStr(sample.messages));
-            setIcon(ApplicationIcons.confirm);
-            setTimeout(() => {
-              setIcon(ApplicationIcons.copy);
-            }, 1250);
+          if (transcriptMessages.length > 0) {
+            navigator.clipboard.writeText(
+              messagesToStr(transcriptMessages),
+            );
+            flashCopyIcon();
           }
         },
       }}
     />,
   );
+
+  if (canDownloadFiles && sample) {
+    const sampleId = sample.id ?? "sample";
+    tools.push(
+      <ToolDropdownButton
+        key="sample-download"
+        label="Download"
+        icon={ApplicationIcons.downloadLog}
+        items={{
+          "Sample JSON": () => {
+            api.download_file(
+              `${sampleId}.json`,
+              JSON.stringify(sample, null, 2),
+            );
+          },
+          Messages: () => {
+            api.download_file(
+              `${sampleId}-messages.txt`,
+              messagesToStr(sample.messages ?? []),
+            );
+          },
+          Transcript: () => {
+            api.download_file(
+              `${sampleId}-transcript.txt`,
+              messagesToStr(transcriptMessages),
+            );
+          },
+        }}
+      />,
+    );
+  }
 
   if (selectedTab === kSampleTranscriptTabId) {
     const label = isDebugFilter

--- a/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/SampleDisplay.tsx
@@ -222,14 +222,10 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
   const { isDebugFilter, isDefaultFilter } = useTranscriptFilter();
 
   const transcriptMessages = useMemo((): Messages => {
-    const events = sample?.events;
-    if (events && events.length > 0) {
-      const fromEvents = messagesFromEvents(events);
-      if (fromEvents.length > 0) {
-        return fromEvents;
-      }
-    }
-    return sample?.messages ?? [];
+    const fromEvents = sample?.events
+      ? messagesFromEvents(sample.events)
+      : [];
+    return fromEvents.length > 0 ? fromEvents : (sample?.messages ?? []);
   }, [sample?.events, sample?.messages]);
 
   const tools = [];
@@ -252,24 +248,38 @@ export const SampleDisplay: FC<SampleDisplayProps> = ({
       label="Copy"
       icon={icon}
       items={{
-        UUID: () => {
+        UUID: async () => {
           if (sample?.uuid) {
-            navigator.clipboard.writeText(sample.uuid);
-            flashCopyIcon();
+            try {
+              await navigator.clipboard.writeText(sample.uuid);
+              flashCopyIcon();
+            } catch {
+              // clipboard access denied
+            }
           }
         },
-        Messages: () => {
+        Messages: async () => {
           if (sample?.messages && sample.messages.length > 0) {
-            navigator.clipboard.writeText(messagesToStr(sample.messages));
-            flashCopyIcon();
+            try {
+              await navigator.clipboard.writeText(
+                messagesToStr(sample.messages),
+              );
+              flashCopyIcon();
+            } catch {
+              // clipboard access denied
+            }
           }
         },
-        Transcript: () => {
+        Transcript: async () => {
           if (transcriptMessages.length > 0) {
-            navigator.clipboard.writeText(
-              messagesToStr(transcriptMessages),
-            );
-            flashCopyIcon();
+            try {
+              await navigator.clipboard.writeText(
+                messagesToStr(transcriptMessages),
+              );
+              flashCopyIcon();
+            } catch {
+              // clipboard access denied
+            }
           }
         },
       }}

--- a/src/inspect_ai/_view/www/src/app/samples/chat/messages.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/chat/messages.ts
@@ -176,9 +176,11 @@ export const messagesFromEvents = (runningEvents: Events): Messages => {
           messages.set(inputMessage.id, inputMessage);
         }
       }
-      const outputMessage = e.output.choices[0].message;
-      if (outputMessage.id) {
-        messages.set(outputMessage.id, outputMessage);
+      if (e.output.choices.length > 0) {
+        const outputMessage = e.output.choices[0].message;
+        if (outputMessage.id) {
+          messages.set(outputMessage.id, outputMessage);
+        }
       }
     });
 

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ApprovalEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ApprovalEventView.tsx
@@ -2,6 +2,7 @@ import { FC } from "react";
 import { ApprovalEvent } from "../../../@types/log";
 import { ApplicationIcons } from "../../appearance/icons";
 import { EventRow } from "./event/EventRow";
+import { eventTitle } from "./event/utils";
 import { EventNode } from "./types";
 
 interface ApprovalEventViewProps {
@@ -19,33 +20,13 @@ export const ApprovalEventView: FC<ApprovalEventViewProps> = ({
   const event = eventNode.event;
   return (
     <EventRow
-      title={decisionLabel(event.decision)}
+      title={eventTitle(event)}
       icon={decisionIcon(event.decision)}
       className={className}
     >
       {event.explanation || ""}
     </EventRow>
   );
-};
-
-/**
- * Determines the label for a decision
- */
-const decisionLabel = (decision: string): string => {
-  switch (decision) {
-    case "approve":
-      return "Approved";
-    case "reject":
-      return "Rejected";
-    case "terminate":
-      return "Terminated";
-    case "escalate":
-      return "Escalated";
-    case "modify":
-      return "Modified";
-    default:
-      return decision;
-  }
 };
 
 /**

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/CompactionEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/CompactionEventView.tsx
@@ -3,7 +3,7 @@ import { CompactionEvent } from "../../../@types/log";
 import { formatDateTime } from "../../../utils/format";
 import { ApplicationIcons } from "../../appearance/icons";
 import { EventPanel } from "./event/EventPanel";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 import { EventNode } from "./types";
 import { MetaDataGrid } from "../../content/MetaDataGrid";
 
@@ -31,13 +31,11 @@ export const CompactionEventView: FC<CompactionEventViewProps> = ({
   }
   data = { ...data, ...(event.metadata || {}) };
 
-  const source = event.source && event.source !== "inspect" ? event.source : "";
-
   return (
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle("Compaction" + source, undefined, event.working_start)}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       className={className}
       subTitle={formatDateTime(new Date(event.timestamp))}
       icon={ApplicationIcons.info}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ErrorEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ErrorEventView.tsx
@@ -4,7 +4,7 @@ import { ANSIDisplay } from "../../../components/AnsiDisplay";
 import { formatDateTime } from "../../../utils/format";
 import { ApplicationIcons } from "../../appearance/icons";
 import { EventPanel } from "./event/EventPanel";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 import { EventNode } from "./types";
 
 interface ErrorEventViewProps {
@@ -24,7 +24,7 @@ export const ErrorEventView: FC<ErrorEventViewProps> = ({
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle("Error", undefined, event.working_start)}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       className={className}
       subTitle={formatDateTime(new Date(event.timestamp))}
       icon={ApplicationIcons.error}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/InfoEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/InfoEventView.tsx
@@ -6,7 +6,7 @@ import { formatDateTime } from "../../../utils/format";
 import { ApplicationIcons } from "../../appearance/icons";
 import { RenderedText } from "../../content/RenderedText";
 import { EventPanel } from "./event/EventPanel";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 import styles from "./InfoEventView.module.css";
 import { EventNode } from "./types";
 
@@ -40,11 +40,7 @@ export const InfoEventView: FC<InfoEventViewProps> = ({
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle(
-        "Info" + (event.source ? ": " + event.source : ""),
-        undefined,
-        event.working_start,
-      )}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       className={className}
       subTitle={formatDateTime(new Date(event.timestamp))}
       icon={ApplicationIcons.info}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/InputEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/InputEventView.tsx
@@ -4,7 +4,7 @@ import { ANSIDisplay } from "../../../components/AnsiDisplay";
 import { formatDateTime } from "../../../utils/format";
 import { ApplicationIcons } from "../../appearance/icons";
 import { EventPanel } from "./event/EventPanel";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 import { EventNode } from "./types";
 
 interface InputEventViewProps {
@@ -24,7 +24,7 @@ export const InputEventView: FC<InputEventViewProps> = ({
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle("Input", undefined, event.working_start)}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       className={className}
       subTitle={formatDateTime(new Date(event.timestamp))}
       icon={ApplicationIcons.input}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/LoggerEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/LoggerEventView.tsx
@@ -2,6 +2,7 @@ import clsx from "clsx";
 import { LoggerEvent } from "../../../@types/log";
 import { ApplicationIcons } from "../../appearance/icons";
 import { EventRow } from "./event/EventRow";
+import { eventTitle } from "./event/utils";
 
 import { FC } from "react";
 import ExpandablePanel from "../../../components/ExpandablePanel";
@@ -27,7 +28,7 @@ export const LoggerEventView: FC<LoggerEventViewProps> = ({
   return (
     <EventRow
       className={className}
-      title={event.message.level}
+      title={eventTitle(event)}
       icon={ApplicationIcons.logging[event.message.level.toLowerCase()]}
     >
       <div className={clsx("text-size-base", styles.grid)}>

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ModelEventView.tsx
@@ -19,7 +19,7 @@ import { Message } from "../chat/messages";
 import styles from "./ModelEventView.module.css";
 import { EventNodeContext } from "./TranscriptVirtualList";
 import { EventTimingPanel } from "./event/EventTimingPanel";
-import { formatTiming, formatTitle } from "./event/utils";
+import { eventTitle, formatTiming, formatTitle } from "./event/utils";
 import { EventNode } from "./types";
 
 interface ModelEventViewProps {
@@ -89,9 +89,7 @@ export const ModelEventView: FC<ModelEventViewProps> = ({
     }
   }
 
-  const panelTitle = event.role
-    ? `Model Call (${event.role}): ${event.model}`
-    : `Model Call: ${event.model}`;
+  const panelTitle = eventTitle(event);
 
   const turnLabel = context?.turnInfo
     ? `turn ${context.turnInfo.turnNumber}/${context.turnInfo.totalTurns}`

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/SampleInitEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/SampleInitEventView.tsx
@@ -10,7 +10,7 @@ import { EventSection } from "./event/EventSection";
 
 import clsx from "clsx";
 import { FC } from "react";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 import styles from "./SampleInitEventView.module.css";
 import { EventNode } from "./types";
 
@@ -60,7 +60,7 @@ export const SampleInitEventView: FC<SampleInitEventViewProps> = ({
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
       className={className}
-      title={formatTitle("Sample", undefined, event.working_start)}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       icon={ApplicationIcons.sample}
       subTitle={formatDateTime(new Date(event.timestamp))}
     >

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/SampleLimitEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/SampleLimitEventView.tsx
@@ -4,7 +4,7 @@ import { SampleLimitEvent, Type17 } from "../../../@types/log";
 import { formatDateTime } from "../../../utils/format";
 import { ApplicationIcons } from "../../appearance/icons";
 import { EventPanel } from "./event/EventPanel";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 import { EventNode } from "./types";
 
 interface SampleLimitEventViewProps {
@@ -19,25 +19,6 @@ export const SampleLimitEventView: FC<SampleLimitEventViewProps> = ({
   eventNode,
   className,
 }) => {
-  const resolve_title = (type: Type17) => {
-    switch (type) {
-      case "custom":
-        return "Custom Limit Exceeded";
-      case "time":
-        return "Time Limit Exceeded";
-      case "message":
-        return "Message Limit Exceeded";
-      case "token":
-        return "Token Limit Exceeded";
-      case "operator":
-        return "Operator Canceled";
-      case "working":
-        return "Execution Time Limit Exceeded";
-      case "cost":
-        return "Cost Limit Exceeded";
-    }
-  };
-
   const resolve_icon = (type: Type17) => {
     switch (type) {
       case "custom":
@@ -57,14 +38,17 @@ export const SampleLimitEventView: FC<SampleLimitEventViewProps> = ({
     }
   };
 
-  const title = resolve_title(eventNode.event.type);
   const icon = resolve_icon(eventNode.event.type);
 
   return (
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle(title, undefined, eventNode.event.working_start)}
+      title={formatTitle(
+        eventTitle(eventNode.event),
+        undefined,
+        eventNode.event.working_start,
+      )}
       subTitle={formatDateTime(new Date(eventNode.event.timestamp))}
       icon={icon}
       className={className}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/SandboxEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/SandboxEventView.tsx
@@ -9,7 +9,7 @@ import clsx from "clsx";
 import { FC } from "react";
 import { RenderedContent } from "../../content/RenderedContent";
 import styles from "./SandboxEventView.module.css";
-import { formatTiming, formatTitle } from "./event/utils";
+import { eventTitle, formatTiming, formatTitle } from "./event/utils";
 import { EventNode } from "./types";
 
 interface SandboxEventViewProps {
@@ -30,11 +30,7 @@ export const SandboxEventView: FC<SandboxEventViewProps> = ({
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
       className={className}
-      title={formatTitle(
-        `Sandbox: ${event.action}`,
-        undefined,
-        event.working_start,
-      )}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       icon={ApplicationIcons.sandbox}
       subTitle={formatTiming(event.timestamp, event.working_start)}
     >

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ScoreEditEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ScoreEditEventView.tsx
@@ -11,7 +11,7 @@ import { RecordTree } from "../../content/RecordTree";
 import { RenderedText } from "../../content/RenderedText";
 import styles from "./ScoreEditEventView.module.css";
 import { renderScore } from "./ScoreEventView";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 
 interface ScoreEditEventViewProps {
   eventNode: EventNode<ScoreEditEvent>;
@@ -36,7 +36,7 @@ export const ScoreEditEventView: FC<ScoreEditEventViewProps> = ({
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle("Edit Score", undefined, event.working_start)}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       className={clsx(className, "text-size-small")}
       subTitle={subtitle}
       collapsibleContent={true}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ScoreEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ScoreEventView.tsx
@@ -8,7 +8,7 @@ import { EventPanel } from "./event/EventPanel";
 import clsx from "clsx";
 import { RecordTree } from "../../content/RecordTree";
 import { RenderedText } from "../../content/RenderedText";
-import { formatTitle } from "./event/utils";
+import { eventTitle, formatTitle } from "./event/utils";
 import styles from "./ScoreEventView.module.css";
 import { EventNode } from "./types";
 
@@ -35,11 +35,7 @@ export const ScoreEventView: FC<ScoreEventViewProps> = ({
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle(
-        (event.intermediate ? "Intermediate " : "") + "Score",
-        undefined,
-        event.working_start,
-      )}
+      title={formatTitle(eventTitle(event), undefined, event.working_start)}
       className={clsx(className, "text-size-small")}
       subTitle={formatDateTime(new Date(event.timestamp))}
       icon={ApplicationIcons.scorer}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/SpanEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/SpanEventView.tsx
@@ -3,8 +3,7 @@ import { FC, useMemo } from "react";
 import { SpanBeginEvent } from "../../../@types/log";
 import { formatDateTime } from "../../../utils/format";
 import { EventPanel } from "./event/EventPanel";
-import { formatTitle } from "./event/utils";
-import { kSandboxSignalName } from "./transform/fixups";
+import { eventTitle, formatTitle } from "./event/utils";
 import { EventNode, EventType } from "./types";
 
 interface SpanEventViewProps {
@@ -23,9 +22,7 @@ export const SpanEventView: FC<SpanEventViewProps> = ({
 }) => {
   const event = eventNode.event;
   const descriptor = spanDescriptor(event);
-  const title =
-    descriptor.name ||
-    `${event.type ? event.type + ": " : "Step: "}${event.name}`;
+  const title = eventTitle(event);
 
   const text = useMemo(() => summarize(children), [children]);
   const childIds = useMemo(() => children.map((child) => child.id), [children]);
@@ -87,73 +84,21 @@ const summarize = (children: EventNode[]) => {
  */
 const spanDescriptor = (
   event: SpanBeginEvent,
-): { icon?: string; name?: string; endSpace?: boolean } => {
+): { icon?: string; endSpace?: boolean } => {
   const rootStepDescriptor = {
     endSpace: true,
   };
 
-  if (event.type === "solver") {
-    switch (event.name) {
-      case "chain_of_thought":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "generate":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "self_critique":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "system_message":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "use_tools":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "multiple_choice":
-        return {
-          ...rootStepDescriptor,
-        };
-      default:
-        return {
-          ...rootStepDescriptor,
-        };
-    }
-  } else if (event.type === "scorer") {
-    return {
-      ...rootStepDescriptor,
-    };
+  if (event.type === "solver" || event.type === "scorer") {
+    return { ...rootStepDescriptor };
   } else if (event.event === "span_begin") {
-    if (event.span_id === kSandboxSignalName) {
-      return {
-        ...rootStepDescriptor,
-        name: "Sandbox Events",
-      };
-    } else if (event.name === "init") {
-      return {
-        ...rootStepDescriptor,
-        name: "Init",
-      };
-    } else {
-      return {
-        ...rootStepDescriptor,
-      };
-    }
+    return { ...rootStepDescriptor };
   } else {
     switch (event.name) {
       case "sample_init":
-        return {
-          ...rootStepDescriptor,
-          name: "Sample Init",
-        };
+        return { ...rootStepDescriptor };
       default:
-        return {
-          endSpace: false,
-        };
+        return { endSpace: false };
     }
   }
 };

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/StepEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/StepEventView.tsx
@@ -3,8 +3,7 @@ import { FC } from "react";
 import { StepEvent } from "../../../@types/log";
 import { formatDateTime } from "../../../utils/format";
 import { EventPanel } from "./event/EventPanel";
-import { formatTitle } from "./event/utils";
-import { kSandboxSignalName } from "./transform/fixups";
+import { eventTitle, formatTitle } from "./event/utils";
 import { EventNode, EventType } from "./types";
 
 interface StepEventViewProps {
@@ -23,9 +22,7 @@ export const StepEventView: FC<StepEventViewProps> = ({
 }) => {
   const event = eventNode.event;
   const descriptor = stepDescriptor(event);
-  const title =
-    descriptor.name ||
-    `${event.type ? event.type + ": " : "Step: "}${event.name}`;
+  const title = eventTitle(event);
   const text = summarize(children);
 
   return (
@@ -88,73 +85,21 @@ const summarize = (children: EventNode[]) => {
  */
 const stepDescriptor = (
   event: StepEvent,
-): { icon?: string; name?: string; endSpace?: boolean } => {
+): { icon?: string; endSpace?: boolean } => {
   const rootStepDescriptor = {
     endSpace: true,
   };
 
-  if (event.type === "solver") {
-    switch (event.name) {
-      case "chain_of_thought":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "generate":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "self_critique":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "system_message":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "use_tools":
-        return {
-          ...rootStepDescriptor,
-        };
-      case "multiple_choice":
-        return {
-          ...rootStepDescriptor,
-        };
-      default:
-        return {
-          ...rootStepDescriptor,
-        };
-    }
-  } else if (event.type === "scorer") {
-    return {
-      ...rootStepDescriptor,
-    };
+  if (event.type === "solver" || event.type === "scorer") {
+    return { ...rootStepDescriptor };
   } else if (event.event === "step") {
-    if (event.name === kSandboxSignalName) {
-      return {
-        ...rootStepDescriptor,
-        name: "Sandbox Events",
-      };
-    } else if (event.name === "init") {
-      return {
-        ...rootStepDescriptor,
-        name: "Init",
-      };
-    } else {
-      return {
-        ...rootStepDescriptor,
-      };
-    }
+    return { ...rootStepDescriptor };
   } else {
     switch (event.name) {
       case "sample_init":
-        return {
-          ...rootStepDescriptor,
-          name: "Sample Init",
-        };
+        return { ...rootStepDescriptor };
       default:
-        return {
-          endSpace: false,
-        };
+        return { endSpace: false };
     }
   }
 };

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/SubtaskEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/SubtaskEventView.tsx
@@ -4,7 +4,7 @@ import { Input2, Input5, Result3, SubtaskEvent } from "../../../@types/log";
 import { ApplicationIcons } from "../../appearance/icons";
 import { MetaDataGrid } from "../../content/MetaDataGrid";
 import { EventPanel } from "./event/EventPanel";
-import { formatTiming, formatTitle } from "./event/utils";
+import { eventTitle, formatTiming, formatTitle } from "./event/utils";
 import styles from "./SubtaskEventView.module.css";
 import { EventNode, EventType } from "./types";
 
@@ -43,18 +43,12 @@ export const SubtaskEventView: FC<SubtaskEventViewProps> = ({
     );
   }
 
-  // Is this a traditional subtask or a fork?
-  const type = event.type === "fork" ? "Fork" : "Subtask";
   return (
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
       className={className}
-      title={formatTitle(
-        `${type}: ${event.name}`,
-        undefined,
-        event.working_time,
-      )}
+      title={formatTitle(eventTitle(event), undefined, event.working_time)}
       subTitle={formatTiming(event.timestamp, event.working_start)}
       childIds={children.map((child) => child.id)}
       collapseControl="bottom"

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/ToolEventView.tsx
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/ToolEventView.tsx
@@ -10,7 +10,7 @@ import { FC, useMemo } from "react";
 import { PulsingDots } from "../../../components/PulsingDots";
 import { ChatView } from "../chat/ChatView";
 import { EventNodeContext } from "./TranscriptVirtualList";
-import { formatTiming, formatTitle } from "./event/utils";
+import { eventTitle, formatTiming, formatTitle } from "./event/utils";
 import styles from "./ToolEventView.module.css";
 import { EventNode, EventType } from "./types";
 
@@ -59,12 +59,11 @@ export const ToolEventView: FC<ToolEventViewProps> = ({
     };
   }, [children]);
 
-  const title = `Tool: ${event.view?.title || event.function}`;
   return (
     <EventPanel
       eventNodeId={eventNode.id}
       depth={eventNode.depth}
-      title={formatTitle(title, undefined, event.working_time)}
+      title={formatTitle(eventTitle(event), undefined, event.working_time)}
       className={className}
       subTitle={formatTiming(event.timestamp, event.working_start)}
       icon={ApplicationIcons.solvers.use_tools}

--- a/src/inspect_ai/_view/www/src/app/samples/transcript/event/utils.ts
+++ b/src/inspect_ai/_view/www/src/app/samples/transcript/event/utils.ts
@@ -3,6 +3,86 @@ import {
   formatNumber,
   formatTime,
 } from "../../../../utils/format";
+import { kSandboxSignalName } from "../transform/fixups";
+import { EventType } from "../types";
+
+const sampleLimitTitles: Record<string, string> = {
+  custom: "Custom Limit Exceeded",
+  time: "Time Limit Exceeded",
+  message: "Message Limit Exceeded",
+  token: "Token Limit Exceeded",
+  operator: "Operator Canceled",
+  working: "Execution Time Limit Exceeded",
+  cost: "Cost Limit Exceeded",
+};
+
+const approvalDecisionLabels: Record<string, string> = {
+  approve: "Approved",
+  reject: "Rejected",
+  terminate: "Terminated",
+  escalate: "Escalated",
+  modify: "Modified",
+};
+
+/**
+ * Returns the base title string for any event type.
+ * Used by both event rendering components and search text extraction.
+ */
+export const eventTitle = (event: EventType): string => {
+  switch (event.event) {
+    case "model":
+      return event.role
+        ? `Model Call (${event.role}): ${event.model}`
+        : `Model Call: ${event.model}`;
+    case "tool":
+      return `Tool: ${event.view?.title || event.function}`;
+    case "error":
+      return "Error";
+    case "logger":
+      return event.message.level;
+    case "info":
+      return "Info" + (event.source ? ": " + event.source : "");
+    case "compaction": {
+      const source =
+        event.source && event.source !== "inspect" ? event.source : "";
+      return "Compaction" + source;
+    }
+    case "step":
+      if (event.name === kSandboxSignalName) return "Sandbox Events";
+      if (event.name === "init") return "Init";
+      if (event.name === "sample_init") return "Sample Init";
+      return event.type
+        ? `${event.type}: ${event.name}`
+        : `Step: ${event.name}`;
+    case "subtask":
+      return event.type === "fork"
+        ? `Fork: ${event.name}`
+        : `Subtask: ${event.name}`;
+    case "span_begin":
+      if (event.span_id === kSandboxSignalName) return "Sandbox Events";
+      if (event.name === "init") return "Init";
+      if (event.name === "sample_init") return "Sample Init";
+      return event.type
+        ? `${event.type}: ${event.name}`
+        : `Step: ${event.name}`;
+    case "score":
+      return (event.intermediate ? "Intermediate " : "") + "Score";
+    case "score_edit":
+      return "Edit Score";
+    case "sample_init":
+      return "Sample";
+    case "sample_limit":
+      return sampleLimitTitles[event.type] ?? event.type;
+    case "input":
+      return "Input";
+    case "approval":
+      return approvalDecisionLabels[event.decision] ?? event.decision;
+    case "sandbox":
+      return `Sandbox: ${event.action}`;
+    default:
+      return "";
+  }
+};
 
 export const formatTiming = (timestamp: string, working_start?: number) => {
   if (working_start) {

--- a/src/inspect_ai/_view/www/src/tests/transcript/eventSearchText.test.ts
+++ b/src/inspect_ai/_view/www/src/tests/transcript/eventSearchText.test.ts
@@ -1,0 +1,335 @@
+import { eventSearchText } from "../../app/samples/transcript/eventSearchText";
+import { EventNode } from "../../app/samples/transcript/types";
+
+const makeNode = (event: Record<string, unknown>): EventNode => {
+  return new EventNode("test-id", event as never, 0);
+};
+
+describe("eventSearchText", () => {
+  test("score: includes 'Intermediate Score' for intermediate scores", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "score",
+        score: { answer: "yes", explanation: "partial", value: 0.5 },
+        target: null,
+        intermediate: true,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Intermediate Score");
+  });
+
+  test("score: includes 'Score' for non-intermediate scores", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "score",
+        score: { answer: "yes", explanation: "correct", value: "C" },
+        target: "expected",
+        intermediate: false,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Score");
+    expect(texts).not.toContain("Intermediate Score");
+  });
+
+  test("score_edit: includes 'Edit Score' title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "score_edit",
+        edit: { answer: "new", explanation: "fixed", provenance: null },
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Edit Score");
+  });
+
+  test("sample_limit: maps all limit types to titles", () => {
+    const typeToTitle: Record<string, string> = {
+      custom: "Custom Limit Exceeded",
+      time: "Time Limit Exceeded",
+      message: "Message Limit Exceeded",
+      token: "Token Limit Exceeded",
+      operator: "Operator Canceled",
+      working: "Execution Time Limit Exceeded",
+      cost: "Cost Limit Exceeded",
+    };
+    for (const [type, expectedTitle] of Object.entries(typeToTitle)) {
+      const texts = eventSearchText(
+        makeNode({
+          event: "sample_limit",
+          type,
+          message: "",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+      );
+      expect(texts).toContain(expectedTitle);
+    }
+  });
+
+  test("approval: includes decision label", () => {
+    const decisions: Record<string, string> = {
+      approve: "Approved",
+      reject: "Rejected",
+      terminate: "Terminated",
+    };
+    for (const [decision, expected] of Object.entries(decisions)) {
+      const texts = eventSearchText(
+        makeNode({
+          event: "approval",
+          decision,
+          explanation: "",
+          timestamp: "2024-01-01T00:00:00Z",
+        }),
+      );
+      expect(texts).toContain(expected);
+    }
+  });
+
+  test("sandbox: includes action in title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "sandbox",
+        action: "exec",
+        cmd: "ls -la",
+        file: null,
+        input: null,
+        output: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Sandbox: exec");
+    expect(texts).toContain("ls -la");
+  });
+
+  test("model: includes title with role when present", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "model",
+        model: "gpt-4",
+        role: "assistant",
+        output: { choices: [] },
+        input: [],
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Model Call (assistant): gpt-4");
+  });
+
+  test("model: includes title without role when absent", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "model",
+        model: "gpt-4",
+        role: null,
+        output: { choices: [] },
+        input: [],
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Model Call: gpt-4");
+  });
+
+  test("step: includes formatted title with type prefix", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "step",
+        name: "generate",
+        type: "solver",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("solver: generate");
+  });
+
+  test("step: includes 'Step: name' when no type", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "step",
+        name: "my_step",
+        type: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Step: my_step");
+  });
+
+  test("subtask: 'Fork:' for fork type, 'Subtask:' for others", () => {
+    const fork = eventSearchText(
+      makeNode({
+        event: "subtask",
+        name: "parallel",
+        type: "fork",
+        input: null,
+        result: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(fork).toContain("Fork: parallel");
+
+    const sub = eventSearchText(
+      makeNode({
+        event: "subtask",
+        name: "check",
+        type: "subtask",
+        input: null,
+        result: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(sub).toContain("Subtask: check");
+  });
+
+  test("tool: includes 'Tool:' title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "tool",
+        function: "search",
+        view: { title: "Web Search" },
+        arguments: null,
+        result: null,
+        error: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Tool: Web Search");
+    expect(texts).toContain("search");
+  });
+
+  test("error: includes 'Error' title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "error",
+        error: { message: "something broke", traceback: null },
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Error");
+    expect(texts).toContain("something broke");
+  });
+
+  test("logger: includes level as title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "logger",
+        message: {
+          level: "WARNING",
+          message: "disk space low",
+          filename: "main.py",
+        },
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("WARNING");
+    expect(texts).toContain("disk space low");
+  });
+
+  test("info: includes 'Info' title with source", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "info",
+        source: "system",
+        data: "startup complete",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Info: system");
+    expect(texts).toContain("startup complete");
+  });
+
+  test("info: includes 'Info' title without source", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "info",
+        source: null,
+        data: "startup complete",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Info");
+  });
+
+  test("sample_init: includes 'Sample' title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "sample_init",
+        sample: { target: "expected answer" },
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Sample");
+    expect(texts).toContain("expected answer");
+  });
+
+  test("input: includes 'Input' title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "input",
+        input_ansi: "user typed this",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Input");
+    expect(texts).toContain("user typed this");
+  });
+
+  test("span_begin: includes formatted title with type prefix", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "span_begin",
+        name: "evaluate",
+        type: "solver",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("solver: evaluate");
+  });
+
+  test("span_begin: uses 'Init' override for init name", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "span_begin",
+        name: "init",
+        type: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Init");
+  });
+
+  test("span_begin: includes 'Step: name' when no type and no override", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "span_begin",
+        name: "my_span",
+        type: null,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Step: my_span");
+  });
+
+  test("compaction: includes 'Compaction' title", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "compaction",
+        source: "inspect",
+        tokens_before: 1000,
+        tokens_after: 500,
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toContain("Compaction");
+    expect(texts).toContain("inspect");
+  });
+
+  test("unknown event: returns empty array", () => {
+    const texts = eventSearchText(
+      makeNode({
+        event: "state",
+        timestamp: "2024-01-01T00:00:00Z",
+      }),
+    );
+    expect(texts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The Copy > Transcript button actually copies Messages. Same with Download > Transcript.

### What is the new behavior?

- **Renamed** Copy/Download > "Transcript" to Copy/Download > "Messages" 
- **Added** Copy/Download > "Transcript" that extracts messages from model events via `messagesFromEvents()`.

### Does this PR introduce a breaking change?

No. You just need to use a different button.

### Other information:
