### PR TITLE
Add AnchorEvent and span_id_provider; simplify BranchEvent

### DIFF
--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -330,8 +330,6 @@ def render_info_event(event: InfoEvent) -> EventDisplay:
 
 def render_branch_event(event: BranchEvent) -> EventDisplay:
     branch: dict[str, JsonValue] = {}
-    if event.from_span is not None:
-        branch["from_span"] = event.from_span
     if event.from_anchor is not None:
         branch["from_anchor"] = event.from_anchor
     if event.metadata:

--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -332,8 +332,8 @@ def render_branch_event(event: BranchEvent) -> EventDisplay:
     branch: dict[str, JsonValue] = {}
     if event.from_span is not None:
         branch["from_span"] = event.from_span
-    if event.from_message is not None:
-        branch["from_message"] = event.from_message
+    if event.from_anchor is not None:
+        branch["from_anchor"] = event.from_anchor
     if event.metadata:
         branch["metadata"] = event.metadata
 

--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -330,7 +330,7 @@ def render_info_event(event: InfoEvent) -> EventDisplay:
 
 def render_branch_event(event: BranchEvent) -> EventDisplay:
     branch: dict[str, JsonValue] = {}
-    if event.from_anchor is not None:
+    if event.from_anchor:
         branch["from_anchor"] = event.from_anchor
     if event.metadata:
         branch["metadata"] = event.metadata

--- a/src/inspect_ai/_view/dist/assets/index.css
+++ b/src/inspect_ai/_view/dist/assets/index.css
@@ -17978,13 +17978,13 @@ button._segment_13qph_10._compact_13qph_31 i {
   margin-top: -0.1rem;
   margin-bottom: -0.1rem;
 }
