### PR TITLE
sandbox-tools CI gates: regression + publish verification (#3704)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -120,11 +120,14 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv cache prune --ci
 
+  # See design/sandbox-tools-ci-gates.md for the full gate matrix.
+
   check-tool-paths:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       tools_changed: ${{ steps.filter.outputs.tools }}
+      injectable_src_changed: ${{ steps.filter.outputs.injectable_src }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@v3
@@ -135,9 +138,57 @@ jobs:
               - "src/inspect_ai/tool/**"
               - "src/inspect_sandbox_tools/**"
               - "tests/tools/**"
+            injectable_src:
+              - "src/inspect_sandbox_tools/**"
 
-  slow-tool-tests:
+  # Fast gate: confirm sandbox_tools_version.txt is bumped to exactly N+1
+  # when the injectable source changed. Blocks downstream slow jobs on
+  # failure so PR contributors don't wait on a Docker build to learn they
+  # forgot the bump.
+  check-version-bump:
     needs: check-tool-paths
+    if: needs.check-tool-paths.outputs.tools_changed == 'true'
+    runs-on: ubuntu-latest
+    outputs:
+      version_correctly_bumped: ${{ steps.bump.outputs.correctly_bumped }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Check version bump
+        id: bump
+        env:
+          INJECTABLE_SRC_CHANGED: ${{ needs.check-tool-paths.outputs.injectable_src_changed }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          VERSION_PATH="src/inspect_ai/tool/_sandbox_tools_utils/sandbox_tools_version.txt"
+          BASE_VERSION=$(git show "origin/${BASE_REF}:${VERSION_PATH}" | tr -d '[:space:]')
+          PR_VERSION=$(tr -d '[:space:]' < "${VERSION_PATH}")
+          EXPECTED=$((BASE_VERSION + 1))
+          echo "Base (${BASE_REF}): v${BASE_VERSION}; PR: v${PR_VERSION}; expected on bump: v${EXPECTED}; injectable_src_changed=${INJECTABLE_SRC_CHANGED}"
+          if [ "$INJECTABLE_SRC_CHANGED" = "true" ]; then
+            if [ "$PR_VERSION" = "$EXPECTED" ]; then
+              echo "correctly_bumped=true" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::src/inspect_sandbox_tools/ changed but ${VERSION_PATH} is v${PR_VERSION}; bump it to v${EXPECTED}."
+              exit 1
+            fi
+          else
+            if [ "$PR_VERSION" = "$BASE_VERSION" ]; then
+              echo "correctly_bumped=false" >> "$GITHUB_OUTPUT"
+            else
+              echo "::error::${VERSION_PATH} changed to v${PR_VERSION} but src/inspect_sandbox_tools/ is unchanged. Either revert the version change or include the injectable source change."
+              exit 1
+            fi
+          fi
+
+  # Developer gate: run the sandbox slow-test suite. When the injectable
+  # source or version changed, build a -dev binary first; otherwise let
+  # pytest resolve the published v{N} via the runtime's S3 download path.
+  slow-tool-tests-dev:
+    needs: [check-tool-paths, check-version-bump]
     if: needs.check-tool-paths.outputs.tools_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -173,25 +224,83 @@ jobs:
           uv venv
           uv pip install .[dev]
 
-      - name: Pre-seed sandbox tools -dev binary (CI stopgap)
-        # The `edited` install-state triggers a `-dev`-suffixed binary lookup
-        # that isn't published to S3 by design. Download the published non-dev
-        # v{N} and save it under the `-dev` name so the local-binary check in
-        # `_open_executable_for_arch` short-circuits before the interactive
-        # build prompt. Remove once the install-state logic is fixed.
-        run: |
-          VERSION=$(cat src/inspect_ai/tool/_sandbox_tools_utils/sandbox_tools_version.txt)
-          ARCH=amd64  # ubuntu-latest runner
-          mkdir -p src/inspect_ai/binaries
-          curl -fSL \
-            -o "src/inspect_ai/binaries/inspect-sandbox-tools-${ARCH}-v${VERSION}-dev" \
-            "https://inspect-sandbox-tools.s3.us-east-2.amazonaws.com/inspect-sandbox-tools-${ARCH}-v${VERSION}"
-          chmod +x "src/inspect_ai/binaries/inspect-sandbox-tools-${ARCH}-v${VERSION}-dev"
+      - name: Build sandbox-tools -dev binary
+        if: needs.check-tool-paths.outputs.injectable_src_changed == 'true' || needs.check-version-bump.outputs.version_correctly_bumped == 'true'
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+        run: uv run python src/inspect_ai/tool/_sandbox_tools_utils/build_within_container.py --arch amd64
 
       - name: Run slow tool tests
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
+        run: uv run pytest --runslow -m slow tests/tools/ -x
+
+      - name: Minimize uv cache
+        if: ${{ !cancelled() }}
+        run: uv cache prune --ci
+
+  # Release gate: runs only when the version bumped to N+1. Verifies the
+  # new v{N+1} artifact is published to S3 (fails fast with upload_to_s3.py
+  # hint if not), then re-runs the slow tests against it. Maintainer reruns
+  # from the Actions UI after uploading.
+  slow-tool-tests-release:
+    needs: [check-tool-paths, check-version-bump, slow-tool-tests-dev]
+    if: needs.check-tool-paths.outputs.tools_changed == 'true' && needs.check-version-bump.outputs.version_correctly_bumped == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: true
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          version: latest
+          driver-opts: |
+            network=host
+          buildkitd-flags: |
+            --allow-insecure-entitlement security.insecure
+            --allow-insecure-entitlement network.host
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |-
+          uv venv
+          uv pip install .[dev]
+
+      - name: Fetch published non-dev sandbox-tools binary
+        run: |
+          VERSION=$(tr -d '[:space:]' < src/inspect_ai/tool/_sandbox_tools_utils/sandbox_tools_version.txt)
+          ARCH=amd64
+          FILENAME="inspect-sandbox-tools-${ARCH}-v${VERSION}"
+          URL="https://inspect-sandbox-tools.s3.us-east-2.amazonaws.com/${FILENAME}"
+          if ! curl -fsI "$URL" >/dev/null; then
+            echo "::error::Non-dev binary v${VERSION} not found at ${URL}. Run: python src/inspect_ai/tool/_sandbox_tools_utils/upload_to_s3.py ${VERSION} then rerun this job."
+            exit 1
+          fi
+          mkdir -p src/inspect_ai/binaries
+          curl -fSL -o "src/inspect_ai/binaries/${FILENAME}" "$URL"
+          chmod +x "src/inspect_ai/binaries/${FILENAME}"
+
+      - name: Run slow tool tests against published artifact
+        env:
+          DOCKER_BUILDKIT: 1
+          BUILDKIT_PROGRESS: plain
+          # Force install-state=clean so _open_executable_for_arch resolves
+          # the non-dev name; _check_main_divergence would otherwise return
+          # "edited" on this PR (version.txt differs from main).
+          INSPECT_SANDBOX_TOOLS_INSTALL_STATE: clean
         run: uv run pytest --runslow -m slow tests/tools/ -x
 
       - name: Minimize uv cache

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,5 +41,4 @@ Additional files provide context when working in specific areas:
 
 ## Design Documentation
 
-- [Model Proxy Lifecycle: startup, communication, and termination flow](design/model-proxy-lifecycle.md)
-- [Timezone Handling Architecture: principles and patterns for temporal data](design/temporal-data-handling.md)
+`design/` contains architecture notes, subsystem internals, and documentation of repo/CI/development processes and workflows. Browse it before diving into an unfamiliar area.

--- a/design/sandbox-tools-ci-gates.md
+++ b/design/sandbox-tools-ci-gates.md
@@ -1,0 +1,51 @@
+# Sandbox Tools CI Gates
+
+Design for the CI jobs that protect the sandbox-tools injection pipeline on pull requests. See issue #3704 for background.
+
+## Problem
+
+The sandbox-tools binary (`inspect-sandbox-tools`) is injected into user containers at runtime. There are two artifact flavors:
+
+- **Published `-v{N}`**: built by maintainers and uploaded to S3. The PyPI publish flow downloads the S3 artifact and bundles it into the wheel (under `src/inspect_ai/binaries/`), so PyPI users resolve it via the local-file path with no runtime S3 access. Editable installs whose sandbox-tools source matches `main` fall through to an S3 download at first use and cache the result locally.
+- **`-v{N}-dev`**: built locally via Docker. Used by contributors iterating on the injectable source; never published to S3.
+
+Selection happens in `sandbox.py::_get_install_state()`, which classifies an editable install as `clean` or `edited` by diffing `src/inspect_sandbox_tools/` and `sandbox_tools_version.txt` against `main`. `edited` forces the `-dev` name; `clean` uses the published name. PyPI installs are classified `pypi` and always use the bundled non-dev binary.
+
+The CI gates exist to prevent two failure modes:
+
+1. **Regression in sandbox-related tool behavior.** The end-to-end tests under `tests/tools/` that exercise real sandboxes are too slow to run in the normal test gate, so they're excluded there and run in a dedicated slow-test gate instead. That gate only triggers when a PR touches code that could plausibly regress them — the host-side tool code, the injectable, or the tests themselves. PRs touching those paths pay the cost of the slower tests; PRs that don't, don't.
+2. **Merging injectable source changes that haven't been published.** If `src/inspect_sandbox_tools/` changes but `sandbox_tools_version.txt` isn't bumped (and the new `v{N}` isn't uploaded to S3), the next PyPI wheel build will either fail or bundle the wrong binary, and editable installs on `main` will S3-download a binary that doesn't match the source tree. The gates force the bump and verify the S3 upload before the PR can land.
+
+## Gates
+
+Three jobs run in sequence on PRs:
+
+```
+check-tool-paths ──► check-version-bump ──► slow-tool-tests-dev ──► slow-tool-tests-release
+```
+
+- **`check-tool-paths`** — detects whether the PR touches tool-related paths relative to the PR base branch. Emits `tools_changed` and `injectable_src_changed`.
+- **`check-version-bump`** — fast, cheap. Reads `sandbox_tools_version.txt` on the PR and on the base branch. Enforces the invariant "injectable source and version move together": fails when the injectable source changed without a correct `N+1` bump, and also when the version was bumped without an injectable change.
+- **`slow-tool-tests-dev`** — runs `pytest --runslow -m slow tests/tools/`. Green = "your code works from a developer perspective." Conditionally builds a `-dev` binary in CI when the PR changed the injected code; otherwise uses the published `v{N}` via the runtime's normal S3 download path.
+- **`slow-tool-tests-release`** — runs only when a version bump is present. Prechecks S3 for the new `v{N+1}`; on 404 fails fast with a message telling the maintainer to run `upload_to_s3.py`. On success, downloads the published artifact and re-runs the slow tests against it. Maintainer reruns this job manually from the Actions UI after publishing.
+
+## Behavior matrix
+
+When `check-tool-paths` returns false, none of the downstream gates execute. The table describes the four possibilities when `check-tool-paths` returns true. `N` = version on the PR base branch.
+
+| Scenario | injectable src | `...version.txt` | check-version-bump | slow-tool-tests-dev | slow-tool-tests-release |
+|---|---|---|---|---|---|
+| Tool changes unrelated&nbsp;to&nbsp;the&nbsp;injectable | unchanged | unchanged | pass | **run** — no build; pytest resolves `v{N}` via normal S3 download path | skip |
+| Same as above with mistaken&nbsp;version.txt&nbsp;change | unchanged | any change | **fail** — "unexpected version bump" | skip | skip |
+| Injectable change with&nbsp;correct&nbsp;bump | changed | bumped to N+1 | pass | **run** — conditional build; pytest uses freshly-built `-dev v{N+1}` | **run** — precheck `v{N+1}`; download; pytest with `INSTALL_STATE = clean` |
+| Injectable change, bump&nbsp;missing&nbsp;or&nbsp;wrong | changed | unchanged OR changed to anything ≠ N+1 | **fail** — "missing or incorrect version bump" | skip | skip |
+
+## Gate conditions
+
+- `check-version-bump`: `needs: check-tool-paths`; `if: tools_changed == 'true'`. Enforces that injectable source and version move together — passes when both changed (injectable edit + N→N+1 bump) or neither changed; fails otherwise. Emits `version_correctly_bumped` for downstream jobs.
+- `slow-tool-tests-dev`: `needs: [check-tool-paths, check-version-bump]`; `if: tools_changed == 'true'`; build step conditional on `injectable_src_changed || version_correctly_bumped`.
+- `slow-tool-tests-release`: `needs: [check-tool-paths, check-version-bump, slow-tool-tests-dev]`; `if: tools_changed == 'true' && version_correctly_bumped == 'true'`.
+
+## `INSPECT_SANDBOX_TOOLS_INSTALL_STATE` escape hatch
+
+`slow-tool-tests-release` tests against the downloaded non-dev `v{N+1}`, but the runtime's install-state check would return `edited` on a release PR (because `sandbox_tools_version.txt` differs from main) and resolve the `-dev` name. To avoid duplicating the divergence logic, the release gate sets `INSPECT_SANDBOX_TOOLS_INSTALL_STATE=clean`, forcing the non-dev resolution. The dev gate does not set it — the host-side-change case relies on the natural `clean` classification to exercise the real S3 download path.

--- a/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
+++ b/src/inspect_ai/tool/_sandbox_tools_utils/sandbox.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import sys
 import warnings
@@ -5,7 +6,7 @@ from contextlib import asynccontextmanager
 from importlib import resources
 from logging import getLogger
 from pathlib import Path
-from typing import AsyncIterator, BinaryIO, Literal
+from typing import AsyncIterator, BinaryIO, Literal, get_args
 from urllib.parse import unquote, urlparse
 
 import httpx
@@ -264,8 +265,32 @@ async def _build_it(arch: Architecture, dev_executable_name: str) -> None:
     print(f"Successfully built {dev_executable_name}")
 
 
+_INSTALL_STATE_OVERRIDE_ENV = "INSPECT_SANDBOX_TOOLS_INSTALL_STATE"
+
+
+def _install_state_override() -> InstallState | None:
+    """Read the CI escape-hatch env var; None if unset.
+
+    Release-gate jobs force "clean" so the non-dev binary name is resolved
+    even when version.txt has diverged from main on a release PR. See #3704.
+    """
+    match os.environ.get(_INSTALL_STATE_OVERRIDE_ENV):
+        case None:
+            return None
+        case "pypi" | "clean" | "edited" as s:
+            return s
+        case other:
+            raise ValueError(
+                f"{_INSTALL_STATE_OVERRIDE_ENV}={other!r} invalid; "
+                f"must be one of {get_args(InstallState)}"
+            )
+
+
 def _get_install_state() -> InstallState:
     """Detect the state of the inspect-ai installation."""
+    if (override := _install_state_override()) is not None:
+        return override
+
     if (direct_url := get_package_direct_url("inspect-ai")) is None:
         return "pypi"
 


### PR DESCRIPTION
Closes #3704.

## Summary

Replaces the single `slow-tool-tests` job with a four-job chain that separates regression testing from release verification and fails fast on cheap checks before running slow ones.

```
check-tool-paths ──► check-version-bump ──► slow-tool-tests-dev ──► slow-tool-tests-release
```

- **`check-tool-paths`** — unchanged filter; additionally emits `injectable_src_changed`.
- **`check-version-bump`** *(new)* — compares PR's `sandbox_tools_version.txt` to base branch's. Enforces the invariant that injectable source and version must move together: fails fast when `src/inspect_sandbox_tools/` changed without a correct `N → N+1` bump, **and** when the version changed without an injectable edit. Emits `version_correctly_bumped` for downstream gates.
- **`slow-tool-tests-dev`** — runs whenever tool paths changed; **build step is conditional**. On host-side-only changes (no injectable edit, no bump), skip the Docker `-dev` build and let pytest's existing S3 path pull the published `v{N}`. On a release-style PR, build `-dev v{N+1}` first.
- **`slow-tool-tests-release`** — gated on `version_correctly_bumped`; runs only on a correct bump. Prechecks S3 with `curl -fsI`, fails fast with an `upload_to_s3.py` hint on 404; else downloads and tests the published artifact with `INSPECT_SANDBOX_TOOLS_INSTALL_STATE=clean`.

Adds `INSPECT_SANDBOX_TOOLS_INSTALL_STATE` env override in `sandbox.py::_get_install_state()` so the release gate can force `clean` without duplicating the divergence-detection logic (accepts `pypi`/`clean`/`edited`; invalid → `ValueError`).

Removes the curl-preseed stopgap that saved the non-dev binary under a `-dev` filename.

Also trims root `CLAUDE.md`: replaces the enumerated list of design docs with a pointer to the `design/` directory, so new docs don't require a CLAUDE.md edit.

### Behavior across developer scenarios

| Scenario | check-version-bump | slow-tool-tests-dev | slow-tool-tests-release |
|---|---|---|---|
| Tool changes unrelated to the injectable | pass | **run** (no build; S3-download `v{N}`) | skip |
| Same as above with mistaken `version.txt` change | **fail** — "unexpected version bump" | skip | skip |
| Injectable change with correct bump | pass | **run** (build `-dev v{N+1}`; test) | **run** (precheck S3, download, test) |
| Injectable change, bump missing or wrong | **fail** — "missing or incorrect version bump" | skip | skip |

See the [design doc](design/sandbox-tools-ci-gates.md) for full details including `check-tool-paths=false` and the install-state escape hatch.