### PR TITLE
docs: update sync_harbor.py

### DIFF
--- a/docs/evals/evals.json
+++ b/docs/evals/evals.json
@@ -1,7 +1,7 @@
 [
   {
-    "id": "ade_bench_1_0",
-    "name": "Ade Bench",
+    "id": "dbt_labs_ade_bench",
+    "name": "ADE-Bench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -12,13 +12,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Analytics Data Engineer Bench: tasks evaluating AI agents on dbt/SQL data analytics engineering bugs.",
+    "desc": "Analytics Data Engineer Bench: dbt and SQL data-engineering tasks across DuckDB and Snowflake backends.",
     "paper": "https://github.com/dbt-labs/ade-bench",
-    "code": "inspect_harbor/ade_bench_1_0",
+    "code": "inspect_harbor/dbt_labs_ade_bench",
     "contributors": [],
     "samples": 48,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/ade_bench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/dbt_labs_ade_bench.html",
     "model_cards": []
   },
   {
@@ -31,7 +31,7 @@
     "tags": [],
     "kind": "generation",
     "modalities": [
-      "sandbox"
+      "text"
     ],
     "desc": "A benchmark designed to evaluate LLMs as Agents",
     "paper": "https://arxiv.org/abs/2308.03688",
@@ -47,7 +47,7 @@
     "model_cards": []
   },
   {
-    "id": "aider_polyglot_1_0",
+    "id": "aider_polyglot",
     "name": "Aider Polyglot",
     "source": "harbor",
     "categories": [
@@ -59,21 +59,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A polyglot coding benchmark that evaluates AI agents' ability to perform code editing and generation tasks across multiple programming languages.",
+    "desc": "Aider's polyglot coding benchmark: Exercism exercises across C++, Go, Java, JavaScript, Python, and Rust testing LLMs on multi-language code editing.",
     "paper": "https://arxiv.org/abs/2503.03656",
-    "code": "inspect_harbor/aider_polyglot_1_0",
+    "code": "inspect_harbor/aider_polyglot",
     "contributors": [],
     "samples": 225,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/aider_polyglot_1_0.html",
-    "model_cards": [
-      "chatgpt",
-      "claude"
-    ]
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/aider_polyglot.html",
+    "model_cards": []
   },
   {
-    "id": "algotune_1_0",
-    "name": "Algotune",
+    "id": "algotune",
+    "name": "AlgoTune",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -84,13 +81,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "AlgoTune: 154 algorithm optimization tasks focusing on speedup-based scoring from the AlgoTune benchmark.",
+    "desc": "AlgoTune: NeurIPS 2025 benchmark of math/physics/CS problems where the model writes code that matches reference output but runs faster than existing implementations.",
     "paper": "https://arxiv.org/abs/2507.15887",
-    "code": "inspect_harbor/algotune_1_0",
+    "code": "inspect_harbor/algotune",
     "contributors": [],
     "samples": 154,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/algotune_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/algotune.html",
     "model_cards": []
   },
   {
@@ -117,7 +114,7 @@
     "model_cards": []
   },
   {
-    "id": "autocodebench_lite200",
+    "id": "tencent_autocodebench",
     "name": "AutoCodeBench",
     "source": "harbor",
     "categories": [
@@ -131,11 +128,11 @@
     ],
     "desc": "Multilingual automated code generation benchmark evaluating LLMs across diverse programming tasks and languages.",
     "paper": "https://arxiv.org/abs/2508.09101",
-    "code": "inspect_harbor/autocodebench_lite200",
+    "code": "inspect_harbor/tencent_autocodebench",
     "contributors": [],
     "samples": 200,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/autocodebench_lite200.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/tencent_autocodebench.html",
     "model_cards": []
   },
   {
@@ -162,8 +159,8 @@
     "model_cards": []
   },
   {
-    "id": "bigcodebench_hard_complete_1_0_0",
-    "name": "Bigcodebench Hard Complete",
+    "id": "bigcode_bigcodebench_hard_complete",
+    "name": "BigCodeBench-Hard (Complete)",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -174,35 +171,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "BigCodeBench-Hard complete benchmark adapter for Harbor - challenging Python programming tasks with reward-based verification.",
+    "desc": "BigCodeBench-Hard (Complete split): hard subset evaluating LLMs on code generation with diverse function calls and complex instructions, in completion format.",
     "paper": "https://arxiv.org/abs/2406.15877",
-    "code": "inspect_harbor/bigcodebench_hard_complete_1_0_0",
+    "code": "inspect_harbor/bigcode_bigcodebench_hard_complete",
     "contributors": [],
     "samples": 145,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bigcodebench_hard_complete_1_0_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "bird_bench_parity",
-    "name": "Bird Bench",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "BIRD SQL parity subset (150 tasks, seed 42).",
-    "paper": "https://arxiv.org/abs/2305.03111",
-    "code": "inspect_harbor/bird_bench_parity",
-    "contributors": [],
-    "samples": 150,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bird_bench_parity.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bigcode_bigcodebench_hard_complete.html",
     "model_cards": []
   },
   {
@@ -229,8 +204,8 @@
     "model_cards": []
   },
   {
-    "id": "code_contests_1_0",
-    "name": "Code Contests",
+    "id": "nvats_codeskills_bench",
+    "name": "CodeSkills-Bench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -241,18 +216,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A competitive programming benchmark from DeepMind that evaluates AI agents' ability to solve algorithmic problems, covering algorithms, data structures, and competitive programming challenges.",
-    "paper": "https://arxiv.org/abs/2203.07814",
-    "code": "inspect_harbor/code_contests_1_0",
+    "desc": "A small set of real-life programming tasks: bug fixes, merge-conflict resolution, dependency cleanup, API migration, and performance regressions across compact Python repositories.",
+    "paper": "https://github.com/namanvats/codeskills-bench",
+    "code": "inspect_harbor/nvats_codeskills_bench",
     "contributors": [],
-    "samples": 9644,
+    "samples": 23,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/code_contests_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/nvats_codeskills_bench.html",
     "model_cards": []
   },
   {
-    "id": "compilebench_1_0",
-    "name": "Compilebench",
+    "id": "quesma_compilebench",
+    "name": "CompileBench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -263,13 +238,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Version 1.0 of CompileBench, a benchmark on real open-source projects against dependency hell, legacy toolchains, and complex build systems.",
+    "desc": "CompileBench: real-world build/compile tasks (curl, GNU coreutils, jq, etc.) ranging from easy builds to reviving 2003-era code and cross-compiling.",
     "paper": "https://arxiv.org/abs/2509.25248",
-    "code": "inspect_harbor/compilebench_1_0",
+    "code": "inspect_harbor/quesma_compilebench",
     "contributors": [],
     "samples": 15,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/compilebench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/quesma_compilebench.html",
     "model_cards": []
   },
   {
@@ -282,7 +257,7 @@
     "tags": [],
     "kind": "generation",
     "modalities": [
-      "sandbox"
+      "text"
     ],
     "desc": "Evaluates LLM capability to generate correct CUDA code for kernel implementation, memory management, and parallel algorithm optimization tasks.",
     "paper": null,
@@ -296,8 +271,8 @@
     "model_cards": []
   },
   {
-    "id": "cooperbench_1_0",
-    "name": "Cooperbench",
+    "id": "crustbench",
+    "name": "CRUST-Bench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -308,40 +283,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "CooperBench: multi-agent cooperation benchmark. 652 feature pairs across 12 repos requiring two agents to coordinate via messaging.",
-    "paper": "https://arxiv.org/abs/2601.13295",
-    "code": "inspect_harbor/cooperbench_1_0",
-    "contributors": [],
-    "samples": 652,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/cooperbench_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "crustbench_1_0",
-    "name": "Crustbench",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "CRUST-bench: 100 C-to-safe-Rust transpilation tasks from real-world C repositories.",
+    "desc": "CRUST-Bench: real-world C repositories paired with hand-written safe-Rust interfaces and tests, benchmarking LLMs on C-to-safe-Rust transpilation.",
     "paper": "https://arxiv.org/abs/2504.15254",
-    "code": "inspect_harbor/crustbench_1_0",
+    "code": "inspect_harbor/crustbench",
     "contributors": [],
     "samples": 100,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/crustbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/crustbench.html",
     "model_cards": []
   },
   {
-    "id": "deveval_1_0",
-    "name": "Deveval",
+    "id": "deveval",
+    "name": "DevEval",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -352,21 +305,22 @@
       "agent",
       "sandbox"
     ],
-    "desc": "DevEval benchmark: comprehensive evaluation of LLMs across software development lifecycle (implementation, unit testing, acceptance testing) for 21 real-world repositories across Python, C++, Java, and JavaScript.",
+    "desc": "DevEval: manually-annotated code-generation samples from real-world Python repositories, aligned to practical software development.",
     "paper": "https://arxiv.org/abs/2403.08604",
-    "code": "inspect_harbor/deveval_1_0",
+    "code": "inspect_harbor/deveval",
     "contributors": [],
     "samples": 63,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/deveval_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/deveval.html",
     "model_cards": []
   },
   {
-    "id": "ds_1000_head",
-    "name": "Ds 1000",
+    "id": "michaely310_devopsgym",
+    "name": "DevOps-Gym",
     "source": "harbor",
     "categories": [
-      "Coding"
+      "Coding",
+      "Professional"
     ],
     "tags": [],
     "kind": "agent",
@@ -374,13 +328,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "DS-1000 is a code generation benchmark with 1000 realistic data science problems across seven popular Python libraries.",
-    "paper": "https://arxiv.org/abs/2211.11501",
-    "code": "inspect_harbor/ds_1000_head",
+    "desc": "DevOps-Gym benchmark adapted to Harbor format - 729 tasks across 5 categories: Build, Monitoring, Issue Resolving, Test Generation, and End-to-End.",
+    "paper": "https://arxiv.org/abs/2601.20882",
+    "code": "inspect_harbor/michaely310_devopsgym",
     "contributors": [],
-    "samples": 1000,
+    "samples": 728,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/ds_1000_head.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/michaely310_devopsgym.html",
     "model_cards": []
   },
   {
@@ -407,8 +361,8 @@
     "model_cards": []
   },
   {
-    "id": "evoeval_1_0",
-    "name": "Evoeval",
+    "id": "xlang_ds_1000",
+    "name": "DS-1000",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -419,18 +373,40 @@
       "agent",
       "sandbox"
     ],
-    "desc": "EvoEval_difficult: 100 challenging Python programming tasks evolved from HumanEval.",
+    "desc": "DS-1000: data-science code-generation problems from StackOverflow across NumPy, Pandas, TensorFlow, PyTorch, SciPy, Scikit-learn, and Matplotlib, with execution-based grading.",
+    "paper": "https://arxiv.org/abs/2211.11501",
+    "code": "inspect_harbor/xlang_ds_1000",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/xlang_ds_1000.html",
+    "model_cards": []
+  },
+  {
+    "id": "evoeval",
+    "name": "EvoEval",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "EvoEval: evolving suite that mutates HumanEval problems along several axes (difficulty, creative, subtle, tool-use) for a contamination-resistant view of LLM coding ability.",
     "paper": "https://github.com/evo-eval/evoeval",
-    "code": "inspect_harbor/evoeval_1_0",
+    "code": "inspect_harbor/evoeval",
     "contributors": [],
     "samples": 100,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/evoeval_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/evoeval.html",
     "model_cards": []
   },
   {
-    "id": "featurebench_1_0",
-    "name": "Featurebench",
+    "id": "featurebench",
+    "name": "FeatureBench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -441,18 +417,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "FeatureBench full split: 200 feature-implementation tasks across 24 Python repos. 7 tasks require Ampere+ GPU.",
+    "desc": "FeatureBench: agentic coding on end-to-end feature-development tasks derived from open-source repositories.",
     "paper": "https://arxiv.org/abs/2602.10975",
-    "code": "inspect_harbor/featurebench_1_0",
+    "code": "inspect_harbor/featurebench",
     "contributors": [],
     "samples": 200,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench.html",
     "model_cards": []
   },
   {
-    "id": "featurebench_lite_1_0",
-    "name": "Featurebench Lite",
+    "id": "featurebench_modal",
+    "name": "FeatureBench (Modal)",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -463,57 +439,57 @@
       "agent",
       "sandbox"
     ],
