### PR TITLE
add press_enter support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Google: Honor the `press_enter` default on Gemini's `type_text_at` action so typed text commits with Enter as the spec specifies.
 - vLLM: Support `use_chat_template=false` for base model evaluation (complements existing HF provider support).
 - Log recovery: Stream segment-at-a-time to bound memory on large evals.
 - Scoring: Neutralize structural delimiters in model graded scorer inputs.

--- a/src/inspect_ai/model/_providers/_google_computer_use.py
+++ b/src/inspect_ai/model/_providers/_google_computer_use.py
@@ -107,7 +107,10 @@ def gemini_action_from_tool_call(
     elif action == "type":
         text = str(arguments.get("text", ""))
         x, y = _normalize_coordinate(arguments.get("coordinate", [0, 0]))
-        return "type_text_at", {"text": text, "x": x, "y": y}
+        result: dict[str, object] = {"text": text, "x": x, "y": y}
+        if "press_enter" in arguments:
+            result["press_enter"] = bool(arguments["press_enter"])
+        return "type_text_at", result
 
     elif action == "scroll":
         direction = str(arguments.get("scroll_direction", "down"))
@@ -161,7 +164,12 @@ def _parse_gemini_action(name: str, args: dict[str, object]) -> dict[str, object
     elif name == "type_text_at":
         x, y = _denormalize_coordinate(args)
         text = str(args.get("text", ""))
-        return {"action": "type", "text": text, "coordinate": [x, y]}
+        return {
+            "action": "type",
+            "text": text,
+            "coordinate": [x, y],
+            "press_enter": bool(args.get("press_enter", True)),
+        }
 
     elif name == "hover_at":
         x, y = _denormalize_coordinate(args)

--- a/src/inspect_ai/tool/_tools/_computer/_computer.py
+++ b/src/inspect_ai/tool/_tools/_computer/_computer.py
@@ -53,6 +53,7 @@ _COMPUTER_TOOL_PARAMETERS: frozenset[str] = frozenset(
         "scroll_direction",
         "start_coordinate",
         "text",
+        "press_enter",
         "actions",
     ]
 )
@@ -98,6 +99,7 @@ def computer(max_screenshots: int | None = 1, timeout: int | None = 180) -> Tool
         scroll_direction: Literal["up", "down", "left", "right"] | None = None,
         start_coordinate: list[int] | None = None,
         text: str | None = None,
+        press_enter: bool | None = None,
         actions: list[dict[str, object]] | None = None,
     ) -> ToolResult:
         """
@@ -149,6 +151,7 @@ def computer(max_screenshots: int | None = 1, timeout: int | None = 180) -> Tool
           scroll_direction (Literal["up", "down", "left", "right] | None): The direction to scroll the screen. Required only by `action=scroll`.
           start_coordinate (tuple[int, int] | None): The (x, y) pixel coordinate on the screen from which to initiate a drag. Required only by `action=scroll`.
           text (str | None): The text to type or the key to press. Required when action is "key" or "type".
+          press_enter (bool): If True and action is "type", press Return after typing. Defaults to False.
           actions (list[dict] | None): A list of action dicts to execute sequentially (OpenAI multi-action format).
 
         Returns:
@@ -167,6 +170,7 @@ def computer(max_screenshots: int | None = 1, timeout: int | None = 180) -> Tool
                     scroll_direction,
                     start_coordinate,
                     text,
+                    press_enter,
                 )
             ]
             if action is not None
@@ -206,7 +210,10 @@ def computer(max_screenshots: int | None = 1, timeout: int | None = 180) -> Tool
             case "type":
                 if coordinate is not None:
                     await common.left_click(coordinate, timeout=timeout)
-                return await common.type(not_none(text, "text"), timeout=timeout)
+                result = await common.type(not_none(text, "text"), timeout=timeout)
+                if bool(args.get("press_enter")):
+                    result = await common.press_key("Return", timeout=timeout)
+                return result
             case "cursor_position":
                 return await common.cursor_position(timeout=timeout)
             case "mouse_move":
@@ -282,6 +289,7 @@ def computer(max_screenshots: int | None = 1, timeout: int | None = 180) -> Tool
         scroll_direction: Literal["up", "down", "left", "right"] | None,
         start_coordinate: list[int] | None,
         text: str | None,
+        press_enter: bool | None,
     ) -> dict[str, object]:
         return {
             k: v
@@ -294,6 +302,7 @@ def computer(max_screenshots: int | None = 1, timeout: int | None = 180) -> Tool
                 scroll_direction=scroll_direction,
                 start_coordinate=start_coordinate,
                 text=text,
+                press_enter=press_enter,
             ).items()
             if v is not None
         }

--- a/tests/tools/test_google_computer_use_transforms.py
+++ b/tests/tools/test_google_computer_use_transforms.py
@@ -37,7 +37,12 @@ def test_hover_at_bidirectional():
 
 
 def test_type_text_at_bidirectional():
-    args = {"action": "type", "text": "hello world", "coordinate": [507, 361]}
+    args = {
+        "action": "type",
+        "text": "hello world",
+        "coordinate": [507, 361],
+        "press_enter": True,
+    }
     tool_call = ToolCall(id="test", function="computer", arguments=args)
     action_name, action_args = gemini_action_from_tool_call(tool_call)
 
@@ -45,10 +50,33 @@ def test_type_text_at_bidirectional():
     assert action_args["text"] == "hello world"
     assert abs(action_args["x"] - 371) <= 1
     assert abs(action_args["y"] - 470) <= 1
+    assert action_args["press_enter"] is True
 
     function_call = FunctionCall(name=action_name, args=action_args)
     parsed = tool_call_from_gemini_computer_action(function_call)
     assert parsed.arguments == args
+
+
+def test_type_text_at_press_enter_false():
+    function_call = FunctionCall(
+        name="type_text_at",
+        args={"text": "hello world", "press_enter": False},
+    )
+    parsed = tool_call_from_gemini_computer_action(function_call)
+
+    assert parsed.arguments["action"] == "type"
+    assert parsed.arguments["press_enter"] is False
+
+
+def test_type_text_at_default_press_enter():
+    function_call = FunctionCall(
+        name="type_text_at",
+        args={"text": "hello world"},
+    )
+    parsed = tool_call_from_gemini_computer_action(function_call)
+
+    assert parsed.arguments["action"] == "type"
+    assert parsed.arguments["press_enter"] is True
 
 
 def test_key_combination_bidirectional():

--- a/tests/tools/test_openai_computer_use_transforms.py
+++ b/tests/tools/test_openai_computer_use_transforms.py
@@ -369,6 +369,7 @@ def _computer_tool_info():
                     "scroll_direction",
                     "start_coordinate",
                     "text",
+                    "press_enter",
                     "actions",
                 ]
             }


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If you run an eval that uses `computer()` and the Gemini API response includes a `function_call` representing the action `type_text_at`, our code doesn't implement the execution logic for pressing ENTER after typing.

### What is the new behavior?

Our code implements the logic.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

I found this bug when I ran OSWorld and `gemini-3-flash-preview` double-typed in a cell in LibreOffice Calc.

[The docs](https://ai.google.dev/gemini-api/docs/computer-use) say the `press_enter` argument to the function call is optional and True by default.