### PR TITLE
Log model retries at WARNING when backoff >= 60s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Model API: Log model retries at WARNING when backoff >= 60s.
+
 ## 0.3.207 (16 April 2026)
 
 - Anthropic: Auto-detect correct context window and max tokens for Opus 4.7.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1903,8 +1903,9 @@ def combine_messages(
 
 
 def log_model_retry(model_name: str, retry_state: RetryCallState) -> None:
+    level = logging.WARNING if retry_state.upcoming_sleep >= 60 else HTTP
     logger.log(
-        HTTP,
+        level,
         f"-> {model_name} retry {retry_state.attempt_number} (retrying in {retry_state.upcoming_sleep:,.0f} seconds)",
     )
 


### PR DESCRIPTION
## Summary

- Model retry messages were logged at `HTTP` level (15), below the default display and transcript thresholds. Even sustained multi-hour retry loops (e.g. 16 retries with 30-minute backoffs from 429s) were invisible outside the trace log.
- Escalate to `WARNING` when the upcoming backoff sleep is >= 60 seconds. With the standard exponential backoff (`initial=3s, max=30min`), retries 1–5 (~3–48s) stay quiet while retries 6+ (~96s+) become visible in the console and eval log.

## Context

We discovered this investigating an eval run that appeared stuck for ~4 hours. The trace log showed 16 consecutive 429 retries with exponential backoff up to the 30-minute cap, but no WARNING or INFO message was ever emitted. The only evidence was in the trace-level log.

## Known limitation

`ModelEvent.retries` in the transcript is also broken for these outer tenacity retries. The counter only increments for SDK-level (inner) retries because `report_active_sample_retry()` runs after `track_active_model_event()` has exited, so `_active_model_event` is `None`. This means the structured transcript data shows `retries: 0` even during multi-hour retry storms.

There are multiple ways to fix this, but I think I will leave it up to you to decide how. Possibilities include: extending the `track_active_model_event()` context to wrap the full tenacity retry sequence (so the model event spans all attempts), or passing the model event explicitly to `report_active_sample_retry()` rather than relying on the thread-local `_active_model_event`.

## Test plan

- [x] Verify short retries (< 60s backoff) still log at HTTP level
- [x] Verify long retries (>= 60s backoff) log at WARNING level
- [x] Confirm WARNING messages appear in console output and eval log