### PR TITLE
add Print mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Computer Use: Map `PRTSCR` (OpenAI vocab) to xdotool `Print` keysym so key combos like `ALT+PRTSCR` work correctly.
+
 ## 0.3.212 (24 April 2026)
 
 - Google: Honor the `press_enter` default on Gemini's `type_text_at` action so typed text commits with Enter as the spec specifies.

--- a/src/inspect_ai/tool/_tools/_computer/_common.py
+++ b/src/inspect_ai/tool/_tools/_computer/_common.py
@@ -307,8 +307,9 @@ _KEY_ALIASES.update(
         "arrowup": "Up",
         "arrowright": "Right",
         "arrowdown": "Down",
-        # xdotool doesn't recognize "PRINTSCREEN" — it needs the keysym name "Print".
+        # xdotool doesn't recognize "PRINTSCREEN" or "PRTSCR" — it needs the keysym name "Print".
         "printscreen": "Print",
+        "prtscr": "Print",
         # Modifier abbreviations — map to xdotool's built-in aliases
         "ctl": "ctrl",
         "control": "ctrl",

--- a/tests/tools/test_key_normalization.py
+++ b/tests/tools/test_key_normalization.py
@@ -122,6 +122,10 @@ from inspect_ai.tool._tools._computer._common import (
         ("PrintScreen", "Print"),
         ("printscreen", "Print"),
         ("PRINTSCREEN", "Print"),
+        # PRTSCR
+        ("PrtScr", "Print"),
+        ("prtscr", "Print"),
+        ("PRTSCR", "Print"),
     ],
 )
 def test_single_key(input_key: str, expected: str) -> None:
@@ -169,6 +173,7 @@ def test_modifier_combo_lowercases_letter(input_combo: str, expected: str) -> No
         ("ctrl+esc", "ctrl+Escape"),
         ("ctrl+,", "ctrl+comma"),
         ("alt+printscreen", "alt+Print"),
+        ("alt+prtscr", "alt+Print"),
         ("ctrl+s", "ctrl+s"),
     ],
 )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

If you run an eval that uses `computer()` on `openai/gpt-5.4` and the model wants to press the `PRTSCR` key, you get the error
```
BadRequestError("Error code: 400 - {'error': {'message': 'The image data you provided does not represent a valid image.
Please check your input and try again.', 'type': 'invalid_request_error', 'param': 'input', 'code': 'invalid_value'}}")
```
.

### What is the new behavior?

You don't get the error.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

I found this bug when I ran OSWorld and GPT-5.4 wanted to press `ALT+ PRTSCR`, but there was no such key as `PRTSCR` for `xdotool`, and so `computer_call_output()` set `ComputerCallOutput.output.image_url` to `_PLACEHOLDER_IMAGE`.