### PR TITLE
docs(computer): fix start_coordinate action requirement

### DIFF
--- a/src/inspect_ai/tool/_tools/_computer/_computer.py
+++ b/src/inspect_ai/tool/_tools/_computer/_computer.py
@@ -149,7 +149,7 @@ def computer(max_screenshots: int | None = 1, timeout: int | None = 180) -> Tool
           region (list[int] | None): The region to zoom into as [x0, y0, x1, y1] coordinates. Required only by `action=zoom`.
           scroll_amount (int | None): The number of 'clicks' to scroll. Required only by `action=scroll`.
           scroll_direction (Literal["up", "down", "left", "right] | None): The direction to scroll the screen. Required only by `action=scroll`.
-          start_coordinate (tuple[int, int] | None): The (x, y) pixel coordinate on the screen from which to initiate a drag. Required only by `action=scroll`.
+          start_coordinate (tuple[int, int] | None): The (x, y) pixel coordinate on the screen from which to initiate a drag. Required only by `action=left_click_drag`.
           text (str | None): The text to type or the key to press. Required when action is "key" or "type".
           press_enter (bool): If True and action is "type", press Return after typing. Defaults to False.
           actions (list[dict] | None): A list of action dicts to execute sequentially (OpenAI multi-action format).


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`start_coordinate` is required for `scroll`.
### What is the new behavior?
`start_coordinate` is required for `left_click_drag`.
### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No
### Other information:
Update the tool docstring to match the implementation and avoid misleading tool callers about required parameters.