### PR TITLE
Responses API BugFix: Gracefully catch when response.tools is null and normalize it to []

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- OpenAI: Gracefully catch when response.tools is null and normalize it to []
 - Model API: Log the first 5 API calls per-model by default. 
 - Avoid deep copy of messages when applying custom tool model input handler.
 - Inspect View: Metadata with more than 5 children will be collapsed by default (for real).

--- a/src/inspect_ai/model/_providers/openai_responses.py
+++ b/src/inspect_ai/model/_providers/openai_responses.py
@@ -65,7 +65,7 @@ def _fix_function_tool_parameters(response: Response) -> None:
     """
     from openai.types.responses import FunctionTool
 
-    for tool in response.tools:
+    for tool in response.tools if response.tools is not None else []:
         if isinstance(tool, FunctionTool) and isinstance(tool.parameters, str):
             try:
                 tool.parameters = json.loads(tool.parameters)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When working with Responses API, if the `tools` field (which is optional per OpenAI's spec) is not included in the response, then the `_fix_function_tool_parameters` raises an exception because the field gets set to `None` when processed, which is not an iterable type.

### What is the new behavior?

Identify if the `response.tools` is `None` and yield a `[]` in that case, which gracefully causes the expected behavior of a quick exit from this loop due to an empty iterable.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:

N/A - Small change