### PR TITLE
Add direct link to one-time front-end submodule setup in project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you use VS Code, you should be sure to have installed the recommended extensi
 
 The web UI lives in a git submodule at `src/inspect_ai/_view/ts-mono/`. **These steps are only needed if you plan to work on the TypeScript/React frontend** — Python-only contributors can skip this entirely.
 
-Initialize the submodule and install dependencies — see the [one-time setup guide](src/inspect_ai/_view/ts-mono/docs/submodule-guide.md#one-time-setup).
+Initialize the submodule and install dependencies — see the [one-time setup guide](https://github.com/meridianlabs-ai/ts-mono/blob/main/docs/submodule-guide.md#one-time-setup).
 
 ### Documentation
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Viewing the [README docs for setting up the submodules](https://github.com/UKGovernmentBEIS/inspect_ai#frontend-development-typescript), the link breaks trying to load a file within a submodule. ([direct link](https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/src/inspect_ai/_view/ts-mono/docs/submodule-guide.md#one-time-setup))

### What is the new behavior?

The new link is the documentation page within the submodule's repo itself. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

N/A

### Other information:

This link would work on a locally cloned repo that has had the submodule initialized, but not for anyone that hasn't done this step, and would need the documentation on how to perform this step. 
