### PR TITLE
fix 400 on claude opus 4.7 when temperature is set

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -179,6 +179,15 @@ logger = getLogger(__name__)
 
 ANTHROPIC_API_KEY = "ANTHROPIC_API_KEY"
 AZUREAI_ANTHROPIC_API_KEY = "AZUREAI_ANTHROPIC_API_KEY"
+
+_THINKING_WARNING = (
+    "anthropic models do not support the '{parameter}' parameter "
+    "when using extended thinking."
+)
+_ADAPTIVE_ONLY_WARNING = (
+    "anthropic model '{model}' does not support the '{parameter}' parameter "
+    "(adaptive thinking only)."
+)
 AZURE_ANTHROPIC_API_KEY = "AZURE_ANTHROPIC_API_KEY"
 
 # Azure base URL environment variables
@@ -742,23 +751,31 @@ class AnthropicAPI(ModelAPI):
         if anthropic_beta_header:
             betas.extend([h.strip() for h in anthropic_beta_header.split(",")])
 
-        # temperature not compatible with extended thinking
-        THINKING_WARNING = "anthropic models do not support the '{parameter}' parameter when using extended thinking."
+        # Opus 4.7+ is always in adaptive thinking and rejects these params
+        # regardless of config; other models only reject them under thinking.
+        adaptive_only = self._forbids_sampling_params()
+        forbid_sampling_params = adaptive_only or self.is_using_thinking(config)
+
+        def sampling_param_warning(parameter: str) -> str:
+            if adaptive_only:
+                return _ADAPTIVE_ONLY_WARNING.format(
+                    parameter=parameter, model=self.service_model_name()
+                )
+            return _THINKING_WARNING.format(parameter=parameter)
+
         if config.temperature is not None:
-            if self.is_using_thinking(config):
-                warn_once(logger, THINKING_WARNING.format(parameter="temperature"))
+            if forbid_sampling_params:
+                warn_once(logger, sampling_param_warning("temperature"))
             else:
                 params["temperature"] = config.temperature
-        # top_p not compatible with extended thinking
         if config.top_p is not None:
-            if self.is_using_thinking(config):
-                warn_once(logger, THINKING_WARNING.format(parameter="top_p"))
+            if forbid_sampling_params:
+                warn_once(logger, sampling_param_warning("top_p"))
             else:
                 params["top_p"] = config.top_p
-        # top_k not compatible with extended thinking
         if config.top_k is not None:
-            if self.is_using_thinking(config):
-                warn_once(logger, THINKING_WARNING.format(parameter="top_k"))
+            if forbid_sampling_params:
+                warn_once(logger, sampling_param_warning("top_k"))
             else:
                 params["top_k"] = config.top_k
 
@@ -878,6 +895,13 @@ class AnthropicAPI(ModelAPI):
             (config.reasoning_tokens is not None)
             or (self.effort_from_reasoning_effort(config) is not None)
         )
+
+    def _forbids_sampling_params(self) -> bool:
+        # Opus 4.7+ is adaptive-thinking-only and rejects temperature/top_p/top_k.
+        # is_claude_4_7_or_later already covers is_claude_latest so future Opus
+        # minors and majors inherit this by default.
+        # https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#adaptive-thinking
+        return "opus" in self.service_model_name() and self.is_claude_4_7_or_later()
 
     # see https://github.com/anthropics/anthropic-sdk-python?tab=readme-ov-file#long-requests
     def auto_streaming(self, config: GenerateConfig) -> bool:

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -506,6 +506,118 @@ def test_anthropic_reasoning_effort_returns_none_for_old_models() -> None:
 
 
 # ---------------------------------------------------------------------------
