### PR TITLE
VACUUM and shrink_memory for buffer database

### DIFF
--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -289,6 +289,30 @@ class SampleBufferDatabase(SampleBuffer):
             finally:
                 cursor.close()
 
+        self._vacuum()
+
+    def _vacuum(self) -> None:
+        """Compact the database file to reclaim disk space."""
+        try:
+            conn = sqlite3.connect(self.db_path, timeout=30)
+            try:
+                conn.execute("VACUUM")
+            finally:
+                conn.close()
+        except sqlite3.OperationalError as ex:
+            logger.warning(f"VACUUM failed (non-fatal): {ex}")
+
+    def _shrink_memory(self) -> None:
+        """Release unused SQLite page cache memory."""
+        try:
+            conn = sqlite3.connect(self.db_path, timeout=30)
+            try:
+                conn.execute("PRAGMA shrink_memory")
+            finally:
+                conn.close()
+        except sqlite3.OperationalError as ex:
+            logger.warning(f"PRAGMA shrink_memory failed (non-fatal): {ex}")
+
     def cleanup(self) -> None:
         cleanup_sample_buffer_db(self.db_path)
         if self._sync_filestore is not None:
@@ -447,6 +471,7 @@ class SampleBufferDatabase(SampleBuffer):
                     sync_to_filestore(self, self._sync_filestore)
 
                 self._sync_time = time.monotonic()
+                self._shrink_memory()
 
     def _increment_version(self, conn: Connection) -> None:
         conn.execute("""

--- a/tests/log/test_buffer_compaction.py
+++ b/tests/log/test_buffer_compaction.py
@@ -1,0 +1,67 @@
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.log._log import EvalSampleSummary
+from inspect_ai.log._recorders.buffer import SampleBufferDatabase
+from inspect_ai.log._recorders.types import SampleEvent
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_output import ModelOutput
+
+
+@pytest.fixture
+def db() -> Generator[SampleBufferDatabase, None, None]:
+    with tempfile.TemporaryDirectory() as db_dir:
+        test_db = SampleBufferDatabase(location="test_location", db_dir=Path(db_dir))
+        yield test_db
+        test_db.cleanup()
+
+
+def _make_model_event(input_msgs: list) -> ModelEvent:
+    return ModelEvent(
+        model="test-model",
+        input=input_msgs,
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("test-model", "response"),
+    )
+
+
+def test_vacuum_after_remove_samples(db: SampleBufferDatabase) -> None:
+    """DB file shrinks after remove_samples due to VACUUM."""
+    for i in range(20):
+        sample_id = f"s{i}"
+        sample = EvalSampleSummary(id=sample_id, epoch=1, input="test", target="target")
+        db.start_sample(sample)
+        for j in range(10):
+            msg = ChatMessageUser(content=f"Message {i}-{j} " + "x" * 500)
+            db.log_events(
+                [SampleEvent(id=sample_id, epoch=1, event=_make_model_event([msg]))]
+            )
+
+    size_before = db.db_path.stat().st_size
+    assert size_before > 0
+
+    db.remove_samples([(f"s{i}", 1) for i in range(20)])
+
+    size_after = db.db_path.stat().st_size
+
+    assert size_after < size_before * 0.5, (
+        f"Expected significant shrinkage: before={size_before}, after={size_after}"
+    )
+
+
+def test_shrink_memory_on_sync(db: SampleBufferDatabase) -> None:
+    """PRAGMA shrink_memory executes without error."""
+    sample = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
+    db.start_sample(sample)
+
+    msg = ChatMessageUser(content="Hello")
+    db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg]))])
+
+    db._shrink_memory()


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

The SQLite buffer database grows as events accumulate during eval execution. When samples complete and `remove_samples()` deletes their rows, the freed disk space is never reclaimed -- SQLite reuses the pages internally but the file (and its OS page cache footprint) never shrinks.

### What is the new behavior?

- Call `VACUUM` after `remove_samples()` to compact the database file, reducing on-disk size and OS page cache footprint
- Call `PRAGMA shrink_memory` after filestore sync as a low-cost hedge to release unused SQLite internal page cache

### Does this PR introduce a breaking change?

No.

### Other information:

Part of addressing OOM issues in long-running evals where the buffer system's SQLite DB contributes to cgroup memory pressure via OS page cache.

For evals with many short-lived samples that complete frequently, VACUUM reclaims dead space after each flush batch. For long-running single samples, the benefit is modest since `remove_samples()` fires rarely.