### PR TITLE
fix: add OpenRouter attribution headers

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1211,6 +1211,8 @@ export OPENROUTER_API_KEY=your-openrouter-api-key
 inspect eval arc.py --model openrouter/gryphe/mythomax-l2-13b
 ```
 
+Inspect sends OpenRouter [app attribution](https://openrouter.ai/docs/app-attribution) headers by default (`HTTP-Referer: https://inspect.aisi.org.uk` and `X-OpenRouter-Title: Inspect AI`). To attribute requests to your own application, pass `extra_headers` in the generation config or `default_headers` as a model arg.
+
 For the `openrouter` provider, the following custom model args (`-M`) are supported (click the argument name to see its docs on the OpenRouter site):
 
 | Argument | Example |

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -30,6 +30,10 @@ from .._generate_config import GenerateConfig
 from .openai_compatible import OpenAICompatibleAPI
 
 OPENROUTER_API_KEY = "OPENROUTER_API_KEY"
+OPENROUTER_APP_HEADERS = {
+    "HTTP-Referer": "https://inspect.aisi.org.uk",
+    "X-OpenRouter-Title": "Inspect AI",
+}
 
 logger = getLogger(__name__)
 
@@ -96,6 +100,10 @@ class OpenRouterAPI(OpenAICompatibleAPI):
         if self.reasoning_enabled is not None:
             if not isinstance(self.reasoning_enabled, bool):
                 raise PrerequisiteError("reasoning_enabled must be a boolean")
+
+        model_args["default_headers"] = openrouter_default_headers(
+            model_args.pop("default_headers", None)
+        )
 
         # call super
         super().__init__(
@@ -280,6 +288,12 @@ class OpenRouterAPI(OpenAICompatibleAPI):
                 params[EXTRA_BODY]["reasoning"] = reasoning
 
         return params
+
+
+def openrouter_default_headers(
+    default_headers: dict[str, str] | None = None,
+) -> dict[str, str]:
+    return OPENROUTER_APP_HEADERS | (default_headers or {})
 
 
 OPENROUTER_REASONING_DETAILS_SIGNATURE = "reasoning-details://"

--- a/tests/model/test_openrouter_headers.py
+++ b/tests/model/test_openrouter_headers.py
@@ -1,0 +1,22 @@
+from inspect_ai.model._providers.openrouter import openrouter_default_headers
+
+
+def test_openrouter_app_attribution_headers() -> None:
+    assert openrouter_default_headers() == {
+        "HTTP-Referer": "https://inspect.aisi.org.uk",
+        "X-OpenRouter-Title": "Inspect AI",
+    }
+
+
+def test_openrouter_default_headers_override_app_attribution() -> None:
+    assert openrouter_default_headers(
+        {
+            "HTTP-Referer": "https://example.com",
+            "X-OpenRouter-Title": "Example App",
+            "X-Custom": "1",
+        }
+    ) == {
+        "HTTP-Referer": "https://example.com",
+        "X-OpenRouter-Title": "Example App",
+        "X-Custom": "1",
+    }


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #2690.

Inspect's OpenRouter provider does not send default app-attribution headers, so Inspect requests do not identify the application to OpenRouter unless every caller configures `default_headers` manually.

### What is the new behavior?

OpenRouter clients now receive Inspect's default `HTTP-Referer` and `X-OpenRouter-Title` headers. User-supplied `default_headers` are merged over the defaults, so existing custom attribution or header configuration still wins.

The provider docs now describe the default headers and the override path.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Existing custom `default_headers` continue to override Inspect's defaults. Users who do not configure headers get OpenRouter attribution automatically.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/model/test_openrouter_headers.py -v`
    - Asserts OpenRouter clients now receive default `HTTP-Referer` and `X-OpenRouter-Title` attribution headers.
    - Asserts user-provided `default_headers` override Inspect's defaults, so existing customization remains supported.
  - Checked the header names against current OpenRouter app-attribution documentation before adding the defaults.
- Regression:
  - `uv run make check`
  - `uv run make test`

CI/CD coverage expected:
- Standard Build workflow should cover ruff, ruff format, mypy, pre-commit, package build, and pytest on Python 3.10 and 3.11.
- Provider behavior is covered by unit tests without requiring OpenRouter credentials.
- Log viewer and sandbox-tools special gates should not require extra artifacts because this PR does not touch `_view`, `src/inspect_ai/tool`, or `src/inspect_sandbox_tools`.

Closes #2690.
