### PR TITLE
docs: describe raw text generation paths

### DIFF
--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -79,6 +79,20 @@ inspect eval arc.py --model google/gemini-2.5-pro -M location=us-east5
 
 See the documentation for the requisite model provider for information on how model args are passed through to model clients.
 
+## Open-Ended and Raw Text Generation
+
+Inspect tasks are not limited to multiple choice. If your dataset sample contains a prompt and your solver calls `generate()`, the model output is available as `state.output.completion` and can be scored by any scorer that understands free-form text, such as a custom scorer or model-graded scorer.
+
+Most providers expose chat-completion APIs, so Inspect represents inputs as chat messages and local providers may apply a tokenizer chat template before generation. This is usually what you want for instruction-tuned models. If you need a base model to receive raw prompt text without role markers or a chat template, use a provider-specific raw-completion path:
+
+-   For vLLM, use the `vllm-completions` provider. It routes through vLLM's `/v1/completions` endpoint and sends the single user message as raw text:
+
+    ``` bash
+    inspect eval task.py --model vllm-completions/EleutherAI/pythia-70m
+    ```
+
+-   For local Hugging Face or vLLM chat providers, use `-M use_chat_template=false` or provide an explicit `chat_template` model arg when you want to control the rendered prompt yourself. See the [Hugging Face](providers.qmd#hugging-face) and [vLLM](providers.qmd#vllm) provider docs for examples.
+
 ## Max Connections
 
 Inspect uses an asynchronous architecture to run task samples in parallel. If your model provider can handle 100 concurrent connections, then Inspect can utilise all of those connections to get the highest possible throughput. The limiting factor on parallelism is therefore not typically local parallelism (e.g. number of cores) but rather what the underlying rate limit is for your interface to the provider.

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -917,6 +917,16 @@ inspect eval gsm8k.py --model vllm/Qwen/Qwen3-1.7B-Base -M use_chat_template=fal
 `use_chat_template` only takes effect when Inspect starts the vLLM server. When connecting to an existing server via `VLLM_BASE_URL`, set `--chat-template` when starting the server instead.
 :::
 
+### Raw Text Completions
+
+Use the `vllm-completions` provider when you want vLLM to receive a raw text prompt rather than chat messages rendered through a chat template:
+
+``` bash
+inspect eval task.py --model vllm-completions/EleutherAI/pythia-70m
+```
+
+This provider uses vLLM's `/v1/completions` endpoint. It accepts a single user message, sends that message content as the raw prompt, and is useful for base-model generation and log-probability based evaluations.
+
 ### Tool Use and Reasoning
 
 vLLM supports tool use and reasoning; however, the usage is often model dependant and requires additional configuration. See the [Tool Use](https://docs.vllm.ai/en/stable/features/tool_calling.html) and [Reasoning](https://docs.vllm.ai/en/stable/features/reasoning_outputs.html) sections of the vLLM documentation for details.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #3676.

The docs do not clearly separate general open-ended generation in Inspect from provider-specific raw prompt text paths. Users looking for free-form generation or raw vLLM prompting have to infer whether they need `generate()`, a free-form scorer, `vllm-completions`, or vLLM chat-template options.

### What is the new behavior?

The model docs now describe open-ended generation with `generate()` and free-form scorers, and the provider docs document the `vllm-completions` path for raw prompt text without chat-template rendering. The vLLM docs also keep the `-M use_chat_template=false` path distinct for users who still want the chat API.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This is a docs-only clarification of existing model and provider behavior.

### Other information:

Validation:
- Targeted:
  - Checked the documented paths against the existing model/provider implementation:
    - Standard Inspect tasks can already call `generate()` without multiple-choice targets and score free-form completions.
    - `vllm-completions` is an existing provider path for raw prompt text.
    - `-M use_chat_template=false` is the documented vLLM chat path for disabling chat-template rendering while still using the chat API.
  - Reviewed the new `docs/models.qmd` and `docs/providers.qmd` sections together to ensure the issue's two cases are separated: open-ended generation in Inspect generally, and raw text prompting through vLLM specifically.
- Regression:
  - `uv run make check`
  - `uv run make test`

CI/CD coverage expected:
- Standard Build workflow should cover ruff, ruff format, mypy, pre-commit, package build, and pytest on Python 3.10 and 3.11.
- Docs are excluded from ruff's source lint, but the pre-commit typos hook covers markdown/docs text.
- Log viewer and sandbox-tools special gates should not require extra artifacts because this PR only changes model/provider docs.

Closes #3676.
