### PR TITLE
Evict pool entries on CompactionEvent to reduce memory

### DIFF
--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from logging import getLogger
 from pathlib import Path
 from sqlite3 import Connection, OperationalError
-from typing import Callable, Iterator, Literal
+from typing import Callable, Iterator, Literal, cast
 
 import psutil
 from pydantic import BaseModel, JsonValue
@@ -22,6 +22,7 @@ from inspect_ai._util.file import basename, dirname, filesystem
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.trace import trace_action
+from inspect_ai.event._compaction import CompactionEvent
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.model import ChatMessage
 
@@ -169,10 +170,10 @@ class SampleBufferDatabase(SampleBuffer):
 
         # Per-sample pool indices for message/call dedup
         self._msg_pools: dict[
-            tuple[str | int, int], tuple[list[ChatMessage], dict[str, int]]
+            tuple[str | int, int], tuple[list[ChatMessage | None], dict[str, int]]
         ] = {}
         self._call_pools: dict[
-            tuple[str | int, int], tuple[list[JsonValue], dict[str, int]]
+            tuple[str | int, int], tuple[list[JsonValue | None], dict[str, int]]
         ] = {}
 
         # create sync filestore if log_shared
@@ -639,6 +640,18 @@ class SampleBufferDatabase(SampleBuffer):
         # insert attachments
         self._insert_attachments(conn, event.id, event.epoch, attachments)
 
+        # evict pool entries on compaction to free memory
+        if isinstance(event.event, CompactionEvent):
+            key = (event.id, event.epoch)
+            if key in self._msg_pools:
+                msg_evict_pool, _msg_evict_index = self._msg_pools[key]
+                for i in range(len(msg_evict_pool)):
+                    msg_evict_pool[i] = None
+            if key in self._call_pools:
+                call_evict_pool, _call_evict_index = self._call_pools[key]
+                for i in range(len(call_evict_pool)):
+                    call_evict_pool[i] = None
+
         # message/call pool dedup for ModelEvents
         if isinstance(event.event, ModelEvent):
             key = (event.id, event.epoch)
@@ -646,30 +659,33 @@ class SampleBufferDatabase(SampleBuffer):
             # message pool
             msg_pool, msg_index = self._msg_pools.get(key, ([], {}))
             prev_msg_len = len(msg_pool)
