### PR TITLE
fix: reject unknown generate config fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Logging: `INSPECT_PY_LOGGER_FORMAT` env var (`rich`/`plain`/`json`) for non-TTY-friendly single-line console logs.
 - Docker Compose: accept depends_on / pull_policy / privileged / shm_size / ulimits in ComposeService.
 - Task Display: Honor terminal `COLUMNS` and `LINES` for dumb terminals.
+- Validation: Reject unknown `GenerateConfig` fields with an error.
 - Memory: Log condensing no longer retains unchanged JSON copies in long evals.
 - Memory: Don't retain message lists in buffer DB (memory leak on long agentic samples).
 - Memory: Collapse user messages at compaction time to avoid carrying extra messages.

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -351,7 +351,7 @@ def _read_header_streaming(log_file: str) -> EvalLog:
             elif k == "eval":
                 eval = EvalSpec.model_validate(v, context=get_deserializing_context())
             elif k == "plan":
-                plan = EvalPlan.model_validate(v)
+                plan = EvalPlan.model_validate(v, context=get_deserializing_context())
             elif k == "results":
                 results = EvalResults.model_validate(v)
             elif k == "stats":

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -2,10 +2,16 @@ from contextvars import ContextVar
 from copy import deepcopy
 from typing import Any, Literal, Union
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationInfo,
+    field_validator,
+    model_validator,
+)
 from typing_extensions import TypedDict
 
-from inspect_ai._util.constants import DEFAULT_BATCH_SIZE
+from inspect_ai._util.constants import DEFAULT_BATCH_SIZE, DESERIALIZING
 from inspect_ai.model._cache import CachePolicy
 from inspect_ai.util._concurrency import AdaptiveConcurrency
 from inspect_ai.util._json import JSONSchema
@@ -308,6 +314,30 @@ class GenerateConfig(BaseModel):
 
     batch: bool | int | BatchConfig | None = Field(default=None)
     """Use batching API when available. True to enable batching with default configuration, False to disable batching, a number to enable batching of the specified batch size, or a BatchConfig object specifying the batching configuration."""
+
+    # reject unknown fields unless we are reading older logs
+    @model_validator(mode="before")
+    @classmethod
+    def handle_unknown_fields(cls, data: Any, info: ValidationInfo) -> Any:
+        if isinstance(data, dict):
+            data = dict(data)
+            extra = set(data) - set(cls.model_fields)
+            if extra:
+                if isinstance(info.context, dict) and info.context.get(
+                    DESERIALIZING, False
+                ):
+                    data = {
+                        key: value
+                        for key, value in data.items()
+                        if key in cls.model_fields
+                    }
+                else:
+                    fields = ", ".join(sorted(extra))
+                    raise ValueError(
+                        f"Unknown GenerateConfig field(s): {fields}. "
+                        "Use extra_body for provider-specific options."
+                    )
+        return data
 
     # migrate reasoning_history as a bool
     @model_validator(mode="before")

--- a/tests/model/test_generate_config.py
+++ b/tests/model/test_generate_config.py
@@ -1,5 +1,7 @@
 import pytest
+from pydantic import ValidationError
 
+from inspect_ai._util.constants import get_deserializing_context
 from inspect_ai.model import GenerateConfig
 from inspect_ai.util import AdaptiveConcurrency
 
@@ -22,6 +24,29 @@ def test_generate_config_merge_copies_nested_override_values() -> None:
 
     assert override.extra_body == {"background": True}
     assert override.extra_headers == {"x-test-header": "value"}
+
+
+def test_generate_config_rejects_unknown_fields() -> None:
+    with pytest.raises(ValidationError, match="response_format"):
+        GenerateConfig.model_validate(
+            {
+                "temperature": 0,
+                "response_format": {"type": "json_object"},
+            }
+        )
+
+
+def test_generate_config_drops_unknown_fields_when_deserializing() -> None:
+    config = GenerateConfig.model_validate(
+        {
+            "temperature": 0,
+            "response_format": {"type": "json_object"},
+        },
+        context=get_deserializing_context(),
+    )
+
+    assert config.temperature == 0
+    assert "response_format" not in config.model_dump()
 
 
 # AdaptiveConcurrency tests


### PR DESCRIPTION
Fixes #3918. GenerateConfig now checks raw input before Pydantic drops extra keys, so direct construction fails loudly for provider-specific names such as response_format and points callers to extra_body. Log deserialization still passes the existing deserializing context and drops unknown config fields for backwards compatibility, including the streaming JSON header path for EvalPlan. Validation: uv run pytest tests\\model\\test_generate_config.py -q --basetemp .tmp\\pytest -p no:cacheprovider; targeted EvalPlan deserialization snippet; uv run ruff check; uv run ruff format --check; uv run mypy --config-file pyproject.toml src\\inspect_ai\\model\\_generate_config.py src\\inspect_ai\\log\\_recorders\\json.py; schema/type generation via src\\inspect_ai\\_view\\schema.py with pnpm.cmd on Windows; python -m py_compile; git diff --check. Note: the full tests/log/test_eval_log.py file exceeded the local timeout, so I did not use that as a pass/fail signal for this patch.