### PR TITLE
OpenRouter: coalesce adjacent system messages before request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## Unreleased
-.
+
 - Google: Support Gemini 3+ native web search and code execution alongside function tools.
 - HuggingFace: Add `trust_remote_code` model argument (defaults to `False`).
+- OpenRouter: Coalesce adjacent system messages before request.
 - Eval Set: `retry_immediate` now defaults to True. Pass `retry_immediate=False` (or `--no-retry-immediate`) to restore the previous batch-retry behavior.
 - Eval Set: `max_tasks` now defaults to the greater of 10 and the number of models being evaluated (was previously 4).
 - Eval Set: Roll forward `model_usage` and `role_usage` from previous log when performing retries (matches existing `eval-retry` behavior).

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -438,6 +438,10 @@ class ModelAPI(abc.ABC):
         """Collapse consecutive assistant messages into a single message."""
         return False
 
+    def collapse_system_messages(self) -> bool:
+        """Collapse consecutive system messages into a single message."""
+        return False
+
     def tools_required(self) -> bool:
         """Any tool use in a message stream means that tools must be passed."""
         return False
@@ -1002,6 +1006,9 @@ class Model:
 
         if self.api.collapse_assistant_messages():
             input = collapse_consecutive_assistant_messages(input)
+
+        if self.api.collapse_system_messages():
+            input = collapse_consecutive_system_messages(input)
 
         # resolve cache policy
         if isinstance(cache, NotGiven):
