### PR TITLE
fix: lock Compact handler against concurrent AgentBridge calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Added `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
+- Compaction: Lock Compact handler against concurrent AgentBridge calls.
 
 ## 0.3.216 (01 May 2026)
 

--- a/docs/agent-custom.qmd
+++ b/docs/agent-custom.qmd
@@ -171,8 +171,8 @@ def my_agent(tools: Sequence[Tool | ToolDef | ToolSource]):
                 )
                 state.messages.append(state.output.message)
 
-                # record output for token calibration  # <3>
-                compact.record_output(state.output)    # <3>
+                # record output for token calibration              # <3>
+                await compact.record_output(input, state.output)   # <3>
 
                 # make tool calls or terminate if there are none
                 if state.output.message.tool_calls:
@@ -195,7 +195,7 @@ def my_agent(tools: Sequence[Tool | ToolDef | ToolSource]):
 3. Call `record_output()` after `model.generate()` to calibrate token estimation using the model's actual reported usage. This improves the accuracy of compaction threshold detection.
 
 ::: {.callout-note}
-The returned `compact` handler maintains internal state and is designed for sequential use within a single conversation's agent loop. Do not call it concurrently.
+The returned `compact` handler maintains internal state for a single growing conversation history. Concurrent calls within the same conversation are safe, but do not share one handler across divergent message histories — the compacted result mixes them.
 :::
 
 There are various configurable compaction strategies available---see the [Compaction](compaction.qmd) documentation for details.

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -127,7 +127,7 @@ async def bridge_generate(
         # Update the compaction baseline with the actual input token
         # count from the generate call (most accurate source of truth)
         if compact is not None:
-            compact.record_output(output)
+            await compact.record_output(input_messages, output)
 
         # Check for refusal and retry if needed
         if (

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -582,7 +582,7 @@ def _model_generate(
             # update the compaction baseline with the actual input token
             # count from the generate call (most accurate source of truth)
             if compact is not None:
-                compact.record_output(output)
+                await compact.record_output(input_messages, output)
 
             break
         return state

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -86,24 +86,28 @@ def compaction(
             raise RuntimeError("Message must have an ID")
         return message.id
 
-    def record_output_fn(output: ModelOutput) -> None:
+    async def record_output_fn(input: list[ChatMessage], output: ModelOutput) -> None:
         """Record output from generate call to calibrate token baseline."""
         nonlocal baseline_tokens, baseline_message_ids
 
         if output.usage is None:
             return
 
-        # Compute total input tokens including cached tokens
-        input_tokens = output.usage.input_tokens
-        if output.usage.input_tokens_cache_read:
-            input_tokens += output.usage.input_tokens_cache_read
-        if output.usage.input_tokens_cache_write:
-            input_tokens += output.usage.input_tokens_cache_write
+        async with _lock:
+            # Compute total input tokens including cached tokens
+            input_tokens = output.usage.input_tokens
+            if output.usage.input_tokens_cache_read:
+                input_tokens += output.usage.input_tokens_cache_read
+            if output.usage.input_tokens_cache_write:
+                input_tokens += output.usage.input_tokens_cache_write
 
-        # The baseline reflects the token count for messages currently in
-        # compacted_input (what was sent to generate)
-        baseline_tokens = input_tokens
-        baseline_message_ids = {message_id(m) for m in compacted_input}
+            # The baseline reflects the token count for the messages that
+            # were actually passed to generate (the source of `output.usage`).
+            # Reading from the closure's `compacted_input` here would race with
+            # any concurrent compact_input call that mutated it after this
+            # generate started.
+            baseline_tokens = input_tokens
+            baseline_message_ids = {message_id(m) for m in input}
 
     async def compact_fn(
         messages: list[ChatMessage],
@@ -249,8 +253,10 @@ def compaction(
         ) -> tuple[list[ChatMessage], ChatMessageUser | None]:
             return await compact_fn(messages)
 
-        def record_output(self, output: ModelOutput) -> None:
-            record_output_fn(output)
+        async def record_output(
+            self, input: list[ChatMessage], output: ModelOutput
+        ) -> None:
+            await record_output_fn(input, output)
 
     return _CompactHandler()
 

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -64,8 +64,8 @@ def compaction(
     # snapshot the prefix in case it changes
     prefix = prefix.copy()
 
-    # lock serializing closure-state mutation across concurrent callers
-    # (relevant when the same Compact instance is shared via AgentBridge).
+    # serializes closure-state mutation when the same Compact instance is
+    # shared across concurrent callers (e.g. via AgentBridge)
     _lock = anyio.Lock()
 
     # resolve target model
@@ -101,11 +101,9 @@ def compaction(
             if output.usage.input_tokens_cache_write:
                 input_tokens += output.usage.input_tokens_cache_write
 
-            # The baseline reflects the token count for the messages that
-            # were actually passed to generate (the source of `output.usage`).
-            # Reading from the closure's `compacted_input` here would race with
-            # any concurrent compact_input call that mutated it after this
-            # generate started.
+            # `input` is the messages that produced output.usage; under
+            # concurrent bridge use the closure's `compacted_input` may
+            # already reflect a later call
             baseline_tokens = input_tokens
             baseline_message_ids = {message_id(m) for m in input}
 

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from logging import getLogger
 from typing import Sequence
 
+import anyio
+
 from inspect_ai.tool import Tool, ToolDef, ToolInfo, ToolSource
 
 from .._call_tools import get_tools_info, resolve_tools
@@ -62,6 +64,10 @@ def compaction(
     # snapshot the prefix in case it changes
     prefix = prefix.copy()
 
+    # lock serializing closure-state mutation across concurrent callers
+    # (relevant when the same Compact instance is shared via AgentBridge).
+    _lock = anyio.Lock()
+
     # resolve target model
     target_model = get_model(model)
 
@@ -108,129 +114,134 @@ def compaction(
         nonlocal tool_tokens, tools_info, prefix_tokens, memory_warning_issued
         nonlocal baseline_tokens, baseline_message_ids
 
-        # one time resolution of tool_tokens and prefix_tokens
-        # (must be done here b/c calls are async)
-        if tool_tokens is None:
-            tools_info = get_tools_info(await resolve_tools(tools or []))
-            tool_tokens = await target_model.count_tool_tokens(tools_info)
-        if prefix_tokens is None:
-            prefix_tokens = await target_model.count_tokens(prefix) if prefix else 0
+        async with _lock:
+            # one time resolution of tool_tokens and prefix_tokens
+            # (must be done here b/c calls are async)
+            if tool_tokens is None:
+                tools_info = get_tools_info(await resolve_tools(tools or []))
+                tool_tokens = await target_model.count_tool_tokens(tools_info)
+            if prefix_tokens is None:
+                prefix_tokens = await target_model.count_tokens(prefix) if prefix else 0
 
-        # determine unprocessed messages (messages not yet added to input).
-        # we allow unprocessed messages to accumulate in the input until
-        # the compaction 'threshold' is reached.
-        unprocessed: list[ChatMessage] = [
-            m for m in messages if message_id(m) not in processed_message_ids
-        ]
-
-        # estimate total tokens using the most accurate method available
-        target_messages = compacted_input + unprocessed
-        target_message_ids = {message_id(m) for m in target_messages}
-        if baseline_tokens is not None and baseline_message_ids.issubset(
-            target_message_ids
-        ):
-            # Use the baseline from the last generate call (most accurate).
-            # The baseline already includes tool definitions, system messages,
-            # and API-level overhead. We only need to count NEW messages
-            # added since the baseline was established.
-            new_since_baseline = [
-                m for m in target_messages if message_id(m) not in baseline_message_ids
+            # determine unprocessed messages (messages not yet added to input).
+            # we allow unprocessed messages to accumulate in the input until
+            # the compaction 'threshold' is reached.
+            unprocessed: list[ChatMessage] = [
+                m for m in messages if message_id(m) not in processed_message_ids
             ]
-            new_tokens = (
-                await target_model.count_tokens(new_since_baseline)
-                if new_since_baseline
-                else 0
-            )
-            total_tokens = baseline_tokens + new_tokens
-        else:
-            # No baseline yet (first call). Fall back to per-message counting.
-            message_tokens = await target_model.count_tokens(target_messages)
-            total_tokens = tool_tokens + message_tokens
 
-        if total_tokens > threshold:
-            # perform compaction (with iteration if needed)
-            c_input, c_message = await _perform_compaction(
-                strategy=strategy,
-                messages=target_messages,
-                tools=tools_info,
-                model=target_model,
-                threshold=threshold,
-                tool_tokens=tool_tokens,
-                prefix_tokens=prefix_tokens,
-            )
-
-            # track all messages that were processed in this compaction pass
-            for m in compacted_input + unprocessed:
-                processed_message_ids.add(message_id(m))
-
-            # c_message is a compaction side effect to append to the history
-            # (e.g. a summary). track it as processed as well
-            if c_message is not None:
-                processed_message_ids.add(message_id(c_message))
-
-            # Preserve prefix messages based on strategy type
-            if strategy.preserve_prefix:
-                # Non-native strategies: prepend any prefix messages not in output
-                input_ids = {message_id(m) for m in c_input}
-                prepend_prefix = [m for m in prefix if message_id(m) not in input_ids]
-            else:
-                # Native compaction: only prepend system messages
-                # (user content is preserved by provider or in compaction block)
-                prepend_prefix = [m for m in prefix if m.role == "system"]
-            c_input = prepend_prefix + c_input
-
-            # update input
-            compacted_input.clear()
-            compacted_input.extend(c_input)
-
-            # log compaction
-            compacted_tokens = await target_model.count_tokens(compacted_input)
-            transcript()._event(
-                CompactionEvent(
-                    type=strategy.type,
-                    source="inspect",
-                    tokens_before=total_tokens,
-                    tokens_after=compacted_tokens,
-                    metadata={
-                        "strategy": strategy.__class__.__name__,
-                        "messages_before": len(target_messages),
-                        "messages_after": len(compacted_input),
-                    },
-                )
-            )
-
-            # clear memory warning state
-            memory_warning_issued = False
-
-            # invalidate baseline (compaction changed the messages)
-            baseline_tokens = None
-            baseline_message_ids = set()
-
-            # return input and any extra message to append
-            return list(c_input), c_message
-
-        else:
-            # track unprocessed messages as now processed
-            for m in unprocessed:
-                processed_message_ids.add(message_id(m))
-
-            # extend input with unprocessed messages
-            compacted_input.extend(unprocessed)
-
-            # check if we need to do a memory warning
-            if (
-                strategy.memory is True
-                and MEMORY_TOOL in [t.name for t in tools_info]
-                and total_tokens > memory_warning_threshold
-                and not memory_warning_issued
+            # estimate total tokens using the most accurate method available
+            target_messages = compacted_input + unprocessed
+            target_message_ids = {message_id(m) for m in target_messages}
+            if baseline_tokens is not None and baseline_message_ids.issubset(
+                target_message_ids
             ):
-                memory_message = memory_warning_message()
-                compacted_input.append(memory_message)
-                processed_message_ids.add(message_id(memory_message))
-                memory_warning_issued = True
+                # Use the baseline from the last generate call (most accurate).
+                # The baseline already includes tool definitions, system messages,
+                # and API-level overhead. We only need to count NEW messages
+                # added since the baseline was established.
+                new_since_baseline = [
+                    m
+                    for m in target_messages
+                    if message_id(m) not in baseline_message_ids
+                ]
+                new_tokens = (
+                    await target_model.count_tokens(new_since_baseline)
+                    if new_since_baseline
+                    else 0
+                )
+                total_tokens = baseline_tokens + new_tokens
+            else:
+                # No baseline yet (first call). Fall back to per-message counting.
+                message_tokens = await target_model.count_tokens(target_messages)
+                total_tokens = tool_tokens + message_tokens
 
-            # return
-            return list(compacted_input), None
+            if total_tokens > threshold:
+                # perform compaction (with iteration if needed)
+                c_input, c_message = await _perform_compaction(
+                    strategy=strategy,
+                    messages=target_messages,
+                    tools=tools_info,
+                    model=target_model,
+                    threshold=threshold,
+                    tool_tokens=tool_tokens,
+                    prefix_tokens=prefix_tokens,
+                )
+
+                # track all messages that were processed in this compaction pass
+                for m in compacted_input + unprocessed:
+                    processed_message_ids.add(message_id(m))
+
+                # c_message is a compaction side effect to append to the history
+                # (e.g. a summary). track it as processed as well
+                if c_message is not None:
+                    processed_message_ids.add(message_id(c_message))
+
+                # Preserve prefix messages based on strategy type
+                if strategy.preserve_prefix:
+                    # Non-native strategies: prepend any prefix messages not in output
+                    input_ids = {message_id(m) for m in c_input}
+                    prepend_prefix = [
+                        m for m in prefix if message_id(m) not in input_ids
+                    ]
+                else:
+                    # Native compaction: only prepend system messages
+                    # (user content is preserved by provider or in compaction block)
+                    prepend_prefix = [m for m in prefix if m.role == "system"]
+                c_input = prepend_prefix + c_input
+
+                # update input
+                compacted_input.clear()
+                compacted_input.extend(c_input)
+
+                # log compaction
+                compacted_tokens = await target_model.count_tokens(compacted_input)
+                transcript()._event(
+                    CompactionEvent(
+                        type=strategy.type,
+                        source="inspect",
+                        tokens_before=total_tokens,
+                        tokens_after=compacted_tokens,
+                        metadata={
+                            "strategy": strategy.__class__.__name__,
+                            "messages_before": len(target_messages),
+                            "messages_after": len(compacted_input),
+                        },
+                    )
+                )
+
+                # clear memory warning state
+                memory_warning_issued = False
+
+                # invalidate baseline (compaction changed the messages)
+                baseline_tokens = None
+                baseline_message_ids = set()
+
+                # return input and any extra message to append
+                return list(c_input), c_message
+
+            else:
+                # track unprocessed messages as now processed
+                for m in unprocessed:
+                    processed_message_ids.add(message_id(m))
+
+                # extend input with unprocessed messages
+                compacted_input.extend(unprocessed)
+
+                # check if we need to do a memory warning
+                if (
+                    strategy.memory is True
+                    and MEMORY_TOOL in [t.name for t in tools_info]
+                    and total_tokens > memory_warning_threshold
+                    and not memory_warning_issued
+                ):
+                    memory_message = memory_warning_message()
+                    compacted_input.append(memory_message)
+                    processed_message_ids.add(message_id(memory_message))
+                    memory_warning_issued = True
+
+                # return
+                return list(compacted_input), None
 
     class _CompactHandler:
         async def compact_input(

--- a/src/inspect_ai/model/_compaction/types.py
+++ b/src/inspect_ai/model/_compaction/types.py
@@ -90,15 +90,15 @@ class Compact(Protocol):
     ) -> None:
         """Record the output from a generate call.
 
-        After each generate call, pass the input that was sent to generate and
-        the resulting ModelOutput to calibrate the compaction's token estimation.
-        This accounts for API-level overhead (tool definitions, system messages,
-        thinking configuration) that per-message counting cannot capture.
+        Calibrates the compaction's token estimation against the actual
+        input token count from `output.usage`. This captures API-level
+        overhead (tool definitions, system messages, thinking configuration)
+        that per-message counting cannot.
 
-        Passing `input` (rather than re-reading internal state) ensures the
-        baseline message ids match the messages that produced `output.usage` —
-        important when the same `Compact` instance is shared across concurrent
-        callers (e.g. via AgentBridge).
+        `input` must be the messages that were passed to `model.generate`
+        — it determines the baseline message ids that produced
+        `output.usage`. This matters when one `Compact` instance is shared
+        across concurrent callers (e.g. via AgentBridge).
 
         Args:
             input: The list of messages that was passed to model.generate.

--- a/src/inspect_ai/model/_compaction/types.py
+++ b/src/inspect_ai/model/_compaction/types.py
@@ -85,15 +85,23 @@ class Compact(Protocol):
         """
         ...
 
-    def record_output(self, output: ModelOutput) -> None:
+    async def record_output(
+        self, input: list[ChatMessage], output: ModelOutput
+    ) -> None:
         """Record the output from a generate call.
 
-        After each generate call, pass the ModelOutput to calibrate
-        the compaction's token estimation. This accounts for API-level
-        overhead (tool definitions, system messages, thinking
-        configuration) that per-message counting cannot capture.
+        After each generate call, pass the input that was sent to generate and
+        the resulting ModelOutput to calibrate the compaction's token estimation.
+        This accounts for API-level overhead (tool definitions, system messages,
+        thinking configuration) that per-message counting cannot capture.
+
+        Passing `input` (rather than re-reading internal state) ensures the
+        baseline message ids match the messages that produced `output.usage` —
+        important when the same `Compact` instance is shared across concurrent
+        callers (e.g. via AgentBridge).
 
         Args:
+            input: The list of messages that was passed to model.generate.
             output: The ModelOutput from the generate call.
         """
         ...

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -760,3 +760,60 @@ async def test_compaction_strips_citations() -> None:
                     assert content.citations is None, (
                         f"Expected citations to be None, got {content.citations}"
                     )
+
+
+# ==============================================================================
+# Concurrent access regression test (race #1 from spec
+# 2026-05-01-compaction-bridge-race-fix-design.md)
+# ==============================================================================
+async def test_compact_input_concurrent_no_duplicate_messages() -> None:
+    """Concurrent compact_input calls must not duplicate messages in the closure.
+
+    Reproduces the AgentBridge / SandboxAgentBridge race where multiple
+    coroutines share one Compact handler.
+    """
+    import anyio
+
+    from inspect_ai._util._async import tg_collect
+    from inspect_ai.model._generate_config import GenerateConfig
+
+    # threshold high enough that we always take the else branch (no compaction)
+    strategy = CompactionEdit(threshold=10_000_000)
+
+    model = get_model("mockllm/model")
+
+    # Patch count_tokens to yield explicitly. This forces the scheduler to
+    # interleave concurrent compact_input calls at the await point on
+    # _compaction.py:147, deterministically opening the race window.
+    async def yielding_count_tokens(
+        input: str | list[ChatMessage],
+        config: GenerateConfig | None = None,
+    ) -> int:
+        await anyio.sleep(0)
+        return 1
+
+    model.count_tokens = yielding_count_tokens  # type: ignore[method-assign]
+
+    prefix: list[ChatMessage] = []
+    compact = compaction(strategy, prefix=prefix, tools=None, model=model)
+
+    messages: list[ChatMessage] = [
+        user_msg("hello", "msg1"),
+        assistant_msg("hi", "msg2"),
+    ]
+
+    # N concurrent compact_input calls, all observing the same (empty)
+    # processed_message_ids set when they compute `unprocessed`.
+    N = 10
+
+    async def call_once() -> tuple[list[ChatMessage], object]:
+        return await compact.compact_input(messages)
+
+    await tg_collect([call_once for _ in range(N)])
+
+    # Final snapshot: one more call returns list(compacted_input).
+    final, _ = await compact.compact_input(messages)
+    final_ids = [m.id for m in final]
+    assert len(final_ids) == len(set(final_ids)), (
+        f"compacted_input contains duplicate message ids: {final_ids}"
+    )

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -762,29 +762,26 @@ async def test_compaction_strips_citations() -> None:
                     )
 
 
-# ==============================================================================
-# Concurrent access regression test (race #1 from spec
-# 2026-05-01-compaction-bridge-race-fix-design.md)
-# ==============================================================================
 async def test_compact_input_concurrent_no_duplicate_messages() -> None:
-    """Concurrent compact_input calls must not duplicate messages in the closure.
+    """Concurrent compact_input calls must not duplicate closure state.
 
-    Reproduces the AgentBridge / SandboxAgentBridge race where multiple
-    coroutines share one Compact handler.
+    When the same Compact instance is shared (e.g. through AgentBridge),
+    parallel callers must not lose updates to compacted_input.
     """
     import anyio
 
     from inspect_ai._util._async import tg_collect
     from inspect_ai.model._generate_config import GenerateConfig
 
-    # threshold high enough that we always take the else branch (no compaction)
+    # high threshold so compaction never triggers; exercises the no-compaction
+    # branch where concurrent callers all extend compacted_input
     strategy = CompactionEdit(threshold=10_000_000)
 
     model = get_model("mockllm/model")
 
-    # Patch count_tokens to yield explicitly. This forces the scheduler to
-    # interleave concurrent compact_input calls at the await point on
-    # _compaction.py:147, deterministically opening the race window.
+    # yield inside count_tokens so the scheduler interleaves concurrent
+    # callers; without an explicit yield, asyncio may run each coroutine
+    # to completion without context-switching
     async def yielding_count_tokens(
         input: str | list[ChatMessage],
         config: GenerateConfig | None = None,
@@ -802,16 +799,11 @@ async def test_compact_input_concurrent_no_duplicate_messages() -> None:
         assistant_msg("hi", "msg2"),
     ]
 
-    # N concurrent compact_input calls, all observing the same (empty)
-    # processed_message_ids set when they compute `unprocessed`.
-    N = 10
-
     async def call_once() -> tuple[list[ChatMessage], ChatMessageUser | None]:
         return await compact.compact_input(messages)
 
-    await tg_collect([call_once for _ in range(N)])
+    await tg_collect([call_once for _ in range(10)])
 
-    # Final snapshot: one more call returns list(compacted_input).
     final, _ = await compact.compact_input(messages)
     final_ids = [m.id for m in final]
     assert len(final_ids) == len(set(final_ids)), (

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -806,7 +806,7 @@ async def test_compact_input_concurrent_no_duplicate_messages() -> None:
     # processed_message_ids set when they compute `unprocessed`.
     N = 10
 
-    async def call_once() -> tuple[list[ChatMessage], object]:
+    async def call_once() -> tuple[list[ChatMessage], ChatMessageUser | None]:
         return await compact.compact_input(messages)
 
     await tg_collect([call_once for _ in range(N)])


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

The `Compact` handler at `src/inspect_ai/model/_compaction/_compaction.py` is a closure-based state machine with no internal locking. It mutates nonlocal state (`compacted_input`, `processed_message_ids`, `baseline_tokens`, `baseline_message_ids`, `memory_warning_issued`) across `await` points.

In `react()` and `deepagent()` this is fine — each `execute()` creates its own `Compact` and tools run serially. But `AgentBridge` shares one `Compact` instance across all coroutines spawned inside `async with agent_bridge():`. `SandboxAgentBridge.handle_requests` (`src/inspect_ai/util/_sandbox/service.py:258-276`) dispatches each pending request file via `tg.start_soon()`, so multiple model requests from a sandboxed agent (e.g. Claude Code's parallel `messages.create` calls) flow through one shared `Compact`. Concrete races result:

1. **Lost-update on `compacted_input`/`processed_message_ids`** — both coroutines compute the same `unprocessed` set and both extend `compacted_input`, producing duplicate messages on subsequent turns.
2. **Baseline drift** — `record_output` reads `compacted_input` directly, but a concurrent `compact_input` may have mutated it after the generate started, so the baseline is keyed on the wrong messages.
3. **Concurrent compaction** — both observe `total_tokens > threshold`, both call `_perform_compaction`, two `CompactionEvent`s are emitted.
4. **Duplicate memory warnings** — both observe `memory_warning_issued is False` and both append the warning message.

Symptoms: duplicate messages in compacted history, premature or missed compaction, double `CompactionEvent`s, double memory-warning user messages. Nothing crashes; compaction just behaves badly.

### What is the new behavior?

A single `anyio.Lock` lives inside the `Compact` handler closure and is shared by `compact_fn` and `record_output_fn`. Two changes:

1. **Lock placement is intentionally inside the handler, not at the bridge.** Locking at `bridge_generate` would serialize all parallel model calls in a `SandboxAgentBridge` and destroy the concurrency benefit of `tg.start_soon`. The user-facing `model.generate` calls between `compact_input` and `record_output` still run in parallel.

2. **`Compact.record_output` becomes async and takes `input`.** The new signature is `async def record_output(self, input: list[ChatMessage], output: ModelOutput) -> None`. The `input` parameter is the messages that were passed to `model.generate`, so `baseline_message_ids` is now derived from those exact messages rather than re-reading the closure's `compacted_input` (which may have moved on under concurrency). This eliminates race #2.

A regression test in `tests/model/test_compaction.py::test_compact_input_concurrent_no_duplicate_messages` deterministically reproduces race #1 by running 10 concurrent `compact_input` calls through a real `mockllm/model` whose `count_tokens` is monkey-patched to yield via `anyio.sleep(0)`. Without the lock, the test fails with `['msg1', 'msg2'] × 10` duplicates; with the lock, it passes.

### Does this PR introduce a breaking change?

`Compact.record_output` changed from `def record_output(self, output)` to `async def record_output(self, input, output)`. The `Compact` protocol is internal-facing — both call sites in `src/` (`agent/_bridge/util.py` and `agent/_react.py`) are updated in the same commit. Third-party customizations of the `Compact` protocol (uncommon — there is no documented public extension point for it) would need to update both the `async` declaration and the new `input` parameter.

### Other information:

- Trade-off note: `_lock` is held across `_perform_compaction` (LLM call) and `count_tokens` inside `compact_fn`. When one coroutine triggers compaction, others wait. This is intentional — it avoids duplicate compactions (race 3) and any latency cost is paid only when compaction actually triggers (rare). The narrower-lock alternative (read/release/work/re-acquire/commit) is meaningfully more complex and not required for correctness.