### PR TITLE
fix: parse OpenRouter reasoning_details in OpenAI-compatible responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - OpenAI: Add GPT 5.5 as computer use model and exclude 'chat' and 'instant' models from computer use.
+- OpenAI Compatible: Parse OpenRouter-style `reasoning_details` in OpenAI-compatible responses.
 - VLLM: Preserve dotted vLLM server arg keys.
 - Bedrock: Drop unsupported sampling params for Claude 4.7+.
 - SageMaker: Add `prompt_logprobs` support in chat mode via `GenerateConfig`, parse prompt logprobs from completion mode responses, enabling `perplexity()` and `target_perplexity()` scorers end-to-end.

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -76,6 +76,9 @@ from inspect_ai.model._model_output import (
     Logprobs,
     TopLogprob,
 )
+from inspect_ai.model._openrouter_reasoning import (
+    openrouter_reasoning_details_to_reasoning,
+)
 from inspect_ai.model._reasoning import (
     parse_content_with_reasoning,
     reasoning_to_think_tag,
@@ -541,9 +544,8 @@ async def messages_from_openai(
             # other sources
             parse_result = parse_reasoning_content(message)
             if parse_result is not None:
-                reasoning: ContentReasoning | None = ContentReasoning(
-                    internal=parse_result[0].source,
-                    reasoning=str(parse_result[0].reasoning),
+                reasoning: ContentReasoning | None = (
+                    content_reasoning_from_openai_reasoning(parse_result[0])
                 )
             else:
                 reasoning = None
@@ -708,6 +710,22 @@ class CompletionsReasoningContent:
     reasoning: JsonValue
 
 
+def content_reasoning_from_openai_reasoning(
+    reasoning_content: CompletionsReasoningContent,
+) -> ContentReasoning:
+    if reasoning_content.source == "reasoning_details" and isinstance(
+        reasoning_content.reasoning, list
+    ):
+        return openrouter_reasoning_details_to_reasoning(
+            cast(list[dict[str, Any]], reasoning_content.reasoning)
+        )
+
+    return ContentReasoning(
+        reasoning=str(reasoning_content.reasoning),
+        internal=reasoning_content.source,
+    )
+
+
 ReasoningExtractor: TypeAlias = Callable[
     [CompletionsReasoningContent], ContentReasoning | None
 ]
@@ -731,10 +749,7 @@ def chat_message_assistant_from_openai(
         if reasoning_extractor is not None:
             reasoning = reasoning_extractor(reasoning_content)
         if reasoning is None:
-            reasoning = ContentReasoning(
-                reasoning=str(reasoning_content.reasoning),
-                internal=reasoning_content.source,
-            )
+            reasoning = content_reasoning_from_openai_reasoning(reasoning_content)
 
         content: str | list[Content] = [
             reasoning,
@@ -764,9 +779,17 @@ def parse_reasoning_content(
         list[CompletionsReasoningSource],
         ["reasoning_details", "reasoning_content", "reasoning"],
     ):
-        reasoning = getattr(message, source, None)
+        if isinstance(message, dict):
+            reasoning = message.get(source, None)
+        else:
+            reasoning = getattr(message, source, None)
         if reasoning:
-            return CompletionsReasoningContent(source=source, reasoning=reasoning), None
+            return (
+                CompletionsReasoningContent(
+                    source=source, reasoning=cast(JsonValue, reasoning)
+                ),
+                None,
+            )
 
     # not found, look for <think> tag
     content = (

--- a/src/inspect_ai/model/_openrouter_reasoning.py
+++ b/src/inspect_ai/model/_openrouter_reasoning.py
@@ -1,0 +1,99 @@
+import json
+from logging import getLogger
+from typing import Annotated, Any, Literal, Union
+
+from pydantic import BaseModel, Field, TypeAdapter, ValidationError
+
+from inspect_ai._util.content import ContentReasoning
+
+logger = getLogger(__name__)
+
+OPENROUTER_REASONING_DETAILS_SIGNATURE = "reasoning-details://"
+
+
+class ReasoningDetailBase(BaseModel):
+    id: str | None = Field(default=None)
+    format: str | None = Field(default=None)
+    index: int | None = Field(default=None)
+
+
+class ReasoningDetailSummary(ReasoningDetailBase):
+    type: Literal["reasoning.summary"]
+    summary: str
+
+
+class ReasoningDetailEncrypted(ReasoningDetailBase):
+    type: Literal["reasoning.encrypted"]
+    data: str
+
+
+class ReasoningDetailText(ReasoningDetailBase):
+    type: Literal["reasoning.text"]
+    text: str
+    signature: str | None = Field(default=None)
+
+
+ReasoningDetail = Annotated[
+    Union[ReasoningDetailSummary, ReasoningDetailEncrypted, ReasoningDetailText],
+    Field(discriminator="type"),
+]
+
+
+def openrouter_reasoning_details_to_reasoning(
+    reasoning_details: list[dict[str, Any]],
+) -> ContentReasoning:
+    details_json = json.dumps(reasoning_details)
+    signature = f"{OPENROUTER_REASONING_DETAILS_SIGNATURE}{details_json}"
+
+    try:
+        adapter = TypeAdapter(list[ReasoningDetail])
+        details = adapter.validate_python(reasoning_details)
+    except ValidationError as ex:
+        logger.warning(
+            f"Error parsing OpenRouter reasoning details: {ex}\n\n{details_json}"
+        )
+        return ContentReasoning(reasoning=details_json, signature=signature)
+
+    reasoning: str | None = None
+    summary: str | None = None
+    redacted = False
+    for detail in details:
+        match detail.type:
+            case "reasoning.summary":
+                summary = detail.summary
+            case "reasoning.text":
+                reasoning = detail.text
+            case "reasoning.encrypted":
+                if reasoning is not None:
+                    summary = reasoning
+                reasoning = detail.data
+                redacted = True
+
+    if reasoning is None:
+        if summary is not None:
+            reasoning = summary
+            summary = None
+        else:
+            logger.warning(
+                f"Error parsing OpenRouter reasoning details: Reasoning content not provided.\n\n{details_json}"
+            )
+            return ContentReasoning(reasoning=details_json, signature=signature)
+
+    return ContentReasoning(
+        reasoning=reasoning, summary=summary, redacted=redacted, signature=signature
+    )
+
+
+def reasoning_to_openrouter_reasoning_details(
+    content: ContentReasoning,
+) -> dict[str, Any] | None:
+    if content.signature and content.signature.startswith(
+        OPENROUTER_REASONING_DETAILS_SIGNATURE
+    ):
+        return {
+            "reasoning_details": json.loads(
+                content.signature.replace(OPENROUTER_REASONING_DETAILS_SIGNATURE, "", 1)
+            )
+        }
+
+    return None

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -1,17 +1,18 @@
 import json
 from logging import getLogger
-from typing import Annotated, Any, Literal, Union, cast
+from typing import Any, cast
 
 from openai.types.chat import (
     ChatCompletion,
     ChatCompletionMessageParam,
 )
-from pydantic import BaseModel, Field, JsonValue, TypeAdapter, ValidationError
+from pydantic import JsonValue
 from typing_extensions import NotRequired, TypedDict, override
 
 from inspect_ai._util.content import ContentReasoning
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.logger import warn_once
+from inspect_ai.model import _openrouter_reasoning
 from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._model import RetryDecision
 from inspect_ai.model._model_output import ChatCompletionChoice
@@ -32,6 +33,16 @@ from .openai_compatible import OpenAICompatibleAPI
 OPENROUTER_API_KEY = "OPENROUTER_API_KEY"
 
 logger = getLogger(__name__)
+
+OPENROUTER_REASONING_DETAILS_SIGNATURE = (
+    _openrouter_reasoning.OPENROUTER_REASONING_DETAILS_SIGNATURE
+)
+openrouter_reasoning_details_to_reasoning = (
+    _openrouter_reasoning.openrouter_reasoning_details_to_reasoning
+)
+reasoning_to_openrouter_reasoning_details = (
+    _openrouter_reasoning.reasoning_to_openrouter_reasoning_details
+)
 
 
 class ErrorResponse(TypedDict):
@@ -280,104 +291,3 @@ class OpenRouterAPI(OpenAICompatibleAPI):
                 params[EXTRA_BODY]["reasoning"] = reasoning
 
         return params
-
-
-OPENROUTER_REASONING_DETAILS_SIGNATURE = "reasoning-details://"
-
-
-class ReasoningDetailBase(BaseModel):
-    id: str | None = Field(default=None)
-    format: str | None = Field(default=None)
-    index: int | None = Field(default=None)
-
-
-class ReasoningDetailSummary(ReasoningDetailBase):
-    type: Literal["reasoning.summary"]
-    summary: str
-
-
-class ReasoningDetailEncrypted(ReasoningDetailBase):
-    type: Literal["reasoning.encrypted"]
-    data: str
-
-
-class ReasoningDetailText(ReasoningDetailBase):
-    type: Literal["reasoning.text"]
-    text: str
-    signature: str | None = Field(default=None)
-
-
-ReasoningDetail = Annotated[
-    Union[ReasoningDetailSummary, ReasoningDetailEncrypted, ReasoningDetailText],
-    Field(discriminator="type"),
-]
-
-
-# openrouter uses reasoning_details
-# https://openrouter.ai/docs/guides/best-practices/reasoning-tokens#responses-api-shape
-def openrouter_reasoning_details_to_reasoning(
-    reasoning_details: list[dict[str, Any]],
-) -> ContentReasoning:
-    # store the full data structure in the signature for replay
-    details_json = json.dumps(reasoning_details)
-    signature = f"{OPENROUTER_REASONING_DETAILS_SIGNATURE}{details_json}"
-
-    # attempt to parse out the details
-    try:
-        adapter = TypeAdapter(list[ReasoningDetail])
-        details = adapter.validate_python(reasoning_details)
-    except ValidationError as ex:
-        logger.warning(
-            f"Error parsing OpenRouter reasoning details: {ex}\n\n{details_json}"
-        )
-        return ContentReasoning(reasoning=details_json, signature=signature)
-
-    # collect reasoning fields from details
-    reasoning: str | None = None
-    summary: str | None = None
-    redacted: bool = False
-    for detail in details:
-        match detail.type:
-            case "reasoning.summary":
-                summary = detail.summary
-            case "reasoning.text":
-                reasoning = detail.text
-            case "reasoning.encrypted":
-                if reasoning is not None:
-                    summary = reasoning
-                reasoning = detail.data
-                redacted = True
-
-    # resolve reasoning
-    if reasoning is None:
-        # summary becomes reasoning if there is no reasoning
-        if summary is not None:
-            reasoning = summary
-            summary = None
-        # otherwise this an unepxected state
-        else:
-            logger.warning(
-                f"Error parsing OpenRouter reasoning details: Reasoning content not provided.\n\n{details_json}"
-            )
-            return ContentReasoning(reasoning=details_json, signature=signature)
-
-    # return reasoning
-    return ContentReasoning(
-        reasoning=reasoning, summary=summary, redacted=redacted, signature=signature
-    )
-
-
-def reasoning_to_openrouter_reasoning_details(
-    content: ContentReasoning,
-) -> dict[str, Any] | None:
-    if content.signature and content.signature.startswith(
-        OPENROUTER_REASONING_DETAILS_SIGNATURE
-    ):
-        return {
-            "reasoning_details": json.loads(
-                content.signature.replace(OPENROUTER_REASONING_DETAILS_SIGNATURE, "", 1)
-            )
-        }
-
-    # default to no handling
-    return None

--- a/tests/model/test_openai_chat_messages.py
+++ b/tests/model/test_openai_chat_messages.py
@@ -65,6 +65,31 @@ async def test_assistant_message_with_smuggled_tags():
             assert "<think" not in c.text
 
 
+async def test_assistant_message_with_openrouter_reasoning_details():
+    messages = [
+        DummyMessage("assistant", content="assistant output"),
+    ]
+    messages[0]["reasoning_details"] = [
+        {
+            "type": "reasoning.text",
+            "text": "visible reasoning",
+            "format": "unknown",
+            "index": 0,
+        }
+    ]
+
+    chat_msgs = await messages_from_openai(messages)
+
+    assert len(chat_msgs) == 1
+    msg = chat_msgs[0]
+    assert isinstance(msg.content, list)
+    assert isinstance(msg.content[0], ContentReasoning)
+    assert msg.content[0].reasoning == "visible reasoning"
+    assert "reasoning.text" not in msg.content[0].reasoning
+    assert isinstance(msg.content[1], ContentText)
+    assert msg.content[1].text == "assistant output"
+
+
 async def test_user_message_passthrough():
     # User message should be passed through unchanged
     user_content = "user says hello"

--- a/tests/model/test_openai_convert.py
+++ b/tests/model/test_openai_convert.py
@@ -29,6 +29,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageAssistant,
 )
 from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.model._openai import chat_message_assistant_from_openai
 from inspect_ai.model._openai_responses import (
     reasoning_from_responses_reasoning,
     responses_reasoning_from_reasoning,
@@ -124,6 +125,32 @@ async def test_model_output_from_openai_with_tool_calls() -> None:
     assert message.tool_calls is not None
     assert len(message.tool_calls) == 1
     assert message.tool_calls[0].function == "get_weather"
+
+
+async def test_chat_completion_openrouter_reasoning_details() -> None:
+    details = [
+        {
+            "type": "reasoning.text",
+            "text": "I should answer directly.",
+            "format": "unknown",
+            "index": 0,
+        }
+    ]
+    message = ChatCompletionMessage.model_construct(
+        role="assistant",
+        content="Final answer",
+        reasoning_details=details,
+    )
+
+    result = chat_message_assistant_from_openai("gpt-4o", message, [])
+
+    assert isinstance(result.content, list)
+    assert isinstance(result.content[0], ContentReasoning)
+    assert result.content[0].reasoning == "I should answer directly."
+    assert "reasoning.text" not in result.content[0].reasoning
+    assert result.content[0].signature is not None
+    assert isinstance(result.content[1], ContentText)
+    assert result.content[1].text == "Final answer"
 
 
 async def test_model_output_from_openai_dict_input() -> None:

--- a/tests/model/test_reasoning_openrouter.py
+++ b/tests/model/test_reasoning_openrouter.py
@@ -112,7 +112,7 @@ class TestOpenrouterReasoningDetailsToReasoning:
 
     def test_empty_list_logs_warning(self):
         """Empty reasoning_details list logs warning and returns raw JSON."""
-        with patch("inspect_ai.model._providers.openrouter.logger") as mock_logger:
+        with patch("inspect_ai.model._openrouter_reasoning.logger") as mock_logger:
             details = []
             result = openrouter_reasoning_details_to_reasoning(details)
 
@@ -123,7 +123,7 @@ class TestOpenrouterReasoningDetailsToReasoning:
 
     def test_invalid_format_logs_warning(self):
         """Invalid/malformed data logs warning and returns raw JSON."""
-        with patch("inspect_ai.model._providers.openrouter.logger") as mock_logger:
+        with patch("inspect_ai.model._openrouter_reasoning.logger") as mock_logger:
             details = [{"type": "unknown.type", "foo": "bar"}]
             result = openrouter_reasoning_details_to_reasoning(details)
 


### PR DESCRIPTION
﻿## Summary

Fixes #3899.

OpenAI-compatible providers can return OpenRouter-shaped `reasoning_details` as a structured list. The generic OpenAI conversion path was treating that list as a Python string repr, so `ContentReasoning.reasoning` contained the raw list/dict text instead of the reasoning text.

This change moves the OpenRouter `reasoning_details` parser into a shared helper, reuses it from the OpenAI-compatible conversion path, and keeps the OpenRouter provider exports intact for existing internal tests/imports.

## To verify

- `python -m pytest tests/model/test_openai_convert.py::test_chat_completion_openrouter_reasoning_details tests/model/test_openai_chat_messages.py::test_assistant_message_with_openrouter_reasoning_details tests/model/test_reasoning_openrouter.py -q`
- `python -m ruff check src/inspect_ai/model/_openai.py src/inspect_ai/model/_providers/openrouter.py src/inspect_ai/model/_openrouter_reasoning.py tests/model/test_openai_convert.py tests/model/test_openai_chat_messages.py tests/model/test_reasoning_openrouter.py`
- `python -m ruff format --check src/inspect_ai/model/_openai.py src/inspect_ai/model/_providers/openrouter.py src/inspect_ai/model/_openrouter_reasoning.py tests/model/test_openai_convert.py tests/model/test_openai_chat_messages.py tests/model/test_reasoning_openrouter.py`
- `python -m py_compile src/inspect_ai/model/_openai.py src/inspect_ai/model/_providers/openrouter.py src/inspect_ai/model/_openrouter_reasoning.py tests/model/test_openai_convert.py tests/model/test_openai_chat_messages.py tests/model/test_reasoning_openrouter.py`
