### PR TITLE
docs: point inspect-sandboxes entries at gh-pages

### DIFF
--- a/docs/extensions/_extensions_content.md
+++ b/docs/extensions/_extensions_content.md
@@ -6,7 +6,7 @@
 [EC2 Sandbox](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox) &mdash; <small><a href="https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox" style="text-decoration:none">UK AISI</a></small>
 :   Python package that provides a EC2 virtual machine sandbox environment for Inspect.
 
-[Modal Sandbox](https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/modal) &mdash; <small><a href="https://github.com/meridianlabs-ai/inspect_sandboxes" style="text-decoration:none">Meridian</a></small>
+[Modal Sandbox](https://meridianlabs-ai.github.io/inspect_sandboxes/modal.html) &mdash; <small><a href="https://github.com/meridianlabs-ai/inspect_sandboxes" style="text-decoration:none">Meridian</a></small>
 :   Serverless container sandbox for Inspect using Modal's cloud infrastructure.
 
 [Proxmox Sandbox](https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox) &mdash; <small><a href="https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox" style="text-decoration:none">UK AISI</a></small>
@@ -18,7 +18,7 @@
 [Inspect Vagrant Sandbox](https://github.com/jasongwartz/inspect_vagrant_sandbox) &mdash; <small><a href="https://github.com/jasongwartz" style="text-decoration:none">Jason Gwartz</a></small>
 :   Use any virtual machine hypervisor supported by Hashicorp Vagrant as Inspect sandboxes.
 
-[Daytona Sandbox](https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/daytona) &mdash; <small><a href="https://github.com/meridianlabs-ai/inspect_sandboxes" style="text-decoration:none">Meridian</a></small>
+[Daytona Sandbox](https://meridianlabs-ai.github.io/inspect_sandboxes/daytona.html) &mdash; <small><a href="https://github.com/meridianlabs-ai/inspect_sandboxes" style="text-decoration:none">Meridian</a></small>
 :   Sandbox environment for Inspect using Daytona's cloud infrastructure.
 
 [Podman Sandbox](https://github.com/VectorInstitute/inspect-podman) &mdash; <small><a href="https://github.com/VectorInstitute/inspect-podman" style="text-decoration:none">Vector Institute and National Research Council of Canada</a></small>

--- a/docs/extensions/extensions.json
+++ b/docs/extensions/extensions.json
@@ -13,7 +13,7 @@
   {
     "id": "modal-sandbox",
     "name": "Modal Sandbox",
-    "url": "https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/modal",
+    "url": "https://meridianlabs-ai.github.io/inspect_sandboxes/modal.html",
     "desc": "Serverless container sandbox for Inspect using Modal's cloud infrastructure.",
     "author": "Meridian",
     "author_url": "https://github.com/meridianlabs-ai/inspect_sandboxes",
@@ -24,7 +24,7 @@
   {
     "id": "daytona-sandbox",
     "name": "Daytona Sandbox",
-    "url": "https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/daytona",
+    "url": "https://meridianlabs-ai.github.io/inspect_sandboxes/daytona.html",
     "desc": "Sandbox environment for Inspect using Daytona's cloud infrastructure.",
     "author": "Meridian",
     "author_url": "https://github.com/meridianlabs-ai/inspect_sandboxes",

--- a/docs/extensions/extensions.yml
+++ b/docs/extensions/extensions.yml
@@ -106,13 +106,13 @@
   author: "[UK AISI](https://github.com/UKGovernmentBEIS/inspect_k8s_sandbox)"
   categories: ["Sandboxes"]
 
-- name: "[Modal Sandbox](https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/modal)"
+- name: "[Modal Sandbox](https://meridianlabs-ai.github.io/inspect_sandboxes/modal.html)"
   description: |
     Serverless container sandbox for Inspect using Modal's cloud infrastructure.
   author: "[Meridian](https://github.com/meridianlabs-ai/inspect_sandboxes)"
   categories: ["Sandboxes"]
 
-- name: "[Daytona Sandbox](https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/daytona)"
+- name: "[Daytona Sandbox](https://meridianlabs-ai.github.io/inspect_sandboxes/daytona.html)"
   description: |
     Sandbox environment for Inspect using Daytona's cloud infrastructure.
   author: "[Meridian](https://github.com/meridianlabs-ai/inspect_sandboxes)"

--- a/docs/sandboxing.qmd
+++ b/docs/sandboxing.qmd
@@ -95,8 +95,8 @@ There are two sandbox environments built in to Inspect and five available as ext
 |------------------|------------------|------------------|------------------|
 | `docker` | Built-in | Yes | [Docker](#sec-docker-configuration) local installation. |
 | `k8s` | [inspect-k8s-sandbox](https://pypi.org/project/inspect-k8s-sandbox/) | Yes | [Kubernetes](https://k8s-sandbox.aisi.org.uk/) cluster. |
-| `daytona` | [inspect-sandboxes](https://pypi.org/project/inspect-sandboxes/) | Yes | [Daytona](https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/daytona) cloud sandbox. |
-| `modal` | [inspect-sandboxes](https://pypi.org/project/inspect-sandboxes/) | Yes | [Modal](https://github.com/meridianlabs-ai/inspect_sandboxes/tree/main/src/inspect_sandboxes/modal) cloud sandbox. |
+| `daytona` | [inspect-sandboxes](https://pypi.org/project/inspect-sandboxes/) | Yes | [Daytona](https://meridianlabs-ai.github.io/inspect_sandboxes/daytona.html) cloud sandbox. |
+| `modal` | [inspect-sandboxes](https://pypi.org/project/inspect-sandboxes/) | Yes | [Modal](https://meridianlabs-ai.github.io/inspect_sandboxes/modal.html) cloud sandbox. |
 | `ec2` | [inspect_ec2_sandbox](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox) | No | [AWS EC2](https://github.com/UKGovernmentBEIS/inspect_ec2_sandbox) virtual machine. |
 | `proxmox` | [inspect_proxmox_sandbox](https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox) | No | [Proxmox](https://github.com/UKGovernmentBEIS/inspect_proxmox_sandbox) with virtual machines. |
 | `local` | Built-in | No | Local file system (no sandbox). |


### PR DESCRIPTION
- Repoint the Modal and Daytona entries in the sandboxing providers table (`docs/sandboxing.qmd`) from GitHub folder views to the Quarto-rendered hosted provider pages.
- Same fix in `docs/extensions/extensions.yml` and `docs/extensions/_extensions_content.md` (and regenerated `extensions.json` via `generate.py`).