### PR TITLE
Model API: Cache lookup of openai and anthropic packages at sample initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Model Info: Cache model info database lookup results so that failed lookups don't repeat fuzzy model name search.
 - Model API: Cache lookup of openai and anthropic packages at sample initialization.
+- Model API: Remove semaphore around calls to `count_tokens()` (they are already retried and gated by `max_samples`).
 - Hooks: Cache list of registered hooks (invalidate cache on `registry_add()`).
 - Docker Compose: accept depends_on / pull_policy / privileged / shm_size / ulimits in ComposeService.
 - Bugfix: Ensure that models don't share GenerateConfig instance via default get_model argument.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -810,29 +810,31 @@ class Model:
                (e.g., reasoning parameters that affect token allocation).
         """
         config = self._resolve_config(config)
-        model_name = ModelName(self)
-        key = f"ModelCountTokens({self.api.connection_key()})"
-        async with concurrency(f"{model_name}_count_tokens", 10, key, visible=False):
-            # retry handler for token counting
-            @retry(
-                **model_retry_config(
-                    self.api.model_name,
-                    self.config.max_retries,
-                    self.config.timeout,
-                    self.should_retry,
-                    self.before_retry,
-                    log_model_retry,
-                    report_sample_waiting_time,
-                    self.api.retry_wait(),
-                )
-            )
-            async def _count_tokens(
-                input: str | list[ChatMessage], config: GenerateConfig | None
-            ) -> int:
-                return await self.api.count_tokens(input, config)
 
-            # count tokens
-            return await _count_tokens(input, config)
+        # retry handler for token counting (429/timeouts retried with the
+        # same backoff and adaptive-controller signaling as `generate`).
+        # No per-model concurrency cap: count_tokens is O(delta) under the
+        # compaction baseline mechanism, max_samples already provides the
+        # structural ceiling, retries handle rate limits, and provider
+        # count_tokens envelopes are wider than generate envelopes.
+        @retry(
+            **model_retry_config(
+                self.api.model_name,
+                self.config.max_retries,
+                self.config.timeout,
+                self.should_retry,
+                self.before_retry,
+                log_model_retry,
+                report_sample_waiting_time,
+                self.api.retry_wait(),
+            )
+        )
+        async def _count_tokens(
+            input: str | list[ChatMessage], config: GenerateConfig | None
+        ) -> int:
+            return await self.api.count_tokens(input, config)
+
+        return await _count_tokens(input, config)
 
     async def count_tool_tokens(self, tools: Sequence[ToolInfo]) -> int:
         """Count tokens for tool definitions.

--- a/tests/model/test_adaptive_connections.py
+++ b/tests/model/test_adaptive_connections.py
@@ -490,3 +490,51 @@ async def test_transient_retry_blocks_success_counting() -> None:
     assert len(ctrls) == 1
     # because each generate had a transient retry, none counted as a clean success
     assert ctrls[0].concurrency == 4
+
+
+# ---------- count_tokens has no per-model concurrency cap ----------
+
+
+@pytest.mark.anyio
+async def test_count_tokens_no_concurrency_cap(monkeypatch) -> None:
+    """`Model.count_tokens` is not capped — concurrent calls all run in parallel.
+
+    Historically there was a per-model `concurrency(...)` semaphore at limit
+    10 around `count_tokens`. It was removed because (a) the cost is O(delta)
+    via compaction's baseline mechanism, (b) `max_samples` already provides a
+    structural ceiling, (c) retries handle 429s symmetrically with generate,
+    and (d) provider count_tokens envelopes are wider than generate envelopes.
+
+    This guards against re-introducing such a cap. We monkey-patch the model
+    API's `count_tokens` to track peak in-flight calls; without a cap the
+    peak should reach (or near) the launched-task count, well above 10.
+    """
+    import anyio
+
+    from inspect_ai._util._async import tg_collect
+
+    init_concurrency()
+    model = get_model("mockllm/model")
+
+    in_flight = 0
+    peak_in_flight = 0
+
+    async def counting_count_tokens(self, input, config=None):
+        nonlocal in_flight, peak_in_flight
+        in_flight += 1
+        peak_in_flight = max(peak_in_flight, in_flight)
+        try:
+            await anyio.sleep(0.05)
+            return 1
+        finally:
+            in_flight -= 1
+
+    monkeypatch.setattr(type(model.api), "count_tokens", counting_count_tokens)
+
+    # Launch 50 concurrent count_tokens calls. With the old 10-cap, peak
+    # in-flight would max at 10. Without the cap, peak should be ~50.
+    await tg_collect([lambda: model.count_tokens("hello") for _ in range(50)])
+
+    assert peak_in_flight > 10, (
+        f"count_tokens appears capped at <=10 concurrent: peak in-flight = {peak_in_flight}"
+    )


### PR DESCRIPTION
The 10-per-model cap on `Model.count_tokens` is redundant: cost is O(delta) under compaction's baseline mechanism, `max_samples` already provides a structural ceiling on concurrent calls, retries handle 429s with the same backoff and adaptive-controller signaling as generate, and provider envelopes are wider than generate envelopes (or local tiktoken, where there's no rate limit at all). Removes ~1-2 s of artificial queueing latency per generate when compaction is on at adaptive scale.
