### PR TITLE
fix: honor terminal width for dumb terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Model Info: Cache model info database lookup results so that failed lookups don't repeat fuzzy model name search.
 - Hooks: Cache list of registered hooks (invalidate cache on `registry_add()`).
 - Docker Compose: accept depends_on / pull_policy / privileged / shm_size / ulimits in ComposeService.
+- Task Display: Honor terminal `COLUMNS` and `LINES` for dumb terminals.
 - Memory: Log condensing no longer retains unchanged JSON copies in long evals.
 - Memory: Don't retain message lists in buffer DB (memory leak on long agentic samples).
 - Memory: Collapse user messages at compaction time to avoid carrying extra messages.

--- a/src/inspect_ai/_display/core/rich.py
+++ b/src/inspect_ai/_display/core/rich.py
@@ -1,3 +1,4 @@
+import os
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import Any, Iterator
@@ -28,12 +29,20 @@ def rich_initialise(
     # default args
     display = display if display is not None else display_type()
     plain = plain if plain is not None else display_type_plain()
+    size_kwargs = _dumb_terminal_size_kwargs()
 
     # reflect ansi prefs
     if plain:
-        rich.reconfigure(no_color=True, force_terminal=False, force_interactive=False)
+        rich.reconfigure(
+            no_color=True,
+            force_terminal=False,
+            force_interactive=False,
+            **size_kwargs,
+        )
     elif rich_no_color(plain):
-        rich.reconfigure(no_color=True)
+        rich.reconfigure(no_color=True, **size_kwargs)
+    elif size_kwargs:
+        rich.reconfigure(**size_kwargs)
 
     # reflect display == none
     if display == "none":
@@ -58,6 +67,28 @@ def rich_initialise(
 
     Markdown.elements["fence"] = CustomCodeBlock
     Markdown.elements["code_block"] = CustomCodeBlock
+
+
+def _dumb_terminal_size_kwargs() -> dict[str, int]:
+    if os.environ.get("TERM") != "dumb":
+        return {}
+
+    columns = _positive_int_env("COLUMNS")
+    if columns is None:
+        return {}
+
+    return {
+        "width": columns,
+        "height": _positive_int_env("LINES") or 25,
+    }
+
+
+def _positive_int_env(name: str) -> int | None:
+    try:
+        value = int(os.environ[name])
+    except (KeyError, ValueError):
+        return None
+    return value if value > 0 else None
 
 
 @dataclass

--- a/tests/display/test_rich.py
+++ b/tests/display/test_rich.py
@@ -1,0 +1,25 @@
+from inspect_ai._display.core.rich import _dumb_terminal_size_kwargs
+
+
+def test_dumb_terminal_uses_columns_with_default_height(monkeypatch):
+    monkeypatch.setenv("TERM", "dumb")
+    monkeypatch.setenv("COLUMNS", "10000")
+    monkeypatch.delenv("LINES", raising=False)
+
+    assert _dumb_terminal_size_kwargs() == {"width": 10000, "height": 25}
+
+
+def test_dumb_terminal_uses_lines_when_available(monkeypatch):
+    monkeypatch.setenv("TERM", "dumb")
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setenv("LINES", "50")
+
+    assert _dumb_terminal_size_kwargs() == {"width": 200, "height": 50}
+
+
+def test_terminal_size_override_requires_dumb_term(monkeypatch):
+    monkeypatch.setenv("TERM", "xterm-256color")
+    monkeypatch.setenv("COLUMNS", "200")
+    monkeypatch.setenv("LINES", "50")
+
+    assert _dumb_terminal_size_kwargs() == {}


### PR DESCRIPTION
﻿## Summary
- honor `COLUMNS` when Rich is running under `TERM=dumb`
- pass a fallback height with the width override so Rich does not fall back to 80 columns
- add regression coverage for `COLUMNS` / `LINES` parsing

Part of #3841.

This does not implement the full structured JSON/plain log output requested in the issue. It fixes the concrete dumb-terminal width bug identified in the thread so long non-TTY logs can be captured without the 80-column Rich fallback.

## To verify
- `python -m py_compile src/inspect_ai/_display/core/rich.py tests/display/test_rich.py`
- `python -m pytest tests/display/test_rich.py -q`
- `ruff check src/inspect_ai/_display/core/rich.py tests/display/test_rich.py`