+# sampling param stripping for Opus 4.7 (adaptive-thinking-only)
+# ---------------------------------------------------------------------------
+
+
+_SAMPLING_PARAMS: dict[str, float | int] = {
+    "temperature": 0.0,
+    "top_p": 0.9,
+    "top_k": 40,
+}
+
+
+def _cfg(**kwargs: Any) -> GenerateConfig:
+    return GenerateConfig(max_tokens=64, **kwargs)
+
+
+@pytest.mark.parametrize("param,value", list(_SAMPLING_PARAMS.items()))
+def test_anthropic_opus_4_7_strips_sampling_params(
+    param: str, value: float | int
+) -> None:
+    """Opus 4.7 rejects temperature/top_p/top_k outright; the provider must omit them."""
+    api = AnthropicAPI(model_name="claude-opus-4-7", api_key="test-key")
+    params, _extra_body, _headers, _betas = api.completion_config(
+        _cfg(**{param: value})
+    )
+    assert param not in params
+
+
+@pytest.mark.parametrize("param,value", list(_SAMPLING_PARAMS.items()))
+def test_anthropic_opus_4_7_strips_sampling_params_with_reasoning_effort_none(
+    param: str, value: float | int
+) -> None:
+    """reasoning_effort='none' must not re-enable sending sampling params on 4.7."""
+    api = AnthropicAPI(model_name="claude-opus-4-7", api_key="test-key")
+    params, _extra_body, _headers, _betas = api.completion_config(
+        _cfg(reasoning_effort="none", **{param: value})
+    )
+    assert param not in params
+
+
+@pytest.mark.parametrize("param,value", list(_SAMPLING_PARAMS.items()))
+def test_anthropic_opus_4_6_keeps_sampling_params_without_thinking(
+    param: str, value: float | int
+) -> None:
+    """Opus 4.6 still accepts sampling params when thinking is off."""
+    api = AnthropicAPI(model_name="claude-opus-4-6", api_key="test-key")
+    params, _extra_body, _headers, _betas = api.completion_config(
+        _cfg(**{param: value})
+    )
+    assert params[param] == value
+
+
+@pytest.mark.parametrize("model_name", ["claude-opus-4-8", "claude-opus-5-0"])
+@pytest.mark.parametrize("param,value", list(_SAMPLING_PARAMS.items()))
+def test_anthropic_future_opus_strips_sampling_params(
+    model_name: str, param: str, value: float | int
+) -> None:
+    """Future Opus minor and major releases inherit the 4.7 restriction."""
+    api = AnthropicAPI(model_name=model_name, api_key="test-key")
+    params, _extra_body, _headers, _betas = api.completion_config(
+        _cfg(**{param: value})
+    )
+    assert param not in params
+
+
+@pytest.mark.parametrize("param,value", list(_SAMPLING_PARAMS.items()))
+def test_anthropic_future_non_opus_keeps_sampling_params(
+    param: str, value: float | int
+) -> None:
+    """The restriction is Opus-specific; non-Opus future models still accept sampling params."""
+    api = AnthropicAPI(model_name="claude-sonnet-5-0", api_key="test-key")
+    params, _extra_body, _headers, _betas = api.completion_config(
+        _cfg(**{param: value})
+    )
+    assert params[param] == value
+
+
+@pytest.fixture
+def _reset_warn_once_cache() -> Any:
+    # warn_once dedupes via a module-level list; clear it so each test sees the emit.
+    from inspect_ai._util import logger as _inspect_logger
+
+    _inspect_logger._warned.clear()
+    yield
+    _inspect_logger._warned.clear()
+
+
+def test_anthropic_opus_4_7_emits_adaptive_only_warning(
+    caplog: pytest.LogCaptureFixture, _reset_warn_once_cache: Any
+) -> None:
+    """Opus 4.7 should emit the adaptive-only message, not the extended-thinking one."""
+    api = AnthropicAPI(model_name="claude-opus-4-7", api_key="test-key")
+    with caplog.at_level("WARNING", logger="inspect_ai.model._providers.anthropic"):
+        api.completion_config(_cfg(temperature=0.0))
+    assert any(
+        "adaptive thinking only" in r.message and "claude-opus-4-7" in r.message
+        for r in caplog.records
+    )
+    assert not any("when using extended thinking" in r.message for r in caplog.records)
+
+
+def test_anthropic_thinking_model_emits_extended_thinking_warning(
+    caplog: pytest.LogCaptureFixture, _reset_warn_once_cache: Any
+) -> None:
+    """A non-adaptive-only thinking model should emit the extended-thinking message."""
+    api = AnthropicAPI(model_name="claude-opus-4-6", api_key="test-key")
+    with caplog.at_level("WARNING", logger="inspect_ai.model._providers.anthropic"):
+        api.completion_config(_cfg(reasoning_effort="low", temperature=0.0))
+    assert any("when using extended thinking" in r.message for r in caplog.records)
+    assert not any("adaptive thinking only" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
 # live API exercises against claude-opus-4-7 (require --runapi)
 # ---------------------------------------------------------------------------
 
@@ -538,6 +650,36 @@ async def test_anthropic_reasoning_effort_xhigh_max_live(
         ),
     )
     response = await model.generate(input="What is 2 + 2? Briefly.")
