### PR TITLE
compaction: fix blind spot for re-injected encrypted reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,12 @@
 - Add `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Add `download()` and `gdrive_download()` helpers for fetching external files with SHA256 verification, caching, and transient-error retry. `gdrive_download()` requires the optional `gdown` dependency, installed via `pip install inspect_ai[gdown]`.
 - Compaction: Lock Compact handler against concurrent AgentBridge calls.
+- Compaction: Detect re-injected encrypted reasoning content in already-counted messages and recount via the provider's authoritative `count_tokens()` so the threshold trigger fires correctly for OpenAI Responses with `store=false` and `include=['reasoning.encrypted_content']`.
+- Compaction: Add forced-compaction recovery in `_handle_overflow`. When generate returns `stop_reason='model_length'` and a compaction strategy is configured, the agent attempts a forced compaction before falling through to the overflow filter. Forced compactions emit `CompactionEvent.source='inspect_recovery'`.
 - Analysis: Fix wrong `working_time` path in `SampleSummary` columns.
 
 ## 0.3.216 (01 May 2026)
+
 
 - OpenRouter: Escape signature attribute in <think> tag round-trip.
 - Logging: Add sample id, epoch, and task name to log records.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 - Add `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Add `download()` and `gdrive_download()` helpers for fetching external files with SHA256 verification, caching, and transient-error retry. `gdrive_download()` requires the optional `gdown` dependency, installed via `pip install inspect_ai[gdown]`.
 - Compaction: Lock Compact handler against concurrent AgentBridge calls.
-- Compaction: Detect re-injected encrypted reasoning content in already-counted messages and recount via the provider's authoritative `count_tokens()` so the threshold trigger fires correctly for OpenAI Responses with `store=false` and `include=['reasoning.encrypted_content']`.
-- Compaction: Add forced-compaction recovery in `_handle_overflow`. When generate returns `stop_reason='model_length'` and a compaction strategy is configured, the agent attempts a forced compaction before falling through to the overflow filter. Forced compactions emit `CompactionEvent` with `metadata['trigger']='forced'` (predictive compactions emit `'threshold'`).
+- Compaction: Fix threshold blind spot for OpenAI Responses preserving encrypted reasoning across turns (`store=false` + `include=['reasoning.encrypted_content']`).
+- Compaction: On `stop_reason='model_length'`, force-compact before falling through to the overflow filter.
 - Analysis: Fix wrong `working_time` path in `SampleSummary` columns.
 
 ## 0.3.216 (01 May 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Add `download()` and `gdrive_download()` helpers for fetching external files with SHA256 verification, caching, and transient-error retry. `gdrive_download()` requires the optional `gdown` dependency, installed via `pip install inspect_ai[gdown]`.
 - Compaction: Lock Compact handler against concurrent AgentBridge calls.
 - Compaction: Detect re-injected encrypted reasoning content in already-counted messages and recount via the provider's authoritative `count_tokens()` so the threshold trigger fires correctly for OpenAI Responses with `store=false` and `include=['reasoning.encrypted_content']`.
-- Compaction: Add forced-compaction recovery in `_handle_overflow`. When generate returns `stop_reason='model_length'` and a compaction strategy is configured, the agent attempts a forced compaction before falling through to the overflow filter. Forced compactions emit `CompactionEvent.source='inspect_recovery'`.
+- Compaction: Add forced-compaction recovery in `_handle_overflow`. When generate returns `stop_reason='model_length'` and a compaction strategy is configured, the agent attempts a forced compaction before falling through to the overflow filter. Forced compactions emit `CompactionEvent` with `metadata['trigger']='forced'` (predictive compactions emit `'threshold'`).
 - Analysis: Fix wrong `working_time` path in `SampleSummary` columns.
 
 ## 0.3.216 (01 May 2026)

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -482,32 +482,24 @@ async def _handle_overflow(
 ) -> tuple[AgentState, bool]:
     from inspect_ai.log._transcript import transcript
 
-    # state.messages[-1] is the failed assistant turn that _model_generate
-    # appended unconditionally even on stop_reason=model_length. Drop it; it
-    # has no usable content. The next loop iteration will produce a fresh
-    # assistant message via generate.
+    # Drop the failed assistant turn appended by _model_generate; it has no
+    # usable content and the next iteration will generate a fresh one.
     previous_messages = state.messages[:-1]
 
-    # Try forced compaction first if configured. Compaction is more
-    # semantically faithful than truncation (it preserves intent, not just
-    # bytes) and uses the same strategy already chosen for predictive
-    # compaction.
+    # Try forced compaction first: preserves intent via the same strategy
+    # used for predictive compaction; the overflow filter only truncates.
     if compact is not None:
         try:
             compacted, c_message = await compact.compact_input(
                 previous_messages, force=True
             )
-            # If compact_input returned successfully, _perform_compaction
-            # already validated that total_compacted <= threshold (it raises
-            # otherwise). Trust that; do not gate on length reduction
-            # (CompactionEdit reduces content not message count).
-            #
-            # For the four built-in strategies c_message is either None
-            # (Trim/Edit/Native) or the same object as compacted[-1]
-            # (Summary), so no append is needed. Custom strategies may
-            # return a distinct c_message; append it so we don't silently
-            # drop it (the predictive path appends it via _react_loop).
+            # A successful return means _perform_compaction validated
+            # total_compacted <= threshold, so don't gate on length
+            # (CompactionEdit reduces content, not count).
             state.messages = compacted
+            # CompactionSummary returns its summary as compacted[-1] AND
+            # as c_message (same object); Trim/Edit/Native return None.
+            # Append only for custom strategies that return a distinct one.
             if c_message is not None and (
                 not compacted or compacted[-1] is not c_message
             ):
@@ -517,11 +509,8 @@ async def _handle_overflow(
             )
             return state, True
         except Exception as ex:
