### PR TITLE
Anthropic: skip top-level cache_control on Bedrock/Vertex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Anthropic: Skip the top-level `cache_control` auto-caching field on Bedrock and Vertex, which [per Anthropic's docs](https://docs.claude.com/en/docs/build-with-claude/prompt-caching#automatic-caching) don't yet support it and reject the request with `cache_control: Extra inputs are not permitted`. Per-block cache breakpoints (system/tools/messages) are unaffected.
+
 ## 0.3.218 (06 May 2026)
 
 - Google: Support Gemini 3+ native web search and code execution alongside function tools.

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -392,8 +392,15 @@ class AnthropicAPI(ModelAPI):
             # prepare request params (assembled this way so we can log the raw model call)
             request: dict[str, Any] = dict(messages=messages)
 
-            # automatic caching for messages (system/tools use explicit breakpoints)
-            if cache_prompt:
+            # automatic caching for messages (system/tools use explicit breakpoints).
+            # Per Anthropic's docs, the top-level `cache_control` field is only
+            # supported on the direct Claude API and Azure AI Foundry (preview);
+            # "support for Amazon Bedrock and Google Vertex AI is coming later." On
+            # those services it is rejected as
+            # `cache_control: Extra inputs are not permitted`. Fall back to the
+            # per-block markers added in resolve_chat_input on those services.
+            # ref: https://docs.claude.com/en/docs/build-with-claude/prompt-caching#automatic-caching
+            if cache_prompt and not (self.is_bedrock() or self.is_vertex()):
                 request["cache_control"] = {"type": "ephemeral"}
 
             # system messages and tools

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -488,23 +488,18 @@ async def test_anthropic_top_level_cache_control_skipped_on_bedrock_vertex(
 
     captured: dict[str, Any] = {}
 
-    async def fake_perform(request, streaming, tools, config):  # type: ignore[no-untyped-def]
+    from inspect_ai.model._model_output import ModelOutput
+
+    async def fake_perform(
+        request: dict[str, Any],
+        streaming: bool,
+        tools: list[Any],
+        config: GenerateConfig,
+        pending_tool_uses: Any = None,
+        pending_mcp_tool_uses: Any = None,
+    ) -> tuple[dict[str, Any], ModelOutput]:
         captured.update(request)
-        # short-circuit with a minimal valid response
-        from anthropic.types import Message, TextBlock, Usage
-
-        from inspect_ai.model._model_output import ModelOutput
-
-        msg = Message(
-            id="msg",
-            type="message",
-            role="assistant",
-            model=api.service_model_name(),
-            stop_reason="end_turn",
-            content=[TextBlock(type="text", text="ok")],
-            usage=Usage(input_tokens=1, output_tokens=1),
-        )
-        return msg, ModelOutput.from_content(
+        return {}, ModelOutput.from_content(
             model=api.service_model_name(), content="ok"
         )
 

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -456,6 +456,71 @@ async def test_anthropic_cache_marks_penultimate_block() -> None:
 
 
 @pytest.mark.anyio
+@pytest.mark.parametrize(
+    "model_name,expects_top_level_cache_control",
+    [
+        ("claude-sonnet-4-6", True),
+        ("bedrock/us.anthropic.claude-sonnet-4-6", False),
+        ("vertex/claude-sonnet-4-6@20250929", False),
+    ],
+)
+async def test_anthropic_top_level_cache_control_skipped_on_bedrock_vertex(
+    model_name: str, expects_top_level_cache_control: bool
+) -> None:
+    """Skip top-level cache_control on Bedrock/Vertex.
+
+    Per Anthropic's docs, top-level cache_control is only supported on the direct
+    Claude API and Azure AI Foundry; "support for Amazon Bedrock and Google Vertex
+    AI is coming later." Regression: the field was added in PR #3656 without
+    gating those services, breaking Anthropic-on-Bedrock with
+    `cache_control: Extra inputs are not permitted`.
+    ref: https://docs.claude.com/en/docs/build-with-claude/prompt-caching#automatic-caching
+    """
+    import os
+
+    os.environ.setdefault("AWS_REGION", "us-east-1")
+    os.environ.setdefault("AWS_ACCESS_KEY_ID", "fake")
+    os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "fake")
+    os.environ.setdefault("ANTHROPIC_VERTEX_PROJECT_ID", "fake")
+    os.environ.setdefault("ANTHROPIC_VERTEX_REGION", "us-east5")
+
+    api = AnthropicAPI(model_name=model_name, api_key="test-key")
+
+    captured: dict[str, Any] = {}
+
+    async def fake_perform(request, streaming, tools, config):  # type: ignore[no-untyped-def]
+        captured.update(request)
+        # short-circuit with a minimal valid response
+        from anthropic.types import Message, TextBlock, Usage
+
+        from inspect_ai.model._model_output import ModelOutput
+
+        msg = Message(
+            id="msg",
+            type="message",
+            role="assistant",
+            model=api.service_model_name(),
+            stop_reason="end_turn",
+            content=[TextBlock(type="text", text="ok")],
+            usage=Usage(input_tokens=1, output_tokens=1),
+        )
+        return msg, ModelOutput.from_content(
+            model=api.service_model_name(), content="ok"
+        )
+
+    api._perform_request_and_continuations = fake_perform  # type: ignore[method-assign]
+
+    await api.generate(
+        input=[ChatMessageUser(content="hello")],
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(cache_prompt=True),
+    )
+
+    assert ("cache_control" in captured) is expects_top_level_cache_control
+
+
+@pytest.mark.anyio
 @skip_if_no_anthropic
 async def test_anthropic_prompt_caching_changing_suffix() -> None:
     """Verify caching when only the last content block changes.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Since #3656 ("anthropic: use request level 'auto' caching mode"), the Anthropic provider unconditionally writes a top-level `cache_control: {type: ephemeral}` field on every request when `cache_prompt` is enabled (the default for Claude 3.5+).

The direct Anthropic API and Azure AI Foundry accept this. Bedrock and Vertex don't — Anthropic's own docs say [automatic caching support for those services is "coming later"](https://platform.claude.com/docs/en/build-with-claude/prompt-caching#edge-cases). They reject the request with:

```
BadRequestError: Error code: 400 - {'message': 'cache_control: Extra inputs are not permitted'}
```

This breaks `anthropic/bedrock/...` and `anthropic/vertex/...` model paths entirely on inspect_ai 0.3.206+ for any request where prompt caching kicks in (i.e. effectively all Claude 4.x calls).

### What is the new behavior?

Gate the top-level `cache_control` write on `not (self.is_bedrock() or self.is_vertex())`, matching the existing precedent for unsupported features (`supports_remote_mcp`). Per-block cache breakpoints applied in `resolve_chat_input` (system, tools, last messages) continue to work on all services — Bedrock and Vertex have always supported those.

A parametrized regression test (`test_anthropic_top_level_cache_control_skipped_on_bedrock_vertex`) covers all three paths: anthropic direct keeps the field, bedrock and vertex don't.

### Does this PR introduce a breaking change?

No. It restores behavior that was working before #3656 for users on Bedrock/Vertex. Users on the direct Anthropic API or Azure are unaffected.

### Other information:

When Anthropic ships automatic caching support on Bedrock/Vertex, the gate should be removed.