### PR TITLE
fix(sandbox-bridge): propagate user to model_proxy exec_remote

### DIFF
--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -44,6 +44,7 @@ async def sandbox_agent_bridge(
     compaction: CompactionStrategy | None = None,
     sandbox: str | None = None,
     port: int = 13131,
+    user: str | None = None,
     web_search: WebSearchProviders | None = None,
     code_execution: CodeExecutionProviders | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
@@ -73,6 +74,12 @@ async def sandbox_agent_bridge(
             the model's context window. See [Compaction](https://inspect.aisi.org.uk/compaction.html) for details on compaction strategies.
         sandbox: Sandbox to run model proxy server within.
         port: Port to run proxy server on.
+        user: User to run the model proxy process as within the sandbox.
+            This also determines the user of the persistent sandbox-tools
+            server that hosts subsequent `exec_remote` calls, so pass the
+            same user the agent will run as (e.g. `"ubuntu"`) to avoid
+            a root-owned server spawning child processes with the wrong
+            HOME/identity.
         web_search: Configuration for mapping model internal
             web_search tools to Inspect. By default, will map to the
             internal provider of the target model (supported for OpenAI,
@@ -145,6 +152,7 @@ async def sandbox_agent_bridge(
                 bridge,
                 instance,
                 started,
+                user,
             )
 
             # wait for model service to start
@@ -159,6 +167,7 @@ async def sandbox_agent_bridge(
                         f"{MODEL_SERVICE.upper()}_PORT": str(port),
                         f"{MODEL_SERVICE.upper()}_INSTANCE": instance,
                     },
+                    user=user,
                     poll_timeout=600,
                 ),
             )

--- a/src/inspect_ai/agent/_bridge/sandbox/service.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/service.py
@@ -28,6 +28,7 @@ async def run_model_service(
     bridge: SandboxAgentBridge,
     instance: str,
     started: anyio.Event,
+    user: str | None = None,
 ) -> None:
     await sandbox_service(
         name=MODEL_SERVICE,
@@ -45,6 +46,7 @@ async def run_model_service(
         },
         until=lambda: False,
         sandbox=sandbox,
+        user=user,
         instance=instance,
         polling_interval=2,
         started=started,


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If you specify user for claude_code, the exec_remote process starts as root and things are very confusing

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
