### PR TITLE
fix(agent): react assistant_prompt/submit_prompt .format crash on braces (follow-up to #3912)

### DIFF
--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -301,8 +301,8 @@ def react(
                         if not state.output.message.tool_calls:
                             state.messages.append(
                                 ChatMessageUser(
-                                    content=_sub_submit(
-                                        DEFAULT_CONTINUE_PROMPT, submit_tool.name
+                                    content=DEFAULT_CONTINUE_PROMPT.replace(
+                                        "{submit}", submit_tool.name
                                     )
                                 )
                             )
@@ -310,7 +310,9 @@ def react(
                         # send back the user message
                         state.messages.append(
                             ChatMessageUser(
-                                content=_sub_submit(do_continue, submit_tool.name)
+                                content=do_continue.replace(
+                                    "{submit}", submit_tool.name
+                                )
                             )
                         )
                     elif isinstance(do_continue, AgentState):
@@ -328,7 +330,7 @@ def react(
                     )
                     state.messages.append(
                         ChatMessageUser(
-                            content=_sub_submit(continue_msg, submit_tool.name)
+                            content=continue_msg.replace("{submit}", submit_tool.name)
                         )
                     )
 
@@ -438,16 +440,6 @@ def react_no_submit(
     return _resolve_agent(execute, name, description)
 
 
-def _sub_submit(text: str, submit_name: str) -> str:
-    """Substitute the documented `{submit}` placeholder for the submit tool name.
-
-    Uses literal replace rather than `str.format` so that other braces in
-    user-supplied prompts (e.g. JSON examples) are left intact and do not
-    raise `KeyError`/`IndexError`.
-    """
-    return text.replace("{submit}", submit_name)
-
-
 def _prompt_to_system_message(
     prompt: str | AgentPrompt | None,
     tools: list[Tool | ToolDef | ToolSource],
@@ -466,10 +458,13 @@ def _prompt_to_system_message(
                 and ("{submit}" not in prompt.assistant_prompt)
                 and prompt.submit_prompt
             ):
-                assistant_prompt = f"{prompt.assistant_prompt}\n{_sub_submit(prompt.submit_prompt, submit_tool)}"
+                assistant_prompt = (
+                    f"{prompt.assistant_prompt}\n"
+                    f"{prompt.submit_prompt.replace('{submit}', submit_tool)}"
+                )
             else:
-                assistant_prompt = _sub_submit(
-                    prompt.assistant_prompt, submit_tool or "submit"
+                assistant_prompt = prompt.assistant_prompt.replace(
+                    "{submit}", submit_tool or "submit"
                 )
             prompt_lines.append(assistant_prompt)
         prompt_content = "\n\n".join(prompt_lines)

--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -301,8 +301,8 @@ def react(
                         if not state.output.message.tool_calls:
                             state.messages.append(
                                 ChatMessageUser(
-                                    content=DEFAULT_CONTINUE_PROMPT.replace(
-                                        "{submit}", submit_tool.name
+                                    content=_sub_submit(
+                                        DEFAULT_CONTINUE_PROMPT, submit_tool.name
                                     )
                                 )
                             )
@@ -310,9 +310,7 @@ def react(
                         # send back the user message
                         state.messages.append(
                             ChatMessageUser(
-                                content=do_continue.replace(
-                                    "{submit}", submit_tool.name
-                                )
+                                content=_sub_submit(do_continue, submit_tool.name)
                             )
                         )
                     elif isinstance(do_continue, AgentState):
@@ -330,7 +328,7 @@ def react(
                     )
                     state.messages.append(
                         ChatMessageUser(
-                            content=continue_msg.replace("{submit}", submit_tool.name)
+                            content=_sub_submit(continue_msg, submit_tool.name)
                         )
                     )
 
@@ -440,6 +438,16 @@ def react_no_submit(
     return _resolve_agent(execute, name, description)
 
 
+def _sub_submit(text: str, submit_name: str) -> str:
+    """Substitute the documented `{submit}` placeholder for the submit tool name.
+
+    Uses literal replace rather than `str.format` so that other braces in
+    user-supplied prompts (e.g. JSON examples) are left intact and do not
+    raise `KeyError`/`IndexError`.
+    """
+    return text.replace("{submit}", submit_name)
+
+
 def _prompt_to_system_message(
     prompt: str | AgentPrompt | None,
     tools: list[Tool | ToolDef | ToolSource],
@@ -458,10 +466,10 @@ def _prompt_to_system_message(
                 and ("{submit}" not in prompt.assistant_prompt)
                 and prompt.submit_prompt
             ):
-                assistant_prompt = f"{prompt.assistant_prompt}\n{prompt.submit_prompt.format(submit=submit_tool)}"
+                assistant_prompt = f"{prompt.assistant_prompt}\n{_sub_submit(prompt.submit_prompt, submit_tool)}"
             else:
-                assistant_prompt = prompt.assistant_prompt.format(
-                    submit=submit_tool or "submit"
+                assistant_prompt = _sub_submit(
+                    prompt.assistant_prompt, submit_tool or "submit"
                 )
             prompt_lines.append(assistant_prompt)
         prompt_content = "\n\n".join(prompt_lines)

--- a/tests/agent/test_agent_react.py
+++ b/tests/agent/test_agent_react.py
@@ -449,6 +449,44 @@ def test_react_agent_on_continue_func_with_braces():
     assert messages[-2].text == 'You said "I refuse. {pwned}". Please call submit.'
 
 
+def test_react_agent_assistant_prompt_with_braces():
+    # a user-supplied assistant_prompt / submit_prompt may legitimately contain
+    # literal braces (e.g. a JSON output schema). Only the documented {submit}
+    # placeholder is substituted; other braces must be left intact and must
+    # not raise via str.format().
+    assistant_prompt = 'You are helpful. Output {"json": true}. Use {submit} to finish.'
+    log = run_react_agent(
+        prompt=AgentPrompt(assistant_prompt=assistant_prompt),
+        tools=[addition()],
+    )
+    assert log.status == "success"
+    assert log.samples
+    assert log.samples[0].error is None
+    system_msg = next(
+        m for m in log.samples[0].messages if isinstance(m, ChatMessageSystem)
+    )
+    assert '{"json": true}' in system_msg.text
+    assert f"Use {AGENT_SUBMIT_TOOL_NAME} to finish." in system_msg.text
+
+    # also exercise the branch where assistant_prompt has no {submit} so the
+    # separate submit_prompt (with braces of its own) is appended
+    log = run_react_agent(
+        prompt=AgentPrompt(
+            assistant_prompt='Respond with {"done": false} until ready.',
+            submit_prompt='When ready call {submit}() with {"done": true}.',
+        ),
+        tools=[addition()],
+    )
+    assert log.status == "success"
+    assert log.samples
+    assert log.samples[0].error is None
+    system_msg = next(
+        m for m in log.samples[0].messages if isinstance(m, ChatMessageSystem)
+    )
+    assert '{"done": false}' in system_msg.text
+    assert f'call {AGENT_SUBMIT_TOOL_NAME}() with {{"done": true}}.' in system_msg.text
+
+
 def test_react_agent_on_continue_func():
     async def on_continue(state: AgentState) -> bool | str:
         if state.output.completion == "5":


### PR DESCRIPTION
Follow-up to #3912, which fixed `.format(submit=...)` crashes for `on_continue` strings but missed two more sites in `_prompt_to_system_message()`:

- `prompt.assistant_prompt.format(submit=...)` (line ~471)
- `prompt.submit_prompt.format(submit=...)` (line ~469)

Both are user-supplied strings; a prompt containing literal `{` / `}` (e.g., a JSON example) raises `KeyError`.

This PR:
- Adds a single `_sub_submit(text, name)` helper that does `.replace("{submit}", name)`
- Routes all 5 substitution sites through it (the 3 fixed in #3912 + the 2 missed here)
- Adds `test_react_agent_assistant_prompt_with_braces` exercising both branches with literal JSON braces

The `"{submit}" not in prompt.assistant_prompt` guard is unchanged — it only decides whether to append the default submit prompt, independent of substitution.