-    "desc": "FeatureBench lite split: 30 feature-implementation tasks (26 lv1 + 4 lv2) across Python repos.",
+    "desc": "FeatureBench's full task suite executed on Modal's cloud sandbox runner.",
     "paper": "https://arxiv.org/abs/2602.10975",
-    "code": "inspect_harbor/featurebench_lite_1_0",
-    "contributors": [],
-    "samples": 30,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench_lite_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "featurebench_lite_modal_1_0",
-    "name": "Featurebench Lite Modal",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "FeatureBench lite split for Modal: 30 feature-implementation tasks with gpus=1 for GPU tasks (7/30). Use with -e modal.",
-    "paper": "https://arxiv.org/abs/2602.10975",
-    "code": "inspect_harbor/featurebench_lite_modal_1_0",
-    "contributors": [],
-    "samples": 30,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench_lite_modal_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "featurebench_modal_1_0",
-    "name": "Featurebench Modal",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "FeatureBench full split for Modal: 200 feature-implementation tasks with gpus=1 for GPU tasks (44/200). Use with -e modal.",
-    "paper": "https://arxiv.org/abs/2602.10975",
-    "code": "inspect_harbor/featurebench_modal_1_0",
+    "code": "inspect_harbor/featurebench_modal",
     "contributors": [],
     "samples": 200,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench_modal_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench_modal.html",
+    "model_cards": []
+  },
+  {
+    "id": "featurebench_lite",
+    "name": "FeatureBench-Lite",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Lightweight subset of FeatureBench for cheaper evaluation while preserving model rankings.",
+    "paper": "https://arxiv.org/abs/2602.10975",
+    "code": "inspect_harbor/featurebench_lite",
+    "contributors": [],
+    "samples": 30,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench_lite.html",
+    "model_cards": []
+  },
+  {
+    "id": "featurebench_lite_modal",
+    "name": "FeatureBench-Lite (Modal)",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "FeatureBench-Lite executed on Modal's cloud sandbox runner.",
+    "paper": "https://arxiv.org/abs/2602.10975",
+    "code": "inspect_harbor/featurebench_lite_modal",
+    "contributors": [],
+    "samples": 30,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/featurebench_lite_modal.html",
     "model_cards": []
   },
   {
@@ -543,11 +519,12 @@
     "model_cards": []
   },
   {
-    "id": "gso_1_0",
-    "name": "Gso",
+    "id": "yanagiorigami_frontier_cs",
+    "name": "Frontier-CS",
     "source": "harbor",
     "categories": [
-      "Coding"
+      "Coding",
+      "Reasoning"
     ],
     "tags": [],
     "kind": "agent",
@@ -555,21 +532,22 @@
       "agent",
       "sandbox"
     ],
-    "desc": "GSO: 102 software optimization tasks focusing on performance improvement.",
-    "paper": "https://arxiv.org/abs/2505.23671",
-    "code": "inspect_harbor/gso_1_0",
+    "desc": "Frontier-CS competitive programming benchmark: 172 open-ended algorithmic problems with partial scoring via go-judge.",
+    "paper": "https://arxiv.org/abs/2512.15699",
+    "code": "inspect_harbor/yanagiorigami_frontier_cs",
     "contributors": [],
