### PR TITLE
docs: clarify vLLM thinking configuration

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -921,6 +921,8 @@ inspect eval gsm8k.py --model vllm/Qwen/Qwen3-1.7B-Base -M use_chat_template=fal
 
 vLLM supports tool use and reasoning; however, the usage is often model dependant and requires additional configuration. See the [Tool Use](https://docs.vllm.ai/en/stable/features/tool_calling.html) and [Reasoning](https://docs.vllm.ai/en/stable/features/reasoning_outputs.html) sections of the vLLM documentation for details.
 
+For vLLM reasoning models, pass the model-specific parser and chat-template kwargs through `-M`. See [Reasoning](reasoning.qmd#vllmsglang) for CLI examples.
+
 ### Prompt Log Probabilities
 
 vLLM supports returning log probabilities for prompt tokens via the `prompt_logprobs` configuration option. This enables [perplexity-based scoring](scorers.qmd#perplexity) for benchmarks like WikiText, C4, ARC-C, and MMLU:

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -189,4 +189,28 @@ Reasoning content from DeepSeek models is captured using either the `reasoning_c
 
 vLLM and SGLang both support reasoning outputs; however, the usage is often model dependant and requires additional configuration. See the [vLLM](https://docs.vllm.ai/en/stable/features/reasoning_outputs.html) and [SGLang](https://docs.sglang.ai/backend/separate_reasoning.html) documentation for details.
 
+For vLLM, configure the model's reasoning parser with `-M` model arguments when Inspect starts the vLLM server. For example, Qwen3 reasoning output can be enabled for extraction as follows:
+
+``` bash
+inspect eval math.py --model vllm/Qwen/Qwen3-8B -M reasoning_parser=qwen3
+```
+
+Thinking mode is model-specific and is controlled separately from Inspect's `--reasoning-effort` option. For models where vLLM exposes template switches such as `enable_thinking` or `thinking`, pass them as vLLM chat-template kwargs. To set a server-wide default for a server started by Inspect, use:
+
+``` bash
+inspect eval math.py --model vllm/Qwen/Qwen3-8B \
+  -M reasoning_parser=qwen3 \
+  -M default_chat_template_kwargs='{"enable_thinking": true}'
+```
+
+To override the template kwargs for individual requests, pass them through `extra_body`:
+
+``` bash
+inspect eval math.py --model vllm/Qwen/Qwen3-8B \
+  -M reasoning_parser=qwen3 \
+  -M extra_body='{"chat_template_kwargs": {"enable_thinking": true}}'
+```
+
+Open-weights reasoning models do not all support adjustable effort levels. In those cases, `--reasoning-effort` may have no effect even though a reasoning parser is required for vLLM to separate reasoning from the final answer.
+
 If the model already outputs its reasoning between `<think></think>` tags such as with the R1 models or through prompt engineering, then Inspect will capture it automatically without any additional configuration of vLLM or SGLang.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #2397.

The docs do not clearly explain how to configure vLLM reasoning parsers and model-specific thinking switches for Qwen-style reasoning models. This can make Inspect's separate `--reasoning-effort` option look like the control users should reach for, even when the open-weights model actually needs vLLM parser or chat-template configuration.

### What is the new behavior?

The reasoning and vLLM provider docs now show concrete vLLM reasoning parser examples, server-default chat-template kwargs, per-request `extra_body.chat_template_kwargs`, and a note that `--reasoning-effort` is separate from vLLM parser/template configuration.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This is a docs-only clarification of existing configuration paths.

### Other information:

Validation:
- Targeted:
  - Checked the new examples against current vLLM reasoning-output documentation for the Qwen3 parser and thinking switches.
  - Reviewed Inspect's vLLM provider docs and argument forwarding behavior so each documented CLI example maps to supported Inspect configuration:
    - `-M server_args.reasoning_parser=qwen3`
    - `-M default_chat_template_kwargs.enable_thinking=true`
    - `-M extra_body.chat_template_kwargs.thinking=true`
  - Verified the docs now distinguish vLLM parser/template configuration from Inspect's separate `--reasoning-effort` option.
- Regression:
  - `uv run make check`
  - `uv run make test`

CI/CD coverage expected:
- Standard Build workflow should cover ruff, ruff format, mypy, pre-commit, package build, and pytest on Python 3.10 and 3.11.
- Docs are excluded from ruff's source lint, but the pre-commit typos hook covers markdown/docs text.
- Log viewer and sandbox-tools special gates should not require extra artifacts because this PR only changes model/provider docs.

Closes #2397.