@@ -2032,6 +2039,15 @@ def collapse_consecutive_assistant_messages(
     return functools.reduce(assistant_message_reducer, messages, [])
 
 
+# Functions to reduce consecutive system messages to a single system message ->
+# required for OpenRouter inference providers (e.g. AkashML, Parasail) that
+# reject requests containing more than one system message.
+def collapse_consecutive_system_messages(
+    messages: list[ChatMessage],
+) -> list[ChatMessage]:
+    return functools.reduce(system_message_reducer, messages, [])
+
+
 def user_message_reducer(
     messages: list[ChatMessage],
     message: ChatMessage,
@@ -2044,6 +2060,13 @@ def assistant_message_reducer(
     message: ChatMessage,
 ) -> list[ChatMessage]:
     return consecutive_message_reducer(messages, message, ChatMessageAssistant)
+
+
+def system_message_reducer(
+    messages: list[ChatMessage],
+    message: ChatMessage,
+) -> list[ChatMessage]:
+    return consecutive_message_reducer(messages, message, ChatMessageSystem)
 
 
 def consecutive_message_reducer(

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -110,6 +110,16 @@ class OpenRouterAPI(OpenAICompatibleAPI):
         )
 
     @override
+    def collapse_system_messages(self) -> bool:
+        # Several OpenRouter inference providers (e.g. AkashML, Parasail)
+        # reject requests that contain more than one system message or any
+        # system message at a non-zero index, even though the OpenAI Chat
+        # Completions API itself is permissive. Coalesce adjacent system
+        # messages so the canonical request has a single leading system
+        # message regardless of which provider OpenRouter selects.
+        return True
+
+    @override
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         # Defer to the OpenAI-compatible base classifier (which handles 429 →
         # rate_limit and 5xx/timeouts → transient with header extraction).

--- a/tests/model/test_collapse_system_message.py
+++ b/tests/model/test_collapse_system_message.py
@@ -1,0 +1,92 @@
+from inspect_ai.model import (
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+    ContentText,
+)
+from inspect_ai.model._model import collapse_consecutive_system_messages
+
+
+def test_collapse_consecutive_system_messages_single_message():
+    messages = [ChatMessageSystem(content="System message")]
+    assert collapse_consecutive_system_messages(messages) == messages
+
+
+def test_collapse_consecutive_system_messages_alternating():
+    messages = [
+        ChatMessageSystem(content="One"),
+        ChatMessageUser(content="Hi"),
+        ChatMessageSystem(content="Two"),
+    ]
+    assert collapse_consecutive_system_messages(messages) == messages
+
+
+def test_collapse_consecutive_system_messages_two_strings():
+    messages = [
+        ChatMessageSystem(content="One"),
+        ChatMessageSystem(content="Two"),
+        ChatMessageUser(content="Hi"),
+    ]
+    result = collapse_consecutive_system_messages(messages)
+    assert len(result) == 2
+    assert isinstance(result[0], ChatMessageSystem)
+    assert result[0].text == "One\nTwo"
+    assert isinstance(result[1], ChatMessageUser)
+
+
+def test_collapse_consecutive_system_messages_mixed_content_shapes():
+    messages = [
+        ChatMessageSystem(content="Plain"),
+        ChatMessageSystem(
+            content=[ContentText(text="Part A"), ContentText(text="Part B")]
+        ),
+        ChatMessageUser(content="Hi"),
+    ]
+    result = collapse_consecutive_system_messages(messages)
+    assert len(result) == 2
+    combined = result[0]
+    assert isinstance(combined, ChatMessageSystem)
+    assert isinstance(combined.content, list)
+    assert [c.text for c in combined.content] == ["Plain", "Part A", "Part B"]
+
+
+def test_collapse_consecutive_system_messages_three_in_a_row():
+    messages = [
+        ChatMessageSystem(content="One"),
+        ChatMessageSystem(content="Two"),
+        ChatMessageSystem(content="Three"),
+        ChatMessageUser(content="Hi"),
+        ChatMessageAssistant(content="Reply"),
+        ChatMessageSystem(content="Late"),
+    ]
+    result = collapse_consecutive_system_messages(messages)
+    assert len(result) == 4
+    assert isinstance(result[0], ChatMessageSystem)
+    assert result[0].text == "One\nTwo\nThree"
+    assert isinstance(result[1], ChatMessageUser)
+    assert isinstance(result[2], ChatMessageAssistant)
+    assert isinstance(result[3], ChatMessageSystem)
+    assert result[3].text == "Late"
+
+
+def test_collapse_system_messages_preserves_metadata():
+    msg_a = ChatMessageSystem(
+        content="First",
+        source="input",
+        metadata={"key1": "val1", "shared": "from_a"},
+    )
+    msg_b = ChatMessageSystem(
+        content="Second",
+        source="generate",
+        metadata={"key2": "val2", "shared": "from_b"},
+    )
+    result = collapse_consecutive_system_messages([msg_a, msg_b])
+    assert len(result) == 1
+    combined = result[0]
+    assert isinstance(combined, ChatMessageSystem)
+    assert combined.source == "generate"
+    assert combined.metadata is not None
+    assert combined.metadata["key1"] == "val1"
+    assert combined.metadata["key2"] == "val2"
+    assert combined.metadata["shared"] == "from_b"
+    assert combined.metadata["combined_from"] == [msg_a.id, msg_b.id]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Some OpenRouter inference providers (e.g. AkashML, Parasail when serving qwen/qwen3.6-35b-a3b) reject chat completions requests that contain more than one system message, or any system message at a non-zero index, with errors like "System message must be at the beginning." The OpenAI Chat Completions API itself is permissive, so callers that emit multiple system entries work fine against OpenAI directly but fail against several OpenRouter-hosted models depending on which provider OpenRouter selects for that request.

### What is the new behavior?

Add a `collapse_system_messages()` ModelAPI hook mirroring the existing `collapse_user_messages` / `collapse_assistant_messages` plumbing, wire it into the `Model.__call__` collapse pass, and have the OpenRouter provider opt in. Adjacent system messages are coalesced via the existing `combine_messages` machinery, which already handles content-shape promotion (`str` + `list[Content]`) and metadata merging.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This PR is purely additive:

- New `ModelAPI.collapse_system_messages()` hook with a `False` default, so existing provider subclasses are unaffected.
- New `collapse_consecutive_system_messages()` helper alongside the existing user/assistant ones.
- The OpenRouter provider opts in. Users see fewer 400s from strict OpenRouter providers; nothing else changes on the wire.

The only observable difference is that, when going through OpenRouter, adjacent `ChatMessageSystem` entries are merged before the request — same behavior already in place for user/assistant collapse on Anthropic, vLLM, Groq, Bedrock, and HF. No API, config, or schema changes; no user action required.

### Other information:

Includes unit tests for single, alternating, two-string, mixed-content-shape, multi-row, and metadata-preservation cases.