### PR TITLE
deepagent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Agents: Add `deepagent()` — a batteries-included agent with subagent delegation, persistent memory, structured planning, and an opinionated system prompt. Includes built-in `research()`, `plan()`, and `general()` subagent factories, a `task` multiplexer tool for delegation, and support for both isolated and forked (prompt-cache-preserving) dispatch modes.
 - Tools: Add `todo_write()` planning tool for structured task tracking.
 - Tools: Add `read_file()`, `list_files()`, and `grep()` read-only sandbox tools for agents that need filesystem access without write capabilities.
 - Tools: Add `readonly` parameter to `memory()` tool for read-only access to shared memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Tools: Add `todo_write()` planning tool for structured task tracking.
 - Tools: Add `read_file()`, `list_files()`, and `grep()` read-only sandbox tools for agents that need filesystem access without write capabilities.
+- Tools: Add `readonly` parameter to `memory()` tool for read-only access to shared memory.
 
 ## 0.3.212 (24 April 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Tools: Add `todo_write()` planning tool for structured task tracking.
+- Tools: Add `read_file()`, `list_files()`, and `grep()` read-only sandbox tools for agents that need filesystem access without write capabilities.
+
 ## 0.3.212 (24 April 2026)
 
 - vLLM: Support `use_chat_template=false` for base model evaluation (complements existing HF provider support).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Tools: Add `todo_write()` planning tool for structured task tracking.
 - Tools: Add `read_file()`, `list_files()`, and `grep()` read-only sandbox tools for agents that need filesystem access without write capabilities.
 - Tools: Add `readonly` parameter to `memory()` tool for read-only access to shared memory.
+- Skills: Add `instance` parameter to `skill()` for independent per-subagent skill stores. Skill names are now validated for uniqueness in `skill()`, `install_skills()`, and across `deepagent()` parent/subagent scopes.
 
 ## 0.3.212 (24 April 2026)
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -699,18 +699,30 @@ Built the prompt composition logic.
 - Placeholder expansion uses `str.replace()` (not `.format()`) to avoid conflicts with other braces in custom prompts.
 - Also beefed up subagent factory prompts (`research.py`, `plan.py`, `general.py`) with persistence, error recovery, and verification guidance (~12-15 lines each, up from ~8).
 
-### Phase 8: `deepagent()` function
+### Phase 8: `deepagent()` function (a94c56eba)
 
-Wire everything together.
+Wired everything together.
 
-- Implement `deepagent.py` — the top-level assembly function.
-- Assembly: resolve subagents, construct task tool, collect tools (user tools + task + memory + todo_write + skills), build system prompt, delegate to `react()`.
-- Tool inheritance: user tools flow to top-level and `general()` only, not to `research()`/`plan()`.
-- `memory=False` disables memory everywhere.
-- `web_search=` parameter adds `web_search()` to all subagents' `extra_tools`.
-- Validation: after resolving tools for each subagent, raise an error if any subagent has no tools (e.g. no sandbox, `web_search=False`, and no `extra_tools`). A subagent with no tools can't do useful work.
-- Prompt layering: pass `AgentPrompt(instructions=prompt, assistant_prompt=None, submit_prompt=None, handoff_prompt=None)` to `react()` to suppress its defaults — `CORE_BEHAVIOR` already covers what `DEFAULT_ASSISTANT_PROMPT` covers. Same for subagent prompts in `task_tool.py`.
-- Test: end-to-end with `mockllm`, tool wiring, system prompt content, memory kill switch, subagent model routing, no-tools validation error.
+**Files created:**
+- `src/inspect_ai/agent/_deepagent/deepagent.py` — `deepagent()` top-level assembly function decorated with `@agent`. Assembly sequence: resolve subagents (defaults to research/plan/general), inject web_search, apply memory kill switch, propagate compaction, set general's tools to parent tools, construct task_tool with get_messages callback, collect top-level tools, build system prompt (or expand placeholders), suppress react() defaults via `AgentPrompt`, delegate to `react()`.
+- `tests/agent/deepagent/test_deepagent.py` — 7 unit tests: constructibility, basic e2e, memory kill switch, instructions, custom prompt, extra tools, default subagents.
+- `tests/agent/deepagent/test_deepagent_e2e.py` — 15 comprehensive e2e tests using mockllm: multi-step delegation, memory write + subagent read, todo_write plan tracking, submit tool, custom subagents, instructions in system message, memory kill switch, full workflow (memory → plan → delegate → submit), plan subagent dispatch, general inherits parent tools, todo_write disabled, multiple calls to same subagent, interleaved tool use and delegation, custom prompt with placeholders, unknown tool graceful error.
+
+**Files modified:**
+- `src/inspect_ai/agent/_deepagent/task_tool.py` — `_resolve_tools` now provides sandbox-aware default read-only tools when `sa.tools is None`, injects `memory()`/`memory(readonly=True)` based on `sa.memory`, and passes `compaction=sa.compaction` to child `react()`.
+- `src/inspect_ai/agent/_deepagent/subagent.py` — added `compaction: CompactionStrategy | None = None` field.
+- `src/inspect_ai/agent/_deepagent/__init__.py` — added `deepagent` export.
+- `src/inspect_ai/agent/__init__.py` — added `deepagent` to public API.
+- `docs/reference/inspect_ai.agent.qmd` — added `### deepagent` to Deep Agent section.
+
+**Design decisions:**
+- `web_search: Tool | bool = False` — accepts `True` for defaults or a pre-configured `web_search()` instance. Off by default (evals value reproducibility and controlled environments).
+- Default subagents: `None` → `[research(), plan(), general()]`. The whole point of `deepagent()` is the opinionated assembly; users who don't want subagents use `react()`.
+- Suppressed react() default prompts via `AgentPrompt(instructions=prompt, assistant_prompt=None, submit_prompt=None, handoff_prompt=None)` — `CORE_BEHAVIOR` already covers what react's defaults provide.
+- Forked dispatch `get_messages` callback uses a mutable `_state_ref` that points to `state.messages` once the agent starts executing. Since react modifies messages in-place, the reference stays current.
+- Compaction propagation: parent's `CompactionStrategy` propagates to subagents that don't set their own. Safe because each `react()` creates its own `Compact` instance from the strategy.
+- `general()` subagent inherits parent tools via name-based check in `_apply_parent_tools_to_general`.
+- All e2e tests use `submit=True` and terminate via `_submit()` helper to avoid mockllm output exhaustion from react's continue prompts.
 
 ### Phase 9: Public API and exports
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -65,7 +65,7 @@ Each is a factory function that returns a `subagent()` configured with appropria
 
 - `research()` over `explore()`: we expect a meaningful share of evals built on `deepagent()` to be AI-Scientist-flavored (literature synthesis, web research) rather than codebase-flavored. `explore` reads awkwardly there. Pydantic-deep also blesses `research` as its single default. The underlying behavior — read-only delegation for information gathering — is the same as CC's Explore.
 - `plan()` matches CC directly.
-- `general()` is the shorter form of CC/LangChain's `general_purpose`. No semantic loss; consistent with the other one-word factories. The string `"general_purpose"` will be aliased on the tool side to absorb model habits trained on CC's vocabulary.
+- `general()` is the shorter form of CC/LangChain's `general_purpose`. No semantic loss; consistent with the other one-word factories.
 
 #### The `subagent()` primitive
 
@@ -391,7 +391,7 @@ task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 **Description generation.** A standalone function `subagent_dispatch_description(subagents: list[Subagent]) -> str` generates the `task()` tool description from the registered subagents. It produces the enumeration of available `subagent_type` values with their descriptions, plus when-to/when-not-to dispatch guidance and worked examples. The `task()` constructor calls this to set its description, keeping the tool description always in sync with the actual subagent list.
 
 **Dispatch mechanics:**
-- Look up the `Subagent` by `subagent_type` (with alias handling: `"general_purpose"` → `"general"`).
+- Look up the `Subagent` by `subagent_type`.
 - Construct a `react()` agent from the `Subagent` config.
 - If `fork=False`: invoke via `as_tool()` semantics — isolated context, summary returns as tool result.
 - If `fork=True`: the `task()` tool implements custom dispatch logic inspired by `handoff()` but adapted for the multiplexer context. It strips system messages, repairs the active tool call (removes sibling calls, adds a tool result boundary), and passes the remaining history verbatim to preserve prompt-cache compatibility. The child runs via `run()` and only its final output returns to the parent via `_extract_result()`. Wrapped in `timeline_branch()` for proper log viewer rendering.
@@ -469,7 +469,7 @@ Stored as string constants in `prompt.py`, with assembly logic that composes the
 
 **Layers assembled by `deepagent()`:**
 - **Core behavior** (~20-30 lines). Goal-oriented: action bias, verify-iterate, conciseness, batched tool calls, don't over-ask. Written as expectations, not procedures.
-- **Subagent dispatch** (included when subagents are configured). Generated from the `Subagent` list — names each available subagent, its role, and provides high-level guidance on when to delegate vs. do the work directly. This gives subagent awareness more weight than the tool description alone. The detailed dispatch mechanics (parameter usage, worked examples, alias handling) remain in the `task()` tool description.
+- **Subagent dispatch** (included when subagents are configured). Generated from the `Subagent` list — names each available subagent, its role, and provides high-level guidance on when to delegate vs. do the work directly. This gives subagent awareness more weight than the tool description alone. The detailed dispatch mechanics (parameter usage, worked examples) remain in the `task()` tool description.
 - **Memory/plan coordination** (included when memory and/or todo_write are enabled). Cross-tool guidance: "Use memory to offload large intermediate results. Use the plan to track high-level task decomposition."
 - **User instructions** (`instructions=` text appended at the end).
 
@@ -532,7 +532,7 @@ However, this is a significant infrastructure change with nontrivial risks:
 #### 9. Testing strategy
 
 - **Unit tests:** `Subagent` construction, `task()` parameter schema generation, system prompt assembly and placeholder expansion, recursion depth tracking (verify closure-based depth is parallel-safe).
-- **Integration tests:** `deepagent()` end-to-end with `mockllm` — verify tool wiring, subagent dispatch (both isolated and forked), system prompt content, alias handling.
+- **Integration tests:** `deepagent()` end-to-end with `mockllm` — verify tool wiring, subagent dispatch (both isolated and forked), system prompt content.
 - **Tool inheritance tests:** verify `research()`/`plan()` do not receive user-provided mutating tools; verify `general()` inherits the full parent tool set; verify `extra_tools=` works on all subagents.
 - **Skill inheritance tests:** verify `general()` inherits parent skills through normal tool inheritance.
 - **Memory ACL tests:** verify `research()`/`plan()` get `memory(readonly=True)` and cannot write; verify `general()` gets full read-write memory.
@@ -640,7 +640,7 @@ Built the multiplexer tool that dispatches to subagents.
 
 **Files created:**
 - `src/inspect_ai/agent/_deepagent/task_tool.py` — `task_tool()` factory creating a `@tool`-decorated `task` function. Dispatches via `run()` for both modes: isolated (string prompt) and forked (parent messages with system stripped and tool call repaired + prompt). Includes `_build_task_description()` for dynamic tool description, `_resolve_tools()` for child tool assembly with recursion guard, `_dispatch()` for unified limit handling, and `_extract_result()` for output extraction.
-- `tests/agent/deepagent/test_task_tool.py` — 9 tests: description generation (2), alias mapping (1), constructibility (1), mockllm dispatch (1), invalid subagent_type error (1), alias dispatch end-to-end (1), recursion guard included/excluded (2).
+- `tests/agent/deepagent/test_task_tool.py` — tests for description generation, constructibility, mockllm dispatch, invalid subagent_type error, general dispatch, recursion guard, forked dispatch, and forked input preparation.
 
 **Files modified:**
 - `src/inspect_ai/agent/_deepagent/__init__.py` — added `task_tool` export (internal only).
@@ -649,7 +649,7 @@ Built the multiplexer tool that dispatches to subagents.
 - Used `run()` for both isolated and forked dispatch — handles string→messages, limit application with `catch_errors=True`, span creation with `name=sa.name`, and returns `AgentState` + optional `LimitExceededError`.
 - For forked dispatch, parent messages are passed with minimal filtering (system stripped, tool call repaired) to preserve prompt cache. Parent messages accessed via `get_messages` callback (wired by `deepagent()` in Phase 8).
 - Recursion guard: `_resolve_tools()` includes a recursive `task_tool` at `depth < max_depth`, omits it at `depth >= max_depth`. Depth tracked via closure.
-- Alias handling: `"general_purpose"` → `"general"` to absorb CC vocabulary habits.
+- `subagent_type` parameter has a dynamic `enum` constraint in the JSON schema for structured model guidance.
 - Tool named `"task"` internally — no conflict with `@task` decorator (separate registries). Not publicly exported to avoid API confusion.
 - `task_description` parameter name (not `description`) to avoid shadowing.
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -681,7 +681,9 @@ Wire everything together.
 - Assembly: resolve subagents, construct task tool, collect tools (user tools + task + memory + todo_write + skills), build system prompt, delegate to `react()`.
 - Tool inheritance: user tools flow to top-level and `general()` only, not to `research()`/`plan()`.
 - `memory=False` disables memory everywhere.
-- Test: end-to-end with `mockllm`, tool wiring, system prompt content, memory kill switch, subagent model routing.
+- `web_search=` parameter adds `web_search()` to all subagents' `extra_tools`.
+- Validation: after resolving tools for each subagent, raise an error if any subagent has no tools (e.g. no sandbox, `web_search=False`, and no `extra_tools`). A subagent with no tools can't do useful work.
+- Test: end-to-end with `mockllm`, tool wiring, system prompt content, memory kill switch, subagent model routing, no-tools validation error.
 
 ### Phase 9: Public API and exports
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -276,7 +276,7 @@ The reference frameworks implement a mix of context-management strategies to kee
 
 LangChain's `TASK_SYSTEM_PROMPT` heavily emphasizes launching multiple subagents in parallel: "Whenever you have independent steps to complete — kick off tasks in parallel to accomplish them faster." Claude Code does the same — models can invoke the `task()` tool multiple times in a single response.
 
-**Inspect status:** Inspect's current `execute_tools` processes tool calls sequentially, and `handoff()` explicitly disables parallel tool calls. In v1, subagent dispatch is sequential — multiple `task()` calls in one response execute one at a time. The system prompt should not encourage multiple subagent calls in a single response, as this adds latency and cost with no execution-time benefit in v1. Guidance should be: delegate when helpful; focus on one delegation at a time. Parallel subagent execution is a future enhancement (see Implementation Blueprint section 8).
+**Inspect status:** Inspect's current `execute_tools` processes tool calls sequentially, but `task()` is marked `parallel=True` (the default). Multiple `task()` calls in one response execute one at a time in v1 but are architecturally safe — forked dispatch strips the trailing assistant message entirely (rather than repairing specific tool calls), so each child sees the same clean conversation prefix regardless of sibling calls. When parallel tool execution lands, `task()` will benefit without changes.
 
 #### Async / background subagents
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -560,13 +560,23 @@ New documentation file: `docs/deep-agent.qmd` — a standalone guide covering:
 3. **Full tests at each step.** Every phase produces both implementation and tests.
 4. **Update this document.** After completing a phase but before committing, replace the phase's overview section below with a summary of what was actually built and tested — files created/modified, key design decisions made during implementation, and test coverage.
 
-### Phase 1: `Subagent` type and `subagent()` factory
+### Phase 1: `Subagent` type and `subagent()` factory (063553f62)
 
-Create the `Subagent` dataclass and `subagent()` factory function. This is the foundation everything else builds on.
+Created the `Subagent` dataclass and `subagent()` factory function.
 
-- Define `Subagent` with fields: name, description, prompt, tools, model, fork, output_filter, memory, limits.
-- `subagent()` validates inputs and returns a `Subagent` instance.
-- Test: construction, field defaults, validation errors for invalid inputs.
+**Files created:**
+- `src/inspect_ai/agent/_deepagent/__init__.py` — package exports.
+- `src/inspect_ai/agent/_deepagent/subagent.py` — `Subagent` dataclass (`@dataclass(kw_only=True)`) and `subagent()` factory with input validation.
+- `tests/agent/deepagent/test_subagent.py` — 15 unit tests covering construction, defaults, field validation (name, description, prompt, memory).
+
+**Files modified:**
+- `src/inspect_ai/agent/__init__.py` — added `Subagent` and `subagent` to public API.
+
+**Design decisions:**
+- Used `@dataclass(kw_only=True)` (not Pydantic) to match agent module conventions and allow required fields after fields with defaults.
+- Dropped `output_filter` parameter — forked subagents always use `last_message`. Simplifies the API; can be added later if needed.
+- Dropped `instructions` from `Subagent` — only `prompt` is stored. Built-in factories (`research()`, `plan()`, `general()`) accept `instructions=` and merge it with their default prompt before constructing the `Subagent`.
+- Field order: `name`, `description`, `prompt` (identity), then `tools`, `extra_tools` (adjacent), `model`, `fork`, `skills`, `memory`, `limits`.
 
 ### Phase 2: `todo_write()` tool
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -94,7 +94,7 @@ Subagents support two dispatch modes, corresponding to Inspect's existing `as_to
 
 - **Isolated** (default) — the subagent runs with a fresh message history. The parent sends a prompt; only the subagent's summary returns. This is the standard CC/LangChain pattern and is what `as_tool()` provides.
 
-- **Forked** — the subagent inherits the parent's full message history (filtered through `content_only` on input so tool calls, reasoning traces, and system messages don't confound a potentially different model). The subagent works with the accumulated context but only its final message returns to the parent (via `last_message` output filter), keeping the parent context lean. This maps to Inspect's `handoff()` with `input_filter=content_only` and `output_filter=last_message`.
+- **Forked** — the subagent inherits the parent's full message history with minimal filtering: system messages are stripped (the child gets its own) and the active tool call is repaired (sibling calls removed, tool result boundary added). Message content is preserved verbatim to maintain provider prompt-cache compatibility. Only the subagent's final output returns to the parent. Use the same model or model family as the parent when forking.
 
 Claude Code recently added fork semantics to its general-purpose agent. We expose the same choice on `subagent()`:
 
@@ -109,7 +109,7 @@ def reviewer():
     )
 ```
 
-The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent behaves like `as_tool()` — isolated context, only the summary returns. When `fork=True`, it behaves like `handoff()` with `input_filter=content_only` and `output_filter=last_message` — the subagent sees the parent's conversation but only its final message returns, keeping the parent context lean. An optional `output_filter` parameter (only valid when `fork=True`) allows overriding the default `last_message` filter.
+The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent runs with isolated context via `run()` — only the summary returns. When `fork=True`, the subagent inherits the parent's message history with minimal filtering (system messages stripped, active tool call repaired) to preserve provider prompt-cache compatibility. Only the subagent's final output returns to the parent. Use the same model or model family when forking to avoid errors from incompatible tool call formats or reasoning content.
 
 The built-in subagents default as follows:
 
@@ -394,7 +394,7 @@ task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 - Look up the `Subagent` by `subagent_type` (with alias handling: `"general_purpose"` → `"general"`).
 - Construct a `react()` agent from the `Subagent` config.
 - If `fork=False`: invoke via `as_tool()` semantics — isolated context, summary returns as tool result.
-- If `fork=True`: the `task()` tool implements custom dispatch logic inspired by `handoff()` but adapted for the multiplexer context. It filters the parent's messages via `content_only` on input, runs the child `react()` agent, and applies `output_filter` (default `last_message`) to the result. This cannot be a trivial `handoff()` wrapper because `task()` has a different tool schema, needs to construct the child agent from `Subagent` config, and must control exactly what returns to the parent. The `output_filter` is configurable on `subagent()` (defaults to `last_message`); only valid when `fork=True`.
+- If `fork=True`: the `task()` tool implements custom dispatch logic inspired by `handoff()` but adapted for the multiplexer context. It strips system messages, repairs the active tool call (removes sibling calls, adds a tool result boundary), and passes the remaining history verbatim to preserve prompt-cache compatibility. The child runs via `run()` and only its final output returns to the parent via `_extract_result()`. Wrapped in `timeline_branch()` for proper log viewer rendering.
 - The `task()` tool creates `span(type="agent")` for each dispatch explicitly. (Unlike `as_tool()`/`handoff()` which create spans automatically, `task()` manages its own dispatch lifecycle.)
 - V1 dispatches subagents sequentially. Both isolated and forked dispatch are architecturally safe for future parallel execution — forked subagents receive a copy of the parent's messages and only their filtered result returns. See section 8 for the deferred parallel execution plan.
 
@@ -640,7 +640,7 @@ Added read-only mode to the existing `memory()` tool.
 Built the multiplexer tool that dispatches to subagents.
 
 **Files created:**
-- `src/inspect_ai/agent/_deepagent/task_tool.py` — `task_tool()` factory creating a `@tool`-decorated `task` function. Dispatches via `run()` for both modes: isolated (string prompt) and forked (`content_only` filtered parent messages + prompt). Includes `_build_task_description()` for dynamic tool description, `_resolve_tools()` for child tool assembly with recursion guard, `_dispatch()` for unified limit handling, and `_extract_result()` for output extraction.
+- `src/inspect_ai/agent/_deepagent/task_tool.py` — `task_tool()` factory creating a `@tool`-decorated `task` function. Dispatches via `run()` for both modes: isolated (string prompt) and forked (parent messages with system stripped and tool call repaired + prompt). Includes `_build_task_description()` for dynamic tool description, `_resolve_tools()` for child tool assembly with recursion guard, `_dispatch()` for unified limit handling, and `_extract_result()` for output extraction.
 - `tests/agent/deepagent/test_task_tool.py` — 9 tests: description generation (2), alias mapping (1), constructibility (1), mockllm dispatch (1), invalid subagent_type error (1), alias dispatch end-to-end (1), recursion guard included/excluded (2).
 
 **Files modified:**
@@ -648,7 +648,7 @@ Built the multiplexer tool that dispatches to subagents.
 
 **Design decisions:**
 - Used `run()` for both isolated and forked dispatch — handles string→messages, limit application with `catch_errors=True`, span creation with `name=sa.name`, and returns `AgentState` + optional `LimitExceededError`.
-- For forked dispatch, `content_only` filters parent messages (strips system messages, reasoning, converts tool calls to text) so the child agent works safely with potentially different models. Parent messages accessed via `get_messages` callback (wired by `deepagent()` in Phase 8).
+- For forked dispatch, parent messages are passed with minimal filtering (system stripped, tool call repaired) to preserve prompt cache. Parent messages accessed via `get_messages` callback (wired by `deepagent()` in Phase 8).
 - Recursion guard: `_resolve_tools()` includes a recursive `task_tool` at `depth < max_depth`, omits it at `depth >= max_depth`. Depth tracked via closure.
 - Alias handling: `"general_purpose"` → `"general"` to absorb CC vocabulary habits.
 - Tool named `"task"` internally — no conflict with `@task` decorator (separate registries). Not publicly exported to avoid API confusion.

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -1,0 +1,344 @@
+# Deep Agent Harness for Inspect
+
+## RFC
+
+We're planning on adding a `deepagent()` to Inspect as a peer to `react()`. This would be an alternate top-level agent that bundles the patterns popularized by Claude Code, OpenAI Codex CLI, LangChain deepagents, and Pydantic AI deepagents into a single batteries-included entry point. This RFC describes the proposed design and asks for community feedback before we commit to an API.
+
+### Background
+
+The `react()` loop — model + tools + scaffolding — handles short-horizon tasks well, but tends to flatten under longer horizons: agents lose the plot, exhaust their context window with intermediate tool output, and don't reliably plan or decompose work. The "deep agent" pattern, which emerged from Claude Code and was generalized by LangChain and others, addresses this with four ingredients:
+
+1. **A planner / todo tool:** Explicit, model-managed task decomposition.
+
+2. **A persistent scratchpad:** Place to offload large intermediate results out of the message history (a virtual filesystem in LangChain/Pydantic, real files in CC and Codex).
+
+3. **Subagent delegation:** Spawn isolated workers with their own context windows; only their summary returns to the parent.
+
+4. **A detailed system prompt:** Opinionated instructions that teach the model when to use each of the above.
+
+Inspect already has the underlying machinery for most of this: `react()` provides the agent loop, the `memory()` tool plus skills handle context engineering, sandboxes provide a real filesystem, `as_tool(agent)` turns any agent into a tool, `update_plan()` is a todo-style planner, and limits/spans/compaction are wired through. What's missing is the opinionated assembly: a single entry point, the canonical subagent set, the default system prompt, and a couple of naming alignments with the broader deep-agent vocabulary.
+
+### Proposed API
+
+``` python
+from inspect_ai.agent import deepagent, research, plan, general
+
+agent = deepagent(
+    tools=[...],                      # additional tools beyond defaults
+    subagents=[                       # default subagents
+        research(), plan(), general()
+    ],  
+    todo_write=True,                  # planner tool
+    memory=True,                      # context-engineering tool
+    skills=[...],                     # additional skills
+    instructions="...",               # additional sysprompt instructions
+)
+```
+
+`deepagent()` is a factory that returns an agent — usable anywhere `react()` is usable, including as a solver, as a subagent inside another `deepagent()`, or as a tool via `as_tool()`.
+
+### Key Design Decisions
+
+#### Three built-in subagents: `research()`, `plan()`, `general()`
+
+``` python
+subagents=[
+    research(),   # read-only information gathering
+    plan(),       # structured planning, no execution
+    general(),    # full tools, isolated context for noisy work
+]
+```
+
+Each is a factory function that returns a `subagent()` configured with appropriate tools, prompt, and permissions. All three accept additive customization (`instructions=`, `extra_tools=`, `model=`).
+
+**Comparison to prior art:**
+
+| Framework              | Built-in subagents                        |
+|------------------------|-------------------------------------------|
+| Claude Code            | `Explore`, `Plan`, `general-purpose`      |
+| LangChain `deepagents` | `general-purpose` only                    |
+| Pydantic `deepagents`  | `research` only                           |
+| Codex CLI              | None — user defines via `[agents]` config |
+| **Inspect (proposed)** | `research`, `plan`, `general`             |
+
+**Naming notes:**
+
+- `research()` over `explore()`: we expect a meaningful share of evals built on `deepagent()` to be AI-Scientist-flavored (literature synthesis, web research) rather than codebase-flavored. `explore` reads awkwardly there. Pydantic-deep also blesses `research` as its single default. The underlying behavior — read-only delegation for information gathering — is the same as CC's Explore.
+- `plan()` matches CC directly.
+- `general()` is the shorter form of CC/LangChain's `general_purpose`. No semantic loss; consistent with the other one-word factories. The string `"general_purpose"` will be aliased on the tool side to absorb model habits trained on CC's vocabulary.
+
+#### The `subagent()` primitive
+
+For fully custom subagents:
+
+``` python
+from inspect_ai.agent import subagent
+
+reviewer = subagent(
+    name="reviewer",
+    description="Reviews code for security and correctness.",
+    prompt="...",
+    tools=[grep(), read_file()],
+    model="anthropic/claude-sonnet-4",  # optional, inherits parent by default
+)
+
+agent = deepagent(subagents=[research(), plan(), general(), reviewer()])
+```
+
+Internally, `subagent()` is a thin wrapper around `react()` that captures name/description metadata for `task()` multiplexing, enforces the recursion guard, and provides additive customization fields. No new abstraction layer.
+
+#### Subagent dispatch: isolated vs forked
+
+Subagents support two dispatch modes, corresponding to Inspect's existing `as_tool()` and `handoff()` primitives:
+
+- **Isolated** (default) — the subagent runs with a fresh message history. The parent sends a prompt; only the subagent's summary returns. This is the standard CC/LangChain pattern and is what `as_tool()` provides.
+
+- **Forked** — the subagent inherits the parent's full message history (filtered through `content_only` so tool calls, reasoning traces, and system messages don't confound a potentially different model). The subagent works with the accumulated context and its output is filtered back to the parent. This maps directly to Inspect's `handoff()` with `output_filter=content_only`.
+
+Claude Code recently added fork semantics to its general-purpose agent. We expose the same choice on `subagent()`:
+
+``` python
+reviewer = subagent(
+    name="reviewer",
+    description="Reviews code for security and correctness.",
+    prompt="...",
+    tools=[grep(), read_file()],
+    fork=False,  # default: isolated context
+)
+```
+
+The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent behaves like `as_tool()` — isolated context, only the summary returns. When `fork=True`, it behaves like `handoff()` with `content_only` filters — the subagent sees the parent's conversation and its filtered output is appended to the parent's history.
+
+The built-in subagents default as follows:
+
+| Subagent       | Default `fork` | Rationale |
+|----------------|----------------|-----------|
+| `research()`   | `False`        | Information gathering is self-contained; isolated context keeps the parent lean. |
+| `plan()`       | `False`        | Planning from a clean slate avoids anchoring on noisy intermediate output. |
+| `general()`    | `False`        | Matches CC's original default. `general(fork=True)` opts into CC's newer fork behavior. |
+
+All three accept `fork=True` as an override.
+
+#### The `task()` tool
+
+`deepagent()` exposes subagents to the model via a single multiplexer tool (`task`), matching CC and Pydantic-deep convention. The tool takes `(description, subagent_type, prompt)` and dispatches to the named subagent. This keeps the model's tool list small as more subagents are added — the enumeration grows in the `subagent_type` parameter description, not the tool list itself.
+
+`as_tool(agent)` remains available as a primitive for users who prefer per-subagent tool exposure (better when there are 1–2 specialized subagents and you want maximum descriptive room).
+
+#### State inheritance
+
+Default behavior matches the convergent pattern across CC, LangChain, and Pydantic-deep:
+
+- **Sandbox** — shared (already true per-sample in Inspect).
+- **Memory** — shared, read by default, write opt-in per subagent. `research()` is read-only by default; `general()` can write; custom subagents declare explicitly.
+- **Skills** — shared.
+- **Message history** — isolated (this is what subagents are *for*).
+- **Tools** — subset declared by the subagent's definition.
+
+#### Subagent excursions
+
+Inspect's `span(type="agent")` already renders subagent work as swimlanes in the log viewer. The `task()` tool dispatch will open a span automatically — no new viewer work needed. Limits (`token_limit`, `message_limit`, `time_limit`, `cost_limit`) apply globally across the parent and all subagent excursions.
+
+#### System prompt
+
+The system prompt is the spine of the deep-agent pattern. We will treat it as a separately versioned text asset (not a Python string literal) so it can be reviewed, diffed, and tuned independently. Users can extend additively with `instructions=` (90% case) or fully replace with `prompt=` (escape hatch).
+
+The subsections below analyze the system prompts shipped by Claude Code, Codex CLI, LangChain deepagents, and Pydantic AI deepagents — what they share, where they diverge, and implications for Inspect.
+
+##### Scale and structure
+
+The four frameworks span a wide range of prompt size and modularity:
+
+| Framework   | Approx. size | Structure |
+|-------------|-------------|-----------|
+| Claude Code | Very large (~160 component files) | Modular: assembled at runtime from categorized markdown fragments (core behavior, tool descriptions, agent dispatch, memory, git safety, formatting). Subagent prompts are separate files. |
+| Codex CLI   | ~200 lines | Single monolithic markdown file. Focused and concise. |
+| LangChain   | ~60 lines (base) + ~80 lines (task dispatch) | Two constants: `BASE_AGENT_PROMPT` for core behavior, `TASK_SYSTEM_PROMPT` for subagent dispatch instructions. |
+| Pydantic AI | ~100 lines | Single `BASE_PROMPT` constant. Comprehensive but self-contained. |
+
+##### What they all share
+
+Despite significant differences in scope, all four converge on a core set of behavioral instructions:
+
+1. **Action bias.** All four tell the model to act rather than narrate intent. "Don't say 'I'll now do X' — just do it" appears nearly verbatim in LangChain, Pydantic, and CC. Codex expresses this through its "just do it" task execution style.
+
+2. **Verify-iterate loops.** All four include some form of "your first attempt is rarely correct — iterate." The loop structure varies (CC: implicit in tool usage; Codex: implicit; LangChain: understand→act→verify; Pydantic: research→understand→implement→verify→retry) but the principle is universal.
+
+3. **Conciseness.** Every prompt instructs the model to be direct and avoid preamble. CC and Codex add specific formatting rules; LangChain and Pydantic keep it to a general directive.
+
+4. **Parallel tool use.** All four instruct the model to batch independent tool calls into a single response rather than making sequential round-trips.
+
+5. **Don't over-ask.** All four tell the model to use reasonable defaults rather than asking clarifying questions for every detail. Only ask when genuinely blocked.
+
+##### Where they diverge
+
+| Concern | Claude Code | Codex CLI | LangChain | Pydantic AI |
+|---------|------------|-----------|-----------|-------------|
+| **Workflow prescription** | Implicit — behavior emerges from many small rules | Minimal — "understand, act, verify" is implied but not codified | Explicit 3-step: understand → act → verify | Explicit 5-step: research → understand → implement → verify → retry |
+| **Domain specificity** | Heavily code/git oriented (git safety protocol, commit conventions, PR creation) | Code-oriented (editing constraints, dirty worktree handling, `rg` preference) | Domain-agnostic | Code-oriented but less so than CC/Codex (file reading pagination, code quality rules) |
+| **Tool-specific rules** | Extensive — dedicated instructions per tool (Read vs cat, Edit vs sed, Bash constraints) | Moderate — `apply_patch` guidance, `rg` preference | Minimal — "use tools" | Moderate — prefer specialized tools over shell equivalents, file reading pagination |
+| **Formatting/presentation** | Detailed rules (markdown, code references, line numbers) | Very detailed (plain text, bullet structure, monospace rules, file reference format, final answer structure) | Minimal | Minimal — "be concise, include file:line references" |
+| **Safety guardrails** | Extensive (git safety, destructive operation warnings, security vulnerability awareness, OWASP top 10) | Moderate (never revert uncommitted changes, no destructive git commands) | None | Minimal (security vulnerability awareness) |
+| **Subagent dispatch** | Detailed per-agent-type instructions in the `task()` tool description | N/A (no built-in subagents) | Separate `TASK_SYSTEM_PROMPT` with lifecycle rules, when-to/when-not-to guidance, and worked examples | Brief "delegate specialized subtasks to subagents" |
+| **Memory/context** | Elaborate file-based memory system with types, lifecycle rules, and anti-patterns | None | None | None |
+| **Planning** | Dedicated plan mode with structured workflow | "Skip for easy tasks; don't make single-step plans; update after each step" | None (planning is a subagent concern) | None |
+
+##### Model-adaptive prompting: lessons from Codex CLI
+
+Codex CLI maintains separate system prompts per model generation, and the differences are instructive. The repository contains five prompt files:
+
+| File | Model | Lines | Content |
+|------|-------|-------|---------|
+| `gpt_5_codex_prompt.md` | GPT-5 (Codex-tuned) | ~80 | Concise: editing constraints, plan tool (3 rules), formatting guidelines. |
+| `gpt-5.1-codex-max_prompt.md` | GPT-5 (Codex Max) | ~90 | Same as above + frontend design section. |
+| `gpt_5_1_prompt.md` | GPT-5.1 (generic) | ~500 | Expansive: personality, AGENTS.md spec, autonomy/persistence, user update spec with examples, detailed planning with good/bad plan examples, task execution, validation, ambition vs precision, progress updates, full formatting rules, tool documentation. |
+| `gpt_5_2_prompt.md` | GPT-5.2 (generic) | ~480 | Similar to 5.1, slightly trimmed (responsiveness section emptied). |
+| `gpt-5.2-codex_prompt.md` | GPT-5.2 (Codex-tuned) | ~80 | Same concise format as GPT-5 base. Adds frontend tasks. |
+
+The pattern is stark: **models post-trained for agentic coding (the `-codex` variants) get ~80-line prompts. Generic models of the same generation get ~500-line prompts.** The Codex-tuned models have already internalized planning behavior, task execution workflow, progress updates, and tool usage patterns during post-training — the system prompt only needs to provide tool-specific constraints and domain rules. Generic models need the full behavioral scaffolding taught in-context.
+
+Specific sections that appear only in the generic-model prompts:
+
+- **Autonomy and persistence** — "Persist until the task is fully handled end-to-end."
+- **User update spec** — detailed rules for progress updates with 8 worked examples.
+- **Planning guidance** — when to plan, high-quality vs low-quality plan examples, status management rules.
+- **Task execution** — "keep going until the query is completely resolved."
+- **Ambition vs precision** — "be ambitious for new tasks, surgical for existing codebases."
+- **Validation** — when to run tests proactively vs wait for approval.
+- **Tool documentation** — `apply_patch` format specification, `update_plan` usage.
+
+The Codex-tuned prompts assume the model already knows all of this. They only teach what the model *can't* know from training: the specific tool names available in this session, editing constraints for this environment, and presentation formatting rules.
+
+##### Implications for Inspect
+
+Inspect's `deepagent()` prompt must navigate two tensions the coding assistants don't face:
+
+1. **Task-agnostic.** CC and Codex can hard-code git workflows and file-editing conventions because they know they're coding tools. Inspect agents run evals that might involve coding, research, math, web browsing, or domain-specific tool use. The prompt cannot assume the task domain.
+
+2. **Model-agnostic.** Inspect must work well with models at very different levels of agentic post-training — from frontier models that have been heavily tuned for agentic tool use to models with minimal agentic post-training that need guidance. The prompt cannot assume a specific level of model capability.
+
+The Codex evidence shows that what harms capable models is **prescriptive workflow** — rigid step-by-step procedures ("1. Research, 2. Understand, 3. Implement...") that constrain the model's natural decision-making and can override better-trained instincts. What *doesn't* harm them is goal-oriented framing, environmental descriptions, and tool-level documentation. This suggests a single prompt can serve both populations if written in the right style.
+
+Key design principles for Inspect's system prompt:
+
+1. **Layer the prompt.** Follow CC's modular approach — not its scale. Separate the prompt into composable layers:
+   - **Core behavior** (action bias, verify-iterate, conciseness, parallel tool use) — always included.
+   - **Tool dispatch** (when to use `task()`, how to delegate, when not to) — included when subagents are configured.
+   - **Domain-specific instructions** — provided by the user via `instructions=`, not baked in.
+
+2. **Write goals, not procedures.** The scaffolding that weaker models need (planning, persistence, verification) can be included without harming capable models if framed as expectations rather than prescribed steps. Compare:
+
+   - *Prescriptive (harms capable models):* "Follow these steps: 1. Research the environment. 2. Read relevant files. 3. Understand patterns. 4. Implement changes. 5. Verify. 6. Retry on failure."
+   - *Goal-oriented (safe for all):* "Complete tasks autonomously. Plan when the task is complex or multi-step. Verify your work before finishing. If verification fails, diagnose and retry rather than declaring done."
+
+   The first constrains a well-trained model into a rigid loop it doesn't need. The second gives weaker models the right signals (plan, verify, retry) while letting capable models apply their own judgment about when and how.
+
+3. **Push detail into tool descriptions.** Even Codex-tuned models — which need almost no behavioral scaffolding — still get tool-specific instructions. Tool descriptions are read by every model regardless of training. This is the right place for worked examples, usage heuristics, and dispatch guidance. In particular, the `task()` tool description should carry the subagent dispatch logic: when to delegate (complex, independent, context-heavy work), when not to (trivial lookups, dependent steps), and examples of good vs. unnecessary delegation. This follows LangChain's `TASK_SYSTEM_PROMPT` pattern but places it where models naturally look.
+
+4. **Keep the core small.** The shared patterns (action bias, verify-iterate, conciseness, parallel tools, don't over-ask) are ~20-30 lines in goal-oriented style. That's the floor. Everything above it should earn its place.
+
+5. **Don't embed domain knowledge.** CC's git safety rules and Codex's editing constraints are valuable for coding — but they belong in the user's `instructions=` parameter or in tool-level descriptions, not in the base prompt. Inspect's prompt should teach the *pattern* (plan, delegate, verify) without assuming what the tools do.
+
+6. **Provide the escape hatch.** The `prompt=` parameter allows full replacement for users who need complete control — researchers running novel agent architectures, or teams with heavily customized system prompts from prior work. Custom prompts can include named placeholders that `deepagent()` will inject at assembly time. Placeholders are optional — if omitted, the corresponding content is simply not included. This lets users control both *what* is included and *where* it appears in their prompt. Placeholder names and the content they expand to will be documented; likely candidates include:
+
+   - `{tool_descriptions}` — formatted descriptions of all configured tools.
+   - `{subagent_dispatch}` — the `task()` tool dispatch guidance (available subagent types, when to delegate, worked examples).
+   - `{memory_instructions}` — memory tool usage guidance.
+   - `{plan_instructions}` — planning/todo tool usage guidance.
+   - `{instructions}` — the user's `instructions=` text.
+
+7. **Tools communicate through descriptions, not prompt injection.** When users pass tools to `deepagent()` — including custom subagents created with `handoff()` or `as_tool()` — we won't always know their capabilities (e.g., whether fork is enabled). Rather than adding an API for tools to inject content into the system prompt, we rely on the tool's own `description` field. The person who creates the tool controls its description and can communicate relevant behavior ("this agent sees your full conversation history" vs "this agent starts with a fresh context"). This is consistent with principle #3 above and avoids prompt bloat from many tools each injecting content. Cross-tool coordination guidance (e.g., "use memory to offload large findings, use the plan to track high-level progress") belongs in the core prompt layer, which `deepagent()` assembles.
+
+### Additional Capabilities
+
+The following capabilities emerged from a survey of LangChain deepagents, Pydantic AI deepagents, Codex CLI, and the broader multi-agent research literature. Some are already present in Inspect's existing primitives; others represent gaps in the current RFC. We assess each for relevance to `deepagent()` and recommend whether to include, defer, or exclude.
+
+#### Context management and compaction
+
+All three major frameworks implement multi-tier context management to keep long-running agents within their context window:
+
+1. **Tool output eviction.** LangChain and Pydantic AI both evict large tool outputs (>20K tokens) to the filesystem, replacing them with a short preview and a reference path. The agent can retrieve the full content later via filesystem tools if needed. This prevents a single large tool response from consuming the context budget.
+
+2. **Summarization / compaction.** When the context window approaches capacity (~85-90% in LangChain/Pydantic), the frameworks trigger an LLM-generated summary that compresses the conversation while preserving key facts, then continues from the summary.
+
+3. **Mid-turn compaction.** Codex CLI supports compaction during a streaming model response — injecting a summary mid-turn when the context limit is hit during generation.
+
+**Inspect status:** Inspect already has compaction infrastructure (`CompactionEdit`, `CompactionTrim`, `CompactionSummary`, native provider compaction) wired through `react()`. The `deepagent()` RFC should clarify how it exposes compaction configuration — likely through existing `react()` parameters that `deepagent()` passes through. Tool output eviction is a separate concern not currently in Inspect and may be worth adding as a standalone capability that `deepagent()` enables by default.
+
+#### Parallel subagent execution
+
+LangChain's `TASK_SYSTEM_PROMPT` heavily emphasizes launching multiple subagents in parallel: "Whenever you have independent steps to complete — kick off tasks in parallel to accomplish them faster." Claude Code does the same — models can invoke the `task()` tool multiple times in a single response.
+
+**Inspect status:** This works automatically if the `task()` tool allows parallel invocation. The model emits multiple `task()` tool calls in one response, and Inspect's tool execution machinery runs them concurrently. No new infrastructure needed — but the `task()` tool description and system prompt should explicitly encourage this pattern, and the tool definition should not set `parallel=False`.
+
+#### Cost-aware model routing
+
+The RFC mentions `model=` per subagent but doesn't frame it as cost-aware routing. In practice, this is one of the highest-leverage features: route simple subtasks (file reading, grep, summarization) to cheaper/faster models and reserve expensive models for complex reasoning. Research reports 85% cost reduction while maintaining 95% quality.
+
+**Inspect status:** Already supported — `subagent(model=...)` and `research(model=...)` etc. allow per-subagent model selection. The system prompt should teach this pattern to users through documentation rather than adding new API surface. The `deepagent()` constructor could accept a `subagent_model=` default that built-in subagents inherit unless overridden.
+
+#### Stuck loop detection
+
+Pydantic AI ships a built-in `StuckLoopDetection` capability that detects when an agent is repeating the same tool calls. This is important for eval reliability — a stuck agent burns tokens and time without progress.
+
+**Inspect status:** Not currently in the RFC. This is worth including as a default behavior in `deepagent()`. Implementation could be a lightweight check in the agent loop that detects N consecutive identical (or near-identical) tool call sequences and injects a "you appear to be repeating the same actions" nudge, or terminates with a diagnostic message. This is a natural fit for `deepagent()`'s opinionated defaults.
+
+#### Tool call repair
+
+Pydantic AI's `PatchToolCallsCapability` detects orphaned tool calls (calls with no matching result) and orphaned tool results (results with no matching call), injecting synthetic responses to keep the conversation well-formed. This matters when models produce malformed tool-use sequences or when errors interrupt tool execution.
+
+**Inspect status:** Inspect's `react()` loop already handles tool execution errors, but orphaned-call repair is a resilience feature worth considering. If models occasionally produce tool calls that fail silently, the conversation history becomes inconsistent. This is lower priority than stuck loop detection but worth noting for robustness.
+
+#### Checkpointing integration
+
+The separate [Inspect Checkpointing design](../design/checkpointing.md) proposes mid-sample durability for long-running evals. `deepagent()` is a primary consumer of this capability — deep agent evals are exactly the ones that run for hours or days and need crash recovery.
+
+**Inspect status:** The checkpointing design is proceeding in parallel. `deepagent()` should accept a `checkpoint=CheckpointConfig(...)` parameter, consistent with `react()`. The integration is straightforward — checkpoints fire at turn boundaries in the agent loop, which `deepagent()` inherits from `react()`.
+
+#### Reflection and self-critique
+
+Recent research (Multi-Agent Reflexion, dual-loop reflection) shows that having agents critique their own output before returning it to the parent can improve quality. The pattern: agent produces a result, a critic (possibly the same model, possibly a cheaper one) evaluates it, and if the critique identifies issues, the agent revises.
+
+**Inspect status:** Not in the RFC. This is an interesting pattern but may be better left to users who can implement it as a custom subagent (e.g., a `reviewer()` subagent) rather than baked into `deepagent()` defaults. The `subagent()` primitive is flexible enough to support this. We should mention it as a documented pattern rather than a built-in feature.
+
+#### Hooks and middleware
+
+LangChain implements a composable middleware pipeline (PlanningMiddleware, FilesystemMiddleware, SubAgentMiddleware, SummarizationMiddleware, etc.). Pydantic AI has 8 lifecycle hook events (PRE_TOOL_USE, POST_TOOL_USE, BEFORE_RUN, AFTER_RUN, etc.). Codex CLI has a hook system that can inject context back into the prompt.
+
+**Inspect status:** Inspect does not have a middleware system for agents, and adding one would be a significant new abstraction. However, many of the use cases that middleware serves in other frameworks are already covered by Inspect's existing primitives: compaction handles context management, spans handle observability, limits handle resource control, and tool-level logic handles approval. We should not add middleware to `deepagent()` — it would add complexity without clear benefit given Inspect's existing architecture.
+
+#### Human-in-the-loop
+
+LangChain provides granular `interrupt_on` configuration per tool, allowing agents to pause for human approval before destructive actions. Codex CLI has a Guardian approval system with 7 approval types.
+
+**Inspect status:** Less relevant for eval workloads, where the goal is typically autonomous execution. Inspect's sandbox isolation provides the safety boundary. If needed, users can implement approval logic at the tool level. Not recommended for `deepagent()` defaults.
+
+### Open Questions
+
+We'd particularly value input on:
+
+1. **Built-in subagent set.** Are `research`, `plan`, `general` the right three? Should we ship more (e.g., `reviewer`, `tester`)? Fewer? Different names?
+
+2. **`research()` vs `explore()`.** Our reasoning is above — does this match the use cases you'd build on `deepagent()`?
+
+3. **Memory write defaults.** Is read-by-default / write-opt-in the right posture for built-in subagents, or should `general()` get write access by default?
+
+4. **Recursion depth.** Hard cap at 1 level (matching Claude Code and Codex), or expose an opt-in for deeper delegation?
+
+5. **`task()` vs `as_tool()` as the default exposure.** Multiplexer (CC/Pydantic-deep style) or per-subagent tools (more granular description text)?
+
+6. **What's missing.** Are there deep-agent patterns you've found valuable in other frameworks that aren't covered above?
+
+7. **Naming.** `deepagent` vs `deep_agent` vs something else.
+
+### Prior Art
+
+- [Claude Code subagents documentation](https://code.claude.com/docs/en/sub-agents)
+- [LangChain `deepagents`](https://github.com/langchain-ai/deepagents) and [docs](https://docs.langchain.com/oss/python/deepagents/overview)
+- [Pydantic `deepagents`](https://github.com/vstorm-co/pydantic-deepagents)
+- [OpenAI Codex CLI subagents](https://developers.openai.com/codex/subagents)
+- ["Deep Agents" — LangChain blog post](https://blog.langchain.com/deep-agents/)
+
+## Implementation Blueprint
+
+*To be written after the open design questions above are resolved.*

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -74,13 +74,14 @@ For fully custom subagents:
 ``` python
 from inspect_ai.agent import subagent
 
-reviewer = subagent(
-    name="reviewer",
-    description="Reviews code for security and correctness.",
-    prompt="...",
-    tools=[grep(), read_file()],
-    model="anthropic/claude-sonnet-4",  # optional, inherits parent by default
-)
+def reviewer(model="anthropic/claude-sonnet-4"):
+    return subagent(
+        name="reviewer",
+        description="Reviews code for security and correctness.",
+        prompt="...",
+        tools=[grep(), read_file()],
+        model=model,
+    )
 
 agent = deepagent(subagents=[research(), plan(), general(), reviewer()])
 ```
@@ -98,13 +99,14 @@ Subagents support two dispatch modes, corresponding to Inspect's existing `as_to
 Claude Code recently added fork semantics to its general-purpose agent. We expose the same choice on `subagent()`:
 
 ``` python
-reviewer = subagent(
-    name="reviewer",
-    description="Reviews code for security and correctness.",
-    prompt="...",
-    tools=[grep(), read_file()],
-    fork=False,  # default: isolated context
-)
+def reviewer():
+    return subagent(
+        name="reviewer",
+        description="Reviews code for security and correctness.",
+        prompt="...",
+        tools=[grep(), read_file()],
+        fork=False,  # default: isolated context
+    )
 ```
 
 The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent behaves like `as_tool()` — isolated context, only the summary returns. When `fork=True`, it behaves like `handoff()` with `input_filter=content_only` and `output_filter=last_message` — the subagent sees the parent's conversation but only its final message returns, keeping the parent context lean. An optional `output_filter` parameter (only valid when `fork=True`) allows overriding the default `last_message` filter.
@@ -141,7 +143,7 @@ Inspect's `span(type="agent")` already renders subagent work as swimlanes in the
 
 #### System prompt
 
-The system prompt is the spine of the deep-agent pattern. We will treat it as a separately versioned text asset (not a Python string literal) so it can be reviewed, diffed, and tuned independently. Users can extend additively with `instructions=` (90% case) or fully replace with `prompt=` (escape hatch).
+The system prompt is the spine of the deep-agent pattern. It lives as string constants in a dedicated module (`prompt.py`) with assembly logic that composes layers based on configuration. Users can extend additively with `instructions=` (90% case) or fully replace with `prompt=` (escape hatch).
 
 The subsections below analyze the system prompts shipped by Claude Code, Codex CLI, LangChain deepagents, and Pydantic AI deepagents — what they share, where they diverge, and implications for Inspect.
 
@@ -263,7 +265,7 @@ All three major frameworks implement multi-tier context management to keep long-
 
 3. **Mid-turn compaction.** Codex CLI supports compaction during a streaming model response — injecting a summary mid-turn when the context limit is hit during generation.
 
-**Inspect status:** Inspect already has compaction infrastructure (`CompactionEdit`, `CompactionTrim`, `CompactionSummary`, native provider compaction) wired through `react()`. The `deepagent()` RFC should clarify how it exposes compaction configuration — likely through existing `react()` parameters that `deepagent()` passes through. Tool output eviction is a separate concern not currently in Inspect and may be worth adding as a standalone capability that `deepagent()` enables by default.
+**Inspect status:** Inspect already has compaction infrastructure (`CompactionEdit`, `CompactionTrim`, `CompactionSummary`, native provider compaction) wired through `react()`. `deepagent()` exposes compaction configuration via the existing `compaction=` parameter, passed through to `react()`.
 
 #### Parallel subagent execution
 
@@ -315,15 +317,14 @@ We'd particularly value input on:
 
 2. **`research()` vs `explore()`.** Our reasoning is above — does this match the use cases you'd build on `deepagent()`?
 
-3. **Memory write defaults.** Is read-by-default / write-opt-in the right posture for built-in subagents, or should `general()` get write access by default?
+3. **What's missing.** Are there deep-agent patterns you've found valuable in other frameworks that aren't covered above?
 
-4. **Recursion depth.** Hard cap at 1 level (matching Claude Code and Codex), or expose an opt-in for deeper delegation?
+#### Resolved
 
-5. **`task()` vs `as_tool()` as the default exposure.** Multiplexer (CC/Pydantic-deep style) or per-subagent tools (more granular description text)?
-
-6. **What's missing.** Are there deep-agent patterns you've found valuable in other frameworks that aren't covered above?
-
-7. **Naming.** `deepagent` vs `deep_agent` vs something else.
+- **Memory write defaults.** `research()` and `plan()` are read-only; `general()` gets read-write. Custom subagents declare explicitly.
+- **Recursion depth.** Default cap at 1 level (matching CC and Codex), configurable via `max_depth=`.
+- **`task()` vs `as_tool()`.** `task()` multiplexer is the default. `as_tool()` remains available for users who prefer per-subagent tool exposure.
+- **Naming.** `deepagent()`.
 
 ### Prior Art
 
@@ -358,7 +359,7 @@ reviewer = subagent(
 
 `Subagent` holds: name, description, prompt, tools, model, fork, output_filter, limits, memory write access. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
 
-**Recursion guard.** Depth is tracked per-sample (e.g., via `Store`) and incremented on each `task()` dispatch. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_subagent_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
+**Recursion guard.** Depth is tracked per-sample (e.g., via `Store`) and incremented on each `task()` dispatch. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
 
 #### 2. `task()` tool
 
@@ -366,7 +367,7 @@ The multiplexer. Takes a list of `Subagent` objects at construction time and exp
 
 ``` python
 # Constructed internally by deepagent():
-task_tool = task(subagents=[research(), plan(), general(), reviewer])
+task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 ```
 
 **Parameters exposed to the model:** `(description: str, subagent_type: str, prompt: str)`. The `subagent_type` enum is generated dynamically from the `Subagent` names and descriptions.
@@ -427,6 +428,7 @@ def deepagent(
     instructions: str | None = None,
     prompt: str | None = None,                      # full replacement with placeholders
     compaction: CompactionStrategy | None = None,
+    max_depth: int = 1,                             # max subagent recursion depth
     model: str | Model | None = None,
     submit: AgentSubmit | bool | None = None,
     attempts: int | AgentAttempts = 1,
@@ -472,6 +474,7 @@ No changes to existing `react()`, `as_tool()`, `handoff()`, or `Agent` APIs.
 #### 7. File layout
 
 New directory `src/inspect_ai/agent/_deepagent/`:
+- `__init__.py` — package init.
 - `deepagent.py` — `deepagent()` function.
 - `subagent.py` — `Subagent` type and `subagent()` factory.
 - `research.py` — `research()` built-in subagent factory.
@@ -480,8 +483,16 @@ New directory `src/inspect_ai/agent/_deepagent/`:
 - `task_tool.py` — `task()` multiplexer tool.
 - `prompt.py` — system prompt text constants and assembly logic.
 
+New tools in `src/inspect_ai/tool/_tools/`:
+- `_grep.py` — `grep()` read-only search tool.
+- `_read_file.py` — `read_file()` read-only file reading tool.
+- `_list_files.py` — `list_files()` read-only directory listing tool.
+- `_todo_write.py` — `todo_write()` planning tool (replaces `update_plan()`).
+
 Modified files:
 - `src/inspect_ai/agent/__init__.py` — add new exports.
+- `src/inspect_ai/tool/_tools/__init__.py` — add new tool exports.
+- `src/inspect_ai/tool/_tools/_update_plan.py` — deprecate with alias to `todo_write()`.
 
 #### 8. Testing strategy
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -137,7 +137,7 @@ Default behavior matches the convergent pattern across CC, LangChain, and Pydant
 
 - **Sandbox** — shared (already true per-sample in Inspect).
 - **Memory** — shared, read by default, write opt-in per subagent. `research()` and `plan()` get `memory(readonly=True)`; `general()` gets full read-write `memory()`. Custom subagents declare explicitly. Note: `memory(readonly=True)` is a new mode that must be implemented — the current `memory()` tool supports all CRUD operations.
-- **Skills** — defined once at the `deepagent()` level. The `skill()` tool is included in the parent tool set and flows to `general()` through normal tool inheritance. `research()` and `plan()` do not inherit skills (they are read-only focused).
+- **Skills** — composable across parent and subagents. `deepagent(skills=[...])` defines parent skills available to the top-level agent. Each subagent can also define its own skills via `skills=`. At dispatch time, parent and subagent skills are merged into a single `skill()` tool with instance-scoped storage (no store contention). A subagent with `skills=[C]` and a parent with `skills=[A, B]` sees all three skills.
 - **Message history** — isolated (this is what subagents are *for*).
 - **Tools** — subset declared by the subagent's definition.
 
@@ -377,7 +377,7 @@ reviewer = subagent(
 )
 ```
 
-`Subagent` holds: name, description, prompt, tools, model, fork, limits, memory mode, and compaction. The memory parameter is `memory: Literal["readwrite", "readonly", False] = "readonly"` — `"readonly"` gives the subagent `memory(readonly=True)`, `"readwrite"` gives full `memory()`, and `False` disables memory entirely. **Precedence:** if `deepagent(memory=False)` is set, memory is disabled for the top-level agent and all subagents regardless of their individual `memory` setting. The optional `limits` parameter takes scoped Inspect limits (e.g. `token_limit`, `message_limit`, `time_limit`, `cost_limit`) that apply to the child agent invocation. Skills are defined once at the `deepagent()` level and flow to `general()` through normal tool inheritance. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
+`Subagent` holds: name, description, prompt, tools, model, fork, limits, memory mode, and compaction. The memory parameter is `memory: Literal["readwrite", "readonly", False] = "readonly"` — `"readonly"` gives the subagent `memory(readonly=True)`, `"readwrite"` gives full `memory()`, and `False` disables memory entirely. **Precedence:** if `deepagent(memory=False)` is set, memory is disabled for the top-level agent and all subagents regardless of their individual `memory` setting. The optional `limits` parameter takes scoped Inspect limits (e.g. `token_limit`, `message_limit`, `time_limit`, `cost_limit`) that apply to the child agent invocation. Skills compose across parent and subagents: parent skills from `deepagent(skills=...)` merge with subagent-specific skills from `sa.skills` at dispatch time, with instance-scoped `skill()` tool stores to avoid contention. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
 
 **Recursion guard.** Depth is tracked via closure — the current depth is closed over when constructing the child agent's tool set, so each dispatch path carries its own depth counter. This is parallel-safe: sibling subagents dispatched concurrently (in a future parallel v2) won't interfere with each other's depth tracking. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
 
@@ -538,7 +538,7 @@ However, this is a significant infrastructure change with nontrivial risks:
 - **Unit tests:** `Subagent` construction, `task()` parameter schema generation, system prompt assembly and placeholder expansion, recursion depth tracking (verify closure-based depth is parallel-safe).
 - **Integration tests:** `deepagent()` end-to-end with `mockllm` — verify tool wiring, subagent dispatch (both isolated and forked), system prompt content.
 - **Tool inheritance tests:** verify `research()`/`plan()` do not receive user-provided mutating tools; verify `general()` inherits the full parent tool set; verify `extra_tools=` works on all subagents.
-- **Skill inheritance tests:** verify `general()` inherits parent skills through normal tool inheritance.
+- **Skill composition tests:** verify parent + subagent skills merge correctly; verify instance-scoped stores don't collide.
 - **Memory ACL tests:** verify `research()`/`plan()` get `memory(readonly=True)` and cannot write; verify `general()` gets full read-write memory.
 - **Limit tests:** verify sample-level limits apply across parent and child agents; verify `subagent(limits=[...])` applies additional scoped limits to child invocations.
 - **Sandbox/no-sandbox tests:** verify read-only tools are constructible without a sandbox and fail clearly at runtime; verify they work correctly with a sandbox.

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -94,7 +94,7 @@ Subagents support two dispatch modes, corresponding to Inspect's existing `as_to
 
 - **Isolated** (default) — the subagent runs with a fresh message history. The parent sends a prompt; only the subagent's summary returns. This is the standard CC/LangChain pattern and is what `as_tool()` provides.
 
-- **Forked** — the subagent inherits the parent's full message history with minimal filtering: system messages are stripped (the child gets its own) and the active tool call is repaired (sibling calls removed, tool result boundary added). Message content is preserved verbatim to maintain provider prompt-cache compatibility. Only the subagent's final output returns to the parent. Use the same model or model family as the parent when forking.
+- **Forked** — the subagent inherits the parent's full message history including the system prompt. The trailing assistant message (in-flight tool call) is stripped, and the subagent's instructions (if any) plus the task prompt are appended as a user message. This preserves the provider prompt cache on all providers since the message prefix is unchanged. Only the subagent's final output returns to the parent. `prompt` is optional for forked subagents — omit it for a transparent fork that continues as the parent. Use the same model or model family when forking.
 
 Claude Code recently added fork semantics to its general-purpose agent. We expose the same choice on `subagent()`:
 
@@ -109,7 +109,7 @@ def reviewer():
     )
 ```
 
-The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent runs with isolated context via `run()` — only the summary returns. When `fork=True`, the subagent inherits the parent's message history with minimal filtering (system messages stripped, active tool call repaired) to preserve provider prompt-cache compatibility. Only the subagent's final output returns to the parent. Use the same model or model family when forking to avoid errors from incompatible tool call formats or reasoning content.
+The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent runs with isolated context via `run()` — only the summary returns. When `fork=True`, the subagent inherits the parent's full message history (including system prompt) with only the trailing assistant message stripped. The subagent's instructions (if any) are prepended to the task prompt in a user message appended after the cached prefix, preserving the prompt cache on all providers. `prompt` is optional for forked subagents. The child runs via `react(prompt=None)` so it doesn't add its own system message. Use the same model or model family when forking.
 
 The built-in subagents default as follows:
 
@@ -394,7 +394,7 @@ task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 - Look up the `Subagent` by `subagent_type`.
 - Construct a `react()` agent from the `Subagent` config.
 - If `fork=False`: invoke via `as_tool()` semantics — isolated context, summary returns as tool result.
-- If `fork=True`: the `task()` tool implements custom dispatch logic inspired by `handoff()` but adapted for the multiplexer context. It strips system messages, repairs the active tool call (removes sibling calls, adds a tool result boundary), and passes the remaining history verbatim to preserve prompt-cache compatibility. The child runs via `run()` and only its final output returns to the parent via `_extract_result()`. Wrapped in `timeline_branch()` for proper log viewer rendering.
+- If `fork=True`: the `task()` tool keeps the parent's full message history (including system prompt), strips only the trailing assistant message, and appends the subagent's instructions + task prompt as a user message. The child runs via `react(prompt=None)` and `run()`, preserving the prompt cache on all providers. Only the final output returns via `_extract_result()`. Wrapped in `timeline_branch()` for log viewer rendering.
 - The `task()` tool creates `span(type="agent")` for each dispatch explicitly. (Unlike `as_tool()`/`handoff()` which create spans automatically, `task()` manages its own dispatch lifecycle.)
 - V1 dispatches subagents sequentially. Both isolated and forked dispatch are architecturally safe for future parallel execution — forked subagents receive a copy of the parent's messages and only their filtered result returns. See section 8 for the deferred parallel execution plan.
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -683,14 +683,21 @@ Implemented the three opinionated subagent factories plus related improvements.
 - Forked dispatch passes messages through as-is (no `content_only` filter) to preserve prompt cache. Documentation recommends same model/family when forking.
 - Forked dispatch wrapped in `timeline_branch()` with `BranchEvent` for proper log viewer swimlane rendering.
 
-### Phase 7: System prompt assembly
+### Phase 7: System prompt assembly (07e8d96d2)
 
-Build the prompt composition logic.
+Built the prompt composition logic.
 
-- Implement `prompt.py` with string constants for each layer (core behavior, subagent dispatch, memory/plan coordination).
-- Implement assembly logic: layer composition for default path, placeholder expansion for `prompt=` path.
-- `subagent_dispatch_description()` generates both system prompt content and task tool description from `Subagent` list.
-- Test: layer assembly with various configurations (with/without memory, with/without subagents), placeholder expansion, missing placeholder handling.
+**Files created:**
+- `src/inspect_ai/agent/_deepagent/prompt.py` — String constants (`CORE_BEHAVIOR`, `MEMORY_INSTRUCTIONS`, `MEMORY_ONLY_INSTRUCTIONS`, `PLAN_ONLY_INSTRUCTIONS`) plus `build_system_prompt()` for layered assembly, `build_subagent_dispatch()` for dynamic subagent listing, and `expand_prompt_placeholders()` for the `prompt=` escape hatch using `str.replace()`.
+- `tests/agent/deepagent/test_prompt.py` — 19 tests covering default assembly, subagent inclusion/exclusion, memory/todo_write combinations, user instructions ordering, placeholder expansion (all/partial/missing/cleared), and task-agnostic verification.
+
+**Design decisions:**
+- Surveyed CC (~160 component files), Codex (~500 lines for generic models, ~80 for tuned), LangChain (~60 lines), Pydantic (~100 lines). Our approach: ~30 lines of goal-oriented core behavior (not prescriptive procedures) that works across capability levels.
+- `CORE_BEHAVIOR` covers: action bias, persistence ("keep going until fully resolved"), error recovery ("diagnose what went wrong"), conciseness, batched tool calls, planning/verification, don't over-ask.
+- Memory instructions include recovery prompt: "Check your memory at the start of your work to recover any earlier progress" — complements the compaction system's pre-compaction memory warning with post-compaction recovery guidance.
+- Subagent dispatch section includes delegation prompt guidance: "Include all necessary context — the subagent cannot see your conversation history."
+- Placeholder expansion uses `str.replace()` (not `.format()`) to avoid conflicts with other braces in custom prompts.
+- Also beefed up subagent factory prompts (`research.py`, `plan.py`, `general.py`) with persistence, error recovery, and verification guidance (~12-15 lines each, up from ~8).
 
 ### Phase 8: `deepagent()` function
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -133,7 +133,7 @@ Default behavior matches the convergent pattern across CC, LangChain, and Pydant
 
 - **Sandbox** — shared (already true per-sample in Inspect).
 - **Memory** — shared, read by default, write opt-in per subagent. `research()` and `plan()` get `memory(readonly=True)`; `general()` gets full read-write `memory()`. Custom subagents declare explicitly. Note: `memory(readonly=True)` is a new mode that must be implemented — the current `memory()` tool supports all CRUD operations.
-- **Skills** — inherited only by `general()` by default. `research()`, `plan()`, and custom subagents get skills only when explicitly configured. This keeps read-only and specialist subagents focused and avoids silently expanding their context or capabilities.
+- **Skills** — defined once at the `deepagent()` level. The `skill()` tool is included in the parent tool set and flows to `general()` through normal tool inheritance. `research()` and `plan()` do not inherit skills (they are read-only focused).
 - **Message history** — isolated (this is what subagents are *for*).
 - **Tools** — subset declared by the subagent's definition.
 
@@ -373,7 +373,7 @@ reviewer = subagent(
 )
 ```
 
-`Subagent` holds: name, description, prompt, tools, model, fork, output_filter, limits, skills, and memory mode. The memory parameter is `memory: Literal["readwrite", "readonly", False] = "readonly"` — `"readonly"` gives the subagent `memory(readonly=True)`, `"readwrite"` gives full `memory()`, and `False` disables memory entirely. **Precedence:** if `deepagent(memory=False)` is set, memory is disabled for the top-level agent and all subagents regardless of their individual `memory` setting. The optional `limits` parameter takes scoped Inspect limits (e.g. `token_limit`, `message_limit`, `time_limit`, `cost_limit`) that apply to the child agent invocation. The optional `skills` parameter provides subagent-specific skills; only `general()` inherits parent skills automatically. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
+`Subagent` holds: name, description, prompt, tools, model, fork, limits, memory mode, and compaction. The memory parameter is `memory: Literal["readwrite", "readonly", False] = "readonly"` — `"readonly"` gives the subagent `memory(readonly=True)`, `"readwrite"` gives full `memory()`, and `False` disables memory entirely. **Precedence:** if `deepagent(memory=False)` is set, memory is disabled for the top-level agent and all subagents regardless of their individual `memory` setting. The optional `limits` parameter takes scoped Inspect limits (e.g. `token_limit`, `message_limit`, `time_limit`, `cost_limit`) that apply to the child agent invocation. Skills are defined once at the `deepagent()` level and flow to `general()` through normal tool inheritance. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
 
 **Recursion guard.** Depth is tracked via closure — the current depth is closed over when constructing the child agent's tool set, so each dispatch path carries its own depth counter. This is parallel-safe: sibling subagents dispatched concurrently (in a future parallel v2) won't interfere with each other's depth tracking. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
 
@@ -400,27 +400,26 @@ task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 
 #### 3. Built-in subagent factories: `research()`, `plan()`, `general()`
 
-Each returns a `Subagent` with opinionated defaults. All accept additive customization via `instructions=`, `extra_tools=`, `model=`, `fork=`, `limits=`, and `skills=`.
+Each returns a `Subagent` with opinionated defaults. All accept additive customization via `instructions=`, `extra_tools=`, `model=`, `fork=`, and `limits=`.
 
 **`research()`** — Read-only information gathering.
 - Tools: read-only defaults (see below).
 - Fork: `False` (isolated context).
 - Memory: read-only.
-- Skills: none by default.
+- Skills: does not inherit top-level skills.
 - Prompt: goal-oriented, emphasizes gathering and synthesizing information.
 
 **`plan()`** — Structured planning, no execution.
 - Tools: same read-only defaults as `research()`.
 - Fork: `False`.
 - Memory: read-only.
-- Skills: none by default.
+- Skills: does not inherit top-level skills.
 - Prompt: goal-oriented, emphasizes decomposing work and producing a structured plan.
 
 **`general()`** — Full tools, isolated context for noisy work.
-- Tools: inherits all parent tools.
+- Tools: inherits parent tools (including skills) by default.
 - Fork: `False` (user can opt into `True` for CC-style fork behavior).
 - Memory: read-write.
-- Skills: inherits parent skills by default.
 - Prompt: goal-oriented, emphasizes autonomous task completion.
 
 **Default tool sets.** `research()` and `plan()` share the same read-only tool defaults: `grep()`, `read_file()`, and `list_files()` — new standalone read-only tools to be added to Inspect's toolset. These tools are always constructible regardless of whether a sandbox is configured; they fail clearly at runtime if no sandbox is available. (These are useful beyond `deepagent()` — any eval that wants read-only filesystem access currently requires `bash()` or `text_editor()`, both of which are read-write.)
@@ -429,7 +428,7 @@ User tools passed to `deepagent(tools=[...])` are available to the top-level age
 
 This is a default capability boundary, not a hard security guarantee. If a user explicitly gives a read-only subagent mutating tools through `extra_tools=` or gives it read-write memory, the subagent can mutate through those capabilities. Hard isolation should be enforced through sandboxing, approval policies, or task-specific tool design.
 
-`general()` inherits the `deepagent()`'s assembled tool list (user tools + memory + todo_write + skills), minus the `task()` tool itself at max depth per the recursion guard.
+`general()` inherits the `deepagent()`'s parent tool list (user tools + skills), minus the `task()` tool itself at max depth per the recursion guard. Memory and todo_write are added by `_resolve_tools()` at dispatch time.
 
 **`todo_write()` tool.** A new `todo_write()` tool replaces the existing `update_plan()`, aligning with the deep-agent vocabulary used by CC and LangChain. The implementation is largely the same — a planning tool that tracks steps and progress — but renamed for consistency. `update_plan()` will be deprecated with an alias pointing to `todo_write()`.
 
@@ -535,7 +534,7 @@ However, this is a significant infrastructure change with nontrivial risks:
 - **Unit tests:** `Subagent` construction, `task()` parameter schema generation, system prompt assembly and placeholder expansion, recursion depth tracking (verify closure-based depth is parallel-safe).
 - **Integration tests:** `deepagent()` end-to-end with `mockllm` — verify tool wiring, subagent dispatch (both isolated and forked), system prompt content, alias handling.
 - **Tool inheritance tests:** verify `research()`/`plan()` do not receive user-provided mutating tools; verify `general()` inherits the full parent tool set; verify `extra_tools=` works on all subagents.
-- **Skill inheritance tests:** verify `general()` inherits parent skills by default; verify `research()`/`plan()` and custom subagents do not inherit skills unless explicitly configured.
+- **Skill inheritance tests:** verify `general()` inherits parent skills through normal tool inheritance.
 - **Memory ACL tests:** verify `research()`/`plan()` get `memory(readonly=True)` and cannot write; verify `general()` gets full read-write memory.
 - **Limit tests:** verify sample-level limits apply across parent and child agents; verify `subagent(limits=[...])` applies additional scoped limits to child invocations.
 - **Sandbox/no-sandbox tests:** verify read-only tools are constructible without a sandbox and fail clearly at runtime; verify they work correctly with a sandbox.
@@ -576,7 +575,7 @@ Created the `Subagent` dataclass and `subagent()` factory function.
 - Used `@dataclass(kw_only=True)` (not Pydantic) to match agent module conventions and allow required fields after fields with defaults.
 - Dropped `output_filter` parameter — forked subagents always use `last_message`. Simplifies the API; can be added later if needed.
 - Dropped `instructions` from `Subagent` — only `prompt` is stored. Built-in factories (`research()`, `plan()`, `general()`) accept `instructions=` and merge it with their default prompt before constructing the `Subagent`.
-- Field order: `name`, `description`, `prompt` (identity), then `tools`, `extra_tools` (adjacent), `model`, `fork`, `skills`, `memory`, `limits`.
+- Field order: `name`, `description`, `prompt` (identity), then `tools`, `extra_tools` (adjacent), `model`, `fork`, `memory`, `limits`, `compaction`.
 
 ### Phase 2: `todo_write()` tool (713c8ea0c)
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -635,15 +635,24 @@ Added read-only mode to the existing `memory()` tool.
 - Readonly memory naturally sidesteps Anthropic native tool auto-binding because the parameter set doesn't match the 10-parameter signature check.
 - Initial data seeding still works in readonly mode (it's setup, not a model action).
 
-### Phase 5: `task()` tool
+### Phase 5: `task()` tool (8c2bb0315)
 
-Build the multiplexer tool that dispatches to subagents.
+Built the multiplexer tool that dispatches to subagents.
 
-- Implement `task_tool.py` — takes `list[Subagent]`, generates dynamic tool description via `subagent_dispatch_description()`.
-- Implement dispatch: construct `react()` from `Subagent` config, invoke with isolated or forked semantics.
-- Implement closure-based recursion depth tracking.
-- Handle alias mapping (`"general_purpose"` → `"general"`).
-- Test: schema generation, dispatch (both fork modes), recursion guard (task tool omitted at max depth), alias handling, span creation.
+**Files created:**
+- `src/inspect_ai/agent/_deepagent/task_tool.py` — `task_tool()` factory creating a `@tool`-decorated `task` function. Dispatches via `run()` for both modes: isolated (string prompt) and forked (`content_only` filtered parent messages + prompt). Includes `_build_task_description()` for dynamic tool description, `_resolve_tools()` for child tool assembly with recursion guard, `_dispatch()` for unified limit handling, and `_extract_result()` for output extraction.
+- `tests/agent/deepagent/test_task_tool.py` — 9 tests: description generation (2), alias mapping (1), constructibility (1), mockllm dispatch (1), invalid subagent_type error (1), alias dispatch end-to-end (1), recursion guard included/excluded (2).
+
+**Files modified:**
+- `src/inspect_ai/agent/_deepagent/__init__.py` — added `task_tool` export (internal only).
+
+**Design decisions:**
+- Used `run()` for both isolated and forked dispatch — handles string→messages, limit application with `catch_errors=True`, span creation with `name=sa.name`, and returns `AgentState` + optional `LimitExceededError`.
+- For forked dispatch, `content_only` filters parent messages (strips system messages, reasoning, converts tool calls to text) so the child agent works safely with potentially different models. Parent messages accessed via `get_messages` callback (wired by `deepagent()` in Phase 8).
+- Recursion guard: `_resolve_tools()` includes a recursive `task_tool` at `depth < max_depth`, omits it at `depth >= max_depth`. Depth tracked via closure.
+- Alias handling: `"general_purpose"` → `"general"` to absorb CC vocabulary habits.
+- Tool named `"task"` internally — no conflict with `@task` decorator (separate registries). Not publicly exported to avoid API confusion.
+- `task_description` parameter name (not `description`) to avoid shadowing.
 
 ### Phase 6: Built-in subagent factories (`research`, `plan`, `general`)
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -396,11 +396,20 @@ task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 
 **Dispatch mechanics:**
 - Look up the `Subagent` by `subagent_type`.
-- Construct a `react()` agent from the `Subagent` config.
-- If `fork=False`: invoke via `as_tool()` semantics — isolated context, summary returns as tool result.
-- If `fork=True`: the `task()` tool keeps the parent's full message history (including system prompt), strips only the trailing assistant message, and appends the subagent's instructions + task prompt as a user message. The child runs via `react(prompt=None)` and `run()`, preserving the prompt cache on all providers. Only the final output returns via `_extract_result()`. Wrapped in `timeline_branch()` for log viewer rendering.
+- Construct a `react()` agent from the `Subagent` config with `submit=AgentSubmit(answer_only=True)`.
+- If `fork=False`: invoke via `as_tool()` semantics — isolated context, submitted answer returns as tool result. The subagent's system prompt includes `SUBAGENT_SUBMIT_PROMPT` (via `AgentPrompt.assistant_prompt`) which instructs the model to call `submit()` with its complete findings and emphasizes that the parent cannot see conversation history.
+- If `fork=True`: the `task()` tool keeps the parent's full message history (including system prompt), strips only the trailing assistant message, and appends the subagent's instructions + task prompt + submit instructions as a user message. Submit instructions are appended to the user message (not as a system message) to preserve the prompt cache. The child runs via `react(prompt=None)` and `run()`, preserving the prompt cache on all providers. Only the submitted answer returns via `_extract_result()`. Wrapped in `timeline_branch()` for log viewer rendering.
 - The `task()` tool creates `span(type="agent")` for each dispatch explicitly. (Unlike `as_tool()`/`handoff()` which create spans automatically, `task()` manages its own dispatch lifecycle.)
 - V1 dispatches subagents sequentially. Both isolated and forked dispatch are architecturally safe for future parallel execution — forked subagents receive a copy of the parent's messages and only their filtered result returns. See section 8 for the deferred parallel execution plan.
+
+**Subagent submit behavior.** Subagents use `react()`'s `submit()` tool to explicitly report results back to the parent. This was introduced because without submit, subagents terminated when the model stopped calling tools, and the last assistant message often contained just a tool call or minimal text — making `_extract_result()` unreliable. With submit enabled:
+
+- Each subagent gets a `submit()` tool added by `react()`. The model must call `submit(answer=...)` to terminate and report results.
+- If the model stops calling tools without submitting, `react()`'s default continue prompt nudges it: "If you believe you have completed the task, please call the `submit()` tool with your final answer."
+- `AgentSubmit(answer_only=True)` ensures `state.output.completion` contains just the submitted answer (not the model's reasoning preamble). `_extract_result()` reads `completion` first, falling back to `message.text` if no submission occurred (e.g., limit exceeded).
+- Submit tool calls are removed from the subagent's message history after completion (`keep_in_messages=False`), preventing the parent from seeing submit calls that could confuse its own submit tracking.
+- The `SUBAGENT_SUBMIT_PROMPT` (defined in `prompt.py`) tells the model: "The parent agent that dispatched you cannot see your conversation history or tool calls — the content you pass to submit() is the only information that will be returned."
+- Built-in factory prompts (`research.py`, `plan.py`, `general.py`) reference `submit()` in their output guidance (e.g., "Submit your findings using the submit() tool").
 
 #### 3. Built-in subagent factories: `research()`, `plan()`, `general()`
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -654,15 +654,34 @@ Built the multiplexer tool that dispatches to subagents.
 - Tool named `"task"` internally — no conflict with `@task` decorator (separate registries). Not publicly exported to avoid API confusion.
 - `task_description` parameter name (not `description`) to avoid shadowing.
 
-### Phase 6: Built-in subagent factories (`research`, `plan`, `general`)
+### Phase 6: Built-in subagent factories (`research`, `plan`, `general`) (630a40397)
 
-Implement the three opinionated factories.
+Implemented the three opinionated subagent factories plus related improvements.
 
-- Each calls `subagent()` with appropriate defaults (tools, memory mode, prompt, fork).
-- `research()` and `plan()`: read-only tools + `memory="readonly"`.
-- `general()`: inherits parent tools + `memory="readwrite"`.
-- Additive customization via `instructions=`, `extra_tools=`, `model=`, `fork=`.
-- Test: default configurations, customization overrides, tool inheritance behavior.
+**Files created:**
+- `src/inspect_ai/agent/_deepagent/research.py` — `research()` factory with task-agnostic prompt, `tools="default"` → `None` (resolved at dispatch time to read-only tools if sandbox available).
+- `src/inspect_ai/agent/_deepagent/plan.py` — `plan()` factory, same pattern.
+- `src/inspect_ai/agent/_deepagent/general.py` — `general()` factory, `memory="readwrite"`, inherits parent tools.
+- `tests/agent/deepagent/test_factories.py` — 27 tests covering defaults, instructions merge, custom/empty/extra tools, overrides, and task-agnostic prompt verification.
+
+**Files modified:**
+- `src/inspect_ai/agent/_deepagent/__init__.py` — added `research`, `plan`, `general` exports.
+- `src/inspect_ai/agent/__init__.py` — added public exports.
+- `docs/reference/inspect_ai.agent.qmd` — added Deep Agent section with `subagent`, `Subagent`, `research`, `plan`, `general`.
+- `src/inspect_ai/agent/_deepagent/task_tool.py` — forked dispatch now uses `timeline_branch()` for proper log viewer rendering; removed `content_only` filtering on forked input to preserve prompt cache and avoid incompatible format errors.
+- `src/inspect_ai/agent/_deepagent/subagent.py` — removed fork+model validation (documented guidance instead); updated fork docstrings across all factories to recommend same model/family for cache and compatibility.
+
+**Additional test coverage added:**
+- `tests/tools/test_read_file.py` — offset, limit, offset+limit, file-not-found error (Docker/slow).
+- `tests/tools/test_list_files.py` — depth parameter (Docker/slow).
+- `tests/tools/test_grep.py` — glob, fixed_strings, no matches, files_with_matches mode, count mode (Docker/slow).
+- `tests/agent/deepagent/test_task_tool.py` — forked dispatch via mockllm.
+
+**Design decisions:**
+- All factories accept `tools: Sequence[...] | Literal["default"] = "default"` — allows replacing defaults entirely or passing empty list.
+- Prompts are task-agnostic — no references to "codebase", "code review", etc. Works for coding, cyber, AI scientist, literature synthesis, and other domains.
+- Forked dispatch passes messages through as-is (no `content_only` filter) to preserve prompt cache. Documentation recommends same model/family when forking.
+- Forked dispatch wrapped in `timeline_branch()` with `BranchEvent` for proper log viewer swimlane rendering.
 
 ### Phase 7: System prompt assembly
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -620,13 +620,20 @@ Created three standalone read-only sandbox tools for `research()` and `plan()` s
 - Tools are always constructible without a sandbox; `sandbox()` raises `ProcessLookupError` at runtime if none is available.
 - No additional output limiting needed — existing `max_tool_output` (16 KiB default) handles large results; models can use `offset`/`limit` to paginate.
 
-### Phase 4: `memory(readonly=True)` mode
+### Phase 4: `memory(readonly=True)` mode (ccf86a82a)
 
-Add read-only mode to the existing `memory()` tool.
+Added read-only mode to the existing `memory()` tool.
 
-- Modify `src/inspect_ai/tool/_tools/_memory.py` to support `readonly=True`.
-- Read-only mode exposes only read/search operations; write operations return an error.
-- Test: readonly mode rejects writes, allows reads; readwrite mode unchanged.
+**Files modified:**
+- `src/inspect_ai/tool/_tools/_memory.py` — added `readonly: bool = False` parameter. When `True`, returns a separate `execute_readonly` function with `command: Literal["view"]` and only `path`/`view_range` parameters, so the model's tool schema only advertises read operations. Also fixed `/memories` root to always be treated as existing in `_path_exists`/`_is_dir`.
+- `tests/tools/test_memory.py` — added 3 readonly tests (view file, view directory, no write params accepted).
+- `docs/tools-standard.qmd` — added Read-Only Mode section to memory documentation.
+- `CHANGELOG.md` — added entry.
+
+**Design decisions:**
+- Used a separate inner function (not a runtime guard) so the model sees only `command: Literal["view"]` in the tool schema — write commands are never advertised.
+- Readonly memory naturally sidesteps Anthropic native tool auto-binding because the parameter set doesn't match the 10-parameter signature check.
+- Initial data seeding still works in readonly mode (it's setup, not a model action).
 
 ### Phase 5: `task()` tool
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -86,7 +86,7 @@ def reviewer(model="anthropic/claude-sonnet-4"):
 agent = deepagent(subagents=[research(), plan(), general(), reviewer()])
 ```
 
-Internally, `subagent()` is a thin wrapper around `react()` that captures name/description metadata for `task()` multiplexing, enforces the recursion guard, and provides additive customization fields. No new abstraction layer.
+Internally, `subagent()` returns a `Subagent` configuration object — a typed blueprint analogous to how `ToolDef` relates to `Tool`. The actual `Agent` is constructed fresh by the `task()` multiplexer at dispatch time via `react()`. The `Subagent` type captures name/description metadata for `task()` multiplexing, fork mode, tool subset, and other dispatch configuration.
 
 #### Subagent dispatch: isolated vs forked
 
@@ -132,7 +132,7 @@ All three accept `fork=True` as an override.
 Default behavior matches the convergent pattern across CC, LangChain, and Pydantic-deep:
 
 - **Sandbox** — shared (already true per-sample in Inspect).
-- **Memory** — shared, read by default, write opt-in per subagent. `research()` is read-only by default; `general()` can write; custom subagents declare explicitly.
+- **Memory** — shared, read by default, write opt-in per subagent. `research()` and `plan()` get `memory(readonly=True)`; `general()` gets full read-write `memory()`. Custom subagents declare explicitly. Note: `memory(readonly=True)` is a new mode that must be implemented — the current `memory()` tool supports all CRUD operations.
 - **Skills** — shared.
 - **Message history** — isolated (this is what subagents are *for*).
 - **Tools** — subset declared by the subagent's definition.
@@ -168,7 +168,7 @@ Despite significant differences in scope, all four converge on a core set of beh
 
 3. **Conciseness.** Every prompt instructs the model to be direct and avoid preamble. CC and Codex add specific formatting rules; LangChain and Pydantic keep it to a general directive.
 
-4. **Parallel tool use.** All four instruct the model to batch independent tool calls into a single response rather than making sequential round-trips.
+4. **Batched tool calls.** All four instruct the model to batch independent tool calls into a single response rather than making sequential round-trips.
 
 5. **Don't over-ask.** All four tell the model to use reasonable defaults rather than asking clarifying questions for every detail. Only ask when genuinely blocked.
 
@@ -224,7 +224,7 @@ The Codex evidence shows that what harms capable models is **prescriptive workfl
 Key design principles for Inspect's system prompt:
 
 1. **Layer the prompt.** Follow CC's modular approach — not its scale. Separate the prompt into composable layers:
-   - **Core behavior** (action bias, verify-iterate, conciseness, parallel tool use) — always included.
+   - **Core behavior** (action bias, verify-iterate, conciseness, batched tool calls) — always included.
    - **Tool dispatch** (when to use `task()`, how to delegate, when not to) — included when subagents are configured.
    - **Domain-specific instructions** — provided by the user via `instructions=`, not baked in.
 
@@ -237,16 +237,15 @@ Key design principles for Inspect's system prompt:
 
 3. **Push detail into tool descriptions.** Even Codex-tuned models — which need almost no behavioral scaffolding — still get tool-specific instructions. Tool descriptions are read by every model regardless of training. This is the right place for worked examples, usage heuristics, and dispatch guidance. In particular, the `task()` tool description should carry the subagent dispatch logic: when to delegate (complex, independent, context-heavy work), when not to (trivial lookups, dependent steps), and examples of good vs. unnecessary delegation. This follows LangChain's `TASK_SYSTEM_PROMPT` pattern but places it where models naturally look.
 
-4. **Keep the core small.** The shared patterns (action bias, verify-iterate, conciseness, parallel tools, don't over-ask) are ~20-30 lines in goal-oriented style. That's the floor. Everything above it should earn its place.
+4. **Keep the core small.** The shared patterns (action bias, verify-iterate, conciseness, batched tool calls, don't over-ask) are ~20-30 lines in goal-oriented style. That's the floor. Everything above it should earn its place.
 
 5. **Don't embed domain knowledge.** CC's git safety rules and Codex's editing constraints are valuable for coding — but they belong in the user's `instructions=` parameter or in tool-level descriptions, not in the base prompt. Inspect's prompt should teach the *pattern* (plan, delegate, verify) without assuming what the tools do.
 
 6. **Provide the escape hatch.** The `prompt=` parameter allows full replacement for users who need complete control — researchers running novel agent architectures, or teams with heavily customized system prompts from prior work. Custom prompts can include named placeholders that `deepagent()` will inject at assembly time. Placeholders are optional — if omitted, the corresponding content is simply not included. This lets users control both *what* is included and *where* it appears in their prompt. Placeholder names and the content they expand to will be documented; likely candidates include:
 
-   - `{tool_descriptions}` — formatted descriptions of all configured tools.
-   - `{subagent_dispatch}` — the `task()` tool dispatch guidance (available subagent types, when to delegate, worked examples).
-   - `{memory_instructions}` — memory tool usage guidance.
-   - `{plan_instructions}` — planning/todo tool usage guidance.
+   - `{core_behavior}` — the core behavior layer.
+   - `{subagent_dispatch}` — subagent names, roles, and delegation guidance (generated from the `Subagent` list).
+   - `{memory_instructions}` — memory/plan coordination guidance.
    - `{instructions}` — the user's `instructions=` text.
 
 7. **Tools communicate through descriptions, not prompt injection.** When users pass tools to `deepagent()` — including custom subagents created with `handoff()` or `as_tool()` — we won't always know their capabilities (e.g., whether fork is enabled). Rather than adding an API for tools to inject content into the system prompt, we rely on the tool's own `description` field. The person who creates the tool controls its description and can communicate relevant behavior ("this agent sees your full conversation history" vs "this agent starts with a fresh context"). This is consistent with principle #3 above and avoids prompt bloat from many tools each injecting content. Cross-tool coordination guidance (e.g., "use memory to offload large findings, use the plan to track high-level progress") belongs in the core prompt layer, which `deepagent()` assembles.
@@ -271,7 +270,7 @@ All three major frameworks implement multi-tier context management to keep long-
 
 LangChain's `TASK_SYSTEM_PROMPT` heavily emphasizes launching multiple subagents in parallel: "Whenever you have independent steps to complete — kick off tasks in parallel to accomplish them faster." Claude Code does the same — models can invoke the `task()` tool multiple times in a single response.
 
-**Inspect status:** This works automatically if the `task()` tool allows parallel invocation. The model emits multiple `task()` tool calls in one response, and Inspect's tool execution machinery runs them concurrently. No new infrastructure needed — but the `task()` tool description and system prompt should explicitly encourage this pattern, and the tool definition should not set `parallel=False`.
+**Inspect status:** Inspect's current `execute_tools` processes tool calls sequentially, and `handoff()` explicitly disables parallel tool calls. In v1, subagent dispatch is sequential — multiple `task()` calls in one response execute one at a time. The system prompt should not encourage multiple subagent calls in a single response, as this adds latency and cost with no execution-time benefit in v1. Guidance should be: delegate when helpful; focus on one delegation at a time. Parallel subagent execution is a future enhancement (see Implementation Blueprint section 8).
 
 #### Cost-aware model routing
 
@@ -353,13 +352,14 @@ reviewer = subagent(
     prompt="...",
     tools=[grep(), read_file()],
     model="anthropic/claude-sonnet-4",
+    memory="readonly",  # "readwrite", "readonly", or False
     fork=False,
 )
 ```
 
-`Subagent` holds: name, description, prompt, tools, model, fork, output_filter, limits, memory write access. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
+`Subagent` holds: name, description, prompt, tools, model, fork, output_filter, limits, and memory mode. The memory parameter is `memory: Literal["readwrite", "readonly", False] = "readonly"` — `"readonly"` gives the subagent `memory(readonly=True)`, `"readwrite"` gives full `memory()`, and `False` disables memory entirely. **Precedence:** if `deepagent(memory=False)` is set, memory is disabled for the top-level agent and all subagents regardless of their individual `memory` setting. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
 
-**Recursion guard.** Depth is tracked per-sample (e.g., via `Store`) and incremented on each `task()` dispatch. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
+**Recursion guard.** Depth is tracked via closure — the current depth is closed over when constructing the child agent's tool set, so each dispatch path carries its own depth counter. This is parallel-safe: sibling subagents dispatched concurrently (in a future parallel v2) won't interfere with each other's depth tracking. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
 
 #### 2. `task()` tool
 
@@ -378,9 +378,9 @@ task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 - Look up the `Subagent` by `subagent_type` (with alias handling: `"general_purpose"` → `"general"`).
 - Construct a `react()` agent from the `Subagent` config.
 - If `fork=False`: invoke via `as_tool()` semantics — isolated context, summary returns as tool result.
-- If `fork=True`: invoke via `handoff()` with `input_filter=content_only` and `output_filter=last_message` — parent history inherited, only the subagent's final message returns. This matches CC's fork pattern: the subagent gets full context but keeps the parent lean. The `output_filter` is configurable on `subagent()` (defaults to `last_message`); `output_filter` is only valid when `fork=True`.
-- `as_tool()` and `handoff()` already create `span(type="agent")` automatically — no additional span logic needed in `task()`.
-- `parallel=True` on the tool definition so the model can launch multiple subagents concurrently.
+- If `fork=True`: the `task()` tool implements custom dispatch logic inspired by `handoff()` but adapted for the multiplexer context. It filters the parent's messages via `content_only` on input, runs the child `react()` agent, and applies `output_filter` (default `last_message`) to the result. This cannot be a trivial `handoff()` wrapper because `task()` has a different tool schema, needs to construct the child agent from `Subagent` config, and must control exactly what returns to the parent. The `output_filter` is configurable on `subagent()` (defaults to `last_message`); only valid when `fork=True`.
+- The `task()` tool creates `span(type="agent")` for each dispatch explicitly. (Unlike `as_tool()`/`handoff()` which create spans automatically, `task()` manages its own dispatch lifecycle.)
+- V1 dispatches subagents sequentially. Both isolated and forked dispatch are architecturally safe for future parallel execution — forked subagents receive a copy of the parent's messages and only their filtered result returns. See section 8 for the deferred parallel execution plan.
 
 #### 3. Built-in subagent factories: `research()`, `plan()`, `general()`
 
@@ -404,9 +404,9 @@ Each returns a `Subagent` with opinionated defaults. All accept additive customi
 - Memory: read-write.
 - Prompt: goal-oriented, emphasizes autonomous task completion.
 
-**Default tool sets.** `research()` and `plan()` share the same read-only tool defaults. When a sandbox is present, they get `grep()`, `read_file()`, and `list_files()` — new standalone read-only tools to be added to Inspect's toolset. (These are useful beyond `deepagent()` — any eval that wants read-only filesystem access currently requires `bash()` or `text_editor()`, both of which are read-write.)
+**Default tool sets.** `research()` and `plan()` share the same read-only tool defaults: `grep()`, `read_file()`, and `list_files()` — new standalone read-only tools to be added to Inspect's toolset. These tools are always constructible regardless of whether a sandbox is configured; they fail clearly at runtime if no sandbox is available. (These are useful beyond `deepagent()` — any eval that wants read-only filesystem access currently requires `bash()` or `text_editor()`, both of which are read-write.)
 
-Tools the user passes to `deepagent(tools=[...])` are available to the top-level agent and also flow down to `research()` and `plan()`. For example, if the user includes `web_search()`, it's available at all levels; if they don't, nobody gets it. We don't auto-enable tools that require external configuration. All built-in subagents also accept `extra_tools=` for additive customization.
+User tools passed to `deepagent(tools=[...])` are available to the top-level agent and flow down to `general()`, but do **not** automatically flow to `research()` or `plan()`. This preserves their read-only-by-default posture — if the user passes `bash()` or `text_editor()`, those mutating tools must not reach read-only subagents. Users can explicitly extend `research()` or `plan()` with additional tools via `extra_tools=`, but doing so overrides the read-only default at the user's discretion. All built-in subagents accept `extra_tools=` for additive customization.
 
 `general()` inherits the `deepagent()`'s assembled tool list (user tools + memory + todo_write + skills), minus the `task()` tool itself at max depth per the recursion guard.
 
@@ -423,7 +423,7 @@ def deepagent(
     tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     subagents: list[Subagent] | None = None,       # default: [research(), plan(), general()]
     todo_write: bool = True,
-    memory: bool = True,
+    memory: bool = True,                             # top-level kill switch; False disables memory everywhere
     skills: list[Skill] | None = None,
     instructions: str | None = None,
     prompt: str | None = None,                      # full replacement with placeholders
@@ -448,7 +448,7 @@ def deepagent(
 Stored as string constants in `prompt.py`, with assembly logic that composes the layers based on `deepagent()` configuration.
 
 **Layers assembled by `deepagent()`:**
-- **Core behavior** (~20-30 lines). Goal-oriented: action bias, verify-iterate, conciseness, parallel tool use, don't over-ask. Written as expectations, not procedures.
+- **Core behavior** (~20-30 lines). Goal-oriented: action bias, verify-iterate, conciseness, batched tool calls, don't over-ask. Written as expectations, not procedures.
 - **Subagent dispatch** (included when subagents are configured). Generated from the `Subagent` list — names each available subagent, its role, and provides high-level guidance on when to delegate vs. do the work directly. This gives subagent awareness more weight than the tool description alone. The detailed dispatch mechanics (parameter usage, worked examples, alias handling) remain in the `task()` tool description.
 - **Memory/plan coordination** (included when memory and/or todo_write are enabled). Cross-tool guidance: "Use memory to offload large intermediate results. Use the plan to track high-level task decomposition."
 - **User instructions** (`instructions=` text appended at the end).
@@ -468,6 +468,8 @@ New exports from `inspect_ai.agent`:
 - `subagent` — the custom subagent factory.
 - `Subagent` — the typed configuration object.
 - `research`, `plan`, `general` — built-in subagent factories.
+
+The `task()` tool factory is **not** exported — it is internal to `_deepagent/task_tool.py` and constructed by `deepagent()`. This avoids a naming collision with Inspect's existing `@task` decorator. The model-facing tool is still named `"task"` in its tool definition.
 
 No changes to existing `react()`, `as_tool()`, `handoff()`, or `Agent` APIs.
 
@@ -493,13 +495,29 @@ Modified files:
 - `src/inspect_ai/agent/__init__.py` — add new exports.
 - `src/inspect_ai/tool/_tools/__init__.py` — add new tool exports.
 - `src/inspect_ai/tool/_tools/_update_plan.py` — deprecate with alias to `todo_write()`.
+- `src/inspect_ai/tool/_tools/_memory.py` — add `readonly=True` mode that exposes only read operations.
 
-#### 8. Testing strategy
+#### 8. Parallel tool execution (deferred)
 
-- **Unit tests:** `Subagent` construction, `task()` parameter schema generation, system prompt assembly and placeholder expansion.
+The current `_execute_tools_impl` in `src/inspect_ai/model/_call_tools.py:300` processes tool calls sequentially. Parallel tool execution would benefit all agents — including `react()` — and would unblock concurrent subagent dispatch for `deepagent()`.
+
+However, this is a significant infrastructure change with nontrivial risks:
+
+- **Breaking change.** `@tool` defaults `parallel=True` and `ToolDef` defaults unspecified tools to parallel-capable, but current execution is sequential. Flipping to concurrent would silently change behavior for existing tools whose authors never had to consider races.
+- **Output conflicts.** Current execution tracks a single `result_output`. Parallel batches with multiple tools returning `ExecuteToolsResult.output` need conflict resolution semantics.
+- **Approval flows.** Approval policies and interactive tools may not be safe to run concurrently even if the underlying tool is marked `parallel=True`.
+
+**Decision.** Defer parallel tool execution to a separate project. `deepagent()` v1 dispatches subagents sequentially. Both isolated and forked dispatch are architecturally safe to parallelize (forked subagents receive a copy of the parent's messages), so when parallel execution lands, `task()` can opt in without design changes.
+
+#### 9. Testing strategy
+
+- **Unit tests:** `Subagent` construction, `task()` parameter schema generation, system prompt assembly and placeholder expansion, recursion depth tracking (verify closure-based depth is parallel-safe).
 - **Integration tests:** `deepagent()` end-to-end with `mockllm` — verify tool wiring, subagent dispatch (both isolated and forked), system prompt content, alias handling.
+- **Tool inheritance tests:** verify `research()`/`plan()` do not receive user-provided mutating tools; verify `general()` inherits the full parent tool set; verify `extra_tools=` works on all subagents.
+- **Memory ACL tests:** verify `research()`/`plan()` get `memory(readonly=True)` and cannot write; verify `general()` gets full read-write memory.
+- **Sandbox/no-sandbox tests:** verify read-only tools are constructible without a sandbox and fail clearly at runtime; verify they work correctly with a sandbox.
 
-#### 9. Documentation
+#### 10. Documentation
 
 New documentation file: `docs/deep-agent.qmd` — a standalone guide covering:
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -578,13 +578,25 @@ Created the `Subagent` dataclass and `subagent()` factory function.
 - Dropped `instructions` from `Subagent` — only `prompt` is stored. Built-in factories (`research()`, `plan()`, `general()`) accept `instructions=` and merge it with their default prompt before constructing the `Subagent`.
 - Field order: `name`, `description`, `prompt` (identity), then `tools`, `extra_tools` (adjacent), `model`, `fork`, `skills`, `memory`, `limits`.
 
-### Phase 2: `todo_write()` tool
+### Phase 2: `todo_write()` tool (713c8ea0c)
 
-Create `todo_write()` as a replacement for `update_plan()`. Deprecate `update_plan()` with an alias.
+Created `todo_write()` as a new tool alongside `update_plan()`.
 
-- Implement `todo_write()` in `src/inspect_ai/tool/_tools/_todo_write.py`.
-- Add deprecation alias in `_update_plan.py`.
-- Test: tool creation, plan step tracking, deprecation warning on `update_plan()`.
+**Files created:**
+- `src/inspect_ai/tool/_tools/_todo_write.py` — `TodoStep` model (with `content`/`status` fields, status as `Literal` enum) and `todo_write()` tool using standard `@tool` pattern.
+- `tests/tools/test_todo_write.py` — basic + mockllm integration tests.
+
+**Files modified:**
+- `src/inspect_ai/tool/__init__.py` — added `todo_write` export.
+- `docs/tools-standard.qmd` — renamed section to "Todo Write", updated examples.
+
+**Design decisions:**
+- Surveyed tool descriptions from Claude Code (`TodoWrite`), LangChain (`write_todos`), and Codex CLI (`update_plan`). Synthesized best practices: when-to/when-not-to guidance from CC/LangChain, quality examples from Codex, real-time status rules from LangChain.
+- Renamed `step` field to `content` and `plan` param to `todos` to match CC/LangChain vocabulary.
+- `status` typed as `Literal["pending", "in_progress", "completed"]` (validated, not free-form string).
+- `update_plan()` left completely unchanged — no deprecation, no warnings. Removed from docs but existing harnesses continue to work silently.
+- `TodoStep` not exported in public API — it's internal; models and tests pass dicts.
+- Used standard `@tool` pattern (not `ToolDef().as_tool()`).
 
 ### Phase 3: Read-only tools (`grep`, `read_file`, `list_files`)
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -550,3 +550,101 @@ New documentation file: `docs/deep-agent.qmd` — a standalone guide covering:
 - System prompt customization: `instructions=` for the common case, `prompt=` with placeholders for full control.
 - Tool configuration: default tool sets, adding `web_search()`, `extra_tools=`.
 - Examples: basic usage, custom subagents, cost-aware model routing, fork mode.
+
+## Implementation
+
+### Guidelines
+
+1. **One phase at a time.** Create a dedicated plan for the phase. Do not proceed with implementation or exit plan mode until the user has approved the plan. Implement, test, and verify each phase before moving to the next.
+2. **Review before commit.** After tests pass, pause and review the code together before committing. Do not auto-commit.
+3. **Full tests at each step.** Every phase produces both implementation and tests.
+4. **Update this document.** After completing a phase but before committing, replace the phase's overview section below with a summary of what was actually built and tested — files created/modified, key design decisions made during implementation, and test coverage.
+
+### Phase 1: `Subagent` type and `subagent()` factory
+
+Create the `Subagent` dataclass and `subagent()` factory function. This is the foundation everything else builds on.
+
+- Define `Subagent` with fields: name, description, prompt, tools, model, fork, output_filter, memory, limits.
+- `subagent()` validates inputs and returns a `Subagent` instance.
+- Test: construction, field defaults, validation errors for invalid inputs.
+
+### Phase 2: `todo_write()` tool
+
+Create `todo_write()` as a replacement for `update_plan()`. Deprecate `update_plan()` with an alias.
+
+- Implement `todo_write()` in `src/inspect_ai/tool/_tools/_todo_write.py`.
+- Add deprecation alias in `_update_plan.py`.
+- Test: tool creation, plan step tracking, deprecation warning on `update_plan()`.
+
+### Phase 3: Read-only tools (`grep`, `read_file`, `list_files`)
+
+Create standalone read-only sandbox tools.
+
+- Implement each tool in `src/inspect_ai/tool/_tools/`.
+- Tools are always constructible; fail clearly at runtime if no sandbox is available.
+- Test: each tool with and without sandbox, error messages, output formatting.
+- Add documentation to the standard tools document and update inspect_ai.tool.qmd with the new tools.
+
+### Phase 4: `memory(readonly=True)` mode
+
+Add read-only mode to the existing `memory()` tool.
+
+- Modify `src/inspect_ai/tool/_tools/_memory.py` to support `readonly=True`.
+- Read-only mode exposes only read/search operations; write operations return an error.
+- Test: readonly mode rejects writes, allows reads; readwrite mode unchanged.
+
+### Phase 5: `task()` tool
+
+Build the multiplexer tool that dispatches to subagents.
+
+- Implement `task_tool.py` — takes `list[Subagent]`, generates dynamic tool description via `subagent_dispatch_description()`.
+- Implement dispatch: construct `react()` from `Subagent` config, invoke with isolated or forked semantics.
+- Implement closure-based recursion depth tracking.
+- Handle alias mapping (`"general_purpose"` → `"general"`).
+- Test: schema generation, dispatch (both fork modes), recursion guard (task tool omitted at max depth), alias handling, span creation.
+
+### Phase 6: Built-in subagent factories (`research`, `plan`, `general`)
+
+Implement the three opinionated factories.
+
+- Each calls `subagent()` with appropriate defaults (tools, memory mode, prompt, fork).
+- `research()` and `plan()`: read-only tools + `memory="readonly"`.
+- `general()`: inherits parent tools + `memory="readwrite"`.
+- Additive customization via `instructions=`, `extra_tools=`, `model=`, `fork=`.
+- Test: default configurations, customization overrides, tool inheritance behavior.
+
+### Phase 7: System prompt assembly
+
+Build the prompt composition logic.
+
+- Implement `prompt.py` with string constants for each layer (core behavior, subagent dispatch, memory/plan coordination).
+- Implement assembly logic: layer composition for default path, placeholder expansion for `prompt=` path.
+- `subagent_dispatch_description()` generates both system prompt content and task tool description from `Subagent` list.
+- Test: layer assembly with various configurations (with/without memory, with/without subagents), placeholder expansion, missing placeholder handling.
+
+### Phase 8: `deepagent()` function
+
+Wire everything together.
+
+- Implement `deepagent.py` — the top-level assembly function.
+- Assembly: resolve subagents, construct task tool, collect tools (user tools + task + memory + todo_write + skills), build system prompt, delegate to `react()`.
+- Tool inheritance: user tools flow to top-level and `general()` only, not to `research()`/`plan()`.
+- `memory=False` disables memory everywhere.
+- Test: end-to-end with `mockllm`, tool wiring, system prompt content, memory kill switch, subagent model routing.
+
+### Phase 9: Public API and exports
+
+Finalize the public surface.
+
+- Update `src/inspect_ai/agent/__init__.py` with new exports.
+- Update `src/inspect_ai/tool/_tools/__init__.py` with new tool exports.
+- Verify no naming collisions (task tool is internal, not exported).
+- Test: import paths, backward compatibility of existing APIs.
+
+### Phase 10: Documentation
+
+Write `docs/deep-agent.qmd`.
+
+- Overview, API reference, configuration guide, examples.
+- System prompt customization guide (`instructions=` vs `prompt=` with placeholders).
+- Update inspect_ai.agent.qmd with reference sections.

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -93,7 +93,7 @@ Subagents support two dispatch modes, corresponding to Inspect's existing `as_to
 
 - **Isolated** (default) — the subagent runs with a fresh message history. The parent sends a prompt; only the subagent's summary returns. This is the standard CC/LangChain pattern and is what `as_tool()` provides.
 
-- **Forked** — the subagent inherits the parent's full message history (filtered through `content_only` so tool calls, reasoning traces, and system messages don't confound a potentially different model). The subagent works with the accumulated context and its output is filtered back to the parent. This maps directly to Inspect's `handoff()` with `output_filter=content_only`.
+- **Forked** — the subagent inherits the parent's full message history (filtered through `content_only` on input so tool calls, reasoning traces, and system messages don't confound a potentially different model). The subagent works with the accumulated context but only its final message returns to the parent (via `last_message` output filter), keeping the parent context lean. This maps to Inspect's `handoff()` with `input_filter=content_only` and `output_filter=last_message`.
 
 Claude Code recently added fork semantics to its general-purpose agent. We expose the same choice on `subagent()`:
 
@@ -107,7 +107,7 @@ reviewer = subagent(
 )
 ```
 
-The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent behaves like `as_tool()` — isolated context, only the summary returns. When `fork=True`, it behaves like `handoff()` with `content_only` filters — the subagent sees the parent's conversation and its filtered output is appended to the parent's history.
+The `fork` parameter controls which dispatch primitive is used under the hood. When `fork=False` (the default), the subagent behaves like `as_tool()` — isolated context, only the summary returns. When `fork=True`, it behaves like `handoff()` with `input_filter=content_only` and `output_filter=last_message` — the subagent sees the parent's conversation but only its final message returns, keeping the parent context lean. An optional `output_filter` parameter (only valid when `fork=True`) allows overriding the default `last_message` filter.
 
 The built-in subagents default as follows:
 
@@ -275,19 +275,13 @@ LangChain's `TASK_SYSTEM_PROMPT` heavily emphasizes launching multiple subagents
 
 The RFC mentions `model=` per subagent but doesn't frame it as cost-aware routing. In practice, this is one of the highest-leverage features: route simple subtasks (file reading, grep, summarization) to cheaper/faster models and reserve expensive models for complex reasoning. Research reports 85% cost reduction while maintaining 95% quality.
 
-**Inspect status:** Already supported — `subagent(model=...)` and `research(model=...)` etc. allow per-subagent model selection. The system prompt should teach this pattern to users through documentation rather than adding new API surface. The `deepagent()` constructor could accept a `subagent_model=` default that built-in subagents inherit unless overridden.
-
-#### Stuck loop detection
-
-Pydantic AI ships a built-in `StuckLoopDetection` capability that detects when an agent is repeating the same tool calls. This is important for eval reliability — a stuck agent burns tokens and time without progress.
-
-**Inspect status:** Not currently in the RFC. This is worth including as a default behavior in `deepagent()`. Implementation could be a lightweight check in the agent loop that detects N consecutive identical (or near-identical) tool call sequences and injects a "you appear to be repeating the same actions" nudge, or terminates with a diagnostic message. This is a natural fit for `deepagent()`'s opinionated defaults.
+**Inspect status:** Already supported — `subagent(model=...)` and `research(model=...)` etc. allow per-subagent model selection. Each built-in subagent has different cognitive demands (e.g., `research()` might use a cheaper model, `plan()` a stronger one, `general()` the main agent model), so routing is best configured per-subagent rather than with a blanket default.
 
 #### Tool call repair
 
 Pydantic AI's `PatchToolCallsCapability` detects orphaned tool calls (calls with no matching result) and orphaned tool results (results with no matching call), injecting synthetic responses to keep the conversation well-formed. This matters when models produce malformed tool-use sequences or when errors interrupt tool execution.
 
-**Inspect status:** Inspect's `react()` loop already handles tool execution errors, but orphaned-call repair is a resilience feature worth considering. If models occasionally produce tool calls that fail silently, the conversation history becomes inconsistent. This is lower priority than stuck loop detection but worth noting for robustness.
+**Inspect status:** Inspect's `react()` loop already handles tool execution errors, but orphaned-call repair is a resilience feature worth considering. If models occasionally produce tool calls that fail silently, the conversation history becomes inconsistent. Lower priority but worth noting for robustness.
 
 #### Checkpointing integration
 
@@ -341,4 +335,166 @@ We'd particularly value input on:
 
 ## Implementation Blueprint
 
-*To be written after the open design questions above are resolved.*
+### Outline
+
+Sections are ordered by dependency — each builds on the ones above it.
+
+#### 1. `Subagent` type and `subagent()` factory
+
+`subagent()` returns a `Subagent` — a typed configuration object, not an `Agent` or `Tool`. This is analogous to how `ToolDef` relates to `Tool`: `Subagent` is a blueprint; the actual `Agent` is constructed fresh by `task()` at dispatch time via `react()`.
+
+``` python
+from inspect_ai.agent import subagent
+
+reviewer = subagent(
+    name="reviewer",
+    description="Reviews code for security and correctness.",
+    prompt="...",
+    tools=[grep(), read_file()],
+    model="anthropic/claude-sonnet-4",
+    fork=False,
+)
+```
+
+`Subagent` holds: name, description, prompt, tools, model, fork, output_filter, limits, memory write access. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
+
+**Recursion guard.** Depth is tracked per-sample (e.g., via `Store`) and incremented on each `task()` dispatch. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_subagent_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
+
+#### 2. `task()` tool
+
+The multiplexer. Takes a list of `Subagent` objects at construction time and exposes them to the model as a single tool.
+
+``` python
+# Constructed internally by deepagent():
+task_tool = task(subagents=[research(), plan(), general(), reviewer])
+```
+
+**Parameters exposed to the model:** `(description: str, subagent_type: str, prompt: str)`. The `subagent_type` enum is generated dynamically from the `Subagent` names and descriptions.
+
+**Description generation.** A standalone function `subagent_dispatch_description(subagents: list[Subagent]) -> str` generates the `task()` tool description from the registered subagents. It produces the enumeration of available `subagent_type` values with their descriptions, plus when-to/when-not-to dispatch guidance and worked examples. The `task()` constructor calls this to set its description, keeping the tool description always in sync with the actual subagent list.
+
+**Dispatch mechanics:**
+- Look up the `Subagent` by `subagent_type` (with alias handling: `"general_purpose"` → `"general"`).
+- Construct a `react()` agent from the `Subagent` config.
+- If `fork=False`: invoke via `as_tool()` semantics — isolated context, summary returns as tool result.
+- If `fork=True`: invoke via `handoff()` with `input_filter=content_only` and `output_filter=last_message` — parent history inherited, only the subagent's final message returns. This matches CC's fork pattern: the subagent gets full context but keeps the parent lean. The `output_filter` is configurable on `subagent()` (defaults to `last_message`); `output_filter` is only valid when `fork=True`.
+- `as_tool()` and `handoff()` already create `span(type="agent")` automatically — no additional span logic needed in `task()`.
+- `parallel=True` on the tool definition so the model can launch multiple subagents concurrently.
+
+#### 3. Built-in subagent factories: `research()`, `plan()`, `general()`
+
+Each returns a `Subagent` with opinionated defaults. All accept additive customization via `instructions=`, `extra_tools=`, `model=`, `fork=`.
+
+**`research()`** — Read-only information gathering.
+- Tools: read-only defaults (see below).
+- Fork: `False` (isolated context).
+- Memory: read-only.
+- Prompt: goal-oriented, emphasizes gathering and synthesizing information.
+
+**`plan()`** — Structured planning, no execution.
+- Tools: same read-only defaults as `research()`.
+- Fork: `False`.
+- Memory: read-only.
+- Prompt: goal-oriented, emphasizes decomposing work and producing a structured plan.
+
+**`general()`** — Full tools, isolated context for noisy work.
+- Tools: inherits all parent tools.
+- Fork: `False` (user can opt into `True` for CC-style fork behavior).
+- Memory: read-write.
+- Prompt: goal-oriented, emphasizes autonomous task completion.
+
+**Default tool sets.** `research()` and `plan()` share the same read-only tool defaults. When a sandbox is present, they get `grep()`, `read_file()`, and `list_files()` — new standalone read-only tools to be added to Inspect's toolset. (These are useful beyond `deepagent()` — any eval that wants read-only filesystem access currently requires `bash()` or `text_editor()`, both of which are read-write.)
+
+Tools the user passes to `deepagent(tools=[...])` are available to the top-level agent and also flow down to `research()` and `plan()`. For example, if the user includes `web_search()`, it's available at all levels; if they don't, nobody gets it. We don't auto-enable tools that require external configuration. All built-in subagents also accept `extra_tools=` for additive customization.
+
+`general()` inherits the `deepagent()`'s assembled tool list (user tools + memory + todo_write + skills), minus the `task()` tool itself at max depth per the recursion guard.
+
+**`todo_write()` tool.** A new `todo_write()` tool replaces the existing `update_plan()`, aligning with the deep-agent vocabulary used by CC and LangChain. The implementation is largely the same — a planning tool that tracks steps and progress — but renamed for consistency. `update_plan()` will be deprecated with an alias pointing to `todo_write()`.
+
+#### 4. `deepagent()` function
+
+The top-level assembly. Returns an `Agent` usable anywhere `react()` is usable.
+
+``` python
+@agent
+def deepagent(
+    *,
+    tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    subagents: list[Subagent] | None = None,       # default: [research(), plan(), general()]
+    todo_write: bool = True,
+    memory: bool = True,
+    skills: list[Skill] | None = None,
+    instructions: str | None = None,
+    prompt: str | None = None,                      # full replacement with placeholders
+    compaction: CompactionStrategy | None = None,
+    model: str | Model | None = None,
+    submit: AgentSubmit | bool | None = None,
+    attempts: int | AgentAttempts = 1,
+    # ... other react() passthrough parameters
+) -> Agent:
+```
+
+**Assembly sequence:**
+1. Resolve subagents: use provided list or default `[research(), plan(), general()]`.
+2. Construct `task()` tool from the subagent list.
+3. Collect tools: user tools + `task()` + (optionally) `memory()` + (optionally) `todo_write()` + (optionally) skill tools.
+4. Assemble the system prompt from layers (or expand placeholders if `prompt=` is provided).
+5. Delegate to `react()` with the assembled tools, prompt, compaction, and other parameters.
+
+#### 5. System prompt text asset
+
+Stored as string constants in `prompt.py`, with assembly logic that composes the layers based on `deepagent()` configuration.
+
+**Layers assembled by `deepagent()`:**
+- **Core behavior** (~20-30 lines). Goal-oriented: action bias, verify-iterate, conciseness, parallel tool use, don't over-ask. Written as expectations, not procedures.
+- **Subagent dispatch** (included when subagents are configured). Generated from the `Subagent` list — names each available subagent, its role, and provides high-level guidance on when to delegate vs. do the work directly. This gives subagent awareness more weight than the tool description alone. The detailed dispatch mechanics (parameter usage, worked examples, alias handling) remain in the `task()` tool description.
+- **Memory/plan coordination** (included when memory and/or todo_write are enabled). Cross-tool guidance: "Use memory to offload large intermediate results. Use the plan to track high-level task decomposition."
+- **User instructions** (`instructions=` text appended at the end).
+
+**`prompt=` full replacement.** When provided, `deepagent()` expands named placeholders and uses the result as the complete system prompt. Documented placeholders:
+- `{core_behavior}` — the core behavior layer.
+- `{subagent_dispatch}` — subagent names, roles, and delegation guidance (generated from the `Subagent` list).
+- `{memory_instructions}` — memory/plan coordination guidance.
+- `{instructions}` — the user's `instructions=` text.
+
+Placeholders are optional — if omitted, that content is excluded.
+
+#### 6. Public API surface
+
+New exports from `inspect_ai.agent`:
+- `deepagent` — the top-level factory.
+- `subagent` — the custom subagent factory.
+- `Subagent` — the typed configuration object.
+- `research`, `plan`, `general` — built-in subagent factories.
+
+No changes to existing `react()`, `as_tool()`, `handoff()`, or `Agent` APIs.
+
+#### 7. File layout
+
+New directory `src/inspect_ai/agent/_deepagent/`:
+- `deepagent.py` — `deepagent()` function.
+- `subagent.py` — `Subagent` type and `subagent()` factory.
+- `research.py` — `research()` built-in subagent factory.
+- `plan.py` — `plan()` built-in subagent factory.
+- `general.py` — `general()` built-in subagent factory.
+- `task_tool.py` — `task()` multiplexer tool.
+- `prompt.py` — system prompt text constants and assembly logic.
+
+Modified files:
+- `src/inspect_ai/agent/__init__.py` — add new exports.
+
+#### 8. Testing strategy
+
+- **Unit tests:** `Subagent` construction, `task()` parameter schema generation, system prompt assembly and placeholder expansion.
+- **Integration tests:** `deepagent()` end-to-end with `mockllm` — verify tool wiring, subagent dispatch (both isolated and forked), system prompt content, alias handling.
+
+#### 9. Documentation
+
+New documentation file: `docs/deep-agent.qmd` — a standalone guide covering:
+
+- Overview of the deep agent pattern and when to use `deepagent()` vs `react()`.
+- API reference for `deepagent()`, `subagent()`, and built-in subagents (`research()`, `plan()`, `general()`).
+- Configuring subagents: custom subagents, per-subagent model routing, fork mode.
+- System prompt customization: `instructions=` for the common case, `prompt=` with placeholders for full control.
+- Tool configuration: default tool sets, adding `web_search()`, `extra_tools=`.
+- Examples: basic usage, custom subagents, cost-aware model routing, fork mode.

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -726,12 +726,13 @@ Wired everything together.
 
 ### Phase 9: Public API and exports
 
-Finalize the public surface.
+Already complete — exports were added incrementally in each preceding phase. Verified:
 
-- Update `src/inspect_ai/agent/__init__.py` with new exports.
-- Update `src/inspect_ai/tool/_tools/__init__.py` with new tool exports.
-- Verify no naming collisions (task tool is internal, not exported).
-- Test: import paths, backward compatibility of existing APIs.
+- `inspect_ai.agent`: `deepagent`, `subagent`, `Subagent`, `research`, `plan`, `general` all exported.
+- `inspect_ai.tool`: `read_file`, `list_files`, `grep`, `todo_write` all exported. `update_plan` still exported (undocumented backward compat).
+- `task_tool` is internal only (not in public API, no naming collision with `@task` decorator — separate registries).
+- `docs/reference/inspect_ai.agent.qmd`: Deep Agent section with all entries.
+- `docs/reference/inspect_ai.tool.qmd`: read_file, list_files, grep entries added.
 
 ### Phase 10: Documentation
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -1,6 +1,6 @@
 # Deep Agent Harness for Inspect
 
-## RFC
+## Design
 
 We're planning on adding a `deepagent()` to Inspect as a peer to `react()`. This would be an alternate top-level agent that bundles the patterns popularized by Claude Code, OpenAI Codex CLI, LangChain deepagents, and Pydantic AI deepagents into a single batteries-included entry point. This RFC describes the proposed design and asks for community feedback before we commit to an API.
 
@@ -702,6 +702,7 @@ Wire everything together.
 - `memory=False` disables memory everywhere.
 - `web_search=` parameter adds `web_search()` to all subagents' `extra_tools`.
 - Validation: after resolving tools for each subagent, raise an error if any subagent has no tools (e.g. no sandbox, `web_search=False`, and no `extra_tools`). A subagent with no tools can't do useful work.
+- Prompt layering: pass `AgentPrompt(instructions=prompt, assistant_prompt=None, submit_prompt=None, handoff_prompt=None)` to `react()` to suppress its defaults — `CORE_BEHAVIOR` already covers what `DEFAULT_ASSISTANT_PROMPT` covers. Same for subagent prompts in `task_tool.py`.
 - Test: end-to-end with `mockllm`, tool wiring, system prompt content, memory kill switch, subagent model routing, no-tools validation error.
 
 ### Phase 9: Public API and exports

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -598,14 +598,27 @@ Created `todo_write()` as a new tool alongside `update_plan()`.
 - `TodoStep` not exported in public API — it's internal; models and tests pass dicts.
 - Used standard `@tool` pattern (not `ToolDef().as_tool()`).
 
-### Phase 3: Read-only tools (`grep`, `read_file`, `list_files`)
+### Phase 3: Read-only tools (`grep`, `read_file`, `list_files`) (40da3105f)
 
-Create standalone read-only sandbox tools.
+Created three standalone read-only sandbox tools for `research()` and `plan()` subagents.
 
-- Implement each tool in `src/inspect_ai/tool/_tools/`.
-- Tools are always constructible; fail clearly at runtime if no sandbox is available.
-- Test: each tool with and without sandbox, error messages, output formatting.
-- Add documentation to the standard tools document and update inspect_ai.tool.qmd with the new tools.
+**Files created:**
+- `src/inspect_ai/tool/_tools/_read_file.py` — `read_file()` tool using `SandboxEnvironment.read_file()` with line numbers and `offset`/`limit` pagination.
+- `src/inspect_ai/tool/_tools/_list_files.py` — `list_files()` tool using `find` with optional `depth` control.
+- `src/inspect_ai/tool/_tools/_grep.py` — `grep()` tool using `grep -rn` with `glob` filter, `fixed_strings`, and `output_mode` ("content" / "files_with_matches" / "count").
+- `tests/tools/test_read_file.py`, `test_list_files.py`, `test_grep.py` — constructibility + Docker integration tests.
+
+**Files modified:**
+- `src/inspect_ai/tool/__init__.py` — added `read_file`, `list_files`, `grep` exports.
+- `docs/tools-standard.qmd` — added Read-Only Tools section with examples.
+- `docs/reference/inspect_ai.tool.qmd` — added reference entries.
+- `CHANGELOG.md` — added Unreleased section with entries for read-only tools and `todo_write()`.
+
+**Design decisions:**
+- Surveyed Claude Code and LangChain deep agents for parameter naming conventions. Aligned: `file_path` (not `file`), `offset`/`limit` (not `start_line`/`end_line`), `glob` (not `include`), `output_mode` with three enum values.
+- All three tools accept `timeout`, `user`, and `sandbox` parameters matching `bash()`.
+- Tools are always constructible without a sandbox; `sandbox()` raises `ProcessLookupError` at runtime if none is available.
+- No additional output limiting needed — existing `max_tool_output` (16 KiB default) handles large results; models can use `offset`/`limit` to paginate.
 
 ### Phase 4: `memory(readonly=True)` mode
 

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -133,7 +133,7 @@ Default behavior matches the convergent pattern across CC, LangChain, and Pydant
 
 - **Sandbox** — shared (already true per-sample in Inspect).
 - **Memory** — shared, read by default, write opt-in per subagent. `research()` and `plan()` get `memory(readonly=True)`; `general()` gets full read-write `memory()`. Custom subagents declare explicitly. Note: `memory(readonly=True)` is a new mode that must be implemented — the current `memory()` tool supports all CRUD operations.
-- **Skills** — shared.
+- **Skills** — inherited only by `general()` by default. `research()`, `plan()`, and custom subagents get skills only when explicitly configured. This keeps read-only and specialist subagents focused and avoids silently expanding their context or capabilities.
 - **Message history** — isolated (this is what subagents are *for*).
 - **Tools** — subset declared by the subagent's definition.
 
@@ -256,15 +256,17 @@ The following capabilities emerged from a survey of LangChain deepagents, Pydant
 
 #### Context management and compaction
 
-All three major frameworks implement multi-tier context management to keep long-running agents within their context window:
+The reference frameworks implement a mix of context-management strategies to keep long-running agents within their context window:
 
-1. **Tool output eviction.** LangChain and Pydantic AI both evict large tool outputs (>20K tokens) to the filesystem, replacing them with a short preview and a reference path. The agent can retrieve the full content later via filesystem tools if needed. This prevents a single large tool response from consuming the context budget.
+1. **Tool output caps / truncation.** Claude Code and Codex CLI rely primarily on bounded tool output, truncation, and targeted follow-up reads. This keeps any single command or file read from flooding context, at the cost of sometimes requiring the model to issue narrower follow-up tool calls.
 
-2. **Summarization / compaction.** When the context window approaches capacity (~85-90% in LangChain/Pydantic), the frameworks trigger an LLM-generated summary that compresses the conversation while preserving key facts, then continues from the summary.
+2. **Tool output eviction.** LangChain and Pydantic AI go further by evicting large tool outputs (>20K tokens) to the filesystem, replacing them with a short preview and a reference path. The agent can retrieve the full content later via filesystem tools if needed. This preserves more information but adds artifact lifecycle, security, and retrieval semantics.
 
-3. **Mid-turn compaction.** Codex CLI supports compaction during a streaming model response — injecting a summary mid-turn when the context limit is hit during generation.
+3. **Summarization / compaction.** When the context window approaches capacity (~85-90% in LangChain/Pydantic), the frameworks trigger an LLM-generated summary that compresses the conversation while preserving key facts, then continues from the summary.
 
-**Inspect status:** Inspect already has compaction infrastructure (`CompactionEdit`, `CompactionTrim`, `CompactionSummary`, native provider compaction) wired through `react()`. `deepagent()` exposes compaction configuration via the existing `compaction=` parameter, passed through to `react()`.
+4. **Mid-turn compaction.** Codex CLI supports compaction during a streaming model response — injecting a summary mid-turn when the context limit is hit during generation.
+
+**Inspect status:** Inspect already bounds tool output via `max_tool_output` (default 16 KiB), which prevents runaway tool results from saturating context. `deepagent()` v1 should lean into this existing behavior: read-only filesystem tools should support explicit ranges/limits, `grep()` should be bounded, and truncation messages should make it clear how to retrieve narrower context. Inspect also has compaction infrastructure (`CompactionEdit`, `CompactionTrim`, `CompactionSummary`, native provider compaction) wired through `react()`, and `deepagent()` exposes compaction configuration via the existing `compaction=` parameter. Durable large-output eviction can be considered later if capped outputs prove too lossy, but it is not a v1 requirement.
 
 #### Parallel subagent execution
 
@@ -272,11 +274,23 @@ LangChain's `TASK_SYSTEM_PROMPT` heavily emphasizes launching multiple subagents
 
 **Inspect status:** Inspect's current `execute_tools` processes tool calls sequentially, and `handoff()` explicitly disables parallel tool calls. In v1, subagent dispatch is sequential — multiple `task()` calls in one response execute one at a time. The system prompt should not encourage multiple subagent calls in a single response, as this adds latency and cost with no execution-time benefit in v1. Guidance should be: delegate when helpful; focus on one delegation at a time. Parallel subagent execution is a future enhancement (see Implementation Blueprint section 8).
 
+#### Async / background subagents
+
+Claude Code, Codex CLI, LangChain, and Pydantic Deep Agents all support some form of background or async subagent work: launch a long-running worker, continue in the parent, inspect status, and optionally steer or cancel the child.
+
+**Inspect status:** Out of scope for v1. `deepagent()` dispatch is synchronous: the parent blocks until the child returns its summary. Async/background subagents require new lifecycle concepts (task handles, status, cancellation, UI/log presentation, and possibly durable state) and should be designed as a separate feature.
+
 #### Cost-aware model routing
 
 The RFC mentions `model=` per subagent but doesn't frame it as cost-aware routing. In practice, this is one of the highest-leverage features: route simple subtasks (file reading, grep, summarization) to cheaper/faster models and reserve expensive models for complex reasoning. Research reports 85% cost reduction while maintaining 95% quality.
 
 **Inspect status:** Already supported — `subagent(model=...)` and `research(model=...)` etc. allow per-subagent model selection. Each built-in subagent has different cognitive demands (e.g., `research()` might use a cheaper model, `plan()` a stronger one, `general()` the main agent model), so routing is best configured per-subagent rather than with a blanket default.
+
+#### Limits and budgets
+
+Long-horizon agents need hard resource limits: message counts, tokens, wall-clock time, working time, and cost. LangChain and Pydantic expose these through middleware/capabilities; Inspect already has them as core task and agent primitives.
+
+**Inspect status:** Covered. Sample-level limits apply across the parent and all subagent excursions, and `subagent(limits=[...])` can apply additional scoped limits to a child agent. This gives authors both a global budget for the whole sample and per-subagent budgets for expensive or exploratory workers.
 
 #### Tool call repair
 
@@ -345,6 +359,7 @@ Sections are ordered by dependency — each builds on the ones above it.
 
 ``` python
 from inspect_ai.agent import subagent
+from inspect_ai.util import token_limit
 
 reviewer = subagent(
     name="reviewer",
@@ -352,12 +367,13 @@ reviewer = subagent(
     prompt="...",
     tools=[grep(), read_file()],
     model="anthropic/claude-sonnet-4",
+    limits=[token_limit(50_000)],
     memory="readonly",  # "readwrite", "readonly", or False
     fork=False,
 )
 ```
 
-`Subagent` holds: name, description, prompt, tools, model, fork, output_filter, limits, and memory mode. The memory parameter is `memory: Literal["readwrite", "readonly", False] = "readonly"` — `"readonly"` gives the subagent `memory(readonly=True)`, `"readwrite"` gives full `memory()`, and `False` disables memory entirely. **Precedence:** if `deepagent(memory=False)` is set, memory is disabled for the top-level agent and all subagents regardless of their individual `memory` setting. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
+`Subagent` holds: name, description, prompt, tools, model, fork, output_filter, limits, skills, and memory mode. The memory parameter is `memory: Literal["readwrite", "readonly", False] = "readonly"` — `"readonly"` gives the subagent `memory(readonly=True)`, `"readwrite"` gives full `memory()`, and `False` disables memory entirely. **Precedence:** if `deepagent(memory=False)` is set, memory is disabled for the top-level agent and all subagents regardless of their individual `memory` setting. The optional `limits` parameter takes scoped Inspect limits (e.g. `token_limit`, `message_limit`, `time_limit`, `cost_limit`) that apply to the child agent invocation. The optional `skills` parameter provides subagent-specific skills; only `general()` inherits parent skills automatically. The `task()` tool reads this metadata to build its parameter schema and to configure `react()` at dispatch time.
 
 **Recursion guard.** Depth is tracked via closure — the current depth is closed over when constructing the child agent's tool set, so each dispatch path carries its own depth counter. This is parallel-safe: sibling subagents dispatched concurrently (in a future parallel v2) won't interfere with each other's depth tracking. Default cap at 1 level, matching CC and Codex. Configurable via `deepagent(max_depth=...)`. Enforcement is by omission: when constructing the `react()` agent at max depth, the `task()` tool is simply not included in the tool list. The model never sees a tool it can't use.
 
@@ -384,29 +400,34 @@ task_tool = task(subagents=[research(), plan(), general(), reviewer()])
 
 #### 3. Built-in subagent factories: `research()`, `plan()`, `general()`
 
-Each returns a `Subagent` with opinionated defaults. All accept additive customization via `instructions=`, `extra_tools=`, `model=`, `fork=`.
+Each returns a `Subagent` with opinionated defaults. All accept additive customization via `instructions=`, `extra_tools=`, `model=`, `fork=`, `limits=`, and `skills=`.
 
 **`research()`** — Read-only information gathering.
 - Tools: read-only defaults (see below).
 - Fork: `False` (isolated context).
 - Memory: read-only.
+- Skills: none by default.
 - Prompt: goal-oriented, emphasizes gathering and synthesizing information.
 
 **`plan()`** — Structured planning, no execution.
 - Tools: same read-only defaults as `research()`.
 - Fork: `False`.
 - Memory: read-only.
+- Skills: none by default.
 - Prompt: goal-oriented, emphasizes decomposing work and producing a structured plan.
 
 **`general()`** — Full tools, isolated context for noisy work.
 - Tools: inherits all parent tools.
 - Fork: `False` (user can opt into `True` for CC-style fork behavior).
 - Memory: read-write.
+- Skills: inherits parent skills by default.
 - Prompt: goal-oriented, emphasizes autonomous task completion.
 
 **Default tool sets.** `research()` and `plan()` share the same read-only tool defaults: `grep()`, `read_file()`, and `list_files()` — new standalone read-only tools to be added to Inspect's toolset. These tools are always constructible regardless of whether a sandbox is configured; they fail clearly at runtime if no sandbox is available. (These are useful beyond `deepagent()` — any eval that wants read-only filesystem access currently requires `bash()` or `text_editor()`, both of which are read-write.)
 
 User tools passed to `deepagent(tools=[...])` are available to the top-level agent and flow down to `general()`, but do **not** automatically flow to `research()` or `plan()`. This preserves their read-only-by-default posture — if the user passes `bash()` or `text_editor()`, those mutating tools must not reach read-only subagents. Users can explicitly extend `research()` or `plan()` with additional tools via `extra_tools=`, but doing so overrides the read-only default at the user's discretion. All built-in subagents accept `extra_tools=` for additive customization.
+
+This is a default capability boundary, not a hard security guarantee. If a user explicitly gives a read-only subagent mutating tools through `extra_tools=` or gives it read-write memory, the subagent can mutate through those capabilities. Hard isolation should be enforced through sandboxing, approval policies, or task-specific tool design.
 
 `general()` inherits the `deepagent()`'s assembled tool list (user tools + memory + todo_write + skills), minus the `task()` tool itself at max depth per the recursion guard.
 
@@ -514,7 +535,9 @@ However, this is a significant infrastructure change with nontrivial risks:
 - **Unit tests:** `Subagent` construction, `task()` parameter schema generation, system prompt assembly and placeholder expansion, recursion depth tracking (verify closure-based depth is parallel-safe).
 - **Integration tests:** `deepagent()` end-to-end with `mockllm` — verify tool wiring, subagent dispatch (both isolated and forked), system prompt content, alias handling.
 - **Tool inheritance tests:** verify `research()`/`plan()` do not receive user-provided mutating tools; verify `general()` inherits the full parent tool set; verify `extra_tools=` works on all subagents.
+- **Skill inheritance tests:** verify `general()` inherits parent skills by default; verify `research()`/`plan()` and custom subagents do not inherit skills unless explicitly configured.
 - **Memory ACL tests:** verify `research()`/`plan()` get `memory(readonly=True)` and cannot write; verify `general()` gets full read-write memory.
+- **Limit tests:** verify sample-level limits apply across parent and child agents; verify `subagent(limits=[...])` applies additional scoped limits to child invocations.
 - **Sandbox/no-sandbox tests:** verify read-only tools are constructible without a sandbox and fail clearly at runtime; verify they work correctly with a sandbox.
 
 #### 10. Documentation

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -426,7 +426,7 @@ Each returns a `Subagent` with opinionated defaults. All accept additive customi
 - Memory: read-write.
 - Prompt: goal-oriented, emphasizes autonomous task completion.
 
-**Default tool sets.** `research()` and `plan()` share the same read-only tool defaults: `grep()`, `read_file()`, and `list_files()` — new standalone read-only tools to be added to Inspect's toolset. These tools are always constructible regardless of whether a sandbox is configured; they fail clearly at runtime if no sandbox is available. (These are useful beyond `deepagent()` — any eval that wants read-only filesystem access currently requires `bash()` or `text_editor()`, both of which are read-write.)
+**Default tool sets.** `research()` and `plan()` share the same sandbox-aware read-only tool defaults: `grep()`, `read_file()`, and `list_files()` when a sandbox is configured, and no filesystem tools when there is no sandbox context. The underlying tools remain standalone read-only tools in Inspect's toolset: they are constructible regardless of sandbox configuration and fail clearly at runtime if explicitly called without an available sandbox. (These are useful beyond `deepagent()` — any eval that wants read-only filesystem access currently requires `bash()` or `text_editor()`, both of which are read-write.)
 
 User tools passed to `deepagent(tools=[...])` are available to the top-level agent and flow down to `general()`, but do **not** automatically flow to `research()` or `plan()`. This preserves their read-only-by-default posture — if the user passes `bash()` or `text_editor()`, those mutating tools must not reach read-only subagents. Users can explicitly extend `research()` or `plan()` with additional tools via `extra_tools=`, but doing so overrides the read-only default at the user's discretion. All built-in subagents accept `extra_tools=` for additive customization.
 
@@ -541,11 +541,11 @@ However, this is a significant infrastructure change with nontrivial risks:
 - **Skill composition tests:** verify parent + subagent skills merge correctly; verify instance-scoped stores don't collide.
 - **Memory ACL tests:** verify `research()`/`plan()` get `memory(readonly=True)` and cannot write; verify `general()` gets full read-write memory.
 - **Limit tests:** verify sample-level limits apply across parent and child agents; verify `subagent(limits=[...])` applies additional scoped limits to child invocations.
-- **Sandbox/no-sandbox tests:** verify read-only tools are constructible without a sandbox and fail clearly at runtime; verify they work correctly with a sandbox.
+- **Sandbox/no-sandbox tests:** verify read-only tools are constructible without a sandbox and fail clearly at runtime when explicitly called; verify `deepagent()`'s default read-only subagent tools are included only with a sandbox context; verify the tools work correctly with a sandbox.
 
 #### 10. Documentation
 
-New documentation file: `docs/deep-agent.qmd` — a standalone guide covering:
+New documentation file: `docs/deepagent.qmd` — a standalone guide covering:
 
 - Overview of the deep agent pattern and when to use `deepagent()` vs `react()`.
 - API reference for `deepagent()`, `subagent()`, and built-in subagents (`research()`, `plan()`, `general()`).

--- a/design/deepagents.md
+++ b/design/deepagents.md
@@ -117,9 +117,13 @@ The built-in subagents default as follows:
 |----------------|----------------|-----------|
 | `research()`   | `False`        | Information gathering is self-contained; isolated context keeps the parent lean. |
 | `plan()`       | `False`        | Planning from a clean slate avoids anchoring on noisy intermediate output. |
-| `general()`    | `False`        | Matches CC's original default. `general(fork=True)` opts into CC's newer fork behavior. |
+| `general()`    | `False`        | Isolated by default — avoids context rot and provides predictable behavior. |
 
 All three accept `fork=True` as an override.
+
+**Why isolated is the default for `general()`:** Claude Code, LangChain deep agents, and Codex CLI all default to isolated subagents. Isolation prevents context rot (quality degradation after ~200k tokens of accumulated history), enables true parallelism, and provides predictable behavior. For eval workloads — which are batch jobs where reproducibility matters — isolation is the safer baseline.
+
+**When to use `fork=True`:** Forked dispatch is valuable when the subagent needs substantial background from the parent conversation without re-explanation, when the parent context is still fresh (well under context window limits), and when using the same model family (to preserve prompt cache). In forked mode, the parent's system prompt and full message history are preserved verbatim, and the subagent's instructions (if any) are appended as a user message — keeping the provider prompt cache intact on all providers. Use `general(fork=True)` to opt into this behavior.
 
 #### The `task()` tool
 
@@ -737,6 +741,15 @@ Already complete — exports were added incrementally in each preceding phase. V
 
 Write `docs/deep-agent.qmd`.
 
-- Overview, API reference, configuration guide, examples.
-- System prompt customization guide (`instructions=` vs `prompt=` with placeholders).
+- Overview of the deep agent pattern and when to use `deepagent()` vs `react()`.
+- API reference for `deepagent()`, `subagent()`, and built-in subagents (`research()`, `plan()`, `general()`).
+- **Isolated vs forked dispatch guide** — explain the tradeoff clearly:
+  - Default is isolated (`fork=False`): subagent gets fresh context with only the task prompt. Prevents context rot, enables parallelism, predictable behavior. All major frameworks (Claude Code, LangChain, Codex) default to this.
+  - Forked (`fork=True`): subagent inherits parent's full conversation history. Preserves prompt cache on all providers (system prompt and message prefix unchanged). Best when subagent needs substantial background context and parent history is fresh. Use same model/family. Instructions appended as user message after cached prefix.
+  - When to choose each, with examples.
+- Configuring subagents: custom subagents, per-subagent model routing, fork mode.
+- System prompt customization: `instructions=` for the common case, `prompt=` with placeholders for full control.
+- Tool configuration: default tool sets, `web_search=`, `extra_tools=`.
+- Memory and planning: `memory=`, `todo_write=`, `memory=False` kill switch.
+- Examples: basic usage, custom subagents, forked dispatch, cost-aware model routing.
 - Update inspect_ai.agent.qmd with reference sections.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -70,6 +70,7 @@ inspect-docs:
       contents:
         - href: agents.qmd
         - href: react-agent.qmd
+        - href: deepagent.qmd
         - href: multi-agent.qmd
         - href: agent-custom.qmd
         - href: agent-bridge.qmd

--- a/docs/agents.qmd
+++ b/docs/agents.qmd
@@ -9,13 +9,15 @@ Agents combine planning, memory, and tool usage to pursue more complex, longer h
 
 1.  Using Inspect's built-in [ReAct Agent](react-agent.qmd).
 
-2.  Implementing a fully [Custom Agent](agent-custom.qmd).
+2.  Using the [Deep Agent](deepagent.qmd) for long-horizon tasks with subagent delegation, memory, and planning.
 
-3.  Composing agents into [Multi Agent](multi-agent.qmd) architectures.
+3.  Implementing a fully [Custom Agent](agent-custom.qmd).
 
-4.  Integrating external frameworks via the [Agent Bridge](agent-bridge.qmd).
+4.  Composing agents into [Multi Agent](multi-agent.qmd) architectures.
 
-5.  Using the [Human Agent](human-agent.qmd) for human baselining of computing tasks.
+5.  Integrating external frameworks via the [Agent Bridge](agent-bridge.qmd).
+
+6.  Using the [Human Agent](human-agent.qmd) for human baselining of computing tasks.
 
 Below, we'll cover the basic role and function of agents in Inspect. Subsequent articles provide more details on the ReAct agent, custom agents, and multi-agent systems.
 

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -79,7 +79,9 @@ The `memory()` tool provides a scratchpad for the top-level agent for the durati
 
 Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress. When compaction is enabled, the model is instructed to checkpoint important state to memory before context is reduced, ensuring progress survives across compaction boundaries.
 
-By default, only the top-level agent has memory — subagents do not. Subagents communicate their findings back through their return value, which is the designed channel for information flow. This avoids cross-contamination where subagent scratch notes could pollute the parent's memory. To enable subagent memory access, set `memory="readonly"` or `memory="readwrite"` on individual subagents when [customizing](#sec-customizing-builtins).
+The `memory()` tool is based on Anthropic's [native memory tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool) and binds to it natively on Anthropic models.
+
+By default, only the top-level agent has memory — subagents do not. Subagents communicate their findings back through their return value, which is the designed channel for information flow. This avoids cross-contamination where subagent scratch notes could pollute the parent's memory. If a subagent is given memory access (via `memory="readwrite"` on [customized subagents](#sec-customizing-builtins)), its writes are visible to the parent and to subsequent subagent invocations, since all memory tools share the same underlying store.
 
 ### Planning
 
@@ -367,7 +369,7 @@ Pass `submit=False` to disable the submit tool entirely (the agent will terminat
 
 `deepagent()` supports several additional options from `react()`:
 
-- `retry_refusals` --- Retry when the model refuses a request due to content filters (default: 3). Applies to the top-level agent and all subagents. See [Refusals](react-agent.qmd#refusals) for details.
+- `retry_refusals` --- Retry when the model refuses a request due to content filters (default: 3). Applies to the top-level agent and all subagents. If a subagent refuses and retries are exhausted, the refusal text becomes the subagent's return value to the parent. See [Refusals](react-agent.qmd#refusals) for details.
 
 - `on_continue` --- Control continuation behavior when the model stops calling tools. Applies to the top-level agent only. See [Continuation](react-agent.qmd#continuation) for details.
 

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -162,7 +162,7 @@ deepagent(
 )
 ```
 
-Parent skills are available to the top-level agent. At dispatch time, parent skills and subagent-specific skills are merged so that a subagent sees both its own skills and the parent's. See the [Skills](tools-standard.qmd#sec-skill) documentation for details on creating and using skills.
+Parent skills are available to the top-level agent. At dispatch time, parent skills and subagent-specific skills are merged so that a subagent sees both its own skills and the parent's. Skills use the [Agent Skills](https://agentskills.io) specification (`SKILL.md` with YAML frontmatter), which is compatible with skills directories from other agent frameworks. See the [Skills](tools-standard.qmd#sec-skill) documentation for details on creating and using skills.
 
 ## Compaction
 

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -358,3 +358,19 @@ deepagent(
 ```
 
 Pass `submit=False` to disable the submit tool entirely (the agent will terminate when it stops calling tools). For more advanced configuration, pass an `AgentSubmit` or `AgentAttempts` instance. See the [ReAct Agent](react-agent.qmd#attempts) documentation for details.
+
+## Refusals, Continuation, and Approval
+
+`deepagent()` supports several additional options from `react()`:
+
+``` python
+deepagent(
+    tools=[bash(), text_editor()],
+    retry_refusals=3,                                       # <1>
+    on_continue="Please continue working on the task.",     # <2>
+    approval=[ApprovalPolicy(human_approver(), "bash")],    # <3>
+)
+```
+1. Retry when the model refuses a request due to content filters. Applies to the top-level agent and all subagents. See [Refusals](react-agent.qmd#refusals) for details.
+2. Control continuation behavior when the model stops calling tools. Applies to the top-level agent only. See [Continuation](react-agent.qmd#continuation) for details.
+3. Apply approval policies for tool calls. Applies to the top-level agent only. See [Approval](approval.qmd) for details.

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -256,6 +256,8 @@ deepagent(
 
 The `subagent()` factory accepts the same customization parameters as the built-in factories (`model`, `limits`, `memory`, `skills`, `fork`, `compaction`) plus the required `name`, `description`, and `prompt`.
 
+By default, subagents cannot delegate to further subagents (`max_depth=1`). Set `max_depth=2` on `deepagent()` to allow one level of nested delegation. Higher values increase token usage and latency; `max_depth=1` is sufficient for most tasks.
+
 ### Fork Mode {#sec-fork-mode}
 
 By default, subagents run in isolated context: they start with a fresh message history and only their summary returns to the parent. This is the standard pattern used by Claude Code, LangChain, and Codex CLI, and it prevents context rot in long-running conversations.
@@ -280,7 +282,9 @@ deepagent(
 1.  The `general` subagent inherits the parent's full message history.
 2.  Use the same model for parent and forked subagents.
 
-Fork mode is useful when the subagent needs substantial background from the parent conversation without re-explanation, and when the parent's context is still fresh (well under context window limits). It preserves the prompt cache on all providers because the message prefix is unchanged.
+Fork mode is useful when the subagent needs substantial background from the parent conversation without re-explanation, and when the parent's context is still fresh (well under context window limits).
+
+Fork mode also preserves prompt cache efficiency: the forked subagent reuses the parent's message prefix, so cached tokens carry over. Isolated subagents start with a fresh message history, which invalidates the cache.
 
 ::: {.callout-note appearance="simple"}
 Use the same model or model family when forking to preserve the prompt cache and avoid errors from incompatible tool call formats or reasoning content in the inherited message history. Fork mode is not supported with `max_depth > 1`.

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -1,0 +1,360 @@
+---
+title: Deep Agent
+llms-description: Using and customizing the built-in deep agent with subagent delegation, memory, and planning.
+---
+
+## Overview
+
+The `deepagent()` agent is a batteries-included entry point for long-horizon tasks. It builds on the [ReAct Agent](react-agent.qmd) with four additions: subagent delegation, persistent memory, structured planning, and an opinionated system prompt that teaches the model when to use each.
+
+The `react()` agent handles short-horizon tasks well, but tends to flatten under longer horizons: agents lose context, exhaust their context window with intermediate tool output, and don't reliably plan or decompose work. The `deepagent()` bundles the patterns that address this, drawing from Claude Code, Codex CLI, and other deep agent frameworks:
+
+1.  **Subagent delegation.** Spawn isolated workers (`research`, `plan`, `general`) with their own context windows. Only their summary returns to the parent.
+
+2.  **Persistent memory.** A scratchpad for offloading intermediate results out of the message history so they survive context compaction.
+
+3.  **Structured planning.** A todo tool for explicit task decomposition and progress tracking.
+
+4.  **Opinionated system prompt.** Goal-oriented instructions that teach the model to act autonomously, delegate effectively, and verify its work.
+
+### Example
+
+Here is a `ctf_agent()` that uses `deepagent()` with `bash()` and `text_editor()` tools:
+
+``` python
+from textwrap import dedent
+from inspect_ai import Task, task
+from inspect_ai.agent import deepagent
+from inspect_ai.dataset import json_dataset
+from inspect_ai.scorer import includes
+from inspect_ai.tool import bash, text_editor
+
+@task
+def ctf_challenge():
+    return Task(
+        dataset=json_dataset("ctf_challenge.json"),
+        solver=deepagent(
+            tools=[bash(), text_editor()],   # <1>
+        ),
+        scorer=includes(),
+        sandbox="docker",
+    )
+```
+1. Tools are the only required customization for most tasks. Everything else is handled by defaults.
+
+::: {.callout-note appearance="simple"}
+Behind the scenes, `deepagent()` provides three subagents (research, plan, general), a persistent memory tool, a todo_write planning tool, and a system prompt that teaches the model when to use each. The sections below describe these defaults and how to customize them.
+:::
+
+
+## What You Get
+
+When you call `deepagent()` with no configuration beyond tools, you get a fully assembled agent with the following capabilities.
+
+### Subagent Delegation {#sec-subagent-delegation}
+
+The parent agent has a `task()` tool that lets it delegate work to specialized subagents. Three are included by default:
+
+| Subagent | Role | Tools | Memory |
+|----------|------|-------|--------|
+| `research` | Read-only information gathering and synthesis | `read_file`, `list_files`, `grep` | Read-only |
+| `plan` | Structured task decomposition and planning | `read_file`, `list_files`, `grep` | Read-only |
+| `general` | General-purpose autonomous task completion | Inherits parent's tools | Read-write |
+
+: {tbl-colwidths="[15,35,25,15]"}
+
+The parent agent decides when to delegate vs. do work directly. The system prompt guides it to delegate when the work is complex, independent, or would benefit from an isolated context, and to do the work directly when it's a simple lookup or a single tool call.
+
+Subagents run in isolated context by default. Each gets a fresh message history with only the task prompt, and only its summary returns to the parent. This prevents context rot and keeps the parent's context lean.
+
+### Memory
+
+The `memory()` tool provides a persistent scratchpad shared across the parent and all subagents. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.
+
+Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress.
+
+The `research` and `plan` subagents have read-only memory access (they can view but not modify entries), while `general` has full read-write access.
+
+### Planning
+
+The `todo_write()` tool provides structured task tracking. The model uses it to decompose complex tasks into steps and track progress:
+
+- `pending` -- step not yet started
+- `in_progress` -- step currently being worked on
+- `completed` -- step finished
+
+The system prompt instructs the model to update the plan as it works, marking steps in progress as it starts them and completed as it finishes.
+
+### System Prompt
+
+The default system prompt is goal-oriented rather than procedurally prescriptive, which works well across models at different levels of agentic post-training:
+
+- Act rather than narrate intent.
+- Keep going until fully resolved; diagnose failures and try different approaches.
+- Be concise; avoid preamble and unnecessary explanation.
+- Batch independent tool calls in a single response rather than making sequential round-trips.
+- Plan when tasks are complex; break large tasks into smaller pieces and verify results.
+- Use reasonable defaults rather than asking clarifying questions for every detail.
+
+The prompt also includes cross-tool coordination guidance (use memory for intermediate results, use the plan for decomposition) and subagent delegation guidance (when to delegate, how to pass context to subagents).
+
+
+## Instructions
+
+The simplest way to customize `deepagent()` is to add domain-specific instructions appended to the default system prompt:
+
+``` python
+from textwrap import dedent
+from inspect_ai.agent import deepagent
+from inspect_ai.tool import bash, text_editor
+
+deepagent(
+    tools=[bash(), text_editor()],
+    instructions=dedent("""
+        You are a penetration tester. Focus on identifying
+        security vulnerabilities in the target system. Document
+        each finding with severity and evidence.
+    """),
+)
+```
+
+Instructions are appended to the end of the system prompt, after the core behavior, delegation guidance, and memory/planning instructions.
+
+
+## Tools {#sec-tools}
+
+Pass additional tools to `deepagent()` with the `tools` parameter. These tools are available to the top-level agent and automatically flow to the `general()` subagent:
+
+``` python
+from inspect_ai.agent import deepagent
+from inspect_ai.tool import bash, text_editor, web_search
+
+deepagent(
+    tools=[bash(), text_editor()],
+    web_search=True,                    # <1>
+)
+```
+1. Pass `True` for default web search configuration, or a pre-configured `web_search()` instance for custom setup. Web search is added to all agents (parent and subagents).
+
+::: {.callout-note appearance="simple"}
+Tools passed to `deepagent()` do not automatically flow to the `research()` or `plan()` subagents. This preserves their read-only posture. To add tools to those subagents, use `extra_tools=` when [customizing built-in subagents](#sec-customizing-builtins).
+:::
+
+
+## Skills
+
+Skills are structured task packages (bundles of instructions, scripts, and references) that agents can invoke via a `skill()` tool. Pass them to `deepagent()` with the `skills` parameter:
+
+``` python
+from inspect_ai.agent import deepagent
+from inspect_ai.tool import Skill
+
+pdf_skill = Skill(
+    name="pdf_analysis",
+    description="Extract and analyze content from PDF documents.",
+    instructions="Use pdfplumber to extract tables and text...",
+    scripts={"extract_pdf.py": "..."},
+)
+
+deepagent(
+    skills=[pdf_skill],
+    ...
+)
+```
+
+Parent skills are available to the top-level agent. At dispatch time, parent skills and subagent-specific skills are merged so that a subagent sees both its own skills and the parent's. See the [Skills](tools-standard.qmd#sec-skill) documentation for details on creating and using skills.
+
+
+## Compaction
+
+Long-running agents can exhaust their context window. Use the `compaction` parameter to automatically manage conversation context as it grows:
+
+``` python
+from inspect_ai.agent import deepagent
+from inspect_ai.model import CompactionSummary
+from inspect_ai.tool import bash, text_editor
+
+deepagent(
+    tools=[bash(), text_editor()],
+    compaction=CompactionSummary(),
+)
+```
+
+Compaction propagates to subagents that don't set their own strategy, so a single `compaction=` on `deepagent()` covers the parent and all subagents. Individual subagents can override with their own strategy when [customized](#sec-customizing-builtins).
+
+See the [Compaction](compaction.qmd) documentation for details on available strategies (`CompactionSummary`, `CompactionEdit`, `CompactionTrim`, `CompactionAuto`, and `CompactionNative`).
+
+
+## Subagent Configuration {#sec-subagent-config}
+
+### Customizing Built-in Subagents {#sec-customizing-builtins}
+
+The built-in subagent factories (`research()`, `plan()`, and `general()`) all accept customization parameters. Pass a customized `subagents` list to `deepagent()`:
+
+``` python
+from inspect_ai.agent import deepagent, research, plan, general
+from inspect_ai.tool import bash, text_editor
+from inspect_ai.util import token_limit
+
+deepagent(
+    tools=[bash(), text_editor()],
+    subagents=[
+        research(
+            instructions="Focus on configuration files and logs.",
+            model="anthropic/claude-haiku-3-5",         # <1>
+        ),
+        plan(
+            instructions="Create conservative, step-by-step plans.",
+        ),
+        general(
+            limits=[token_limit(100_000)],              # <2>
+        ),
+    ],
+)
+```
+1. Use a cheaper model for information gathering to reduce costs.
+2. Apply a scoped token limit to each `general` subagent invocation.
+
+The customization parameters available on all three factories:
+
+| Parameter | Description |
+|-----------|-------------|
+| `instructions` | Additional text appended to the default subagent prompt. |
+| `model` | Model override (default inherits parent's model). |
+| `limits` | Scoped limits per invocation (`token_limit`, `message_limit`, `time_limit`, `cost_limit`). |
+| `memory` | Memory access level: `"readwrite"`, `"readonly"`, or `False`. |
+| `extra_tools` | Additional tools merged with the subagent's defaults. |
+| `tools` | Replace the default tool set entirely. |
+| `skills` | Subagent-specific skills (merged with parent skills). |
+| `fork` | Dispatch mode. See [Fork Mode](#sec-fork-mode). |
+| `compaction` | Compaction strategy override. |
+
+: {tbl-colwidths="[20,80]"}
+
+### Custom Subagents {#sec-custom-subagents}
+
+Use the `subagent()` factory to create wholly new subagent types beyond the three built-ins:
+
+``` python
+from inspect_ai.agent import deepagent, research, plan, general, subagent
+from inspect_ai.tool import bash, read_file, grep, text_editor
+
+reviewer = subagent(
+    name="reviewer",                                    # <1>
+    description="Reviews work for correctness and completeness.",
+    prompt="You are a careful reviewer. Examine the work "
+           "done so far and identify errors, omissions, or "
+           "improvements. Be specific about what needs to change.",
+    tools=[read_file(), grep()],                        # <2>
+    memory="readonly",
+)
+
+deepagent(
+    tools=[bash(), text_editor()],
+    subagents=[research(), plan(), general(), reviewer], # <3>
+)
+```
+1. Name must be a valid Python identifier. It becomes the `subagent_type` value in the `task()` tool.
+2. Custom subagents declare their own tools explicitly.
+3. Add the custom subagent alongside the built-ins.
+
+The `subagent()` factory accepts the same customization parameters as the built-in factories (`model`, `limits`, `memory`, `skills`, `fork`, `compaction`) plus the required `name`, `description`, and `prompt`.
+
+### Fork Mode {#sec-fork-mode}
+
+By default, subagents run in isolated context: they start with a fresh message history and only their summary returns to the parent. This is the standard pattern used by Claude Code, LangChain, and Codex CLI, and it prevents context rot in long-running conversations.
+
+Forked dispatch (`fork=True`) is an alternative where the subagent inherits the parent's full conversation history:
+
+``` python
+from inspect_ai.agent import deepagent, research, plan, general
+from inspect_ai.tool import bash, text_editor
+
+deepagent(
+    tools=[bash(), text_editor()],
+    subagents=[
+        research(),
+        plan(),
+        general(fork=True),                             # <1>
+    ],
+    model="anthropic/claude-sonnet-4",                  # <2>
+)
+```
+1. The `general` subagent inherits the parent's full message history.
+2. Use the same model for parent and forked subagents.
+
+Fork mode is useful when the subagent needs substantial background from the parent conversation without re-explanation, and when the parent's context is still fresh (well under context window limits). It preserves the prompt cache on all providers because the message prefix is unchanged.
+
+::: {.callout-note appearance="simple"}
+Use the same model or model family when forking to preserve the prompt cache and avoid errors from incompatible tool call formats or reasoning content in the inherited message history. Fork mode is not supported with `max_depth > 1`.
+:::
+
+
+## Prompt Customization {#sec-prompt}
+
+When `instructions=` is not sufficient, use the `prompt=` parameter for full system prompt replacement. Named placeholders are expanded at assembly time:
+
+``` python
+from inspect_ai.agent import deepagent
+from inspect_ai.tool import bash, text_editor
+
+deepagent(
+    tools=[bash(), text_editor()],
+    prompt="""You are a security assessment agent.
+
+{core_behavior}
+
+{subagent_dispatch}
+
+{memory_instructions}
+
+Security-specific rules:
+- Prioritize high-severity findings
+- Document evidence for each vulnerability
+- Test remediation before reporting
+
+{instructions}""",
+    instructions="Target system runs Ubuntu 22.04.",
+)
+```
+
+Available placeholders:
+
+| Placeholder | Content |
+|-------------|---------|
+| `{core_behavior}` | Core behavioral expectations (act, persist, verify, batch). |
+| `{subagent_dispatch}` | Subagent names, roles, and delegation guidance (generated from the subagent list). |
+| `{memory_instructions}` | Memory and planning coordination guidance. |
+| `{instructions}` | The user's `instructions=` text. |
+
+: {tbl-colwidths="[25,75]"}
+
+Placeholders are optional. Omit any to exclude that content from the final prompt.
+
+### Disabling Defaults
+
+You can disable the memory and planning tools:
+
+``` python
+deepagent(
+    tools=[bash(), text_editor()],
+    memory=False,       # <1>
+    todo_write=False,   # <2>
+)
+```
+1. Disables the memory tool for the top-level agent and all subagents, regardless of their individual `memory` setting.
+2. Disables the todo_write planning tool.
+
+
+## Submit and Attempts
+
+By default, `deepagent()` includes a `submit()` tool that the model calls to report its final answer. You can configure multiple attempts so that if the score is incorrect the model is allowed to continue and try again:
+
+``` python
+deepagent(
+    tools=[bash(), text_editor()],
+    attempts=3,
+)
+```
+
+Pass `submit=False` to disable the submit tool entirely (the agent will terminate when it stops calling tools). For more advanced configuration, pass an `AgentSubmit` or `AgentAttempts` instance. See the [ReAct Agent](react-agent.qmd#attempts) documentation for details.

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -63,8 +63,8 @@ The parent agent has a `task()` tool that lets it delegate work to specialized s
 
 | Subagent | Role | Tools | Memory |
 |----------------------|-----------------|-----------------|-----------------|
-| `research()` | Read-only information gathering and synthesis | `read_file()`, `list_files()`, `grep()` | Read-only |
-| `plan()` | Structured task decomposition and planning | `read_file()`, `list_files()`, `grep()` | Read-only |
+| `research()` | Read-only information gathering and synthesis | `read_file()`, `list_files()`, `grep()`^[Sandbox file tools are included only when a sandbox is configured.] | Read-only |
+| `plan()` | Structured task decomposition and planning | `read_file()`, `list_files()`, `grep()`^[Sandbox file tools are included only when a sandbox is configured.] | Read-only |
 | `general()` | General-purpose autonomous task completion | Inherits parent's tools | Read-write |
 
 : {tbl-colwidths=\[20,30,30,20\]}

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -79,7 +79,7 @@ The `memory()` tool provides a scratchpad shared across the parent and all subag
 
 Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress. When compaction is enabled, the model is instructed to checkpoint important state to memory before context is reduced, ensuring progress survives across compaction boundaries.
 
-The `research()` and `plan()` subagents have read-only memory access (they can view but not modify entries), while `general()` has full read-write access.
+Memory is a single shared store: entries written by the parent are immediately visible to subagents, and entries written by `general()` are visible to the parent after the subagent returns. The `research()` and `plan()` subagents have read-only memory access (they can view but not modify entries), while `general()` has full read-write access.
 
 ### Planning
 
@@ -101,6 +101,8 @@ The default system prompt is goal-oriented rather than procedurally prescriptive
 - Batch independent tool calls in a single response rather than making sequential round-trips.
 - Plan when tasks are complex; break large tasks into smaller pieces and verify results.
 - Use reasonable defaults rather than asking clarifying questions for every detail.
+
+The prompt is oriented toward autonomous execution — the agent acts on reasonable defaults rather than pausing to ask clarifying questions. This is deliberate for evaluation workloads where the task is fully specified and human-in-the-loop clarification is not available.
 
 The prompt also includes cross-tool coordination guidance (use memory for intermediate results, use the plan for decomposition) and subagent delegation guidance (when to delegate, how to pass context to subagents).
 

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -147,21 +147,13 @@ Tools passed to `deepagent()` do not automatically flow to the `research()` or `
 
 ## Skills
 
-Skills are structured task packages (bundles of instructions, scripts, and references) that agents can invoke via a `skill()` tool. Pass them to `deepagent()` with the `skills` parameter:
+Skills are structured task packages (bundles of instructions, scripts, and references) that agents can invoke via a `skill()` tool. Pass directories containing a `SKILL.md` file to `deepagent()` with the `skills` parameter:
 
 ``` python
 from inspect_ai.agent import deepagent
-from inspect_ai.tool import Skill
-
-pdf_skill = Skill(
-    name="pdf-analysis",
-    description="Extract and analyze content from PDF documents.",
-    instructions="Use pdfplumber to extract tables and text...",
-    scripts={"extract_pdf.py": "..."},
-)
 
 deepagent(
-    skills=[pdf_skill],
+    skills=["./skills/pdf-analysis", "./skills/data-cleaning"],
     ...
 )
 ```

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -236,25 +236,27 @@ Use the `subagent()` factory to create wholly new subagent types beyond the thre
 from inspect_ai.agent import deepagent, research, plan, general, subagent
 from inspect_ai.tool import bash, read_file, grep, text_editor
 
-reviewer = subagent(
-    name="reviewer",                                    # <1>
-    description="Reviews work for correctness and completeness.",
-    prompt="You are a careful reviewer. Examine the work "
-           "done so far and identify errors, omissions, or "
-           "improvements. Be specific about what needs to change.",
-    tools=[read_file(), grep()],                        # <2>
-    memory="readonly",
-)
+def reviewer():                                         # <1>
+    return subagent(
+        name="reviewer",
+        description="Reviews work for correctness and completeness.",
+        prompt="You are a careful reviewer. Examine the work "
+               "done so far and identify errors, omissions, or "
+               "improvements. Be specific about what needs to change.",
+        tools=[read_file(), grep()],                    # <2>
+        model="anthropic/claude-opus-4-7",              # <3>
+        memory="readonly",
+    )
 
 deepagent(
     tools=[bash(), text_editor()],
-    subagents=[research(), plan(), general(), reviewer], # <3>
+    subagents=[research(), plan(), general(), reviewer()],
 )
 ```
 
-1.  Name must be a valid Python identifier. It becomes the `subagent_type` value in the `task()` tool.
+1.  Define custom subagents as factory functions, consistent with the built-in `research()`, `plan()`, and `general()`.
 2.  Custom subagents declare their own tools explicitly.
-3.  Add the custom subagent alongside the built-ins.
+3.  Use a stronger model for review — the parent can consult this subagent for a second opinion on complex decisions or to verify its own work.
 
 The `subagent()` factory accepts the same customization parameters as the built-in factories (`model`, `limits`, `memory`, `skills`, `fork`, `compaction`) plus the required `name`, `description`, and `prompt`.
 
@@ -289,7 +291,7 @@ Fork mode is useful when the subagent needs substantial background from the pare
 Fork mode also preserves prompt cache efficiency: the forked subagent reuses the parent's message prefix, so cached tokens carry over. Isolated subagents start with a fresh message history, which invalidates the cache.
 
 ::: {.callout-note appearance="simple"}
-Use the same model or model family when forking to preserve the prompt cache and avoid errors from incompatible tool call formats or reasoning content in the inherited message history. Fork mode is not supported with `max_depth > 1`.
+Use the same model or model family when forking to preserve the prompt cache and avoid errors from incompatible tool call formats or reasoning content in the inherited message history. Fork mode is not supported with `max_depth > 1`. If compaction has run on the parent, the forked subagent inherits the compacted messages, not the original history.
 :::
 
 ## System Prompt {#sec-prompt}

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -5,21 +5,21 @@ llms-description: Using and customizing the built-in deep agent with subagent de
 
 ## Overview
 
-The `deepagent()` agent is a batteries-included entry point for long-horizon tasks. It builds on the [ReAct Agent](react-agent.qmd) with four additions: subagent delegation, persistent memory, structured planning, and an opinionated system prompt that teaches the model when to use each.
+The deep agent is a batteries-included entry point for long-horizon tasks. It builds on the [ReAct Agent](react-agent.qmd) with four additions: subagent delegation, persistent memory, structured planning, and an opinionated system prompt that teaches the model when to use each.
 
-The `react()` agent handles short-horizon tasks well, but tends to flatten under longer horizons: agents lose context, exhaust their context window with intermediate tool output, and don't reliably plan or decompose work. The `deepagent()` bundles the patterns that address this, drawing from Claude Code, Codex CLI, and other deep agent frameworks:
+The `react()` agent handles short-horizon tasks well, but can degrade in performance under longer horizons, losing context and not reliably decomposing work. The `deepagent()` bundles the patterns that address this, drawing from Claude Code, Codex CLI, and other deep agent frameworks:
 
-1.  **Subagent delegation.** Spawn isolated workers (`research`, `plan`, `general`) with their own context windows. Only their summary returns to the parent.
+1.  Subagent delegation. Spawn isolated workers (`research()`, `plan()`, and `general()`) with their own context windows. Only their summary returns to the parent.
 
-2.  **Persistent memory.** A scratchpad for offloading intermediate results out of the message history so they survive context compaction.
+2.  Persistent memory. A `memory()` tool for offloading intermediate results out of the message history so they survive context compaction.
 
-3.  **Structured planning.** A todo tool for explicit task decomposition and progress tracking.
+3.  Structured planning. A `todo_write()` tool for explicit task decomposition and progress tracking.
 
-4.  **Opinionated system prompt.** Goal-oriented instructions that teach the model to act autonomously, delegate effectively, and verify its work.
+4.  Opinionated system prompt. Goal-oriented instructions that teach the model to act autonomously, delegate effectively, and verify its work.
 
 ### Example
 
-Here is a `ctf_agent()` that uses `deepagent()` with `bash()` and `text_editor()` tools:
+Here is a CTF task that uses `deepagent()` with `bash()` and `text_editor()` tools:
 
 ``` python
 from textwrap import dedent
@@ -34,34 +34,32 @@ def ctf_challenge():
     return Task(
         dataset=json_dataset("ctf_challenge.json"),
         solver=deepagent(
-            tools=[bash(), text_editor()],   # <1>
+            tools=[bash(), text_editor()]
         ),
         scorer=includes(),
         sandbox="docker",
     )
 ```
-1. Tools are the only required customization for most tasks. Everything else is handled by defaults.
 
-::: {.callout-note appearance="simple"}
-Behind the scenes, `deepagent()` provides three subagents (research, plan, general), a persistent memory tool, a todo_write planning tool, and a system prompt that teaches the model when to use each. The sections below describe these defaults and how to customize them.
-:::
+Tools are the only required customization for most tasks. Everything else is handled by defaults.
 
+Behind the scenes, `deepagent()` provides three subagents (`research()`, `plan()`, and `general()`), a `memory()` tool, a `todo_write()` planning tool, and a system prompt that teaches the model when to use each. The sections below describe these defaults and how to customize them.
 
-## What You Get
+## Agent Defaults
 
-When you call `deepagent()` with no configuration beyond tools, you get a fully assembled agent with the following capabilities.
+When you call `deepagent()` with no configuration beyond tools, you get a fully assembled agent with the following default capabilities.
 
 ### Subagent Delegation {#sec-subagent-delegation}
 
 The parent agent has a `task()` tool that lets it delegate work to specialized subagents. Three are included by default:
 
 | Subagent | Role | Tools | Memory |
-|----------|------|-------|--------|
-| `research` | Read-only information gathering and synthesis | `read_file`, `list_files`, `grep` | Read-only |
-| `plan` | Structured task decomposition and planning | `read_file`, `list_files`, `grep` | Read-only |
-| `general` | General-purpose autonomous task completion | Inherits parent's tools | Read-write |
+|----------------------|-----------------|-----------------|-----------------|
+| `research()` | Read-only information gathering and synthesis | `read_file()`, `list_files()`, `grep()` | Read-only |
+| `plan()` | Structured task decomposition and planning | `read_file()`, `list_files()`, `grep()` | Read-only |
+| `general()` | General-purpose autonomous task completion | Inherits parent's tools | Read-write |
 
-: {tbl-colwidths="[15,35,25,15]"}
+: {tbl-colwidths=\[20,30,30,20\]}
 
 The parent agent decides when to delegate vs. do work directly. The system prompt guides it to delegate when the work is complex, independent, or would benefit from an isolated context, and to do the work directly when it's a simple lookup or a single tool call.
 
@@ -73,15 +71,15 @@ The `memory()` tool provides a persistent scratchpad shared across the parent an
 
 Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress.
 
-The `research` and `plan` subagents have read-only memory access (they can view but not modify entries), while `general` has full read-write access.
+The `research()` and `plan()` subagents have read-only memory access (they can view but not modify entries), while `general()` has full read-write access.
 
 ### Planning
 
 The `todo_write()` tool provides structured task tracking. The model uses it to decompose complex tasks into steps and track progress:
 
-- `pending` -- step not yet started
-- `in_progress` -- step currently being worked on
-- `completed` -- step finished
+- `pending` — step not yet started
+- `in_progress` — step currently being worked on
+- `completed` — step finished
 
 The system prompt instructs the model to update the plan as it works, marking steps in progress as it starts them and completed as it finishes.
 
@@ -97,7 +95,6 @@ The default system prompt is goal-oriented rather than procedurally prescriptive
 - Use reasonable defaults rather than asking clarifying questions for every detail.
 
 The prompt also includes cross-tool coordination guidance (use memory for intermediate results, use the plan for decomposition) and subagent delegation guidance (when to delegate, how to pass context to subagents).
-
 
 ## Instructions
 
@@ -120,10 +117,9 @@ deepagent(
 
 Instructions are appended to the end of the system prompt, after the core behavior, delegation guidance, and memory/planning instructions.
 
-
 ## Tools {#sec-tools}
 
-Pass additional tools to `deepagent()` with the `tools` parameter. These tools are available to the top-level agent and automatically flow to the `general()` subagent:
+Pass task specific tools to `deepagent()` with the `tools` parameter. These tools are available to the top-level agent and automatically flow to the `general()` subagent:
 
 ``` python
 from inspect_ai.agent import deepagent
@@ -131,15 +127,15 @@ from inspect_ai.tool import bash, text_editor, web_search
 
 deepagent(
     tools=[bash(), text_editor()],
-    web_search=True,                    # <1>
+    web_search=True
 )
 ```
-1. Pass `True` for default web search configuration, or a pre-configured `web_search()` instance for custom setup. Web search is added to all agents (parent and subagents).
+
+Pass `True` for default web search configuration, or a pre-configured `web_search()` instance for custom setup. Web search is added to all agents (parent and subagents).
 
 ::: {.callout-note appearance="simple"}
 Tools passed to `deepagent()` do not automatically flow to the `research()` or `plan()` subagents. This preserves their read-only posture. To add tools to those subagents, use `extra_tools=` when [customizing built-in subagents](#sec-customizing-builtins).
 :::
-
 
 ## Skills
 
@@ -164,7 +160,6 @@ deepagent(
 
 Parent skills are available to the top-level agent. At dispatch time, parent skills and subagent-specific skills are merged so that a subagent sees both its own skills and the parent's. See the [Skills](tools-standard.qmd#sec-skill) documentation for details on creating and using skills.
 
-
 ## Compaction
 
 Long-running agents can exhaust their context window. Use the `compaction` parameter to automatically manage conversation context as it grows:
@@ -184,10 +179,9 @@ Compaction propagates to subagents that don't set their own strategy, so a singl
 
 See the [Compaction](compaction.qmd) documentation for details on available strategies (`CompactionSummary`, `CompactionEdit`, `CompactionTrim`, `CompactionAuto`, and `CompactionNative`).
 
+## Subagents {#sec-subagent-config}
 
-## Subagent Configuration {#sec-subagent-config}
-
-### Customizing Built-in Subagents {#sec-customizing-builtins}
+### Built-in Subagents {#sec-customizing-builtins}
 
 The built-in subagent factories (`research()`, `plan()`, and `general()`) all accept customization parameters. Pass a customized `subagents` list to `deepagent()`:
 
@@ -212,13 +206,14 @@ deepagent(
     ],
 )
 ```
-1. Use a cheaper model for information gathering to reduce costs.
-2. Apply a scoped token limit to each `general` subagent invocation.
 
-The customization parameters available on all three factories:
+1.  Use a cheaper model for information gathering to reduce costs.
+2.  Apply a scoped token limit to each `general` subagent invocation.
+
+These customization parameters available on all three builtin subagents:
 
 | Parameter | Description |
-|-----------|-------------|
+|---------------------------------|---------------------------------------|
 | `instructions` | Additional text appended to the default subagent prompt. |
 | `model` | Model override (default inherits parent's model). |
 | `limits` | Scoped limits per invocation (`token_limit`, `message_limit`, `time_limit`, `cost_limit`). |
@@ -229,7 +224,7 @@ The customization parameters available on all three factories:
 | `fork` | Dispatch mode. See [Fork Mode](#sec-fork-mode). |
 | `compaction` | Compaction strategy override. |
 
-: {tbl-colwidths="[20,80]"}
+: {tbl-colwidths=\[35,65\]}
 
 ### Custom Subagents {#sec-custom-subagents}
 
@@ -254,9 +249,10 @@ deepagent(
     subagents=[research(), plan(), general(), reviewer], # <3>
 )
 ```
-1. Name must be a valid Python identifier. It becomes the `subagent_type` value in the `task()` tool.
-2. Custom subagents declare their own tools explicitly.
-3. Add the custom subagent alongside the built-ins.
+
+1.  Name must be a valid Python identifier. It becomes the `subagent_type` value in the `task()` tool.
+2.  Custom subagents declare their own tools explicitly.
+3.  Add the custom subagent alongside the built-ins.
 
 The `subagent()` factory accepts the same customization parameters as the built-in factories (`model`, `limits`, `memory`, `skills`, `fork`, `compaction`) plus the required `name`, `description`, and `prompt`.
 
@@ -280,8 +276,9 @@ deepagent(
     model="anthropic/claude-sonnet-4",                  # <2>
 )
 ```
-1. The `general` subagent inherits the parent's full message history.
-2. Use the same model for parent and forked subagents.
+
+1.  The `general` subagent inherits the parent's full message history.
+2.  Use the same model for parent and forked subagents.
 
 Fork mode is useful when the subagent needs substantial background from the parent conversation without re-explanation, and when the parent's context is still fresh (well under context window limits). It preserves the prompt cache on all providers because the message prefix is unchanged.
 
@@ -289,8 +286,7 @@ Fork mode is useful when the subagent needs substantial background from the pare
 Use the same model or model family when forking to preserve the prompt cache and avoid errors from incompatible tool call formats or reasoning content in the inherited message history. Fork mode is not supported with `max_depth > 1`.
 :::
 
-
-## Prompt Customization {#sec-prompt}
+## System Prompt {#sec-prompt}
 
 When `instructions=` is not sufficient, use the `prompt=` parameter for full system prompt replacement. Named placeholders are expanded at assembly time:
 
@@ -321,13 +317,13 @@ Security-specific rules:
 Available placeholders:
 
 | Placeholder | Content |
-|-------------|---------|
+|------------------------------------------|------------------------------|
 | `{core_behavior}` | Core behavioral expectations (act, persist, verify, batch). |
 | `{subagent_dispatch}` | Subagent names, roles, and delegation guidance (generated from the subagent list). |
 | `{memory_instructions}` | Memory and planning coordination guidance. |
 | `{instructions}` | The user's `instructions=` text. |
 
-: {tbl-colwidths="[25,75]"}
+: {tbl-colwidths=\[35,65\]}
 
 Placeholders are optional. Omit any to exclude that content from the final prompt.
 
@@ -342,11 +338,11 @@ deepagent(
     todo_write=False,   # <2>
 )
 ```
-1. Disables the memory tool for the top-level agent and all subagents, regardless of their individual `memory` setting.
-2. Disables the todo_write planning tool.
 
+1.  Disables the memory tool for the top-level agent and all subagents, regardless of their individual `memory` setting.
+2.  Disables the todo_write planning tool.
 
-## Submit and Attempts
+## Submission
 
 By default, `deepagent()` includes a `submit()` tool that the model calls to report its final answer. You can configure multiple attempts so that if the score is incorrect the model is allowed to continue and try again:
 
@@ -359,18 +355,26 @@ deepagent(
 
 Pass `submit=False` to disable the submit tool entirely (the agent will terminate when it stops calling tools). For more advanced configuration, pass an `AgentSubmit` or `AgentAttempts` instance. See the [ReAct Agent](react-agent.qmd#attempts) documentation for details.
 
-## Refusals, Continuation, and Approval
+## Advanced
 
 `deepagent()` supports several additional options from `react()`:
+
+- `retry_refusals` --- Retry when the model refuses a request due to content filters (default: 3). Applies to the top-level agent and all subagents. See [Refusals](react-agent.qmd#refusals) for details.
+
+- `on_continue` --- Control continuation behavior when the model stops calling tools. Applies to the top-level agent only. See [Continuation](react-agent.qmd#continuation) for details.
+
+- `approval` --- Apply approval policies for tool calls. Applies to the top-level agent only. See [Approval](approval.qmd) for details.
+
+For example:
 
 ``` python
 deepagent(
     tools=[bash(), text_editor()],
-    retry_refusals=3,                                       # <1>
-    on_continue="Please continue working on the task.",     # <2>
-    approval=[ApprovalPolicy(human_approver(), "bash")],    # <3>
+    retry_refusals=3,
+    on_continue="Please continue working on the task.",
+    approval=[
+        ApprovalPolicy(human_approver(), "bash"),
+        ApprovalPolicy(auto_approver(), "*"),
+    ],
 )
 ```
-1. Retry when the model refuses a request due to content filters. Applies to the top-level agent and all subagents. See [Refusals](react-agent.qmd#refusals) for details.
-2. Control continuation behavior when the model stops calling tools. Applies to the top-level agent only. See [Continuation](react-agent.qmd#continuation) for details.
-3. Apply approval policies for tool calls. Applies to the top-level agent only. See [Approval](approval.qmd) for details.

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -53,6 +53,12 @@ Tools are the only required customization for most tasks. Everything else is han
 
 Behind the scenes, `deepagent()` provides three subagents (`research()`, `plan()`, and `general()`), a `memory()` tool, a `todo_write()` planning tool, and a system prompt that teaches the model when to use each. The sections below describe these defaults and how to customize them.
 
+### Use Cases
+
+The `deepagent()` is designed for long-horizon tasks that benefit from planning, decomposition, and persistent memory. These are tasks where the agent needs to work for extended periods, manage intermediate results across context compaction, and coordinate multiple phases of work.
+
+For shorter but still difficult benchmarks (e.g. Cybench, Terminal Bench 2.0), we do not observe  performance differences between the `react()`, `deepagent()`, and `claude_code()` agents. You should only reach for `deepagent()` when you are confident that the task will benefit from it, and you should always measure against a `react()` baseline to be sure.
+
 ## Agent Defaults
 
 When you call `deepagent()` with no configuration beyond tools, you get a fully assembled agent with the following default behavior.

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -77,7 +77,7 @@ Subagents run in isolated context by default. Each gets a fresh message history 
 
 The `memory()` tool provides a scratchpad shared across the parent and all subagents for the duration of the evaluation. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.
 
-Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress.
+Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress. When compaction is enabled, the model is instructed to checkpoint important state to memory before context is reduced, ensuring progress survives across compaction boundaries.
 
 The `research()` and `plan()` subagents have read-only memory access (they can view but not modify entries), while `general()` has full read-write access.
 

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -75,7 +75,7 @@ Subagents run in isolated context by default. Each gets a fresh message history 
 
 ### Memory
 
-The `memory()` tool provides a persistent scratchpad shared across the parent and all subagents. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.
+The `memory()` tool provides a scratchpad shared across the parent and all subagents for the duration of the evaluation. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.
 
 Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress.
 
@@ -154,7 +154,7 @@ from inspect_ai.agent import deepagent
 from inspect_ai.tool import Skill
 
 pdf_skill = Skill(
-    name="pdf_analysis",
+    name="pdf-analysis",
     description="Extract and analyze content from PDF documents.",
     instructions="Use pdfplumber to extract tables and text...",
     scripts={"extract_pdf.py": "..."},
@@ -347,7 +347,7 @@ deepagent(
 )
 ```
 
-1.  Disables the memory tool for the top-level agent and all subagents, regardless of their individual `memory` setting.
+1.  Disables the automatically added memory tool for the top-level agent and all subagents.
 2.  Disables the todo_write planning tool.
 
 ## Submission
@@ -371,7 +371,7 @@ Pass `submit=False` to disable the submit tool entirely (the agent will terminat
 
 - `on_continue` --- Control continuation behavior when the model stops calling tools. Applies to the top-level agent only. See [Continuation](react-agent.qmd#continuation) for details.
 
-- `approval` --- Apply approval policies for tool calls. Applies to the top-level agent only. See [Approval](approval.qmd) for details.
+- `approval` --- Apply approval policies for tool calls. Applies to the top-level agent and all subagents. See [Approval](approval.qmd) for details.
 
 For example:
 

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -63,23 +63,23 @@ The parent agent has a `task()` tool that lets it delegate work to specialized s
 
 | Subagent | Role | Tools | Memory |
 |----------------------|-----------------|-----------------|-----------------|
-| `research()` | Read-only information gathering and synthesis | `read_file()`, `list_files()`, `grep()`^[Sandbox file tools are included only when a sandbox is configured.] | Read-only |
-| `plan()` | Structured task decomposition and planning | `read_file()`, `list_files()`, `grep()`^[Sandbox file tools are included only when a sandbox is configured.] | Read-only |
-| `general()` | General-purpose autonomous task completion | Inherits parent's tools | Read-write |
+| `research()` | Read-only information gathering and synthesis | `read_file()`, `list_files()`, `grep()`^[Sandbox file tools are included only when a sandbox is configured.] | None |
+| `plan()` | Structured task decomposition and planning | `read_file()`, `list_files()`, `grep()`^[Sandbox file tools are included only when a sandbox is configured.] | None |
+| `general()` | General-purpose autonomous task completion | Inherits parent's tools | None |
 
 : {tbl-colwidths=\[20,30,30,20\]}
 
 The parent agent decides when to delegate vs. do work directly. The system prompt guides it to delegate when the work is complex, independent, or would benefit from an isolated context, and to do the work directly when it's a simple lookup or a single tool call.
 
-Subagents run in isolated context by default. Each gets a fresh message history with only the task prompt, and only its summary returns to the parent. This prevents context rot and keeps the parent's context lean. See [Subagents](#sec-customizing-builtins) below for how to customize or replace the defaults.
+Subagents run in isolated context by default. Each gets a fresh message history with only the task prompt, and only its summary returns to the parent. This prevents context rot and keeps the parent's context lean. All subagents inherit the parent's model by default — for cost-sensitive workloads, consider overriding `research()` with a cheaper model (e.g. `research(model="anthropic/claude-haiku-4-5")`), since read-only information gathering is the highest-volume subagent task. See [Subagents](#sec-customizing-builtins) below for how to customize or replace the defaults.
 
 ### Memory
 
-The `memory()` tool provides a scratchpad shared across the parent and all subagents for the duration of the evaluation. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.
+The `memory()` tool provides a scratchpad for the top-level agent for the duration of the evaluation. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.
 
 Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress. When compaction is enabled, the model is instructed to checkpoint important state to memory before context is reduced, ensuring progress survives across compaction boundaries.
 
-Memory is a single shared store: entries written by the parent are immediately visible to subagents, and entries written by `general()` are visible to the parent after the subagent returns. The `research()` and `plan()` subagents have read-only memory access (they can view but not modify entries), while `general()` has full read-write access.
+By default, only the top-level agent has memory — subagents do not. Subagents communicate their findings back through their return value, which is the designed channel for information flow. This avoids cross-contamination where subagent scratch notes could pollute the parent's memory. To enable subagent memory access, set `memory="readonly"` or `memory="readwrite"` on individual subagents when [customizing](#sec-customizing-builtins).
 
 ### Planning
 
@@ -219,7 +219,7 @@ These customization parameters available on all three builtin subagents:
 | `instructions` | Additional text appended to the default subagent prompt. |
 | `model` | Model override (default inherits parent's model). |
 | `limits` | Scoped limits per invocation (`token_limit`, `message_limit`, `time_limit`, `cost_limit`). |
-| `memory` | Memory access level: `"readwrite"`, `"readonly"`, or `False`. |
+| `memory` | Memory access level: `"readwrite"`, `"readonly"`, or `False` (default). |
 | `extra_tools` | Additional tools merged with the subagent's defaults. |
 | `tools` | Replace the default tool set entirely. |
 | `skills` | Subagent-specific skills (merged with parent skills). |

--- a/docs/deepagent.qmd
+++ b/docs/deepagent.qmd
@@ -3,9 +3,17 @@ title: Deep Agent
 llms-description: Using and customizing the built-in deep agent with subagent delegation, memory, and planning.
 ---
 
+::: callout-note
+The `deepagent()` described below is available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
 ## Overview
 
-The deep agent is a batteries-included entry point for long-horizon tasks. It builds on the [ReAct Agent](react-agent.qmd) with four additions: subagent delegation, persistent memory, structured planning, and an opinionated system prompt that teaches the model when to use each.
+The `deepagent()` is a batteries-included entry point for long-horizon tasks. It builds on the [ReAct Agent](react-agent.qmd) with four additions: subagent delegation, persistent memory, structured planning, and an opinionated system prompt that teaches the model when to use each.
 
 The `react()` agent handles short-horizon tasks well, but can degrade in performance under longer horizons, losing context and not reliably decomposing work. The `deepagent()` bundles the patterns that address this, drawing from Claude Code, Codex CLI, and other deep agent frameworks:
 
@@ -47,9 +55,9 @@ Behind the scenes, `deepagent()` provides three subagents (`research()`, `plan()
 
 ## Agent Defaults
 
-When you call `deepagent()` with no configuration beyond tools, you get a fully assembled agent with the following default capabilities.
+When you call `deepagent()` with no configuration beyond tools, you get a fully assembled agent with the following default behavior.
 
-### Subagent Delegation {#sec-subagent-delegation}
+### Subagents {#sec-subagent-delegation}
 
 The parent agent has a `task()` tool that lets it delegate work to specialized subagents. Three are included by default:
 
@@ -63,7 +71,7 @@ The parent agent has a `task()` tool that lets it delegate work to specialized s
 
 The parent agent decides when to delegate vs. do work directly. The system prompt guides it to delegate when the work is complex, independent, or would benefit from an isolated context, and to do the work directly when it's a simple lookup or a single tool call.
 
-Subagents run in isolated context by default. Each gets a fresh message history with only the task prompt, and only its summary returns to the parent. This prevents context rot and keeps the parent's context lean.
+Subagents run in isolated context by default. Each gets a fresh message history with only the task prompt, and only its summary returns to the parent. This prevents context rot and keeps the parent's context lean. See [Subagents](#sec-customizing-builtins) below for how to customize or replace the defaults.
 
 ### Memory
 
@@ -195,7 +203,7 @@ deepagent(
     subagents=[
         research(
             instructions="Focus on configuration files and logs.",
-            model="anthropic/claude-haiku-3-5",         # <1>
+            model="anthropic/claude-haiku-4-5",         # <1>
         ),
         plan(
             instructions="Create conservative, step-by-step plans.",
@@ -273,7 +281,7 @@ deepagent(
         plan(),
         general(fork=True),                             # <1>
     ],
-    model="anthropic/claude-sonnet-4",                  # <2>
+    model="anthropic/claude-sonnet-4-6",                # <2>
 )
 ```
 
@@ -355,7 +363,7 @@ deepagent(
 
 Pass `submit=False` to disable the submit tool entirely (the agent will terminate when it stops calling tools). For more advanced configuration, pass an `AgentSubmit` or `AgentAttempts` instance. See the [ReAct Agent](react-agent.qmd#attempts) documentation for details.
 
-## Advanced
+## More Options
 
 `deepagent()` supports several additional options from `react()`:
 

--- a/docs/multi-agent.qmd
+++ b/docs/multi-agent.qmd
@@ -3,6 +3,10 @@ title: Multi Agent
 llms-description: Composing agents together in multi-agent architectures.
 ---
 
+::: {.callout-tip appearance="simple"}
+If you need subagent delegation, persistent memory, and structured planning, consider the [Deep Agent](deepagent.qmd) first — it provides these out of the box without requiring custom multi-agent wiring.
+:::
+
 ## Overview
 
 There are several ways to implement multi-agent systems using the Inspect `Agent` protocol:

--- a/docs/reference/inspect_ai.agent.qmd
+++ b/docs/reference/inspect_ai.agent.qmd
@@ -10,6 +10,14 @@ description: Agent scaffolds and protocol.
 
 ## Deep Agent
 
+::: callout-note
+The `deepagent()` described below is available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
 ### deepagent
 ### subagent
 ### Subagent

--- a/docs/reference/inspect_ai.agent.qmd
+++ b/docs/reference/inspect_ai.agent.qmd
@@ -8,6 +8,15 @@ description: Agent scaffolds and protocol.
 ### react
 ### human_cli
 
+## Deep Agent
+
+### subagent
+### Subagent
+### research
+### plan
+### general
+
+
 ## Execution
 
 ### handoff

--- a/docs/reference/inspect_ai.agent.qmd
+++ b/docs/reference/inspect_ai.agent.qmd
@@ -10,6 +10,7 @@ description: Agent scaffolds and protocol.
 
 ## Deep Agent
 
+### deepagent
 ### subagent
 ### Subagent
 ### research

--- a/docs/reference/inspect_ai.tool.qmd
+++ b/docs/reference/inspect_ai.tool.qmd
@@ -18,7 +18,7 @@ description: Built-in and custom tool functions.
 
 ### skill
 ### memory
-### update_plan
+### todo_write
 ### think
 
 ## MCP

--- a/docs/reference/inspect_ai.tool.qmd
+++ b/docs/reference/inspect_ai.tool.qmd
@@ -13,6 +13,9 @@ description: Built-in and custom tool functions.
 ### computer
 ### code_execution
 ### web_browser
+### read_file
+### list_files
+### grep
 
 ## Agentic Tools
 

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -660,7 +660,7 @@ def intercode_ctf():
 
 ## Read-Only Tools {#sec-read-only-tools}
 
-Inspect provides three read-only sandbox tools — `read_file()`, `list_files()`, and `grep()` — for agents that need filesystem access without write capabilities. These are the default tools for `research()` and `plan()` subagents in the [deep agent](deep-agent.qmd) system, but are useful in any eval where you want to give a model read-only access.
+Inspect provides three read-only sandbox tools — `read_file()`, `list_files()`, and `grep()` — for agents that need filesystem access without write capabilities. These are the default tools for `research()` and `plan()` subagents in the deep agent system, but are useful in any eval where you want to give a model read-only access.
 
 All three tools require a [Sandbox Environment](sandboxing.qmd) and accept optional `timeout`, `user`, and `sandbox` parameters matching the `bash()` tool.
 
@@ -778,7 +778,7 @@ Keys should be valid `/memories` paths (e.g. "/memories/notes.md"). Values are r
 
 ### Read-Only Mode
 
-Use `memory(readonly=True)` to provide read-only access to the memory directory. In readonly mode, only the `view` command is available — write operations (`create`, `str_replace`, `insert`, `delete`, `rename`) are not exposed to the model. This is used by `research()` and `plan()` subagents in the [deep agent](deep-agent.qmd) system to share context without allowing mutation.
+Use `memory(readonly=True)` to provide read-only access to the memory directory. In readonly mode, only the `view` command is available — write operations (`create`, `str_replace`, `insert`, `delete`, `rename`) are not exposed to the model. This is used by `research()` and `plan()` subagents in the deep agent system to share context without allowing mutation.
 
 ``` python
 # read-only memory with pre-seeded data
@@ -790,7 +790,7 @@ memory(
 
 ### Tool Binding
 
-The schema for the `memory()` tool is based on the standard Anthropic [memory tool type](hhttps://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool). The `memory()` works with all models that support tool calling, but when using Claude, the memory tool will automatically bind to the native Claude tool definition.
+The schema for the `memory()` tool is based on the standard Anthropic [memory tool type](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool). The `memory()` works with all models that support tool calling, but when using Claude, the memory tool will automatically bind to the native Claude tool definition.
 
 ## Think {#sec-think}
 

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -776,9 +776,21 @@ memory(
 
 Keys should be valid `/memories` paths (e.g. "/memories/notes.md"). Values are resolved via `resource()`, supporting inline strings, file paths, or remote resources (s3://, https://). Seeding happens once on first tool execution. The model is prompted to read any pre-seeded memories before beginning work.
 
+### Read-Only Mode
+
+Use `memory(readonly=True)` to provide read-only access to the memory directory. In readonly mode, only the `view` command is available — write operations (`create`, `str_replace`, `insert`, `delete`, `rename`) are not exposed to the model. This is used by `research()` and `plan()` subagents in the [deep agent](deep-agent.qmd) system to share context without allowing mutation.
+
+``` python
+# read-only memory with pre-seeded data
+memory(
+    initial_data={"/memories/context.md": "shared context"},
+    readonly=True,
+)
+```
+
 ### Tool Binding
 
-The schema for the `memory()` tool is based on the standard Anthropic [memory tool type](hhttps://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool). The `memory()` works with all models that support tool calling, but when using Claude, the text editor tool will automatically bind to the native Claude tool definition.
+The schema for the `memory()` tool is based on the standard Anthropic [memory tool type](hhttps://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool). The `memory()` works with all models that support tool calling, but when using Claude, the memory tool will automatically bind to the native Claude tool definition.
 
 ## Think {#sec-think}
 

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -658,6 +658,81 @@ def intercode_ctf():
 ```
 
 
+## Read-Only Tools {#sec-read-only-tools}
+
+Inspect provides three read-only sandbox tools — `read_file()`, `list_files()`, and `grep()` — for agents that need filesystem access without write capabilities. These are the default tools for `research()` and `plan()` subagents in the [deep agent](deep-agent.qmd) system, but are useful in any eval where you want to give a model read-only access.
+
+All three tools require a [Sandbox Environment](sandboxing.qmd) and accept optional `timeout`, `user`, and `sandbox` parameters matching the `bash()` tool.
+
+### read_file
+
+Read the contents of a file, optionally selecting a range of lines:
+
+``` python
+from inspect_ai.tool import read_file
+
+# default configuration
+read_file()
+
+# with timeout and user
+read_file(timeout=30, user="nobody")
+```
+
+The model can specify `start_line` and `end_line` parameters to read a range. Output includes line numbers for reference.
+
+### list_files
+
+List files and directories, with optional depth control:
+
+``` python
+from inspect_ai.tool import list_files
+
+# default configuration (recursive)
+list_files()
+
+# with depth limit
+list_files(timeout=30)
+```
+
+The model can specify a `path` and `depth` parameter. `depth=1` lists only immediate contents; omitting it lists everything recursively.
+
+### grep
+
+Search for patterns in files:
+
+``` python
+from inspect_ai.tool import grep
+
+# default configuration
+grep()
+
+# with timeout
+grep(timeout=60)
+```
+
+The model can specify a `pattern`, `path`, optional `include` glob (e.g. `"*.py"`), and `fixed_strings` flag for literal matching. Results include file paths and line numbers.
+
+### Task Setup
+
+A task configured with read-only tools might look like this:
+
+``` python
+from inspect_ai import Task, task
+from inspect_ai.scorer import includes
+from inspect_ai.agent import react
+from inspect_ai.tool import read_file, list_files, grep
+
+@task
+def code_analysis():
+    return Task(
+        dataset=read_dataset(),
+        solver=react(tools=[read_file(), list_files(), grep()]),
+        scorer=includes(),
+        sandbox=("docker", "compose.yaml")
+    )
+```
+
+
 ## Memory {#sec-memory}
 
 The memory tool enables models to store and retrieve information into a virtual `/memories` file directory. Models can create, read, update, and delete files, enabling them to preserve knowledge over time without keeping everything in the context window.

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -606,7 +606,7 @@ The `skill()` tool takes a list of paths that contain standard skill specificati
 from inspect_ai import Task, task
 from inspect_ai.scorer import includes
 from inspect_ai.agent import react
-from inspect_ai.tool import bash, skill, update_plan
+from inspect_ai.tool import bash, skill, todo_write
 
 SKILLS_DIR = Path(__file__).parent / "skills"
 
@@ -631,33 +631,32 @@ def intercode_ctf():
 
 Note that use of the `skill()` tool requires a that a [sandbox](sandboxing.qmd) be defined for the task so there is a filesystem to publish the skills within.
 
-## Update Plan {#sec-update-plan}
+## Todo Write {#sec-todo-write}
 
-The `update_plan()` tool provides models with a way to track steps and progress in longer horizon tasks where it might otherwise lose track of where it is or forget earlier goals as context grows. It can also make agent behavior more interpretable, since you can inspect the plan to understand what the model thinks it's trying to accomplish.
+The `todo_write()` tool provides models with a way to track steps and progress in longer horizon tasks where it might otherwise lose track of where it is or forget earlier goals as context grows. It can also make agent behavior more interpretable, since you can inspect the plan to understand what the model thinks it's trying to accomplish.
 
 Note though that for simpler tasks, plan maintenance is just overhead, and some models may fixate on updating the plan rather than actually executing it.
 
 ### Task Setup
 
-A task configured to use the update_plan tool might look like this:
+A task configured to use the todo_write tool might look like this:
 
 ``` python
 from inspect_ai import Task, task
 from inspect_ai.scorer import includes
 from inspect_ai.agent import react
-from inspect_ai.tool import bash, update_plan
+from inspect_ai.tool import bash, todo_write
 
 @task
 def intercode_ctf():
     return Task(
         dataset=read_dataset(),
-        solver=react(tools=[bash(timeout=180), update_plan()]),
+        solver=react(tools=[bash(timeout=180), todo_write()]),
         scorer=includes(),
         sandbox=("docker", "compose.yaml")
     )
 ```
 
-The update_plan tool is based on the update_plan tool used by [Codex CLI](https://github.com/openai/codex). The default tool description is taken from the GPT 5.1 system prompt for Codex. Pass a custom `description` to override this.
 
 ## Memory {#sec-memory}
 

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -678,7 +678,7 @@ read_file()
 read_file(timeout=30, user="nobody")
 ```
 
-The model can specify `start_line` and `end_line` parameters to read a range. Output includes line numbers for reference.
+The model can specify `offset` (0-indexed line to start from) and `limit` (max lines to read) for pagination. Output includes line numbers for reference.
 
 ### list_files
 
@@ -710,7 +710,7 @@ grep()
 grep(timeout=60)
 ```
 
-The model can specify a `pattern`, `path`, optional `include` glob (e.g. `"*.py"`), and `fixed_strings` flag for literal matching. Results include file paths and line numbers.
+The model can specify a `pattern`, `path`, optional `glob` filter (e.g. `"*.py"`), `fixed_strings` flag for literal matching, and `output_mode` (`"content"`, `"files_with_matches"`, or `"count"`). Results include file paths and line numbers by default.
 
 ### Task Setup
 

--- a/src/inspect_ai/_view/dist/assets/index.css
+++ b/src/inspect_ai/_view/dist/assets/index.css
@@ -17077,35 +17077,52 @@ button._segment_19z32_10 {
   font-size: var(--inspect-font-size-smallest);
   padding: 0.1em 0.5em;
 }
-._outer_usp41_1 {
+._outer_1j47y_1 {
   /* Positioned so the block-left sticky toggle's containing block is this
      wrapper — keeps sticky behavior scoped to the panel instead of leaking
      to some arbitrary positioned ancestor up the tree. */
   position: relative;
 }
 
-._expandablePanel_usp41_8 {
+._expandablePanel_1j47y_8 {
   position: relative;
 }
 
-._expandableBordered_usp41_12 {
+._expandableBordered_1j47y_12 {
   border: solid var(--bs-light-border-subtle) 1px;
   padding: 0.5em;
 }
 
-._expandableTogglable_usp41_17 {
+._expandableTogglable_1j47y_17 {
   margin-bottom: 1em;
 }
 
-._expandableContents_usp41_21 {
+._expandableContents_1j47y_21 {
   font-size: var(--inspect-font-size-base);
 }
 
-._expandableCollapsed_usp41_25 {
-  overflow: hidden;
+/* Fade-out at the bottom of truncated content to signal "more below".
+   Applied only when collapsed AND the content overflows.
+
+   The wrapper carries `overflow: hidden` + `max-height` (set inline), so its
+   box matches the visible region — the mask gradient's "bottom" lands on the
+   last visible line rather than on the bottom of the natural-height content
+   (which would sit off-screen).
+
+   We mask the content itself (rather than overlaying a background-color
+   gradient) so the affordance works on any surface, regardless of the
+   panel's bg. The inline-right toggle is a sibling of this wrapper, so it
+   stays fully opaque. */
+._expandableTruncated_1j47y_37 {
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    black calc(100% - 3rem),
+    transparent
+  );
+  mask-image: linear-gradient(to bottom, black calc(100% - 3rem), transparent);
 }
 
-._moreToggle_usp41_29 {
+._moreToggle_1j47y_46 {
   display: flex;
   margin-top: 0;
   height: 20px;
@@ -17115,11 +17132,11 @@ button._segment_19z32_10 {
   color: var(--bs-link-color);
 }
 
-._moreToggle_usp41_29._bordered_usp41_39 {
+._moreToggle_1j47y_46._bordered_1j47y_56 {
   border-top: solid var(--bs-light-border-subtle) 1px;
 }
 
-._moreToggleButton_usp41_43 {
+._moreToggleButton_1j47y_60 {
   font-size: var(--inspect-font-size-smaller);
   border: none;
   padding: 0rem 0.5rem;
@@ -17127,7 +17144,7 @@ button._segment_19z32_10 {
   color: var(--bs-body-color);
 }
 
-._separator_usp41_51 {
+._separator_1j47y_68 {
   height: 1px;
   background-color: var(--bs-light-border-subtle);
   margin-top: -1px;
@@ -17136,7 +17153,7 @@ button._segment_19z32_10 {
 /* Fills the panel so its sticky child is bounded by the panel's rect.
    pointer-events: none lets clicks pass through to the content behind;
    the sticky child re-enables pointer events on itself. */
-._inlineToggleHolder_usp41_60 {
+._inlineToggleHolder_1j47y_77 {
   position: absolute;
   inset: 0;
   display: flex;
@@ -17148,13 +17165,13 @@ button._segment_19z32_10 {
   z-index: 2;
 }
 
-._inlineToggleSticky_usp41_72 {
+._inlineToggleSticky_1j47y_89 {
   position: sticky;
   bottom: 0.25em;
   pointer-events: auto;
 }
 
-._moreToggle_usp41_29._blockLeft_usp41_78 {
+._moreToggle_1j47y_46._blockLeft_1j47y_95 {
   width: fit-content;
   margin-top: 0.2em;
   margin-bottom: 0.5em;

--- a/src/inspect_ai/_view/dist/assets/index.css
+++ b/src/inspect_ai/_view/dist/assets/index.css
@@ -17077,42 +17077,49 @@ button._segment_19z32_10 {
   font-size: var(--inspect-font-size-smallest);
   padding: 0.1em 0.5em;
 }
-._expandablePanel_1ka1g_1 {
+._outer_usp41_1 {
+  /* Positioned so the block-left sticky toggle's containing block is this
+     wrapper — keeps sticky behavior scoped to the panel instead of leaking
+     to some arbitrary positioned ancestor up the tree. */
   position: relative;
 }
 
-._expandableBordered_1ka1g_5 {
+._expandablePanel_usp41_8 {
+  position: relative;
+}
+
+._expandableBordered_usp41_12 {
   border: solid var(--bs-light-border-subtle) 1px;
   padding: 0.5em;
 }
 
-._expandableTogglable_1ka1g_10 {
+._expandableTogglable_usp41_17 {
   margin-bottom: 1em;
 }
 
-._expandableContents_1ka1g_14 {
+._expandableContents_usp41_21 {
   font-size: var(--inspect-font-size-base);
 }
 
-._expandableCollapsed_1ka1g_18 {
+._expandableCollapsed_usp41_25 {
   overflow: hidden;
 }
 
-._moreToggle_1ka1g_22 {
+._moreToggle_usp41_29 {
   display: flex;
   margin-top: 0;
   height: 20px;
-  background-color: var(--bs-body-bg);
+  background-color: var(--bs-tertiary-bg);
   border-radius: 5px;
   border: solid var(--bs-light-border-subtle) 1px;
   color: var(--bs-link-color);
 }
 
-._moreToggle_1ka1g_22._bordered_1ka1g_32 {
+._moreToggle_usp41_29._bordered_usp41_39 {
   border-top: solid var(--bs-light-border-subtle) 1px;
 }
 
-._moreToggleButton_1ka1g_36 {
+._moreToggleButton_usp41_43 {
   font-size: var(--inspect-font-size-smaller);
   border: none;
   padding: 0rem 0.5rem;
@@ -17120,22 +17127,40 @@ button._segment_19z32_10 {
   color: var(--bs-body-color);
 }
 
-._separator_1ka1g_44 {
+._separator_usp41_51 {
   height: 1px;
   background-color: var(--bs-light-border-subtle);
   margin-top: -1px;
 }
 
-._moreToggle_1ka1g_22._inlineRight_1ka1g_50 {
+/* Fills the panel so its sticky child is bounded by the panel's rect.
+   pointer-events: none lets clicks pass through to the content behind;
+   the sticky child re-enables pointer events on itself. */
+._inlineToggleHolder_usp41_60 {
   position: absolute;
-  bottom: 0.25em;
-  right: 0.25em;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: flex-end;
+  padding: 0.25em;
+  pointer-events: none;
+  z-index: 2;
 }
 
-._moreToggle_1ka1g_22._blockLeft_1ka1g_56 {
+._inlineToggleSticky_usp41_72 {
+  position: sticky;
+  bottom: 0.25em;
+  pointer-events: auto;
+}
+
+._moreToggle_usp41_29._blockLeft_usp41_78 {
   width: fit-content;
   margin-top: 0.2em;
   margin-bottom: 0.5em;
+  position: sticky;
+  bottom: 0.25em;
+  z-index: 2;
 }
 ._carouselThumbs_1mvg8_1 {
   display: grid;
@@ -18502,18 +18527,21 @@ a._citationLink_1ggvf_9:hover {
     break-inside: avoid;
   }
 }
-._title_19l1b_1 {
-  margin-left: 0.5em;
+._title_xefxk_1 {
   display: grid;
   grid-template-columns: max-content max-content minmax(0, 1fr);
-  column-gap: 0.5em;
+  column-gap: 0.3em;
 }
 
-._contents_19l1b_8 {
+._contents_xefxk_7 {
   padding: 0.4em;
   margin-bottom: 0;
   border: solid 1px var(--bs-light-border-subtle);
   border-radius: var(--bs-border-radius);
+}
+
+._below_xefxk_14 {
+  margin-top: 0.4em;
 }
 ._container_1ww70_1 {
   margin: 1em 0 0 0;
@@ -19628,6 +19656,18 @@ a._citationLink_1ggvf_9:hover {
 ._sidebarHeaderClose_130zy_166:hover {
   opacity: 0.7;
 }
+._headline_1l22a_1 {
+  display: block;
+  min-width: 0;
+}
+
+._inlineExplanation_1l22a_6 {
+  margin-left: 0.3em;
+}
+
+._rejected_1l22a_10 {
+  color: var(--bs-danger);
+}
 ._panel_8zdtn_1 {
   margin: 0.5em 0;
 }
@@ -19942,46 +19982,56 @@ a._citationLink_1ggvf_9:hover {
 ._subtaskLabel_ac4z2_17 {
   padding: 0 2em;
 }
-._summary_1qsnv_1 {
+._summary_1gtzx_1 {
   margin: 0.5em 0;
   width: 100%;
 }
 
-._approval_1qsnv_6 {
+._approvalWrap_1gtzx_6 {
+  margin-top: 0.5rem;
+}
+
+._approval_1gtzx_6 {
   border: none;
   padding: 0;
   margin-bottom: 0;
 }
 
-._progress_1qsnv_12 {
+._progress_1gtzx_16 {
   margin-left: 0.5em;
 }
-._node_1nuy2_1 {
+._node_miohh_1 {
   padding-top: 0.8rem;
 }
 
-._attached_1nuy2_5 {
+._attached_miohh_5 {
   padding-top: 0rem;
 }
 
-._attachedParent_1nuy2_9 {
+._attachedParent_miohh_9 {
   padding-bottom: 0px;
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
   border-bottom: none;
 }
 
-._attachedChild_1nuy2_16 {
+._attachedChild_miohh_16 {
   border-top-left-radius: 0;
   border-top-right-radius: 0;
 }
 
-._last_1nuy2_21 {
+._depthRoot_miohh_21 {
+  border-left: none;
+  border-right: none;
+  border-radius: 0;
+}
+
+._last_miohh_27 {
   padding-bottom: 0.8rem;
 }
 
 @media print {
-  ._node_1nuy2_1 {
+  ._node_miohh_1 {
     break-inside: avoid;
   }
 }

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -8192,6 +8192,11 @@
             ],
             "title": "Span Type"
           },
+          "tool_invoked": {
+            "default": false,
+            "title": "Tool Invoked",
+            "type": "boolean"
+          },
           "type": {
             "const": "span",
             "default": "span",
@@ -8210,7 +8215,8 @@
           "name",
           "content",
           "branches",
-          "utility"
+          "utility",
+          "tool_invoked"
         ],
         "title": "TimelineSpan",
         "type": "object"

--- a/src/inspect_ai/agent/__init__.py
+++ b/src/inspect_ai/agent/__init__.py
@@ -7,6 +7,7 @@ from ._bridge.bridge import agent_bridge, bridge
 from ._bridge.sandbox.bridge import sandbox_agent_bridge
 from ._bridge.sandbox.types import SandboxAgentBridge
 from ._bridge.types import AgentBridge
+from ._deepagent import Subagent, subagent
 from ._filter import MessageFilter, content_only, last_message, remove_tools
 from ._handoff import handoff
 from ._human.agent import human_cli
@@ -45,4 +46,6 @@ __all__ = [
     "AgentAttempts",
     "AgentContinue",
     "AgentSubmit",
+    "Subagent",
+    "subagent",
 ]

--- a/src/inspect_ai/agent/__init__.py
+++ b/src/inspect_ai/agent/__init__.py
@@ -7,7 +7,7 @@ from ._bridge.bridge import agent_bridge, bridge
 from ._bridge.sandbox.bridge import sandbox_agent_bridge
 from ._bridge.sandbox.types import SandboxAgentBridge
 from ._bridge.types import AgentBridge
-from ._deepagent import Subagent, subagent
+from ._deepagent import Subagent, general, plan, research, subagent
 from ._filter import MessageFilter, content_only, last_message, remove_tools
 from ._handoff import handoff
 from ._human.agent import human_cli
@@ -48,4 +48,7 @@ __all__ = [
     "AgentSubmit",
     "Subagent",
     "subagent",
+    "research",
+    "plan",
+    "general",
 ]

--- a/src/inspect_ai/agent/__init__.py
+++ b/src/inspect_ai/agent/__init__.py
@@ -7,7 +7,7 @@ from ._bridge.bridge import agent_bridge, bridge
 from ._bridge.sandbox.bridge import sandbox_agent_bridge
 from ._bridge.sandbox.types import SandboxAgentBridge
 from ._bridge.types import AgentBridge
-from ._deepagent import Subagent, general, plan, research, subagent
+from ._deepagent import Subagent, deepagent, general, plan, research, subagent
 from ._filter import MessageFilter, content_only, last_message, remove_tools
 from ._handoff import handoff
 from ._human.agent import human_cli
@@ -47,6 +47,7 @@ __all__ = [
     "AgentContinue",
     "AgentSubmit",
     "Subagent",
+    "deepagent",
     "subagent",
     "research",
     "plan",

--- a/src/inspect_ai/agent/_deepagent/__init__.py
+++ b/src/inspect_ai/agent/_deepagent/__init__.py
@@ -1,3 +1,4 @@
+from .deepagent import deepagent
 from .general import general
 from .plan import plan
 from .research import research
@@ -5,6 +6,7 @@ from .subagent import Subagent, subagent
 from .task_tool import task_tool
 
 __all__ = [
+    "deepagent",
     "Subagent",
     "subagent",
     "general",

--- a/src/inspect_ai/agent/_deepagent/__init__.py
+++ b/src/inspect_ai/agent/_deepagent/__init__.py
@@ -1,8 +1,14 @@
+from .general import general
+from .plan import plan
+from .research import research
 from .subagent import Subagent, subagent
 from .task_tool import task_tool
 
 __all__ = [
     "Subagent",
     "subagent",
+    "general",
+    "plan",
+    "research",
     "task_tool",
 ]

--- a/src/inspect_ai/agent/_deepagent/__init__.py
+++ b/src/inspect_ai/agent/_deepagent/__init__.py
@@ -1,0 +1,6 @@
+from .subagent import Subagent, subagent
+
+__all__ = [
+    "Subagent",
+    "subagent",
+]

--- a/src/inspect_ai/agent/_deepagent/__init__.py
+++ b/src/inspect_ai/agent/_deepagent/__init__.py
@@ -1,6 +1,8 @@
 from .subagent import Subagent, subagent
+from .task_tool import task_tool
 
 __all__ = [
     "Subagent",
     "subagent",
+    "task_tool",
 ]

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -160,7 +160,6 @@ def deepagent(
             instructions=system_prompt,
             handoff_prompt=None,
             assistant_prompt=None,
-            submit_prompt=None,
         )
 
         inner = react(

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -5,7 +5,13 @@ from typing import Sequence
 
 from inspect_ai.agent._agent import Agent, AgentState, agent
 from inspect_ai.agent._react import react
-from inspect_ai.agent._types import AgentAttempts, AgentPrompt, AgentSubmit
+from inspect_ai.agent._types import (
+    AgentAttempts,
+    AgentContinue,
+    AgentPrompt,
+    AgentSubmit,
+)
+from inspect_ai.approval._policy import ApprovalPolicy
 from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._compaction import CompactionStrategy
 from inspect_ai.model._model import Model
@@ -26,14 +32,17 @@ def deepagent(
     *,
     tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     subagents: list[Subagent] | None = None,
-    todo_write: bool = True,
     memory: bool = True,
+    todo_write: bool = True,
     web_search: bool | Tool = False,
     skills: list[Skill] | None = None,
-    compaction: CompactionStrategy | None = None,
-    submit: AgentSubmit | bool | None = None,
-    attempts: int | AgentAttempts = 1,
     model: str | Model | None = None,
+    attempts: int | AgentAttempts = 1,
+    submit: AgentSubmit | bool | None = None,
+    on_continue: str | AgentContinue | None = None,
+    retry_refusals: int | None = None,
+    compaction: CompactionStrategy | None = None,
+    approval: list[ApprovalPolicy] | None = None,
     instructions: str | None = None,
     prompt: str | None = None,
     max_depth: int = 1,
@@ -51,17 +60,23 @@ def deepagent(
             agent and to general() subagents.
         subagents: Subagent configurations. Defaults to
             [research(), plan(), general()].
-        todo_write: Include the todo_write planning tool.
         memory: Include the memory tool. False disables memory for the
             top-level agent and all subagents.
+        todo_write: Include the todo_write planning tool.
         web_search: Include web_search tool for all agents. Pass True
             for default config, or a pre-configured web_search() tool
             instance for custom setup.
         skills: Skills available to the agent.
-        compaction: Compaction strategy for context management.
-        submit: Submit tool configuration.
-        attempts: Number of submission attempts.
         model: Model to use.
+        attempts: Number of submission attempts.
+        submit: Submit tool configuration.
+        on_continue: Continuation behavior when the model stops calling
+            tools. Applies to the top-level agent only.
+        retry_refusals: Number of times to retry on content filter
+            refusals. Propagated to subagents.
+        compaction: Compaction strategy for context management.
+        approval: Approval policies for tool calls. Applies to the
+            top-level agent only.
         instructions: Additional instructions appended to the system
             prompt.
         prompt: Full replacement system prompt. Supports placeholders:
@@ -128,6 +143,7 @@ def deepagent(
             depth=0,
             max_depth=max_depth,
             get_messages=get_messages,
+            retry_refusals=retry_refusals,
         )
 
         # Top-level tools = parent tools + task + memory + skills
@@ -176,6 +192,9 @@ def deepagent(
             submit=submit,
             attempts=attempts,
             compaction=compaction,
+            on_continue=on_continue,
+            retry_refusals=retry_refusals,
+            approval=approval,
         )
 
         return await inner(state)

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -156,10 +156,13 @@ def deepagent(
                 instructions=instructions,
             )
 
+        from inspect_ai.agent._types import DEFAULT_SUBMIT_PROMPT
+
         agent_prompt = AgentPrompt(
             instructions=system_prompt,
             handoff_prompt=None,
-            assistant_prompt=None,
+            assistant_prompt=DEFAULT_SUBMIT_PROMPT if submit is not False else None,
+            submit_prompt=None,
         )
 
         inner = react(

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -1,6 +1,7 @@
 """Top-level deep agent assembly."""
 
 from dataclasses import replace
+from pathlib import Path
 from typing import Sequence
 
 from inspect_ai.agent._agent import Agent, AgentState, agent
@@ -35,7 +36,7 @@ def deepagent(
     memory: bool = True,
     todo_write: bool = True,
     web_search: bool | Tool = False,
-    skills: list[Skill] | None = None,
+    skills: list[str | Path | Skill] | None = None,
     model: str | Model | None = None,
     attempts: int | AgentAttempts = 1,
     submit: AgentSubmit | bool | None = None,
@@ -296,7 +297,7 @@ def _validate_fork_depth(subagents: list[Subagent], max_depth: int) -> None:
 
 
 def _validate_skill_names(
-    parent_skills: list[Skill] | None,
+    parent_skills: list[str | Path | Skill] | None,
     subagents: list[Subagent],
 ) -> None:
     """Validate skill names are unique across parent and all subagents.
@@ -305,14 +306,18 @@ def _validate_skill_names(
     name appears more than once. This prevents sandbox install directory
     collisions and ambiguous skill lookups.
     """
+    from inspect_ai.tool._tools._skill import read_skills
+
+    resolved_parent = read_skills(parent_skills) if parent_skills else []
     all_names: dict[str, str] = {}
-    for sk in parent_skills or []:
+    for sk in resolved_parent:
         if sk.name in all_names:
             raise ValueError(f"Duplicate skill name '{sk.name}' in parent skills.")
         all_names[sk.name] = "parent"
 
     for sa in subagents:
-        for sk in sa.skills or []:
+        resolved_sa = read_skills(sa.skills) if sa.skills else []
+        for sk in resolved_sa:
             if sk.name in all_names:
                 source = all_names[sk.name]
                 raise ValueError(

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -21,7 +21,7 @@ from .subagent import Subagent
 from .task_tool import task_tool
 
 
-@agent
+@agent(description="Autonomous agent for complex, multi-step tasks.")
 def deepagent(
     *,
     tools: Sequence[Tool | ToolDef | ToolSource] | None = None,

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -1,5 +1,6 @@
 """Top-level deep agent assembly."""
 
+from dataclasses import replace
 from typing import Sequence
 
 from inspect_ai.agent._agent import Agent, AgentState, agent
@@ -69,83 +70,82 @@ def deepagent(
             prompt entirely.
         max_depth: Maximum subagent recursion depth.
     """
-    resolved_subagents = (
-        subagents if subagents is not None else [research(), plan(), general()]
-    )
-
-    _apply_web_search(resolved_subagents, web_search, tools)
-    _apply_memory_kill_switch(resolved_subagents, memory)
-    _apply_compaction(resolved_subagents, compaction)
-    _apply_parent_tools_to_general(resolved_subagents, tools)
-
-    # Mutable reference for forked dispatch — points to state.messages
-    # once the agent starts executing
-    _state_ref: list[AgentState | None] = [None]
-
-    def get_messages() -> list[ChatMessage]:
-        return list(_state_ref[0].messages) if _state_ref[0] else []
-
-    # Build task tool
-    parent_tools = list(tools or [])
-    task = task_tool(
-        subagents=resolved_subagents,
-        parent_tools=parent_tools,
-        depth=0,
-        max_depth=max_depth,
-        get_messages=get_messages,
-    )
-
-    # Collect top-level tools
-    all_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
-    all_tools.append(task)
-    if memory:
-        from inspect_ai.tool._tools._memory import memory as memory_tool
-
-        all_tools.append(memory_tool())
-    if todo_write:
-        from inspect_ai.tool._tools._todo_write import todo_write as todo_write_tool
-
-        all_tools.append(todo_write_tool())
-    if skills:
-        from inspect_ai.tool._tools._skill import skill as skill_tool
-
-        all_tools.append(skill_tool(skills))
-
-    # Build system prompt
-    if prompt is not None:
-        system_prompt = expand_prompt_placeholders(
-            prompt,
-            subagents=resolved_subagents,
-            memory=memory,
-            todo_write=todo_write,
-            instructions=instructions,
-        )
-    else:
-        system_prompt = build_system_prompt(
-            subagents=resolved_subagents,
-            memory=memory,
-            todo_write=todo_write,
-            instructions=instructions,
-        )
-
-    agent_prompt = AgentPrompt(
-        instructions=system_prompt,
-        handoff_prompt=None,
-        assistant_prompt=None,
-        submit_prompt=None,
-    )
-
-    inner = react(
-        tools=all_tools,
-        prompt=agent_prompt,
-        model=model,
-        submit=submit,
-        attempts=attempts,
-        compaction=compaction,
-    )
 
     async def execute(state: AgentState) -> AgentState:
-        _state_ref[0] = state
+        # All setup runs per-sample inside execute() so there is no
+        # shared mutable state across concurrent samples.
+        resolved_subagents = (
+            [_clone_subagent(sa) for sa in subagents]
+            if subagents is not None
+            else [research(), plan(), general()]
+        )
+
+        _apply_web_search(resolved_subagents, web_search, tools)
+        _apply_memory_kill_switch(resolved_subagents, memory)
+        _apply_compaction(resolved_subagents, compaction)
+        _apply_parent_tools_to_general(resolved_subagents, tools)
+
+        def get_messages() -> list[ChatMessage]:
+            return list(state.messages)
+
+        parent_tools = list(tools or [])
+        task = task_tool(
+            subagents=resolved_subagents,
+            parent_tools=parent_tools,
+            depth=0,
+            max_depth=max_depth,
+            get_messages=get_messages,
+        )
+
+        all_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
+        all_tools.append(task)
+        if memory:
+            from inspect_ai.tool._tools._memory import memory as memory_tool
+
+            all_tools.append(memory_tool())
+        if todo_write:
+            from inspect_ai.tool._tools._todo_write import (
+                todo_write as todo_write_tool,
+            )
+
+            all_tools.append(todo_write_tool())
+        if skills:
+            from inspect_ai.tool._tools._skill import skill as skill_tool
+
+            all_tools.append(skill_tool(skills))
+
+        if prompt is not None:
+            system_prompt = expand_prompt_placeholders(
+                prompt,
+                subagents=resolved_subagents,
+                memory=memory,
+                todo_write=todo_write,
+                instructions=instructions,
+            )
+        else:
+            system_prompt = build_system_prompt(
+                subagents=resolved_subagents,
+                memory=memory,
+                todo_write=todo_write,
+                instructions=instructions,
+            )
+
+        agent_prompt = AgentPrompt(
+            instructions=system_prompt,
+            handoff_prompt=None,
+            assistant_prompt=None,
+            submit_prompt=None,
+        )
+
+        inner = react(
+            tools=all_tools,
+            prompt=agent_prompt,
+            model=model,
+            submit=submit,
+            attempts=attempts,
+            compaction=compaction,
+        )
+
         return await inner(state)
 
     return execute
@@ -197,3 +197,18 @@ def _apply_parent_tools_to_general(
     for sa in subagents:
         if sa.name == "general" and sa.tools is None:
             sa.tools = list(tools or [])
+
+
+def _clone_subagent(sa: Subagent) -> Subagent:
+    """Shallow clone a Subagent with fresh list copies.
+
+    Preserves Tool/Model/Limit object identity but avoids mutating the
+    caller's Subagent objects or their list fields.
+    """
+    return replace(
+        sa,
+        tools=list(sa.tools) if sa.tools is not None else None,
+        extra_tools=list(sa.extra_tools) if sa.extra_tools is not None else None,
+        skills=list(sa.skills) if sa.skills is not None else None,
+        limits=list(sa.limits) if sa.limits is not None else None,
+    )

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -134,9 +134,11 @@ def deepagent(
         all_tools: list[Tool | ToolDef | ToolSource] = list(parent_tools)
         all_tools.append(task)
         if memory:
+            from inspect_ai.agent._deepagent.task_tool import _has_memory_tool
             from inspect_ai.tool._tools._memory import memory as memory_tool
 
-            all_tools.append(memory_tool())
+            if not _has_memory_tool(all_tools):
+                all_tools.append(memory_tool())
         if skills:
             from inspect_ai.tool._tools._skill import skill as skill_fn
 

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -75,8 +75,8 @@ def deepagent(
         retry_refusals: Number of times to retry on content filter
             refusals (default: 3). Propagated to subagents.
         compaction: Compaction strategy for context management.
-        approval: Approval policies for tool calls. Applies to the
-            top-level agent only.
+        approval: Approval policies for tool calls. Propagated to
+            subagents.
         instructions: Additional instructions appended to the system
             prompt.
         prompt: Full replacement system prompt. Supports placeholders:
@@ -146,6 +146,7 @@ def deepagent(
             max_depth=max_depth,
             get_messages=get_messages,
             retry_refusals=retry_refusals,
+            approval=approval,
         )
 
         # Top-level tools = parent tools + task + memory + skills

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -80,6 +80,8 @@ def deepagent(
             else [research(), plan(), general()]
         )
 
+        _validate_subagent_names(resolved_subagents)
+        _validate_fork_depth(resolved_subagents, max_depth)
         _validate_skill_names(skills, resolved_subagents)
         _apply_memory_kill_switch(resolved_subagents, memory)
         _apply_compaction(resolved_subagents, compaction)
@@ -236,6 +238,37 @@ def _apply_parent_tools_to_general(
     for sa in subagents:
         if sa.name == "general" and sa.tools is None:
             sa.tools = list(tools or [])
+
+
+def _validate_subagent_names(subagents: list[Subagent]) -> None:
+    """Validate subagent names are non-empty, unique, and list is non-empty."""
+    if not subagents:
+        raise ValueError("At least one subagent must be configured.")
+    seen: set[str] = set()
+    for sa in subagents:
+        if sa.name in seen:
+            raise ValueError(
+                f"Duplicate subagent name '{sa.name}'. "
+                f"Each subagent must have a unique name."
+            )
+        seen.add(sa.name)
+
+
+def _validate_fork_depth(subagents: list[Subagent], max_depth: int) -> None:
+    """Reject fork=True with max_depth > 1.
+
+    Forked dispatch inherits the top-level agent's conversation, not
+    the calling subagent's. With max_depth > 1, a nested fork would
+    get the wrong conversation context. Raise early rather than
+    silently producing incorrect behavior.
+    """
+    if max_depth > 1 and any(sa.fork for sa in subagents):
+        raise ValueError(
+            "fork=True is not supported with max_depth > 1. Forked "
+            "subagents inherit the top-level conversation context, "
+            "which is incorrect for nested delegation. Use fork=False "
+            "for subagents when max_depth > 1."
+        )
 
 
 def _validate_skill_names(

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -95,6 +95,8 @@ def deepagent(
             else [research(), plan(), general()]
         )
 
+        if max_depth < 1:
+            raise ValueError("max_depth must be >= 1.")
         _validate_subagent_names(resolved_subagents)
         _validate_fork_depth(resolved_subagents, max_depth)
         _validate_skill_names(skills, resolved_subagents)

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -40,7 +40,7 @@ def deepagent(
     attempts: int | AgentAttempts = 1,
     submit: AgentSubmit | bool | None = None,
     on_continue: str | AgentContinue | None = None,
-    retry_refusals: int | None = None,
+    retry_refusals: int | None = 3,
     compaction: CompactionStrategy | None = None,
     approval: list[ApprovalPolicy] | None = None,
     instructions: str | None = None,
@@ -73,7 +73,7 @@ def deepagent(
         on_continue: Continuation behavior when the model stops calling
             tools. Applies to the top-level agent only.
         retry_refusals: Number of times to retry on content filter
-            refusals. Propagated to subagents.
+            refusals (default: 3). Propagated to subagents.
         compaction: Compaction strategy for context management.
         approval: Approval policies for tool calls. Applies to the
             top-level agent only.

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -100,11 +100,18 @@ def deepagent(
                 resolved_subagents, ws_tool_instance, skip=inherits_parent
             )
 
-        # Parent tools = user tools + web_search. Flow to general().
+        # Parent tools = user tools + web_search + todo_write.
+        # These flow to general() via _apply_parent_tools_to_general.
         # Skills flow separately via _resolve_tools merge.
         parent_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
         if ws_tool_instance:
             parent_tools.append(ws_tool_instance)
+        if todo_write:
+            from inspect_ai.tool._tools._todo_write import (
+                todo_write as todo_write_tool,
+            )
+
+            parent_tools.append(todo_write_tool())
 
         _apply_parent_tools_to_general(resolved_subagents, parent_tools)
 
@@ -121,19 +128,13 @@ def deepagent(
             get_messages=get_messages,
         )
 
-        # Top-level tools = parent tools + task + memory + todo_write + skills
+        # Top-level tools = parent tools + task + memory + skills
         all_tools: list[Tool | ToolDef | ToolSource] = list(parent_tools)
         all_tools.append(task)
         if memory:
             from inspect_ai.tool._tools._memory import memory as memory_tool
 
             all_tools.append(memory_tool())
-        if todo_write:
-            from inspect_ai.tool._tools._todo_write import (
-                todo_write as todo_write_tool,
-            )
-
-            all_tools.append(todo_write_tool())
         if skills:
             from inspect_ai.tool._tools._skill import skill as skill_fn
 

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -85,9 +85,19 @@ def deepagent(
 
         # Build shared tool instances once so they appear in both
         # top-level tools and general()'s inherited set
+        # Subagents that inherit parent tools get web_search/skill
+        # through parent_tools — skip them to avoid duplicates
+        inherits_parent = {
+            sa.name
+            for sa in resolved_subagents
+            if sa.name == "general" and sa.tools is None
+        }
+
         ws_tool_instance = _resolve_web_search(web_search)
         if ws_tool_instance:
-            _inject_extra_tool(resolved_subagents, ws_tool_instance)
+            _inject_extra_tool(
+                resolved_subagents, ws_tool_instance, skip=inherits_parent
+            )
 
         skill_tool_instance: Tool | None = None
         if skills:
@@ -177,9 +187,20 @@ def _resolve_web_search(web_search: Tool | bool) -> Tool | None:
     return web_search
 
 
-def _inject_extra_tool(subagents: list[Subagent], tool: Tool) -> None:
-    """Add a tool to every subagent's extra_tools."""
+def _inject_extra_tool(
+    subagents: list[Subagent], tool: Tool, skip: set[str] | None = None
+) -> None:
+    """Add a tool to subagents' extra_tools.
+
+    Args:
+        subagents: Subagents to modify.
+        tool: Tool to inject.
+        skip: Subagent names to skip (e.g. those that inherit parent
+            tools which already include this tool).
+    """
     for sa in subagents:
+        if skip and sa.name in skip:
+            continue
         if sa.extra_tools is None:
             sa.extra_tools = [tool]
         else:

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -80,6 +80,7 @@ def deepagent(
             else [research(), plan(), general()]
         )
 
+        _validate_skill_names(skills, resolved_subagents)
         _apply_memory_kill_switch(resolved_subagents, memory)
         _apply_compaction(resolved_subagents, compaction)
 
@@ -99,18 +100,11 @@ def deepagent(
                 resolved_subagents, ws_tool_instance, skip=inherits_parent
             )
 
-        skill_tool_instance: Tool | None = None
-        if skills:
-            from inspect_ai.tool._tools._skill import skill as skill_tool
-
-            skill_tool_instance = skill_tool(skills)
-
-        # Parent tools = user tools + web_search + skill. Flow to general().
+        # Parent tools = user tools + web_search. Flow to general().
+        # Skills flow separately via _resolve_tools merge.
         parent_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
         if ws_tool_instance:
             parent_tools.append(ws_tool_instance)
-        if skill_tool_instance:
-            parent_tools.append(skill_tool_instance)
 
         _apply_parent_tools_to_general(resolved_subagents, parent_tools)
 
@@ -121,12 +115,13 @@ def deepagent(
             subagents=resolved_subagents,
             parent_tools=parent_tools,
             parent_model=model,
+            parent_skills=skills,
             depth=0,
             max_depth=max_depth,
             get_messages=get_messages,
         )
 
-        # Top-level tools = parent tools + task + memory + todo_write
+        # Top-level tools = parent tools + task + memory + todo_write + skills
         all_tools: list[Tool | ToolDef | ToolSource] = list(parent_tools)
         all_tools.append(task)
         if memory:
@@ -139,6 +134,10 @@ def deepagent(
             )
 
             all_tools.append(todo_write_tool())
+        if skills:
+            from inspect_ai.tool._tools._skill import skill as skill_fn
+
+            all_tools.append(skill_fn(skills))
 
         if prompt is not None:
             system_prompt = expand_prompt_placeholders(
@@ -238,6 +237,34 @@ def _apply_parent_tools_to_general(
             sa.tools = list(tools or [])
 
 
+def _validate_skill_names(
+    parent_skills: list[Skill] | None,
+    subagents: list[Subagent],
+) -> None:
+    """Validate skill names are unique across parent and all subagents.
+
+    Raises ValueError at setup time (not dispatch time) if any skill
+    name appears more than once. This prevents sandbox install directory
+    collisions and ambiguous skill lookups.
+    """
+    all_names: dict[str, str] = {}
+    for sk in parent_skills or []:
+        if sk.name in all_names:
+            raise ValueError(f"Duplicate skill name '{sk.name}' in parent skills.")
+        all_names[sk.name] = "parent"
+
+    for sa in subagents:
+        for sk in sa.skills or []:
+            if sk.name in all_names:
+                source = all_names[sk.name]
+                raise ValueError(
+                    f"Duplicate skill name '{sk.name}' in subagent "
+                    f"'{sa.name}' (also defined in {source}). Skill names "
+                    f"must be unique across parent and all subagents."
+                )
+            all_names[sk.name] = f"subagent '{sa.name}'"
+
+
 def _clone_subagent(sa: Subagent) -> Subagent:
     """Shallow clone a Subagent with fresh list copies.
 
@@ -248,5 +275,6 @@ def _clone_subagent(sa: Subagent) -> Subagent:
         sa,
         tools=list(sa.tools) if sa.tools is not None else None,
         extra_tools=list(sa.extra_tools) if sa.extra_tools is not None else None,
+        skills=list(sa.skills) if sa.skills is not None else None,
         limits=list(sa.limits) if sa.limits is not None else None,
     )

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -83,12 +83,25 @@ def deepagent(
         _apply_web_search(resolved_subagents, web_search, tools)
         _apply_memory_kill_switch(resolved_subagents, memory)
         _apply_compaction(resolved_subagents, compaction)
-        _apply_parent_tools_to_general(resolved_subagents, tools)
+
+        # Build the skill tool once (if configured) so it can be
+        # included in both top-level tools and general()'s inherited set
+        skill_tool_instance: Tool | None = None
+        if skills:
+            from inspect_ai.tool._tools._skill import skill as skill_tool
+
+            skill_tool_instance = skill_tool(skills)
+
+        # Parent tools = user tools + skill tool. These flow to general().
+        parent_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
+        if skill_tool_instance:
+            parent_tools.append(skill_tool_instance)
+
+        _apply_parent_tools_to_general(resolved_subagents, parent_tools)
 
         def get_messages() -> list[ChatMessage]:
             return list(state.messages)
 
-        parent_tools = list(tools or [])
         task = task_tool(
             subagents=resolved_subagents,
             parent_tools=parent_tools,
@@ -97,7 +110,8 @@ def deepagent(
             get_messages=get_messages,
         )
 
-        all_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
+        # Top-level tools = parent tools + task + memory + todo_write
+        all_tools: list[Tool | ToolDef | ToolSource] = list(parent_tools)
         all_tools.append(task)
         if memory:
             from inspect_ai.tool._tools._memory import memory as memory_tool
@@ -109,10 +123,6 @@ def deepagent(
             )
 
             all_tools.append(todo_write_tool())
-        if skills:
-            from inspect_ai.tool._tools._skill import skill as skill_tool
-
-            all_tools.append(skill_tool(skills))
 
         if prompt is not None:
             system_prompt = expand_prompt_placeholders(
@@ -209,6 +219,5 @@ def _clone_subagent(sa: Subagent) -> Subagent:
         sa,
         tools=list(sa.tools) if sa.tools is not None else None,
         extra_tools=list(sa.extra_tools) if sa.extra_tools is not None else None,
-        skills=list(sa.skills) if sa.skills is not None else None,
         limits=list(sa.limits) if sa.limits is not None else None,
     )

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -1,0 +1,199 @@
+"""Top-level deep agent assembly."""
+
+from typing import Sequence
+
+from inspect_ai.agent._agent import Agent, AgentState, agent
+from inspect_ai.agent._react import react
+from inspect_ai.agent._types import AgentAttempts, AgentPrompt, AgentSubmit
+from inspect_ai.model._chat_message import ChatMessage
+from inspect_ai.model._compaction import CompactionStrategy
+from inspect_ai.model._model import Model
+from inspect_ai.tool._tool import Tool, ToolSource
+from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tools._skill import Skill
+
+from .general import general
+from .plan import plan
+from .prompt import build_system_prompt, expand_prompt_placeholders
+from .research import research
+from .subagent import Subagent
+from .task_tool import task_tool
+
+
+@agent
+def deepagent(
+    *,
+    tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    subagents: list[Subagent] | None = None,
+    todo_write: bool = True,
+    memory: bool = True,
+    web_search: bool | Tool = False,
+    skills: list[Skill] | None = None,
+    compaction: CompactionStrategy | None = None,
+    submit: AgentSubmit | bool | None = None,
+    attempts: int | AgentAttempts = 1,
+    model: str | Model | None = None,
+    instructions: str | None = None,
+    prompt: str | None = None,
+    max_depth: int = 1,
+) -> Agent:
+    """Deep agent with subagent delegation, memory, and planning.
+
+    A batteries-included agent that bundles the patterns popularized by
+    Claude Code and Codex CLI into a single
+    entry point. Builds on `react()` with subagent delegation via a task
+    tool, persistent memory, structured planning, and an opinionated
+    system prompt.
+
+    Args:
+        tools: Additional tools beyond defaults. Flow to the top-level
+            agent and to general() subagents.
+        subagents: Subagent configurations. Defaults to
+            [research(), plan(), general()].
+        todo_write: Include the todo_write planning tool.
+        memory: Include the memory tool. False disables memory for the
+            top-level agent and all subagents.
+        web_search: Include web_search tool for all agents. Pass True
+            for default config, or a pre-configured web_search() tool
+            instance for custom setup.
+        skills: Skills available to the agent.
+        compaction: Compaction strategy for context management.
+        submit: Submit tool configuration.
+        attempts: Number of submission attempts.
+        model: Model to use.
+        instructions: Additional instructions appended to the system
+            prompt.
+        prompt: Full replacement system prompt. Supports placeholders:
+            {core_behavior}, {subagent_dispatch}, {memory_instructions},
+            {instructions}. When provided, replaces the default system
+            prompt entirely.
+        max_depth: Maximum subagent recursion depth.
+    """
+    resolved_subagents = (
+        subagents if subagents is not None else [research(), plan(), general()]
+    )
+
+    _apply_web_search(resolved_subagents, web_search, tools)
+    _apply_memory_kill_switch(resolved_subagents, memory)
+    _apply_compaction(resolved_subagents, compaction)
+    _apply_parent_tools_to_general(resolved_subagents, tools)
+
+    # Mutable reference for forked dispatch — points to state.messages
+    # once the agent starts executing
+    _state_ref: list[AgentState | None] = [None]
+
+    def get_messages() -> list[ChatMessage]:
+        return list(_state_ref[0].messages) if _state_ref[0] else []
+
+    # Build task tool
+    parent_tools = list(tools or [])
+    task = task_tool(
+        subagents=resolved_subagents,
+        parent_tools=parent_tools,
+        depth=0,
+        max_depth=max_depth,
+        get_messages=get_messages,
+    )
+
+    # Collect top-level tools
+    all_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
+    all_tools.append(task)
+    if memory:
+        from inspect_ai.tool._tools._memory import memory as memory_tool
+
+        all_tools.append(memory_tool())
+    if todo_write:
+        from inspect_ai.tool._tools._todo_write import todo_write as todo_write_tool
+
+        all_tools.append(todo_write_tool())
+    if skills:
+        from inspect_ai.tool._tools._skill import skill as skill_tool
+
+        all_tools.append(skill_tool(skills))
+
+    # Build system prompt
+    if prompt is not None:
+        system_prompt = expand_prompt_placeholders(
+            prompt,
+            subagents=resolved_subagents,
+            memory=memory,
+            todo_write=todo_write,
+            instructions=instructions,
+        )
+    else:
+        system_prompt = build_system_prompt(
+            subagents=resolved_subagents,
+            memory=memory,
+            todo_write=todo_write,
+            instructions=instructions,
+        )
+
+    agent_prompt = AgentPrompt(
+        instructions=system_prompt,
+        handoff_prompt=None,
+        assistant_prompt=None,
+        submit_prompt=None,
+    )
+
+    inner = react(
+        tools=all_tools,
+        prompt=agent_prompt,
+        model=model,
+        submit=submit,
+        attempts=attempts,
+        compaction=compaction,
+    )
+
+    async def execute(state: AgentState) -> AgentState:
+        _state_ref[0] = state
+        return await inner(state)
+
+    return execute
+
+
+def _apply_web_search(
+    subagents: list[Subagent],
+    web_search: Tool | bool,
+    tools: Sequence[Tool | ToolDef | ToolSource] | None,
+) -> None:
+    if not web_search:
+        return
+    if web_search is True:
+        from inspect_ai.tool._tools._web_search import web_search as ws_factory
+
+        ws_tool: Tool = ws_factory()
+    else:
+        ws_tool = web_search
+    for sa in subagents:
+        if sa.extra_tools is None:
+            sa.extra_tools = [ws_tool]
+        else:
+            sa.extra_tools.append(ws_tool)
+
+
+def _apply_memory_kill_switch(subagents: list[Subagent], memory: bool) -> None:
+    if memory:
+        return
+    for sa in subagents:
+        sa.memory = False
+
+
+def _apply_compaction(
+    subagents: list[Subagent], compaction: CompactionStrategy | None
+) -> None:
+    """Propagate parent compaction to subagents that don't set their own."""
+    if compaction is None:
+        return
+    for sa in subagents:
+        if sa.compaction is None:
+            sa.compaction = compaction
+
+
+def _apply_parent_tools_to_general(
+    subagents: list[Subagent],
+    tools: Sequence[Tool | ToolDef | ToolSource] | None,
+) -> None:
+    """Set general() subagent's tools to parent tools if still defaulted."""
+    for sa in subagents:
+        if sa.name == "general" and sa.tools is None:
+            sa.tools = list(tools or [])

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -80,20 +80,25 @@ def deepagent(
             else [research(), plan(), general()]
         )
 
-        _apply_web_search(resolved_subagents, web_search, tools)
         _apply_memory_kill_switch(resolved_subagents, memory)
         _apply_compaction(resolved_subagents, compaction)
 
-        # Build the skill tool once (if configured) so it can be
-        # included in both top-level tools and general()'s inherited set
+        # Build shared tool instances once so they appear in both
+        # top-level tools and general()'s inherited set
+        ws_tool_instance = _resolve_web_search(web_search)
+        if ws_tool_instance:
+            _inject_extra_tool(resolved_subagents, ws_tool_instance)
+
         skill_tool_instance: Tool | None = None
         if skills:
             from inspect_ai.tool._tools._skill import skill as skill_tool
 
             skill_tool_instance = skill_tool(skills)
 
-        # Parent tools = user tools + skill tool. These flow to general().
+        # Parent tools = user tools + web_search + skill. Flow to general().
         parent_tools: list[Tool | ToolDef | ToolSource] = list(tools or [])
+        if ws_tool_instance:
+            parent_tools.append(ws_tool_instance)
         if skill_tool_instance:
             parent_tools.append(skill_tool_instance)
 
@@ -161,24 +166,24 @@ def deepagent(
     return execute
 
 
-def _apply_web_search(
-    subagents: list[Subagent],
-    web_search: Tool | bool,
-    tools: Sequence[Tool | ToolDef | ToolSource] | None,
-) -> None:
+def _resolve_web_search(web_search: Tool | bool) -> Tool | None:
+    """Build web_search tool instance if configured."""
     if not web_search:
-        return
+        return None
     if web_search is True:
         from inspect_ai.tool._tools._web_search import web_search as ws_factory
 
-        ws_tool: Tool = ws_factory()
-    else:
-        ws_tool = web_search
+        return ws_factory()
+    return web_search
+
+
+def _inject_extra_tool(subagents: list[Subagent], tool: Tool) -> None:
+    """Add a tool to every subagent's extra_tools."""
     for sa in subagents:
         if sa.extra_tools is None:
-            sa.extra_tools = [ws_tool]
+            sa.extra_tools = [tool]
         else:
-            sa.extra_tools.append(ws_tool)
+            sa.extra_tools.append(tool)
 
 
 def _apply_memory_kill_switch(subagents: list[Subagent], memory: bool) -> None:

--- a/src/inspect_ai/agent/_deepagent/deepagent.py
+++ b/src/inspect_ai/agent/_deepagent/deepagent.py
@@ -120,6 +120,7 @@ def deepagent(
         task = task_tool(
             subagents=resolved_subagents,
             parent_tools=parent_tools,
+            parent_model=model,
             depth=0,
             max_depth=max_depth,
             get_messages=get_messages,

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -6,6 +6,7 @@ from inspect_ai.tool._tool_def import ToolDef
 from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
+from .subagent import subagent as subagent_factory
 
 DEFAULT_GENERAL_PROMPT = """
 You are a general-purpose agent. Your job is to complete the task you've
@@ -63,12 +64,12 @@ def general(
 
     resolved_tools = None if tools == "default" else list(tools)
 
-    return Subagent(
+    return subagent_factory(
         name="general",
         description="General-purpose autonomous task completion.",
         prompt=prompt,
         tools=resolved_tools,
-        extra_tools=list(extra_tools) if extra_tools else None,
+        extra_tools=extra_tools,
         model=model,
         fork=fork,
         memory=memory,

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -15,6 +15,7 @@ You are a general-purpose agent. Your job is to complete the task you've
 been given autonomously.
 
 Work through the task step by step. Use your available tools as needed.
+Batch parallel tool calls when performing independent operations.
 Keep going until the task is fully resolved — don't stop at the first
 obstacle. If something doesn't work, diagnose the issue and try a
 different approach.
@@ -70,7 +71,7 @@ def general(
 
     return subagent_factory(
         name="general",
-        description="General-purpose autonomous task completion.",
+        description="Execute a task autonomously using all available tools. Use for substantial work that requires reading, writing, and verifying.",
         prompt=prompt,
         tools=resolved_tools,
         extra_tools=extra_tools,

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -35,7 +35,7 @@ def general(
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
     skills: list[str | Path | Skill] | None = None,
-    memory: Literal["readwrite", "readonly"] | bool = "readwrite",
+    memory: Literal["readwrite", "readonly"] | bool = False,
     limits: list[Limit] | None = None,
     model: str | Model | None = None,
     fork: bool = False,

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -23,9 +23,9 @@ Verify your results before finishing. Check that your output actually
 meets the requirements, not just that it ran without errors. If
 verification reveals problems, fix them.
 
-Be concise in your response. Report what you accomplished and any
-important findings. If you could not fully complete the task, explain
-what you did and what remains.
+Report the outcome and key results directly, not a step-by-step
+replay of actions taken. If you could not fully complete the task,
+state what you accomplished and what remains.
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -3,6 +3,7 @@ from typing import Literal, Sequence
 from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolSource
 from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tools._skill import Skill
 from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
@@ -32,6 +33,7 @@ def general(
     tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
+    skills: list[Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readwrite",
     limits: list[Limit] | None = None,
     model: str | Model | None = None,
@@ -50,6 +52,7 @@ def general(
             custom tools.
         instructions: Additional instructions appended to the default
             general prompt.
+        skills: Subagent-specific skills (merged with parent skills).
         memory: Memory access level ("readwrite", "readonly", or False).
         limits: Scoped limits for each invocation.
         model: Model override (None inherits from parent).
@@ -72,6 +75,7 @@ def general(
         extra_tools=extra_tools,
         model=model,
         fork=fork,
+        skills=skills,
         memory=memory,
         limits=limits,
     )

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -7,18 +7,23 @@ from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
 
-DEFAULT_GENERAL_PROMPT = """\
-You are a general-purpose agent. Your job is to complete the task you've \
+DEFAULT_GENERAL_PROMPT = """
+You are a general-purpose agent. Your job is to complete the task you've
 been given autonomously.
 
-Work through the task step by step. Use your available tools as needed. \
-Verify your results before finishing — if something isn't working, \
-diagnose the issue and try a different approach rather than giving up.
+Work through the task step by step. Use your available tools as needed.
+Keep going until the task is fully resolved — don't stop at the first
+obstacle. If something doesn't work, diagnose the issue and try a
+different approach.
 
-Be concise in your response. Report what you accomplished and any \
-important findings. If you could not fully complete the task, explain \
-what you did and what remains.\
-"""
+Verify your results before finishing. Check that your output actually
+meets the requirements, not just that it ran without errors. If
+verification reveals problems, fix them.
+
+Be concise in your response. Report what you accomplished and any
+important findings. If you could not fully complete the task, explain
+what you did and what remains.
+""".strip()
 
 
 def general(

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -24,8 +24,8 @@ Verify your results before finishing. Check that your output actually
 meets the requirements, not just that it ran without errors. If
 verification reveals problems, fix them.
 
-Report the outcome and key results directly, not a step-by-step
-replay of actions taken. If you could not fully complete the task,
+Submit the outcome and key results using the submit() tool. Do not
+replay actions step-by-step. If you could not fully complete the task,
 state what you accomplished and what remains.
 """.strip()
 

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -38,9 +38,9 @@ def general(
 ) -> Subagent:
     """Create a general-purpose subagent with full tool access.
 
-    The general subagent inherits the parent agent's tools by default
-    and has read-write memory access. It is intended for tasks that
-    require full capabilities in an isolated context.
+    The general subagent inherits the parent agent's tools (including
+    skills) by default and has read-write memory access. It is intended for
+    tasks that require full capabilities in an isolated context.
 
     Args:
         tools: Tools for this subagent. "default" inherits the parent

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -1,0 +1,71 @@
+from typing import Literal, Sequence
+
+from inspect_ai.model._model import Model
+from inspect_ai.tool._tool import Tool, ToolSource
+from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.util._limit import Limit
+
+from .subagent import Subagent
+
+DEFAULT_GENERAL_PROMPT = """\
+You are a general-purpose agent. Your job is to complete the task you've \
+been given autonomously.
+
+Work through the task step by step. Use your available tools as needed. \
+Verify your results before finishing — if something isn't working, \
+diagnose the issue and try a different approach rather than giving up.
+
+Be concise in your response. Report what you accomplished and any \
+important findings. If you could not fully complete the task, explain \
+what you did and what remains.\
+"""
+
+
+def general(
+    *,
+    tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
+    extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    instructions: str | None = None,
+    memory: Literal["readwrite", "readonly"] | bool = "readwrite",
+    limits: list[Limit] | None = None,
+    model: str | Model | None = None,
+    fork: bool = False,
+) -> Subagent:
+    """Create a general-purpose subagent with full tool access.
+
+    The general subagent inherits the parent agent's tools by default
+    and has read-write memory access. It is intended for tasks that
+    require full capabilities in an isolated context.
+
+    Args:
+        tools: Tools for this subagent. "default" inherits the parent
+            agent's tools. Pass a list to replace defaults entirely.
+        extra_tools: Additional tools added on top of the default or
+            custom tools.
+        instructions: Additional instructions appended to the default
+            general prompt.
+        memory: Memory access level ("readwrite", "readonly", or False).
+        limits: Scoped limits for each invocation.
+        model: Model override (None inherits from parent).
+        fork: If True, inherits parent conversation context.
+            Use same model or model family as parent to preserve
+            the prompt cache and avoid errors from incompatible
+            tool call formats or reasoning content.
+    """
+    prompt = DEFAULT_GENERAL_PROMPT
+    if instructions:
+        prompt = f"{prompt}\n\n{instructions}"
+
+    resolved_tools = None if tools == "default" else list(tools)
+
+    return Subagent(
+        name="general",
+        description="General-purpose autonomous task completion.",
+        prompt=prompt,
+        tools=resolved_tools,
+        extra_tools=list(extra_tools) if extra_tools else None,
+        model=model,
+        fork=fork,
+        memory=memory,
+        limits=limits,
+    )

--- a/src/inspect_ai/agent/_deepagent/general.py
+++ b/src/inspect_ai/agent/_deepagent/general.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Literal, Sequence
 
 from inspect_ai.model._model import Model
@@ -33,7 +34,7 @@ def general(
     tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
-    skills: list[Skill] | None = None,
+    skills: list[str | Path | Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readwrite",
     limits: list[Limit] | None = None,
     model: str | Model | None = None,

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -6,6 +6,7 @@ from inspect_ai.tool._tool_def import ToolDef
 from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
+from .subagent import subagent as subagent_factory
 
 DEFAULT_PLAN_PROMPT = """
 You are a planning agent. Your job is to analyze a task and produce a
@@ -64,12 +65,12 @@ def plan(
 
     resolved_tools = None if tools == "default" else list(tools)
 
-    return Subagent(
+    return subagent_factory(
         name="plan",
         description="Structured planning and task decomposition.",
         prompt=prompt,
         tools=resolved_tools,
-        extra_tools=list(extra_tools) if extra_tools else None,
+        extra_tools=extra_tools,
         model=model,
         fork=fork,
         memory=memory,

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -23,9 +23,10 @@ specific enough to execute without ambiguity. Identify dependencies
 between steps, potential risks, and any information gaps that could
 block progress.
 
-Return a clear, ordered plan. Flag any assumptions you're making and
-any decisions that need input before proceeding. If the task can be
-approached multiple ways, recommend one approach and briefly note why.
+Return the plan as an actionable ordered list of concrete steps, not
+a discussion of planning methodology. Flag any assumptions and
+decisions that need input. If the task can be approached multiple
+ways, recommend one approach and briefly note why.
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Literal, Sequence
 
 from inspect_ai.model._model import Model
@@ -33,7 +34,7 @@ def plan(
     tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
-    skills: list[Skill] | None = None,
+    skills: list[str | Path | Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
     model: str | Model | None = None,

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -7,18 +7,23 @@ from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
 
-DEFAULT_PLAN_PROMPT = """\
-You are a planning agent. Your job is to analyze a task and produce a \
+DEFAULT_PLAN_PROMPT = """
+You are a planning agent. Your job is to analyze a task and produce a
 structured plan for accomplishing it.
 
-Use your available tools to understand the current state and constraints. \
-Break the work into concrete, actionable steps. Identify dependencies \
-between steps, potential risks, and any information gaps.
+Use your available tools to understand the current state, constraints,
+and what resources are available. Don't plan in the abstract — ground
+your plan in what you actually observe.
 
-Return a clear, ordered plan. Each step should be specific enough to \
-execute without ambiguity. Flag any assumptions you're making and any \
-decisions that need input before proceeding.\
-"""
+Break the work into concrete, actionable steps. Each step should be
+specific enough to execute without ambiguity. Identify dependencies
+between steps, potential risks, and any information gaps that could
+block progress.
+
+Return a clear, ordered plan. Flag any assumptions you're making and
+any decisions that need input before proceeding. If the task can be
+approached multiple ways, recommend one approach and briefly note why.
+""".strip()
 
 
 def plan(

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -1,0 +1,72 @@
+from typing import Literal, Sequence
+
+from inspect_ai.model._model import Model
+from inspect_ai.tool._tool import Tool, ToolSource
+from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.util._limit import Limit
+
+from .subagent import Subagent
+
+DEFAULT_PLAN_PROMPT = """\
+You are a planning agent. Your job is to analyze a task and produce a \
+structured plan for accomplishing it.
+
+Use your available tools to understand the current state and constraints. \
+Break the work into concrete, actionable steps. Identify dependencies \
+between steps, potential risks, and any information gaps.
+
+Return a clear, ordered plan. Each step should be specific enough to \
+execute without ambiguity. Flag any assumptions you're making and any \
+decisions that need input before proceeding.\
+"""
+
+
+def plan(
+    *,
+    tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
+    extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    instructions: str | None = None,
+    memory: Literal["readwrite", "readonly"] | bool = "readonly",
+    limits: list[Limit] | None = None,
+    model: str | Model | None = None,
+    fork: bool = False,
+) -> Subagent:
+    """Create a plan subagent for structured planning.
+
+    The plan subagent is configured with read-only tools by default
+    and is intended for analyzing tasks and producing structured
+    implementation plans without executing changes.
+
+    Args:
+        tools: Tools for this subagent. "default" provides read-only
+            sandbox tools (read_file, list_files, grep) when a sandbox
+            is available. Pass a list to replace defaults entirely.
+        extra_tools: Additional tools added on top of the default or
+            custom tools.
+        instructions: Additional instructions appended to the default
+            plan prompt.
+        memory: Memory access level ("readonly", "readwrite", or False).
+        limits: Scoped limits for each invocation.
+        model: Model override (None inherits from parent).
+        fork: If True, inherits parent conversation context.
+            Use same model or model family as parent to preserve
+            the prompt cache and avoid errors from incompatible
+            tool call formats or reasoning content.
+    """
+    prompt = DEFAULT_PLAN_PROMPT
+    if instructions:
+        prompt = f"{prompt}\n\n{instructions}"
+
+    resolved_tools = None if tools == "default" else list(tools)
+
+    return Subagent(
+        name="plan",
+        description="Structured planning and task decomposition.",
+        prompt=prompt,
+        tools=resolved_tools,
+        extra_tools=list(extra_tools) if extra_tools else None,
+        model=model,
+        fork=fork,
+        memory=memory,
+        limits=limits,
+    )

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -36,7 +36,7 @@ def plan(
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
     skills: list[str | Path | Skill] | None = None,
-    memory: Literal["readwrite", "readonly"] | bool = "readonly",
+    memory: Literal["readwrite", "readonly"] | bool = False,
     limits: list[Limit] | None = None,
     model: str | Model | None = None,
     fork: bool = False,

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -26,10 +26,10 @@ specific enough to execute without ambiguity. Identify dependencies
 between steps, potential risks, and any information gaps that could
 block progress.
 
-Return the plan as an actionable ordered list of concrete steps, not
-a discussion of planning methodology. Flag any assumptions and
-decisions that need input. If the task can be approached multiple
-ways, recommend one approach and briefly note why.
+Submit the plan using the submit() tool as an actionable ordered list
+of concrete steps, not a discussion of planning methodology. Flag any
+assumptions and decisions that need input. If the task can be approached
+multiple ways, recommend one approach and briefly note why.
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -11,12 +11,15 @@ from .subagent import Subagent
 from .subagent import subagent as subagent_factory
 
 DEFAULT_PLAN_PROMPT = """
-You are a planning agent. Your job is to analyze a task and produce a
-structured plan for accomplishing it.
+You are a planning agent with read-only access. Your job is to analyze
+a task and produce a structured plan for accomplishing it. You cannot
+modify files or run destructive commands — only read, search, and
+analyze.
 
 Use your available tools to understand the current state, constraints,
-and what resources are available. Don't plan in the abstract — ground
-your plan in what you actually observe.
+and what resources are available. Batch parallel tool calls when
+investigating multiple files or paths. Don't plan in the abstract —
+ground your plan in what you actually observe.
 
 Break the work into concrete, actionable steps. Each step should be
 specific enough to execute without ambiguity. Identify dependencies
@@ -72,7 +75,7 @@ def plan(
 
     return subagent_factory(
         name="plan",
-        description="Structured planning and task decomposition.",
+        description="Analyze a task and produce a structured plan. Use when work needs to be decomposed into steps before execution.",
         prompt=prompt,
         tools=resolved_tools,
         extra_tools=extra_tools,

--- a/src/inspect_ai/agent/_deepagent/plan.py
+++ b/src/inspect_ai/agent/_deepagent/plan.py
@@ -3,6 +3,7 @@ from typing import Literal, Sequence
 from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolSource
 from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tools._skill import Skill
 from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
@@ -32,6 +33,7 @@ def plan(
     tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
+    skills: list[Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
     model: str | Model | None = None,
@@ -51,6 +53,7 @@ def plan(
             custom tools.
         instructions: Additional instructions appended to the default
             plan prompt.
+        skills: Subagent-specific skills (merged with parent skills).
         memory: Memory access level ("readonly", "readwrite", or False).
         limits: Scoped limits for each invocation.
         model: Model override (None inherits from parent).
@@ -73,6 +76,7 @@ def plan(
         extra_tools=extra_tools,
         model=model,
         fork=fork,
+        skills=skills,
         memory=memory,
         limits=limits,
     )

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -48,8 +48,7 @@ understanding changes mid-task, update the plan before continuing.
 Only commit to work you will actually do — label anything else as
 optional next steps and exclude it from the plan. Before finishing,
 reconcile every TODO item: mark each as completed, no longer relevant,
-or blocked (with a reason). Do not finish with in_progress or pending
-items.
+or blocked (with a reason and what you tried).
 """.strip()
 
 MEMORY_ONLY_INSTRUCTIONS = """
@@ -68,8 +67,7 @@ understanding changes mid-task, update the plan before continuing.
 Only commit to work you will actually do — label anything else as
 optional next steps and exclude it from the plan. Before finishing,
 reconcile every TODO item: mark each as completed, no longer relevant,
-or blocked (with a reason). Do not finish with in_progress or pending
-items.
+or blocked (with a reason and what you tried).
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -43,6 +43,8 @@ remove stale entries to keep memory organized.
 Use the plan tool to track high-level task decomposition. Mark steps
 in progress as you start them and completed as you finish. If your
 understanding changes mid-task, update the plan before continuing.
+Before finishing, reconcile every TODO item: confirm each is completed
+or no longer relevant.
 """.strip()
 
 MEMORY_ONLY_INSTRUCTIONS = """
@@ -58,6 +60,8 @@ PLAN_ONLY_INSTRUCTIONS = """
 Use the plan tool to track high-level task decomposition. Mark steps
 in progress as you start them and completed as you finish. If your
 understanding changes mid-task, update the plan before continuing.
+Before finishing, reconcile every TODO item: confirm each is completed
+or no longer relevant.
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -6,6 +6,14 @@ content (subagent list, memory/plan configuration, user instructions).
 
 from .subagent import Subagent
 
+SUBAGENT_SUBMIT_PROMPT = """
+When you have completed the task, call the {submit}() tool to report your
+findings. The parent agent that dispatched you cannot see your conversation
+history or tool calls — the content you pass to {submit}() is the only
+information that will be returned. Include all relevant findings, evidence,
+and conclusions in your submission.
+""".strip()
+
 CORE_BEHAVIOR = """
 Complete tasks autonomously using your available tools. Act rather than
 narrate intent — don't say what you plan to do, just do it.

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -13,7 +13,8 @@ narrate intent — don't say what you plan to do, just do it.
 Keep going until the task is fully resolved. Don't stop at the first
 attempt if it doesn't work — diagnose what went wrong and try a
 different approach. If a tool call fails or returns unexpected results,
-consider why it failed before retrying.
+consider why it failed before retrying. If you find yourself repeating
+the same action without progress, stop and reassess your approach.
 
 Be concise and direct. Avoid preamble, unnecessary explanation, and
 restating what you've already done. When you need information, use
@@ -24,8 +25,9 @@ response rather than making sequential round-trips.
 
 Plan when the task is complex or multi-step. Break large tasks into
 smaller pieces and track your progress. Verify your work before
-finishing — check that your output actually meets the requirements,
-not just that it ran without errors.
+finishing — check against the original requirements, not against your
+own output. Confirm the task is actually solved, not just that your
+steps ran without errors.
 
 Use reasonable defaults rather than asking clarifying questions for
 every detail. Only ask when genuinely blocked or when the task is
@@ -43,8 +45,11 @@ remove stale entries to keep memory organized.
 Use the todo_write tool to track high-level task decomposition. Mark steps
 in progress as you start them and completed as you finish. If your
 understanding changes mid-task, update the plan before continuing.
-Before finishing, reconcile every TODO item: confirm each is completed
-or no longer relevant.
+Only commit to work you will actually do — label anything else as
+optional next steps and exclude it from the plan. Before finishing,
+reconcile every TODO item: mark each as completed, no longer relevant,
+or blocked (with a reason). Do not finish with in_progress or pending
+items.
 """.strip()
 
 MEMORY_ONLY_INSTRUCTIONS = """
@@ -60,8 +65,11 @@ PLAN_ONLY_INSTRUCTIONS = """
 Use the todo_write tool to track high-level task decomposition. Mark steps
 in progress as you start them and completed as you finish. If your
 understanding changes mid-task, update the plan before continuing.
-Before finishing, reconcile every TODO item: confirm each is completed
-or no longer relevant.
+Only commit to work you will actually do — label anything else as
+optional next steps and exclude it from the plan. Before finishing,
+reconcile every TODO item: mark each as completed, no longer relevant,
+or blocked (with a reason). Do not finish with in_progress or pending
+items.
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -37,6 +37,9 @@ finishing — check against the original requirements, not against your
 own output. Confirm the task is actually solved, not just that your
 steps ran without errors.
 
+Cross-check important subagent results before acting on them — subagents
+can miss context or return incomplete findings.
+
 Use reasonable defaults rather than asking clarifying questions for
 every detail. Only ask when genuinely blocked or when the task is
 fundamentally ambiguous.

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -37,8 +37,8 @@ finishing — check against the original requirements, not against your
 own output. Confirm the task is actually solved, not just that your
 steps ran without errors.
 
-Cross-check important subagent results before acting on them — subagents
-can miss context or return incomplete findings.
+Cross-check important results from other agents before acting on
+them — they can miss context or return incomplete findings.
 
 Use reasonable defaults rather than asking clarifying questions for
 every detail. Only ask when genuinely blocked or when the task is

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -1,0 +1,181 @@
+"""System prompt assembly for deepagent().
+
+Composes layered system prompts from string constants and dynamic
+content (subagent list, memory/plan configuration, user instructions).
+"""
+
+from .subagent import Subagent
+
+CORE_BEHAVIOR = """
+Complete tasks autonomously using your available tools. Act rather than
+narrate intent — don't say what you plan to do, just do it.
+
+Keep going until the task is fully resolved. Don't stop at the first
+attempt if it doesn't work — diagnose what went wrong and try a
+different approach. If a tool call fails or returns unexpected results,
+consider why it failed before retrying.
+
+Be concise and direct. Avoid preamble, unnecessary explanation, and
+restating what you've already done. When you need information, use
+your tools rather than making assumptions.
+
+When multiple independent tool calls are needed, batch them in a single
+response rather than making sequential round-trips.
+
+Plan when the task is complex or multi-step. Break large tasks into
+smaller pieces and track your progress. Verify your work before
+finishing — check that your output actually meets the requirements,
+not just that it ran without errors.
+
+Use reasonable defaults rather than asking clarifying questions for
+every detail. Only ask when genuinely blocked or when the task is
+fundamentally ambiguous.
+""".strip()
+
+MEMORY_INSTRUCTIONS = """
+Check your memory at the start of your work to recover any earlier
+progress or context. Use the memory tool to persist important
+intermediate results, findings, and status as you go. This protects
+against context window limits and ensures progress is not lost. Record
+key findings rather than trying to remember everything. Update or
+remove stale entries to keep memory organized.
+
+Use the plan tool to track high-level task decomposition. Mark steps
+in progress as you start them and completed as you finish. If your
+understanding changes mid-task, update the plan before continuing.
+""".strip()
+
+MEMORY_ONLY_INSTRUCTIONS = """
+Check your memory at the start of your work to recover any earlier
+progress or context. Use the memory tool to persist important
+intermediate results, findings, and status as you go. This protects
+against context window limits and ensures progress is not lost. Record
+key findings rather than trying to remember everything. Update or
+remove stale entries to keep memory organized.
+""".strip()
+
+PLAN_ONLY_INSTRUCTIONS = """
+Use the plan tool to track high-level task decomposition. Mark steps
+in progress as you start them and completed as you finish. If your
+understanding changes mid-task, update the plan before continuing.
+""".strip()
+
+
+def build_subagent_dispatch(subagents: list[Subagent]) -> str:
+    """Generate system prompt section describing available subagents.
+
+    Args:
+        subagents: List of configured subagents.
+
+    Returns:
+        Prompt text listing subagents and delegation guidance.
+    """
+    lines = [
+        "You can delegate work to specialized subagents using the task tool.",
+        "",
+        "Available subagents:",
+    ]
+    for sa in subagents:
+        lines.append(f"- **{sa.name}**: {sa.description}")
+    lines.append("")
+    lines.append(
+        "Delegate when the work is complex, independent, or would benefit "
+        "from an isolated context. Do the work directly when it's a simple "
+        "lookup, a single tool call, or when the result depends on your "
+        "current conversation state."
+    )
+    lines.append("")
+    lines.append(
+        "When delegating, include all necessary context in the prompt — "
+        "the subagent cannot see your conversation history. Be specific "
+        "about what information you need back."
+    )
+    return "\n".join(lines)
+
+
+def build_system_prompt(
+    *,
+    subagents: list[Subagent] | None = None,
+    memory: bool = True,
+    todo_write: bool = True,
+    instructions: str | None = None,
+) -> str:
+    """Assemble the deepagent system prompt from layers.
+
+    Args:
+        subagents: Configured subagents (omit section if None or empty).
+        memory: Whether the memory tool is enabled.
+        todo_write: Whether the todo_write tool is enabled.
+        instructions: User-provided instructions appended at the end.
+
+    Returns:
+        Assembled system prompt string.
+    """
+    sections: list[str] = [CORE_BEHAVIOR]
+
+    if subagents:
+        sections.append(build_subagent_dispatch(subagents))
+
+    if memory and todo_write:
+        sections.append(MEMORY_INSTRUCTIONS)
+    elif memory:
+        sections.append(MEMORY_ONLY_INSTRUCTIONS)
+    elif todo_write:
+        sections.append(PLAN_ONLY_INSTRUCTIONS)
+
+    if instructions:
+        sections.append(instructions)
+
+    return "\n\n".join(sections)
+
+
+def expand_prompt_placeholders(
+    prompt: str,
+    *,
+    subagents: list[Subagent] | None = None,
+    memory: bool = True,
+    todo_write: bool = True,
+    instructions: str | None = None,
+) -> str:
+    """Expand named placeholders in a custom prompt.
+
+    Supports the following placeholders (all optional — if a placeholder
+    is not present in the template, that content is simply not included):
+
+    - ``{core_behavior}`` — core behavioral expectations
+    - ``{subagent_dispatch}`` — subagent names, roles, delegation guidance
+    - ``{memory_instructions}`` — memory/plan coordination guidance
+    - ``{instructions}`` — user-provided instructions
+
+    Args:
+        prompt: Custom prompt template with optional placeholders.
+        subagents: Configured subagents.
+        memory: Whether the memory tool is enabled.
+        todo_write: Whether the todo_write tool is enabled.
+        instructions: User-provided instructions.
+
+    Returns:
+        Prompt with placeholders expanded.
+    """
+    result = prompt
+    result = result.replace("{core_behavior}", CORE_BEHAVIOR)
+
+    if subagents:
+        result = result.replace(
+            "{subagent_dispatch}", build_subagent_dispatch(subagents)
+        )
+    else:
+        result = result.replace("{subagent_dispatch}", "")
+
+    if memory and todo_write:
+        result = result.replace("{memory_instructions}", MEMORY_INSTRUCTIONS)
+    elif memory:
+        result = result.replace("{memory_instructions}", MEMORY_ONLY_INSTRUCTIONS)
+    elif todo_write:
+        result = result.replace("{memory_instructions}", PLAN_ONLY_INSTRUCTIONS)
+    else:
+        result = result.replace("{memory_instructions}", "")
+
+    result = result.replace("{instructions}", instructions or "")
+
+    return result

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -85,11 +85,20 @@ def build_subagent_dispatch(subagents: list[Subagent]) -> str:
         "current conversation state."
     )
     lines.append("")
-    lines.append(
-        "When delegating, include all necessary context in the prompt — "
-        "the subagent cannot see your conversation history. Be specific "
-        "about what information you need back."
-    )
+    has_forked = any(sa.fork for sa in subagents)
+    if has_forked:
+        lines.append(
+            "When delegating to non-forked subagents, include all necessary "
+            "context in the prompt — they cannot see your conversation "
+            "history. Forked subagents already have your full conversation "
+            "context. Be specific about what information you need back."
+        )
+    else:
+        lines.append(
+            "When delegating, include all necessary context in the prompt — "
+            "the subagent cannot see your conversation history. Be specific "
+            "about what information you need back."
+        )
     return "\n".join(lines)
 
 

--- a/src/inspect_ai/agent/_deepagent/prompt.py
+++ b/src/inspect_ai/agent/_deepagent/prompt.py
@@ -40,7 +40,7 @@ against context window limits and ensures progress is not lost. Record
 key findings rather than trying to remember everything. Update or
 remove stale entries to keep memory organized.
 
-Use the plan tool to track high-level task decomposition. Mark steps
+Use the todo_write tool to track high-level task decomposition. Mark steps
 in progress as you start them and completed as you finish. If your
 understanding changes mid-task, update the plan before continuing.
 Before finishing, reconcile every TODO item: confirm each is completed
@@ -57,7 +57,7 @@ remove stale entries to keep memory organized.
 """.strip()
 
 PLAN_ONLY_INSTRUCTIONS = """
-Use the plan tool to track high-level task decomposition. Mark steps
+Use the todo_write tool to track high-level task decomposition. Mark steps
 in progress as you start them and completed as you finish. If your
 understanding changes mid-task, update the plan before continuing.
 Before finishing, reconcile every TODO item: confirm each is completed

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -36,7 +36,7 @@ def research(
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
     skills: list[str | Path | Skill] | None = None,
-    memory: Literal["readwrite", "readonly"] | bool = "readonly",
+    memory: Literal["readwrite", "readonly"] | bool = False,
     limits: list[Limit] | None = None,
     model: str | Model | None = None,
     fork: bool = False,

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -1,0 +1,72 @@
+from typing import Literal, Sequence
+
+from inspect_ai.model._model import Model
+from inspect_ai.tool._tool import Tool, ToolSource
+from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.util._limit import Limit
+
+from .subagent import Subagent
+
+DEFAULT_RESEARCH_PROMPT = """\
+You are a research agent. Your job is to gather and synthesize information \
+relevant to the task you've been given.
+
+Use your available tools to investigate thoroughly. Cross-reference multiple \
+sources when possible. Focus on finding accurate, relevant information rather \
+than making assumptions.
+
+Return a concise summary of your findings. Include specific details, evidence, \
+and references that will be useful to the caller. If you could not find \
+definitive information, say so clearly and explain what you did find.\
+"""
+
+
+def research(
+    *,
+    tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
+    extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    instructions: str | None = None,
+    memory: Literal["readwrite", "readonly"] | bool = "readonly",
+    limits: list[Limit] | None = None,
+    model: str | Model | None = None,
+    fork: bool = False,
+) -> Subagent:
+    """Create a research subagent for read-only information gathering.
+
+    The research subagent is configured with read-only tools by default
+    and is intended for tasks that involve gathering and synthesizing
+    information without modifying state.
+
+    Args:
+        tools: Tools for this subagent. "default" provides read-only
+            sandbox tools (read_file, list_files, grep) when a sandbox
+            is available. Pass a list to replace defaults entirely.
+        extra_tools: Additional tools added on top of the default or
+            custom tools.
+        instructions: Additional instructions appended to the default
+            research prompt.
+        memory: Memory access level ("readonly", "readwrite", or False).
+        limits: Scoped limits for each invocation.
+        model: Model override (None inherits from parent).
+        fork: If True, inherits parent conversation context.
+            Use same model or model family as parent to preserve
+            the prompt cache and avoid errors from incompatible
+            tool call formats or reasoning content.
+    """
+    prompt = DEFAULT_RESEARCH_PROMPT
+    if instructions:
+        prompt = f"{prompt}\n\n{instructions}"
+
+    resolved_tools = None if tools == "default" else list(tools)
+
+    return Subagent(
+        name="research",
+        description="Read-only information gathering and synthesis.",
+        prompt=prompt,
+        tools=resolved_tools,
+        extra_tools=list(extra_tools) if extra_tools else None,
+        model=model,
+        fork=fork,
+        memory=memory,
+        limits=limits,
+    )

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -26,10 +26,10 @@ Focus on finding specific, actionable information rather than making
 assumptions. If you find partial or conflicting information, report
 what you found and note the gaps or conflicts.
 
-Return your findings directly with specific details and evidence.
-Lead with the most important results, not a narrative of your search
-process. If information is incomplete or conflicting, state what you
-found and what remains uncertain.
+Submit your findings using the submit() tool. Lead with the most
+important results and include specific details and evidence. Do not
+narrate your search process. If information is incomplete or
+conflicting, state what you found and what remains uncertain.
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -3,6 +3,7 @@ from typing import Literal, Sequence
 from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolSource
 from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tools._skill import Skill
 from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
@@ -32,6 +33,7 @@ def research(
     tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
+    skills: list[Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
     model: str | Model | None = None,
@@ -51,6 +53,7 @@ def research(
             custom tools.
         instructions: Additional instructions appended to the default
             research prompt.
+        skills: Subagent-specific skills (merged with parent skills).
         memory: Memory access level ("readonly", "readwrite", or False).
         limits: Scoped limits for each invocation.
         model: Model override (None inherits from parent).
@@ -73,6 +76,7 @@ def research(
         extra_tools=extra_tools,
         model=model,
         fork=fork,
+        skills=skills,
         memory=memory,
         limits=limits,
     )

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -23,9 +23,10 @@ Focus on finding specific, actionable information rather than making
 assumptions. If you find partial or conflicting information, report
 what you found and note the gaps or conflicts.
 
-Return a concise summary of your findings. Include specific details,
-evidence, and references that will be useful to the caller. Structure
-your response so the most important findings come first.
+Return your findings directly with specific details and evidence.
+Lead with the most important results, not a narrative of your search
+process. If information is incomplete or conflicting, state what you
+found and what remains uncertain.
 """.strip()
 
 

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -7,18 +7,23 @@ from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
 
-DEFAULT_RESEARCH_PROMPT = """\
-You are a research agent. Your job is to gather and synthesize information \
+DEFAULT_RESEARCH_PROMPT = """
+You are a research agent. Your job is to gather and synthesize information
 relevant to the task you've been given.
 
-Use your available tools to investigate thoroughly. Cross-reference multiple \
-sources when possible. Focus on finding accurate, relevant information rather \
-than making assumptions.
+Use your available tools to investigate thoroughly. Try multiple search
+strategies if your first approach doesn't find what you need — different
+queries, different paths, different sources. Cross-reference findings
+when possible to verify accuracy.
 
-Return a concise summary of your findings. Include specific details, evidence, \
-and references that will be useful to the caller. If you could not find \
-definitive information, say so clearly and explain what you did find.\
-"""
+Focus on finding specific, actionable information rather than making
+assumptions. If you find partial or conflicting information, report
+what you found and note the gaps or conflicts.
+
+Return a concise summary of your findings. Include specific details,
+evidence, and references that will be useful to the caller. Structure
+your response so the most important findings come first.
+""".strip()
 
 
 def research(

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -6,6 +6,7 @@ from inspect_ai.tool._tool_def import ToolDef
 from inspect_ai.util._limit import Limit
 
 from .subagent import Subagent
+from .subagent import subagent as subagent_factory
 
 DEFAULT_RESEARCH_PROMPT = """
 You are a research agent. Your job is to gather and synthesize information
@@ -64,12 +65,12 @@ def research(
 
     resolved_tools = None if tools == "default" else list(tools)
 
-    return Subagent(
+    return subagent_factory(
         name="research",
         description="Read-only information gathering and synthesis.",
         prompt=prompt,
         tools=resolved_tools,
-        extra_tools=list(extra_tools) if extra_tools else None,
+        extra_tools=extra_tools,
         model=model,
         fork=fork,
         memory=memory,

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import Literal, Sequence
 
 from inspect_ai.model._model import Model
@@ -33,7 +34,7 @@ def research(
     tools: Sequence[Tool | ToolDef | ToolSource] | Literal["default"] = "default",
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     instructions: str | None = None,
-    skills: list[Skill] | None = None,
+    skills: list[str | Path | Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
     model: str | Model | None = None,

--- a/src/inspect_ai/agent/_deepagent/research.py
+++ b/src/inspect_ai/agent/_deepagent/research.py
@@ -11,12 +11,15 @@ from .subagent import Subagent
 from .subagent import subagent as subagent_factory
 
 DEFAULT_RESEARCH_PROMPT = """
-You are a research agent. Your job is to gather and synthesize information
-relevant to the task you've been given.
+You are a research agent with read-only access. Your job is to gather
+and synthesize information relevant to the task you've been given.
+You cannot modify files or run destructive commands — only read, search,
+and analyze.
 
 Use your available tools to investigate thoroughly. Try multiple search
 strategies if your first approach doesn't find what you need — different
-queries, different paths, different sources. Cross-reference findings
+queries, different paths, different sources. Batch parallel tool calls
+when searching across multiple files or paths. Cross-reference findings
 when possible to verify accuracy.
 
 Focus on finding specific, actionable information rather than making
@@ -72,7 +75,7 @@ def research(
 
     return subagent_factory(
         name="research",
-        description="Read-only information gathering and synthesis.",
+        description="Search, read, and analyze information. Use for investigative tasks that require gathering data from multiple sources.",
         prompt=prompt,
         tools=resolved_tools,
         extra_tools=extra_tools,

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -31,7 +31,10 @@ class Subagent:
     """Model override for this subagent."""
 
     fork: bool = False
-    """Dispatch mode (False = isolated, True = forked)."""
+    """Dispatch mode (False = isolated, True = forked). Use same model
+    or model family as parent when forking to preserve the prompt cache
+    and avoid errors from incompatible tool call formats or reasoning
+    content in the inherited message history."""
 
     skills: list[Skill] | None = None
     """Skills available to this subagent."""
@@ -78,10 +81,12 @@ def subagent(
         model: Model override for this subagent. None inherits the
             parent agent's model.
         fork: Dispatch mode. False (default) runs the subagent with
-            isolated context (as_tool semantics — only the summary
-            returns). True runs with forked context (inherits parent
-            messages via content_only filter; only last_message
-            returns).
+            isolated context (only the summary returns). True runs
+            with forked context (inherits the parent's full message
+            history). Use the same model or model family as the
+            parent when forking to preserve the prompt cache and
+            avoid errors from incompatible tool call formats or
+            reasoning content.
         skills: Skills available to this subagent. None means no
             skills (general() overrides this to inherit parent
             skills).

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -5,7 +5,6 @@ from inspect_ai.model._compaction import CompactionStrategy
 from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolSource
 from inspect_ai.tool._tool_def import ToolDef
-from inspect_ai.tool._tools._skill import Skill
 from inspect_ai.util._limit import Limit
 
 
@@ -37,9 +36,6 @@ class Subagent:
     and avoid errors from incompatible tool call formats or reasoning
     content in the inherited message history."""
 
-    skills: list[Skill] | None = None
-    """Skills available to this subagent."""
-
     memory: Literal["readwrite", "readonly"] | bool = "readonly"
     """Memory tool access level."""
 
@@ -60,7 +56,6 @@ def subagent(
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     model: str | Model | None = None,
     fork: bool = False,
-    skills: list[Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
     compaction: CompactionStrategy | None = None,
@@ -93,9 +88,6 @@ def subagent(
             parent when forking to preserve the prompt cache and
             avoid errors from incompatible tool call formats or
             reasoning content.
-        skills: Skills available to this subagent. None means no
-            skills (general() overrides this to inherit parent
-            skills).
         memory: Memory tool access level. "readwrite" gives full
             memory access, "readonly" exposes only read/search
             operations, False disables memory entirely. Overridden
@@ -130,7 +122,6 @@ def subagent(
         extra_tools=list(extra_tools) if extra_tools is not None else None,
         model=model,
         fork=fork,
-        skills=skills,
         memory=memory,
         limits=limits,
         compaction=compaction,

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Literal, Sequence
 
+from inspect_ai.model._compaction import CompactionStrategy
 from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolSource
 from inspect_ai.tool._tool_def import ToolDef
@@ -45,6 +46,10 @@ class Subagent:
     limits: list[Limit] | None = None
     """Scoped limits applied to each invocation of this subagent."""
 
+    compaction: CompactionStrategy | None = None
+    """Compaction strategy for context management. None inherits
+    the parent agent's compaction strategy."""
+
 
 def subagent(
     *,
@@ -58,6 +63,7 @@ def subagent(
     skills: list[Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
+    compaction: CompactionStrategy | None = None,
 ) -> Subagent:
     """Create a subagent configuration for use within a deep agent system.
 
@@ -97,6 +103,8 @@ def subagent(
         limits: Scoped limits applied to each invocation of this
             subagent (e.g. token_limit, message_limit, time_limit,
             cost_limit).
+        compaction: Compaction strategy for context management. None
+            inherits the parent agent's compaction strategy.
 
     Returns:
         A Subagent configuration object.
@@ -125,4 +133,5 @@ def subagent(
         skills=skills,
         memory=memory,
         limits=limits,
+        compaction=compaction,
     )

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -107,8 +107,10 @@ def subagent(
         )
     if not description:
         raise ValueError("Subagent description must not be empty.")
-    if not prompt:
-        raise ValueError("Subagent prompt must not be empty.")
+    if not prompt and not fork:
+        raise ValueError(
+            "Subagent prompt must not be empty for isolated (fork=False) dispatch."
+        )
     if memory is True or memory not in ("readwrite", "readonly", False):
         raise ValueError(
             f"Subagent memory must be 'readwrite', 'readonly', or False, got {memory!r}"

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -5,6 +5,7 @@ from inspect_ai.model._compaction import CompactionStrategy
 from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolSource
 from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tools._skill import Skill
 from inspect_ai.util._limit import Limit
 
 
@@ -36,6 +37,10 @@ class Subagent:
     and avoid errors from incompatible tool call formats or reasoning
     content in the inherited message history."""
 
+    skills: list[Skill] | None = None
+    """Subagent-specific skills. Merged with parent skills at dispatch
+    time — the subagent sees both parent and its own skills."""
+
     memory: Literal["readwrite", "readonly"] | bool = "readonly"
     """Memory tool access level."""
 
@@ -56,6 +61,7 @@ def subagent(
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     model: str | Model | None = None,
     fork: bool = False,
+    skills: list[Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
     compaction: CompactionStrategy | None = None,
@@ -88,6 +94,8 @@ def subagent(
             parent when forking to preserve the prompt cache and
             avoid errors from incompatible tool call formats or
             reasoning content.
+        skills: Subagent-specific skills. Merged with parent skills
+            at dispatch time — the subagent sees both.
         memory: Memory tool access level. "readwrite" gives full
             memory access, "readonly" exposes only read/search
             operations, False disables memory entirely. Overridden
@@ -124,6 +132,7 @@ def subagent(
         extra_tools=list(extra_tools) if extra_tools is not None else None,
         model=model,
         fork=fork,
+        skills=skills,
         memory=memory,
         limits=limits,
         compaction=compaction,

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -1,0 +1,123 @@
+from dataclasses import dataclass
+from typing import Literal, Sequence
+
+from inspect_ai.model._model import Model
+from inspect_ai.tool._tool import Tool, ToolSource
+from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tools._skill import Skill
+from inspect_ai.util._limit import Limit
+
+
+@dataclass(kw_only=True)
+class Subagent:
+    """Configuration blueprint for a subagent within a deep agent system."""
+
+    name: str
+    """Identifier used as the subagent_type value in task() dispatch."""
+
+    description: str
+    """Role description shown in the task() tool description."""
+
+    prompt: str
+    """System prompt for the subagent's react() loop."""
+
+    tools: list[Tool | ToolDef | ToolSource] | None = None
+    """Tools available to this subagent."""
+
+    extra_tools: list[Tool | ToolDef | ToolSource] | None = None
+    """Additional tools merged with the subagent's default tools."""
+
+    model: str | Model | None = None
+    """Model override for this subagent."""
+
+    fork: bool = False
+    """Dispatch mode (False = isolated, True = forked)."""
+
+    skills: list[Skill] | None = None
+    """Skills available to this subagent."""
+
+    memory: Literal["readwrite", "readonly"] | bool = "readonly"
+    """Memory tool access level."""
+
+    limits: list[Limit] | None = None
+    """Scoped limits applied to each invocation of this subagent."""
+
+
+def subagent(
+    *,
+    name: str,
+    description: str,
+    prompt: str,
+    tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    model: str | Model | None = None,
+    fork: bool = False,
+    skills: list[Skill] | None = None,
+    memory: Literal["readwrite", "readonly"] | bool = "readonly",
+    limits: list[Limit] | None = None,
+) -> Subagent:
+    """Create a subagent configuration for use within a deep agent system.
+
+    Args:
+        name: Identifier used as the subagent_type value in task()
+            dispatch. Must be a valid Python identifier (letters,
+            digits, underscores).
+        description: Role description shown in the task() tool
+            description so the model knows when to delegate to
+            this subagent.
+        prompt: System prompt for the subagent's react() loop. For
+            built-in subagents (research, plan, general), this is
+            assembled by the factory from its default prompt plus
+            any user-provided instructions.
+        tools: Tools available to this subagent. None means "use
+            defaults" (built-in factories set their own defaults;
+            task() resolves at dispatch time).
+        extra_tools: Additional tools merged with the subagent's
+            default tools. Use this to extend a built-in subagent
+            without replacing its default tool set.
+        model: Model override for this subagent. None inherits the
+            parent agent's model.
+        fork: Dispatch mode. False (default) runs the subagent with
+            isolated context (as_tool semantics — only the summary
+            returns). True runs with forked context (inherits parent
+            messages via content_only filter; only last_message
+            returns).
+        skills: Skills available to this subagent. None means no
+            skills (general() overrides this to inherit parent
+            skills).
+        memory: Memory tool access level. "readwrite" gives full
+            memory access, "readonly" exposes only read/search
+            operations, False disables memory entirely. Overridden
+            to False when the parent deepagent sets memory=False.
+        limits: Scoped limits applied to each invocation of this
+            subagent (e.g. token_limit, message_limit, time_limit,
+            cost_limit).
+
+    Returns:
+        A Subagent configuration object.
+    """
+    if not name or not name.isidentifier():
+        raise ValueError(
+            f"Subagent name must be a valid Python identifier, got {name!r}"
+        )
+    if not description:
+        raise ValueError("Subagent description must not be empty.")
+    if not prompt:
+        raise ValueError("Subagent prompt must not be empty.")
+    if memory is True or memory not in ("readwrite", "readonly", False):
+        raise ValueError(
+            f"Subagent memory must be 'readwrite', 'readonly', or False, got {memory!r}"
+        )
+
+    return Subagent(
+        name=name,
+        description=description,
+        prompt=prompt,
+        tools=list(tools) if tools is not None else None,
+        extra_tools=list(extra_tools) if extra_tools is not None else None,
+        model=model,
+        fork=fork,
+        skills=skills,
+        memory=memory,
+        limits=limits,
+    )

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -42,7 +42,7 @@ class Subagent:
     """Subagent-specific skills. Merged with parent skills at dispatch
     time — the subagent sees both parent and its own skills."""
 
-    memory: Literal["readwrite", "readonly"] | bool = "readonly"
+    memory: Literal["readwrite", "readonly"] | bool = False
     """Memory tool access level."""
 
     limits: list[Limit] | None = None
@@ -63,7 +63,7 @@ def subagent(
     model: str | Model | None = None,
     fork: bool = False,
     skills: list[str | Path | Skill] | None = None,
-    memory: Literal["readwrite", "readonly"] | bool = "readonly",
+    memory: Literal["readwrite", "readonly"] | bool = False,
     limits: list[Limit] | None = None,
     compaction: CompactionStrategy | None = None,
 ) -> Subagent:

--- a/src/inspect_ai/agent/_deepagent/subagent.py
+++ b/src/inspect_ai/agent/_deepagent/subagent.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal, Sequence
 
 from inspect_ai.model._compaction import CompactionStrategy
@@ -37,7 +38,7 @@ class Subagent:
     and avoid errors from incompatible tool call formats or reasoning
     content in the inherited message history."""
 
-    skills: list[Skill] | None = None
+    skills: list[str | Path | Skill] | None = None
     """Subagent-specific skills. Merged with parent skills at dispatch
     time — the subagent sees both parent and its own skills."""
 
@@ -61,7 +62,7 @@ def subagent(
     extra_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     model: str | Model | None = None,
     fork: bool = False,
-    skills: list[Skill] | None = None,
+    skills: list[str | Path | Skill] | None = None,
     memory: Literal["readwrite", "readonly"] | bool = "readonly",
     limits: list[Limit] | None = None,
     compaction: CompactionStrategy | None = None,

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -54,8 +54,7 @@ def task_tool(
                     unless it uses forked mode.
                 task_description: Brief description of the task.
             """
-            resolved = SUBAGENT_ALIASES.get(subagent_type, subagent_type)
-            sa = subagent_map.get(resolved)
+            sa = subagent_map.get(subagent_type)
             if sa is None:
                 available = ", ".join(subagent_map.keys())
                 raise ToolError(
@@ -86,7 +85,9 @@ def task_tool(
         execute.__doc__ = tool_description
         return execute
 
-    return task()
+    result = task()
+    _apply_subagent_type_enum(result, subagents)
+    return result
 
 
 def _build_task_description(subagents: list[Subagent]) -> str:
@@ -185,6 +186,34 @@ def _extract_result(state: AgentState) -> str:
         return ""
 
 
+def _apply_subagent_type_enum(tool: Tool, subagents: list[Subagent]) -> None:
+    """Patch the subagent_type parameter with an enum constraint.
+
+    Sets all three ToolDescription fields (name, description, parameters)
+    so parse_tool_info() uses them directly instead of re-parsing.
+    """
+    from inspect_ai._util.registry import registry_unqualified_name
+    from inspect_ai.tool._tool_description import (
+        ToolDescription,
+        set_tool_description,
+    )
+    from inspect_ai.tool._tool_info import parse_tool_info
+
+    info = parse_tool_info(tool)
+    param = info.parameters.properties.get("subagent_type")
+    if param:
+        param.enum = [sa.name for sa in subagents]
+
+    set_tool_description(
+        tool,
+        ToolDescription(
+            name=registry_unqualified_name(tool),
+            description=info.description,
+            parameters=info.parameters,
+        ),
+    )
+
+
 def _resolve_tools(
     sa: Subagent,
     subagents: list[Subagent],
@@ -232,8 +261,3 @@ def _last_message_id(messages: list[ChatMessage]) -> str:
         if msg.id:
             return msg.id
     return ""
-
-
-SUBAGENT_ALIASES: dict[str, str] = {
-    "general_purpose": "general",
-}

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -257,7 +257,7 @@ def _resolve_tools(
         from inspect_ai.tool._tools._memory import memory
 
         tools.append(memory(readonly=True))
-    if depth < max_depth:
+    if depth + 1 < max_depth:
         tools.append(
             task_tool(
                 subagents,

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -8,6 +8,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageAssistant,
     ChatMessageUser,
 )
+from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool, tool_result_content
 from inspect_ai.tool._tool_def import ToolDef
 
@@ -17,6 +18,7 @@ from .subagent import Subagent
 def task_tool(
     subagents: list[Subagent],
     parent_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    parent_model: str | Model | None = None,
     depth: int = 0,
     max_depth: int = 1,
     get_messages: Callable[[], list[ChatMessage]] | None = None,
@@ -26,6 +28,8 @@ def task_tool(
     Args:
         subagents: List of available subagent configurations.
         parent_tools: Tools from the parent agent (flow to general()).
+        parent_model: Parent agent's model (inherited by subagents
+            that don't set their own).
         depth: Current recursion depth.
         max_depth: Maximum recursion depth.
         get_messages: Callback returning parent messages (required for
@@ -62,7 +66,13 @@ def task_tool(
                 )
 
             child_tools = _resolve_tools(
-                sa, subagents, parent_tools, depth, max_depth, get_messages
+                sa,
+                subagents,
+                parent_tools,
+                parent_model,
+                depth,
+                max_depth,
+                get_messages,
             )
 
             if sa.fork:
@@ -71,7 +81,7 @@ def task_tool(
                     description=sa.description,
                     prompt=None,
                     tools=child_tools,
-                    model=sa.model,
+                    model=sa.model or parent_model,
                     submit=False,
                     compaction=sa.compaction,
                 )
@@ -83,7 +93,7 @@ def task_tool(
                     description=sa.description,
                     prompt=sa.prompt,
                     tools=child_tools,
-                    model=sa.model,
+                    model=sa.model or parent_model,
                     submit=False,
                     compaction=sa.compaction,
                 )
@@ -224,6 +234,7 @@ def _resolve_tools(
     sa: Subagent,
     subagents: list[Subagent],
     parent_tools: Sequence[Tool | ToolDef | ToolSource] | None,
+    parent_model: str | Model | None,
     depth: int,
     max_depth: int,
     get_messages: Callable[[], list[ChatMessage]] | None,
@@ -245,7 +256,14 @@ def _resolve_tools(
         tools.append(memory(readonly=True))
     if depth < max_depth:
         tools.append(
-            task_tool(subagents, parent_tools, depth + 1, max_depth, get_messages)
+            task_tool(
+                subagents,
+                parent_tools,
+                parent_model,
+                depth + 1,
+                max_depth,
+                get_messages,
+            )
         )
     return tools
 

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -152,6 +152,13 @@ def _build_task_description(subagents: list[Subagent]) -> str:
         "step whose context would be harder to reconstruct in a subagent prompt."
     )
     lines.append("")
+    lines.append(
+        "Examples — delegate: 'Search the codebase for all logging "
+        "configurations and summarize what each one does.' "
+        "Don't delegate: 'Read the file config.yaml and tell me the "
+        "timeout value.'"
+    )
+    lines.append("")
     has_forked = any(sa.fork for sa in subagents)
     if has_forked:
         lines.append(

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -30,6 +30,7 @@ def task_tool(
     depth: int = 0,
     max_depth: int = 1,
     get_messages: Callable[[], list[ChatMessage]] | None = None,
+    retry_refusals: int | None = None,
 ) -> Tool:
     """Create a task multiplexer tool for dispatching to subagents.
 
@@ -44,6 +45,8 @@ def task_tool(
         max_depth: Maximum recursion depth.
         get_messages: Callback returning parent messages (required for
             forked dispatch).
+        retry_refusals: Number of times to retry on content filter
+            refusals.
     """
     subagent_map = {s.name: s for s in subagents}
     tool_description = _build_task_description(subagents)
@@ -84,6 +87,7 @@ def task_tool(
                 depth,
                 max_depth,
                 get_messages,
+                retry_refusals,
             )
 
             agent_span_id = shortuuid()
@@ -97,6 +101,7 @@ def task_tool(
                     model=sa.model or parent_model,
                     submit=False,
                     compaction=sa.compaction,
+                    retry_refusals=retry_refusals,
                 )
                 input, from_message = _prepare_forked_input(prompt, sa, get_messages)
                 result = await _dispatch_forked(
@@ -111,6 +116,7 @@ def task_tool(
                     model=sa.model or parent_model,
                     submit=False,
                     compaction=sa.compaction,
+                    retry_refusals=retry_refusals,
                 )
                 result = await _dispatch(child_agent, sa, prompt, span_id=agent_span_id)
 
@@ -303,6 +309,7 @@ def _resolve_tools(
     depth: int,
     max_depth: int,
     get_messages: Callable[[], list[ChatMessage]] | None,
+    retry_refusals: int | None = None,
 ) -> list[Tool | ToolDef | ToolSource]:
     tools: list[Tool | ToolDef | ToolSource] = []
     if sa.tools is not None:
@@ -341,6 +348,7 @@ def _resolve_tools(
                 depth + 1,
                 max_depth,
                 get_messages,
+                retry_refusals=retry_refusals,
             )
         )
     return tools

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -289,8 +289,9 @@ def _get_memory_initial_data(
     mem = _find_memory_tool(tools)
     if mem is None:
         return None
-    execute = getattr(mem, "execute", mem)
-    return getattr(execute, "initial_data", None)
+    # Tool stores the callable directly; ToolDef stores it on .tool
+    callable_ = getattr(mem, "tool", None) or getattr(mem, "execute", mem)
+    return getattr(callable_, "initial_data", None)
 
 
 def _resolve_tools(

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -1,7 +1,6 @@
 from typing import Callable, Sequence
 
 from inspect_ai.agent._agent import Agent, AgentState
-from inspect_ai.agent._filter import content_only
 from inspect_ai.agent._react import react
 from inspect_ai.agent._run import run
 from inspect_ai.model._chat_message import (
@@ -77,8 +76,8 @@ def task_tool(
             )
 
             if sa.fork:
-                input = await _prepare_forked_input(prompt, sa, get_messages)
-                return await _dispatch(child_agent, sa, input)
+                input = _prepare_forked_input(prompt, sa, get_messages)
+                return await _dispatch_forked(child_agent, sa, input)
             else:
                 return await _dispatch(child_agent, sa, prompt)
 
@@ -127,7 +126,24 @@ async def _dispatch(
     return _extract_result(state)
 
 
-async def _prepare_forked_input(
+async def _dispatch_forked(
+    agent: Agent,
+    sa: Subagent,
+    input: list[ChatMessage],
+) -> str:
+    from inspect_ai.event._timeline import timeline_branch
+    from inspect_ai.util._span import current_span_id
+
+    from_span = current_span_id() or ""
+    from_message = _last_message_id(input)
+
+    async with timeline_branch(
+        name=sa.name, from_span=from_span, from_message=from_message
+    ):
+        return await _dispatch(agent, sa, input)
+
+
+def _prepare_forked_input(
     prompt: str,
     sa: Subagent,
     get_messages: Callable[[], list[ChatMessage]] | None,
@@ -137,10 +153,9 @@ async def _prepare_forked_input(
             f"Forked dispatch for '{sa.name}' requires parent messages, "
             "but no get_messages callback was provided."
         )
-    parent_messages = get_messages()
-    filtered = await content_only(parent_messages)
-    filtered.append(ChatMessageUser(content=prompt, source="input"))
-    return filtered
+    messages = list(get_messages())
+    messages.append(ChatMessageUser(content=prompt, source="input"))
+    return messages
 
 
 def _extract_result(state: AgentState) -> str:
@@ -174,6 +189,13 @@ def _resolve_tools(
             task_tool(subagents, parent_tools, depth + 1, max_depth, get_messages)
         )
     return tools
+
+
+def _last_message_id(messages: list[ChatMessage]) -> str:
+    for msg in reversed(messages):
+        if msg.id:
+            return msg.id
+    return ""
 
 
 SUBAGENT_ALIASES: dict[str, str] = {

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -5,6 +5,8 @@ from typing import TYPE_CHECKING, Callable, Sequence
 if TYPE_CHECKING:
     from inspect_ai.tool._tools._skill import Skill
 
+from shortuuid import uuid as shortuuid
+
 from inspect_ai.agent._agent import Agent, AgentState
 from inspect_ai.agent._react import react
 from inspect_ai.agent._run import run
@@ -84,6 +86,8 @@ def task_tool(
                 get_messages,
             )
 
+            agent_span_id = shortuuid()
+
             if sa.fork:
                 child_agent = react(
                     name=sa.name,
@@ -94,8 +98,10 @@ def task_tool(
                     submit=False,
                     compaction=sa.compaction,
                 )
-                input = _prepare_forked_input(prompt, sa, get_messages)
-                return await _dispatch_forked(child_agent, sa, input)
+                input, from_message = _prepare_forked_input(prompt, sa, get_messages)
+                result = await _dispatch_forked(
+                    child_agent, sa, input, from_message, span_id=agent_span_id
+                )
             else:
                 child_agent = react(
                     name=sa.name,
@@ -106,7 +112,10 @@ def task_tool(
                     submit=False,
                     compaction=sa.compaction,
                 )
-                return await _dispatch(child_agent, sa, prompt)
+                result = await _dispatch(child_agent, sa, prompt, span_id=agent_span_id)
+
+            execute.agent_span_id = agent_span_id  # type: ignore[attr-defined]
+            return result
 
         execute.__doc__ = tool_description
         return execute
@@ -120,7 +129,8 @@ def _build_task_description(subagents: list[Subagent]) -> str:
     lines = ["Delegate a task to a specialized subagent.\n"]
     lines.append("Available subagent types:\n")
     for sa in subagents:
-        lines.append(f"- **{sa.name}**: {sa.description}")
+        suffix = " (has conversation context)" if sa.fork else ""
+        lines.append(f"- **{sa.name}**: {sa.description}{suffix}")
     lines.append("")
     lines.append(
         "Delegate when the work is complex, independent, or would benefit "
@@ -128,14 +138,22 @@ def _build_task_description(subagents: list[Subagent]) -> str:
         "lookup or single tool call."
     )
     lines.append("")
+    has_forked = any(sa.fork for sa in subagents)
     lines.append("Args:")
     lines.append("    subagent_type: Which subagent to use.")
-    lines.append(
-        "    prompt: Detailed instructions for the subagent. Include"
-        " all necessary context — the subagent starts with a fresh"
-        " context and cannot see your conversation history unless"
-        " it uses forked mode."
-    )
+    if has_forked:
+        lines.append(
+            "    prompt: Detailed instructions for the subagent. Non-forked"
+            " subagents start with a fresh context and cannot see your"
+            " conversation history — include all necessary context for them."
+            " Forked subagents already have your full conversation context."
+        )
+    else:
+        lines.append(
+            "    prompt: Detailed instructions for the subagent. Include"
+            " all necessary context — the subagent starts with a fresh"
+            " context and cannot see your conversation history."
+        )
     lines.append("    task_description: Brief description of the task.")
     return "\n".join(lines)
 
@@ -144,17 +162,20 @@ async def _dispatch(
     agent: Agent,
     sa: Subagent,
     input: str | list[ChatMessage],
+    span_id: str | None = None,
 ) -> str:
     from copy import deepcopy
 
     # deepcopy limits per dispatch — Limit objects are single-use
     limits = deepcopy(sa.limits) if sa.limits else []
     if limits:
-        state, limit_error = await run(agent, input=input, limits=limits, name=sa.name)
+        state, limit_error = await run(
+            agent, input=input, limits=limits, name=sa.name, span_id=span_id
+        )
         if limit_error:
-            return f"Subagent '{sa.name}' stopped: {limit_error}"
+            return f"Subagent '{sa.name}' stopped: {limit_error.message}"
     else:
-        state = await run(agent, input=input, name=sa.name)
+        state = await run(agent, input=input, name=sa.name, span_id=span_id)
     return _extract_result(state)
 
 
@@ -162,24 +183,25 @@ async def _dispatch_forked(
     agent: Agent,
     sa: Subagent,
     input: list[ChatMessage],
+    from_message: str,
+    span_id: str | None = None,
 ) -> str:
     from inspect_ai.event._timeline import timeline_branch
     from inspect_ai.util._span import current_span_id
 
     from_span = current_span_id() or ""
-    from_message = _last_message_id(input)
 
     async with timeline_branch(
         name=sa.name, from_span=from_span, from_message=from_message
     ):
-        return await _dispatch(agent, sa, input)
+        return await _dispatch(agent, sa, input, span_id=span_id)
 
 
 def _prepare_forked_input(
     prompt: str,
     sa: Subagent,
     get_messages: Callable[[], list[ChatMessage]] | None,
-) -> list[ChatMessage]:
+) -> tuple[list[ChatMessage], str]:
     if get_messages is None:
         raise ToolError(
             f"Forked dispatch for '{sa.name}' requires parent messages, "
@@ -194,11 +216,14 @@ def _prepare_forked_input(
     if messages and isinstance(messages[-1], ChatMessageAssistant):
         messages.pop()
 
+    # Capture branch point before appending the synthetic child prompt.
+    from_message = _last_message_id(messages)
+
     content = prompt
     if sa.prompt:
         content = f"{sa.prompt}\n\n{content}"
     messages.append(ChatMessageUser(content=content, source="input"))
-    return messages
+    return messages, from_message
 
 
 def _extract_result(state: AgentState) -> str:
@@ -240,6 +265,18 @@ def _apply_subagent_type_enum(tool: Tool, subagents: list[Subagent]) -> None:
     )
 
 
+def _has_memory_tool(tools: list[Tool | ToolDef | ToolSource]) -> bool:
+    from inspect_ai._util.registry import is_registry_object, registry_unqualified_name
+
+    for t in tools:
+        if is_registry_object(t):
+            if registry_unqualified_name(t) == "memory":
+                return True
+        elif isinstance(t, ToolDef) and t.name == "memory":
+            return True
+    return False
+
+
 def _resolve_tools(
     sa: Subagent,
     subagents: list[Subagent],
@@ -257,11 +294,11 @@ def _resolve_tools(
         tools.extend(_default_readonly_tools())
     if sa.extra_tools is not None:
         tools.extend(sa.extra_tools)
-    if sa.memory == "readwrite":
+    if sa.memory == "readwrite" and not _has_memory_tool(tools):
         from inspect_ai.tool._tools._memory import memory
 
         tools.append(memory())
-    elif sa.memory == "readonly":
+    elif sa.memory == "readonly" and not _has_memory_tool(tools):
         from inspect_ai.tool._tools._memory import memory
 
         tools.append(memory(readonly=True))

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -12,6 +12,7 @@ from shortuuid import uuid as shortuuid
 from inspect_ai.agent._agent import Agent, AgentState
 from inspect_ai.agent._react import react
 from inspect_ai.agent._run import run
+from inspect_ai.agent._types import AgentPrompt, AgentSubmit
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -21,6 +22,7 @@ from inspect_ai.model._model import Model
 from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool
 from inspect_ai.tool._tool_def import ToolDef
 
+from .prompt import SUBAGENT_SUBMIT_PROMPT
 from .subagent import Subagent
 
 
@@ -104,7 +106,7 @@ def task_tool(
                     prompt=None,
                     tools=child_tools,
                     model=sa.model or parent_model,
-                    submit=False,
+                    submit=AgentSubmit(answer_only=True),
                     compaction=sa.compaction,
                     retry_refusals=retry_refusals,
                     approval=approval,
@@ -117,10 +119,15 @@ def task_tool(
                 child_agent = react(
                     name=sa.name,
                     description=sa.description,
-                    prompt=sa.prompt,
+                    prompt=AgentPrompt(
+                        instructions=sa.prompt,
+                        assistant_prompt=SUBAGENT_SUBMIT_PROMPT,
+                        submit_prompt=None,
+                        handoff_prompt=None,
+                    ),
                     tools=child_tools,
                     model=sa.model or parent_model,
-                    submit=False,
+                    submit=AgentSubmit(answer_only=True),
                     compaction=sa.compaction,
                     retry_refusals=retry_refusals,
                     approval=approval,
@@ -255,11 +262,15 @@ def _prepare_forked_input(
     content = prompt
     if sa.prompt:
         content = f"{sa.prompt}\n\n{content}"
+    submit_text = SUBAGENT_SUBMIT_PROMPT.format(submit="submit")
+    content = f"{content}\n\n{submit_text}"
     messages.append(ChatMessageUser(content=content, source="input"))
     return messages, from_message
 
 
 def _extract_result(state: AgentState) -> str:
+    if state.output.completion:
+        return state.output.completion
     if not state.output.empty:
         return state.output.message.text
     elif len(state.messages) > 0 and isinstance(

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -14,7 +14,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageUser,
 )
 from inspect_ai.model._model import Model
-from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool, tool_result_content
+from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool
 from inspect_ai.tool._tool_def import ToolDef
 
 from .subagent import Subagent
@@ -203,13 +203,11 @@ def _prepare_forked_input(
 
 def _extract_result(state: AgentState) -> str:
     if not state.output.empty:
-        result = tool_result_content(state.output.message.content)
-        return result if isinstance(result, str) else ""
+        return state.output.message.text
     elif len(state.messages) > 0 and isinstance(
         state.messages[-1], ChatMessageAssistant
     ):
-        result = tool_result_content(state.messages[-1].content)
-        return result if isinstance(result, str) else ""
+        return state.messages[-1].text
     else:
         return ""
 

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Sequence
 
 if TYPE_CHECKING:
@@ -27,7 +28,7 @@ def task_tool(
     subagents: list[Subagent],
     parent_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     parent_model: str | Model | None = None,
-    parent_skills: list[Skill] | None = None,
+    parent_skills: list[str | Path | Skill] | None = None,
     depth: int = 0,
     max_depth: int = 1,
     get_messages: Callable[[], list[ChatMessage]] | None = None,
@@ -311,7 +312,7 @@ def _resolve_tools(
     subagents: list[Subagent],
     parent_tools: Sequence[Tool | ToolDef | ToolSource] | None,
     parent_model: str | Model | None,
-    parent_skills: list[Skill] | None,
+    parent_skills: list[str | Path | Skill] | None,
     depth: int,
     max_depth: int,
     get_messages: Callable[[], list[ChatMessage]] | None,

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -136,7 +136,10 @@ async def _dispatch(
     sa: Subagent,
     input: str | list[ChatMessage],
 ) -> str:
-    limits = sa.limits or []
+    from copy import deepcopy
+
+    # deepcopy limits per dispatch — Limit objects are single-use
+    limits = deepcopy(sa.limits) if sa.limits else []
     if limits:
         state, limit_error = await run(agent, input=input, limits=limits, name=sa.name)
         if limit_error:

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -73,6 +73,7 @@ def task_tool(
                 tools=child_tools,
                 model=sa.model,
                 submit=False,
+                compaction=sa.compaction,
             )
 
             if sa.fork:
@@ -182,13 +183,35 @@ def _resolve_tools(
     tools: list[Tool | ToolDef | ToolSource] = []
     if sa.tools is not None:
         tools.extend(sa.tools)
+    else:
+        tools.extend(_default_readonly_tools())
     if sa.extra_tools is not None:
         tools.extend(sa.extra_tools)
+    if sa.memory == "readwrite":
+        from inspect_ai.tool._tools._memory import memory
+
+        tools.append(memory())
+    elif sa.memory == "readonly":
+        from inspect_ai.tool._tools._memory import memory
+
+        tools.append(memory(readonly=True))
     if depth < max_depth:
         tools.append(
             task_tool(subagents, parent_tools, depth + 1, max_depth, get_messages)
         )
     return tools
+
+
+def _default_readonly_tools() -> list[Tool | ToolDef | ToolSource]:
+    from inspect_ai.util._sandbox.context import sandbox_environments_context_var
+
+    if sandbox_environments_context_var.get(None) is None:
+        return []
+    from inspect_ai.tool._tools._grep import grep
+    from inspect_ai.tool._tools._list_files import list_files
+    from inspect_ai.tool._tools._read_file import read_file
+
+    return [read_file(), list_files(), grep()]
 
 
 def _last_message_id(messages: list[ChatMessage]) -> str:

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -6,7 +6,6 @@ from inspect_ai.agent._run import run
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
-    ChatMessageSystem,
     ChatMessageUser,
 )
 from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool, tool_result_content
@@ -66,20 +65,28 @@ def task_tool(
                 sa, subagents, parent_tools, depth, max_depth, get_messages
             )
 
-            child_agent = react(
-                name=sa.name,
-                description=sa.description,
-                prompt=sa.prompt,
-                tools=child_tools,
-                model=sa.model,
-                submit=False,
-                compaction=sa.compaction,
-            )
-
             if sa.fork:
+                child_agent = react(
+                    name=sa.name,
+                    description=sa.description,
+                    prompt=None,
+                    tools=child_tools,
+                    model=sa.model,
+                    submit=False,
+                    compaction=sa.compaction,
+                )
                 input = _prepare_forked_input(prompt, sa, get_messages)
                 return await _dispatch_forked(child_agent, sa, input)
             else:
+                child_agent = react(
+                    name=sa.name,
+                    description=sa.description,
+                    prompt=sa.prompt,
+                    tools=child_tools,
+                    model=sa.model,
+                    submit=False,
+                    compaction=sa.compaction,
+                )
                 return await _dispatch(child_agent, sa, prompt)
 
         execute.__doc__ = tool_description
@@ -157,19 +164,18 @@ def _prepare_forked_input(
             "but no get_messages callback was provided."
         )
 
-    # Strip system messages (child gets its own) and the trailing
-    # assistant message (which contains the in-flight task() call).
-    # The child sees the conversation history up to the parent's last
-    # user turn, then the delegation prompt as a fresh user message.
-    messages: list[ChatMessage] = []
-    for m in get_messages():
-        if isinstance(m, ChatMessageSystem):
-            continue
-        messages.append(m)
+    # Keep parent system message (preserves prompt cache on all providers).
+    # Strip the trailing assistant message (in-flight task() call).
+    # Subagent instructions + task prompt go in a single user message
+    # appended after the cached prefix.
+    messages = list(get_messages())
     if messages and isinstance(messages[-1], ChatMessageAssistant):
         messages.pop()
 
-    messages.append(ChatMessageUser(content=prompt, source="input"))
+    content = prompt
+    if sa.prompt:
+        content = f"{sa.prompt}\n\n{content}"
+    messages.append(ChatMessageUser(content=content, source="input"))
     return messages
 
 

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -6,6 +6,8 @@ from inspect_ai.agent._run import run
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
     ChatMessageUser,
 )
 from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool, tool_result_content
@@ -154,7 +156,32 @@ def _prepare_forked_input(
             f"Forked dispatch for '{sa.name}' requires parent messages, "
             "but no get_messages callback was provided."
         )
-    messages = list(get_messages())
+
+    messages: list[ChatMessage] = []
+    for m in get_messages():
+        if isinstance(m, ChatMessageSystem):
+            continue
+        messages.append(m)
+
+    # Following agent_handoff() pattern: strip sibling tool calls from
+    # the last assistant message (keep only the task() call that
+    # triggered this dispatch) and add a tool result boundary.
+    if messages and isinstance(messages[-1], ChatMessageAssistant):
+        last = messages[-1]
+        if last.tool_calls:
+            task_call = next(
+                (tc for tc in last.tool_calls if tc.function == "task"), None
+            )
+            if task_call:
+                messages[-1] = last.model_copy(update=dict(tool_calls=[task_call]))
+                messages.append(
+                    ChatMessageTool(
+                        content=f"Transferring to {sa.name}.",
+                        tool_call_id=task_call.id,
+                        function="task",
+                    )
+                )
+
     messages.append(ChatMessageUser(content=prompt, source="input"))
     return messages
 

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -7,7 +7,6 @@ from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
     ChatMessageSystem,
-    ChatMessageTool,
     ChatMessageUser,
 )
 from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool, tool_result_content
@@ -157,30 +156,17 @@ def _prepare_forked_input(
             "but no get_messages callback was provided."
         )
 
+    # Strip system messages (child gets its own) and the trailing
+    # assistant message (which contains the in-flight task() call).
+    # The child sees the conversation history up to the parent's last
+    # user turn, then the delegation prompt as a fresh user message.
     messages: list[ChatMessage] = []
     for m in get_messages():
         if isinstance(m, ChatMessageSystem):
             continue
         messages.append(m)
-
-    # Following agent_handoff() pattern: strip sibling tool calls from
-    # the last assistant message (keep only the task() call that
-    # triggered this dispatch) and add a tool result boundary.
     if messages and isinstance(messages[-1], ChatMessageAssistant):
-        last = messages[-1]
-        if last.tool_calls:
-            task_call = next(
-                (tc for tc in last.tool_calls if tc.function == "task"), None
-            )
-            if task_call:
-                messages[-1] = last.model_copy(update=dict(tool_calls=[task_call]))
-                messages.append(
-                    ChatMessageTool(
-                        content=f"Transferring to {sa.name}.",
-                        tool_call_id=task_call.id,
-                        function="task",
-                    )
-                )
+        messages.pop()
 
     messages.append(ChatMessageUser(content=prompt, source="input"))
     return messages

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -265,16 +265,32 @@ def _apply_subagent_type_enum(tool: Tool, subagents: list[Subagent]) -> None:
     )
 
 
-def _has_memory_tool(tools: list[Tool | ToolDef | ToolSource]) -> bool:
+def _has_memory_tool(tools: Sequence[Tool | ToolDef | ToolSource]) -> bool:
+    return _find_memory_tool(tools) is not None
+
+
+def _find_memory_tool(
+    tools: Sequence[Tool | ToolDef | ToolSource],
+) -> Tool | ToolDef | None:
     from inspect_ai._util.registry import is_registry_object, registry_unqualified_name
 
     for t in tools:
         if is_registry_object(t):
             if registry_unqualified_name(t) == "memory":
-                return True
+                return t  # type: ignore[return-value]
         elif isinstance(t, ToolDef) and t.name == "memory":
-            return True
-    return False
+            return t
+    return None
+
+
+def _get_memory_initial_data(
+    tools: Sequence[Tool | ToolDef | ToolSource],
+) -> dict[str, str] | None:
+    mem = _find_memory_tool(tools)
+    if mem is None:
+        return None
+    execute = getattr(mem, "execute", mem)
+    return getattr(execute, "initial_data", None)
 
 
 def _resolve_tools(
@@ -294,14 +310,14 @@ def _resolve_tools(
         tools.extend(_default_readonly_tools())
     if sa.extra_tools is not None:
         tools.extend(sa.extra_tools)
-    if sa.memory == "readwrite" and not _has_memory_tool(tools):
+    if sa.memory and not _has_memory_tool(tools):
         from inspect_ai.tool._tools._memory import memory
 
-        tools.append(memory())
-    elif sa.memory == "readonly" and not _has_memory_tool(tools):
-        from inspect_ai.tool._tools._memory import memory
-
-        tools.append(memory(readonly=True))
+        parent_initial_data = _get_memory_initial_data(parent_tools or [])
+        if sa.memory == "readwrite":
+            tools.append(memory(initial_data=parent_initial_data))
+        elif sa.memory == "readonly":
+            tools.append(memory(initial_data=parent_initial_data, readonly=True))
 
     # Merge parent + subagent skills with instance scoping.
     # Duplicate names are validated globally in deepagent.execute().

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -275,11 +275,14 @@ def _resolve_tools(
         tools.append(skill_fn(merged_skills, instance=sa.name))
 
     if depth + 1 < max_depth:
+        # Pass the effective model (sa.model or parent_model) so nested
+        # subagents inherit the calling subagent's model, not the top-level
+        effective_model = sa.model or parent_model
         tools.append(
             task_tool(
                 subagents,
                 parent_tools,
-                parent_model,
+                effective_model,
                 parent_skills,
                 depth + 1,
                 max_depth,

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -1,4 +1,9 @@
-from typing import Callable, Sequence
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Callable, Sequence
+
+if TYPE_CHECKING:
+    from inspect_ai.tool._tools._skill import Skill
 
 from inspect_ai.agent._agent import Agent, AgentState
 from inspect_ai.agent._react import react
@@ -19,6 +24,7 @@ def task_tool(
     subagents: list[Subagent],
     parent_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
     parent_model: str | Model | None = None,
+    parent_skills: list[Skill] | None = None,
     depth: int = 0,
     max_depth: int = 1,
     get_messages: Callable[[], list[ChatMessage]] | None = None,
@@ -30,6 +36,8 @@ def task_tool(
         parent_tools: Tools from the parent agent (flow to general()).
         parent_model: Parent agent's model (inherited by subagents
             that don't set their own).
+        parent_skills: Parent agent's skills (merged with subagent
+            skills at dispatch time).
         depth: Current recursion depth.
         max_depth: Maximum recursion depth.
         get_messages: Callback returning parent messages (required for
@@ -70,6 +78,7 @@ def task_tool(
                 subagents,
                 parent_tools,
                 parent_model,
+                parent_skills,
                 depth,
                 max_depth,
                 get_messages,
@@ -238,6 +247,7 @@ def _resolve_tools(
     subagents: list[Subagent],
     parent_tools: Sequence[Tool | ToolDef | ToolSource] | None,
     parent_model: str | Model | None,
+    parent_skills: list[Skill] | None,
     depth: int,
     max_depth: int,
     get_messages: Callable[[], list[ChatMessage]] | None,
@@ -257,12 +267,22 @@ def _resolve_tools(
         from inspect_ai.tool._tools._memory import memory
 
         tools.append(memory(readonly=True))
+
+    # Merge parent + subagent skills with instance scoping.
+    # Duplicate names are validated globally in deepagent.execute().
+    merged_skills = list(parent_skills or []) + list(sa.skills or [])
+    if merged_skills:
+        from inspect_ai.tool._tools._skill import skill as skill_fn
+
+        tools.append(skill_fn(merged_skills, instance=sa.name))
+
     if depth + 1 < max_depth:
         tools.append(
             task_tool(
                 subagents,
                 parent_tools,
                 parent_model,
+                parent_skills,
                 depth + 1,
                 max_depth,
                 get_messages,

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -146,27 +146,40 @@ def _build_task_description(subagents: list[Subagent]) -> str:
         lines.append(f"- **{sa.name}**: {sa.description}{suffix}")
     lines.append("")
     lines.append(
-        "Delegate when the work is complex, independent, or would benefit "
-        "from a fresh context. Do the work directly when it's a simple "
-        "lookup or single tool call."
+        "Delegate when the work is multi-step, benefits from tool isolation, "
+        "or requires independent research or analysis. Do the work directly "
+        "when it's a single tool call, a quick lookup, or a tightly coupled "
+        "step whose context would be harder to reconstruct in a subagent prompt."
     )
     lines.append("")
     has_forked = any(sa.fork for sa in subagents)
-    lines.append("Args:")
-    lines.append("    subagent_type: Which subagent to use.")
     if has_forked:
         lines.append(
-            "    prompt: Detailed instructions for the subagent. Non-forked"
-            " subagents start with a fresh context and cannot see your"
-            " conversation history — include all necessary context for them."
-            " Forked subagents already have your full conversation context."
+            "Non-forked subagents start with a fresh context and cannot see "
+            "your conversation history. Write the prompt as a self-contained "
+            "brief: state the goal, include any relevant findings or data, "
+            "and specify what you need back. Forked subagents already have "
+            "your full conversation context."
         )
     else:
         lines.append(
-            "    prompt: Detailed instructions for the subagent. Include"
-            " all necessary context — the subagent starts with a fresh"
-            " context and cannot see your conversation history."
+            "The subagent starts with a fresh context and cannot see your "
+            "conversation history. Write the prompt as a self-contained "
+            "brief: state the goal, include any relevant findings or data, "
+            "and specify what you need back."
         )
+    lines.append("")
+    lines.append(
+        "The task tool returns the subagent's final text response. If you "
+        "need a specific format, ask for it explicitly in the prompt."
+    )
+    lines.append("")
+    lines.append("Args:")
+    lines.append("    subagent_type: Which subagent to use.")
+    lines.append(
+        "    prompt: Self-contained instructions for the subagent, "
+        "including all necessary context."
+    )
     lines.append("    task_description: Brief description of the task.")
     return "\n".join(lines)
 

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Callable, Sequence
 
 if TYPE_CHECKING:
+    from inspect_ai.approval._policy import ApprovalPolicy
     from inspect_ai.tool._tools._skill import Skill
 
 from shortuuid import uuid as shortuuid
@@ -31,6 +32,7 @@ def task_tool(
     max_depth: int = 1,
     get_messages: Callable[[], list[ChatMessage]] | None = None,
     retry_refusals: int | None = None,
+    approval: list[ApprovalPolicy] | None = None,
 ) -> Tool:
     """Create a task multiplexer tool for dispatching to subagents.
 
@@ -47,6 +49,7 @@ def task_tool(
             forked dispatch).
         retry_refusals: Number of times to retry on content filter
             refusals.
+        approval: Approval policies for tool calls.
     """
     subagent_map = {s.name: s for s in subagents}
     tool_description = _build_task_description(subagents)
@@ -88,6 +91,7 @@ def task_tool(
                 max_depth,
                 get_messages,
                 retry_refusals,
+                approval,
             )
 
             agent_span_id = shortuuid()
@@ -102,6 +106,7 @@ def task_tool(
                     submit=False,
                     compaction=sa.compaction,
                     retry_refusals=retry_refusals,
+                    approval=approval,
                 )
                 input, from_message = _prepare_forked_input(prompt, sa, get_messages)
                 result = await _dispatch_forked(
@@ -117,6 +122,7 @@ def task_tool(
                     submit=False,
                     compaction=sa.compaction,
                     retry_refusals=retry_refusals,
+                    approval=approval,
                 )
                 result = await _dispatch(child_agent, sa, prompt, span_id=agent_span_id)
 
@@ -310,6 +316,7 @@ def _resolve_tools(
     max_depth: int,
     get_messages: Callable[[], list[ChatMessage]] | None,
     retry_refusals: int | None = None,
+    approval: list[ApprovalPolicy] | None = None,
 ) -> list[Tool | ToolDef | ToolSource]:
     tools: list[Tool | ToolDef | ToolSource] = []
     if sa.tools is not None:
@@ -349,6 +356,7 @@ def _resolve_tools(
                 max_depth,
                 get_messages,
                 retry_refusals=retry_refusals,
+                approval=approval,
             )
         )
     return tools

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -1,0 +1,181 @@
+from typing import Callable, Sequence
+
+from inspect_ai.agent._agent import Agent, AgentState
+from inspect_ai.agent._filter import content_only
+from inspect_ai.agent._react import react
+from inspect_ai.agent._run import run
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageUser,
+)
+from inspect_ai.tool._tool import Tool, ToolError, ToolSource, tool, tool_result_content
+from inspect_ai.tool._tool_def import ToolDef
+
+from .subagent import Subagent
+
+
+def task_tool(
+    subagents: list[Subagent],
+    parent_tools: Sequence[Tool | ToolDef | ToolSource] | None = None,
+    depth: int = 0,
+    max_depth: int = 1,
+    get_messages: Callable[[], list[ChatMessage]] | None = None,
+) -> Tool:
+    """Create a task multiplexer tool for dispatching to subagents.
+
+    Args:
+        subagents: List of available subagent configurations.
+        parent_tools: Tools from the parent agent (flow to general()).
+        depth: Current recursion depth.
+        max_depth: Maximum recursion depth.
+        get_messages: Callback returning parent messages (required for
+            forked dispatch).
+    """
+    subagent_map = {s.name: s for s in subagents}
+    tool_description = _build_task_description(subagents)
+
+    @tool
+    def task() -> Tool:
+        """Delegate a task to a specialized subagent."""
+
+        async def execute(
+            subagent_type: str,
+            prompt: str,
+            task_description: str | None = None,
+        ) -> str:
+            """Delegate a task to a specialized subagent.
+
+            Args:
+                subagent_type: Which subagent to use.
+                prompt: Detailed instructions for the subagent. Include
+                    all necessary context — the subagent starts with a
+                    fresh context and cannot see your conversation history
+                    unless it uses forked mode.
+                task_description: Brief description of the task.
+            """
+            resolved = SUBAGENT_ALIASES.get(subagent_type, subagent_type)
+            sa = subagent_map.get(resolved)
+            if sa is None:
+                available = ", ".join(subagent_map.keys())
+                raise ToolError(
+                    f"Unknown subagent_type: {subagent_type!r}. "
+                    f"Available types: {available}"
+                )
+
+            child_tools = _resolve_tools(
+                sa, subagents, parent_tools, depth, max_depth, get_messages
+            )
+
+            child_agent = react(
+                name=sa.name,
+                description=sa.description,
+                prompt=sa.prompt,
+                tools=child_tools,
+                model=sa.model,
+                submit=False,
+            )
+
+            if sa.fork:
+                input = await _prepare_forked_input(prompt, sa, get_messages)
+                return await _dispatch(child_agent, sa, input)
+            else:
+                return await _dispatch(child_agent, sa, prompt)
+
+        execute.__doc__ = tool_description
+        return execute
+
+    return task()
+
+
+def _build_task_description(subagents: list[Subagent]) -> str:
+    lines = ["Delegate a task to a specialized subagent.\n"]
+    lines.append("Available subagent types:\n")
+    for sa in subagents:
+        lines.append(f"- **{sa.name}**: {sa.description}")
+    lines.append("")
+    lines.append(
+        "Delegate when the work is complex, independent, or would benefit "
+        "from a fresh context. Do the work directly when it's a simple "
+        "lookup or single tool call."
+    )
+    lines.append("")
+    lines.append("Args:")
+    lines.append("    subagent_type: Which subagent to use.")
+    lines.append(
+        "    prompt: Detailed instructions for the subagent. Include"
+        " all necessary context — the subagent starts with a fresh"
+        " context and cannot see your conversation history unless"
+        " it uses forked mode."
+    )
+    lines.append("    task_description: Brief description of the task.")
+    return "\n".join(lines)
+
+
+async def _dispatch(
+    agent: Agent,
+    sa: Subagent,
+    input: str | list[ChatMessage],
+) -> str:
+    limits = sa.limits or []
+    if limits:
+        state, limit_error = await run(agent, input=input, limits=limits, name=sa.name)
+        if limit_error:
+            return f"Subagent '{sa.name}' stopped: {limit_error}"
+    else:
+        state = await run(agent, input=input, name=sa.name)
+    return _extract_result(state)
+
+
+async def _prepare_forked_input(
+    prompt: str,
+    sa: Subagent,
+    get_messages: Callable[[], list[ChatMessage]] | None,
+) -> list[ChatMessage]:
+    if get_messages is None:
+        raise ToolError(
+            f"Forked dispatch for '{sa.name}' requires parent messages, "
+            "but no get_messages callback was provided."
+        )
+    parent_messages = get_messages()
+    filtered = await content_only(parent_messages)
+    filtered.append(ChatMessageUser(content=prompt, source="input"))
+    return filtered
+
+
+def _extract_result(state: AgentState) -> str:
+    if not state.output.empty:
+        result = tool_result_content(state.output.message.content)
+        return result if isinstance(result, str) else ""
+    elif len(state.messages) > 0 and isinstance(
+        state.messages[-1], ChatMessageAssistant
+    ):
+        result = tool_result_content(state.messages[-1].content)
+        return result if isinstance(result, str) else ""
+    else:
+        return ""
+
+
+def _resolve_tools(
+    sa: Subagent,
+    subagents: list[Subagent],
+    parent_tools: Sequence[Tool | ToolDef | ToolSource] | None,
+    depth: int,
+    max_depth: int,
+    get_messages: Callable[[], list[ChatMessage]] | None,
+) -> list[Tool | ToolDef | ToolSource]:
+    tools: list[Tool | ToolDef | ToolSource] = []
+    if sa.tools is not None:
+        tools.extend(sa.tools)
+    if sa.extra_tools is not None:
+        tools.extend(sa.extra_tools)
+    if depth < max_depth:
+        tools.append(
+            task_tool(subagents, parent_tools, depth + 1, max_depth, get_messages)
+        )
+    return tools
+
+
+SUBAGENT_ALIASES: dict[str, str] = {
+    "general_purpose": "general",
+}

--- a/src/inspect_ai/agent/_run.py
+++ b/src/inspect_ai/agent/_run.py
@@ -16,6 +16,7 @@ async def run(
     limits: list[Limit],
     *,
     name: str | None = None,
+    span_id: str | None = None,
     **agent_kwargs: Any,
 ) -> tuple[AgentState, LimitExceededError | None]: ...
 
@@ -27,6 +28,7 @@ async def run(
     limits: None = ...,
     *,
     name: str | None = None,
+    span_id: str | None = None,
     **agent_kwargs: Any,
 ) -> AgentState: ...
 
@@ -37,6 +39,7 @@ async def run(
     limits: list[Limit] | None = None,
     *,
     name: str | None = None,
+    span_id: str | None = None,
     **agent_kwargs: Any,
 ) -> AgentState | tuple[AgentState, LimitExceededError | None]:
     """Run an agent.
@@ -51,6 +54,8 @@ async def run(
             exceeded, the `LimitExceededError` is caught and returned.
         name: Optional display name for the transcript entry. If not provided, the
             agent's name as defined in the registry will be used.
+        span_id: Optional span ID for the agent span. If not provided, one is
+            generated automatically.
         **agent_kwargs: Additional arguments to pass to agent.
 
     Returns:
@@ -85,7 +90,7 @@ async def run(
     with apply_limits(limits or [], catch_errors=True) as limit_scope:
         # run the agent
         agent_name = name or registry_unqualified_name(agent)
-        async with span(name=agent_name, type="agent"):
+        async with span(name=agent_name, type="agent", id=span_id):
             state = await agent(state, **agent_kwargs)
             if limits is None:
                 return state

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -223,6 +223,14 @@ class TimelineSpan(BaseModel):
     branched_from: str | None = Field(default=None)
     description: str | None = None
     utility: bool = False
+    tool_invoked: bool = False
+    """True if this agent span was invoked as a tool (via task/as_tool/handoff).
+
+    Tool-invoked subagents are explicit user-intended sub-trajectories and
+    are never classified as `utility` regardless of turn count or prompt
+    differences. The `_classify_utility_agents` heuristic targets internal
+    helper model calls, not explicit subagent invocations.
+    """
     agent_result: str | None = None
     outline: "Outline | None" = None
 
@@ -700,7 +708,11 @@ def _is_agent_span(span: EventTreeSpan) -> bool:
     """
     if span.type in ("agent", "solver"):
         return True
-    if span.type == "tool" and _contains_model_events(span):
+    if (
+        span.type == "tool"
+        and _contains_model_events(span)
+        and not _contains_agent_span(span)
+    ):
         return True
     return False
 
@@ -751,6 +763,7 @@ def _event_to_node(event: Event) -> TimelineEvent | TimelineSpan:
                 span_type="agent",
                 content=nested_content,
                 agent_result=agent_result,
+                tool_invoked=True,
             )
     return TimelineEvent(event=event)
 
@@ -765,9 +778,17 @@ def _build_span_from_generic_span(
     """
     content, branches = _process_children(span.children)
 
-    # Determine the span_type based on span type and content
+    # Determine the span_type based on span type and content. A tool span
+    # that recursively contains model events is treated as a tool-spawned
+    # agent (e.g. bridge-style tools that emit raw model events). But if
+    # the tool already wraps an explicit agent span, leave the
+    # classification alone — the inner agent span represents the agent.
     span_type: str | None
-    if span.type == "tool" and _contains_model_events(span):
+    if (
+        span.type == "tool"
+        and _contains_model_events(span)
+        and not _contains_agent_span(span)
+    ):
         span_type = "agent"
     else:
         span_type = span.type
@@ -796,6 +817,19 @@ def _contains_model_events(span: EventTreeSpan) -> bool:
                 return True
         elif isinstance(child, ModelEvent):
             return True
+    return False
+
+
+def _contains_agent_span(span: EventTreeSpan) -> bool:
+    """Check if a span has any descendant span with type='agent'.
+
+    Used to suppress tool→agent classification when the tool already
+    wraps an explicit agent span (which will represent the agent itself).
+    """
+    for child in span.children:
+        if isinstance(child, EventTreeSpan):
+            if child.type == "agent" or _contains_agent_span(child):
+                return True
     return False
 
 
@@ -844,6 +878,12 @@ def _unroll_span(
     # Emit span begin event
     into.append(TimelineEvent(event=span.begin))
 
+    # An agent span discovered as a direct child of a tool span being
+    # unrolled was invoked as a tool (task/as_tool/handoff). Mark it so
+    # _classify_utility_agents leaves it alone — tool-invoked subagents
+    # are explicit user intent, not internal helper calls.
+    parent_is_tool = span.type == "tool"
+
     # Process children: recurse into non-agent spans, keep agent spans
     for child in span.children:
         if isinstance(child, EventTreeSpan):
@@ -852,6 +892,8 @@ def _unroll_span(
                 if isinstance(node, TimelineSpan) and not node.content:
                     pass  # skip empty agent spans
                 else:
+                    if parent_is_tool and isinstance(node, TimelineSpan):
+                        node.tool_invoked = True
                     into.append(node)
             else:
                 _unroll_span(child, into)
@@ -1400,8 +1442,15 @@ def _classify_utility_agents(
     """
     agent_system_prompt = _get_system_prompt(node)
 
-    # Classify this node (root agent is never utility)
-    if parent_system_prompt is not None and agent_system_prompt is not None:
+    # Classify this node (root agent is never utility). Tool-invoked
+    # subagents (task/as_tool/handoff) are explicit user-intended
+    # sub-trajectories — never utility — even if single-turn. Foreign-prompt
+    # helper model calls are handled separately by _wrap_utility_events.
+    if (
+        parent_system_prompt is not None
+        and agent_system_prompt is not None
+        and not node.tool_invoked
+    ):
         if agent_system_prompt != parent_system_prompt and _is_single_turn(node):
             node.utility = True
 

--- a/src/inspect_ai/tool/__init__.py
+++ b/src/inspect_ai/tool/__init__.py
@@ -48,7 +48,10 @@ from ._tools._bash_session import bash_session
 from ._tools._code_execution import CodeExecutionProviders, code_execution
 from ._tools._computer import computer
 from ._tools._execute import bash, python
+from ._tools._grep import grep
+from ._tools._list_files import list_files
 from ._tools._memory import memory
+from ._tools._read_file import read_file
 from ._tools._skill import Skill, SkillInfo, install_skills, read_skills, skill
 from ._tools._text_editor import text_editor
 from ._tools._think import think
@@ -63,8 +66,11 @@ __all__ = [
     "code_execution",
     "CodeExecutionProviders",
     "computer",
+    "grep",
+    "list_files",
     "memory",
     "python",
+    "read_file",
     "web_browser",
     "web_search",
     "WebSearchProviders",

--- a/src/inspect_ai/tool/__init__.py
+++ b/src/inspect_ai/tool/__init__.py
@@ -52,6 +52,7 @@ from ._tools._memory import memory
 from ._tools._skill import Skill, SkillInfo, install_skills, read_skills, skill
 from ._tools._text_editor import text_editor
 from ._tools._think import think
+from ._tools._todo_write import todo_write
 from ._tools._update_plan import update_plan
 from ._tools._web_browser import web_browser
 from ._tools._web_search import WebSearchProviders, web_search
@@ -68,6 +69,7 @@ __all__ = [
     "web_search",
     "WebSearchProviders",
     "think",
+    "todo_write",
     "update_plan",
     "text_editor",
     "tool",

--- a/src/inspect_ai/tool/_tools/_grep.py
+++ b/src/inspect_ai/tool/_tools/_grep.py
@@ -1,0 +1,79 @@
+from typing import Literal
+
+from inspect_ai.util import sandbox as sandbox_env
+
+from .._tool import Tool, ToolError, tool
+
+
+@tool
+def grep(
+    timeout: int | None = None,
+    user: str | None = None,
+    sandbox: str | None = None,
+) -> Tool:
+    """Read-only text search tool.
+
+    Search for patterns in files within a sandbox environment.
+
+    Args:
+        timeout: Timeout (in seconds) for search.
+        user: User to execute as.
+        sandbox: Optional sandbox environment name.
+    """
+
+    async def execute(
+        pattern: str,
+        path: str = ".",
+        glob: str | None = None,
+        fixed_strings: bool = False,
+        output_mode: Literal["content", "files_with_matches", "count"] = "content",
+    ) -> str:
+        """Search for a pattern in files.
+
+        Recursively searches for a pattern and returns results based
+        on the output_mode setting.
+
+        Args:
+            pattern: Regular expression pattern to search for
+                (or literal string if fixed_strings is True).
+            path: File or directory to search (defaults to working
+                directory).
+            glob: Glob pattern to filter which files to search
+                (e.g. "*.py").
+            fixed_strings: If True, treat pattern as a literal string
+                rather than a regular expression.
+            output_mode: Output format. "content" returns matching
+                lines with file paths and line numbers. "files_with_matches"
+                returns only file paths containing matches. "count"
+                returns match counts per file.
+        """
+        cmd = ["grep", "-rn"]
+        if fixed_strings:
+            cmd.append("-F")
+        if glob:
+            cmd.extend(["--include", glob])
+        if output_mode == "files_with_matches":
+            cmd.append("-l")
+        elif output_mode == "count":
+            cmd.append("-c")
+        cmd.extend(["--", pattern, path])
+
+        result = await sandbox_env(sandbox).exec(cmd=cmd, timeout=timeout, user=user)
+
+        # exit code 1 means no matches (not an error)
+        if result.returncode == 1:
+            return "No matches found."
+
+        if result.returncode != 0:
+            raise ToolError(result.stderr.strip() if result.stderr else "grep failed")
+
+        output = result.stdout.strip()
+
+        # for count mode, filter out files with 0 matches
+        if output_mode == "count":
+            lines = [line for line in output.splitlines() if not line.endswith(":0")]
+            return "\n".join(lines) if lines else "No matches found."
+
+        return output
+
+    return execute

--- a/src/inspect_ai/tool/_tools/_list_files.py
+++ b/src/inspect_ai/tool/_tools/_list_files.py
@@ -1,0 +1,53 @@
+from inspect_ai.util import sandbox as sandbox_env
+
+from .._tool import Tool, ToolError, tool
+
+
+@tool
+def list_files(
+    timeout: int | None = None,
+    user: str | None = None,
+    sandbox: str | None = None,
+) -> Tool:
+    """Read-only directory listing tool.
+
+    List files and directories in a sandbox environment.
+
+    Args:
+        timeout: Timeout (in seconds) for listing.
+        user: User to execute as.
+        sandbox: Optional sandbox environment name.
+    """
+
+    async def execute(path: str = ".", depth: int | None = None) -> str:
+        """List files and directories at the given path.
+
+        Returns one path per line. Use depth to limit the recursion
+        level: 1 lists only immediate contents, None lists everything
+        recursively.
+
+        Args:
+            path: Directory path to list (defaults to working directory).
+            depth: Maximum depth for recursive listing. 1 lists only the
+                immediate directory. None lists all files recursively.
+        """
+        cmd = ["find", path]
+        if depth is not None:
+            cmd.extend(["-maxdepth", str(depth)])
+        cmd.extend(["-not", "-name", ".", "-print"])
+
+        result = await sandbox_env(sandbox).exec(cmd=cmd, timeout=timeout, user=user)
+
+        if not result.success:
+            raise ToolError(
+                result.stderr.strip() if result.stderr else f"Error listing: {path}"
+            )
+
+        output = result.stdout.strip()
+        if not output:
+            return f"No files found in: {path}"
+
+        lines = sorted(output.splitlines())
+        return "\n".join(lines)
+
+    return execute

--- a/src/inspect_ai/tool/_tools/_list_files.py
+++ b/src/inspect_ai/tool/_tools/_list_files.py
@@ -31,10 +31,10 @@ def list_files(
             depth: Maximum depth for recursive listing. 1 lists only the
                 immediate directory. None lists all files recursively.
         """
-        cmd = ["find", "--", path]
+        cmd = ["find", "--", path, "-mindepth", "1"]
         if depth is not None:
             cmd.extend(["-maxdepth", str(depth)])
-        cmd.extend(["-not", "-name", ".", "-print"])
+        cmd.append("-print")
 
         result = await sandbox_env(sandbox).exec(cmd=cmd, timeout=timeout, user=user)
 

--- a/src/inspect_ai/tool/_tools/_list_files.py
+++ b/src/inspect_ai/tool/_tools/_list_files.py
@@ -31,7 +31,7 @@ def list_files(
             depth: Maximum depth for recursive listing. 1 lists only the
                 immediate directory. None lists all files recursively.
         """
-        cmd = ["find", path]
+        cmd = ["find", "--", path]
         if depth is not None:
             cmd.extend(["-maxdepth", str(depth)])
         cmd.extend(["-not", "-name", ".", "-print"])

--- a/src/inspect_ai/tool/_tools/_memory.py
+++ b/src/inspect_ai/tool/_tools/_memory.py
@@ -1,7 +1,7 @@
 """Memory tool for managing persistent information in /memories directory."""
 
 from pathlib import Path
-from typing import Literal
+from typing import Any, Callable, Literal
 
 from pydantic import Field
 
@@ -19,7 +19,9 @@ class MemoryStore(StoreModel):
 
 
 @tool
-def memory(*, initial_data: dict[str, str] | None = None) -> Tool:
+def memory(
+    *, initial_data: dict[str, str] | None = None, readonly: bool = False
+) -> Tool:
     """Memory tool for managing persistent information.
 
     The description for the memory tool is based on the documentation for the Claude
@@ -31,10 +33,22 @@ def memory(*, initial_data: dict[str, str] | None = None) -> Tool:
             "/memories/file.txt"). Values are resolved via resource(), supporting
             inline strings, file paths, or remote resources (s3://, https://).
             Seeding happens once on first tool execution.
+        readonly: If True, only the view command is available. Write operations
+            (create, str_replace, insert, delete, rename) are not exposed.
 
     Returns:
         Memory tool for file operations in /memories directory.
     """
+
+    def _seed(store: MemoryStore) -> None:
+        if not store.seeding_complete:
+            if initial_data:
+                for seed_path, value in initial_data.items():
+                    _create(store, seed_path, resource(value))
+            store.seeding_complete = True
+
+    if readonly:
+        return _readonly_execute(_seed)
 
     async def execute(
         command: Literal["view", "create", "str_replace", "insert", "delete", "rename"],
@@ -90,11 +104,7 @@ def memory(*, initial_data: dict[str, str] | None = None) -> Tool:
             Result message string
         """
         store = store_as(MemoryStore)
-        if not store.seeding_complete:
-            if initial_data:
-                for seed_path, value in initial_data.items():
-                    _create(store, seed_path, resource(value))
-            store.seeding_complete = True
+        _seed(store)
 
         match command:
             case "view":
@@ -113,6 +123,38 @@ def memory(*, initial_data: dict[str, str] | None = None) -> Tool:
                 raise ToolError(f"Unknown command: {command}")
 
     return execute
+
+
+def _readonly_execute(
+    _seed: "Callable[[MemoryStore], None]",
+) -> "Callable[..., Any]":
+    async def execute_readonly(
+        command: Literal["view"],
+        path: str | None = None,
+        view_range: list[int] | None = None,
+    ) -> str:
+        """Read-only memory tool for viewing persistent information.
+
+        This is a read-only view of the memory directory. Use the
+        `view` command to browse files and directories.
+
+        Args:
+            command: Command to execute (view only).
+            path: Path to file or directory in /memories, e.g.
+                `/memories/file.txt` or `/memories/dir`.
+            view_range: Optional line range when viewing a file,
+                e.g. [11, 12] shows lines 11 and 12. Indexing
+                starts at 1. Use [start_line, -1] to show from
+                start_line to end of file.
+
+        Returns:
+            Result message string
+        """
+        store = store_as(MemoryStore)
+        _seed(store)
+        return _view(store, path, view_range)
+
+    return execute_readonly
 
 
 def _validate_path(path: str) -> str:
@@ -147,11 +189,11 @@ def _validate_path(path: str) -> str:
 
 
 def _path_exists(store: MemoryStore, path: str) -> bool:
-    return path in store.files or path in store.dirs
+    return path == "/memories" or path in store.files or path in store.dirs
 
 
 def _is_dir(store: MemoryStore, path: str) -> bool:
-    return path in store.dirs
+    return path == "/memories" or path in store.dirs
 
 
 def _read_file(store: MemoryStore, path: str) -> str:

--- a/src/inspect_ai/tool/_tools/_memory.py
+++ b/src/inspect_ai/tool/_tools/_memory.py
@@ -41,9 +41,10 @@ def memory(
     """
 
     def _seed(store: MemoryStore) -> None:
-        if not store.seeding_complete and initial_data:
-            for seed_path, value in initial_data.items():
-                _create(store, seed_path, resource(value))
+        if not store.seeding_complete:
+            if initial_data:
+                for seed_path, value in initial_data.items():
+                    _create(store, seed_path, resource(value))
             store.seeding_complete = True
 
     if readonly:

--- a/src/inspect_ai/tool/_tools/_memory.py
+++ b/src/inspect_ai/tool/_tools/_memory.py
@@ -41,14 +41,15 @@ def memory(
     """
 
     def _seed(store: MemoryStore) -> None:
-        if not store.seeding_complete:
-            if initial_data:
-                for seed_path, value in initial_data.items():
-                    _create(store, seed_path, resource(value))
+        if not store.seeding_complete and initial_data:
+            for seed_path, value in initial_data.items():
+                _create(store, seed_path, resource(value))
             store.seeding_complete = True
 
     if readonly:
-        return _readonly_execute(_seed)
+        result = _readonly_execute(_seed)
+        result.initial_data = initial_data  # type: ignore[attr-defined]
+        return result
 
     async def execute(
         command: Literal["view", "create", "str_replace", "insert", "delete", "rename"],
@@ -122,6 +123,7 @@ def memory(
             case _:
                 raise ToolError(f"Unknown command: {command}")
 
+    execute.initial_data = initial_data  # type: ignore[attr-defined]
     return execute
 
 

--- a/src/inspect_ai/tool/_tools/_memory.py
+++ b/src/inspect_ai/tool/_tools/_memory.py
@@ -66,15 +66,14 @@ def memory(
     ) -> str:
         """Memory tool for managing persistent information.
 
-        IMPORTANT: ALWAYS VIEW YOUR MEMORY DIRECTORY BEFORE DOING ANYTHING ELSE.
+        View your memory directory at the start of your work to recover
+        any earlier progress. As you work, record important findings,
+        intermediate results, and status to memory — your context window
+        may be compacted at any point, so information not saved to memory
+        can be lost.
 
-        MEMORY PROTOCOL:
-        1. Use the `view` command of your `memory` tool to check for earlier progress.
-        2. ... (work on the task) ...
-            - As you make progress, record status / progress / thoughts etc in your memory.
-        ASSUME INTERRUPTION: Your context window might be reset at any moment, so you risk losing any progress that is not recorded in your memory directory.
-
-        Note: when editing your memory folder, always try to keep its content up-to-date, coherent and organized. You can rename or delete files that are no longer relevant. Do not create new files unless necessary.
+        Keep memory organized: update or remove stale entries rather than
+        accumulating. Do not create new files unless necessary.
 
         Args:
             command: Command to execute (view, create, str_replace, insert, delete,

--- a/src/inspect_ai/tool/_tools/_read_file.py
+++ b/src/inspect_ai/tool/_tools/_read_file.py
@@ -1,0 +1,61 @@
+from inspect_ai.util import sandbox as sandbox_env
+
+from .._tool import Tool, ToolError, tool
+
+
+@tool
+def read_file(
+    timeout: int | None = None,
+    user: str | None = None,
+    sandbox: str | None = None,
+) -> Tool:
+    """Read-only file reading tool.
+
+    Read file contents from a sandbox environment with optional
+    pagination for large files.
+
+    Args:
+        timeout: Timeout (in seconds) for read operation.
+        user: User to execute as.
+        sandbox: Optional sandbox environment name.
+    """
+
+    async def execute(
+        file_path: str,
+        offset: int = 0,
+        limit: int | None = None,
+    ) -> str:
+        """Read the contents of a file.
+
+        Returns the file contents with line numbers prepended. Use
+        offset and limit for pagination of large files.
+
+        Args:
+            file_path: Path to the file to read.
+            offset: Line number to start reading from (0-indexed).
+            limit: Maximum number of lines to read. Reads to end
+                of file if not specified.
+        """
+        try:
+            content = await sandbox_env(sandbox).read_file(file_path, text=True)
+        except FileNotFoundError:
+            raise ToolError(f"File not found: {file_path}")
+        except PermissionError:
+            raise ToolError(f"Permission denied: {file_path}")
+        except IsADirectoryError:
+            raise ToolError(f"Path is a directory, not a file: {file_path}")
+
+        lines = content.splitlines()
+
+        start = max(0, offset)
+        end = (start + limit) if limit is not None else len(lines)
+        end = min(len(lines), end)
+        selected = lines[start:end]
+
+        width = len(str(end))
+        numbered = [
+            f"{start + i + 1:>{width}}\t{line}" for i, line in enumerate(selected)
+        ]
+        return "\n".join(numbered)
+
+    return execute

--- a/src/inspect_ai/tool/_tools/_read_file.py
+++ b/src/inspect_ai/tool/_tools/_read_file.py
@@ -47,9 +47,11 @@ def read_file(
         else:
             awk_prog = f'NR >= {start} {{ printf "%d\\t%s\\n", NR, $0 }}'
 
-        # Pure argv — no shell interpolation of file_path
+        # Pure argv — no shell interpolation of file_path.
+        # Prefix with ./ if path starts with - to prevent awk option parsing.
+        safe_path = f"./{file_path}" if file_path.startswith("-") else file_path
         result = await sandbox_env(sandbox).exec(
-            cmd=["awk", awk_prog, file_path],
+            cmd=["awk", awk_prog, safe_path],
             timeout=timeout,
             user=user,
         )

--- a/src/inspect_ai/tool/_tools/_read_file.py
+++ b/src/inspect_ai/tool/_tools/_read_file.py
@@ -36,26 +36,39 @@ def read_file(
             limit: Maximum number of lines to read. Reads to end
                 of file if not specified.
         """
-        try:
-            content = await sandbox_env(sandbox).read_file(file_path, text=True)
-        except FileNotFoundError:
-            raise ToolError(f"File not found: {file_path}")
-        except PermissionError:
-            raise ToolError(f"Permission denied: {file_path}")
-        except IsADirectoryError:
-            raise ToolError(f"Path is a directory, not a file: {file_path}")
+        start = max(0, offset) + 1
+        if limit is not None:
+            end = start + limit - 1
+            awk_prog = (
+                f"NR >= {start} && NR <= {end} "
+                f'{{ printf "%d\\t%s\\n", NR, $0 }} '
+                f"NR > {end} {{ exit }}"
+            )
+        else:
+            awk_prog = f'NR >= {start} {{ printf "%d\\t%s\\n", NR, $0 }}'
 
-        lines = content.splitlines()
+        # Pure argv — no shell interpolation of file_path
+        result = await sandbox_env(sandbox).exec(
+            cmd=["awk", awk_prog, file_path],
+            timeout=timeout,
+            user=user,
+        )
 
-        start = max(0, offset)
-        end = (start + limit) if limit is not None else len(lines)
-        end = min(len(lines), end)
-        selected = lines[start:end]
+        if not result.success:
+            stderr = result.stderr.strip().lower() if result.stderr else ""
+            if "no such file" in stderr or "not found" in stderr:
+                raise ToolError(f"File not found: {file_path}")
+            elif "permission denied" in stderr:
+                raise ToolError(f"Permission denied: {file_path}")
+            elif "is a directory" in stderr:
+                raise ToolError(f"Path is a directory, not a file: {file_path}")
+            else:
+                raise ToolError(
+                    result.stderr.strip()
+                    if result.stderr
+                    else f"Error reading: {file_path}"
+                )
 
-        width = len(str(end))
-        numbered = [
-            f"{start + i + 1:>{width}}\t{line}" for i, line in enumerate(selected)
-        ]
-        return "\n".join(numbered)
+        return result.stdout.rstrip("\n")
 
     return execute

--- a/src/inspect_ai/tool/_tools/_skill/install.py
+++ b/src/inspect_ai/tool/_tools/_skill/install.py
@@ -25,6 +25,12 @@ async def install_skills(
     Returns:
         List of `SkillInfo` with skill names, descriptions, and locations.
     """
+    # resolve and validate skills before sandbox setup
+    from .validate import check_unique_skill_names
+
+    resolved_skills = read_skills(skills)
+    check_unique_skill_names(resolved_skills)
+
     # resolve sandbox
     sbox = sandbox if isinstance(sandbox, SandboxEnvironment) else sandbox_env(sandbox)
 
@@ -73,7 +79,7 @@ async def install_skills(
 
     # install skills
     skills_info: list[SkillInfo] = []
-    for skill in read_skills(skills):
+    for skill in resolved_skills:
         # determine root skill dir
         skill_dir = skills_dir / skill.name
 

--- a/src/inspect_ai/tool/_tools/_skill/tool.py
+++ b/src/inspect_ai/tool/_tools/_skill/tool.py
@@ -17,6 +17,7 @@ from .types import Skill, SkillInfo
 def skill(
     skills: Sequence[str | Path | Skill],
     *,
+    instance: str | None = None,
     sandbox: str | None = None,
     user: str | None = None,
     dir: str | None = None,
@@ -27,12 +28,18 @@ def skill(
 
     Args:
         skills: Agent skill specifications. Either a directory containing a skill or a full `Skill` specification.
+        instance: Optional instance name for the skill store. Enables
+            multiple independent skill tool instances within a single
+            sample (e.g., different subagents with different skill sets).
         sandbox: Sandbox environment name to copy skills to.
         user: User to write skills files with.
         dir: Directory to install into (defaults to "./skills").
     """
-    # resolve skills
+    from .validate import check_unique_skill_names
+
+    # resolve skills and validate uniqueness
     resolved_skills = read_skills(skills)
+    check_unique_skill_names(resolved_skills)
 
     async def execute(command: str) -> str:
         """Execute a skill within the main conversation.
@@ -41,7 +48,7 @@ def skill(
            command: The skill name (no arguments). E.g., "pdf" or "xlsx"
         """
         # see if we need to install the skills
-        installed = store_as(InstalledSkills)
+        installed = store_as(InstalledSkills, instance=instance)
         if installed.skills is None:
             installed.skills = await install_skills(resolved_skills, sandbox, user, dir)
 

--- a/src/inspect_ai/tool/_tools/_skill/validate.py
+++ b/src/inspect_ai/tool/_tools/_skill/validate.py
@@ -1,0 +1,23 @@
+"""Validation helpers for skills."""
+
+from typing import Sequence
+
+from .types import Skill
+
+
+def check_unique_skill_names(skills: Sequence[Skill]) -> None:
+    """Raise if any skill names are duplicated.
+
+    Args:
+        skills: Skill specifications to validate.
+
+    Raises:
+        ValueError: If two or more skills share the same name.
+    """
+    seen: set[str] = set()
+    for sk in skills:
+        if sk.name in seen:
+            raise ValueError(
+                f"Duplicate skill name '{sk.name}'. Each skill must have a unique name."
+            )
+        seen.add(sk.name)

--- a/src/inspect_ai/tool/_tools/_todo_write.py
+++ b/src/inspect_ai/tool/_tools/_todo_write.py
@@ -49,7 +49,7 @@ def todo_write() -> Tool:
         - **in_progress**: Currently working on this step.
         - **completed**: Step finished successfully.
 
-        Update status in real-time as you work. Mark a step as in_progress before beginning it, and completed immediately after finishing — don't batch completions after the fact. Never jump a step from pending directly to completed.
+        Update status in real-time as you work. Exactly one step should be in_progress at a time. Mark a step as in_progress before beginning it, and completed immediately after finishing — don't batch completions after the fact. Never jump a step from pending directly to completed.
 
         Only mark a step as completed when you have fully accomplished it. Never mark a step as completed if:
 

--- a/src/inspect_ai/tool/_tools/_todo_write.py
+++ b/src/inspect_ai/tool/_tools/_todo_write.py
@@ -61,17 +61,16 @@ def todo_write() -> Tool:
 
         High-quality plans:
 
-        - Add CLI entry with file args
-        - Parse Markdown via CommonMark library
-        - Apply semantic HTML template
-        - Handle code blocks, images, links
-        - Add error handling for invalid files
+        - Identify relevant sources, inputs, and constraints to inspect
+        - Evaluate each candidate approach against the task requirements
+        - Cross-check important findings against available evidence
+        - Summarize conclusions, remaining uncertainty, and next action
 
         Low-quality plans:
 
-        - Create CLI tool
-        - Add Markdown parser
-        - Convert to HTML
+        - Look things up
+        - Compare options
+        - Write summary
 
         If you need to write a plan, only write high quality plans, not low quality ones.
 

--- a/src/inspect_ai/tool/_tools/_todo_write.py
+++ b/src/inspect_ai/tool/_tools/_todo_write.py
@@ -1,0 +1,85 @@
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from .._tool import Tool, tool
+
+
+class TodoStep(BaseModel):
+    content: str = Field(description="Step description.")
+    status: Literal["pending", "in_progress", "completed"] = Field(
+        description="One of: pending, in_progress, completed"
+    )
+
+
+@tool
+def todo_write() -> Tool:
+    """Planning tool to track steps and progress in longer horizon tasks.
+
+    The todo_write tool helps agents organize complex, multi-step work by
+    maintaining a structured task list with status tracking. The tool
+    description synthesizes best practices from Claude Code, LangChain
+    deep agents, and Codex CLI.
+    """
+
+    async def execute(todos: list[TodoStep], explanation: str | None = None) -> str:
+        """Update the task plan.
+
+        Use this tool to create and manage a structured task list for tracking progress on complex work. A good plan breaks the task into meaningful, logically ordered steps that are easy to verify as you go.
+
+        Provide a list of todo items, each with content and status. Optionally provide an explanation when making significant changes to the plan.
+
+        ## When to Use
+
+        - The task requires multiple actions or has logical phases where sequencing matters.
+        - The work has ambiguity that benefits from outlining high-level goals.
+        - The user has asked you to do more than one thing in a single prompt.
+        - You generate additional steps while working and plan to do them before finishing.
+
+        ## When NOT to Use
+
+        - The task is a single straightforward action.
+        - The work is trivial or can be completed in fewer than 3 steps.
+        - The task is purely conversational or informational.
+
+        Do not pad out simple work with filler steps or state the obvious. The content of your plan should not involve doing anything that you aren't capable of doing.
+
+        ## Status Management
+
+        - **pending**: Step not yet started.
+        - **in_progress**: Currently working on this step.
+        - **completed**: Step finished successfully.
+
+        Update status in real-time as you work. Mark a step as in_progress before beginning it, and completed immediately after finishing — don't batch completions after the fact. Never jump a step from pending directly to completed.
+
+        Only mark a step as completed when you have fully accomplished it. If you encounter errors, blockers, or cannot finish, keep it as in_progress and note the issue.
+
+        Remove steps that are no longer relevant from the list entirely. If understanding changes mid-task, update the plan before continuing and provide an explanation of the rationale.
+
+        Do not repeat the full contents of the plan after calling this tool — the harness already displays it. Instead, summarize the change and highlight any important context or next step.
+
+        ## Plan Quality
+
+        High-quality plans:
+
+        - Add CLI entry with file args
+        - Parse Markdown via CommonMark library
+        - Apply semantic HTML template
+        - Handle code blocks, images, links
+        - Add error handling for invalid files
+
+        Low-quality plans:
+
+        - Create CLI tool
+        - Add Markdown parser
+        - Convert to HTML
+
+        If you need to write a plan, only write high quality plans, not low quality ones.
+
+        Args:
+            todos: The list of steps.
+            explanation: Optional explanation of changes to the plan.
+        """
+        return "Plan updated"
+
+    return execute

--- a/src/inspect_ai/tool/_tools/_todo_write.py
+++ b/src/inspect_ai/tool/_tools/_todo_write.py
@@ -41,7 +41,7 @@ def todo_write() -> Tool:
         - The work is trivial or can be completed in fewer than 3 steps.
         - The task is purely conversational or informational.
 
-        Do not pad out simple work with filler steps or state the obvious. The content of your plan should not involve doing anything that you aren't capable of doing.
+        Do not pad out simple work with filler steps or state the obvious. The content of your plan should not involve doing anything that you aren't capable of doing. Aim for 3-7 items unless the task genuinely needs more.
 
         ## Status Management
 
@@ -51,7 +51,13 @@ def todo_write() -> Tool:
 
         Update status in real-time as you work. Mark a step as in_progress before beginning it, and completed immediately after finishing — don't batch completions after the fact. Never jump a step from pending directly to completed.
 
-        Only mark a step as completed when you have fully accomplished it. If you encounter errors, blockers, or cannot finish, keep it as in_progress and note the issue.
+        Only mark a step as completed when you have fully accomplished it. Never mark a step as completed if:
+
+        - Errors remain unresolved.
+        - The implementation is partial or untested.
+        - You encountered blockers you haven't worked around.
+
+        If you cannot finish a step, keep it as in_progress and note the issue.
 
         Remove steps that are no longer relevant from the list entirely. If understanding changes mid-task, update the plan before continuing and provide an explanation of the rationale.
 

--- a/src/inspect_ai/tool/_tools/_todo_write.py
+++ b/src/inspect_ai/tool/_tools/_todo_write.py
@@ -18,8 +18,7 @@ def todo_write() -> Tool:
 
     The todo_write tool helps agents organize complex, multi-step work by
     maintaining a structured task list with status tracking. The tool
-    description synthesizes best practices from Claude Code, LangChain
-    deep agents, and Codex CLI.
+    description synthesizes best practices from Claude Code and Codex CLI.
     """
 
     async def execute(todos: list[TodoStep], explanation: str | None = None) -> str:

--- a/src/inspect_ai/util/_limit.py
+++ b/src/inspect_ai/util/_limit.py
@@ -54,9 +54,9 @@ class LimitExceededError(Exception):
         self.value_str = self._format_float_or_int(value)
         self.limit = limit
         self.limit_str = self._format_float_or_int(limit)
-        self.message = f"Exceeded {type} limit: {limit:,}"
+        self.message = message or f"Exceeded {type} limit: {limit:,}"
         self.source = source
-        super().__init__(message)
+        super().__init__(self.message)
 
     def with_state(self, state: TaskState) -> LimitExceededError:
         warn_once(

--- a/tests/agent/deepagent/test_deepagent.py
+++ b/tests/agent/deepagent/test_deepagent.py
@@ -36,8 +36,12 @@ def test_deepagent_end_to_end() -> None:
                     "prompt": "Find information.",
                 },
             ),
-            # 2. Inner research subagent responds
-            ModelOutput.from_content("mockllm/model", "Found the info."),
+            # 2. Inner research subagent submits
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": "Found the info."},
+            ),
             # 3. Outer agent submits
             ModelOutput.for_tool_call(
                 model="mockllm/model",

--- a/tests/agent/deepagent/test_deepagent.py
+++ b/tests/agent/deepagent/test_deepagent.py
@@ -100,3 +100,37 @@ def test_deepagent_default_subagents() -> None:
     assert r.name == "research"
     assert p.name == "plan"
     assert g.name == "general"
+
+
+def test_deepagent_submit_prompt_included() -> None:
+    """System message includes submit guidance when submit is enabled."""
+    from inspect_ai.agent._react import _prompt_to_system_message
+    from inspect_ai.agent._types import DEFAULT_SUBMIT_PROMPT, AgentPrompt
+
+    prompt = AgentPrompt(
+        instructions="Test.",
+        handoff_prompt=None,
+        assistant_prompt=DEFAULT_SUBMIT_PROMPT,
+        submit_prompt=None,
+    )
+    msg = _prompt_to_system_message(prompt, [], "submit")
+    assert msg is not None
+    assert isinstance(msg.content, str)
+    assert "submit" in msg.content.lower()
+
+
+def test_deepagent_submit_prompt_excluded_when_false() -> None:
+    """System message excludes submit guidance when submit=False."""
+    from inspect_ai.agent._react import _prompt_to_system_message
+    from inspect_ai.agent._types import AgentPrompt
+
+    prompt = AgentPrompt(
+        instructions="Test.",
+        handoff_prompt=None,
+        assistant_prompt=None,
+        submit_prompt=None,
+    )
+    msg = _prompt_to_system_message(prompt, [], None)
+    assert msg is not None
+    assert isinstance(msg.content, str)
+    assert "submit" not in msg.content.lower()

--- a/tests/agent/deepagent/test_deepagent.py
+++ b/tests/agent/deepagent/test_deepagent.py
@@ -1,0 +1,99 @@
+"""Tests for deepagent() top-level assembly."""
+
+from test_helpers.tool_call_utils import get_tool_event
+
+from inspect_ai import Task, eval
+from inspect_ai.agent import deepagent
+from inspect_ai.agent._deepagent.prompt import CORE_BEHAVIOR
+from inspect_ai.dataset import Sample
+from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.solver import generate, use_tools
+from inspect_ai.tool import think
+
+
+def test_deepagent_constructible() -> None:
+    """deepagent() returns an Agent."""
+    agent = deepagent()
+    assert agent is not None
+
+
+def test_deepagent_end_to_end() -> None:
+    """End-to-end: model calls task tool, subagent runs, returns result."""
+    task = Task(
+        dataset=[Sample(input="Research something")],
+        solver=[use_tools(deepagent()), generate()],
+        message_limit=10,
+    )
+
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            # 1. Outer agent calls task tool
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="task",
+                tool_arguments={
+                    "subagent_type": "research",
+                    "prompt": "Find information.",
+                },
+            ),
+            # 2. Inner research subagent responds
+            ModelOutput.from_content("mockllm/model", "Found the info."),
+            # 3. Outer agent finishes
+            ModelOutput.from_content("mockllm/model", "Done"),
+        ],
+    )
+
+    log = eval(task, model=model)[0]
+    assert log.status == "success"
+    tool_event = get_tool_event(log)
+    assert tool_event is not None
+    assert tool_event.function == "task"
+
+
+def test_deepagent_memory_kill_switch() -> None:
+    """memory=False disables memory for all subagents."""
+    agent = deepagent(memory=False)
+    # Verify by checking that the agent is constructible without memory
+    # (deeper verification would require inspecting the tool list)
+    assert agent is not None
+
+
+def test_deepagent_custom_instructions() -> None:
+    """instructions= are included in the system prompt."""
+    from inspect_ai.agent._deepagent.prompt import build_system_prompt
+
+    prompt = build_system_prompt(instructions="Focus on security analysis.")
+    assert "Focus on security analysis." in prompt
+    assert CORE_BEHAVIOR in prompt
+
+
+def test_deepagent_custom_prompt_with_placeholders() -> None:
+    """prompt= replaces default and expands placeholders."""
+    from inspect_ai.agent._deepagent.prompt import expand_prompt_placeholders
+
+    custom = "Custom agent.\n\n{core_behavior}\n\nExtra: {instructions}"
+    result = expand_prompt_placeholders(custom, instructions="Be careful.")
+    assert "Custom agent." in result
+    assert CORE_BEHAVIOR in result
+    assert "Be careful." in result
+
+
+def test_deepagent_with_extra_tools() -> None:
+    """User tools flow to the agent."""
+    agent = deepagent(tools=[think()])
+    assert agent is not None
+
+
+def test_deepagent_default_subagents() -> None:
+    """Default subagents are research, plan, general."""
+    from inspect_ai.agent._deepagent.general import general
+    from inspect_ai.agent._deepagent.plan import plan
+    from inspect_ai.agent._deepagent.research import research
+
+    r = research()
+    p = plan()
+    g = general()
+    assert r.name == "research"
+    assert p.name == "plan"
+    assert g.name == "general"

--- a/tests/agent/deepagent/test_deepagent.py
+++ b/tests/agent/deepagent/test_deepagent.py
@@ -134,3 +134,58 @@ def test_deepagent_submit_prompt_excluded_when_false() -> None:
     assert msg is not None
     assert isinstance(msg.content, str)
     assert "submit" not in msg.content.lower()
+
+
+def test_deepagent_duplicate_subagent_names_rejected() -> None:
+    """Duplicate subagent names raise ValueError at eval time."""
+    from inspect_ai.agent import subagent
+
+    sa1 = subagent(name="research", description="A.", prompt="A.")
+    sa2 = subagent(name="research", description="B.", prompt="B.")
+    da = deepagent(subagents=[sa1, sa2], submit=True)
+    task = Task(
+        dataset=[Sample(input="test")],
+        solver=da,
+        message_limit=5,
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "done")],
+    )
+    log = eval(task, model=model)[0]
+    assert log.status == "error"
+
+
+def test_deepagent_empty_subagents_rejected() -> None:
+    """Empty subagent list raises ValueError at eval time."""
+    da = deepagent(subagents=[], submit=True)
+    task = Task(
+        dataset=[Sample(input="test")],
+        solver=da,
+        message_limit=5,
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "done")],
+    )
+    log = eval(task, model=model)[0]
+    assert log.status == "error"
+
+
+def test_deepagent_fork_with_max_depth_rejected() -> None:
+    """fork=True with max_depth > 1 raises ValueError at eval time."""
+    from inspect_ai.agent import subagent
+
+    sa = subagent(name="forked", description="F.", prompt="", fork=True)
+    da = deepagent(subagents=[sa], max_depth=2, submit=True)
+    task = Task(
+        dataset=[Sample(input="test")],
+        solver=da,
+        message_limit=5,
+    )
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "done")],
+    )
+    log = eval(task, model=model)[0]
+    assert log.status == "error"

--- a/tests/agent/deepagent/test_deepagent.py
+++ b/tests/agent/deepagent/test_deepagent.py
@@ -7,7 +7,6 @@ from inspect_ai.agent import deepagent
 from inspect_ai.agent._deepagent.prompt import CORE_BEHAVIOR
 from inspect_ai.dataset import Sample
 from inspect_ai.model import ModelOutput, get_model
-from inspect_ai.solver import generate, use_tools
 from inspect_ai.tool import think
 
 
@@ -21,7 +20,7 @@ def test_deepagent_end_to_end() -> None:
     """End-to-end: model calls task tool, subagent runs, returns result."""
     task = Task(
         dataset=[Sample(input="Research something")],
-        solver=[use_tools(deepagent()), generate()],
+        solver=deepagent(submit=True),
         message_limit=10,
     )
 
@@ -39,8 +38,12 @@ def test_deepagent_end_to_end() -> None:
             ),
             # 2. Inner research subagent responds
             ModelOutput.from_content("mockllm/model", "Found the info."),
-            # 3. Outer agent finishes
-            ModelOutput.from_content("mockllm/model", "Done"),
+            # 3. Outer agent submits
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": "done"},
+            ),
         ],
     )
 

--- a/tests/agent/deepagent/test_deepagent_e2e.py
+++ b/tests/agent/deepagent/test_deepagent_e2e.py
@@ -1,0 +1,564 @@
+"""End-to-end tests for deepagent() using mockllm deterministic outputs."""
+
+from inspect_ai import Task, eval
+from inspect_ai.agent import deepagent, subagent
+from inspect_ai.dataset import Sample
+from inspect_ai.event._tool import ToolEvent
+from inspect_ai.model import ChatMessageSystem, ModelOutput, get_model
+from inspect_ai.scorer import includes
+
+
+def _eval_deepagent(
+    agent_kwargs: dict,
+    outputs: list[ModelOutput],
+    input: str = "Do the task",
+    target: str = "n/a",
+    message_limit: int = 20,
+) -> dict:
+    """Helper to run a deepagent eval and return results."""
+    agent_kwargs.setdefault("submit", True)
+    da = deepagent(**agent_kwargs)
+    task = Task(
+        dataset=[Sample(input=input, target=target)],
+        solver=[da],
+        scorer=includes(),
+        message_limit=message_limit,
+    )
+    model = get_model("mockllm/model", custom_outputs=outputs)
+    log = eval(task, model=model)[0]
+    return {
+        "log": log,
+        "status": log.status,
+        "messages": log.samples[0].messages if log.samples else [],
+        "events": log.samples[0].events if log.samples else [],
+    }
+
+
+def _submit(answer: str = "done") -> ModelOutput:
+    """Helper to create a submit tool call."""
+    return ModelOutput.for_tool_call(
+        model="mockllm/model",
+        tool_name="submit",
+        tool_arguments={"answer": answer},
+    )
+
+
+class TestMultiStepDelegation:
+    def test_research_then_general(self) -> None:
+        """Model delegates to research, then general sequentially."""
+        result = _eval_deepagent(
+            agent_kwargs={},
+            outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Find background information.",
+                    },
+                ),
+                ModelOutput.from_content(
+                    "mockllm/model", "Found relevant background info."
+                ),
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "general",
+                        "prompt": "Execute based on findings.",
+                    },
+                ),
+                ModelOutput.from_content(
+                    "mockllm/model", "Executed the task successfully."
+                ),
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+
+
+class TestMemoryIntegration:
+    def test_memory_write_then_delegate(self) -> None:
+        """Model writes to memory, then delegates to subagent."""
+        result = _eval_deepagent(
+            agent_kwargs={},
+            outputs=[
+                # 1. Model writes to memory
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="memory",
+                    tool_arguments={
+                        "command": "create",
+                        "path": "/memories/notes.txt",
+                        "file_text": "Important finding: X=42",
+                    },
+                ),
+                # 2. Model delegates to research
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Check memory for context, then investigate further.",
+                    },
+                ),
+                # 3. Research subagent responds
+                ModelOutput.from_content(
+                    "mockllm/model", "Found X=42 in memory, confirmed."
+                ),
+                # 4. Outer agent finishes
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+
+
+class TestTodoWriteIntegration:
+    def test_create_and_update_plan(self) -> None:
+        """Model creates a plan with todo_write, then works through it."""
+        result = _eval_deepagent(
+            agent_kwargs={},
+            outputs=[
+                # 1. Model creates a plan
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="todo_write",
+                    tool_arguments={
+                        "todos": [
+                            {"content": "Research the topic", "status": "in_progress"},
+                            {"content": "Analyze findings", "status": "pending"},
+                        ]
+                    },
+                ),
+                # 2. Model delegates research
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Research the topic.",
+                    },
+                ),
+                # 3. Research responds
+                ModelOutput.from_content("mockllm/model", "Research complete."),
+                # 4. Model updates plan
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="todo_write",
+                    tool_arguments={
+                        "todos": [
+                            {"content": "Research the topic", "status": "completed"},
+                            {"content": "Analyze findings", "status": "in_progress"},
+                        ]
+                    },
+                ),
+                # 5. Model submits
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+
+
+class TestSubmitIntegration:
+    def test_submit_answer(self) -> None:
+        """Model does work then submits an answer."""
+        result = _eval_deepagent(
+            agent_kwargs={"submit": True},
+            target="42",
+            outputs=[
+                # 1. Model delegates to research
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Find the answer.",
+                    },
+                ),
+                # 2. Research responds
+                ModelOutput.from_content("mockllm/model", "The answer is 42."),
+                # 3. Model submits
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "42"},
+                ),
+            ],
+        )
+        assert result["status"] == "success"
+
+
+class TestCustomSubagents:
+    def test_user_defined_subagent(self) -> None:
+        """User-defined subagent is dispatched correctly."""
+        custom = subagent(
+            name="analyzer",
+            description="Analyzes data.",
+            prompt="You are a data analyzer.",
+        )
+        result = _eval_deepagent(
+            agent_kwargs={"subagents": [custom]},
+            outputs=[
+                # 1. Model delegates to custom subagent
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "analyzer",
+                        "prompt": "Analyze this data.",
+                    },
+                ),
+                # 2. Analyzer responds
+                ModelOutput.from_content("mockllm/model", "Analysis complete."),
+                # 3. Outer agent finishes
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+
+
+class TestInstructionsInPrompt:
+    def test_instructions_in_system_message(self) -> None:
+        """Verify instructions= text appears in the system message."""
+        da = deepagent(instructions="Always respond in French.")
+        task = Task(
+            dataset=[Sample(input="Test", target="n/a")],
+            solver=[da],
+            scorer=includes(),
+            message_limit=5,
+        )
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.from_content("mockllm/model", "Bonjour."),
+            ],
+        )
+        log = eval(task, model=model)[0]
+        assert log.samples
+        system_msgs = [
+            m for m in log.samples[0].messages if isinstance(m, ChatMessageSystem)
+        ]
+        assert len(system_msgs) > 0
+        assert "Always respond in French." in system_msgs[0].content
+
+
+class TestMemoryKillSwitch:
+    def test_memory_false_no_memory_tool(self) -> None:
+        """memory=False means memory tool is not available."""
+        result = _eval_deepagent(
+            agent_kwargs={"memory": False},
+            outputs=[
+                # Model tries to use memory — should fail
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="memory",
+                    tool_arguments={
+                        "command": "view",
+                        "path": "/memories",
+                    },
+                ),
+                # Model recovers and finishes
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+        # The memory tool call should have produced an error
+        tool_events = [e for e in result["events"] if isinstance(e, ToolEvent)]
+        memory_events = [e for e in tool_events if e.function == "memory"]
+        if memory_events:
+            assert memory_events[0].error is not None
+
+
+class TestFullWorkflow:
+    def test_memory_plan_delegate_submit(self) -> None:
+        """Full lifecycle: memory → plan → delegate → submit."""
+        result = _eval_deepagent(
+            agent_kwargs={"submit": True},
+            target="success",
+            outputs=[
+                # 1. Write context to memory
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="memory",
+                    tool_arguments={
+                        "command": "create",
+                        "path": "/memories/context.txt",
+                        "file_text": "Task requires finding X.",
+                    },
+                ),
+                # 2. Create a plan
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="todo_write",
+                    tool_arguments={
+                        "todos": [
+                            {"content": "Research X", "status": "in_progress"},
+                            {"content": "Synthesize findings", "status": "pending"},
+                        ]
+                    },
+                ),
+                # 3. Delegate to research
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Research X.",
+                    },
+                ),
+                # 4. Research subagent responds
+                ModelOutput.from_content("mockllm/model", "X = success."),
+                # 5. Update plan
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="todo_write",
+                    tool_arguments={
+                        "todos": [
+                            {"content": "Research X", "status": "completed"},
+                            {"content": "Synthesize findings", "status": "completed"},
+                        ]
+                    },
+                ),
+                # 6. Submit answer
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "success"},
+                ),
+            ],
+        )
+        assert result["status"] == "success"
+
+
+class TestPlanSubagent:
+    def test_plan_dispatch(self) -> None:
+        """Delegate to the plan subagent specifically."""
+        result = _eval_deepagent(
+            agent_kwargs={},
+            outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "plan",
+                        "prompt": "Create a plan for solving this problem.",
+                    },
+                ),
+                ModelOutput.from_content(
+                    "mockllm/model", "Plan: Step 1, Step 2, Step 3."
+                ),
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+        tool_events = [e for e in result["events"] if isinstance(e, ToolEvent)]
+        task_events = [e for e in tool_events if e.function == "task"]
+        assert len(task_events) == 1
+        assert task_events[0].error is None
+
+
+class TestGeneralInheritsParentTools:
+    def test_parent_tool_available_to_general(self) -> None:
+        """A tool passed to deepagent(tools=[...]) is usable by general."""
+        from inspect_ai.tool import think
+
+        result = _eval_deepagent(
+            agent_kwargs={"tools": [think()]},
+            outputs=[
+                # Delegate to general which should have think() available
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "general",
+                        "prompt": "Think carefully then answer.",
+                    },
+                ),
+                # General subagent uses think tool
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="think",
+                    tool_arguments={"thought": "Let me consider..."},
+                ),
+                # General subagent finishes
+                ModelOutput.from_content("mockllm/model", "Thought it through."),
+                # Outer agent finishes
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+
+
+class TestTodoWriteDisabled:
+    def test_todo_write_false(self) -> None:
+        """todo_write=False means todo_write tool is not available."""
+        result = _eval_deepagent(
+            agent_kwargs={"todo_write": False},
+            outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="todo_write",
+                    tool_arguments={
+                        "todos": [
+                            {"content": "Step 1", "status": "pending"},
+                        ]
+                    },
+                ),
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+        tool_events = [e for e in result["events"] if isinstance(e, ToolEvent)]
+        tw_events = [e for e in tool_events if e.function == "todo_write"]
+        if tw_events:
+            assert tw_events[0].error is not None
+
+
+class TestMultipleCallsToSameSubagent:
+    def test_research_called_twice(self) -> None:
+        """Model delegates to research twice in one session."""
+        result = _eval_deepagent(
+            agent_kwargs={},
+            outputs=[
+                # First research call
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Research topic A.",
+                    },
+                ),
+                ModelOutput.from_content("mockllm/model", "Found info about A."),
+                # Second research call
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Research topic B.",
+                    },
+                ),
+                ModelOutput.from_content("mockllm/model", "Found info about B."),
+                # Outer agent finishes
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+        tool_events = [e for e in result["events"] if isinstance(e, ToolEvent)]
+        task_events = [e for e in tool_events if e.function == "task"]
+        assert len(task_events) == 2
+
+
+class TestInterleavedToolUseAndDelegation:
+    def test_mixed_tool_calls(self) -> None:
+        """Model interleaves memory, delegation, and todo_write."""
+        result = _eval_deepagent(
+            agent_kwargs={},
+            outputs=[
+                # 1. Check memory
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="memory",
+                    tool_arguments={"command": "view", "path": "/memories"},
+                ),
+                # 2. Delegate to research
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Find data.",
+                    },
+                ),
+                ModelOutput.from_content("mockllm/model", "Found data."),
+                # 3. Save to memory
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="memory",
+                    tool_arguments={
+                        "command": "create",
+                        "path": "/memories/data.txt",
+                        "file_text": "Data found by research agent.",
+                    },
+                ),
+                # 4. Update plan
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="todo_write",
+                    tool_arguments={
+                        "todos": [
+                            {"content": "Find data", "status": "completed"},
+                            {"content": "Process data", "status": "in_progress"},
+                        ]
+                    },
+                ),
+                # 5. Delegate to general
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "general",
+                        "prompt": "Process the data.",
+                    },
+                ),
+                ModelOutput.from_content("mockllm/model", "Data processed."),
+                # 6. Finish
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"
+        tool_events = [e for e in result["events"] if isinstance(e, ToolEvent)]
+        tool_names = [e.function for e in tool_events]
+        assert "memory" in tool_names
+        assert "task" in tool_names
+        assert "todo_write" in tool_names
+
+
+class TestCustomPromptPlaceholders:
+    def test_custom_prompt_reaches_model(self) -> None:
+        """Custom prompt= with placeholders is what the model sees."""
+        da = deepagent(
+            prompt="CUSTOM_START\n\n{core_behavior}\n\n{instructions}\n\nCUSTOM_END",
+            instructions="Special rule: always verify.",
+        )
+        task = Task(
+            dataset=[Sample(input="Test", target="n/a")],
+            solver=[da],
+            scorer=includes(),
+            message_limit=5,
+        )
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.from_content("mockllm/model", "Done."),
+            ],
+        )
+        log = eval(task, model=model)[0]
+        assert log.samples
+        system_msgs = [
+            m for m in log.samples[0].messages if isinstance(m, ChatMessageSystem)
+        ]
+        assert len(system_msgs) > 0
+        content = system_msgs[0].content
+        assert "CUSTOM_START" in content
+        assert "CUSTOM_END" in content
+        assert "Special rule: always verify." in content
+        assert "Complete tasks autonomously" in content
+
+
+class TestUnknownToolCall:
+    def test_unknown_tool_graceful_error(self) -> None:
+        """Model calls a tool that doesn't exist — should get an error, not crash."""
+        result = _eval_deepagent(
+            agent_kwargs={},
+            outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="nonexistent_tool",
+                    tool_arguments={"arg": "value"},
+                ),
+                _submit(),
+            ],
+        )
+        assert result["status"] == "success"

--- a/tests/agent/deepagent/test_deepagent_e2e.py
+++ b/tests/agent/deepagent/test_deepagent_e2e.py
@@ -57,8 +57,10 @@ class TestMultiStepDelegation:
                         "prompt": "Find background information.",
                     },
                 ),
-                ModelOutput.from_content(
-                    "mockllm/model", "Found relevant background info."
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Found relevant background info."},
                 ),
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
@@ -68,8 +70,10 @@ class TestMultiStepDelegation:
                         "prompt": "Execute based on findings.",
                     },
                 ),
-                ModelOutput.from_content(
-                    "mockllm/model", "Executed the task successfully."
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Executed the task successfully."},
                 ),
                 _submit(),
             ],
@@ -102,9 +106,11 @@ class TestMemoryIntegration:
                         "prompt": "Check memory for context, then investigate further.",
                     },
                 ),
-                # 3. Research subagent responds
-                ModelOutput.from_content(
-                    "mockllm/model", "Found X=42 in memory, confirmed."
+                # 3. Research subagent submits
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Found X=42 in memory, confirmed."},
                 ),
                 # 4. Outer agent finishes
                 _submit(),
@@ -139,8 +145,12 @@ class TestTodoWriteIntegration:
                         "prompt": "Research the topic.",
                     },
                 ),
-                # 3. Research responds
-                ModelOutput.from_content("mockllm/model", "Research complete."),
+                # 3. Research submits
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Research complete."},
+                ),
                 # 4. Model updates plan
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
@@ -175,8 +185,12 @@ class TestSubmitIntegration:
                         "prompt": "Find the answer.",
                     },
                 ),
-                # 2. Research responds
-                ModelOutput.from_content("mockllm/model", "The answer is 42."),
+                # 2. Research submits
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "The answer is 42."},
+                ),
                 # 3. Model submits
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
@@ -208,8 +222,12 @@ class TestCustomSubagents:
                         "prompt": "Analyze this data.",
                     },
                 ),
-                # 2. Analyzer responds
-                ModelOutput.from_content("mockllm/model", "Analysis complete."),
+                # 2. Analyzer submits
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Analysis complete."},
+                ),
                 # 3. Outer agent finishes
                 _submit(),
             ],
@@ -306,8 +324,12 @@ class TestFullWorkflow:
                         "prompt": "Research X.",
                     },
                 ),
-                # 4. Research subagent responds
-                ModelOutput.from_content("mockllm/model", "X = success."),
+                # 4. Research subagent submits
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "X = success."},
+                ),
                 # 5. Update plan
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
@@ -344,8 +366,10 @@ class TestPlanSubagent:
                         "prompt": "Create a plan for solving this problem.",
                     },
                 ),
-                ModelOutput.from_content(
-                    "mockllm/model", "Plan: Step 1, Step 2, Step 3."
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Plan: Step 1, Step 2, Step 3."},
                 ),
                 _submit(),
             ],
@@ -380,8 +404,12 @@ class TestGeneralInheritsParentTools:
                     tool_name="think",
                     tool_arguments={"thought": "Let me consider..."},
                 ),
-                # General subagent finishes
-                ModelOutput.from_content("mockllm/model", "Thought it through."),
+                # General subagent submits
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Thought it through."},
+                ),
                 # Outer agent finishes
                 _submit(),
             ],
@@ -429,7 +457,11 @@ class TestMultipleCallsToSameSubagent:
                         "prompt": "Research topic A.",
                     },
                 ),
-                ModelOutput.from_content("mockllm/model", "Found info about A."),
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Found info about A."},
+                ),
                 # Second research call
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
@@ -439,7 +471,11 @@ class TestMultipleCallsToSameSubagent:
                         "prompt": "Research topic B.",
                     },
                 ),
-                ModelOutput.from_content("mockllm/model", "Found info about B."),
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Found info about B."},
+                ),
                 # Outer agent finishes
                 _submit(),
             ],
@@ -471,7 +507,11 @@ class TestInterleavedToolUseAndDelegation:
                         "prompt": "Find data.",
                     },
                 ),
-                ModelOutput.from_content("mockllm/model", "Found data."),
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Found data."},
+                ),
                 # 3. Save to memory
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
@@ -502,7 +542,11 @@ class TestInterleavedToolUseAndDelegation:
                         "prompt": "Process the data.",
                     },
                 ),
-                ModelOutput.from_content("mockllm/model", "Data processed."),
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Data processed."},
+                ),
                 # 6. Finish
                 _submit(),
             ],

--- a/tests/agent/deepagent/test_deepagent_e2e.py
+++ b/tests/agent/deepagent/test_deepagent_e2e.py
@@ -20,7 +20,7 @@ def _eval_deepagent(
     da = deepagent(**agent_kwargs)
     task = Task(
         dataset=[Sample(input=input, target=target)],
-        solver=[da],
+        solver=da,
         scorer=includes(),
         message_limit=message_limit,
     )
@@ -223,7 +223,7 @@ class TestInstructionsInPrompt:
         da = deepagent(instructions="Always respond in French.")
         task = Task(
             dataset=[Sample(input="Test", target="n/a")],
-            solver=[da],
+            solver=da,
             scorer=includes(),
             message_limit=5,
         )
@@ -524,7 +524,7 @@ class TestCustomPromptPlaceholders:
         )
         task = Task(
             dataset=[Sample(input="Test", target="n/a")],
-            solver=[da],
+            solver=da,
             scorer=includes(),
             message_limit=5,
         )

--- a/tests/agent/deepagent/test_factories.py
+++ b/tests/agent/deepagent/test_factories.py
@@ -16,7 +16,7 @@ class TestResearchDefaults:
         assert research().tools is None
 
     def test_default_memory(self) -> None:
-        assert research().memory == "readonly"
+        assert research().memory is False
 
     def test_default_fork(self) -> None:
         assert research().fork is False
@@ -37,7 +37,7 @@ class TestPlanDefaults:
         assert plan().tools is None
 
     def test_default_memory(self) -> None:
-        assert plan().memory == "readonly"
+        assert plan().memory is False
 
     def test_default_fork(self) -> None:
         assert plan().fork is False
@@ -58,7 +58,7 @@ class TestGeneralDefaults:
         assert general().tools is None
 
     def test_default_memory(self) -> None:
-        assert general().memory == "readwrite"
+        assert general().memory is False
 
     def test_default_fork(self) -> None:
         assert general().fork is False

--- a/tests/agent/deepagent/test_factories.py
+++ b/tests/agent/deepagent/test_factories.py
@@ -1,0 +1,145 @@
+"""Tests for built-in subagent factories (research, plan, general)."""
+
+from inspect_ai.agent import Subagent, general, plan, research
+from inspect_ai.tool import think
+
+
+class TestResearchDefaults:
+    def test_returns_subagent(self) -> None:
+        sa = research()
+        assert isinstance(sa, Subagent)
+
+    def test_name(self) -> None:
+        assert research().name == "research"
+
+    def test_default_tools_is_none(self) -> None:
+        assert research().tools is None
+
+    def test_default_memory(self) -> None:
+        assert research().memory == "readonly"
+
+    def test_default_fork(self) -> None:
+        assert research().fork is False
+
+    def test_prompt_not_empty(self) -> None:
+        assert len(research().prompt) > 0
+
+
+class TestPlanDefaults:
+    def test_returns_subagent(self) -> None:
+        sa = plan()
+        assert isinstance(sa, Subagent)
+
+    def test_name(self) -> None:
+        assert plan().name == "plan"
+
+    def test_default_tools_is_none(self) -> None:
+        assert plan().tools is None
+
+    def test_default_memory(self) -> None:
+        assert plan().memory == "readonly"
+
+    def test_default_fork(self) -> None:
+        assert plan().fork is False
+
+    def test_prompt_not_empty(self) -> None:
+        assert len(plan().prompt) > 0
+
+
+class TestGeneralDefaults:
+    def test_returns_subagent(self) -> None:
+        sa = general()
+        assert isinstance(sa, Subagent)
+
+    def test_name(self) -> None:
+        assert general().name == "general"
+
+    def test_default_tools_is_none(self) -> None:
+        assert general().tools is None
+
+    def test_default_memory(self) -> None:
+        assert general().memory == "readwrite"
+
+    def test_default_fork(self) -> None:
+        assert general().fork is False
+
+    def test_prompt_not_empty(self) -> None:
+        assert len(general().prompt) > 0
+
+
+class TestInstructionsMerge:
+    def test_research_instructions(self) -> None:
+        sa = research(instructions="Focus on security vulnerabilities.")
+        assert "Focus on security vulnerabilities." in sa.prompt
+        assert "research agent" in sa.prompt.lower()
+
+    def test_plan_instructions(self) -> None:
+        sa = plan(instructions="Consider performance constraints.")
+        assert "Consider performance constraints." in sa.prompt
+        assert "planning agent" in sa.prompt.lower()
+
+    def test_general_instructions(self) -> None:
+        sa = general(instructions="Be thorough.")
+        assert "Be thorough." in sa.prompt
+        assert "general-purpose agent" in sa.prompt.lower()
+
+
+class TestCustomTools:
+    def test_tools_replace_defaults(self) -> None:
+        custom = [think()]
+        sa = research(tools=custom)
+        assert sa.tools is not None
+        assert len(sa.tools) == 1
+
+    def test_empty_tools(self) -> None:
+        sa = research(tools=[])
+        assert sa.tools is not None
+        assert len(sa.tools) == 0
+
+    def test_extra_tools_added(self) -> None:
+        sa = research(extra_tools=[think()])
+        assert sa.extra_tools is not None
+        assert len(sa.extra_tools) == 1
+        assert sa.tools is None  # defaults still None
+
+    def test_tools_and_extra_tools(self) -> None:
+        sa = plan(tools=[think()], extra_tools=[think()])
+        assert sa.tools is not None
+        assert len(sa.tools) == 1
+        assert sa.extra_tools is not None
+        assert len(sa.extra_tools) == 1
+
+
+class TestOverrides:
+    def test_model_override(self) -> None:
+        sa = research(model="anthropic/claude-sonnet-4")
+        assert sa.model == "anthropic/claude-sonnet-4"
+
+    def test_fork_override(self) -> None:
+        sa = research(fork=True)
+        assert sa.fork is True
+
+    def test_memory_override(self) -> None:
+        sa = research(memory="readwrite")
+        assert sa.memory == "readwrite"
+
+    def test_memory_false(self) -> None:
+        sa = general(memory=False)
+        assert sa.memory is False
+
+
+class TestTaskAgnosticPrompts:
+    def test_research_no_code_references(self) -> None:
+        prompt = research().prompt
+        assert "codebase" not in prompt.lower()
+        assert "code review" not in prompt.lower()
+
+    def test_plan_no_code_references(self) -> None:
+        prompt = plan().prompt
+        assert "codebase" not in prompt.lower()
+        assert "code review" not in prompt.lower()
+
+    def test_general_no_code_references(self) -> None:
+        prompt = general().prompt
+        assert "codebase" not in prompt.lower()
+        assert "code review" not in prompt.lower()

--- a/tests/agent/deepagent/test_factories.py
+++ b/tests/agent/deepagent/test_factories.py
@@ -110,6 +110,30 @@ class TestCustomTools:
         assert len(sa.extra_tools) == 1
 
 
+class TestSkills:
+    def test_skills_on_research(self) -> None:
+        from inspect_ai.tool import Skill
+
+        sk = Skill(name="test-skill", description="A test.", instructions="Do stuff.")
+        sa = research(skills=[sk])
+        assert sa.skills is not None
+        assert len(sa.skills) == 1
+        assert sa.skills[0].name == "test-skill"
+
+    def test_skills_on_general(self) -> None:
+        from inspect_ai.tool import Skill
+
+        sk = Skill(name="test-skill", description="A test.", instructions="Do stuff.")
+        sa = general(skills=[sk])
+        assert sa.skills is not None
+        assert len(sa.skills) == 1
+
+    def test_skills_default_none(self) -> None:
+        assert research().skills is None
+        assert plan().skills is None
+        assert general().skills is None
+
+
 class TestOverrides:
     def test_model_override(self) -> None:
         sa = research(model="anthropic/claude-sonnet-4")

--- a/tests/agent/deepagent/test_factories.py
+++ b/tests/agent/deepagent/test_factories.py
@@ -118,7 +118,9 @@ class TestSkills:
         sa = research(skills=[sk])
         assert sa.skills is not None
         assert len(sa.skills) == 1
-        assert sa.skills[0].name == "test-skill"
+        skill = sa.skills[0]
+        assert isinstance(skill, Skill)
+        assert skill.name == "test-skill"
 
     def test_skills_on_general(self) -> None:
         from inspect_ai.tool import Skill

--- a/tests/agent/deepagent/test_prompt.py
+++ b/tests/agent/deepagent/test_prompt.py
@@ -1,0 +1,142 @@
+"""Tests for system prompt assembly."""
+
+from inspect_ai.agent._deepagent.prompt import (
+    CORE_BEHAVIOR,
+    MEMORY_INSTRUCTIONS,
+    MEMORY_ONLY_INSTRUCTIONS,
+    PLAN_ONLY_INSTRUCTIONS,
+    build_subagent_dispatch,
+    build_system_prompt,
+    expand_prompt_placeholders,
+)
+from inspect_ai.agent._deepagent.subagent import subagent
+
+
+def _test_subagent(name: str = "research", description: str = "Gather info."):
+    return subagent(name=name, description=description, prompt="prompt")
+
+
+class TestBuildSystemPrompt:
+    def test_default_includes_core_behavior(self) -> None:
+        prompt = build_system_prompt()
+        assert CORE_BEHAVIOR in prompt
+
+    def test_with_subagents(self) -> None:
+        sas = [_test_subagent("research", "Gather info.")]
+        prompt = build_system_prompt(subagents=sas)
+        assert "research" in prompt
+        assert "Gather info." in prompt
+        assert "task tool" in prompt.lower() or "delegate" in prompt.lower()
+
+    def test_without_subagents(self) -> None:
+        prompt = build_system_prompt(subagents=None)
+        assert "delegate" not in prompt.lower()
+        assert "subagent" not in prompt.lower()
+
+    def test_empty_subagents(self) -> None:
+        prompt = build_system_prompt(subagents=[])
+        assert "delegate" not in prompt.lower()
+
+    def test_with_memory_and_todo_write(self) -> None:
+        prompt = build_system_prompt(memory=True, todo_write=True)
+        assert "memory" in prompt.lower()
+        assert "plan" in prompt.lower()
+
+    def test_with_memory_only(self) -> None:
+        prompt = build_system_prompt(memory=True, todo_write=False)
+        assert MEMORY_ONLY_INSTRUCTIONS in prompt
+        assert MEMORY_INSTRUCTIONS not in prompt
+
+    def test_with_todo_write_only(self) -> None:
+        prompt = build_system_prompt(memory=False, todo_write=True)
+        assert PLAN_ONLY_INSTRUCTIONS in prompt
+        assert MEMORY_INSTRUCTIONS not in prompt
+
+    def test_without_memory_or_todo_write(self) -> None:
+        prompt = build_system_prompt(memory=False, todo_write=False)
+        assert "memory tool" not in prompt.lower()
+        assert "plan tool" not in prompt.lower()
+
+    def test_with_instructions(self) -> None:
+        prompt = build_system_prompt(instructions="Focus on security.")
+        assert "Focus on security." in prompt
+        assert prompt.endswith("Focus on security.")
+
+    def test_instructions_at_end(self) -> None:
+        prompt = build_system_prompt(
+            subagents=[_test_subagent()],
+            instructions="Custom instructions here.",
+        )
+        assert prompt.index(CORE_BEHAVIOR) < prompt.index("Custom instructions here.")
+
+
+class TestBuildSubagentDispatch:
+    def test_includes_all_subagents(self) -> None:
+        sas = [
+            _test_subagent("research", "Read-only info gathering."),
+            _test_subagent("plan", "Structured planning."),
+            _test_subagent("general", "General work."),
+        ]
+        dispatch = build_subagent_dispatch(sas)
+        assert "research" in dispatch
+        assert "plan" in dispatch
+        assert "general" in dispatch
+        assert "Read-only info gathering." in dispatch
+
+    def test_includes_delegation_guidance(self) -> None:
+        dispatch = build_subagent_dispatch([_test_subagent()])
+        assert "delegate" in dispatch.lower() or "Delegate" in dispatch
+
+
+class TestExpandPromptPlaceholders:
+    def test_all_placeholders(self) -> None:
+        template = (
+            "CORE:\n{core_behavior}\n\n"
+            "DISPATCH:\n{subagent_dispatch}\n\n"
+            "MEMORY:\n{memory_instructions}\n\n"
+            "USER:\n{instructions}"
+        )
+        result = expand_prompt_placeholders(
+            template,
+            subagents=[_test_subagent("research", "Gather info.")],
+            memory=True,
+            todo_write=True,
+            instructions="Be thorough.",
+        )
+        assert CORE_BEHAVIOR in result
+        assert "research" in result
+        assert "memory" in result.lower()
+        assert "Be thorough." in result
+
+    def test_missing_placeholders_harmless(self) -> None:
+        template = "Just a simple prompt with no placeholders."
+        result = expand_prompt_placeholders(template)
+        assert result == template
+
+    def test_partial_placeholders(self) -> None:
+        template = "Start here.\n\n{core_behavior}\n\nEnd here."
+        result = expand_prompt_placeholders(template)
+        assert "Start here." in result
+        assert CORE_BEHAVIOR in result
+        assert "End here." in result
+
+    def test_no_subagents_clears_placeholder(self) -> None:
+        template = "Before {subagent_dispatch} After"
+        result = expand_prompt_placeholders(template, subagents=None)
+        assert "Before  After" in result
+
+    def test_no_memory_clears_placeholder(self) -> None:
+        template = "Before {memory_instructions} After"
+        result = expand_prompt_placeholders(template, memory=False, todo_write=False)
+        assert "Before  After" in result
+
+
+class TestTaskAgnosticPrompts:
+    def test_core_behavior_no_code_references(self) -> None:
+        assert "codebase" not in CORE_BEHAVIOR.lower()
+        assert "code review" not in CORE_BEHAVIOR.lower()
+        assert "git" not in CORE_BEHAVIOR.lower()
+
+    def test_memory_instructions_no_code_references(self) -> None:
+        assert "codebase" not in MEMORY_INSTRUCTIONS.lower()
+        assert "code review" not in MEMORY_INSTRUCTIONS.lower()

--- a/tests/agent/deepagent/test_subagent.py
+++ b/tests/agent/deepagent/test_subagent.py
@@ -31,6 +31,7 @@ class TestSubagentAllFields:
             extra_tools=[],
             model="anthropic/claude-sonnet-4",
             fork=True,
+            skills=[],
             memory="readwrite",
             limits=[],
         )
@@ -41,6 +42,7 @@ class TestSubagentAllFields:
         assert s.extra_tools == []
         assert s.model == "anthropic/claude-sonnet-4"
         assert s.fork is True
+        assert s.skills == []
         assert s.memory == "readwrite"
         assert s.limits == []
 

--- a/tests/agent/deepagent/test_subagent.py
+++ b/tests/agent/deepagent/test_subagent.py
@@ -13,7 +13,6 @@ class TestSubagentDefaults:
         assert s.extra_tools is None
         assert s.model is None
         assert s.fork is False
-        assert s.skills is None
         assert s.memory == "readonly"
         assert s.limits is None
 
@@ -32,7 +31,6 @@ class TestSubagentAllFields:
             extra_tools=[],
             model="anthropic/claude-sonnet-4",
             fork=True,
-            skills=[],
             memory="readwrite",
             limits=[],
         )
@@ -43,7 +41,6 @@ class TestSubagentAllFields:
         assert s.extra_tools == []
         assert s.model == "anthropic/claude-sonnet-4"
         assert s.fork is True
-        assert s.skills == []
         assert s.memory == "readwrite"
         assert s.limits == []
 

--- a/tests/agent/deepagent/test_subagent.py
+++ b/tests/agent/deepagent/test_subagent.py
@@ -74,9 +74,14 @@ class TestSubagentDescriptionValidation:
 
 
 class TestSubagentPromptValidation:
-    def test_empty_prompt(self) -> None:
+    def test_empty_prompt_isolated_rejected(self) -> None:
         with pytest.raises(ValueError, match="prompt must not be empty"):
             subagent(name="test", description="desc", prompt="")
+
+    def test_empty_prompt_forked_accepted(self) -> None:
+        s = subagent(name="test", description="desc", prompt="", fork=True)
+        assert s.prompt == ""
+        assert s.fork is True
 
 
 class TestSubagentMemoryValidation:

--- a/tests/agent/deepagent/test_subagent.py
+++ b/tests/agent/deepagent/test_subagent.py
@@ -13,7 +13,7 @@ class TestSubagentDefaults:
         assert s.extra_tools is None
         assert s.model is None
         assert s.fork is False
-        assert s.memory == "readonly"
+        assert s.memory is False
         assert s.limits is None
 
     def test_isinstance_subagent(self) -> None:

--- a/tests/agent/deepagent/test_subagent.py
+++ b/tests/agent/deepagent/test_subagent.py
@@ -1,0 +1,104 @@
+import pytest
+
+from inspect_ai.agent import Subagent, subagent
+
+
+class TestSubagentDefaults:
+    def test_required_fields_only(self) -> None:
+        s = subagent(name="test", description="A test agent.", prompt="Do the thing.")
+        assert s.name == "test"
+        assert s.description == "A test agent."
+        assert s.prompt == "Do the thing."
+        assert s.tools is None
+        assert s.extra_tools is None
+        assert s.model is None
+        assert s.fork is False
+        assert s.skills is None
+        assert s.memory == "readonly"
+        assert s.limits is None
+
+    def test_isinstance_subagent(self) -> None:
+        s = subagent(name="test", description="desc", prompt="prompt")
+        assert isinstance(s, Subagent)
+
+
+class TestSubagentAllFields:
+    def test_all_fields_set(self) -> None:
+        s = subagent(
+            name="reviewer",
+            description="Reviews code.",
+            prompt="Review carefully.",
+            tools=[],
+            extra_tools=[],
+            model="anthropic/claude-sonnet-4",
+            fork=True,
+            skills=[],
+            memory="readwrite",
+            limits=[],
+        )
+        assert s.name == "reviewer"
+        assert s.description == "Reviews code."
+        assert s.prompt == "Review carefully."
+        assert s.tools == []
+        assert s.extra_tools == []
+        assert s.model == "anthropic/claude-sonnet-4"
+        assert s.fork is True
+        assert s.skills == []
+        assert s.memory == "readwrite"
+        assert s.limits == []
+
+
+class TestSubagentNameValidation:
+    def test_empty_name(self) -> None:
+        with pytest.raises(ValueError, match="valid Python identifier"):
+            subagent(name="", description="desc", prompt="prompt")
+
+    def test_name_with_spaces(self) -> None:
+        with pytest.raises(ValueError, match="valid Python identifier"):
+            subagent(name="my agent", description="desc", prompt="prompt")
+
+    def test_name_starts_with_digit(self) -> None:
+        with pytest.raises(ValueError, match="valid Python identifier"):
+            subagent(name="123start", description="desc", prompt="prompt")
+
+    def test_name_with_hyphens(self) -> None:
+        with pytest.raises(ValueError, match="valid Python identifier"):
+            subagent(name="my-agent", description="desc", prompt="prompt")
+
+    def test_valid_name_with_underscores(self) -> None:
+        s = subagent(name="my_agent_2", description="desc", prompt="prompt")
+        assert s.name == "my_agent_2"
+
+
+class TestSubagentDescriptionValidation:
+    def test_empty_description(self) -> None:
+        with pytest.raises(ValueError, match="description must not be empty"):
+            subagent(name="test", description="", prompt="prompt")
+
+
+class TestSubagentPromptValidation:
+    def test_empty_prompt(self) -> None:
+        with pytest.raises(ValueError, match="prompt must not be empty"):
+            subagent(name="test", description="desc", prompt="")
+
+
+class TestSubagentMemoryValidation:
+    def test_readwrite(self) -> None:
+        s = subagent(name="test", description="desc", prompt="p", memory="readwrite")
+        assert s.memory == "readwrite"
+
+    def test_readonly(self) -> None:
+        s = subagent(name="test", description="desc", prompt="p", memory="readonly")
+        assert s.memory == "readonly"
+
+    def test_false(self) -> None:
+        s = subagent(name="test", description="desc", prompt="p", memory=False)
+        assert s.memory is False
+
+    def test_true_rejected(self) -> None:
+        with pytest.raises(ValueError, match="memory"):
+            subagent(name="test", description="desc", prompt="p", memory=True)
+
+    def test_invalid_string_rejected(self) -> None:
+        with pytest.raises(ValueError, match="memory"):
+            subagent(name="test", description="desc", prompt="p", memory="write")  # type: ignore[arg-type]

--- a/tests/agent/deepagent/test_subagent.py
+++ b/tests/agent/deepagent/test_subagent.py
@@ -102,3 +102,16 @@ class TestSubagentMemoryValidation:
     def test_invalid_string_rejected(self) -> None:
         with pytest.raises(ValueError, match="memory"):
             subagent(name="test", description="desc", prompt="p", memory="write")  # type: ignore[arg-type]
+
+
+class TestSubagentForkModel:
+    def test_fork_with_model_accepted(self) -> None:
+        s = subagent(
+            name="test",
+            description="desc",
+            prompt="p",
+            fork=True,
+            model="anthropic/claude-sonnet-4",
+        )
+        assert s.fork is True
+        assert s.model == "anthropic/claude-sonnet-4"

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -234,7 +234,7 @@ class TestForkedDispatch:
 
 
 class TestPrepareForkedInput:
-    def test_strips_system_messages(self) -> None:
+    def test_keeps_system_messages(self) -> None:
         from inspect_ai.model._chat_message import ChatMessageSystem
 
         sa = _test_subagent("forked", "Forked agent.")
@@ -244,12 +244,14 @@ class TestPrepareForkedInput:
             ChatMessageAssistant(content="Hi there", id="msg-2"),
         ]
         result = _prepare_forked_input("Do work.", sa, lambda: messages)
-        assert not any(isinstance(m, ChatMessageSystem) for m in result)
-        assert any(
-            isinstance(m, ChatMessageUser) and "Hello" in str(m.content) for m in result
-        )
+        # System message preserved for prompt cache
+        sys_msgs = [m for m in result if isinstance(m, ChatMessageSystem)]
+        assert len(sys_msgs) == 1
+        assert "You are helpful." in str(sys_msgs[0].content)
+        # Trailing assistant stripped
+        assert not any(isinstance(m, ChatMessageAssistant) for m in result)
 
-    def test_strips_trailing_assistant_with_tool_calls(self) -> None:
+    def test_strips_trailing_assistant_keeps_history(self) -> None:
         from inspect_ai.model._chat_message import ChatMessageSystem
         from inspect_ai.tool._tool_call import ToolCall
 
@@ -258,7 +260,7 @@ class TestPrepareForkedInput:
             ChatMessageSystem(content="System prompt."),
             ChatMessageUser(content="Do two things", id="msg-1"),
             ChatMessageAssistant(
-                content="I'll delegate and search.",
+                content="I'll delegate.",
                 id="msg-2",
                 tool_calls=[
                     ToolCall(
@@ -267,21 +269,15 @@ class TestPrepareForkedInput:
                         arguments={"subagent_type": "forked", "prompt": "x"},
                         type="function",
                     ),
-                    ToolCall(
-                        id="call-other-1",
-                        function="web_search",
-                        arguments={"query": "test"},
-                        type="function",
-                    ),
                 ],
             ),
         ]
         result = _prepare_forked_input("Do work.", sa, lambda: messages)
 
-        # No system messages
-        assert not any(isinstance(m, ChatMessageSystem) for m in result)
+        # System message preserved
+        assert any(isinstance(m, ChatMessageSystem) for m in result)
 
-        # Trailing assistant message with tool calls is stripped
+        # Trailing assistant stripped
         assert not any(isinstance(m, ChatMessageAssistant) for m in result)
 
         # Original user message preserved
@@ -289,6 +285,35 @@ class TestPrepareForkedInput:
             isinstance(m, ChatMessageUser) and "Do two things" in str(m.content)
             for m in result
         )
+
+    def test_subagent_prompt_prepended_to_task(self) -> None:
+        sa = _test_subagent("forked", "Forked agent.")
+        messages: list[ChatMessage] = [
+            ChatMessageUser(content="Hello", id="msg-1"),
+        ]
+        result = _prepare_forked_input("Do the task.", sa, lambda: messages)
+        # Last message is user message with subagent prompt + task prompt
+        last = result[-1]
+        assert isinstance(last, ChatMessageUser)
+        content = str(last.content)
+        assert "research assistant" in content.lower()
+        assert "Do the task." in content
+
+    def test_empty_prompt_transparent_fork(self) -> None:
+        sa = subagent(
+            name="transparent",
+            description="Transparent fork.",
+            prompt="",
+            fork=True,
+        )
+        messages: list[ChatMessage] = [
+            ChatMessageUser(content="Hello", id="msg-1"),
+        ]
+        result = _prepare_forked_input("Do work.", sa, lambda: messages)
+        last = result[-1]
+        assert isinstance(last, ChatMessageUser)
+        # Only the task prompt, no prepended instructions
+        assert str(last.content) == "Do work."
 
         # Ends with the child prompt
         assert isinstance(result[-1], ChatMessageUser)

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -8,11 +8,17 @@ from inspect_ai.agent._deepagent.subagent import Subagent, subagent
 from inspect_ai.agent._deepagent.task_tool import (
     SUBAGENT_ALIASES,
     _build_task_description,
+    _prepare_forked_input,
     _resolve_tools,
     task_tool,
 )
 from inspect_ai.dataset import Sample
 from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageUser,
+)
 from inspect_ai.solver import generate, use_tools
 
 
@@ -232,3 +238,72 @@ class TestForkedDispatch:
         assert tool_event is not None
         assert tool_event.function == "task"
         assert tool_event.error is None
+
+
+class TestPrepareForkedInput:
+    def test_strips_system_messages(self) -> None:
+        from inspect_ai.model._chat_message import ChatMessageSystem
+
+        sa = _test_subagent("forked", "Forked agent.")
+        messages: list[ChatMessage] = [
+            ChatMessageSystem(content="You are helpful."),
+            ChatMessageUser(content="Hello", id="msg-1"),
+            ChatMessageAssistant(content="Hi there", id="msg-2"),
+        ]
+        result = _prepare_forked_input("Do work.", sa, lambda: messages)
+        assert not any(isinstance(m, ChatMessageSystem) for m in result)
+        assert any(
+            isinstance(m, ChatMessageUser) and "Hello" in str(m.content) for m in result
+        )
+
+    def test_repairs_sibling_tool_calls(self) -> None:
+        from inspect_ai.model._chat_message import ChatMessageSystem
+        from inspect_ai.tool._tool_call import ToolCall
+
+        sa = _test_subagent("forked", "Forked agent.")
+        messages: list[ChatMessage] = [
+            ChatMessageSystem(content="System prompt."),
+            ChatMessageUser(content="Do two things", id="msg-1"),
+            ChatMessageAssistant(
+                content="I'll delegate and search.",
+                id="msg-2",
+                tool_calls=[
+                    ToolCall(
+                        id="call-task-1",
+                        function="task",
+                        arguments={"subagent_type": "forked", "prompt": "x"},
+                        type="function",
+                    ),
+                    ToolCall(
+                        id="call-other-1",
+                        function="web_search",
+                        arguments={"query": "test"},
+                        type="function",
+                    ),
+                ],
+            ),
+        ]
+        result = _prepare_forked_input("Do work.", sa, lambda: messages)
+
+        # No system messages
+        assert not any(isinstance(m, ChatMessageSystem) for m in result)
+
+        # Last assistant message should have only the task() call
+        assistant_msgs = [m for m in result if isinstance(m, ChatMessageAssistant)]
+        assert len(assistant_msgs) == 1
+        assert assistant_msgs[0].tool_calls is not None
+        assert len(assistant_msgs[0].tool_calls) == 1
+        assert assistant_msgs[0].tool_calls[0].function == "task"
+        assert assistant_msgs[0].tool_calls[0].id == "call-task-1"
+
+        # Should have a ChatMessageTool boundary
+        from inspect_ai.model._chat_message import ChatMessageTool
+
+        tool_msgs = [m for m in result if isinstance(m, ChatMessageTool)]
+        assert len(tool_msgs) == 1
+        assert tool_msgs[0].tool_call_id == "call-task-1"
+        assert "forked" in str(tool_msgs[0].content).lower()
+
+        # Ends with the child prompt
+        assert isinstance(result[-1], ChatMessageUser)
+        assert "Do work." in str(result[-1].content)

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -6,7 +6,6 @@ from inspect_ai import Task, eval
 from inspect_ai._util.registry import is_registry_object, registry_info
 from inspect_ai.agent._deepagent.subagent import Subagent, subagent
 from inspect_ai.agent._deepagent.task_tool import (
-    SUBAGENT_ALIASES,
     _build_task_description,
     _prepare_forked_input,
     _resolve_tools,
@@ -50,11 +49,6 @@ class TestBuildTaskDescription:
     def test_includes_delegation_guidance(self) -> None:
         desc = _build_task_description([_test_subagent()])
         assert "Delegate" in desc or "delegate" in desc
-
-
-class TestAliasHandling:
-    def test_general_purpose_alias(self) -> None:
-        assert SUBAGENT_ALIASES.get("general_purpose") == "general"
 
 
 class TestTaskToolConstructibility:
@@ -132,9 +126,8 @@ class TestTaskToolDispatch:
         tool_event = get_tool_event(log)
         assert tool_event is not None
         assert tool_event.error is not None
-        assert "Unknown subagent_type" in tool_event.error.message
 
-    def test_alias_dispatch(self) -> None:
+    def test_general_dispatch(self) -> None:
         sa = _test_subagent("general", "General work.")
         tt = task_tool(subagents=[sa])
 
@@ -151,7 +144,7 @@ class TestTaskToolDispatch:
                     model="mockllm/model",
                     tool_name="task",
                     tool_arguments={
-                        "subagent_type": "general_purpose",
+                        "subagent_type": "general",
                         "prompt": "Do general work.",
                     },
                 ),

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -181,3 +181,54 @@ class TestRecursionGuard:
         sas = [sa]
         tools = _resolve_tools(sa, sas, None, depth=1, max_depth=1, get_messages=None)
         assert "task" not in self._tool_registry_names(tools)
+
+
+class TestForkedDispatch:
+    def test_forked_via_mockllm(self) -> None:
+        from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
+
+        sa = subagent(
+            name="forked_agent",
+            description="A forked agent.",
+            prompt="You are a forked helper.",
+            fork=True,
+        )
+        parent_messages: list[ChatMessage] = [
+            ChatMessageUser(content="Original context.", id="msg-1")
+        ]
+        tt = task_tool(
+            subagents=[sa],
+            get_messages=lambda: parent_messages,
+        )
+
+        task = Task(
+            dataset=[Sample(input="Do work with fork")],
+            solver=[use_tools(tt), generate()],
+            message_limit=10,
+        )
+
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "forked_agent",
+                        "prompt": "Continue the work.",
+                    },
+                ),
+                # Inner forked agent generates a response
+                ModelOutput.from_content("mockllm/model", "Completed forked work."),
+                # Outer agent finishes
+                ModelOutput.from_content("mockllm/model", "Done"),
+            ],
+        )
+
+        log = eval(task, model=model)[0]
+        assert log.status == "success"
+
+        tool_event = get_tool_event(log)
+        assert tool_event is not None
+        assert tool_event.function == "task"
+        assert tool_event.error is None

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -3,7 +3,7 @@
 from test_helpers.tool_call_utils import get_tool_event
 
 from inspect_ai import Task, eval
-from inspect_ai._util.content import ContentText
+from inspect_ai._util.content import Content, ContentText
 from inspect_ai._util.registry import is_registry_object, registry_info
 from inspect_ai.agent._deepagent.subagent import Subagent, subagent
 from inspect_ai.agent._deepagent.task_tool import (
@@ -295,14 +295,14 @@ class TestExtractResult:
         from inspect_ai.model._chat_message import ChatMessageAssistant
         from inspect_ai.model._model_output import ChatCompletionChoice, ModelOutput
 
-        content_blocks = [ContentText(text="The answer is 42.")]
+        content_blocks: list[Content] = [ContentText(text="The answer is 42.")]
         msg = ChatMessageAssistant(content=content_blocks)
         output = ModelOutput(
             model="test",
             choices=[ChatCompletionChoice(message=msg, stop_reason="stop")],
         )
         state = AgentState(messages=[msg])
-        state._output = output  # type: ignore[attr-defined]
+        state._output = output
 
         result = _extract_result(state)
         assert result == "The answer is 42."

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -81,9 +81,11 @@ class TestTaskToolDispatch:
                         "prompt": "Find relevant information.",
                     },
                 ),
-                # 2. Inner subagent (research) generates a response (no tools, so it stops)
-                ModelOutput.from_content(
-                    "mockllm/model", "I found the relevant information."
+                # 2. Inner subagent (research) submits its findings
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "I found the relevant information."},
                 ),
                 # 3. Outer agent generates final response
                 ModelOutput.from_content("mockllm/model", "Done"),
@@ -149,7 +151,11 @@ class TestTaskToolDispatch:
                         "prompt": "Do general work.",
                     },
                 ),
-                ModelOutput.from_content("mockllm/model", "Did the work."),
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Did the work."},
+                ),
                 ModelOutput.from_content("mockllm/model", "Done"),
             ],
         )
@@ -355,8 +361,12 @@ class TestForkedDispatch:
                         "prompt": "Continue the work.",
                     },
                 ),
-                # Inner forked agent generates a response
-                ModelOutput.from_content("mockllm/model", "Completed forked work."),
+                # Inner forked agent submits its response
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="submit",
+                    tool_arguments={"answer": "Completed forked work."},
+                ),
                 # Outer agent finishes
                 ModelOutput.from_content("mockllm/model", "Done"),
             ],
@@ -458,9 +468,7 @@ class TestPrepareForkedInput:
         assert from_message == "msg-1"
         last = result[-1]
         assert isinstance(last, ChatMessageUser)
-        # Only the task prompt, no prepended instructions
-        assert str(last.content) == "Do work."
-
-        # Ends with the child prompt
-        assert isinstance(result[-1], ChatMessageUser)
-        assert "Do work." in str(result[-1].content)
+        # Task prompt present (no prepended sa.prompt since it's empty)
+        assert "Do work." in str(last.content)
+        # Submit instructions appended
+        assert "submit()" in str(last.content)

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -174,7 +174,7 @@ class TestRecursionGuard:
         sa = _test_subagent("research", "Gather info.")
         sas = [sa]
         tools = _resolve_tools(
-            sa, sas, None, None, depth=0, max_depth=2, get_messages=None
+            sa, sas, None, None, None, depth=0, max_depth=2, get_messages=None
         )
         assert "task" in self._tool_registry_names(tools)
 
@@ -183,9 +183,107 @@ class TestRecursionGuard:
         sa = _test_subagent("research", "Gather info.")
         sas = [sa]
         tools = _resolve_tools(
-            sa, sas, None, None, depth=0, max_depth=1, get_messages=None
+            sa, sas, None, None, None, depth=0, max_depth=1, get_messages=None
         )
         assert "task" not in self._tool_registry_names(tools)
+
+
+class TestSkillComposition:
+    def _find_skill_tools(self, tools: list) -> list:
+        from inspect_ai.tool._tool_def import ToolDef
+
+        result = []
+        for t in tools:
+            try:
+                td = ToolDef(t)
+                if td.name == "skill":
+                    result.append(td)
+            except Exception:
+                pass
+        return result
+
+    def test_parent_skills_flow_to_subagent(self) -> None:
+        from inspect_ai.tool import Skill
+
+        parent_sk = Skill(name="parent-skill", description="P.", instructions="P.")
+        sa = _test_subagent("research", "Gather info.")
+        sas = [sa]
+        tools = _resolve_tools(
+            sa, sas, None, None, [parent_sk], depth=0, max_depth=1, get_messages=None
+        )
+        skill_tools = self._find_skill_tools(tools)
+        assert len(skill_tools) == 1
+        assert "parent-skill" in skill_tools[0].description
+
+    def test_subagent_skills_merge_with_parent(self) -> None:
+        from inspect_ai.tool import Skill
+
+        parent_sk = Skill(name="parent-skill", description="Parent.", instructions="P.")
+        child_sk = Skill(name="child-skill", description="Child.", instructions="C.")
+        sa = subagent(
+            name="custom",
+            description="Custom.",
+            prompt="Custom.",
+            skills=[child_sk],
+        )
+        sas = [sa]
+        tools = _resolve_tools(
+            sa, sas, None, None, [parent_sk], depth=0, max_depth=1, get_messages=None
+        )
+        skill_tools = self._find_skill_tools(tools)
+        assert len(skill_tools) == 1
+        assert "parent-skill" in skill_tools[0].description
+        assert "child-skill" in skill_tools[0].description
+
+    def test_no_skill_tool_when_no_skills(self) -> None:
+        sa = _test_subagent("research", "Gather info.")
+        sas = [sa]
+        tools = _resolve_tools(
+            sa, sas, None, None, None, depth=0, max_depth=1, get_messages=None
+        )
+        skill_tools = self._find_skill_tools(tools)
+        assert len(skill_tools) == 0
+
+    def test_duplicate_skill_names_rejected(self) -> None:
+        import pytest
+
+        from inspect_ai.agent._deepagent.deepagent import _validate_skill_names
+        from inspect_ai.tool import Skill
+
+        parent_sk = Skill(name="pdf", description="Parent PDF.", instructions="P.")
+        child_sk = Skill(name="pdf", description="Child PDF.", instructions="C.")
+        sa = subagent(
+            name="custom",
+            description="Custom.",
+            prompt="Custom.",
+            skills=[child_sk],
+        )
+        with pytest.raises(ValueError, match="Duplicate skill name"):
+            _validate_skill_names([parent_sk], [sa])
+
+    def test_duplicate_across_sibling_subagents_rejected(self) -> None:
+        import pytest
+
+        from inspect_ai.agent._deepagent.deepagent import _validate_skill_names
+        from inspect_ai.tool import Skill
+
+        sk_a = Skill(name="pdf", description="A.", instructions="A.")
+        sk_b = Skill(name="pdf", description="B.", instructions="B.")
+        sa_a = subagent(name="agent_a", description="A.", prompt="A.", skills=[sk_a])
+        sa_b = subagent(name="agent_b", description="B.", prompt="B.", skills=[sk_b])
+        with pytest.raises(ValueError, match="Duplicate skill name"):
+            _validate_skill_names(None, [sa_a, sa_b])
+
+    def test_duplicate_in_parent_skills_rejected(self) -> None:
+        import pytest
+
+        from inspect_ai.agent._deepagent.deepagent import _validate_skill_names
+        from inspect_ai.tool import Skill
+
+        sk1 = Skill(name="pdf", description="First.", instructions="1.")
+        sk2 = Skill(name="pdf", description="Second.", instructions="2.")
+        with pytest.raises(ValueError, match="Duplicate skill name"):
+            _validate_skill_names([sk1, sk2], [])
 
 
 class TestForkedDispatch:

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -1,0 +1,183 @@
+"""Tests for task() multiplexer tool."""
+
+from test_helpers.tool_call_utils import get_tool_event
+
+from inspect_ai import Task, eval
+from inspect_ai._util.registry import is_registry_object, registry_info
+from inspect_ai.agent._deepagent.subagent import Subagent, subagent
+from inspect_ai.agent._deepagent.task_tool import (
+    SUBAGENT_ALIASES,
+    _build_task_description,
+    _resolve_tools,
+    task_tool,
+)
+from inspect_ai.dataset import Sample
+from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.solver import generate, use_tools
+
+
+def _test_subagent(
+    name: str = "research", description: str = "Gather info."
+) -> Subagent:
+    return subagent(
+        name=name,
+        description=description,
+        prompt="You are a helpful research assistant.",
+    )
+
+
+class TestBuildTaskDescription:
+    def test_includes_all_subagent_names(self) -> None:
+        subagents = [
+            _test_subagent("research", "Gather info."),
+            _test_subagent("plan", "Make plans."),
+            _test_subagent("general", "General work."),
+        ]
+        desc = _build_task_description(subagents)
+        assert "research" in desc
+        assert "plan" in desc
+        assert "general" in desc
+        assert "Gather info." in desc
+        assert "Make plans." in desc
+        assert "General work." in desc
+
+    def test_includes_delegation_guidance(self) -> None:
+        desc = _build_task_description([_test_subagent()])
+        assert "Delegate" in desc or "delegate" in desc
+
+
+class TestAliasHandling:
+    def test_general_purpose_alias(self) -> None:
+        assert SUBAGENT_ALIASES.get("general_purpose") == "general"
+
+
+class TestTaskToolConstructibility:
+    def test_constructible(self) -> None:
+        tool = task_tool(subagents=[_test_subagent()])
+        assert tool is not None
+
+
+class TestTaskToolDispatch:
+    def test_via_mockllm(self) -> None:
+        sa = _test_subagent("research", "Read-only information gathering.")
+        tt = task_tool(subagents=[sa])
+
+        task = Task(
+            dataset=[Sample(input="Do some research")],
+            solver=[use_tools(tt), generate()],
+            message_limit=10,
+        )
+
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                # 1. Outer agent calls task() tool
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "research",
+                        "prompt": "Find relevant information.",
+                    },
+                ),
+                # 2. Inner subagent (research) generates a response (no tools, so it stops)
+                ModelOutput.from_content(
+                    "mockllm/model", "I found the relevant information."
+                ),
+                # 3. Outer agent generates final response
+                ModelOutput.from_content("mockllm/model", "Done"),
+            ],
+        )
+
+        log = eval(task, model=model)[0]
+        assert log.status == "success"
+
+        tool_event = get_tool_event(log)
+        assert tool_event is not None
+        assert tool_event.function == "task"
+
+    def test_invalid_subagent_type(self) -> None:
+        sa = _test_subagent("research", "Gather info.")
+        tt = task_tool(subagents=[sa])
+
+        task = Task(
+            dataset=[Sample(input="Do something")],
+            solver=[use_tools(tt), generate()],
+            message_limit=10,
+        )
+
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "nonexistent",
+                        "prompt": "Do something.",
+                    },
+                ),
+                ModelOutput.from_content("mockllm/model", "Done"),
+            ],
+        )
+
+        log = eval(task, model=model)[0]
+        assert log.status == "success"
+        tool_event = get_tool_event(log)
+        assert tool_event is not None
+        assert tool_event.error is not None
+        assert "Unknown subagent_type" in tool_event.error.message
+
+    def test_alias_dispatch(self) -> None:
+        sa = _test_subagent("general", "General work.")
+        tt = task_tool(subagents=[sa])
+
+        task = Task(
+            dataset=[Sample(input="Do work")],
+            solver=[use_tools(tt), generate()],
+            message_limit=10,
+        )
+
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="task",
+                    tool_arguments={
+                        "subagent_type": "general_purpose",
+                        "prompt": "Do general work.",
+                    },
+                ),
+                ModelOutput.from_content("mockllm/model", "Did the work."),
+                ModelOutput.from_content("mockllm/model", "Done"),
+            ],
+        )
+
+        log = eval(task, model=model)[0]
+        assert log.status == "success"
+        tool_event = get_tool_event(log)
+        assert tool_event is not None
+        assert tool_event.error is None
+
+
+class TestRecursionGuard:
+    def _tool_registry_names(self, tools: list) -> list[str]:
+        names = []
+        for t in tools:
+            if is_registry_object(t):
+                name = registry_info(t).name
+                names.append(name.split("/")[-1])
+        return names
+
+    def test_task_tool_included_below_max_depth(self) -> None:
+        sa = _test_subagent("research", "Gather info.")
+        sas = [sa]
+        tools = _resolve_tools(sa, sas, None, depth=0, max_depth=1, get_messages=None)
+        assert "task" in self._tool_registry_names(tools)
+
+    def test_task_tool_excluded_at_max_depth(self) -> None:
+        sa = _test_subagent("research", "Gather info.")
+        sas = [sa]
+        tools = _resolve_tools(sa, sas, None, depth=1, max_depth=1, get_messages=None)
+        assert "task" not in self._tool_registry_names(tools)

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -169,19 +169,21 @@ class TestRecursionGuard:
                 names.append(name.split("/")[-1])
         return names
 
-    def test_task_tool_included_below_max_depth(self) -> None:
+    def test_task_tool_included_when_depth_allows(self) -> None:
+        """max_depth=2 at depth=0: child gets task tool (can delegate once)."""
+        sa = _test_subagent("research", "Gather info.")
+        sas = [sa]
+        tools = _resolve_tools(
+            sa, sas, None, None, depth=0, max_depth=2, get_messages=None
+        )
+        assert "task" in self._tool_registry_names(tools)
+
+    def test_task_tool_excluded_at_default_depth(self) -> None:
+        """max_depth=1 (default) at depth=0: child does NOT get task tool."""
         sa = _test_subagent("research", "Gather info.")
         sas = [sa]
         tools = _resolve_tools(
             sa, sas, None, None, depth=0, max_depth=1, get_messages=None
-        )
-        assert "task" in self._tool_registry_names(tools)
-
-    def test_task_tool_excluded_at_max_depth(self) -> None:
-        sa = _test_subagent("research", "Gather info.")
-        sas = [sa]
-        tools = _resolve_tools(
-            sa, sas, None, None, depth=1, max_depth=1, get_messages=None
         )
         assert "task" not in self._tool_registry_names(tools)
 

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -3,6 +3,7 @@
 from test_helpers.tool_call_utils import get_tool_event
 
 from inspect_ai import Task, eval
+from inspect_ai._util.content import ContentText
 from inspect_ai._util.registry import is_registry_object, registry_info
 from inspect_ai.agent._deepagent.subagent import Subagent, subagent
 from inspect_ai.agent._deepagent.task_tool import (
@@ -284,6 +285,39 @@ class TestSkillComposition:
         sk2 = Skill(name="pdf", description="Second.", instructions="2.")
         with pytest.raises(ValueError, match="Duplicate skill name"):
             _validate_skill_names([sk1, sk2], [])
+
+
+class TestExtractResult:
+    def test_extract_result_with_content_text(self) -> None:
+        """_extract_result handles list[ContentText] from providers like Anthropic."""
+        from inspect_ai.agent._agent import AgentState
+        from inspect_ai.agent._deepagent.task_tool import _extract_result
+        from inspect_ai.model._chat_message import ChatMessageAssistant
+        from inspect_ai.model._model_output import ChatCompletionChoice, ModelOutput
+
+        content_blocks = [ContentText(text="The answer is 42.")]
+        msg = ChatMessageAssistant(content=content_blocks)
+        output = ModelOutput(
+            model="test",
+            choices=[ChatCompletionChoice(message=msg, stop_reason="stop")],
+        )
+        state = AgentState(messages=[msg])
+        state._output = output  # type: ignore[attr-defined]
+
+        result = _extract_result(state)
+        assert result == "The answer is 42."
+
+    def test_extract_result_with_str_content(self) -> None:
+        """_extract_result handles plain string content."""
+        from inspect_ai.agent._agent import AgentState
+        from inspect_ai.agent._deepagent.task_tool import _extract_result
+        from inspect_ai.model._chat_message import ChatMessageAssistant
+
+        msg = ChatMessageAssistant(content="Plain string answer.")
+        state = AgentState(messages=[msg])
+
+        result = _extract_result(state)
+        assert result == "Plain string answer."
 
 
 class TestForkedDispatch:

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -172,13 +172,17 @@ class TestRecursionGuard:
     def test_task_tool_included_below_max_depth(self) -> None:
         sa = _test_subagent("research", "Gather info.")
         sas = [sa]
-        tools = _resolve_tools(sa, sas, None, depth=0, max_depth=1, get_messages=None)
+        tools = _resolve_tools(
+            sa, sas, None, None, depth=0, max_depth=1, get_messages=None
+        )
         assert "task" in self._tool_registry_names(tools)
 
     def test_task_tool_excluded_at_max_depth(self) -> None:
         sa = _test_subagent("research", "Gather info.")
         sas = [sa]
-        tools = _resolve_tools(sa, sas, None, depth=1, max_depth=1, get_messages=None)
+        tools = _resolve_tools(
+            sa, sas, None, None, depth=1, max_depth=1, get_messages=None
+        )
         assert "task" not in self._tool_registry_names(tools)
 
 

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -256,7 +256,7 @@ class TestPrepareForkedInput:
             isinstance(m, ChatMessageUser) and "Hello" in str(m.content) for m in result
         )
 
-    def test_repairs_sibling_tool_calls(self) -> None:
+    def test_strips_trailing_assistant_with_tool_calls(self) -> None:
         from inspect_ai.model._chat_message import ChatMessageSystem
         from inspect_ai.tool._tool_call import ToolCall
 
@@ -288,21 +288,14 @@ class TestPrepareForkedInput:
         # No system messages
         assert not any(isinstance(m, ChatMessageSystem) for m in result)
 
-        # Last assistant message should have only the task() call
-        assistant_msgs = [m for m in result if isinstance(m, ChatMessageAssistant)]
-        assert len(assistant_msgs) == 1
-        assert assistant_msgs[0].tool_calls is not None
-        assert len(assistant_msgs[0].tool_calls) == 1
-        assert assistant_msgs[0].tool_calls[0].function == "task"
-        assert assistant_msgs[0].tool_calls[0].id == "call-task-1"
+        # Trailing assistant message with tool calls is stripped
+        assert not any(isinstance(m, ChatMessageAssistant) for m in result)
 
-        # Should have a ChatMessageTool boundary
-        from inspect_ai.model._chat_message import ChatMessageTool
-
-        tool_msgs = [m for m in result if isinstance(m, ChatMessageTool)]
-        assert len(tool_msgs) == 1
-        assert tool_msgs[0].tool_call_id == "call-task-1"
-        assert "forked" in str(tool_msgs[0].content).lower()
+        # Original user message preserved
+        assert any(
+            isinstance(m, ChatMessageUser) and "Do two things" in str(m.content)
+            for m in result
+        )
 
         # Ends with the child prompt
         assert isinstance(result[-1], ChatMessageUser)

--- a/tests/agent/deepagent/test_task_tool.py
+++ b/tests/agent/deepagent/test_task_tool.py
@@ -381,7 +381,9 @@ class TestPrepareForkedInput:
             ChatMessageUser(content="Hello", id="msg-1"),
             ChatMessageAssistant(content="Hi there", id="msg-2"),
         ]
-        result = _prepare_forked_input("Do work.", sa, lambda: messages)
+        result, from_message = _prepare_forked_input("Do work.", sa, lambda: messages)
+        # Branch point is the last parent message before the synthetic prompt
+        assert from_message == "msg-1"
         # System message preserved for prompt cache
         sys_msgs = [m for m in result if isinstance(m, ChatMessageSystem)]
         assert len(sys_msgs) == 1
@@ -410,7 +412,9 @@ class TestPrepareForkedInput:
                 ],
             ),
         ]
-        result = _prepare_forked_input("Do work.", sa, lambda: messages)
+        result, from_message = _prepare_forked_input("Do work.", sa, lambda: messages)
+        # Branch point is the user message (assistant was stripped)
+        assert from_message == "msg-1"
 
         # System message preserved
         assert any(isinstance(m, ChatMessageSystem) for m in result)
@@ -429,7 +433,10 @@ class TestPrepareForkedInput:
         messages: list[ChatMessage] = [
             ChatMessageUser(content="Hello", id="msg-1"),
         ]
-        result = _prepare_forked_input("Do the task.", sa, lambda: messages)
+        result, from_message = _prepare_forked_input(
+            "Do the task.", sa, lambda: messages
+        )
+        assert from_message == "msg-1"
         # Last message is user message with subagent prompt + task prompt
         last = result[-1]
         assert isinstance(last, ChatMessageUser)
@@ -447,7 +454,8 @@ class TestPrepareForkedInput:
         messages: list[ChatMessage] = [
             ChatMessageUser(content="Hello", id="msg-1"),
         ]
-        result = _prepare_forked_input("Do work.", sa, lambda: messages)
+        result, from_message = _prepare_forked_input("Do work.", sa, lambda: messages)
+        assert from_message == "msg-1"
         last = result[-1]
         assert isinstance(last, ChatMessageUser)
         # Only the task prompt, no prepended instructions

--- a/tests/timeline/generate.py
+++ b/tests/timeline/generate.py
@@ -808,12 +808,17 @@ def validate_nested_sub_agent(timeline: Timeline) -> None:
 
 def validate_utility_agent(timeline: Timeline) -> None:
     root = timeline.root
-    # The inner lookup span should have utility=True
+    # Tool-invoked subagents (via as_tool/handoff/task) are explicit user
+    # invocations and are never auto-classified as utility, even when
+    # single-turn. The lookup agent should be visible and not utility.
     lookup_spans = find_spans(root, "lookup")
     assert len(lookup_spans) >= 1, "Expected at least one 'lookup' span"
-    utility_lookups = [s for s in lookup_spans if s.utility]
-    assert len(utility_lookups) >= 1, (
-        "Expected at least one lookup span with utility=True"
+    tool_invoked_lookups = [s for s in lookup_spans if s.tool_invoked]
+    assert len(tool_invoked_lookups) >= 1, (
+        "Expected at least one lookup span with tool_invoked=True"
+    )
+    assert all(not s.utility for s in tool_invoked_lookups), (
+        "Tool-invoked lookup must not be classified utility"
     )
     assert_repr_labels(timeline, "main", "lookup")
 
@@ -836,19 +841,20 @@ def validate_parallel_collect(timeline: Timeline) -> None:
 
 def validate_handoff_and_as_tool(timeline: Timeline) -> None:
     root = timeline.root
-    # Both sub-agents should exist somewhere in the tree
-    analyst_spans = find_spans(root, "transfer_to_analyst")
+    # Both sub-agents should exist somewhere in the tree under their
+    # actual agent names (not the handoff/as_tool wrapper tool names).
+    analyst_spans = find_spans(root, "analyst")
     calc_spans = find_spans(root, "calculator")
-    assert len(analyst_spans) >= 1, "Expected 'transfer_to_analyst' span"
+    assert len(analyst_spans) >= 1, "Expected 'analyst' span"
     assert len(calc_spans) >= 1, "Expected 'calculator' span"
-    # Both should be agent type
-    assert any(s.span_type == "agent" for s in analyst_spans), (
-        "Expected transfer_to_analyst with span_type='agent'"
+    # Both should be agent type and tool_invoked
+    assert any(s.span_type == "agent" and s.tool_invoked for s in analyst_spans), (
+        "Expected analyst tool-invoked agent span"
     )
-    assert any(s.span_type == "agent" for s in calc_spans), (
-        "Expected calculator with span_type='agent'"
+    assert any(s.span_type == "agent" and s.tool_invoked for s in calc_spans), (
+        "Expected calculator tool-invoked agent span"
     )
-    assert_repr_labels(timeline, "main", "transfer_to_analyst", "calculator")
+    assert_repr_labels(timeline, "main", "analyst", "calculator")
 
 
 def validate_deep_nesting(timeline: Timeline) -> None:
@@ -909,15 +915,17 @@ def validate_sequential_and_parallel(timeline: Timeline) -> None:
 
 def validate_deep_utility(timeline: Timeline) -> None:
     root = timeline.root
+    # Both dispatcher and lookup are tool-invoked subagents (via as_tool),
+    # so neither is auto-classified utility regardless of turn count.
     dispatcher_spans = find_spans(root, "dispatcher")
     assert len(dispatcher_spans) >= 1, "Expected at least one 'dispatcher' span"
-    assert any(not s.utility for s in dispatcher_spans), (
-        "Expected dispatcher span with utility=False"
+    assert any(s.tool_invoked and not s.utility for s in dispatcher_spans), (
+        "Expected dispatcher tool-invoked agent (utility=False)"
     )
     lookup_spans = find_spans(root, "lookup")
     assert len(lookup_spans) >= 1, "Expected at least one 'lookup' span"
-    assert any(s.utility for s in lookup_spans), (
-        "Expected lookup span with utility=True"
+    assert any(s.tool_invoked and not s.utility for s in lookup_spans), (
+        "Expected lookup tool-invoked agent (utility=False)"
     )
     assert_repr_labels(timeline, "main", "dispatcher", "lookup")
 

--- a/tests/tools/test_grep.py
+++ b/tests/tools/test_grep.py
@@ -1,0 +1,45 @@
+"""Tests for grep tool."""
+
+import pytest
+from test_helpers.tasks import minimal_task_for_tool_use
+from test_helpers.tool_call_utils import get_tool_call, get_tool_response
+from test_helpers.utils import skip_if_no_docker
+
+from inspect_ai import eval
+from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.tool import grep
+
+
+def test_grep_constructible() -> None:
+    """Tool is constructible without a sandbox."""
+    tool = grep()
+    assert tool is not None
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_grep_basic() -> None:
+    task = minimal_task_for_tool_use(grep())
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="grep",
+                    tool_arguments={
+                        "pattern": "root",
+                        "path": "/etc/passwd",
+                    },
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    messages = result.samples[0].messages
+    tool_call = get_tool_call(messages, "grep")
+    assert tool_call is not None
+    response = get_tool_response(messages, tool_call)
+    assert response is not None
+    assert "root" in str(response.content)

--- a/tests/tools/test_grep.py
+++ b/tests/tools/test_grep.py
@@ -1,13 +1,21 @@
 """Tests for grep tool."""
 
 import pytest
-from test_helpers.tasks import minimal_task_for_tool_use
 from test_helpers.tool_call_utils import get_tool_call, get_tool_response
 from test_helpers.utils import skip_if_no_docker
 
-from inspect_ai import eval
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
 from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, use_tools
 from inspect_ai.tool import grep
+
+TEST_FILES = {
+    "/tmp/testdir/hello.py": "def hello():\n    print('hello world')\n",
+    "/tmp/testdir/goodbye.txt": "goodbye world\nfarewell\n",
+    "/tmp/testdir/data.csv": "name,value\nalpha,1\nbeta,2\n",
+}
 
 
 def test_grep_constructible() -> None:
@@ -16,10 +24,20 @@ def test_grep_constructible() -> None:
     assert tool is not None
 
 
-@skip_if_no_docker
-@pytest.mark.slow
-def test_grep_basic() -> None:
-    task = minimal_task_for_tool_use(grep())
+def _run_grep(tool_arguments: dict) -> str:
+    task = Task(
+        dataset=[
+            Sample(
+                input="Please use the tool",
+                target="n/a",
+                files=TEST_FILES,
+            )
+        ],
+        solver=[use_tools(grep()), generate()],
+        scorer=includes(),
+        message_limit=3,
+        sandbox="docker",
+    )
     result = eval(
         task,
         model=get_model(
@@ -28,10 +46,7 @@ def test_grep_basic() -> None:
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
                     tool_name="grep",
-                    tool_arguments={
-                        "pattern": "root",
-                        "path": "/etc/passwd",
-                    },
+                    tool_arguments=tool_arguments,
                 ),
             ],
         ),
@@ -42,4 +57,65 @@ def test_grep_basic() -> None:
     assert tool_call is not None
     response = get_tool_response(messages, tool_call)
     assert response is not None
-    assert "root" in str(response.content)
+    return str(response.content)
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_grep_basic() -> None:
+    content = _run_grep({"pattern": "hello", "path": "/tmp/testdir"})
+    assert "hello" in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_grep_with_glob() -> None:
+    content = _run_grep({"pattern": "world", "path": "/tmp/testdir", "glob": "*.py"})
+    assert "hello.py" in content
+    assert "goodbye.txt" not in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_grep_fixed_strings() -> None:
+    content = _run_grep(
+        {
+            "pattern": "print('hello world')",
+            "path": "/tmp/testdir",
+            "fixed_strings": True,
+        }
+    )
+    assert "hello.py" in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_grep_no_matches() -> None:
+    content = _run_grep({"pattern": "zzz_nonexistent_zzz", "path": "/tmp/testdir"})
+    assert "no matches" in content.lower()
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_grep_files_with_matches_mode() -> None:
+    content = _run_grep(
+        {
+            "pattern": "world",
+            "path": "/tmp/testdir",
+            "output_mode": "files_with_matches",
+        }
+    )
+    assert "hello.py" in content
+    assert "goodbye.txt" in content
+    # Should only show file paths, not line content
+    assert "print" not in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_grep_count_mode() -> None:
+    content = _run_grep(
+        {"pattern": "world", "path": "/tmp/testdir", "output_mode": "count"}
+    )
+    # Should show counts, not full lines
+    assert ":" in content

--- a/tests/tools/test_list_files.py
+++ b/tests/tools/test_list_files.py
@@ -78,3 +78,43 @@ def test_list_files_with_depth() -> None:
     assert "sub" in content
     # c.txt is at depth 2, should not appear with depth=1
     assert "c.txt" not in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_list_files_dash_path_safe() -> None:
+    """Path starting with - must not be interpreted as a find predicate."""
+    task = Task(
+        dataset=[
+            Sample(
+                input="Please use the tool",
+                target="n/a",
+                files=TEST_FILES,
+            )
+        ],
+        solver=[use_tools(list_files()), generate()],
+        scorer=includes(),
+        message_limit=3,
+        sandbox="docker",
+    )
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="list_files",
+                    tool_arguments={"path": "-delete"},
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    messages = result.samples[0].messages
+    tool_call = get_tool_call(messages, "list_files")
+    assert tool_call is not None
+    response = get_tool_response(messages, tool_call)
+    assert response is not None
+    # Should get an error (path not found), not execute -delete
+    assert response.error is not None

--- a/tests/tools/test_list_files.py
+++ b/tests/tools/test_list_files.py
@@ -1,0 +1,42 @@
+"""Tests for list_files tool."""
+
+import pytest
+from test_helpers.tasks import minimal_task_for_tool_use
+from test_helpers.tool_call_utils import get_tool_call, get_tool_response
+from test_helpers.utils import skip_if_no_docker
+
+from inspect_ai import eval
+from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.tool import list_files
+
+
+def test_list_files_constructible() -> None:
+    """Tool is constructible without a sandbox."""
+    tool = list_files()
+    assert tool is not None
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_list_files_basic() -> None:
+    task = minimal_task_for_tool_use(list_files())
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="list_files",
+                    tool_arguments={"path": "/etc", "depth": 1},
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    messages = result.samples[0].messages
+    tool_call = get_tool_call(messages, "list_files")
+    assert tool_call is not None
+    response = get_tool_response(messages, tool_call)
+    assert response is not None
+    assert response.content  # should list files

--- a/tests/tools/test_list_files.py
+++ b/tests/tools/test_list_files.py
@@ -1,13 +1,21 @@
 """Tests for list_files tool."""
 
 import pytest
-from test_helpers.tasks import minimal_task_for_tool_use
 from test_helpers.tool_call_utils import get_tool_call, get_tool_response
 from test_helpers.utils import skip_if_no_docker
 
-from inspect_ai import eval
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
 from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, use_tools
 from inspect_ai.tool import list_files
+
+TEST_FILES = {
+    "/tmp/testdir/a.txt": "a",
+    "/tmp/testdir/b.txt": "b",
+    "/tmp/testdir/sub/c.txt": "c",
+}
 
 
 def test_list_files_constructible() -> None:
@@ -16,10 +24,20 @@ def test_list_files_constructible() -> None:
     assert tool is not None
 
 
-@skip_if_no_docker
-@pytest.mark.slow
-def test_list_files_basic() -> None:
-    task = minimal_task_for_tool_use(list_files())
+def _run_list_files(tool_arguments: dict) -> str:
+    task = Task(
+        dataset=[
+            Sample(
+                input="Please use the tool",
+                target="n/a",
+                files=TEST_FILES,
+            )
+        ],
+        solver=[use_tools(list_files()), generate()],
+        scorer=includes(),
+        message_limit=3,
+        sandbox="docker",
+    )
     result = eval(
         task,
         model=get_model(
@@ -28,7 +46,7 @@ def test_list_files_basic() -> None:
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
                     tool_name="list_files",
-                    tool_arguments={"path": "/etc", "depth": 1},
+                    tool_arguments=tool_arguments,
                 ),
             ],
         ),
@@ -39,4 +57,24 @@ def test_list_files_basic() -> None:
     assert tool_call is not None
     response = get_tool_response(messages, tool_call)
     assert response is not None
-    assert response.content  # should list files
+    return str(response.content)
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_list_files_basic() -> None:
+    content = _run_list_files({"path": "/tmp/testdir"})
+    assert "a.txt" in content
+    assert "b.txt" in content
+    assert "c.txt" in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_list_files_with_depth() -> None:
+    content = _run_list_files({"path": "/tmp/testdir", "depth": 1})
+    assert "a.txt" in content
+    assert "b.txt" in content
+    assert "sub" in content
+    # c.txt is at depth 2, should not appear with depth=1
+    assert "c.txt" not in content

--- a/tests/tools/test_memory.py
+++ b/tests/tools/test_memory.py
@@ -327,3 +327,32 @@ async def test_initial_data_invalid_paths(invalid_path: str, match: str) -> None
     # Seeding happens on first execute call
     with pytest.raises(ToolError, match=match):
         await tool(command="view", path="/memories")
+
+
+async def test_memory_readonly_view() -> None:
+    """Test that readonly memory can view seeded data."""
+    tool = memory(
+        initial_data={"/memories/notes.txt": "important info"},
+        readonly=True,
+    )
+    result = await tool(command="view", path="/memories/notes.txt")
+    assert isinstance(result, str) and "important info" in result
+
+
+async def test_memory_readonly_view_directory() -> None:
+    """Test that readonly memory can list directories."""
+    tool = memory(
+        initial_data={"/memories/sub/notes.txt": "content"},
+        readonly=True,
+    )
+    result = await tool(command="view", path="/memories")
+    assert isinstance(result, str) and "notes.txt" in result
+
+
+async def test_memory_readonly_no_write_params() -> None:
+    """Test that readonly memory only exposes view parameters."""
+    ro_tool = memory(readonly=True)
+    # The readonly execute function only accepts command, path, view_range.
+    # Passing write-specific params like file_text raises TypeError.
+    with pytest.raises(TypeError):
+        await ro_tool(command="view", path="/memories", file_text="nope")

--- a/tests/tools/test_read_file.py
+++ b/tests/tools/test_read_file.py
@@ -1,12 +1,14 @@
 """Tests for read_file tool."""
 
 import pytest
-from test_helpers.tasks import minimal_task_for_tool_use
 from test_helpers.tool_call_utils import get_tool_call, get_tool_response
 from test_helpers.utils import skip_if_no_docker
 
-from inspect_ai import eval
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
 from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, use_tools
 from inspect_ai.tool import read_file
 
 
@@ -16,10 +18,23 @@ def test_read_file_constructible() -> None:
     assert tool is not None
 
 
-@skip_if_no_docker
-@pytest.mark.slow
-def test_read_file_basic() -> None:
-    task = minimal_task_for_tool_use(read_file())
+def _read_file_task(files: dict | None = None) -> Task:
+    sample = Sample(
+        input="Please use the tool",
+        target="n/a",
+        files=files or {"/tmp/test.txt": "line1\nline2\nline3\nline4\nline5"},
+    )
+    return Task(
+        dataset=[sample],
+        solver=[use_tools(read_file()), generate()],
+        scorer=includes(),
+        message_limit=3,
+        sandbox="docker",
+    )
+
+
+def _run_read_file(tool_arguments: dict, files: dict | None = None) -> str:
+    task = _read_file_task(files)
     result = eval(
         task,
         model=get_model(
@@ -28,7 +43,7 @@ def test_read_file_basic() -> None:
                 ModelOutput.for_tool_call(
                     model="mockllm/model",
                     tool_name="read_file",
-                    tool_arguments={"file_path": "/etc/hostname"},
+                    tool_arguments=tool_arguments,
                 ),
             ],
         ),
@@ -39,4 +54,68 @@ def test_read_file_basic() -> None:
     assert tool_call is not None
     response = get_tool_response(messages, tool_call)
     assert response is not None
-    assert response.content  # should have some content
+    return str(response.content)
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_read_file_basic() -> None:
+    content = _run_read_file({"file_path": "/tmp/test.txt"})
+    assert "line1" in content
+    assert "line5" in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_read_file_with_offset() -> None:
+    content = _run_read_file({"file_path": "/tmp/test.txt", "offset": 2})
+    assert "line1" not in content
+    assert "line2" not in content
+    assert "line3" in content
+    assert "line5" in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_read_file_with_limit() -> None:
+    content = _run_read_file({"file_path": "/tmp/test.txt", "limit": 2})
+    assert "line1" in content
+    assert "line2" in content
+    assert "line3" not in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_read_file_with_offset_and_limit() -> None:
+    content = _run_read_file({"file_path": "/tmp/test.txt", "offset": 1, "limit": 2})
+    assert "line1" not in content
+    assert "line2" in content
+    assert "line3" in content
+    assert "line4" not in content
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_read_file_not_found() -> None:
+    task = _read_file_task()
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="read_file",
+                    tool_arguments={"file_path": "/tmp/nonexistent.txt"},
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    messages = result.samples[0].messages
+    tool_call = get_tool_call(messages, "read_file")
+    assert tool_call is not None
+    response = get_tool_response(messages, tool_call)
+    assert response is not None
+    assert response.error is not None
+    assert "not found" in response.error.message.lower()

--- a/tests/tools/test_read_file.py
+++ b/tests/tools/test_read_file.py
@@ -1,0 +1,42 @@
+"""Tests for read_file tool."""
+
+import pytest
+from test_helpers.tasks import minimal_task_for_tool_use
+from test_helpers.tool_call_utils import get_tool_call, get_tool_response
+from test_helpers.utils import skip_if_no_docker
+
+from inspect_ai import eval
+from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.tool import read_file
+
+
+def test_read_file_constructible() -> None:
+    """Tool is constructible without a sandbox."""
+    tool = read_file()
+    assert tool is not None
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_read_file_basic() -> None:
+    task = minimal_task_for_tool_use(read_file())
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name="read_file",
+                    tool_arguments={"file_path": "/etc/hostname"},
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    messages = result.samples[0].messages
+    tool_call = get_tool_call(messages, "read_file")
+    assert tool_call is not None
+    response = get_tool_response(messages, tool_call)
+    assert response is not None
+    assert response.content  # should have some content

--- a/tests/tools/test_skill.py
+++ b/tests/tools/test_skill.py
@@ -32,6 +32,32 @@ description: {description}
 """
 
 
+class TestSkillNameUniqueness:
+    def test_duplicate_names_in_skill_tool(self) -> None:
+        """skill() rejects duplicate skill names."""
+        sk1 = Skill(name="pdf", description="First.", instructions="1.")
+        sk2 = Skill(name="pdf", description="Second.", instructions="2.")
+        with pytest.raises(ValueError, match="Duplicate skill name"):
+            skill([sk1, sk2])
+
+    async def test_duplicate_names_in_install_skills(self) -> None:
+        """install_skills() rejects duplicate skill names before sandbox setup."""
+        from inspect_ai.tool._tools._skill.install import install_skills
+
+        sk1 = Skill(name="pdf", description="First.", instructions="1.")
+        sk2 = Skill(name="pdf", description="Second.", instructions="2.")
+        # Should fail with ValueError, not ProcessLookupError (no sandbox)
+        with pytest.raises(ValueError, match="Duplicate skill name"):
+            await install_skills([sk1, sk2])
+
+    def test_unique_names_accepted(self) -> None:
+        """skill() accepts unique skill names."""
+        sk1 = Skill(name="pdf", description="PDF.", instructions="1.")
+        sk2 = Skill(name="xlsx", description="Excel.", instructions="2.")
+        tool = skill([sk1, sk2])
+        assert tool is not None
+
+
 class TestSkillParsing:
     def test_valid_skill_minimal(self, tmp_path: Path) -> None:
         """Test parsing a valid skill with only SKILL.md."""

--- a/tests/tools/test_todo_write.py
+++ b/tests/tools/test_todo_write.py
@@ -1,0 +1,57 @@
+"""Tests for todo_write tool."""
+
+from test_helpers.tool_call_utils import get_tool_event
+
+from inspect_ai import Task, eval
+from inspect_ai.dataset import Sample
+from inspect_ai.model import ModelOutput, get_model
+from inspect_ai.solver import generate, use_tools
+from inspect_ai.tool import todo_write
+
+
+async def test_todo_write_basic() -> None:
+    """Test basic todo write."""
+    tool = todo_write()
+    result = await tool(
+        todos=[
+            {"content": "Step 1", "status": "completed"},
+            {"content": "Step 2", "status": "in_progress"},
+            {"content": "Step 3", "status": "pending"},
+        ],
+        explanation="Making progress",
+    )
+    assert result == "Plan updated"
+
+
+def test_todo_write_via_mockllm() -> None:
+    """Test todo_write through a mocked model evaluation."""
+    task = Task(
+        dataset=[Sample(input="Create a plan")],
+        solver=[use_tools(todo_write()), generate()],
+    )
+
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="todo_write",
+                tool_arguments={
+                    "todos": [
+                        {"content": "Analyze", "status": "in_progress"},
+                        {"content": "Implement", "status": "pending"},
+                    ]
+                },
+            ),
+            ModelOutput.from_content("mockllm/model", "Done"),
+        ],
+    )
+
+    log = eval(task, model=model)[0]
+    assert log.status == "success"
+
+    tool_event = get_tool_event(log)
+    assert tool_event is not None
+    assert tool_event.function == "todo_write"
+    assert isinstance(tool_event.arguments["todos"], list)
+    assert len(tool_event.arguments["todos"]) == 2


### PR DESCRIPTION
## Overview

The `deepagent()` is a batteries-included entry point for long-horizon tasks. It builds on the [ReAct Agent](react-agent.qmd) with four additions: subagent delegation, persistent memory, structured planning, and an opinionated system prompt that teaches the model when to use each.

The `react()` agent handles short-horizon tasks well, but can degrade in performance under longer horizons, losing context and not reliably decomposing work. The `deepagent()` bundles the patterns that address this, drawing from Claude Code, Codex CLI, and other deep agent frameworks:

1.  Subagent delegation. Spawn isolated workers (`research()`, `plan()`, and `general()`) with their own context windows. Only their summary returns to the parent.

2.  Persistent memory. A `memory()` tool for offloading intermediate results out of the message history so they survive context compaction.

3.  Structured planning. A `todo_write()` tool for explicit task decomposition and progress tracking.

4.  Opinionated system prompt. Goal-oriented instructions that teach the model to act autonomously, delegate effectively, and verify its work.

### Example

Here is a CTF task that uses `deepagent()` with `bash()` and `text_editor()` tools:

``` python
from textwrap import dedent
from inspect_ai import Task, task
from inspect_ai.agent import deepagent
from inspect_ai.dataset import json_dataset
from inspect_ai.scorer import includes
from inspect_ai.tool import bash, text_editor

@task
def ctf_challenge():
    return Task(
        dataset=json_dataset("ctf_challenge.json"),
        solver=deepagent(
            tools=[bash(), text_editor()]
        ),
        scorer=includes(),
        sandbox="docker",
    )
```

Tools are the only required customization for most tasks. Everything else is handled by defaults.

Behind the scenes, `deepagent()` provides three subagents (`research()`, `plan()`, and `general()`), a `memory()` tool, a `todo_write()` planning tool, and a system prompt that teaches the model when to use each. The sections below describe these defaults and how to customize them.

## Agent Defaults

When you call `deepagent()` with no configuration beyond tools, you get a fully assembled agent with the following default behavior.

### Subagents

The parent agent has a `task()` tool that lets it delegate work to specialized subagents. Three are included by default:

| Subagent | Role | Tools | Memory |
|---|---|---|---|
| `research()` | Read-only information gathering and synthesis | `read_file()`, `list_files()`, `grep()` (when sandbox configured) | None |
| `plan()` | Structured task decomposition and planning | `read_file()`, `list_files()`, `grep()` (when sandbox configured) | None |
| `general()` | General-purpose autonomous task completion | Inherits parent's tools | None |

The parent agent decides when to delegate vs. do work directly. The system prompt guides it to delegate when the work is complex, independent, or would benefit from an isolated context, and to do the work directly when it's a simple lookup or a single tool call.

Subagents run in isolated context by default. Each gets a fresh message history with only the task prompt, and only its summary returns to the parent. This prevents context rot and keeps the parent's context lean. All subagents inherit the parent's model by default — for cost-sensitive workloads, consider overriding `research()` with a cheaper model (e.g. `research(model="anthropic/claude-haiku-4-5")`), since read-only information gathering is the highest-volume subagent task. See [Subagents](#built-in-subagents) below for how to customize or replace the defaults.

### Memory

The `memory()` tool provides a scratchpad for the top-level agent for the duration of the evaluation. The model can create, view, update, delete, and search memory entries, storing intermediate results, findings, and status as it works.

Memory is important for long-running agents because it survives context [compaction](compaction.qmd). The system prompt instructs the model to save important findings to memory, and to check memory at the start of its work to recover any earlier progress. When compaction is enabled, the model is instructed to checkpoint important state to memory before context is reduced, ensuring progress survives across compaction boundaries.

The `memory()` tool is based on Anthropic's [native memory tool](https://platform.claude.com/docs/en/agents-and-tools/tool-use/memory-tool) and binds to it natively on Anthropic models.

By default, only the top-level agent has memory — subagents do not. Subagents communicate their findings back through their return value, which is the designed channel for information flow. This avoids cross-contamination where subagent scratch notes could pollute the parent's memory. If a subagent is given memory access (via `memory="readwrite"` on [customized subagents](#built-in-subagents)), its writes are visible to the parent and to subsequent subagent invocations, since all memory tools share the same underlying store.

### Planning

The `todo_write()` tool provides structured task tracking. The model uses it to decompose complex tasks into steps and track progress:

- `pending` — step not yet started
- `in_progress` — step currently being worked on
- `completed` — step finished

The system prompt instructs the model to update the plan as it works, marking steps in progress as it starts them and completed as it finishes.

### System Prompt

The default system prompt is goal-oriented rather than procedurally prescriptive, which works well across models at different levels of agentic post-training:

- Act rather than narrate intent.
- Keep going until fully resolved; diagnose failures and try different approaches.
- Be concise; avoid preamble and unnecessary explanation.
- Batch independent tool calls in a single response rather than making sequential round-trips.
- Plan when tasks are complex; break large tasks into smaller pieces and verify results.
- Use reasonable defaults rather than asking clarifying questions for every detail.

The prompt is oriented toward autonomous execution — the agent acts on reasonable defaults rather than pausing to ask clarifying questions. This is deliberate for evaluation workloads where the task is fully specified and human-in-the-loop clarification is not available.

The prompt also includes cross-tool coordination guidance (use memory for intermediate results, use the plan for decomposition) and subagent delegation guidance (when to delegate, how to pass context to subagents).

## Instructions

The simplest way to customize `deepagent()` is to add domain-specific instructions appended to the default system prompt:

``` python
from textwrap import dedent
from inspect_ai.agent import deepagent
from inspect_ai.tool import bash, text_editor

deepagent(
    tools=[bash(), text_editor()],
    instructions=dedent("""
        You are a penetration tester. Focus on identifying
        security vulnerabilities in the target system. Document
        each finding with severity and evidence.
    """),
)
```

Instructions are appended to the end of the system prompt, after the core behavior, delegation guidance, and memory/planning instructions.

## Tools

Pass task specific tools to `deepagent()` with the `tools` parameter. These tools are available to the top-level agent and automatically flow to the `general()` subagent:

``` python
from inspect_ai.agent import deepagent
from inspect_ai.tool import bash, text_editor, web_search

deepagent(
    tools=[bash(), text_editor()],
    web_search=True
)
```

Pass `True` for default web search configuration, or a pre-configured `web_search()` instance for custom setup. Web search is added to all agents (parent and subagents).

> **Note:** Tools passed to `deepagent()` do not automatically flow to the `research()` or `plan()` subagents. This preserves their read-only posture. To add tools to those subagents, use `extra_tools=` when [customizing built-in subagents](#built-in-subagents).

## Skills

Skills are structured task packages (bundles of instructions, scripts, and references) that agents can invoke via a `skill()` tool. Pass directories containing a `SKILL.md` file to `deepagent()` with the `skills` parameter:

``` python
from inspect_ai.agent import deepagent

deepagent(
    skills=["./skills/pdf-analysis", "./skills/data-cleaning"],
    ...
)
```

Parent skills are available to the top-level agent. At dispatch time, parent skills and subagent-specific skills are merged so that a subagent sees both its own skills and the parent's. Skills use the [Agent Skills](https://agentskills.io) specification (`SKILL.md` with YAML frontmatter), which is compatible with skills directories from other agent frameworks. See the [Skills](tools-standard.qmd#sec-skill) documentation for details on creating and using skills.

## Compaction

Long-running agents can exhaust their context window. Use the `compaction` parameter to automatically manage conversation context as it grows:

``` python
from inspect_ai.agent import deepagent
from inspect_ai.model import CompactionSummary
from inspect_ai.tool import bash, text_editor

deepagent(
    tools=[bash(), text_editor()],
    compaction=CompactionSummary(),
)
```

Compaction propagates to subagents that don't set their own strategy, so a single `compaction=` on `deepagent()` covers the parent and all subagents. Individual subagents can override with their own strategy when [customized](#built-in-subagents).

See the [Compaction](compaction.qmd) documentation for details on available strategies (`CompactionSummary`, `CompactionEdit`, `CompactionTrim`, `CompactionAuto`, and `CompactionNative`).

## Subagents

### Built-in Subagents

The built-in subagent factories (`research()`, `plan()`, and `general()`) all accept customization parameters. Pass a customized `subagents` list to `deepagent()`:

``` python
from inspect_ai.agent import deepagent, research, plan, general
from inspect_ai.tool import bash, text_editor
from inspect_ai.util import token_limit

deepagent(
    tools=[bash(), text_editor()],
    subagents=[
        research(
            instructions="Focus on configuration files and logs.",
            model="anthropic/claude-haiku-4-5",
        ),
        plan(
            instructions="Create conservative, step-by-step plans.",
        ),
        general(
            limits=[token_limit(100_000)],
        ),
    ],
)
```

These customization parameters available on all three builtin subagents:

| Parameter | Description |
|---|---|
| `instructions` | Additional text appended to the default subagent prompt. |
| `model` | Model override (default inherits parent's model). |
| `limits` | Scoped limits per invocation (`token_limit`, `message_limit`, `time_limit`, `cost_limit`). |
| `memory` | Memory access level: `"readwrite"`, `"readonly"`, or `False` (default). |
| `extra_tools` | Additional tools merged with the subagent's defaults. |
| `tools` | Replace the default tool set entirely. |
| `skills` | Subagent-specific skills (merged with parent skills). |
| `fork` | Dispatch mode. See [Fork Mode](#fork-mode). |
| `compaction` | Compaction strategy override. |

### Custom Subagents

Use the `subagent()` factory to create wholly new subagent types beyond the three built-ins:

``` python
from inspect_ai.agent import deepagent, research, plan, general, subagent
from inspect_ai.tool import bash, read_file, grep, text_editor

def reviewer():
    return subagent(
        name="reviewer",
        description="Reviews work for correctness and completeness.",
        prompt="You are a careful reviewer. Examine the work "
               "done so far and identify errors, omissions, or "
               "improvements. Be specific about what needs to change.",
        tools=[read_file(), grep()],
        model="anthropic/claude-opus-4-7",
        memory="readonly",
    )

deepagent(
    tools=[bash(), text_editor()],
    subagents=[research(), plan(), general(), reviewer()],
)
```

The `subagent()` factory accepts the same customization parameters as the built-in factories (`model`, `limits`, `memory`, `skills`, `fork`, `compaction`) plus the required `name`, `description`, and `prompt`.

By default, subagents cannot delegate to further subagents (`max_depth=1`). Set `max_depth=2` on `deepagent()` to allow one level of nested delegation. Higher values increase token usage and latency; `max_depth=1` is sufficient for most tasks.

### Fork Mode

By default, subagents run in isolated context: they start with a fresh message history and only their summary returns to the parent. This is the standard pattern used by Claude Code, LangChain, and Codex CLI, and it prevents context rot in long-running conversations.

Forked dispatch (`fork=True`) is an alternative where the subagent inherits the parent's full conversation history:

``` python
from inspect_ai.agent import deepagent, research, plan, general
from inspect_ai.tool import bash, text_editor

deepagent(
    tools=[bash(), text_editor()],
    subagents=[
        research(),
        plan(),
        general(fork=True),
    ],
    model="anthropic/claude-sonnet-4-6",
)
```

Fork mode is useful when the subagent needs substantial background from the parent conversation without re-explanation, and when the parent's context is still fresh (well under context window limits).

Fork mode also preserves prompt cache efficiency: the forked subagent reuses the parent's message prefix, so cached tokens carry over. Isolated subagents start with a fresh message history, which invalidates the cache.

> **Note:** Use the same model or model family when forking to preserve the prompt cache and avoid errors from incompatible tool call formats or reasoning content in the inherited message history. Fork mode is not supported with `max_depth > 1`. If compaction has run on the parent, the forked subagent inherits the compacted messages, not the original history.

## System Prompt

When `instructions=` is not sufficient, use the `prompt=` parameter for full system prompt replacement. Named placeholders are expanded at assembly time:

``` python
from inspect_ai.agent import deepagent
from inspect_ai.tool import bash, text_editor

deepagent(
    tools=[bash(), text_editor()],
    prompt="""You are a security assessment agent.

{core_behavior}

{subagent_dispatch}

{memory_instructions}

Security-specific rules:
- Prioritize high-severity findings
- Document evidence for each vulnerability
- Test remediation before reporting

{instructions}""",
    instructions="Target system runs Ubuntu 22.04.",
)
```

Available placeholders:

| Placeholder | Content |
|---|---|
| `{core_behavior}` | Core behavioral expectations (act, persist, verify, batch). |
| `{subagent_dispatch}` | Subagent names, roles, and delegation guidance (generated from the subagent list). |
| `{memory_instructions}` | Memory and planning coordination guidance. |
| `{instructions}` | The user's `instructions=` text. |

Placeholders are optional. Omit any to exclude that content from the final prompt.

### Disabling Defaults

You can disable the memory and planning tools:

``` python
deepagent(
    tools=[bash(), text_editor()],
    memory=False,
    todo_write=False,
)
```

- `memory=False` disables the automatically added memory tool for the top-level agent and all subagents.
- `todo_write=False` disables the todo_write planning tool.

## Submission

By default, `deepagent()` includes a `submit()` tool that the model calls to report its final answer. You can configure multiple attempts so that if the score is incorrect the model is allowed to continue and try again:

``` python
deepagent(
    tools=[bash(), text_editor()],
    attempts=3,
)
```

Pass `submit=False` to disable the submit tool entirely (the agent will terminate when it stops calling tools). For more advanced configuration, pass an `AgentSubmit` or `AgentAttempts` instance. See the [ReAct Agent](react-agent.qmd#attempts) documentation for details.

## More Options

`deepagent()` supports several additional options from `react()`:

- `retry_refusals` --- Retry when the model refuses a request due to content filters (default: 3). Applies to the top-level agent and all subagents. If a subagent refuses and retries are exhausted, the refusal text becomes the subagent's return value to the parent. See [Refusals](react-agent.qmd#refusals) for details.

- `on_continue` --- Control continuation behavior when the model stops calling tools. Applies to the top-level agent only. See [Continuation](react-agent.qmd#continuation) for details.

- `approval` --- Apply approval policies for tool calls. Applies to the top-level agent and all subagents. See [Approval](approval.qmd) for details.

For example:

``` python
deepagent(
    tools=[bash(), text_editor()],
    retry_refusals=3,
    on_continue="Please continue working on the task.",
    approval=[
        ApprovalPolicy(human_approver(), "bash"),
        ApprovalPolicy(auto_approver(), "*"),
    ],
)
```