-._gridWrapper_1ljdd_1 {
+._gridWrapper_gp0n4_1 {
   height: 100%;
   width: 100%;
   position: relative;
 }
 
-._gridContainer_1ljdd_7 {
+._gridContainer_gp0n4_7 {
   position: absolute;
   top: 0;
   left: 0;
@@ -17995,7 +17995,7 @@ button._segment_13qph_10._compact_13qph_31 i {
 /* Shared chrome — applied to all sample/log grids. Other ag-grids in the
  * app (e.g. the small score-summary table in title-view) intentionally opt
  * out by not adding this class. */
-._gridChrome_1ljdd_18 .ag-row {
+._gridChrome_gp0n4_18 .ag-row {
   cursor: pointer;
   border-bottom: 1px solid var(--bs-border-color);
   background-color: var(--bs-body-bg);
@@ -18007,38 +18007,42 @@ button._segment_13qph_10._compact_13qph_31 i {
 
 /* Match container so rows' min-width: 100% has the full viewport to
  * stretch into. Pinned containers are unaffected. */
-._gridChrome_1ljdd_18 .ag-center-cols-container {
+._gridChrome_gp0n4_18 .ag-center-cols-container {
   min-width: 100%;
 }
 
-._gridChrome_1ljdd_18 .ag-row.ag-row-selected {
+._gridChrome_gp0n4_18 .ag-row.ag-row-selected {
   box-shadow: inset 0 0 0 2px var(--bs-focus-ring-color);
 }
 
-._gridChrome_1ljdd_18 .ag-header-cell {
-  padding: 0;
+._gridChrome_gp0n4_18 .ag-header-cell {
+  /* Right gutter gives the active-filter icon (sibling of the header
+   * label inside `.ag-cell-label-container`) breathing room from the
+   * column boundary. Left padding is handled via the `::before` flex
+   * item below so it shrinks on narrow cells. */
+  padding: 0 4px 0 0;
 }
 
-._gridChrome_1ljdd_18 .ag-header-cell-label::before {
+._gridChrome_gp0n4_18 .ag-header-cell-label::before {
   content: "";
   flex: 0 1 var(--ag-cell-horizontal-padding);
 }
 
-._gridChrome_1ljdd_18 .ag-header-cell-text {
+._gridChrome_gp0n4_18 .ag-header-cell-text {
   font-size: var(--inspect-font-size-smallestest);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-weight: 400;
 }
 
-._gridChrome_1ljdd_18 .ag-sort-order {
+._gridChrome_gp0n4_18 .ag-sort-order {
   font-size: var(--inspect-font-size-smallestest);
   align-self: center;
   margin-right: -10px;
 }
 
 /* List mode — multi-line wrapping cells with vertical padding. */
-._listMode_1ljdd_61 .ag-cell {
+._listMode_gp0n4_65 .ag-cell {
   align-items: flex-start;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
@@ -18046,31 +18050,31 @@ button._segment_13qph_10._compact_13qph_31 i {
 }
 
 /* Grid mode — vertically centered cells; column renderers handle ellipsis. */
-._gridMode_1ljdd_69 .ag-cell {
+._gridMode_gp0n4_73 .ag-cell {
   align-items: center;
 }
 
 /* Cell helpers exposed for column renderers. */
-._cell_1ljdd_74 {
+._cell_gp0n4_78 {
   line-height: var(--bs-body-line-height);
 }
 
-._wrapAnywhere_1ljdd_78 {
+._wrapAnywhere_gp0n4_82 {
   overflow-wrap: break-word;
 }
 
-._noLeft_1ljdd_82 {
+._noLeft_gp0n4_86 {
   padding-left: 0;
 }
 
-._score_1ljdd_86 {
+._score_gp0n4_90 {
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-._centered_1ljdd_93 {
+._centered_gp0n4_97 {
   display: flex;
   justify-content: center;
 }
@@ -19146,7 +19150,7 @@ a._citationLink_1ggvf_9:hover {
 ._dropdownItemActive_djjmp_74 {
   font-weight: 600;
 }
-._swimlane_16dh6_1 {
+._swimlane_1itnu_1 {
   --swimlane-row-height: 18px;
   --swimlane-minimap-height: 24px;
   --swimlane-grid-columns: auto 1fr auto;
@@ -19162,7 +19166,7 @@ a._citationLink_1ggvf_9:hover {
 }
 
 /* Pinned section: minimap + parent row — always visible */
-._pinnedSection_16dh6_17 {
+._pinnedSection_1itnu_17 {
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: subgrid;
@@ -19170,7 +19174,7 @@ a._citationLink_1ggvf_9:hover {
 }
 
 /* Scrollable section: child rows */
-._scrollSection_16dh6_25 {
+._scrollSection_1itnu_25 {
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: subgrid;
@@ -19179,13 +19183,13 @@ a._citationLink_1ggvf_9:hover {
   overflow-y: auto;
 }
 
-._swimlane_16dh6_1:focus-visible {
+._swimlane_1itnu_1:focus-visible {
   box-shadow: inset 0 0 0 1px var(--vscode-focusBorder);
 }
 
 /* Collapsible rows — fade + slide animation */
 
-._collapsibleSection_16dh6_40 {
+._collapsibleSection_1itnu_40 {
   grid-column: 1 / -1;
   display: grid;
   grid-template-columns: subgrid;
@@ -19198,7 +19202,7 @@ a._citationLink_1ggvf_9:hover {
   opacity: 1;
 }
 
-._collapsibleCollapsed_16dh6_53 {
+._collapsibleCollapsed_1itnu_53 {
   grid-template-rows: 0fr;
   padding-bottom: 0;
   opacity: 0;
@@ -19208,11 +19212,11 @@ a._citationLink_1ggvf_9:hover {
    Note: avoid margin-top:-1px here — it causes the content to overflow
    the StickyScroll wrapper, inflating stickySwimLaneHeight by 1px and
    leaving a gap between the swimlane and the event card headers. */
-._swimlaneSticky_16dh6_63 {
+._swimlaneSticky_1itnu_63 {
   background-color: var(--bs-body-bg);
 }
 
-._collapsibleInner_16dh6_67 {
+._collapsibleInner_1itnu_67 {
   grid-column: 1 / -1;
   overflow: hidden;
   display: grid;
@@ -19222,7 +19226,7 @@ a._citationLink_1ggvf_9:hover {
 
 /* Collapse toggle — hangs below the bottom border, centered */
 
-._collapseToggle_16dh6_77 {
+._collapseToggle_1itnu_77 {
   position: absolute;
   bottom: 0;
   left: 50%;
@@ -19243,20 +19247,20 @@ a._citationLink_1ggvf_9:hover {
   line-height: 1;
 }
 
-._collapseToggle_16dh6_77:hover {
+._collapseToggle_1itnu_77:hover {
   color: var(--vscode-foreground);
   background-color: var(--bs-secondary-bg);
 }
 
 /* Row — display:contents so all rows share the parent grid columns */
 
-._row_16dh6_105 {
+._row_1itnu_105 {
   display: contents;
 }
 
 /* Label cell */
 
-._label_16dh6_111 {
+._label_1itnu_111 {
   padding: 0 0.5rem 0 1.45rem;
   white-space: nowrap;
   font-size: var(--inspect-font-size-smallest);
@@ -19270,23 +19274,23 @@ a._citationLink_1ggvf_9:hover {
   cursor: pointer;
 }
 
-._label_16dh6_111:hover {
+._label_1itnu_111:hover {
   color: var(--vscode-textLink-foreground);
 }
 
-._labelSelected_16dh6_129 {
+._labelSelected_1itnu_129 {
   color: var(--vscode-textLink-foreground);
 }
 
 /* Ancestor rows of the selected branch — subtler than selected */
-._labelHighlighted_16dh6_134 {
+._labelHighlighted_1itnu_134 {
   color: var(--vscode-textLink-foreground);
   opacity: 0.6;
 }
 
 /* Expand/collapse chevron in label */
 
-._chevron_16dh6_141 {
+._chevron_1itnu_141 {
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -19297,31 +19301,70 @@ a._citationLink_1ggvf_9:hover {
   font-size: 8px;
 }
 
-._chevron_16dh6_141:hover {
+._chevron_1itnu_141:hover {
   color: var(--vscode-foreground);
 }
 
-._chevronSpacer_16dh6_156 {
+._chevronSpacer_1itnu_156 {
   display: inline-block;
   width: 12px;
   flex-shrink: 0;
 }
 
+._punchDownBtn_1itnu_162 {
+  margin-left: auto;
+  padding: 0 4px;
+  display: inline-flex;
+  align-items: center;
+  border: none;
+  background: none;
+  font-size: 9px;
+  cursor: pointer;
+  color: var(--vscode-descriptionForeground, #717171);
+  opacity: 0;
+}
+
+._label_1itnu_111:hover ._punchDownBtn_1itnu_162,
+._labelSelected_1itnu_129 ._punchDownBtn_1itnu_162 {
+  opacity: 1;
+}
+
+._punchDownBtn_1itnu_162:hover {
+  color: var(--vscode-foreground);
+}
+
+._viewStackBack_1itnu_184 {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--bs-border-color);
+  border-radius: 3px;
+  background: transparent;
+  font-size: var(--inspect-font-size-smallest);
+  color: var(--vscode-foreground);
+  cursor: pointer;
+}
+
+._viewStackBack_1itnu_184:hover {
+  background: var(--vscode-list-hoverBackground, rgba(0, 0, 0, 0.05));
+}
+
 /* Bar area */
 
-._barArea_16dh6_164 {
+._barArea_1itnu_203 {
   height: var(--swimlane-row-height);
   border-left: 1px solid var(--bs-border-color);
   border-right: 1px solid var(--bs-border-color);
 }
 
-._barInner_16dh6_170 {
+._barInner_1itnu_209 {
   position: relative;
   height: 100%;
   margin: 0 4px;
 }
 
-._fill_16dh6_176 {
+._fill_1itnu_215 {
   position: absolute;
   top: 1px;
   bottom: 1px;
@@ -19335,15 +19378,15 @@ a._citationLink_1ggvf_9:hover {
   cursor: pointer;
 }
 
-._fill_16dh6_176:hover {
+._fill_1itnu_215:hover {
   opacity: 0.5;
 }
 
-._fillParent_16dh6_194 {
+._fillParent_1itnu_233 {
   opacity: 0.2;
 }
 
-._fillSelected_16dh6_198 {
+._fillSelected_1itnu_237 {
   opacity: 0.7;
   box-shadow: inset 0 0 0 1px var(--bs-primary);
 }
@@ -19351,7 +19394,7 @@ a._citationLink_1ggvf_9:hover {
 /* Partial highlight overlay — sibling of .fill in barInner.
    Shows the "active" portion of a bar (e.g. parent bar up to fork point
    when a branch is selected). Independent opacity, not stacked with .fill. */
-._fillHighlight_16dh6_206 {
+._fillHighlight_1itnu_245 {
   position: absolute;
   top: 1px;
   bottom: 1px;
@@ -19362,14 +19405,14 @@ a._citationLink_1ggvf_9:hover {
 }
 
 /* Row is selected but a different span within the row is focused */
-._fillDimmed_16dh6_217 {
+._fillDimmed_1itnu_256 {
   opacity: 0.15;
 }
 
 /* Region segment — same as .fill but without :hover (hover is managed via JS).
    Does NOT set opacity here — opacity comes from .fill-style state classes
    (.fillParent, .fillSelected, .fillDimmed) or from .regionHover/.regionDefault. */
-._regionSegment_16dh6_224 {
+._regionSegment_1itnu_263 {
   position: absolute;
   top: 1px;
   bottom: 1px;
@@ -19379,36 +19422,36 @@ a._citationLink_1ggvf_9:hover {
 
 /* Default opacity for region segments — slightly dimmed vs hover
    to give a subtle highlight without making unhovered segments look faded. */
-._regionDefault_16dh6_223 {
+._regionDefault_1itnu_262 {
   opacity: 0.25;
 }
 
 /* Applied via React state when the segment (or whole bar) should show hover */
-._regionHover_16dh6_223 {
+._regionHover_1itnu_262 {
   opacity: 0.45;
 }
 
 /* Region segments — partial border-radius for segmented bars */
-._regionFirst_16dh6_244 {
+._regionFirst_1itnu_283 {
   border-radius: 2px 0 0 2px;
 }
 
-._regionLast_16dh6_248 {
+._regionLast_1itnu_287 {
   border-radius: 0 2px 2px 0;
 }
 
-._regionMiddle_16dh6_252 {
+._regionMiddle_1itnu_291 {
   border-radius: 0;
 }
 
-._parallelBadge_16dh6_256 {
+._parallelBadge_1itnu_295 {
   font-size: var(--inspect-font-size-smallest);
   color: var(--vscode-descriptionForeground, #717171);
 }
 
 /* Markers */
 
-._marker_16dh6_263 {
+._marker_1itnu_302 {
   position: absolute;
   top: 50%;
   transform: translate(-50%, -50%);
@@ -19422,7 +19465,7 @@ a._citationLink_1ggvf_9:hover {
 }
 
 /* White disc behind branch icon so transparent cutouts don't bleed bar color */
-._markerBranch_16dh6_277::before {
+._markerBranch_1itnu_316::before {
   content: "";
   position: absolute;
   width: 6px;
@@ -19432,11 +19475,11 @@ a._citationLink_1ggvf_9:hover {
   z-index: -1;
 }
 
-._marker_16dh6_263 > * {
+._marker_1itnu_302 > * {
   pointer-events: none;
 }
 
-._markerError_16dh6_291 {
+._markerError_1itnu_330 {
   top: 1px;
   bottom: 1px;
   height: auto;
@@ -19447,7 +19490,7 @@ a._citationLink_1ggvf_9:hover {
   cursor: pointer;
 }
 
-._markerError_16dh6_291::after {
+._markerError_1itnu_330::after {
   content: "";
   position: absolute;
   top: 0;
@@ -19457,7 +19500,7 @@ a._citationLink_1ggvf_9:hover {
   background-color: var(--vscode-errorForeground, #f44747);
 }
 
-._markerCompaction_16dh6_312 {
+._markerCompaction_1itnu_351 {
   color: var(--bs-body-bg);
   rotate: none;
   font-size: 16px;
@@ -19471,13 +19514,13 @@ a._citationLink_1ggvf_9:hover {
   cursor: pointer;
 }
 
-._markerBranch_16dh6_277 {
+._markerBranch_1itnu_316 {
   color: var(--vscode-foreground);
   cursor: pointer;
 }
 
 /* Branch connector line from parent marker to branch bar */
-._branchConnector_16dh6_332 {
+._branchConnector_1itnu_371 {
   position: absolute;
   top: 0;
   left: 0;
@@ -19488,7 +19531,7 @@ a._citationLink_1ggvf_9:hover {
 }
 
 /* Right-pointing arrowhead for branch connectors (CSS border triangle) */
-._connectorArrow_16dh6_343 {
+._connectorArrow_1itnu_382 {
   position: absolute;
   top: 50%;
   transform: translate(-1px, -50%);
@@ -19501,7 +19544,7 @@ a._citationLink_1ggvf_9:hover {
 }
 
 /* Horizontal line extending back from arrowhead to the SVG horizontal endpoint */
-._connectorArrow_16dh6_343::before {
+._connectorArrow_1itnu_382::before {
   content: "";
   position: absolute;
   top: 50%;
@@ -19516,7 +19559,7 @@ a._citationLink_1ggvf_9:hover {
 
 /* Breadcrumb row */
 
-._breadcrumbRow_16dh6_371 {
+._breadcrumbRow_1itnu_410 {
   grid-column: 1 / -1;
   display: flex;
   align-items: center;
@@ -19525,7 +19568,7 @@ a._citationLink_1ggvf_9:hover {
   min-width: 0;
 }
 
-._optionsButton_16dh6_380 {
+._optionsButton_1itnu_419 {
   background: none;
   border: 1px solid var(--vscode-widget-border, var(--bs-border-color));
   border-radius: 50%;
@@ -19543,13 +19586,13 @@ a._citationLink_1ggvf_9:hover {
   opacity: 0.6;
 }
 
-._optionsButton_16dh6_380:hover {
+._optionsButton_1itnu_419:hover {
   color: var(--vscode-foreground);
   background: var(--vscode-toolbar-hoverBackground);
   opacity: 1;
 }
 
-._breadcrumbTrail_16dh6_404 {
+._breadcrumbTrail_1itnu_443 {
   display: flex;
   align-items: center;
   gap: 0;
@@ -19557,13 +19600,13 @@ a._citationLink_1ggvf_9:hover {
   overflow: hidden;
 }
 
-._breadcrumbSegment_16dh6_412 {
+._breadcrumbSegment_1itnu_451 {
   display: flex;
   align-items: center;
   white-space: nowrap;
 }
 
-._breadcrumbDivider_16dh6_418 {
+._breadcrumbDivider_1itnu_457 {
   color: var(--vscode-descriptionForeground, #717171);
   font-size: var(--inspect-font-size-smallest);
   padding: 0 2px;
@@ -19571,7 +19614,7 @@ a._citationLink_1ggvf_9:hover {
   user-select: none;
 }
 
-._breadcrumbLink_16dh6_426 {
+._breadcrumbLink_1itnu_465 {
   background: none;
   border: none;
   cursor: pointer;
@@ -19580,12 +19623,12 @@ a._citationLink_1ggvf_9:hover {
   padding: 0 2px;
 }
 
-._breadcrumbLink_16dh6_426:hover {
+._breadcrumbLink_1itnu_465:hover {
   color: var(--vscode-foreground);
   text-decoration: underline;
 }
 
-._breadcrumbCurrent_16dh6_440 {
+._breadcrumbCurrent_1itnu_479 {
   background: none;
   border: none;
   color: var(--vscode-foreground);
@@ -19596,7 +19639,7 @@ a._citationLink_1ggvf_9:hover {
 
 /* Token cell */
 
-._tokens_16dh6_451 {
+._tokens_1itnu_490 {
   padding: 0 0.75rem 0 0.5rem;
   font-size: var(--inspect-font-size-smallest);
   line-height: var(--swimlane-row-height);
@@ -19820,6 +19863,43 @@ a._citationLink_1ggvf_9:hover {
 }
 ._panel_8zdtn_1 {
   margin: 0.5em 0;
+}
+._nav_1t82s_1 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  margin: 4px 0;
+  font-size: var(--inspect-font-size-smallest);
+  color: var(--vscode-descriptionForeground, #717171);
+  border-left: 2px solid var(--bs-border-color);
+  background: var(--vscode-list-hoverBackground, rgba(0, 0, 0, 0.02));
+}
+
+._btn_1t82s_13 {
+  border: none;
+  background: none;
+  padding: 2px 4px;
+  cursor: pointer;
+  color: inherit;
+  font-size: 10px;
+  border-radius: 3px;
+}
+
+._btn_1t82s_13:hover {
+  background: var(--vscode-toolbar-hoverBackground, rgba(0, 0, 0, 0.08));
+  color: var(--vscode-foreground);
+}
+
+._count_1t82s_28 {
+  font-variant-numeric: tabular-nums;
+  min-width: 2.5em;
+  text-align: center;
+}
+
+._label_1t82s_34 {
+  font-weight: 500;
+  color: var(--vscode-foreground);
 }
 ._panel_vz394_1 {
   margin: 0.2em 0;

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -429,6 +429,7 @@
             "type": "string"
           },
           "from_anchor": {
+            "default": "",
             "title": "From Anchor",
             "type": "string"
           },

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -46,6 +46,93 @@
         "title": "AdaptiveConcurrency",
         "type": "object"
       },
+      "AnchorEvent": {
+        "description": "Marks a rollback-able point in a replayable trajectory.\n\nEmitted by an orchestrator immediately after a step it can later roll\nback to (a staged message, a model generate, etc.). Carries no content;\n``anchor_id`` is the addressable identifier that ``TimelineSpan.branched_from``\nreferences. Hidden from the viewer transcript by default.",
+        "properties": {
+          "anchor_id": {
+            "title": "Anchor Id",
+            "type": "string"
+          },
+          "event": {
+            "const": "anchor",
+            "default": "anchor",
+            "title": "Event",
+            "type": "string"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "pending": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Pending"
+          },
+          "source": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source"
+          },
+          "span_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Span Id"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "string"
+          },
+          "uuid": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Uuid"
+          },
+          "working_start": {
+            "title": "Working Start",
+            "type": "number"
+          }
+        },
+        "required": [
+          "timestamp",
+          "working_start",
+          "event",
+          "anchor_id"
+        ],
+        "title": "AnchorEvent",
+        "type": "object"
+      },
       "ApprovalEvent": {
         "description": "Tool approval.",
         "properties": {
@@ -333,7 +420,7 @@
         "type": "object"
       },
       "BranchEvent": {
-        "description": "Branch in conversation history.",
+        "description": "Marks where a branched trajectory's unique content begins.\n\nEmitted at the point where a branch transitions from replaying its\nparent's prefix to live execution. Events before this in the trajectory's\nspan are replay-phase re-execution; events after are the branch's\ngenuine new content.",
         "properties": {
           "event": {
             "const": "branch",
@@ -341,12 +428,8 @@
             "title": "Event",
             "type": "string"
           },
-          "from_message": {
-            "title": "From Message",
-            "type": "string"
-          },
-          "from_span": {
-            "title": "From Span",
+          "from_anchor": {
+            "title": "From Anchor",
             "type": "string"
           },
           "metadata": {
@@ -407,8 +490,7 @@
           "timestamp",
           "working_start",
           "event",
-          "from_span",
-          "from_message"
+          "from_anchor"
         ],
         "title": "BranchEvent",
         "type": "object"
@@ -2731,6 +2813,9 @@
                       "$ref": "#/components/schemas/ToolEvent"
                     },
                     {
+                      "$ref": "#/components/schemas/AnchorEvent"
+                    },
+                    {
                       "$ref": "#/components/schemas/ApprovalEvent"
                     },
                     {
@@ -2922,6 +3007,9 @@
                 },
                 {
                   "$ref": "#/components/schemas/ToolEvent"
+                },
+                {
+                  "$ref": "#/components/schemas/AnchorEvent"
                 },
                 {
                   "$ref": "#/components/schemas/ApprovalEvent"
@@ -4261,6 +4349,9 @@
           },
           {
             "$ref": "#/components/schemas/ToolEvent"
+          },
+          {
+            "$ref": "#/components/schemas/AnchorEvent"
           },
           {
             "$ref": "#/components/schemas/ApprovalEvent"

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -232,7 +232,7 @@ async def _dispatch_forked(
     from_span = current_span_id() or ""
 
     async with timeline_branch(
-        name=sa.name, from_span=from_span, from_message=from_message
+        name=sa.name, from_span=from_span, from_anchor=from_message
     ):
         return await _dispatch(agent, sa, input, span_id=span_id)
 

--- a/src/inspect_ai/agent/_deepagent/task_tool.py
+++ b/src/inspect_ai/agent/_deepagent/task_tool.py
@@ -227,13 +227,8 @@ async def _dispatch_forked(
     span_id: str | None = None,
 ) -> str:
     from inspect_ai.event._timeline import timeline_branch
-    from inspect_ai.util._span import current_span_id
 
-    from_span = current_span_id() or ""
-
-    async with timeline_branch(
-        name=sa.name, from_span=from_span, from_anchor=from_message
-    ):
+    async with timeline_branch(name=sa.name, from_anchor=from_message):
         return await _dispatch(agent, sa, input, span_id=span_id)
 
 

--- a/src/inspect_ai/event/__init__.py
+++ b/src/inspect_ai/event/__init__.py
@@ -1,5 +1,6 @@
 from inspect_ai._util.deprecation import relocated_module_attribute
 
+from ._anchor import AnchorEvent
 from ._approval import ApprovalEvent
 from ._branch import BranchEvent
 from ._compaction import CompactionEvent
@@ -44,6 +45,7 @@ from ._tree import (
 __all__ = [
     "Event",
     "ApprovalEvent",
+    "AnchorEvent",
     "BranchEvent",
     "ErrorEvent",
     "InfoEvent",

--- a/src/inspect_ai/event/_anchor.py
+++ b/src/inspect_ai/event/_anchor.py
@@ -1,0 +1,24 @@
+from typing import Literal
+
+from pydantic import Field
+
+from inspect_ai.event._base import BaseEvent
+
+
+class AnchorEvent(BaseEvent):
+    """Marks a rollback-able point in a replayable trajectory.
+
+    Emitted by an orchestrator immediately after a step it can later roll
+    back to (a staged message, a model generate, etc.). Carries no content;
+    ``anchor_id`` is the addressable identifier that ``TimelineSpan.branched_from``
+    references. Hidden from the viewer transcript by default.
+    """
+
+    event: Literal["anchor"] = Field(default="anchor")
+    """Event type."""
+
+    anchor_id: str
+    """Identifier for this anchor point. ``TimelineSpan.branched_from`` matches this."""
+
+    source: str | None = Field(default=None)
+    """Qualname of the recorded function that produced the anchored value (debugging aid)."""

--- a/src/inspect_ai/event/_branch.py
+++ b/src/inspect_ai/event/_branch.py
@@ -6,13 +6,19 @@ from inspect_ai.event._base import BaseEvent
 
 
 class BranchEvent(BaseEvent):
-    """Branch in conversation history."""
+    """Marks where a branched trajectory's unique content begins.
+
+    Emitted at the point where a branch transitions from replaying its
+    parent's prefix to live execution. Events before this in the trajectory's
+    span are replay-phase re-execution; events after are the branch's
+    genuine new content.
+    """
 
     event: Literal["branch"] = Field(default="branch")
     """Event type."""
 
     from_span: str
-    """Span where the branch originated."""
+    """Span where the branch originated (parent trajectory's span_id)."""
 
-    from_message: str
-    """Message at the branch point."""
+    from_anchor: str
+    """Anchor at the branch point (matches an ``AnchorEvent.anchor_id`` in the parent)."""

--- a/src/inspect_ai/event/_branch.py
+++ b/src/inspect_ai/event/_branch.py
@@ -17,8 +17,5 @@ class BranchEvent(BaseEvent):
     event: Literal["branch"] = Field(default="branch")
     """Event type."""
 
-    from_span: str
-    """Span where the branch originated (parent trajectory's span_id)."""
-
     from_anchor: str
     """Anchor at the branch point (matches an ``AnchorEvent.anchor_id`` in the parent)."""

--- a/src/inspect_ai/event/_branch.py
+++ b/src/inspect_ai/event/_branch.py
@@ -1,6 +1,6 @@
-from typing import Literal
+from typing import Any, Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from inspect_ai.event._base import BaseEvent
 
@@ -17,5 +17,14 @@ class BranchEvent(BaseEvent):
     event: Literal["branch"] = Field(default="branch")
     """Event type."""
 
-    from_anchor: str
+    from_anchor: str = ""
     """Anchor at the branch point (matches an ``AnchorEvent.anchor_id`` in the parent)."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            data.pop("from_span", None)
+            if "from_anchor" not in data and "from_message" in data:
+                data["from_anchor"] = data.pop("from_message") or ""
+        return data

--- a/src/inspect_ai/event/_event.py
+++ b/src/inspect_ai/event/_event.py
@@ -2,6 +2,7 @@ from typing import TypeAlias, Union
 
 from inspect_ai.event._score_edit import ScoreEditEvent
 
+from ._anchor import AnchorEvent
 from ._approval import ApprovalEvent
 from ._branch import BranchEvent
 from ._compaction import CompactionEvent
@@ -29,6 +30,7 @@ Event: TypeAlias = Union[
     StoreEvent,
     ModelEvent,
     ToolEvent,
+    AnchorEvent,
     ApprovalEvent,
     BranchEvent,
     CompactionEvent,

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -434,9 +434,6 @@ def timeline_build(
             root=TimelineSpan(id="root", name="main", span_type=None),
         )
 
-    # Build branch span_id → from_span mapping for relocation
-    from_spans = _build_from_spans(events)
-
     # Use event_tree to get hierarchical structure
     tree = event_tree(events)
 
@@ -499,7 +496,7 @@ def timeline_build(
         if agent_node is not None:
             agent_node.name = "main"
 
-            _classify_spans(agent_node, from_spans)
+            _classify_spans(agent_node)
 
             # Prepend init span to agent content
             if init_span_obj:
@@ -527,20 +524,19 @@ def timeline_build(
     else:
         # No phase spans - treat entire tree as agent
         root = _build_agent_from_tree(tree)
-        _classify_spans(root, from_spans)
+        _classify_spans(root)
 
     return Timeline(name=name, description=description, root=root)
 
 
 @contextlib.asynccontextmanager
 async def timeline_branch(
-    *, name: str, from_span: str, from_anchor: str, id: str | None = None
+    *, name: str, from_anchor: str, id: str | None = None
 ) -> AsyncIterator[None]:
     """Context manager for creating a timeline branch.
 
     Args:
         name (str): Name of branch span.
-        from_span: Span where the branch originated.
         from_anchor: Anchor id at the branch point.
         id (str | None): Optional span ID. Generated if not provided.
     """
@@ -549,19 +545,15 @@ async def timeline_branch(
     from inspect_ai.util._span import span
 
     async with span(name=name, type="branch", id=id):
-        transcript()._event(BranchEvent(from_span=from_span, from_anchor=from_anchor))
+        transcript()._event(BranchEvent(from_anchor=from_anchor))
         yield
 
 
-def _classify_spans(root: TimelineSpan, from_spans: dict[str, str]) -> None:
-    """Run all span classification passes on a root span.
-
-    Classifies utility agents, branch structure, and relocates branches.
-    """
+def _classify_spans(root: TimelineSpan) -> None:
+    """Run all span classification passes on a root span."""
     _wrap_utility_events(root)
     _classify_utility_agents(root)
     _classify_branches(root)
-    _relocate_branches(root, from_spans)
     _extract_agent_results(root)
 
 
@@ -906,7 +898,6 @@ def _unroll_span(
 
 def _process_children(
     children: list[TreeItem],
-    from_spans: dict[str, str] | None = None,
 ) -> tuple[list[TimelineEvent | TimelineSpan], list[TimelineSpan]]:
     """Process a span's children with branch awareness.
 
@@ -916,8 +907,6 @@ def _process_children(
 
     Args:
         children: List of tree items to process.
-        from_spans: Optional dict to accumulate branch span_id → from_span
-            mappings for later relocation.
 
     Returns:
         Tuple of (content nodes, branch list).
@@ -954,8 +943,6 @@ def _process_children(
                     branch_content.append(node)
             if not branch_content:
                 continue
-            if from_spans is not None:
-                from_spans[span.id] = branch_event.from_span
             result.append(
                 TimelineSpan(
                     id=span.id,
@@ -1042,88 +1029,6 @@ def _classify_branches(agent: TimelineSpan) -> None:
         for item in branch.content:
             if isinstance(item, TimelineSpan):
                 _classify_branches(item)
-
-
-# =============================================================================
-# Branch Relocation
-# =============================================================================
-
-
-def _build_from_spans(events: Sequence[Event]) -> dict[str, str]:
-    """Build branch span_id → from_span mapping from BranchEvents.
-
-    Each BranchEvent's span_id identifies the branch span it belongs to,
-    and from_span identifies the span it was forked from.
-
-    Args:
-        events: Flat list of Events from a transcript.
-
-    Returns:
-        Dict mapping branch span_id to the from_span value.
-    """
-    from_spans: dict[str, str] = {}
-    for e in events:
-        if isinstance(e, BranchEvent) and e.span_id:
-            from_spans[e.span_id] = e.from_span
-    return from_spans
-
-
-def _collect_spans(span: TimelineSpan, span_map: dict[str, TimelineSpan]) -> None:
-    """Recursively collect all TimelineSpans into a span_id → span map."""
-    span_map[span.id] = span
-    for item in span.content:
-        if isinstance(item, TimelineSpan):
-            _collect_spans(item, span_map)
-    for branch in span.branches:
-        _collect_spans(branch, span_map)
-
-
-def _relocate_branches(root: TimelineSpan, from_spans: dict[str, str]) -> None:
-    """Relocate branches to the span identified by from_span.
-
-    After initial discovery, all branches from the same _process_children
-    call are flat siblings. If a branch's from_span points to a span
-    inside a sibling branch, move it there.
-
-    Args:
-        root: The root TimelineSpan to process.
-        from_spans: Mapping of branch span_id → from_span (target span_id).
-    """
-    if not from_spans:
-        return
-
-    # Build span_id → TimelineSpan map from entire tree
-    span_map: dict[str, TimelineSpan] = {}
-    _collect_spans(root, span_map)
-
-    # Relocate branches depth-first
-    _do_relocate(root, span_map, from_spans)
-
-
-def _do_relocate(
-    span: TimelineSpan,
-    span_map: dict[str, TimelineSpan],
-    from_spans: dict[str, str],
-) -> None:
-    """Recursively relocate branches in a span and its children."""
-    # Recurse into child spans first (depth-first)
-    for item in span.content:
-        if isinstance(item, TimelineSpan):
-            _do_relocate(item, span_map, from_spans)
-    for branch in span.branches:
-        _do_relocate(branch, span_map, from_spans)
-
-    # Check each branch's from_span and relocate if needed
-    remaining: list[TimelineSpan] = []
-    for branch in span.branches:
-        target_id = from_spans.get(branch.id)
-        target_span = span_map.get(target_id) if target_id else None
-        if target_span is not None and target_span is not span:
-            # Move branch to the target span
-            target_span.branches.append(branch)
-        else:
-            remaining.append(branch)
-    span.branches = remaining
 
 
 # =============================================================================

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -47,15 +47,14 @@ def _min_start_time(
 ) -> datetime:
     """Return the earliest start time among nodes.
 
-    Requires at least one node (all nodes have non-null start_time).
-
     Args:
-        nodes: Non-empty sequence of nodes to check.
+        nodes: Sequence of nodes to check.
 
     Returns:
-        The minimum start_time.
+        The minimum start_time, or ``datetime.max`` if empty (so empty
+        spans sort last and ``min()`` callers don't crash).
     """
-    return min(node.start_time() for node in nodes)
+    return min((node.start_time() for node in nodes), default=datetime.max)
 
 
 def _max_end_time(
@@ -535,14 +534,14 @@ def timeline_build(
 
 @contextlib.asynccontextmanager
 async def timeline_branch(
-    *, name: str, from_span: str, from_message: str, id: str | None = None
+    *, name: str, from_span: str, from_anchor: str, id: str | None = None
 ) -> AsyncIterator[None]:
     """Context manager for creating a timeline branch.
 
     Args:
         name (str): Name of branch span.
         from_span: Span where the branch originated.
-        from_message: Message id at the branch point.
+        from_anchor: Anchor id at the branch point.
         id (str | None): Optional span ID. Generated if not provided.
     """
     from inspect_ai.event._branch import BranchEvent
@@ -550,7 +549,7 @@ async def timeline_branch(
     from inspect_ai.util._span import span
 
     async with span(name=name, type="branch", id=id):
-        transcript()._event(BranchEvent(from_span=from_span, from_message=from_message))
+        transcript()._event(BranchEvent(from_span=from_span, from_anchor=from_anchor))
         yield
 
 
@@ -962,7 +961,7 @@ def _process_children(
                     id=span.id,
                     name=span.name or "branch",
                     span_type="branch",
-                    branched_from=branch_event.from_message,
+                    branched_from=branch_event.from_anchor,
                     content=branch_content,
                 )
             )

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -535,15 +535,19 @@ async def timeline_branch(
 ) -> AsyncIterator[None]:
     """Context manager for creating a timeline branch.
 
+    Emits an `AnchorEvent` in the current (parent) span so the viewer can resolve `from_anchor` to a position, then opens a ``type="branch"`` span and emits a `BranchEvent` inside it.
+
     Args:
         name (str): Name of branch span.
         from_anchor: Anchor id at the branch point.
         id (str | None): Optional span ID. Generated if not provided.
     """
+    from inspect_ai.event._anchor import AnchorEvent
     from inspect_ai.event._branch import BranchEvent
     from inspect_ai.log._transcript import transcript
     from inspect_ai.util._span import span
 
+    transcript()._event(AnchorEvent(anchor_id=from_anchor))
     async with span(name=name, type="branch", id=id):
         transcript()._event(BranchEvent(from_anchor=from_anchor))
         yield

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -27,6 +27,7 @@ from inspect_ai.model import (
     ChatMessageUser,
 )
 
+from ._anchor import AnchorEvent
 from ._branch import BranchEvent
 from ._event import Event
 from ._model import ModelEvent
@@ -60,17 +61,8 @@ def _min_start_time(
 def _max_end_time(
     nodes: Sequence[TimelineEvent | TimelineSpan],
 ) -> datetime:
-    """Return the latest end time among nodes.
-
-    Requires at least one node (all nodes have non-null end_time).
-
-    Args:
-        nodes: Non-empty sequence of nodes to check.
-
-    Returns:
-        The maximum end_time.
-    """
-    return max(node.end_time() for node in nodes)
+    """Return the latest end time among nodes (``datetime.min`` when empty)."""
+    return max((node.end_time() for node in nodes), default=datetime.min)
 
 
 def _sum_tokens(
@@ -409,10 +401,8 @@ def timeline_build(
 
     **Phase 3 — Post-processing passes:**
 
-    - Auto-branch detection (re-rolled ModelEvents with identical inputs)
     - Utility agent classification (single-turn agents with different
       system prompts)
-    - Recursive branch classification
 
     Args:
         events: Flat list of Events from a transcript.
@@ -542,8 +532,6 @@ async def timeline_branch(
         from_anchor: Anchor id at the branch point.
         id (str | None): Optional span ID. Generated if not provided.
     """
-    from inspect_ai.event._anchor import AnchorEvent
-    from inspect_ai.event._branch import BranchEvent
     from inspect_ai.log._transcript import transcript
     from inspect_ai.util._span import span
 

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -216,7 +216,7 @@ class TimelineSpan(BaseModel):
     type: Literal["span"] = "span"
     id: str
     name: str
-    span_type: str | None
+    span_type: str | None = None
     content: list[TimelineContentItem] = Field(default_factory=list)
     branches: list["TimelineSpan"] = Field(default_factory=list)
     branched_from: str | None = Field(default=None)

--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -557,7 +557,6 @@ def _classify_spans(root: TimelineSpan) -> None:
     """Run all span classification passes on a root span."""
     _wrap_utility_events(root)
     _classify_utility_agents(root)
-    _classify_branches(root)
     _extract_agent_results(root)
 
 
@@ -1013,26 +1012,6 @@ def _process_span_as_content(
             if isinstance(node, TimelineSpan) and not node.content:
                 continue
             into.append(node)
-
-
-def _classify_branches(agent: TimelineSpan) -> None:
-    """Recursively classify branches in the agent tree.
-
-    Recurses into child spans in both content and branches.
-
-    Args:
-        agent: The span node to process.
-    """
-    # Recurse into child spans in content
-    for item in agent.content:
-        if isinstance(item, TimelineSpan):
-            _classify_branches(item)
-
-    # Recurse into spans within branches
-    for branch in agent.branches:
-        for item in branch.content:
-            if isinstance(item, TimelineSpan):
-                _classify_branches(item)
 
 
 # =============================================================================

--- a/src/inspect_ai/log/_condense.py
+++ b/src/inspect_ai/log/_condense.py
@@ -102,7 +102,7 @@ def expand_events(
 ) -> list[Event]:
     """Reverse :func:`condense_events` — restore pooled content into events.
 
-    When `events` is a sequence (not a JSON string), the contained `ModelEvent` objects are mutated in place; the returned list aliases them.
+    `ModelEvent` objects in `events` are mutated in place.
 
     Args:
         events: Condensed events (with pool index references), or a JSON-serialized

--- a/src/inspect_ai/log/_condense.py
+++ b/src/inspect_ai/log/_condense.py
@@ -102,6 +102,8 @@ def expand_events(
 ) -> list[Event]:
     """Reverse :func:`condense_events` — restore pooled content into events.
 
+    When `events` is a sequence (not a JSON string), the contained `ModelEvent` objects are mutated in place; the returned list aliases them.
+
     Args:
         events: Condensed events (with pool index references), or a JSON-serialized
             ``list[Event]``.

--- a/src/inspect_ai/log/_convert.py
+++ b/src/inspect_ai/log/_convert.py
@@ -14,7 +14,6 @@ from inspect_ai.log._file import (
     read_eval_log_async,
     write_eval_log,
 )
-from inspect_ai.log._pool import resolve_sample_events_data
 from inspect_ai.log._recorders import create_recorder_for_location
 from inspect_ai.log._recorders.create import recorder_type_for_location
 
@@ -134,10 +133,6 @@ async def _stream_convert_file(
             sample = await input_recorder.read_log_sample(input_file, sample_id, epoch)
             if resolve_attachments:
                 sample = resolve_sample_attachments(sample, resolve_attachments)
-            else:
-                # Must resolve message pool refs before re-condensing,
-                # otherwise condense_sample will overwrite pools with empty lists
-                sample = resolve_sample_events_data(sample)
             sample = condense_sample(sample)
             await output_recorder.log_sample(
                 log_header.eval,

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -24,7 +24,6 @@ from inspect_ai._util.file import (
 from inspect_ai._util.json import to_json_safe
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.log._log import EvalSampleSummary
-from inspect_ai.log._pool import resolve_sample_events_data
 
 from ._log import EvalLog, EvalMetric, EvalSample, EvalStatus
 from ._recorders import (
@@ -351,14 +350,11 @@ async def read_eval_log_async(
             recorder_type = recorder_type_for_format(format)
         log = await recorder_type.read_log(log_file, header_only)
 
-    # always resolve message pool refs so ModelEvent.input is populated
-    if log.samples:
-        log.samples = [resolve_sample_events_data(sample) for sample in log.samples]
-        if resolve_attachments:
-            log.samples = [
-                resolve_sample_attachments(sample, resolve_attachments)
-                for sample in log.samples
-            ]
+    if log.samples and resolve_attachments:
+        log.samples = [
+            resolve_sample_attachments(sample, resolve_attachments)
+            for sample in log.samples
+        ]
 
     # provide sample ids if they aren't there
     if log.eval.dataset.sample_ids is None and log.samples is not None:
@@ -537,8 +533,6 @@ async def read_eval_log_sample_async(
         log_file, id, epoch, uuid, exclude_fields, reader
     )
 
-    # always resolve message pool refs so ModelEvent.input is populated
-    sample = resolve_sample_events_data(sample)
     if resolve_attachments:
         sample = resolve_sample_attachments(sample, resolve_attachments)
 

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -41,7 +41,7 @@ from inspect_ai.util._store_model import SMT
 from inspect_ai.viewer import ViewerConfig
 
 from ..event._event import Event
-from ._pool import resolve_model_event_calls, resolve_model_event_inputs
+from ._pool import resolve_sample_events_data
 from ._util import thin_input, thin_metadata, thin_target, thin_text
 
 logger = getLogger(__name__)
@@ -564,12 +564,7 @@ class EvalSample(BaseModel):
 
         sample: EvalSample = handler(data)
 
-        if sample.events_data is not None:
-            resolve_model_event_inputs(
-                sample.events, sample.events_data["messages"]
-            )
-            resolve_model_event_calls(sample.events, sample.events_data["calls"])
-            sample.events_data = None
+        resolve_sample_events_data(sample)
 
         if raw_timelines:
             events_by_uuid = {e.uuid: e for e in sample.events if e.uuid}

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -41,6 +41,7 @@ from inspect_ai.util._store_model import SMT
 from inspect_ai.viewer import ViewerConfig
 
 from ..event._event import Event
+from ._pool import resolve_model_event_calls, resolve_model_event_inputs
 from ._util import thin_input, thin_metadata, thin_target, thin_text
 
 logger = getLogger(__name__)
@@ -553,14 +554,22 @@ class EvalSample(BaseModel):
 
     @model_validator(mode="wrap")
     @classmethod
-    def _resolve_timelines(
+    def _resolve_references(
         cls, data: Any, handler: Any, info: ValidationInfo
     ) -> "EvalSample":
+        """Resolve message-pool refs in events, then hydrate timeline event uuids."""
         raw_timelines = None
         if isinstance(data, dict) and data.get("timelines"):
             raw_timelines = data.pop("timelines")
 
         sample: EvalSample = handler(data)
+
+        if sample.events_data is not None:
+            resolve_model_event_inputs(
+                sample.events, sample.events_data["messages"]
+            )
+            resolve_model_event_calls(sample.events, sample.events_data["calls"])
+            sample.events_data = None
 
         if raw_timelines:
             events_by_uuid = {e.uuid: e for e in sample.events if e.uuid}

--- a/src/inspect_ai/log/_pool.py
+++ b/src/inspect_ai/log/_pool.py
@@ -202,61 +202,55 @@ def resolve_model_event_calls(
     events: list[Event],
     call_pool: list[JsonValue],
 ) -> list[Event]:
-    """Restore call.request messages from call_pool references."""
+    """Restore call.request messages from call_pool references.
+
+    Mutates the events in place (so refs from e.g. ``sample.timelines`` stay
+    valid) but replaces ``event.call`` with a new object since the call may
+    be aliased from the caller's original sample.
+    """
     if not call_pool:
         return events
-    result: list[Event] = []
     for event in events:
         if isinstance(event, ModelEvent) and event.call and event.call.call_refs:
             msgs = _expand_refs(event.call.call_refs, call_pool)
             msg_key = event.call.call_key or "messages"
-            new_request = dict(event.call.request)
-            new_request[msg_key] = msgs
-            new_call = event.call.model_copy(
+            event.call = event.call.model_copy(
                 update={
-                    "request": new_request,
+                    "request": {**event.call.request, msg_key: msgs},
                     "call_refs": None,
                     "call_key": None,
                 }
             )
-            event = event.model_copy(update={"call": new_call})
-        result.append(event)
-    return result
+    return events
 
 
 def resolve_model_event_inputs(
     events: list[Event],
     message_pool: list[ChatMessage],
 ) -> list[Event]:
-    """Resolve ModelEvent input_refs back to full input lists."""
+    """Resolve ModelEvent input_refs back to full input lists (in place).
+
+    Mutates the events so any existing references (e.g. from
+    ``sample.timelines``) observe the resolved input.
+    """
     if not message_pool:
         return events
-    result: list[Event] = []
     for event in events:
         if isinstance(event, ModelEvent) and event.input_refs is not None:
-            resolved_input = _expand_refs(event.input_refs, message_pool)
-            event = event.model_copy(
-                update={"input": resolved_input, "input_refs": None}
-            )
-        result.append(event)
-    return result
+            event.input = _expand_refs(event.input_refs, message_pool)
+            event.input_refs = None
+    return events
 
 
 def resolve_sample_events_data(sample: EvalSample) -> EvalSample:
-    """Resolve events_data pool references in model events.
+    """Resolve events_data pool references in model events (in place).
 
     Always called on read to ensure ModelEvent.input is populated,
     regardless of the resolve_attachments setting.
     """
     if sample.events_data is None:
         return sample
-    msg_pool = sample.events_data["messages"]
-    call_pool = sample.events_data["calls"]
-    resolved_events = resolve_model_event_inputs(sample.events, msg_pool)
-    resolved_events = resolve_model_event_calls(resolved_events, call_pool)
-    return sample.model_copy(
-        update={
-            "events": resolved_events,
-            "events_data": None,
-        }
-    )
+    resolve_model_event_inputs(sample.events, sample.events_data["messages"])
+    resolve_model_event_calls(sample.events, sample.events_data["calls"])
+    sample.events_data = None
+    return sample

--- a/src/inspect_ai/log/_pool.py
+++ b/src/inspect_ai/log/_pool.py
@@ -16,7 +16,7 @@ content by definition).
 
 import json
 from collections.abc import Mapping, Sequence
-from typing import Final, TypeVar
+from typing import TYPE_CHECKING, Final, TypeVar
 
 from pydantic import JsonValue
 
@@ -25,7 +25,9 @@ from inspect_ai.model._chat_message import ChatMessage
 
 from ..event._event import Event
 from ..event._model import ModelEvent
-from ._log import EvalSample
+
+if TYPE_CHECKING:
+    from ._log import EvalSample
 
 
 def _msg_hash(msg: ChatMessage) -> str:
@@ -202,12 +204,7 @@ def resolve_model_event_calls(
     events: list[Event],
     call_pool: list[JsonValue],
 ) -> list[Event]:
-    """Restore call.request messages from call_pool references.
-
-    Mutates the events in place (so refs from e.g. ``sample.timelines`` stay
-    valid) but replaces ``event.call`` with a new object since the call may
-    be aliased from the caller's original sample.
-    """
+    """Restore call.request messages from call_pool references in place."""
     if not call_pool:
         return events
     for event in events:
@@ -228,11 +225,7 @@ def resolve_model_event_inputs(
     events: list[Event],
     message_pool: list[ChatMessage],
 ) -> list[Event]:
-    """Resolve ModelEvent input_refs back to full input lists (in place).
-
-    Mutates the events so any existing references (e.g. from
-    ``sample.timelines``) observe the resolved input.
-    """
+    """Resolve ModelEvent input_refs back to full input lists in place."""
     if not message_pool:
         return events
     for event in events:
@@ -242,11 +235,10 @@ def resolve_model_event_inputs(
     return events
 
 
-def resolve_sample_events_data(sample: EvalSample) -> EvalSample:
-    """Resolve events_data pool references in model events (in place).
+def resolve_sample_events_data(sample: "EvalSample") -> "EvalSample":
+    """Resolve events_data pool references in model events in place.
 
-    Always called on read to ensure ModelEvent.input is populated,
-    regardless of the resolve_attachments setting.
+    Idempotent — no-op once `events_data` has been cleared.
     """
     if sample.events_data is None:
         return sample

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -52,7 +52,6 @@ from .._log import (
     EvalStatus,
     sort_samples,
 )
-from .._pool import resolve_sample_events_data
 from .file import FileRecorder
 
 logger = getLogger(__name__)
@@ -781,7 +780,7 @@ def _read_log_from_bytes(
                             ),
                         )
             sort_samples(samples_list)
-            eval_log.samples = [resolve_sample_events_data(s) for s in samples_list]
+            eval_log.samples = samples_list
         return eval_log
 
 

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -30,7 +30,6 @@ from .._log import (
     EvalStatus,
     sort_samples,
 )
-from .._pool import resolve_sample_events_data
 from .eval import _s3_bucket_and_key, _write_s3_conditional
 from .file import FileRecorder
 
@@ -138,11 +137,6 @@ class JSONRecorder(FileRecorder):
 
         # stop tracking this data
         del self.data[self._log_file_key(eval)]
-
-        # resolve condensed events data (input_refs/call_refs -> input/call)
-        # so callers see fully populated ModelEvent.input fields
-        if log.data.samples:
-            log.data.samples = [resolve_sample_events_data(s) for s in log.data.samples]
 
         # return the log
         return log.data

--- a/src/inspect_ai/log/_recover/_read.py
+++ b/src/inspect_ai/log/_recover/_read.py
@@ -8,7 +8,6 @@ from inspect_ai._util.async_zip import AsyncZipReader
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.constants import get_deserializing_context
 from inspect_ai.log._log import EvalPlan, EvalSample, EvalSampleSummary, EvalSpec
-from inspect_ai.log._pool import resolve_sample_events_data
 from inspect_ai.log._recorders.eval import (
     HEADER_JSON,
     JOURNAL_DIR,
@@ -106,8 +105,7 @@ async def read_flushed_sample(reader: AsyncZipReader, entry_name: str) -> EvalSa
         The deserialized EvalSample.
     """
     data = await _read_member_json(reader, entry_name)
-    sample = EvalSample.model_validate(data, context=get_deserializing_context())
-    return resolve_sample_events_data(sample)
+    return EvalSample.model_validate(data, context=get_deserializing_context())
 
 
 async def _read_member_json(reader: AsyncZipReader, member: str) -> Any:

--- a/src/inspect_ai/util/__init__.py
+++ b/src/inspect_ai/util/__init__.py
@@ -64,7 +64,7 @@ from ._sandbox import (
     sandbox_with,
     sandboxenv,
 )
-from ._span import current_span_id, span
+from ._span import SpanIdProvider, current_span_id, set_span_id_provider, span
 from ._store import Store, store, store_from_events, store_from_events_as
 from ._store_model import StoreModel, store_as
 from ._subprocess import (
@@ -128,6 +128,8 @@ __all__ = [
     "store_as",
     "span",
     "current_span_id",
+    "set_span_id_provider",
+    "SpanIdProvider",
     "collect",
     "Subtask",
     "subtask",

--- a/src/inspect_ai/util/_span.py
+++ b/src/inspect_ai/util/_span.py
@@ -1,5 +1,6 @@
 import contextlib
 import inspect
+from collections.abc import Awaitable, Callable
 from contextvars import ContextVar
 from logging import getLogger
 from typing import AsyncIterator
@@ -7,6 +8,13 @@ from typing import AsyncIterator
 from shortuuid import uuid as shortuuid
 
 logger = getLogger(__name__)
+
+SpanIdProvider = Callable[[str, str | None], Awaitable[str]]
+"""Signature for a span-ID provider: ``async (name, parent_id) -> id``.
+
+Set via `set_span_id_provider` to make `span()` use orchestrator-supplied IDs
+(e.g. for replay-deterministic span identity across branched trajectories).
+"""
 
 
 @contextlib.asynccontextmanager
@@ -18,7 +26,9 @@ async def span(
     Args:
         name (str): Step name.
         type (str | None): Optional span type.
-        id (str | None): Optional span ID. Generated if not provided.
+        id (str | None): Optional span ID. Generated if not provided. If a
+            span-ID provider is active (`set_span_id_provider`), it is
+            consulted with ``(name, parent_id)`` instead of generating a UUID.
     """
     from inspect_ai.event._span import SpanBeginEvent, SpanEndEvent
     from inspect_ai.log._transcript import (
@@ -27,7 +37,12 @@ async def span(
     )
 
     # span id
-    id = id or shortuuid()
+    if id is None:
+        provider = _span_id_provider.get()
+        if provider is not None:
+            id = await provider(name, _current_span_id.get())
+        else:
+            id = shortuuid()
 
     # capture parent id
     parent_id = _current_span_id.get()
@@ -68,4 +83,23 @@ def current_span_id() -> str | None:
     return _current_span_id.get()
 
 
+@contextlib.contextmanager
+def set_span_id_provider(provider: SpanIdProvider | None):
+    """Set the span-ID provider for the duration of the context.
+
+    When set, `span()` calls without an explicit ``id`` consult
+    ``await provider(name, parent_id)`` instead of generating a fresh UUID.
+    Used by orchestrators that need deterministic span identity across
+    replayed runs (e.g. petri's branching trajectories).
+    """
+    token = _span_id_provider.set(provider)
+    try:
+        yield
+    finally:
+        _span_id_provider.reset(token)
+
+
 _current_span_id: ContextVar[str | None] = ContextVar("_current_span_id", default=None)
+_span_id_provider: ContextVar[SpanIdProvider | None] = ContextVar(
+    "_span_id_provider", default=None
+)

--- a/src/inspect_ai/util/_span.py
+++ b/src/inspect_ai/util/_span.py
@@ -10,8 +10,7 @@ from shortuuid import uuid as shortuuid
 logger = getLogger(__name__)
 
 SpanIdProvider = Callable[[str, str | None, str | None], Awaitable[str]]
-"""``await provider(name, parent_id, requested_id)`` → span id."""
-"""Signature for a span-ID provider: ``async (name, parent_id) -> id``.
+"""Signature for a span-ID provider: ``await provider(name, parent_id, requested_id)`` → span id.
 
 Set via `set_span_id_provider` to make `span()` use orchestrator-supplied IDs
 (e.g. for replay-deterministic span identity across branched trajectories).
@@ -29,7 +28,8 @@ async def span(
         type (str | None): Optional span type.
         id (str | None): Optional span ID. Generated if not provided. If a
             span-ID provider is active (`set_span_id_provider`), it is
-            consulted with ``(name, parent_id)`` instead of generating a UUID.
+            consulted with ``(name, parent_id, requested_id)`` instead of
+            generating a UUID.
     """
     from inspect_ai.event._span import SpanBeginEvent, SpanEndEvent
     from inspect_ai.log._transcript import (
@@ -37,15 +37,15 @@ async def span(
         transcript,
     )
 
+    # capture parent id
+    parent_id = _current_span_id.get()
+
     # span id
     provider = _span_id_provider.get()
     if provider is not None:
-        id = await provider(name, _current_span_id.get(), id)
+        id = await provider(name, parent_id, id)
     elif id is None:
         id = shortuuid()
-
-    # capture parent id
-    parent_id = _current_span_id.get()
 
     # set new current span (reset at the end)
     token = _current_span_id.set(id)

--- a/src/inspect_ai/util/_span.py
+++ b/src/inspect_ai/util/_span.py
@@ -1,6 +1,6 @@
 import contextlib
 import inspect
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Iterator
 from contextvars import ContextVar
 from logging import getLogger
 from typing import AsyncIterator
@@ -9,7 +9,8 @@ from shortuuid import uuid as shortuuid
 
 logger = getLogger(__name__)
 
-SpanIdProvider = Callable[[str, str | None], Awaitable[str]]
+SpanIdProvider = Callable[[str, str | None, str | None], Awaitable[str]]
+"""``await provider(name, parent_id, requested_id)`` → span id."""
 """Signature for a span-ID provider: ``async (name, parent_id) -> id``.
 
 Set via `set_span_id_provider` to make `span()` use orchestrator-supplied IDs
@@ -37,12 +38,11 @@ async def span(
     )
 
     # span id
-    if id is None:
-        provider = _span_id_provider.get()
-        if provider is not None:
-            id = await provider(name, _current_span_id.get())
-        else:
-            id = shortuuid()
+    provider = _span_id_provider.get()
+    if provider is not None:
+        id = await provider(name, _current_span_id.get(), id)
+    elif id is None:
+        id = shortuuid()
 
     # capture parent id
     parent_id = _current_span_id.get()
@@ -84,7 +84,7 @@ def current_span_id() -> str | None:
 
 
 @contextlib.contextmanager
-def set_span_id_provider(provider: SpanIdProvider | None):
+def set_span_id_provider(provider: SpanIdProvider | None) -> Iterator[None]:
     """Set the span-ID provider for the duration of the context.
 
     When set, `span()` calls without an explicit ``id`` consult

--- a/src/inspect_ai/util/_span.py
+++ b/src/inspect_ai/util/_span.py
@@ -87,10 +87,7 @@ def current_span_id() -> str | None:
 def set_span_id_provider(provider: SpanIdProvider | None) -> Iterator[None]:
     """Set the span-ID provider for the duration of the context.
 
-    When set, `span()` calls without an explicit ``id`` consult
-    ``await provider(name, parent_id)`` instead of generating a fresh UUID.
-    Used by orchestrators that need deterministic span identity across
-    replayed runs (e.g. petri's branching trajectories).
+    When set, every `span()` call consults ``await provider(name, parent_id, requested_id)`` to determine the span id (any explicit ``id`` argument is passed through as ``requested_id``).
     """
     token = _span_id_provider.set(provider)
     try:

--- a/tests/log/test_message_pool.py
+++ b/tests/log/test_message_pool.py
@@ -242,6 +242,62 @@ def test_write_read_round_trip(
             assert event.input_refs is None
 
 
+def test_timeline_events_share_resolved_event_identity():
+    """sample.timelines must reference the same (resolved) Event objects as sample.events.
+
+    Regression: previously _resolve_timelines captured event refs during
+    pydantic validation, before resolve_sample_events_data created new
+    objects with input populated — leaving timeline refs pointing at
+    stale condensed copies with empty .input.
+    """
+    from inspect_ai.event import Timeline, TimelineEvent, TimelineSpan
+
+    sample = _make_sample_with_repeated_inputs()
+    sample.timelines = [
+        Timeline(
+            name="t",
+            description="",
+            root=TimelineSpan(
+                id="root",
+                name="root",
+                span_type="branch",
+                content=[TimelineEvent(event=e) for e in sample.events],
+            ),
+        )
+    ]
+    log = EvalLog(
+        version=LOG_SCHEMA_VERSION,
+        status="success",
+        eval=EvalSpec(
+            task="t",
+            task_version=0,
+            task_id="t",
+            model="m",
+            dataset=EvalDataset(name="t", samples=1),
+            config=EvalConfig(),
+            created="2025-01-01T00:00:00Z",
+        ),
+        plan=EvalPlan(),
+        results=EvalResults(total_samples=1, completed_samples=1),
+        stats=EvalStats(
+            started_at="2025-01-01T00:00:00Z", completed_at="2025-01-01T00:01:00Z"
+        ),
+        samples=[condense_sample(sample)],
+    )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "test.eval")
+        write_eval_log(log, path)
+        read = read_eval_log(path)
+
+    s = read.samples[0]
+    by_uuid = {e.uuid: e for e in s.events}
+    tl_events = [it.event for it in s.timelines[0].root.content]
+    for te in tl_events:
+        assert te is by_uuid[te.uuid], "timeline event must be the resolved object"
+        assert isinstance(te, ModelEvent) and len(te.input) > 0
+
+
 def test_write_eval_log_applies_condensing():
     """write_eval_log should apply condense_sample even when given uncondensed samples."""
     sample = _make_sample_with_repeated_inputs()

--- a/tests/log/test_message_pool.py
+++ b/tests/log/test_message_pool.py
@@ -243,13 +243,7 @@ def test_write_read_round_trip(
 
 
 def test_timeline_events_share_resolved_event_identity():
-    """sample.timelines must reference the same (resolved) Event objects as sample.events.
-
-    Regression: previously _resolve_timelines captured event refs during
-    pydantic validation, before resolve_sample_events_data created new
-    objects with input populated — leaving timeline refs pointing at
-    stale condensed copies with empty .input.
-    """
+    """sample.timelines must reference the same resolved Event objects as sample.events."""
     from inspect_ai.event import Timeline, TimelineEvent, TimelineSpan
 
     sample = _make_sample_with_repeated_inputs()

--- a/tests/timeline/test_timeline_branches.py
+++ b/tests/timeline/test_timeline_branches.py
@@ -89,15 +89,14 @@ def _span_end(
 
 
 def _branch_event(
-    *, uuid: str, span_id: str, ts: float, from_span: str, from_message: str
+    *, uuid: str, span_id: str, ts: float, from_anchor: str
 ) -> BranchEvent:
     return BranchEvent(
         uuid=uuid,
         span_id=span_id,
         timestamp=_ts(ts),
         working_start=ts,
-        from_span=from_span,
-        from_message=from_message,
+        from_anchor=from_anchor,
     )
 
 
@@ -131,13 +130,7 @@ def test_branch_with_branch_event_creates_branch_span() -> None:
             name="branch",
             span_type="branch",
         ),
-        _branch_event(
-            uuid="be1",
-            span_id="branch-1",
-            ts=3.1,
-            from_span="agent",
-            from_message="msg-1",
-        ),
+        _branch_event(uuid="be1", span_id="branch-1", ts=3.1, from_anchor="msg-1"),
         _model_event(uuid="m3", span_id="branch-1", ts=4, output_message_id="msg-3"),
         _span_end(uuid="se2", id="branch-1", parent_id="agent", ts=5),
         _span_end(uuid="se1", id="agent", ts=6),
@@ -184,63 +177,6 @@ def test_branch_without_branch_event_becomes_content() -> None:
     assert len(model_events) == 2
 
 
-def test_nested_branch_relocated_to_parent_branch() -> None:
-    """Branch 2 forking from branch 1 is nested inside branch 1."""
-    events: list[Event] = [
-        _span_begin(uuid="sb1", id="agent", ts=0, name="main", span_type="agent"),
-        _model_event(uuid="m1", span_id="agent", ts=1, output_message_id="msg-1"),
-        _span_begin(
-            uuid="sb2",
-            id="branch-1",
-            parent_id="agent",
-            ts=2,
-            name="branch",
-            span_type="branch",
-        ),
-        _branch_event(
-            uuid="be1",
-            span_id="branch-1",
-            ts=2.1,
-            from_span="agent",
-            from_message="msg-1",
-        ),
-        _model_event(uuid="m2", span_id="branch-1", ts=3, output_message_id="msg-2"),
-        _span_end(uuid="se2", id="branch-1", parent_id="agent", ts=4),
-        _span_begin(
-            uuid="sb3",
-            id="branch-2",
-            parent_id="agent",
-            ts=5,
-            name="branch",
-            span_type="branch",
-        ),
-        _branch_event(
-            uuid="be2",
-            span_id="branch-2",
-            ts=5.1,
-            from_span="branch-1",
-            from_message="msg-2",
-        ),
-        _model_event(uuid="m3", span_id="branch-2", ts=6, output_message_id="msg-3"),
-        _span_end(uuid="se3", id="branch-2", parent_id="agent", ts=7),
-        _span_end(uuid="se1", id="agent", ts=8),
-    ]
-
-    timeline = timeline_build(events)
-    agent = _find_span(timeline.root, "agent")
-    assert agent is not None
-
-    # Agent should have 1 branch (branch 1); branch 2 was relocated
-    assert len(agent.branches) == 1
-    branch1 = agent.branches[0]
-    assert branch1.branched_from == "msg-1"
-
-    # Branch 1 should have 1 nested branch (branch 2)
-    assert len(branch1.branches) == 1
-    branch2 = branch1.branches[0]
-    assert branch2.branched_from == "msg-2"
-
-
 def test_branched_from_stores_message_id() -> None:
     """branched_from stores the message_id directly from BranchEvent."""
     events: list[Event] = [
@@ -256,13 +192,7 @@ def test_branched_from_stores_message_id() -> None:
             name="branch",
             span_type="branch",
         ),
-        _branch_event(
-            uuid="be1",
-            span_id="branch-1",
-            ts=4.1,
-            from_span="agent",
-            from_message="msg-B",
-        ),
+        _branch_event(uuid="be1", span_id="branch-1", ts=4.1, from_anchor="msg-B"),
         _model_event(uuid="m4", span_id="branch-1", ts=5, output_message_id="msg-D"),
         _span_end(uuid="se2", id="branch-1", parent_id="agent", ts=6),
         _span_end(uuid="se1", id="agent", ts=7),

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,14 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2026-04-25T02:22:00.83889946Z"
+exclude-newer-span = "P1W"
+
+[options.exclude-newer-package]
+inspect-scout = false
+inspect-ai = false
+
 [[package]]
 name = "adlfs"
 version = "2026.4.0"


### PR DESCRIPTION
## Summary

Foundation for explicit (non-heuristic) branched timelines, driven by petri's target-timeline redesign.

- **`AnchorEvent`**: payload-free marker emitted at each rollback-able point. `TimelineSpan.branched_from` references an `anchor_id`; consumers resolve forks by exact match instead of scanning `ModelEvent` inputs/outputs for message IDs.
- **`set_span_id_provider()`**: contextvar hook so callers can supply deterministic span IDs (petri uses `name#n:traj_id` so spliced branch deltas have reconcilable begin/end pairs).
- **`BranchEvent` simplified**: `from_message` → `from_anchor`; `from_span` removed along with `_relocate_branches`/`_build_from_spans`/`_collect_spans` (~80 LOC). The only producer of cross-sibling `from_span` was petri's old `timeline_branch()` usage; deepagent's branches were already correctly placed via `parent_id` (relocation was a no-op there).
- `_min_start_time` guards empty content.

## Related

- ts-mono viewer: meridianlabs-ai/ts-mono (branch `petri-timeline-anchors`)
- inspect_scout `splice()`: meridianlabs-ai/inspect_scout (branch `petri-timeline-splice`)
- petri redesign: meridianlabs-ai/inspect_petri (branch `timeline-tree-tests`)

## Test plan

- [x] `tests/timeline/` (15 passed)
- [x] `tests/agent/deepagent/` (119 passed — confirms relocation removal is safe)
- [x] mypy on changed modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)