### PR TITLE
fix: preserve filestore recovery pools

### DIFF
--- a/src/inspect_ai/log/_recover/_stream.py
+++ b/src/inspect_ai/log/_recover/_stream.py
@@ -8,8 +8,9 @@ import tempfile
 from logging import getLogger
 from typing import IO
 
-from pydantic import JsonValue
+from pydantic import JsonValue, TypeAdapter
 
+from inspect_ai._util.constants import get_deserializing_context
 from inspect_ai._util.error import EvalError
 from inspect_ai._util.json import to_json_safe
 from inspect_ai.event._sample_init import SampleInitEvent
@@ -28,8 +29,12 @@ from inspect_ai.log._log import (
     EventsData,
 )
 from inspect_ai.log._pool import (
+    _build_call_index,
+    _build_msg_index,
     condense_model_event_calls,
     condense_model_event_inputs,
+    resolve_model_event_calls,
+    resolve_model_event_inputs,
 )
 from inspect_ai.log._recorders.buffer.filestore import Manifest, SampleBufferFilestore
 from inspect_ai.log._recorders.eval import ZipLogFile, _sample_filename
@@ -39,6 +44,8 @@ from ._attachments import StreamingAttachmentStore, write_attachments_field
 from ._reconstruct import MessageAccumulator, _deserialize_events
 
 logger = getLogger(__name__)
