### PR TITLE
Fix CLI bugs in eval and trace help, env vars, and Rich markup

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -409,7 +409,7 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         "--no-score-display",
         type=bool,
         is_flag=True,
-        help=NO_SCORE_HELP,
+        help=NO_SCORE_DISPLAY,
         envvar="INSPECT_EVAL_SCORE_DISPLAY",
     )
     @click.option(
@@ -1468,7 +1468,7 @@ def parse_comma_separated(value: str | None) -> list[str] | None:
     "--no-score-display",
     type=bool,
     is_flag=True,
-    help=NO_SCORE_HELP,
+    help=NO_SCORE_DISPLAY,
     envvar="INSPECT_EVAL_SCORE_DISPLAY",
 )
 @click.option(

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -541,7 +541,7 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         "--verbosity",
         type=click.Choice(["low", "medium", "high"]),
         help='Constrains the verbosity of the model\'s response. Lower values will result in more concise responses, while higher values will result in more verbose responses. GPT 5.x models only (defaults to "medium" for OpenAI models)',
-        envvar="INSPECT_EVAL_EFFORT",
+        envvar="INSPECT_EVAL_VERBOSITY",
     )
     @click.option(
         "--effort",

--- a/src/inspect_ai/_cli/trace.py
+++ b/src/inspect_ai/_cli/trace.py
@@ -248,7 +248,7 @@ def anomolies_command_impl(
         def print_fn(o: RenderableType) -> None:
             console.print(o, highlight=False)
 
-        print_fn(f"[bold]TRACE: {shlex.quote(trace_file_path.as_posix())}[bold]")
+        print_fn(f"[bold]TRACE: {shlex.quote(trace_file_path.as_posix())}[/bold]")
 
         _print_bucket(print_fn, "Running Actions", running_actions)
         _print_bucket(print_fn, "Cancelled Actions", canceled_actions)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Resolves #3751. Three CLI bugs reported there, plus one sibling found while reviewing the source:

1. `_cli/eval.py:544` — `--verbosity` is wired to `envvar="INSPECT_EVAL_EFFORT"`, colliding with `--effort` (line 550). Since 0.3.207 added `xhigh`/`max` to `--effort`'s choices, setting `INSPECT_EVAL_EFFORT=xhigh` for `--effort` crashes Click on `--verbosity` validation.
2. `_cli/eval.py:412` — `--no-score-display` uses `help=NO_SCORE_HELP`. The intended `NO_SCORE_DISPLAY` constant is defined at line 78 but never referenced.
3. `_cli/trace.py:251` — closing `[bold]` should be `[/bold]`. Rich treats both as opens, so bold bleeds into all subsequent output of `inspect trace anomalies`.
4. `_cli/eval.py:1471` *(sibling, not in original issue)* — same bug as #2 in the `eval_retry_command` decorator stack.

### What is the new behavior?

`--verbosity` reads `INSPECT_EVAL_VERBOSITY`; both `--no-score-display` decorators use `NO_SCORE_DISPLAY` ("Do not display scoring metrics in realtime."); the trace header's `[bold]` tag closes properly. Verified locally with `ruff check`, `ruff format --check`, `mypy`, `pytest tests/_cli/`, `pytest tests/cli/`, and `inspect eval --help`.

### Does this PR introduce a breaking change?

No. The previous `INSPECT_EVAL_EFFORT` collision either crashed (`xhigh`/`max`) or produced an unintended verbosity side-effect (`low`/`medium`/`high`); neither was correct behavior. `--verbosity` now reads its own env var.

### Other information:

While reviewing `eval_retry_command` I noticed two related but more speculative concerns and scoped them out — happy to open a follow-up issue:

- `--no-score` uses `INSPECT_EVAL_NO_SCORE` at line 406 but `INSPECT_EVAL_SCORE` at line 1465 — divergent env var names for the same flag across decorator stacks.
- `--no-score-display` (negative flag) is bound to `INSPECT_EVAL_SCORE_DISPLAY` (positive env var). May be intentional UX; flagging in case it isn't.

Both change public env-var contracts.