### PR TITLE
Fix: Bedrock Nova drops maxTokens only for 'high' reasoning effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Google: Support Gemini 3+ native web search and code execution alongside function tools.
 - HuggingFace: Add `trust_remote_code` model argument (defaults to `False`).
 - OpenRouter: Coalesce adjacent system messages before request.
+- Bedrock: Preserve maxTokens when reasoning effort is less than "high".
 - Eval Set: `retry_immediate` now defaults to True. Pass `retry_immediate=False` (or `--no-retry-immediate`) to restore the previous batch-retry behavior.
 - Eval Set: `max_tasks` now defaults to the greater of 10 and the number of models being evaluated (was previously 4).
 - Eval Set: Roll forward `model_usage` and `role_usage` from previous log when performing retries (matches existing `eval-retry` behavior).

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -465,9 +465,13 @@ class BedrockAPI(ModelAPI):
             reasoning_cfg = self.reasoning_config(config)
             additionalModelRequestFields = additionalModelRequestFields | reasoning_cfg
 
-            # Nova with reasoning enabled requires maxTokens to be unset
-            nova_reasoning_enabled = (
-                self.is_nova() and "reasoningConfig" in reasoning_cfg
+            # Nova with reasoning at "high" effort requires maxTokens to be unset.
+            # Lower effort levels ("low", "medium") still accept maxTokens, so we
+            # must only omit it for the "high" case. See issue #3767.
+            nova_high_effort_reasoning = (
+                self.is_nova()
+                and reasoning_cfg.get("reasoningConfig", {}).get("maxReasoningEffort")
+                == "high"
             )
 
             # Make the request
@@ -476,7 +480,7 @@ class BedrockAPI(ModelAPI):
                 messages=messages,
                 system=system,
                 inferenceConfig=ConverseInferenceConfig(
-                    maxTokens=None if nova_reasoning_enabled else config.max_tokens,
+                    maxTokens=None if nova_high_effort_reasoning else config.max_tokens,
                     temperature=config.temperature,
                     topP=config.top_p,
                     stopSequences=config.stop_seqs,

--- a/tests/model/providers/test_bedrock_nova_max_tokens.py
+++ b/tests/model/providers/test_bedrock_nova_max_tokens.py
@@ -1,0 +1,77 @@
+"""Tests for Bedrock Nova maxTokens handling per reasoning effort.
+
+Regression test for https://github.com/UKGovernmentBEIS/inspect_ai/issues/3767
+
+AWS Nova Converse API only requires maxTokens to be unset when reasoning effort
+is "high". For "low" and "medium", maxTokens is a normal supported parameter
+and previously the code was silently dropping the user's max_tokens for ALL
+reasoning effort levels.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("aiobotocore")
+pytest.importorskip("botocore")
+
+from inspect_ai.model._generate_config import GenerateConfig  # noqa: E402
+from inspect_ai.model._providers.bedrock import BedrockAPI  # noqa: E402
+
+
+def _make_nova_api() -> BedrockAPI:
+    """Build a BedrockAPI bound to a Nova model without instantiating a session."""
+    api = BedrockAPI.__new__(BedrockAPI)
+    api.model_name = "amazon.nova-lite-v1:0"
+    return api
+
+
+def _make_claude_api() -> BedrockAPI:
+    """Build a BedrockAPI bound to a Claude model."""
+    api = BedrockAPI.__new__(BedrockAPI)
+    api.model_name = "anthropic.claude-3-sonnet-20240229-v1:0"
+    return api
+
+
+def _nova_high_effort_reasoning(api: BedrockAPI, config: GenerateConfig) -> bool:
+    """Mirror the gate used in BedrockAPI.generate() for testability."""
+    reasoning_cfg = api.reasoning_config(config)
+    return (
+        api.is_nova()
+        and reasoning_cfg.get("reasoningConfig", {}).get("maxReasoningEffort") == "high"
+    )
+
+
+def test_nova_low_effort_keeps_max_tokens():
+    """reasoning_effort='low' on Nova should NOT trigger the maxTokens=None path."""
+    api = _make_nova_api()
+    config = GenerateConfig(reasoning_effort="low", max_tokens=2048)
+    assert _nova_high_effort_reasoning(api, config) is False
+
+
+def test_nova_medium_effort_keeps_max_tokens():
+    """reasoning_effort='medium' on Nova should NOT trigger the maxTokens=None path."""
+    api = _make_nova_api()
+    config = GenerateConfig(reasoning_effort="medium", max_tokens=2048)
+    assert _nova_high_effort_reasoning(api, config) is False
+
+
+def test_nova_high_effort_drops_max_tokens():
+    """reasoning_effort='high' on Nova IS the only case that should drop maxTokens."""
+    api = _make_nova_api()
+    config = GenerateConfig(reasoning_effort="high", max_tokens=2048)
+    assert _nova_high_effort_reasoning(api, config) is True
+
+
+def test_nova_no_reasoning_keeps_max_tokens():
+    """No reasoning_effort on Nova means no reasoningConfig at all → keep maxTokens."""
+    api = _make_nova_api()
+    config = GenerateConfig(max_tokens=2048)
+    assert _nova_high_effort_reasoning(api, config) is False
+
+
+def test_claude_high_effort_keeps_max_tokens():
+    """Claude is not Nova, so the Nova-specific high-effort path never fires."""
+    api = _make_claude_api()
+    config = GenerateConfig(reasoning_effort="high", max_tokens=2048)
+    assert _nova_high_effort_reasoning(api, config) is False


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

Fixes #3767.

The Nova reasoning gate in `bedrock.py` is over-broad. It drops `maxTokens` whenever any `reasoningConfig` is present, which silently caps the user's `max_tokens` for ALL reasoning effort levels. AWS Nova Converse API only requires `maxTokens` to be unset when `maxReasoningEffort="high"`; `"low"` and `"medium"` accept `maxTokens` normally.

Current code (`src/inspect_ai/model/_providers/bedrock.py` ~line 468):

```python
nova_reasoning_enabled = (
    self.is_nova() and "reasoningConfig" in reasoning_cfg
)
maxTokens=None if nova_reasoning_enabled else config.max_tokens,
```

### What is the new behavior?

```python
nova_high_effort_reasoning = (
    self.is_nova()
    and reasoning_cfg.get("reasoningConfig", {}).get("maxReasoningEffort") == "high"
)
maxTokens=None if nova_high_effort_reasoning else config.max_tokens,
```

So Nova users with `reasoning_effort="low"` or `"medium"` now get their `max_tokens` honored, while `"high"` continues to omit it as required by AWS.

5 unit tests added in `tests/model/providers/test_bedrock_nova_max_tokens.py` covering:
- `low` keeps `maxTokens`
- `medium` keeps `maxTokens`
- `high` drops `maxTokens`
- No reasoning effort → keeps `maxTokens`
- Claude (non-Nova) is unaffected

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Existing behavior for `reasoning_effort="high"` is unchanged. Users on `low`/`medium` who were previously hitting silent `max_tokens=None` will now get their configured limit honored — that's the bug fix. No user code changes required.

### Other information:

The AWS Nova docs also indicate that `temperature`, `topP`, and `topK` should be unset when `maxReasoningEffort="high"`. The current `inferenceConfig` still sends `temperature` and `topP` regardless of reasoning effort, and `additionalModelRequestFields` may include `top_k`. This is a parallel latent issue and is intentionally not addressed in this PR — happy to do a follow-up if reviewers want.

Verification:
- `pytest tests/model/providers/test_bedrock_nova_max_tokens.py` — 5 passed
- `make check` (ruff lint + format) — passes