### PR TITLE
openai: exclude gpt-5.4-nano variants from native computer-use tool (…

### DIFF
--- a/src/inspect_ai/model/_providers/_openai_computer_use.py
+++ b/src/inspect_ai/model/_providers/_openai_computer_use.py
@@ -69,9 +69,17 @@ def tool_call_from_openai_computer_tool_call(
 def maybe_computer_use_tool(
     model_name: str, tool: ToolInfo
 ) -> ComputerToolParam | None:
+    # Only `gpt-5.4` and `gpt-5.4-mini` advertise native computer-use support;
+    # the `nano` variant does not. The substring check `"gpt-5.4" in model_name`
+    # would otherwise match `gpt-5.4-nano-*` and force the Responses API to send
+    # a `ComputerToolParam` the model rejects. See issue #3844.
     return (
         ComputerToolParam(type="computer")
-        if "gpt-5.4" in model_name and is_computer_tool_info(tool)
+        if (
+            "gpt-5.4" in model_name
+            and "nano" not in model_name
+            and is_computer_tool_info(tool)
+        )
         else None
     )
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #3844.

`maybe_computer_use_tool` uses a substring check `"gpt-5.4" in model_name` to decide whether to attach a native `ComputerToolParam` to the OpenAI Responses API request. That substring also matches `gpt-5.4-nano-*`, which doesn't advertise native computer-use support per OpenAI's computer-use docs - only `gpt-5.4` and `gpt-5.4-mini` do. The Responses API rejects every call when running OSWorld / similar against `gpt-5.4-nano`.

The reporter has the exact diff and a verified-locally side-by-side in the issue body.

### What is the new behavior?

Adds `"nano" not in model_name` to the gate so `maybe_computer_use_tool` returns `None` for nano variants and the generic vision + function-tool fallback handles them. An inline comment explains the rationale and points at #3844.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. For `gpt-5.4` and `gpt-5.4-mini`, behaviour is unchanged (computer-use still attached). For `gpt-5.4-nano-*`, requests that previously failed at the API now route through the generic fallback that any vision-capable model can drive.

### Other information:

The substring check is fragile long-term - if a future model name happens to contain `nano` legitimately, the gate would mis-trigger. Happy to refactor to an exact-name allow-list (`{"gpt-5.4", "gpt-5.4-mini"}` plus version suffixes) if you prefer; left it as a minimal patch for now to mirror the reporter's diff. No test added in this PR; happy to add one asserting the nano case returns `None`.