### PR TITLE
adaptive connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Add `--adaptive-connections` option to automatically tune model API concurrency between configurable bounds based on rate-limit feedback. Pass `true` to enable, or bounds shorthand like `"4-80"` / `"4-20-80"`.
+- Add `--adaptive-connections` option to automatically tune model API concurrency between configurable bounds based on rate-limit feedback.
 - Add `score_on_error` option to score samples that error rather than failing the task (errors are still counted toward the `fail_on_error` threshold).
 - Add `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Add `download()` and `gdrive_download()` helpers for fetching external files with SHA256 verification, caching, and transient-error retry. `gdrive_download()` requires the optional `gdown` dependency, installed via `pip install inspect_ai[gdown]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Add `--adaptive-connections` option to automatically tune model API concurrency between configurable bounds based on rate-limit feedback. Pass `true` to enable, or bounds shorthand like `"4-80"` / `"4-20-80"`. Explicit `--max-connections` takes precedence over adaptive scaling.
+- Add `--adaptive-connections` option to automatically tune model API concurrency between configurable bounds based on rate-limit feedback. Pass `true` to enable, or bounds shorthand like `"4-80"` / `"4-20-80"`.
 - Add `score_on_error` option to score samples that error rather than failing the task (errors are still counted toward the `fail_on_error` threshold).
 - Add `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Add `download()` and `gdrive_download()` helpers for fetching external files with SHA256 verification, caching, and transient-error retry. `gdrive_download()` requires the optional `gdown` dependency, installed via `pip install inspect_ai[gdown]`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Add `--adaptive-connections` option to automatically tune model API concurrency between configurable bounds based on rate-limit feedback. Pass `true` to enable, or bounds shorthand like `"4-80"` / `"4-20-80"`. Explicit `--max-connections` takes precedence over adaptive scaling.
 - Add `score_on_error` option to score samples that error rather than failing the task (errors are still counted toward the `fail_on_error` threshold).
 - Add `media_resolver()` context manager for scoped URI resolution for media reading (images, audio, etc.).
 - Add `download()` and `gdrive_download()` helpers for fetching external files with SHA256 verification, caching, and transient-error retry. `gdrive_download()` requires the optional `gdown` dependency, installed via `pip install inspect_ai[gdown]`.

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -53,19 +53,12 @@ inspect-docs:
           href: providers.qmd
         - href: caching.qmd
         - href: models-batch.qmd
+        - text: Concurrency
+          href: models-concurrency.qmd
         - href: compaction.qmd
         - href: multimodal.qmd
         - href: reasoning.qmd
         - href: structured.qmd
-    - text: Tools
-      contents:
-        - href: tools.qmd
-        - href: tools-standard.qmd
-        - text: MCP Tools
-          href: tools-mcp.qmd
-        - href: tools-custom.qmd
-        - href: sandboxing.qmd
-        - href: approval.qmd
     - text: Agents
       contents:
         - href: agents.qmd
@@ -75,6 +68,15 @@ inspect-docs:
         - href: agent-custom.qmd
         - href: agent-bridge.qmd
         - href: human-agent.qmd
+    - text: Tools
+      contents:
+        - href: tools.qmd
+        - href: tools-standard.qmd
+        - text: MCP Tools
+          href: tools-mcp.qmd
+        - href: tools-custom.qmd
+        - href: sandboxing.qmd
+        - href: approval.qmd
     - text: Analysis
       contents:
         - href: eval-logs.qmd

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -237,6 +237,8 @@ These sections cover how to use various language models with Inspect:
 
 -   [Batch Mode](models-batch.qmd) covers using batch processing APIs for model inference.
 
+-   [Model Concurrency](models-concurrency.qmd) covers tuning model API connection limits, adaptive concurrency, and rate-limit handling.
+
 -   [Structured Output](structured.qmd) explains how to constrain model output to a particular JSON schema.
 
 These sections describe how to create agent evaluations with Inspect:
@@ -273,7 +275,7 @@ These sections discuss more advanced features and workflows. You don't need to r
 
 -   [Caching](caching.qmd) enables you to cache model output to reduce the number of API calls made, saving both time and expense.
 
--   [Parallelism](parallelism.qmd) delves into how to obtain maximum performance for evaluations. Inspect uses a highly parallel async architecture---here we cover how to tune this parallelism (e.g to stay under API rate limits or to not overburden local compute) for optimal throughput.
+-   [Parallelism](parallelism.qmd) covers running multiple models or tasks in parallel, sandbox container concurrency, and writing parallel custom code (tools, solvers, scorers). For tuning model API connection limits and rate-limit handling, see [Model Concurrency](models-concurrency.qmd).
 
 -   [Interactivity](interactivity.qmd) covers various ways to introduce user interaction into the implementation of tasks (for example, prompting the model dynamically based on the trajectory of the evaluation).
 

--- a/docs/models-concurrency.qmd
+++ b/docs/models-concurrency.qmd
@@ -1,0 +1,174 @@
+---
+title: Model Concurrency
+llms-description: Tuning model API connection limits, adaptive concurrency, and rate-limit handling.
+---
+
+## Overview
+
+Model API rate limits typically constrain evaluation throughput more than anything else. Inspect manages this with per-model concurrency limits (a cap on in-flight requests to a given provider) plus automatic retry on rate-limit and transient errors.
+
+Two modes are available:
+
+- Static. Set a fixed `--max-connections` value. You need to know the right number for your tier.
+
+- Adaptive. Use `--adaptive-connections` to let Inspect tune the number, scaling up while the provider keeps up and backing off on rate-limit retries.
+
+This page covers both modes, plus retry tuning and debugging. For other forms of parallelism (multiple tasks, sandbox containers, custom code), see [Parallelism](parallelism.qmd). For provider-side batch APIs, which run on a separate quota and use a different concurrency model, see [Batch Mode](models-batch.qmd).
+
+## Max Connections
+
+Connections to model APIs are the most fundamental unit of concurrency to manage. The main thing that limits model API concurrency is not local compute or network availability, but rather *rate limits* imposed by model API providers. Here we run an evaluation and set the maximum connections to 20:
+
+``` bash
+$ inspect eval --model openai/gpt-4 --max-connections 20
+```
+
+The default value for max connections is 10. By increasing it we might get better performance due to higher parallelism, however we might get *worse* performance if this causes us to frequently hit rate limits (which are retried with exponential backoff). The "correct" max connections for your evaluations will vary based on your actual rate limit and the size and complexity of your evaluations.
+
+::: {.callout-note appearance="simple"}
+Note that max connections is applied per-model. This means that if you use a grader model from a provider distinct from the one you are evaluating you will get extra concurrency (as each model will enforce its own max connections).
+:::
+
+## Rate Limits
+
+When you run an eval you'll see information reported on the current active connection usage as well as the number of HTTP retries that have occurred (Inspect will automatically retry on rate limits and other errors likely to be transient):
+
+![](images/rate-limit.png){fig-alt="The Inspect task results displayed in the terminal. The number of HTTP rate limit errors that have occurred (25) is printed in the bottom right of the task results."}
+
+Here we've set a higher max connections than the default (30). While you might be tempted to set this very high to see how much concurrent traffic you can sustain, more often than not setting too high a max connections will result in slower evaluations, because retries are done using [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff), and bouncing off of rate limits too frequently will have you waiting minutes for retries to fire.
+
+You should experiment with various values for max connections at different times of day (evening is often very different than daytime!). Generally speaking, you want to see some number of HTTP rate limits enforced so you know that you are somewhere close to ideal utilisation, but if you see hundreds of these you are likely over-saturating and experiencing a net slowdown.
+
+## Adaptive Connections
+
+::: {.callout-note appearance="simple"}
+The adaptive connections feature described below is available only in the development version of Inspect. To install the development version from GitHub:
+
+``` bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+Tuning `--max-connections` by hand is awkward: you have to guess a value, watch for retries, and re-tune for different times of day or different rate-limit tiers. The `--adaptive-connections` option does this for you. It starts at a moderate concurrency, grows while the provider keeps up, and backs off on rate-limit retries.
+
+``` bash
+$ inspect eval --model openai/gpt-4o --adaptive-connections true
+```
+
+By default a per-model controller starts at 20 concurrent connections and scales between 4 and 100. These bounds suit typical paid (non-enterprise) tiers; raise `max` for enterprise tiers, lower it for tighter ones.
+
+When adaptive connections is in effect, `max_samples` automatically tracks the controller's current limit (with a small buffer), so sample setup work like creating sandbox containers stays proportional to actual model concurrency rather than the maximum bound.
+
+
+### Bounds Tuning
+
+The bounds (`min`, `start`, `max`) are the everyday tuning knobs. `start` is where the controller begins (it doubles aggressively during slow-start until the first rate-limit episode), and `max` is the ceiling.
+
+Pass a string shorthand. `min-max` constrains the range (`start` defaults to 20, clamped into the range):
+
+``` bash
+$ inspect eval --model openai/gpt-4o --adaptive-connections "4-80"
+```
+
+`min-start-max` also sets the starting value:
+
+``` bash
+$ inspect eval --model openai/gpt-4o --adaptive-connections "4-40-80"
+```
+
+In Python, pass `True` for defaults or an `AdaptiveConcurrency` to customize:
+
+``` python
+from inspect_ai.util import AdaptiveConcurrency
+
+eval(
+    "task.py",
+    model="openai/gpt-4o",
+    adaptive_connections=AdaptiveConcurrency(min=4, max=80),
+)
+```
+
+A rule of thumb for `max` is *(tier RPM × average request seconds) ÷ 60*. On a 60 RPM tier with 3-second requests, a `max` near 3 is enough; on a 4,000 RPM tier with 1.5-second requests, a `max` around 100 starts to make sense.
+
+### Retry Types
+
+The controller distinguishes two kinds of retries.
+
+- Rate-limit retries: HTTP 429, plus per-provider equivalents like Bedrock `ThrottlingException` and Google `503 RESOURCE_EXHAUSTED`. These shrink the limit by `decrease_factor` (default 0.8) per episode, with a debounce so a single rate-limit burst produces only one cut.
+
+- Transient retries: 5xx, timeouts, and network errors. These pause scale-up (the eventual success won't count toward growth) but do not shrink the limit. Provider 5xx and network blips are usually infra noise unrelated to your concurrency, and lowering concurrency doesn't help an upstream outage. Each provider's `should_retry()` classifies its own errors via a `RetryDecision`, so genuinely-rate-limited 5xx codes are still counted as rate-limit signals where applicable.
+
+After a rate-limit cut, the controller waits at least `cooldown_seconds` (default 15s) before allowing another cut. If the response carries a `Retry-After` header, the cooldown extends to honor it. When `Retry-After` is absent, Inspect falls back to provider-specific reset-window headers: `x-ratelimit-reset-requests` and `x-ratelimit-reset-tokens` (OpenAI, Groq, Azure OpenAI), and `anthropic-ratelimit-*-reset` (Anthropic).
+
+Cache hits and successful-after-retry calls are neutral: they neither grow nor shrink the limit.
+
+### Advanced Tuning
+
+The response curve is also tunable. These fields are Python-only (CLI shorthand stays at `min-max` / `min-start-max`):
+
+- `cooldown_seconds` (default 15): minimum debounce between scale-down cuts. Larger for long-running agent loops where each rate-limit episode takes longer to clear; smaller for short request workloads.
+
+- `decrease_factor` (default 0.8): multiplicative cut on each rate-limit episode. More aggressive (e.g. 0.5) for volatile tiers where overshoots are common; gentler when tiers are stable.
+
+- `scale_up_percent` (default 0.05): additive growth per clean round in steady state. Increase for short evals where slow ramp-up doesn't have time to converge.
+
+``` python
+from inspect_ai.util import AdaptiveConcurrency
+
+eval(
+    "task.py",
+    model="openai/gpt-4o",
+    adaptive_connections=AdaptiveConcurrency(
+        min=4,
+        max=80,
+        cooldown_seconds=30,
+        decrease_factor=0.5,
+        scale_up_percent=0.1,
+    ),
+)
+```
+
+### Limit History
+
+The full history of scale changes is captured in the eval log under `stats.connection_limit_history`. Each entry records the timestamp, model, old and new limits, and a `reason` of `slow_start`, `steady_state_up`, or `rate_limit`. Only `rate_limit` reflects an actual scale-down (transient infra noise no longer appears here). You can stream the same events live in the trace log:
+
+``` bash
+inspect trace dump --filter "[connections]"
+```
+
+## Limiting Retries
+
+By default, Inspect will retry model API calls indefinitely (with exponential backoff) when a recoverable HTTP error occurs. The initial backoff is 3 seconds and exponentiation will result in a 25 minute wait for the 10th request (then 30 minutes for the 11th and subsequent requests). You can limit Inspect's retries using the `--max-retries` option:
+
+``` bash
+inspect eval --model openai/gpt-4 --max-retries 10
+```
+
+Note that model interfaces themselves may have internal retry behavior (for example, the `openai` and `anthropic` packages both retry twice by default).
+
+You can put a limit on the total time for retries using the `--timeout` option:
+
+``` bash
+inspect eval --model openai/gpt-4 --timeout 600
+```
+
+## Debugging Retries
+
+If you want more insight into Model API connections and retries, specify `log_level=http`. For example:
+
+``` bash
+inspect eval --model openai/gpt-4 --log-level=http
+```
+
+You can also view all of the HTTP requests for the current (or most recent) evaluation run using the `inspect trace http` command. For example:
+
+``` bash
+inspect trace http           # show all http requests
+inspect trace http --failed  # show only failed requests
+```
+
+## Learning More
+
+- [Parallelism](parallelism.qmd): running multiple tasks or models in parallel, sandbox container concurrency, and writing parallel custom code.
+
+- [Batch Mode](models-batch.qmd): provider-side batch APIs (separate quota, longer turnaround, lower per-token cost).

--- a/docs/models-concurrency.qmd
+++ b/docs/models-concurrency.qmd
@@ -55,7 +55,7 @@ Tuning `--max-connections` by hand is awkward: you have to guess a value, watch 
 $ inspect eval --model openai/gpt-4o --adaptive-connections true
 ```
 
-By default a per-model controller starts at 20 concurrent connections and scales between 4 and 100. These bounds suit typical paid (non-enterprise) tiers; raise `max` for enterprise tiers, lower it for tighter ones.
+By default a per-model controller starts at 20 concurrent connections and scales between 4 and 200. The controller scales down on rate-limit retries, so a high `max` is harmless for low-tier accounts (they'll never reach it) and useful for high-tier accounts where Inspect would otherwise leave capacity on the floor.
 
 When adaptive connections is in effect, `max_samples` automatically tracks the controller's current limit (with a small buffer), so sample setup work like creating sandbox containers stays proportional to actual model concurrency rather than the maximum bound.
 

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -83,7 +83,7 @@ See the documentation for the requisite model provider for information on how mo
 
 Inspect uses an asynchronous architecture to run task samples in parallel. If your model provider can handle 100 concurrent connections, then Inspect can utilise all of those connections to get the highest possible throughput. The limiting factor on parallelism is therefore not typically local parallelism (e.g. number of cores) but rather what the underlying rate limit is for your interface to the provider.
 
-By default, Inspect uses a `max_connections` value of 10. You can increase this consistent with your account limits. If you are experiencing rate-limit errors you will need to experiment with the `max_connections` option to find the optimal value that keeps you under the rate limit (the section on [Parallelism](parallelism.qmd) includes additional documentation on how to do this).
+By default, Inspect uses a `max_connections` value of 10. You can increase this consistent with your account limits. If you are experiencing rate-limit errors you will need to experiment with the `max_connections` option to find the optimal value that keeps you under the rate limit (see [Model Concurrency](models-concurrency.qmd) for additional documentation, including the `--adaptive-connections` option that tunes this for you automatically).
 
 ## Model API {#model-api}
 

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -1,6 +1,6 @@
 ---
 title: Parallelism
-llms-description: Tuning Inspect's parallel async architecture for optimal throughput while respecting rate limits.
+llms-description: Running multiple tasks and models in parallel, sandbox concurrency, and writing parallel custom code.
 aliases:
   - eval-tuning.html
 ---
@@ -11,159 +11,16 @@ Inspect runs evaluations using a parallel async architecture, eagerly executing 
 
 There are a progression of concurrency concerns, and while most evaluations can rely on the Inspect default behaviour, others will benefit from more customisation. Below we'll cover the following:
 
-1.  Model API connection concurrency.
-2.  Evaluating multiple models in parallel.
-3.  Evaluating multiple tasks in parallel. 
+1.  Evaluating multiple models in parallel.
+2.  Evaluating multiple tasks in parallel.
 3.  Sandbox environment concurrency.
 4.  Writing parallel code in custom tools, solvers, and scorers.
 
+::: {.callout-note appearance="simple"}
+For tuning model API connection limits and rate-limit handling (`max_connections`, adaptive connections, retries) see [Model Concurrency](models-concurrency.qmd).
+:::
+
 Inspect uses [asyncio](https://docs.python.org/3/library/asyncio.html) as its async backend by default, but can also be configured to run against [trio](https://trio.readthedocs.io/en/stable/). See the section on [Async Backends](#async-backends) for additional details.
-
-## Model Connections
-
-### Max Connections
-
-Connections to model APIs are the most fundamental unit of concurrency to manage. The main thing that limits model API concurrency is not local compute or network availability, but rather *rate limits* imposed by model API providers. Here we run an evaluation and set the maximum connections to 20:
-
-``` bash
-$ inspect eval --model openai/gpt-4 --max-connections 20
-```
-
-The default value for max connections is 10. By increasing it we might get better performance due to higher parallelism, however we might get *worse* performance if this causes us to frequently hit rate limits (which are retried with exponential backoff). The "correct" max connections for your evaluations will vary based on your actual rate limit and the size and complexity of your evaluations.
-
-::: {.callout-note appearance="simple"}
-Note that max connections is applied per-model. This means that if you use a grader model from a provider distinct from the one you are evaluating you will get extra concurrency (as each model will enforce its own max connections).
-:::
-
-### Rate Limits
-
-When you run an eval you'll see information reported on the current active connection usage as well as the number of HTTP retries that have occurred (Inspect will automatically retry on rate limits and other errors likely to be transient):
-
-![](images/rate-limit.png){fig-alt="The Inspect task results displayed in the terminal. The number of HTTP rate limit errors that have occurred (25) is printed in the bottom right of the task results."}
-
-Here we've set a higher max connections than the default (30). While you might be tempted to set this very high to see how much concurrent traffic you can sustain, more often than not setting too high a max connections will result in slower evaluations, because retries are done using [exponential backoff](https://en.wikipedia.org/wiki/Exponential_backoff), and bouncing off of rate limits too frequently will have you waiting minutes for retries to fire.
-
-You should experiment with various values for max connections at different times of day (evening is often very different than daytime!). Generally speaking, you want to see some number of HTTP rate limits enforced so you know that you are somewhere close to ideal utilisation, but if you see hundreds of these you are likely over-saturating and experiencing a net slowdown.
-
-### Adaptive Connections
-
-Tuning `--max-connections` by hand is awkward: you have to guess a value, watch for rate-limit retries, and re-tune for different times of day or different rate-limit tiers. The `--adaptive-connections` option lets Inspect tune it for you automatically — starting at a moderate concurrency, growing until rate-limit retries are observed, then backing off.
-
-``` bash
-$ inspect eval --model openai/gpt-4o --adaptive-connections true
-```
-
-A per-model controller starts at `start = 20` concurrent connections and scales between `min = 4` and `max = 100` (the defaults). These bounds are designed for typical paid (non-enterprise) tiers; users on enterprise tiers can raise `max` explicitly, and users with very tight tiers can lower it.
-
-#### How it responds to errors
-
-The controller distinguishes between two kinds of retries:
-
-- **Rate-limit retries.** HTTP 429, plus per-provider equivalents — Bedrock `ThrottlingException`, Google `503 RESOURCE_EXHAUSTED`. These shrink the limit by `decrease_factor` (default 0.8) per episode, with a debounce so a single rate-limit burst produces only one cut.
-- **Transient retries.** 5xx, timeouts, and network errors. These *pause* scale-up — the in-flight request's eventual success won't count toward growth — but they do **not** shrink the limit. Provider 5xx and network blips are usually infra noise unrelated to your concurrency, and lowering concurrency doesn't help a provider-side outage. (Each provider's `should_retry()` method classifies its own errors by returning a `RetryDecision`, so genuinely-rate-limited 5xx codes for that provider are still counted as rate-limit signals.)
-
-After a rate-limit cut, the controller observes a cooldown of at least `cooldown_seconds` (default 15s) before another cut is allowed. If the response carries a `Retry-After` header, the cooldown is extended to honor it. When `Retry-After` is absent, Inspect falls back to provider-specific reset-window headers — `x-ratelimit-reset-requests` / `x-ratelimit-reset-tokens` (OpenAI / Groq / Azure OpenAI) and `anthropic-ratelimit-*-reset` (Anthropic) — so the controller still benefits from server-suggested wait times whenever they're available.
-
-Cache hits and successful-after-retry calls are neutral — they neither grow the limit nor shrink it.
-
-#### Tuning the bounds
-
-The bounds — `min`, `start`, `max` — are the everyday tuning knobs. `start` is where the controller begins (it doubles aggressively from there during slow-start until the first rate-limit episode). `max` is the ceiling.
-
-Pass a string shorthand: `min-max` constrains the controller's range (`start` defaults to 20, clamped into the range):
-
-``` bash
-$ inspect eval --model openai/gpt-4o --adaptive-connections "4-80"
-```
-
-`min-start-max` also sets the starting value:
-
-``` bash
-$ inspect eval --model openai/gpt-4o --adaptive-connections "4-40-80"
-```
-
-In Python, pass `True` for defaults or an `AdaptiveConcurrency` config to customise:
-
-``` python
-from inspect_ai.util import AdaptiveConcurrency
-
-eval(
-    "task.py",
-    model="openai/gpt-4o",
-    adaptive_connections=AdaptiveConcurrency(min=4, max=80),
-)
-```
-
-A reasonable rule of thumb for `max` is roughly *(your tier RPM × average request seconds) ÷ 60* — so on a 60 RPM tier with 3-second requests, a `max` near 3 is enough; on a 4,000 RPM tier with 1.5-second requests, a `max` around 100 starts to make sense.
-
-#### Advanced tuning
-
-The response curve is also tunable, with sensible defaults for typical evaluation workloads. These fields are Python-only (CLI shorthand stays at `min-max` / `min-start-max`):
-
-- **`cooldown_seconds`** (default 15) — minimum debounce between scale-down cuts. Larger for long-running agent loops where each rate-limit episode takes longer to clear; smaller for short request workloads.
-- **`decrease_factor`** (default 0.8) — multiplicative cut on each rate-limit episode. More aggressive (e.g. 0.5) for volatile tiers where overshoots are common; gentler (default) when tiers are stable.
-- **`scale_up_percent`** (default 0.05) — additive growth per clean round in steady state. Increase for short evals where a slow ramp-up doesn't have time to converge.
-
-``` python
-from inspect_ai.util import AdaptiveConcurrency
-
-eval(
-    "task.py",
-    model="openai/gpt-4o",
-    adaptive_connections=AdaptiveConcurrency(
-        min=4,
-        max=80,
-        cooldown_seconds=30,
-        decrease_factor=0.5,
-        scale_up_percent=0.1,
-    ),
-)
-```
-
-::: {.callout-note appearance="simple"}
-**Explicit caps always win.** If you set `--max-connections` together with `--adaptive-connections`, the static cap takes precedence and adaptive scaling is disabled. Likewise, an explicit `max_samples` overrides the dynamic sample limiter. **Batch mode also silently disables adaptive concurrency** — batch APIs run on a separate quota, the per-request concurrency model doesn't bind, and the batch worker's accounting boundary makes adaptive's success/retry signals unreliable; batch evaluations always use the static `max_connections` path. These rules together make it safe to leave adaptive connections enabled in shared configs while still pinning specific evaluations to fixed values when needed.
-:::
-
-When adaptive connections is in effect, `max_samples` automatically tracks the controller's current limit (with a small buffer), so sample setup work — like creating sandbox containers — stays proportional to the actual model concurrency rather than the maximum bound.
-
-#### What's recorded
-
-The full history of scale changes is captured in the eval log under `stats.connection_limit_history`. Each entry records the timestamp, model, old/new limits, and a `reason` of `slow_start`, `steady_state_up`, or `rate_limit` — only `rate_limit` reflects an actual scale-down (transient infra noise no longer appears here). You can stream the same events live in the trace log:
-
-``` bash
-inspect trace dump --filter "[connections]"
-```
-
-### Limiting Retries
-
-By default, Inspect will retry model API calls indefinitely (with exponential backoff) when a recoverable HTTP error occurs. The initial backoff is 3 seconds and exponentiation will result in a 25 minute wait for the 10th request (then 30 minutes for the 11th and subsequent requests). You can limit Inspect's retries using the `--max-retries` option:
-
-``` bash
-inspect eval --model openai/gpt-4 --max-retries 10
-```
-
-Note that model interfaces themselves may have internal retry behavior (for example, the `openai` and `anthropic` packages both retry twice by default).
-
-You can put a limit on the total time for retries using the `--timeout` option:
-
-``` bash
-inspect eval --model openai/gpt-4 --timeout 600 
-```
-
-### Debugging Retries
-
-If you want more insight into Model API connections and retries, specify `log_level=http`. For example:
-
-``` bash
-inspect eval --model openai/gpt-4 --log-level=http
-```
-
-You can also view all of the HTTP requests for the current (or most recent) evaluation run using the `inspect trace http` command. For example:
-
-``` bash
-inspect trace http           # show all http requests
-inspect trace http --failed  # show only failed requests
-```
 
 ## Multiple Models {#sec-multiple-models}
 
@@ -179,7 +36,7 @@ eval("mathematics.py", model=[
 
 ![](images/inspect-multiple-models.png){fig-alt="An evaluation task display showing the progress for 3 different models."}
 
-Since each model provider has its own `max_connections` they don't contend with each other for resources. If you need to evaluate multiple models, doing so concurrently is highly recommended.
+Since each model provider has its own `max_connections` they don't contend with each other for resources (see [Model Concurrency](models-concurrency.qmd) for per-model tuning). If you need to evaluate multiple models, doing so concurrently is highly recommended.
 
 If you want to specify multiple models when using the `--model` CLI argument or `INSPECT_EVAL_MODEL` environment variable, just separate the model names with commas. For example:
 

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -121,7 +121,7 @@ eval(
 ```
 
 ::: {.callout-note appearance="simple"}
-**Explicit caps always win.** If you set `--max-connections` together with `--adaptive-connections`, the static cap takes precedence and adaptive scaling is disabled. Likewise, an explicit `max_samples` overrides the dynamic sample limiter. This makes it safe to leave adaptive connections enabled in shared configs while still pinning specific evaluations to fixed values when needed.
+**Explicit caps always win.** If you set `--max-connections` together with `--adaptive-connections`, the static cap takes precedence and adaptive scaling is disabled. Likewise, an explicit `max_samples` overrides the dynamic sample limiter. **Batch mode also silently disables adaptive concurrency** — batch APIs run on a separate quota, the per-request concurrency model doesn't bind, and the batch worker's accounting boundary makes adaptive's success/retry signals unreliable; batch evaluations always use the static `max_connections` path. These rules together make it safe to leave adaptive connections enabled in shared configs while still pinning specific evaluations to fixed values when needed.
 :::
 
 When adaptive connections is in effect, `max_samples` automatically tracks the controller's current limit (with a small buffer), so sample setup work — like creating sandbox containers — stays proportional to the actual model concurrency rather than the maximum bound.

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -47,15 +47,30 @@ You should experiment with various values for max connections at different times
 
 ### Adaptive Connections
 
-Tuning `--max-connections` by hand is awkward: you have to guess a value, watch for rate-limit retries, and re-tune for different times of day or different rate-limit tiers. The `--adaptive-connections` option lets Inspect tune it for you automatically — starting conservatively and scaling up until rate-limit retries are observed, then backing off.
+Tuning `--max-connections` by hand is awkward: you have to guess a value, watch for rate-limit retries, and re-tune for different times of day or different rate-limit tiers. The `--adaptive-connections` option lets Inspect tune it for you automatically — starting at a moderate concurrency, growing until rate-limit retries are observed, then backing off.
 
 ``` bash
 $ inspect eval --model openai/gpt-4o --adaptive-connections true
 ```
 
-When enabled, a per-model controller starts at 20 concurrent connections, doubles until the first rate-limit retry (slow-start), then settles into additive-increase / multiplicative-decrease behaviour: each clean window of requests adds roughly 5%, and each rate-limit episode multiplies the limit by 0.8. Scale-down is debounced for 15 seconds so a single rate-limit burst doesn't cause repeated cuts.
+A per-model controller starts at `start = 20` concurrent connections and scales between `min = 4` and `max = 100` (the defaults). These bounds are designed for typical paid (non-enterprise) tiers; users on enterprise tiers can raise `max` explicitly, and users with very tight tiers can lower it.
 
-To customise the bounds, pass a string shorthand. `min-max` constrains the controller's range (start defaults to 20):
+#### How it responds to errors
+
+The controller distinguishes between two kinds of retries:
+
+- **Rate-limit retries.** HTTP 429, plus per-provider equivalents — Bedrock `ThrottlingException`, Google `503 RESOURCE_EXHAUSTED`. These shrink the limit by `decrease_factor` (default 0.8) per episode, with a debounce so a single rate-limit burst produces only one cut.
+- **Transient retries.** 5xx, timeouts, and network errors. These *pause* scale-up — the in-flight request's eventual success won't count toward growth — but they do **not** shrink the limit. Provider 5xx and network blips are usually infra noise unrelated to your concurrency, and lowering concurrency doesn't help a provider-side outage. (Each provider's `should_retry()` method classifies its own errors by returning a `RetryDecision`, so genuinely-rate-limited 5xx codes for that provider are still counted as rate-limit signals.)
+
+After a rate-limit cut, the controller observes a cooldown of at least `cooldown_seconds` (default 15s) before another cut is allowed. If the response carries a `Retry-After` header, the cooldown is extended to honor it. When `Retry-After` is absent, Inspect falls back to provider-specific reset-window headers — `x-ratelimit-reset-requests` / `x-ratelimit-reset-tokens` (OpenAI / Groq / Azure OpenAI) and `anthropic-ratelimit-*-reset` (Anthropic) — so the controller still benefits from server-suggested wait times whenever they're available.
+
+Cache hits and successful-after-retry calls are neutral — they neither grow the limit nor shrink it.
+
+#### Tuning the bounds
+
+The bounds — `min`, `start`, `max` — are the everyday tuning knobs. `start` is where the controller begins (it doubles aggressively from there during slow-start until the first rate-limit episode). `max` is the ceiling.
+
+Pass a string shorthand: `min-max` constrains the controller's range (`start` defaults to 20, clamped into the range):
 
 ``` bash
 $ inspect eval --model openai/gpt-4o --adaptive-connections "4-80"
@@ -79,13 +94,41 @@ eval(
 )
 ```
 
+A reasonable rule of thumb for `max` is roughly *(your tier RPM × average request seconds) ÷ 60* — so on a 60 RPM tier with 3-second requests, a `max` near 3 is enough; on a 4,000 RPM tier with 1.5-second requests, a `max` around 100 starts to make sense.
+
+#### Advanced tuning
+
+The response curve is also tunable, with sensible defaults for typical evaluation workloads. These fields are Python-only (CLI shorthand stays at `min-max` / `min-start-max`):
+
+- **`cooldown_seconds`** (default 15) — minimum debounce between scale-down cuts. Larger for long-running agent loops where each rate-limit episode takes longer to clear; smaller for short request workloads.
+- **`decrease_factor`** (default 0.8) — multiplicative cut on each rate-limit episode. More aggressive (e.g. 0.5) for volatile tiers where overshoots are common; gentler (default) when tiers are stable.
+- **`scale_up_percent`** (default 0.05) — additive growth per clean round in steady state. Increase for short evals where a slow ramp-up doesn't have time to converge.
+
+``` python
+from inspect_ai.util import AdaptiveConcurrency
+
+eval(
+    "task.py",
+    model="openai/gpt-4o",
+    adaptive_connections=AdaptiveConcurrency(
+        min=4,
+        max=80,
+        cooldown_seconds=30,
+        decrease_factor=0.5,
+        scale_up_percent=0.1,
+    ),
+)
+```
+
 ::: {.callout-note appearance="simple"}
-**`max_connections` always wins.** If you set both `--max-connections` and `--adaptive-connections`, the explicit static cap takes precedence and adaptive scaling is disabled. This makes it safe to leave adaptive connections enabled by default in shared configs while still letting individual evaluations pin a fixed value when needed.
+**Explicit caps always win.** If you set `--max-connections` together with `--adaptive-connections`, the static cap takes precedence and adaptive scaling is disabled. Likewise, an explicit `max_samples` overrides the dynamic sample limiter. This makes it safe to leave adaptive connections enabled in shared configs while still pinning specific evaluations to fixed values when needed.
 :::
 
 When adaptive connections is in effect, `max_samples` automatically tracks the controller's current limit (with a small buffer), so sample setup work — like creating sandbox containers — stays proportional to the actual model concurrency rather than the maximum bound.
 
-The full history of scale changes is captured in the eval log under `stats.connection_limit_history` (each entry records the timestamp, model, old/new limits, and reason). You can see these changes via the trace log:
+#### What's recorded
+
+The full history of scale changes is captured in the eval log under `stats.connection_limit_history`. Each entry records the timestamp, model, old/new limits, and a `reason` of `slow_start`, `steady_state_up`, or `rate_limit` — only `rate_limit` reflects an actual scale-down (transient infra noise no longer appears here). You can stream the same events live in the trace log:
 
 ``` bash
 inspect trace dump --filter "[connections]"

--- a/docs/parallelism.qmd
+++ b/docs/parallelism.qmd
@@ -45,6 +45,52 @@ Here we've set a higher max connections than the default (30). While you might b
 
 You should experiment with various values for max connections at different times of day (evening is often very different than daytime!). Generally speaking, you want to see some number of HTTP rate limits enforced so you know that you are somewhere close to ideal utilisation, but if you see hundreds of these you are likely over-saturating and experiencing a net slowdown.
 
+### Adaptive Connections
+
+Tuning `--max-connections` by hand is awkward: you have to guess a value, watch for rate-limit retries, and re-tune for different times of day or different rate-limit tiers. The `--adaptive-connections` option lets Inspect tune it for you automatically — starting conservatively and scaling up until rate-limit retries are observed, then backing off.
+
+``` bash
+$ inspect eval --model openai/gpt-4o --adaptive-connections true
+```
+
+When enabled, a per-model controller starts at 20 concurrent connections, doubles until the first rate-limit retry (slow-start), then settles into additive-increase / multiplicative-decrease behaviour: each clean window of requests adds roughly 5%, and each rate-limit episode multiplies the limit by 0.8. Scale-down is debounced for 15 seconds so a single rate-limit burst doesn't cause repeated cuts.
+
+To customise the bounds, pass a string shorthand. `min-max` constrains the controller's range (start defaults to 20):
+
+``` bash
+$ inspect eval --model openai/gpt-4o --adaptive-connections "4-80"
+```
+
+`min-start-max` also sets the starting value:
+
+``` bash
+$ inspect eval --model openai/gpt-4o --adaptive-connections "4-40-80"
+```
+
+In Python, pass `True` for defaults or an `AdaptiveConcurrency` config to customise:
+
+``` python
+from inspect_ai.util import AdaptiveConcurrency
+
+eval(
+    "task.py",
+    model="openai/gpt-4o",
+    adaptive_connections=AdaptiveConcurrency(min=4, max=80),
+)
+```
+
+::: {.callout-note appearance="simple"}
+**`max_connections` always wins.** If you set both `--max-connections` and `--adaptive-connections`, the explicit static cap takes precedence and adaptive scaling is disabled. This makes it safe to leave adaptive connections enabled by default in shared configs while still letting individual evaluations pin a fixed value when needed.
+:::
+
+When adaptive connections is in effect, `max_samples` automatically tracks the controller's current limit (with a small buffer), so sample setup work — like creating sandbox containers — stays proportional to the actual model concurrency rather than the maximum bound.
+
+The full history of scale changes is captured in the eval log under `stats.connection_limit_history` (each entry records the timestamp, model, old/new limits, and reason). You can see these changes via the trace log:
+
+``` bash
+inspect trace dump --filter "[connections]"
+```
+
 ### Limiting Retries
 
 By default, Inspect will retry model API calls indefinitely (with exponential backoff) when a recoverable HTTP error occurs. The initial backoff is 3 seconds and exponentiation will result in a 25 minute wait for the 10th request (then 30 minutes for the 11th and subsequent requests). You can limit Inspect's retries using the `--max-retries` option:

--- a/docs/reference/inspect_ai.model.qmd
+++ b/docs/reference/inspect_ai.model.qmd
@@ -21,6 +21,7 @@ description: Model interface and providers.
 ### ChatCompletionChoice
 ### OutputModality
 ### ImageOutput
+### RetryDecision
 
 ## Messages
 

--- a/docs/reference/inspect_ai.util.qmd
+++ b/docs/reference/inspect_ai.util.qmd
@@ -30,6 +30,7 @@ description: Miscellaneous utility functions.
 ### concurrency
 ### subprocess
 ### ExecResult
+### AdaptiveConcurrency
 
 ## Display
 

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -34,6 +34,7 @@ from inspect_ai.model._generate_config import (  # noqa: F811
 )
 from inspect_ai.scorer._reducer import create_reducers
 from inspect_ai.solver._solver import SolverSpec
+from inspect_ai.util import AdaptiveConcurrency
 from inspect_ai.util._resource import resource
 
 from .common import (
@@ -78,6 +79,12 @@ NO_SCORE_HELP = (
 )
 NO_SCORE_DISPLAY = "Do not display scoring metrics in realtime."
 MAX_CONNECTIONS_HELP = f"Maximum number of concurrent connections to Model API (defaults to {DEFAULT_MAX_CONNECTIONS})"
+ADAPTIVE_CONNECTIONS_HELP = (
+    "Enable adaptive concurrency for Model API connections, automatically "
+    "scaling between bounds based on rate-limit feedback. Pass `true` for "
+    "defaults (min=1, start=20, max=200), `false` to explicitly disable, or "
+    'bounds as "min-max" (e.g. "4-80") or "min-start-max" (e.g. "4-20-80").'
+)
 MAX_RETRIES_HELP = (
     "Maximum number of times to retry model API requests (defaults to unlimited)"
 )
@@ -238,6 +245,13 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         type=int,
         help=MAX_CONNECTIONS_HELP,
         envvar="INSPECT_EVAL_MAX_CONNECTIONS",
+    )
+    @click.option(
+        "--adaptive-connections",
+        type=str,
+        default=None,
+        help=ADAPTIVE_CONNECTIONS_HELP,
+        envvar="INSPECT_EVAL_ADAPTIVE_CONNECTIONS",
     )
     @click.option(
         "--max-retries",
@@ -668,6 +682,7 @@ def eval_command(
     timeout: int | None,
     attempt_timeout: int | None,
     max_connections: int | None,
+    adaptive_connections: str | None,
     max_tokens: int | None,
     system_message: str | None,
     best_of: int | None,
@@ -897,6 +912,7 @@ def eval_set_command(
     timeout: int | None,
     attempt_timeout: int | None,
     max_connections: int | None,
+    adaptive_connections: str | None,
     max_tokens: int | None,
     system_message: str | None,
     best_of: int | None,
@@ -1240,6 +1256,34 @@ def eval_exec(
         return True
 
 
+def _parse_adaptive_connections_cli(
+    value: str | None,
+) -> bool | AdaptiveConcurrency | None:
+    """Parse a CLI string into an adaptive_connections value.
+
+    Accepts: None (passthrough), bool keywords ("true"/"false"/"1"/"0"/"yes"/"no",
+    case-insensitive), or shorthand like "4-80" / "4-20-80" delegated to
+    AdaptiveConcurrency's parser. Raises `click.BadParameter` on invalid input
+    so the CLI surfaces a clean usage message instead of a raw pydantic
+    ValidationError.
+    """
+    if value is None:
+        return None
+    v = value.strip().lower()
+    if v in ("true", "1", "yes"):
+        return True
+    if v in ("false", "0", "no"):
+        return False
+    try:
+        return AdaptiveConcurrency.model_validate(value)
+    except Exception as ex:
+        raise click.BadParameter(
+            f"{value!r} is not a valid value. Expected `true`, `false`, or "
+            f"bounds shorthand like `4-80` or `4-20-80`.",
+            param_hint="--adaptive-connections",
+        ) from ex
+
+
 def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
     # start with config file if specified
     adapter = TypeAdapter(GenerateConfigArgs)
@@ -1300,6 +1344,9 @@ def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
                 match value:
                     case str():
                         value = BatchConfig.model_validate(resolve_args(value))
+
+            if key == "adaptive_connections" and isinstance(value, str):
+                value = _parse_adaptive_connections_cli(value)
 
             if key == "modalities":
                 value = parse_modalities(value)
@@ -1501,6 +1548,13 @@ def parse_comma_separated(value: str | None) -> list[str] | None:
     envvar="INSPECT_EVAL_MAX_CONNECTIONS",
 )
 @click.option(
+    "--adaptive-connections",
+    type=str,
+    default=None,
+    help=ADAPTIVE_CONNECTIONS_HELP,
+    envvar="INSPECT_EVAL_ADAPTIVE_CONNECTIONS",
+)
+@click.option(
     "--max-retries", type=int, help=MAX_RETRIES_HELP, envvar="INSPECT_EVAL_MAX_RETRIES"
 )
 @click.option("--timeout", type=int, help=TIMEOUT_HELP, envvar="INSPECT_EVAL_TIMEOUT")
@@ -1544,6 +1598,7 @@ def eval_retry_command(
     no_score: bool | None,
     no_score_display: bool | None,
     max_connections: int | None,
+    adaptive_connections: str | None,
     max_retries: int | None,
     timeout: int | None,
     attempt_timeout: int | None,
@@ -1578,6 +1633,9 @@ def eval_retry_command(
         log_file_info(filesystem(log_file).info(log_file)) for log_file in log_files
     ]
 
+    # parse adaptive_connections (str → bool | AdaptiveConcurrency)
+    adaptive_connections_value = _parse_adaptive_connections_cli(adaptive_connections)
+
     # retry
     eval_retry(
         retry_log_files,
@@ -1608,4 +1666,5 @@ def eval_retry_command(
         timeout=timeout,
         attempt_timeout=attempt_timeout,
         max_connections=max_connections,
+        adaptive_connections=adaptive_connections_value,
     )

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -82,7 +82,7 @@ MAX_CONNECTIONS_HELP = f"Maximum number of concurrent connections to Model API (
 ADAPTIVE_CONNECTIONS_HELP = (
     "Enable adaptive concurrency for Model API connections, automatically "
     "scaling between bounds based on rate-limit feedback. Pass `true` for "
-    "defaults (min=1, start=20, max=200), `false` to explicitly disable, or "
+    "defaults (min=4, start=20, max=100), `false` to explicitly disable, or "
     'bounds as "min-max" (e.g. "4-80") or "min-start-max" (e.g. "4-20-80").'
 )
 MAX_RETRIES_HELP = (

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -82,7 +82,7 @@ MAX_CONNECTIONS_HELP = f"Maximum number of concurrent connections to Model API (
 ADAPTIVE_CONNECTIONS_HELP = (
     "Enable adaptive concurrency for Model API connections, automatically "
     "scaling between bounds based on rate-limit feedback. Pass `true` for "
-    "defaults (min=4, start=20, max=100), `false` to explicitly disable, or "
+    "defaults (min=4, start=20, max=200), `false` to explicitly disable, or "
     'bounds as "min-max" (e.g. "4-80") or "min-start-max" (e.g. "4-20-80").'
 )
 MAX_RETRIES_HELP = (

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -69,6 +69,7 @@ from inspect_ai.scorer._reducer import reducer_log_names
 from inspect_ai.solver._chain import chain
 from inspect_ai.solver._solver import Solver, SolverSpec
 from inspect_ai.util import SandboxEnvironmentType
+from inspect_ai.util._concurrency import AdaptiveConcurrency
 from inspect_ai.util._display import (
     DisplayType,
     display_type,
@@ -871,6 +872,7 @@ def eval_retry(
     timeout: int | None = None,
     attempt_timeout: int | None = None,
     max_connections: int | None = None,
+    adaptive_connections: bool | AdaptiveConcurrency | None = None,
 ) -> list[EvalLog]:
     """Retry a previously failed evaluation task.
 
@@ -930,6 +932,10 @@ def eval_retry(
             Timeout (in seconds) for any given attempt (if exceeded, will abandon attempt and retry according to max_retries).
         max_connections:
             Maximum number of concurrent connections to Model API (default is per Model API)
+        adaptive_connections:
+            Enable adaptive concurrency for Model API connections. `True` for defaults
+            (min=1, max=200, start=20), or pass an `AdaptiveConcurrency` to customize bounds.
+            An explicit `max_connections` overrides this and uses static concurrency.
 
     Returns:
         List of EvalLog (one for each task)
@@ -970,6 +976,7 @@ def eval_retry(
             timeout=timeout,
             attempt_timeout=attempt_timeout,
             max_connections=max_connections,
+            adaptive_connections=adaptive_connections,
         )
 
     return task_display().run_task_app(with_async_fs(run_task_app))
@@ -1004,6 +1011,7 @@ async def eval_retry_async(
     timeout: int | None = None,
     attempt_timeout: int | None = None,
     max_connections: int | None = None,
+    adaptive_connections: bool | AdaptiveConcurrency | None = None,
 ) -> list[EvalLog]:
     """Retry a previously failed evaluation task.
 
@@ -1051,6 +1059,7 @@ async def eval_retry_async(
         timeout: Request timeout (in seconds)
         attempt_timeout: Timeout (in seconds) for any given attempt (if exceeded, will abandon attempt and retry according to max_retries).
         max_connections: Maximum number of concurrent connections to Model API (default is per Model API)
+        adaptive_connections: Enable adaptive concurrency for Model API connections. `True` for defaults (min=1, max=200, start=20), or pass an `AdaptiveConcurrency` to customize bounds. An explicit `max_connections` overrides this and uses static concurrency.
 
     Returns:
         List of EvalLog (one for each task)
@@ -1246,6 +1255,8 @@ async def eval_retry_async(
         config.timeout = timeout or config.timeout
         config.attempt_timeout = attempt_timeout or config.attempt_timeout
         config.max_connections = max_connections or config.max_connections
+        if adaptive_connections is not None:
+            config.adaptive_connections = adaptive_connections
 
         # extract previous model usage to continue token counting (make a deep copy to avoid modifying the original log)
         initial_model_usage = (

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -934,7 +934,7 @@ def eval_retry(
             Maximum number of concurrent connections to Model API (default is per Model API)
         adaptive_connections:
             Enable adaptive concurrency for Model API connections. `True` for defaults
-            (min=4, start=20, max=100), or pass an `AdaptiveConcurrency` to customize
+            (min=4, start=20, max=200), or pass an `AdaptiveConcurrency` to customize
             bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent).
             An explicit `max_connections` overrides this and uses static concurrency.
 
@@ -1060,7 +1060,7 @@ async def eval_retry_async(
         timeout: Request timeout (in seconds)
         attempt_timeout: Timeout (in seconds) for any given attempt (if exceeded, will abandon attempt and retry according to max_retries).
         max_connections: Maximum number of concurrent connections to Model API (default is per Model API)
-        adaptive_connections: Enable adaptive concurrency for Model API connections. `True` for defaults (min=4, start=20, max=100), or pass an `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency.
+        adaptive_connections: Enable adaptive concurrency for Model API connections. `True` for defaults (min=4, start=20, max=200), or pass an `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency.
 
     Returns:
         List of EvalLog (one for each task)

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -934,7 +934,8 @@ def eval_retry(
             Maximum number of concurrent connections to Model API (default is per Model API)
         adaptive_connections:
             Enable adaptive concurrency for Model API connections. `True` for defaults
-            (min=1, max=200, start=20), or pass an `AdaptiveConcurrency` to customize bounds.
+            (min=4, start=20, max=100), or pass an `AdaptiveConcurrency` to customize
+            bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent).
             An explicit `max_connections` overrides this and uses static concurrency.
 
     Returns:
@@ -1059,7 +1060,7 @@ async def eval_retry_async(
         timeout: Request timeout (in seconds)
         attempt_timeout: Timeout (in seconds) for any given attempt (if exceeded, will abandon attempt and retry according to max_retries).
         max_connections: Maximum number of concurrent connections to Model API (default is per Model API)
-        adaptive_connections: Enable adaptive concurrency for Model API connections. `True` for defaults (min=1, max=200, start=20), or pass an `AdaptiveConcurrency` to customize bounds. An explicit `max_connections` overrides this and uses static concurrency.
+        adaptive_connections: Enable adaptive concurrency for Model API connections. `True` for defaults (min=4, start=20, max=100), or pass an `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency.
 
     Returns:
         List of EvalLog (one for each task)

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -375,6 +375,19 @@ def eval_set(
     # resolve some parameters
     retry_connections = retry_connections or 1.0
     retry_cleanup = retry_cleanup is not False
+    # adaptive_connections subsumes retry_connections — the controller manages
+    # scale-down internally on retry signals. Force retry_connections to 1.0
+    # silently (rather than warning), so that this stays quiet when adaptive
+    # eventually becomes default-on. Only fires when adaptive will actually be
+    # active: explicit max_connections takes precedence (per the precedence
+    # rule in Model._connection_concurrency), and in that case retry_connections
+    # decay should still apply to the static cap.
+    adaptive_will_be_active = (
+        bool(kwargs.get("adaptive_connections"))
+        and kwargs.get("max_connections") is None
+    )
+    if adaptive_will_be_active:
+        retry_connections = 1.0
     max_connections = starting_max_connections(models, GenerateConfig(**kwargs))
     max_tasks = max_tasks if max_tasks is not None else max(len(models), 4)
     log_dir_allow_dirty = log_dir_allow_dirty is True
@@ -385,10 +398,22 @@ def eval_set(
 
     # before sleep
     def before_sleep(retry_state: RetryCallState) -> None:
-        # compute/update next max_connections
+        # Compute/update next max_connections, but only inject into kwargs when
+        # retry_connections actually decays (!= 1.0). Reasons:
+        #   1. If adaptive will be active at eval-set level, retry_connections
+        #      was already forced to 1.0 above (controller handles scale-down).
+        #   2. With default retry_connections=1.0, the "decayed" value equals
+        #      the original — injecting would be a no-op for static behavior
+        #      but would silently override any task-level adaptive_connections
+        #      (since any non-None max_connections disables adaptive per the
+        #      precedence rule in Model._connection_concurrency).
+        # When the user explicitly opts into decay (retry_connections != 1.0),
+        # we inject — this preserves the long-standing static behavior, with
+        # the trade-off that task-level adaptive yields to the explicit decay.
         nonlocal max_connections
-        max_connections = max(round(max_connections * retry_connections), 1)
-        kwargs["max_connections"] = max_connections
+        if retry_connections != 1.0:
+            max_connections = max(round(max_connections * retry_connections), 1)
+            kwargs["max_connections"] = max_connections
 
         # print waiting status
         msg = (

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -380,11 +380,18 @@ def eval_set(
     # silently (rather than warning), so that this stays quiet when adaptive
     # eventually becomes default-on. Only fires when adaptive will actually be
     # active: explicit max_connections takes precedence (per the precedence
-    # rule in Model._connection_concurrency), and in that case retry_connections
-    # decay should still apply to the static cap.
+    # rule in Model._connection_concurrency), batch mode disables adaptive
+    # entirely (worker tasks don't propagate retry signals), and in those
+    # cases retry_connections decay should still apply to the static cap.
+    # The predicate must match Model._connection_concurrency and
+    # create_sample_semaphore exactly — otherwise a user passing
+    # batch=True + adaptive_connections=True + retry_connections=0.5 would
+    # silently lose decay (evalset suppresses it, but the model path goes
+    # static and never sets up an adaptive controller).
     adaptive_will_be_active = (
         bool(kwargs.get("adaptive_connections"))
         and kwargs.get("max_connections") is None
+        and not kwargs.get("batch")
     )
     if adaptive_will_be_active:
         retry_connections = 1.0

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -376,10 +376,31 @@ async def log_start(
 
 
 def collect_eval_data(stats: EvalStats) -> None:
+    from inspect_ai.log._log import ConnectionLimitChange
+    from inspect_ai.util._concurrency import adaptive_controllers
+
     # collect stats
     stats.completed_at = iso_now()
     stats.model_usage = model_usage()
     stats.role_usage = role_usage()
+
+    # capture adaptive-connections controller history. The tuple's second
+    # element is the controller's display name (model name), NOT the underlying
+    # connection_key (which often contains an api_key) — see _set_limit.
+    history: list[ConnectionLimitChange] = []
+    for controller in adaptive_controllers():
+        for ts, model, old, new, reason in controller.history:
+            history.append(
+                ConnectionLimitChange(
+                    timestamp=ts,
+                    model=model,
+                    old_limit=old,
+                    new_limit=new,
+                    reason=reason,  # type: ignore[arg-type]
+                )
+            )
+    history.sort(key=lambda e: e.timestamp)
+    stats.connection_limit_history = history
 
 
 def resolve_eval_metrics(

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1494,13 +1494,15 @@ def create_sample_semaphore(
         # would fire for nearly every deliberate max_samples setting
         return anyio.Semaphore(config.max_samples)
     elif (
-        generate_config.adaptive_connections and generate_config.max_connections is None
+        generate_config.adaptive_connections
+        and generate_config.max_connections is None
+        and not generate_config.batch
     ):
         # adaptive: dynamic limiter that tracks the controller(s) — sample
         # concurrency grows with the controller's current limit so setup work
         # (sandboxes etc.) stays proportional to actual model concurrency.
-        # Explicit max_connections wins silently (matches the precedence in
-        # Model._connection_concurrency).
+        # Both explicit max_connections and batch mode silently override
+        # adaptive (matches the precedence in Model._connection_concurrency).
         adaptive = (
             generate_config.adaptive_connections
             if isinstance(generate_config.adaptive_connections, AdaptiveConcurrency)

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from logging import getLogger
 from pathlib import PurePath
-from typing import Awaitable, Callable, Literal
+from typing import Any, Awaitable, Callable, Literal
 
 import anyio
 from anyio.abc import TaskGroup
@@ -750,7 +750,7 @@ async def task_run_sample(
     error_retries: list[EvalRetryError],
     time_limit: int | None,
     working_limit: int | None,
-    semaphore: anyio.Semaphore,
+    semaphore: contextlib.AbstractAsyncContextManager[Any],
     eval_set_id: str | None,
     run_id: str,
     task_id: str,
@@ -1485,24 +1485,41 @@ def create_sample_semaphore(
     config: EvalConfig,
     generate_config: GenerateConfig,
     modelapi: ModelAPI | None = None,
-) -> anyio.Semaphore:
-    # if the user set max_samples then use that
+) -> contextlib.AbstractAsyncContextManager[Any]:
+    from inspect_ai.util._concurrency import AdaptiveConcurrency, DynamicSampleLimiter
+
     if config.max_samples is not None:
+        # explicit max_samples wins silently — anticipating that adaptive_connections
+        # may become default-on, in which case warning when max_samples < adaptive.max
+        # would fire for nearly every deliberate max_samples setting
         return anyio.Semaphore(config.max_samples)
-
-    # use max_connections
-    max_samples = (
-        generate_config.max_connections
-        if generate_config.max_connections is not None
-        else DEFAULT_MAX_CONNECTIONS_BATCH
-        if generate_config.batch
-        else modelapi.max_connections()
-        if modelapi
-        else DEFAULT_MAX_CONNECTIONS
-    )
-
-    # return the semaphore
-    return anyio.Semaphore(max_samples)
+    elif (
+        generate_config.adaptive_connections
+        and generate_config.max_connections is None
+    ):
+        # adaptive: dynamic limiter that tracks the controller(s) — sample
+        # concurrency grows with the controller's current limit so setup work
+        # (sandboxes etc.) stays proportional to actual model concurrency.
+        # Explicit max_connections wins silently (matches the precedence in
+        # Model._connection_concurrency).
+        adaptive = (
+            generate_config.adaptive_connections
+            if isinstance(generate_config.adaptive_connections, AdaptiveConcurrency)
+            else AdaptiveConcurrency()
+        )
+        return DynamicSampleLimiter(adaptive)
+    else:
+        # static path (existing behavior, unchanged)
+        max_samples = (
+            generate_config.max_connections
+            if generate_config.max_connections is not None
+            else DEFAULT_MAX_CONNECTIONS_BATCH
+            if generate_config.batch
+            else modelapi.max_connections()
+            if modelapi
+            else DEFAULT_MAX_CONNECTIONS
+        )
+        return anyio.Semaphore(max_samples)
 
 
 def init_sample_assistant_internal() -> None:

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1494,8 +1494,7 @@ def create_sample_semaphore(
         # would fire for nearly every deliberate max_samples setting
         return anyio.Semaphore(config.max_samples)
     elif (
-        generate_config.adaptive_connections
-        and generate_config.max_connections is None
+        generate_config.adaptive_connections and generate_config.max_connections is None
     ):
         # adaptive: dynamic limiter that tracks the controller(s) — sample
         # concurrency grows with the controller's current limit so setup work

--- a/src/inspect_ai/_util/http.py
+++ b/src/inspect_ai/_util/http.py
@@ -1,3 +1,128 @@
+import re
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+
+
 # see https://cloud.google.com/storage/docs/retry-strategy
 def is_retryable_http_status(status_code: int) -> bool:
     return status_code in [408, 429] or (500 <= status_code < 600)
+
+
+# Provider-specific reset-window headers (used as fallback when Retry-After is absent).
+# OpenAI / Groq / Azure OpenAI use the `x-ratelimit-reset-*` family; Anthropic
+# uses an `anthropic-ratelimit-*` family of its own (per
+# https://docs.anthropic.com/en/api/rate-limits).
+_RATELIMIT_RESET_HEADERS = (
+    "x-ratelimit-reset-requests",
+    "x-ratelimit-reset-tokens",
+    "anthropic-ratelimit-requests-reset",
+    "anthropic-ratelimit-tokens-reset",
+    "anthropic-ratelimit-input-tokens-reset",
+    "anthropic-ratelimit-output-tokens-reset",
+)
+
+# OpenAI-style duration shorthand, e.g. "1m30s", "500ms", "1.5s". Units are summed.
+_DURATION_UNITS = {
+    "ms": 0.001,
+    "s": 1.0,
+    "m": 60.0,
+    "h": 3600.0,
+    "d": 86400.0,
+}
+_DURATION_RE = re.compile(r"(\d+(?:\.\d+)?)(ms|s|m|h|d)")
+
+
+def parse_retry_after(headers: Mapping[str, str]) -> float | None:
+    """Extract a recommended wait time (seconds) from response headers.
+
+    Resolution order:
+      1. `Retry-After` (RFC 9110): delta-seconds or HTTP-date.
+      2. Fallback: provider-specific reset-window headers (`x-ratelimit-reset-*`
+         from OpenAI/Groq/Azure, `anthropic-ratelimit-*-reset` from Anthropic).
+         Each value may be delta-seconds, an OpenAI-style duration string
+         (`"1m30s"`, `"500ms"`), or an ISO 8601 timestamp.
+
+    When several reset-window headers are present (e.g. requests and tokens
+    both reported), the *largest* is used: a 429 may have been triggered by
+    any one dimension, but without parsing the response body we don't know
+    which — so the conservative cooldown is the longest reset. As a cooldown
+    floor this is safe (debounces the controller's next cut without affecting
+    request scheduling).
+
+    Returns None when no header is present or values are unparseable / negative.
+    """
+    # case-insensitive lookup
+    lower = {k.lower(): v for k, v in headers.items()}
+
+    retry_after = lower.get("retry-after")
+    if retry_after is not None:
+        seconds = _parse_retry_after_value(retry_after)
+        if seconds is not None:
+            return seconds
+
+    reset_values = [
+        s
+        for h in _RATELIMIT_RESET_HEADERS
+        if (raw := lower.get(h)) is not None
+        and (s := _parse_retry_after_value(raw)) is not None
+    ]
+    if reset_values:
+        return max(reset_values)
+
+    return None
+
+
+def _parse_retry_after_value(value: str) -> float | None:
+    """Parse a single header value into seconds-from-now.
+
+    Accepts delta-seconds, OpenAI-style duration strings (`"1m30s"`),
+    HTTP-date (RFC 9110), and ISO 8601 timestamps. Returns None for
+    unparseable input or non-positive durations.
+    """
+    value = value.strip()
+    if not value:
+        return None
+
+    # delta-seconds (most common)
+    try:
+        seconds = float(value)
+        return seconds if seconds > 0 else None
+    except ValueError:
+        pass
+
+    # duration shorthand like "1m30s" / "500ms" / "1.5s" — chain of units
+    compact = value.replace(" ", "")
+    matches = _DURATION_RE.findall(compact)
+    if matches and "".join(a + u for a, u in matches) == compact:
+        total = sum(float(a) * _DURATION_UNITS[u] for a, u in matches)
+        return total if total > 0 else None
+
+    # HTTP-date (RFC 9110, e.g. "Wed, 21 Oct 2026 07:28:00 GMT").
+    # parsedate_to_datetime can return a *naive* datetime for malformed dates
+    # (e.g. ones missing the GMT offset). Coerce to UTC so we can subtract —
+    # RFC 9110 mandates HTTP-dates are GMT, and a wrong assumption here just
+    # gives us a less-accurate cooldown rather than a TypeError.
+    try:
+        dt = parsedate_to_datetime(value)
+    except (TypeError, ValueError):
+        dt = None
+    if dt is not None:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        seconds = (dt - datetime.now(timezone.utc)).total_seconds()
+        return seconds if seconds > 0 else None
+
+    # ISO 8601 / RFC 3339 timestamp
+    try:
+        # fromisoformat in 3.10 doesn't accept trailing 'Z'; normalize
+        normalized = value.replace("Z", "+00:00")
+        dt = datetime.fromisoformat(normalized)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        seconds = (dt - datetime.now(timezone.utc)).total_seconds()
+        return seconds if seconds > 0 else None
+    except ValueError:
+        pass
+
+    return None

--- a/src/inspect_ai/_util/http.py
+++ b/src/inspect_ai/_util/http.py
@@ -73,6 +73,22 @@ def parse_retry_after(headers: Mapping[str, str]) -> float | None:
     return None
 
 
+def parse_retry_after_from_exception(ex: BaseException) -> float | None:
+    """Best-effort Retry-After / x-ratelimit-reset-* extraction from an exception.
+
+    Walks `ex.response.headers` if present and delegates to `parse_retry_after`.
+    Returns None on any failure (missing attributes, parse error). Used by
+    every provider's `should_retry` → `RetryDecision.rate_limit` path.
+    """
+    headers = getattr(getattr(ex, "response", None), "headers", None)
+    if headers is None:
+        return None
+    try:
+        return parse_retry_after(headers)
+    except Exception:
+        return None
+
+
 def _parse_retry_after_value(value: str) -> float | None:
     """Parse a single header value into seconds-from-now.
 

--- a/src/inspect_ai/_util/httpx.py
+++ b/src/inspect_ai/_util/httpx.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import httpcore
 import httpx
@@ -7,7 +7,10 @@ from httpx import HTTPStatusError
 from tenacity import RetryCallState
 
 from inspect_ai._util.constants import HTTP
-from inspect_ai._util.http import is_retryable_http_status
+from inspect_ai._util.http import is_retryable_http_status, parse_retry_after
+
+if TYPE_CHECKING:
+    from inspect_ai.model._model import RetryDecision
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +35,27 @@ def httpx_should_retry(ex: BaseException) -> bool:
     # don't retry
     else:
         return False
+
+
+def httpx_classify_retry(ex: BaseException) -> "RetryDecision | None":
+    """Classify an httpx-based exception as rate_limit / transient / not retryable.
+
+    Returns None when the exception isn't retryable (mirrors `httpx_should_retry == False`).
+    Reads `Retry-After` and `x-ratelimit-reset-*` from the response headers when available.
+    """
+    from inspect_ai.model._model import RetryDecision
+
+    if isinstance(ex, HTTPStatusError):
+        status = ex.response.status_code
+        retry_after = parse_retry_after(ex.response.headers)
+        if status == 429:
+            return RetryDecision.rate_limit(retry_after=retry_after)
+        if is_retryable_http_status(status):
+            return RetryDecision.transient(retry_after=retry_after)
+        return None
+    if httpx_should_retry_no_status_code(ex):
+        return RetryDecision.transient()
+    return None
 
 
 def log_httpx_retry_attempt(context: str) -> Callable[[RetryCallState], None]:

--- a/src/inspect_ai/_util/retry.py
+++ b/src/inspect_ai/_util/retry.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from tenacity import RetryCallState
@@ -8,7 +8,17 @@ if TYPE_CHECKING:
 _http_retries_count: int = 0
 
 
-def report_http_retry() -> None:
+def report_http_retry(
+    kind: Literal["rate_limit", "transient"] = "transient",
+    retry_after: float | None = None,
+) -> None:
+    """Report an HTTP retry event.
+
+    `kind="rate_limit"` (HTTP 429 or provider-specific equivalents) signals
+    the adaptive controller to scale down. `kind="transient"` (default —
+    5xx, timeouts, network errors) only marks the request as retried,
+    pausing scale-up but not triggering a cut.
+    """
     from inspect_ai.log._samples import report_active_sample_retry
     from inspect_ai.util._concurrency import _active_controller, _request_had_retry
 
@@ -19,11 +29,14 @@ def report_http_retry() -> None:
     # report sample retry
     report_active_sample_retry()
 
-    # signal adaptive controller (if any) and mark request as retried
+    # mark request as retried so the eventual success won't count as scale-up
     _request_had_retry.set(True)
-    controller = _active_controller.get()
-    if controller is not None:
-        controller.notify_retry()
+
+    # only rate-limit retries scale the controller down
+    if kind == "rate_limit":
+        controller = _active_controller.get()
+        if controller is not None:
+            controller.notify_retry(retry_after=retry_after)
 
 
 def http_retries_count() -> int:

--- a/src/inspect_ai/_util/retry.py
+++ b/src/inspect_ai/_util/retry.py
@@ -10,6 +10,7 @@ _http_retries_count: int = 0
 
 def report_http_retry() -> None:
     from inspect_ai.log._samples import report_active_sample_retry
+    from inspect_ai.util._concurrency import _active_controller, _request_had_retry
 
     # bump global counter
     global _http_retries_count
@@ -17,6 +18,12 @@ def report_http_retry() -> None:
 
     # report sample retry
     report_active_sample_retry()
+
+    # signal adaptive controller (if any) and mark request as retried
+    _request_had_retry.set(True)
+    controller = _active_controller.get()
+    if controller is not None:
+        controller.notify_retry()
 
 
 def http_retries_count() -> int:

--- a/src/inspect_ai/_view/dist/assets/index.css
+++ b/src/inspect_ai/_view/dist/assets/index.css
@@ -15857,16 +15857,16 @@ li > ul {
   padding: 0 0.2rem;
   background-color: var(--bs-body-bg);
 }
-.btn._toolButton_wcmr6_1 {
+.btn._toolButton_dd6ny_1 {
   background-color: var(--bs-light-border-subtle);
   white-space: nowrap;
 }
 
-._marginRight_wcmr6_6 {
+._marginRight_dd6ny_6 {
   margin-right: 0.5em;
 }
 
-._toolButton_wcmr6_1:focus {
+._toolButton_dd6ny_1:focus {
   outline: none;
   box-shadow:
     0 0 0 2px rgba(var(--bs-primary-rgb), 0.5),
@@ -15874,15 +15874,15 @@ li > ul {
     inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-._latched_wcmr6_18,
-._latched_wcmr6_18:hover {
+._latched_dd6ny_18,
+._latched_dd6ny_18:hover {
   box-shadow:
     inset 0 2px 4px rgba(0, 0, 0, 0.15),
     inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-.btn._toolButton_wcmr6_1._subtle_wcmr6_25 {
-  background-color: var(--bs-body-bg);
+.btn._toolButton_dd6ny_1._subtle_dd6ny_25 {
+  background-color: var(--bs-light);
 }
 ._headerContainer_gh2j2_1 {
   display: grid;
@@ -16843,7 +16843,7 @@ span.ap-marker-container:hover span.ap-marker {
     opacity: 0.8;
   }
 }
-._rootControl_19z32_1 {
+._rootControl_13qph_1 {
   background-color: var(--bs-body-bg);
   border-radius: var(--bs-border-radius);
   display: flex;
@@ -16852,12 +16852,12 @@ span.ap-marker-container:hover span.ap-marker {
   border: solid 1px var(--bs-border-color);
 }
 
-._segment_19z32_10._selected_19z32_10 {
+._segment_13qph_10._selected_13qph_10 {
   background-color: var(--bs-secondary-bg);
   border-radius: var(--bs-border-radius);
 }
 
-button._segment_19z32_10 {
+button._segment_13qph_10 {
   margin: 1px;
   background-color: var(--bs-body-bg);
   border-radius: var(--bs-border-radius);
@@ -16869,8 +16869,17 @@ button._segment_19z32_10 {
   height: calc(100% - 2px);
 }
 
-._segment_19z32_10 i {
+._segment_13qph_10 i {
   margin-right: 0.2em;
+}
+
+button._segment_13qph_10._compact_13qph_31 {
+  padding-inline-start: 4px;
+  padding-inline-end: 4px;
+}
+
+button._segment_13qph_10._compact_13qph_31 i {
+  margin-right: 0;
 }
 ._sourcePanel_bat6y_1 {
   width: 100%;
@@ -16935,29 +16944,29 @@ button._segment_19z32_10 {
 ._hidden_1linb_42 {
   opacity: 0 !important;
 }
-.btn._toolButton_1q996_1 {
+.btn._toolButton_1swkv_1 {
   background-color: var(--bs-light-border-subtle);
 }
 
-.btn._toolButton_1q996_1._bodyColor_1q996_5 {
-  background-color: var(--bs-body-bg);
+.btn._toolButton_1swkv_1._bodyColor_1swkv_5 {
+  background-color: var(--bs-light);
 }
 
-._toolButton_1q996_1 {
+._toolButton_1swkv_1 {
   white-space: nowrap;
 }
 
-._toolButton_1q996_1 i {
+._toolButton_1swkv_1 i {
   margin-right: 0.5em;
 }
 
-._toolButton_1q996_1 ._chevron_1q996_17 {
+._toolButton_1swkv_1 ._chevron_1swkv_17 {
   margin-left: 0.5em;
   margin-right: 0;
   font-size: 0.75em;
 }
 
-._toolButton_1q996_1:focus {
+._toolButton_1swkv_1:focus {
   outline: none;
   box-shadow:
     0 0 0 2px rgba(var(--bs-primary-rgb), 0.5),
@@ -16965,7 +16974,7 @@ button._segment_19z32_10 {
     inset 0 1px 2px rgba(0, 0, 0, 0.1);
 }
 
-._backdrop_1q996_31 {
+._backdrop_1swkv_31 {
   position: fixed;
   top: 0;
   left: 0;
@@ -16975,7 +16984,7 @@ button._segment_19z32_10 {
   z-index: 1049;
 }
 
-._dropdownMenu_1q996_41 {
+._dropdownMenu_1swkv_41 {
   position: fixed;
   background: var(--bs-body-bg);
   border: 1px solid var(--bs-border-color);
@@ -16986,7 +16995,7 @@ button._segment_19z32_10 {
   overflow: hidden;
 }
 
-._dropdownItem_1q996_52 {
+._dropdownItem_1swkv_52 {
   display: block;
   width: 100%;
   padding: 0.25rem 0.75rem;
@@ -16999,11 +17008,11 @@ button._segment_19z32_10 {
   transition: background-color 0.15s ease-in-out;
 }
 
-._dropdownItem_1q996_52:hover {
+._dropdownItem_1swkv_52:hover {
   background-color: var(--bs-tertiary-bg);
 }
 
-._dropdownItem_1q996_52:active {
+._dropdownItem_1swkv_52:active {
   background-color: var(--bs-secondary-bg);
 }
 ._tabs_1wfac_1 {
@@ -17969,13 +17978,13 @@ button._segment_19z32_10 {
   margin-top: -0.1rem;
   margin-bottom: -0.1rem;
 }
-._gridWrapper_egqgb_1 {
+._gridWrapper_1ljdd_1 {
   height: 100%;
   width: 100%;
   position: relative;
 }
 
-._gridContainer_egqgb_7 {
+._gridContainer_1ljdd_7 {
   position: absolute;
   top: 0;
   left: 0;
@@ -17986,39 +17995,50 @@ button._segment_19z32_10 {
 /* Shared chrome — applied to all sample/log grids. Other ag-grids in the
  * app (e.g. the small score-summary table in title-view) intentionally opt
  * out by not adding this class. */
-._gridChrome_egqgb_18 .ag-row {
+._gridChrome_1ljdd_18 .ag-row {
   cursor: pointer;
   border-bottom: 1px solid var(--bs-border-color);
+  background-color: var(--bs-body-bg);
+  /* Stretch rows to fill the viewport so the bottom-border separator
+   * spans edge-to-edge even when columns total less than the viewport.
+   * `min-width` overrides the inline `width` AG Grid sets on each row. */
+  min-width: 100%;
 }
 
-._gridChrome_egqgb_18 .ag-row.ag-row-selected {
+/* Match container so rows' min-width: 100% has the full viewport to
+ * stretch into. Pinned containers are unaffected. */
+._gridChrome_1ljdd_18 .ag-center-cols-container {
+  min-width: 100%;
+}
+
+._gridChrome_1ljdd_18 .ag-row.ag-row-selected {
   box-shadow: inset 0 0 0 2px var(--bs-focus-ring-color);
 }
 
-._gridChrome_egqgb_18 .ag-header-cell {
+._gridChrome_1ljdd_18 .ag-header-cell {
   padding: 0;
 }
 
-._gridChrome_egqgb_18 .ag-header-cell-label::before {
+._gridChrome_1ljdd_18 .ag-header-cell-label::before {
   content: "";
   flex: 0 1 var(--ag-cell-horizontal-padding);
 }
 
-._gridChrome_egqgb_18 .ag-header-cell-text {
+._gridChrome_1ljdd_18 .ag-header-cell-text {
   font-size: var(--inspect-font-size-smallestest);
   text-transform: uppercase;
   letter-spacing: 0.05em;
   font-weight: 400;
 }
 
-._gridChrome_egqgb_18 .ag-sort-order {
+._gridChrome_1ljdd_18 .ag-sort-order {
   font-size: var(--inspect-font-size-smallestest);
   align-self: center;
   margin-right: -10px;
 }
 
 /* List mode — multi-line wrapping cells with vertical padding. */
-._listMode_egqgb_50 .ag-cell {
+._listMode_1ljdd_61 .ag-cell {
   align-items: flex-start;
   padding-top: 0.5rem;
   padding-bottom: 0.5rem;
@@ -18026,31 +18046,31 @@ button._segment_19z32_10 {
 }
 
 /* Grid mode — vertically centered cells; column renderers handle ellipsis. */
-._gridMode_egqgb_58 .ag-cell {
+._gridMode_1ljdd_69 .ag-cell {
   align-items: center;
 }
 
 /* Cell helpers exposed for column renderers. */
-._cell_egqgb_63 {
+._cell_1ljdd_74 {
   line-height: var(--bs-body-line-height);
 }
 
-._wrapAnywhere_egqgb_67 {
+._wrapAnywhere_1ljdd_78 {
   overflow-wrap: break-word;
 }
 
-._noLeft_egqgb_71 {
+._noLeft_1ljdd_82 {
   padding-left: 0;
 }
 
-._score_egqgb_75 {
+._score_1ljdd_86 {
   text-align: center;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-._centered_egqgb_82 {
+._centered_1ljdd_93 {
   display: flex;
   justify-content: center;
 }
@@ -19586,7 +19606,7 @@ a._citationLink_1ggvf_9:hover {
   -webkit-user-select: none;
   user-select: none;
 }
-._root_130zy_1 {
+._root_1mbr3_1 {
   display: flex;
   flex-direction: column;
   width: 100%;
@@ -19594,7 +19614,7 @@ a._citationLink_1ggvf_9:hover {
   min-height: 0;
 }
 
-._container_130zy_9 {
+._container_1mbr3_9 {
   display: grid;
   width: 100%;
   grid-template-columns: var(--outline-width, 180px) 1px 1fr 1px var(
@@ -19604,44 +19624,44 @@ a._citationLink_1ggvf_9:hover {
   min-height: 100vh;
 }
 
-._container_130zy_9 > * {
+._container_1mbr3_9 > * {
   min-width: 0;
   padding-bottom: 1rem;
 }
 
-._container_130zy_9._outlineCollapsed_130zy_24 {
+._container_1mbr3_9._outlineCollapsed_1mbr3_24 {
   grid-template-columns: 22px 1px 1fr 1px var(--right-pane-width, 360px);
 }
 
-._container_130zy_9._noOutline_130zy_28 {
+._container_1mbr3_9._noOutline_1mbr3_28 {
   grid-template-columns: 1fr 1px var(--right-pane-width, 360px);
 }
 
-._container_130zy_9._rightPaneCollapsed_130zy_32 {
+._container_1mbr3_9._rightPaneCollapsed_1mbr3_32 {
   grid-template-columns: var(--outline-width, 180px) 1px 1fr 1px 22px;
 }
 
-._container_130zy_9._outlineCollapsed_130zy_24._rightPaneCollapsed_130zy_32 {
+._container_1mbr3_9._outlineCollapsed_1mbr3_24._rightPaneCollapsed_1mbr3_32 {
   grid-template-columns: 22px 1px 1fr 1px 22px;
 }
 
-._container_130zy_9._noOutline_130zy_28._rightPaneCollapsed_130zy_32 {
+._container_1mbr3_9._noOutline_1mbr3_28._rightPaneCollapsed_1mbr3_32 {
   grid-template-columns: 1fr 1px 22px;
 }
 
-._container_130zy_9._noRightPane_130zy_44 {
+._container_1mbr3_9._noRightPane_1mbr3_44 {
   grid-template-columns: var(--outline-width, 180px) 1px 1fr;
 }
 
-._container_130zy_9._outlineCollapsed_130zy_24._noRightPane_130zy_44 {
+._container_1mbr3_9._outlineCollapsed_1mbr3_24._noRightPane_1mbr3_44 {
   grid-template-columns: 22px 1px 1fr;
 }
 
-._container_130zy_9._noOutline_130zy_28._noRightPane_130zy_44 {
+._container_1mbr3_9._noOutline_1mbr3_28._noRightPane_1mbr3_44 {
   grid-template-columns: 1fr;
 }
 
-._outline_130zy_24 {
+._outline_1mbr3_24 {
   padding-left: 0.6rem;
   padding-top: 0.2rem;
   /* Prevent stretching to the full grid-row height so that
@@ -19652,13 +19672,13 @@ a._citationLink_1ggvf_9:hover {
 /* Cap height to the visible area below the sticky offset and
    scroll internally when the outline is taller.
    Only when expanded — overflow clips the toggle button when collapsed. */
-._container_130zy_9:not(._outlineCollapsed_130zy_24) > ._outline_130zy_24 {
+._container_1mbr3_9:not(._outlineCollapsed_1mbr3_24) > ._outline_1mbr3_24 {
   max-height: calc(var(--scroller-height, 100vh) - var(--outline-top, 0px));
   overflow-y: auto;
   scrollbar-width: thin;
 }
 
-._outlineToggle_130zy_73 {
+._outlineToggle_1mbr3_73 {
   all: unset;
   cursor: pointer;
   font-size: 0.8em;
@@ -19667,26 +19687,26 @@ a._citationLink_1ggvf_9:hover {
   right: 0.2rem;
 }
 
-._outlineToggle_130zy_73[aria-disabled="true"] {
+._outlineToggle_1mbr3_73[aria-disabled="true"] {
   cursor: default;
   opacity: 0.4;
 }
 
-._separator_130zy_87 {
+._separator_1mbr3_87 {
   background-color: var(--bs-border-color);
 }
 
-._rightSeparator_130zy_91 {
+._rightSeparator_1mbr3_91 {
   background-color: var(--bs-border-color);
 }
 
-._rightPane_130zy_32 {
+._rightPane_1mbr3_32 {
   padding-top: 0rem;
   padding-right: 0.2rem;
   align-self: start;
 }
 
-._container_130zy_9:not(._rightPaneCollapsed_130zy_32) > ._rightPane_130zy_32 {
+._container_1mbr3_9:not(._rightPaneCollapsed_1mbr3_32) > ._rightPane_1mbr3_32 {
   padding-left: 0.2rem;
   /* Leave room on the right for the absolutely-positioned close button. */
   padding-right: 1.2rem;
@@ -19695,7 +19715,7 @@ a._citationLink_1ggvf_9:hover {
   scrollbar-width: thin;
 }
 
-._rightPaneResizer_130zy_110 {
+._rightPaneResizer_1mbr3_110 {
   position: absolute;
   left: -3px;
   top: 0;
@@ -19709,12 +19729,12 @@ a._citationLink_1ggvf_9:hover {
   transition: background-color 120ms ease;
 }
 
-._rightPaneResizer_130zy_110:hover,
-._rightPaneResizer_130zy_110:active {
+._rightPaneResizer_1mbr3_110:hover,
+._rightPaneResizer_1mbr3_110:active {
   background-color: var(--bs-primary-border-subtle);
 }
 
-._rightPaneToggle_130zy_129 {
+._rightPaneToggle_1mbr3_129 {
   all: unset;
   cursor: pointer;
   font-size: 0.8em;
@@ -19723,11 +19743,11 @@ a._citationLink_1ggvf_9:hover {
   left: 0.2rem;
 }
 
-._eventsList_130zy_138 {
+._eventsList_1mbr3_138 {
   padding-bottom: 1rem;
 }
 
-._sidebarHeader_130zy_142 {
+._sidebarHeader_1mbr3_142 {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -19735,12 +19755,12 @@ a._citationLink_1ggvf_9:hover {
   margin-bottom: 0.3rem;
 }
 
-._sidebarHeaderIcon_130zy_150 {
+._sidebarHeaderIcon_1mbr3_150 {
   font-size: 0.9em;
   flex-shrink: 0;
 }
 
-._sidebarHeaderTitle_130zy_155 {
+._sidebarHeaderTitle_1mbr3_155 {
   flex: 1;
   min-width: 0;
   font-weight: normal;
@@ -19751,18 +19771,36 @@ a._citationLink_1ggvf_9:hover {
   top: 1px;
 }
 
-._sidebarHeaderClose_130zy_166 {
+/* 0-height sticky anchor that keeps the close button glued to the top of
+   the visible scroll area. The button itself is absolutely positioned
+   inside the anchor so it doesn't push surrounding content. z-index sits
+   above sibling sticky headers (e.g. SampleScansSidebar's scanner picker
+   at z-index: 2) so the close button paints on top. */
+._sidebarHeaderCloseAnchor_1mbr3_171 {
+  position: sticky;
+  top: 0;
+  height: 0;
+  z-index: 3;
+}
+
+/* In the right pane, extend the anchor into the parent's right padding so
+   the button lines up with the existing visual position. */
+._rightPane_1mbr3_32 ._sidebarHeaderCloseAnchor_1mbr3_171 {
+  margin-right: -1.2rem;
+}
+
+._sidebarHeaderClose_1mbr3_171 {
   all: unset;
   cursor: pointer;
   font-size: 0.9em;
-  padding: 0 0.2em;
+  padding: 0.2rem 0.4rem;
   position: absolute;
-  top: 0.2rem;
-  right: 0.1rem;
-  z-index: 1;
+  top: 0;
+  right: 0;
+  background-color: var(--bs-body-bg);
 }
 
-._sidebarHeaderClose_130zy_166:hover {
+._sidebarHeaderClose_1mbr3_171:hover {
   opacity: 0.7;
 }
 ._headline_1l22a_1 {
@@ -20144,43 +20182,49 @@ a._citationLink_1ggvf_9:hover {
     break-inside: avoid;
   }
 }
-._tabControls_1si8b_1 {
+/* The tabs sticky-pin beneath the (dynamic-height) sample header.
+ * The header itself uses `<StickyScroll>` and changes height between
+ * full and compact (headroom collapse), publishing its current
+ * height as `--inspect-sample-header-height` on the tabs container.
+ * The tabs slide up automatically when the header collapses and
+ * back down when it expands. */
+._tabControls_10ac3_7 {
   position: sticky;
   z-index: 1001;
-  top: 0;
+  top: var(--inspect-sample-header-height, 0);
   padding: 0.25rem 0.5rem;
   border-bottom: solid 1px var(--bs-border-color);
   background-color: var(--bs-body-bg);
 }
 
-._fullWidth_1si8b_10 {
+._fullWidth_10ac3_16 {
   width: 100%;
 }
 
-._metadataPanel_1si8b_14 {
+._metadataPanel_10ac3_20 {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
 }
 
-._padded_1si8b_20 {
+._padded_10ac3_26 {
   padding-left: 0.8em;
   margin-top: 0.4em;
 }
 
-._error_1si8b_25 {
+._error_10ac3_31 {
   padding-top: 0.5em;
 }
 
-._ansi_1si8b_29 {
+._ansi_10ac3_35 {
   margin: 1em 0;
 }
 
-._noTop_1si8b_33 {
+._noTop_10ac3_39 {
   margin-top: 0;
 }
 
-._timePanel_1si8b_37 {
+._timePanel_10ac3_43 {
   display: grid;
   grid-template-columns: max-content max-content;
   grid-template-rows: auto;
@@ -20188,19 +20232,19 @@ a._citationLink_1ggvf_9:hover {
   min-width: 200px;
 }
 
-._chat_1si8b_45 {
+._chat_10ac3_51 {
   padding: 1em;
 }
 
-._padded_1si8b_20 {
+._padded_10ac3_26 {
   padding: 1em;
 }
 
-._overflowVisible_1si8b_53 {
+._overflowVisible_10ac3_59 {
   overflow-y: visible;
 }
 
-._retriedErrors_1si8b_57 {
+._retriedErrors_10ac3_63 {
   margin: 0.5rem;
   min-width: 0;
   overflow: hidden;
@@ -20258,74 +20302,438 @@ a._citationLink_1ggvf_9:hover {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-._target_1foh6_1 {
-  padding-left: 0;
-}
-
-._answer_1foh6_5 {
-  padding-left: 0;
-}
-
-._grid_1foh6_9 {
-  display: grid;
-  grid-column-gap: 1em;
-  border-bottom: solid var(--bs-border-color) 1px;
-  padding: 0.5rem;
-}
-
-._centerLabel_1foh6_16 {
+._panel_h02oy_1 {
+  background: transparent;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
 }
 
-._centerValue_1foh6_21 {
+._panelHeader_h02oy_9 {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  /* Match body left/right padding so the label/controls align with
+   * the rows/chips below. */
+  padding: 2px 12px;
+}
+
+._scoresHeader_h02oy_19 {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex: 1;
+  min-width: 0;
+}
+
+._scoresCount_h02oy_27 {
+  font-size: var(--inspect-font-size-smallest, 0.7rem);
+  color: var(--bs-tertiary-color, var(--bs-secondary));
+  font-variant-numeric: tabular-nums;
+}
+
+._columnLabel_h02oy_33 {
+  font-size: var(--inspect-font-size-smallest, 0.7rem);
+  font-weight: 400;
+  color: var(--bs-secondary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+._headerControls_h02oy_41 {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+/* Wrap the sort dropdown in the same outer chrome as the
+ * SegmentedControl so its border / body-bg / border-radius match the
+ * segments next to it. The inner ToolDropdownButton is then stripped
+ * back to a flat, transparent trigger. */
+._sortWrapper_h02oy_51 {
+  display: inline-flex;
+  background-color: var(--bs-body-bg);
+  border-radius: var(--bs-border-radius);
+  border: solid 1px var(--bs-border-color);
+}
+
+.btn._sortButton_h02oy_58 {
+  background: transparent;
+  border: none;
+  border-radius: var(--bs-border-radius);
+  color: var(--bs-secondary);
+  margin: 1px;
+  padding: 0 5px;
+  height: calc(100% - 2px);
+  line-height: 1.5;
+  display: inline-flex;
+  align-items: center;
+  font-size: var(--inspect-font-size-smallest, 0.7rem);
+}
+
+.btn._sortButton_h02oy_58:hover {
+  color: var(--bs-body-color);
+}
+
+.btn._sortButton_h02oy_58 i {
+  margin-right: 0;
+}
+
+._panelBody_h02oy_80 {
+  min-height: 0;
+}
+
+._bodyGrid_h02oy_84 {
+  padding: 4px 12px;
+}
+
+._panel_h02oy_1._tight_h02oy_88 ._bodyGrid_h02oy_84 {
+  padding: 3px 12px;
+}
+
+._bodyChips_h02oy_92 {
+  padding: 6px 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+._panel_h02oy_1._tight_h02oy_88 ._bodyChips_h02oy_92 {
+  padding: 5px 12px;
+}
+
+/* Cap the body at ~5 grid rows. Anything larger scrolls inside the
+ * panel so the rest of the header layout stays put. The cap is
+ * shared across grid and chips so the panel can't suddenly grow
+ * vertically when the user toggles views. */
+._dense_h02oy_107 {
+  max-height: 125px;
+  overflow-y: auto;
+}
+
+/* ── Grid rows ─────────────────────────────────────────────────────── */
+._row_h02oy_113 {
+  display: grid;
+  grid-template-columns: minmax(60px, 1fr) auto;
+  align-items: center;
+  column-gap: 12px;
+  padding: 2px 0;
+  min-width: 0;
+}
+
+._rowTight_h02oy_122 {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
+._rowName_h02oy_127 {
+  font-size: var(--inspect-font-size-small, 0.8rem);
+  color: var(--bs-body-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-variant-numeric: tabular-nums;
+  min-width: 0;
+}
+
+/* ── Chips ─────────────────────────────────────────────────────────── */
+._chip_h02oy_138 {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 8px 2px 4px;
+  background: var(--bs-body-bg);
+  border: 1px solid var(--bs-border-color);
+  border-radius: 999px;
+  font-size: var(--inspect-font-size-small, 0.8rem);
+  line-height: 1.3;
+  max-width: 220px;
+  min-width: 0;
+}
+
+._chipFail_h02oy_152 {
+  border-color: var(--bs-danger);
+}
+
+._chipWarn_h02oy_156 {
+  border-color: var(--bs-orange);
+}
+
+._chipName_h02oy_160 {
+  color: var(--bs-body-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+._circle_kcau9_1 {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  color: #fff;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+._circlePass_kcau9_13 {
+  background: var(--bs-success);
+}
+
+._circleFail_kcau9_17 {
+  background: var(--bs-danger);
+}
+
+._circleWarn_kcau9_21 {
+  background: var(--bs-orange);
+}
+
+._circleNeutral_kcau9_25 {
+  background: var(--bs-secondary);
+}
+
+._text_kcau9_29 {
+  font-size: var(--inspect-font-size-small, 0.8rem);
+  font-weight: 400;
+  font-variant-numeric: tabular-nums;
+  display: inline-block;
+  max-width: 12em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: middle;
+}
+
+._textPass_kcau9_41 {
+  color: var(--bs-success);
+}
+
+._textFail_kcau9_45 {
+  color: var(--bs-danger);
+}
+
+._textWarn_kcau9_49 {
+  color: var(--bs-orange);
+}
+
+._textNeutral_kcau9_53 {
+  color: var(--bs-body-color);
+}
+
+/* Smaller pill used inside ScoreChip. The mini pill has a fixed-ish
+ * height and gets a colored background for tone scores; neutral
+ * scores stay subtle. */
+._miniPill_kcau9_60 {
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
+  min-width: 18px;
+  max-width: 8em;
+  height: 16px;
+  line-height: 16px;
+  padding: 0 6px;
+  box-sizing: border-box;
+  border-radius: 999px;
+  font-size: var(--inspect-font-size-smallestest, 0.6rem);
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  flex-shrink: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+._miniPillPass_kcau9_80 {
+  background: var(--bs-success);
+  color: #fff;
+}
+
+._miniPillFail_kcau9_85 {
+  background: var(--bs-danger);
+  color: #fff;
+}
+
+._miniPillWarn_kcau9_90 {
+  background: var(--bs-orange);
+  color: #fff;
+}
+
+._miniPillNeutral_kcau9_95 {
+  background: var(--bs-secondary-bg-subtle);
+  color: var(--bs-secondary);
+}
+._root_rr9mf_1 {
+  background: var(--bs-light);
+  color: var(--bs-body-color);
+  border-bottom: 1px solid var(--bs-border-color);
+}
+
+/* Outer two-column layout. The right column gets a clamped range so
+ * its width adapts to viewport but stays in a band that yields
+ * roughly 2–3 chips per row regardless of chip set. The body fields
+ * (1fr) keep the rest. The 1-2 score case uses `noRight` instead and
+ * inlines the score cells into the field grid. */
+._layout_rr9mf_12 {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(160px, 220px);
+}
+
+._layout_rr9mf_12._wideRight_rr9mf_17 {
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 440px);
+}
+
+._layout_rr9mf_12._noRight_rr9mf_21 {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+._left_rr9mf_25 {
+  padding: 8px 0.5rem;
+  min-width: 0;
+}
+
+._layout_rr9mf_12._noRight_rr9mf_21 ._left_rr9mf_25 {
+  border-right: none;
+}
+
+._right_rr9mf_34 {
+  padding: 0;
+  background: var(--bs-light);
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+._metaLine_rr9mf_42 {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  column-gap: 8px;
+  row-gap: 2px;
+  margin-bottom: 8px;
+  color: var(--bs-secondary);
+}
+
+._metaSep_rr9mf_52 {
+  color: var(--bs-tertiary-color, var(--bs-secondary));
+}
+
+._metaId_rr9mf_56 {
+  font-family: var(--bs-font-monospace);
+  color: var(--bs-body-color);
+  font-size: var(--inspect-font-size-base);
+  font-weight: 500;
+}
+
+/* Field row: Input | Target | Answer in a single row. Target gets a
+ * fixed-ish middle slot, Input and Answer flex. */
+._fields_rr9mf_65 {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(60px, auto) minmax(0, 1fr);
+  gap: 8px 24px;
+}
+
+._field_rr9mf_65 {
+  min-width: 0;
+}
+
+._fieldTarget_rr9mf_75 {
+  max-width: 200px;
+}
+
+._fieldLabel_rr9mf_79 {
+  font-size: var(--inspect-font-size-smallest, 0.7rem);
+  font-weight: 400;
+  color: var(--bs-secondary);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+._fieldValue_rr9mf_87 {
+  font-size: var(--inspect-font-size-smaller, 0.9rem);
+  color: var(--bs-body-color);
+  line-height: 1.5;
+  margin-top: 4px;
+}
+
+._clamp_rr9mf_94 {
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* Score "field" cell — used in compact (1-2 scores) mode when scores
+ * are inlined into the same fields grid as Input/Target/Answer. The
+ * label gets the same FieldLabel chrome; the value sits directly
+ * beneath it, vertically aligned with the body field values. */
+._scoreField_rr9mf_106 {
+  max-width: 140px;
+}
+
+._scoreFieldValue_rr9mf_110 {
+  margin-top: 4px;
+  display: flex;
+  align-items: center;
+  min-width: 0;
+}
+
+._errorBlock_rr9mf_117 {
+  padding: 10px 18px;
+  border-top: 1px dashed var(--bs-border-color);
+}
+
+/* Collapsed state — meta line only. Used both as a standalone band
+ * inside SampleSummaryView and (more usefully) as the content of the
+ * sticky overlay rendered by `SampleDisplay` when the user has
+ * scrolled past the full header. Positioning lives at the call-site
+ * because the parent owns the scroll context. */
+._collapsedMeta_rr9mf_127 {
+  padding: 2px 0.5rem;
   display: flex;
   align-items: center;
 }
 
-._wrap_1foh6_26 {
-  word-wrap: anywhere;
-}
-
-._titled_1foh6_30:hover {
-  cursor: pointer;
-}
-
-._value_1foh6_34 {
-  flex-direction: column;
-  padding-top: 0.1em;
+/* In the collapsed band there's no fields row beneath the meta line,
+ * so suppress the bottom margin that the expanded layout uses. */
+._collapsedMeta_rr9mf_127 ._metaLine_rr9mf_42 {
+  margin-bottom: 0;
 }
 
 /* Invalidation banner styles */
-._invalidationBanner_1foh6_40 {
+._invalidationBanner_rr9mf_140 {
   display: flex;
   align-items: flex-start;
   gap: 0.75em;
   padding: 0.75em 1em;
-  background-color: var(--bs-warning-bg-subtle, #fff3cd);
-  border-bottom: 1px solid var(--bs-warning-border-subtle, #ffecb5);
-  color: var(--bs-warning-text-emphasis, #664d03);
+  background-color: var(--bs-warning-bg-subtle);
+  border-bottom: 1px solid var(--bs-warning-border-subtle);
+  color: var(--bs-warning-text-emphasis);
 }
 
-._invalidationIcon_1foh6_50 {
+._invalidationIcon_rr9mf_150 {
   font-size: 1.25em;
   line-height: 1;
   flex-shrink: 0;
 }
 
-._invalidationContent_1foh6_56 {
+._invalidationContent_rr9mf_156 {
   display: flex;
   flex-direction: column;
   gap: 0.25em;
   min-width: 0;
 }
 
-._invalidationTitle_1foh6_63 {
+._invalidationTitle_rr9mf_163 {
   font-weight: 600;
   font-size: 0.9em;
 }
 
-._invalidationDetails_1foh6_68 {
+._invalidationDetails_rr9mf_168 {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5em 1.5em;
@@ -20333,7 +20741,7 @@ a._citationLink_1ggvf_9:hover {
   opacity: 0.9;
 }
 
-._invalidationReason_1foh6_76 {
+._invalidationReason_rr9mf_176 {
   flex-basis: 100%;
 }
 ._statusCell_hunte_1 {

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -2,17 +2,32 @@
   "components": {
     "schemas": {
       "AdaptiveConcurrency": {
-        "description": "Bounds for an adaptive concurrency controller.\n\nConfigures the bounds within which an adaptive controller is allowed to\nscale: starting at `start`, growing up to `max`, and never falling below\n`min`. Accepts a string shorthand (\"min-max\" or \"min-start-max\") for use\nin CLI flags and config files.",
+        "description": "Bounds and tuning for an adaptive concurrency controller.\n\nBasic fields (`min`, `start`, `max`) bound the range the controller will\nscale within. Advanced fields (`cooldown_seconds`, `decrease_factor`,\n`scale_up_percent`) tune the response curve and have sensible defaults\nfor typical evaluation workloads \u2014 see the parallelism docs for guidance.\nAccepts a string shorthand (\"min-max\" or \"min-start-max\") for use in CLI\nflags and config files; advanced fields are Python-only.",
         "properties": {
+          "cooldown_seconds": {
+            "default": 15.0,
+            "title": "Cooldown Seconds",
+            "type": "number"
+          },
+          "decrease_factor": {
+            "default": 0.8,
+            "title": "Decrease Factor",
+            "type": "number"
+          },
           "max": {
-            "default": 200,
+            "default": 100,
             "title": "Max",
             "type": "integer"
           },
           "min": {
-            "default": 1,
+            "default": 4,
             "title": "Min",
             "type": "integer"
+          },
+          "scale_up_percent": {
+            "default": 0.05,
+            "title": "Scale Up Percent",
+            "type": "number"
           },
           "start": {
             "default": 20,
@@ -23,7 +38,10 @@
         "required": [
           "min",
           "max",
-          "start"
+          "start",
+          "cooldown_seconds",
+          "decrease_factor",
+          "scale_up_percent"
         ],
         "title": "AdaptiveConcurrency",
         "type": "object"

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -1,6 +1,33 @@
 {
   "components": {
     "schemas": {
+      "AdaptiveConcurrency": {
+        "description": "Bounds for an adaptive concurrency controller.\n\nConfigures the bounds within which an adaptive controller is allowed to\nscale: starting at `start`, growing up to `max`, and never falling below\n`min`. Accepts a string shorthand (\"min-max\" or \"min-start-max\") for use\nin CLI flags and config files.",
+        "properties": {
+          "max": {
+            "default": 200,
+            "title": "Max",
+            "type": "integer"
+          },
+          "min": {
+            "default": 1,
+            "title": "Min",
+            "type": "integer"
+          },
+          "start": {
+            "default": 20,
+            "title": "Start",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "min",
+          "max",
+          "start"
+        ],
+        "title": "AdaptiveConcurrency",
+        "type": "object"
+      },
       "ApprovalEvent": {
         "description": "Tool approval.",
         "properties": {
@@ -1082,6 +1109,45 @@
           "type"
         ],
         "title": "CompactionEvent",
+        "type": "object"
+      },
+      "ConnectionLimitChange": {
+        "description": "Record of an adaptive-connections controller scale change.",
+        "properties": {
+          "model": {
+            "title": "Model",
+            "type": "string"
+          },
+          "new_limit": {
+            "title": "New Limit",
+            "type": "integer"
+          },
+          "old_limit": {
+            "title": "Old Limit",
+            "type": "integer"
+          },
+          "reason": {
+            "enum": [
+              "slow_start",
+              "steady_state_up",
+              "rate_limit"
+            ],
+            "title": "Reason",
+            "type": "string"
+          },
+          "timestamp": {
+            "title": "Timestamp",
+            "type": "number"
+          }
+        },
+        "required": [
+          "timestamp",
+          "model",
+          "old_limit",
+          "new_limit",
+          "reason"
+        ],
+        "title": "ConnectionLimitChange",
         "type": "object"
       },
       "Content": {
@@ -4111,6 +4177,13 @@
             ],
             "title": "Completed At"
           },
+          "connection_limit_history": {
+            "items": {
+              "$ref": "#/components/schemas/ConnectionLimitChange"
+            },
+            "title": "Connection Limit History",
+            "type": "array"
+          },
           "model_usage": {
             "additionalProperties": {
               "$ref": "#/components/schemas/ModelUsage"
@@ -4142,7 +4215,8 @@
           "started_at",
           "completed_at",
           "model_usage",
-          "role_usage"
+          "role_usage",
+          "connection_limit_history"
         ],
         "title": "EvalStats",
         "type": "object"
@@ -4289,6 +4363,20 @@
       "GenerateConfig": {
         "description": "Model generation options.",
         "properties": {
+          "adaptive_connections": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "$ref": "#/components/schemas/AdaptiveConcurrency"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Adaptive Connections"
+          },
           "attempt_timeout": {
             "anyOf": [
               {

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -15,7 +15,7 @@
             "type": "number"
           },
           "max": {
-            "default": 100,
+            "default": 200,
             "title": "Max",
             "type": "integer"
           },

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -32,6 +32,7 @@ from ._file import (
     write_log_dir_manifest,
 )
 from ._log import (
+    ConnectionLimitChange,
     EvalConfig,
     EvalDataset,
     EvalLog,
@@ -123,6 +124,7 @@ __all__ = [
     "recoverable_eval_logs",
     "RecoverableEvalLog",
     "RecoveryNotAvailable",
+    "ConnectionLimitChange",
 ]
 
 

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -993,6 +993,25 @@ def eval_error(
     )
 
 
+class ConnectionLimitChange(BaseModel):
+    """Record of an adaptive-connections controller scale change."""
+
+    timestamp: float
+    """Unix timestamp (seconds since epoch) of the change."""
+
+    model: str
+    """Display name of the model whose connection limit changed (e.g. `openai/gpt-4o`)."""
+
+    old_limit: int
+    """Concurrency limit before the change."""
+
+    new_limit: int
+    """Concurrency limit after the change."""
+
+    reason: Literal["slow_start", "steady_state_up", "rate_limit"]
+    """Why the change occurred."""
+
+
 class EvalStats(BaseModel):
     """Timing and usage statistics."""
 
@@ -1007,6 +1026,9 @@ class EvalStats(BaseModel):
 
     role_usage: dict[str, ModelUsage] = Field(default_factory=dict)
     """Model token usage by role for evaluation."""
+
+    connection_limit_history: list[ConnectionLimitChange] = Field(default_factory=list)
+    """History of adaptive-connections controller scale changes (empty unless `adaptive_connections` was enabled)."""
 
     # allow field model_usage
     model_config = ConfigDict(protected_namespaces=())

--- a/src/inspect_ai/model/__init__.py
+++ b/src/inspect_ai/model/__init__.py
@@ -65,6 +65,7 @@ from ._model import (
     Model,
     ModelAPI,
     ModelName,
+    RetryDecision,
     get_model,
     model_roles,
 )
@@ -148,6 +149,7 @@ __all__ = [
     "Model",
     "ModelAPI",
     "ModelName",
+    "RetryDecision",
     "ModelConfig",
     "ModelUsage",
     "StopReason",

--- a/src/inspect_ai/model/_cache.py
+++ b/src/inspect_ai/model/_cache.py
@@ -142,6 +142,7 @@ def _cache_key(entry: CacheEntry) -> str:
             exclude=set(
                 [
                     "max_connections",
+                    "adaptive_connections",
                     "max_retries",
                     "timeout",
                     "cache",

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -7,6 +7,7 @@ from typing_extensions import TypedDict
 
 from inspect_ai._util.constants import DEFAULT_BATCH_SIZE
 from inspect_ai.model._cache import CachePolicy
+from inspect_ai.util._concurrency import AdaptiveConcurrency
 from inspect_ai.util._json import JSONSchema
 
 
@@ -82,6 +83,9 @@ class GenerateConfigArgs(TypedDict, total=False):
 
     max_connections: int | None
     """Maximum number of concurrent connections to Model API (default is model specific)."""
+
+    adaptive_connections: bool | AdaptiveConcurrency | None
+    """Enable adaptive concurrency for model API connections. `True` for defaults (min=1, max=200, start=20), or pass `AdaptiveConcurrency` to customize bounds. An explicit `max_connections` overrides this and uses static concurrency."""
 
     system_message: str | None
     """Override the default system message."""
@@ -193,6 +197,9 @@ class GenerateConfig(BaseModel):
 
     max_connections: int | None = Field(default=None)
     """Maximum number of concurrent connections to Model API (default is model specific)."""
+
+    adaptive_connections: bool | AdaptiveConcurrency | None = Field(default=None)
+    """Enable adaptive concurrency for model API connections. `True` for defaults (min=1, max=200, start=20), or pass `AdaptiveConcurrency` to customize bounds. An explicit `max_connections` overrides this and uses static concurrency."""
 
     system_message: str | None = Field(default=None)
     """Override the default system message."""

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -85,7 +85,7 @@ class GenerateConfigArgs(TypedDict, total=False):
     """Maximum number of concurrent connections to Model API (default is model specific)."""
 
     adaptive_connections: bool | AdaptiveConcurrency | None
-    """Enable adaptive concurrency for model API connections. `True` for defaults (min=4, start=20, max=100), or pass `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency."""
+    """Enable adaptive concurrency for model API connections. `True` for defaults (min=4, start=20, max=200), or pass `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency."""
 
     system_message: str | None
     """Override the default system message."""
@@ -199,7 +199,7 @@ class GenerateConfig(BaseModel):
     """Maximum number of concurrent connections to Model API (default is model specific)."""
 
     adaptive_connections: bool | AdaptiveConcurrency | None = Field(default=None)
-    """Enable adaptive concurrency for model API connections. `True` for defaults (min=4, start=20, max=100), or pass `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency."""
+    """Enable adaptive concurrency for model API connections. `True` for defaults (min=4, start=20, max=200), or pass `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency."""
 
     system_message: str | None = Field(default=None)
     """Override the default system message."""

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -85,7 +85,7 @@ class GenerateConfigArgs(TypedDict, total=False):
     """Maximum number of concurrent connections to Model API (default is model specific)."""
 
     adaptive_connections: bool | AdaptiveConcurrency | None
-    """Enable adaptive concurrency for model API connections. `True` for defaults (min=1, max=200, start=20), or pass `AdaptiveConcurrency` to customize bounds. An explicit `max_connections` overrides this and uses static concurrency."""
+    """Enable adaptive concurrency for model API connections. `True` for defaults (min=4, start=20, max=100), or pass `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency."""
 
     system_message: str | None
     """Override the default system message."""
@@ -199,7 +199,7 @@ class GenerateConfig(BaseModel):
     """Maximum number of concurrent connections to Model API (default is model specific)."""
 
     adaptive_connections: bool | AdaptiveConcurrency | None = Field(default=None)
-    """Enable adaptive concurrency for model API connections. `True` for defaults (min=1, max=200, start=20), or pass `AdaptiveConcurrency` to customize bounds. An explicit `max_connections` overrides this and uses static concurrency."""
+    """Enable adaptive concurrency for model API connections. `True` for defaults (min=4, start=20, max=100), or pass `AdaptiveConcurrency` to customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` overrides this and uses static concurrency."""
 
     system_message: str | None = Field(default=None)
     """Override the default system message."""

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1263,11 +1263,21 @@ class Model:
         model_name = ModelName(self)
         key = f"Model{self.api.connection_key()}"
 
-        # adaptive path: controller-managed CapacityLimiter. Explicit
-        # max_connections wins silently — anticipating adaptive_connections
-        # becoming default-on, in which case any deliberate max_connections
-        # setting must continue to be honored.
-        if config.adaptive_connections and config.max_connections is None:
+        # adaptive path: controller-managed CapacityLimiter. Two precedence
+        # rules — both silent — anticipating adaptive_connections becoming
+        # default-on, in which case any deliberate override must keep working:
+        #   * Explicit max_connections wins (existing behavior).
+        #   * Batch mode wins. Batch APIs run on a separate quota, the per-
+        #     request concurrency model doesn't bind (DEFAULT_MAX_CONNECTIONS_BATCH
+        #     is a sentinel ceiling), and the worker's background-task
+        #     ContextVars don't propagate retry/success signals back to
+        #     awaiting generates — so adaptive's success/retry accounting
+        #     would be incorrect anyway. See docs/parallelism.qmd.
+        if (
+            config.adaptive_connections
+            and config.max_connections is None
+            and not config.batch
+        ):
             adaptive = (
                 config.adaptive_connections
                 if isinstance(config.adaptive_connections, AdaptiveConcurrency)

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -951,6 +951,12 @@ class Model:
                         output=existing,
                         call=None,
                     )
+                    # mark this request as a cache hit so the post-call
+                    # adaptive-controller success notification is suppressed —
+                    # cache hits don't exercise the rate limit
+                    from inspect_ai.util._concurrency import _request_was_cache_hit
+
+                    _request_was_cache_hit.set(True)
                     if existing.usage:
                         await emit_model_cache_usage(
                             model_name=str(self), usage=existing.usage
@@ -1076,6 +1082,24 @@ class Model:
         time_start = time.monotonic()
         model_output, event = await generate()
         total_time = time.monotonic() - time_start
+
+        # notify the adaptive controller of a clean success (no retries during
+        # this logical request, AND not a cache hit since cache hits don't
+        # exercise the rate limit). Successful-after-retry and cache hits are
+        # both treated as neutral.
+        from inspect_ai.util._concurrency import (
+            _active_controller,
+            _request_had_retry,
+            _request_was_cache_hit,
+        )
+
+        controller = _active_controller.get()
+        if (
+            controller is not None
+            and not _request_had_retry.get()
+            and not _request_was_cache_hit.get()
+        ):
+            controller.notify_success()
         if model_output.time:
             # we've already reported some of the waiting time in tenacity callbacks
             # any remaining waiting time will have been due to internal retry within
@@ -1097,6 +1121,13 @@ class Model:
             # attempt timeout is always retried (we rely on `timeout`
             # and/or `max_retries` for termination)
             if isinstance(ex, AttemptTimeoutError):
+                # report so the global retry counter, ModelEvent.retries,
+                # _request_had_retry, and the adaptive controller all see
+                # this as a retry — otherwise a request that timed out one
+                # or more attempts and then succeeded would count as a clean
+                # adaptive success and could drive the controller upward
+                # under timeout pressure.
+                report_http_retry()
                 return True
 
             # check standard should_retry() method
@@ -1160,20 +1191,58 @@ class Model:
         self, config: GenerateConfig
     ) -> AsyncIterator[None]:
         """Get the appropriate connection semaphore for this model instance."""
-        max_connections = (
-            config.max_connections
-            if config.max_connections
-            else DEFAULT_MAX_CONNECTIONS_BATCH
-            if config.batch
-            else self.api.max_connections()
+        from inspect_ai.util._concurrency import (
+            AdaptiveConcurrency,
+            AdaptiveConcurrencyController,
+            _active_controller,
+            _request_had_retry,
+            _request_was_cache_hit,
         )
+
         model_name = ModelName(self)
-        async with concurrency(
-            name=str(model_name),
-            concurrency=max_connections,
-            key=f"Model{self.api.connection_key()}",
-        ):
-            yield
+        key = f"Model{self.api.connection_key()}"
+
+        # adaptive path: controller-managed CapacityLimiter. Explicit
+        # max_connections wins silently — anticipating adaptive_connections
+        # becoming default-on, in which case any deliberate max_connections
+        # setting must continue to be honored.
+        if config.adaptive_connections and config.max_connections is None:
+            adaptive = (
+                config.adaptive_connections
+                if isinstance(config.adaptive_connections, AdaptiveConcurrency)
+                else AdaptiveConcurrency()
+            )
+            async with concurrency(
+                name=str(model_name),
+                concurrency=adaptive.start,
+                key=key,
+                adaptive=adaptive,
+            ) as sem:
+                assert isinstance(sem, AdaptiveConcurrencyController)
+                token_c = _active_controller.set(sem)
+                token_r = _request_had_retry.set(False)
+                token_h = _request_was_cache_hit.set(False)
+                try:
+                    yield
+                finally:
+                    _active_controller.reset(token_c)
+                    _request_had_retry.reset(token_r)
+                    _request_was_cache_hit.reset(token_h)
+        else:
+            # static path (existing behavior, unchanged)
+            max_connections = (
+                config.max_connections
+                if config.max_connections
+                else DEFAULT_MAX_CONNECTIONS_BATCH
+                if config.batch
+                else self.api.max_connections()
+            )
+            async with concurrency(
+                name=str(model_name),
+                concurrency=max_connections,
+                key=key,
+            ):
+                yield
 
     def _resolve_config(self, config: GenerateConfig | None) -> GenerateConfig:
         # base config for this model
@@ -1189,6 +1258,7 @@ class Model:
             base_config = base_config.merge(
                 GenerateConfig(
                     max_connections=active_config.max_connections,
+                    adaptive_connections=active_config.adaptive_connections,
                     max_retries=active_config.max_retries,
                     timeout=active_config.timeout,
                 )

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1,5 +1,6 @@
 import abc
 import contextlib
+import dataclasses
 import functools
 import json
 import logging
@@ -125,6 +126,56 @@ class GenerateInput(NamedTuple):
 
     config: GenerateConfig
     """Model configuration."""
+
+
+@dataclasses.dataclass(frozen=True)
+class RetryDecision:
+    """Classification of a retryable exception for `ModelAPI.should_retry`.
+
+    `should_retry()` may return either a plain `bool` (legacy: any True
+    is treated as a generic transient retry) or a `RetryDecision` to
+    additionally classify the retry kind and pass server-suggested wait
+    times to the adaptive concurrency controller.
+
+    `RetryDecision` is truthy iff `retry` is True, so existing callers
+    written against the `bool` return (`if api.should_retry(ex): ...`)
+    keep working unchanged.
+
+    Use the `no()`, `transient()`, and `rate_limit()` factory methods
+    rather than constructing directly.
+    """
+
+    retry: bool
+    """Whether to retry the request."""
+
+    kind: Literal["rate_limit", "transient"] = "transient"
+    """How to account for the retry against the adaptive controller.
+
+    `rate_limit` triggers a scale-down. `transient` (5xx, timeouts,
+    network errors) only marks the request as retried so the eventual
+    success won't count toward scale-up — it does not shrink the limit.
+    """
+
+    retry_after: float | None = None
+    """Recommended seconds to wait before retrying, if the server provided one (e.g. via `Retry-After`)."""
+
+    def __bool__(self) -> bool:
+        return self.retry
+
+    @classmethod
+    def no(cls) -> "RetryDecision":
+        """Don't retry."""
+        return cls(retry=False)
+
+    @classmethod
+    def transient(cls, retry_after: float | None = None) -> "RetryDecision":
+        """Retry as a transient error (pauses scale-up but doesn't scale down)."""
+        return cls(retry=True, kind="transient", retry_after=retry_after)
+
+    @classmethod
+    def rate_limit(cls, retry_after: float | None = None) -> "RetryDecision":
+        """Retry as a rate-limit error (scales the adaptive controller down)."""
+        return cls(retry=True, kind="rate_limit", retry_after=retry_after)
 
 
 class ModelAPI(abc.ABC):
@@ -336,8 +387,15 @@ class ModelAPI(abc.ABC):
         """Scope for enforcement of max_connections."""
         return "default"
 
-    def should_retry(self, ex: Exception) -> bool:
+    def should_retry(self, ex: Exception) -> bool | RetryDecision:
         """Should this exception be retried?
+
+        Returns either a plain `bool` (any True is treated as a transient
+        retry by the adaptive controller) or a `RetryDecision` to
+        additionally classify the retry as `rate_limit` vs `transient`
+        and to pass through any server-suggested `retry_after`. Built-in
+        providers return `RetryDecision` so the adaptive controller scales
+        only on real rate-limit signals.
 
         Args:
            ex: Exception to check for retry
@@ -1119,28 +1177,31 @@ class Model:
     def should_retry(self, ex: BaseException) -> bool:
         if isinstance(ex, Exception):
             # attempt timeout is always retried (we rely on `timeout`
-            # and/or `max_retries` for termination)
+            # and/or `max_retries` for termination). Classified as transient:
+            # _request_had_retry still flips so the eventual success won't
+            # count toward adaptive scale-up, but the controller doesn't
+            # scale down for what's essentially infra noise.
             if isinstance(ex, AttemptTimeoutError):
-                # report so the global retry counter, ModelEvent.retries,
-                # _request_had_retry, and the adaptive controller all see
-                # this as a retry — otherwise a request that timed out one
-                # or more attempts and then succeeded would count as a clean
-                # adaptive success and could drive the controller upward
-                # under timeout pressure.
                 report_http_retry()
                 return True
 
-            # check standard should_retry() method
-            retry = self.api.should_retry(ex)
-            if retry:
+            # check standard should_retry() method — may return bool or RetryDecision
+            decision = self.api.should_retry(ex)
+            if isinstance(decision, RetryDecision):
+                if decision.retry:
+                    report_http_retry(
+                        kind=decision.kind, retry_after=decision.retry_after
+                    )
+                    return True
+            elif decision:
+                # legacy bool-True path: provider didn't classify, treat as transient
                 report_http_retry()
                 return True
 
             from inspect_ai.hooks._hooks import has_api_key_override
 
             if has_api_key_override():
-                retry = self.api.is_auth_failure(ex)
-                if retry:
+                if self.api.is_auth_failure(ex):
                     report_http_retry()
                     return True
 
@@ -1152,9 +1213,9 @@ class Model:
                     f"provider '{self.name}' implements deprecated is_rate_limit() method, "
                     + "please change to should_retry()",
                 )
-                retry = cast(bool, is_rate_limit(ex))
-                if retry:
-                    report_http_retry()
+                if cast(bool, is_rate_limit(ex)):
+                    # legacy method's name says it all — treat as rate-limit
+                    report_http_retry(kind="rate_limit")
                     return True
 
         # no retry

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -57,7 +57,10 @@ from inspect_ai._util.content import (
     ContentReasoning,
     ContentText,
 )
-from inspect_ai._util.http import is_retryable_http_status
+from inspect_ai._util.http import (
+    is_retryable_http_status,
+    parse_retry_after_from_exception,
+)
 from inspect_ai._util.images import file_as_data_uri
 from inspect_ai._util.url import is_http_url
 from inspect_ai.model._call_tools import parse_tool_call
@@ -929,10 +932,12 @@ def openai_classify_retry(ex: BaseException) -> "RetryDecision | None":
     from inspect_ai.model._model import RetryDecision
 
     if isinstance(ex, RateLimitError):
-        return RetryDecision.rate_limit(retry_after=_response_retry_after(ex))
+        return RetryDecision.rate_limit(
+            retry_after=parse_retry_after_from_exception(ex)
+        )
     if isinstance(ex, APIStatusError):
         status = ex.status_code
-        retry_after = _response_retry_after(ex)
+        retry_after = parse_retry_after_from_exception(ex)
         if status == 429:
             return RetryDecision.rate_limit(retry_after=retry_after)
         if is_retryable_http_status(status):
@@ -950,20 +955,6 @@ def openai_classify_retry(ex: BaseException) -> "RetryDecision | None":
     if isinstance(ex, APIConnectionError | APITimeoutError):
         return RetryDecision.transient()
     return None
-
-
-def _response_retry_after(ex: APIStatusError) -> float | None:
-    """Best-effort Retry-After / x-ratelimit-reset-* extraction from an OpenAI exception."""
-    from inspect_ai._util.http import parse_retry_after
-
-    response = getattr(ex, "response", None)
-    headers = getattr(response, "headers", None)
-    if headers is None:
-        return None
-    try:
-        return parse_retry_after(headers)
-    except Exception:
-        return None
 
 
 def openai_handle_bad_request(

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -4,7 +4,10 @@ import logging
 import re
 from copy import copy
 from dataclasses import dataclass
-from typing import Any, Callable, Literal, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, cast
+
+if TYPE_CHECKING:
+    from inspect_ai.model._model import RetryDecision
 
 import httpx
 from openai import (
@@ -913,16 +916,54 @@ def _parse_prompt_logprobs(response: Any) -> Logprobs | None:
 
 
 def openai_should_retry(ex: BaseException) -> bool:
+    return openai_classify_retry(ex) is not None
+
+
+def openai_classify_retry(ex: BaseException) -> "RetryDecision | None":
+    """Classify an OpenAI SDK exception as rate_limit / transient / not retryable.
+
+    Returns None when the exception isn't retryable. Reads `Retry-After` and
+    `x-ratelimit-reset-*` from the response headers when available so the
+    adaptive controller can honor server-suggested wait times.
+    """
+    from inspect_ai.model._model import RetryDecision
+
     if isinstance(ex, RateLimitError):
-        return True
-    elif isinstance(ex, APIStatusError):
-        return is_retryable_http_status(ex.status_code)
-    elif isinstance(ex, OpenAIResponseError):
-        return ex.code in ["rate_limit_exceeded", "server_error"]
-    elif isinstance(ex, APIConnectionError | APITimeoutError):
-        return True
-    else:
-        return False
+        return RetryDecision.rate_limit(retry_after=_response_retry_after(ex))
+    if isinstance(ex, APIStatusError):
+        status = ex.status_code
+        retry_after = _response_retry_after(ex)
+        if status == 429:
+            return RetryDecision.rate_limit(retry_after=retry_after)
+        if is_retryable_http_status(status):
+            return RetryDecision.transient(retry_after=retry_after)
+        return None
+    if isinstance(ex, OpenAIResponseError):
+        # OpenAIResponseError is the structured error from the Responses API.
+        # `rate_limit_exceeded` is the explicit rate-limit code; `server_error`
+        # is a generic backend failure (treat as transient).
+        if ex.code == "rate_limit_exceeded":
+            return RetryDecision.rate_limit()
+        if ex.code == "server_error":
+            return RetryDecision.transient()
+        return None
+    if isinstance(ex, APIConnectionError | APITimeoutError):
+        return RetryDecision.transient()
+    return None
+
+
+def _response_retry_after(ex: APIStatusError) -> float | None:
+    """Best-effort Retry-After / x-ratelimit-reset-* extraction from an OpenAI exception."""
+    from inspect_ai._util.http import parse_retry_after
+
+    response = getattr(ex, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        return parse_retry_after(headers)
+    except Exception:
+        return None
 
 
 def openai_handle_bad_request(

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -150,7 +150,7 @@ from inspect_ai.util._json import (
     set_additional_properties_false,
 )
 
-from ..._util.httpx import httpx_should_retry
+from ..._util.httpx import httpx_classify_retry
 from .._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -158,7 +158,7 @@ from .._chat_message import (
     ChatMessageUser,
 )
 from .._generate_config import GenerateConfig, normalized_batch_config
-from .._model import ModelAPI, log_model_retry
+from .._model import ModelAPI, RetryDecision, log_model_retry
 from .._model_call import ModelCall, as_error_response
 from .._model_output import ChatCompletionChoice, ModelOutput, ModelUsage, StopReason
 from .._providers._anthropic_citations import (
@@ -999,14 +999,15 @@ class AnthropicAPI(ModelAPI):
             return self.canonical_name()
 
     @override
-    def should_retry(self, ex: BaseException) -> bool:
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, APIStatusError):
+            retry_after = _anthropic_retry_after(ex)
             # when streaming, anthropic does not set status_code == 529
             # for overloaded or internal server errors so we check for them explicitly
             if isinstance(ex.body, dict):
                 body_str = str(ex.body).lower()
                 if "overloaded" in body_str or "internal server error" in body_str:
-                    return True
+                    return RetryDecision.transient(retry_after=retry_after)
                 # TCP interruptions can truncate large request bodies in transit,
                 # causing a 400 even though json.dumps() produced valid JSON.
                 if (
@@ -1014,16 +1015,21 @@ class AnthropicAPI(ModelAPI):
                     and "not valid json" in body_str
                     and "unexpected end of data" in body_str
                 ):
-                    return True
+                    return RetryDecision.transient(retry_after=retry_after)
 
             # standard http status code checking
-            return is_retryable_http_status(ex.status_code)
-        elif httpx_should_retry(ex):
-            return True
-        elif isinstance(ex, APIConnectionError | APITimeoutError):
-            return True
-        else:
-            return False
+            if not is_retryable_http_status(ex.status_code):
+                return RetryDecision.no()
+            if ex.status_code == 429:
+                return RetryDecision.rate_limit(retry_after=retry_after)
+            return RetryDecision.transient(retry_after=retry_after)
+
+        decision = httpx_classify_retry(ex)
+        if decision is not None:
+            return decision
+        if isinstance(ex, APIConnectionError | APITimeoutError):
+            return RetryDecision.transient()
+        return RetryDecision.no()
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:
@@ -3097,3 +3103,17 @@ def is_image_type(media_type: str) -> bool:
 
 def anthropic_extra_body_fields() -> list[str]:
     return ["metadata", "service_tier"]
+
+
+def _anthropic_retry_after(ex: APIStatusError) -> float | None:
+    """Extract Retry-After / x-ratelimit-reset-* from an Anthropic APIStatusError."""
+    from inspect_ai._util.http import parse_retry_after
+
+    response = getattr(ex, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        return parse_retry_after(headers)
+    except Exception:
+        return None

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -122,7 +122,10 @@ from inspect_ai._util.content import (
 )
 from inspect_ai._util.error import exception_message
 from inspect_ai._util.hash import mm3_hash
-from inspect_ai._util.http import is_retryable_http_status
+from inspect_ai._util.http import (
+    is_retryable_http_status,
+    parse_retry_after_from_exception,
+)
 from inspect_ai._util.images import file_as_data, file_as_data_uri
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.logger import warn_once
@@ -1001,7 +1004,7 @@ class AnthropicAPI(ModelAPI):
     @override
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, APIStatusError):
-            retry_after = _anthropic_retry_after(ex)
+            retry_after = parse_retry_after_from_exception(ex)
             # when streaming, anthropic does not set status_code == 529
             # for overloaded or internal server errors so we check for them explicitly
             if isinstance(ex.body, dict):
@@ -3103,17 +3106,3 @@ def is_image_type(media_type: str) -> bool:
 
 def anthropic_extra_body_fields() -> list[str]:
     return ["metadata", "service_tier"]
-
-
-def _anthropic_retry_after(ex: APIStatusError) -> float | None:
-    """Extract Retry-After / x-ratelimit-reset-* from an Anthropic APIStatusError."""
-    from inspect_ai._util.http import parse_retry_after
-
-    response = getattr(ex, "response", None)
-    headers = getattr(response, "headers", None)
-    if headers is None:
-        return None
-    try:
-        return parse_retry_after(headers)
-    except Exception:
-        return None

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -55,7 +55,7 @@ from .._chat_message import (
     ChatMessageUser,
 )
 from .._generate_config import GenerateConfig
-from .._model import ModelAPI
+from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall
 from .._model_output import (
     ChatCompletionChoice,
@@ -288,13 +288,17 @@ class AzureAIAPI(ModelAPI):
             return DEFAULT_MAX_TOKENS
 
     @override
-    def should_retry(self, ex: Exception) -> bool:
+    def should_retry(self, ex: Exception) -> bool | RetryDecision:
         if isinstance(ex, HttpResponseError) and ex.status_code is not None:
-            return is_retryable_http_status(ex.status_code)
-        elif isinstance(ex, ServiceResponseError):
-            return True
-        else:
-            return False
+            if not is_retryable_http_status(ex.status_code):
+                return RetryDecision.no()
+            retry_after = _azure_retry_after(ex)
+            if ex.status_code == 429:
+                return RetryDecision.rate_limit(retry_after=retry_after)
+            return RetryDecision.transient(retry_after=retry_after)
+        if isinstance(ex, ServiceResponseError):
+            return RetryDecision.transient()
+        return RetryDecision.no()
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:
@@ -601,3 +605,17 @@ def chat_completion_stop_reason(reason: str) -> StopReason:
 
         case _:
             return "unknown"
+
+
+def _azure_retry_after(ex: HttpResponseError) -> float | None:
+    """Extract Retry-After / x-ratelimit-reset-* from an azure-core HttpResponseError."""
+    from inspect_ai._util.http import parse_retry_after
+
+    response = getattr(ex, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        return parse_retry_after(headers)
+    except Exception:
+        return None

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -38,7 +38,10 @@ from typing_extensions import override
 from inspect_ai._util.constants import DEFAULT_MAX_TOKENS
 from inspect_ai._util.content import Content, ContentImage, ContentText
 from inspect_ai._util.error import PrerequisiteError
-from inspect_ai._util.http import is_retryable_http_status
+from inspect_ai._util.http import (
+    is_retryable_http_status,
+    parse_retry_after_from_exception,
+)
 from inspect_ai._util.images import file_as_data_uri
 from inspect_ai.log._samples import set_active_model_event_call
 from inspect_ai.tool import ToolChoice, ToolInfo
@@ -292,7 +295,7 @@ class AzureAIAPI(ModelAPI):
         if isinstance(ex, HttpResponseError) and ex.status_code is not None:
             if not is_retryable_http_status(ex.status_code):
                 return RetryDecision.no()
-            retry_after = _azure_retry_after(ex)
+            retry_after = parse_retry_after_from_exception(ex)
             if ex.status_code == 429:
                 return RetryDecision.rate_limit(retry_after=retry_after)
             return RetryDecision.transient(retry_after=retry_after)
@@ -605,17 +608,3 @@ def chat_completion_stop_reason(reason: str) -> StopReason:
 
         case _:
             return "unknown"
-
-
-def _azure_retry_after(ex: HttpResponseError) -> float | None:
-    """Extract Retry-After / x-ratelimit-reset-* from an azure-core HttpResponseError."""
-    from inspect_ai._util.http import parse_retry_after
-
-    response = getattr(ex, "response", None)
-    headers = getattr(response, "headers", None)
-    if headers is None:
-        return None
-    try:
-        return parse_retry_after(headers)
-    except Exception:
-        return None

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -31,7 +31,7 @@ from .._chat_message import (
     ChatMessageUser,
 )
 from .._generate_config import GenerateConfig
-from .._model import ModelAPI
+from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall, as_error_response
 from .._model_output import ChatCompletionChoice, ModelOutput, ModelUsage
 from .util import (
@@ -325,27 +325,43 @@ class BedrockAPI(ModelAPI):
         else:
             return DEFAULT_MAX_TOKENS
 
+    # Bedrock returns AWS-specific error codes; the throttling-family codes
+    # are documented as the 429 equivalent and indicate true capacity
+    # throttling. The infra-family codes (RequestTimeout, ServiceUnavailable)
+    # are retryable but represent AWS-side issues, not client over-saturation —
+    # so they're classified as transient (pause scale-up, don't scale down).
+    _BEDROCK_THROTTLE_CODES = frozenset(
+        [
+            "ThrottlingException",
+            "RequestLimitExceeded",
+            "Throttling",
+            "RequestThrottled",
+            "TooManyRequestsException",
+            "ProvisionedThroughputExceededException",
+        ]
+    )
+    _BEDROCK_TRANSIENT_CODES = frozenset(
+        [
+            "TransactionInProgressException",
+            "RequestTimeout",
+            "ServiceUnavailable",
+            "ServiceUnavailableException",
+        ]
+    )
+
     @override
-    def should_retry(self, ex: Exception) -> bool:
+    def should_retry(self, ex: Exception) -> bool | RetryDecision:
         from botocore.exceptions import ClientError
 
-        # Look for an explicit throttle exception
         if isinstance(ex, ClientError):
             error_code = ex.response.get("Error", {}).get("Code", "")
-            return error_code in [
-                "ThrottlingException",
-                "RequestLimitExceeded",
-                "Throttling",
-                "RequestThrottled",
-                "TooManyRequestsException",
-                "ProvisionedThroughputExceededException",
-                "TransactionInProgressException",
-                "RequestTimeout",
-                "ServiceUnavailable",
-                "ServiceUnavailableException",
-            ]
-        else:
-            return False
+            if error_code in self._BEDROCK_THROTTLE_CODES:
+                # AWS doesn't include Retry-After on ThrottlingException — fall
+                # back to the controller's configured cooldown floor.
+                return RetryDecision.rate_limit()
+            if error_code in self._BEDROCK_TRANSIENT_CODES:
+                return RetryDecision.transient()
+        return RetryDecision.no()
 
     @override
     def collapse_user_messages(self) -> bool:

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -68,7 +68,10 @@ from inspect_ai._util.content import (
     ContentVideo,
 )
 from inspect_ai._util.error import PrerequisiteError
-from inspect_ai._util.http import is_retryable_http_status
+from inspect_ai._util.http import (
+    is_retryable_http_status,
+    parse_retry_after_from_exception,
+)
 from inspect_ai._util.images import file_as_data
 from inspect_ai._util.kvstore import inspect_kvstore
 from inspect_ai._util.logger import warn_once
@@ -677,7 +680,7 @@ class GoogleGenAIAPI(ModelAPI):
         if isinstance(ex, APIError) and ex.code is not None:
             if not is_retryable_http_status(ex.code):
                 return RetryDecision.no()
-            retry_after = _google_retry_after(ex)
+            retry_after = parse_retry_after_from_exception(ex)
             if ex.code == 429:
                 return RetryDecision.rate_limit(retry_after=retry_after)
             status = getattr(ex, "status", "") or ""
@@ -1827,17 +1830,3 @@ def _malformed_function_message(candidate: Candidate | GenerateContentResponse) 
         return candidate.finish_message
     else:
         return DEFAULT_FINISH_MESSAGE
-
-
-def _google_retry_after(ex: APIError) -> float | None:
-    """Extract Retry-After / x-ratelimit-reset-* from an APIError's response."""
-    from inspect_ai._util.http import parse_retry_after
-
-    response = getattr(ex, "response", None)
-    headers = getattr(response, "headers", None)
-    if headers is None:
-        return None
-    try:
-        return parse_retry_after(headers)
-    except Exception:
-        return None

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -91,7 +91,7 @@ from inspect_ai.model import (
 )
 from inspect_ai.model._chat_message import ChatMessageSystem
 from inspect_ai.model._generate_config import has_image_output, normalized_batch_config
-from inspect_ai.model._model import log_model_retry
+from inspect_ai.model._model import RetryDecision, log_model_retry
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._providers._google_batch import GoogleBatcher, batch_request_dict
 from inspect_ai.model._providers._google_citations import (
@@ -669,11 +669,22 @@ class GoogleGenAIAPI(ModelAPI):
         ) and "-pro" in self.service_model_name()
 
     @override
-    def should_retry(self, ex: BaseException) -> bool:
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
+        # HTTP 429 is always a rate-limit signal regardless of SDK status text.
+        # 503 needs a guard: Google sometimes returns 503 RESOURCE_EXHAUSTED
+        # for sustained capacity pressure on Gemini (rate-limit), while plain
+        # 503 UNAVAILABLE is infra unavailability (transient).
         if isinstance(ex, APIError) and ex.code is not None:
-            return is_retryable_http_status(ex.code)
-        else:
-            return False
+            if not is_retryable_http_status(ex.code):
+                return RetryDecision.no()
+            retry_after = _google_retry_after(ex)
+            if ex.code == 429:
+                return RetryDecision.rate_limit(retry_after=retry_after)
+            status = getattr(ex, "status", "") or ""
+            if ex.code == 503 and "RESOURCE_EXHAUSTED" in status.upper():
+                return RetryDecision.rate_limit(retry_after=retry_after)
+            return RetryDecision.transient(retry_after=retry_after)
+        return RetryDecision.no()
 
     @override
     def connection_key(self) -> str:
@@ -1816,3 +1827,17 @@ def _malformed_function_message(candidate: Candidate | GenerateContentResponse) 
         return candidate.finish_message
     else:
         return DEFAULT_FINISH_MESSAGE
+
+
+def _google_retry_after(ex: APIError) -> float | None:
+    """Extract Retry-After / x-ratelimit-reset-* from an APIError's response."""
+    from inspect_ai._util.http import parse_retry_after
+
+    response = getattr(ex, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        return parse_retry_after(headers)
+    except Exception:
+        return None

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -49,7 +49,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageTool,
     ChatMessageUser,
 )
-from inspect_ai.model._model import ModelAPI, log_model_retry
+from inspect_ai.model._model import ModelAPI, RetryDecision, log_model_retry
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.model._providers.util.util import model_base_url
@@ -302,16 +302,21 @@ class GrokAPI(ModelAPI):
             and ex.code() == grpc.StatusCode.UNAUTHENTICATED
         )
 
-    def should_retry(self, ex: BaseException) -> bool:
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, grpc.RpcError):
-            return ex.code() in {
+            code = ex.code()
+            # RESOURCE_EXHAUSTED is the gRPC equivalent of HTTP 429 — the only
+            # one that indicates rate-limiting. UNKNOWN / UNAVAILABLE /
+            # DEADLINE_EXCEEDED are infrastructure transients.
+            if code == grpc.StatusCode.RESOURCE_EXHAUSTED:
+                return RetryDecision.rate_limit()
+            if code in {
                 grpc.StatusCode.UNKNOWN,
                 grpc.StatusCode.UNAVAILABLE,
                 grpc.StatusCode.DEADLINE_EXCEEDED,
-                grpc.StatusCode.RESOURCE_EXHAUSTED,
-            }
-        else:
-            return False
+            }:
+                return RetryDecision.transient()
+        return RetryDecision.no()
 
     @override
     def retry_wait(self) -> WaitBaseT | None:

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -302,6 +302,15 @@ class GrokAPI(ModelAPI):
             and ex.code() == grpc.StatusCode.UNAUTHENTICATED
         )
 
+    @override
+    def connection_key(self) -> str:
+        """Scope max_connections per API key.
+
+        Without this override Grok would inherit the default `"default"` and
+        every Grok request would globally share one concurrency slot.
+        """
+        return str(self.api_key)
+
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, grpc.RpcError):
             code = ex.code()

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -29,7 +29,10 @@ from inspect_ai._util.constants import (
     DEFAULT_MAX_TOKENS,
 )
 from inspect_ai._util.content import Content, ContentReasoning, ContentText
-from inspect_ai._util.http import is_retryable_http_status
+from inspect_ai._util.http import (
+    is_retryable_http_status,
+    parse_retry_after_from_exception,
+)
 from inspect_ai._util.images import file_as_data_uri
 from inspect_ai._util.url import is_http_url
 from inspect_ai.log._samples import set_active_model_event_call
@@ -244,7 +247,7 @@ class GroqAPI(ModelAPI):
         if isinstance(ex, APIStatusError):
             if not is_retryable_http_status(ex.status_code):
                 return RetryDecision.no()
-            retry_after = _groq_retry_after(ex)
+            retry_after = parse_retry_after_from_exception(ex)
             if ex.status_code == 429:
                 return RetryDecision.rate_limit(retry_after=retry_after)
             return RetryDecision.transient(retry_after=retry_after)
@@ -430,17 +433,3 @@ def model_call_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
         value = copy(value)
         value.update(url=BASE_64_DATA_REMOVED)
     return value
-
-
-def _groq_retry_after(ex: APIStatusError) -> float | None:
-    """Extract Retry-After / x-ratelimit-reset-* from a Groq APIStatusError."""
-    from inspect_ai._util.http import parse_retry_after
-
-    response = getattr(ex, "response", None)
-    headers = getattr(response, "headers", None)
-    if headers is None:
-        return None
-    try:
-        return parse_retry_after(headers)
-    except Exception:
-        return None

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -46,7 +46,7 @@ from .._chat_message import (
     ChatMessageUser,
 )
 from .._generate_config import GenerateConfig
-from .._model import ModelAPI
+from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall, as_error_response
 from .._model_output import (
     ChatCompletionChoice,
@@ -240,13 +240,17 @@ class GroqAPI(ModelAPI):
         ]
 
     @override
-    def should_retry(self, ex: Exception) -> bool:
+    def should_retry(self, ex: Exception) -> bool | RetryDecision:
         if isinstance(ex, APIStatusError):
-            return is_retryable_http_status(ex.status_code)
-        elif isinstance(ex, APITimeoutError):
-            return True
-        else:
-            return False
+            if not is_retryable_http_status(ex.status_code):
+                return RetryDecision.no()
+            retry_after = _groq_retry_after(ex)
+            if ex.status_code == 429:
+                return RetryDecision.rate_limit(retry_after=retry_after)
+            return RetryDecision.transient(retry_after=retry_after)
+        if isinstance(ex, APITimeoutError):
+            return RetryDecision.transient()
+        return RetryDecision.no()
 
     @override
     def connection_key(self) -> str:
@@ -426,3 +430,17 @@ def model_call_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
         value = copy(value)
         value.update(url=BASE_64_DATA_REMOVED)
     return value
+
+
+def _groq_retry_after(ex: APIStatusError) -> float | None:
+    """Extract Retry-After / x-ratelimit-reset-* from a Groq APIStatusError."""
+    from inspect_ai._util.http import parse_retry_after
+
+    response = getattr(ex, "response", None)
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    try:
+        return parse_retry_after(headers)
+    except Exception:
+        return None

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -58,14 +58,14 @@ from inspect_ai.model._reasoning import parse_content_with_reasoning
 from inspect_ai.tool import ToolCall, ToolChoice, ToolFunction, ToolInfo
 from inspect_ai.util._json import json_schema_dump
 
-from ..._util.httpx import httpx_should_retry
+from ..._util.httpx import httpx_classify_retry
 from .._call_tools import parse_tool_call
 from .._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
 )
 from .._generate_config import GenerateConfig
-from .._model import ModelAPI
+from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall, as_error_response
 from .._model_output import (
     ChatCompletionChoice,
@@ -271,13 +271,15 @@ class MistralAPI(ModelAPI):
         return f"mistral/{self.service_model_name()}"
 
     @override
-    def should_retry(self, ex: Exception) -> bool:
+    def should_retry(self, ex: Exception) -> bool | RetryDecision:
         if isinstance(ex, SDKError):
-            return is_retryable_http_status(ex.status_code)
-        elif httpx_should_retry(ex):
-            return True
-        else:
-            return False
+            if not is_retryable_http_status(ex.status_code):
+                return RetryDecision.no()
+            if ex.status_code == 429:
+                return RetryDecision.rate_limit()
+            return RetryDecision.transient()
+        decision = httpx_classify_retry(ex)
+        return decision if decision is not None else RetryDecision.no()
 
     @override
     def connection_key(self) -> str:

--- a/src/inspect_ai/model/_providers/ollama.py
+++ b/src/inspect_ai/model/_providers/ollama.py
@@ -26,6 +26,18 @@ class OllamaAPI(OpenAICompatibleAPI):
         )
 
     @override
+    def connection_key(self) -> str:
+        """Scope max_connections per Ollama endpoint.
+
+        Override the OpenAI-compatible default (which keys by api_key) since
+        Ollama is a local server: the rate-limit boundary is the endpoint URL,
+        not the credential (which defaults to the literal `"ollama"` for all
+        instances). Without this override two Ollama servers on different
+        hosts/ports would collapse to one concurrency slot.
+        """
+        return self.base_url or "ollama"
+
+    @override
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         params = super().completion_params(config, tools)
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -30,14 +30,14 @@ from inspect_ai.tool import ToolChoice, ToolInfo
 
 from .._chat_message import ChatMessage
 from .._generate_config import GenerateConfig
-from .._model import ModelAPI, log_model_retry
+from .._model import ModelAPI, RetryDecision, log_model_retry
 from .._model_call import ModelCall
 from .._model_output import ModelOutput, ModelUsage
 from .._openai import (
     OpenAIAsyncHttpxClient,
     is_gpt_5_model,
     is_o_series_model,
-    openai_should_retry,
+    openai_classify_retry,
 )
 from .._openai_responses import (
     chat_messages_from_compact_response,
@@ -470,17 +470,15 @@ class OpenAIAPI(ModelAPI):
         return f"openai/{self.service_model_name()}"
 
     @override
-    def should_retry(self, ex: BaseException) -> bool:
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, RateLimitError):
-            # Do not retry on these rate limit errors
-            # The quota exceeded one is related to monthly account quotas.
+            # quota-exceeded is a permanent monthly-quota error, not a transient
+            # rate limit — do not retry.
             if "You exceeded your current quota" in ex.message:
                 warn_once(logger, f"OpenAI quota exceeded, not retrying: {ex.message}")
-                return False
-            else:
-                return True
-        else:
-            return openai_should_retry(ex)
+                return RetryDecision.no()
+        decision = openai_classify_retry(ex)
+        return decision if decision is not None else RetryDecision.no()
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -20,7 +20,7 @@ from typing_extensions import override
 
 from inspect_ai._util.logger import warn_once
 from inspect_ai.log._samples import set_active_model_event_call
-from inspect_ai.model._openai import chat_choices_from_openai
+from inspect_ai.model._openai import chat_choices_from_openai, openai_classify_retry
 from inspect_ai.model._openai_responses import ResponsesModelInfo
 from inspect_ai.model._providers.openai_responses import generate_responses
 from inspect_ai.model._providers.util.chatapi import (
@@ -35,7 +35,7 @@ from inspect_ai.util._json import JSON_SCHEMA_EXTENDED_FIELDS
 
 from .._chat_message import ChatMessage, ChatMessageTool
 from .._generate_config import GenerateConfig
-from .._model import ModelAPI
+from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall, as_error_response
 from .._model_output import ChatCompletionChoice, ModelOutput
 from .._openai import (
@@ -49,7 +49,6 @@ from .._openai import (
     openai_completion_params,
     openai_handle_bad_request,
     openai_media_filter,
-    openai_should_retry,
 )
 from .util import environment_prerequisite_error, model_base_url
 
@@ -314,8 +313,9 @@ class OpenAICompatibleAPI(ModelAPI):
         return self.service_model_name()
 
     @override
-    def should_retry(self, ex: BaseException) -> bool:
-        return openai_should_retry(ex)
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
+        decision = openai_classify_retry(ex)
+        return decision if decision is not None else RetryDecision.no()
 
     @override
     def connection_key(self) -> str:

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -13,6 +13,7 @@ from inspect_ai._util.content import ContentReasoning
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.logger import warn_once
 from inspect_ai.model._chat_message import ChatMessage
+from inspect_ai.model._model import RetryDecision
 from inspect_ai.model._model_output import ChatCompletionChoice
 from inspect_ai.model._openai import (
     CompletionsReasoningContent,
@@ -109,13 +110,20 @@ class OpenRouterAPI(OpenAICompatibleAPI):
         )
 
     @override
-    def should_retry(self, ex: BaseException) -> bool:
-        if super().should_retry(ex):
-            return True
-        elif isinstance(ex, json.JSONDecodeError):
-            return True
-        else:
-            return False
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
+        # Defer to the OpenAI-compatible base classifier (which handles 429 →
+        # rate_limit and 5xx/timeouts → transient with header extraction).
+        # OpenRouter additionally surfaces malformed-JSON responses; treat
+        # those as transient (parsing flake, not a quota issue).
+        decision = super().should_retry(ex)
+        if isinstance(decision, RetryDecision):
+            if decision.retry:
+                return decision
+        elif decision:
+            return RetryDecision.transient()
+        if isinstance(ex, json.JSONDecodeError):
+            return RetryDecision.transient()
+        return RetryDecision.no()
 
     @override
     def canonical_name(self) -> str:

--- a/src/inspect_ai/model/_providers/sagemaker.py
+++ b/src/inspect_ai/model/_providers/sagemaker.py
@@ -26,7 +26,7 @@ from .._chat_message import (
     ChatMessageUser,
 )
 from .._generate_config import GenerateConfig
-from .._model import ModelAPI
+from .._model import ModelAPI, RetryDecision
 from .._model_call import ModelCall
 from .._model_output import ModelOutput
 
@@ -133,19 +133,19 @@ class SagemakerAPI(ModelAPI):
         return DEFAULT_MAX_TOKENS
 
     @override
-    def should_retry(self, ex: Exception) -> bool:
+    def should_retry(self, ex: Exception) -> bool | RetryDecision:
+        # Sagemaker's retryable codes are all infrastructure transients
+        # (container timeout, ServiceUnavailable, GatewayTimeout) — none are
+        # rate-limit signals — so they all classify as transient.
         if isinstance(ex, ClientError):
             error_code = ex.response.get("Error", {}).get("Code", "")
             status_code = ex.response.get("OriginalStatusCode", -1)
-
-            should_retry_ = (
+            if (
                 error_code == "ModelError"
                 and status_code in SAGEMAKER_RETRY_ERROR_CODES
-            )
-
-            return should_retry_
-        else:
-            return False
+            ):
+                return RetryDecision.transient()
+        return RetryDecision.no()
 
     @override
     def collapse_user_messages(self) -> bool:

--- a/src/inspect_ai/model/_providers/sglang.py
+++ b/src/inspect_ai/model/_providers/sglang.py
@@ -182,6 +182,18 @@ class SGLangAPI(OpenAICompatibleAPI):
         return self.server_process.poll() is None
 
     @override
+    def connection_key(self) -> str:
+        """Scope max_connections per SGLang endpoint.
+
+        Override the OpenAI-compatible default (which keys by api_key) since
+        SGLang is a local server: the rate-limit boundary is the endpoint
+        URL, not the credential (which defaults to the literal `"inspectai"`
+        for all instances). Without this override two SGLang servers on
+        different hosts/ports would collapse to one concurrency slot.
+        """
+        return self.base_url or "sglang"
+
+    @override
     def collapse_user_messages(self) -> bool:
         return True
 

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -16,7 +16,7 @@ from inspect_ai.tool._tool_info import ToolInfo
 
 from .._chat_message import ChatMessage, ChatMessageAssistant
 from .._generate_config import GenerateConfig, normalized_batch_config
-from .._model import ModelAPI, log_model_retry
+from .._model import ModelAPI, RetryDecision, log_model_retry
 from .._model_output import (
     ChatCompletionChoice,
     Logprob,
@@ -33,9 +33,8 @@ from .util import (
     chat_api_input,
     chat_api_request,
     model_base_url,
-    should_retry_chat_api_error,
 )
-from .util.chatapi import ChatAPIHandler
+from .util.chatapi import ChatAPIHandler, classify_chat_api_error
 
 
 def chat_choices_from_response_together(
@@ -289,8 +288,9 @@ class TogetherRESTAPI(ModelAPI):
             return ModelOutput(model=model, choices=choices, usage=usage)
 
     @override
-    def should_retry(self, ex: Exception) -> bool:
-        return should_retry_chat_api_error(ex)
+    def should_retry(self, ex: Exception) -> bool | RetryDecision:
+        decision = classify_chat_api_error(ex)
+        return decision if decision is not None else RetryDecision.no()
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/util/__init__.py
+++ b/src/inspect_ai/model/_providers/util/__init__.py
@@ -10,6 +10,7 @@ from .chatapi import (
     ChatAPIMessage,
     chat_api_input,
     chat_api_request,
+    classify_chat_api_error,
     should_retry_chat_api_error,
 )
 from .hf_handler import HFHandler
@@ -22,6 +23,7 @@ __all__ = [
     "chat_api_request",
     "chat_api_input",
     "should_retry_chat_api_error",
+    "classify_chat_api_error",
     "model_base_url",
     "parse_tool_call",
     "require_azure_base_url",

--- a/src/inspect_ai/model/_providers/util/chatapi.py
+++ b/src/inspect_ai/model/_providers/util/chatapi.py
@@ -1,5 +1,8 @@
 from logging import getLogger
-from typing import Any, Literal
+from typing import TYPE_CHECKING, Any, Literal
+
+if TYPE_CHECKING:
+    from inspect_ai.model._model import RetryDecision
 
 import httpx
 from tenacity import (
@@ -10,8 +13,7 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from inspect_ai._util.http import is_retryable_http_status
-from inspect_ai._util.httpx import httpx_should_retry, log_httpx_retry_attempt
+from inspect_ai._util.httpx import log_httpx_retry_attempt
 from inspect_ai.model._chat_message import ChatMessageAssistant, ChatMessageTool
 from inspect_ai.tool._tool_info import ToolInfo
 
@@ -104,6 +106,25 @@ def chat_api_handler_message(
         return message
 
 
+def _classified_should_retry(ex: BaseException) -> bool:
+    """Tenacity predicate that also reports the retry to the adaptive controller.
+
+    Without this, a chatapi-internal retry that succeeds on attempt 2 would
+    raise no RetryError, classify_chat_api_error would never run, and the
+    swallowed 429 would never reach the controller (the eventual success
+    would even count as a clean scale-up signal).
+    """
+    from inspect_ai._util.httpx import httpx_classify_retry
+    from inspect_ai._util.retry import report_http_retry
+
+    decision = httpx_classify_retry(ex)
+    if decision is None:
+        return False
+    if decision.retry:
+        report_http_retry(kind=decision.kind, retry_after=decision.retry_after)
+    return decision.retry
+
+
 async def chat_api_request(
     client: httpx.AsyncClient,
     model_name: str,
@@ -115,7 +136,7 @@ async def chat_api_request(
     @retry(
         wait=wait_exponential_jitter(),
         stop=(stop_after_attempt(2)),
-        retry=retry_if_exception(httpx_should_retry),
+        retry=retry_if_exception(_classified_should_retry),
         before_sleep=log_httpx_retry_attempt(model_name),
     )
     async def call_api() -> Any:
@@ -132,20 +153,23 @@ async def chat_api_request(
 # look at its `__cause__`. we've observed Cloudflare giving transient 500
 # status as well as a ReadTimeout, so we count these as rate limit errors
 def should_retry_chat_api_error(ex: BaseException) -> bool:
-    # not a tenacity RetryError
+    return classify_chat_api_error(ex) is not None
+
+
+def classify_chat_api_error(ex: BaseException) -> "RetryDecision | None":
+    """Classify a chat-API exception (wrapped in tenacity RetryError) for adaptive concurrency.
+
+    The chatapi helper retries httpx errors at a layer below this one, so by
+    the time we see the exception it's been wrapped in `tenacity.RetryError`
+    and the actual cause lives in `__cause__`.
+    """
+    from inspect_ai._util.httpx import httpx_classify_retry
+
     if not isinstance(ex, RetryError):
-        return False
+        return None
 
     cause = ex.__cause__
-
     if cause is None:
         raise RuntimeError(f"Tenacity RetryError with no __cause__: {ex}")
 
-    if isinstance(cause, httpx.HTTPStatusError):
-        if is_retryable_http_status(cause.response.status_code):
-            return True
-
-    if httpx_should_retry(cause):
-        return True
-
-    return False
+    return httpx_classify_retry(cause)

--- a/src/inspect_ai/model/_providers/util/chatapi.py
+++ b/src/inspect_ai/model/_providers/util/chatapi.py
@@ -1,11 +1,12 @@
 from logging import getLogger
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Callable, Literal
 
 if TYPE_CHECKING:
     from inspect_ai.model._model import RetryDecision
 
 import httpx
 from tenacity import (
+    RetryCallState,
     RetryError,
     retry,
     retry_if_exception,
@@ -13,7 +14,12 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from inspect_ai._util.httpx import log_httpx_retry_attempt
+from inspect_ai._util.httpx import (
+    httpx_classify_retry,
+    httpx_should_retry,
+    log_httpx_retry_attempt,
+)
+from inspect_ai._util.retry import report_http_retry
 from inspect_ai.model._chat_message import ChatMessageAssistant, ChatMessageTool
 from inspect_ai.tool._tool_info import ToolInfo
 
@@ -106,23 +112,38 @@ def chat_api_handler_message(
         return message
 
 
-def _classified_should_retry(ex: BaseException) -> bool:
-    """Tenacity predicate that also reports the retry to the adaptive controller.
+def _log_and_report_before_sleep(
+    model_name: str,
+) -> Callable[[RetryCallState], None]:
+    """Build a tenacity `before_sleep` that logs AND reports the retry.
 
-    Without this, a chatapi-internal retry that succeeds on attempt 2 would
-    raise no RetryError, classify_chat_api_error would never run, and the
-    swallowed 429 would never reach the controller (the eventual success
-    would even count as a clean scale-up signal).
+    Reporting from `before_sleep` (rather than the retry predicate) ensures
+    we fire `report_http_retry` exactly once per actual retry: the predicate
+    is called even on the final stopped attempt, but `before_sleep` only fires
+    when tenacity will actually wait and try again. This matters because the
+    chatapi-internal retry's logical 429 episode would otherwise inflate the
+    global `_http_retries_count` (predicate runs on every attempt) plus the
+    outer `Model.should_retry` adds its own report when the wrapping
+    `RetryError` bubbles up.
+
+    A chatapi-internal retry that succeeds on attempt 2 still reports here,
+    so the controller and stats see the rate-limit signal even when the
+    eventual call returns success.
     """
-    from inspect_ai._util.httpx import httpx_classify_retry
-    from inspect_ai._util.retry import report_http_retry
+    log = log_httpx_retry_attempt(model_name)
 
-    decision = httpx_classify_retry(ex)
-    if decision is None:
-        return False
-    if decision.retry:
-        report_http_retry(kind=decision.kind, retry_after=decision.retry_after)
-    return decision.retry
+    def cb(retry_state: RetryCallState) -> None:
+        log(retry_state)
+        if retry_state.outcome is None:
+            return
+        ex = retry_state.outcome.exception()
+        if ex is None:
+            return
+        decision = httpx_classify_retry(ex)
+        if decision is not None and decision.retry:
+            report_http_retry(kind=decision.kind, retry_after=decision.retry_after)
+
+    return cb
 
 
 async def chat_api_request(
@@ -136,8 +157,8 @@ async def chat_api_request(
     @retry(
         wait=wait_exponential_jitter(),
         stop=(stop_after_attempt(2)),
-        retry=retry_if_exception(_classified_should_retry),
-        before_sleep=log_httpx_retry_attempt(model_name),
+        retry=retry_if_exception(httpx_should_retry),
+        before_sleep=_log_and_report_before_sleep(model_name),
     )
     async def call_api() -> Any:
         response = await client.post(url=url, headers=headers, json=json)
@@ -163,8 +184,6 @@ def classify_chat_api_error(ex: BaseException) -> "RetryDecision | None":
     the time we see the exception it's been wrapped in `tenacity.RetryError`
     and the actual cause lives in `__cause__`.
     """
-    from inspect_ai._util.httpx import httpx_classify_retry
-
     if not isinstance(ex, RetryError):
         return None
 

--- a/src/inspect_ai/model/_providers/util/hooks.py
+++ b/src/inspect_ai/model/_providers/util/hooks.py
@@ -1,20 +1,41 @@
 import re
 import time
 from logging import getLogger
-from typing import Any, Mapping, NamedTuple, cast
+from typing import Any, Literal, Mapping, NamedTuple, cast
 
 import httpx
 from shortuuid import uuid
 
 from inspect_ai._util.constants import HTTP
+from inspect_ai._util.http import parse_retry_after
 from inspect_ai._util.retry import report_http_retry
 
 logger = getLogger(__name__)
 
 
+# Classification of the most recent response for retry-reporting purposes.
+# `None` means "infer from HTTP status" (default: status==429 is rate_limit).
+RetryKind = Literal["rate_limit", "transient"]
+
+
 class RequestInfo(NamedTuple):
     attempts: int
     last_request: float
+    # populated by response_hook for the most recent attempt — used by
+    # update_request_time on the next retry to classify rate_limit vs transient
+    # and to honor server-provided wait times.
+    last_status: int | None = None
+    # Stored as an absolute monotonic deadline (time.monotonic() + retry_after)
+    # rather than a duration. Between recording and consuming, the SDK may do
+    # its own backoff, so we recompute the *remaining* seconds at consumption
+    # time — otherwise the controller's `now + retry_after` cooldown formula
+    # would double-count any time the SDK already waited.
+    last_retry_after_deadline: float | None = None
+    # Provider-supplied classification for the previous response. Set by
+    # subclasses (e.g. ConverseHooks) when the HTTP status alone isn't enough
+    # to classify (Bedrock throttling errors don't necessarily surface as 429).
+    # When None, update_request_time falls back to inferring from status.
+    last_kind: RetryKind | None = None
 
 
 class HttpHooks:
@@ -55,48 +76,201 @@ class HttpHooks:
         # return elapsed time
         return time.monotonic() - request_info.last_request
 
+    def record_response(
+        self,
+        request_id: str | None,
+        status: int,
+        headers: Mapping[str, str] | None,
+        *,
+        kind: RetryKind | None = None,
+    ) -> None:
+        """Record the most recent response for a request_id.
+
+        Called from response_hook so that the next request_hook (when this
+        attempt is retried) can classify the retry based on what the previous
+        attempt actually returned.
+
+        Args:
+            request_id: The Inspect request id (from User-Agent / header).
+            status: HTTP status code.
+            headers: Response headers (used to extract Retry-After fallback).
+            kind: Optional explicit classification. Pass when the HTTP status
+                alone doesn't determine kind — e.g. Bedrock's
+                ThrottlingException, where the error code in the body is the
+                authoritative signal. When None (default), update_request_time
+                infers kind from `status == 429`.
+        """
+        if not request_id:
+            return
+        info = self._requests.get(request_id)
+        if info is None:
+            return
+        # Convert the relative Retry-After to an absolute monotonic deadline
+        # so any SDK-side backoff between now and the next retry is accounted
+        # for when we report remaining seconds to the controller.
+        deadline: float | None = None
+        if headers is not None:
+            try:
+                retry_after = parse_retry_after(headers)
+            except Exception:
+                retry_after = None
+            if retry_after is not None and retry_after > 0:
+                deadline = time.monotonic() + retry_after
+        self._requests[request_id] = RequestInfo(
+            info.attempts, info.last_request, status, deadline, kind
+        )
+
     def update_request_time(self, request_id: str) -> None:
         request_info = self._requests.get(request_id, None)
         if not request_info:
             logger.warning(f"Hooks: No request registered for request_id: {request_id}")
             return
 
-        # update the attempts and last request time
-        request_info = RequestInfo(request_info.attempts + 1, time.monotonic())
-        self._requests[request_id] = request_info
+        new_attempts = request_info.attempts + 1
+        # snapshot the previous attempt's response info before clearing —
+        # we use it to classify the retry below, and clearing prevents
+        # reusing this 429 if a subsequent attempt fails before its own
+        # response arrives (which would otherwise scale the controller down
+        # again from stale state — classic infra-noise contamination).
+        prev_status = request_info.last_status
+        prev_kind = request_info.last_kind
+        # Compute remaining seconds from the absolute deadline at the moment
+        # the retry actually fires — accounts for any SDK-side backoff
+        # already elapsed since the response was received.
+        prev_retry_after: float | None = None
+        if request_info.last_retry_after_deadline is not None:
+            remaining = request_info.last_retry_after_deadline - time.monotonic()
+            if remaining > 0:
+                prev_retry_after = remaining
 
-        # trace a retry if this is attempt > 1
-        if request_info.attempts > 1:
-            report_http_retry()
+        # store the new attempts/timestamp; last_status/last_retry_after reset
+        # to None so they're only repopulated by the next response_hook call.
+        self._requests[request_id] = RequestInfo(
+            new_attempts, time.monotonic(), None, None, None
+        )
+
+        # trace a retry if this is the 2nd or later attempt; classify based
+        # on either an explicit provider-supplied kind (set via record_response
+        # when the HTTP status alone is insufficient — e.g. Bedrock) or
+        # falling back to status==429 detection.
+        if new_attempts > 1:
+            if prev_kind is not None:
+                report_http_retry(kind=prev_kind, retry_after=prev_retry_after)
+            elif prev_status == 429:
+                report_http_retry(kind="rate_limit", retry_after=prev_retry_after)
+            else:
+                report_http_retry()
 
 
 class ConverseHooks(HttpHooks):
+    # Key under which we stash the Inspect request_id on botocore's per-call
+    # context dict so the response-received handler can look it up.
+    _CTX_REQUEST_ID = "_inspect_request_id"
+
     def __init__(self, session: Any) -> None:
         from aiobotocore.session import AioSession
 
         super().__init__()
 
-        # register hooks
+        # register hooks. We use:
+        #   * request-created (per-attempt): record start time + stash request_id
+        #     on the request's context dict so response-received can look it up.
+        #     We use this rather than before-send because before-send receives
+        #     an AWSPreparedRequest, which has no `.context` — the AWSRequest
+        #     emitted from request-created does, and that context dict IS the
+        #     same per-call context that flows into response-received.
+        #   * response-received (per-attempt): record the response status for
+        #     the *next* retry's classification. (after-call fires only once
+        #     at the end of all SDK-internal retries, so it would miss the
+        #     per-attempt 429s that botocore swallows via adaptive retry.)
         session = cast(AioSession, session._session)
         session.register(
-            "before-send.bedrock-runtime.Converse", self.converse_before_send
+            "request-created.bedrock-runtime.Converse",
+            self.converse_request_created,
         )
         session.register(
-            "after-call.bedrock-runtime.Converse", self.converse_after_call
+            "response-received.bedrock-runtime.Converse",
+            self.converse_response_received,
         )
 
-    def converse_before_send(self, **kwargs: Any) -> None:
-        user_agent = kwargs["request"].headers["User-Agent"].decode()
+    def converse_request_created(self, **kwargs: Any) -> None:
+        request = kwargs.get("request")
+        if request is None:
+            return
+        user_agent = request.headers.get("User-Agent", b"")
+        if isinstance(user_agent, bytes):
+            user_agent = user_agent.decode()
         match = re.search(rf"{self.USER_AGENT_PREFIX}(\w+)", user_agent)
-        if match:
-            request_id = match.group(1)
-            self.update_request_time(request_id)
+        if not match:
+            return
+        request_id = match.group(1)
+        # stash request_id where response-received can find it. AWSRequest's
+        # `.context` IS the per-call context dict (same identity, see
+        # botocore.awsrequest.create_request_object), so this survives across
+        # the request-created → response-received boundary, and across all
+        # SDK-internal retries within one API call.
+        ctx = getattr(request, "context", None)
+        if isinstance(ctx, dict):
+            ctx[self._CTX_REQUEST_ID] = request_id
+        self.update_request_time(request_id)
 
-    def converse_after_call(self, http_response: Any, **kwargs: Any) -> None:
-        from botocore.awsrequest import AWSResponse
+    # AWS error codes that indicate true rate-limiting (the 429-equivalent on
+    # Bedrock). Kept in sync with BedrockAPI._BEDROCK_THROTTLE_CODES — duplicated
+    # here so the hook layer doesn't need to import the provider.
+    _THROTTLE_CODES = frozenset(
+        [
+            "ThrottlingException",
+            "RequestLimitExceeded",
+            "Throttling",
+            "RequestThrottled",
+            "TooManyRequestsException",
+            "ProvisionedThroughputExceededException",
+        ]
+    )
 
-        response = cast(AWSResponse, http_response)
-        logger.log(HTTP, f"POST {response.url} - {response.status_code}")
+    def converse_response_received(
+        self,
+        response_dict: dict[str, Any] | None = None,
+        parsed_response: dict[str, Any] | None = None,
+        context: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        # Fires after each HTTP attempt (including ones that botocore will
+        # internally retry), so the recorded status arrives in time for the
+        # next request-created to classify the retry.
+        if response_dict is None:
+            return
+        status = response_dict.get("status_code")
+        if status is None:
+            return
+        url = response_dict.get("url", "")
+        logger.log(HTTP, f"POST {url} - {status}")
+        request_id = (
+            context.get(self._CTX_REQUEST_ID) if isinstance(context, dict) else None
+        )
+        if not request_id:
+            return
+        # Classify based on AWS error code (the authoritative signal on Bedrock,
+        # since ThrottlingException doesn't always come back as HTTP 429). When
+        # there's an error in parsed_response, look at its Code; otherwise let
+        # update_request_time fall back to status-based inference.
+        kind: RetryKind | None = None
+        if isinstance(parsed_response, dict):
+            error = parsed_response.get("Error")
+            if isinstance(error, dict):
+                code = error.get("Code", "")
+                if code in self._THROTTLE_CODES:
+                    kind = "rate_limit"
+                elif code:
+                    # Any non-throttle AWS error code → transient (don't let
+                    # the status fallback misclassify a 429 from non-throttling
+                    # validation errors, etc.)
+                    kind = "transient"
+        # Bedrock doesn't include Retry-After per AWS docs, but pass response
+        # headers through anyway in case a future API does — parse_retry_after
+        # just returns None when no recognized header is present.
+        headers = response_dict.get("headers")
+        self.record_response(request_id, status, headers, kind=kind)
 
     def user_agent_extra(self, request_id: str) -> str:
         return f"{self.USER_AGENT_PREFIX}{request_id}"
@@ -121,6 +295,9 @@ class HttpxHooks(HttpHooks):
     async def response_hook(self, response: httpx.Response) -> None:
         message = f'{response.request.method} {response.request.url} "{response.http_version} {response.status_code} {response.reason_phrase}" '
         logger.log(HTTP, message)
+        # record status + Retry-After / x-ratelimit-reset-* for next retry classification
+        request_id = response.request.headers.get(self.REQUEST_ID_HEADER, None)
+        self.record_response(request_id, response.status_code, response.headers)
 
 
 def urllib3_hooks() -> HttpHooks:
@@ -136,10 +313,24 @@ def urllib3_hooks() -> HttpHooks:
                 self.update_request_time(request_id)
 
         def response_hook(
-            self, method: str, url: str, response: BaseHTTPResponse
+            self,
+            method: str,
+            url: str,
+            response: BaseHTTPResponse,
+            request_headers: Mapping[str, str] | None = None,
         ) -> None:
             message = f'{method} {url} "{response.version_string} {response.status} {response.reason}" '
             logger.log(HTTP, message)
+            # record status + headers for next retry classification
+            request_id = (
+                request_headers.get(self.REQUEST_ID_HEADER) if request_headers else None
+            )
+            # urllib3 BaseHTTPResponse.headers is HTTPHeaderDict, treat as Mapping[str, str]
+            self.record_response(
+                request_id,
+                response.status,
+                cast(Mapping[str, str], response.headers),
+            )
 
     global _urlilb3_hooks
     if _urlilb3_hooks is None:
@@ -153,7 +344,7 @@ def urllib3_hooks() -> HttpHooks:
             headers = kwargs.get("headers", {})
             urlilb3_hooks.request_hook(headers)
             response = original_urlopen(self, method, url, **kwargs)
-            urlilb3_hooks.response_hook(method, f"{self.host}{url}", response)
+            urlilb3_hooks.response_hook(method, f"{self.host}{url}", response, headers)
             return response
 
         urllib3.connectionpool.HTTPConnectionPool.urlopen = patched_urlopen  # type: ignore[assignment,method-assign]

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -31,6 +31,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageUser,
 )
 from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model import RetryDecision
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.tool._tool_choice import ToolChoice
@@ -383,24 +384,25 @@ class VLLMAPI(OpenAICompatibleAPI):
         return list(tokens)
 
     @override
-    def should_retry(self, ex: BaseException) -> bool:
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if _is_fatal_vllm_error(ex):
             logger.error(
                 "Detected fatal vLLM error (OOM/illegal CUDA state); not retrying."
             )
-            return False
+            return RetryDecision.no()
 
         if _is_dead_local_vllm_endpoint(ex, self.base_url):
             logger.error(
                 "vLLM endpoint %s is unreachable. Failing fast.",
                 self.base_url,
             )
-            return False
+            return RetryDecision.no()
 
         if self._server.process is not None and not self.server_is_running:
             logger.error("Inspect-managed vLLM server process exited; not retrying.")
-            return False
+            return RetryDecision.no()
 
+        # Defer to the OpenAI-compatible classifier inherited from the base.
         return super().should_retry(ex)
 
     # -- generation ----------------------------------------------------------

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -384,6 +384,18 @@ class VLLMAPI(OpenAICompatibleAPI):
         return list(tokens)
 
     @override
+    def connection_key(self) -> str:
+        """Scope max_connections per vLLM endpoint.
+
+        Override the OpenAI-compatible default (which keys by api_key) since
+        vLLM is a local server: the rate-limit boundary is the endpoint URL,
+        not the credential. Multiple vLLM servers on different hosts/ports
+        are independent concurrency scopes, but all default to the same
+        api_key (`"inspectai"`) and would otherwise collapse to one slot.
+        """
+        return self.base_url or "vllm"
+
+    @override
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if _is_fatal_vllm_error(ex):
             logger.error(

--- a/src/inspect_ai/model/_retry.py
+++ b/src/inspect_ai/model/_retry.py
@@ -1,4 +1,4 @@
-from typing import Awaitable, Callable
+from typing import TYPE_CHECKING, Awaitable, Callable
 
 from tenacity import (
     RetryCallState,
@@ -13,6 +13,9 @@ from tenacity.stop import StopBaseT
 from tenacity.wait import WaitBaseT
 from typing_extensions import TypedDict
 
+if TYPE_CHECKING:
+    from inspect_ai.model._model import RetryDecision
+
 
 class ModelRetryConfig(TypedDict):
     wait: WaitBaseT
@@ -25,7 +28,7 @@ def model_retry_config(
     model_name: str,
     max_retries: int | None,
     timeout: int | None,
-    should_retry: Callable[[BaseException], bool],
+    should_retry: "Callable[[BaseException], bool | RetryDecision]",
     before_retry: Callable[[BaseException], (Awaitable[None] | None)],
     log_model_retry: Callable[[str, RetryCallState], Awaitable[None] | None],
     report_waiting_time: Callable[[float], None] | None = None,
@@ -62,9 +65,34 @@ def model_retry_config(
         else wait_exponential_jitter(initial=3, max=(30 * 60), jitter=3)
     )
 
+    # tenacity's retry_if_exception expects a bool predicate; coerce
+    # RetryDecision returns to bool here so providers can pass their classifier
+    # directly without a wrapper at every callsite.
+    #
+    # When the predicate is a provider's `api.should_retry` (returning
+    # RetryDecision), this wrapper is the only place the decision is observed —
+    # provider-internal retry loops (batchers, etc.) bypass `Model.should_retry`,
+    # so without firing report_http_retry here, rate-limit retries inside those
+    # loops would never reach the adaptive controller.
+    #
+    # When the predicate is `Model.should_retry` (returning plain bool),
+    # `Model.should_retry` already calls `report_http_retry` itself based on
+    # the underlying RetryDecision — and returns bool, so this branch is a
+    # pure pass-through that doesn't double-report.
+    def _retry_predicate(ex: BaseException) -> bool:
+        from inspect_ai._util.retry import report_http_retry
+        from inspect_ai.model._model import RetryDecision
+
+        result = should_retry(ex)
+        if isinstance(result, RetryDecision):
+            if result.retry:
+                report_http_retry(kind=result.kind, retry_after=result.retry_after)
+            return result.retry
+        return bool(result)
+
     return {
         "wait": wait,
-        "retry": retry_if_exception(should_retry),
+        "retry": retry_if_exception(_retry_predicate),
         "before_sleep": on_before_sleep,
         "stop": (
             stop_after_attempt(max_retries) | stop_after_delay(timeout)

--- a/src/inspect_ai/util/__init__.py
+++ b/src/inspect_ai/util/__init__.py
@@ -24,7 +24,7 @@ from inspect_ai.util._limit import (
 
 from ._background import background
 from ._collect import collect
-from ._concurrency import concurrency
+from ._concurrency import AdaptiveConcurrency, concurrency
 from ._console import input_screen
 from ._display import DisplayType, display_counter, display_type
 from ._early_stopping import (
@@ -85,6 +85,7 @@ __all__ = [
     "ComposeHealthcheck",
     "ComposeService",
     "ExecResult",
+    "AdaptiveConcurrency",
     "concurrency",
     "download",
     "gdrive_download",

--- a/src/inspect_ai/util/_concurrency.py
+++ b/src/inspect_ai/util/_concurrency.py
@@ -181,9 +181,14 @@ async def get_or_create_semaphore(
 
     Delegates to the global _concurrency_registry.
     """
-    return await _concurrency_registry.get_or_create(
-        name, concurrency, key, visible, adaptive
-    )
+    if adaptive is None:
+        return await _concurrency_registry.get_or_create(
+            name, concurrency, key, visible
+        )
+    else:
+        return await _concurrency_registry.get_or_create(
+            name, concurrency, key, visible, adaptive
+        )
 
 
 @contextlib.asynccontextmanager

--- a/src/inspect_ai/util/_concurrency.py
+++ b/src/inspect_ai/util/_concurrency.py
@@ -14,33 +14,47 @@ from inspect_ai._util.working import sample_waiting_for
 logger = getLogger(__name__)
 
 
-class AdaptiveConcurrency(BaseModel):
-    """Bounds for an adaptive concurrency controller.
+_DEFAULT_MIN = 4
+_DEFAULT_START = 20
+_DEFAULT_MAX = 100
 
-    Configures the bounds within which an adaptive controller is allowed to
-    scale: starting at `start`, growing up to `max`, and never falling below
-    `min`. Accepts a string shorthand ("min-max" or "min-start-max") for use
-    in CLI flags and config files.
+
+class AdaptiveConcurrency(BaseModel):
+    """Bounds and tuning for an adaptive concurrency controller.
+
+    Basic fields (`min`, `start`, `max`) bound the range the controller will
+    scale within. Advanced fields (`cooldown_seconds`, `decrease_factor`,
+    `scale_up_percent`) tune the response curve and have sensible defaults
+    for typical evaluation workloads — see the parallelism docs for guidance.
+    Accepts a string shorthand ("min-max" or "min-start-max") for use in CLI
+    flags and config files; advanced fields are Python-only.
     """
 
-    min: int = Field(default=1)
+    min: int = Field(default=_DEFAULT_MIN)
     """Minimum concurrency (must be >= 1)."""
 
-    max: int = Field(default=200)
+    max: int = Field(default=_DEFAULT_MAX)
     """Maximum concurrency."""
 
-    start: int = Field(default=20)
+    start: int = Field(default=_DEFAULT_START)
     """Starting concurrency (must be within [min, max])."""
+
+    cooldown_seconds: float = Field(default=15.0)
+    """Minimum seconds between scale-down cuts. The server's `Retry-After` header (or the `x-ratelimit-reset-*` family as a fallback) extends this when larger."""
+
+    decrease_factor: float = Field(default=0.8)
+    """Multiplicative cut applied on each rate-limit episode (must be in (0, 1))."""
+
+    scale_up_percent: float = Field(default=0.05)
+    """Steady-state additive growth per clean round, as a fraction of current limit (must be in (0, 1])."""
 
     @model_validator(mode="before")
     @classmethod
     def parse_shorthand(cls, data: Any) -> Any:
         # Accept "min-max" or "min-start-max" string shorthand, and clamp the
-        # implicit start (= field default of 20) into [min, max] when start is
-        # not explicitly provided. Without clamping, AdaptiveConcurrency(min=1, max=15)
+        # implicit start (= field default) into [min, max] when start is not
+        # explicitly provided. Without clamping, AdaptiveConcurrency(min=1, max=15)
         # would fail bounds validation because the default start exceeds max.
-        DEFAULT_START = 20
-
         if isinstance(data, str):
             parts = data.split("-")
             try:
@@ -55,7 +69,7 @@ class AdaptiveConcurrency(BaseModel):
                 return {
                     "min": min_val,
                     "max": max_val,
-                    "start": max(min_val, min(DEFAULT_START, max_val)),
+                    "start": max(min_val, min(_DEFAULT_START, max_val)),
                 }
             elif len(ints) == 3:
                 return {"min": ints[0], "start": ints[1], "max": ints[2]}
@@ -68,11 +82,11 @@ class AdaptiveConcurrency(BaseModel):
         # struct form: clamp implicit start when min/max are provided but
         # start is not, so AdaptiveConcurrency(min=1, max=15) just works
         if isinstance(data, dict) and "start" not in data:
-            min_val = data.get("min", 1)
-            max_val = data.get("max", 200)
+            min_val = data.get("min", _DEFAULT_MIN)
+            max_val = data.get("max", _DEFAULT_MAX)
             if isinstance(min_val, int) and isinstance(max_val, int):
                 data = dict(data)
-                data["start"] = max(min_val, min(DEFAULT_START, max_val))
+                data["start"] = max(min_val, min(_DEFAULT_START, max_val))
 
         return data
 
@@ -88,6 +102,21 @@ class AdaptiveConcurrency(BaseModel):
             raise ValueError(
                 f"AdaptiveConcurrency start ({self.start}) must be within "
                 f"[min={self.min}, max={self.max}]"
+            )
+        if self.cooldown_seconds < 0:
+            raise ValueError(
+                f"AdaptiveConcurrency cooldown_seconds must be >= 0 "
+                f"(got {self.cooldown_seconds})"
+            )
+        if not (0 < self.decrease_factor < 1):
+            raise ValueError(
+                f"AdaptiveConcurrency decrease_factor must be in (0, 1) "
+                f"(got {self.decrease_factor})"
+            )
+        if not (0 < self.scale_up_percent <= 1):
+            raise ValueError(
+                f"AdaptiveConcurrency scale_up_percent must be in (0, 1] "
+                f"(got {self.scale_up_percent})"
             )
         return self
 
@@ -356,21 +385,18 @@ LimitChangeRecord = tuple[float, str, int, int, str]
 class AdaptiveConcurrencyController:
     """Adaptive concurrency controller using anyio.CapacityLimiter.
 
-    Implements slow-start + AIMD based on retry signals:
-      * notify_success(): one logical request completed without retries
-      * notify_retry(): a rate-limit / transient error retry occurred
+    Implements slow-start + AIMD based on retry signals. Only rate-limit
+    retries scale down — provider 5xx and network blips pause scale-up
+    (the in-flight success won't count) but don't shrink the limit. See
+    `ModelAPI.should_retry()` and the `RetryDecision` it returns for the
+    per-provider classification.
 
-    Tuning constants:
-      * DECREASE_FACTOR (0.8): multiplicative decrease on retry episode
-      * COOLDOWN_SECONDS (15): debounce between scale-down events
-      * ROUND_SIZE_FLOOR (4): minimum successes before evaluating scale-up
-      * SCALE_UP_PERCENT (0.05): steady-state additive increase as % of current
+    Behavioral tunables come from the `AdaptiveConcurrency` config
+    (`cooldown_seconds`, `decrease_factor`, `scale_up_percent`).
+    `ROUND_SIZE_FLOOR` and `HISTORY_LIMIT` are internal class constants.
     """
 
-    DECREASE_FACTOR = 0.8
-    COOLDOWN_SECONDS = 15.0
     ROUND_SIZE_FLOOR = 4
-    SCALE_UP_PERCENT = 0.05
     HISTORY_LIMIT = 200
 
     def __init__(
@@ -440,37 +466,56 @@ class AdaptiveConcurrencyController:
             new = min(old * 2, self._config.max)
             reason = "slow_start"
         else:
-            increment = max(1, round(old * self.SCALE_UP_PERCENT))
+            increment = max(1, round(old * self._config.scale_up_percent))
             new = min(_ceil_to_nice(old + increment), self._config.max)
             reason = "steady_state_up"
         if new != old:
             self._set_limit(new, reason)
 
-    def notify_retry(self) -> None:
-        """Record a retry signal (rate-limit or transient error).
+    def notify_retry(self, retry_after: float | None = None) -> None:
+        """Record a rate-limit retry signal.
+
+        Only called for retries the provider classifies as rate-limit
+        (HTTP 429 or provider-specific equivalents like Bedrock
+        `ThrottlingException` or Google `503 RESOURCE_EXHAUSTED`).
+        Other retries don't reach this method.
 
         Cooldown debounces the *limit cut* — a single rate-limit episode
         produces multiple retries (Inspect-level + SDK-internal) and we
-        cut at most once per episode. But success-counting is reset on
-        every retry signal regardless of cooldown, so a debounced retry
-        still invalidates the in-progress clean window. Without this,
-        under high throughput the controller could climb to a scale-up
+        cut at most once per episode. Success-counting is reset on every
+        call regardless of cooldown, so a debounced retry still
+        invalidates the in-progress clean window — without this, under
+        high throughput the controller could climb to a scale-up
         immediately after a suppressed retry.
+
+        If `retry_after` is provided (from the server's `Retry-After`
+        header or the `x-ratelimit-reset-*` fallback), the cooldown is
+        extended to honor it when larger than the configured floor.
         """
         # always reset success accounting on any retry signal (even debounced)
         self._success_count = 0
         self._first_retry_seen = True
 
-        # debounce the limit cut itself
         now = time.monotonic()
+
+        # already in cooldown from a previous cut?
         if now < self._cooldown_until:
+            # don't cut again — but a longer server hint should still push
+            # the cooldown horizon out so a subsequent 429 within the same
+            # window can't trip a second cut, and so success-counting stays
+            # suppressed for the full server-recommended wait.
+            if retry_after is not None and retry_after > 0:
+                extended = now + retry_after
+                if extended > self._cooldown_until:
+                    self._cooldown_until = extended
             return
 
         old = self.concurrency
-        target = int(old * self.DECREASE_FACTOR)
+        target = int(old * self._config.decrease_factor)
         new = _floor_to_nice(target)
         new = max(new, self._config.min, 1)
-        self._cooldown_until = now + self.COOLDOWN_SECONDS
+        cooldown = max(retry_after or 0.0, self._config.cooldown_seconds)
+        self._cooldown_until = now + cooldown
         if new != old:
             self._set_limit(new, "rate_limit")
 
@@ -545,7 +590,9 @@ class DynamicSampleLimiter:
         # limiter created after a controller has already scaled would sit at
         # `start + BUFFER` until the next scale change
         if existing:
-            self._on_controller_change(0, 0)  # args ignored; recomputes from controllers
+            self._on_controller_change(
+                0, 0
+            )  # args ignored; recomputes from controllers
         # register for future controllers — fired by the registry on creation
         add_controller_created_observer(self._on_controller_created)
 

--- a/src/inspect_ai/util/_concurrency.py
+++ b/src/inspect_ai/util/_concurrency.py
@@ -405,9 +405,16 @@ class _SaturationTrackingLimiter:
     async def __aenter__(self) -> None:
         c = self._controller
         await c._limiter.acquire()
-        borrowed = int(c._limiter.borrowed_tokens)
-        if borrowed > c._max_borrowed_this_round:
-            c._max_borrowed_this_round = borrowed
+        # Skip the saturation update during a post-cut cooldown. notify_retry
+        # already reset the mark to 0; in-flight acquires arriving while the
+        # cooldown is active are pre-cut traffic at the new (lower) limit, so
+        # they're not relevant evidence for the next round's growth decision.
+        # Without this gate, the first post-cooldown round can pass the 0.8
+        # saturation threshold from peaks observed during cooldown alone.
+        if time.monotonic() >= c._cooldown_until:
+            borrowed = int(c._limiter.borrowed_tokens)
+            if borrowed > c._max_borrowed_this_round:
+                c._max_borrowed_this_round = borrowed
 
     async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
         self._controller._limiter.release()
@@ -478,12 +485,16 @@ class AdaptiveConcurrencyController:
 
     @property
     def value(self) -> int:
-        """Tokens currently available (== limit - borrowed).
+        """Tokens currently available (== limit - borrowed), clamped to >= 0.
 
         Status display computes `concurrency - value` to show borrowed count,
-        matching the Semaphore-based path.
+        matching the Semaphore-based path. Clamped because `notify_retry` may
+        lower `total_tokens` below current `borrowed_tokens` (CapacityLimiter
+        accepts this and blocks new acquires until in-flight drains); without
+        the clamp, `value` would go negative and the status display would
+        render in-flight as exceeding the cap.
         """
-        return int(self._limiter.total_tokens - self._limiter.borrowed_tokens)
+        return max(0, int(self._limiter.total_tokens - self._limiter.borrowed_tokens))
 
     @property
     def history(self) -> list[LimitChangeRecord]:

--- a/src/inspect_ai/util/_concurrency.py
+++ b/src/inspect_ai/util/_concurrency.py
@@ -16,7 +16,7 @@ logger = getLogger(__name__)
 
 _DEFAULT_MIN = 4
 _DEFAULT_START = 20
-_DEFAULT_MAX = 100
+_DEFAULT_MAX = 200
 
 
 class AdaptiveConcurrency(BaseModel):

--- a/src/inspect_ai/util/_concurrency.py
+++ b/src/inspect_ai/util/_concurrency.py
@@ -387,6 +387,32 @@ LimitChangeRecord = tuple[float, str, int, int, str]
 """(timestamp, model_name, old_limit, new_limit, reason)."""
 
 
+class _SaturationTrackingLimiter:
+    """Wraps a CapacityLimiter to record peak in-flight count on each acquire.
+
+    Recording on release would undercount: at success-completion time the
+    just-borrowed slot has already been returned to the limiter, so
+    `borrowed_tokens` reflects only OTHER in-flight requests. At low limits
+    (e.g. limit=4 with full saturation), every sample would observe at most
+    3 — below the 0.8 saturation threshold — and growth would never trigger.
+    Recording on acquire, when the slot is still counted, captures the true
+    high-water mark across the round.
+    """
+
+    def __init__(self, controller: "AdaptiveConcurrencyController") -> None:
+        self._controller = controller
+
+    async def __aenter__(self) -> None:
+        c = self._controller
+        await c._limiter.acquire()
+        borrowed = int(c._limiter.borrowed_tokens)
+        if borrowed > c._max_borrowed_this_round:
+            c._max_borrowed_this_round = borrowed
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._controller._limiter.release()
+
+
 class AdaptiveConcurrencyController:
     """Adaptive concurrency controller using anyio.CapacityLimiter.
 
@@ -423,16 +449,23 @@ class AdaptiveConcurrencyController:
         self._config = config
         self.visible = visible
         self._limiter = anyio.CapacityLimiter(config.start)
-        self.semaphore: contextlib.AbstractAsyncContextManager[Any] = self._limiter
         # `concurrency` mirrors the limiter's `total_tokens` (kept in sync via
         # _set_limit). It's a plain attribute to satisfy the ConcurrencySemaphore
         # Protocol (which expects a settable int).
         self.concurrency: int = config.start
         self._success_count = 0
         # high-water mark of in-flight (borrowed) requests within the current
-        # round; reset at end of round and on rate-limit cut. Used by the
-        # saturation gate in notify_success.
+        # round; reset at end of round and on rate-limit cut. Updated on each
+        # acquire via the wrapping context manager below — sampling on acquire
+        # captures the just-borrowed slot, where sampling on release would
+        # undercount by one (and at low limits like 4, every sample would
+        # observe peak=3, blocking growth even under full saturation).
         self._max_borrowed_this_round = 0
+        # Wrap the underlying limiter so each acquire records its borrowed
+        # count toward the round's high-water mark.
+        self.semaphore: contextlib.AbstractAsyncContextManager[Any] = (
+            _SaturationTrackingLimiter(self)
+        )
         self._first_retry_seen = False
         self._cooldown_until = 0.0
         self._history: list[LimitChangeRecord] = []
@@ -473,13 +506,8 @@ class AdaptiveConcurrencyController:
         if time.monotonic() < self._cooldown_until:
             return
 
-        # Sample saturation: track the high-water mark of in-flight requests
-        # observed during this round. `borrowed_tokens` at success-completion
-        # time is off-by-one (the just-completed request is no longer counted),
-        # but for a peak-across-the-round metric the off-by-one is negligible.
-        borrowed = int(self._limiter.borrowed_tokens)
-        if borrowed > self._max_borrowed_this_round:
-            self._max_borrowed_this_round = borrowed
+        # `_max_borrowed_this_round` is updated on each acquire via the
+        # _SaturationTrackingLimiter wrapper — no need to sample here.
 
         self._success_count += 1
         old = self.concurrency

--- a/src/inspect_ai/util/_concurrency.py
+++ b/src/inspect_ai/util/_concurrency.py
@@ -403,6 +403,15 @@ class AdaptiveConcurrencyController:
 
     ROUND_SIZE_FLOOR = 4
     HISTORY_LIMIT = 200
+    # Minimum saturation (peak-borrowed / current-limit) within a round
+    # required to scale up. Without this gate, the controller would treat any
+    # round-sized batch of successes as proof the limit is binding, even when
+    # peak in-flight was well below the limit (e.g. running 250 in flight at
+    # a 500 cap because the work simply isn't there to fill it). Growing in
+    # that case is incorrect: the next time work surges to the new higher
+    # limit, we may exceed the provider's actual rate limit since we never
+    # validated capacity beyond the peak we actually hit.
+    SATURATION_THRESHOLD = 0.8
 
     def __init__(
         self,
@@ -420,6 +429,10 @@ class AdaptiveConcurrencyController:
         # Protocol (which expects a settable int).
         self.concurrency: int = config.start
         self._success_count = 0
+        # high-water mark of in-flight (borrowed) requests within the current
+        # round; reset at end of round and on rate-limit cut. Used by the
+        # saturation gate in notify_success.
+        self._max_borrowed_this_round = 0
         self._first_retry_seen = False
         self._cooldown_until = 0.0
         self._history: list[LimitChangeRecord] = []
@@ -460,13 +473,30 @@ class AdaptiveConcurrencyController:
         if time.monotonic() < self._cooldown_until:
             return
 
+        # Sample saturation: track the high-water mark of in-flight requests
+        # observed during this round. `borrowed_tokens` at success-completion
+        # time is off-by-one (the just-completed request is no longer counted),
+        # but for a peak-across-the-round metric the off-by-one is negligible.
+        borrowed = int(self._limiter.borrowed_tokens)
+        if borrowed > self._max_borrowed_this_round:
+            self._max_borrowed_this_round = borrowed
+
         self._success_count += 1
         old = self.concurrency
         round_size = max(old, self.ROUND_SIZE_FLOOR)
         if self._success_count < round_size:
             return
 
+        # End of round. Only scale up if we observed real saturation —
+        # otherwise the current limit isn't binding, and growing it gives us
+        # untested headroom that may exceed the provider's actual rate limit
+        # the next time work surges enough to fill it.
+        peak_borrowed = self._max_borrowed_this_round
+        self._max_borrowed_this_round = 0
         self._success_count = 0
+        if old > 0 and peak_borrowed < self.SATURATION_THRESHOLD * old:
+            return
+
         if not self._first_retry_seen:
             new = min(old * 2, self._config.max)
             reason = "slow_start"
@@ -497,8 +527,11 @@ class AdaptiveConcurrencyController:
         header or the `x-ratelimit-reset-*` fallback), the cooldown is
         extended to honor it when larger than the configured floor.
         """
-        # always reset success accounting on any retry signal (even debounced)
+        # always reset success accounting on any retry signal (even debounced).
+        # Also reset the saturation high-water mark — peak in-flight observed
+        # before the cut is no longer relevant evidence at the new (lower) limit.
         self._success_count = 0
+        self._max_borrowed_this_round = 0
         self._first_retry_seen = True
 
         now = time.monotonic()

--- a/src/inspect_ai/util/_concurrency.py
+++ b/src/inspect_ai/util/_concurrency.py
@@ -1,10 +1,95 @@
 import contextlib
-from collections.abc import Iterable
+import time
+from collections.abc import Callable, Iterable
+from contextvars import ContextVar
+from logging import getLogger
 from typing import Any, AsyncIterator, Protocol
 
 import anyio
+from pydantic import BaseModel, Field, model_validator
 
+from inspect_ai._util.constants import HTTP
 from inspect_ai._util.working import sample_waiting_for
+
+logger = getLogger(__name__)
+
+
+class AdaptiveConcurrency(BaseModel):
+    """Bounds for an adaptive concurrency controller.
+
+    Configures the bounds within which an adaptive controller is allowed to
+    scale: starting at `start`, growing up to `max`, and never falling below
+    `min`. Accepts a string shorthand ("min-max" or "min-start-max") for use
+    in CLI flags and config files.
+    """
+
+    min: int = Field(default=1)
+    """Minimum concurrency (must be >= 1)."""
+
+    max: int = Field(default=200)
+    """Maximum concurrency."""
+
+    start: int = Field(default=20)
+    """Starting concurrency (must be within [min, max])."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def parse_shorthand(cls, data: Any) -> Any:
+        # Accept "min-max" or "min-start-max" string shorthand, and clamp the
+        # implicit start (= field default of 20) into [min, max] when start is
+        # not explicitly provided. Without clamping, AdaptiveConcurrency(min=1, max=15)
+        # would fail bounds validation because the default start exceeds max.
+        DEFAULT_START = 20
+
+        if isinstance(data, str):
+            parts = data.split("-")
+            try:
+                ints = [int(p) for p in parts]
+            except ValueError:
+                raise ValueError(
+                    f"Invalid AdaptiveConcurrency shorthand {data!r}: "
+                    "expected 'min-max' or 'min-start-max'"
+                )
+            if len(ints) == 2:
+                min_val, max_val = ints
+                return {
+                    "min": min_val,
+                    "max": max_val,
+                    "start": max(min_val, min(DEFAULT_START, max_val)),
+                }
+            elif len(ints) == 3:
+                return {"min": ints[0], "start": ints[1], "max": ints[2]}
+            else:
+                raise ValueError(
+                    f"Invalid AdaptiveConcurrency shorthand {data!r}: "
+                    "expected 'min-max' or 'min-start-max'"
+                )
+
+        # struct form: clamp implicit start when min/max are provided but
+        # start is not, so AdaptiveConcurrency(min=1, max=15) just works
+        if isinstance(data, dict) and "start" not in data:
+            min_val = data.get("min", 1)
+            max_val = data.get("max", 200)
+            if isinstance(min_val, int) and isinstance(max_val, int):
+                data = dict(data)
+                data["start"] = max(min_val, min(DEFAULT_START, max_val))
+
+        return data
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> "AdaptiveConcurrency":
+        if self.min < 1:
+            raise ValueError(f"AdaptiveConcurrency min must be >= 1 (got {self.min})")
+        if self.max < self.min:
+            raise ValueError(
+                f"AdaptiveConcurrency max ({self.max}) must be >= min ({self.min})"
+            )
+        if self.start < self.min or self.start > self.max:
+            raise ValueError(
+                f"AdaptiveConcurrency start ({self.start}) must be within "
+                f"[min={self.min}, max={self.max}]"
+            )
+        return self
 
 
 class ConcurrencySemaphore(Protocol):
@@ -34,14 +119,17 @@ class ConcurrencySemaphoreRegistry(Protocol):
         concurrency: int,
         key: str | None,
         visible: bool,
+        adaptive: AdaptiveConcurrency | None = None,
     ) -> ConcurrencySemaphore:
         """Get existing semaphore or create a new one.
 
         Args:
             name: Display name for the semaphore
-            concurrency: Maximum concurrent holders
+            concurrency: Maximum concurrent holders (ignored when adaptive is set)
             key: Unique key for storage (defaults to name if None)
             visible: Whether visible in status display
+            adaptive: Adaptive bounds (when set, creates an
+                AdaptiveConcurrencyController instead of a fixed Semaphore)
 
         Returns:
             The semaphore instance
@@ -54,19 +142,29 @@ class ConcurrencySemaphoreRegistry(Protocol):
 
 
 async def get_or_create_semaphore(
-    name: str, concurrency: int, key: str | None, visible: bool
+    name: str,
+    concurrency: int,
+    key: str | None,
+    visible: bool,
+    adaptive: AdaptiveConcurrency | None = None,
 ) -> ConcurrencySemaphore:
     """Get or create a concurrency semaphore.
 
     Delegates to the global _concurrency_registry.
     """
-    return await _concurrency_registry.get_or_create(name, concurrency, key, visible)
+    return await _concurrency_registry.get_or_create(
+        name, concurrency, key, visible, adaptive
+    )
 
 
 @contextlib.asynccontextmanager
 async def concurrency(
-    name: str, concurrency: int, key: str | None = None, visible: bool = True
-) -> AsyncIterator[None]:
+    name: str,
+    concurrency: int,
+    key: str | None = None,
+    visible: bool = True,
+    adaptive: AdaptiveConcurrency | None = None,
+) -> AsyncIterator[ConcurrencySemaphore]:
     """Concurrency context manager.
 
     A concurrency context can be used to limit the number of coroutines
@@ -87,23 +185,26 @@ async def concurrency(
          display name for the context, and also the unique context
          key (if the `key` parameter is omitted)
       concurrency: Maximum number of coroutines that can
-         enter the context.
+         enter the context (ignored if `adaptive` is set).
       key: Unique context key for this context. Optional.
          Used if the unique key isn't human readable -- e.g. includes
          api tokens or account ids so that the more readable `name`
          can be presented to users e.g in console UI>
       visible: Should context utilization be visible in the status bar.
+      adaptive: When set, creates an adaptive controller managing a
+         CapacityLimiter that scales between `adaptive.min` and
+         `adaptive.max` based on retry feedback.
     """
     # sort out key
     key = key if key else name
 
     # do we have an existing semaphore? if not create one and store it
-    semaphore = await get_or_create_semaphore(name, concurrency, key, visible)
+    semaphore = await get_or_create_semaphore(name, concurrency, key, visible, adaptive)
 
     # wait and yield to protected code (sample_waiting_for tracks concurrent waits
     # to avoid double-counting overlapping wait times within a sample)
     async with sample_waiting_for(semaphore.semaphore):
-        yield
+        yield semaphore
 
 
 def concurrency_status_display() -> dict[str, tuple[int, int]]:
@@ -141,6 +242,8 @@ def init_concurrency(
     """
     global _concurrency_registry
     _concurrency_registry = _AnyIOSemaphoreRegistry() if registry is None else registry
+    # clear controller-creation observers so each eval starts fresh
+    _controller_created_observers.clear()
 
 
 class _AnyIOSemaphoreRegistry:
@@ -155,11 +258,26 @@ class _AnyIOSemaphoreRegistry:
         concurrency: int,
         key: str | None,
         visible: bool,
+        adaptive: AdaptiveConcurrency | None = None,
     ) -> ConcurrencySemaphore:
-        k = key if key else name
+        # Adaptive and static modes get separate storage entries even when they
+        # share the same caller-provided `key`. Otherwise: (a) a static call
+        # followed by an adaptive call would return the existing Semaphore but
+        # the caller's `assert isinstance(..., AdaptiveConcurrencyController)`
+        # would fail, and (b) an adaptive call followed by a static call would
+        # silently get the AdaptiveConcurrencyController, defeating the
+        # "explicit max_connections wins" precedence rule.
+        base = key if key else name
+        k = f"{base}#adaptive" if adaptive is not None else f"{base}#static"
         if k in self._semaphores:
             return self._semaphores[k]
 
+        sem: ConcurrencySemaphore
+        if adaptive is not None:
+            ctrl = AdaptiveConcurrencyController(name, adaptive, visible)
+            self._semaphores[k] = ctrl
+            _fire_controller_created(ctrl)
+            return ctrl
         sem = _create_anyio_semaphore(name, concurrency, visible)
         self._semaphores[k] = sem
         return sem
@@ -190,3 +308,268 @@ def _create_anyio_semaphore(
 
 # Global registry instance
 _concurrency_registry: ConcurrencySemaphoreRegistry = _AnyIOSemaphoreRegistry()
+
+
+# Module-level observer list invoked when a new AdaptiveConcurrencyController is
+# created by the registry. DynamicSampleLimiter uses this so it can subscribe to
+# every controller eagerly — including ones born mid-eval (graders, etc.).
+_controller_created_observers: list[
+    "Callable[[AdaptiveConcurrencyController], None]"
+] = []
+
+
+def add_controller_created_observer(
+    callback: "Callable[[AdaptiveConcurrencyController], None]",
+) -> None:
+    """Register a callback fired when a new AdaptiveConcurrencyController is created."""
+    _controller_created_observers.append(callback)
+
+
+def _fire_controller_created(ctrl: "AdaptiveConcurrencyController") -> None:
+    for obs in list(_controller_created_observers):
+        obs(ctrl)
+
+
+# ContextVars for adaptive concurrency controller signal flow.
+# Set by Model._connection_concurrency at the start of a generate call,
+# read by report_http_retry() and by the post-generate success notification.
+_active_controller: ContextVar["AdaptiveConcurrencyController | None"] = ContextVar(
+    "_active_controller", default=None
+)
+_request_had_retry: ContextVar[bool] = ContextVar("_request_had_retry", default=False)
+
+# Set to True when a generate() returns from the cache without making an actual
+# provider call. Cache hits are neutral for the adaptive controller — they
+# neither succeeded nor failed against the rate limit.
+_request_was_cache_hit: ContextVar[bool] = ContextVar(
+    "_request_was_cache_hit", default=False
+)
+
+
+# Internal tuple record of a single scale change held by AdaptiveConcurrencyController.
+# The second element is the controller's display name (e.g. "openai/gpt-4o"),
+# never the secret-bearing connection_key from the provider.
+LimitChangeRecord = tuple[float, str, int, int, str]
+"""(timestamp, model_name, old_limit, new_limit, reason)."""
+
+
+class AdaptiveConcurrencyController:
+    """Adaptive concurrency controller using anyio.CapacityLimiter.
+
+    Implements slow-start + AIMD based on retry signals:
+      * notify_success(): one logical request completed without retries
+      * notify_retry(): a rate-limit / transient error retry occurred
+
+    Tuning constants:
+      * DECREASE_FACTOR (0.8): multiplicative decrease on retry episode
+      * COOLDOWN_SECONDS (15): debounce between scale-down events
+      * ROUND_SIZE_FLOOR (4): minimum successes before evaluating scale-up
+      * SCALE_UP_PERCENT (0.05): steady-state additive increase as % of current
+    """
+
+    DECREASE_FACTOR = 0.8
+    COOLDOWN_SECONDS = 15.0
+    ROUND_SIZE_FLOOR = 4
+    SCALE_UP_PERCENT = 0.05
+    HISTORY_LIMIT = 200
+
+    def __init__(
+        self,
+        name: str,
+        config: AdaptiveConcurrency,
+        visible: bool,
+    ) -> None:
+        self.name = name
+        self._config = config
+        self.visible = visible
+        self._limiter = anyio.CapacityLimiter(config.start)
+        self.semaphore: contextlib.AbstractAsyncContextManager[Any] = self._limiter
+        # `concurrency` mirrors the limiter's `total_tokens` (kept in sync via
+        # _set_limit). It's a plain attribute to satisfy the ConcurrencySemaphore
+        # Protocol (which expects a settable int).
+        self.concurrency: int = config.start
+        self._success_count = 0
+        self._first_retry_seen = False
+        self._cooldown_until = 0.0
+        self._history: list[LimitChangeRecord] = []
+        # observers notified on each scale change as (old_limit, new_limit)
+        self._observers: list[Callable[[int, int], None]] = []
+
+    def add_observer(self, callback: Callable[[int, int], None]) -> None:
+        """Register a callback fired on each scale change as (old_limit, new_limit)."""
+        self._observers.append(callback)
+
+    @property
+    def value(self) -> int:
+        """Tokens currently available (== limit - borrowed).
+
+        Status display computes `concurrency - value` to show borrowed count,
+        matching the Semaphore-based path.
+        """
+        return int(self._limiter.total_tokens - self._limiter.borrowed_tokens)
+
+    @property
+    def history(self) -> list[LimitChangeRecord]:
+        """Bounded history of scale changes for eval log capture."""
+        return list(self._history)
+
+    def notify_success(self) -> None:
+        """Record a successful logical request (no retries occurred).
+
+        Successful-after-retry calls are treated as neutral by the caller
+        (which checks `_request_had_retry` before calling here).
+        """
+        # During the retry cooldown, suppress success accounting entirely.
+        # Successes arriving during cooldown were almost certainly in flight
+        # from before the rate-limit cut, so they tell us nothing about whether
+        # the new lower limit is sustainable. Counting them would let
+        # back-pressure evaporate immediately after a cut (e.g. a cut from 100
+        # to 80 followed by 80 in-flight clean completions could trigger
+        # steady_state_up to 85 inside the cooldown window).
+        if time.monotonic() < self._cooldown_until:
+            return
+
+        self._success_count += 1
+        old = self.concurrency
+        round_size = max(old, self.ROUND_SIZE_FLOOR)
+        if self._success_count < round_size:
+            return
+
+        self._success_count = 0
+        if not self._first_retry_seen:
+            new = min(old * 2, self._config.max)
+            reason = "slow_start"
+        else:
+            increment = max(1, round(old * self.SCALE_UP_PERCENT))
+            new = min(_ceil_to_nice(old + increment), self._config.max)
+            reason = "steady_state_up"
+        if new != old:
+            self._set_limit(new, reason)
+
+    def notify_retry(self) -> None:
+        """Record a retry signal (rate-limit or transient error).
+
+        Cooldown debounces the *limit cut* — a single rate-limit episode
+        produces multiple retries (Inspect-level + SDK-internal) and we
+        cut at most once per episode. But success-counting is reset on
+        every retry signal regardless of cooldown, so a debounced retry
+        still invalidates the in-progress clean window. Without this,
+        under high throughput the controller could climb to a scale-up
+        immediately after a suppressed retry.
+        """
+        # always reset success accounting on any retry signal (even debounced)
+        self._success_count = 0
+        self._first_retry_seen = True
+
+        # debounce the limit cut itself
+        now = time.monotonic()
+        if now < self._cooldown_until:
+            return
+
+        old = self.concurrency
+        target = int(old * self.DECREASE_FACTOR)
+        new = _floor_to_nice(target)
+        new = max(new, self._config.min, 1)
+        self._cooldown_until = now + self.COOLDOWN_SECONDS
+        if new != old:
+            self._set_limit(new, "rate_limit")
+
+    def _set_limit(self, new: int, reason: str) -> None:
+        old = self.concurrency
+        self._limiter.total_tokens = new
+        self.concurrency = new
+        entry: LimitChangeRecord = (time.time(), self.name, old, new, reason)
+        self._history.append(entry)
+        if len(self._history) > self.HISTORY_LIMIT:
+            self._history.pop(0)
+        logger.log(
+            HTTP,
+            f"[connections] {self.name} {old} -> {new} ({reason})",
+            extra={
+                "model": self.name,
+                "old_limit": old,
+                "new_limit": new,
+                "reason": reason,
+            },
+        )
+        # notify observers (copy list to tolerate mutation during iteration)
+        for obs in list(self._observers):
+            obs(old, new)
+
+
+def _ceil_to_nice(value: int) -> int:
+    """Smallest 'nice' integer >= value: multiples of 5 above 10, integers below."""
+    if value < 10:
+        return max(1, value)
+    return ((value + 4) // 5) * 5
+
+
+def _floor_to_nice(value: int) -> int:
+    """Largest 'nice' integer <= value: multiples of 5 above 10, integers below."""
+    if value < 10:
+        return max(1, value)
+    return (value // 5) * 5
+
+
+def adaptive_controllers() -> list[AdaptiveConcurrencyController]:
+    """All currently-registered adaptive controllers (for eval log capture)."""
+    return [
+        c
+        for c in _concurrency_registry.values()
+        if isinstance(c, AdaptiveConcurrencyController)
+    ]
+
+
+class DynamicSampleLimiter:
+    """Sample-concurrency limiter that tracks adaptive controllers' current limits.
+
+    Wraps an `anyio.CapacityLimiter`. Subscribes to every adaptive controller
+    eagerly — both ones existing at construction time and ones created later
+    (via the module-level controller-creation hook). On each controller scale
+    change, `total_tokens` is updated to `max(c.concurrency for c in ctrls) + BUFFER`,
+    so sample concurrency tracks model API concurrency (plus a small slack).
+    """
+
+    BUFFER = 5
+
+    def __init__(self, adaptive: AdaptiveConcurrency) -> None:
+        self._adaptive = adaptive
+        initial = min(adaptive.start, adaptive.max) + self.BUFFER
+        self._limiter = anyio.CapacityLimiter(initial)
+        # subscribe to existing controllers (e.g. when the registry is reused
+        # across tasks within an eval set)
+        existing = list(adaptive_controllers())
+        for ctrl in existing:
+            ctrl.add_observer(self._on_controller_change)
+        # catch up to existing controllers' current limits — without this, a
+        # limiter created after a controller has already scaled would sit at
+        # `start + BUFFER` until the next scale change
+        if existing:
+            self._on_controller_change(0, 0)  # args ignored; recomputes from controllers
+        # register for future controllers — fired by the registry on creation
+        add_controller_created_observer(self._on_controller_created)
+
+    def _on_controller_created(self, ctrl: AdaptiveConcurrencyController) -> None:
+        ctrl.add_observer(self._on_controller_change)
+        # catch up: recompute target including this fresh controller
+        self._on_controller_change(0, ctrl.concurrency)
+
+    def _on_controller_change(self, old: int, new: int) -> None:
+        ctrls = list(adaptive_controllers())
+        if not ctrls:
+            return
+        max_cc = max(c.concurrency for c in ctrls)
+        target = min(max_cc + self.BUFFER, self._adaptive.max + self.BUFFER)
+        if target != self._limiter.total_tokens:
+            self._limiter.total_tokens = target
+
+    @property
+    def total_tokens(self) -> int:
+        """Current capacity (for tests / introspection)."""
+        return int(self._limiter.total_tokens)
+
+    async def __aenter__(self) -> None:
+        await self._limiter.__aenter__()
+
+    async def __aexit__(self, *args: Any) -> Any:
+        return await self._limiter.__aexit__(*args)

--- a/tests/model/providers/test_bedrock_hooks.py
+++ b/tests/model/providers/test_bedrock_hooks.py
@@ -1,0 +1,298 @@
+"""Tests for Bedrock ConverseHooks per-attempt retry classification.
+
+Verifies that the hook chain works end-to-end against a *real* AWSRequest /
+context dict — the previous implementation silently no-op'd because
+AWSPreparedRequest has no `.context` attribute, and `getattr` returned None
+without surfacing any error. These tests catch that class of regression.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+pytest.importorskip("aiobotocore")
+pytest.importorskip("botocore")
+
+from botocore.awsrequest import AWSRequest  # noqa: E402
+
+from inspect_ai.model._providers.util.hooks import ConverseHooks  # noqa: E402
+
+
+def _make_hooks() -> ConverseHooks:
+    """Build a ConverseHooks instance without registering with a real session."""
+    # The constructor expects a session-like object with `_session.register`,
+    # but we bypass it for unit testing.
+    hooks = ConverseHooks.__new__(ConverseHooks)
+    # call HttpHooks.__init__ to set up self._requests
+    hooks._requests = {}
+    return hooks
+
+
+def _make_aws_request(user_agent: str) -> AWSRequest:
+    """Build an AWSRequest with a User-Agent header and an empty per-call context."""
+    return AWSRequest(
+        method="POST",
+        url="https://bedrock.example.com/model/x/converse",
+        headers={"User-Agent": user_agent},
+        data=b"",
+    )
+
+
+def test_request_created_stashes_request_id_on_context() -> None:
+    """request-created handler must put the Inspect request_id on AWSRequest.context.
+
+    AWSRequest.context IS the same dict botocore threads through to
+    response-received as the `context` parameter, so this is the only
+    durable channel between the two events.
+    """
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"botocore/x.y ins/rid#{request_id}")
+    hooks.converse_request_created(request=request)
+    # the per-call context dict now carries our request_id
+    assert request.context.get(ConverseHooks._CTX_REQUEST_ID) == request_id
+
+
+def test_request_created_increments_attempts() -> None:
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"ins/rid#{request_id}")
+    # Patch report_http_retry: the second converse_request_created call would
+    # otherwise call the real one and pollute the _request_had_retry ContextVar
+    # for any subsequent tests in the same process.
+    with patch("inspect_ai.model._providers.util.hooks.report_http_retry"):
+        hooks.converse_request_created(request=request)
+        assert hooks._requests[request_id].attempts == 1
+        hooks.converse_request_created(request=request)
+        assert hooks._requests[request_id].attempts == 2
+
+
+def test_response_received_records_status_via_context() -> None:
+    """The full chain: request-created stashes id → response-received reads id from context."""
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"ins/rid#{request_id}")
+    with patch("inspect_ai.model._providers.util.hooks.report_http_retry"):
+        hooks.converse_request_created(request=request)
+        # response arrives — context is the SAME dict as request.context
+        hooks.converse_response_received(
+            response_dict={"status_code": 429, "headers": {}, "url": ""},
+            context=request.context,
+        )
+        info = hooks._requests[request_id]
+        assert info.last_status == 429
+
+
+def test_throttle_then_retry_classifies_as_rate_limit() -> None:
+    """End-to-end: 429 response → next request-created reports rate_limit retry.
+
+    This is the scenario the reviewer flagged: SDK-internal retries on
+    ThrottlingException must reach the adaptive controller, not be silently
+    classified as transient (or dropped entirely because request_id was None).
+    """
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"ins/rid#{request_id}")
+
+    # Attempt 1 — fires request-created, then response-received with 429
+    hooks.converse_request_created(request=request)
+    hooks.converse_response_received(
+        response_dict={"status_code": 429, "headers": {}, "url": ""},
+        context=request.context,
+    )
+
+    # Attempt 2 — request-created fires again (botocore creates a new request
+    # per retry, but the context dict is the same identity)
+    new_request = _make_aws_request(f"ins/rid#{request_id}")
+    new_request.context = request.context  # botocore reuses the same context
+    with patch(
+        "inspect_ai.model._providers.util.hooks.report_http_retry"
+    ) as mock_report:
+        hooks.converse_request_created(request=new_request)
+    # report_http_retry must have been called with kind="rate_limit"
+    assert mock_report.called
+    call_kwargs = mock_report.call_args.kwargs
+    assert call_kwargs.get("kind") == "rate_limit"
+
+
+def test_throttling_exception_classified_via_parsed_response() -> None:
+    """ThrottlingException detected via parsed_response.Error.Code, not status.
+
+    ThrottlingException doesn't always come back as HTTP 429 from Bedrock.
+    """
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"ins/rid#{request_id}")
+
+    # Attempt 1 — request-created stashes id; response-received sees a non-429
+    # status but a ThrottlingException error code in parsed_response
+    with patch("inspect_ai.model._providers.util.hooks.report_http_retry"):
+        hooks.converse_request_created(request=request)
+    hooks.converse_response_received(
+        response_dict={"status_code": 400, "headers": {}, "url": ""},
+        parsed_response={"Error": {"Code": "ThrottlingException", "Message": "x"}},
+        context=request.context,
+    )
+
+    # Attempt 2 — fires retry. Should be classified as rate_limit because the
+    # parsed_response.Error.Code was ThrottlingException, even though HTTP
+    # status was 400 (not 429).
+    new_request = _make_aws_request(f"ins/rid#{request_id}")
+    new_request.context = request.context
+    with patch(
+        "inspect_ai.model._providers.util.hooks.report_http_retry"
+    ) as mock_report:
+        hooks.converse_request_created(request=new_request)
+    assert mock_report.called
+    assert mock_report.call_args.kwargs.get("kind") == "rate_limit"
+
+
+def test_validation_exception_classified_as_transient() -> None:
+    """An explicit non-throttle AWS error code wins over status-based inference.
+
+    Without this, a 429 body with a non-throttle Code (e.g. ValidationException)
+    would be misclassified as rate_limit by the status-based fallback.
+    """
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"ins/rid#{request_id}")
+
+    with patch("inspect_ai.model._providers.util.hooks.report_http_retry"):
+        hooks.converse_request_created(request=request)
+    hooks.converse_response_received(
+        response_dict={"status_code": 429, "headers": {}, "url": ""},
+        parsed_response={"Error": {"Code": "ValidationException", "Message": "x"}},
+        context=request.context,
+    )
+
+    new_request = _make_aws_request(f"ins/rid#{request_id}")
+    new_request.context = request.context
+    with patch(
+        "inspect_ai.model._providers.util.hooks.report_http_retry"
+    ) as mock_report:
+        hooks.converse_request_created(request=new_request)
+    # Even though HTTP was 429, the explicit "ValidationException" code
+    # routes us to transient.
+    assert mock_report.called
+    assert mock_report.call_args.kwargs.get("kind") != "rate_limit"
+
+
+def test_5xx_then_retry_classifies_as_transient() -> None:
+    """5xx response should NOT scale the controller down on the next retry."""
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"ins/rid#{request_id}")
+
+    hooks.converse_request_created(request=request)
+    hooks.converse_response_received(
+        response_dict={"status_code": 503, "headers": {}, "url": ""},
+        context=request.context,
+    )
+
+    new_request = _make_aws_request(f"ins/rid#{request_id}")
+    new_request.context = request.context
+    with patch(
+        "inspect_ai.model._providers.util.hooks.report_http_retry"
+    ) as mock_report:
+        hooks.converse_request_created(request=new_request)
+    # transient: report_http_retry called with no kwargs (defaults to transient)
+    assert mock_report.called
+    assert mock_report.call_args.kwargs.get("kind") != "rate_limit"
+
+
+def test_response_without_stashed_id_is_noop() -> None:
+    """If the User-Agent didn't carry our marker, response-received does nothing."""
+    hooks = _make_hooks()
+    # response-received with an empty context — no _inspect_request_id
+    hooks.converse_response_received(
+        response_dict={"status_code": 429, "headers": {}, "url": ""},
+        context={},
+    )
+    # nothing recorded
+    assert hooks._requests == {}
+
+
+def test_user_agent_without_marker_is_noop() -> None:
+    """A request without our User-Agent marker shouldn't crash or create state."""
+    hooks = _make_hooks()
+    request = _make_aws_request("botocore/1.40.61 Python/3.13")
+    hooks.converse_request_created(request=request)
+    # no request_id was extracted, nothing tracked
+    assert hooks._requests == {}
+    assert ConverseHooks._CTX_REQUEST_ID not in request.context
+
+
+def test_ignores_calls_without_request_kwarg() -> None:
+    hooks = _make_hooks()
+    # botocore may emit other events with different kwargs — handler must
+    # tolerate absence of `request`
+    hooks.converse_request_created()  # no kwargs at all
+    hooks.converse_request_created(operation_name="Converse")  # no request
+    assert hooks._requests == {}
+
+
+def test_retry_after_deadline_decays_across_sdk_backoff() -> None:
+    """Retry-After is reported as *remaining* time, not the original duration.
+
+    If the response says Retry-After: 30, then 30s of SDK-internal backoff
+    elapses, the next retry should report ~0 remaining (not 30 again — that
+    would double-count, the controller would extend its cooldown by another
+    30s for a total of 60s wait). Reproduce by manually advancing the
+    recorded deadline backwards.
+    """
+    import time
+
+    from inspect_ai.model._providers.util.hooks import (
+        ConverseHooks,
+        RequestInfo,
+    )
+
+    hooks = _make_hooks()
+    request_id = hooks.start_request()
+    request = _make_aws_request(f"ins/rid#{request_id}")
+
+    # Attempt 1 — record a response with Retry-After: 30
+    with patch("inspect_ai.model._providers.util.hooks.report_http_retry"):
+        hooks.converse_request_created(request=request)
+    hooks.converse_response_received(
+        response_dict={
+            "status_code": 429,
+            "headers": {"retry-after": "30"},
+            "url": "",
+        },
+        context=request.context,
+    )
+
+    # The deadline stored in RequestInfo should be ~30s in the future
+    info = hooks._requests[request_id]
+    assert info.last_retry_after_deadline is not None
+    assert (info.last_retry_after_deadline - time.monotonic()) > 25
+
+    # Simulate SDK-internal backoff: pretend 30s have elapsed by rewinding
+    # the deadline (any time past it should report 0 remaining).
+    hooks._requests[request_id] = RequestInfo(
+        info.attempts,
+        info.last_request,
+        info.last_status,
+        time.monotonic() - 1,  # deadline is in the past
+        info.last_kind,
+    )
+
+    new_request = _make_aws_request(f"ins/rid#{request_id}")
+    new_request.context = request.context
+    with patch(
+        "inspect_ai.model._providers.util.hooks.report_http_retry"
+    ) as mock_report:
+        hooks.converse_request_created(request=new_request)
+    # report_http_retry should fire with retry_after=None (deadline already
+    # past — no remaining wait to suggest). NOT 30s.
+    assert mock_report.called
+    kwargs = mock_report.call_args.kwargs
+    assert kwargs.get("retry_after") is None
+
+    # And specifically, kind should still be rate_limit (status=429)
+    assert kwargs.get("kind") == "rate_limit"
+    # Silence unused import warning if test infrastructure trimmed it
+    _ = ConverseHooks

--- a/tests/model/providers/test_sagemaker.py
+++ b/tests/model/providers/test_sagemaker.py
@@ -127,7 +127,7 @@ class TestShouldRetry:
             {"Error": {"Code": "ModelError"}, "OriginalStatusCode": 503},
             "InvokeEndpoint",
         )
-        assert api.should_retry(ex) is True
+        assert api.should_retry(ex).retry is True
 
     def test_retry_on_504(self):
         api = _make_api()
@@ -135,7 +135,7 @@ class TestShouldRetry:
             {"Error": {"Code": "ModelError"}, "OriginalStatusCode": 504},
             "InvokeEndpoint",
         )
-        assert api.should_retry(ex) is True
+        assert api.should_retry(ex).retry is True
 
     def test_no_retry_on_400(self):
         api = _make_api()
@@ -143,7 +143,7 @@ class TestShouldRetry:
             {"Error": {"Code": "ModelError"}, "OriginalStatusCode": 400},
             "InvokeEndpoint",
         )
-        assert api.should_retry(ex) is False
+        assert api.should_retry(ex).retry is False
 
     def test_no_retry_on_non_model_error(self):
         api = _make_api()
@@ -151,11 +151,11 @@ class TestShouldRetry:
             {"Error": {"Code": "ValidationError"}, "OriginalStatusCode": 503},
             "InvokeEndpoint",
         )
-        assert api.should_retry(ex) is False
+        assert api.should_retry(ex).retry is False
 
     def test_no_retry_on_non_client_error(self):
         api = _make_api()
-        assert api.should_retry(RuntimeError("boom")) is False
+        assert api.should_retry(RuntimeError("boom")).retry is False
 
 
 # -- Request body building tests ---------------------------------------------

--- a/tests/model/test_adaptive_connections.py
+++ b/tests/model/test_adaptive_connections.py
@@ -1,0 +1,379 @@
+"""End-to-end tests for adaptive_connections wiring through Model.generate."""
+
+from collections.abc import Callable
+
+import pytest
+
+from inspect_ai._util.retry import report_http_retry
+from inspect_ai.model import (
+    GenerateConfig,
+    get_model,
+)
+from inspect_ai.model._chat_message import ChatMessage
+from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.tool import ToolChoice, ToolInfo
+from inspect_ai.util import AdaptiveConcurrency
+from inspect_ai.util._concurrency import (
+    _active_controller,
+    _request_had_retry,
+    adaptive_controllers,
+    init_concurrency,
+)
+
+
+def _make_output_fn() -> Callable[..., ModelOutput]:
+    def out(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        return ModelOutput.from_content(model="mockllm", content="ok")
+
+    return out
+
+
+def _capture_controller_during_generate() -> Callable[..., ModelOutput]:
+    """Build a custom_outputs fn that reports the active controller / had_retry on each call."""
+    captures: list[tuple[object, bool]] = []
+
+    def out(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        captures.append((_active_controller.get(), _request_had_retry.get()))
+        return ModelOutput.from_content(model="mockllm", content="ok")
+
+    out.captures = captures  # type: ignore[attr-defined]
+    return out
+
+
+@pytest.mark.anyio
+async def test_adaptive_off_by_default() -> None:
+    """Without adaptive_connections, no controller is set during generate."""
+    init_concurrency()
+    fn = _capture_controller_during_generate()
+    model = get_model("mockllm/model", custom_outputs=fn)
+    await model.generate("hello")
+    captures = fn.captures  # type: ignore[attr-defined]
+    assert captures == [(None, False)]
+    assert adaptive_controllers() == []
+
+
+@pytest.mark.anyio
+async def test_adaptive_sets_active_controller_during_generate() -> None:
+    init_concurrency()
+    fn = _capture_controller_during_generate()
+    model = get_model("mockllm/model", custom_outputs=fn)
+    await model.generate(
+        "hello",
+        config=GenerateConfig(adaptive_connections=True),
+    )
+    captures = fn.captures  # type: ignore[attr-defined]
+    assert len(captures) == 1
+    controller, had_retry = captures[0]
+    assert controller is not None
+    assert had_retry is False
+    # controller is registered for status display / log capture
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+
+
+@pytest.mark.anyio
+async def test_adaptive_struct_config_used() -> None:
+    init_concurrency()
+    fn = _make_output_fn()
+    model = get_model("mockllm/model", custom_outputs=fn)
+    await model.generate(
+        "hello",
+        config=GenerateConfig(
+            adaptive_connections=AdaptiveConcurrency(min=2, max=50, start=15)
+        ),
+    )
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+    assert ctrls[0].concurrency == 15  # started at custom value
+
+
+@pytest.mark.anyio
+async def test_adaptive_with_max_retries_zero_works() -> None:
+    """max_retries=0 doesn't disable retry feedback to the controller.
+
+    Provider SDK internal retries (tracked by HttpHooks) fire report_http_retry
+    independently of Inspect's outer retry loop, so the controller still gets
+    scale-down signals. And the controller's `max` bound caps growth even if
+    no retry signals ever arrive.
+    """
+    init_concurrency()
+    model = get_model("mockllm/model")
+    await model.generate(
+        "hello",
+        config=GenerateConfig(adaptive_connections=True, max_retries=0),
+    )
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+
+
+@pytest.mark.anyio
+async def test_explicit_max_connections_wins_over_adaptive() -> None:
+    """Explicit max_connections takes precedence over adaptive_connections.
+
+    Once adaptive becomes default-on, deliberate max_connections settings must
+    continue to be honored — so the static path is taken when both are set.
+    """
+    init_concurrency()
+    fn = _capture_controller_during_generate()
+    model = get_model("mockllm/model", custom_outputs=fn)
+    await model.generate(
+        "hello",
+        config=GenerateConfig(adaptive_connections=True, max_connections=20),
+    )
+    captures = fn.captures  # type: ignore[attr-defined]
+    # static path was taken: no controller is active during generate
+    assert captures == [(None, False)]
+    # no adaptive controller was created
+    assert adaptive_controllers() == []
+
+
+@pytest.mark.anyio
+async def test_report_http_retry_signals_active_controller() -> None:
+    """When called inside generate, report_http_retry sets had_retry and notifies controller."""
+    init_concurrency()
+
+    saw_controller: list[object] = []
+
+    def out(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        # simulate provider-level retry signal during the generate call
+        report_http_retry()
+        saw_controller.append(_active_controller.get())
+        return ModelOutput.from_content(model="mockllm", content="ok")
+
+    model = get_model("mockllm/model", custom_outputs=out)
+    await model.generate(
+        "hello",
+        config=GenerateConfig(adaptive_connections=True),
+    )
+
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+    # the retry should have been observed and recorded a scale-down event
+    history = ctrls[0].history
+    assert any(entry[4] == "rate_limit" for entry in history)
+
+
+@pytest.mark.anyio
+async def test_clean_success_does_not_modify_limit_below_round_size() -> None:
+    """A single clean generate doesn't reach round_size, so no scale change happens."""
+    init_concurrency()
+    model = get_model("mockllm/model", custom_outputs=_make_output_fn())
+    await model.generate("hello", config=GenerateConfig(adaptive_connections=True))
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+    # default start=20, round_size=20, only 1 success → no change yet
+    assert ctrls[0].concurrency == 20
+    assert ctrls[0].history == []
+
+
+@pytest.mark.anyio
+async def test_connection_limit_history_captured_in_eval_stats() -> None:
+    """collect_eval_data populates EvalStats.connection_limit_history from registered controllers."""
+    from inspect_ai._eval.task.log import collect_eval_data
+    from inspect_ai.log._log import EvalStats
+
+    init_concurrency()
+
+    def out(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        report_http_retry()
+        return ModelOutput.from_content(model="mockllm", content="ok")
+
+    model = get_model("mockllm/model", custom_outputs=out)
+    await model.generate("hello", config=GenerateConfig(adaptive_connections=True))
+
+    stats = EvalStats()
+    collect_eval_data(stats)
+    assert len(stats.connection_limit_history) >= 1
+    entry = stats.connection_limit_history[0]
+    assert entry.reason == "rate_limit"
+    assert entry.model  # non-empty
+
+
+def test_parse_adaptive_connections_cli_value_forms() -> None:
+    """The CLI parser handles bool keywords and shorthand strings, with None passthrough.
+
+    Verifies the four user-visible forms of `--adaptive-connections VALUE`.
+    """
+    from inspect_ai._cli.eval import _parse_adaptive_connections_cli
+
+    # absence
+    assert _parse_adaptive_connections_cli(None) is None
+
+    # bool keywords (case-insensitive)
+    assert _parse_adaptive_connections_cli("true") is True
+    assert _parse_adaptive_connections_cli("TRUE") is True
+    assert _parse_adaptive_connections_cli("1") is True
+    assert _parse_adaptive_connections_cli("yes") is True
+    assert _parse_adaptive_connections_cli("false") is False
+    assert _parse_adaptive_connections_cli("0") is False
+    assert _parse_adaptive_connections_cli("no") is False
+
+    # bounds shorthand
+    result = _parse_adaptive_connections_cli("4-80")
+    assert isinstance(result, AdaptiveConcurrency)
+    assert (result.min, result.max, result.start) == (4, 80, 20)
+
+    result = _parse_adaptive_connections_cli("4-20-80")
+    assert isinstance(result, AdaptiveConcurrency)
+    assert (result.min, result.start, result.max) == (4, 20, 80)
+
+
+def test_parse_adaptive_connections_cli_invalid_raises_click_error() -> None:
+    """Invalid values raise click.BadParameter, not raw pydantic ValidationError.
+
+    This way the CLI surfaces a clean usage message. Without this wrapping,
+    users hitting `--adaptive-connections nope` saw a multi-line pydantic
+    traceback as the error output.
+    """
+    import click
+
+    from inspect_ai._cli.eval import _parse_adaptive_connections_cli
+
+    with pytest.raises(click.BadParameter, match="not a valid value"):
+        _parse_adaptive_connections_cli("nope")
+    with pytest.raises(click.BadParameter, match="not a valid value"):
+        _parse_adaptive_connections_cli("1-2-3-4")  # too many parts
+    with pytest.raises(click.BadParameter, match="not a valid value"):
+        _parse_adaptive_connections_cli("not-a-number")
+
+
+def test_attempt_timeout_marks_as_retry_in_should_retry() -> None:
+    """should_retry(AttemptTimeoutError) must fire report_http_retry.
+
+    Otherwise timeout pressure is invisible to the adaptive controller and
+    a request that timed out and then succeeded would be counted as a clean
+    success — pushing the controller upward under timeout pressure.
+    """
+    from inspect_ai.model._model import AttemptTimeoutError
+    from inspect_ai.util._concurrency import _request_had_retry, init_concurrency
+
+    init_concurrency()
+    # set up a model and use should_retry directly
+    model = get_model("mockllm/model")
+    # ContextVars need to be in a fresh state. Capture token + reset in finally
+    # so we don't leak the changed value across tests.
+    token = _request_had_retry.set(False)
+    try:
+        result = model.should_retry(AttemptTimeoutError(timeout=30))
+        assert result is True
+        assert _request_had_retry.get() is True
+    finally:
+        _request_had_retry.reset(token)
+
+
+@pytest.mark.anyio
+async def test_cache_hits_do_not_count_as_adaptive_successes(tmp_path) -> None:
+    """Cache-served generates don't fire notify_success on the controller.
+
+    Cache hits don't exercise the rate limit, so they must be neutral —
+    otherwise a cached run could slow-start the controller to its max without
+    any provider traffic, and uncached calls would then hit the API at
+    inflated concurrency.
+    """
+    from inspect_ai.model._cache import CachePolicy
+
+    # point cache at a temp dir so we don't pollute the user's cache
+    monkey_env = pytest.MonkeyPatch()
+    monkey_env.setenv("INSPECT_CACHE_DIR", str(tmp_path))
+    try:
+        init_concurrency()
+        model = get_model("mockllm/model")
+        cfg = GenerateConfig(
+            adaptive_connections=AdaptiveConcurrency(min=1, max=200, start=10),
+            cache=CachePolicy(),
+        )
+
+        # First call populates the cache (this will count as a real success)
+        await model.generate("hello", config=cfg)
+
+        ctrls = adaptive_controllers()
+        assert len(ctrls) == 1
+        success_count_after_first = ctrls[0]._success_count
+
+        # Many cache hits — none should bump the success counter
+        for _ in range(50):
+            await model.generate("hello", config=cfg)
+
+        # success counter should be unchanged from the first (real) call
+        assert ctrls[0]._success_count == success_count_after_first
+        # and limit should not have grown
+        assert ctrls[0].concurrency == 10
+    finally:
+        monkey_env.undo()
+
+
+# ---------- create_sample_semaphore ----------
+
+
+def test_sample_semaphore_uses_dynamic_for_adaptive() -> None:
+    """When adaptive is set and max_samples is unset, returns DynamicSampleLimiter."""
+    import anyio as _anyio
+
+    from inspect_ai._eval.task.run import create_sample_semaphore
+    from inspect_ai.log._log import EvalConfig
+    from inspect_ai.util._concurrency import DynamicSampleLimiter, init_concurrency
+
+    init_concurrency()
+    sem = create_sample_semaphore(
+        config=EvalConfig(),  # max_samples unset
+        generate_config=GenerateConfig(adaptive_connections=True),
+        modelapi=None,
+    )
+    assert isinstance(sem, DynamicSampleLimiter)
+    assert not isinstance(sem, _anyio.Semaphore)
+
+
+def test_sample_semaphore_explicit_max_samples_wins() -> None:
+    """Explicit max_samples returns plain Semaphore even when adaptive is enabled.
+
+    No warning — anticipating adaptive becoming default-on, in which case any
+    deliberate max_samples setting would otherwise produce noise.
+    """
+    import anyio as _anyio
+
+    from inspect_ai._eval.task.run import create_sample_semaphore
+    from inspect_ai.log._log import EvalConfig
+
+    sem = create_sample_semaphore(
+        config=EvalConfig(max_samples=5),
+        generate_config=GenerateConfig(
+            adaptive_connections=AdaptiveConcurrency(min=1, max=80, start=10)
+        ),
+        modelapi=None,
+    )
+    assert isinstance(sem, _anyio.Semaphore)
+
+
+def test_sample_semaphore_static_path_unchanged() -> None:
+    """Without adaptive, returns Semaphore with the legacy max_connections-derived size."""
+    import anyio as _anyio
+
+    from inspect_ai._eval.task.run import create_sample_semaphore
+    from inspect_ai.log._log import EvalConfig
+
+    sem = create_sample_semaphore(
+        config=EvalConfig(),
+        generate_config=GenerateConfig(max_connections=15),
+        modelapi=None,
+    )
+    assert isinstance(sem, _anyio.Semaphore)

--- a/tests/model/test_adaptive_connections.py
+++ b/tests/model/test_adaptive_connections.py
@@ -150,8 +150,8 @@ async def test_report_http_retry_signals_active_controller() -> None:
         tool_choice: ToolChoice,
         config: GenerateConfig,
     ) -> ModelOutput:
-        # simulate provider-level retry signal during the generate call
-        report_http_retry()
+        # simulate provider-level rate-limit signal during the generate call
+        report_http_retry(kind="rate_limit")
         saw_controller.append(_active_controller.get())
         return ModelOutput.from_content(model="mockllm", content="ok")
 
@@ -195,7 +195,7 @@ async def test_connection_limit_history_captured_in_eval_stats() -> None:
         tool_choice: ToolChoice,
         config: GenerateConfig,
     ) -> ModelOutput:
-        report_http_retry()
+        report_http_retry(kind="rate_limit")
         return ModelOutput.from_content(model="mockllm", content="ok")
 
     model = get_model("mockllm/model", custom_outputs=out)
@@ -377,3 +377,61 @@ def test_sample_semaphore_static_path_unchanged() -> None:
         modelapi=None,
     )
     assert isinstance(sem, _anyio.Semaphore)
+
+
+# ---------- Rate-limit vs transient classification (end-to-end) ----------
+
+
+@pytest.mark.anyio
+async def test_transient_retries_do_not_scale_controller_down() -> None:
+    """5xx / timeout retries during generate must not shrink the adaptive controller.
+
+    Earlier code conflated all retries with rate-limit signals; the fix is for
+    transients to pause scale-up only.
+    """
+    init_concurrency()
+
+    def out(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        report_http_retry()  # default: kind="transient"
+        return ModelOutput.from_content(model="mockllm", content="ok")
+
+    model = get_model("mockllm/model", custom_outputs=out)
+    await model.generate("hello", config=GenerateConfig(adaptive_connections=True))
+
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+    # transient retry must not have produced any scale-down history
+    assert all(entry[4] != "rate_limit" for entry in ctrls[0].history)
+
+
+@pytest.mark.anyio
+async def test_transient_retry_blocks_success_counting() -> None:
+    """A transient retry during generate prevents that success from counting toward scale-up."""
+    init_concurrency()
+
+    def out(
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        report_http_retry()  # transient
+        return ModelOutput.from_content(model="mockllm", content="ok")
+
+    model = get_model("mockllm/model", custom_outputs=out)
+    cfg = GenerateConfig(
+        adaptive_connections=AdaptiveConcurrency(min=1, max=200, start=4)
+    )
+    # 4 generates would normally complete a slow-start round (round_size=max(4,4)=4)
+    for _ in range(4):
+        await model.generate("hello", config=cfg)
+
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+    # because each generate had a transient retry, none counted as a clean success
+    assert ctrls[0].concurrency == 4

--- a/tests/model/test_adaptive_connections.py
+++ b/tests/model/test_adaptive_connections.py
@@ -138,6 +138,33 @@ async def test_explicit_max_connections_wins_over_adaptive() -> None:
 
 
 @pytest.mark.anyio
+async def test_batch_mode_disables_adaptive() -> None:
+    """Batch mode silently overrides adaptive_connections.
+
+    Batch APIs run on a separate quota, the per-request concurrency model
+    doesn't bind, and the batch worker's background-task ContextVars don't
+    propagate retry/success signals back to awaiting generates — so adaptive
+    accounting would be incorrect even if we did set up the controller.
+    """
+    from inspect_ai.model._generate_config import BatchConfig
+
+    init_concurrency()
+    fn = _capture_controller_during_generate()
+    model = get_model("mockllm/model", custom_outputs=fn)
+    await model.generate(
+        "hello",
+        config=GenerateConfig(
+            adaptive_connections=True,
+            batch=BatchConfig(),
+        ),
+    )
+    captures = fn.captures  # type: ignore[attr-defined]
+    # static path was taken: no controller active during generate
+    assert captures == [(None, False)]
+    assert adaptive_controllers() == []
+
+
+@pytest.mark.anyio
 async def test_report_http_retry_signals_active_controller() -> None:
     """When called inside generate, report_http_retry sets had_retry and notifies controller."""
     init_concurrency()
@@ -377,6 +404,34 @@ def test_sample_semaphore_static_path_unchanged() -> None:
         modelapi=None,
     )
     assert isinstance(sem, _anyio.Semaphore)
+
+
+def test_sample_semaphore_batch_mode_disables_adaptive() -> None:
+    """Batch mode silently overrides adaptive_connections at the sample limiter layer too.
+
+    Without this, a batched eval with adaptive_connections=True would create
+    a DynamicSampleLimiter that tracks a controller no one is feeding signals
+    to (since Model._connection_concurrency takes the static path in batch
+    mode).
+    """
+    import anyio as _anyio
+
+    from inspect_ai._eval.task.run import create_sample_semaphore
+    from inspect_ai.log._log import EvalConfig
+    from inspect_ai.model._generate_config import BatchConfig
+    from inspect_ai.util._concurrency import DynamicSampleLimiter, init_concurrency
+
+    init_concurrency()
+    sem = create_sample_semaphore(
+        config=EvalConfig(),
+        generate_config=GenerateConfig(
+            adaptive_connections=True,
+            batch=BatchConfig(),
+        ),
+        modelapi=None,
+    )
+    assert isinstance(sem, _anyio.Semaphore)
+    assert not isinstance(sem, DynamicSampleLimiter)
 
 
 # ---------- Rate-limit vs transient classification (end-to-end) ----------

--- a/tests/model/test_chatapi_retry.py
+++ b/tests/model/test_chatapi_retry.py
@@ -1,0 +1,209 @@
+"""Tests for chat_api_request retry reporting via tenacity before_sleep.
+
+The fix moves `report_http_retry` from the tenacity *predicate* (which fires
+on every attempt, including the final stopped one) to a `before_sleep`
+callback (which fires only on retries that actually sleep). This eliminates
+the chatapi-specific 3× inflation of `_http_retries_count` while still
+surfacing inner-retry-success cases (which were invisible in main).
+"""
+
+import contextlib
+from collections.abc import Iterator
+
+import httpx
+import pytest
+
+from inspect_ai._util import retry as retry_module
+from inspect_ai._util.retry import http_retries_count
+from inspect_ai.model._providers.util.chatapi import chat_api_request
+
+
+@contextlib.contextmanager
+def _reset_retry_counter() -> Iterator[int]:
+    """Snapshot + restore the global retry counter so tests are isolated."""
+    before = retry_module._http_retries_count
+    yield before
+    retry_module._http_retries_count = before
+
+
+def _client_with_responses(responses: list[httpx.Response]) -> httpx.AsyncClient:
+    """Build an AsyncClient whose POSTs return the given responses in order."""
+    iter_responses = iter(responses)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        try:
+            return next(iter_responses)
+        except StopIteration:
+            raise AssertionError(
+                "test made more requests than mocked responses"
+            ) from None
+
+    transport = httpx.MockTransport(handler)
+    return httpx.AsyncClient(transport=transport)
+
+
+@pytest.mark.anyio
+async def test_chatapi_429_then_success_reports_one_retry() -> None:
+    """One actual retry happened (between attempts 1 and 2). Counter += 1."""
+    responses = [
+        httpx.Response(429, headers={"Retry-After": "1"}),
+        httpx.Response(200, json={"ok": True}),
+    ]
+    client = _client_with_responses(responses)
+    with _reset_retry_counter() as before:
+        result = await chat_api_request(
+            client,
+            model_name="test-model",
+            url="https://example.invalid/v1/chat",
+            headers={},
+            json={"input": "hello"},
+        )
+        assert result == {"ok": True}
+        assert http_retries_count() == before + 1
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_chatapi_429_then_429_stop_reports_one_inner_retry() -> None:
+    """Two failed attempts; only one ACTUAL retry (between 1 and 2). Inner += 1.
+
+    The outer Model.should_retry would add its own report when the wrapping
+    RetryError bubbles up, but that's tested separately at the Model layer.
+    Inside the chatapi unit, only the inner-attempt-1→2 retry is counted.
+    """
+    from tenacity import RetryError
+
+    responses = [
+        httpx.Response(429, headers={"Retry-After": "1"}),
+        httpx.Response(429, headers={"Retry-After": "1"}),
+    ]
+    client = _client_with_responses(responses)
+    with _reset_retry_counter() as before:
+        with pytest.raises(RetryError):
+            await chat_api_request(
+                client,
+                model_name="test-model",
+                url="https://example.invalid/v1/chat",
+                headers={},
+                json={"input": "hello"},
+            )
+        # Exactly one inner report — for the sleep between attempts 1 and 2.
+        # The final stopped attempt does NOT call before_sleep.
+        assert http_retries_count() == before + 1
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_chatapi_no_retry_on_400() -> None:
+    """A non-retryable status doesn't retry and doesn't report."""
+    responses = [httpx.Response(400, json={"error": "bad request"})]
+    client = _client_with_responses(responses)
+    with _reset_retry_counter() as before:
+        with pytest.raises(httpx.HTTPStatusError):
+            await chat_api_request(
+                client,
+                model_name="test-model",
+                url="https://example.invalid/v1/chat",
+                headers={},
+                json={"input": "hello"},
+            )
+        assert http_retries_count() == before
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_chatapi_429_signals_active_controller_with_rate_limit_kind() -> None:
+    """End-to-end: before_sleep → report_http_retry → controller.notify_retry.
+
+    Verifies the chatapi inner retry actually reaches the adaptive controller
+    with kind="rate_limit" and the parsed retry_after — not just that the
+    counter increments. This is the integration the fix was designed to
+    preserve when moving the report from the predicate to before_sleep.
+    """
+    from inspect_ai.util._concurrency import (
+        AdaptiveConcurrency,
+        AdaptiveConcurrencyController,
+        _active_controller,
+        _request_had_retry,
+        init_concurrency,
+    )
+
+    init_concurrency()
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=15.0)
+    controller = AdaptiveConcurrencyController("t-int", cfg, visible=True)
+
+    # Sequence: 429 with Retry-After: 10 → 200. before_sleep should fire
+    # between the two attempts and report rate_limit.
+    responses = [
+        httpx.Response(429, headers={"Retry-After": "10"}),
+        httpx.Response(200, json={"ok": True}),
+    ]
+    client = _client_with_responses(responses)
+
+    token_c = _active_controller.set(controller)
+    token_r = _request_had_retry.set(False)
+    try:
+        with _reset_retry_counter():
+            await chat_api_request(
+                client,
+                model_name="test-model",
+                url="https://example.invalid/v1/chat",
+                headers={},
+                json={"input": "hello"},
+            )
+        # Controller scaled down on rate_limit signal: 40 * 0.8 = 32, floor → 30
+        assert controller.concurrency == 30
+        assert controller.history[-1][4] == "rate_limit"
+        # Retry-After: 10 is below configured cooldown floor (15); cooldown
+        # uses the floor. (Confirms retry_after was passed through — if it
+        # had been larger, cooldown would extend; we check via the longer
+        # retry-after below.)
+        assert _request_had_retry.get() is True
+    finally:
+        _active_controller.reset(token_c)
+        _request_had_retry.reset(token_r)
+    await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_chatapi_retry_after_extends_cooldown() -> None:
+    """A long Retry-After from the response header propagates to controller cooldown."""
+    import time
+
+    from inspect_ai.util._concurrency import (
+        AdaptiveConcurrency,
+        AdaptiveConcurrencyController,
+        _active_controller,
+        _request_had_retry,
+        init_concurrency,
+    )
+
+    init_concurrency()
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=5.0)
+    controller = AdaptiveConcurrencyController("t-rtafter", cfg, visible=True)
+
+    # Retry-After: 60 is well above the 5s cooldown floor
+    responses = [
+        httpx.Response(429, headers={"Retry-After": "60"}),
+        httpx.Response(200, json={"ok": True}),
+    ]
+    client = _client_with_responses(responses)
+
+    token_c = _active_controller.set(controller)
+    token_r = _request_had_retry.set(False)
+    try:
+        before = time.monotonic()
+        with _reset_retry_counter():
+            await chat_api_request(
+                client,
+                model_name="test-model",
+                url="https://example.invalid/v1/chat",
+                headers={},
+                json={"input": "hello"},
+            )
+        # cooldown extended to honor the 60s server hint (allow scheduling slack)
+        assert controller._cooldown_until >= before + 50
+    finally:
+        _active_controller.reset(token_c)
+        _request_had_retry.reset(token_r)
+    await client.aclose()

--- a/tests/model/test_generate_config.py
+++ b/tests/model/test_generate_config.py
@@ -29,9 +29,15 @@ def test_generate_config_merge_copies_nested_override_values() -> None:
 
 def test_adaptive_connections_defaults() -> None:
     a = AdaptiveConcurrency()
-    assert a.min == 1
-    assert a.max == 200
+    # tightened from the original 1/200/20 in 2026 to bound at realistic
+    # (non-enterprise) tier sizes by default
+    assert a.min == 4
+    assert a.max == 100
     assert a.start == 20
+    # advanced tuning fields default to documented values
+    assert a.cooldown_seconds == 15.0
+    assert a.decrease_factor == 0.8
+    assert a.scale_up_percent == 0.05
 
 
 def test_adaptive_connections_struct() -> None:
@@ -124,6 +130,25 @@ def test_generate_config_round_trip_adaptive_connections() -> None:
     assert restored.adaptive_connections.min == 4
     assert restored.adaptive_connections.max == 80
     assert restored.adaptive_connections.start == 20
+
+
+def test_generate_config_round_trip_adaptive_advanced_fields() -> None:
+    cfg = GenerateConfig(
+        adaptive_connections=AdaptiveConcurrency(
+            min=2,
+            max=50,
+            start=10,
+            cooldown_seconds=30.0,
+            decrease_factor=0.5,
+            scale_up_percent=0.1,
+        )
+    )
+    restored = GenerateConfig.model_validate(cfg.model_dump())
+    a = restored.adaptive_connections
+    assert isinstance(a, AdaptiveConcurrency)
+    assert a.cooldown_seconds == 30.0
+    assert a.decrease_factor == 0.5
+    assert a.scale_up_percent == 0.1
 
 
 def test_generate_config_old_log_no_adaptive_connections_field() -> None:

--- a/tests/model/test_generate_config.py
+++ b/tests/model/test_generate_config.py
@@ -1,4 +1,7 @@
+import pytest
+
 from inspect_ai.model import GenerateConfig
+from inspect_ai.util import AdaptiveConcurrency
 
 
 def test_generate_config_merge_copies_nested_override_values() -> None:
@@ -19,3 +22,120 @@ def test_generate_config_merge_copies_nested_override_values() -> None:
 
     assert override.extra_body == {"background": True}
     assert override.extra_headers == {"x-test-header": "value"}
+
+
+# AdaptiveConcurrency tests
+
+
+def test_adaptive_connections_defaults() -> None:
+    a = AdaptiveConcurrency()
+    assert a.min == 1
+    assert a.max == 200
+    assert a.start == 20
+
+
+def test_adaptive_connections_struct() -> None:
+    a = AdaptiveConcurrency(min=4, max=80, start=20)
+    assert (a.min, a.max, a.start) == (4, 80, 20)
+
+
+def test_adaptive_connections_shorthand_two_values() -> None:
+    a = AdaptiveConcurrency.model_validate("4-80")
+    assert (a.min, a.max, a.start) == (4, 80, 20)
+
+
+def test_adaptive_connections_shorthand_clamps_implicit_start_to_max() -> None:
+    # max < default start (20) → start clamped down to max
+    a = AdaptiveConcurrency.model_validate("1-15")
+    assert (a.min, a.max, a.start) == (1, 15, 15)
+
+
+def test_adaptive_connections_shorthand_clamps_implicit_start_to_min() -> None:
+    # min > default start → start clamped up to min
+    a = AdaptiveConcurrency.model_validate("30-100")
+    assert (a.min, a.max, a.start) == (30, 100, 30)
+
+
+def test_adaptive_connections_struct_clamps_implicit_start() -> None:
+    # struct form with no explicit start: same clamping behavior as shorthand
+    a = AdaptiveConcurrency(min=1, max=15)
+    assert (a.min, a.max, a.start) == (1, 15, 15)
+    a = AdaptiveConcurrency(min=30, max=100)
+    assert (a.min, a.max, a.start) == (30, 100, 30)
+
+
+def test_adaptive_connections_explicit_start_preserved_through_clamping() -> None:
+    # explicit start is never clamped (and out-of-bounds still errors)
+    a = AdaptiveConcurrency.model_validate("1-10-15")
+    assert (a.min, a.max, a.start) == (1, 15, 10)
+    a = AdaptiveConcurrency(min=1, max=15, start=5)
+    assert (a.min, a.max, a.start) == (1, 15, 5)
+    with pytest.raises(ValueError):
+        AdaptiveConcurrency(min=1, max=15, start=30)
+
+
+def test_adaptive_connections_shorthand_three_values() -> None:
+    a = AdaptiveConcurrency.model_validate("4-20-80")
+    assert (a.min, a.max, a.start) == (4, 80, 20)
+
+
+def test_adaptive_connections_shorthand_invalid() -> None:
+    with pytest.raises(ValueError):
+        AdaptiveConcurrency.model_validate("not-a-number")
+    with pytest.raises(ValueError):
+        AdaptiveConcurrency.model_validate("1-2-3-4")
+
+
+def test_adaptive_connections_bounds_validation() -> None:
+    # min < 1
+    with pytest.raises(ValueError):
+        AdaptiveConcurrency(min=0, max=80)
+    # max < min
+    with pytest.raises(ValueError):
+        AdaptiveConcurrency(min=10, max=5)
+    # start out of bounds
+    with pytest.raises(ValueError):
+        AdaptiveConcurrency(min=4, max=80, start=2)
+    with pytest.raises(ValueError):
+        AdaptiveConcurrency(min=4, max=80, start=100)
+
+
+def test_generate_config_accepts_bool_for_adaptive_connections() -> None:
+    cfg = GenerateConfig(adaptive_connections=True)
+    assert cfg.adaptive_connections is True
+
+    cfg = GenerateConfig(adaptive_connections=False)
+    assert cfg.adaptive_connections is False
+
+
+def test_generate_config_accepts_struct_for_adaptive_connections() -> None:
+    cfg = GenerateConfig(adaptive_connections=AdaptiveConcurrency(min=4, max=80))
+    assert isinstance(cfg.adaptive_connections, AdaptiveConcurrency)
+    assert cfg.adaptive_connections.min == 4
+
+
+def test_generate_config_round_trip_adaptive_connections() -> None:
+    cfg = GenerateConfig(
+        adaptive_connections=AdaptiveConcurrency(min=4, max=80, start=20)
+    )
+    data = cfg.model_dump()
+    restored = GenerateConfig.model_validate(data)
+    assert isinstance(restored.adaptive_connections, AdaptiveConcurrency)
+    assert restored.adaptive_connections.min == 4
+    assert restored.adaptive_connections.max == 80
+    assert restored.adaptive_connections.start == 20
+
+
+def test_generate_config_old_log_no_adaptive_connections_field() -> None:
+    # simulate old log: dict without the new field
+    cfg = GenerateConfig.model_validate({"max_connections": 20})
+    assert cfg.adaptive_connections is None
+    assert cfg.max_connections == 20
+
+
+def test_generate_config_merge_picks_up_adaptive_connections() -> None:
+    base = GenerateConfig(max_connections=10)
+    override = GenerateConfig(adaptive_connections=AdaptiveConcurrency(min=4, max=80))
+    merged = base.merge(override)
+    assert isinstance(merged.adaptive_connections, AdaptiveConcurrency)
+    assert merged.max_connections == 10  # untouched

--- a/tests/model/test_generate_config.py
+++ b/tests/model/test_generate_config.py
@@ -29,11 +29,9 @@ def test_generate_config_merge_copies_nested_override_values() -> None:
 
 def test_adaptive_connections_defaults() -> None:
     a = AdaptiveConcurrency()
-    # tightened from the original 1/200/20 in 2026 to bound at realistic
-    # (non-enterprise) tier sizes by default
     assert a.min == 4
-    assert a.max == 100
     assert a.start == 20
+    assert a.max == 200
     # advanced tuning fields default to documented values
     assert a.cooldown_seconds == 15.0
     assert a.decrease_factor == 0.8

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -1,0 +1,578 @@
+"""Tests verifying each provider's should_retry classifies real SDK exceptions correctly.
+
+These tests construct the actual exception types each provider's SDK raises and
+assert that should_retry returns the correct RetryDecision (kind + retry_after).
+This is the evidence that our classification works against real-world exception
+shapes, not just our naive default that assumes `.status_code` is universal.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from inspect_ai.model import RetryDecision
+
+
+def _http_response(
+    status: int, headers: dict[str, str] | None = None
+) -> httpx.Response:
+    """Build a stand-in httpx.Response for SDK exception constructors."""
+    request = httpx.Request("POST", "https://example.com/v1/chat/completions")
+    return httpx.Response(
+        status_code=status,
+        headers=headers or {},
+        request=request,
+    )
+
+
+# ---------- Default ModelAPI base ----------
+
+
+def test_base_should_retry_returns_false() -> None:
+    from inspect_ai.model._model import ModelAPI
+
+    class _DummyAPI(ModelAPI):
+        async def generate(self, *args, **kwargs):
+            raise NotImplementedError
+
+    api = _DummyAPI(
+        model_name="x",
+        base_url=None,
+        api_key=None,
+        api_key_vars=[],
+    )
+    assert api.should_retry(RuntimeError("any")) is False
+
+
+# ---------- OpenAI shared classifier (covers openai, openai_compatible, openrouter) ----------
+
+
+def test_openai_classify_rate_limit_429() -> None:
+    from openai import APIStatusError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    response = _http_response(429, {"retry-after": "30"})
+    ex = APIStatusError(message="rate limited", response=response, body=None)
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.retry is True
+    assert decision.kind == "rate_limit"
+    assert decision.retry_after == 30.0
+
+
+def test_openai_classify_transient_5xx() -> None:
+    from openai import APIStatusError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    ex = APIStatusError(
+        message="internal error",
+        response=_http_response(503),
+        body=None,
+    )
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.kind == "transient"
+    assert decision.retry_after is None
+
+
+def test_openai_classify_non_retryable_4xx_returns_none() -> None:
+    from openai import APIStatusError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    ex = APIStatusError(
+        message="bad request",
+        response=_http_response(400),
+        body=None,
+    )
+    assert openai_classify_retry(ex) is None
+
+
+def test_openai_classify_rate_limit_error_subclass() -> None:
+    from openai import RateLimitError
+
+    from inspect_ai.model._openai import openai_classify_retry
+
+    response = _http_response(429, {"retry-after": "5"})
+    ex = RateLimitError(message="too many", response=response, body=None)
+    decision = openai_classify_retry(ex)
+    assert decision is not None
+    assert decision.kind == "rate_limit"
+    assert decision.retry_after == 5.0
+
+
+def test_openai_provider_quota_exceeded_does_not_retry() -> None:
+    """OpenAI's monthly-quota error (RateLimitError with specific message) shouldn't retry."""
+    from openai import RateLimitError
+
+    from inspect_ai.model._providers.openai import OpenAIAPI
+
+    api = OpenAIAPI.__new__(OpenAIAPI)  # avoid full init
+    ex = RateLimitError(
+        message="You exceeded your current quota, please check your plan.",
+        response=_http_response(429),
+        body=None,
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is False
+
+
+def test_openai_provider_429_classifies_as_rate_limit() -> None:
+    from openai import RateLimitError
+
+    from inspect_ai.model._providers.openai import OpenAIAPI
+
+    api = OpenAIAPI.__new__(OpenAIAPI)
+    ex = RateLimitError(
+        message="rate limited",
+        response=_http_response(429, {"retry-after": "10"}),
+        body=None,
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "rate_limit"
+    assert decision.retry_after == 10.0
+
+
+def test_openrouter_json_decode_classifies_as_transient() -> None:
+    """OpenRouter occasionally returns malformed JSON — classify as transient."""
+    import json
+
+    from inspect_ai.model._providers.openrouter import OpenRouterAPI
+
+    api = OpenRouterAPI.__new__(OpenRouterAPI)
+    ex = json.JSONDecodeError("bad json", "doc", 0)
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+
+# ---------- Anthropic ----------
+
+
+def test_anthropic_429_classifies_as_rate_limit() -> None:
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message="rate limited",
+        response=_http_response(429, {"retry-after": "20"}),
+        body=None,
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+    assert decision.retry_after == 20.0
+
+
+def test_anthropic_503_classifies_as_transient() -> None:
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message="overloaded",
+        response=_http_response(503),
+        body=None,
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+def test_anthropic_streaming_overloaded_body_classifies_as_transient() -> None:
+    """Anthropic streaming sets a non-rate-limit status with overloaded body — should be transient."""
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._providers.anthropic import AnthropicAPI
+
+    api = AnthropicAPI.__new__(AnthropicAPI)
+    ex = APIStatusError(
+        message="overloaded",
+        response=_http_response(200),
+        body={"error": {"message": "overloaded"}},
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is True
+    assert decision.kind == "transient"
+
+
+# ---------- Groq ----------
+
+
+def test_groq_429_classifies_as_rate_limit() -> None:
+    from groq import APIStatusError
+
+    from inspect_ai.model._providers.groq import GroqAPI
+
+    api = GroqAPI.__new__(GroqAPI)
+    ex = APIStatusError(
+        message="rate limited",
+        response=_http_response(429, {"retry-after": "1m30s"}),
+        body=None,
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+    assert decision.retry_after == 90.0
+
+
+def test_groq_500_classifies_as_transient() -> None:
+    from groq import APIStatusError
+
+    from inspect_ai.model._providers.groq import GroqAPI
+
+    api = GroqAPI.__new__(GroqAPI)
+    ex = APIStatusError(message="srv err", response=_http_response(500), body=None)
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+# ---------- Mistral ----------
+
+
+def test_mistral_429_classifies_as_rate_limit() -> None:
+    pytest.importorskip("mistralai")
+    from mistralai.client.errors import SDKError
+
+    from inspect_ai.model._providers.mistral import MistralAPI
+
+    api = MistralAPI.__new__(MistralAPI)
+    ex = SDKError.__new__(SDKError)
+    ex.status_code = 429
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+def test_mistral_500_classifies_as_transient() -> None:
+    pytest.importorskip("mistralai")
+    from mistralai.client.errors import SDKError
+
+    from inspect_ai.model._providers.mistral import MistralAPI
+
+    api = MistralAPI.__new__(MistralAPI)
+    ex = SDKError.__new__(SDKError)
+    ex.status_code = 500
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+# ---------- Azure OpenAI ----------
+
+
+def test_azure_429_classifies_as_rate_limit() -> None:
+    pytest.importorskip("azure.core")
+    from azure.core.exceptions import HttpResponseError
+
+    from inspect_ai.model._providers.azureai import AzureAIAPI
+
+    api = AzureAIAPI.__new__(AzureAIAPI)
+    ex = HttpResponseError.__new__(HttpResponseError)
+    ex.status_code = 429
+    ex.response = None  # no headers available — retry_after is None
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+def test_azure_503_classifies_as_transient() -> None:
+    pytest.importorskip("azure.core")
+    from azure.core.exceptions import HttpResponseError
+
+    from inspect_ai.model._providers.azureai import AzureAIAPI
+
+    api = AzureAIAPI.__new__(AzureAIAPI)
+    ex = HttpResponseError.__new__(HttpResponseError)
+    ex.status_code = 503
+    ex.response = None
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+# ---------- Bedrock ----------
+
+
+def test_bedrock_throttling_classifies_as_rate_limit() -> None:
+    from botocore.exceptions import ClientError
+
+    from inspect_ai.model._providers.bedrock import BedrockAPI
+
+    api = BedrockAPI.__new__(BedrockAPI)
+    ex = ClientError(
+        error_response={"Error": {"Code": "ThrottlingException", "Message": "x"}},
+        operation_name="Converse",
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+def test_bedrock_internal_failure_classifies_as_transient() -> None:
+    from botocore.exceptions import ClientError
+
+    from inspect_ai.model._providers.bedrock import BedrockAPI
+
+    api = BedrockAPI.__new__(BedrockAPI)
+    ex = ClientError(
+        error_response={"Error": {"Code": "ServiceUnavailable", "Message": "x"}},
+        operation_name="Converse",
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+def test_bedrock_unknown_code_does_not_retry() -> None:
+    from botocore.exceptions import ClientError
+
+    from inspect_ai.model._providers.bedrock import BedrockAPI
+
+    api = BedrockAPI.__new__(BedrockAPI)
+    ex = ClientError(
+        error_response={"Error": {"Code": "ValidationException", "Message": "x"}},
+        operation_name="Converse",
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is False
+
+
+# ---------- Google ----------
+
+
+def test_google_429_resource_exhausted_classifies_as_rate_limit() -> None:
+    from google.genai.errors import APIError
+
+    from inspect_ai.model._providers.google import GoogleGenAIAPI
+
+    api = GoogleGenAIAPI.__new__(GoogleGenAIAPI)
+    ex = APIError.__new__(APIError)
+    ex.code = 429
+    ex.status = "RESOURCE_EXHAUSTED"
+    ex.message = ""
+    ex.details = None
+    ex.response = None
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+def test_google_503_resource_exhausted_classifies_as_rate_limit() -> None:
+    from google.genai.errors import APIError
+
+    from inspect_ai.model._providers.google import GoogleGenAIAPI
+
+    api = GoogleGenAIAPI.__new__(GoogleGenAIAPI)
+    ex = APIError.__new__(APIError)
+    ex.code = 503
+    ex.status = "RESOURCE_EXHAUSTED"
+    ex.message = ""
+    ex.details = None
+    ex.response = None
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+def test_google_429_without_status_text_still_classifies_as_rate_limit() -> None:
+    """Plain HTTP 429 from Google is unconditionally a rate-limit signal.
+
+    The RESOURCE_EXHAUSTED guard is only needed to disambiguate 503.
+    """
+    from google.genai.errors import APIError
+
+    from inspect_ai.model._providers.google import GoogleGenAIAPI
+
+    api = GoogleGenAIAPI.__new__(GoogleGenAIAPI)
+    ex = APIError.__new__(APIError)
+    ex.code = 429
+    ex.status = None  # SDK didn't populate status — still rate_limit
+    ex.message = ""
+    ex.details = None
+    ex.response = None
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+    # And with arbitrary status text — still rate_limit
+    ex2 = APIError.__new__(APIError)
+    ex2.code = 429
+    ex2.status = "QUOTA_EXCEEDED"  # not "RESOURCE_EXHAUSTED"
+    ex2.message = ""
+    ex2.details = None
+    ex2.response = None
+    decision = api.should_retry(ex2)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+def test_google_503_unavailable_classifies_as_transient() -> None:
+    from google.genai.errors import APIError
+
+    from inspect_ai.model._providers.google import GoogleGenAIAPI
+
+    api = GoogleGenAIAPI.__new__(GoogleGenAIAPI)
+    ex = APIError.__new__(APIError)
+    ex.code = 503
+    ex.status = "UNAVAILABLE"
+    ex.message = ""
+    ex.details = None
+    ex.response = None
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+# ---------- Grok (gRPC) ----------
+
+
+def test_grok_resource_exhausted_classifies_as_rate_limit() -> None:
+    pytest.importorskip("grpc")
+    import grpc
+
+    from inspect_ai.model._providers.grok import GrokAPI
+
+    api = GrokAPI.__new__(GrokAPI)
+
+    class _RpcError(grpc.RpcError):
+        def __init__(self, code: grpc.StatusCode):
+            self._code = code
+
+        def code(self):
+            return self._code
+
+    decision = api.should_retry(_RpcError(grpc.StatusCode.RESOURCE_EXHAUSTED))
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+
+
+def test_grok_unavailable_classifies_as_transient() -> None:
+    pytest.importorskip("grpc")
+    import grpc
+
+    from inspect_ai.model._providers.grok import GrokAPI
+
+    api = GrokAPI.__new__(GrokAPI)
+
+    class _RpcError(grpc.RpcError):
+        def __init__(self, code: grpc.StatusCode):
+            self._code = code
+
+        def code(self):
+            return self._code
+
+    decision = api.should_retry(_RpcError(grpc.StatusCode.UNAVAILABLE))
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+# ---------- Sagemaker ----------
+
+
+def test_sagemaker_503_classifies_as_transient() -> None:
+    from botocore.exceptions import ClientError
+
+    from inspect_ai.model._providers.sagemaker import SagemakerAPI
+
+    api = SagemakerAPI.__new__(SagemakerAPI)
+    ex = ClientError(
+        error_response={
+            "Error": {"Code": "ModelError", "Message": "x"},
+            "OriginalStatusCode": 503,  # type: ignore[typeddict-unknown-key]
+        },
+        operation_name="InvokeEndpoint",
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+def test_sagemaker_other_error_does_not_retry() -> None:
+    from botocore.exceptions import ClientError
+
+    from inspect_ai.model._providers.sagemaker import SagemakerAPI
+
+    api = SagemakerAPI.__new__(SagemakerAPI)
+    ex = ClientError(
+        error_response={
+            "Error": {"Code": "ValidationException", "Message": "x"},
+            "OriginalStatusCode": 400,  # type: ignore[typeddict-unknown-key]
+        },
+        operation_name="InvokeEndpoint",
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry is False
+
+
+# ---------- Together (RetryError unwrapping) ----------
+
+
+def test_together_rest_unwraps_retry_error_and_classifies_429() -> None:
+    """TogetherRESTAPI uses the chatapi shared helper which wraps causes in tenacity.RetryError."""
+    from tenacity import RetryError
+
+    from inspect_ai.model._providers.together import TogetherRESTAPI
+
+    api = TogetherRESTAPI.__new__(TogetherRESTAPI)
+    cause = httpx.HTTPStatusError(
+        "rate limited",
+        request=httpx.Request("POST", "https://api.together.ai/v1/chat"),
+        response=_http_response(429, {"retry-after": "30"}),
+    )
+    wrapped = RetryError(last_attempt=None)  # type: ignore[arg-type]
+    wrapped.__cause__ = cause
+    decision = api.should_retry(wrapped)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+    assert decision.retry_after == 30.0
+
+
+def test_together_rest_unwraps_retry_error_and_classifies_5xx() -> None:
+    from tenacity import RetryError
+
+    from inspect_ai.model._providers.together import TogetherRESTAPI
+
+    api = TogetherRESTAPI.__new__(TogetherRESTAPI)
+    cause = httpx.HTTPStatusError(
+        "srv err",
+        request=httpx.Request("POST", "https://api.together.ai/v1/chat"),
+        response=_http_response(500),
+    )
+    wrapped = RetryError(last_attempt=None)  # type: ignore[arg-type]
+    wrapped.__cause__ = cause
+    decision = api.should_retry(wrapped)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "transient"
+
+
+def test_together_openai_compatible_429_classifies_as_rate_limit() -> None:
+    """TogetherAIAPI inherits OpenAI-compatible classification (no RetryError unwrap)."""
+    from openai import APIStatusError
+
+    from inspect_ai.model._providers.together import TogetherAIAPI
+
+    api = TogetherAIAPI.__new__(TogetherAIAPI)
+    ex = APIStatusError(
+        message="rate limited",
+        response=_http_response(429, {"retry-after": "15"}),
+        body=None,
+    )
+    decision = api.should_retry(ex)
+    assert isinstance(decision, RetryDecision)
+    assert decision.kind == "rate_limit"
+    assert decision.retry_after == 15.0

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -21,6 +21,27 @@ from inspect_ai.util._concurrency import (
 )
 
 
+def _saturated_successes(
+    c: AdaptiveConcurrencyController, n: int | None = None
+) -> None:
+    """Run n successful completions with the current limit fully saturated.
+
+    notify_success samples the limiter's `borrowed_tokens` (in-flight count)
+    to track per-round saturation; tests that don't actually acquire slots
+    would otherwise see zero saturation and never trigger scale-up. This
+    helper pre-sets the high-water mark before each call so growth-testing
+    code paths run as if the limit was binding. Defaults to one full round
+    (`max(concurrency, ROUND_SIZE_FLOOR)` successes).
+    """
+    n = n if n is not None else max(c.concurrency, c.ROUND_SIZE_FLOOR)
+    for _ in range(n):
+        # set the high-water mark each iteration: notify_success resets it
+        # to 0 at end-of-round, so a later round in the same test needs the
+        # mark re-established.
+        c._max_borrowed_this_round = c.concurrency
+        c.notify_success()
+
+
 def test_ceil_to_nice() -> None:
     # below 10: just the value
     assert _ceil_to_nice(1) == 1
@@ -59,17 +80,14 @@ def test_slow_start_doubles_until_first_retry() -> None:
     c = AdaptiveConcurrencyController(
         "t", AdaptiveConcurrency(min=1, max=200, start=10), visible=True
     )
-    # round_size starts at max(10, 4) = 10. Need 10 successes for first scale-up.
-    for _ in range(10):
-        c.notify_success()
+    # round_size starts at max(10, 4) = 10. Need 10 saturated successes.
+    _saturated_successes(c, 10)
     assert c.concurrency == 20
     # next round: 20 successes
-    for _ in range(20):
-        c.notify_success()
+    _saturated_successes(c, 20)
     assert c.concurrency == 40
     # one more: 40 successes
-    for _ in range(40):
-        c.notify_success()
+    _saturated_successes(c, 40)
     assert c.concurrency == 80
     # entries should all be slow_start
     assert all(entry[4] == "slow_start" for entry in c.history)
@@ -92,8 +110,7 @@ def test_aimd_after_first_retry() -> None:
     c._cooldown_until = time.monotonic() - 1
 
     # successful round: round_size = max(30, 4) = 30. +max(1, 30*0.05) = +2 → ceil_to_nice(32) = 35
-    for _ in range(30):
-        c.notify_success()
+    _saturated_successes(c, 30)
     assert c.concurrency == 35
     assert c.history[-1][4] == "steady_state_up"
 
@@ -125,10 +142,9 @@ def test_no_success_accounting_during_cooldown() -> None:
     assert c.concurrency == 80  # debounced
     assert c._success_count == 0
 
-    # advance past cooldown — fresh successes should now count
+    # advance past cooldown — fresh saturated successes should now count
     c._cooldown_until = time.monotonic() - 1
-    for _ in range(80):
-        c.notify_success()
+    _saturated_successes(c, 80)
     # 80 successes = round_size; +max(1, 80*0.05) = +4 → ceil_to_nice(84) = 85
     assert c.concurrency == 85
 
@@ -154,8 +170,7 @@ def test_bounds_clamping() -> None:
     c = AdaptiveConcurrencyController(
         "t", AdaptiveConcurrency(min=1, max=15, start=10), visible=True
     )
-    for _ in range(10):
-        c.notify_success()
+    _saturated_successes(c, 10)
     # would double to 20, capped at 15
     assert c.concurrency == 15
 
@@ -173,8 +188,7 @@ def test_steady_state_up_does_not_exceed_max() -> None:
         "t", AdaptiveConcurrency(min=1, max=20, start=20), visible=True
     )
     c._first_retry_seen = True
-    for _ in range(20):
-        c.notify_success()
+    _saturated_successes(c, 20)
     assert c.concurrency == 20  # would be 25 with ceil_to_nice, capped at 20
 
 
@@ -183,11 +197,9 @@ def test_round_size_floor_at_low_limits() -> None:
         "t", AdaptiveConcurrency(min=1, max=200, start=2), visible=True
     )
     # round_size = max(2, 4) = 4 (not 2)
-    c.notify_success()
-    c.notify_success()
+    _saturated_successes(c, 2)
     assert c.concurrency == 2  # still at start
-    c.notify_success()
-    c.notify_success()
+    _saturated_successes(c, 2)
     assert c.concurrency == 4  # 2*2=4
 
 
@@ -198,6 +210,77 @@ def test_history_bounded() -> None:
     for _ in range(c.HISTORY_LIMIT + 50):
         c._set_limit(c.concurrency + 1, "test")
     assert len(c.history) == c.HISTORY_LIMIT
+
+
+# ---------- saturation gate ----------
+
+
+def test_growth_blocked_when_saturation_below_threshold() -> None:
+    """A round of clean successes that didn't exercise the limit shouldn't grow it.
+
+    Without the saturation gate the controller would treat any round-sized
+    batch of successes as proof the limit is binding, even when peak
+    in-flight was well below it (e.g. the 250-of-500 case where work just
+    isn't there to fill the cap). Growing in that case gives untested
+    headroom that may exceed the provider's actual rate limit later.
+    """
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=10), visible=True
+    )
+    # 50% saturation (peak 5 of limit 10) — below 0.8 threshold
+    c._max_borrowed_this_round = 5
+    for _ in range(10):
+        c.notify_success()
+    assert c.concurrency == 10  # no growth
+    assert c.history == []
+    # high-water mark resets at end of round so the next round must re-prove
+    assert c._max_borrowed_this_round == 0
+
+
+def test_growth_unblocked_at_saturation_threshold() -> None:
+    """Saturation exactly at the threshold should still permit scale-up."""
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=10), visible=True
+    )
+    # 80% saturation (peak 8 of limit 10) — exactly the threshold
+    c._max_borrowed_this_round = 8
+    for _ in range(10):
+        c.notify_success()
+    assert c.concurrency == 20  # scaled up
+    assert c.history[-1][4] == "slow_start"
+
+
+def test_small_workload_stays_at_start() -> None:
+    """A workload too small to fill `start` doesn't trigger slow-start.
+
+    With start=20 and a workload that only ever has a handful of in-flight
+    requests, the controller should stay at 20 forever — no point growing
+    the cap when we aren't using what we have.
+    """
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=20), visible=True
+    )
+    # Many rounds of "successes" but peak in-flight is only 3 (15% saturation)
+    for _ in range(5):
+        c._max_borrowed_this_round = 3
+        for _ in range(20):
+            c.notify_success()
+    assert c.concurrency == 20  # never grew
+    assert c.history == []
+
+
+def test_saturation_gate_resets_on_rate_limit_cut() -> None:
+    """A rate-limit cut clears the high-water mark.
+
+    Peak in-flight observed before the cut is no longer relevant evidence
+    at the new (lower) limit — the next round must re-establish saturation.
+    """
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=40), visible=True
+    )
+    c._max_borrowed_this_round = 35
+    c.notify_retry()  # cut — should reset the mark
+    assert c._max_borrowed_this_round == 0
 
 
 def test_default_bounds() -> None:
@@ -240,8 +323,7 @@ def test_advanced_fields_override_controller_behavior() -> None:
     cfg2 = AdaptiveConcurrency(min=1, max=200, start=20, scale_up_percent=0.5)
     c2 = AdaptiveConcurrencyController("t", cfg2, visible=True)
     c2._first_retry_seen = True  # skip slow-start
-    for _ in range(20):
-        c2.notify_success()
+    _saturated_successes(c2, 20)
     # 20 + max(1, round(20 * 0.5)) = 30, ceil_to_nice(30) = 30
     assert c2.concurrency == 30
 
@@ -395,8 +477,7 @@ def test_observer_called_on_scale_change() -> None:
     events2: list[tuple[int, int]] = []
     c.add_observer(lambda old, new: events.append((old, new)))
     c.add_observer(lambda old, new: events2.append((old, new)))
-    for _ in range(10):
-        c.notify_success()
+    _saturated_successes(c, 10)
     assert events == [(10, 20)]
     assert events2 == [(10, 20)]
 
@@ -451,9 +532,8 @@ async def test_dynamic_sample_limiter_grows_with_controller() -> None:
         pass
     ctrls = adaptive_controllers()
     assert len(ctrls) == 1
-    # scale ctrl from 10 to 20 (one full slow-start round)
-    for _ in range(10):
-        ctrls[0].notify_success()
+    # scale ctrl from 10 to 20 (one full saturated slow-start round)
+    _saturated_successes(ctrls[0], 10)
     assert ctrls[0].concurrency == 20
     # limiter should track: 20 + 5 = 25
     assert lim.total_tokens == 25
@@ -545,13 +625,11 @@ async def test_dynamic_sample_limiter_caps_at_adaptive_max_plus_buffer() -> None
         pass
     ctrls = adaptive_controllers()
     # scale to ctrl.max (20) — limiter capped at 20 + 5 = 25
-    for _ in range(10):
-        ctrls[0].notify_success()
+    _saturated_successes(ctrls[0], 10)
     assert ctrls[0].concurrency == 20
     assert lim.total_tokens == 25
     # further successes don't grow ctrl past max, limiter stays at cap
-    for _ in range(20):
-        ctrls[0].notify_success()
+    _saturated_successes(ctrls[0], 20)
     assert lim.total_tokens == 25
 
 
@@ -565,8 +643,7 @@ async def test_dynamic_sample_limiter_catches_up_to_existing_controllers() -> No
         pass
     ctrls = adaptive_controllers()
     assert len(ctrls) == 1
-    for _ in range(10):
-        ctrls[0].notify_success()
+    _saturated_successes(ctrls[0], 10)
     assert ctrls[0].concurrency == 20  # scaled up via slow-start
 
     # now create a DynamicSampleLimiter — it should catch up to 20 + buffer
@@ -615,8 +692,7 @@ async def test_dynamic_sample_limiter_multi_controller() -> None:
     assert len(ctrls) == 2
     # scale m2 only
     target = next(c for c in ctrls if c.name == "m2")
-    for _ in range(10):
-        target.notify_success()
+    _saturated_successes(target, 10)
     assert target.concurrency == 20
     # limiter tracks max across controllers (= 20)
     assert lim.total_tokens == 25

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -201,11 +201,11 @@ def test_history_bounded() -> None:
 
 
 def test_default_bounds() -> None:
-    """Defaults are min=4, start=20, max=100 — tightened from the original 1/20/200."""
+    """Defaults are min=4, start=20, max=200."""
     cfg = AdaptiveConcurrency()
     assert cfg.min == 4
     assert cfg.start == 20
-    assert cfg.max == 100
+    assert cfg.max == 200
 
 
 def test_advanced_fields_default_to_documented_values() -> None:

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -2,6 +2,7 @@
 
 import time
 
+import anyio
 import pytest
 
 from inspect_ai.util._concurrency import (
@@ -472,6 +473,67 @@ async def test_dynamic_sample_limiter_shrinks_with_controller() -> None:
     # ctrl drops to floor_to_nice(40*0.8=32) = 30; limiter = 30 + 5 = 35
     assert ctrls[0].concurrency == 30
     assert lim.total_tokens == 35
+
+
+@pytest.mark.anyio
+async def test_dynamic_sample_limiter_recovers_after_shrinking_below_borrowed() -> None:
+    """Shrinking below borrowed tokens should block new samples, not deadlock."""
+    init_concurrency()
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=80, start=10))
+    cfg = AdaptiveConcurrency(min=1, max=80, start=10)
+    async with concurrency(name="m", concurrency=10, key="k", adaptive=cfg):
+        pass
+    ctrl = adaptive_controllers()[0]
+
+    initial_tokens = 10 + DynamicSampleLimiter.BUFFER
+    release_events = [anyio.Event() for _ in range(initial_tokens)]
+    all_holders_entered = anyio.Event()
+    extra_started = anyio.Event()
+    extra_entered = anyio.Event()
+    entered_holders = 0
+
+    async def holder(index: int) -> None:
+        nonlocal entered_holders
+        async with lim:
+            entered_holders += 1
+            if entered_holders == initial_tokens:
+                all_holders_entered.set()
+            await release_events[index].wait()
+
+    async def extra_holder() -> None:
+        extra_started.set()
+        async with lim:
+            extra_entered.set()
+
+    async with anyio.create_task_group() as tg:
+        try:
+            for i in range(initial_tokens):
+                tg.start_soon(holder, i)
+            with anyio.fail_after(1):
+                await all_holders_entered.wait()
+
+            ctrl.notify_retry()
+            assert ctrl.concurrency == 8
+            assert lim.total_tokens == 8 + DynamicSampleLimiter.BUFFER
+
+            tg.start_soon(extra_holder)
+            await extra_started.wait()
+            await anyio.sleep(0)
+            assert not extra_entered.is_set()
+
+            # Releasing only down to the new capacity should not admit another
+            # sample. CapacityLimiter wakes waiters only once borrowed < total.
+            release_events[0].set()
+            release_events[1].set()
+            await anyio.sleep(0)
+            assert not extra_entered.is_set()
+
+            release_events[2].set()
+            with anyio.fail_after(1):
+                await extra_entered.wait()
+        finally:
+            for event in release_events:
+                event.set()
 
 
 @pytest.mark.anyio

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -1,0 +1,404 @@
+"""Tests for AdaptiveConcurrencyController and _ceil_to_nice/_floor_to_nice."""
+
+import time
+
+import pytest
+
+from inspect_ai.util._concurrency import (
+    AdaptiveConcurrency,
+    AdaptiveConcurrencyController,
+    DynamicSampleLimiter,
+    _active_controller,
+    _ceil_to_nice,
+    _controller_created_observers,
+    _floor_to_nice,
+    _request_had_retry,
+    adaptive_controllers,
+    add_controller_created_observer,
+    concurrency,
+    init_concurrency,
+)
+
+
+def test_ceil_to_nice() -> None:
+    # below 10: just the value
+    assert _ceil_to_nice(1) == 1
+    assert _ceil_to_nice(9) == 9
+    # at 10: stays
+    assert _ceil_to_nice(10) == 10
+    # above 10: ceil to nearest 5
+    assert _ceil_to_nice(11) == 15
+    assert _ceil_to_nice(15) == 15
+    assert _ceil_to_nice(16) == 20
+    assert _ceil_to_nice(64) == 65
+    assert _ceil_to_nice(100) == 100
+    assert _ceil_to_nice(101) == 105
+
+
+def test_floor_to_nice() -> None:
+    assert _floor_to_nice(1) == 1
+    assert _floor_to_nice(9) == 9
+    assert _floor_to_nice(10) == 10
+    assert _floor_to_nice(14) == 10
+    assert _floor_to_nice(15) == 15
+    assert _floor_to_nice(64) == 60
+    assert _floor_to_nice(100) == 100
+
+
+def test_initial_state() -> None:
+    c = AdaptiveConcurrencyController(
+        "test", AdaptiveConcurrency(min=2, max=80, start=10), visible=True
+    )
+    assert c.concurrency == 10
+    assert c.value == 10  # nothing borrowed yet
+    assert c.history == []
+
+
+def test_slow_start_doubles_until_first_retry() -> None:
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=10), visible=True
+    )
+    # round_size starts at max(10, 4) = 10. Need 10 successes for first scale-up.
+    for _ in range(10):
+        c.notify_success()
+    assert c.concurrency == 20
+    # next round: 20 successes
+    for _ in range(20):
+        c.notify_success()
+    assert c.concurrency == 40
+    # one more: 40 successes
+    for _ in range(40):
+        c.notify_success()
+    assert c.concurrency == 80
+    # entries should all be slow_start
+    assert all(entry[4] == "slow_start" for entry in c.history)
+
+
+def test_aimd_after_first_retry() -> None:
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=40), visible=True
+    )
+    # trigger retry → drops to floor_to_nice(32) = 30
+    c.notify_retry()
+    assert c.concurrency == 30
+    assert c.history[-1][4] == "rate_limit"
+
+    # cooldown is 15s; immediate further retry is debounced (no-op)
+    c.notify_retry()
+    assert c.concurrency == 30  # unchanged
+
+    # advance past cooldown so notify_success can resume counting
+    c._cooldown_until = time.monotonic() - 1
+
+    # successful round: round_size = max(30, 4) = 30. +max(1, 30*0.05) = +2 → ceil_to_nice(32) = 35
+    for _ in range(30):
+        c.notify_success()
+    assert c.concurrency == 35
+    assert c.history[-1][4] == "steady_state_up"
+
+
+def test_no_success_accounting_during_cooldown() -> None:
+    """Successes arriving during the retry cooldown are dropped entirely.
+
+    Repro for the bug where a cut from N to N*0.8 could be reversed by N*0.8
+    in-flight clean completions arriving inside the cooldown window. After the
+    cut, those successes were almost certainly in flight from before the cut
+    so they tell us nothing — and counting them would let back-pressure
+    evaporate immediately.
+    """
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=100), visible=True
+    )
+    # cut: 100 → floor_to_nice(80) = 80; cooldown begins
+    c.notify_retry()
+    assert c.concurrency == 80
+
+    # 80 in-flight successes arrive during cooldown — none should accumulate
+    for _ in range(80):
+        c.notify_success()
+    assert c._success_count == 0
+    assert c.concurrency == 80  # NOT scaled up to 85
+
+    # debounced retries within cooldown also keep things stable
+    c.notify_retry()
+    assert c.concurrency == 80  # debounced
+    assert c._success_count == 0
+
+    # advance past cooldown — fresh successes should now count
+    c._cooldown_until = time.monotonic() - 1
+    for _ in range(80):
+        c.notify_success()
+    # 80 successes = round_size; +max(1, 80*0.05) = +4 → ceil_to_nice(84) = 85
+    assert c.concurrency == 85
+
+
+def test_retry_debounce_via_cooldown() -> None:
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=80), visible=True
+    )
+    c.notify_retry()
+    first = c.concurrency
+    # immediate retries are no-ops
+    for _ in range(5):
+        c.notify_retry()
+    assert c.concurrency == first
+    # simulate cooldown elapsed
+    c._cooldown_until = time.monotonic() - 1
+    c.notify_retry()
+    assert c.concurrency < first
+
+
+def test_bounds_clamping() -> None:
+    # max bound on slow-start
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=15, start=10), visible=True
+    )
+    for _ in range(10):
+        c.notify_success()
+    # would double to 20, capped at 15
+    assert c.concurrency == 15
+
+    # min bound on retry
+    c2 = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=8, max=200, start=10), visible=True
+    )
+    c2.notify_retry()
+    # 10 * 0.8 = 8 → floor_to_nice(8) = 8 (below 10), clamped to min=8
+    assert c2.concurrency == 8
+
+
+def test_steady_state_up_does_not_exceed_max() -> None:
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=20, start=20), visible=True
+    )
+    c._first_retry_seen = True
+    for _ in range(20):
+        c.notify_success()
+    assert c.concurrency == 20  # would be 25 with ceil_to_nice, capped at 20
+
+
+def test_round_size_floor_at_low_limits() -> None:
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=2), visible=True
+    )
+    # round_size = max(2, 4) = 4 (not 2)
+    c.notify_success()
+    c.notify_success()
+    assert c.concurrency == 2  # still at start
+    c.notify_success()
+    c.notify_success()
+    assert c.concurrency == 4  # 2*2=4
+
+
+def test_history_bounded() -> None:
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=1000, start=10), visible=True
+    )
+    for _ in range(c.HISTORY_LIMIT + 50):
+        c._set_limit(c.concurrency + 1, "test")
+    assert len(c.history) == c.HISTORY_LIMIT
+
+
+@pytest.mark.anyio
+async def test_concurrency_creates_adaptive_controller() -> None:
+    init_concurrency()
+    cfg = AdaptiveConcurrency(min=2, max=50, start=10)
+    async with concurrency(
+        name="model-x", concurrency=10, key="kx", adaptive=cfg
+    ) as sem:
+        assert isinstance(sem, AdaptiveConcurrencyController)
+        assert sem.concurrency == 10
+        assert sem.name == "model-x"
+    # registered for status display
+    assert any(c.name == "model-x" for c in adaptive_controllers())
+
+
+@pytest.mark.anyio
+async def test_contextvars_default_in_fresh_context() -> None:
+    # Run in a fresh contextvars Context to bypass test-order pollution
+    import contextvars
+
+    def check() -> tuple[object, bool]:
+        return _active_controller.get(), _request_had_retry.get()
+
+    ctx = contextvars.Context()
+    controller, had_retry = ctx.run(check)
+    assert controller is None
+    assert had_retry is False
+
+
+# ---------- Observer pattern + DynamicSampleLimiter ----------
+
+
+def test_observer_called_on_scale_change() -> None:
+    c = AdaptiveConcurrencyController(
+        "t", AdaptiveConcurrency(min=1, max=200, start=10), visible=True
+    )
+    events: list[tuple[int, int]] = []
+    events2: list[tuple[int, int]] = []
+    c.add_observer(lambda old, new: events.append((old, new)))
+    c.add_observer(lambda old, new: events2.append((old, new)))
+    for _ in range(10):
+        c.notify_success()
+    assert events == [(10, 20)]
+    assert events2 == [(10, 20)]
+
+
+@pytest.mark.anyio
+async def test_controller_created_observer_fires_on_registry_creation() -> None:
+    init_concurrency()
+    seen: list[AdaptiveConcurrencyController] = []
+    add_controller_created_observer(lambda ctrl: seen.append(ctrl))
+    cfg = AdaptiveConcurrency(min=2, max=50, start=10)
+    async with concurrency(name="model-y", concurrency=10, key="ky", adaptive=cfg):
+        pass
+    assert len(seen) == 1
+    assert seen[0].name == "model-y"
+
+
+def test_init_concurrency_clears_controller_created_observers() -> None:
+    init_concurrency()
+    add_controller_created_observer(lambda _ctrl: None)
+    add_controller_created_observer(lambda _ctrl: None)
+    assert len(_controller_created_observers) == 2
+    init_concurrency()
+    assert _controller_created_observers == []
+
+
+def test_dynamic_sample_limiter_initial_size() -> None:
+    init_concurrency()
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=80, start=10))
+    assert lim.total_tokens == 10 + DynamicSampleLimiter.BUFFER  # 15
+
+
+@pytest.mark.anyio
+async def test_dynamic_sample_limiter_picks_up_new_controller() -> None:
+    init_concurrency()
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=80, start=10))
+    # initially 15 (10 + 5)
+    assert lim.total_tokens == 15
+    # create a controller via the registry — limiter should be wired in immediately
+    cfg = AdaptiveConcurrency(min=1, max=80, start=10)
+    async with concurrency(name="m", concurrency=10, key="k", adaptive=cfg):
+        pass
+    # still 15 (controller starts at 10 → 10 + 5)
+    assert lim.total_tokens == 15
+
+
+@pytest.mark.anyio
+async def test_dynamic_sample_limiter_grows_with_controller() -> None:
+    init_concurrency()
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=80, start=10))
+    cfg = AdaptiveConcurrency(min=1, max=80, start=10)
+    async with concurrency(name="m", concurrency=10, key="k", adaptive=cfg):
+        pass
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+    # scale ctrl from 10 to 20 (one full slow-start round)
+    for _ in range(10):
+        ctrls[0].notify_success()
+    assert ctrls[0].concurrency == 20
+    # limiter should track: 20 + 5 = 25
+    assert lim.total_tokens == 25
+
+
+@pytest.mark.anyio
+async def test_dynamic_sample_limiter_shrinks_with_controller() -> None:
+    init_concurrency()
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=200, start=40))
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40)
+    async with concurrency(name="m", concurrency=40, key="k", adaptive=cfg):
+        pass
+    ctrls = adaptive_controllers()
+    # initial: ctrl=40, limiter = 40 + 5 = 45
+    assert lim.total_tokens == 45
+    ctrls[0].notify_retry()
+    # ctrl drops to floor_to_nice(40*0.8=32) = 30; limiter = 30 + 5 = 35
+    assert ctrls[0].concurrency == 30
+    assert lim.total_tokens == 35
+
+
+@pytest.mark.anyio
+async def test_dynamic_sample_limiter_caps_at_adaptive_max_plus_buffer() -> None:
+    init_concurrency()
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=20, start=10))
+    cfg = AdaptiveConcurrency(min=1, max=20, start=10)
+    async with concurrency(name="m", concurrency=10, key="k", adaptive=cfg):
+        pass
+    ctrls = adaptive_controllers()
+    # scale to ctrl.max (20) — limiter capped at 20 + 5 = 25
+    for _ in range(10):
+        ctrls[0].notify_success()
+    assert ctrls[0].concurrency == 20
+    assert lim.total_tokens == 25
+    # further successes don't grow ctrl past max, limiter stays at cap
+    for _ in range(20):
+        ctrls[0].notify_success()
+    assert lim.total_tokens == 25
+
+
+@pytest.mark.anyio
+async def test_dynamic_sample_limiter_catches_up_to_existing_controllers() -> None:
+    """A limiter created after a controller has already scaled picks up the current limit immediately, not the controller's start value."""
+    init_concurrency()
+    cfg = AdaptiveConcurrency(min=1, max=200, start=10)
+    # create a controller and scale it up (simulate prior activity)
+    async with concurrency(name="m", concurrency=10, key="k", adaptive=cfg):
+        pass
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 1
+    for _ in range(10):
+        ctrls[0].notify_success()
+    assert ctrls[0].concurrency == 20  # scaled up via slow-start
+
+    # now create a DynamicSampleLimiter — it should catch up to 20 + buffer
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=200, start=10))
+    assert lim.total_tokens == 20 + DynamicSampleLimiter.BUFFER  # 25, not 15
+
+
+@pytest.mark.anyio
+async def test_registry_separates_adaptive_and_static_storage() -> None:
+    """Static and adaptive calls for the same key get independent storage.
+
+    Otherwise: a static call followed by adaptive would return the existing
+    Semaphore (failing the caller's isinstance assert), and adaptive followed
+    by static would silently use the AdaptiveConcurrencyController, defeating
+    the 'explicit max_connections wins' precedence rule.
+    """
+    init_concurrency()
+
+    # Static call for key K — gets a plain Semaphore
+    async with concurrency(name="m", concurrency=10, key="K") as static_sem:
+        assert not isinstance(static_sem, AdaptiveConcurrencyController)
+
+    # Adaptive call for SAME key K — must get an AdaptiveConcurrencyController
+    cfg = AdaptiveConcurrency(min=1, max=80, start=10)
+    async with concurrency(
+        name="m", concurrency=10, key="K", adaptive=cfg
+    ) as adaptive_sem:
+        assert isinstance(adaptive_sem, AdaptiveConcurrencyController)
+
+    # Subsequent static call for K must still get a Semaphore (not the
+    # adaptive controller cached above)
+    async with concurrency(name="m", concurrency=10, key="K") as static_sem2:
+        assert not isinstance(static_sem2, AdaptiveConcurrencyController)
+
+
+@pytest.mark.anyio
+async def test_dynamic_sample_limiter_multi_controller() -> None:
+    init_concurrency()
+    lim = DynamicSampleLimiter(AdaptiveConcurrency(min=1, max=200, start=10))
+    cfg = AdaptiveConcurrency(min=1, max=200, start=10)
+    async with concurrency(name="m1", concurrency=10, key="k1", adaptive=cfg):
+        pass
+    async with concurrency(name="m2", concurrency=10, key="k2", adaptive=cfg):
+        pass
+    ctrls = adaptive_controllers()
+    assert len(ctrls) == 2
+    # scale m2 only
+    target = next(c for c in ctrls if c.name == "m2")
+    for _ in range(10):
+        target.notify_success()
+    assert target.concurrency == 20
+    # limiter tracks max across controllers (= 20)
+    assert lim.total_tokens == 25

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -199,6 +199,162 @@ def test_history_bounded() -> None:
     assert len(c.history) == c.HISTORY_LIMIT
 
 
+def test_default_bounds() -> None:
+    """Defaults are min=4, start=20, max=100 — tightened from the original 1/20/200."""
+    cfg = AdaptiveConcurrency()
+    assert cfg.min == 4
+    assert cfg.start == 20
+    assert cfg.max == 100
+
+
+def test_advanced_fields_default_to_documented_values() -> None:
+    cfg = AdaptiveConcurrency()
+    assert cfg.cooldown_seconds == 15.0
+    assert cfg.decrease_factor == 0.8
+    assert cfg.scale_up_percent == 0.05
+
+
+def test_advanced_fields_validate_ranges() -> None:
+    with pytest.raises(ValueError, match="cooldown_seconds"):
+        AdaptiveConcurrency(cooldown_seconds=-1)
+    with pytest.raises(ValueError, match="decrease_factor"):
+        AdaptiveConcurrency(decrease_factor=0)
+    with pytest.raises(ValueError, match="decrease_factor"):
+        AdaptiveConcurrency(decrease_factor=1)
+    with pytest.raises(ValueError, match="scale_up_percent"):
+        AdaptiveConcurrency(scale_up_percent=0)
+    with pytest.raises(ValueError, match="scale_up_percent"):
+        AdaptiveConcurrency(scale_up_percent=1.5)
+
+
+def test_advanced_fields_override_controller_behavior() -> None:
+    # custom decrease_factor of 0.5 cuts harder than default 0.8
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, decrease_factor=0.5)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    c.notify_retry()
+    # 40 * 0.5 = 20, floor_to_nice(20) = 20
+    assert c.concurrency == 20
+
+    # custom scale_up_percent of 0.5 grows faster than default 5%
+    cfg2 = AdaptiveConcurrency(min=1, max=200, start=20, scale_up_percent=0.5)
+    c2 = AdaptiveConcurrencyController("t", cfg2, visible=True)
+    c2._first_retry_seen = True  # skip slow-start
+    for _ in range(20):
+        c2.notify_success()
+    # 20 + max(1, round(20 * 0.5)) = 30, ceil_to_nice(30) = 30
+    assert c2.concurrency == 30
+
+
+def test_retry_after_extends_cooldown() -> None:
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=5.0)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    before = time.monotonic()
+    c.notify_retry(retry_after=60.0)
+    # cooldown should be at least 60 seconds out, even though default is 5
+    assert c._cooldown_until >= before + 60.0
+
+
+def test_longer_retry_after_during_cooldown_extends_horizon() -> None:
+    """A second 429 with a longer Retry-After should extend cooldown, not be discarded.
+
+    Regression: the early-return for cooldown previously dropped the new
+    retry_after entirely, so a 60s server hint inside an existing 15s
+    cooldown was ignored.
+    """
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=15.0)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    # First retry — establishes a 15s cooldown
+    c.notify_retry()
+    cooldown_after_first = c._cooldown_until
+    # Limit was cut once
+    assert c.concurrency < 40
+    cut_concurrency = c.concurrency
+
+    # Second retry inside the cooldown window with a longer server hint
+    c.notify_retry(retry_after=60.0)
+    # Limit must NOT have been cut again (debounce)
+    assert c.concurrency == cut_concurrency
+    # But cooldown must have been extended past the 15s floor
+    assert c._cooldown_until > cooldown_after_first
+    # And honor the 60s server hint
+    assert c._cooldown_until >= time.monotonic() + 50  # ~60s, allow scheduling slack
+
+
+def test_shorter_retry_after_during_cooldown_does_not_shrink_horizon() -> None:
+    """A subsequent shorter Retry-After must not pull the cooldown horizon back in."""
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=15.0)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    c.notify_retry(retry_after=60.0)  # establishes a 60s cooldown
+    long_horizon = c._cooldown_until
+    c.notify_retry(retry_after=5.0)  # shorter — must not pull horizon in
+    assert c._cooldown_until == long_horizon
+
+
+def test_retry_after_smaller_than_cooldown_uses_floor() -> None:
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=15.0)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    before = time.monotonic()
+    c.notify_retry(retry_after=2.0)
+    # cooldown should be the configured floor (15s), not the smaller server hint
+    assert c._cooldown_until >= before + 15.0
+    assert c._cooldown_until < before + 60.0
+
+
+def test_retry_after_none_falls_back_to_cooldown() -> None:
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=10.0)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    before = time.monotonic()
+    c.notify_retry(retry_after=None)
+    assert c._cooldown_until >= before + 10.0
+
+
+def test_report_http_retry_transient_does_not_scale_down() -> None:
+    """report_http_retry(kind='transient') marks request as retried but doesn't notify controller."""
+    from inspect_ai._util.retry import report_http_retry
+
+    init_concurrency()
+
+    # set up a controller as the active one (mimics what _connection_concurrency does)
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    token_c = _active_controller.set(c)
+    token_r = _request_had_retry.set(False)
+    try:
+        report_http_retry()  # default kind="transient"
+        # no scale-down occurred
+        assert c.concurrency == 40
+        assert c.history == []
+        # but the request IS marked as retried (so success-after-retry won't count)
+        assert _request_had_retry.get() is True
+    finally:
+        _active_controller.reset(token_c)
+        _request_had_retry.reset(token_r)
+
+
+def test_report_http_retry_rate_limit_scales_down() -> None:
+    from inspect_ai._util.retry import report_http_retry
+
+    init_concurrency()
+
+    cfg = AdaptiveConcurrency(min=1, max=200, start=40, cooldown_seconds=15.0)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+    token_c = _active_controller.set(c)
+    token_r = _request_had_retry.set(False)
+    try:
+        report_http_retry(kind="rate_limit", retry_after=30.0)
+        # 40 * 0.8 = 32, floor_to_nice(32) = 30
+        assert c.concurrency == 30
+        # history records it as a rate_limit cut
+        assert len(c.history) == 1
+        assert c.history[0][4] == "rate_limit"
+        # cooldown extended by retry_after (30s > default 15s)
+        before = time.monotonic()
+        assert c._cooldown_until >= before + 25.0  # ~30s minus a bit
+    finally:
+        _active_controller.reset(token_c)
+        _request_had_retry.reset(token_r)
+
+
 @pytest.mark.anyio
 async def test_concurrency_creates_adaptive_controller() -> None:
     init_concurrency()

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -757,3 +757,88 @@ async def test_dynamic_sample_limiter_multi_controller() -> None:
     assert target.concurrency == 20
     # limiter tracks max across controllers (= 20)
     assert lim.total_tokens == 25
+
+
+@pytest.mark.anyio
+async def test_max_borrowed_not_inflated_during_cooldown() -> None:
+    """Acquires during the post-cut cooldown must not raise the saturation mark.
+
+    notify_retry resets _max_borrowed_this_round to 0 on cut. Without the
+    cooldown gate in __aenter__, in-flight acquires that arrive during the
+    cooldown window would re-raise the mark — and the first post-cooldown
+    round would pass the 0.8 saturation threshold based on stale evidence
+    from before the cooldown ended.
+    """
+    cfg = AdaptiveConcurrency(min=1, max=200, start=10, cooldown_seconds=15.0)
+    c = AdaptiveConcurrencyController("t-cooldown", cfg, visible=True)
+    c.notify_retry()  # cut → 8, cooldown begins
+    assert c.concurrency == 8
+    assert c._max_borrowed_this_round == 0
+
+    # acquires during cooldown — mark must stay at 0
+    for _ in range(3):
+        async with c.semaphore:
+            pass
+    assert c._max_borrowed_this_round == 0
+
+    # advance past cooldown — fresh acquires should now update the mark
+    c._cooldown_until = time.monotonic() - 1
+    async with c.semaphore:
+        pass
+    assert c._max_borrowed_this_round == 1
+
+
+@pytest.mark.anyio
+async def test_value_clamped_when_borrowed_exceeds_total() -> None:
+    """After a cut, total_tokens may be below borrowed_tokens; value must be >= 0.
+
+    notify_retry lowers total_tokens; CapacityLimiter accepts the inversion and
+    blocks future acquires until in-flight drains. Without clamping, `value`
+    would be negative and `concurrency_status_display`'s `concurrency - value`
+    would exceed `concurrency`, rendering as e.g. "10 / 6" in the UI.
+    """
+    from inspect_ai.util._concurrency import concurrency_status_display
+
+    init_concurrency()
+    cfg = AdaptiveConcurrency(min=1, max=80, start=10, decrease_factor=0.5)
+    # register via concurrency() so status display sees it
+    async with concurrency(name="m-clamp", concurrency=10, key="kc", adaptive=cfg):
+        pass
+    c = next(x for x in adaptive_controllers() if x.name == "m-clamp")
+
+    holders = 8
+    release = anyio.Event()
+    all_in = anyio.Event()
+    in_flight = 0
+
+    async def holder() -> None:
+        nonlocal in_flight
+        async with c.semaphore:
+            in_flight += 1
+            if in_flight == holders:
+                all_in.set()
+            await release.wait()
+
+    async with anyio.create_task_group() as tg:
+        try:
+            for _ in range(holders):
+                tg.start_soon(holder)
+            with anyio.fail_after(1):
+                await all_in.wait()
+            # Cut to below in-flight: 10 * 0.5 = 5, floor_to_nice(5) = 5,
+            # but 8 are currently borrowed.
+            c.notify_retry()
+            assert c.concurrency == 5
+            assert c._limiter.borrowed_tokens == 8
+            # value clamped to 0, not negative
+            assert c.value == 0
+            # status display: used not exceeding total
+            status = concurrency_status_display()
+            entry = status.get("m-clamp") or next(
+                v for k, v in status.items() if "m-clamp" in k
+            )
+            used, total = entry
+            assert total == 5
+            assert used == 5  # 5 - max(0, value) = 5 - 0 = 5, not 13
+        finally:
+            release.set()

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -283,6 +283,66 @@ def test_saturation_gate_resets_on_rate_limit_cut() -> None:
     assert c._max_borrowed_this_round == 0
 
 
+@pytest.mark.anyio
+async def test_saturation_at_low_limits_via_real_limiter() -> None:
+    """At low limits, the high-water mark must include the just-acquired slot.
+
+    If we sampled `borrowed_tokens` after release (in notify_success), at
+    limit=4 with full saturation every sample would observe at most 3 —
+    blocking growth even under maximum load. The wrapper records on acquire,
+    when the just-borrowed slot is still counted, so peak correctly reaches 4.
+    Exercises real limiter acquire/release rather than the test helper.
+    """
+    cfg = AdaptiveConcurrency(min=1, max=200, start=4)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+
+    holders_entered = anyio.Event()
+    release = anyio.Event()
+    entered = 0
+
+    async def holder() -> None:
+        nonlocal entered
+        async with c.semaphore:
+            entered += 1
+            if entered == 4:
+                holders_entered.set()
+            await release.wait()
+        c.notify_success()
+
+    async with anyio.create_task_group() as tg:
+        for _ in range(4):
+            tg.start_soon(holder)
+        with anyio.fail_after(1):
+            await holders_entered.wait()
+        # all 4 slots borrowed simultaneously now; peak should be 4
+        release.set()
+
+    # ROUND_SIZE_FLOOR=4, so 4 successes complete a round. Saturation 4/4=1.0
+    # ≥ 0.8 → scale up via slow-start
+    assert c.concurrency == 8
+    assert c.history[-1][4] == "slow_start"
+
+
+@pytest.mark.anyio
+async def test_serial_workload_at_low_limit_does_not_grow() -> None:
+    """A serial workload (one in flight at a time) shouldn't grow.
+
+    Even when notifications accumulate to a full round at low limit:
+    real acquire/release with peak=1 against limit=10 = 10% saturation,
+    well below the 0.8 threshold.
+    """
+    cfg = AdaptiveConcurrency(min=1, max=200, start=10)
+    c = AdaptiveConcurrencyController("t", cfg, visible=True)
+
+    for _ in range(10):
+        async with c.semaphore:
+            pass
+        c.notify_success()
+
+    assert c.concurrency == 10  # never grew
+    assert c.history == []
+
+
 def test_default_bounds() -> None:
     """Defaults are min=4, start=20, max=200."""
     cfg = AdaptiveConcurrency()

--- a/tests/util/test_adaptive_concurrency.py
+++ b/tests/util/test_adaptive_concurrency.py
@@ -26,11 +26,12 @@ def _saturated_successes(
 ) -> None:
     """Run n successful completions with the current limit fully saturated.
 
-    notify_success samples the limiter's `borrowed_tokens` (in-flight count)
-    to track per-round saturation; tests that don't actually acquire slots
-    would otherwise see zero saturation and never trigger scale-up. This
-    helper pre-sets the high-water mark before each call so growth-testing
-    code paths run as if the limit was binding. Defaults to one full round
+    The controller's per-round saturation high-water mark is updated by the
+    semaphore wrapper on each acquire. Tests that call notify_success
+    directly (without going through the semaphore) would otherwise leave
+    the mark at zero and never trigger scale-up. This helper pre-sets the
+    mark before each call so growth-testing code paths run as if the limit
+    was binding. Defaults to one full round
     (`max(concurrency, ROUND_SIZE_FLOOR)` successes).
     """
     n = n if n is not None else max(c.concurrency, c.ROUND_SIZE_FLOOR)

--- a/tests/util/test_concurrency.py
+++ b/tests/util/test_concurrency.py
@@ -4,12 +4,16 @@ Tests the public interface of concurrency control functionality including
 the concurrency context manager, status display, and initialization.
 """
 
+import contextlib
 import time
+from collections.abc import Iterable
+from typing import Any, cast
 
 import anyio
 import pytest
 
 from inspect_ai.util._concurrency import (
+    ConcurrencySemaphore,
     concurrency,
     concurrency_status_display,
     get_or_create_semaphore,
@@ -98,6 +102,56 @@ async def test_get_or_create_sem_semaphore_is_usable() -> None:
             assert sem.value == 0  # Both slots taken
 
     assert sem.value == 2  # Both slots released
+
+
+@pytest.mark.anyio
+async def test_legacy_registry_without_adaptive_argument() -> None:
+    """Static/default calls remain compatible with pre-adaptive custom registries."""
+
+    class LegacySemaphore:
+        def __init__(self, name: str, concurrency: int, visible: bool) -> None:
+            self.name = name
+            self.concurrency = concurrency
+            self.visible = visible
+            self._sem = anyio.Semaphore(concurrency)
+            self.semaphore: contextlib.AbstractAsyncContextManager[Any] = self._sem
+
+        @property
+        def value(self) -> int:
+            return self._sem.value
+
+    class LegacyRegistry:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, int, str | None, bool]] = []
+
+        async def get_or_create(
+            self,
+            name: str,
+            concurrency: int,
+            key: str | None,
+            visible: bool,
+        ) -> ConcurrencySemaphore:
+            self.calls.append((name, concurrency, key, visible))
+            return LegacySemaphore(name, concurrency, visible)
+
+        def values(self) -> Iterable[ConcurrencySemaphore]:
+            return []
+
+    registry = LegacyRegistry()
+    init_concurrency(cast(Any, registry))
+    try:
+        sem = await get_or_create_semaphore("legacy-resource", 2, None, True)
+        assert sem.name == "legacy-resource"
+
+        async with concurrency("legacy-context", 1):
+            pass
+
+        assert registry.calls == [
+            ("legacy-resource", 2, None, True),
+            ("legacy-context", 1, "legacy-context", True),
+        ]
+    finally:
+        init_concurrency()
 
 
 # Basic Concurrency Control Tests

--- a/tests/util/test_parse_retry_after.py
+++ b/tests/util/test_parse_retry_after.py
@@ -1,9 +1,12 @@
-"""Tests for parse_retry_after()."""
+"""Tests for parse_retry_after() and parse_retry_after_from_exception()."""
 
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
 
-from inspect_ai._util.http import parse_retry_after
+from inspect_ai._util.http import (
+    parse_retry_after,
+    parse_retry_after_from_exception,
+)
 
 
 def test_retry_after_delta_seconds() -> None:
@@ -126,3 +129,58 @@ def test_anthropic_reset_headers_recognized() -> None:
     seconds = parse_retry_after({"anthropic-ratelimit-tokens-reset": future})
     assert seconds is not None
     assert 20 < seconds <= 30
+
+
+# ---------- parse_retry_after_from_exception ----------
+
+
+class _FakeResponse:
+    def __init__(self, headers: dict[str, str]) -> None:
+        self.headers = headers
+
+
+class _FakeError(Exception):
+    def __init__(self, response: _FakeResponse | None) -> None:
+        self.response = response
+
+
+def test_from_exception_with_retry_after_header() -> None:
+    ex = _FakeError(_FakeResponse({"Retry-After": "30"}))
+    assert parse_retry_after_from_exception(ex) == 30.0
+
+
+def test_from_exception_without_response_returns_none() -> None:
+    ex = Exception("no response attr")
+    assert parse_retry_after_from_exception(ex) is None
+
+
+def test_from_exception_with_response_but_no_headers_returns_none() -> None:
+    class _NoHeaders:
+        pass
+
+    ex = _FakeError(_NoHeaders())  # type: ignore[arg-type]
+    assert parse_retry_after_from_exception(ex) is None
+
+
+def test_from_exception_with_none_response_returns_none() -> None:
+    ex = _FakeError(None)
+    assert parse_retry_after_from_exception(ex) is None
+
+
+def test_from_exception_swallows_parse_errors() -> None:
+    """If parse_retry_after itself raises, we return None rather than propagating.
+
+    The caller is in a retry-classification fast path; an unparseable header
+    shouldn't break the retry decision.
+    """
+
+    # build a "headers" object that raises when iterated/looked up
+    class _BadHeaders:
+        def __iter__(self) -> object:
+            raise RuntimeError("malformed headers")
+
+        def items(self) -> object:
+            raise RuntimeError("malformed headers")
+
+    ex = _FakeError(_FakeResponse(headers=_BadHeaders()))  # type: ignore[arg-type]
+    assert parse_retry_after_from_exception(ex) is None

--- a/tests/util/test_parse_retry_after.py
+++ b/tests/util/test_parse_retry_after.py
@@ -1,0 +1,128 @@
+"""Tests for parse_retry_after()."""
+
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+from inspect_ai._util.http import parse_retry_after
+
+
+def test_retry_after_delta_seconds() -> None:
+    assert parse_retry_after({"Retry-After": "30"}) == 30.0
+    assert parse_retry_after({"retry-after": "1.5"}) == 1.5
+
+
+def test_retry_after_http_date() -> None:
+    future = datetime.now(timezone.utc) + timedelta(seconds=45)
+    header = format_datetime(future, usegmt=True)
+    seconds = parse_retry_after({"Retry-After": header})
+    assert seconds is not None
+    assert 30 < seconds <= 45
+
+
+def test_retry_after_negative_returns_none() -> None:
+    assert parse_retry_after({"Retry-After": "-5"}) is None
+    assert parse_retry_after({"Retry-After": "0"}) is None
+
+
+def test_retry_after_unparseable_falls_through() -> None:
+    # garbage in Retry-After but a valid reset header — should fall back
+    headers = {
+        "Retry-After": "not-a-date",
+        "x-ratelimit-reset-requests": "20",
+    }
+    assert parse_retry_after(headers) == 20.0
+
+
+def test_ratelimit_reset_delta_seconds() -> None:
+    assert parse_retry_after({"x-ratelimit-reset-requests": "30"}) == 30.0
+
+
+def test_ratelimit_reset_duration_string() -> None:
+    # OpenAI-style duration shorthand
+    assert parse_retry_after({"x-ratelimit-reset-requests": "1m30s"}) == 90.0
+    assert parse_retry_after({"x-ratelimit-reset-requests": "500ms"}) == 0.5
+    assert parse_retry_after({"x-ratelimit-reset-requests": "1.5s"}) == 1.5
+    assert parse_retry_after({"x-ratelimit-reset-tokens": "2h"}) == 7200.0
+
+
+def test_ratelimit_reset_iso_timestamp() -> None:
+    future = datetime.now(timezone.utc) + timedelta(seconds=60)
+    header = future.isoformat().replace("+00:00", "Z")
+    seconds = parse_retry_after({"x-ratelimit-reset-tokens": header})
+    assert seconds is not None
+    assert 50 < seconds <= 60
+
+
+def test_ratelimit_reset_takes_larger_of_two() -> None:
+    """Conservative cooldown picks the longer reset window.
+
+    Without knowing which dimension triggered the 429, the longer reset is
+    the safer floor for the next-cut debounce.
+    """
+    headers = {
+        "x-ratelimit-reset-requests": "60",
+        "x-ratelimit-reset-tokens": "20",
+    }
+    assert parse_retry_after(headers) == 60.0
+
+
+def test_retry_after_wins_over_ratelimit_reset() -> None:
+    # server is the authority on its own 429 — even if reset is smaller, honor Retry-After
+    headers = {
+        "Retry-After": "30",
+        "x-ratelimit-reset-requests": "5",
+    }
+    assert parse_retry_after(headers) == 30.0
+
+
+def test_no_relevant_headers_returns_none() -> None:
+    assert parse_retry_after({}) is None
+    assert parse_retry_after({"content-type": "application/json"}) is None
+
+
+def test_case_insensitive_lookup() -> None:
+    # headers may arrive with arbitrary case from different SDKs
+    assert parse_retry_after({"RETRY-AFTER": "10"}) == 10.0
+    assert parse_retry_after({"X-RateLimit-Reset-Requests": "15"}) == 15.0
+
+
+def test_unparseable_reset_returns_none() -> None:
+    assert parse_retry_after({"x-ratelimit-reset-requests": "garbage"}) is None
+
+
+def test_naive_http_date_does_not_raise() -> None:
+    """parsedate_to_datetime returns a naive datetime for HTTP-dates missing the GMT offset.
+
+    Subtracting that from an aware now() would raise TypeError. We coerce to
+    UTC and either return a positive seconds value or None.
+    """
+    # Malformed (no zone) but in the past → coerced to UTC, returns None for non-positive
+    assert parse_retry_after({"Retry-After": "Wed, 21 Oct 1990 07:28:00"}) is None
+    # Malformed but in the future → coerced to UTC, returns positive
+    assert parse_retry_after({"Retry-After": "Wed, 21 Oct 2099 07:28:00"}) is not None
+
+
+def test_ratelimit_reset_uses_max_not_min_when_multiple() -> None:
+    """Conservative cooldown picks the largest of multiple reset windows.
+
+    When requests and tokens both report reset times, we don't know which
+    dimension triggered the 429, so use the *largest* reset to avoid
+    prematurely cutting again.
+    """
+    headers = {
+        "x-ratelimit-reset-requests": "10",
+        "x-ratelimit-reset-tokens": "60",
+    }
+    assert parse_retry_after(headers) == 60.0
+
+
+def test_anthropic_reset_headers_recognized() -> None:
+    """Anthropic's own anthropic-ratelimit-*-reset family is a fallback signal.
+
+    We should recognize it when Retry-After is absent.
+    """
+    # ISO timestamp ~30s in the future
+    future = (datetime.now(timezone.utc) + timedelta(seconds=30)).isoformat()
+    seconds = parse_retry_after({"anthropic-ratelimit-tokens-reset": future})
+    assert seconds is not None
+    assert 20 < seconds <= 30


### PR DESCRIPTION
The `--adaptive-connections` option starts at a moderate concurrency, grows while the provider keeps up, and backs off on rate-limit retries.

``` bash
$ inspect eval --model openai/gpt-4o --adaptive-connections true
```

By default a per-model controller starts at 20 concurrent connections and scales between 4 and 100. These bounds suit typical paid (non-enterprise) tiers; raise `max` for enterprise tiers, lower it for tighter ones.

When adaptive connections is in effect, `max_samples` automatically tracks the controller's current limit (with a small buffer), so sample setup work like creating sandbox containers stays proportional to actual model concurrency rather than the maximum bound.


### Bounds Tuning

The bounds (`min`, `start`, `max`) are the everyday tuning knobs. `start` is where the controller begins (it doubles aggressively during slow-start until the first rate-limit episode), and `max` is the ceiling.

Pass a string shorthand. `min-max` constrains the range (`start` defaults to 20, clamped into the range):

``` bash
$ inspect eval --model openai/gpt-4o --adaptive-connections "4-80"
```

`min-start-max` also sets the starting value:

``` bash
$ inspect eval --model openai/gpt-4o --adaptive-connections "4-40-80"
```

In Python, pass `True` for defaults or an `AdaptiveConcurrency` to customize:

``` python
from inspect_ai.util import AdaptiveConcurrency

eval(
    "task.py",
    model="openai/gpt-4o",
    adaptive_connections=AdaptiveConcurrency(min=4, max=80),
)
```

A rule of thumb for `max` is *(tier RPM × average request seconds) ÷ 60*. On a 60 RPM tier with 3-second requests, a `max` near 3 is enough; on a 4,000 RPM tier with 1.5-second requests, a `max` around 100 starts to make sense.

### Retry Types

The controller distinguishes two kinds of retries.

- Rate-limit retries: HTTP 429, plus per-provider equivalents like Bedrock `ThrottlingException` and Google `503 RESOURCE_EXHAUSTED`. These shrink the limit by `decrease_factor` (default 0.8) per episode, with a debounce so a single rate-limit burst produces only one cut.

- Transient retries: 5xx, timeouts, and network errors. These pause scale-up (the eventual success won't count toward growth) but do not shrink the limit. Provider 5xx and network blips are usually infra noise unrelated to your concurrency, and lowering concurrency doesn't help an upstream outage. Each provider's `should_retry()` classifies its own errors via a `RetryDecision`, so genuinely-rate-limited 5xx codes are still counted as rate-limit signals where applicable.

After a rate-limit cut, the controller waits at least `cooldown_seconds` (default 15s) before allowing another cut. If the response carries a `Retry-After` header, the cooldown extends to honor it. When `Retry-After` is absent, Inspect falls back to provider-specific reset-window headers: `x-ratelimit-reset-requests` and `x-ratelimit-reset-tokens` (OpenAI, Groq, Azure OpenAI), and `anthropic-ratelimit-*-reset` (Anthropic).

Cache hits and successful-after-retry calls are neutral: they neither grow nor shrink the limit.

### Advanced Tuning

The response curve is also tunable. These fields are Python-only (CLI shorthand stays at `min-max` / `min-start-max`):

- `cooldown_seconds` (default 15): minimum debounce between scale-down cuts. Larger for long-running agent loops where each rate-limit episode takes longer to clear; smaller for short request workloads.

- `decrease_factor` (default 0.8): multiplicative cut on each rate-limit episode. More aggressive (e.g. 0.5) for volatile tiers where overshoots are common; gentler when tiers are stable.

- `scale_up_percent` (default 0.05): additive growth per clean round in steady state. Increase for short evals where slow ramp-up doesn't have time to converge.

``` python
from inspect_ai.util import AdaptiveConcurrency

eval(
    "task.py",
    model="openai/gpt-4o",
    adaptive_connections=AdaptiveConcurrency(
        min=4,
        max=80,
        cooldown_seconds=30,
        decrease_factor=0.5,
        scale_up_percent=0.1,
    ),
)
```

### Limit History

The full history of scale changes is captured in the eval log under `stats.connection_limit_history`. Each entry records the timestamp, model, old and new limits, and a `reason` of `slow_start`, `steady_state_up`, or `rate_limit`. Only `rate_limit` reflects an actual scale-down (transient infra noise no longer appears here). You can stream the same events live in the trace log:

``` bash
inspect trace dump --filter "[connections]"
```