-            # Compaction failed (e.g., RuntimeError "compaction insufficient").
-            # Fall through to the overflow filter below. Emit a transcript
-            # info so operators see compaction was attempted (the
-            # CompactionEvent itself never fires when _perform_compaction
-            # raises before logging it).
+            # CompactionEvent isn't emitted when _perform_compaction raises
+            # before logging it; surface the attempt + failure for operators.
             transcript().info(
                 f"Forced compaction failed during overflow recovery: {ex}; "
                 "falling back to overflow filter."
@@ -628,10 +617,9 @@ def _model_generate(
             # update the compaction baseline with the actual input token
             # count from the generate call (most accurate source of truth)
             if compact is not None:
-                # Note: when output has stop_reason='model_length', record_output sees
-                # an over-the-window usage value. baseline_tokens gets set to that
-                # value, but the subsequent forced compaction (if any) in
-                # _handle_overflow resets baseline_tokens during its housekeeping.
+                # On stop_reason='model_length' the recorded baseline may
+                # exceed the context window; _handle_overflow's forced
+                # compaction (if any) resets it during housekeeping.
                 await compact.record_output(input_messages, output)
 
             break

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -213,7 +213,7 @@ def react(
 
                 # check for context window overflow
                 if state.output.stop_reason == "model_length":
-                    state, handled = await _handle_overflow(state, overflow)
+                    state, handled = await _handle_overflow(state, overflow, compact)
                     if handled:
                         continue
                     else:
@@ -381,7 +381,7 @@ def react_no_submit(
 
                 # check for context window overflow
                 if state.output.stop_reason == "model_length":
-                    state, handled = await _handle_overflow(state, overflow)
+                    state, handled = await _handle_overflow(state, overflow, compact)
                     if handled:
                         continue
                     else:
@@ -476,12 +476,41 @@ def _resolve_overflow(
 
 
 async def _handle_overflow(
-    state: AgentState, overflow: MessageFilter | None
+    state: AgentState,
+    overflow: MessageFilter | None,
+    compact: Compact | None = None,
 ) -> tuple[AgentState, bool]:
     from inspect_ai.log._transcript import transcript
 
+    # state.messages[-1] is the failed assistant turn that _model_generate
+    # appended unconditionally even on stop_reason=model_length. Drop it; it
+    # has no usable content. The next loop iteration will produce a fresh
+    # assistant message via generate.
+    previous_messages = state.messages[:-1]
+
+    # Try forced compaction first if configured. Compaction is more
+    # semantically faithful than truncation (it preserves intent, not just
+    # bytes) and uses the same strategy already chosen for predictive
+    # compaction.
+    if compact is not None:
+        try:
+            compacted, c_message = await compact.compact_input(
+                previous_messages, force=True
+            )
+            if len(compacted) < len(previous_messages):
+                state.messages = compacted
+                if c_message is not None:
+                    state.messages.append(c_message)
+                transcript().info(
+                    "Agent exceeded model context window, performing forced compaction and continuing."
+                )
+                return state, True
+        except Exception:
+            # Compaction failed (e.g., RuntimeError "compaction insufficient").
+            # Fall through to the overflow filter below.
+            pass
+
     if overflow is not None:
-        previous_messages = state.messages[:-1]
         state.messages = await overflow(previous_messages)
         if len(state.messages) < len(previous_messages):
             transcript().info(
@@ -582,6 +611,10 @@ def _model_generate(
             # update the compaction baseline with the actual input token
             # count from the generate call (most accurate source of truth)
             if compact is not None:
+                # Note: when output has stop_reason='model_length', record_output sees
+                # an over-the-window usage value. baseline_tokens gets set to that
+                # value, but the subsequent forced compaction (if any) in
+                # _handle_overflow resets baseline_tokens during its housekeeping.
                 await compact.record_output(input_messages, output)
 
             break

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -494,17 +494,22 @@ async def _handle_overflow(
     # compaction.
     if compact is not None:
         try:
-            compacted, c_message = await compact.compact_input(
+            compacted, _c_message = await compact.compact_input(
                 previous_messages, force=True
             )
-            if len(compacted) < len(previous_messages):
-                state.messages = compacted
-                if c_message is not None:
-                    state.messages.append(c_message)
-                transcript().info(
-                    "Agent exceeded model context window, performing forced compaction and continuing."
-                )
-                return state, True
+            # If compact_input returned successfully, _perform_compaction
+            # already validated that total_compacted <= threshold (it raises
+            # otherwise). Trust that; do not gate on length reduction
+            # (CompactionEdit reduces content not message count).
+            #
+            # For CompactionSummary the summary is the last element of
+            # compacted, so we don't append c_message again (would duplicate).
+            # For other strategies c_message is None.
+            state.messages = compacted
+            transcript().info(
+                "Agent exceeded model context window, performing forced compaction and continuing."
+            )
+            return state, True
         except Exception:
             # Compaction failed (e.g., RuntimeError "compaction insufficient").
             # Fall through to the overflow filter below.

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -494,7 +494,7 @@ async def _handle_overflow(
     # compaction.
     if compact is not None:
         try:
-            compacted, _c_message = await compact.compact_input(
+            compacted, c_message = await compact.compact_input(
                 previous_messages, force=True
             )
             # If compact_input returned successfully, _perform_compaction
@@ -502,18 +502,30 @@ async def _handle_overflow(
             # otherwise). Trust that; do not gate on length reduction
             # (CompactionEdit reduces content not message count).
             #
-            # For CompactionSummary the summary is the last element of
-            # compacted, so we don't append c_message again (would duplicate).
-            # For other strategies c_message is None.
+            # For the four built-in strategies c_message is either None
+            # (Trim/Edit/Native) or the same object as compacted[-1]
+            # (Summary), so no append is needed. Custom strategies may
+            # return a distinct c_message; append it so we don't silently
+            # drop it (the predictive path appends it via _react_loop).
             state.messages = compacted
+            if c_message is not None and (
+                not compacted or compacted[-1] is not c_message
+            ):
+                state.messages.append(c_message)
             transcript().info(
                 "Agent exceeded model context window, performing forced compaction and continuing."
             )
             return state, True
-        except Exception:
+        except Exception as ex:
             # Compaction failed (e.g., RuntimeError "compaction insufficient").
-            # Fall through to the overflow filter below.
-            pass
+            # Fall through to the overflow filter below. Emit a transcript
+            # info so operators see compaction was attempted (the
+            # CompactionEvent itself never fires when _perform_compaction
+            # raises before logging it).
+            transcript().info(
+                f"Forced compaction failed during overflow recovery: {ex}; "
+                "falling back to overflow filter."
+            )
 
     if overflow is not None:
         state.messages = await overflow(previous_messages)

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -230,13 +230,14 @@ def compaction(
                 transcript()._event(
                     CompactionEvent(
                         type=strategy.type,
-                        source="inspect_recovery" if force else "inspect",
+                        source="inspect",
                         tokens_before=total_tokens,
                         tokens_after=compacted_tokens,
                         metadata={
                             "strategy": strategy.__class__.__name__,
                             "messages_before": len(target_messages),
                             "messages_after": len(compacted_input),
+                            "trigger": "forced" if force else "threshold",
                         },
                     )
                 )

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -5,6 +5,7 @@ from typing import Sequence
 
 import anyio
 
+from inspect_ai._util.content import ContentReasoning
 from inspect_ai.tool import Tool, ToolDef, ToolInfo, ToolSource
 
 from .._call_tools import get_tools_info, resolve_tools
@@ -16,6 +17,24 @@ from .memory import MEMORY_TOOL, memory_warning_message
 from .types import Compact, CompactionStrategy
 
 logger = getLogger(__name__)
+
+
+def _has_redacted_reasoning_in(messages: list[ChatMessage]) -> bool:
+    """Return True if any message contains a redacted (encrypted) reasoning item.
+
+    Used to detect the OpenAI Responses + store=false + include=encrypted_content
+    case where usage.input_tokens (and thus baseline_tokens) under-counts the
+    actual context cost of the input. In that case the baseline shortcut is
+    unsafe and we must recount the full target_messages list via count_tokens
+    (which calls the provider's native counting API for OpenAI Responses,
+    Anthropic, and Google).
+    """
+    for m in messages:
+        if isinstance(m.content, list):
+            for c in m.content:
+                if isinstance(c, ContentReasoning) and c.redacted:
+                    return True
+    return False
 
 
 def compaction(
@@ -136,13 +155,25 @@ def compaction(
             # estimate total tokens using the most accurate method available
             target_messages = compacted_input + unprocessed
             target_message_ids = {message_id(m) for m in target_messages}
-            if baseline_tokens is not None and baseline_message_ids.issubset(
-                target_message_ids
-            ):
-                # Use the baseline from the last generate call (most accurate).
-                # The baseline already includes tool definitions, system messages,
-                # and API-level overhead. We only need to count NEW messages
-                # added since the baseline was established.
+
+            # The baseline shortcut trusts usage.input_tokens for messages already
+            # counted by a prior generate call. That trust is misplaced when those
+            # messages contain redacted reasoning items, because some providers (OpenAI
+            # Responses with store=false + include=encrypted_content) don't include
+            # encrypted reasoning blobs in usage.input_tokens, even though the blobs
+            # do consume context window space. In that case fall back to a full recount
+            # via count_tokens, which calls the provider's native counting endpoint
+            # (authoritative for OpenAI Responses, Anthropic, and Google).
+            baseline_messages = [
+                m for m in target_messages if message_id(m) in baseline_message_ids
+            ]
+            baseline_trustworthy = (
+                baseline_tokens is not None
+                and baseline_message_ids.issubset(target_message_ids)
+                and not _has_redacted_reasoning_in(baseline_messages)
+            )
+            if baseline_trustworthy:
+                assert baseline_tokens is not None  # narrowed by baseline_trustworthy
                 new_since_baseline = [
                     m
                     for m in target_messages
@@ -155,7 +186,6 @@ def compaction(
                 )
                 total_tokens = baseline_tokens + new_tokens
             else:
-                # No baseline yet (first call). Fall back to per-message counting.
                 message_tokens = await target_model.count_tokens(target_messages)
                 total_tokens = tool_tokens + message_tokens
 

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -145,6 +145,13 @@ def compaction(
             if prefix_tokens is None:
                 prefix_tokens = await target_model.count_tokens(prefix) if prefix else 0
 
+            # provider signal: does usage.input_tokens cover all input content?
+            # When False (e.g. OpenAI Responses with encrypted reasoning), the
+            # baseline shortcut is unsafe if any redacted reasoning is in baseline.
+            provider_input_tokens_complete = (
+                target_model.api.usage_input_tokens_complete()
+            )
+
             # determine unprocessed messages (messages not yet added to input).
             # we allow unprocessed messages to accumulate in the input until
             # the compaction 'threshold' is reached.
@@ -158,19 +165,26 @@ def compaction(
 
             # The baseline shortcut trusts usage.input_tokens for messages already
             # counted by a prior generate call. That trust is misplaced when those
-            # messages contain redacted reasoning items, because some providers (OpenAI
-            # Responses with store=false + include=encrypted_content) don't include
-            # encrypted reasoning blobs in usage.input_tokens, even though the blobs
-            # do consume context window space. In that case fall back to a full recount
-            # via count_tokens, which calls the provider's native counting endpoint
-            # (authoritative for OpenAI Responses, Anthropic, and Google).
-            baseline_messages = [
-                m for m in target_messages if message_id(m) in baseline_message_ids
-            ]
+            # messages contain redacted reasoning items AND the provider's
+            # usage.input_tokens may omit them (the known case is OpenAI Responses
+            # with store=false + include=encrypted_content). In that case fall back
+            # to a full recount via count_tokens, which calls the provider's native
+            # counting endpoint (authoritative for OpenAI Responses, Anthropic,
+            # and Google).
+            baseline_messages_have_uncounted_reasoning = (
+                not provider_input_tokens_complete
+                and _has_redacted_reasoning_in(
+                    [
+                        m
+                        for m in target_messages
+                        if message_id(m) in baseline_message_ids
+                    ]
+                )
+            )
             baseline_trustworthy = (
                 baseline_tokens is not None
                 and baseline_message_ids.issubset(target_message_ids)
-                and not _has_redacted_reasoning_in(baseline_messages)
+                and not baseline_messages_have_uncounted_reasoning
             )
             if baseline_trustworthy:
                 assert baseline_tokens is not None  # narrowed by baseline_trustworthy

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -137,9 +137,7 @@ def compaction(
             if prefix_tokens is None:
                 prefix_tokens = await target_model.count_tokens(prefix) if prefix else 0
 
-            # provider signal: does usage.input_tokens cover all input content?
-            # When False (e.g. OpenAI Responses with encrypted reasoning), the
-            # baseline shortcut is unsafe if any redacted reasoning is in baseline.
+            # False for providers whose usage.input_tokens may omit reasoning content.
             provider_input_tokens_complete = (
                 target_model.api.usage_input_tokens_complete()
             )
@@ -155,14 +153,11 @@ def compaction(
             target_messages = compacted_input + unprocessed
             target_message_ids = {message_id(m) for m in target_messages}
 
-            # The baseline shortcut trusts usage.input_tokens for messages already
-            # counted by a prior generate call. That trust is misplaced when those
-            # messages contain redacted reasoning items AND the provider's
-            # usage.input_tokens may omit them (the known case is OpenAI Responses
-            # with store=false + include=encrypted_content). In that case fall back
-            # to a full recount via count_tokens, which calls the provider's native
-            # counting endpoint (authoritative for OpenAI Responses, Anthropic,
-            # and Google).
+            # Skip the baseline shortcut when the provider's usage.input_tokens
+            # may omit redacted reasoning that's present in already-counted
+            # messages (OpenAI Responses with encrypted-reasoning preservation).
+            # Recount via count_tokens, which authoritatively counts encrypted
+            # reasoning blocks.
             if (
                 baseline_tokens is not None
                 and baseline_message_ids.issubset(target_message_ids)

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -20,21 +20,13 @@ logger = getLogger(__name__)
 
 
 def _has_redacted_reasoning_in(messages: list[ChatMessage]) -> bool:
-    """Return True if any message contains a redacted (encrypted) reasoning item.
-
-    Used to detect the OpenAI Responses + store=false + include=encrypted_content
-    case where usage.input_tokens (and thus baseline_tokens) under-counts the
-    actual context cost of the input. In that case the baseline shortcut is
-    unsafe and we must recount the full target_messages list via count_tokens
-    (which calls the provider's native counting API for OpenAI Responses,
-    Anthropic, and Google).
-    """
-    for m in messages:
-        if isinstance(m.content, list):
-            for c in m.content:
-                if isinstance(c, ContentReasoning) and c.redacted:
-                    return True
-    return False
+    """Return True if any message contains a redacted (encrypted) ContentReasoning."""
+    return any(
+        isinstance(c, ContentReasoning) and c.redacted
+        for m in messages
+        if isinstance(m.content, list)
+        for c in m.content
+    )
 
 
 def compaction(
@@ -171,23 +163,20 @@ def compaction(
             # to a full recount via count_tokens, which calls the provider's native
             # counting endpoint (authoritative for OpenAI Responses, Anthropic,
             # and Google).
-            baseline_messages_have_uncounted_reasoning = (
-                not provider_input_tokens_complete
-                and _has_redacted_reasoning_in(
-                    [
-                        m
-                        for m in target_messages
-                        if message_id(m) in baseline_message_ids
-                    ]
-                )
-            )
-            baseline_trustworthy = (
+            if (
                 baseline_tokens is not None
                 and baseline_message_ids.issubset(target_message_ids)
-                and not baseline_messages_have_uncounted_reasoning
-            )
-            if baseline_trustworthy:
-                assert baseline_tokens is not None  # narrowed by baseline_trustworthy
+                and not (
+                    not provider_input_tokens_complete
+                    and _has_redacted_reasoning_in(
+                        [
+                            m
+                            for m in target_messages
+                            if message_id(m) in baseline_message_ids
+                        ]
+                    )
+                )
+            ):
                 new_since_baseline = [
                     m
                     for m in target_messages

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -109,6 +109,7 @@ def compaction(
 
     async def compact_fn(
         messages: list[ChatMessage],
+        force: bool = False,
     ) -> tuple[list[ChatMessage], ChatMessageUser | None]:
         from inspect_ai.event._compaction import CompactionEvent
 
@@ -158,7 +159,7 @@ def compaction(
                 message_tokens = await target_model.count_tokens(target_messages)
                 total_tokens = tool_tokens + message_tokens
 
-            if total_tokens > threshold:
+            if force or total_tokens > threshold:
                 # perform compaction (with iteration if needed)
                 c_input, c_message = await _perform_compaction(
                     strategy=strategy,
@@ -201,7 +202,7 @@ def compaction(
                 transcript()._event(
                     CompactionEvent(
                         type=strategy.type,
-                        source="inspect",
+                        source="inspect_recovery" if force else "inspect",
                         tokens_before=total_tokens,
                         tokens_after=compacted_tokens,
                         metadata={
@@ -247,9 +248,11 @@ def compaction(
 
     class _CompactHandler:
         async def compact_input(
-            self, messages: list[ChatMessage]
+            self,
+            messages: list[ChatMessage],
+            force: bool = False,
         ) -> tuple[list[ChatMessage], ChatMessageUser | None]:
-            return await compact_fn(messages)
+            return await compact_fn(messages, force=force)
 
         async def record_output(
             self, input: list[ChatMessage], output: ModelOutput

--- a/src/inspect_ai/model/_compaction/types.py
+++ b/src/inspect_ai/model/_compaction/types.py
@@ -74,12 +74,17 @@ class Compact(Protocol):
     """Interface for compaction strategies."""
 
     async def compact_input(
-        self, messages: list[ChatMessage]
+        self,
+        messages: list[ChatMessage],
+        force: bool = False,
     ) -> tuple[list[ChatMessage], ChatMessageUser | None]:
         """Compact messages for input to the model.
 
         Args:
-            messages: Full message history
+            messages: Full message history.
+            force: If True, perform compaction unconditionally (skip the
+                threshold gate). Used by overflow recovery paths after a
+                model_length error.
 
         Returns: Input to present to the model and (optionally) a message to append to the history (e.g. a summarization).
         """

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -336,6 +336,22 @@ class ModelAPI(abc.ABC):
         """Scope for enforcement of max_connections."""
         return "default"
 
+    def usage_input_tokens_complete(self) -> bool:
+        """Whether usage.input_tokens covers all tokens present in the request input.
+
+        Returns False for providers that may omit some content from the
+        `usage.input_tokens` they report. The known case is OpenAI Responses
+        when reasoning items are preserved across turns via
+        `store=false` + `include=["reasoning.encrypted_content"]`: the
+        encrypted reasoning items consume context window space but are not
+        reflected in usage.input_tokens.
+
+        Compaction uses this signal to decide whether the baseline-tokens
+        shortcut is safe when redacted reasoning content is present.
+        Conservative default: True (assume input_tokens is complete).
+        """
+        return True
+
     def should_retry(self, ex: Exception) -> bool:
         """Should this exception be retried?
 

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -337,18 +337,12 @@ class ModelAPI(abc.ABC):
         return "default"
 
     def usage_input_tokens_complete(self) -> bool:
-        """Whether usage.input_tokens covers all tokens present in the request input.
+        """Whether usage.input_tokens covers all tokens in the request input.
 
-        Returns False for providers that may omit some content from the
-        `usage.input_tokens` they report. The known case is OpenAI Responses
-        when reasoning items are preserved across turns via
-        `store=false` + `include=["reasoning.encrypted_content"]`: the
-        encrypted reasoning items consume context window space but are not
-        reflected in usage.input_tokens.
-
-        Compaction uses this signal to decide whether the baseline-tokens
-        shortcut is safe when redacted reasoning content is present.
-        Conservative default: True (assume input_tokens is complete).
+        Override to return False for providers that may omit content from
+        `usage.input_tokens` (e.g., OpenAI Responses with encrypted
+        reasoning preserved across turns). Compaction uses this signal to
+        decide whether the baseline-tokens shortcut is safe.
         """
         return True
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -493,6 +493,18 @@ class OpenAIAPI(ModelAPI):
         """Scope for enforcing max_connections (could also use endpoint)."""
         return str(self.api_key)
 
+    @override
+    def usage_input_tokens_complete(self) -> bool:
+        # Responses API may omit reasoning items from usage.input_tokens when
+        # encrypted reasoning is preserved across turns via
+        # `store=false` + `include=["reasoning.encrypted_content"]`. We don't
+        # try to inspect per-call config; conservatively return False whenever
+        # Responses mode is active. The cost of a false positive is at most
+        # one extra count_tokens call per turn.
+        if self.responses_api:
+            return False
+        return super().usage_input_tokens_complete()
+
     async def reasoning_summaries(self) -> bool:
         # validate that reasoning summaries are supported for this account
         # (needs to be a 'verified organization'). we do this by making a

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -495,12 +495,10 @@ class OpenAIAPI(ModelAPI):
 
     @override
     def usage_input_tokens_complete(self) -> bool:
-        # Responses API may omit reasoning items from usage.input_tokens when
-        # encrypted reasoning is preserved across turns via
-        # `store=false` + `include=["reasoning.encrypted_content"]`. We don't
-        # try to inspect per-call config; conservatively return False whenever
-        # Responses mode is active. The cost of a false positive is at most
-        # one extra count_tokens call per turn.
+        # Responses API may omit encrypted reasoning from usage.input_tokens
+        # (when store=false + include=encrypted_content); conservatively False
+        # for all Responses mode. False positives cost one extra count_tokens
+        # call per turn.
         if self.responses_api:
             return False
         return super().usage_input_tokens_complete()

--- a/tests/agent/test_agent_overflow_compaction.py
+++ b/tests/agent/test_agent_overflow_compaction.py
@@ -82,16 +82,16 @@ def test_model_length_with_compaction_triggers_force_and_continues(
     log = eval(task, model=model)[0]
     assert log.status == "success", f"Agent should have recovered. Status: {log.status}"
 
-    # Verify the recovery emitted a differentiated CompactionEvent. This is
-    # the load-bearing assertion: it confirms that _handle_overflow invoked
-    # compact_input(force=True), which is the wiring this task adds.
+    # Verify the recovery emitted a CompactionEvent with trigger=forced.
+    # This confirms _handle_overflow invoked compact_input(force=True).
     from inspect_ai.event import CompactionEvent
 
     assert log.samples
     events = [e for e in log.samples[0].events if isinstance(e, CompactionEvent)]
-    assert any(e.source == "inspect_recovery" for e in events), (
-        "Expected at least one CompactionEvent with source='inspect_recovery' "
-        f"from forced compaction; got sources {[e.source for e in events]}"
+    triggers = [(e.metadata or {}).get("trigger") for e in events]
+    assert "forced" in triggers, (
+        f"Expected a CompactionEvent with metadata.trigger='forced' "
+        f"from overflow recovery; got triggers {triggers}"
     )
 
 

--- a/tests/agent/test_agent_overflow_compaction.py
+++ b/tests/agent/test_agent_overflow_compaction.py
@@ -1,0 +1,226 @@
+"""Tests for forced-compaction recovery in the react agent's overflow path."""
+
+import pytest
+from typing_extensions import override
+
+from inspect_ai import Task, eval
+from inspect_ai.agent import react
+from inspect_ai.dataset import Sample
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageUser,
+    Model,
+    ModelOutput,
+    get_model,
+)
+from inspect_ai.model._compaction import CompactionStrategy
+from inspect_ai.model._compaction.trim import CompactionTrim
+from inspect_ai.tool._tool_info import ToolInfo
+
+
+class _AlwaysRaisesCompaction(CompactionStrategy):
+    """Test-only strategy that always raises when compact() is called."""
+
+    def __init__(self) -> None:
+        # High threshold so predictive compaction never triggers; only
+        # forced compaction (force=True) will invoke compact().
+        super().__init__(type="trim", threshold=10_000, memory=False)
+
+    @override
+    async def compact(
+        self, model: Model, messages: list[ChatMessage], tools: list[ToolInfo]
+    ) -> tuple[list[ChatMessage], ChatMessageUser | None]:
+        raise RuntimeError("simulated compaction failure")
+
+
+@pytest.mark.parametrize(
+    "react_factory",
+    [
+        pytest.param(lambda **kw: react(**kw), id="react"),
+        pytest.param(
+            lambda **kw: react(submit=False, **kw),  # exercises react_no_submit path
+            id="react_no_submit",
+        ),
+    ],
+)
+def test_model_length_with_compaction_triggers_force_and_continues(
+    react_factory,
+) -> None:
+    """Forced compaction recovers from model_length when compaction is configured.
+
+    When generate returns model_length and compaction is configured,
+    the overflow handler invokes forced compaction and the agent continues.
+    """
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Failed turn (overflow)",
+                stop_reason="model_length",
+            ),
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Recovered after compaction",
+            ),
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": "done"},
+            ),
+        ],
+    )
+
+    task = Task(
+        dataset=[Sample(input="Test", target="done")],
+        solver=react_factory(
+            compaction=CompactionTrim(threshold=10_000),
+        ),
+    )
+
+    log = eval(task, model=model)[0]
+    assert log.status == "success", f"Agent should have recovered. Status: {log.status}"
+
+    # Verify the recovery emitted a differentiated CompactionEvent. This is
+    # the load-bearing assertion: it confirms that _handle_overflow invoked
+    # compact_input(force=True), which is the wiring this task adds.
+    from inspect_ai.event import CompactionEvent
+
+    assert log.samples
+    events = [e for e in log.samples[0].events if isinstance(e, CompactionEvent)]
+    assert any(e.source == "inspect_recovery" for e in events), (
+        "Expected at least one CompactionEvent with source='inspect_recovery' "
+        f"from forced compaction; got sources {[e.source for e in events]}"
+    )
+
+
+def test_model_length_with_compaction_recovers_and_continues() -> None:
+    """With a realistic conversation, forced compaction reduces messages and the agent continues.
+
+    The conversation must be large enough that CompactionTrim actually
+    reduces message count, otherwise the len(compacted) < len(previous)
+    guard in _handle_overflow correctly skips the compaction result.
+    The submit answer is the canary -- if the agent broke out on overflow
+    instead of recovering, it would never reach submit.
+    """
+    # Build conversation: 10 plain turns (each adds an assistant message
+    # and a default-continue user prompt = 20 messages), then overflow,
+    # then recovery, then submit.
+    custom_outputs = [
+        ModelOutput.from_content(model="mockllm/model", content=f"Turn {i}")
+        for i in range(10)
+    ]
+    custom_outputs.extend(
+        [
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Failed turn (overflow)",
+                stop_reason="model_length",
+            ),
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Recovered after compaction",
+            ),
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": "done"},
+            ),
+        ]
+    )
+
+    model = get_model("mockllm/model", custom_outputs=custom_outputs)
+
+    task = Task(
+        dataset=[Sample(input="Test", target="done")],
+        solver=react(compaction=CompactionTrim(threshold=10_000, preserve=0.5)),
+        message_limit=100,
+    )
+
+    log = eval(task, model=model)[0]
+    assert log.status == "success"
+
+    # Canary: the submit was reached only if the agent recovered from overflow.
+    assert log.samples
+    output_text = log.samples[0].output.completion or ""
+    assert "done" in output_text, (
+        f"Expected agent to reach submit after overflow recovery; "
+        f"got output completion: {output_text!r}"
+    )
+
+
+def test_model_length_with_compaction_failure_falls_through_to_filter() -> None:
+    """Falls through to overflow filter when forced compaction fails.
+
+    If forced compaction raises (e.g., RuntimeError 'compaction insufficient'),
+    the existing overflow filter takes over.
+    """
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Failed turn (overflow)",
+                stop_reason="model_length",
+            ),
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Recovered after truncation",
+            ),
+            ModelOutput.for_tool_call(
+                model="mockllm/model",
+                tool_name="submit",
+                tool_arguments={"answer": "done"},
+            ),
+        ],
+    )
+
+    # Use a strategy that always raises when compact() is invoked.
+    # The high threshold ensures predictive compaction never triggers;
+    # only forced compaction in _handle_overflow will invoke compact().
+    impossible_strategy = _AlwaysRaisesCompaction()
+
+    task = Task(
+        dataset=[Sample(input="Test", target="done")],
+        solver=react(
+            compaction=impossible_strategy,
+            truncation="auto",  # Falls back to message-trim filter
+        ),
+    )
+
+    log = eval(task, model=model)[0]
+    assert log.status == "success", (
+        "Agent should have recovered via the truncation filter even when "
+        f"forced compaction fails. Status: {log.status}"
+    )
+
+
+def test_model_length_without_recovery_terminates() -> None:
+    """No compaction, no overflow filter: the agent terminates cleanly."""
+    model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.from_content(
+                model="mockllm/model",
+                content="Failed turn (overflow)",
+                stop_reason="model_length",
+            ),
+        ],
+    )
+
+    task = Task(
+        dataset=[Sample(input="Test", target="done")],
+        solver=react(),  # No compaction, default truncation="disabled"
+    )
+
+    log = eval(task, model=model)[0]
+    # Agent should NOT have submitted (no successful path).
+    assert log.samples
+    sample = log.samples[0]
+    last_message = sample.messages[-1] if sample.messages else None
+    if last_message is not None:
+        # If there's a final message, it should be the failed assistant turn,
+        # not a submit tool call.
+        assert "submit" not in (
+            last_message.content if isinstance(last_message.content, str) else ""
+        ), "Agent should not have reached submit when no recovery is configured"

--- a/tests/agent/test_agent_overflow_compaction.py
+++ b/tests/agent/test_agent_overflow_compaction.py
@@ -14,6 +14,7 @@ from inspect_ai.model import (
     get_model,
 )
 from inspect_ai.model._compaction import CompactionStrategy
+from inspect_ai.model._compaction.edit import CompactionEdit
 from inspect_ai.model._compaction.trim import CompactionTrim
 from inspect_ai.tool._tool_info import ToolInfo
 
@@ -94,14 +95,32 @@ def test_model_length_with_compaction_triggers_force_and_continues(
     )
 
 
-def test_model_length_with_compaction_recovers_and_continues() -> None:
-    """With a realistic conversation, forced compaction reduces messages and the agent continues.
+@pytest.mark.parametrize(
+    "strategy_factory",
+    [
+        pytest.param(
+            lambda: CompactionTrim(threshold=10_000, preserve=0.5),
+            id="trim",
+        ),
+        # CompactionEdit reduces message *content* (replaces tool results
+        # with TOOL_RESULT_REMOVED) but not message *count*. This test
+        # verifies that recovery happens despite no count reduction --
+        # the previous len(compacted) < len(previous_messages) gate broke
+        # this path.
+        pytest.param(
+            lambda: CompactionEdit(threshold=10_000, keep_tool_uses=0),
+            id="edit",
+        ),
+    ],
+)
+def test_model_length_with_compaction_recovers_and_continues(strategy_factory) -> None:
+    """With a realistic conversation, forced compaction recovers and the agent continues.
 
-    The conversation must be large enough that CompactionTrim actually
-    reduces message count, otherwise the len(compacted) < len(previous)
-    guard in _handle_overflow correctly skips the compaction result.
     The submit answer is the canary -- if the agent broke out on overflow
-    instead of recovering, it would never reach submit.
+    instead of recovering, it would never reach submit. We additionally
+    assert there are no duplicate message IDs in the recovered history,
+    which guards against summary-style strategies where the c_message
+    object is also the last element of the compacted input.
     """
     # Build conversation: 10 plain turns (each adds an assistant message
     # and a default-continue user prompt = 20 messages), then overflow,
@@ -133,7 +152,7 @@ def test_model_length_with_compaction_recovers_and_continues() -> None:
 
     task = Task(
         dataset=[Sample(input="Test", target="done")],
-        solver=react(compaction=CompactionTrim(threshold=10_000, preserve=0.5)),
+        solver=react(compaction=strategy_factory()),
         message_limit=100,
     )
 
@@ -146,6 +165,13 @@ def test_model_length_with_compaction_recovers_and_continues() -> None:
     assert "done" in output_text, (
         f"Expected agent to reach submit after overflow recovery; "
         f"got output completion: {output_text!r}"
+    )
+
+    # Guard against C1 (CompactionSummary duplicate-summary regression):
+    # any message with an id should appear exactly once.
+    ids = [m.id for m in log.samples[0].messages if m.id]
+    assert len(ids) == len(set(ids)), (
+        f"Duplicate message IDs detected in recovered history: {ids}"
     )
 
 

--- a/tests/agent/test_agent_overflow_compaction.py
+++ b/tests/agent/test_agent_overflow_compaction.py
@@ -102,11 +102,9 @@ def test_model_length_with_compaction_triggers_force_and_continues(
             lambda: CompactionTrim(threshold=10_000, preserve=0.5),
             id="trim",
         ),
-        # CompactionEdit reduces message *content* (replaces tool results
-        # with TOOL_RESULT_REMOVED) but not message *count*. This test
-        # verifies that recovery happens despite no count reduction --
-        # the previous len(compacted) < len(previous_messages) gate broke
-        # this path.
+        # CompactionEdit reduces message content (replaces tool results
+        # with TOOL_RESULT_REMOVED) but not message count, so recovery
+        # must not gate on length reduction.
         pytest.param(
             lambda: CompactionEdit(threshold=10_000, keep_tool_uses=0),
             id="edit",
@@ -167,8 +165,8 @@ def test_model_length_with_compaction_recovers_and_continues(strategy_factory) -
         f"got output completion: {output_text!r}"
     )
 
-    # Guard against C1 (CompactionSummary duplicate-summary regression):
-    # any message with an id should appear exactly once.
+    # Recovered history should not contain duplicate message IDs
+    # (e.g., a summary appearing as both compacted[-1] and c_message).
     ids = [m.id for m in log.samples[0].messages if m.id]
     assert len(ids) == len(set(ids)), (
         f"Duplicate message IDs detected in recovered history: {ids}"

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -865,10 +865,17 @@ async def test_redacted_reasoning_in_baseline_triggers_full_recount(
     When baseline messages contain redacted reasoning, count_tokens must be
     called on the full target_messages list (not just new_since_baseline).
     Regression guard for the OpenAI Responses + store=false +
-    include=encrypted_content blind spot.
+    include=encrypted_content blind spot. We patch
+    `usage_input_tokens_complete` to False to simulate an
+    OpenAI-Responses-style provider whose usage.input_tokens may omit
+    encrypted reasoning content.
     """
     strategy = CompactionTrim(threshold=10_000)
     model = get_model("mockllm/model")
+
+    # Simulate a provider that may omit reasoning content from usage.input_tokens
+    # (e.g. OpenAI Responses with store=false + include=encrypted_content).
+    monkeypatch.setattr(model.api, "usage_input_tokens_complete", lambda: False)
 
     prefix: list[ChatMessage] = []
     compact = compaction(strategy, prefix=prefix, tools=None, model=model)

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -809,3 +809,37 @@ async def test_compact_input_concurrent_no_duplicate_messages() -> None:
     assert len(final_ids) == len(set(final_ids)), (
         f"compacted_input contains duplicate message ids: {final_ids}"
     )
+
+
+async def test_force_compaction_skips_threshold() -> None:
+    """force=True compacts even when total tokens are well under threshold.
+
+    Without force=True, CompactionTrim with threshold=1_000_000 should not
+    trim (way under the threshold). With force=True, compaction runs
+    unconditionally and trim's preserve=0.5 reduces the message count.
+
+    The differentiated CompactionEvent source ('inspect_recovery') is
+    verified separately via integration tests in Task 4.
+    """
+    strategy = CompactionTrim(threshold=1_000_000, preserve=0.5)
+    model = get_model("mockllm/model")
+
+    prefix: list[ChatMessage] = []
+
+    messages: list[ChatMessage] = [user_msg(f"msg{i}", f"u{i}") for i in range(10)]
+
+    # Predictive (no force) should not trim under a huge threshold.
+    compact = compaction(strategy, prefix=prefix, tools=None, model=model)
+    result_predictive, _ = await compact.compact_input(messages)
+    assert len(result_predictive) == len(messages), (
+        f"Predictive compaction should not trim under threshold; "
+        f"got {len(result_predictive)} vs {len(messages)} messages"
+    )
+
+    # Force should trim regardless of threshold.
+    compact = compaction(strategy, prefix=prefix, tools=None, model=model)
+    result_forced, _ = await compact.compact_input(messages, force=True)
+    assert len(result_forced) < len(messages), (
+        f"force=True should trigger compaction (trim with preserve=0.5); "
+        f"got {len(result_forced)} vs {len(messages)} messages"
+    )

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -5,7 +5,7 @@ from typing import Literal
 import pytest
 
 from inspect_ai._util.citation import UrlCitation
-from inspect_ai._util.content import ContentImage, ContentText
+from inspect_ai._util.content import ContentImage, ContentReasoning, ContentText
 from inspect_ai.model import (
     ChatMessage,
     ChatMessageAssistant,
@@ -843,3 +843,118 @@ async def test_force_compaction_skips_threshold() -> None:
         f"force=True should trigger compaction (trim with preserve=0.5); "
         f"got {len(result_forced)} vs {len(messages)} messages"
     )
+
+
+def _assistant_with_redacted_reasoning(
+    content: str, encrypted: str, id: str
+) -> ChatMessageAssistant:
+    return ChatMessageAssistant(
+        content=[
+            ContentReasoning(reasoning=encrypted, redacted=True),
+            ContentText(text=content),
+        ],
+        id=id,
+    )
+
+
+async def test_redacted_reasoning_in_baseline_triggers_full_recount(
+    monkeypatch,
+) -> None:
+    """Recount full target_messages when baseline contains redacted reasoning.
+
+    When baseline messages contain redacted reasoning, count_tokens must be
+    called on the full target_messages list (not just new_since_baseline).
+    Regression guard for the OpenAI Responses + store=false +
+    include=encrypted_content blind spot.
+    """
+    strategy = CompactionTrim(threshold=10_000)
+    model = get_model("mockllm/model")
+
+    prefix: list[ChatMessage] = []
+    compact = compaction(strategy, prefix=prefix, tools=None, model=model)
+
+    # First call to establish a baseline. Mock record_output to install one.
+    initial: list[ChatMessage] = [
+        user_msg("Question 1", "u1"),
+        _assistant_with_redacted_reasoning("Answer", "ENCRYPTED_BLOB", "a1"),
+    ]
+    await compact.compact_input(initial)
+
+    # Simulate record_output establishing a baseline.
+    from inspect_ai.model._model_output import ModelOutput, ModelUsage
+
+    output = ModelOutput.from_content(model="mockllm/model", content="dummy")
+    output.usage = ModelUsage(input_tokens=100, output_tokens=10, total_tokens=110)
+    await compact.record_output(initial, output)
+
+    # Now add new messages and re-run compaction. Patch count_tokens to track inputs.
+    call_inputs: list[list[ChatMessage]] = []
+    real_count_tokens = model.count_tokens
+
+    async def tracking_count_tokens(input, config=None):
+        if isinstance(input, list):
+            call_inputs.append(list(input))
+        return await real_count_tokens(input, config)
+
+    monkeypatch.setattr(model, "count_tokens", tracking_count_tokens)
+
+    next_messages: list[ChatMessage] = initial + [
+        user_msg("Question 2", "u2"),
+    ]
+    await compact.compact_input(next_messages)
+
+    # The recount path was taken: count_tokens was called with the full target list,
+    # not just the new message.
+    assert any(len(inp) >= len(initial) + 1 for inp in call_inputs), (
+        "Expected count_tokens to be called on the full target_messages "
+        f"(>= {len(initial) + 1} messages); call inputs were: "
+        f"{[len(inp) for inp in call_inputs]}"
+    )
+
+
+async def test_no_redacted_reasoning_preserves_baseline_shortcut(monkeypatch) -> None:
+    """Preserve baseline shortcut when baseline contains no redacted reasoning.
+
+    When baseline messages don't contain redacted reasoning, count_tokens
+    is called only on new_since_baseline (existing behavior preserved).
+    """
+    strategy = CompactionTrim(threshold=10_000)
+    model = get_model("mockllm/model")
+
+    prefix: list[ChatMessage] = []
+    compact = compaction(strategy, prefix=prefix, tools=None, model=model)
+
+    initial: list[ChatMessage] = [
+        user_msg("Question 1", "u1"),
+        assistant_msg("Plain answer", "a1"),  # No reasoning content
+    ]
+    await compact.compact_input(initial)
+
+    from inspect_ai.model._model_output import ModelOutput, ModelUsage
+
+    output = ModelOutput.from_content(model="mockllm/model", content="dummy")
+    output.usage = ModelUsage(input_tokens=100, output_tokens=10, total_tokens=110)
+    await compact.record_output(initial, output)
+
+    call_inputs: list[list[ChatMessage]] = []
+    real_count_tokens = model.count_tokens
+
+    async def tracking_count_tokens(input, config=None):
+        if isinstance(input, list):
+            call_inputs.append(list(input))
+        return await real_count_tokens(input, config)
+
+    monkeypatch.setattr(model, "count_tokens", tracking_count_tokens)
+
+    next_messages: list[ChatMessage] = initial + [
+        user_msg("Question 2", "u2"),
+    ]
+    await compact.compact_input(next_messages)
+
+    # The baseline shortcut path was taken: count_tokens was called with only
+    # the new message(s) since baseline, not the full list.
+    if call_inputs:
+        assert all(len(inp) <= 1 for inp in call_inputs), (
+            "Expected count_tokens to be called only on new_since_baseline "
+            f"(<= 1 message); call inputs were: {[len(inp) for inp in call_inputs]}"
+        )

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -960,8 +960,8 @@ async def test_no_redacted_reasoning_preserves_baseline_shortcut(monkeypatch) ->
 
     # The baseline shortcut path was taken: count_tokens was called with only
     # the new message(s) since baseline, not the full list.
-    if call_inputs:
-        assert all(len(inp) <= 1 for inp in call_inputs), (
-            "Expected count_tokens to be called only on new_since_baseline "
-            f"(<= 1 message); call inputs were: {[len(inp) for inp in call_inputs]}"
-        )
+    assert call_inputs, "expected count_tokens to be called on new messages"
+    assert all(len(inp) <= 1 for inp in call_inputs), (
+        "Expected count_tokens to be called only on new_since_baseline "
+        f"(<= 1 message); call inputs were: {[len(inp) for inp in call_inputs]}"
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [x] Code refactor

### What is the current behavior?

OpenAI with reasoning _and_ compaction calculates the compaction window incorrectly. The compaction handler calculates the current context usage as `output.usage.input_tokens + cache_read + cache_write`, but for OpenAI the `usage.input_tokens` field does not include the reasoning tokens.

This causes runs to fail with "Your input exceeds the context window of this model. Please adjust your input and try again" even though they have compaction enabled.

#### Details:

When the OpenAI Responses API is used with `store=false` and `include=["reasoning.encrypted_content"]`, encrypted reasoning items from prior turns are re-injected into `input` on every subsequent turn. These items consume context window space but are NOT counted in `usage.input_tokens`. The compaction handler at `model/_compaction/_compaction.py` trusts `usage.input_tokens` for its baseline shortcut, so the threshold check never trips even as actual context approaches the model's hard ceiling. Long agent runs (~133 turns observed) hit `context_length_exceeded` despite a configured compaction `threshold=0.8`.

### What is the new behavior?

**Predictive fix.** Add a provider signal \`ModelAPI.usage_input_tokens_complete()\` (default \`True\`). When redacted reasoning is present in already-counted messages **and** the provider returns \`False\` (currently only OpenAI Responses), the baseline shortcut is bypassed and \`count_tokens(target_messages)\` is called instead. For OpenAI Responses, \`count_tokens\` calls \`client.responses.input_tokens.count(...)\` natively, which authoritatively counts encrypted reasoning blocks.

**Reactive fix.** New \`force: bool = False\` parameter on the \`Compact\` protocol. When generate returns \`stop_reason="model_length"\` and a compaction strategy is configured, \`_handle_overflow\` invokes \`compact_input(force=True)\` before falling through to the existing overflow filter. Forced compactions emit \`CompactionEvent.source="inspect_recovery"\` so analysts can distinguish predictive from reactive compaction in transcripts.

### Does this PR introduce a breaking change?

No.