### PR TITLE
Bridge: fix serialization of bridged-tool results that return Pydantic content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Grok: Support `reasoning_effort` for Grok 4 models.
 - MCP: Raise `ToolError` when timeout error occurs in MCP tool call.
 - Eval Logs: Disable boto3 1.36+ default integrity checksums on S3 log writes to avoid intermittent `IncompleteBody` errors during multipart uploads under concurrent flushes.
+- Bugfix: Fix bridged-tool result serialization to handle Pydantic models (e.g. `list[ContentText]` returned by inspect_ai MCP tools) instead of crashing in `json.dumps`.
 
 ## 0.3.219 (06 May 2026)
 

--- a/src/inspect_ai/agent/_bridge/sandbox/service.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/service.py
@@ -1,9 +1,9 @@
-import json
 from logging import getLogger  # noqa: E402
 from typing import Any, Awaitable, Callable
 
 import anyio
 from pydantic import JsonValue
+from pydantic_core import to_json
 
 from inspect_ai.model._call_tools import get_tools_info
 from inspect_ai.tool._tools._code_execution import CodeExecutionProviders
@@ -144,9 +144,12 @@ def call_tool(
         tool_fn = server_tools[tool]
         result = await tool_fn(**arguments)
 
-        # MCP returns strings, so serialize if needed
+        # Plain strings are returned verbatim (the MCP `tools/call` text part
+        # carries them as-is). For anything else, use pydantic_core.to_json so
+        # Pydantic models (e.g. list[ContentText] from real MCP tools) are
+        # serialized correctly — json.dumps can't handle BaseModel.
         if isinstance(result, str):
             return result
-        return json.dumps(result)
+        return to_json(result).decode("utf-8")
 
     return execute

--- a/tests/tools/test_tools_bridge.py
+++ b/tests/tools/test_tools_bridge.py
@@ -10,6 +10,7 @@ import pytest
 from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai import Task, eval, task
+from inspect_ai._util.content import ContentText
 from inspect_ai.agent import BridgedToolsSpec, sandbox_agent_bridge
 from inspect_ai.dataset import Sample
 from inspect_ai.log import EvalLog
@@ -50,6 +51,20 @@ def get_structured_data(call_log: list[dict]):
         """
         call_log.append({"tool": "get_structured_data", "key": key})
         return json.dumps({"key": key, "values": [1, 2, 3], "nested": {"a": "b"}})
+
+    return execute
+
+
+@tool
+def content_returning_tool(call_log: list[dict]):
+    async def execute(text: str) -> list[ContentText]:
+        """Echo a string back as a list of content blocks.
+
+        Args:
+            text: Text to echo back.
+        """
+        call_log.append({"tool": "content_returning_tool", "text": text})
+        return [ContentText(text=text)]
 
     return execute
 
@@ -338,3 +353,45 @@ def test_duplicate_bridged_tools_names_raises_error():
     eval_bridged_tools_task(test_solver())
 
     assert error_raised, "Expected ValueError for duplicate bridged_tools names"
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_content_returning_tool_serializes_correctly() -> None:
+    """Bridged tools returning list[ContentText] must serialize without error.
+
+    Regression test for json.dumps choking on Pydantic BaseModel — list[ContentText]
+    is the standard return type for inspect_ai MCP tools.
+    """
+    call_log: list[dict] = []
+
+    @solver
+    def test_solver():
+        async def solve(state, generate):
+            async with sandbox_agent_bridge(
+                bridged_tools=[
+                    BridgedToolsSpec(
+                        name="content", tools=[content_returning_tool(call_log)]
+                    )
+                ]
+            ) as bridge:
+                config = bridge.mcp_server_configs[0]
+                response = await call_mcp_tool(
+                    config, "content_returning_tool", {"text": "hello"}
+                )
+
+                assert response["jsonrpc"] == "2.0"
+                # Bridge serializes the tool's return value into a single MCP
+                # text part; for non-strings it's a JSON-encoded payload.
+                payload = json.loads(response["result"]["content"][0]["text"])
+                assert isinstance(payload, list)
+                assert payload[0]["type"] == "text"
+                assert payload[0]["text"] == "hello"
+
+            return state
+
+        return solve
+
+    eval_bridged_tools_task(test_solver())
+
+    assert call_log == [{"tool": "content_returning_tool", "text": "hello"}]


### PR DESCRIPTION
## Summary

- Bridged tools that return `list[ContentText]` (the standard return type for inspect_ai MCP tools) currently crash in `call_tool` with `TypeError: Object of type ContentText is not JSON serializable`, because the result path uses `json.dumps(result)` which can't handle Pydantic `BaseModel`.
- Fix: serialize via `pydantic_core.to_json(result).decode("utf-8")`. The plain-`str` short-circuit is preserved so existing tools that pre-serialize (e.g. `secret_lookup` from `inspect_swe/examples/bridged_tools/task.py`) continue to flow through untouched as the MCP text part.
- Bug introduced in #3008. The existing example/test only exercises the `str` branch, so the regression went unnoticed. Real-world repro: connect any inspect_ai MCP tool source (e.g. `mcp_server_http(...)`) into a `BridgedToolsSpec` and call any of its tools from a sandboxed agent.

## Test plan

- [x] New regression test `tests/tools/test_tools_bridge.py::test_content_returning_tool_serializes_correctly` — defines an `@tool` returning `[ContentText(text=...)]`, bridges it via `BridgedToolsSpec`, calls it via the MCP HTTP endpoint, and asserts the round-tripped content matches.
- [x] All 6 tests in `tests/tools/test_tools_bridge.py` pass under Docker with `--runslow` (verified locally).
- [x] `ruff check` / `ruff format --check` / `mypy` clean on the changed files.