### PR TITLE
Agent bridge: keep ChatMessageSystem.id stable across content mutations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Agent bridge: Treat the system prompt as a single slot per conversation so `ChatMessageSystem.id` stays stable when scaffolds mutate the prompt mid-conversation (Gemini CLI's plan-mode toggle, skill activation, etc.). Previously each mutation minted a fresh id and forked downstream transcript trees per mutation.
 - Handle split UTF-16 "lone surrogate" in log message condensation.
 
 ## 0.3.214 (29 April 2026)

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -41,6 +41,7 @@ class AgentBridge:
         self._compaction_prefix = state.messages.copy()
         self._compact: Compact | None = None
         self._message_ids = {}
+        self._system_message_id = None
         self._last_message_count = 0
 
     state: AgentState
@@ -111,7 +112,16 @@ class AgentBridge:
         # return the id
         return message_id
 
+    def _id_for_system_message(self) -> str:
+        # treat the system prompt as a single slot per bridge: the same id is
+        # returned across content mutations (plan-mode toggles, skill activation,
+        # etc.) so downstream consumers don't see N parallel transcript roots.
+        if self._system_message_id is None:
+            self._system_message_id = uuid()
+        return self._system_message_id
+
     _message_ids: dict[str, list[str]]
+    _system_message_id: str | None
 
     def _track_state(self, input: list[ChatMessage], output: ModelOutput) -> None:
         # automatically track agent state based on observing generations made through

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -5,7 +5,11 @@ from typing import Sequence, cast
 from typing_extensions import TypeIs
 
 from inspect_ai.agent._bridge.types import AgentBridge
-from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
 from inspect_ai.model._generate_config import GenerateConfig, active_generate_config
 from inspect_ai.model._model import (
     GenerateFilter,
@@ -202,6 +206,12 @@ def apply_message_ids(bridge: AgentBridge, messages: list[ChatMessage]) -> None:
         message.id = None
 
     # allocate ids based on message content (re-applying the same id for the same
-    # content, but also ensuring that if an id is already used we generate a new one)
+    # content, but also ensuring that if an id is already used we generate a new one).
+    # ChatMessageSystem is treated specially: a single slot per bridge keeps the id
+    # stable across content mutations (plan-mode toggles, skill activation, etc.) so
+    # downstream consumers don't see N parallel transcript roots.
     for message in messages:
-        message.id = bridge._id_for_message(message, messages)
+        if isinstance(message, ChatMessageSystem):
+            message.id = bridge._id_for_system_message()
+        else:
+            message.id = bridge._id_for_message(message, messages)

--- a/tests/agent/test_bridge_system_message_id.py
+++ b/tests/agent/test_bridge_system_message_id.py
@@ -1,0 +1,71 @@
+"""Tests for stable ``ChatMessageSystem.id`` across system-prompt mutations.
+
+Bridged scaffolds (Gemini CLI's plan-mode toggle, skill activation, etc.)
+routinely mutate the system prompt mid-conversation. A pure content-hash
+approach mints a fresh ``ChatMessageSystem.id`` every time, splitting the
+downstream transcript tree into N parallel roots. The bridge treats the
+system prompt as a single slot per conversation: same slot, same id,
+regardless of content.
+"""
+
+from __future__ import annotations
+
+from inspect_ai.agent._agent import AgentState
+from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.util import apply_message_ids
+from inspect_ai.model._chat_message import ChatMessageSystem, ChatMessageUser
+
+
+def _make_bridge() -> AgentBridge:
+    return AgentBridge(state=AgentState(messages=[]))
+
+
+def test_system_message_id_preserved_across_content_mutation() -> None:
+    """The system message's id stays stable when its *content* changes."""
+    bridge = _make_bridge()
+
+    sys_v1 = ChatMessageSystem(content="You are a helpful assistant.")
+    user_msg = ChatMessageUser(content="Hello")
+    turn1_input: list = [sys_v1, user_msg]
+    apply_message_ids(bridge, turn1_input)
+    first_id = turn1_input[0].id
+    assert first_id is not None
+
+    # Turn 2: agent toggled plan mode. Same conversation, mutated system text.
+    sys_v2 = ChatMessageSystem(
+        content="You are a helpful assistant. (Plan mode active.)",
+    )
+    follow_up = ChatMessageUser(content="Plan it.")
+    turn2_input: list = [sys_v2, user_msg, follow_up]
+    apply_message_ids(bridge, turn2_input)
+
+    assert turn2_input[0].id == first_id, (
+        "mutated system prompt must keep the id from the first turn"
+    )
+
+    # Turn 3: content reverts (plan-mode off). Still the same slot.
+    sys_v3 = ChatMessageSystem(content="You are a helpful assistant.")
+    turn3_input: list = [sys_v3, user_msg, follow_up]
+    apply_message_ids(bridge, turn3_input)
+
+    assert turn3_input[0].id == first_id, (
+        "reverted system prompt must keep the id from the first turn"
+    )
+
+
+def test_system_message_id_independent_per_bridge() -> None:
+    """Each ``AgentBridge`` instance gets its own slot id."""
+    bridge_a = _make_bridge()
+    bridge_b = _make_bridge()
+
+    sys = ChatMessageSystem(content="You are a helpful assistant.")
+
+    apply_message_ids(bridge_a, [sys])
+    a_id = sys.id
+
+    sys.id = None
+    apply_message_ids(bridge_b, [sys])
+    b_id = sys.id
+
+    assert a_id is not None and b_id is not None
+    assert a_id != b_id, "two bridges must allocate independent system-message ids"


### PR DESCRIPTION
## Summary

When an agent driven through `agent_bridge()` mutates its own system prompt mid-conversation (Gemini CLI's plan-mode toggle, skill activation, etc.), the bridge currently mints a fresh `ChatMessageSystem.id` for every mutated version. A downstream consumer that groups by root-message-id then sees N parallel root subtrees that are turn-for-turn identical except for the system message.

This PR treats the system prompt as a **single slot per `AgentBridge` instance**: the same id is returned across content mutations, so downstream consumers see one root regardless of how many times the prompt got rewritten. Bridge instances are conversation-scoped, so the slot does not leak between sessions.

## How

* `AgentBridge.__init__` adds `self._system_message_id = None`.
* `_id_for_system_message()` lazily mints a uuid the first time a system message is seen on this bridge and returns the same uuid forever after.
* `apply_message_ids` routes any `ChatMessageSystem` through that slot; non-system messages still go through the existing content-hash path unchanged.

The fix lives entirely in the bridge translation layer. `ChatMessage`, `ToolCall`, and `ModelEvent` schemas are unchanged — consumers just see one stable id for the system prompt now.

## Why this is its own PR

This is a deliberate behavioral choice that reasonable people might disagree on. Two alternatives I considered:

1. **Slot-based (this PR).** One id per bridge, regardless of content. Simple, matches what downstream consumers actually want for transcript-tree grouping.
2. **Content-hash (status quo).** Each distinct content gets its own id. Surfaces "the prompt changed" cleanly but explodes into N roots when scaffolds toggle prompts.
3. **Content-hash + downstream merge heuristic.** What Apollo's apex repo currently does (`merge_system_prompt_mutations()` in `lib/transcript/forest.py`) — content-prefix-equivalence collapsing. Brittle and after-the-fact.

The slot approach is the cleanest fix, but I'm not married to it — happy to take direction if you'd prefer a different shape (e.g. a slot-per-bridge that *also* records each distinct content somewhere on the message metadata, or content-hash with an opt-in slot mode).

## Test plan

- [x] New: `tests/agent/test_bridge_system_message_id.py` — 2 tests
  - `test_system_message_id_preserved_across_content_mutation` — content mutates twice, then reverts; id stays the same throughout
  - `test_system_message_id_independent_per_bridge` — two `AgentBridge` instances allocate independent slot ids
- [x] Full agent suite: 227 passed, 78 skipped (`pytest tests/agent/`)
- [x] `ruff check`, `ruff format --check`, `mypy --exclude tests/test_package` all clean on touched files

## Companion PR

Companion: #3805 (assistant + tool-call id stability across turns) — independent and uncontroversial; either PR can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)