+
+_CHAT_MESSAGES_ADAPTER: TypeAdapter[list[ChatMessage]] = TypeAdapter(list[ChatMessage])
 
 
 def _write_json_field(
@@ -161,6 +168,33 @@ def _write_sample_streaming(
                 for att in seg_data.attachments:
                     attachments[att.hash] = att.content
 
+                # Segment files written by sync_to_filestore already carry
+                # condensed events; their pools live alongside the events.
+                if seg_data.message_pool:
+                    message_pool.extend(
+                        _CHAT_MESSAGES_ADAPTER.validate_python(
+                            [
+                                json_module.loads(entry.data)
+                                for entry in sorted(
+                                    seg_data.message_pool, key=lambda entry: entry.id
+                                )
+                            ],
+                            context=get_deserializing_context(),
+                        )
+                    )
+                    msg_index = _build_msg_index(message_pool)
+
+                if seg_data.call_pool:
+                    call_pool.extend(
+                        [
+                            json_module.loads(entry.data)
+                            for entry in sorted(
+                                seg_data.call_pool, key=lambda entry: entry.id
+                            )
+                        ]
+                    )
+                    call_index = _build_call_index(call_pool)
+
                 # Deserialize events from this segment
                 raw_events = _deserialize_events([ed.event for ed in seg_data.events])
                 if not raw_events:
@@ -177,8 +211,11 @@ def _write_sample_streaming(
                     if isinstance(ev, SampleLimitEvent):
                         sample_limit_event = ev  # keep the last
 
-                # Feed to message accumulator (before condensing)
-                accumulator.process_events(raw_events)
+                # Feed resolved events to the message accumulator. The events
+                # written to the recovered log stay condensed below.
+                resolved_events = resolve_model_event_inputs(raw_events, message_pool)
+                resolved_events = resolve_model_event_calls(resolved_events, call_pool)
+                accumulator.process_events(resolved_events)
 
                 if include_events:
                     # Attachment walking per event

--- a/src/inspect_ai/log/_recover/_stream.py
+++ b/src/inspect_ai/log/_recover/_stream.py
@@ -171,29 +171,39 @@ def _write_sample_streaming(
                 # Segment files written by sync_to_filestore already carry
                 # condensed events; their pools live alongside the events.
                 if seg_data.message_pool:
-                    message_pool.extend(
-                        _CHAT_MESSAGES_ADAPTER.validate_python(
-                            [
-                                json_module.loads(entry.data)
-                                for entry in sorted(
-                                    seg_data.message_pool, key=lambda entry: entry.id
-                                )
-                            ],
-                            context=get_deserializing_context(),
-                        )
-                    )
-                    msg_index = _build_msg_index(message_pool)
-
-                if seg_data.call_pool:
-                    call_pool.extend(
+                    new_messages = _CHAT_MESSAGES_ADAPTER.validate_python(
                         [
                             json_module.loads(entry.data)
                             for entry in sorted(
-                                seg_data.call_pool, key=lambda entry: entry.id
+                                seg_data.message_pool, key=lambda entry: entry.id
                             )
-                        ]
+                        ],
+                        context=get_deserializing_context(),
                     )
-                    call_index = _build_call_index(call_pool)
+                    pool_start = len(message_pool)
+                    message_pool.extend(new_messages)
+                    msg_index.update(
+                        {
+                            key: pool_start + index
+                            for key, index in _build_msg_index(new_messages).items()
+                        }
+                    )
+
+                if seg_data.call_pool:
+                    new_calls = [
+                        json_module.loads(entry.data)
+                        for entry in sorted(
+                            seg_data.call_pool, key=lambda entry: entry.id
+                        )
+                    ]
+                    pool_start = len(call_pool)
+                    call_pool.extend(new_calls)
+                    call_index.update(
+                        {
+                            key: pool_start + index
+                            for key, index in _build_call_index(new_calls).items()
+                        }
+                    )
 
                 # Deserialize events from this segment
                 raw_events = _deserialize_events([ed.event for ed in seg_data.events])

--- a/tests/log/test_recover_filestore.py
+++ b/tests/log/test_recover_filestore.py
@@ -4,6 +4,7 @@ import json
 import os
 import tempfile
 from datetime import datetime, timezone
+from pathlib import Path
 from zipfile import ZipFile
 
 import pytest
@@ -26,6 +27,10 @@ from inspect_ai.log._log import (
     EvalSampleSummary,
     EvalSpec,
 )
+from inspect_ai.log._recorders.buffer.database import (
+    SampleBufferDatabase,
+    sync_to_filestore,
+)
 from inspect_ai.log._recorders.buffer.filestore import (
     Manifest,
     SampleBufferFilestore,
@@ -40,6 +45,7 @@ from inspect_ai.log._recorders.buffer.types import (
     SampleData,
 )
 from inspect_ai.log._recorders.eval import LogStart
+from inspect_ai.log._recorders.types import SampleEvent
 from inspect_ai.log._recover import (
     recover_eval_log_async,
     recoverable_eval_logs,
@@ -650,6 +656,75 @@ async def test_streaming_recovery_has_events_data() -> None:
             for me in read_model_events:
                 assert len(me.input) > 0
                 assert me.input_refs is None
+
+
+async def test_streaming_recovery_preserves_synced_message_pool() -> None:
+    """Recovery keeps pools from segments produced by sync_to_filestore."""
+    async with AsyncFilesystem():
+        with tempfile.TemporaryDirectory() as temp_dir:
+            eval_path = os.path.join(temp_dir, "test.eval")
+            db_dir = Path(temp_dir) / "db"
+            db_dir.mkdir()
+
+            db = SampleBufferDatabase(location=eval_path, create=True, db_dir=db_dir)
+            filestore = SampleBufferFilestore(eval_path, create=True)
+
+            db.start_sample(_make_summary(id="sample1", epoch=1, completed=False))
+            db.log_events(
+                [
+                    SampleEvent(
+                        id="sample1",
+                        epoch=1,
+                        event=ModelEvent(
+                            model="mockllm/model",
+                            input=[ChatMessageUser(content="pooled user message")],
+                            tools=[],
+                            tool_choice="auto",
+                            config=GenerateConfig(),
+                            output=ModelOutput.from_content(
+                                model="mockllm/model", content="pooled response"
+                            ),
+                        ),
+                    )
+                ]
+            )
+            db.complete_sample(_make_summary(id="sample1", epoch=1, completed=True))
+            sync_to_filestore(db, filestore)
+
+            _write_crashed_eval(eval_path)
+            output_path = os.path.join(temp_dir, "test-recovered.eval")
+
+            await recover_eval_log_async(
+                eval_path,
+                output=output_path,
+                cleanup=False,
+                _db_dir=os.path.join(temp_dir, "empty_db_dir"),
+            )
+
+            with ZipFile(output_path, "r") as zf:
+                sample_names = [
+                    n
+                    for n in zf.namelist()
+                    if n.startswith("samples/") and n.endswith(".json")
+                ]
+                raw = json.loads(zf.read(sample_names[0]))
+
+            assert raw["events_data"] is not None
+            assert raw["events_data"]["messages"][0]["content"] == (
+                "pooled user message"
+            )
+            [model_event] = [e for e in raw["events"] if e.get("event") == "model"]
+            assert model_event["input"] == []
+            assert model_event["input_refs"] == [[0, 1]]
+
+            read_log = read_eval_log(output_path)
+            assert read_log.samples is not None
+            [read_sample] = read_log.samples
+            [read_model_event] = [
+                e for e in read_sample.events if isinstance(e, ModelEvent)
+            ]
+            assert read_model_event.input[0].content == "pooled user message"
+            assert read_sample.messages[0].content == "pooled user message"
 
 
 async def test_streaming_recovery_sample_with_no_events() -> None:


### PR DESCRIPTION
﻿## Summary
- load message and call pools from filestore segments during streaming recovery
- resolve pooled model events before feeding them to the message accumulator
- add a regression test that uses real `sync_to_filestore()` output

Fixes #3883.

## To verify
- `python -m py_compile src/inspect_ai/log/_recover/_stream.py tests/log/test_recover_filestore.py`
- `python -m pytest tests/log/test_recover_filestore.py::test_streaming_recovery_has_events_data tests/log/test_recover_filestore.py::test_streaming_recovery_preserves_synced_message_pool tests/log/test_recover_filestore.py::test_streaming_recovery_empty_pools_emits_null_events_data -q`
- `ruff check src/inspect_ai/log/_recover/_stream.py tests/log/test_recover_filestore.py`