+    assert len(response.completion) >= 1
+
+
+@pytest.mark.anyio
+@skip_if_no_anthropic
+async def test_anthropic_opus_4_7_accepts_temperature_config_live() -> None:
+    """Regression for #3721: explicit temperature=0.0 must not 400 on Opus 4.7."""
+    model = get_model(
+        "anthropic/claude-opus-4-7",
+        config=GenerateConfig(temperature=0.0, max_tokens=64),
+    )
+    response = await model.generate(input="Say hello in one short sentence.")
+    assert len(response.completion) >= 1
+
+
+@pytest.mark.anyio
+@skip_if_no_anthropic
+async def test_anthropic_opus_4_7_accepts_temperature_with_reasoning_effort_none_live() -> (
+    None
+):
+    """Regression for #3721: reasoning_effort='none' + temperature must not 400 on Opus 4.7."""
+    model = get_model(
+        "anthropic/claude-opus-4-7",
+        config=GenerateConfig(
+            reasoning_effort="none",
+            temperature=0.0,
+            max_tokens=64,
+        ),
+    )
+    response = await model.generate(input="Say hello in one short sentence.")
     assert len(response.completion) >= 1
 
 

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -583,38 +583,39 @@ def test_anthropic_future_non_opus_keeps_sampling_params(
 
 
 @pytest.fixture
-def _reset_warn_once_cache() -> Any:
-    # warn_once dedupes via a module-level list; clear it so each test sees the emit.
+def _warn_once_messages() -> Any:
+    # warn_once dedupes via a module-level list; clear it and yield it so the
+    # test can assert on what was emitted. caplog isn't reliable here because
+    # init_logger sets propagate=False on the inspect_ai logger once any
+    # earlier test triggers it.
     from inspect_ai._util import logger as _inspect_logger
 
     _inspect_logger._warned.clear()
-    yield
+    yield _inspect_logger._warned
     _inspect_logger._warned.clear()
 
 
 def test_anthropic_opus_4_7_emits_adaptive_only_warning(
-    caplog: pytest.LogCaptureFixture, _reset_warn_once_cache: Any
+    _warn_once_messages: list[str],
 ) -> None:
     """Opus 4.7 should emit the adaptive-only message, not the extended-thinking one."""
     api = AnthropicAPI(model_name="claude-opus-4-7", api_key="test-key")
-    with caplog.at_level("WARNING", logger="inspect_ai.model._providers.anthropic"):
-        api.completion_config(_cfg(temperature=0.0))
+    api.completion_config(_cfg(temperature=0.0))
     assert any(
-        "adaptive thinking only" in r.message and "claude-opus-4-7" in r.message
-        for r in caplog.records
+        "adaptive thinking only" in m and "claude-opus-4-7" in m
+        for m in _warn_once_messages
     )
-    assert not any("when using extended thinking" in r.message for r in caplog.records)
+    assert not any("when using extended thinking" in m for m in _warn_once_messages)
 
 
 def test_anthropic_thinking_model_emits_extended_thinking_warning(
-    caplog: pytest.LogCaptureFixture, _reset_warn_once_cache: Any
+    _warn_once_messages: list[str],
 ) -> None:
     """A non-adaptive-only thinking model should emit the extended-thinking message."""
     api = AnthropicAPI(model_name="claude-opus-4-6", api_key="test-key")
-    with caplog.at_level("WARNING", logger="inspect_ai.model._providers.anthropic"):
-        api.completion_config(_cfg(reasoning_effort="low", temperature=0.0))
-    assert any("when using extended thinking" in r.message for r in caplog.records)
-    assert not any("adaptive thinking only" in r.message for r in caplog.records)
+    api.completion_config(_cfg(reasoning_effort="low", temperature=0.0))
+    assert any("when using extended thinking" in m for m in _warn_once_messages)
+    assert not any("adaptive thinking only" in m for m in _warn_once_messages)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
opus 4.7 is adaptive-thinking-only and rejects temperature/top_p/top_k outright, but the anthropic provider only stripped these when reasoning was explicitly enabled. extend the guard to cover adaptive-only opus models and emit a model-specific warning.
                                                                                                                                                                               
  refs #3721
                                                                                                                                                                               
  ## This PR contains: 
  - [ ] New features
  - [ ] Changes to dev-tools e.g. CI config / github tooling
  - [ ] Docs
  - [x] Bug fixes
  - [ ] Code refactor                                                                                                                                                          
   
  ### What is the current behavior? (You can also link to an open issue here)                                                                                                  
                  
  Setting `temperature` (or `top_p` / `top_k`) in `GenerateConfig` against `anthropic/claude-opus-4-7` returns a 400:                                                          
   
  BadRequestError: Error code: 400 - {'type': 'error', 'error': {'type': 'invalid_request_error', 'message': 'temperature is deprecated for this model.'}}                     
                  
  This also reproduces with `reasoning_effort='none'` plus an explicit `temperature=0.0`. Any eval or task that sets `temperature` (a common pattern for deterministic output) fails on Opus 4.7.                                                                                                                                                           
   
  Root cause is in `anthropic.py::completion_config`: sampling params were only stripped when `is_using_thinking(config)` was true, which requires `reasoning_tokens` or reasoning_effort` to be set. Opus 4.7 is always in adaptive thinking server-side, so the API rejects these params even when Inspect hasn't opted into thinking explicitly.
                                                                                                                                                                               
  See #3721 for the full report.                                                                                                                                               
   
  ### What is the new behavior?                                                                                                                                                
                  
  A new `_forbids_sampling_params()` predicate identifies adaptive-thinking-only models (Opus 4.7 and any `is_claude_4_7_or_later` Opus, so future minor and major Opus releases inherit the restriction automatically). When it returns true, `temperature` / `top_p` / `top_k` are stripped regardless of reasoning config, and a model-specific warning is emitted:                                                                                                                                                          
                  
  anthropic model 'claude-opus-4-7' does not support the 'temperature' parameter (adaptive thinking only).                                                                     
   
  The existing extended-thinking warning is preserved for non-adaptive-only models where thinking is enabled. The restriction is scoped to Opus by name, so Sonnet / Haiku of the same or later version continue to accept sampling params.                                                                                                                
   
  Test coverage:                                                                                                                                                               
  - Opus 4.7 strips each of `temperature` / `top_p` / `top_k`
  - Opus 4.7 + `reasoning_effort='none'` still strips them                                                                                                                     
  - Opus 4.6 control keeps sampling params when thinking is off                                                                                                                
  - Future Opus (4.8, 5.0) inherit the restriction                                                                                                                             
  - Future non-Opus (Sonnet 5.0) still accepts sampling params                                                                                                                 
  - Warning variants: Opus 4.7 gets the adaptive-only message, 4.6 under thinking gets the extended-thinking message                                                           
  - Live `--runapi` regressions that call Opus 4.7 with `temperature=0.0` and with `reasoning_effort='none' + temperature=0.0`                                                 
                                                                                                                                                                               
  ### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)                                                   
                                                                                                                                                                               
  No. Requests that used to 400 now succeed with a warning. Nothing that previously succeeded changes.                                                                         
   
  ### Other information:                                                                                                                                                       
                  
  The predicate uses a substring check on `"opus"` to mirror the existing style of `is_claude_4_opus()` elsewhere in the file. If Anthropic later ships adaptive-thinking-only Sonnet or Haiku variants, this gate can be broadened.