### PR TITLE
fix: correct stale input_tokens for gpt-5.4 / gpt-5.5 entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Inspect View: Add score comparator with NaN filtering and regex-escaped property matching (#167)
 - Inspect View: Improve grid sorting with NaN values and fix sample column sizing (#166)
 - Inspect View: Make live-streaming message/call pool processing idempotent by entry id to prevent duplicated messages in API request views (#168)
+- Model database: Fix incorrect `input_tokens` for `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, `gpt-5.5-pro` (was 778000, now 922000 = 1,050,000 context − 128,000 output).
 
 ## 0.3.215 (30 April 2026)
 

--- a/src/inspect_ai/model/_model_data/openai.yml
+++ b/src/inspect_ai/model/_model_data/openai.yml
@@ -336,7 +336,7 @@ openai:
       knowledge_cutoff_date: 2025-08-31
       context_length: 1050000
       output_tokens: 128000
-      input_tokens: 778000
+      input_tokens: 922000
       reasoning: True
       versions:
         gpt-5.4-2026-03-05:
@@ -347,7 +347,7 @@ openai:
       knowledge_cutoff_date: 2025-08-31
       context_length: 1050000
       output_tokens: 128000
-      input_tokens: 778000
+      input_tokens: 922000
       reasoning: True
       versions:
         gpt-5.4-pro-2026-03-05:
@@ -380,7 +380,7 @@ openai:
       knowledge_cutoff_date: 2025-12-01
       context_length: 1050000
       output_tokens: 128000
-      input_tokens: 778000
+      input_tokens: 922000
       reasoning: True
       versions:
         gpt-5.5-2026-04-23:
@@ -391,7 +391,7 @@ openai:
       knowledge_cutoff_date: 2025-12-01
       context_length: 1050000
       output_tokens: 128000
-      input_tokens: 778000
+      input_tokens: 922000
       reasoning: True
       versions:
         gpt-5.5-2026-04-23:


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

The `input_tokens` value for `gpt-5.4`, `gpt-5.4-pro`, `gpt-5.5`, and `gpt-5.5-pro` is set to 778000. This doesn't follow the usual pattern for OpenAI models (`input_tokens = context_length - output_tokens`, since OpenAI uses a shared context budget where `input + output <= context_length`). I might be missing a subtlety here, though, so please verify.

### What is the new behavior?

The four entries are corrected to `input_tokens: 922000`.

### Does this PR introduce a breaking change?

No user-facing breaking change. `ModelInfo.input_tokens` for these four models increases from 778,000 to 922,000, which delays compaction trigger slightly for users running these specific models.