### PR TITLE
feat: accept depends_on / pull_policy / privileged / shm_size / ulimits in ComposeService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Docker Compose: accept depends_on / pull_policy / privileged / shm_size / ulimits in ComposeService.
+
 ## 0.3.220 (08 May 2026)
 
 - Anthropic: Skip the top-level `cache_control` auto-caching field on Bedrock and Vertex where they are not supported.

--- a/src/inspect_ai/util/_sandbox/compose.py
+++ b/src/inspect_ai/util/_sandbox/compose.py
@@ -265,6 +265,21 @@ class ComposeService(ComposeModel):
     init: bool | None = Field(default=None)
     """Run an init process inside the container."""
 
+    privileged: bool | None = Field(default=None)
+    """Run the container in privileged mode."""
+
+    shm_size: str | int | None = Field(default=None)
+    """Size of ``/dev/shm`` (e.g. ``1g``, ``256m``, or bytes as int)."""
+
+    ulimits: dict[str, int | dict[str, int]] | None = Field(default=None)
+    """Per-container ulimits (e.g. ``nofile: {soft: 20000, hard: 40000}``)."""
+
+    depends_on: list[str] | dict[str, Any] | None = Field(default=None)
+    """Service startup dependencies. Short (list) or long (dict) form per Compose spec."""
+
+    pull_policy: str | None = Field(default=None)
+    """Image pull policy (e.g. ``always``, ``never``, ``missing``, ``build``)."""
+
     deploy: ComposeDeploy | None = Field(default=None)
     """Deployment configuration including resources."""
 

--- a/tests/util/sandbox/test_compose.py
+++ b/tests/util/sandbox/test_compose.py
@@ -72,6 +72,91 @@ x-inspect_k8s_sandbox:
         parse_compose_yaml(str(compose_file))
 
 
+def test_parse_compose_yaml_accepts_depends_on_short_form(tmp_path):
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("""
+services:
+  default:
+    image: ubuntu
+    depends_on:
+      - judge
+      - postgres
+""")
+    config = parse_compose_yaml(str(compose_file))
+    assert config.services["default"].depends_on == ["judge", "postgres"]
+
+
+def test_parse_compose_yaml_accepts_depends_on_long_form(tmp_path):
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("""
+services:
+  default:
+    image: ubuntu
+    depends_on:
+      judge:
+        condition: service_started
+""")
+    config = parse_compose_yaml(str(compose_file))
+    assert config.services["default"].depends_on == {
+        "judge": {"condition": "service_started"}
+    }
+
+
+def test_parse_compose_yaml_accepts_pull_policy(tmp_path):
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("""
+services:
+  default:
+    image: ubuntu
+    pull_policy: never
+""")
+    config = parse_compose_yaml(str(compose_file))
+    assert config.services["default"].pull_policy == "never"
+
+
+def test_parse_compose_yaml_accepts_privileged(tmp_path):
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("""
+services:
+  default:
+    image: ubuntu
+    privileged: true
+""")
+    config = parse_compose_yaml(str(compose_file))
+    assert config.services["default"].privileged is True
+
+
+def test_parse_compose_yaml_accepts_shm_size(tmp_path):
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("""
+services:
+  default:
+    image: ubuntu
+    shm_size: 2g
+""")
+    config = parse_compose_yaml(str(compose_file))
+    assert config.services["default"].shm_size == "2g"
+
+
+def test_parse_compose_yaml_accepts_ulimits(tmp_path):
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("""
+services:
+  default:
+    image: ubuntu
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 20000
+        hard: 40000
+""")
+    config = parse_compose_yaml(str(compose_file))
+    assert config.services["default"].ulimits == {
+        "nproc": 65535,
+        "nofile": {"soft": 20000, "hard": 40000},
+    }
+
+
 def test_parse_compose_yaml_rejects_unknown_field(tmp_path):
     compose_file = tmp_path / "compose.yaml"
     compose_file.write_text("""


### PR DESCRIPTION
- Extend `ComposeService` to accept five additional standard Compose-spec fields that were previously rejected by the validator: `depends_on`, `pull_policy`, `privileged`, `shm_size`, `ulimits`.
- Pure passthrough: fields are stored on the model, interpretation is up to sandbox providers (mirrors how existing fields like `runtime`, `network_mode`, `init` work).

## Why
Surfaced while running [inspect_harbor](https://github.com/meridianlabs-ai/inspect_harbor)'s slow test suite against live Harbor datasets. Four datasets failed at parse time:

| Dataset | Field used |
|---|---|
| `grafana/o11y-bench` | `depends_on` |
| `scale-ai/hil-bench` | `pull_policy` |
| `sierra-research/tau3-bench` | `depends_on` |
| `yanagiorigami/frontier-cs` | `depends_on`, `privileged`, `shm_size`, `ulimits` |

All four now load and instantiate cleanly.