-    "samples": 102,
+    "samples": 172,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gso_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/yanagiorigami_frontier_cs.html",
     "model_cards": []
   },
   {
-    "id": "hello_world_1_0",
-    "name": "Hello World",
+    "id": "scale_ai_hil_bench",
+    "name": "HiL-Bench",
     "source": "harbor",
     "categories": [
-      "Coding"
+      "Coding",
+      "Behavior"
     ],
     "tags": [],
     "kind": "agent",
@@ -577,13 +555,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A simple example task to create a hello.txt file with 'Hello, world!' as content.",
-    "paper": null,
-    "code": "inspect_harbor/hello_world_1_0",
+    "desc": "HiL-Bench (Human-in-the-Loop): tests if agents know when to ask for help rather than proceed with uncertain knowledge.",
+    "paper": "https://arxiv.org/abs/2604.09408",
+    "code": "inspect_harbor/scale_ai_hil_bench",
     "contributors": [],
-    "samples": 1,
+    "samples": 600,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/hello_world_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/scale_ai_hil_bench.html",
     "model_cards": []
   },
   {
@@ -610,8 +588,8 @@
     "model_cards": []
   },
   {
-    "id": "humanevalfix_1_0",
-    "name": "Humanevalfix",
+    "id": "bigcode_humanevalfix",
+    "name": "HumanEvalFix",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -622,13 +600,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "HumanEvalFix: 164 Python code repair tasks from HumanEvalPack.",
+    "desc": "HumanEvalFix (OctoPack): buggy functions across Python, JavaScript, Java, Go, C++, and Rust that models must repair given the failing unit tests.",
     "paper": "https://arxiv.org/abs/2308.07124",
-    "code": "inspect_harbor/humanevalfix_1_0",
+    "code": "inspect_harbor/bigcode_humanevalfix",
     "contributors": [],
     "samples": 164,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/humanevalfix_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bigcode_humanevalfix.html",
     "model_cards": []
   },
   {
@@ -664,7 +642,7 @@
     "tags": [],
     "kind": "generation",
     "modalities": [
-      "sandbox"
+      "text"
     ],
     "desc": "A benchmark for evaluating the ability of LLMs to write efficient GPU kernels.",
     "paper": "https://arxiv.org/html/2502.10517v1",
@@ -678,8 +656,8 @@
     "model_cards": []
   },
   {
-    "id": "legacy_bench_1_0",
-    "name": "Legacy Bench",
+    "id": "factory_ai_legacy_bench",
+    "name": "Legacy-Bench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -690,18 +668,41 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A benchmark for evaluating AI agents on legacy code maintenance and modernization tasks across multiple language families including COBOL, Java 7, C, Fortran, and Assembly.",
+    "desc": "Legacy-Bench public sample tasks for evaluating AI coding agents on legacy software engineering tasks.",
     "paper": "https://factory.ai/news/legacy-bench",
-    "code": "inspect_harbor/legacy_bench_1_0",
+    "code": "inspect_harbor/factory_ai_legacy_bench",
     "contributors": [],
     "samples": 10,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/legacy_bench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/factory_ai_legacy_bench.html",
     "model_cards": []
   },
   {
-    "id": "livecodebench_6_0",
-    "name": "Livecodebench",
+    "id": "litecoder_rl",
+    "name": "LiteCoder-RL",
+    "source": "harbor",
+    "categories": [
+      "Coding",
+      "Assistants"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "LiteCoder: terminal-based RL training environments spanning developer workflows, scientific/numerical computing, and games.",
+    "paper": "https://github.com/icip-cas/LiteCoder",
+    "code": "inspect_harbor/litecoder_rl",
+    "contributors": [],
+    "samples": 602,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/litecoder_rl.html",
+    "model_cards": []
+  },
+  {
+    "id": "livecodebench",
+    "name": "LiveCodeBench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -712,13 +713,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A subset of 100 sampled tasks from the release_v6 version of LiveCodeBench tasks.",
+    "desc": "LiveCodeBench: contamination-free coding benchmark continuously collected from LeetCode, AtCoder, and Codeforces, supporting code generation, self-repair, execution, and test-output prediction.",
     "paper": "https://arxiv.org/abs/2403.07974",
-    "code": "inspect_harbor/livecodebench_6_0",
+    "code": "inspect_harbor/livecodebench",
     "contributors": [],
     "samples": 100,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/livecodebench_6_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/livecodebench.html",
     "model_cards": []
   },
   {
@@ -768,28 +769,6 @@
     "model_cards": []
   },
   {
-    "id": "ml_dev_bench_1_0",
-    "name": "Ml Dev Bench",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "ML-Dev-Bench: A benchmark for testing AI agents on machine learning development tasks including model implementation, training, debugging, and optimization.",
-    "paper": "https://arxiv.org/abs/2502.00964",
-    "code": "inspect_harbor/ml_dev_bench_1_0",
-    "contributors": [],
-    "samples": 33,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/ml_dev_bench_1_0.html",
-    "model_cards": []
-  },
-  {
     "id": "mle_bench",
     "name": "MLE-bench",
     "source": "evals",
@@ -816,8 +795,8 @@
     "model_cards": []
   },
   {
-    "id": "mlgym_bench_1_0",
-    "name": "Mlgym Bench",
+    "id": "meta_mlgym_bench",
+    "name": "MLGym-Bench",
     "source": "harbor",
     "categories": [
       "Coding",
@@ -829,13 +808,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Evaluates agents on ML tasks across computer vision, RL, tabular ML, and game theory.",
+    "desc": "MLGym-Bench: Meta's framework and benchmark for AI research agents covering CV, NLP, RL, and game-theory tasks requiring ideation, implementation, training, and analysis of ML experiments.",
     "paper": "https://arxiv.org/abs/2502.14499",
-    "code": "inspect_harbor/mlgym_bench_1_0",
+    "code": "inspect_harbor/meta_mlgym_bench",
     "contributors": [],
     "samples": 12,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/mlgym_bench_1_0.html",
+    "featured": true,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/meta_mlgym_bench.html",
     "model_cards": []
   },
   {
@@ -865,11 +844,12 @@
     "model_cards": []
   },
   {
-    "id": "openthoughts_tblite_2_0",
-    "name": "Openthoughts Tblite",
+    "id": "grafana_o11y_bench",
+    "name": "o11y-bench",
     "source": "harbor",
     "categories": [
-      "Coding"
+      "Coding",
+      "Professional"
     ],
     "tags": [],
     "kind": "agent",
@@ -877,18 +857,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "OpenThoughts-TBLite: A difficulty-calibrated benchmark of 100 tasks for building terminal agents. By OpenThoughts Agent team, Snorkel AI, Bespoke Labs.",
-    "paper": "https://github.com/open-thoughts/OpenThoughts-TBLite",
-    "code": "inspect_harbor/openthoughts_tblite_2_0",
+    "desc": "o11y-bench: an open agentic observability benchmark. Measures how well AI agents perform 63 real-world observability tasks across logs, metrics, traces, dashboards, and incident workflows.",
+    "paper": "https://github.com/grafana/o11y-bench",
+    "code": "inspect_harbor/grafana_o11y_bench",
     "contributors": [],
-    "samples": 100,
+    "samples": 63,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/openthoughts_tblite_2_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/grafana_o11y_bench.html",
     "model_cards": []
   },
   {
-    "id": "otel_bench_1_0",
-    "name": "Otel Bench",
+    "id": "quesma_otel_bench",
+    "name": "OTel-Bench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -899,13 +879,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "OpenTelemetry Benchmark - evaluates AI agents' ability to instrument applications with OpenTelemetry tracing across multiple languages.",
+    "desc": "AI-agent benchmark for OpenTelemetry instrumentation tasks across multiple programming languages.",
     "paper": "https://github.com/QuesmaOrg/otel-bench",
-    "code": "inspect_harbor/otel_bench_1_0",
+    "code": "inspect_harbor/quesma_otel_bench",
     "contributors": [],
     "samples": 26,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/otel_bench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/quesma_otel_bench.html",
     "model_cards": []
   },
   {
@@ -936,8 +916,8 @@
     "model_cards": []
   },
   {
-    "id": "quixbugs_1_0",
-    "name": "Quixbugs",
+    "id": "quixbugs",
+    "name": "QuixBugs",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -948,18 +928,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "QuixBugs is a multi-lingual program repair benchmark with 40 Python and 40 Java programs, each containing a single-line defect. Tasks cover algorithms and data structures including sorting, graph, dynamic programming, math, and string/array operations.",
+    "desc": "QuixBugs: small classic-algorithm programs (Python and Java) each containing a one-line bug, used to evaluate automated program repair.",
     "paper": "https://github.com/jkoppel/QuixBugs",
-    "code": "inspect_harbor/quixbugs_1_0",
+    "code": "inspect_harbor/quixbugs",
     "contributors": [],
     "samples": 80,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/quixbugs_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/quixbugs.html",
     "model_cards": []
   },
   {
-    "id": "researchcodebench_1_0",
-    "name": "Researchcodebench",
+    "id": "rexbench",
+    "name": "RExBench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -970,40 +950,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "ResearchCodeBench evaluates AI agents' ability to implement algorithms from academic papers. Contains 212 code implementation tasks across 20 ML/AI research problems from top-tier venues (ICLR, NeurIPS, CVPR, COLM). Tests paper comprehension, algorithm understanding, and precise code implementation skills with 1,449 lines of reference code.",
-    "paper": "https://arxiv.org/abs/2506.02314",
-    "code": "inspect_harbor/researchcodebench_1_0",
-    "contributors": [],
-    "samples": 212,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/researchcodebench_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "rexbench_1_0",
-    "name": "Rexbench",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "A benchmark to evaluate the ability of AI agents to extend existing AI research through research experiment implementation tasks.",
+    "desc": "RExBench - 2 tasks (cogs, othello) evaluating AI agents' ability to extend existing AI research through research experiment implementation. Tasks require an A100 40GB GPU and may take multiple hours (cogs: ~2.5h oracle; othello: ~45min oracle). Parity: openhands@1.4.0 / anthropic/claude-sonnet-4-5, 3 runs — cogs: 100% Harbor vs 66.67% original; othello: 100% Harbor vs 100% original. Adapter by Nicholas Edwards (nicholas.edwards@univie.ac.at), one of the original RExBench authors. Acknowledgements: We thank 2077 AI for generously funding API credits to support running parity experiments.",
     "paper": "https://arxiv.org/abs/2506.22598",
-    "code": "inspect_harbor/rexbench_1_0",
+    "code": "inspect_harbor/rexbench",
     "contributors": [],
     "samples": 2,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/rexbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/rexbench.html",
     "model_cards": []
   },
   {
-    "id": "seta_env_1_0",
-    "name": "Seta Env",
+    "id": "camel_ai_seta_env",
+    "name": "SETA-Env",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1014,106 +972,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "CAMEL SETA Environment for RL training.",
-    "paper": null,
-    "code": "inspect_harbor/seta_env_1_0",
-    "contributors": [],
-    "samples": 1376,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/seta_env_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "spider2_dbt_1_0",
-    "name": "Spider2 Dbt",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "Spider 2.0-DBT is a comprehensive code generation agent task that includes 68 examples. Solving these tasks requires models to understand project code, navigating complex SQL environments and handling long contexts, surpassing traditional text-to-SQL challenges.",
-    "paper": "https://arxiv.org/abs/2411.07763",
-    "code": "inspect_harbor/spider2_dbt_1_0",
-    "contributors": [],
-    "samples": 64,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/spider2_dbt_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "scale_ai_swe_atlas_qna_1_0",
-    "name": "Swe Atlas Qna",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "SWE-Atlas Codebase QnA benchmark that evaluates AI agents' ability to comprehend and query existing codebases.",
-    "paper": "https://github.com/scaleapi/SWE-Atlas",
-    "code": "inspect_harbor/scale_ai_swe_atlas_qna_1_0",
-    "contributors": [],
-    "samples": 124,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/scale_ai_swe_atlas_qna_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "scale_ai_swe_atlas_tw_1_0",
-    "name": "Swe Atlas Tw",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "SWE-Atlas Test Writing benchmark that evaluates AI agents' ability to write comprehensive unit tests.",
-    "paper": "https://github.com/scaleapi/SWE-Atlas",
-    "code": "inspect_harbor/scale_ai_swe_atlas_tw_1_0",
-    "contributors": [],
-    "samples": 90,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/scale_ai_swe_atlas_tw_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "swe_gen_js_1_0",
-    "name": "Swe Gen Js",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "SWE-gen-JS: 1000 JavaScript/TypeScript bug fix tasks from 30 open-source GitHub repos, generated using SWE-gen.",
-    "paper": "https://www.swebench.com/post-260113-swesmith-javascript.html",
-    "code": "inspect_harbor/swe_gen_js_1_0",
+    "desc": "SETA (Scaling Environments for Terminal Agents): CAMEL-AI's verifiable terminal-agent tasks spanning software engineering, sysadmin, and DevOps for evaluating and RL-training agents.",
+    "paper": "https://github.com/camel-ai/seta-env",
+    "code": "inspect_harbor/camel_ai_seta_env",
     "contributors": [],
     "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swe_gen_js_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/camel_ai_seta_env.html",
     "model_cards": []
   },
   {
-    "id": "swe_lancer_diamond_all",
-    "name": "Swe Lancer Diamond",
+    "id": "gabeorlanski_slopcodebench",
+    "name": "SlopCodeBench",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1124,18 +994,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Both manager and individual contributor tasks.",
-    "paper": "https://arxiv.org/abs/2502.12115",
-    "code": "inspect_harbor/swe_lancer_diamond_all",
+    "desc": "SlopCodeBench multi-checkpoint coding benchmark tasks converted for Harbor.",
+    "paper": "https://arxiv.org/abs/2603.24755",
+    "code": "inspect_harbor/gabeorlanski_slopcodebench",
     "contributors": [],
-    "samples": 463,
+    "samples": 36,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swe_lancer_diamond_all.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gabeorlanski_slopcodebench.html",
     "model_cards": []
   },
   {
-    "id": "swe_lancer_diamond_ic",
-    "name": "Swe Lancer Diamond",
+    "id": "scale_ai_swe_atlas_qna",
+    "name": "SWE-Atlas (QnA)",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1146,20 +1016,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Only the individual contributor SWE tasks.",
-    "paper": "https://arxiv.org/abs/2502.12115",
-    "code": "inspect_harbor/swe_lancer_diamond_ic",
+    "desc": "SWE-Atlas - Codebase QnA is a benchmark of deep codebase comprehension and QnA problems for coding agents. Checkout for instructions on running it.",
+    "paper": "https://github.com/scaleapi/SWE-Atlas",
+    "code": "inspect_harbor/scale_ai_swe_atlas_qna",
     "contributors": [],
-    "samples": 198,
+    "samples": 124,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swe_lancer_diamond_ic.html",
-    "model_cards": [
-      "chatgpt"
-    ]
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/scale_ai_swe_atlas_qna.html",
+    "model_cards": []
   },
   {
-    "id": "swe_lancer_diamond_manager",
-    "name": "Swe Lancer Diamond",
+    "id": "scale_ai_swe_atlas_tw",
+    "name": "SWE-Atlas (Test Writing)",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1170,13 +1038,57 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Only the manager tasks.",
-    "paper": "https://arxiv.org/abs/2502.12115",
-    "code": "inspect_harbor/swe_lancer_diamond_manager",
+    "desc": "SWE-Atlas - Test Writing -- A benchmark of comprehensive test writing problems for coding agents. Checkout for instructions on running it.",
+    "paper": "https://github.com/scaleapi/SWE-Atlas",
+    "code": "inspect_harbor/scale_ai_swe_atlas_tw",
     "contributors": [],
-    "samples": 265,
+    "samples": 90,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swe_lancer_diamond_manager.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/scale_ai_swe_atlas_tw.html",
+    "model_cards": []
+  },
+  {
+    "id": "cais_swebenchpro",
+    "name": "SWE-bench Pro",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "SWE-bench Pro with anti-exploitation (git history isolation + GitHub network blocking). 731 tasks, Python/JS/TS/Go.",
+    "paper": "https://arxiv.org/abs/2509.16941",
+    "code": "inspect_harbor/cais_swebenchpro",
+    "contributors": [],
+    "samples": 731,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/cais_swebenchpro.html",
+    "model_cards": []
+  },
+  {
+    "id": "scale_ai_swe_bench_pro",
+    "name": "SWE-bench Pro",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "SWE-Bench-Pro: long-horizon enterprise software engineering tasks.",
+    "paper": "https://arxiv.org/abs/2509.16941",
+    "code": "inspect_harbor/scale_ai_swe_bench_pro",
+    "contributors": [],
+    "samples": 731,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/scale_ai_swe_bench_pro.html",
     "model_cards": []
   },
   {
@@ -1210,6 +1122,138 @@
     ]
   },
   {
+    "id": "swe_bench_verified",
+    "name": "SWE-bench Verified",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "SWE-bench Verified: human-filtered subset of SWE-bench (collaboration with OpenAI) where human SWEs confirmed each real GitHub issue is solvable given the available repository context.",
+    "paper": "https://arxiv.org/abs/2310.06770",
+    "code": "inspect_harbor/swe_bench_verified",
+    "contributors": [],
+    "samples": 500,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swe_bench_verified.html",
+    "model_cards": []
+  },
+  {
+    "id": "abundant_swe_gen_cpp",
+    "name": "SWE-gen (C++)",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Dataset of C++ SWE tasks. Generated by abundant-ai/SWE-gen tool.",
+    "paper": "https://github.com/abundant-ai/SWE-gen-Cpp",
+    "code": "inspect_harbor/abundant_swe_gen_cpp",
+    "contributors": [],
+    "samples": 999,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/abundant_swe_gen_cpp.html",
+    "model_cards": []
+  },
+  {
+    "id": "abundant_swe_gen_go",
+    "name": "SWE-gen (Go)",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Dataset of Go SWE tasks. Generated by abundant-ai/SWE-gen tool.",
+    "paper": "https://github.com/abundant-ai/SWE-gen-Go",
+    "code": "inspect_harbor/abundant_swe_gen_go",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/abundant_swe_gen_go.html",
+    "model_cards": []
+  },
+  {
+    "id": "abundant_swe_gen_java",
+    "name": "SWE-gen (Java)",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Dataset of Java SWE tasks. Generated by abundant-ai/SWE-gen tool.",
+    "paper": "https://github.com/abundant-ai/SWE-gen-Java",
+    "code": "inspect_harbor/abundant_swe_gen_java",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/abundant_swe_gen_java.html",
+    "model_cards": []
+  },
+  {
+    "id": "abundant_swe_gen_js",
+    "name": "SWE-gen (JS/TS)",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Dataset of JS/TS SWE tasks. Generated by abundant-ai/SWE-gen tool.",
+    "paper": "https://github.com/abundant-ai/SWE-gen",
+    "code": "inspect_harbor/abundant_swe_gen_js",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/abundant_swe_gen_js.html",
+    "model_cards": []
+  },
+  {
+    "id": "abundant_swe_gen_rust",
+    "name": "SWE-gen (Rust)",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Dataset of Rust SWE tasks. Generated by abundant-ai/SWE-gen tool.",
+    "paper": "https://github.com/abundant-ai/SWE-gen-Rust",
+    "code": "inspect_harbor/abundant_swe_gen_rust",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/abundant_swe_gen_rust.html",
+    "model_cards": []
+  },
+  {
     "id": "swe_lancer",
     "name": "SWE-Lancer",
     "source": "evals",
@@ -1237,8 +1281,8 @@
     "model_cards": []
   },
   {
-    "id": "swebench_multilingual_1_0",
-    "name": "Swebench Multilingual",
+    "id": "openai_swe_lancer_diamond_all",
+    "name": "SWE-Lancer Diamond (Full)",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1249,42 +1293,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "SWE-bench Multilingual extends the original Python-focused SWE-bench benchmark to support multiple programming languages.",
-    "paper": "https://arxiv.org/abs/2504.02605",
-    "code": "inspect_harbor/swebench_multilingual_1_0",
+    "desc": "SWE-Lancer Diamond (full): public split of OpenAI's SWE-Lancer benchmark — real Upwork freelance software-engineering tasks worth $500,800, combining IC engineering tasks and managerial decision tasks.",
+    "paper": "https://arxiv.org/abs/2502.12115",
+    "code": "inspect_harbor/openai_swe_lancer_diamond_all",
     "contributors": [],
-    "samples": 300,
+    "samples": 463,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swebench_multilingual_1_0.html",
-    "model_cards": [
-      "claude"
-    ]
-  },
-  {
-    "id": "swebench_verified_1_0",
-    "name": "Swebench Verified",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "A human-validated subset of 500 SWE-bench tasks.",
-    "paper": "https://arxiv.org/abs/2310.06770",
-    "code": "inspect_harbor/swebench_verified_1_0",
-    "contributors": [],
-    "samples": 500,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swebench_verified_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/openai_swe_lancer_diamond_all.html",
     "model_cards": []
   },
   {
-    "id": "swebenchpro_1_0",
-    "name": "Swebenchpro",
+    "id": "openai_swe_lancer_diamond_ic",
+    "name": "SWE-Lancer Diamond (IC)",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1295,22 +1315,41 @@
       "agent",
       "sandbox"
     ],
-    "desc": "SWE-bench Pro: A multi-language software engineering benchmark with 731 instances covering Python, JavaScript/TypeScript, and Go. Evaluates AI systems' ability to resolve real-world bugs and implement features across diverse production codebases.",
-    "paper": "https://arxiv.org/abs/2509.16941",
-    "code": "inspect_harbor/swebenchpro_1_0",
+    "desc": "A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Individual Contributor (IC) variant: end-to-end engineering tasks.",
+    "paper": "https://arxiv.org/abs/2502.12115",
+    "code": "inspect_harbor/openai_swe_lancer_diamond_ic",
     "contributors": [],
-    "samples": 731,
+    "samples": 198,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swebenchpro_1_0.html",
-    "model_cards": [
-      "chatgpt",
-      "claude",
-      "gemini"
-    ]
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/openai_swe_lancer_diamond_ic.html",
+    "model_cards": []
   },
   {
-    "id": "swesmith_1_0",
-    "name": "Swesmith",
+    "id": "openai_swe_lancer_diamond_manager",
+    "name": "SWE-Lancer Diamond (Manager)",
+    "source": "harbor",
+    "categories": [
+      "Coding",
+      "Professional"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "A benchmark of freelance software engineering tasks from Upwork, valued at $1 million USD total in real-world payouts. Manager variant: picking between technical implementation proposals.",
+    "paper": "https://arxiv.org/abs/2502.12115",
+    "code": "inspect_harbor/openai_swe_lancer_diamond_manager",
+    "contributors": [],
+    "samples": 265,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/openai_swe_lancer_diamond_manager.html",
+    "model_cards": []
+  },
+  {
+    "id": "pgcodellm_rebench_v2_test",
+    "name": "SWE-rebench V2",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1321,18 +1360,40 @@
       "agent",
       "sandbox"
     ],
-    "desc": "SWE-smith is a synthetically generated dataset of software engineering tasks derived from GitHub issues for training and evaluating code generation models.",
+    "desc": "SWE-rebench V2: language-agnostic dataset of executable SWE tasks across 20 languages, with pre-built images for reproducible execution.",
+    "paper": "https://arxiv.org/abs/2602.23866",
+    "code": "inspect_harbor/pgcodellm_rebench_v2_test",
+    "contributors": [],
+    "samples": 20,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/pgcodellm_rebench_v2_test.html",
+    "model_cards": []
+  },
+  {
+    "id": "swe_bench_swe_smith",
+    "name": "SWE-smith",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "SWE-smith: NeurIPS 2025 toolkit for synthesizing unlimited SWE-bench-style task instances from any Python repository, plus released task instances and agent trajectories.",
     "paper": "https://arxiv.org/abs/2504.21798",
-    "code": "inspect_harbor/swesmith_1_0",
+    "code": "inspect_harbor/swe_bench_swe_smith",
     "contributors": [],
     "samples": 100,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swesmith_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swe_bench_swe_smith.html",
     "model_cards": []
   },
   {
-    "id": "swtbench_verified_1_0",
-    "name": "Swtbench Verified",
+    "id": "swt_bench_verified",
+    "name": "SWT-Bench Verified",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1343,18 +1404,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "SWTBench Verified - Software Testing Benchmark for code generation.",
+    "desc": "SWT-Bench Verified: human-validated subset of SWT-Bench evaluating LLMs on generating reproducing unit tests for real GitHub issues — tests must fail on buggy code and pass after the fix.",
     "paper": "https://arxiv.org/abs/2406.12952",
-    "code": "inspect_harbor/swtbench_verified_1_0",
+    "code": "inspect_harbor/swt_bench_verified",
     "contributors": [],
     "samples": 433,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swtbench_verified_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/swt_bench_verified.html",
     "model_cards": []
   },
   {
-    "id": "termigen_environments_1_0",
-    "name": "Termigen Environments",
+    "id": "termigen_environments",
+    "name": "TermiGen-Environments",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1365,18 +1426,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "3,500+ verified Docker environments for training and evaluating terminal agents, spanning 11 task categories across infrastructure, data/algorithm applications, and specialized domains including software build, system administration, security, data processing, ML/MLOps, algorithms, scientific computing, and more.",
-    "paper": null,
-    "code": "inspect_harbor/termigen_environments_1_0",
+    "desc": "TermiGen-Environments: verified Docker environments with executable terminal-agent tasks across 11 categories, generated by an end-to-end multi-agent synthesis pipeline.",
+    "paper": "https://arxiv.org/abs/2602.07274",
+    "code": "inspect_harbor/termigen_environments",
     "contributors": [],
-    "samples": 3566,
+    "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/termigen_environments_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/termigen_environments.html",
     "model_cards": []
   },
   {
-    "id": "terminal_bench_2_0",
-    "name": "Terminal Bench",
+    "id": "terminal_bench_pro",
+    "name": "Terminal-Bench Pro",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1387,47 +1448,45 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Version 2.0 of Terminal-Bench, a benchmark for testing agents in terminal environments. More tasks, harder, and higher quality than 1.0.",
+    "desc": "Terminal-Bench Pro: tasks across 8 domains — data processing, games, debugging, sysadmin, scientific computing, SWE, ML, and security — extending Terminal-Bench with harder real-world scenarios.",
     "paper": "https://arxiv.org/abs/2601.11868",
-    "code": "inspect_harbor/terminal_bench_2_0",
+    "code": "inspect_harbor/terminal_bench_pro",
+    "contributors": [],
+    "samples": 200,
+    "featured": true,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/terminal_bench_pro.html",
+    "model_cards": []
+  },
+  {
+    "id": "terminal_bench_2",
+    "name": "Terminal-Bench v2",
+    "source": "harbor",
+    "categories": [
+      "Coding",
+      "Assistants"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Terminal-Bench v2: benchmark for testing AI agents in real terminal environments — from compiling code to training models and setting up servers.",
+    "paper": "https://arxiv.org/abs/2601.11868",
+    "code": "inspect_harbor/terminal_bench_2",
     "contributors": [],
     "samples": 89,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/terminal_bench_2_0.html",
-    "model_cards": [
-      "chatgpt",
-      "claude",
-      "gemini"
-    ]
-  },
-  {
-    "id": "terminal_bench_pro_1_0",
-    "name": "Terminal Bench Pro",
-    "source": "harbor",
-    "categories": [
-      "Coding"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "Terminal-Bench Pro (Public Set) is an extended benchmark dataset for testing AI agents in real terminal environments. From compiling code to training models and setting up servers, Terminal-Bench Pro evaluates how well agents can handle real-world, end-to-end tasks autonomously.",
-    "paper": "https://arxiv.org/abs/2601.11868",
-    "code": "inspect_harbor/terminal_bench_pro_1_0",
-    "contributors": [],
-    "samples": 200,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/terminal_bench_pro_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/terminal_bench_2.html",
     "model_cards": []
   },
   {
-    "id": "terminal_bench_sample_2_0",
-    "name": "Terminal Bench Sample",
+    "id": "terminal_bench_2_1",
+    "name": "Terminal-Bench v2.1",
     "source": "harbor",
     "categories": [
-      "Coding"
+      "Coding",
+      "Assistants"
     ],
     "tags": [],
     "kind": "agent",
@@ -1435,13 +1494,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A sample of tasks from Terminal-Bench 2.0.",
+    "desc": "Terminal-Bench v2.1 (point release of v2): benchmark for testing AI agents in real terminal environments — from compiling code to training models and setting up servers.",
     "paper": "https://arxiv.org/abs/2601.11868",
-    "code": "inspect_harbor/terminal_bench_sample_2_0",
+    "code": "inspect_harbor/terminal_bench_2_1",
     "contributors": [],
-    "samples": 10,
+    "samples": 89,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/terminal_bench_sample_2_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/terminal_bench_2_1.html",
     "model_cards": []
   },
   {
@@ -1468,8 +1527,8 @@
     "model_cards": []
   },
   {
-    "id": "usaco_2_0",
-    "name": "Usaco",
+    "id": "usaco",
+    "name": "USACO",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1480,18 +1539,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "USACO: 304 Python programming problems from USACO competition.",
+    "desc": "USACO: USA Computing Olympiad problems across bronze/silver/gold/platinum tiers with high-quality unit tests, reference code, and official analyses for ad-hoc algorithmic reasoning.",
     "paper": "https://arxiv.org/abs/2404.10952",
-    "code": "inspect_harbor/usaco_2_0",
+    "code": "inspect_harbor/usaco",
     "contributors": [],
     "samples": 304,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/usaco_2_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/usaco.html",
     "model_cards": []
   },
   {
-    "id": "vmax_tasks_1_0",
-    "name": "Vmax Tasks",
+    "id": "vmax_tasks",
+    "name": "vmax-tasks",
     "source": "harbor",
     "categories": [
       "Coding"
@@ -1502,13 +1561,35 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A collection of 1,043 validated real-world bug-fixing tasks from popular open-source JavaScript projects including Vue.js, Docusaurus, Redux, and Chalk. Each task presents an authentic bug report with reproduction steps and expected behavior.",
+    "desc": "Code-transformation tasks across JavaScript projects (Docusaurus, Vue, Redux).",
     "paper": null,
-    "code": "inspect_harbor/vmax_tasks_1_0",
+    "code": "inspect_harbor/vmax_tasks",
     "contributors": [],
-    "samples": 1043,
+    "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/vmax_tasks_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/vmax_tasks.html",
+    "model_cards": []
+  },
+  {
+    "id": "webgen_bench",
+    "name": "WebGen-Bench",
+    "source": "harbor",
+    "categories": [
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "WebGen-Bench: Evaluating LLMs on Generating Interactive and Functional Websites from Scratch (101 test tasks).",
+    "paper": "https://arxiv.org/abs/2505.03733",
+    "code": "inspect_harbor/webgen_bench",
+    "contributors": [],
+    "samples": 101,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/webgen_bench.html",
     "model_cards": []
   },
   {
@@ -1556,14 +1637,14 @@
     "contributors": [
       "alex-remedios-aisi"
     ],
-    "samples": 4981,
+    "samples": 3981,
     "featured": false,
     "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/assistants/bfcl/",
     "model_cards": []
   },
   {
-    "id": "bfcl_1_0",
-    "name": "Bfcl",
+    "id": "gorilla_bfcl",
+    "name": "BFCL",
     "source": "harbor",
     "categories": [
       "Assistants"
@@ -1574,18 +1655,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Berkeley Function-Calling Leaderboard: 3,641 function calling tasks for evaluating LLM tool use capabilities across simple, multiple, parallel, and irrelevance categories.",
+    "desc": "Berkeley Function-Calling Leaderboard: LLM tool-use across function-calling categories spanning Python, Java, JavaScript, and REST APIs.",
     "paper": "https://github.com/ShishirPatil/gorilla",
-    "code": "inspect_harbor/bfcl_1_0",
+    "code": "inspect_harbor/gorilla_bfcl",
     "contributors": [],
-    "samples": 3641,
+    "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bfcl_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gorilla_bfcl.html",
     "model_cards": []
   },
   {
-    "id": "bfcl_parity_1_0",
-    "name": "Bfcl Parity",
+    "id": "gorilla_bfcl_parity",
+    "name": "BFCL (parity)",
     "source": "harbor",
     "categories": [
       "Assistants"
@@ -1596,13 +1677,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "BFCL parity subset: 123 stratified sampled tasks for validating Harbor adapter equivalence with original BFCL benchmark.",
+    "desc": "Stratified parity subset of BFCL validating that Harbor's adapter matches the upstream implementation.",
     "paper": "https://github.com/ShishirPatil/gorilla",
-    "code": "inspect_harbor/bfcl_parity_1_0",
+    "code": "inspect_harbor/gorilla_bfcl_parity",
     "contributors": [],
     "samples": 123,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bfcl_parity_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gorilla_bfcl_parity.html",
     "model_cards": []
   },
   {
@@ -1662,8 +1743,8 @@
     "model_cards": []
   },
   {
-    "id": "gaia_1_0",
-    "name": "Gaia",
+    "id": "gaia",
+    "name": "GAIA",
     "source": "harbor",
     "categories": [
       "Assistants",
@@ -1675,13 +1756,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "GAIA (General AI Assistants): 165 validation tasks for multi-step reasoning, tool use, and multimodal question answering.",
+    "desc": "GAIA: real-world questions across three difficulty levels evaluating general AI assistants on reasoning, multimodality, web browsing, and tool use.",
     "paper": "https://arxiv.org/abs/2311.12983",
-    "code": "inspect_harbor/gaia_1_0",
+    "code": "inspect_harbor/gaia",
     "contributors": [],
     "samples": 165,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gaia_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gaia.html",
     "model_cards": []
   },
   {
@@ -1705,6 +1786,31 @@
     "samples": 7775,
     "featured": false,
     "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/assistants/mind2web/",
+    "model_cards": []
+  },
+  {
+    "id": "apple_mmau",
+    "name": "MMAU",
+    "source": "harbor",
+    "categories": [
+      "Assistants",
+      "Coding",
+      "Mathematics",
+      "Reasoning"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "MMAU (Massive Multitask Agent Understanding): Apple's holistic agent benchmark covering tool-use, DAG QA, data science/ML coding, contest programming, and mathematics.",
+    "paper": "https://arxiv.org/abs/2410.19168",
+    "code": "inspect_harbor/apple_mmau",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/apple_mmau.html",
     "model_cards": []
   },
   {
@@ -1789,36 +1895,55 @@
     ]
   },
   {
-    "id": "theagentcompany",
-    "name": "The Agent Company",
-    "source": "evals",
+    "id": "sierra_research_tau3_bench",
+    "name": "τ³-bench",
+    "source": "harbor",
     "categories": [
-      "Assistants"
+      "Assistants",
+      "Professional",
+      "Behavior"
     ],
-    "tags": [
-      "Agent",
-      "Tools"
-    ],
+    "tags": [],
     "kind": "agent",
     "modalities": [
       "agent",
-      "tool-use",
       "sandbox"
     ],
-    "desc": "The Agent Company benchmark evaluates autonomous agents in a realistic, self-contained company environment.",
-    "paper": "https://arxiv.org/abs/2412.14161",
-    "code": "inspect_evals/theagentcompany",
-    "contributors": [
-      "bndxn"
-    ],
-    "samples": 3,
+    "desc": "Third generation of τ-bench, extending the original with knowledge and voice. A simulation framework for evaluating customer service agents across airline, retail, telecom, and banking knowledge domains.",
+    "paper": "https://arxiv.org/abs/2406.12045",
+    "code": "inspect_harbor/sierra_research_tau3_bench",
+    "contributors": [],
+    "samples": 375,
     "featured": false,
-    "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/assistants/theagentcompany/",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/sierra_research_tau3_bench.html",
     "model_cards": []
   },
   {
-    "id": "arc_agi_2_1_0",
-    "name": "Arc Agi 2",
+    "id": "minnesotanlp_aar",
+    "name": "AAR",
+    "source": "harbor",
+    "categories": [
+      "Reasoning",
+      "Assistants"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "The Amazing Agent Race (AAR): 1400 multi-step scavenger-hunt puzzles for evaluating LLM agents on tool use, web navigation, and arithmetic reasoning. Includes linear (800) and DAG (600) variants across 4 difficulty levels.",
+    "paper": "https://arxiv.org/abs/2604.10261",
+    "code": "inspect_harbor/minnesotanlp_aar",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/minnesotanlp_aar.html",
+    "model_cards": []
+  },
+  {
+    "id": "arcprize_arc_agi_2",
+    "name": "ARC-AGI-2",
     "source": "harbor",
     "categories": [
       "Reasoning",
@@ -1830,18 +1955,14 @@
       "agent",
       "sandbox"
     ],
-    "desc": "ARC-AGI-2: A benchmark measuring abstract reasoning through visual grid puzzles requiring rule inference and generalization.",
+    "desc": "ARC-AGI-2: visual reasoning tasks testing general fluid intelligence — humans solve them easily but state-of-the-art models still struggle.",
     "paper": "https://arxiv.org/abs/2505.11831",
-    "code": "inspect_harbor/arc_agi_2_1_0",
+    "code": "inspect_harbor/arcprize_arc_agi_2",
     "contributors": [],
     "samples": 167,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/arc_agi_2_1_0.html",
-    "model_cards": [
-      "chatgpt",
-      "claude",
-      "gemini"
-    ]
+    "featured": true,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/arcprize_arc_agi_2.html",
+    "model_cards": []
   },
   {
     "id": "bbh",
@@ -1982,30 +2103,8 @@
     "model_cards": []
   },
   {
-    "id": "kumo_1_0",
-    "name": "Kumo",
-    "source": "harbor",
-    "categories": [
-      "Reasoning"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "KUMO full dataset (5300 tasks; 50 instances per scenario).",
-    "paper": null,
-    "code": "inspect_harbor/kumo_1_0",
-    "contributors": [],
-    "samples": 5300,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/kumo_1_0.html",
-    "model_cards": []
-  },
-  {
     "id": "kumo_easy",
-    "name": "Kumo",
+    "name": "KUMO (easy)",
     "source": "harbor",
     "categories": [
       "Reasoning"
@@ -2016,18 +2115,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "KUMO(easy) split (5050 tasks; 50 instances per scenario).",
-    "paper": null,
+    "desc": "KUMO (easy split): easier-difficulty procedurally-generated reasoning tasks from KUMO's benchmark across 100 domains.",
+    "paper": "https://arxiv.org/abs/2504.02810",
     "code": "inspect_harbor/kumo_easy",
     "contributors": [],
-    "samples": 5050,
+    "samples": 1000,
     "featured": false,
     "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/kumo_easy.html",
     "model_cards": []
   },
   {
     "id": "kumo_hard",
-    "name": "Kumo",
+    "name": "KUMO (hard)",
     "source": "harbor",
     "categories": [
       "Reasoning"
@@ -2038,8 +2137,8 @@
       "agent",
       "sandbox"
     ],
-    "desc": "KUMO(hard) split (250 tasks; 50 instances per scenario).",
-    "paper": null,
+    "desc": "KUMO (hard split): hard-difficulty procedurally-generated reasoning tasks from KUMO's benchmark across 100 domains.",
+    "paper": "https://arxiv.org/abs/2504.02810",
     "code": "inspect_harbor/kumo_hard",
     "contributors": [],
     "samples": 250,
@@ -2048,8 +2147,8 @@
     "model_cards": []
   },
   {
-    "id": "kumo_parity",
-    "name": "Kumo",
+    "id": "kumo_1",
+    "name": "KUMO (kumo-1)",
     "source": "harbor",
     "categories": [
       "Reasoning"
@@ -2060,8 +2159,30 @@
       "agent",
       "sandbox"
     ],
-    "desc": "KUMO parity subset (seeds 0/1; 212 tasks).",
-    "paper": null,
+    "desc": "KUMO (kumo-1 split): procedurally-generated multi-turn reasoning games combining LLMs with symbolic engines across 100 open-ended domains.",
+    "paper": "https://arxiv.org/abs/2504.02810",
+    "code": "inspect_harbor/kumo_1",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/kumo_1.html",
+    "model_cards": []
+  },
+  {
+    "id": "kumo_parity",
+    "name": "KUMO (parity)",
+    "source": "harbor",
+    "categories": [
+      "Reasoning"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "KUMO (parity split): subset of the KUMO procedural-reasoning benchmark used for parity / regression checks against the upstream evaluation.",
+    "paper": "https://arxiv.org/abs/2504.02810",
     "code": "inspect_harbor/kumo_parity",
     "contributors": [],
     "samples": 212,
@@ -2260,8 +2381,8 @@
     "model_cards": []
   },
   {
-    "id": "reasoning_gym_easy_parity",
-    "name": "Reasoning Gym Easy",
+    "id": "reasoning_gym_easy",
+    "name": "Reasoning Gym (easy)",
     "source": "harbor",
     "categories": [
       "Reasoning"
@@ -2272,18 +2393,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Reasoning Gym benchmark (easy difficulty).",
+    "desc": "Reasoning Gym (easy split): procedurally-generated, algorithmically-verifiable reasoning tasks (algebra, arithmetic, logic, geometry, graphs, games) at easier difficulty for evaluating and RL-training reasoning models.",
     "paper": "https://arxiv.org/abs/2505.24760",
-    "code": "inspect_harbor/reasoning_gym_easy_parity",
+    "code": "inspect_harbor/reasoning_gym_easy",
     "contributors": [],
     "samples": 288,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/reasoning_gym_easy_parity.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/reasoning_gym_easy.html",
     "model_cards": []
   },
   {
-    "id": "reasoning_gym_hard_parity",
-    "name": "Reasoning Gym Hard",
+    "id": "reasoning_gym_hard",
+    "name": "Reasoning Gym (hard)",
     "source": "harbor",
     "categories": [
       "Reasoning"
@@ -2294,18 +2415,41 @@
       "agent",
       "sandbox"
     ],
-    "desc": "Reasoning Gym benchmark (hard difficulty).",
+    "desc": "Reasoning Gym (hard split): procedurally-generated, algorithmically-verifiable reasoning tasks at harder difficulty across 90+ task families.",
     "paper": "https://arxiv.org/abs/2505.24760",
-    "code": "inspect_harbor/reasoning_gym_hard_parity",
+    "code": "inspect_harbor/reasoning_gym_hard",
     "contributors": [],
     "samples": 288,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/reasoning_gym_hard_parity.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/reasoning_gym_hard.html",
     "model_cards": []
   },
   {
-    "id": "satbench_1_0",
-    "name": "Satbench",
+    "id": "maxbittker_runebench",
+    "name": "runebench",
+    "source": "harbor",
+    "categories": [
+      "Reasoning",
+      "Behavior"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Benchmark suite for evaluating AI agents on RuneScape gameplay tasks.",
+    "paper": "https://github.com/MaxBittker/rs-sdk",
+    "code": "inspect_harbor/maxbittker_runebench",
+    "contributors": [],
+    "samples": 32,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/maxbittker_runebench.html",
+    "model_cards": []
+  },
+  {
+    "id": "satbench",
+    "name": "SATBench",
     "source": "harbor",
     "categories": [
       "Reasoning"
@@ -2316,13 +2460,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "SATBench is a benchmark for evaluating the logical reasoning capabilities of LLMs through logical puzzles derived from Boolean satisfiability (SAT) problems.",
+    "desc": "SATBench: logical-reasoning puzzles automatically generated from SAT formulas with adjustable difficulty, validated through both LLM and SAT-solver consistency checks.",
     "paper": "https://arxiv.org/abs/2505.14615",
-    "code": "inspect_harbor/satbench_1_0",
+    "code": "inspect_harbor/satbench",
     "contributors": [],
-    "samples": 2100,
+    "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/satbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/satbench.html",
     "model_cards": []
   },
   {
@@ -2564,6 +2708,30 @@
     "model_cards": []
   },
   {
+    "id": "kgmon_deepsearchqa",
+    "name": "DeepSearchQA",
+    "source": "harbor",
+    "categories": [
+      "Knowledge",
+      "Reasoning",
+      "Assistants"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "DeepSearchQA is a 900-prompt factuality benchmark from Google DeepMind for evaluating deep research agents on difficult multi-step information-seeking tasks.",
+    "paper": "https://arxiv.org/abs/2601.20975",
+    "code": "inspect_harbor/kgmon_deepsearchqa",
+    "contributors": [],
+    "samples": 900,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/kgmon_deepsearchqa.html",
+    "model_cards": []
+  },
+  {
     "id": "hle",
     "name": "Humanity's Last Exam",
     "source": "evals",
@@ -2660,8 +2828,8 @@
     "model_cards": []
   },
   {
-    "id": "mmmlu_parity",
-    "name": "Mmmlu",
+    "id": "openai_mmmlu",
+    "name": "MMMLU",
     "source": "harbor",
     "categories": [
       "Knowledge",
@@ -2673,13 +2841,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "MMMLU (Multilingual MMLU) parity validation subset with 10 tasks per language across 15 languages (150 tasks total). Evaluates language models' subject knowledge and reasoning across multiple languages using multiple-choice questions covering 57 academic subjects.",
+    "desc": "MMMLU (Multilingual MMLU): OpenAI's professional-human-translation of the MMLU test set into 14 languages for multilingual knowledge and reasoning evaluation.",
     "paper": "https://arxiv.org/abs/2503.10497",
-    "code": "inspect_harbor/mmmlu_parity",
+    "code": "inspect_harbor/openai_mmmlu",
     "contributors": [],
     "samples": 150,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/mmmlu_parity.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/openai_mmmlu.html",
     "model_cards": []
   },
   {
@@ -2729,8 +2897,8 @@
     "model_cards": []
   },
   {
-    "id": "simpleqa_1_0",
-    "name": "Simpleqa",
+    "id": "openai_simpleqa",
+    "name": "SimpleQA",
     "source": "harbor",
     "categories": [
       "Knowledge"
@@ -2741,13 +2909,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "SimpleQA: 4,326 short, fact-seeking questions from OpenAI for evaluating language model factuality. Uses LLM-as-a-judge grading.",
+    "desc": "SimpleQA: short, fact-seeking questions adversarially collected against GPT-4 to measure short-form factuality and calibration of frontier LLMs.",
     "paper": "https://arxiv.org/abs/2411.04368",
-    "code": "inspect_harbor/simpleqa_1_0",
+    "code": "inspect_harbor/openai_simpleqa",
     "contributors": [],
-    "samples": 4326,
+    "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/simpleqa_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/openai_simpleqa.html",
     "model_cards": []
   },
   {
@@ -2821,8 +2989,8 @@
     "model_cards": []
   },
   {
-    "id": "binary_audit_1_0",
-    "name": "Binary Audit",
+    "id": "binary_audit",
+    "name": "BinaryAudit",
     "source": "harbor",
     "categories": [
       "Cybersecurity"
@@ -2833,13 +3001,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "An open-source benchmark for evaluating AI agents' ability to find backdoors hidden in compiled binaries.",
+    "desc": "BinaryAudit: AI-agent benchmark for finding backdoors hidden in compiled binaries via reverse engineering.",
     "paper": "https://github.com/QuesmaOrg/BinaryAudit",
-    "code": "inspect_harbor/binary_audit_1_0",
+    "code": "inspect_harbor/binary_audit",
     "contributors": [],
     "samples": 46,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/binary_audit_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/binary_audit.html",
     "model_cards": []
   },
   {
@@ -2854,8 +3022,7 @@
     ],
     "kind": "agent",
     "modalities": [
-      "agent",
-      "sandbox"
+      "agent"
     ],
     "desc": "A benchmark for evaluating the capabilities of LLM agents in cyber offense.",
     "paper": "https://arxiv.org/abs/2410.09114",
@@ -2868,32 +3035,6 @@
     "samples": 13,
     "featured": false,
     "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/cybersecurity/threecb/",
-    "model_cards": []
-  },
-  {
-    "id": "cti_realm",
-    "name": "CTI-REALM",
-    "source": "evals",
-    "categories": [
-      "Cybersecurity"
-    ],
-    "tags": [
-      "Agent"
-    ],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "Evaluates AI systems' ability to analyze cyber threat intelligence and develop comprehensive detection capabilities through a realistic 5-subtask workflow: MITRE technique mapping, data source discovery, Sigma rule generation, KQL development and testing against real telemetry data, and results analysis.",
-    "paper": "https://arxiv.org/abs/2603.13517",
-    "code": "inspect_evals/cti_realm",
-    "contributors": [
-      "arjun180-new"
-    ],
-    "samples": 25,
-    "featured": false,
-    "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/cybersecurity/cti_realm/",
     "model_cards": []
   },
   {
@@ -3328,34 +3469,6 @@
     "model_cards": []
   },
   {
-    "id": "ipi_coding_agent",
-    "name": "CodeIPI",
-    "source": "evals",
-    "categories": [
-      "Safeguards"
-    ],
-    "tags": [
-      "safety",
-      "agents",
-      "prompt-injection",
-      "coding"
-    ],
-    "kind": "generation",
-    "modalities": [
-      "text"
-    ],
-    "desc": "Measures coding agent vulnerability to indirect prompt injection attacks embedded in software engineering artifacts (issue descriptions, code comments, README files).",
-    "paper": null,
-    "code": "inspect_evals/ipi_coding_agent",
-    "contributors": [
-      "debu-sinha"
-    ],
-    "samples": 45,
-    "featured": false,
-    "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/ipi_coding_agent/",
-    "model_cards": []
-  },
-  {
     "id": "fortress",
     "name": "FORTRESS",
     "source": "evals",
@@ -3459,8 +3572,7 @@
     ],
     "kind": "agent",
     "modalities": [
-      "agent",
-      "sandbox"
+      "agent"
     ],
     "desc": "Tests whether an AI system can act as a safety guardrail by generating and executing code to protect web navigation agents from unsafe actions based on user constraints.",
     "paper": "https://arxiv.org/abs/2406.09187",
@@ -3567,8 +3679,8 @@
     "model_cards": []
   },
   {
-    "id": "strongreject_parity",
-    "name": "Strongreject",
+    "id": "strongreject",
+    "name": "StrongREJECT",
     "source": "harbor",
     "categories": [
       "Safeguards"
@@ -3579,39 +3691,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "StrongReject benchmark for evaluating LLM safety and jailbreak resistance. Parity subset with 150 tasks (50 prompts * 3 jailbreaks).",
+    "desc": "StrongREJECT: forbidden prompts plus an automated evaluator for measuring how effective jailbreaks are at eliciting genuinely harmful, specific responses.",
     "paper": "https://arxiv.org/abs/2402.10260",
-    "code": "inspect_harbor/strongreject_parity",
+    "code": "inspect_harbor/strongreject",
     "contributors": [],
     "samples": 150,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/strongreject_parity.html",
-    "model_cards": []
-  },
-  {
-    "id": "tac",
-    "name": "TAC",
-    "source": "evals",
-    "categories": [
-      "Safeguards"
-    ],
-    "tags": [
-      "Agent"
-    ],
-    "kind": "agent",
-    "modalities": [
-      "agent"
-    ],
-    "desc": "Tests whether AI agents show implicit animal welfare awareness when purchasing tickets and experiences on behalf of users.",
-    "paper": null,
-    "code": "inspect_evals/tac",
-    "contributors": [
-      "darkness8i8",
-      "joel-christoph"
-    ],
-    "samples": 48,
-    "featured": false,
-    "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/safeguards/tac/",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/strongreject.html",
     "model_cards": []
   },
   {
@@ -3685,8 +3771,8 @@
     "model_cards": []
   },
   {
-    "id": "bixbench_1_5",
-    "name": "Bixbench",
+    "id": "futurehouse_bixbench",
+    "name": "BixBench",
     "source": "harbor",
     "categories": [
       "Science",
@@ -3699,18 +3785,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "BixBench - A benchmark for evaluating AI agents on bioinformatics and computational biology tasks.",
+    "desc": "BixBench: real-world bioinformatics analysis capsules with open-answer questions evaluating LLM agents' ability to author multi-step Jupyter notebooks for biological data analysis.",
     "paper": "https://arxiv.org/abs/2503.00096",
-    "code": "inspect_harbor/bixbench_1_5",
+    "code": "inspect_harbor/futurehouse_bixbench",
     "contributors": [],
     "samples": 205,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bixbench_1_5.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/futurehouse_bixbench.html",
     "model_cards": []
   },
   {
-    "id": "bixbench_cli_1_5",
-    "name": "Bixbench Cli",
+    "id": "futurehouse_bixbench_cli",
+    "name": "BixBench (CLI)",
     "source": "harbor",
     "categories": [
       "Science",
@@ -3723,13 +3809,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "bixbench-cli - A benchmark for evaluating AI agents on bioinformatics and computational biology tasks. (Adapted for CLI execution).",
+    "desc": "CLI variant of BixBench: agents solve the same bioinformatics analysis tasks via a command-line / shell interface rather than notebook authoring.",
     "paper": "https://arxiv.org/abs/2503.00096",
-    "code": "inspect_harbor/bixbench_cli_1_5",
+    "code": "inspect_harbor/futurehouse_bixbench_cli",
     "contributors": [],
     "samples": 205,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/bixbench_cli_1_5.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/futurehouse_bixbench_cli.html",
     "model_cards": []
   },
   {
@@ -3750,9 +3836,7 @@
     "paper": "https://arxiv.org/pdf/2404.01475v2",
     "code": "inspect_evals/chembench",
     "contributors": [
-      "Esther-Guo",
-      "MrtinoRG",
-      "r-fedorov"
+      "Esther-Guo"
     ],
     "samples": 2786,
     "featured": false,
@@ -3760,8 +3844,8 @@
     "model_cards": []
   },
   {
-    "id": "codepde_1_0",
-    "name": "Codepde",
+    "id": "codepde",
+    "name": "CodePDE",
     "source": "harbor",
     "categories": [
       "Science",
@@ -3774,13 +3858,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "CodePDE evaluates code generation capabilities on scientific computing tasks, specifically focusing on Partial Differential Equation (PDE) solving.",
+    "desc": "CodePDE: framing partial-differential-equation solving as a code-generation task to benchmark LLMs on producing correct, efficient PDE solvers.",
     "paper": "https://arxiv.org/abs/2505.08783",
-    "code": "inspect_harbor/codepde_1_0",
+    "code": "inspect_harbor/codepde",
     "contributors": [],
     "samples": 5,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/codepde_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/codepde.html",
     "model_cards": []
   },
   {
@@ -3872,8 +3956,8 @@
     ]
   },
   {
-    "id": "gpqa_diamond_1_0",
-    "name": "Gpqa Diamond",
+    "id": "gpqa_diamond",
+    "name": "GPQA Diamond",
     "source": "harbor",
     "categories": [
       "Science",
@@ -3888,13 +3972,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "GPQA Diamond subset: 198 graduate-level multiple-choice questions in biology, physics, and chemistry for evaluating scientific reasoning.",
+    "desc": "GPQA Diamond: expert-validated graduate-level multiple-choice questions in biology, physics, and chemistry, designed to be Google-proof for non-experts.",
     "paper": "https://arxiv.org/abs/2311.12022",
-    "code": "inspect_harbor/gpqa_diamond_1_0",
+    "code": "inspect_harbor/gpqa_diamond",
     "contributors": [],
     "samples": 198,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gpqa_diamond_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/gpqa_diamond.html",
     "model_cards": []
   },
   {
@@ -3925,8 +4009,8 @@
     ]
   },
   {
-    "id": "labbench_1_0",
-    "name": "Labbench",
+    "id": "futurehouse_labbench",
+    "name": "LAB-Bench",
     "source": "harbor",
     "categories": [
       "Science",
@@ -3939,13 +4023,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "LAB-Bench FigQA: 181 scientific figure reasoning tasks in biology from Future-House LAB-Bench.",
+    "desc": "LAB-Bench (Language Agent Biology Benchmark): questions across 8 categories (literature QA, database lookup, sequence manipulation, figure/table reasoning, protocols) testing LLMs on biology-research tasks.",
     "paper": "https://arxiv.org/abs/2407.10362",
-    "code": "inspect_harbor/labbench_1_0",
+    "code": "inspect_harbor/futurehouse_labbench",
     "contributors": [],
     "samples": 181,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/labbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/futurehouse_labbench.html",
     "model_cards": []
   },
   {
@@ -3975,8 +4059,8 @@
     "model_cards": []
   },
   {
-    "id": "qcircuitbench_1_0",
-    "name": "Qcircuitbench",
+    "id": "qcircuitbench",
+    "name": "QCircuitBench",
     "source": "harbor",
     "categories": [
       "Science",
@@ -3989,18 +4073,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "QCircuitBench evaluates agents on quantum algorithm design using quantum programming languages.",
+    "desc": "QCircuitBench: large-scale benchmark for LLM-driven quantum-algorithm design, spanning oracle construction, algorithm design, and random circuits with automatic verification.",
     "paper": "https://arxiv.org/abs/2410.07961",
-    "code": "inspect_harbor/qcircuitbench_1_0",
+    "code": "inspect_harbor/qcircuitbench",
     "contributors": [],
     "samples": 28,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/qcircuitbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/qcircuitbench.html",
     "model_cards": []
   },
   {
-    "id": "replicationbench_1_0",
-    "name": "Replicationbench",
+    "id": "replicationbench",
+    "name": "ReplicationBench",
     "source": "harbor",
     "categories": [
       "Science",
@@ -4013,41 +4097,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "ReplicationBench - A benchmark for evaluating AI agents on reproducing computational results from astrophysics research papers. Adapted from Christine8888/replicationbench-release.",
+    "desc": "ReplicationBench: end-to-end replication of astrophysics research papers — agents reproduce implementation, methodology, and core findings of expert-validated papers, scored on result accuracy.",
     "paper": "https://arxiv.org/abs/2510.24591",
-    "code": "inspect_harbor/replicationbench_1_0",
+    "code": "inspect_harbor/replicationbench",
     "contributors": [],
     "samples": 90,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/replicationbench_1_0.html",
-    "model_cards": []
-  },
-  {
-    "id": "scbench",
-    "name": "scBench",
-    "source": "evals",
-    "categories": [
-      "Science",
-      "Biology",
-      "Coding"
-    ],
-    "tags": [
-      "Agent"
-    ],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "Evaluates whether models can solve practical single-cell RNA-seq analysis tasks with deterministic grading.",
-    "paper": "https://arxiv.org/abs/2602.09063",
-    "code": "inspect_evals/scbench",
-    "contributors": [
-      "retroam"
-    ],
-    "samples": 30,
-    "featured": false,
-    "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/coding/scbench/",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/replicationbench.html",
     "model_cards": []
   },
   {
@@ -4077,6 +4133,30 @@
     ]
   },
   {
+    "id": "scienceagentbench",
+    "name": "ScienceAgentBench",
+    "source": "harbor",
+    "categories": [
+      "Science",
+      "Coding",
+      "Reasoning"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "ScienceAgentBench: data-driven scientific discovery via Python programs across 4 disciplines.",
+    "paper": "https://arxiv.org/abs/2410.05080",
+    "code": "inspect_harbor/scienceagentbench",
+    "contributors": [],
+    "samples": 102,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/scienceagentbench.html",
+    "model_cards": []
+  },
+  {
     "id": "sciknoweval",
     "name": "SciKnowEval",
     "source": "evals",
@@ -4101,8 +4181,8 @@
     "model_cards": []
   },
   {
-    "id": "sldbench_1_0",
-    "name": "Sldbench",
+    "id": "sldbench",
+    "name": "SLDBench",
     "source": "harbor",
     "categories": [
       "Science",
@@ -4115,13 +4195,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "SLDBench: A benchmark for scaling law discovery with symbolic regression tasks.",
+    "desc": "SLDBench: first benchmark for scaling-law discovery — tasks curated from LLM training experiments where agents must autonomously fit and extrapolate scaling laws.",
     "paper": "https://arxiv.org/abs/2507.21184",
-    "code": "inspect_harbor/sldbench_1_0",
+    "code": "inspect_harbor/sldbench",
     "contributors": [],
     "samples": 8,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/sldbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/sldbench.html",
     "model_cards": []
   },
   {
@@ -4151,8 +4231,8 @@
     "model_cards": []
   },
   {
-    "id": "aime_1_0",
-    "name": "Aime",
+    "id": "aime",
+    "name": "AIME",
     "source": "harbor",
     "categories": [
       "Mathematics"
@@ -4163,13 +4243,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "American Invitational Mathematics Examination (AIME) benchmark for evaluating mathematical reasoning and problem-solving capabilities. Contains 60 competition-level mathematics problems from AIME 2024, 2025-I, and 2025-II competitions.",
+    "desc": "Problems from the American Invitational Mathematics Examination (AIME), a 3-hour high-school competition with integer answers (0–999) used to evaluate mathematical reasoning.",
     "paper": null,
-    "code": "inspect_harbor/aime_1_0",
+    "code": "inspect_harbor/aime",
     "contributors": [],
     "samples": 60,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/aime_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/aime.html",
     "model_cards": []
   },
   {
@@ -4267,8 +4347,8 @@
     "model_cards": []
   },
   {
-    "id": "ineqmath_1_0",
-    "name": "Ineqmath",
+    "id": "ineqmath",
+    "name": "IneqMath",
     "source": "harbor",
     "categories": [
       "Mathematics",
@@ -4280,13 +4360,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "This adapter brings IneqMath, the dev set of the first inequality-proof Q\\&A benchmark for LLMs, into Harbor, enabling standardized evaluation of models on mathematical reasoning and proof construction.",
+    "desc": "IneqMath: Olympiad-level inequality benchmark with expert-reviewed test problems, formulated as bound-estimation and relation-prediction subtasks with stepwise judging.",
     "paper": "https://arxiv.org/abs/2506.07927",
-    "code": "inspect_harbor/ineqmath_1_0",
+    "code": "inspect_harbor/ineqmath",
     "contributors": [],
     "samples": 100,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/ineqmath_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/ineqmath.html",
     "model_cards": []
   },
   {
@@ -4386,8 +4466,8 @@
     "model_cards": []
   },
   {
-    "id": "dabstep_1_0",
-    "name": "Dabstep",
+    "id": "adyen_dabstep",
+    "name": "DABstep",
     "source": "harbor",
     "categories": [
       "Professional",
@@ -4401,41 +4481,14 @@
       "agent",
       "sandbox"
     ],
-    "desc": "DABstep: Data Agent Benchmark for Multi-step Reasoning. 450 tasks where agents analyze payment transaction data with Python/pandas to answer business questions.",
+    "desc": "DABstep: real-world data analysis tasks from Adyen's workloads requiring multi-step reasoning by LLM agents.",
     "paper": "https://arxiv.org/abs/2506.23719",
-    "code": "inspect_harbor/dabstep_1_0",
+    "code": "inspect_harbor/adyen_dabstep",
     "contributors": [],
     "samples": 450,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/dabstep_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/adyen_dabstep.html",
     "model_cards": []
-  },
-  {
-    "id": "financeagent_public",
-    "name": "Financeagent",
-    "source": "harbor",
-    "categories": [
-      "Professional",
-      "Finance",
-      "Assistants"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "Finance Agent is a tool for financial research and analysis that leverages large language models and specialized financial tools to answer complex queries about companies, financial statements, and SEC filings.",
-    "paper": "https://arxiv.org/abs/2508.00828",
-    "code": "inspect_harbor/financeagent_public",
-    "contributors": [],
-    "samples": 50,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/financeagent_public.html",
-    "model_cards": [
-      "chatgpt",
-      "claude"
-    ]
   },
   {
     "id": "gdpval",
@@ -4500,8 +4553,8 @@
     ]
   },
   {
-    "id": "lawbench_1_0",
-    "name": "Lawbench",
+    "id": "lawbench",
+    "name": "LawBench",
     "source": "harbor",
     "categories": [
       "Professional",
@@ -4514,18 +4567,18 @@
       "agent",
       "sandbox"
     ],
-    "desc": "LawBench: Benchmarking Legal Knowledge of Large Language Models.",
+    "desc": "LawBench: tasks evaluating LLMs on Chinese-law knowledge — legal entity recognition, reading comprehension, criminal-damage calculation, legal consulting — plus an abstention-rate metric.",
     "paper": "https://arxiv.org/abs/2309.16289",
-    "code": "inspect_harbor/lawbench_1_0",
+    "code": "inspect_harbor/lawbench",
     "contributors": [],
     "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/lawbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/lawbench.html",
     "model_cards": []
   },
   {
-    "id": "medagentbench_1_0",
-    "name": "Medagentbench",
+    "id": "stanford_medagentbench",
+    "name": "MedAgentBench",
     "source": "harbor",
     "categories": [
       "Professional",
@@ -4538,13 +4591,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "MedAgentBench: 300 patient-specific clinically-derived tasks across 10 categories in a FHIR-compliant interactive healthcare environment.",
+    "desc": "MedAgentBench: clinically-relevant tasks across 10 categories in a FHIR-compliant virtual EHR, benchmarking LLM agents on medical decision-making, planning, and execution.",
     "paper": "https://arxiv.org/abs/2501.14654",
-    "code": "inspect_harbor/medagentbench_1_0",
+    "code": "inspect_harbor/stanford_medagentbench",
     "contributors": [],
     "samples": 300,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/medagentbench_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/stanford_medagentbench.html",
     "model_cards": []
   },
   {
@@ -4574,30 +4627,6 @@
     "model_cards": []
   },
   {
-    "id": "pixiu_parity",
-    "name": "Pixiu",
-    "source": "harbor",
-    "categories": [
-      "Professional",
-      "Finance",
-      "Knowledge"
-    ],
-    "tags": [],
-    "kind": "agent",
-    "modalities": [
-      "agent",
-      "sandbox"
-    ],
-    "desc": "PIXIU: A Large Language Model, Instruction Data and Evaluation Benchmark for Finance. Total tasks: 435 across 29 financial NLP datasets.",
-    "paper": "https://arxiv.org/abs/2306.05443",
-    "code": "inspect_harbor/pixiu_parity",
-    "contributors": [],
-    "samples": 435,
-    "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/pixiu_parity.html",
-    "model_cards": []
-  },
-  {
     "id": "pre_flight",
     "name": "Pre-Flight",
     "source": "evals",
@@ -4623,12 +4652,13 @@
     "model_cards": []
   },
   {
-    "id": "spreadsheetbench_verified_1_0",
-    "name": "Spreadsheetbench Verified",
+    "id": "theagentcompany",
+    "name": "TheAgentCompany",
     "source": "harbor",
     "categories": [
       "Professional",
-      "Assistants"
+      "Assistants",
+      "Coding"
     ],
     "tags": [],
     "kind": "agent",
@@ -4636,13 +4666,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "A benchmark evaluating AI agents on real-world spreadsheet manipulation tasks (400 tasks from verified_400). Tasks involve Excel file manipulation including formula writing, data transformation, formatting, and conditional logic.",
-    "paper": "https://arxiv.org/abs/2406.14991",
-    "code": "inspect_harbor/spreadsheetbench_verified_1_0",
+    "desc": "An agent benchmark with tasks in a simulated software company across GitLab, Plane, OwnCloud, and RocketChat services, evaluating LLM agents on real-world professional work.",
+    "paper": "https://arxiv.org/abs/2412.14161",
+    "code": "inspect_harbor/theagentcompany",
     "contributors": [],
-    "samples": 400,
+    "samples": 174,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/spreadsheetbench_verified_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/theagentcompany.html",
     "model_cards": []
   },
   {
@@ -4671,6 +4701,30 @@
     "model_cards": []
   },
   {
+    "id": "vals_financeagent",
+    "name": "Vals Finance Agent",
+    "source": "harbor",
+    "categories": [
+      "Professional",
+      "Finance",
+      "Assistants"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Vals AI Finance Agent Benchmark: expert-validated finance questions across nine task categories (retrieval, market research, projections) with EDGAR/SEC search tools for evaluating financial agents.",
+    "paper": "https://arxiv.org/abs/2508.00828",
+    "code": "inspect_harbor/vals_financeagent",
+    "contributors": [],
+    "samples": 50,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/vals_financeagent.html",
+    "model_cards": []
+  },
+  {
     "id": "docvqa",
     "name": "DocVQA",
     "source": "evals",
@@ -4696,11 +4750,12 @@
     "model_cards": []
   },
   {
-    "id": "mmau_1_0",
-    "name": "Mmau",
+    "id": "lica_world_gdb",
+    "name": "GraphicDesignBench",
     "source": "harbor",
     "categories": [
-      "Multimodal"
+      "Multimodal",
+      "Professional"
     ],
     "tags": [],
     "kind": "agent",
@@ -4708,13 +4763,13 @@
       "agent",
       "sandbox"
     ],
-    "desc": "MMAU: 1000 carefully curated audio clips paired with human-annotated natural language questions and answers spanning speech, environmental sounds, and music.",
-    "paper": "https://arxiv.org/abs/2410.19168",
-    "code": "inspect_harbor/mmau_1_0",
+    "desc": "GraphicDesignBench (GDB): evaluating AI on graphic design tasks across layout, typography, infographics, template design, and animation.",
+    "paper": "https://arxiv.org/abs/2604.04192",
+    "code": "inspect_harbor/lica_world_gdb",
     "contributors": [],
     "samples": 1000,
     "featured": false,
-    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/mmau_1_0.html",
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/lica_world_gdb.html",
     "model_cards": []
   },
   {
@@ -4741,6 +4796,29 @@
     "model_cards": []
   },
   {
+    "id": "cmu_refav",
+    "name": "RefAV",
+    "source": "harbor",
+    "categories": [
+      "Multimodal",
+      "Coding"
+    ],
+    "tags": [],
+    "kind": "agent",
+    "modalities": [
+      "agent",
+      "sandbox"
+    ],
+    "desc": "Autonomous-vehicle scenario mining via VLM.",
+    "paper": "https://arxiv.org/abs/2505.20981",
+    "code": "inspect_harbor/cmu_refav",
+    "contributors": [],
+    "samples": 1000,
+    "featured": false,
+    "url": "https://meridianlabs-ai.github.io/inspect_harbor/registry/cmu_refav.html",
+    "model_cards": []
+  },
+  {
     "id": "vstar_bench",
     "name": "V*Bench",
     "source": "evals",
@@ -4763,31 +4841,6 @@
     "samples": 115,
     "featured": false,
     "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/multimodal/vstar_bench/",
-    "model_cards": []
-  },
-  {
-    "id": "vqa_rad",
-    "name": "VQA-RAD",
-    "source": "evals",
-    "categories": [
-      "Multimodal"
-    ],
-    "tags": [
-      "Multimodal"
-    ],
-    "kind": "multimodal",
-    "modalities": [
-      "vision"
-    ],
-    "desc": "VQA-RAD is the first manually constructed VQA dataset in radiology, where clinicians asked naturally occurring questions about radiology images and provided reference answers.",
-    "paper": "https://doi.org/10.1038/sdata.2018.251",
-    "code": "inspect_evals/vqa_rad",
-    "contributors": [
-      "MattFisher"
-    ],
-    "samples": 451,
-    "featured": false,
-    "url": "https://ukgovernmentbeis.github.io/inspect_evals/evals/multimodal/vqa_rad/",
     "model_cards": []
   },
   {
@@ -4878,8 +4931,7 @@
     ],
     "kind": "agent",
     "modalities": [
-      "agent",
-      "sandbox"
+      "agent"
     ],
     "desc": "Test AI's ability to reason about its environment.",
     "paper": "https://arxiv.org/abs/2505.01420",
@@ -4905,8 +4957,7 @@
     ],
     "kind": "agent",
     "modalities": [
-      "agent",
-      "sandbox"
+      "agent"
     ],
     "desc": "Test AI's ability to reason about and circumvent oversight.",
     "paper": "https://arxiv.org/abs/2505.01420",

--- a/docs/evals/sync_all.py
+++ b/docs/evals/sync_all.py
@@ -61,13 +61,13 @@ def main() -> None:
     if missing_category:
         print(
             f"\nerror: {len(missing_category)} harbor dataset(s) missing required "
-            f"'categories' in harbor_overrides.yml:",
+            f"'categories' in inspect_harbor's docs/overrides.yml:",
             file=sys.stderr,
         )
         for name in missing_category:
             print(f"  - {name}", file=sys.stderr)
         print(
-            "\nAdd a `categories: [...]` entry for each in docs/evals/harbor_overrides.yml.",
+            "\nAdd a `categories: [...]` entry for each in inspect_harbor's docs/overrides.yml.",
             file=sys.stderr,
         )
         sys.exit(1)

--- a/docs/evals/sync_harbor.py
+++ b/docs/evals/sync_harbor.py
@@ -1,13 +1,11 @@
 """Load inspect_harbor evals into normalized EvalRecord dicts.
 
-Fetches the Harbor dataset registry plus inspect_harbor's generated `_tasks.py`
-(for exposed Python function names), joins with inspect_harbor's
-`docs/overrides.yml` for fields the registry lacks, and returns records
-matching the design schema.
+Fetches inspect_harbor's ``docs/registry-listing.yml`` and joins with
+``docs/overrides.yml`` for fields the listing lacks.
 
 Writes are handled by sync_all.py.
 
-`categories` (array) is REQUIRED per entry in overrides.yml; entries
+``categories`` (array) is REQUIRED per entry in overrides.yml; entries
 missing categories are reported back to the caller. inspect_harbor's CI
 validates this file on every PR, so in practice reaching this code path
 with a missing-category entry means the upstream validation was bypassed.
@@ -15,8 +13,6 @@ with a missing-category entry means the upstream validation was bypassed.
 
 from __future__ import annotations
 
-import ast
-import json
 from pathlib import Path
 from typing import Any
 from urllib.request import urlopen
@@ -26,12 +22,9 @@ import yaml
 HERE = Path(__file__).parent
 CACHE_DIR = HERE / ".cache"
 
-REGISTRY_URL = (
-    "https://raw.githubusercontent.com/laude-institute/harbor/refs/heads/main/registry.json"
-)
-TASKS_URL = (
+REGISTRY_LISTING_URL = (
     "https://raw.githubusercontent.com/meridianlabs-ai/inspect_harbor"
-    "/refs/heads/main/src/inspect_harbor/_tasks.py"
+    "/refs/heads/main/docs/registry-listing.yml"
 )
 OVERRIDES_URL = (
     "https://raw.githubusercontent.com/meridianlabs-ai/inspect_harbor"
@@ -40,34 +33,9 @@ OVERRIDES_URL = (
 INSPECT_HARBOR_DOCS_BASE = "https://meridianlabs-ai.github.io/inspect_harbor"
 
 
-GENERIC_IMPLEMENTATION_REPOS = {
-    "https://github.com/laude-institute/harbor.git",
-    "https://github.com/laude-institute/harbor-datasets.git",
-    "https://huggingface.co/datasets/harborframework/harbor-datasets",
-}
-
-
-import re
-
-
-def _clean_desc(desc: str) -> str:
-    """Strip 'Original benchmark: URL', 'Adapter: URL', inline URLs, etc."""
-    desc = re.sub(
-        r"\s*(Original benchmark|Adapter details|Adapter|Source|Website)"
-        r":\s*https?://\S+\.?\s*",
-        " ", desc,
-    )
-    desc = re.sub(r"\(https?://\S+\)", "", desc)
-    desc = re.sub(r"https?://\S+", "", desc)
-    desc = re.sub(r"Adapter for \S+ \.", "", desc)
-    desc = re.sub(r"\s{2,}", " ", desc)
-    result = desc.strip().rstrip(".")
-    return (result + ".") if result else ""
-
-
-def _derive_title(name: str) -> str:
-    leaf = name.rsplit("/", 1)[-1]
-    return leaf.replace("-", " ").replace("_", " ").strip().title()
+def _derive_title(slug: str) -> str:
+    """Fallback title from an ``org/name`` slug when no ``title`` override is set."""
+    return slug.rsplit("/", 1)[-1]
 
 
 def _fetch_to_cache(url: str, dest: Path, use_cache: bool) -> str:
@@ -81,116 +49,71 @@ def _fetch_to_cache(url: str, dest: Path, use_cache: bool) -> str:
     return text
 
 
-def _extract_dataset_metadata(tasks_py_source: str) -> dict[str, str]:
-    """Parse `_tasks.py` docstrings to map dataset id → Python function name.
-
-    Built from the `Dataset:` line in each `@task`-decorated function's
-    docstring. Used to reject registry entries that aren't exposed by
-    inspect_harbor yet (e.g. Harbor added a dataset after the last
-    `_tasks.py` regeneration).
-    """
-    tree = ast.parse(tasks_py_source)
-    function_map: dict[str, str] = {}
-    for node in tree.body:
-        if not isinstance(node, ast.FunctionDef):
-            continue
-        has_task_decorator = any(
-            (isinstance(d, ast.Name) and d.id == "task")
-            or (isinstance(d, ast.Attribute) and d.attr == "task")
-            for d in node.decorator_list
-        )
-        if not has_task_decorator:
-            continue
-        doc = ast.get_docstring(node) or ""
-        for line in doc.splitlines():
-            line = line.strip()
-            if line.startswith("Dataset:"):
-                dataset_id = line.split(":", 1)[1].strip()
-                if dataset_id:
-                    function_map[dataset_id] = node.name
-                break
-    return function_map
+def _load_listing(use_cache: bool) -> list[dict[str, Any]]:
+    text = _fetch_to_cache(
+        REGISTRY_LISTING_URL, CACHE_DIR / "registry-listing.yml", use_cache
+    )
+    data = yaml.safe_load(text) or []
+    if not isinstance(data, list):
+        raise ValueError(f"{REGISTRY_LISTING_URL} must be a list of entries")
+    return data
 
 
 def _load_overlay(use_cache: bool) -> dict[str, dict[str, Any]]:
     """Fetch inspect_harbor's overrides.yml and return it as a mapping.
 
-    Cached in the same `.cache/` directory as the registry and tasks
-    fetches so `--no-fetch` runs offline cleanly.
+    Cached in the same ``.cache/`` directory as the listing fetch so
+    ``--no-fetch`` runs offline cleanly.
     """
     text = _fetch_to_cache(OVERRIDES_URL, CACHE_DIR / "overrides.yml", use_cache)
     data = yaml.safe_load(text) or {}
     if not isinstance(data, dict):
-        raise ValueError(f"{OVERRIDES_URL} must be a mapping keyed by dataset name")
+        raise ValueError(f"{OVERRIDES_URL} must be a mapping keyed by org/name slug")
     return data
 
 
 def load_harbor(
     *, use_cache: bool = False
 ) -> tuple[list[dict[str, Any]], list[str]]:
-    """Return (records, missing_category_names).
+    """Return (records, missing_category_slugs).
 
-    Callers (sync_all.py) error out when missing_category_names is non-empty.
+    Callers (sync_all.py) error out when missing_category_slugs is non-empty.
     """
-    registry_text = _fetch_to_cache(REGISTRY_URL, CACHE_DIR / "registry.json", use_cache)
-    tasks_text = _fetch_to_cache(TASKS_URL, CACHE_DIR / "_tasks.py", use_cache)
-
-    registry = json.loads(registry_text)
-    function_map = _extract_dataset_metadata(tasks_text)
+    listing = _load_listing(use_cache)
     overlay = _load_overlay(use_cache)
 
-    sorted_registry = sorted(
-        registry, key=lambda d: (d.get("name", ""), d.get("version", ""))
-    )
-
-    seen_names: set[str] = set()
     records: list[dict[str, Any]] = []
     missing_category: list[str] = []
-    skipped: list[str] = []
 
-    for entry in sorted_registry:
-        name = entry.get("name")
-        version = entry.get("version")
-        if not name or not version:
-            continue
+    for entry in listing:
+        slug = entry["title"]
+        function_name = entry["task_function"]
 
-        name_version = f"{name}@{version}"
-        function_name = function_map.get(name_version)
-        if function_name is None:
-            skipped.append(f"{name_version} (not exposed in _tasks.py)")
-            continue
-
-        is_latest = name not in seen_names
-        seen_names.add(name)
-
-        ov = overlay.get(name, {})
+        ov = overlay.get(slug, {})
         categories = ov.get("categories") or []
-        if not categories and is_latest:
-            missing_category.append(name)
+        if not categories:
+            missing_category.append(slug)
 
-        tasks = entry.get("tasks", []) or []
+        desc = ov.get("desc") or entry.get("desc", "")
         paper = ov.get("arxiv") or ov.get("repo")
 
-        records.append({
-            "id": function_name,
-            "name": ov.get("title") or _derive_title(name),
-            "source": "harbor",
-            "categories": categories or ["Other"],
-            "tags": list(ov.get("tags") or []),
-            "kind": ov.get("kind", "agent"),
-            "modalities": list(ov.get("modalities") or ["agent", "sandbox"]),
-            "desc": ov.get("desc") or _clean_desc(entry.get("description", "")),
-            "paper": paper,
-            "code": f"inspect_harbor/{function_name}",
-            "contributors": list(ov.get("contributors") or []),
-            "samples": len(tasks),
-            "featured": bool(ov.get("featured", False)),
-            "url": f"{INSPECT_HARBOR_DOCS_BASE}/registry/{function_name}.html",
-        })
-
-    if skipped:
-        print(f"skipped {len(skipped)} registry entries not exposed by inspect_harbor:")
-        for s in skipped:
-            print(f"  - {s}")
+        records.append(
+            {
+                "id": function_name,
+                "name": ov.get("title") or _derive_title(slug),
+                "source": "harbor",
+                "categories": categories or ["Other"],
+                "tags": list(ov.get("tags") or []),
+                "kind": ov.get("kind", "agent"),
+                "modalities": list(ov.get("modalities") or ["agent", "sandbox"]),
+                "desc": desc,
+                "paper": paper,
+                "code": f"inspect_harbor/{function_name}",
+                "contributors": list(ov.get("contributors") or []),
+                "samples": entry.get("samples", 0),
+                "featured": bool(ov.get("featured", False)),
+                "url": f"{INSPECT_HARBOR_DOCS_BASE}/registry/{function_name}.html",
+            }
+        )
 
     return records, missing_category


### PR DESCRIPTION
- Rewrites `docs/evals/sync_harbor.py` to consume inspect_harbor 0.5's new `docs/registry-listing.yml` instead of the legacy `registry.json`. inspect_harbor switched to the self-service Harbor hub at hub.harborframework.com (see [meridianlabs-ai/inspect_harbor#69](https://github.com/meridianlabs-ai/inspect_harbor/pull/69)) — datasets are now keyed by `org/name` slug, content-addressed by digest, and the canonical list lives in `registry-listing.yml`.
- Output schema (`EvalRecord` dicts merged into `evals.json`) is unchanged.