### PR TITLE
fix: prevent shell exec-optimization from hiding leaked processes in self-check

### DIFF
--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -438,9 +438,13 @@ async def test_exec_timeout_kills_process(sandbox_env: SandboxEnvironment) -> No
         random.choices(string.ascii_lowercase + string.digits, k=16)
     )
 
+    # The trailing "; :" prevents the shell from exec-optimizing into
+    # `sleep 30` (which would strip the marker from the process cmdline,
+    # making ps unable to detect a leaked process).
     with Raises(TimeoutError):
         await sandbox_env.exec(
-            ["sh", "-c", f"echo '{unique_marker}' > /dev/null && sleep 30"], timeout=2
+            ["sh", "-c", f"echo '{unique_marker}' > /dev/null && sleep 30; :"],
+            timeout=2,
         )
 
     # give cleanup a moment to complete


### PR DESCRIPTION
- `test_exec_timeout_kills_process` in `self_check.py` can falsely pass when a sandbox provider does **not** kill processes on timeout
- The command `sh -c "echo 'MARKER' > /dev/null && sleep 30"` allows the shell to exec-optimize into `sleep 30` after `echo` completes, stripping the marker from the process cmdline
- `ps aux | grep MARKER` then finds nothing regardless of whether the process was actually killed
- Fix: append `; :` (a no-op) so the shell can't exec-optimize — it must stay alive to run `:`, keeping its full cmdline (with marker) visible to `ps`