### PR TITLE
fix: disable default S3 integrity checksums to avoid IncompleteBody on multipart writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bugfix: Disable boto3 1.36+ default integrity checksums on S3 log writes to avoid intermittent `IncompleteBody` errors during multipart uploads under concurrent flushes.
+
 ## 0.3.219 (06 May 2026)
 
 - Inspect View: Fix extraneous console errors

--- a/src/inspect_ai/_util/asyncfiles.py
+++ b/src/inspect_ai/_util/asyncfiles.py
@@ -342,6 +342,12 @@ class AsyncFilesystem(AbstractAsyncContextManager["AsyncFilesystem"]):
             config = Config(
                 max_pool_connections=50,
                 retries={"max_attempts": 10, "mode": "adaptive"},
+                # Disable boto3 1.36+ default integrity checksums.
+                # The AwsChunkedWrapper body framing is buggy under
+                # concurrent multipart uploads and intermittently
+                # produces IncompleteBody from S3. See GH-3858.
+                request_checksum_calculation="when_required",
+                response_checksum_validation="when_required",
                 **({"signature_version": UNSIGNED} if self._anonymous else {}),
             )
             self._s3_client = boto3.client(
@@ -371,6 +377,12 @@ class AsyncFilesystem(AbstractAsyncContextManager["AsyncFilesystem"]):
         config = AioConfig(
             max_pool_connections=50,
             retries={"max_attempts": 10, "mode": "adaptive"},
+            # Disable boto3 1.36+ default integrity checksums.
+            # The AwsChunkedWrapper body framing is buggy under
+            # concurrent multipart uploads and intermittently
+            # produces IncompleteBody from S3. See GH-3858.
+            request_checksum_calculation="when_required",
+            response_checksum_validation="when_required",
             **({"signature_version": UNSIGNED} if anonymous else {}),
         )
         return await session.client(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #3858.

When `--log-dir` is an `s3://` URL and an eval produces per-sample logs large enough for the cumulative `.eval` zip to cross the 8 MB multipart-upload threshold, `EvalRecorder.flush()` intermittently aborts the whole task with:

```
botocore.exceptions.ClientError: An error occurred (IncompleteBody)
  when calling the UploadPart operation: You did not provide the
  number of bytes specified by the Content-Length HTTP header
```

Probability of failure climbs sharply with concurrent flushes (i.e. agentic evals with many in-flight samples), so it surfaces in long-sample / high-throughput runs and is rare in short evals.

**Root cause** is the default integrity-checksum behavior introduced in `boto3` 1.36 (Jan 2025). Every `PutObject` / `UploadPart` body now gets wrapped in `botocore.httpchecksum.AwsChunkedWrapper`, framed with `Transfer-Encoding: chunked` + `Content-Encoding: aws-chunked` + an `x-amz-checksum-crc32` trailer, and signed with a streaming-trailer signature. That code path has a documented stream of multipart-upload bugs ([boto3#4102](https://github.com/boto/boto3/issues/4102), [aws-cli#10026](https://github.com/aws/aws-cli/issues/10026), [aiobotocore PR#1293](https://github.com/aio-libs/aiobotocore/pull/1293)) that produce exactly this `IncompleteBody` symptom under concurrent multipart uploads.

(The seek+read race the linked issue speculates about doesn't actually exist in either `aioboto3` or `s3transfer` — both have always serialized file reads in a single thread/coroutine and copied per-part bodies into bytearray/BytesIO before parallel upload. But the `IncompleteBody` is real and the user's `max_concurrency=1` workaround coincidentally fixes it by serializing the buggy framing path.)

### What is the new behavior?

Set `request_checksum_calculation="when_required"` and `response_checksum_validation="when_required"` on both the sync `Config` and the async `AioConfig` used by `AsyncFilesystem`. This is the AWS-recommended escape hatch for the integrity-checksum default and bypasses `AwsChunkedWrapper` entirely for our writes — bodies go out as plain HTTP with a normal `Content-Length`, no aws-chunked framing, no CRC32 trailer.

Reproduced and verified empirically against real S3:

| | params | result |
|---|---|---|
| Pre-fix | 50 samples × 1.5 MB, `max-samples 25` | `IncompleteBody` at iter 2/10 |
| Post-fix | same params | 10/10 iterations clean across ~70 minutes |

Wire trace post-fix confirms log uploads carry plain `Content-Length: <n>` and a `BytesIO` body, with no `Content-Encoding: aws-chunked` / `X-Amz-Trailer` / `AwsChunkedWrapper`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The change is scoped to the S3 client used by `AsyncFilesystem` for log writes — other `boto3` / `aioboto3` usage in inspect_ai (Bedrock, SageMaker, user code) is unaffected, and per-call `ChecksumAlgorithm=...` overrides still work because `when_required` respects explicit caller intent.

Tradeoff: future log objects written to S3 won't have a CRC32 checksum stored as object metadata, and clients downloading them won't auto-validate via the (absent) checksum. TLS already integrity-checks bytes on the wire and S3 still validates `Content-Length`, so realistic in-transit corruption is still caught.

### Other information:

The two regression tests I prototyped (`test_write_file_streaming_s3_temp_file_multipart`, `test_write_file_streaming_s3_repeated_flushes_of_growing_temp_file`) were dropped: `moto` doesn't enforce strict server-side `Content-Length` / aws-chunked framing the way real S3 does, so they pass on both sides of the fix and aren't a deterministic reproducer.