### PR TITLE
fix: `SampleSummary` has the wrong `working_time` path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Added `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Compaction: Lock Compact handler against concurrent AgentBridge calls.
-- Analysis: Fix `samples_df()` `working_time` column reading from `total_time` JSON path instead of `working_time`.
+- Analysis: Fix wrong `working_time` path in `SampleSummary` columns.
 
 ## 0.3.216 (01 May 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Added `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Compaction: Lock Compact handler against concurrent AgentBridge calls.
+- Analysis: Fix `samples_df()` `working_time` column reading from `total_time` JSON path instead of `working_time`.
 
 ## 0.3.216 (01 May 2026)
 

--- a/src/inspect_ai/analysis/_dataframe/samples/columns.py
+++ b/src/inspect_ai/analysis/_dataframe/samples/columns.py
@@ -70,7 +70,7 @@ SampleSummary: list[Column] = [
     SampleColumn("model_usage", path="model_usage"),
     SampleColumn("total_tokens", path=sample_total_tokens),
     SampleColumn("total_time", path="total_time"),
-    SampleColumn("working_time", path="total_time"),
+    SampleColumn("working_time", path="working_time"),
     SampleColumn("message_count", path="message_count", default=None),
     SampleColumn("error", path="error", default=""),
     SampleColumn("limit", path="limit"),


### PR DESCRIPTION
`SampleSummary` has a typo where it loads the `working_time` column from the wrong path.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The `working_time` column is retrieving data from `total_time` instead of `working_time`.

### What is the new behavior?
It's reading from the right source.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes. The data is now different.

### Other information:
