### PR TITLE
feat(scorer): add aggregate(key, agg=metric) factory for dict-valued Score.value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scoring: Added `aggregate(key, agg=metric)` factory composing any existing `Metric` with a dict-key selector for dict-valued `Score.value` -- removes per-eval re-implementation of `mean_of` / `stderr_of` / etc.
 - OpenAI: Add GPT 5.5 as computer use model and exclude 'chat' and 'instant' models from computer use.
 - OpenAI Compatible: Parse OpenRouter-style `reasoning_details` in OpenAI-compatible responses.
 - VLLM: Preserve dotted vLLM server arg keys.

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -22,6 +22,7 @@ from ._metric import (
     value_to_float,
 )
 from ._metrics.accuracy import accuracy
+from ._metrics.aggregate import aggregate
 from ._metrics.grouped import grouped
 from ._metrics.mean import mean
 from ._metrics.perplexity import perplexity_per_seq, perplexity_per_token
@@ -65,6 +66,7 @@ __all__ = [
     "Value",
     "ValueToFloat",
     "accuracy",
+    "aggregate",
     "answer",
     "at_least",
     "bootstrap_stderr",

--- a/src/inspect_ai/scorer/_metrics/__init__.py
+++ b/src/inspect_ai/scorer/_metrics/__init__.py
@@ -1,4 +1,5 @@
 from .accuracy import accuracy
+from .aggregate import aggregate
 from .grouped import grouped
 from .mean import mean
 from .perplexity import perplexity_per_seq, perplexity_per_token
@@ -6,6 +7,7 @@ from .std import bootstrap_stderr, std, stderr, var
 
 __all__ = [
     "accuracy",
+    "aggregate",
     "mean",
     "grouped",
     "perplexity_per_token",

--- a/src/inspect_ai/scorer/_metrics/aggregate.py
+++ b/src/inspect_ai/scorer/_metrics/aggregate.py
@@ -1,0 +1,118 @@
+from typing import Literal, cast
+
+from .._metric import (
+    Metric,
+    MetricProtocol,
+    SampleScore,
+    Score,
+    Value,
+    ValueToFloat,
+    metric,
+    value_to_float,
+)
+
+
+@metric
+def aggregate(
+    key: str,
+    agg: Metric,
+    *,
+    to_float: ValueToFloat = value_to_float(),
+    on_missing: Literal["error", "skip", "zero"] = "error",
+) -> Metric:
+    """Apply ``agg`` to the ``key`` field extracted from each dict-valued ``Score.value``.
+
+    Many scorers emit a ``dict`` as ``Score.value`` (multiple numeric fields
+    per sample). ``aggregate`` composes any existing ``Metric`` (``mean``,
+    ``stderr``, ``std``, etc.) with a key-selector so per-key aggregation
+    doesn't have to be re-implemented in every eval.
+
+    Args:
+        key: The key to extract from each sample's ``score.value`` dict.
+        agg: The aggregator metric to apply once the per-sample scalar values
+            have been unwrapped. Typically ``mean()``, ``stderr()``, ``std()``,
+            ``accuracy()``, or any other registered ``Metric`` whose
+            implementation reads ``score.value``.
+        to_float: Function for mapping the extracted dict-value to ``float``.
+            Defaults to :func:`value_to_float` (handles CORRECT/INCORRECT,
+            booleans, and numeric values).
+        on_missing: How to handle samples whose ``score.value`` dict is
+            missing ``key`` or has it set to ``None``:
+
+            - ``"error"`` (default) -- raise ``ValueError``.
+            - ``"skip"`` -- exclude the sample from the aggregator.
+            - ``"zero"`` -- treat the missing entry as ``0.0``.
+
+    Returns:
+        A new metric that returns whatever ``agg`` returns when applied to the
+        per-sample scalar values extracted at ``key``.
+
+    Raises:
+        ValueError: If ``Score.value`` is not a ``dict``, or if ``key`` is
+            missing/``None`` and ``on_missing="error"``.
+
+    Examples:
+        ```python
+        from inspect_ai.scorer import (
+            Metric, aggregate, mean, metric, stderr,
+        )
+
+        @metric
+        def element_accuracy() -> Metric:
+            return aggregate("element_acc", agg=mean(), on_missing="skip")
+
+        @metric
+        def element_accuracy_stderr() -> Metric:
+            return aggregate("element_acc", agg=stderr(), on_missing="skip")
+        ```
+    """
+    agg_protocol = cast(MetricProtocol, agg)
+
+    def aggregate_metric(scores: list[SampleScore]) -> Value:
+        unwrapped: list[SampleScore] = []
+        for sample_score in scores:
+            value = sample_score.score.value
+            if not isinstance(value, dict):
+                raise ValueError(
+                    f"aggregate('{key}') requires Score.value to be a dict, "
+                    f"got {type(value).__name__}: {value!r}"
+                )
+
+            if key not in value or value[key] is None:
+                if on_missing == "error":
+                    if key not in value:
+                        raise ValueError(
+                            f"aggregate('{key}') key not found in Score.value. "
+                            f"Available keys: {list(value.keys())}"
+                        )
+                    raise ValueError(
+                        f"aggregate('{key}') value is None in Score.value."
+                    )
+                if on_missing == "skip":
+                    continue
+                # on_missing == "zero"
+                extracted: float = 0.0
+            else:
+                extracted = to_float(value[key])
+
+            # Rebuild the SampleScore with the unwrapped scalar value so that
+            # ``agg`` (which reads ``score.value`` via ``score.as_float()`` or
+            # ``to_float``) sees a single number rather than the original dict.
+            unwrapped.append(
+                SampleScore(
+                    score=Score(
+                        value=extracted,
+                        answer=sample_score.score.answer,
+                        explanation=sample_score.score.explanation,
+                        metadata=sample_score.score.metadata,
+                        history=sample_score.score.history,
+                    ),
+                    sample_id=sample_score.sample_id,
+                    sample_metadata=sample_score.sample_metadata,
+                    scorer=sample_score.scorer,
+                )
+            )
+
+        return agg_protocol(unwrapped)
+
+    return aggregate_metric

--- a/tests/scorer/test_aggregate.py
+++ b/tests/scorer/test_aggregate.py
@@ -1,0 +1,129 @@
+"""Unit tests for the ``aggregate`` metric factory."""
+
+import math
+
+import pytest
+
+from inspect_ai.scorer import (
+    Metric,
+    Score,
+    SampleScore,
+    aggregate,
+    mean,
+    metric,
+    std,
+    stderr,
+    value_to_float,
+)
+
+
+def _sample(value: object, sample_id: int = 0) -> SampleScore:
+    return SampleScore(
+        score=Score(value=value),  # type: ignore[arg-type]
+        sample_id=sample_id,
+    )
+
+
+class TestAggregateBasics:
+    def test_mean_of_key(self) -> None:
+        scores = [
+            _sample({"acc": 1.0, "other": 9.0}, 0),
+            _sample({"acc": 0.0, "other": 8.0}, 1),
+            _sample({"acc": 0.5, "other": 7.0}, 2),
+        ]
+        result = aggregate("acc", agg=mean())(scores)
+        assert math.isclose(float(result), 0.5)
+
+    def test_stderr_of_key(self) -> None:
+        scores = [
+            _sample({"acc": 1.0}, 0),
+            _sample({"acc": 0.0}, 1),
+            _sample({"acc": 1.0}, 2),
+            _sample({"acc": 0.0}, 3),
+        ]
+        result = aggregate("acc", agg=stderr())(scores)
+        assert float(result) > 0.0
+
+    def test_std_of_key(self) -> None:
+        scores = [
+            _sample({"acc": 1.0}, 0),
+            _sample({"acc": 3.0}, 1),
+            _sample({"acc": 5.0}, 2),
+        ]
+        result = aggregate("acc", agg=std())(scores)
+        assert float(result) > 1.0
+
+    def test_passes_metadata_through(self) -> None:
+        seen_metadata: list[dict] = []
+
+        @metric
+        def collect_metadata() -> Metric:
+            def metric_fn(samples: list[SampleScore]) -> float:
+                for s in samples:
+                    seen_metadata.append(s.sample_metadata or {})
+                return float(len(samples))
+
+            return metric_fn
+
+        scores = [
+            SampleScore(
+                score=Score(value={"acc": 1.0}),
+                sample_id=i,
+                sample_metadata={"group": grp},
+            )
+            for i, grp in enumerate(["a", "b", "a"])
+        ]
+        aggregate("acc", agg=collect_metadata())(scores)
+        assert seen_metadata == [{"group": "a"}, {"group": "b"}, {"group": "a"}]
+
+
+class TestOnMissing:
+    def test_error_on_missing_key(self) -> None:
+        scores = [
+            _sample({"acc": 1.0}, 0),
+            _sample({"other": 0.0}, 1),
+        ]
+        with pytest.raises(ValueError, match="key not found"):
+            aggregate("acc", agg=mean())(scores)
+
+    def test_error_on_none_value(self) -> None:
+        scores = [
+            _sample({"acc": 1.0}, 0),
+            _sample({"acc": None}, 1),
+        ]
+        with pytest.raises(ValueError, match="value is None"):
+            aggregate("acc", agg=mean())(scores)
+
+    def test_skip_excludes_missing(self) -> None:
+        scores = [
+            _sample({"acc": 1.0}, 0),
+            _sample({"other": 0.0}, 1),
+            _sample({"acc": 0.0}, 2),
+        ]
+        result = aggregate("acc", agg=mean(), on_missing="skip")(scores)
+        assert math.isclose(float(result), 0.5)
+
+    def test_zero_treats_missing_as_zero(self) -> None:
+        scores = [
+            _sample({"acc": 1.0}, 0),
+            _sample({"other": 0.0}, 1),
+            _sample({"acc": 1.0}, 2),
+        ]
+        result = aggregate("acc", agg=mean(), on_missing="zero")(scores)
+        assert math.isclose(float(result), 2.0 / 3.0)
+
+
+class TestValueShapes:
+    def test_rejects_non_dict_value(self) -> None:
+        scores = [_sample(0.5, 0)]
+        with pytest.raises(ValueError, match="requires Score.value to be a dict"):
+            aggregate("acc", agg=mean())(scores)
+
+    def test_to_float_converts_correctly(self) -> None:
+        scores = [
+            _sample({"label": "C"}, 0),
+            _sample({"label": "I"}, 1),
+            _sample({"label": "C"}, 2),
+        ]
+        result = aggregate("label", agg=mean(), to_float=value_to_float())(scores)
+        assert math.isclose(float(result), 2.0 / 3.0)


### PR DESCRIPTION
## Summary

Closes #3735.

Adds `aggregate(key, agg=metric)` — a composition primitive that applies any registered `Metric` (e.g. `mean()`, `stderr()`, `std()`, `accuracy()`) to the per-sample scalar values extracted at `key` from a dict-valued `Score.value`. Many scorers in `inspect_evals` emit dict-valued scores (multiple numeric fields per sample) and re-implement that plumbing by hand; this lifts the pattern to the framework.

## Public API

```python
from inspect_ai.scorer import Metric, aggregate, mean, metric, stderr

@metric
def element_accuracy() -> Metric:
    return aggregate("element_acc", agg=mean(), on_missing="skip")

@metric
def element_accuracy_stderr() -> Metric:
    return aggregate("element_acc", agg=stderr(), on_missing="skip")
```

Signature:

```python
def aggregate(
    key: str,
    agg: Metric,
    *,
    to_float: ValueToFloat = value_to_float(),
    on_missing: Literal["error", "skip", "zero"] = "error",
) -> Metric: ...
```

## Implementation notes

- Mirrors the wrapper shape of `grouped`: cast the inner `Metric` to `MetricProtocol`, rebuild each `SampleScore` with the unwrapped scalar value, then call the inner aggregator on the rebuilt list.
- Preserves `sample_id`, `sample_metadata`, `scorer`, and the score's `answer` / `explanation` / `metadata` / `history` so the inner aggregator sees the same `SampleScore` shape it would receive from a per-key scorer.
- `on_missing` semantics match `inspect_evals.utils.metrics.mean_of` for downstream-migration parity:
  - `"error"` (default) — raise `ValueError` on missing or `None` value
  - `"skip"` — exclude sample from the aggregator
  - `"zero"` — treat missing or `None` value as `0.0`

## Files

- `src/inspect_ai/scorer/_metrics/aggregate.py` — new factory (~100 LOC including docstring)
- `src/inspect_ai/scorer/_metrics/__init__.py` — re-export
- `src/inspect_ai/scorer/__init__.py` — public-API export, alphabetical `__all__` entry
- `tests/scorer/test_aggregate.py` — 10 unit tests (3 classes: basics, on_missing semantics, value-shape errors)
- `CHANGELOG.md` — `Unreleased` bullet

## Tests

10 cases, all pass locally against `inspect_ai==0.3.220`:

```
tests/scorer/test_aggregate.py::TestAggregateBasics::test_mean_of_key
tests/scorer/test_aggregate.py::TestAggregateBasics::test_stderr_of_key
tests/scorer/test_aggregate.py::TestAggregateBasics::test_std_of_key
tests/scorer/test_aggregate.py::TestAggregateBasics::test_passes_metadata_through
tests/scorer/test_aggregate.py::TestOnMissing::test_error_on_missing_key
tests/scorer/test_aggregate.py::TestOnMissing::test_error_on_none_value
tests/scorer/test_aggregate.py::TestOnMissing::test_skip_excludes_missing
tests/scorer/test_aggregate.py::TestOnMissing::test_zero_treats_missing_as_zero
tests/scorer/test_aggregate.py::TestValueShapes::test_rejects_non_dict_value
tests/scorer/test_aggregate.py::TestValueShapes::test_to_float_converts_correctly
```

Verified manually:

- `aggregate("acc", agg=mean())` over `[{"acc": 1.0}, {"acc": 0.0}, {"acc": 0.5}]` → `0.5`
- `aggregate("acc", agg=stderr())` over a four-sample bimodal series → `≈ 0.289` (non-zero, sensible)
- `aggregate("acc", agg=mean(), on_missing="skip")` over `[{"acc": 1.0}, {"other": 0.0}, {"acc": 0.0}]` → `0.5`
- `aggregate("acc", agg=mean(), on_missing="zero")` over the same → `0.667`

## Disclosure: AI-assistance

Per common OSS practice for AI-assisted contributions:

- **Tool used:** Claude Code (Anthropic Claude Opus 4.7).
- **What was AI-assisted:** drafting the docstring, the SampleScore-rebuild logic, the unit-test scaffolding, and verifying the implementation against the existing `grouped` and `mean_of` patterns.
- **What the human contributor did:** picked this issue from the open queue, designed the migration-parity choice with `mean_of`'s `on_missing` semantics, audited the `Score`/`SampleScore`/`MetricProtocol` API to make sure `aggregate` could compose cleanly with any existing metric (not just `mean`), and ran the local smoke tests against `inspect_ai==0.3.220` before submitting.

## DCO

The commit has a `Signed-off-by` line.