### PR TITLE
Serialize CompactionStrategy parameters in eval logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Capture compaction strategy params in eval log.
+
 ## 0.3.208 (19 April 2026)
 
 - Google: Correct counting for cached input tokens. 

--- a/src/inspect_ai/_util/registry.py
+++ b/src/inspect_ai/_util/registry.py
@@ -139,6 +139,9 @@ def extract_named_params(
 
     # callables are not serializable so use their names
     for param in named_params.keys():
+        if hasattr(named_params[param], "_repr_params_"):
+            named_params[param] = named_params[param]._repr_params_()
+
         if is_registry_object(named_params[param]):
             named_params[param] = registry_info(named_params[param]).name
         elif callable(named_params[param]) and hasattr(named_params[param], "__name__"):

--- a/src/inspect_ai/model/_compaction/auto.py
+++ b/src/inspect_ai/model/_compaction/auto.py
@@ -5,7 +5,7 @@ and falls back to summary-based compaction for unsupported providers.
 """
 
 from logging import getLogger
-from typing import Literal
+from typing import Any, Literal
 
 from typing_extensions import override
 
@@ -81,6 +81,13 @@ class CompactionAuto(CompactionStrategy):
             # Return True only after we've fallen back to summary
             return self._use_fallback
         return self._memory_setting
+
+    @override
+    def _repr_params_(self) -> dict[str, Any]:
+        params = super()._repr_params_()
+        params["instructions"] = self._instructions
+        params["memory"] = self._memory_setting
+        return params
 
     @override
     async def compact(

--- a/src/inspect_ai/model/_compaction/edit.py
+++ b/src/inspect_ai/model/_compaction/edit.py
@@ -1,4 +1,4 @@
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 from shortuuid import uuid
 from typing_extensions import override
@@ -72,6 +72,19 @@ class CompactionEdit(CompactionStrategy):
         self.keep_tool_uses = keep_tool_uses
         self.keep_tool_inputs = keep_tool_inputs
         self.exclude_tools = exclude_tools
+
+    @override
+    def _repr_params_(self) -> dict[str, Any]:
+        params = super()._repr_params_()
+        params.update(
+            {
+                "keep_thinking_turns": self.keep_thinking_turns,
+                "keep_tool_uses": self.keep_tool_uses,
+                "keep_tool_inputs": self.keep_tool_inputs,
+                "exclude_tools": self.exclude_tools,
+            }
+        )
+        return params
 
     @override
     async def compact(

--- a/src/inspect_ai/model/_compaction/native.py
+++ b/src/inspect_ai/model/_compaction/native.py
@@ -5,6 +5,7 @@ compaction endpoints (e.g., OpenAI Codex's responses.compact API).
 """
 
 from logging import getLogger
+from typing import Any
 
 from typing_extensions import override
 
@@ -60,6 +61,12 @@ class CompactionNative(CompactionStrategy):
         encoded in the compaction block (Anthropic).
         """
         return False
+
+    @override
+    def _repr_params_(self) -> dict[str, Any]:
+        params = super()._repr_params_()
+        params["instructions"] = self._instructions
+        return params
 
     @override
     async def compact(

--- a/src/inspect_ai/model/_compaction/summary.py
+++ b/src/inspect_ai/model/_compaction/summary.py
@@ -1,4 +1,5 @@
 from textwrap import dedent
+from typing import Any
 
 from typing_extensions import override
 
@@ -45,6 +46,18 @@ class CompactionSummary(CompactionStrategy):
         self.model = get_model(model) if model is not None else model
         self.instructions = instructions
         self.prompt = prompt or self.DEFAULT_SUMMARY_PROMPT
+
+    @override
+    def _repr_params_(self) -> dict[str, Any]:
+        params = super()._repr_params_()
+        params.update(
+            {
+                "model": self.model.name if self.model is not None else None,
+                "instructions": self.instructions,
+                "prompt": self.prompt,
+            }
+        )
+        return params
 
     @override
     async def compact(

--- a/src/inspect_ai/model/_compaction/trim.py
+++ b/src/inspect_ai/model/_compaction/trim.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from typing_extensions import override
 
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
@@ -37,6 +39,12 @@ class CompactionTrim(CompactionStrategy):
         """
         super().__init__(type="trim", threshold=threshold, memory=memory)
         self.preserve = preserve
+
+    @override
+    def _repr_params_(self) -> dict[str, Any]:
+        params = super()._repr_params_()
+        params["preserve"] = self.preserve
+        return params
 
     @override
     async def compact(

--- a/src/inspect_ai/model/_compaction/types.py
+++ b/src/inspect_ai/model/_compaction/types.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Literal, Protocol
+from typing import Any, Literal, Protocol
 
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
 from inspect_ai.model._model import Model
@@ -33,6 +33,13 @@ class CompactionStrategy(abc.ABC):
     def memory(self) -> bool:
         """Whether to warn the model to save content to memory before compaction."""
         return self._memory
+
+    def _repr_params_(self) -> dict[str, Any]:
+        return {
+            "type": self.type,
+            "threshold": self.threshold,
+            "memory": self.memory,
+        }
 
     @property
     def preserve_prefix(self) -> bool:

--- a/tests/agent/test_agent_compaction.py
+++ b/tests/agent/test_agent_compaction.py
@@ -105,6 +105,26 @@ def test_react_compaction_edit_reduces_input() -> None:
     assert max_count < 15, f"Expected compaction to limit messages, got {max_count}"
 
 
+def test_react_compaction_params_logged() -> None:
+    """Verify compaction parameters are fully serialized in eval log."""
+    log = run_react_with_compaction(
+        compaction=CompactionEdit(threshold=500, keep_tool_uses=1, memory=False),
+    )
+
+    assert log.status == "success"
+
+    # Check plan step params contains compaction as a dict with full params
+    compaction_params = log.plan.steps[0].params["compaction"]
+    assert isinstance(compaction_params, dict)
+    assert compaction_params["type"] == "edit"
+    assert compaction_params["threshold"] == 500
+    assert compaction_params["keep_tool_uses"] == 1
+    assert compaction_params["memory"] is False
+    assert compaction_params["keep_thinking_turns"] == 1
+    assert compaction_params["keep_tool_inputs"] is True
+    assert compaction_params["exclude_tools"] is None
+
+
 def test_react_compaction_trim_reduces_input() -> None:
     """Verify CompactionTrim trims older messages when threshold exceeded."""
     log = run_react_with_compaction(

--- a/tests/util/test_registry.py
+++ b/tests/util/test_registry.py
@@ -1,6 +1,7 @@
 from inspect_ai import Task, eval, task
 from inspect_ai._util.constants import PKG_NAME
 from inspect_ai._util.registry import (
+    extract_named_params,
     registry_create_from_dict,
     registry_info,
     registry_kwargs,
@@ -8,6 +9,12 @@ from inspect_ai._util.registry import (
     registry_value,
 )
 from inspect_ai.dataset import Sample
+from inspect_ai.model._compaction.auto import CompactionAuto
+from inspect_ai.model._compaction.edit import CompactionEdit
+from inspect_ai.model._compaction.native import CompactionNative
+from inspect_ai.model._compaction.summary import CompactionSummary
+from inspect_ai.model._compaction.trim import CompactionTrim
+from inspect_ai.model._compaction.types import CompactionStrategy
 from inspect_ai.scorer import Metric, metric
 from inspect_ai.scorer._metric import SampleScore
 from inspect_ai.solver import Solver, solver, use_tools
@@ -111,3 +118,68 @@ def test_registry_kwargs() -> None:
         args["solver_dict"]["inner_solver"],
     ):
         assert isinstance(arg_solver, Solver)
+
+
+def _extract(fn, *args, **kwargs):
+    """Helper to call extract_named_params with apply_defaults=True."""
+    return extract_named_params(fn, True, *args, **kwargs)
+
+
+def test_repr_params_serialization() -> None:
+    """Test that objects with _repr_params_ are serialized as dicts, not class names."""
+
+    def my_solver(compaction: CompactionStrategy) -> None: ...
+
+    result = _extract(
+        my_solver, compaction=CompactionEdit(threshold=0.8, keep_tool_uses=5)
+    )
+
+    assert isinstance(result["compaction"], dict)
+    assert result["compaction"]["type"] == "edit"
+    assert result["compaction"]["threshold"] == 0.8
+    assert result["compaction"]["keep_tool_uses"] == 5
+    assert result["compaction"]["memory"] is True
+    assert result["compaction"]["keep_thinking_turns"] == 1
+    assert result["compaction"]["keep_tool_inputs"] is True
+    assert result["compaction"]["exclude_tools"] is None
+
+
+def test_repr_params_all_strategies() -> None:
+    """Test _repr_params_ for each CompactionStrategy subclass."""
+
+    def my_solver(compaction: CompactionStrategy) -> None: ...
+
+    # CompactionEdit
+    result = _extract(my_solver, compaction=CompactionEdit(threshold=0.7))
+    assert result["compaction"]["type"] == "edit"
+    assert result["compaction"]["threshold"] == 0.7
+    assert "keep_tool_uses" in result["compaction"]
+
+    # CompactionTrim
+    result = _extract(my_solver, compaction=CompactionTrim(threshold=0.6, preserve=0.5))
+    assert result["compaction"]["type"] == "trim"
+    assert result["compaction"]["threshold"] == 0.6
+    assert result["compaction"]["preserve"] == 0.5
+
+    # CompactionSummary
+    result = _extract(
+        my_solver,
+        compaction=CompactionSummary(threshold=0.85, instructions="Keep code"),
+    )
+    assert result["compaction"]["type"] == "summary"
+    assert result["compaction"]["threshold"] == 0.85
+    assert result["compaction"]["instructions"] == "Keep code"
+
+    # CompactionNative
+    result = _extract(
+        my_solver, compaction=CompactionNative(threshold=0.9, instructions="Be concise")
+    )
+    assert result["compaction"]["threshold"] == 0.9
+    assert result["compaction"]["instructions"] == "Be concise"
+
+    # CompactionAuto
+    result = _extract(
+        my_solver, compaction=CompactionAuto(threshold=0.75, memory="auto")
+    )
+    assert result["compaction"]["threshold"] == 0.75
+    assert result["compaction"]["memory"] == "auto"


### PR DESCRIPTION
CompactionStrategy instances (e.g., `CompactionEdit`, `CompactionTrim`) were being logged as just their class name (e.g., `"CompactionEdit"`) in eval plan step params, losing all configuration details like `threshold`, `memory`, `keep_tool_uses`, etc.

### Approach

Introduced a `_repr_params_()` convention (following Jupyter's single-underscore `_repr_html_` precedent) that objects can implement to return a dict of their meaningful parameters. `extract_named_params()` in `registry.py` checks for this method and converts the object to a dict, which then flows through the existing `to_jsonable_python` serialization path.

### Changes

- `registry.py`: Added `_repr_params_` resolution in `extract_named_params()` before the existing type-dispatch chain
- `CompactionStrategy` base class: Implements `_repr_params_()` returning `type`, `threshold`, `memory`
- All subclasses override to add their strategy-specific params (e.g., `keep_tool_uses` for edit, `preserve` for trim, `instructions` for summary/native/auto)
- Added tests verifying all strategy types serialize to dicts with full parameters
