### PR TITLE
fix: google provider splits cached tokens out of input_tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Google: Correct counting for cached input tokens. 
 - Model API: Log model retries at WARNING when backoff >= 60s.
 - Model API: Enrich retry log messages with task/sample/model context and error summary.
 - Text Editor: Return `OSError` from path validation (e.g. `ENAMETOOLONG`) to the model as a tool error instead of crashing the eval.

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -1589,10 +1589,18 @@ def usage_metadata_to_model_usage(
 ) -> ModelUsage | None:
     if metadata is None:
         return None
+    # Gemini reports `prompt_token_count` as the full prompt size including
+    # any cached portion. To match the convention used by the OpenAI and
+    # Anthropic providers — where `input_tokens` is fresh (uncached) input
+    # and `input_tokens_cache_read` is the cache hit — subtract out the
+    # cached count from `input_tokens` and surface it separately.
+    cached = metadata.cached_content_token_count or 0
+    prompt = metadata.prompt_token_count or 0
     return ModelUsage(
-        input_tokens=metadata.prompt_token_count or 0,
+        input_tokens=max(prompt - cached, 0),
         output_tokens=metadata.candidates_token_count or 0,
         total_tokens=metadata.total_token_count or 0,
+        input_tokens_cache_read=cached or None,
         reasoning_tokens=metadata.thoughts_token_count or 0,
     )
 

--- a/tests/model/test_google_convert.py
+++ b/tests/model/test_google_convert.py
@@ -288,6 +288,76 @@ async def test_model_output_from_google_with_reasoning() -> None:
     assert has_text
 
 
+async def test_model_output_from_google_with_cached_content() -> None:
+    """Check cached content is surfaced as `input_tokens_cache_read`.
+
+    Gemini returns `cached_content_token_count` when implicit or explicit
+    context caching applies. That count must be surfaced as
+    `input_tokens_cache_read` and excluded from `input_tokens`, matching the
+    convention used by the OpenAI and Anthropic providers.
+    """
+    response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[Part(text="cached reply")],
+                ),
+                finish_reason=FinishReason.STOP,
+                index=0,
+            )
+        ],
+        usage_metadata=GenerateContentResponseUsageMetadata(
+            prompt_token_count=1000,
+            cached_content_token_count=800,
+            candidates_token_count=25,
+            total_token_count=1025,
+        ),
+        model_version="gemini-2.5-pro",
+    )
+
+    result = await model_output_from_google(response)
+
+    assert result.usage is not None
+    # prompt_token_count (1000) includes the cached portion; fresh input is 200
+    assert result.usage.input_tokens == 200
+    assert result.usage.input_tokens_cache_read == 800
+    assert result.usage.output_tokens == 25
+    assert result.usage.total_tokens == 1025
+
+
+async def test_model_output_from_google_without_cached_content() -> None:
+    """Check `input_tokens_cache_read` stays None when no caching occurred.
+
+    When no caching occurred, `input_tokens_cache_read` stays None so the
+    field doesn't appear in serialized usage for non-caching models.
+    """
+    response = GenerateContentResponse(
+        candidates=[
+            Candidate(
+                content=Content(
+                    role="model",
+                    parts=[Part(text="fresh")],
+                ),
+                finish_reason=FinishReason.STOP,
+                index=0,
+            )
+        ],
+        usage_metadata=GenerateContentResponseUsageMetadata(
+            prompt_token_count=100,
+            candidates_token_count=10,
+            total_token_count=110,
+        ),
+        model_version="gemini-2.5-flash",
+    )
+
+    result = await model_output_from_google(response)
+
+    assert result.usage is not None
+    assert result.usage.input_tokens == 100
+    assert result.usage.input_tokens_cache_read is None
+
+
 async def test_model_output_from_google_dict_input() -> None:
     """Test conversion from dict representation of GenerateContentResponse."""
     response_dict = {


### PR DESCRIPTION
Gemini's `prompt_token_count` includes the cached prefix, so reporting it directly as `input_tokens` double-counted cache hits relative to the OpenAI and Anthropic providers. Subtract `cached_content_token_count` from `input_tokens` and surface it as `input_tokens_cache_read`.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Inspect discards the cache tokens for gemini model usage. 
### What is the new behavior?
Inspect logs the cache token usage and subtracts this from input token usage (inline with openai and anthropic inspect standards)
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
