### PR TITLE
grok: forward tool_call_id to xAI tool_result helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-- Support `reasoning_effort` for Grok 4 models.
+- Grok: Forward `tool_call_id` in tool responses (parallel tool calling).
+- Grok: Support `reasoning_effort` for Grok 4 models.
 
 ## 0.3.219 (06 May 2026)
 

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -629,7 +629,8 @@ async def _grok_message(message: ChatMessage) -> chat_pb2.Message:
             return await _grok_assistant_message(message)
         case ChatMessageTool():
             return tool_result(
-                f"Error: {message.error.message}" if message.error else message.text
+                f"Error: {message.error.message}" if message.error else message.text,
+                tool_call_id=message.tool_call_id,
             )
 
 


### PR DESCRIPTION
xai_sdk.chat.tool_result accepts an optional tool_call_id argument that is "essential for parallel_tool_calls or multiple tools to associate results correctly" (per its docstring). Without it, xAI falls back to positional inference, which can mis-associate results across parallel tool calls. ChatMessageTool already carries the id; this just forwards it.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

We don't provide the tool call id

### What is the new behavior?

We provide it

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No

### Other information:
