### PR TITLE
Stop operator-interrupted samples from failing eval on scorer error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Grok: Forward `tool_call_id` in tool responses (parallel tool calling).
 - Grok: Support `reasoning_effort` for Grok 4 models.
+- Scoring: Don't retry samples interrupted by operator during scoring.
 - MCP: Raise `ToolError` when timeout error occurs in MCP tool call.
 - Eval Logs: Disable boto3 1.36+ default integrity checksums on S3 log writes to avoid intermittent `IncompleteBody` errors during multipart uploads under concurrent flushes.
 - Bugfix: Fix bridged-tool result serialization to handle `list[ContentText]`.

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1243,8 +1243,16 @@ async def task_run_sample(
                                 transcript()._event(ErrorEvent(error=error))
 
                         except Exception as ex:
-                            # handle error
-                            error, raise_error = handle_error(ex)
+                            if active.interrupt_action is not None:
+                                # Operator-interrupted: log to transcript but
+                                # don't propagate to error/retry. The operator
+                                # EvalSampleLimit is set in the run() handler.
+                                scorer_error = eval_error(
+                                    ex, type(ex), ex, ex.__traceback__
+                                )
+                                transcript()._event(ErrorEvent(error=scorer_error))
+                            else:
+                                error, raise_error = handle_error(ex)
                         finally:
                             # run task cleanup if required (inside sandbox context)
                             if cleanup is not None:
@@ -1307,7 +1315,12 @@ async def task_run_sample(
     # error that should be retried (we do this outside of the above scope so that we can
     # retry outside of the original semaphore -- our retry will therefore go to the back
     # of the sample queue)
-    if error and retry_on_error > 0 and cancelled_error is None:
+    if (
+        error
+        and retry_on_error > 0
+        and cancelled_error is None
+        and active.interrupt_action is None
+    ):
         await emit_attempt_end(will_retry=True)
 
         # remove any buffered sample events

--- a/tests/test_operator_interrupt.py
+++ b/tests/test_operator_interrupt.py
@@ -1,0 +1,50 @@
+"""Operator-interrupted samples whose scorers also error must not fail or retry the eval."""
+
+import anyio
+
+from inspect_ai import Task, eval
+from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.log._samples import sample_active
+from inspect_ai.scorer import Score, Scorer, Target, accuracy, scorer
+from inspect_ai.solver import Generate, TaskState, solver
+
+
+@solver
+def operator_interrupting_solver():
+    async def solve(state: TaskState, generate: Generate):
+        active = sample_active()
+        assert active is not None, "expected an active sample"
+        active.interrupt("score")
+        # interrupt cancels the surrounding scope; sleep_forever guarantees
+        # we never return normally — must be cancelled by the interrupt.
+        await anyio.sleep_forever()
+        return state
+
+    return solve
+
+
+@scorer(metrics=[accuracy()])
+def buggy_scorer() -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        raise RuntimeError("buggy scorer")
+
+    return score
+
+
+def test_operator_interrupt_with_scorer_error():
+    """Sample is operator-limited (not error-counted), eval succeeds, no retries."""
+    log = eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=operator_interrupting_solver(),
+            scorer=buggy_scorer(),
+        ),
+        retry_on_error=3,
+    )[0]
+
+    assert log.status == "success"
+    assert log.samples is not None
+    sample = log.samples[0]
+    assert sample.limit is not None
+    assert sample.limit.type == "operator"
+    assert sample.error_retries == []


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

When a sample is operator-interrupted via `active.interrupt("score")` and the scorer subsequently raises, the sample's `error` field is set and `sample_error_count` increments. The eval is marked `status="error"` and per-sample retry fires (when `retry_on_error > 0`). Wrapped in `eval_set`'s retry loop, this turns a single operator-stop on an eval-set with a buggy-scorer sample into a retry storm until the retry budget is exhausted.

### What is the new behavior?

When `active.interrupt_action` is set, the sample is treated as operator-limited regardless of scoring outcome. If the scorer raises:

- The scorer error is logged to the transcript (`ErrorEvent`) so it remains visible.
- The error does **not** flow into `error` / `sample_error_count` / `retry_on_error`. The `EvalSampleLimit("operator")` already set in `run()` drives the sample status.
- The eval-level `all_evals_succeeded` returns `True`, so the eval-set retry loop doesn't fire.

The per-sample retry guard also gets an explicit `active.interrupt_action is None` clause as defense in depth.

### Does this PR introduce a breaking change?

No. Behavior changes only for samples that have been operator-interrupted *and* whose scorer also errors — previously a retry storm, now a clean operator-limited result.

### Other information:

Scope is `interrupt_action="score"` (the default). `interrupt_action="error"` semantics are unchanged.