-            [condensed_event], msg_pool = condense_model_event_inputs(
-                [event.event], msg_pool, msg_index
+            [condensed_event], new_msg_pool = condense_model_event_inputs(
+                [event.event], cast(list[ChatMessage], msg_pool), msg_index
             )
             event = SampleEvent(id=event.id, epoch=event.epoch, event=condensed_event)
-            for i in range(prev_msg_len, len(msg_pool)):
-                msg = msg_pool[i]
+            for i in range(prev_msg_len, len(new_msg_pool)):
+                msg = new_msg_pool[i]
                 msg_id = msg.id if msg.id is not None else _msg_hash(msg)
                 self._insert_message_pool_entry(
                     conn, event.id, event.epoch, msg_id, msg
                 )
-            self._msg_pools[key] = (msg_pool, msg_index)
+            self._msg_pools[key] = (
+                cast(list[ChatMessage | None], new_msg_pool),
+                msg_index,
+            )
 
             # call pool
             call_pool, call_index = self._call_pools.get(key, ([], {}))
             prev_call_len = len(call_pool)
-            [condensed_event], call_pool = condense_model_event_calls(
+            [condensed_event], new_call_pool = condense_model_event_calls(
                 [event.event], call_pool, call_index
             )
             event = SampleEvent(id=event.id, epoch=event.epoch, event=condensed_event)
-            for i in range(prev_call_len, len(call_pool)):
-                call_msg = call_pool[i]
+            for i in range(prev_call_len, len(new_call_pool)):
+                call_msg = new_call_pool[i]
                 h = mm3_hash(json.dumps(call_msg, sort_keys=True))
                 self._insert_call_pool_entry(conn, event.id, event.epoch, h, call_msg)
-            self._call_pools[key] = (call_pool, call_index)
+            self._call_pools[key] = (new_call_pool, call_index)
 
         return event
 

--- a/tests/log/test_buffer_pool_eviction.py
+++ b/tests/log/test_buffer_pool_eviction.py
@@ -1,0 +1,201 @@
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from inspect_ai.event._compaction import CompactionEvent
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.log._log import EvalSampleSummary
+from inspect_ai.log._recorders.buffer import SampleBufferDatabase
+from inspect_ai.log._recorders.types import SampleEvent
+from inspect_ai.model._chat_message import ChatMessageAssistant, ChatMessageUser
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput
+
+
+@pytest.fixture
+def db() -> Generator[SampleBufferDatabase, None, None]:
+    with tempfile.TemporaryDirectory() as db_dir:
+        test_db = SampleBufferDatabase(location="test_location", db_dir=Path(db_dir))
+        yield test_db
+        test_db.cleanup()
+
+
+def _make_model_event(input_msgs: list) -> ModelEvent:
+    return ModelEvent(
+        model="test-model",
+        input=input_msgs,
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("test-model", "response"),
+    )
+
+
+def _make_model_event_with_call(input_msgs: list, call_messages: list) -> ModelEvent:
+    event = _make_model_event(input_msgs)
+    return event.model_copy(
+        update={
+            "call": ModelCall(
+                request={"model": "test", "messages": call_messages},
+                response={"id": "r1", "choices": []},
+            )
+        }
+    )
+
+
+def test_compaction_event_nulls_pool_entries(db: SampleBufferDatabase) -> None:
+    """CompactionEvent nulls pool list entries but preserves the index."""
+    sample = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
+    db.start_sample(sample)
+
+    msg_a = ChatMessageUser(content="Hello")
+    msg_b = ChatMessageAssistant(content="Hi there")
+
+    db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_a]))])
+    db.log_events(
+        [SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_a, msg_b]))]
+    )
+
+    key = ("s1", 1)
+    pool, index = db._msg_pools[key]
+    pool_len_before = len(pool)
+    assert pool_len_before > 0
+    assert all(entry is not None for entry in pool)
+
+    compaction_event = CompactionEvent(
+        type="summary",
+        source="inspect",
+        tokens_before=1000,
+        tokens_after=200,
+    )
+    db.log_events([SampleEvent(id="s1", epoch=1, event=compaction_event)])
+
+    pool, index = db._msg_pools[key]
+    assert len(pool) == pool_len_before
+    assert all(entry is None for entry in pool)
+
+
+def test_new_messages_append_after_eviction(db: SampleBufferDatabase) -> None:
+    """After pool eviction, new messages append correctly to the pool."""
+    sample = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
+    db.start_sample(sample)
+
+    msg_a = ChatMessageUser(content="Hello")
+    msg_b = ChatMessageAssistant(content="Hi there")
+
+    db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_a]))])
+    db.log_events(
+        [SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_a, msg_b]))]
+    )
+
+    key = ("s1", 1)
+    pool_len_before_compaction = len(db._msg_pools[key][0])
+
+    compaction_event = CompactionEvent(
+        type="summary", source="inspect", tokens_before=1000, tokens_after=200
+    )
+    db.log_events([SampleEvent(id="s1", epoch=1, event=compaction_event)])
+
+    msg_c = ChatMessageUser(content="Compacted summary of conversation")
+    db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_c]))])
+
+    pool, index = db._msg_pools[key]
+
+    # Pool grew by the new message(s)
+    assert len(pool) > pool_len_before_compaction
+    # Old entries are still None
+    for i in range(pool_len_before_compaction):
+        assert pool[i] is None
+    # New entry at the end is not None
+    assert pool[-1] is not None
+    assert pool[-1].content == "Compacted summary of conversation"
+
+    # DB still returns data
+    data = db.get_sample_data("s1", 1)
+    assert data is not None
+    assert len(data.message_pool) > 0
+
+
+def test_multi_sample_pool_eviction_is_isolated(db: SampleBufferDatabase) -> None:
+    """Compaction on one sample does not affect another sample's pool."""
+    sample1 = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
+    sample2 = EvalSampleSummary(id="s2", epoch=1, input="test", target="target")
+    db.start_sample(sample1)
+    db.start_sample(sample2)
+
+    msg_a = ChatMessageUser(content="Hello from s1")
+    msg_b = ChatMessageUser(content="Hello from s2")
+
+    db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_a]))])
+    db.log_events([SampleEvent(id="s2", epoch=1, event=_make_model_event([msg_b]))])
+
+    key1 = ("s1", 1)
+    key2 = ("s2", 1)
+    assert len(db._msg_pools[key1][0]) > 0
+    assert len(db._msg_pools[key2][0]) > 0
+
+    # Compact only s1
+    compaction_event = CompactionEvent(
+        type="summary", source="inspect", tokens_before=1000, tokens_after=200
+    )
+    db.log_events([SampleEvent(id="s1", epoch=1, event=compaction_event)])
+
+    # s1 pool entries are nulled
+    pool1, _ = db._msg_pools[key1]
+    assert all(entry is None for entry in pool1)
+
+    # s2 pool entries are untouched
+    pool2, _ = db._msg_pools[key2]
+    assert all(entry is not None for entry in pool2)
+
+
+def test_call_pool_eviction(db: SampleBufferDatabase) -> None:
+    """CompactionEvent also nulls call pool entries."""
+    sample = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
+    db.start_sample(sample)
+
+    call_msgs = [{"role": "user", "content": "Hello"}]
+    db.log_events(
+        [
+            SampleEvent(
+                id="s1",
+                epoch=1,
+                event=_make_model_event_with_call(
+                    [ChatMessageUser(content="Hello")], call_msgs
+                ),
+            )
+        ]
+    )
+
+    key = ("s1", 1)
+    call_pool, call_index = db._call_pools[key]
+    assert len(call_pool) > 0
+    assert all(entry is not None for entry in call_pool)
+
+    compaction_event = CompactionEvent(
+        type="summary", source="inspect", tokens_before=1000, tokens_after=200
+    )
+    db.log_events([SampleEvent(id="s1", epoch=1, event=compaction_event)])
+
+    call_pool, call_index = db._call_pools[key]
+    assert all(entry is None for entry in call_pool)
+
+
+def test_compaction_without_prior_pool_is_noop(db: SampleBufferDatabase) -> None:
+    """CompactionEvent on a sample with no pool entries doesn't error."""
+    sample = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
+    db.start_sample(sample)
+
+    compaction_event = CompactionEvent(
+        type="summary", source="inspect", tokens_before=1000, tokens_after=200
+    )
+    # Should not raise
+    db.log_events([SampleEvent(id="s1", epoch=1, event=compaction_event)])
+
+    # Pools should not exist for this key
+    key = ("s1", 1)
+    assert key not in db._msg_pools
+    assert key not in db._call_pools


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

The in-memory dedup pools (`_msg_pools`, `_call_pools`) in `SampleBufferDatabase` accumulate every unique message and tool call for the entire sample lifetime. After model context compaction replaces old messages with a summary, the old pool entries are dead weight but never freed. For long-running samples (hours/days), these pools grow without bound.

### What is the new behavior?

When a `CompactionEvent` flows through `_condense_event()`, all entries in the message pool and call pool for that sample/epoch are nulled. The index dict is kept intact so that positional references in the DB and segments remain valid. New messages from subsequent model events are appended at the end of the pool.

This frees the `ChatMessage` objects (the primary memory consumers) while preserving the dedup index for correctness.

### Does this PR introduce a breaking change?

No.

### Other information:

The pool type annotations change from `list[ChatMessage]` to `list[ChatMessage | None]` (and similarly for call pools). A `cast()` is used at the boundary where pools are passed to `condense_model_event_inputs()` since that function never reads existing pool entries (it only checks the index and appends).