### PR TITLE
Google: support Gemini 3 native tools alongside function tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Google: Support Gemini 3+ native web search and code execution alongside function tools.
 - Add `score_on_error` option to score samples that error rather than failing the task (errors are still counted toward the `fail_on_error` threshold).
 - Add `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Add `download()` and `gdrive_download()` helpers for fetching external files with SHA256 verification, caching, and transient-error retry. `gdrive_download()` requires the optional `gdown` dependency, installed via `pip install inspect_ai[gdown]`.

--- a/docs/tools-standard.qmd
+++ b/docs/tools-standard.qmd
@@ -80,8 +80,8 @@ For more details, see [Grounding with Google Search](https://ai.google.dev/gemin
 
 Note that when using the "gemini" provider, you should also specify a fallback external provider (like "tavily", "exa", or "google") if you are also running the evaluation with non-Gemini models.
 
-::: callout-warning
-Google's search grounding does not currently support use with other tools. Attempting to use `web_search("gemini")` alongside other tools will result in an error.
+::: callout-note
+Gemini 3 and later models can use `web_search("gemini")` alongside other tools. For Gemini 2.x models, Google's search grounding does not support use with other function tools, so Inspect will raise an error if you attempt to combine them. Use an external search provider such as "tavily", "exa", or "google" when you need web search alongside other tools on Gemini 2.x.
 :::
 
 ### Grok Options
@@ -463,6 +463,8 @@ def code_execution_task():
 ### Availability
 
 [OpenAI](https://platform.openai.com/docs/guides/tools-code-interpreter), [Anthropic](https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool), [Google](https://ai.google.dev/gemini-api/docs/code-execution), and [Grok](https://docs.x.ai/docs/guides/tools/code-execution-tool) models all have support for native server-side Python code execution. Note that Anthropic can additionally execute bash and text editor commands, but the primary execution language used is still Python.
+
+For Gemini models, `code_execution()` uses Google's native code execution tool when the Google provider is enabled. Gemini 3 and later models can use native code execution alongside other tools. For Gemini 2.x models, Google's native tools do not support use with other function tools, so Inspect will raise an error if you attempt to combine them; disable the Google native provider to use the `python()` fallback in that case.
 
 ::: callout-important
 Note that some providers bill separately for code execution, so you should consult their documentation for details before enabling this feature.

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -24,6 +24,7 @@ from google.genai.types import (
     ExecutableCode,
     File,
     FinishReason,
+    FunctionCall,
     FunctionCallingConfig,
     FunctionCallingConfigMode,
     FunctionDeclaration,
@@ -310,11 +311,12 @@ class GoogleGenAIAPI(ModelAPI):
             has_native_tools, gemini_tools = (
                 self.chat_tools(tools) if len(tools) > 0 else (False, None)
             )
-            gemini_tool_config = (
-                chat_tool_config(tool_choice)
-                if not has_native_tools and len(tools) > 0
-                else None
-            )
+            if gemini_native_tool_combination(gemini_tools):
+                gemini_tool_config = gemini_native_tool_combination_config(tool_choice)
+            elif not has_native_tools and len(tools) > 0:
+                gemini_tool_config = chat_tool_config(tool_choice)
+            else:
+                gemini_tool_config = None
             system_instruction = await extract_system_message_as_parts(
                 client, input, tools, include_function_calling_hint=not has_native_tools
             )
@@ -873,11 +875,23 @@ class GoogleGenAIAPI(ModelAPI):
             )
         )
 
-        # native search/code execution tools (cannot mix with function declarations)
+        # native search/code execution tools
         if google_search or code_execution:
             if function_declarations:
-                raise ValueError(
-                    "Gemini does not yet support native web search or code execution concurrently with other tools."
+                if not self.is_gemini_3_plus():
+                    raise ValueError(
+                        f"Combining native web search or code execution with custom function tools requires Gemini 3 or later. The model '{self.model_name}' does not support this combination."
+                    )
+                combined_native_tools: ToolListUnion = [
+                    Tool(function_declarations=function_declarations)
+                ]
+                if google_search:
+                    combined_native_tools.append(Tool(google_search=google_search))
+                if code_execution:
+                    combined_native_tools.append(Tool(code_execution=code_execution))
+                return (
+                    True,
+                    combined_native_tools,
                 )
             native_tools: ToolListUnion = []
             if google_search:
@@ -1044,6 +1058,42 @@ async def content(
         )
     elif isinstance(message, ChatMessageAssistant):
         content_parts: list[Part] = []
+        emitted_tool_call_ids: set[str] = set()
+        server_tool_signature: bytes | None = None
+
+        def part_from_tool_call(tool_call: ToolCall) -> Part:
+            if tool_call.function == "computer":
+                action_name = (
+                    tool_call.id.rsplit("_", 1)[0] if tool_call.id else "computer"
+                )
+                _, action_args = gemini_action_from_tool_call(tool_call)
+                return Part(
+                    function_call=FunctionCall(
+                        id=tool_call.id,
+                        name=action_name,
+                        args=action_args,
+                    )
+                )
+            else:
+                return Part(
+                    function_call=FunctionCall(
+                        id=tool_call.id,
+                        name=tool_call.function,
+                        args=tool_call.arguments,
+                    )
+                )
+
+        def apply_reasoning_signature(
+            part: Part, reasoning_block: ContentReasoning
+        ) -> None:
+            if reasoning_block.reasoning is not None and reasoning_block.redacted:
+                part.thought_signature = base64.b64decode(
+                    reasoning_block.reasoning.encode()
+                )
+            else:
+                logger.warning(
+                    "Reasoning block must have a reasoning signature to set thought_signature."
+                )
 
         if isinstance(message.content, str):
             content_parts.append(Part(text=message.content or NO_CONTENT))
@@ -1056,6 +1106,30 @@ async def content(
                         # if this is encrypted reasoning, save it for applying the thought_signature
                         # to the next part (don't emit a separate thought part during replay)
                         if content.redacted:
+                            function_call_id = (
+                                content.internal.get("gemini_function_call_id")
+                                if isinstance(content.internal, dict)
+                                else None
+                            )
+                            if (
+                                isinstance(function_call_id, str)
+                                and message.tool_calls is not None
+                            ):
+                                tool_call = next(
+                                    (
+                                        tool_call
+                                        for tool_call in message.tool_calls
+                                        if tool_call.id == function_call_id
+                                    ),
+                                    None,
+                                )
+                                if tool_call is not None:
+                                    part = part_from_tool_call(tool_call)
+                                    apply_reasoning_signature(part, content)
+                                    content_parts.append(part)
+                                    emitted_tool_call_ids.add(tool_call.id)
+                                    working_reasoning_block = None
+                                    continue
                             working_reasoning_block = content
                         else:
                             # unencrypted reasoning (for older models or debugging)
@@ -1067,10 +1141,25 @@ async def content(
                     # server side tool use
                     if isinstance(content, ContentToolUse):
                         parts_to_append = parts_from_server_tool_use(content)
+                        if (
+                            message.tool_calls is not None
+                            and server_tool_signature is None
+                        ):
+                            server_tool_signature = next(
+                                (
+                                    part.thought_signature
+                                    for part in parts_to_append
+                                    if part.thought_signature is not None
+                                ),
+                                None,
+                            )
 
                     # other content
                     else:
                         parts_to_append = [await content_part(client, content)]
+
+                    if not parts_to_append:
+                        continue
 
                     # If previously there was a reasoning block, we need to set the "thought_signature"
                     # using the reasoning from that block.
@@ -1105,36 +1194,24 @@ async def content(
             # The loop below applies the signature to the first tool call (when working_reasoning_block
             # is not None), then clears it so subsequent tool calls don't get it.
             for tool_call in message.tool_calls:
-                if tool_call.function == "computer":
-                    action_name = (
-                        tool_call.id.rsplit("_", 1)[0] if tool_call.id else "computer"
-                    )
-                    _, action_args = gemini_action_from_tool_call(tool_call)
-                    part = Part.from_function_call(
-                        name=action_name,
-                        args=action_args,
-                    )
-                else:
-                    part = Part.from_function_call(
-                        name=tool_call.function,
-                        args=tool_call.arguments,
-                    )
+                if tool_call.id in emitted_tool_call_ids:
+                    continue
+
+                part = part_from_tool_call(tool_call)
 
                 # handle reasoning block if available
                 if working_reasoning_block is not None:
                     # tool call reasoning should always use a thought_signature
-                    if (
-                        working_reasoning_block.reasoning is not None
-                        and working_reasoning_block.redacted
-                    ):
-                        part.thought_signature = base64.b64decode(
-                            working_reasoning_block.reasoning.encode()
-                        )
-                    else:
-                        logger.warning(
-                            "Reasoning block must have a reasoning signature to set thought_signature."
-                        )
+                    apply_reasoning_signature(part, working_reasoning_block)
                     working_reasoning_block = None
+                elif server_tool_signature is not None:
+                    # Gemini can omit a signature on a client function_call when
+                    # the same step also includes signed server-side tool calls.
+                    # On replay, Gemini still validates the client function_call,
+                    # so use the step's server-side signature for the first
+                    # unsigned client function_call.
+                    part.thought_signature = server_tool_signature
+                    server_tool_signature = None
 
                 content_parts.append(part)
         return Content(role="model", parts=content_parts)
@@ -1160,6 +1237,7 @@ async def content(
             response_name = message.function or ""
             fn_response_parts = None
         response = FunctionResponse(
+            id=message.tool_call_id,
             name=response_name,
             response=response_dict,
             parts=fn_response_parts,
@@ -1275,6 +1353,44 @@ def chat_tool_config(tool_choice: ToolChoice) -> ToolConfig:
         )
 
 
+def gemini_native_tool_combination(tools: ToolListUnion | None) -> bool:
+    """Check whether Gemini tools combine function declarations and native tools."""
+    if tools is None:
+        return False
+    has_function_declarations = any(
+        isinstance(tool, Tool) and bool(tool.function_declarations) for tool in tools
+    )
+    has_builtin_tool = any(
+        isinstance(tool, Tool)
+        and (tool.google_search is not None or tool.code_execution is not None)
+        for tool in tools
+    )
+    return has_function_declarations and has_builtin_tool
+
+
+def gemini_native_tool_combination_config(tool_choice: ToolChoice) -> ToolConfig:
+    """Build ToolConfig for Gemini 3 native tools plus function declarations."""
+    if isinstance(tool_choice, ToolFunction):
+        function_calling_config = FunctionCallingConfig(
+            mode=FunctionCallingConfigMode.ANY,
+            allowed_function_names=[tool_choice.name],
+        )
+    else:
+        # Gemini 3 requires VALIDATED rather than AUTO when a request combines
+        # native server-side tools with custom function declarations.
+        function_calling_config = FunctionCallingConfig(
+            mode=(
+                FunctionCallingConfigMode.VALIDATED
+                if tool_choice == "auto"
+                else cast(FunctionCallingConfigMode, tool_choice.upper())
+            )
+        )
+    return ToolConfig(
+        include_server_side_tool_invocations=True,
+        function_calling_config=function_calling_config,
+    )
+
+
 def _consolidate_thought_signature(
     signature: bytes,
     working_reasoning_block: ContentReasoning | None,
@@ -1326,6 +1442,7 @@ def completion_choice_from_candidate(
     # content parts -- we need to consolidate this into a single ContentReasoning
     # to match our schema (we'll unroll it back into parts on replay)
     working_reasoning_block: ContentReasoning | None = None
+    function_call_ids: dict[int, str] = {}
 
     # content can be None when the finish_reason is SAFETY
     # content.parts can be None when the finish_reason is MALFORMED_FUNCTION_CALL
@@ -1333,6 +1450,42 @@ def completion_choice_from_candidate(
         # traverse parts
         parts = candidate.content.parts
         for i, part in enumerate(parts):
+            if part.tool_response is not None:
+                continue  # We pickup tool responses with part.tool_call
+
+            if part.function_call is not None:
+                if part.thought_signature is not None and part.function_call.name:
+                    function_call_id = part.function_call.id or (
+                        f"{part.function_call.name}_{uuid()}"
+                    )
+                    function_call_ids[i] = function_call_id
+                    content.append(
+                        ContentReasoning(
+                            reasoning=base64.b64encode(part.thought_signature).decode(),
+                            redacted=True,
+                            internal={"gemini_function_call_id": function_call_id},
+                        )
+                    )
+                    working_reasoning_block = None
+                continue
+
+            if part.tool_call is not None:
+                tool_response_part = next(
+                    (
+                        candidate_part
+                        for candidate_part in parts[i + 1 :]
+                        if candidate_part.tool_response is not None
+                        and candidate_part.tool_response.id == part.tool_call.id
+                    ),
+                    None,
+                )
+                server_tool_use = server_tool_use_from_tool_call(
+                    part, tool_response_part
+                )
+                if server_tool_use is not None:
+                    content.append(server_tool_use)
+                continue
+
             if part.text is None and part.executable_code is None:
                 # Handle inline_data parts (images, audio)
                 if part.inline_data is not None:
@@ -1415,7 +1568,7 @@ def completion_choice_from_candidate(
     # now tool calls
     tool_calls: list[ToolCall] = []
     if candidate.content is not None and candidate.content.parts is not None:
-        for part in candidate.content.parts:
+        for i, part in enumerate(candidate.content.parts):
             if part.function_call:
                 if (
                     part.function_call is None
@@ -1425,16 +1578,22 @@ def completion_choice_from_candidate(
                     raise ValueError(f"Incomplete function call: {part.function_call}")
 
                 # If the part has a thought_signature, try and associate it with the previous working block
-                if part.thought_signature:
+                if part.thought_signature and i not in function_call_ids:
+                    function_call_reasoning = ContentReasoning(
+                        reasoning=base64.b64encode(part.thought_signature).decode(),
+                        redacted=True,
+                    )
                     if working_reasoning_block is None:
                         # We make the assumption that tool calls don't have independent reasoning
                         # blocks unless they are preceded by a reasoning block.
-                        reasoning_block = ContentReasoning(
-                            reasoning=base64.b64encode(part.thought_signature).decode(),
-                            redacted=True,
-                        )
-
-                        content.append(reasoning_block)
+                        content.append(function_call_reasoning)
+                    elif not working_reasoning_block.redacted:
+                        # Preserve visible thought text as a thought part on replay.
+                        # The function_call signature still needs to be returned
+                        # with the function_call part itself, so store it as a
+                        # separate redacted reasoning carrier.
+                        content.append(function_call_reasoning)
+                        working_reasoning_block = None
                     else:
                         # attach the thought_signature to the previous reasoning block
                         working_reasoning_block.summary = (
@@ -1467,9 +1626,12 @@ def completion_choice_from_candidate(
                 else:
                     if part.function_call.args:
                         part.function_call.args.pop("safety_decision", None)
+                    function_call_id = function_call_ids.get(i) or (
+                        part.function_call.id or f"{part.function_call.name}_{uuid()}"
+                    )
                     tool_calls.append(
                         ToolCall(
-                            id=f"{part.function_call.name}_{uuid()}",
+                            id=function_call_id,
                             function=part.function_call.name,
                             arguments=part.function_call.args,
                         )
@@ -1630,18 +1792,74 @@ def server_tool_use_from_executable_code(
     )
 
 
+def server_tool_use_from_tool_call(
+    tool_call_part: Part, tool_response_part: Part | None
+) -> ContentToolUse | None:
+    """Convert a Gemini server-side tool call into Inspect content."""
+    assert tool_call_part.tool_call is not None
+    tool_call = tool_call_part.tool_call
+    tool_response = (
+        tool_response_part.tool_response if tool_response_part is not None else None
+    )
+    internal_parts = [
+        tool_call_part.model_dump(exclude_none=True, by_alias=True, mode="json")
+    ]
+    if tool_response_part is not None:
+        internal_parts.append(
+            tool_response_part.model_dump(exclude_none=True, by_alias=True, mode="json")
+        )
+    tool_type = str(tool_call.tool_type or "")
+    if "SEARCH" not in tool_type:
+        warn_once(
+            logger,
+            f"Skipping unsupported Google server-side tool call type: {tool_type}.",
+        )
+        return None
+    return ContentToolUse(
+        tool_type="web_search",
+        id=tool_call.id or "",
+        name=tool_type,
+        arguments=json.dumps(tool_call.args or {}),
+        result=json.dumps(tool_response.response if tool_response else {}),
+        internal={"gemini_parts": cast(JsonValue, internal_parts)},
+    )
+
+
 def parts_from_server_tool_use(tool: ContentToolUse) -> list[Part]:
-    parts: list[Part] = [
+    """Reconstruct Gemini request parts from server-side tool use."""
+    if tool.tool_type == "web_search":
+        if (
+            isinstance(tool.internal, dict)
+            and (gemini_parts := tool.internal.get("gemini_parts")) is not None
+            and isinstance(gemini_parts, list)
+        ):
+            gemini_request_parts = [Part.model_validate(part) for part in gemini_parts]
+            missing_signature = any(
+                part.tool_call is not None and part.thought_signature is None
+                for part in gemini_request_parts
+            )
+            if not missing_signature:
+                return gemini_request_parts
+            warn_once(
+                logger,
+                "Skipping Gemini server-side web search replay because the saved tool call is missing a thought_signature.",
+            )
+        return []
+
+    if tool.tool_type != "code_execution":
+        return []
+
+    code_execution_parts: list[Part] = [
         Part.from_executable_code(code=tool.arguments, language=Language(tool.name))
     ]
     if tool.result or tool.error:
-        parts.append(
+        code_execution_parts.append(
             Part.from_code_execution_result(
                 outcome=Outcome(tool.error) if tool.error else Outcome.OUTCOME_OK,
                 output=tool.result,
             )
         )
-    return parts
+    return code_execution_parts
 
 
 def finish_reason_to_stop_reason(finish_reason: FinishReason) -> StopReason:

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import os
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -13,7 +14,17 @@ from google.genai.types import (
     FunctionCallingConfigMode,
     GenerateContentResponse,
     JobState,
+    Language,
+    Outcome,
     Part,
+    ToolResponse,
+    ToolType,
+)
+from google.genai.types import (
+    Tool as GeminiTool,
+)
+from google.genai.types import (
+    ToolCall as GeminiToolCall,
 )
 from test_helpers.utils import skip_if_no_google
 
@@ -26,9 +37,11 @@ from inspect_ai._util.content import (
     ContentImage,
     ContentReasoning,
     ContentText,
+    ContentToolUse,
 )
+from inspect_ai.agent import react
 from inspect_ai.dataset import Sample
-from inspect_ai.model import ChatMessageAssistant, ChatMessageTool
+from inspect_ai.model import ChatMessageAssistant, ChatMessageTool, ModelOutput
 from inspect_ai.model._chat_message import ChatMessageUser
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._providers._google_citations import (
@@ -40,10 +53,22 @@ from inspect_ai.model._providers.google import (
     _malformed_function_retry,
     completion_choice_from_candidate,
     content,
+    gemini_native_tool_combination,
+    gemini_native_tool_combination_config,
+    parts_from_server_tool_use,
 )
 from inspect_ai.scorer import includes
 from inspect_ai.solver import use_tools
-from inspect_ai.tool import ToolCall, ToolInfo, ToolParam, ToolParams, tool
+from inspect_ai.tool import (
+    Tool,
+    ToolCall,
+    ToolFunction,
+    ToolInfo,
+    ToolParam,
+    ToolParams,
+    tool,
+    web_search,
+)
 
 
 @skip_if_no_google
@@ -627,6 +652,575 @@ def _create_test_tool() -> ToolInfo:
             required=["x"],
         ),
     )
+
+
+def _create_gemini_web_search_tool() -> ToolInfo:
+    """Create a Gemini-native web search tool for testing."""
+    return ToolInfo(
+        name="web_search",
+        description="Search the web",
+        options={"gemini": {}},
+    )
+
+
+def _create_google_code_execution_tool() -> ToolInfo:
+    """Create a Google-native code execution tool for testing."""
+    return ToolInfo(
+        name="code_execution",
+        description="Execute Python code",
+        options={"providers": {"google": {}}},
+    )
+
+
+def _create_record_result_tool() -> ToolInfo:
+    """Create a string-valued custom tool for live mixed-tool tests."""
+    return ToolInfo(
+        name="record_result",
+        description="Record an answer",
+        parameters=ToolParams(
+            type="object",
+            properties={
+                "answer": ToolParam(type="string", description="Answer summary")
+            },
+            required=["answer"],
+        ),
+    )
+
+
+def _create_days_in_year_tool() -> ToolInfo:
+    """Create a days-in-year custom tool for mixed native/custom replay tests."""
+    return ToolInfo(
+        name="days_in_year",
+        description="Return the number of days in a year.",
+        parameters=ToolParams(
+            type="object",
+            properties={
+                "year": ToolParam(type="integer", description="The year to check.")
+            },
+            required=["year"],
+        ),
+    )
+
+
+def _days_in_year_tool() -> Tool:
+    @tool
+    def days_in_year() -> Tool:
+        async def execute(year: int) -> str:
+            """Return the number of days in a year.
+
+            Args:
+                year: The year to check.
+            """
+            leap = (year % 4 == 0 and year % 100 != 0) or (year % 400 == 0)
+            return f"{year} has {366 if leap else 365} days."
+
+        return execute
+
+    return days_in_year()
+
+
+def test_gemini_3_native_search_can_combine_with_function_declarations() -> None:
+    api = GoogleGenAIAPI(
+        model_name="gemini-3.1-pro-preview",
+        base_url=None,
+        api_key="test-key",
+    )
+
+    has_native_tools, gemini_tools = api.chat_tools(
+        [_create_gemini_web_search_tool(), _create_test_tool()]
+    )
+
+    assert has_native_tools is True
+    assert gemini_native_tool_combination(gemini_tools)
+    assert len(gemini_tools) == 2
+    assert isinstance(gemini_tools[0], GeminiTool)
+    assert isinstance(gemini_tools[1], GeminiTool)
+    assert gemini_tools[0].function_declarations is not None
+    assert gemini_tools[0].function_declarations[0].name == "my_tool"
+    assert gemini_tools[1].google_search is not None
+
+
+def test_gemini_3_native_code_execution_can_combine_with_functions() -> None:
+    api = GoogleGenAIAPI(
+        model_name="gemini-3.1-pro-preview",
+        base_url=None,
+        api_key="test-key",
+    )
+
+    has_native_tools, gemini_tools = api.chat_tools(
+        [_create_google_code_execution_tool(), _create_test_tool()]
+    )
+
+    assert has_native_tools is True
+    assert gemini_native_tool_combination(gemini_tools)
+    assert len(gemini_tools) == 2
+    assert isinstance(gemini_tools[0], GeminiTool)
+    assert isinstance(gemini_tools[1], GeminiTool)
+    assert gemini_tools[0].function_declarations is not None
+    assert gemini_tools[0].function_declarations[0].name == "my_tool"
+    assert gemini_tools[1].code_execution is not None
+
+
+def test_gemini_2_5_native_search_still_rejects_function_declarations() -> None:
+    api = GoogleGenAIAPI(
+        model_name="gemini-2.5-pro",
+        base_url=None,
+        api_key="test-key",
+    )
+
+    with pytest.raises(ValueError, match="requires Gemini 3 or later"):
+        api.chat_tools([_create_gemini_web_search_tool(), _create_test_tool()])
+
+
+def test_gemini_2_5_native_code_execution_still_rejects_function_declarations() -> None:
+    api = GoogleGenAIAPI(
+        model_name="gemini-2.5-pro",
+        base_url=None,
+        api_key="test-key",
+    )
+
+    with pytest.raises(ValueError, match="code execution"):
+        api.chat_tools([_create_google_code_execution_tool(), _create_test_tool()])
+
+
+def test_gemini_native_tool_combination_config_respects_tool_choice() -> None:
+    auto_config = gemini_native_tool_combination_config("auto")
+    assert auto_config.function_calling_config is not None
+    assert (
+        auto_config.function_calling_config.mode == FunctionCallingConfigMode.VALIDATED
+    )
+
+    any_config = gemini_native_tool_combination_config("any")
+    assert any_config.function_calling_config is not None
+    assert any_config.function_calling_config.mode == FunctionCallingConfigMode.ANY
+
+    none_config = gemini_native_tool_combination_config("none")
+    assert none_config.function_calling_config is not None
+    assert none_config.function_calling_config.mode == FunctionCallingConfigMode.NONE
+
+    function_config = gemini_native_tool_combination_config(
+        ToolFunction(name="my_tool")
+    )
+    assert function_config.function_calling_config is not None
+    assert function_config.function_calling_config.mode == FunctionCallingConfigMode.ANY
+    assert function_config.function_calling_config.allowed_function_names == ["my_tool"]
+
+
+@pytest.mark.anyio
+async def test_gemini_3_tool_combination_uses_server_side_tool_invocations() -> None:
+    mock_generate = AsyncMock(
+        return_value=GenerateContentResponse(
+            candidates=[
+                Candidate(
+                    finish_reason=FinishReason.STOP,
+                    content=Content(role="model", parts=[Part(text="done")]),
+                )
+            ],
+            usage_metadata=None,
+        )
+    )
+    mock_client = _create_mock_google_client(mock_generate)
+
+    with patch("inspect_ai.model._providers.google.Client", return_value=mock_client):
+        api = GoogleGenAIAPI(
+            model_name="gemini-3.1-pro-preview",
+            base_url=None,
+            api_key="test-key",
+        )
+
+        await api.generate(
+            input=[ChatMessageUser(content="Search and call my_tool")],
+            tools=[_create_gemini_web_search_tool(), _create_test_tool()],
+            tool_choice="auto",
+            config=GenerateConfig(),
+        )
+
+    config = mock_generate.call_args.kwargs["config"]
+    assert config.tool_config == gemini_native_tool_combination_config("auto")
+    assert config.tool_config.include_server_side_tool_invocations is True
+    assert config.tool_config.function_calling_config.mode == (
+        FunctionCallingConfigMode.VALIDATED
+    )
+
+
+@pytest.mark.anyio
+async def test_gemini_3_code_exec_combo_uses_server_invocations() -> None:
+    mock_generate = AsyncMock(
+        return_value=GenerateContentResponse(
+            candidates=[
+                Candidate(
+                    finish_reason=FinishReason.STOP,
+                    content=Content(role="model", parts=[Part(text="done")]),
+                )
+            ],
+            usage_metadata=None,
+        )
+    )
+    mock_client = _create_mock_google_client(mock_generate)
+
+    with patch("inspect_ai.model._providers.google.Client", return_value=mock_client):
+        api = GoogleGenAIAPI(
+            model_name="gemini-3.1-pro-preview",
+            base_url=None,
+            api_key="test-key",
+        )
+
+        await api.generate(
+            input=[ChatMessageUser(content="Run code and call my_tool")],
+            tools=[_create_google_code_execution_tool(), _create_test_tool()],
+            tool_choice="auto",
+            config=GenerateConfig(),
+        )
+
+    config = mock_generate.call_args.kwargs["config"]
+    assert config.tool_config == gemini_native_tool_combination_config("auto")
+    assert config.tool_config.include_server_side_tool_invocations is True
+    assert config.tools is not None
+    assert isinstance(config.tools[0], GeminiTool)
+    assert isinstance(config.tools[1], GeminiTool)
+    assert config.tools[0].function_declarations is not None
+    assert config.tools[0].function_declarations[0].name == "my_tool"
+    assert config.tools[1].code_execution is not None
+
+
+def test_gemini_server_tool_call_round_trips_for_replay() -> None:
+    candidate = Candidate(
+        finish_reason=FinishReason.STOP,
+        content=Content(
+            role="model",
+            parts=[
+                Part(
+                    thought_signature=b"search-context",
+                    tool_call=GeminiToolCall(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        args={"queries": ["current Gemini API tool combination docs"]},
+                    ),
+                ),
+                Part(
+                    thought_signature=b"search-context-response",
+                    tool_response=ToolResponse(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        response={"search_suggestions": ["Gemini tool combination"]},
+                    ),
+                ),
+            ],
+        ),
+    )
+
+    choice = completion_choice_from_candidate("gemini-3.1-pro-preview", candidate)
+
+    assert isinstance(choice.message.content, list)
+    assert isinstance(choice.message.content[0], ContentToolUse)
+    tool_use = choice.message.content[0]
+    replayed_parts = parts_from_server_tool_use(tool_use)
+    assert replayed_parts[0].tool_call is not None
+    assert replayed_parts[0].tool_call.id == "search-1"
+    assert replayed_parts[0].thought_signature == b"search-context"
+    assert replayed_parts[1].tool_response is not None
+    assert replayed_parts[1].tool_response.id == "search-1"
+    assert replayed_parts[1].thought_signature == b"search-context-response"
+
+
+def test_gemini_server_tool_call_without_signature_is_omitted_for_replay() -> None:
+    candidate = Candidate(
+        finish_reason=FinishReason.STOP,
+        content=Content(
+            role="model",
+            parts=[
+                Part(
+                    tool_call=GeminiToolCall(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        args={"queries": ["current Gemini API tool combination docs"]},
+                    ),
+                ),
+                Part(
+                    tool_response=ToolResponse(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        response={"search_suggestions": ["Gemini tool combination"]},
+                    ),
+                ),
+            ],
+        ),
+    )
+
+    choice = completion_choice_from_candidate("gemini-3.1-pro-preview", candidate)
+
+    assert isinstance(choice.message.content, list)
+    assert isinstance(choice.message.content[0], ContentToolUse)
+    tool_use = choice.message.content[0]
+    assert parts_from_server_tool_use(tool_use) == []
+
+
+@pytest.mark.anyio
+async def test_gemini_signed_function_call_replays_before_server_tool() -> None:
+    candidate = Candidate(
+        finish_reason=FinishReason.STOP,
+        content=Content(
+            role="model",
+            parts=[
+                Part(text="Plan", thought=True),
+                Part(
+                    thought_signature=b"days-signature",
+                    function_call=FunctionCall(
+                        id="days-1",
+                        name="days_in_year",
+                        args={"year": 2024},
+                    ),
+                ),
+                Part(
+                    thought_signature=b"search-signature",
+                    tool_call=GeminiToolCall(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        args={"queries": ["most populous country"]},
+                    ),
+                ),
+                Part(
+                    thought_signature=b"search-response-signature",
+                    tool_response=ToolResponse(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        response={"search_suggestions": ["India population"]},
+                    ),
+                ),
+            ],
+        ),
+    )
+
+    choice = completion_choice_from_candidate("gemini-3.1-pro-preview", candidate)
+    google_content = await content(MagicMock(), choice.message, emulate_reasoning=False)
+
+    assert google_content.parts is not None
+    assert google_content.parts[0].text == "Plan"
+    assert google_content.parts[0].thought is True
+    assert google_content.parts[1].function_call is not None
+    assert google_content.parts[1].function_call.id == "days-1"
+    assert google_content.parts[1].thought_signature == b"days-signature"
+    assert google_content.parts[2].tool_call is not None
+    assert google_content.parts[2].tool_call.id == "search-1"
+    assert google_content.parts[2].thought_signature == b"search-signature"
+    assert google_content.parts[3].tool_response is not None
+    assert google_content.parts[3].tool_response.id == "search-1"
+
+
+@pytest.mark.anyio
+async def test_gemini_unsigned_function_call_uses_server_tool_signature() -> None:
+    candidate = Candidate(
+        finish_reason=FinishReason.STOP,
+        content=Content(
+            role="model",
+            parts=[
+                Part(text="Plan", thought=True),
+                Part(
+                    thought_signature=b"search-signature",
+                    tool_call=GeminiToolCall(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        args={"queries": ["most populous country"]},
+                    ),
+                ),
+                Part(
+                    thought_signature=b"search-response-signature",
+                    tool_response=ToolResponse(
+                        id="search-1",
+                        tool_type=ToolType.GOOGLE_SEARCH_WEB,
+                        response={"search_suggestions": ["India population"]},
+                    ),
+                ),
+                Part(
+                    function_call=FunctionCall(
+                        id="days-1",
+                        name="days_in_year",
+                        args={"year": 2024},
+                    ),
+                ),
+            ],
+        ),
+    )
+
+    choice = completion_choice_from_candidate("gemini-3.1-pro-preview", candidate)
+    google_content = await content(MagicMock(), choice.message, emulate_reasoning=False)
+
+    assert google_content.parts is not None
+    assert google_content.parts[0].text == "Plan"
+    assert google_content.parts[1].tool_call is not None
+    assert google_content.parts[1].thought_signature == b"search-signature"
+    assert google_content.parts[2].tool_response is not None
+    assert google_content.parts[3].function_call is not None
+    assert google_content.parts[3].function_call.id == "days-1"
+    assert google_content.parts[3].thought_signature == b"search-signature"
+
+
+def test_gemini_unsupported_server_tool_call_is_omitted() -> None:
+    candidate = Candidate(
+        finish_reason=FinishReason.STOP,
+        content=Content(
+            role="model",
+            parts=[
+                Part(
+                    thought_signature=b"url-context",
+                    tool_call=GeminiToolCall(
+                        id="url-context-1",
+                        tool_type=ToolType.URL_CONTEXT,
+                        args={"urls": ["https://example.com"]},
+                    ),
+                ),
+            ],
+        ),
+    )
+
+    choice = completion_choice_from_candidate("gemini-3.1-pro-preview", candidate)
+
+    assert choice.message.content == ""
+
+
+def test_gemini_code_execution_round_trips_for_replay() -> None:
+    candidate = Candidate(
+        finish_reason=FinishReason.STOP,
+        content=Content(
+            role="model",
+            parts=[
+                Part.from_executable_code(
+                    code="print(6 * 7)",
+                    language=Language.PYTHON,
+                ),
+                Part.from_code_execution_result(
+                    outcome=Outcome.OUTCOME_OK,
+                    output="42\n",
+                ),
+            ],
+        ),
+    )
+
+    choice = completion_choice_from_candidate("gemini-3.1-pro-preview", candidate)
+
+    assert isinstance(choice.message.content, list)
+    assert isinstance(choice.message.content[0], ContentToolUse)
+    tool_use = choice.message.content[0]
+    assert tool_use.tool_type == "code_execution"
+    assert tool_use.name == Language.PYTHON
+    assert tool_use.arguments == "print(6 * 7)"
+    assert tool_use.result == "42\n"
+
+    replayed_parts = parts_from_server_tool_use(tool_use)
+    assert replayed_parts[0].executable_code is not None
+    assert replayed_parts[0].executable_code.language == Language.PYTHON
+    assert replayed_parts[0].executable_code.code == "print(6 * 7)"
+    assert replayed_parts[1].code_execution_result is not None
+    assert replayed_parts[1].code_execution_result.outcome == Outcome.OUTCOME_OK
+    assert replayed_parts[1].code_execution_result.output == "42\n"
+
+
+@pytest.mark.anyio
+async def test_gemini_function_response_preserves_tool_call_id() -> None:
+    message = ChatMessageTool(
+        content="42",
+        tool_call_id="call-123",
+        function="my_tool",
+    )
+
+    google_content = await content(MagicMock(), message, emulate_reasoning=False)
+
+    assert google_content.parts is not None
+    assert google_content.parts[0].function_response is not None
+    assert google_content.parts[0].function_response.id == "call-123"
+
+
+@pytest.mark.anyio
+async def test_gemini_function_call_preserves_tool_call_id() -> None:
+    message = ChatMessageAssistant(
+        content=[],
+        tool_calls=[
+            ToolCall(
+                id="call-123",
+                function="my_tool",
+                arguments={"x": 42},
+            )
+        ],
+    )
+
+    google_content = await content(MagicMock(), message, emulate_reasoning=False)
+
+    assert google_content.parts is not None
+    assert google_content.parts[0].function_call is not None
+    assert google_content.parts[0].function_call.id == "call-123"
+
+
+@pytest.mark.anyio
+@skip_if_no_google
+async def test_gemini_3_native_search_with_function_tool_replays() -> None:
+    api = GoogleGenAIAPI(
+        model_name="gemini-3.1-pro-preview",
+        base_url=None,
+        api_key=os.environ["GOOGLE_API_KEY"],
+    )
+    user = ChatMessageUser(
+        content=(
+            "Use days_in_year(2024) AND web search 'most populous country'. "
+            "Then a 1-line answer."
+        )
+    )
+
+    first_output, _ = await api.generate(
+        input=[user],
+        tools=[_create_gemini_web_search_tool(), _create_days_in_year_tool()],
+        tool_choice="auto",
+        config=GenerateConfig(max_tokens=2048),
+    )
+    assert isinstance(first_output, ModelOutput)
+    assistant = first_output.choices[0].message
+
+    assert isinstance(assistant.content, list)
+    assert any(isinstance(item, ContentToolUse) for item in assistant.content)
+    assert assistant.tool_calls is not None
+    assert len(assistant.tool_calls) > 0
+
+    tool_call = assistant.tool_calls[0]
+    tool_result = ChatMessageTool(
+        content="2024 has 366 days.",
+        tool_call_id=tool_call.id,
+        function=tool_call.function,
+    )
+
+    second_output, _ = await api.generate(
+        input=[user, assistant, tool_result],
+        tools=[_create_gemini_web_search_tool(), _create_days_in_year_tool()],
+        tool_choice="auto",
+        config=GenerateConfig(max_tokens=2048),
+    )
+    assert isinstance(second_output, ModelOutput)
+
+    assert second_output.choices[0].stop_reason == "stop"
+    assert second_output.choices[0].message.text is not None
+
+
+@skip_if_no_google
+def test_gemini_3_native_search_with_function_tool_react_loop() -> None:
+    result = eval(
+        Task(
+            dataset=[
+                Sample(
+                    input=(
+                        "Use days_in_year(2024) AND web search 'most populous "
+                        "country'. Then submit a one-line summary."
+                    )
+                )
+            ],
+            solver=react(tools=[web_search(providers="gemini"), _days_in_year_tool()]),
+        ),
+        model="google/gemini-3.1-pro-preview",
+        message_limit=10,
+        max_tokens=4096,
+        fail_on_error=False,
+    )[0]
+
+    assert result.status == "success"
+    assert result.samples
+    assert result.samples[0].output is not None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Calling `web_search("gemini")` (or native `code_execution()`) alongside any custom function tool raises a `ValueError`, even on Gemini 3+ which supports the combination. If a user routes around the error and forces the request through, the second turn fails with:

```text
400 INVALID_ARGUMENT. Function call is missing a thought_signature in functionCall parts.
... function call `google:search` , position 2.
```

The root cause is in the existing replay path. When Gemini's response interleaves a visible thought-text part with a function-call that carries its own `thought_signature`, `completion_choice_from_candidate` was overwriting the text-reasoning on the working `ContentReasoning` block with the encoded signature and demoting the text to `summary`. The text was then dropped on replay because `as_chat_messages` only emits redacted reasoning blocks as signature carriers, never as text. Without that thought-text part, Gemini's validator rejects the next turn.

This breaks `react()` agent loops that combine `web_search("gemini")` with custom function tools, which is the realistic case for users who want grounded retrieval alongside tool use.

### What is the new behavior?

Gemini 3+ requests can now combine native server-side tools (`web_search("gemini")` and `code_execution()`) with custom function declarations. Multi-turn replay preserves the original part ordering and signature placement that Gemini's validator requires, per the [Gemini thought-signature docs](https://ai.google.dev/gemini-api/docs/thought-signatures).

Specifically:

- **Provider config**: when a request mixes native tools with function declarations, the provider sets `include_server_side_tool_invocations=True` and `FunctionCallingConfigMode.VALIDATED` rather than `AUTO` on `ToolConfig`, as required by Gemini 3.
- **Capture**: signed function-call parts now create a dedicated `ContentReasoning(redacted=True, internal={"gemini_function_call_id": ...})` linked to the originating call, instead of overwriting the working `ContentReasoning` for a preceding visible-thought part.
- **Replay**: `ChatMessageAssistant` to Gemini `Content` emits the function-call at the position implied by the linked `ContentReasoning`, with the saved signature applied, preserving the original ordering rather than always trailing all function calls.
- **ID symmetry**: outbound `function_call` parts now carry `id`, matching the existing `function_response.id`, via `Part(function_call=FunctionCall(id=..., ...))` instead of `Part.from_function_call(...)`.
- **Defensive replay**: signed server-side tool calls are replayed as-is; a saved server `tool_call` missing a `thought_signature` is skipped with `warn_once` rather than producing a 400. Unsupported server tool types (`URL_CONTEXT`, `GOOGLE_MAPS`, `FILE_SEARCH`) warn-and-skip rather than raising.
- **Server-tool signature fallback**: if the model emits an unsigned client `function_call` in a step that also includes signed server tool calls, the first unsigned client `function_call` inherits the server-tool signature on replay.
- **Gemini 2.x**: behavior is unchanged: it still raises `ValueError`, now with a clearer message that includes the model name.

Docs in `docs/tools-standard.qmd` are updated to describe the new Gemini 3+ support and the Gemini 2.x fallback: use an external search provider such as `tavily`, `exa`, or `google`, or disable the Google native code-execution provider to fall back to `python()`.

This builds on:
- #2702 (Google: capture/playback of `thought_signature` in `ContentReasoning`)
- #2819 (Google: attach signature to the first function call, even with text)
- #3535 (Google: omit function-calling hint for native-only tools)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

- Gemini 2.x behavior is unchanged: the same `ValueError` is raised when combining native tools with function tools, with a more informative message that includes the model name.
- Existing Gemini 3+ flows that don't combine native + function tools are unchanged.
- No public API surface changes.

### Other information:

**Validation:**

Static checks:
- `ruff format --check src/inspect_ai/model/_providers/google.py tests/model/providers/test_google.py` - pass
- `ruff check src/inspect_ai/model/_providers/google.py tests/model/providers/test_google.py` - pass
- `mypy --follow-imports=silent src/inspect_ai/model/_providers/google.py tests/model/providers/test_google.py` - pass
- `pytest tests/model/providers/test_google.py -q` - 48 passed, 35 skipped
- `pytest tests/model/ -q` - 923 passed, 597 skipped

Live `--runapi` tests against `gemini-3.1-pro-preview` added in this PR:
- `test_gemini_3_native_search_with_function_tool_replays` - manual two-turn replay with native search + custom function tool
- `test_gemini_3_native_search_with_function_tool_react_loop` - end-to-end `react()` agent loop with the same tools

New structural unit tests:
- `test_gemini_signed_function_call_replays_before_server_tool` - signed function-call before server search retains original part ordering
- `test_gemini_unsigned_function_call_uses_server_tool_signature` - unsigned function-call inherits server-tool signature
- `test_gemini_server_tool_call_without_signature_is_omitted_for_replay` - defensive replay skip
- `test_gemini_unsupported_server_tool_call_is_omitted` - unsupported types are warned and skipped
- `test_gemini_function_call_preserves_tool_call_id` - outbound id symmetry
- Tests for `gemini_native_tool_combination` and `gemini_native_tool_combination_config` across `tool_choice` values: `auto`, `any`, `none`, and `ToolFunction`

Additional local validation against `gemini-3.1-pro-preview` covered scenarios not in the test file:
- `code_execution()` + custom function tool, parallel/AND prompt
- `web_search` + `code_execution` + custom function tool, three tools at once
- multiple custom functions alongside `web_search`
- multi-search across turns in a `react()` loop
- sequential, parallel/AND, and natural prompt phrasings
- Gemini 2.5 rejection path

**How the bug was found:** Initial unit-test coverage validated that server `tool_call` / `tool_response` parts round-tripped cleanly in isolation, but didn't exercise whether the next request succeeded against the live API. A two-turn live test with a parallel/AND prompt reproduced Gemini's `400 INVALID_ARGUMENT` consistently. Diffing the resulting Inspect-side `ContentReasoning` between a passing prompt phrasing and the failing one surfaced the visible-thought-text destruction described above; the structural fix in `completion_choice_from_candidate` and `as_chat_messages` addresses both the manual-replay and `react()` agent-loop cases.
