### PR TITLE
compute inspect-evals count dynamically on extensions page

### DIFF
--- a/docs/extensions/_extensions_content.md
+++ b/docs/extensions/_extensions_content.md
@@ -82,7 +82,7 @@
 ## Evals {#sec-evals}
 
 [Inspect Evals](https://ukgovernmentbeis.github.io/inspect_evals/) &mdash; <small><a href="https://github.com/UKGovernmentBEIS/inspect_evals" style="text-decoration:none">UK AISI</a></small>
-:   Over 1000 LLM evaluations covering safety, coding, reasoning, knowledge, and agent capabilities.
+:   Over 120 LLM evaluations covering safety, coding, reasoning, knowledge, and agent capabilities.
 
 [OpenBench](https://github.com/groq/openbench) &mdash; <small><a href="https://github.com/groq" style="text-decoration:none">Groq</a></small>
 :   Standardized, reproducible benchmarking for LLMs across 30+ evals.

--- a/docs/extensions/extensions.yml
+++ b/docs/extensions/extensions.yml
@@ -84,7 +84,7 @@
 
 - name: "[Inspect Evals](https://ukgovernmentbeis.github.io/inspect_evals/)"
   description: |
-    Over 1000 LLM evaluations covering safety, coding, reasoning, knowledge, and agent capabilities.
+    Over {INSPECT_EVALS_COUNT} LLM evaluations covering safety, coding, reasoning, knowledge, and agent capabilities.
   author: "[UK AISI](https://github.com/UKGovernmentBEIS/inspect_evals)"
   categories: ["Evals"]
 

--- a/docs/extensions/generate.py
+++ b/docs/extensions/generate.py
@@ -1,6 +1,6 @@
-from pathlib import Path
-
+import json
 import re
+from pathlib import Path
 
 import yaml
 
@@ -28,6 +28,12 @@ SECTION_IDS = {
 with open(PATH / "extensions.yml", "r") as f:
     records = yaml.safe_load(f)
 
+evals_json = PATH.parent / "evals" / "evals.json"
+inspect_evals_count = sum(
+    1 for r in json.loads(evals_json.read_text()) if r.get("source") == "evals"
+)
+inspect_evals_count_floor = (inspect_evals_count // 10) * 10
+
 groups: dict[str, list] = {cat: [] for cat in CATEGORY_ORDER}
 for record in records:
     cat = record.get("categories", ["Tooling"])[0]
@@ -41,6 +47,7 @@ for cat, items in groups.items():
     for item in items:
         name = item.get("name", "").strip()
         desc = item.get("description", "").strip().replace("\n", " ")
+        desc = desc.replace("{INSPECT_EVALS_COUNT}", str(inspect_evals_count_floor))
         author_raw = item.get("author", "").strip()
         # Convert markdown link to HTML <a> with no underline
         author_match = re.match(r"\[(.+?)\]\((.+?)\)", author_raw)


### PR DESCRIPTION
The [Inspect Evals card here](https://inspect.aisi.org.uk/extensions/) says 1000 evaluations (maybe this meant to be 100), but inspect_evals ships ~120, and it is a [moving target](https://sdsimmons.com/experiments/inspect-evals/)

<img width="723" height="283" alt="image" src="https://github.com/user-attachments/assets/4e402f29-f9c2-4641-bce2-bb4189e6499d" />
 



Derive the count from docs/evals/evals.json (source == "evals") floored to the nearest 10 and substitute `{INSPECT_EVALS_COUNT}` in the description via generate.py,

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [X] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

<img width="1058" height="294" alt="image" src="https://github.com/user-attachments/assets/123326f2-f282-4b7b-9c59-61724813e3d3" />


### What is the new behavior?

<img width="741" height="190" alt="image" src="https://github.com/user-attachments/assets/d2fa2904-aa9f-471a-bf96-cba68caa032b" />


### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

N/A

### Other information:

N/A