### PR TITLE
fix: replace haiku-3

### DIFF
--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -131,7 +131,7 @@ Note that you can combine parallel tasks with parallel models as follows:
 ``` python
 eval(
     tasks, # 6 tasks for various temperature values
-    model=["openai/gpt-4", "anthropic/claude-3-haiku-20240307"],
+    model=["openai/gpt-4", "anthropic/claude-haiku-4-5"],
     max_tasks=5,
 )
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ dev = [
   "anthropic>=0.96.0",
   "azure-identity",
   "azure-ai-inference",
-  "fastapi",
+  "fastapi>=0.119.0",
   "google-genai>=1.69.0",
   "griffe>=2",
   "groq>=0.28.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -181,7 +181,7 @@ dev = [
   "markdown",
   "mcp>=1.10.0",
   "mistralai>=2.0.0",
-  "moto[server]",
+  "moto[server]>=5.1.5",
   "mypy>=1.17.0",
   "nbformat",
   "openai>=2.26.0",

--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -804,7 +804,7 @@ def check_anthropic_bridge_log_json(log_json: str, tools: bool):
 
 
 def check_google_bridge_log_json(log_json: str, tools: bool):
-    assert r'"model": "google/gemini-2.0-flash"' in log_json
+    assert r'"model": "google/gemini-3.1-flash-lite-preview"' in log_json
     # Note: Google generation config params (temperature, top_p, top_k, max_tokens)
     # are not logged the same way as OpenAI/Anthropic - they're set on the SDK client
     if tools:
@@ -813,20 +813,25 @@ def check_google_bridge_log_json(log_json: str, tools: bool):
 
 @skip_if_no_google
 def test_bridged_agent_google():
-    log_json = eval_bridged_task("google/gemini-2.0-flash", agent=google_agent(False))
+    log_json = eval_bridged_task(
+        "google/gemini-3.1-flash-lite-preview", agent=google_agent(False)
+    )
     check_google_bridge_log_json(log_json, tools=False)
 
 
 @skip_if_no_google
 def test_bridged_agent_google_tools():
-    log_json = eval_bridged_task("google/gemini-2.0-flash", agent=google_agent(True))
+    log_json = eval_bridged_task(
+        "google/gemini-3.1-flash-lite-preview", agent=google_agent(True)
+    )
     check_google_bridge_log_json(log_json, tools=True)
 
 
 @skip_if_no_google
 def test_bridged_web_search_tool_google():
     log = eval(
-        web_search_task(google_web_search_agent()), model="google/gemini-2.0-flash"
+        web_search_task(google_web_search_agent()),
+        model="google/gemini-3.1-flash-lite-preview",
     )[0]
     log_json = log.model_dump_json(exclude_none=True, indent=2)
     # Google SDK uses camelCase field names in serialized output
@@ -839,7 +844,7 @@ def test_bridged_web_search_tool_google():
 def test_bridged_code_execution_tool_google():
     log = eval(
         code_execution_task(google_code_execution_agent()),
-        model="google/gemini-2.0-flash",
+        model="google/gemini-3.1-flash-lite-preview",
     )[0]
     log_json = log.model_dump_json(exclude_none=True, indent=2)
     assert '"codeExecution"' in log_json

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -72,7 +72,7 @@ def test_google_block_reason():
             # TODO: we can't seem to get a content filter to trigger!
             dataset=[Sample(input="you are a shameful model")],
         ),
-        model="google/gemini-2.0-flash",
+        model="google/gemini-3.1-flash-lite-preview",
         model_args=dict(safety_settings=safety_settings),
     )[0]
     # TODO: comment in once we have an input that triggers the filter
@@ -754,7 +754,7 @@ async def test_google_count_tokens_single_tool_call() -> None:
     """Test counting tokens for a single assistant message with one tool call."""
     from inspect_ai.model import get_model
 
-    model = get_model("google/gemini-2.0-flash")
+    model = get_model("google/gemini-3.1-flash-lite-preview")
 
     # Create an assistant message with a single tool call (no tool result)
     assistant_msg = ChatMessageAssistant(
@@ -779,7 +779,7 @@ async def test_google_count_tokens_multiple_tool_calls() -> None:
     """Test counting tokens for a single assistant message with multiple tool calls."""
     from inspect_ai.model import get_model
 
-    model = get_model("google/gemini-2.0-flash")
+    model = get_model("google/gemini-3.1-flash-lite-preview")
 
     # Create an assistant message with multiple tool calls (no tool results)
     assistant_msg = ChatMessageAssistant(
@@ -814,7 +814,7 @@ async def test_google_count_tokens_single_tool_result() -> None:
     """Test counting tokens for a single tool result message (no preceding tool use)."""
     from inspect_ai.model import get_model
 
-    model = get_model("google/gemini-2.0-flash")
+    model = get_model("google/gemini-3.1-flash-lite-preview")
 
     # Create a tool result message without a preceding assistant message
     tool_msg = ChatMessageTool(
@@ -836,7 +836,7 @@ def test_google_streaming_basic():
             dataset=[Sample(input="Say hello in one sentence", target="hello")],
             scorer=includes(),
         ),
-        model="google/gemini-2.0-flash",
+        model="google/gemini-3.1-flash-lite-preview",
         model_args=dict(streaming=True),
     )[0]
 
@@ -869,7 +869,7 @@ def test_google_streaming_with_tools():
             solver=use_tools([add]),
             scorer=includes(),
         ),
-        model="google/gemini-2.0-flash",
+        model="google/gemini-3.1-flash-lite-preview",
         model_args=dict(streaming=True),
     )[0]
 
@@ -889,7 +889,7 @@ def test_google_streaming_large_output():
             ],
             scorer=includes(),
         ),
-        model="google/gemini-2.0-flash",
+        model="google/gemini-3.1-flash-lite-preview",
         model_args=dict(streaming=True),
         max_tokens=4096,
     )[0]

--- a/tests/model/test_collapse_user_message.py
+++ b/tests/model/test_collapse_user_message.py
@@ -106,7 +106,7 @@ async def test_anthropic_user_tool_messages() -> None:
     # call response, this results in an error unless the user messages are
     # correctly combined into a single one w/ tool and text content.
     try:
-        model = get_model("anthropic/claude-3-haiku-20240307")
+        model = get_model("anthropic/claude-haiku-4-5")
         await model.generate(
             input=[
                 ChatMessageUser(content="What is 1 + 1?"),

--- a/tests/model/test_compaction_native.py
+++ b/tests/model/test_compaction_native.py
@@ -168,7 +168,7 @@ async def test_anthropic_unsupported_model_raises_not_implemented() -> None:
     # Use an older model that doesn't support compaction
     # This test verifies the BadRequestError -> NotImplementedError conversion
     config = GenerateConfig(max_tokens=4096)
-    model = get_model("anthropic/anthropic/claude-haiku-4-5", config=config)
+    model = get_model("anthropic/claude-haiku-4-5", config=config)
     messages = _long_messages()  # Need enough tokens to pass minimum threshold
 
     # Direct call to the provider's compact method should raise NotImplementedError

--- a/tests/model/test_compaction_native.py
+++ b/tests/model/test_compaction_native.py
@@ -168,7 +168,7 @@ async def test_anthropic_unsupported_model_raises_not_implemented() -> None:
     # Use an older model that doesn't support compaction
     # This test verifies the BadRequestError -> NotImplementedError conversion
     config = GenerateConfig(max_tokens=4096)
-    model = get_model("anthropic/claude-3-haiku-20240307", config=config)
+    model = get_model("anthropic/anthropic/claude-haiku-4-5", config=config)
     messages = _long_messages()  # Need enough tokens to pass minimum threshold
 
     # Direct call to the provider's compact method should raise NotImplementedError

--- a/tests/model/test_extended_json_schema.py
+++ b/tests/model/test_extended_json_schema.py
@@ -111,14 +111,14 @@ async def test_anthropic_extended_response_schema():
 
 @skip_if_no_google
 async def test_google_extended_tool_schema():
-    model = get_model("google/gemini-2.0-flash")
+    model = get_model("google/gemini-3.1-flash-lite-preview")
     result = await model.generate(input=INPUT_TOOL, tools=[CONSTRAINED_TOOL])
     assert result.completion is not None
 
 
 @skip_if_no_google
 async def test_google_extended_response_schema():
-    model = get_model("google/gemini-2.0-flash")
+    model = get_model("google/gemini-3.1-flash-lite-preview")
     result = await model.generate(input=INPUT_SCHEMA, config=_response_config())
     assert result.completion is not None
 

--- a/tests/model/test_get_model.py
+++ b/tests/model/test_get_model.py
@@ -84,12 +84,12 @@ async def test_context_manager_async_required():
 @skip_if_no_google
 async def test_context_manager_no_close():
     # use with sync context mananger
-    with get_model("google/gemini-2.0-flash") as model:
+    with get_model("google/gemini-3.1-flash-lite-preview") as model:
         output = await model.generate("Say hello")
         assert "hello" in output.completion.lower()
 
     # use with async context manager
-    async with get_model("google/gemini-2.0-flash") as model:
+    async with get_model("google/gemini-3.1-flash-lite-preview") as model:
         output = await model.generate("Say hello")
         assert "hello" in output.completion.lower()
 

--- a/tests/model/test_logprobs.py
+++ b/tests/model/test_logprobs.py
@@ -16,7 +16,11 @@ async def generate_with_logprobs(model_name, **model_kwargs) -> ModelOutput:
     model = get_model(
         model_name,
         config=GenerateConfig(
-            logprobs=True, top_logprobs=2, temperature=0.001, max_tokens=50
+            logprobs=True,
+            top_logprobs=2,
+            temperature=0.001,
+            max_tokens=50,
+            max_retries=0,
         ),
         **model_kwargs,
     )

--- a/tests/model/test_logprobs.py
+++ b/tests/model/test_logprobs.py
@@ -1,9 +1,7 @@
 import pytest
 from test_helpers.utils import (
-    flaky_retry,
     skip_if_github_action,
     skip_if_no_accelerate,
-    skip_if_no_google,
     skip_if_no_llama_cpp_python,
     skip_if_no_openai,
     skip_if_no_together,
@@ -41,17 +39,6 @@ async def test_openai_responses_logprobs() -> None:
     assert response.choices[0].logprobs is not None
     assert response.choices[0].logprobs.content[0].top_logprobs is not None
     assert len(response.choices[0].logprobs.content[0].top_logprobs) == 2
-
-
-@pytest.mark.anyio
-@skip_if_no_google
-@flaky_retry(max_retries=3)
-async def test_google_logprobs() -> None:
-    response = await generate_with_logprobs("google/gemini-3.1-flash-lite-preview")
-    assert response.choices[0].logprobs is not None
-    assert response.choices[0].logprobs.content[0].top_logprobs is not None
-    # 10/16/25: Google returning only 1 top logprob even when set to to
-    # assert len(response.choices[0].logprobs.content[0].top_logprobs) == 2
 
 
 @pytest.mark.anyio

--- a/tests/model/test_logprobs.py
+++ b/tests/model/test_logprobs.py
@@ -47,7 +47,7 @@ async def test_openai_responses_logprobs() -> None:
 @skip_if_no_google
 @flaky_retry(max_retries=3)
 async def test_google_logprobs() -> None:
-    response = await generate_with_logprobs("google/gemini-2.0-flash")
+    response = await generate_with_logprobs("google/gemini-3.1-flash-lite-preview")
     assert response.choices[0].logprobs is not None
     assert response.choices[0].logprobs.content[0].top_logprobs is not None
     # 10/16/25: Google returning only 1 top logprob even when set to to

--- a/tests/model/test_model_length.py
+++ b/tests/model/test_model_length.py
@@ -25,7 +25,7 @@ GPT_4O = "openai/gpt-4o"
 GPT_4O_MINI_AZURE = "openai/azure/gpt-4o-mini"
 CLAUDE_4_6_SONNET = "anthropic/claude-sonnet-4-6"
 CLAUDE_4_6_OPUS = "anthropic/claude-opus-4-6"
-GEMINI_2_0_FLASH = "google/gemini-2.0-flash"
+GEMINI_3_FLASH_PREVIEW = "google/gemini-3-flash-preview"
 MISTRAL_LARGE_2411 = "mistral/mistral-large-2411"
 GROK_3_MINI = "grok/grok-3-mini"
 GROQ_LLAMA_3_3_70B_VERSATILE = "groq/llama-3.3-70b-versatile"
@@ -38,7 +38,7 @@ MODELS = {
     GPT_4O_MINI_AZURE: 128000,
     CLAUDE_4_6_SONNET: 1000000,
     CLAUDE_4_6_OPUS: 1000000,
-    GEMINI_2_0_FLASH: 1000000,
+    GEMINI_3_FLASH_PREVIEW: 1048576,
     MISTRAL_LARGE_2411: 131000,
     GROK_3_MINI: 131072,
     GROQ_LLAMA_3_3_70B_VERSATILE: 128000,
@@ -101,7 +101,7 @@ async def test_model_length_anthropic():
 # TODO: Anthropic Bedrock
 @skip_if_no_google
 async def test_model_length_google():
-    await check_model_length(GEMINI_2_0_FLASH)
+    await check_model_length(GEMINI_3_FLASH_PREVIEW)
 
 
 @skip_if_no_mistral

--- a/tests/model/test_model_roles.py
+++ b/tests/model/test_model_roles.py
@@ -14,7 +14,7 @@ from inspect_ai.solver import solver
 
 RED_TEAM = "red_team"
 RED_TEAM_DEFAULT = "openai/gpt-4o"
-GEMINI_FLASH_20 = "google/gemini-2.0-flash"
+GEMINI_FLASH_3_PREVIEW = "google/gemini-3-flash-preview"
 
 
 @solver
@@ -40,10 +40,10 @@ def role_task():
 @skip_if_no_google
 @skip_if_no_openai
 def test_model_role() -> None:
-    log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_20})[0]
+    log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_3_PREVIEW})[0]
     assert log.eval.model_roles
-    assert log.eval.model_roles[RED_TEAM].model == GEMINI_FLASH_20
-    check_model_role(log, RED_TEAM, GEMINI_FLASH_20)
+    assert log.eval.model_roles[RED_TEAM].model == GEMINI_FLASH_3_PREVIEW
+    check_model_role(log, RED_TEAM, GEMINI_FLASH_3_PREVIEW)
 
 
 @skip_if_no_openai
@@ -55,13 +55,13 @@ def test_model_role_default() -> None:
 @skip_if_no_google
 @skip_if_no_openai
 def test_model_role_retry() -> None:
-    log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_20})[0]
+    log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_3_PREVIEW})[0]
     log.status = "cancelled"
     log.samples = []
     log = eval_retry(log)[0]
     assert log.eval.model_roles
-    assert log.eval.model_roles[RED_TEAM].model == GEMINI_FLASH_20
-    check_model_role(log, RED_TEAM, GEMINI_FLASH_20)
+    assert log.eval.model_roles[RED_TEAM].model == GEMINI_FLASH_3_PREVIEW
+    check_model_role(log, RED_TEAM, GEMINI_FLASH_3_PREVIEW)
 
 
 @task
@@ -73,10 +73,10 @@ def role_task_init():
 @skip_if_no_google
 @skip_if_no_openai
 def test_model_role_task_init():
-    log = eval(role_task_init, model_roles={RED_TEAM: GEMINI_FLASH_20})[0]
+    log = eval(role_task_init, model_roles={RED_TEAM: GEMINI_FLASH_3_PREVIEW})[0]
     assert log.eval.model_roles
-    assert log.eval.model_roles[RED_TEAM].model == GEMINI_FLASH_20
-    check_model_role(log, RED_TEAM, GEMINI_FLASH_20)
+    assert log.eval.model_roles[RED_TEAM].model == GEMINI_FLASH_3_PREVIEW
+    check_model_role(log, RED_TEAM, GEMINI_FLASH_3_PREVIEW)
 
 
 @skip_if_no_google
@@ -94,9 +94,11 @@ def test_model_role_eval_set() -> None:
             log_dir=log_dir,
             retry_wait=0.001,
             retry_attempts=5,
-            model_roles={RED_TEAM: GEMINI_FLASH_20},
+            model_roles={RED_TEAM: GEMINI_FLASH_3_PREVIEW},
         )
-        check_model_role(read_eval_log(logs[0].location), RED_TEAM, GEMINI_FLASH_20)
+        check_model_role(
+            read_eval_log(logs[0].location), RED_TEAM, GEMINI_FLASH_3_PREVIEW
+        )
 
 
 def check_model_role(log: EvalLog, role: str, model: str) -> None:
@@ -172,7 +174,7 @@ def test_role_usage_eval_retry() -> None:
 @skip_if_no_google
 @skip_if_no_openai
 def test_role_usage_tracking() -> None:
-    log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_20})[0]
+    log = eval(role_task(), model_roles={RED_TEAM: GEMINI_FLASH_3_PREVIEW})[0]
 
     assert log.stats.role_usage is not None
     assert RED_TEAM in log.stats.role_usage
@@ -220,7 +222,8 @@ def check_memoize_solver():
 def test_model_role_memoize() -> None:
     # check with role specified
     log = eval(
-        Task(solver=check_memoize_solver()), model_roles={RED_TEAM: GEMINI_FLASH_20}
+        Task(solver=check_memoize_solver()),
+        model_roles={RED_TEAM: GEMINI_FLASH_3_PREVIEW},
     )[0]
     assert log.status == "success"
 

--- a/tests/model/test_stop_reason.py
+++ b/tests/model/test_stop_reason.py
@@ -54,7 +54,7 @@ async def test_openai_responses_stop_reason() -> None:
 @skip_if_no_anthropic
 @skip_if_trio
 async def test_anthropic_stop_reason() -> None:
-    await check_stop_reason("anthropic/anthropic/claude-haiku-4-5")
+    await check_stop_reason("anthropic/claude-haiku-4-5")
 
 
 @pytest.mark.flaky

--- a/tests/model/test_stop_reason.py
+++ b/tests/model/test_stop_reason.py
@@ -54,7 +54,7 @@ async def test_openai_responses_stop_reason() -> None:
 @skip_if_no_anthropic
 @skip_if_trio
 async def test_anthropic_stop_reason() -> None:
-    await check_stop_reason("anthropic/claude-3-haiku-20240307")
+    await check_stop_reason("anthropic/anthropic/claude-haiku-4-5")
 
 
 @pytest.mark.flaky

--- a/tests/model/test_structured_output.py
+++ b/tests/model/test_structured_output.py
@@ -165,8 +165,8 @@ def test_openai_responses_structured_output_pydantic():
 
 @skip_if_no_google
 def test_google_structured_output():
-    check_color_structured_output("google/gemini-2.0-flash")
-    check_nested_pydantic_output("google/gemini-2.0-flash")
+    check_color_structured_output("google/gemini-3.1-flash-lite-preview")
+    check_nested_pydantic_output("google/gemini-3.1-flash-lite-preview")
 
 
 @pytest.mark.flaky

--- a/tests/test_canonical_model_name.py
+++ b/tests/test_canonical_model_name.py
@@ -18,8 +18,8 @@ from inspect_ai.scorer import match
 @pytest.mark.parametrize(
     "model",
     [
-        "google/vertex/gemini-2.0-flash",
-        "google/gemini-2.0-flash",
+        "google/vertex/gemini-3.1-flash-lite-preview",
+        "google/gemini-3.1-flash-lite-preview",
     ],
 )
 @skip_if_no_google
@@ -34,7 +34,7 @@ def test_google_canonical_name_in_eval_log(model):
         model=model,
     )[0]
 
-    assert log.eval.model == "google/gemini-2.0-flash"
+    assert log.eval.model == "google/gemini-3.1-flash-lite-preview"
 
 
 @pytest.mark.parametrize(

--- a/tests/tools/test_mcp_tools_remote.py
+++ b/tests/tools/test_mcp_tools_remote.py
@@ -29,7 +29,7 @@ def test_anthropic_remote_mcp() -> None:
 @skip_if_no_google
 def test_google_remote_mcp() -> None:
     with pytest.raises(RuntimeError, match="Remote MCP"):
-        check_remote_mcp("google/gemini-2.0-flash", debug_errors=True)
+        check_remote_mcp("google/gemini-3.1-flash-lite-preview", debug_errors=True)
 
 
 # doesn't appear to be enabled server-side right now

--- a/uv.lock
+++ b/uv.lock
@@ -1790,7 +1790,7 @@ requires-dist = [
     { name = "mcp-server-git", marker = "extra == 'dev-mcp-tests'" },
     { name = "mistralai", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "mmh3", specifier = ">3.1.0" },
-    { name = "moto", extras = ["server"], marker = "extra == 'dev'" },
+    { name = "moto", extras = ["server"], marker = "extra == 'dev'", specifier = ">=5.1.5" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.17.0" },
     { name = "nbclient", marker = "extra == 'doc'" },
     { name = "nbformat", marker = "extra == 'dev'" },
@@ -2937,7 +2937,7 @@ wheels = [
 
 [[package]]
 name = "moto"
-version = "5.1.4"
+version = "5.1.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -2950,9 +2950,9 @@ dependencies = [
     { name = "werkzeug" },
     { name = "xmltodict" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4e/17/059cd6fa5962fa75575f74bb8d31d0e9cb3e656414cb79b4b3736b2b40eb/moto-5.1.4.tar.gz", hash = "sha256:b339c3514f2986ebefa465671b688bdbf51796705702214b1bad46490b68507a", size = 6796440, upload-time = "2025-04-20T20:16:19.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/6a/a73bef67261bfab55714390f07c7df97531d00cea730b7c0ace4d0ad7669/moto-5.1.18.tar.gz", hash = "sha256:45298ef7b88561b839f6fe3e9da2a6e2ecd10283c7bf3daf43a07a97465885f9", size = 8271655, upload-time = "2025-11-30T22:03:59.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/44/98/346e3252767e1fe78a0842804cfffbbbef103b960149d4bb217b4cc31a19/moto-5.1.4-py3-none-any.whl", hash = "sha256:9a19d7a64c3f03824389cfbd478b64c82bd4d8da21b242a34259360d66cd108b", size = 4898363, upload-time = "2025-04-20T20:16:16.849Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d4/6991df072b34741a0c115e8d21dc2fe142e4b497319d762e957f6677f001/moto-5.1.18-py3-none-any.whl", hash = "sha256:b65aa8fc9032c5c574415451e14fd7da4e43fd50b8bdcb5f10289ad382c25bcf", size = 6357278, upload-time = "2025-11-30T22:03:56.831Z" },
 ]
 
 [package.optional-dependencies]
@@ -3980,11 +3980,11 @@ wheels = [
 
 [[package]]
 name = "py-partiql-parser"
-version = "0.6.1"
+version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/58/a1/0a2867e48b232b4f82c4929ef7135f2a5d72c3886b957dccf63c70aa2fcb/py_partiql_parser-0.6.1.tar.gz", hash = "sha256:8583ff2a0e15560ef3bc3df109a7714d17f87d81d33e8c38b7fed4e58a63215d", size = 17120, upload-time = "2024-12-25T22:06:41.327Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/84/0e410c20bbe9a504fc56e97908f13261c2b313d16cbb3b738556166f044a/py_partiql_parser-0.6.1-py2.py3-none-any.whl", hash = "sha256:ff6a48067bff23c37e9044021bf1d949c83e195490c17e020715e927fe5b2456", size = 23520, upload-time = "2024-12-25T22:06:39.106Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -200,6 +200,15 @@ wheels = [
 ]
 
 [[package]]
+name = "annotated-doc"
+version = "0.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/ba/046ceea27344560984e26a590f90bc7f4a75b06701f653222458922b558c/annotated_doc-0.0.4.tar.gz", hash = "sha256:fbcda96e87e9c92ad167c2e53839e57503ecfda18804ea28102353485033faa4", size = 7288, upload-time = "2025-11-10T22:07:42.062Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl", hash = "sha256:571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320", size = 5303, upload-time = "2025-11-10T22:07:40.673Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1024,16 +1033,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.118.0"
+version = "0.136.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/28/3c/2b9345a6504e4055eaa490e0b41c10e338ad61d9aeaae41d97807873cdf2/fastapi-0.118.0.tar.gz", hash = "sha256:5e81654d98c4d2f53790a7d32d25a7353b30c81441be7d0958a26b5d761fa1c8", size = 310536, upload-time = "2025-09-29T03:37:23.126Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/d9/e66315807e41e69e7f6a1b42a162dada2f249c5f06ad3f1a95f84ab336ef/fastapi-0.136.0.tar.gz", hash = "sha256:cf08e067cc66e106e102d9ba659463abfac245200752f8a5b7b1e813de4ff73e", size = 396607, upload-time = "2026-04-16T11:47:13.623Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/54e2bdaad22ca91a59455251998d43094d5c3d3567c52c7c04774b3f43f2/fastapi-0.118.0-py3-none-any.whl", hash = "sha256:705137a61e2ef71019d2445b123aa8845bd97273c395b744d5a7dfe559056855", size = 97694, upload-time = "2025-09-29T03:37:21.338Z" },
+    { url = "https://files.pythonhosted.org/packages/26/a3/0bd5f0cdb0bbc92650e8dc457e9250358411ee5d1b65e42b6632387daf81/fastapi-0.136.0-py3-none-any.whl", hash = "sha256:8793d44ec7378e2be07f8a013cf7f7aa47d6327d0dfe9804862688ec4541a6b4", size = 117556, upload-time = "2026-04-16T11:47:11.922Z" },
 ]
 
 [[package]]
@@ -1765,7 +1776,7 @@ requires-dist = [
     { name = "debugpy" },
     { name = "docstring-parser", specifier = ">=0.16" },
     { name = "exceptiongroup", marker = "python_full_version < '3.11'", specifier = ">=1.0.2" },
-    { name = "fastapi", marker = "extra == 'dev'" },
+    { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.119.0" },
     { name = "fsspec", specifier = ">=2023.1.0,<=2025.9.0" },
     { name = "google-genai", marker = "extra == 'dev'", specifier = ">=1.69.0" },
     { name = "griffe", marker = "extra == 'dev'", specifier = ">=2" },


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

API tests fail because haiku-3 is not avaible and gemini-2.0-flash is timing out

### What is the new behavior?

Use haiku-4-5 and gemini-3.1-flash-lite-preview
Remove google logprobs test because not supported by newer model
Added min version requirements to dev packages to support features required by tests

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

no

### Other information:
