### PR TITLE
Correct type generation in the the presence of field validators

### DIFF
--- a/src/inspect_ai/_view/_openapi.py
+++ b/src/inspect_ai/_view/_openapi.py
@@ -26,7 +26,12 @@ class _CustomJsonSchemaGenerator(GenerateJsonSchema):
         schema_type = schema.get("type")
         if schema_type == "nullable":
             return True
-        if schema_type == "default":
+        if schema_type in (
+            "default",
+            "function-before",
+            "function-after",
+            "function-wrap",
+        ):
             return self._is_nullable_schema(schema.get("schema", {}))
         return False
 

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -4730,9 +4730,6 @@
             "title": "Verbosity"
           }
         },
-        "required": [
-          "prompt_logprobs"
-        ],
         "title": "GenerateConfig",
         "type": "object"
       },
@@ -8060,8 +8057,7 @@
         },
         "required": [
           "scorer",
-          "name",
-          "value"
+          "name"
         ],
         "title": "TaskDisplayMetric",
         "type": "object"

--- a/tests/_view/test_custom_json_schema_generator.py
+++ b/tests/_view/test_custom_json_schema_generator.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import pytest
 from fastapi import FastAPI
-from pydantic import BaseModel, Field, JsonValue
+from pydantic import BaseModel, Field, JsonValue, field_validator
 
 from inspect_ai._view._openapi import _CustomJsonSchemaGenerator, build_openapi_schema
 
@@ -41,6 +41,33 @@ class NestedNonNullable(BaseModel):
 
 class NestedNullable(BaseModel):
     nested: NonNullableNoDefault | None = Field(default=None)
+
+
+class NullableWithValidator(BaseModel):
+    field: int | None = Field(default=None)
+
+    @field_validator("field")
+    @classmethod
+    def _validate(cls, v: int | None) -> int | None:
+        return v
+
+
+class NullableWithBeforeValidator(BaseModel):
+    field: int | None = Field(default=None)
+
+    @field_validator("field", mode="before")
+    @classmethod
+    def _validate(cls, v: int | None) -> int | None:
+        return v
+
+
+class NullableWithWrapValidator(BaseModel):
+    field: int | None = Field(default=None)
+
+    @field_validator("field", mode="wrap")
+    @classmethod
+    def _validate(cls, v: Any, handler: Any) -> int | None:
+        return handler(v)
 
 
 # Test models for JsonValue
@@ -81,6 +108,10 @@ def _get_openapi_schemas(model: type[BaseModel]) -> dict[str, Any]:
         # Nested models follow same rules
         (NestedNonNullable, "nested", True),
         (NestedNullable, "nested", False),
+        # Nullable fields with validators are still not required
+        (NullableWithValidator, "field", False),
+        (NullableWithBeforeValidator, "field", False),
+        (NullableWithWrapValidator, "field", False),
     ],
     ids=[
         "str_no_default",
@@ -90,6 +121,9 @@ def _get_openapi_schemas(model: type[BaseModel]) -> dict[str, Any]:
         "str|None_default_value",
         "nested_non_nullable",
         "nested_nullable",
+        "int|None_with_after_validator",
+        "int|None_with_before_validator",
+        "int|None_with_wrap_validator",
     ],
 )
 def test_field_requiredness(


### PR DESCRIPTION
When pydantic sees `@field_validator`, it wraps the field's core schema in a `function-after` node. For `prompt_logprobs` the schema tree becomes:

```
default
└── function-after   ← validator wrapper
    └── nullable
        └── int
```

Previously we did:

```
def _is_nullable_schema(self, schema: CoreSchema) -> bool:
    schema_type = schema.get("type")
    if schema_type == "nullable":
        return True
    if schema_type == "default":
        return self._is_nullable_schema(schema.get("schema", {}))
    return False
```

which descends through default but stops at `function-after` (returning False), so the field is treated as `non-nullable` and gets added to `required`. This will recurse through.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
