### PR TITLE
(WIP) perf: lazy package init + CLI — import inspect_ai 1.3s→0.08s, all --help ~0.1s

### DIFF
--- a/src/inspect_ai/__init__.py
+++ b/src/inspect_ai/__init__.py
@@ -1,21 +1,10 @@
-# ruff: noqa: F401 F403 F405
+# ruff: noqa: F401
 
 from importlib.metadata import version as importlib_version
+from typing import TYPE_CHECKING
 
-from inspect_ai._eval.eval import eval, eval_async, eval_retry, eval_retry_async
-from inspect_ai._eval.evalset import eval_set
-from inspect_ai._eval.list import list_tasks
-from inspect_ai._eval.registry import task
-from inspect_ai._eval.score import score, score_async
-from inspect_ai._eval.task import Epochs, Task, TaskInfo, task_with
-from inspect_ai._eval.task.scan import EvalScannerConfig
-from inspect_ai._eval.task.tasks import Tasks
 from inspect_ai._util.constants import PKG_NAME
-from inspect_ai._view.view import view
-from inspect_ai.agent._human.agent import human_cli
-from inspect_ai.log._metric import recompute_metrics
-from inspect_ai.log._score import edit_score
-from inspect_ai.solver._human_agent import human_agent
+from inspect_ai._util.lazy import lazy_attributes
 
 __version__ = importlib_version(PKG_NAME)
 
@@ -41,3 +30,46 @@ __all__ = [
     "task_with",
     "view",
 ]
+
+
+if TYPE_CHECKING:
+    from inspect_ai._eval.eval import eval, eval_async, eval_retry, eval_retry_async
+    from inspect_ai._eval.evalset import eval_set
+    from inspect_ai._eval.list import list_tasks
+    from inspect_ai._eval.registry import task
+    from inspect_ai._eval.score import score, score_async
+    from inspect_ai._eval.task import Epochs, Task, TaskInfo, task_with
+    from inspect_ai._eval.task.scan import EvalScannerConfig
+    from inspect_ai._eval.task.tasks import Tasks
+    from inspect_ai._view.view import view
+    from inspect_ai.agent._human.agent import human_cli
+    from inspect_ai.log._metric import recompute_metrics
+    from inspect_ai.log._score import edit_score
+    from inspect_ai.solver._human_agent import human_agent
+
+
+lazy_attributes(
+    __name__,
+    {
+        "eval": "inspect_ai._eval.eval",
+        "eval_async": "inspect_ai._eval.eval",
+        "eval_retry": "inspect_ai._eval.eval",
+        "eval_retry_async": "inspect_ai._eval.eval",
+        "eval_set": "inspect_ai._eval.evalset",
+        "list_tasks": "inspect_ai._eval.list",
+        "task": "inspect_ai._eval.registry",
+        "score": "inspect_ai._eval.score",
+        "score_async": "inspect_ai._eval.score",
+        "Epochs": "inspect_ai._eval.task",
+        "Task": "inspect_ai._eval.task",
+        "TaskInfo": "inspect_ai._eval.task",
+        "task_with": "inspect_ai._eval.task",
+        "EvalScannerConfig": "inspect_ai._eval.task.scan",
+        "Tasks": "inspect_ai._eval.task.tasks",
+        "view": "inspect_ai._view.view",
+        "human_cli": "inspect_ai.agent._human.agent",
+        "recompute_metrics": "inspect_ai.log._metric",
+        "edit_score": "inspect_ai.log._score",
+        "human_agent": "inspect_ai.solver._human_agent",
+    },
+)

--- a/src/inspect_ai/__init__.py
+++ b/src/inspect_ai/__init__.py
@@ -1,8 +1,13 @@
 # ruff: noqa: F401
 
+from importlib.metadata import version as importlib_version
 from typing import TYPE_CHECKING
 
+from inspect_ai._util.constants import PKG_NAME
 from inspect_ai._util.lazy import lazy_attributes
+
+__version__ = importlib_version(PKG_NAME)
+
 
 __all__ = [
     "__version__",
@@ -28,7 +33,6 @@ __all__ = [
 
 
 if TYPE_CHECKING:
-    __version__: str
     from inspect_ai._eval.eval import eval, eval_async, eval_retry, eval_retry_async
     from inspect_ai._eval.evalset import eval_set
     from inspect_ai._eval.list import list_tasks
@@ -42,18 +46,6 @@ if TYPE_CHECKING:
     from inspect_ai.log._metric import recompute_metrics
     from inspect_ai.log._score import edit_score
     from inspect_ai.solver._human_agent import human_agent
-
-
-def __getattr__(name: str) -> object:
-    # ``importlib.metadata`` pulls in email/zipfile/inspect/urllib (~45ms),
-    # so resolve the version lazily on first access. ``lazy_attributes``
-    # below chains to this for names it doesn't own.
-    if name == "__version__":
-        from importlib.metadata import version
-
-        globals()["__version__"] = v = version("inspect_ai")
-        return v
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 lazy_attributes(

--- a/src/inspect_ai/__init__.py
+++ b/src/inspect_ai/__init__.py
@@ -1,13 +1,8 @@
 # ruff: noqa: F401
 
-from importlib.metadata import version as importlib_version
 from typing import TYPE_CHECKING
 
-from inspect_ai._util.constants import PKG_NAME
 from inspect_ai._util.lazy import lazy_attributes
-
-__version__ = importlib_version(PKG_NAME)
-
 
 __all__ = [
     "__version__",
@@ -33,6 +28,7 @@ __all__ = [
 
 
 if TYPE_CHECKING:
+    __version__: str
     from inspect_ai._eval.eval import eval, eval_async, eval_retry, eval_retry_async
     from inspect_ai._eval.evalset import eval_set
     from inspect_ai._eval.list import list_tasks
@@ -46,6 +42,18 @@ if TYPE_CHECKING:
     from inspect_ai.log._metric import recompute_metrics
     from inspect_ai.log._score import edit_score
     from inspect_ai.solver._human_agent import human_agent
+
+
+def __getattr__(name: str) -> object:
+    # ``importlib.metadata`` pulls in email/zipfile/inspect/urllib (~45ms),
+    # so resolve the version lazily on first access. ``lazy_attributes``
+    # below chains to this for names it doesn't own.
+    if name == "__version__":
+        from importlib.metadata import version
+
+        globals()["__version__"] = v = version("inspect_ai")
+        return v
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 lazy_attributes(

--- a/src/inspect_ai/_cli/_lazy_group.py
+++ b/src/inspect_ai/_cli/_lazy_group.py
@@ -1,0 +1,103 @@
+"""Lazy-loading click command group.
+
+This is the ``LazyGroup`` recipe from the click documentation:
+https://click.palletsprojects.com/en/stable/complex/#lazily-loading-subcommands
+
+It defers importing a subcommand's module until that subcommand is actually
+requested, so ``inspect --help`` / ``inspect --version`` don't pay the cost of
+importing the whole ``inspect_ai`` package.
+
+Deviation from the upstream recipe: ``lazy_subcommands`` maps each name to
+``("pkg.module:attr", short_help)`` rather than a bare dotted path. The
+``short_help`` is stored statically so the top-level ``--help`` screen can be
+rendered without importing any subcommand (the upstream recipe calls
+``get_command()`` for each entry to read its help string, which would import
+everything). An empty ``short_help`` marks a hidden command. The ``:``
+separator is used because module paths themselves contain dots.
+"""
+
+import importlib
+from typing import Any
+
+import click
+
+
+class LazyGroup(click.Group):
+    def __init__(
+        self,
+        *args: Any,
+        lazy_subcommands: dict[str, tuple[str, str]] | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        # {command-name} -> ({module-path}:{command-attr}, {short-help})
+        self.lazy_subcommands = lazy_subcommands or {}
+        self._dotenv_done = False
+
+    def list_commands(self, ctx: click.Context) -> list[str]:
+        base = super().list_commands(ctx)
+        lazy = sorted(self.lazy_subcommands)
+        return base + [name for name in lazy if name not in base]
+
+    def get_command(self, ctx: click.Context, cmd_name: str) -> click.Command | None:
+        if cmd_name in self.lazy_subcommands:
+            return self._lazy_load(cmd_name)
+        return super().get_command(ctx, cmd_name)
+
+    def format_commands(
+        self, ctx: click.Context, formatter: click.HelpFormatter
+    ) -> None:
+        rows: list[tuple[str, str]] = []
+        for name in self.list_commands(ctx):
+            entry = self.lazy_subcommands.get(name)
+            if entry is not None:
+                _, short_help = entry
+                if short_help:
+                    rows.append((name, short_help))
+            else:
+                cmd = super().get_command(ctx, name)
+                if cmd is not None and not cmd.hidden:
+                    rows.append((name, cmd.get_short_help_str()))
+        if rows:
+            with formatter.section("Commands"):
+                formatter.write_dl(rows)
+
+    def _lazy_load(self, cmd_name: str) -> click.Command:
+        # load .env before click parses subcommand options (envvar= defaults).
+        if not self._dotenv_done:
+            self._dotenv_done = True
+            from inspect_ai._util.dotenv import init_dotenv
+
+            init_dotenv()
+
+        import_path, _ = self.lazy_subcommands[cmd_name]
+        modname, cmd_object_name = import_path.rsplit(":", 1)
+        mod = importlib.import_module(modname)
+        cmd_object = getattr(mod, cmd_object_name)
+        if not isinstance(cmd_object, click.Command):
+            raise TypeError(
+                f"Lazy loading of {import_path} did not yield a click.Command"
+            )
+
+        # ``set_exception_hook`` lives in ``_util.error`` which pulls in
+        # pydantic + rich, so defer it past click's ``--help`` short-circuit
+        # by hooking it onto leaf-command ``invoke()``.
+        self._wrap_leaves(cmd_object)
+
+        self.add_command(cmd_object, name=cmd_name)
+        return cmd_object
+
+    def _wrap_leaves(self, cmd: click.Command) -> None:
+        if isinstance(cmd, click.Group):
+            for sub in cmd.commands.values():
+                self._wrap_leaves(sub)
+            return
+        original_invoke = cmd.invoke
+
+        def invoke_with_hook(ctx: click.Context) -> Any:
+            from inspect_ai._util.error import set_exception_hook
+
+            set_exception_hook()
+            return original_invoke(ctx)
+
+        cmd.invoke = invoke_with_hook  # type: ignore[method-assign]

--- a/src/inspect_ai/_cli/_run_config.py
+++ b/src/inspect_ai/_cli/_run_config.py
@@ -1,0 +1,186 @@
+"""Parsing for the ``--run-config`` option of ``inspect eval``.
+
+Kept in its own module so that ``_cli/eval.py`` can stay import-light: the
+pydantic models below reference ``GenerateConfig`` / ``EvalConfig`` /
+``ModelConfig`` / ``SandboxEnvironmentSpec`` in their field annotations, which
+forces those (heavy) modules to be imported at class-definition time. By
+isolating them here and importing this module lazily inside the command
+callbacks, ``inspect eval --help`` avoids paying that cost.
+"""
+
+from typing import Any
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    ValidationError,
+    field_validator,
+)
+
+from inspect_ai import Epochs
+from inspect_ai._util.config import resolve_args
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai.log._log import EvalConfig
+from inspect_ai.model import GenerateConfig, get_model
+from inspect_ai.model._model_config import ModelConfig
+from inspect_ai.scorer._reducer import create_reducers
+from inspect_ai.solver._solver import SolverSpec
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+
+from .util import parse_sandbox
+
+
+class TaskInput(BaseModel):
+    task: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class SolverInput(BaseModel):
+    solver: str
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class RunConfigInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    task: str | TaskInput | None = None
+    model: str | ModelConfig | None = None
+    model_roles: dict[str, ModelConfig] = Field(default_factory=dict)
+    generate_config: GenerateConfig = Field(default_factory=GenerateConfig)
+    eval_config: EvalConfig = Field(default_factory=EvalConfig)
+    solver: str | SolverInput | None = None
+    tags: list[str] = Field(default_factory=list)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    sandbox: str | SandboxEnvironmentSpec | None = None
+
+    @field_validator("generate_config", mode="before")
+    @classmethod
+    def check_generate_config_fields(cls, v: Any) -> Any:
+        if isinstance(v, dict):
+            unknown = set(v.keys()) - set(GenerateConfig.model_fields.keys())
+            if unknown:
+                raise ValueError(f"Unknown generate_config fields: {unknown}")
+        return v
+
+    @field_validator("eval_config", mode="before")
+    @classmethod
+    def check_eval_config_fields(cls, v: Any) -> Any:
+        if isinstance(v, dict):
+            unknown = set(v.keys()) - set(EvalConfig.model_fields.keys())
+            if unknown:
+                raise ValueError(f"Unknown eval_config fields: {unknown}")
+        return v
+
+    def to_params(self) -> dict[str, Any]:
+        params: dict[str, Any] = {}
+
+        # Task
+        if self.task is not None:
+            if isinstance(self.task, str):
+                params["tasks"] = self.task
+            else:
+                params["tasks"] = self.task.task
+                if self.task.args:
+                    params["task_args"] = self.task.args
+
+        # Model
+        if self.model is not None:
+            if isinstance(self.model, str):
+                params["model"] = self.model
+            else:
+                params["model"] = self.model.model
+                if self.model.base_url is not None:
+                    params["model_base_url"] = self.model.base_url
+                if self.model.args:
+                    params["model_args"] = self.model.args
+                model_gc = self.model.config.model_dump(exclude_none=True)
+                if model_gc:
+                    params.update(model_gc)
+
+        # Top-level generate_config overrides any model-level config
+        top_gc = self.generate_config.model_dump(exclude_none=True)
+        if top_gc:
+            params.update(top_gc)
+
+        # Model roles
+        if self.model_roles:
+            params["model_roles"] = {
+                role: get_model(
+                    mc.model, config=mc.config, base_url=mc.base_url, **mc.args
+                )
+                for role, mc in self.model_roles.items()
+            }
+
+        # Solver
+        if self.solver is not None:
+            if isinstance(self.solver, str):
+                params["solver"] = SolverSpec(self.solver, {}, {})
+            else:
+                params["solver"] = SolverSpec(
+                    self.solver.solver, self.solver.args, self.solver.args
+                )
+
+        # Eval config — combine epochs + epochs_reducer into Epochs
+        ec = self.eval_config.model_dump(exclude_none=True)
+        epochs = ec.pop("epochs", None)
+        epochs_reducer = ec.pop("epochs_reducer", None)
+        if epochs is not None:
+            ec["epochs"] = Epochs(epochs, create_reducers(epochs_reducer))
+        params.update(ec)
+
+        # Tags and metadata
+        if self.tags:
+            params["tags"] = self.tags
+        if self.metadata:
+            params["metadata"] = self.metadata
+
+        # Sandbox
+        if self.sandbox is not None:
+            if isinstance(self.sandbox, str):
+                params["sandbox"] = parse_sandbox(self.sandbox)
+            else:
+                params["sandbox"] = self.sandbox
+
+        return params
+
+
+def parse_run_config(config: str) -> dict[str, Any]:
+    from jsonschema import Draft7Validator
+
+    config_dict = resolve_args(config)
+    try:
+        run_config = RunConfigInput.model_validate(config_dict)
+    except ValidationError as ex:
+        # Surface a more readable error via Draft7Validator. Fall back to
+        # pydantic's message when the JSON schema doesn't capture the
+        # failure (e.g. custom field_validators on generate_config/eval_config).
+        schema = RunConfigInput.model_json_schema()
+        errors = list(Draft7Validator(schema).iter_errors(config_dict))
+        if errors:
+            message = "\n".join(
+                [f"Invalid run config '{config}':"]
+                + [f" - {error.message}" for error in errors]
+            )
+        else:
+            message = f"Invalid run config '{config}': {ex}"
+        raise PrerequisiteError(message)
+    return run_config.to_params()
+
+
+def merge_run_config_params(
+    run_params: dict[str, Any], cli_params: dict[str, Any]
+) -> dict[str, Any]:
+    params = dict(run_params)
+    for key, value in cli_params.items():
+        if value is None or value == {}:
+            continue
+        if key == "score" and value is True:
+            continue
+        if key in ("task_args", "model_args") and key in params:
+            params[key] = params[key] | value
+        elif key == "model_roles" and key in params:
+            params[key] = params[key] | value
+        else:
+            params[key] = value
+    return params

--- a/src/inspect_ai/_cli/cache.py
+++ b/src/inspect_ai/_cli/cache.py
@@ -1,16 +1,6 @@
-import click
-from rich import print
-from rich.table import Table
+from __future__ import annotations
 
-from inspect_ai._util.logger import init_logger
-from inspect_ai.model import (
-    ModelName,
-    cache_clear,
-    cache_list_expired,
-    cache_path,
-    cache_prune,
-    cache_size,
-)
+import click
 
 from .common import log_level_options
 
@@ -31,6 +21,9 @@ def _print_table(title: str, paths: list[tuple[str, int]]) -> None:
         title(str): Title of the table.
         paths(list[tuple[str, int]]): List of paths and their sizes (in bytes).
     """
+    from rich import print
+    from rich.table import Table
+
     table = Table(title=title)
     table.add_column("Model")
     table.add_column("Size", justify="right")
@@ -67,6 +60,9 @@ def cache_command() -> None:
 )
 def clear(all: bool, model: tuple[str, ...], log_level: str) -> None:
     """Clear all cache files. Requires either --all or --model flags."""
+    from inspect_ai._util.logger import init_logger
+    from inspect_ai.model import ModelName, cache_clear, cache_size
+
     init_logger(log_level)
 
     if model:
@@ -85,6 +81,10 @@ def clear(all: bool, model: tuple[str, ...], log_level: str) -> None:
 @cache_command.command()
 def path() -> None:
     """Prints the location of the cache directory."""
+    from rich import print
+
+    from inspect_ai.model import cache_path
+
     print(cache_path())
 
 
@@ -97,6 +97,10 @@ def path() -> None:
 )
 def list_caches(pruneable: bool) -> None:
     """Lists all current model caches with their sizes."""
+    from rich import print
+
+    from inspect_ai.model import cache_list_expired, cache_size
+
     if pruneable:
         expired_cache_entries = cache_list_expired()
         if expired_cache_entries:
@@ -127,6 +131,11 @@ def prune(log_level: str, model: tuple[str, ...]) -> None:
     expired. This command will remove all expired cache entries for ease of
     maintenance.
     """
+    from rich import print
+
+    from inspect_ai._util.logger import init_logger
+    from inspect_ai.model import cache_list_expired, cache_prune, cache_size
+
     init_logger(log_level)
 
     expired_cache_entries = cache_list_expired(list(model))

--- a/src/inspect_ai/_cli/common.py
+++ b/src/inspect_ai/_cli/common.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 import functools
 import os
 from typing import Any, Callable, Literal, cast
 
 import click
-import rich
 from typing_extensions import TypedDict
 
 from inspect_ai._util.constants import (
@@ -11,8 +12,6 @@ from inspect_ai._util.constants import (
     DEFAULT_DISPLAY,
     DEFAULT_LOG_LEVEL,
 )
-from inspect_ai._util.dotenv import init_cli_env
-from inspect_ai.util._display import init_display_type
 
 from .util import parse_cli_args
 
@@ -113,6 +112,11 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 
 
 def process_common_options(options: CommonOptions) -> None:
+    import rich
+
+    from inspect_ai._util.dotenv import init_cli_env
+    from inspect_ai.util._display import init_display_type
+
     # set environment variables
     env_args = parse_cli_args(options["env"])
     init_cli_env(env_args)

--- a/src/inspect_ai/_cli/download.py
+++ b/src/inspect_ai/_cli/download.py
@@ -11,16 +11,14 @@ is ``inspect download <kind>`` so other downloadable artifacts can slot
 in without restructuring the namespace.
 """
 
-import anyio
-import click
-from rich import box
-from rich.console import Console
-from rich.table import Table
+from __future__ import annotations
 
-from inspect_ai._util._async import configured_async_backend
-from inspect_ai.util._restic import Platform, resolve_restic
-from inspect_ai.util._restic._platform import SUPPORTED_PLATFORMS
-from inspect_ai.util._restic._resolver import cache_path
+from typing import TYPE_CHECKING
+
+import click
+
+if TYPE_CHECKING:
+    from inspect_ai.util._restic import Platform
 
 
 @click.group("download", hidden=True)
@@ -31,10 +29,22 @@ def download_command() -> None:
 @download_command.command("restic", hidden=True)
 def restic_command() -> None:
     """Pre-warm the restic binary cache for every supported platform."""
+    import anyio
+
+    from inspect_ai._util._async import configured_async_backend
+
     anyio.run(_download_all_restic, backend=configured_async_backend())
 
 
 async def _download_all_restic() -> None:
+    from rich import box
+    from rich.console import Console
+    from rich.table import Table
+
+    from inspect_ai.util._restic import resolve_restic
+    from inspect_ai.util._restic._platform import SUPPORTED_PLATFORMS
+    from inspect_ai.util._restic._resolver import cache_path
+
     console = Console()
 
     for platform in SUPPORTED_PLATFORMS:

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -25,8 +25,6 @@ if TYPE_CHECKING:
     from inspect_ai.model._generate_config import ResponseSchema
     from inspect_ai.util import AdaptiveConcurrency
 
-    from ._run_config import RunConfigInput as RunConfigInput  # noqa: F401
-
 from .common import (
     CommonOptions,
     common_options,
@@ -1299,28 +1297,6 @@ def eval_set_command(
 
     # exit code indicating whether the evals are all complete
     ctx.exit(0 if success else 1)
-
-
-_RUN_CONFIG_REEXPORTS = frozenset(
-    {
-        "TaskInput",
-        "SolverInput",
-        "RunConfigInput",
-        "parse_run_config",
-        "merge_run_config_params",
-    }
-)
-
-
-def __getattr__(name: str) -> Any:
-    # Lazy re-export of run-config helpers so this module stays import-light
-    # (the underlying pydantic models pull in inspect_ai.model / log / util at
-    # class-definition time). See _run_config.py for details.
-    if name in _RUN_CONFIG_REEXPORTS:
-        from . import _run_config
-
-        return getattr(_run_config, name)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def eval_exec(

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -1,23 +1,14 @@
+from __future__ import annotations
+
 import functools
 import json
 from collections.abc import Callable
-from typing import Any, Literal, cast
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 import click
 import yaml
-from pydantic import (
-    BaseModel,
-    ConfigDict,
-    Field,
-    TypeAdapter,
-    ValidationError,
-    field_validator,
-)
 from typing_extensions import Unpack
 
-from inspect_ai import Epochs, eval, eval_retry
-from inspect_ai._eval.evalset import eval_set
-from inspect_ai._util.config import resolve_args
 from inspect_ai._util.constants import (
     ALL_LOG_LEVELS,
     DEFAULT_BATCH_SIZE,
@@ -28,26 +19,13 @@ from inspect_ai._util.constants import (
     DEFAULT_MAX_CONNECTIONS,
     DEFAULT_RETRY_ON_ERROR,
 )
-from inspect_ai._util.error import PrerequisiteError
-from inspect_ai._util.file import filesystem
-from inspect_ai._util.samples import parse_sample_id, parse_samples_limit
-from inspect_ai.log._file import log_file_info
-from inspect_ai.log._log import EvalConfig
-from inspect_ai.model import GenerateConfig, GenerateConfigArgs, get_model
-from inspect_ai.model._cache import CachePolicy
-from inspect_ai.model._generate_config import (  # noqa: F811
-    BatchConfig,
-    ImageOutput,
-    OutputModality,
-    ResponseSchema,
-)
-from inspect_ai.model._model_config import ModelConfig
-from inspect_ai.scorer._reducer import create_reducers
-from inspect_ai.solver._solver import SolverSpec
-from inspect_ai.util import AdaptiveConcurrency
-from inspect_ai.util._checkpoint.parse_cli import parse_checkpoint
-from inspect_ai.util._resource import resource
-from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+
+if TYPE_CHECKING:
+    from inspect_ai.model import GenerateConfigArgs
+    from inspect_ai.model._generate_config import ResponseSchema
+    from inspect_ai.util import AdaptiveConcurrency
+
+    from ._run_config import RunConfigInput as RunConfigInput  # noqa: F401
 
 from .common import (
     CommonOptions,
@@ -825,6 +803,8 @@ def eval_command(ctx: click.Context, /, **params: Any) -> None:
     if params.get("run_config"):
         from click.core import ParameterSource
 
+        from ._run_config import parse_run_config
+
         run_params = parse_run_config(params["run_config"])
 
         # Map Click parameter name -> the cli_params key it ultimately produces
@@ -1321,159 +1301,26 @@ def eval_set_command(
     ctx.exit(0 if success else 1)
 
 
-class TaskInput(BaseModel):
-    task: str
-    args: dict[str, Any] = Field(default_factory=dict)
+_RUN_CONFIG_REEXPORTS = frozenset(
+    {
+        "TaskInput",
+        "SolverInput",
+        "RunConfigInput",
+        "parse_run_config",
+        "merge_run_config_params",
+    }
+)
 
 
-class SolverInput(BaseModel):
-    solver: str
-    args: dict[str, Any] = Field(default_factory=dict)
+def __getattr__(name: str) -> Any:
+    # Lazy re-export of run-config helpers so this module stays import-light
+    # (the underlying pydantic models pull in inspect_ai.model / log / util at
+    # class-definition time). See _run_config.py for details.
+    if name in _RUN_CONFIG_REEXPORTS:
+        from . import _run_config
 
-
-class RunConfigInput(BaseModel):
-    model_config = ConfigDict(extra="forbid")
-
-    task: str | TaskInput | None = None
-    model: str | ModelConfig | None = None
-    model_roles: dict[str, ModelConfig] = Field(default_factory=dict)
-    generate_config: GenerateConfig = Field(default_factory=GenerateConfig)
-    eval_config: EvalConfig = Field(default_factory=EvalConfig)
-    solver: str | SolverInput | None = None
-    tags: list[str] = Field(default_factory=list)
-    metadata: dict[str, Any] = Field(default_factory=dict)
-    sandbox: str | SandboxEnvironmentSpec | None = None
-
-    @field_validator("generate_config", mode="before")
-    @classmethod
-    def check_generate_config_fields(cls, v: Any) -> Any:
-        if isinstance(v, dict):
-            unknown = set(v.keys()) - set(GenerateConfig.model_fields.keys())
-            if unknown:
-                raise ValueError(f"Unknown generate_config fields: {unknown}")
-        return v
-
-    @field_validator("eval_config", mode="before")
-    @classmethod
-    def check_eval_config_fields(cls, v: Any) -> Any:
-        if isinstance(v, dict):
-            unknown = set(v.keys()) - set(EvalConfig.model_fields.keys())
-            if unknown:
-                raise ValueError(f"Unknown eval_config fields: {unknown}")
-        return v
-
-    def to_params(self) -> dict[str, Any]:
-        params: dict[str, Any] = {}
-
-        # Task
-        if self.task is not None:
-            if isinstance(self.task, str):
-                params["tasks"] = self.task
-            else:
-                params["tasks"] = self.task.task
-                if self.task.args:
-                    params["task_args"] = self.task.args
-
-        # Model
-        if self.model is not None:
-            if isinstance(self.model, str):
-                params["model"] = self.model
-            else:
-                params["model"] = self.model.model
-                if self.model.base_url is not None:
-                    params["model_base_url"] = self.model.base_url
-                if self.model.args:
-                    params["model_args"] = self.model.args
-                model_gc = self.model.config.model_dump(exclude_none=True)
-                if model_gc:
-                    params.update(model_gc)
-
-        # Top-level generate_config overrides any model-level config
-        top_gc = self.generate_config.model_dump(exclude_none=True)
-        if top_gc:
-            params.update(top_gc)
-
-        # Model roles
-        if self.model_roles:
-            params["model_roles"] = {
-                role: get_model(
-                    mc.model, config=mc.config, base_url=mc.base_url, **mc.args
-                )
-                for role, mc in self.model_roles.items()
-            }
-
-        # Solver
-        if self.solver is not None:
-            if isinstance(self.solver, str):
-                params["solver"] = SolverSpec(self.solver, {}, {})
-            else:
-                params["solver"] = SolverSpec(
-                    self.solver.solver, self.solver.args, self.solver.args
-                )
-
-        # Eval config — combine epochs + epochs_reducer into Epochs
-        ec = self.eval_config.model_dump(exclude_none=True)
-        epochs = ec.pop("epochs", None)
-        epochs_reducer = ec.pop("epochs_reducer", None)
-        if epochs is not None:
-            ec["epochs"] = Epochs(epochs, create_reducers(epochs_reducer))
-        params.update(ec)
-
-        # Tags and metadata
-        if self.tags:
-            params["tags"] = self.tags
-        if self.metadata:
-            params["metadata"] = self.metadata
-
-        # Sandbox
-        if self.sandbox is not None:
-            if isinstance(self.sandbox, str):
-                params["sandbox"] = parse_sandbox(self.sandbox)
-            else:
-                params["sandbox"] = self.sandbox
-
-        return params
-
-
-def parse_run_config(config: str) -> dict[str, Any]:
-    from jsonschema import Draft7Validator
-
-    config_dict = resolve_args(config)
-    try:
-        run_config = RunConfigInput.model_validate(config_dict)
-    except ValidationError as ex:
-        # Surface a more readable error via Draft7Validator. Fall back to
-        # pydantic's message when the JSON schema doesn't capture the
-        # failure (e.g. custom field_validators on generate_config/eval_config).
-        schema = RunConfigInput.model_json_schema()
-        errors = list(Draft7Validator(schema).iter_errors(config_dict))
-        if errors:
-            message = "\n".join(
-                [f"Invalid run config '{config}':"]
-                + [f" - {error.message}" for error in errors]
-            )
-        else:
-            message = f"Invalid run config '{config}': {ex}"
-        raise PrerequisiteError(message)
-    return run_config.to_params()
-
-
-def merge_run_config_params(
-    run_params: dict[str, Any], cli_params: dict[str, Any]
-) -> dict[str, Any]:
-    params = dict(run_params)
-    for key, value in cli_params.items():
-        if value is None or value == {}:
-            continue
-        if key == "score" and value is True:
-            continue
-        if key in ("task_args", "model_args") and key in params:
-            params[key] = params[key] | value
-        elif key == "model_roles" and key in params:
-            params[key] = params[key] | value
-        else:
-            params[key] = value
-    return params
+        return getattr(_run_config, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def eval_exec(
@@ -1558,6 +1405,16 @@ def eval_exec(
     eval_set_id: str | None = None,
     **kwargs: Unpack[GenerateConfigArgs],
 ) -> bool:
+    from inspect_ai import Epochs, eval
+    from inspect_ai._eval.evalset import eval_set
+    from inspect_ai._util.error import PrerequisiteError
+    from inspect_ai._util.samples import parse_sample_id, parse_samples_limit
+    from inspect_ai.scorer._reducer import create_reducers
+    from inspect_ai.solver._solver import SolverSpec
+    from inspect_ai.util._checkpoint.parse_cli import parse_checkpoint
+
+    from ._run_config import merge_run_config_params, parse_run_config
+
     if run_config and is_eval_set:
         raise PrerequisiteError("--run-config is only supported by inspect eval.")
     if run_config and task_config:
@@ -1759,6 +1616,8 @@ def _parse_adaptive_connections_cli(
     Note: `"1"`/`"0"` are treated as the integer-max shorthand, not as
     bool aliases. Users who want explicit on/off should pass `true`/`false`.
     """
+    from inspect_ai.util import AdaptiveConcurrency
+
     if value is None:
         return None
     v = value.strip().lower()
@@ -1781,6 +1640,14 @@ def _parse_adaptive_connections_cli(
 
 
 def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
+    from pydantic import TypeAdapter
+
+    from inspect_ai._util.config import resolve_args
+    from inspect_ai._util.error import PrerequisiteError
+    from inspect_ai.model import GenerateConfigArgs
+    from inspect_ai.model._cache import CachePolicy
+    from inspect_ai.model._generate_config import BatchConfig, ResponseSchema
+
     # start with config file if specified
     adapter = TypeAdapter(GenerateConfigArgs)
     run_config_file = locals.get("run_config")
@@ -1856,6 +1723,11 @@ def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
 
 def parse_modalities(value: str) -> list[Any]:
     """Parse modalities from comma-separated names or YAML/JSON file."""
+    from inspect_ai._util.error import PrerequisiteError
+    from inspect_ai._util.file import filesystem
+    from inspect_ai.model._generate_config import ImageOutput, OutputModality
+    from inspect_ai.util._resource import resource
+
     # Check if it's a file path
     fs = filesystem(value)
     if fs.exists(value):
@@ -2119,6 +1991,10 @@ def eval_retry_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Retry failed evaluation(s)"""
+    from inspect_ai import eval_retry
+    from inspect_ai._util.file import filesystem
+    from inspect_ai.log._file import log_file_info
+
     # resolve common options
     process_common_options(common)
 

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import click
+import yaml
+from typing_extensions import Unpack
 
 from inspect_ai._util.constants import (
     ALL_LOG_LEVELS,
@@ -19,8 +21,6 @@ from inspect_ai._util.constants import (
 )
 
 if TYPE_CHECKING:
-    from typing_extensions import Unpack
-
     from inspect_ai.model import GenerateConfigArgs
     from inspect_ai.model._generate_config import ResponseSchema
     from inspect_ai.util import AdaptiveConcurrency
@@ -1699,8 +1699,6 @@ def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
 
 def parse_modalities(value: str) -> list[Any]:
     """Parse modalities from comma-separated names or YAML/JSON file."""
-    import yaml
-
     from inspect_ai._util.error import PrerequisiteError
     from inspect_ai._util.file import filesystem
     from inspect_ai.model._generate_config import ImageOutput, OutputModality

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -6,8 +6,6 @@ from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, cast
 
 import click
-import yaml
-from typing_extensions import Unpack
 
 from inspect_ai._util.constants import (
     ALL_LOG_LEVELS,
@@ -21,6 +19,8 @@ from inspect_ai._util.constants import (
 )
 
 if TYPE_CHECKING:
+    from typing_extensions import Unpack
+
     from inspect_ai.model import GenerateConfigArgs
     from inspect_ai.model._generate_config import ResponseSchema
     from inspect_ai.util import AdaptiveConcurrency
@@ -1699,6 +1699,8 @@ def config_from_locals(locals: dict[str, Any]) -> GenerateConfigArgs:
 
 def parse_modalities(value: str) -> list[Any]:
     """Parse modalities from comma-separated names or YAML/JSON file."""
+    import yaml
+
     from inspect_ai._util.error import PrerequisiteError
     from inspect_ai._util.file import filesystem
     from inspect_ai.model._generate_config import ImageOutput, OutputModality

--- a/src/inspect_ai/_cli/info.py
+++ b/src/inspect_ai/_cli/info.py
@@ -4,9 +4,6 @@ from json import dumps
 
 import click
 
-from inspect_ai import __version__
-from inspect_ai._util.constants import PKG_PATH
-
 from .log import headers, schema, types
 
 
@@ -26,6 +23,9 @@ def info_command() -> None:
 )
 def version(json: bool) -> None:
     """Output version and path info."""
+    from inspect_ai import __version__
+    from inspect_ai._util.constants import PKG_PATH
+
     if json:
         print(dumps(dict(version=__version__, path=PKG_PATH.as_posix()), indent=2))
     else:

--- a/src/inspect_ai/_cli/info.py
+++ b/src/inspect_ai/_cli/info.py
@@ -4,6 +4,9 @@ from json import dumps
 
 import click
 
+from inspect_ai import __version__
+from inspect_ai._util.constants import PKG_PATH
+
 from .log import headers, schema, types
 
 
@@ -23,9 +26,6 @@ def info_command() -> None:
 )
 def version(json: bool) -> None:
     """Output version and path info."""
-    from inspect_ai import __version__
-    from inspect_ai._util.constants import PKG_PATH
-
     if json:
         print(dumps(dict(version=__version__, path=PKG_PATH.as_posix()), indent=2))
     else:

--- a/src/inspect_ai/_cli/info.py
+++ b/src/inspect_ai/_cli/info.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 from json import dumps
 
 import click
 
 from inspect_ai import __version__
 from inspect_ai._util.constants import PKG_PATH
-from inspect_ai._view.common import resolve_header_only
-from inspect_ai.log._file import eval_log_json_str, read_eval_log
 
 from .log import headers, schema, types
 
@@ -44,6 +44,9 @@ def version(json: bool) -> None:
 )
 def log(path: str, header_only: int) -> None:
     """Print log file contents as JSON."""
+    from inspect_ai._view.common import resolve_header_only
+    from inspect_ai.log._file import eval_log_json_str, read_eval_log
+
     header_only = resolve_header_only(path, header_only)
 
     log = read_eval_log(path, header_only=header_only)

--- a/src/inspect_ai/_cli/list.py
+++ b/src/inspect_ai/_cli/list.py
@@ -1,15 +1,18 @@
+from __future__ import annotations
+
 from json import dumps
+from typing import TYPE_CHECKING
 
 import click
-from pydantic_core import to_jsonable_python
 from typing_extensions import Unpack
 
 from inspect_ai._cli.common import CommonOptions, common_options, process_common_options
 from inspect_ai._cli.log import list_logs_options, log_list
 from inspect_ai._cli.util import parse_cli_args
-from inspect_ai._eval.list import list_tasks
-from inspect_ai._eval.task import TaskInfo
-from inspect_ai.log import EvalStatus
+
+if TYPE_CHECKING:
+    from inspect_ai._eval.task import TaskInfo
+    from inspect_ai.log import EvalStatus
 
 
 @click.group("list")
@@ -49,6 +52,10 @@ def tasks(
     **kwargs: Unpack[CommonOptions],
 ) -> None:
     """List tasks in given directories."""
+    from pydantic_core import to_jsonable_python
+
+    from inspect_ai._eval.list import list_tasks
+
     # resolve common options
     process_common_options(kwargs)
 

--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -1,24 +1,20 @@
+from __future__ import annotations
+
 import functools
 import os
 from json import dumps
-from typing import Any, Callable, Literal, cast
+from typing import TYPE_CHECKING, Any, Callable, Literal, cast
 from urllib.parse import urlparse
 
 import click
-from fsspec.core import split_protocol  # type: ignore
-from pydantic_core import to_jsonable_python
 from typing_extensions import Unpack
 
 from inspect_ai._cli.common import CommonOptions, common_options, process_common_options
 from inspect_ai._cli.util import int_or_bool_flag_callback
 from inspect_ai._util.constants import PKG_PATH
-from inspect_ai.log import EvalStatus, list_eval_logs
-from inspect_ai.log._convert import convert_eval_logs
-from inspect_ai.log._file import (
-    eval_log_json_str,
-    read_eval_log,
-    read_eval_log_headers,
-)
+
+if TYPE_CHECKING:
+    from inspect_ai.log import EvalStatus
 
 
 @click.group("log")
@@ -79,6 +75,10 @@ def log_list(
     no_recursive: bool | None,
     **common: Unpack[CommonOptions],
 ) -> None:
+    from fsspec.core import split_protocol  # type: ignore
+
+    from inspect_ai.log import list_eval_logs
+
     process_common_options(common)
 
     # list the logs
@@ -157,6 +157,8 @@ def dump_command(
     path: str, header_only: bool, resolve_attachments: bool | Literal["full", "core"]
 ) -> None:
     """Print log file contents as JSON."""
+    from inspect_ai.log._file import eval_log_json_str, read_eval_log
+
     log = read_eval_log(
         path, header_only=header_only, resolve_attachments=resolve_attachments
     )
@@ -210,6 +212,8 @@ def convert_command(
     stream: int | bool = False,
 ) -> None:
     """Convert between log file formats."""
+    from inspect_ai.log._convert import convert_eval_logs
+
     convert_eval_logs(
         path,
         to,
@@ -229,6 +233,10 @@ def headers_command(files: tuple[str, ...]) -> None:
 
 def headers(files: tuple[str, ...]) -> None:
     """Print log file headers as JSON."""
+    from pydantic_core import to_jsonable_python
+
+    from inspect_ai.log._file import read_eval_log_headers
+
     headers = read_eval_log_headers(list(files))
     print(dumps(to_jsonable_python(headers, exclude_none=True), indent=2))
 

--- a/src/inspect_ai/_cli/main.py
+++ b/src/inspect_ai/_cli/main.py
@@ -1,8 +1,4 @@
-from importlib.metadata import version
-
 import click
-
-from inspect_ai._util.constants import PKG_NAME
 
 from ._lazy_group import LazyGroup
 
@@ -92,7 +88,9 @@ def inspect(ctx: click.Context, version: bool) -> None:
 
 
 def _version() -> str:
-    return version(PKG_NAME)
+    from inspect_ai import __version__
+
+    return __version__
 
 
 def main() -> None:

--- a/src/inspect_ai/_cli/main.py
+++ b/src/inspect_ai/_cli/main.py
@@ -1,4 +1,8 @@
+from importlib.metadata import version
+
 import click
+
+from inspect_ai._util.constants import PKG_NAME
 
 from ._lazy_group import LazyGroup
 
@@ -88,9 +92,7 @@ def inspect(ctx: click.Context, version: bool) -> None:
 
 
 def _version() -> str:
-    from inspect_ai import __version__
-
-    return __version__
+    return version(PKG_NAME)
 
 
 def main() -> None:

--- a/src/inspect_ai/_cli/main.py
+++ b/src/inspect_ai/_cli/main.py
@@ -1,22 +1,75 @@
+from importlib.metadata import version
+
 import click
 
-from inspect_ai._util.dotenv import init_dotenv
-from inspect_ai._util.error import set_exception_hook
+from inspect_ai._util.constants import PKG_NAME
 
-from .. import __version__
-from .cache import cache_command
-from .download import download_command
-from .eval import eval_command, eval_retry_command, eval_set_command
-from .info import info_command
-from .list import list_command
-from .log import log_command
-from .sandbox import sandbox_command
-from .score import score_command
-from .trace import trace_command
-from .view import view_command
+from ._lazy_group import LazyGroup
+
+# Registry of subcommands: name -> (import path, short help).
+#
+# The import path is resolved lazily the first time the subcommand is used,
+# so ``inspect --help`` only needs to import ``click`` and this module. The
+# short help string is duplicated here (rather than read from the command
+# docstring) so the top-level help screen can be rendered without importing
+# any subcommand module. An empty short help marks a hidden command.
+_SUBCOMMANDS: dict[str, tuple[str, str]] = {
+    "cache": (
+        "inspect_ai._cli.cache:cache_command",
+        "Manage the inspect model output cache.",
+    ),
+    "download": (
+        "inspect_ai._cli.download:download_command",
+        "",  # hidden
+    ),
+    "eval": (
+        "inspect_ai._cli.eval:eval_command",
+        "Evaluate tasks.",
+    ),
+    "eval-retry": (
+        "inspect_ai._cli.eval:eval_retry_command",
+        "Retry failed evaluation(s)",
+    ),
+    "eval-set": (
+        "inspect_ai._cli.eval:eval_set_command",
+        "Evaluate a set of tasks with retries.",
+    ),
+    "info": (
+        "inspect_ai._cli.info:info_command",
+        "Read configuration and log info.",
+    ),
+    "list": (
+        "inspect_ai._cli.list:list_command",
+        "List tasks on the filesystem.",
+    ),
+    "log": (
+        "inspect_ai._cli.log:log_command",
+        "Query, read, and convert logs.",
+    ),
+    "sandbox": (
+        "inspect_ai._cli.sandbox:sandbox_command",
+        "Manage Sandbox Environments.",
+    ),
+    "score": (
+        "inspect_ai._cli.score:score_command",
+        "Score a previous evaluation run.",
+    ),
+    "trace": (
+        "inspect_ai._cli.trace:trace_command",
+        "List and read execution traces.",
+    ),
+    "view": (
+        "inspect_ai._cli.view:view_command",
+        "Inspect log viewer.",
+    ),
+}
 
 
-@click.group(invoke_without_command=True)
+@click.group(
+    cls=LazyGroup,
+    lazy_subcommands=_SUBCOMMANDS,
+    invoke_without_command=True,
+)
 @click.option(
     "--version",
     type=bool,
@@ -31,30 +84,18 @@ def inspect(ctx: click.Context, version: bool) -> None:
         return
 
     if version:
-        print(__version__)
+        print(_version())
         ctx.exit()
     else:
         click.echo(ctx.get_help())
         ctx.exit()
 
 
-inspect.add_command(cache_command)
-inspect.add_command(download_command)
-inspect.add_command(eval_command)
-inspect.add_command(eval_set_command)
-inspect.add_command(eval_retry_command)
-inspect.add_command(info_command)
-inspect.add_command(list_command)
-inspect.add_command(log_command)
-inspect.add_command(score_command)
-inspect.add_command(view_command)
-inspect.add_command(sandbox_command)
-inspect.add_command(trace_command)
+def _version() -> str:
+    return version(PKG_NAME)
 
 
 def main() -> None:
-    set_exception_hook()
-    init_dotenv()
     inspect(auto_envvar_prefix="INSPECT")  # pylint: disable=no-value-for-parameter
 
 

--- a/src/inspect_ai/_cli/sandbox.py
+++ b/src/inspect_ai/_cli/sandbox.py
@@ -1,8 +1,6 @@
-import anyio
-import click
+from __future__ import annotations
 
-from inspect_ai._util._async import configured_async_backend
-from inspect_ai.util._sandbox.registry import registry_find_sandboxenv
+import click
 
 
 @click.group("sandbox")
@@ -25,6 +23,11 @@ def sandbox_cleanup(type: str, environment_id: str | None) -> None:
     Pass an ENVIRONMENT_ID to cleanup only a single environment
     (otherwise all environments will be cleaned up).
     """
+    import anyio
+
+    from inspect_ai._util._async import configured_async_backend
+    from inspect_ai.util._sandbox.registry import registry_find_sandboxenv
+
     sandboxenv_type = registry_find_sandboxenv(type)
     cli_cleanup = getattr(sandboxenv_type, "cli_cleanup")
     anyio.run(cli_cleanup, environment_id, backend=configured_async_backend())

--- a/src/inspect_ai/_cli/score.py
+++ b/src/inspect_ai/_cli/score.py
@@ -1,33 +1,17 @@
 from __future__ import annotations
 
 import contextlib
-from typing import AsyncGenerator
+from typing import TYPE_CHECKING, AsyncGenerator
 
-import anyio
 import click
-import rich
-from rich.panel import Panel
-from rich.prompt import Prompt
-from rich.table import Table
 from typing_extensions import Unpack
 
 from inspect_ai._cli.util import int_or_bool_flag_callback, parse_cli_config
-from inspect_ai._display import display
-from inspect_ai._display.core.results import task_scores
-from inspect_ai._display.core.rich import rich_theme
-from inspect_ai._eval.context import init_eval_context
-from inspect_ai._eval.loader import metric_from_spec
-from inspect_ai._eval.score import (
-    ScoreAction,
-    resolve_scorers,
-    score_async,
-)
-from inspect_ai._util._async import configured_async_backend
-from inspect_ai._util.file import filesystem
-from inspect_ai._util.platform import platform_init
-from inspect_ai.log._log import EvalLog, EvalSample
-from inspect_ai.log._recorders import create_recorder_for_location
-from inspect_ai.scorer._metric import Metric, MetricSpec
+
+if TYPE_CHECKING:
+    from inspect_ai._eval.score import ScoreAction
+    from inspect_ai.log._log import EvalLog, EvalSample
+    from inspect_ai.scorer._metric import Metric
 
 from .common import CommonOptions, common_options, process_common_options
 
@@ -96,6 +80,10 @@ def score_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Score a previous evaluation run."""
+    import anyio
+
+    from inspect_ai._util._async import configured_async_backend
+
     process_common_options(common)
 
     async def run_score() -> None:
@@ -127,6 +115,13 @@ async def score(
     output_file: str | None = None,
     stream: int | bool = False,
 ) -> None:
+    import anyio
+
+    from inspect_ai._eval.context import init_eval_context
+    from inspect_ai._eval.score import resolve_scorers, score_async
+    from inspect_ai._util.platform import platform_init
+    from inspect_ai.log._recorders import create_recorder_for_location
+
     platform_init()
 
     init_eval_context(log_level, None, log_refusals=True)
@@ -206,6 +201,14 @@ async def score(
 
 
 def print_results(output_file: str, eval_log: EvalLog) -> None:
+    import rich
+    from rich.panel import Panel
+    from rich.table import Table
+
+    from inspect_ai._display import display
+    from inspect_ai._display.core.results import task_scores
+    from inspect_ai._display.core.rich import rich_theme
+
     # the theme
     theme = rich_theme()
 
@@ -236,6 +239,10 @@ def print_results(output_file: str, eval_log: EvalLog) -> None:
 def _resolve_output_file(
     log_file: str, output_file: str | None, overwrite: bool
 ) -> str:
+    from rich.prompt import Prompt
+
+    from inspect_ai._util.file import filesystem
+
     # resolve the output file (we may overwrite, use the passed file name, or suggest a new name)
     output_file = output_file or log_file
     output_fs = filesystem(output_file or log_file)
@@ -276,6 +283,9 @@ def _resolve_output_file(
 def resolve_metrics(
     metric: tuple[str, ...] | None,
 ) -> list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]] | None:
+    from inspect_ai._eval.loader import metric_from_spec
+    from inspect_ai.scorer._metric import MetricSpec
+
     if metric is not None and len(metric) > 0:
         return [metric_from_spec(MetricSpec(m)) for m in metric]
     else:
@@ -283,6 +293,8 @@ def resolve_metrics(
 
 
 def resolve_action(eval_log: EvalLog, action: ScoreAction | None) -> ScoreAction:
+    from rich.prompt import Prompt
+
     if action is not None:
         return action
 

--- a/src/inspect_ai/_cli/trace.py
+++ b/src/inspect_ai/_cli/trace.py
@@ -1,25 +1,19 @@
+from __future__ import annotations
+
 import os
 import shlex
 import time
 from datetime import datetime
 from json import dumps
 from pathlib import Path
-from typing import Callable
+from typing import TYPE_CHECKING, Callable
 
 import click
-from pydantic_core import to_json
-from rich import print as r_print
-from rich.console import Console, RenderableType
-from rich.table import Column, Table
 
-from inspect_ai._util.error import PrerequisiteError
-from inspect_ai._util.trace import (
-    ActionTraceRecord,
-    TraceRecord,
-    inspect_trace_dir,
-    list_trace_files,
-    read_trace_file,
-)
+if TYPE_CHECKING:
+    from rich.console import RenderableType
+
+    from inspect_ai._util.trace import ActionTraceRecord, TraceRecord
 
 
 @click.group("trace")
@@ -48,6 +42,11 @@ def list_command(json: bool) -> None:
 
 def list_command_impl(json: bool, trace_dir: Path | None = None) -> None:
     """List all trace files."""
+    from rich import print as r_print
+    from rich.table import Table
+
+    from inspect_ai._util.trace import list_trace_files
+
     trace_files = list_trace_files(trace_dir)
     if json:
         print(
@@ -84,6 +83,10 @@ def dump_command_impl(
     trace_file: str | None, filter: str | None, trace_dir: Path | None = None
 ) -> None:
     """Dump a trace file to stdout (as a JSON array of log records)."""
+    from pydantic_core import to_json
+
+    from inspect_ai._util.trace import read_trace_file
+
     trace_file_path = _resolve_trace_file_path(trace_file, trace_dir)
 
     traces = read_trace_file(trace_file_path)
@@ -123,6 +126,9 @@ def http_command_impl(
     trace_dir: Path | None = None,
 ) -> None:
     """View all HTTP requests in the trace log."""
+    from rich import print as r_print
+    from rich.table import Column, Table
+
     _, traces = _read_traces(trace_file, "HTTP", filter, trace_dir)
 
     last_timestamp = ""
@@ -164,6 +170,10 @@ def anomolies_command_impl(
     trace_file: str | None, filter: str | None, all: bool, trace_dir: Path | None = None
 ) -> None:
     """Look for anomalies in a trace file (never completed or cancelled actions)."""
+    from rich.console import Console
+
+    from inspect_ai._util.trace import ActionTraceRecord
+
     trace_file_path, traces = _read_traces(trace_file, None, filter, trace_dir)
 
     # Track started actions
@@ -265,6 +275,8 @@ def _read_traces(
     filter: str | None = None,
     trace_dir: Path | None = None,
 ) -> tuple[Path, list[TraceRecord]]:
+    from inspect_ai._util.trace import read_trace_file
+
     trace_file_path = _resolve_trace_file_path(trace_file, trace_dir)
     traces = read_trace_file(trace_file_path)
 
@@ -283,6 +295,8 @@ def _print_bucket(
     label: str,
     bucket: dict[str, ActionTraceRecord],
 ) -> None:
+    from rich.table import Column, Table
+
     if len(bucket) > 0:
         # Sort the items in chronological order of when
         # they finished so the first finished item is at the top
@@ -338,6 +352,9 @@ def _print_bucket(
 
 
 def _resolve_trace_file(trace_file: str | None, trace_dir: Path | None = None) -> str:
+    from inspect_ai._util.error import PrerequisiteError
+    from inspect_ai._util.trace import list_trace_files
+
     if trace_file is None:
         trace_files = list_trace_files(trace_dir)
         if len(trace_files) == 0:
@@ -349,6 +366,9 @@ def _resolve_trace_file(trace_file: str | None, trace_dir: Path | None = None) -
 def _resolve_trace_file_path(
     trace_file: str | None, trace_dir: Path | None = None
 ) -> Path:
+    from inspect_ai._util.error import PrerequisiteError
+    from inspect_ai._util.trace import inspect_trace_dir
+
     trace_dir = trace_dir or inspect_trace_dir()
     trace_file = _resolve_trace_file(trace_file, trace_dir)
     trace_file_path = Path(trace_file)

--- a/src/inspect_ai/_cli/util.py
+++ b/src/inspect_ai/_cli/util.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable
 
 import click
+import yaml
 
 if TYPE_CHECKING:
     from inspect_ai.model import Model
@@ -129,8 +130,6 @@ def parse_cli_config(
 def parse_cli_args(
     args: tuple[str, ...] | list[str] | None, force_str: bool = False
 ) -> dict[str, Any]:
-    import yaml
-
     params: dict[str, Any] = dict()
     if args:
         for arg in list(args):

--- a/src/inspect_ai/_cli/util.py
+++ b/src/inspect_ai/_cli/util.py
@@ -1,12 +1,13 @@
-from typing import Any, Callable
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
 
 import click
 import yaml
-from pydantic import ValidationError
 
-from inspect_ai._util.config import resolve_args
-from inspect_ai.model import GenerateConfig, Model, get_model
-from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+if TYPE_CHECKING:
+    from inspect_ai.model import Model
+    from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
 
 def int_or_bool_flag_callback(
@@ -113,6 +114,8 @@ def int_bool_or_str_flag_callback(
 def parse_cli_config(
     args: tuple[str, ...] | list[str] | None, config: str | None
 ) -> dict[str, Any]:
+    from inspect_ai._util.config import resolve_args
+
     # start with file if any
     cli_config: dict[str, Any] = {}
     if config is not None:
@@ -157,6 +160,10 @@ def parse_model_role_cli_args(
         ("grader={model: mockllm/model, temperature: 0.5}",) -> {'grader': <Model>}
         ('grader={"model": "mockllm/model", "temperature": 0.5}',) -> {'grader': <Model>}
     """
+    from pydantic import ValidationError
+
+    from inspect_ai.model import GenerateConfig, get_model
+
     try:
         parsed_args = parse_cli_args(model_roles, force_str=False)
     except Exception as e:
@@ -223,6 +230,8 @@ class SectionedCommand(click.Command):
 
 
 def parse_sandbox(sandbox: str | None) -> SandboxEnvironmentSpec | None:
+    from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+
     if sandbox is not None:
         parts = sandbox.split(":", maxsplit=1)
         if len(parts) == 1:

--- a/src/inspect_ai/_cli/util.py
+++ b/src/inspect_ai/_cli/util.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any, Callable
 
 import click
-import yaml
 
 if TYPE_CHECKING:
     from inspect_ai.model import Model
@@ -130,6 +129,8 @@ def parse_cli_config(
 def parse_cli_args(
     args: tuple[str, ...] | list[str] | None, force_str: bool = False
 ) -> dict[str, Any]:
+    import yaml
+
     params: dict[str, Any] = dict()
     if args:
         for arg in list(args):

--- a/src/inspect_ai/_cli/view.py
+++ b/src/inspect_ai/_cli/view.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import functools
 import os
 from typing import Any, Callable, cast
@@ -6,8 +8,6 @@ import click
 from typing_extensions import Unpack
 
 from inspect_ai._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
-from inspect_ai._view.view import view
-from inspect_ai.log._bundle import bundle_log_dir, embed_log_dir
 
 from .common import CommonOptions, common_options, process_common_options
 
@@ -59,6 +59,8 @@ def start(
     **common: Unpack[CommonOptions],
 ) -> None:
     """View evaluation logs."""
+    from inspect_ai._view.view import view
+
     # read common options
     process_common_options(common)
 
@@ -104,6 +106,8 @@ def bundle_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Bundle evaluation logs"""
+    from inspect_ai.log._bundle import bundle_log_dir
+
     # process common options
     process_common_options(common)
 
@@ -118,6 +122,8 @@ def embed_command(
     **common: Unpack[CommonOptions],
 ) -> None:
     """Embed a lightweight viewer into a log directory."""
+    from inspect_ai.log._bundle import embed_log_dir
+
     process_common_options(common)
 
     embed_log_dir(log_dir=common["log_dir"])

--- a/src/inspect_ai/_util/dotenv.py
+++ b/src/inspect_ai/_util/dotenv.py
@@ -6,7 +6,7 @@ from urllib.parse import urlparse
 
 from dotenv import dotenv_values, find_dotenv, load_dotenv
 
-from .file import absolute_file_path
+from .path import absolute_file_path
 from .platform import is_running_in_vscode
 
 INSPECT_LOG_DIR_VAR = "INSPECT_LOG_DIR"

--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -25,6 +25,8 @@ from inspect_ai._util.azure import (
     is_azure_path,
 )
 from inspect_ai._util.error import PrerequisiteError
+from inspect_ai._util.path import absolute_file_path as absolute_file_path  # noqa: F401
+from inspect_ai._util.path import strip_trailing_sep as strip_trailing_sep  # noqa: F401
 from inspect_ai._util.trace import trace_message
 
 # https://filesystem-spec.readthedocs.io/en/latest/_modules/fsspec/spec.html#AbstractFileSystem
@@ -379,14 +381,6 @@ def filesystem(path: str, fs_options: dict[str, Any] = {}) -> FileSystem:
     return FileSystem(fs)
 
 
-def absolute_file_path(file: str) -> str:
-    # check for a relative dir, if we find one then resolve to absolute
-    fs_scheme = urlparse(file).scheme
-    if not fs_scheme and not os.path.isabs(file):
-        file = Path(file).resolve().as_posix()
-    return strip_trailing_sep(file)
-
-
 def to_uri(path_or_uri: str) -> str:
     # Check if it's already a URI
     parsed = urlparse(path_or_uri)
@@ -513,22 +507,6 @@ def clean_filename_component(component: str) -> str:
         .replace(":", "-")
         .replace("+", "-")
     )
-
-
-def strip_trailing_sep(path: str) -> str:
-    """Remove trailing separators from a path, preserving the root.
-
-    Matches pathlib behavior: exactly ``//`` is preserved per POSIX,
-    any other all-separator path collapses to a single separator.
-    """
-    fs = filesystem(path)
-    stripped = path.rstrip(fs.sep)
-    if stripped:
-        return stripped
-    # All separators — preserve exactly "//" per POSIX, otherwise collapse
-    if path == fs.sep * 2:
-        return path
-    return fs.sep
 
 
 logger = logging.getLogger(__name__)

--- a/src/inspect_ai/_util/lazy.py
+++ b/src/inspect_ai/_util/lazy.py
@@ -1,0 +1,59 @@
+"""PEP 562 lazy attribute loader for package ``__init__`` modules.
+
+Several ``inspect_ai`` subpackages re-export both lightweight type/protocol
+modules and heavyweight implementation modules. Eagerly importing the latter
+from ``__init__.py`` creates a latent circular import between ``log``,
+``event``, ``scorer``, ``solver`` and ``agent`` (each package's eager imports
+transitively reach back into one of the others before it has finished
+initialising). ``lazy_attributes()`` lets a package keep its full public
+surface while only paying the import cost for an attribute when it is first
+accessed.
+"""
+
+import sys
+from importlib import import_module
+from typing import Any
+
+
+def lazy_attributes(module_name: str, attrs: dict[str, str]) -> None:
+    """Install a PEP 562 ``__getattr__``/``__dir__`` pair on ``module_name``.
+
+    Args:
+        module_name: Fully-qualified name of the module to patch
+            (callers pass ``__name__``).
+        attrs: Mapping of attribute name to the absolute dotted path of the
+            module that defines it. The attribute is imported from that
+            module on first access and cached on the package.
+
+    Any pre-existing ``__getattr__`` (e.g. one installed by
+    :func:`inspect_ai._util.deprecation.relocated_module_attribute`) is
+    chained so deprecated aliases keep working.
+    """
+    mod = sys.modules[module_name]
+    # only chain to instance-level hooks set on this module's __dict__;
+    # getattr(mod, "__dir__") would return ModuleType.__dir__, which per
+    # PEP 562 delegates back to mod.__dict__["__dir__"] -> infinite recursion.
+    prev_getattr = vars(mod).get("__getattr__")
+    prev_dir = vars(mod).get("__dir__")
+
+    # clear any previously-cached lazy attrs so importlib.reload() picks up
+    # fresh values rather than returning stale objects from the old module
+    for k in attrs:
+        vars(mod).pop(k, None)
+
+    def __getattr__(name: str) -> Any:
+        target = attrs.get(name)
+        if target is not None:
+            val = getattr(import_module(target), name)
+            setattr(mod, name, val)
+            return val
+        if prev_getattr is not None:
+            return prev_getattr(name)
+        raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+
+    def __dir__() -> list[str]:
+        base = list(prev_dir()) if prev_dir is not None else list(vars(mod))
+        return sorted(set(base) | set(attrs))
+
+    mod.__getattr__ = __getattr__  # type: ignore[method-assign]
+    mod.__dir__ = __dir__  # type: ignore[method-assign]

--- a/src/inspect_ai/_util/path.py
+++ b/src/inspect_ai/_util/path.py
@@ -3,12 +3,34 @@ import sys
 from collections import deque
 from contextlib import AbstractContextManager, contextmanager
 from copy import deepcopy
-from pathlib import PurePath
+from pathlib import Path, PurePath
 from typing import Any, Iterator, overload
+from urllib.parse import urlparse
 
-from fsspec.implementations.local import LocalFileSystem  # type: ignore
 
-from inspect_ai._util.file import filesystem
+def absolute_file_path(file: str) -> str:
+    # check for a relative dir, if we find one then resolve to absolute
+    fs_scheme = urlparse(file).scheme
+    if not fs_scheme and not os.path.isabs(file):
+        file = Path(file).resolve().as_posix()
+    return strip_trailing_sep(file)
+
+
+def strip_trailing_sep(path: str) -> str:
+    r"""Remove trailing path separators, preserving the root.
+
+    Handles both local paths and fsspec URLs (``s3://...``, ``gs://...``).
+    Strips both ``/`` and ``\`` so Windows-native paths are normalised too.
+    Per POSIX, a path of exactly ``//`` is preserved; any other all-separator
+    input collapses to ``/``.
+    """
+    stripped = path.rstrip("/\\")
+    if stripped:
+        return stripped
+    # All separators — preserve exactly "//" per POSIX, otherwise collapse
+    if path == "//":
+        return path
+    return "/"
 
 
 @contextmanager
@@ -103,6 +125,10 @@ def cwd_relative_path(file: str | None, walk_up: bool = False) -> str | None:
 
 
 def pretty_path(file: str) -> str:
+    from fsspec.implementations.local import LocalFileSystem  # type: ignore
+
+    from inspect_ai._util.file import filesystem
+
     fs = filesystem(file)
     if fs.is_local():
         file = LocalFileSystem._strip_protocol(file)
@@ -112,6 +138,10 @@ def pretty_path(file: str) -> str:
 
 
 def native_path(file: str) -> str:
+    from fsspec.implementations.local import LocalFileSystem  # type: ignore
+
+    from inspect_ai._util.file import filesystem
+
     fs = filesystem(file)
     if fs.is_local():
         file = LocalFileSystem._strip_protocol(file)

--- a/src/inspect_ai/_util/platform.py
+++ b/src/inspect_ai/_util/platform.py
@@ -1,10 +1,6 @@
 import importlib.util
 import os
 
-from inspect_ai._util._async import init_nest_asyncio
-
-from .error import set_exception_hook
-
 
 def running_in_notebook() -> bool:
     try:
@@ -20,6 +16,13 @@ def running_in_notebook() -> bool:
 
 
 def platform_init(hooks: bool = True) -> None:
+    # imported lazily so this module stays stdlib-only at import time —
+    # callers like _util.dotenv only need the cheap env-detection helpers
+    # below and shouldn't pay for anyio/rich/pydantic.
+    from inspect_ai._util._async import init_nest_asyncio
+
+    from .error import set_exception_hook
+
     if hooks:
         from inspect_ai.hooks._startup import init_hooks
 

--- a/src/inspect_ai/_util/registry.py
+++ b/src/inspect_ai/_util/registry.py
@@ -35,6 +35,25 @@ if TYPE_CHECKING:
 
 obj_type = type
 
+# Subpackages whose ``__init__`` is lazy (see ``inspect_ai._util.lazy``).
+# Built-in implementations registered via ``@scorer`` / ``@solver`` / etc.
+# only enter the registry when their defining module is imported, so a
+# bare ``registry_lookup("scorer", "match")`` can miss before anything has
+# touched ``inspect_ai.scorer.match``. ``registry_lookup`` consults this
+# table on a miss and pokes the package's ``__getattr__`` to give the lazy
+# loader a chance to register the symbol before retrying.
+_BUILTIN_PKG: dict[str, tuple[str, ...]] = {
+    "agent": ("inspect_ai.agent",),
+    "approver": ("inspect_ai.approval",),
+    "metric": ("inspect_ai.scorer",),
+    "modelapi": ("inspect_ai.model",),
+    "sandboxenv": ("inspect_ai.util",),
+    "score_reducer": ("inspect_ai.scorer",),
+    "scorer": ("inspect_ai.scorer",),
+    "solver": ("inspect_ai.solver",),
+    "tool": ("inspect_ai.tool", "inspect_ai.agent"),
+}
+
 RegistryType = Literal[
     "agent",
     "approver",
@@ -205,17 +224,35 @@ def registry_lookup(type: RegistryType, name: str) -> object | None:
             return None
 
     o = _lookup()
-
-    # try to recover
-    if o is None:
-        # load entry points for this package as required
-        if name.find("/") != -1 and name.find(".") == -1:
-            package = name.split("/")[0]
-            ensure_entry_points(package)
-
-        return _lookup()
-    else:
+    if o is not None:
         return o
+
+    # try to recover: built-in objects live behind lazy package attrs.
+    # first try the cheap path (touch just the requested name); if that
+    # doesn't register it (private name, or the decorator lives in a
+    # different module than the public attr), force-load the package's
+    # full ``__all__`` so every decorator in it fires.
+    short_name = name.removeprefix(f"{PKG_NAME}/")
+    for pkg_name in _BUILTIN_PKG.get(type, ()):
+        from importlib import import_module
+
+        pkg = import_module(pkg_name)
+        getattr(pkg, short_name, None)
+        o = _lookup()
+        if o is not None:
+            return o
+        for attr in getattr(pkg, "__all__", ()):
+            getattr(pkg, attr, None)
+        o = _lookup()
+        if o is not None:
+            return o
+
+    # external packages: load entry points for this package as required
+    if name.find("/") != -1 and name.find(".") == -1:
+        package = name.split("/")[0]
+        ensure_entry_points(package)
+
+    return _lookup()
 
 
 def registry_package_name(name: str) -> str | None:

--- a/src/inspect_ai/agent/__init__.py
+++ b/src/inspect_ai/agent/__init__.py
@@ -1,17 +1,15 @@
-from inspect_ai.tool._mcp._tools_bridge import BridgedToolsSpec
+from typing import TYPE_CHECKING
 
+from inspect_ai._util.lazy import lazy_attributes
+
+# eager: core types and lightweight helpers that only reach into
+# ``model`` / ``tool`` / ``util`` (and ``scorer._metric``); none of these
+# pull ``log`` or ``event`` at import time.
 from ._agent import Agent, AgentState, agent, agent_with, is_agent
 from ._as_solver import as_solver
 from ._as_tool import as_tool
-from ._bridge.bridge import agent_bridge, bridge
-from ._bridge.sandbox.bridge import sandbox_agent_bridge
-from ._bridge.sandbox.types import SandboxAgentBridge
-from ._bridge.types import AgentBridge
-from ._deepagent import Subagent, deepagent, general, plan, research, subagent
 from ._filter import MessageFilter, content_only, last_message, remove_tools
 from ._handoff import handoff
-from ._human.agent import human_cli
-from ._react import react
 from ._run import run
 from ._types import (
     AgentAttempts,
@@ -19,6 +17,24 @@ from ._types import (
     AgentPrompt,
     AgentSubmit,
 )
+
+if TYPE_CHECKING:
+    # lazy: built-in agents and the bridge machinery (the latter imports
+    # ``inspect_ai.log._samples`` at module level, which is the historic
+    # source of the agent <-> log import cycle).
+    from inspect_ai.tool._mcp._tools_bridge import BridgedToolsSpec
+
+    from ._bridge.bridge import agent_bridge, bridge
+    from ._bridge.sandbox.bridge import sandbox_agent_bridge
+    from ._bridge.sandbox.types import SandboxAgentBridge
+    from ._bridge.types import AgentBridge
+    from ._deepagent.deepagent import deepagent
+    from ._deepagent.general import general
+    from ._deepagent.plan import plan
+    from ._deepagent.research import research
+    from ._deepagent.subagent import Subagent, subagent
+    from ._human.agent import human_cli
+    from ._react import react
 
 __all__ = [
     "react",
@@ -53,3 +69,23 @@ __all__ = [
     "plan",
     "general",
 ]
+
+lazy_attributes(
+    __name__,
+    {
+        "react": "inspect_ai.agent._react",
+        "agent_bridge": "inspect_ai.agent._bridge.bridge",
+        "bridge": "inspect_ai.agent._bridge.bridge",
+        "sandbox_agent_bridge": "inspect_ai.agent._bridge.sandbox.bridge",
+        "SandboxAgentBridge": "inspect_ai.agent._bridge.sandbox.types",
+        "AgentBridge": "inspect_ai.agent._bridge.types",
+        "human_cli": "inspect_ai.agent._human.agent",
+        "Subagent": "inspect_ai.agent._deepagent",
+        "deepagent": "inspect_ai.agent._deepagent",
+        "general": "inspect_ai.agent._deepagent",
+        "plan": "inspect_ai.agent._deepagent",
+        "research": "inspect_ai.agent._deepagent",
+        "subagent": "inspect_ai.agent._deepagent",
+        "BridgedToolsSpec": "inspect_ai.tool._mcp._tools_bridge",
+    },
+)

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -1,14 +1,14 @@
+from typing import TYPE_CHECKING
+
 from inspect_ai._util.deprecation import relocated_module_attribute
 from inspect_ai._util.error import EvalError, WriteConflictError
+from inspect_ai._util.lazy import lazy_attributes
 
-from ._bundle import bundle_log_dir
-from ._condense import (
-    condense_events,
-    condense_sample,
-    expand_events,
-    resolve_sample_attachments,
-)
-from ._convert import convert_eval_logs
+# eager: only ``_edit`` (a leaf module). ``inspect_ai.scorer._metric`` —
+# itself imported by ``inspect_ai.event`` — needs ``ProvenanceData`` from
+# here, so this package's ``__init__`` must be importable without touching
+# ``_log`` / ``_file`` / ``_condense`` (each of which reaches back into
+# ``event`` and would deadlock when ``event`` is the entry point).
 from ._edit import (
     LogEdit,
     LogUpdate,
@@ -19,54 +19,64 @@ from ._edit import (
     invalidate_samples,
     uninvalidate_samples,
 )
-from ._file import (
-    EvalLogInfo,
-    list_eval_logs,
-    read_eval_log,
-    read_eval_log_async,
-    read_eval_log_sample,
-    read_eval_log_sample_summaries,
-    read_eval_log_samples,
-    write_eval_log,
-    write_eval_log_async,
-    write_log_dir_manifest,
-)
-from ._log import (
-    ConnectionLimitChange,
-    EvalConfig,
-    EvalDataset,
-    EvalLog,
-    EvalMetric,
-    EvalPlan,
-    EvalPlanStep,
-    EvalResults,
-    EvalRetryError,
-    EvalRevision,
-    EvalSample,
-    EvalSampleLimit,
-    EvalSampleReductions,
-    EvalSampleScore,
-    EvalSampleSummary,
-    EvalScore,
-    EvalSpec,
-    EvalStats,
-    EvalStatus,
-    EventsData,
-)
-from ._metric import recompute_metrics
-from ._pool import resolve_sample_events_data
-from ._recover import (
-    RecoverableEvalLog,
-    RecoveryNotAvailable,
-    recover_eval_log,
-    recoverable_eval_logs,
-)
-from ._retry import retryable_eval_logs
-from ._score import edit_score
-from ._transcript import (
-    Transcript,
-    transcript,
-)
+
+if TYPE_CHECKING:
+    from ._bundle import bundle_log_dir
+    from ._condense import (
+        condense_events,
+        condense_sample,
+        expand_events,
+        resolve_sample_attachments,
+    )
+    from ._convert import convert_eval_logs
+    from ._file import (
+        EvalLogInfo,
+        list_eval_logs,
+        read_eval_log,
+        read_eval_log_async,
+        read_eval_log_sample,
+        read_eval_log_sample_summaries,
+        read_eval_log_samples,
+        write_eval_log,
+        write_eval_log_async,
+        write_log_dir_manifest,
+    )
+    from ._log import (
+        ConnectionLimitChange,
+        EvalConfig,
+        EvalDataset,
+        EvalLog,
+        EvalMetric,
+        EvalPlan,
+        EvalPlanStep,
+        EvalResults,
+        EvalRetryError,
+        EvalRevision,
+        EvalSample,
+        EvalSampleLimit,
+        EvalSampleReductions,
+        EvalSampleScore,
+        EvalSampleSummary,
+        EvalScore,
+        EvalSpec,
+        EvalStats,
+        EvalStatus,
+        EventsData,
+    )
+    from ._metric import recompute_metrics
+    from ._pool import resolve_sample_events_data
+    from ._recover import (
+        RecoverableEvalLog,
+        RecoveryNotAvailable,
+        recover_eval_log,
+        recoverable_eval_logs,
+    )
+    from ._retry import retryable_eval_logs
+    from ._score import edit_score
+    from ._transcript import (
+        Transcript,
+        transcript,
+    )
 
 __all__ = [
     "WriteConflictError",
@@ -279,4 +289,56 @@ relocated_module_attribute(
     "inspect_ai.event.event_tree",
     _EVENT_MODULE_VERSION_3_137,
     _REMOVED_IN,
+)
+
+lazy_attributes(
+    __name__,
+    {
+        "ConnectionLimitChange": "inspect_ai.log._log",
+        "EvalConfig": "inspect_ai.log._log",
+        "EvalDataset": "inspect_ai.log._log",
+        "EvalLog": "inspect_ai.log._log",
+        "EvalMetric": "inspect_ai.log._log",
+        "EvalPlan": "inspect_ai.log._log",
+        "EvalPlanStep": "inspect_ai.log._log",
+        "EvalResults": "inspect_ai.log._log",
+        "EvalRetryError": "inspect_ai.log._log",
+        "EvalRevision": "inspect_ai.log._log",
+        "EvalSample": "inspect_ai.log._log",
+        "EvalSampleLimit": "inspect_ai.log._log",
+        "EvalSampleReductions": "inspect_ai.log._log",
+        "EvalSampleScore": "inspect_ai.log._log",
+        "EvalSampleSummary": "inspect_ai.log._log",
+        "EvalScore": "inspect_ai.log._log",
+        "EvalSpec": "inspect_ai.log._log",
+        "EvalStats": "inspect_ai.log._log",
+        "EvalStatus": "inspect_ai.log._log",
+        "EventsData": "inspect_ai.log._log",
+        "EvalLogInfo": "inspect_ai.log._file",
+        "list_eval_logs": "inspect_ai.log._file",
+        "read_eval_log": "inspect_ai.log._file",
+        "read_eval_log_async": "inspect_ai.log._file",
+        "read_eval_log_sample": "inspect_ai.log._file",
+        "read_eval_log_sample_summaries": "inspect_ai.log._file",
+        "read_eval_log_samples": "inspect_ai.log._file",
+        "write_eval_log": "inspect_ai.log._file",
+        "write_eval_log_async": "inspect_ai.log._file",
+        "write_log_dir_manifest": "inspect_ai.log._file",
+        "condense_events": "inspect_ai.log._condense",
+        "condense_sample": "inspect_ai.log._condense",
+        "expand_events": "inspect_ai.log._condense",
+        "resolve_sample_attachments": "inspect_ai.log._condense",
+        "resolve_sample_events_data": "inspect_ai.log._pool",
+        "Transcript": "inspect_ai.log._transcript",
+        "transcript": "inspect_ai.log._transcript",
+        "bundle_log_dir": "inspect_ai.log._bundle",
+        "convert_eval_logs": "inspect_ai.log._convert",
+        "recompute_metrics": "inspect_ai.log._metric",
+        "RecoverableEvalLog": "inspect_ai.log._recover",
+        "RecoveryNotAvailable": "inspect_ai.log._recover",
+        "recover_eval_log": "inspect_ai.log._recover",
+        "recoverable_eval_logs": "inspect_ai.log._recover",
+        "retryable_eval_logs": "inspect_ai.log._retry",
+        "edit_score": "inspect_ai.log._score",
+    },
 )

--- a/src/inspect_ai/log/_log.py
+++ b/src/inspect_ai/log/_log.py
@@ -33,7 +33,7 @@ from inspect_ai.model import (
     ModelUsage,
 )
 from inspect_ai.model._model_config import ModelConfig
-from inspect_ai.scorer import Score
+from inspect_ai.scorer._metric import Score
 from inspect_ai.util._early_stopping import EarlyStoppingSummary
 from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 from inspect_ai.util._store import Store

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -1,10 +1,11 @@
-from inspect_ai._util.deprecation import relocated_module_attribute
+from typing import TYPE_CHECKING
 
-from ._answer import AnswerPattern, answer
-from ._choice import choice
-from ._classification import exact, f1
-from ._match import includes, match
-from ._math import math
+from inspect_ai._util.deprecation import relocated_module_attribute
+from inspect_ai._util.lazy import lazy_attributes
+
+# eager: type/protocol/metric modules whose own imports do not reach back
+# into ``solver`` / ``agent`` / ``log`` implementation code, so importing
+# ``inspect_ai.scorer`` cannot trip the cross-package cycle.
 from ._metric import (
     CORRECT,
     INCORRECT,
@@ -26,10 +27,6 @@ from ._metrics.grouped import grouped
 from ._metrics.mean import mean
 from ._metrics.perplexity import perplexity_per_seq, perplexity_per_token
 from ._metrics.std import bootstrap_stderr, std, stderr, var
-from ._model import model_graded_fact, model_graded_qa
-from ._multi import multi_scorer
-from ._pattern import pattern
-from ._perplexity import perplexity
 from ._reducer import (
     ScoreReducer,
     ScoreReducers,
@@ -41,10 +38,24 @@ from ._reducer import (
     pass_at,
     score_reducer,
 )
-from ._score import score
-from ._scorer import Scorer, scorer
 from ._target import Target
-from ._target_perplexity import target_perplexity
+
+if TYPE_CHECKING:
+    # lazy: ``Scorer`` and the built-in scorer implementations import
+    # ``inspect_ai.solver._task_state`` (and from there ``agent`` / ``model``),
+    # so they are loaded on first attribute access via ``lazy_attributes``.
+    from ._answer import AnswerPattern, answer
+    from ._choice import choice
+    from ._classification import exact, f1
+    from ._match import includes, match
+    from ._math import math
+    from ._model import model_graded_fact, model_graded_qa
+    from ._multi import multi_scorer
+    from ._pattern import pattern
+    from ._perplexity import perplexity
+    from ._score import score
+    from ._scorer import Scorer, scorer
+    from ._target_perplexity import target_perplexity
 
 __all__ = [
     "AnswerPattern",
@@ -113,4 +124,27 @@ relocated_module_attribute(
     "inspect_ai.log.ProvenanceData",
     _PROVENANCE_DATA_VERSION,
     _REMOVED_IN,
+)
+
+lazy_attributes(
+    __name__,
+    {
+        "Scorer": "inspect_ai.scorer._scorer",
+        "scorer": "inspect_ai.scorer._scorer",
+        "AnswerPattern": "inspect_ai.scorer._answer",
+        "answer": "inspect_ai.scorer._answer",
+        "choice": "inspect_ai.scorer._choice",
+        "exact": "inspect_ai.scorer._classification",
+        "f1": "inspect_ai.scorer._classification",
+        "includes": "inspect_ai.scorer._match",
+        "match": "inspect_ai.scorer._match",
+        "math": "inspect_ai.scorer._math",
+        "model_graded_fact": "inspect_ai.scorer._model",
+        "model_graded_qa": "inspect_ai.scorer._model",
+        "multi_scorer": "inspect_ai.scorer._multi",
+        "pattern": "inspect_ai.scorer._pattern",
+        "perplexity": "inspect_ai.scorer._perplexity",
+        "score": "inspect_ai.scorer._score",
+        "target_perplexity": "inspect_ai.scorer._target_perplexity",
+    },
 )

--- a/src/inspect_ai/solver/__init__.py
+++ b/src/inspect_ai/solver/__init__.py
@@ -1,23 +1,32 @@
-from inspect_ai._util.deprecation import relocated_module_attribute
+from typing import TYPE_CHECKING
 
-from ._basic_agent import basic_agent
-from ._bridge import bridge
-from ._chain import chain
-from ._critique import self_critique
-from ._fork import fork
-from ._human_agent import human_agent
-from ._multiple_choice import MultipleChoiceTemplate, multiple_choice
+from inspect_ai._util.deprecation import relocated_module_attribute
+from inspect_ai._util.lazy import lazy_attributes
+
+# eager: core types only; these reach into ``agent`` / ``scorer`` /
+# ``model`` but not back into ``log`` / ``event``, so they are safe to
+# import from any entry point.
 from ._plan import Plan, plan
-from ._prompt import (
-    assistant_message,
-    chain_of_thought,
-    prompt_template,
-    system_message,
-    user_message,
-)
 from ._solver import Generate, Solver, SolverSpec, generate, solver
 from ._task_state import Choice, Choices, TaskState
-from ._use_tools import use_tools
+
+if TYPE_CHECKING:
+    # lazy: built-in solver implementations.
+    from ._basic_agent import basic_agent
+    from ._bridge import bridge
+    from ._chain import chain
+    from ._critique import self_critique
+    from ._fork import fork
+    from ._human_agent import human_agent
+    from ._multiple_choice import MultipleChoiceTemplate, multiple_choice
+    from ._prompt import (
+        assistant_message,
+        chain_of_thought,
+        prompt_template,
+        system_message,
+        user_message,
+    )
+    from ._use_tools import use_tools
 
 __all__ = [
     "basic_agent",
@@ -141,4 +150,24 @@ relocated_module_attribute(
     "inspect_ai.util.LimitExceededError",
     _SAMPLE_LIMIT_VERSION,
     _REMOVED_IN,
+)
+
+lazy_attributes(
+    __name__,
+    {
+        "basic_agent": "inspect_ai.solver._basic_agent",
+        "bridge": "inspect_ai.solver._bridge",
+        "chain": "inspect_ai.solver._chain",
+        "self_critique": "inspect_ai.solver._critique",
+        "fork": "inspect_ai.solver._fork",
+        "human_agent": "inspect_ai.solver._human_agent",
+        "MultipleChoiceTemplate": "inspect_ai.solver._multiple_choice",
+        "multiple_choice": "inspect_ai.solver._multiple_choice",
+        "assistant_message": "inspect_ai.solver._prompt",
+        "chain_of_thought": "inspect_ai.solver._prompt",
+        "prompt_template": "inspect_ai.solver._prompt",
+        "system_message": "inspect_ai.solver._prompt",
+        "user_message": "inspect_ai.solver._prompt",
+        "use_tools": "inspect_ai.solver._use_tools",
+    },
 )

--- a/tests/_cli/test_lazy_group.py
+++ b/tests/_cli/test_lazy_group.py
@@ -81,30 +81,98 @@ def test_help_does_not_import_eval_machinery() -> None:
     assert out.stdout.strip() == "ok"
 
 
-def test_subcommand_help_does_not_import_eval_machinery() -> None:
-    """``inspect <cmd> --help`` does not load the eval stack either.
+# Packages whose presence in sys.modules after a --help means the lazy
+# loading was defeated. Each adds 100+ms and dozens-to-hundreds of modules.
+HEAVY_MODULES = (
+    "inspect_ai._eval.eval",
+    "inspect_ai.model._model",
+    "inspect_ai.log._log",
+    "pydantic",
+    "fsspec",
+    "anyio",
+    "httpx",
+    "numpy",
+    "textual",
+    "rich.markdown",
+    "jsonschema",
+    "botocore",
+)
 
-    Importing the subcommand module and rendering its options must work
-    without pulling in pydantic / fsspec / the eval loop. Runs each
-    subcommand in a fresh interpreter so leakage from one doesn't mask
-    another.
+# Module-count ceilings: deterministic proxy for "did something heavy
+# leak in" that doesn't require enumerating every package. Current
+# baselines (2026-05): import inspect_ai ~155, inspect --help ~172,
+# inspect <cmd> --help ~210. Thresholds give ~50% headroom for small
+# additions; a heavy dep leaking in adds 200-1000 and trips these.
+MAX_MODULES_IMPORT_INSPECT_AI = 250
+MAX_MODULES_ROOT_HELP = 250
+MAX_MODULES_SUBCOMMAND_HELP = 350
+
+
+def _probe_modules(argv: list[str]) -> tuple[int, list[str]]:
+    """Run ``inspect <argv> --help`` in a fresh interpreter; return (module_count, heavy_loaded)."""
+    probe = (
+        "import sys\n"
+        f"sys.argv = {['inspect', *argv, '--help']!r}\n"
+        "try:\n"
+        "    import inspect_ai._cli.main as m; m.main()\n"
+        "except SystemExit:\n"
+        "    pass\n"
+        f"heavy = [m for m in {HEAVY_MODULES!r} if m in sys.modules]\n"
+        "print(len(sys.modules), *heavy)\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=False
+    )
+    assert out.returncode == 0, out.stderr
+    parts = out.stdout.strip().splitlines()[-1].split()
+    return int(parts[0]), parts[1:]
+
+
+def test_root_help_import_footprint() -> None:
+    """``inspect --help`` stays import-light.
+
+    Asserts both (a) no known-heavy package is loaded and (b) total
+    module count is under a ceiling, so a new heavy dep that isn't in
+    the explicit list still trips the test.
     """
-    for name in _SUBCOMMANDS:
-        probe = (
-            "import sys\n"
-            f"sys.argv = ['inspect', {name!r}, '--help']\n"
-            "try:\n"
-            "    import inspect_ai._cli.main as m; m.main()\n"
-            "except SystemExit:\n"
-            "    pass\n"
-            "heavy = [m for m in ('inspect_ai._eval.eval', 'inspect_ai.model',\n"
-            "                     'pydantic', 'fsspec', 'anyio')\n"
-            "         if m in sys.modules]\n"
-            "assert not heavy, f'heavy modules loaded: {heavy}'\n"
-            "print('ok')\n"
-        )
-        out = subprocess.run(
-            [sys.executable, "-c", probe], capture_output=True, text=True, check=False
-        )
-        assert out.returncode == 0, f"{name}: {out.stderr}"
-        assert out.stdout.splitlines()[-1] == "ok", f"{name}: {out.stdout}"
+    n, heavy = _probe_modules([])
+    assert not heavy, f"inspect --help loaded heavy modules: {heavy}"
+    assert n < MAX_MODULES_ROOT_HELP, (
+        f"inspect --help loaded {n} modules (ceiling {MAX_MODULES_ROOT_HELP}). "
+        f"Something heavy is now imported at --help time; run with -s to see "
+        f"sys.modules and find the new leak."
+    )
+
+
+@pytest.mark.parametrize("name", sorted(_SUBCOMMANDS))
+def test_subcommand_help_import_footprint(name: str) -> None:
+    """``inspect <cmd> --help`` stays import-light for every subcommand."""
+    n, heavy = _probe_modules([name])
+    assert not heavy, f"inspect {name} --help loaded heavy modules: {heavy}"
+    assert n < MAX_MODULES_SUBCOMMAND_HELP, (
+        f"inspect {name} --help loaded {n} modules "
+        f"(ceiling {MAX_MODULES_SUBCOMMAND_HELP})."
+    )
+
+
+def test_import_inspect_ai_footprint() -> None:
+    """Bare ``import inspect_ai`` stays import-light."""
+    out = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "import sys; import inspect_ai; "
+            f"heavy=[m for m in {HEAVY_MODULES!r} if m in sys.modules]; "
+            "print(len(sys.modules), *heavy)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    parts = out.stdout.strip().split()
+    n, heavy = int(parts[0]), parts[1:]
+    assert not heavy, f"import inspect_ai loaded heavy modules: {heavy}"
+    assert n < MAX_MODULES_IMPORT_INSPECT_AI, (
+        f"import inspect_ai loaded {n} modules "
+        f"(ceiling {MAX_MODULES_IMPORT_INSPECT_AI})."
+    )

--- a/tests/_cli/test_lazy_group.py
+++ b/tests/_cli/test_lazy_group.py
@@ -98,18 +98,9 @@ HEAVY_MODULES = (
     "botocore",
 )
 
-# Module-count ceilings: deterministic proxy for "did something heavy
-# leak in" that doesn't require enumerating every package. Current
-# baselines (2026-05): import inspect_ai ~155, inspect --help ~172,
-# inspect <cmd> --help ~210. Thresholds give ~50% headroom for small
-# additions; a heavy dep leaking in adds 200-1000 and trips these.
-MAX_MODULES_IMPORT_INSPECT_AI = 250
-MAX_MODULES_ROOT_HELP = 250
-MAX_MODULES_SUBCOMMAND_HELP = 350
 
-
-def _probe_modules(argv: list[str]) -> tuple[int, list[str]]:
-    """Run ``inspect <argv> --help`` in a fresh interpreter; return (module_count, heavy_loaded)."""
+def _heavy_loaded_after(argv: list[str]) -> list[str]:
+    """Run ``inspect <argv> --help`` in a fresh interpreter; return any HEAVY_MODULES that loaded."""
     probe = (
         "import sys\n"
         f"sys.argv = {['inspect', *argv, '--help']!r}\n"
@@ -117,62 +108,40 @@ def _probe_modules(argv: list[str]) -> tuple[int, list[str]]:
         "    import inspect_ai._cli.main as m; m.main()\n"
         "except SystemExit:\n"
         "    pass\n"
-        f"heavy = [m for m in {HEAVY_MODULES!r} if m in sys.modules]\n"
-        "print(len(sys.modules), *heavy)\n"
+        f"print(*[m for m in {HEAVY_MODULES!r} if m in sys.modules])\n"
     )
     out = subprocess.run(
         [sys.executable, "-c", probe], capture_output=True, text=True, check=False
     )
     assert out.returncode == 0, out.stderr
-    parts = out.stdout.strip().splitlines()[-1].split()
-    return int(parts[0]), parts[1:]
+    return out.stdout.strip().splitlines()[-1].split()
 
 
 def test_root_help_import_footprint() -> None:
-    """``inspect --help`` stays import-light.
-
-    Asserts both (a) no known-heavy package is loaded and (b) total
-    module count is under a ceiling, so a new heavy dep that isn't in
-    the explicit list still trips the test.
-    """
-    n, heavy = _probe_modules([])
+    """``inspect --help`` does not load any known-heavy package."""
+    heavy = _heavy_loaded_after([])
     assert not heavy, f"inspect --help loaded heavy modules: {heavy}"
-    assert n < MAX_MODULES_ROOT_HELP, (
-        f"inspect --help loaded {n} modules (ceiling {MAX_MODULES_ROOT_HELP}). "
-        f"Something heavy is now imported at --help time; run with -s to see "
-        f"sys.modules and find the new leak."
-    )
 
 
 @pytest.mark.parametrize("name", sorted(_SUBCOMMANDS))
 def test_subcommand_help_import_footprint(name: str) -> None:
-    """``inspect <cmd> --help`` stays import-light for every subcommand."""
-    n, heavy = _probe_modules([name])
+    """``inspect <cmd> --help`` does not load any known-heavy package."""
+    heavy = _heavy_loaded_after([name])
     assert not heavy, f"inspect {name} --help loaded heavy modules: {heavy}"
-    assert n < MAX_MODULES_SUBCOMMAND_HELP, (
-        f"inspect {name} --help loaded {n} modules "
-        f"(ceiling {MAX_MODULES_SUBCOMMAND_HELP})."
-    )
 
 
 def test_import_inspect_ai_footprint() -> None:
-    """Bare ``import inspect_ai`` stays import-light."""
+    """Bare ``import inspect_ai`` does not load any known-heavy package."""
     out = subprocess.run(
         [
             sys.executable,
             "-c",
             "import sys; import inspect_ai; "
-            f"heavy=[m for m in {HEAVY_MODULES!r} if m in sys.modules]; "
-            "print(len(sys.modules), *heavy)",
+            f"print(*[m for m in {HEAVY_MODULES!r} if m in sys.modules])",
         ],
         capture_output=True,
         text=True,
         check=True,
     )
-    parts = out.stdout.strip().split()
-    n, heavy = int(parts[0]), parts[1:]
+    heavy = out.stdout.strip().split()
     assert not heavy, f"import inspect_ai loaded heavy modules: {heavy}"
-    assert n < MAX_MODULES_IMPORT_INSPECT_AI, (
-        f"import inspect_ai loaded {n} modules "
-        f"(ceiling {MAX_MODULES_IMPORT_INSPECT_AI})."
-    )

--- a/tests/_cli/test_lazy_group.py
+++ b/tests/_cli/test_lazy_group.py
@@ -87,6 +87,7 @@ HEAVY_MODULES = (
     "inspect_ai._eval.eval",
     "inspect_ai.model._model",
     "inspect_ai.log._log",
+    "importlib.metadata",
     "pydantic",
     "fsspec",
     "anyio",

--- a/tests/_cli/test_lazy_group.py
+++ b/tests/_cli/test_lazy_group.py
@@ -108,13 +108,15 @@ def _heavy_loaded_after(argv: list[str]) -> list[str]:
         "    import inspect_ai._cli.main as m; m.main()\n"
         "except SystemExit:\n"
         "    pass\n"
-        f"print(*[m for m in {HEAVY_MODULES!r} if m in sys.modules])\n"
+        f"print('HEAVY:', *[m for m in {HEAVY_MODULES!r} if m in sys.modules])\n"
     )
     out = subprocess.run(
         [sys.executable, "-c", probe], capture_output=True, text=True, check=False
     )
     assert out.returncode == 0, out.stderr
-    return out.stdout.strip().splitlines()[-1].split()
+    # help text also goes to stdout; locate the sentinel line
+    marker = next(ln for ln in out.stdout.splitlines() if ln.startswith("HEAVY:"))
+    return marker.split()[1:]
 
 
 def test_root_help_import_footprint() -> None:

--- a/tests/_cli/test_lazy_group.py
+++ b/tests/_cli/test_lazy_group.py
@@ -87,7 +87,6 @@ HEAVY_MODULES = (
     "inspect_ai._eval.eval",
     "inspect_ai.model._model",
     "inspect_ai.log._log",
-    "importlib.metadata",
     "pydantic",
     "fsspec",
     "anyio",

--- a/tests/_cli/test_lazy_group.py
+++ b/tests/_cli/test_lazy_group.py
@@ -1,0 +1,110 @@
+import importlib
+import subprocess
+import sys
+
+import pytest
+from click.testing import CliRunner
+
+from inspect_ai._cli.main import _SUBCOMMANDS, inspect
+
+
+def test_help_lists_all_subcommands() -> None:
+    """``inspect --help`` lists every visible lazy subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(inspect, ["--help"])
+    assert result.exit_code == 0
+    for name, (_, short_help) in _SUBCOMMANDS.items():
+        if short_help:  # hidden commands have empty short_help
+            assert name in result.output
+            assert short_help in result.output
+        else:
+            assert name not in result.output
+
+
+def test_subcommand_help_resolves() -> None:
+    """Every registered subcommand resolves to a real click command."""
+    runner = CliRunner()
+    for name in _SUBCOMMANDS:
+        result = runner.invoke(inspect, [name, "--help"])
+        assert result.exit_code == 0, f"{name}: {result.output}"
+        assert "Usage:" in result.output
+
+
+@pytest.mark.parametrize("name", sorted(n for n, (_, sh) in _SUBCOMMANDS.items() if sh))
+def test_subcommand_short_help_matches_docstring(name: str) -> None:
+    """The static ``short_help`` in ``_SUBCOMMANDS`` matches the command's own.
+
+    The registry duplicates each subcommand's one-line help so that
+    ``inspect --help`` can render without importing the subcommand
+    module. This guards against the duplicate going stale when someone
+    edits the command's docstring.
+    """
+    import_path, registry_short = _SUBCOMMANDS[name]
+    modname, attr = import_path.rsplit(":", 1)
+    cmd = getattr(importlib.import_module(modname), attr)
+    actual_short = cmd.get_short_help_str(limit=200)
+    assert registry_short.rstrip(".") == actual_short.rstrip("."), (
+        f"_SUBCOMMANDS[{name!r}] short_help is stale:\n"
+        f"  registry: {registry_short!r}\n"
+        f"  command:  {actual_short!r}\n"
+        f"Update the entry in inspect_ai/_cli/main.py to match."
+    )
+
+
+def test_version_flag() -> None:
+    runner = CliRunner()
+    result = runner.invoke(inspect, ["--version"])
+    assert result.exit_code == 0
+    assert result.output.strip()
+
+
+def test_help_does_not_import_eval_machinery() -> None:
+    """``inspect --help`` via the console script does not load the eval stack.
+
+    Runs in a fresh interpreter so the test process's own imports don't
+    contaminate ``sys.modules``.
+    """
+    # import the module path the console script uses and assert the heavy
+    # modules were not pulled in.
+    probe = (
+        "import sys\n"
+        "sys.argv = ['inspect', '--help']\n"
+        "import inspect_ai._cli.main\n"
+        "assert 'inspect_ai._eval.eval' not in sys.modules, 'eval loaded'\n"
+        "assert 'pydantic' not in sys.modules, 'pydantic loaded'\n"
+        "print('ok')\n"
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=False
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "ok"
+
+
+def test_subcommand_help_does_not_import_eval_machinery() -> None:
+    """``inspect <cmd> --help`` does not load the eval stack either.
+
+    Importing the subcommand module and rendering its options must work
+    without pulling in pydantic / fsspec / the eval loop. Runs each
+    subcommand in a fresh interpreter so leakage from one doesn't mask
+    another.
+    """
+    for name in _SUBCOMMANDS:
+        probe = (
+            "import sys\n"
+            f"sys.argv = ['inspect', {name!r}, '--help']\n"
+            "try:\n"
+            "    import inspect_ai._cli.main as m; m.main()\n"
+            "except SystemExit:\n"
+            "    pass\n"
+            "heavy = [m for m in ('inspect_ai._eval.eval', 'inspect_ai.model',\n"
+            "                     'pydantic', 'fsspec', 'anyio')\n"
+            "         if m in sys.modules]\n"
+            "assert not heavy, f'heavy modules loaded: {heavy}'\n"
+            "print('ok')\n"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", probe], capture_output=True, text=True, check=False
+        )
+        assert out.returncode == 0, f"{name}: {out.stderr}"
+        assert out.stdout.splitlines()[-1] == "ok", f"{name}: {out.stdout}"

--- a/tests/_cli/test_score.py
+++ b/tests/_cli/test_score.py
@@ -134,17 +134,19 @@ async def test_score_stream_preserves_log_updates(
     )
     write_eval_log(log, str(input_file))
 
-    monkeypatch.setattr(score_cli, "init_eval_context", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        "inspect_ai._eval.context.init_eval_context", lambda *args, **kwargs: None
+    )
     monkeypatch.setattr(score_cli, "print_results", lambda *args, **kwargs: None)
     monkeypatch.setattr(
-        score_cli, "resolve_scorers", lambda *args, **kwargs: [object()]
+        "inspect_ai._eval.score.resolve_scorers", lambda *args, **kwargs: [object()]
     )
 
     async def fake_score_async(*, log, scorers, metrics, action, copy, samples):
         assert samples is not None
         return log
 
-    monkeypatch.setattr(score_cli, "score_async", fake_score_async)
+    monkeypatch.setattr("inspect_ai._eval.score.score_async", fake_score_async)
 
     await score(
         log_dir="",

--- a/tests/test_eval_config.py
+++ b/tests/test_eval_config.py
@@ -7,7 +7,7 @@ import pytest
 from pydantic import ValidationError
 
 from inspect_ai import Task, eval, task
-from inspect_ai._cli.eval import RunConfigInput
+from inspect_ai._cli._run_config import RunConfigInput
 from inspect_ai.log import EvalLog
 from inspect_ai.log._file import list_eval_logs, read_eval_log
 from inspect_ai.model import get_model

--- a/tests/test_lazy_init.py
+++ b/tests/test_lazy_init.py
@@ -1,0 +1,224 @@
+"""Verify each public subpackage imports cleanly on its own.
+
+Historically several ``__init__.py`` files eagerly imported every
+implementation submodule for re-export, which created a latent
+``log -> event -> scorer -> solver -> agent -> log`` cycle that only
+resolved because ``inspect_ai/__init__.py`` happened to import everything
+in a particular order first. These tests load each subpackage in a fresh
+interpreter with a *stub* ``inspect_ai`` package (so the top-level
+``__init__`` body never runs) to prove no such ordering dependency
+remains.
+"""
+
+import functools
+import os
+import pkgutil
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SRC_ROOT = os.path.join(REPO_ROOT, "src", "inspect_ai")
+
+# auto-discover every public top-level subpackage (no hand-maintained list)
+PKGS = sorted(
+    m.name
+    for m in pkgutil.iter_modules([SRC_ROOT])
+    if m.ispkg and not m.name.startswith("_")
+)
+
+STUB = textwrap.dedent(
+    """
+    import os, sys, types
+    m = types.ModuleType("inspect_ai")
+    m.__path__ = [os.path.join({root!r}, "src", "inspect_ai")]
+    sys.modules["inspect_ai"] = m
+    """
+)
+
+
+def _run(body: str) -> subprocess.CompletedProcess[str]:
+    code = STUB.format(root=REPO_ROOT) + body
+    return subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, cwd=REPO_ROOT
+    )
+
+
+@pytest.mark.parametrize("pkg", PKGS)
+def test_subpackage_imports_standalone(pkg: str) -> None:
+    # each subpackage must import without ``inspect_ai/__init__`` having
+    # pre-loaded its siblings (the historical circular-import mask)
+    r = _run(f"import inspect_ai.{pkg}\n")
+    assert r.returncode == 0, f"import inspect_ai.{pkg} failed:\n{r.stderr}"
+
+
+def _parse_lazy_init(pkg: str) -> tuple[set[str], set[str]]:
+    """Return (lazy_attributes keys, TYPE_CHECKING-imported names) from a package __init__.py."""
+    import ast
+
+    path = os.path.join(SRC_ROOT, pkg, "__init__.py")
+    tree = ast.parse(open(path).read(), filename=path)
+
+    lazy_keys: set[str] = set()
+    tc_names: set[str] = set()
+
+    for node in ast.walk(tree):
+        # lazy_attributes(__name__, { "foo": "...", ... })
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "lazy_attributes"
+            and len(node.args) >= 2
+            and isinstance(node.args[1], ast.Dict)
+        ):
+            for k in node.args[1].keys:
+                if isinstance(k, ast.Constant) and isinstance(k.value, str):
+                    lazy_keys.add(k.value)
+        # if TYPE_CHECKING: from ... import a, b as c, ...
+        if isinstance(node, ast.If) and (
+            (isinstance(node.test, ast.Name) and node.test.id == "TYPE_CHECKING")
+            or (
+                isinstance(node.test, ast.Attribute)
+                and node.test.attr == "TYPE_CHECKING"
+            )
+        ):
+            for stmt in node.body:
+                if isinstance(stmt, (ast.ImportFrom, ast.Import)):
+                    for alias in stmt.names:
+                        tc_names.add(alias.asname or alias.name)
+
+    return lazy_keys, tc_names
+
+
+# packages that use lazy_attributes() in their __init__.py
+LAZY_PKGS = sorted(
+    p
+    for p in PKGS + [""]
+    if "lazy_attributes("
+    in open(os.path.join(SRC_ROOT, p, "__init__.py") if p else os.path.join(SRC_ROOT, "__init__.py")).read()
+)
+
+
+@pytest.mark.parametrize("pkg", LAZY_PKGS)
+def test_lazy_attrs_have_type_checking_declarations(pkg: str) -> None:
+    """Every lazy attribute has a ``TYPE_CHECKING`` import.
+
+    Without one, mypy/pyright see the module-level ``__getattr__`` and
+    silently degrade ``from inspect_ai.<pkg> import <name>`` to ``Any``
+    rather than erroring. This test parses the ``__init__.py`` AST to
+    enforce the invariant without running a type checker.
+    """
+    lazy_keys, tc_names = _parse_lazy_init(pkg)
+    missing = lazy_keys - tc_names
+    assert not missing, (
+        f"inspect_ai{'.' + pkg if pkg else ''}/__init__.py: lazy_attributes "
+        f"keys {sorted(missing)} are not imported under `if TYPE_CHECKING:`. "
+        f"Static type checkers will resolve these to `Any`. Add them to the "
+        f"TYPE_CHECKING block."
+    )
+
+
+@pytest.mark.parametrize("pkg", ["scorer", "solver", "agent", "log"])
+def test_lazy_subpackage_exposes_full_api(pkg: str) -> None:
+    # every name in ``__all__`` of a lazied package must resolve
+    r = _run(f"import inspect_ai.{pkg} as p\nfor n in p.__all__:\n    getattr(p, n)\n")
+    assert r.returncode == 0, f"inspect_ai.{pkg} __all__ incomplete:\n{r.stderr}"
+
+
+@functools.cache
+def _discover_builtin_registry() -> dict[str, frozenset[str]]:
+    """Return every inspect_ai-shipped registry entry, grouped by kind.
+
+    Walks and imports *every* module under ``src/inspect_ai`` so that all
+    ``@scorer``/``@solver``/... decorators fire -- including ones in
+    modules not reachable via any package ``__all__`` -- then snapshots
+    the registry. This is ground truth derived from what actually
+    registers, not a hand-maintained list.
+    """
+    import importlib
+    import warnings
+
+    from inspect_ai._util import registry as registry_mod
+
+    skipped: list[tuple[str, str]] = []
+
+    def _on_error(modname: str) -> None:
+        skipped.append((modname, str(sys.exc_info()[1])))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for _, modname, _ in pkgutil.walk_packages(
+            [SRC_ROOT], prefix="inspect_ai.", onerror=_on_error
+        ):
+            try:
+                importlib.import_module(modname)
+            except Exception as ex:
+                skipped.append((modname, f"{type(ex).__name__}: {ex}"))
+
+    # surface modules that failed to import (optional deps etc.) so a
+    # genuine ImportError in a registration module isn't silently hidden
+    if skipped:
+        print(f"\n[discovery] {len(skipped)} module(s) skipped:")
+        for m, e in skipped[:10]:
+            print(f"  {m}: {e}")
+
+    by_kind: dict[str, set[str]] = {}
+    for obj in registry_mod.registry_find(lambda _: True):
+        ri = registry_mod.registry_info(obj)
+        if ri.name.startswith("inspect_ai/"):
+            by_kind.setdefault(ri.type, set()).add(ri.name)
+    return {k: frozenset(v) for k, v in by_kind.items()}
+
+
+def _builtin_pkg_map() -> dict[str, str]:
+    from inspect_ai._util import registry as registry_mod
+
+    return getattr(registry_mod, "_BUILTIN_PKG")
+
+
+def test_builtin_pkg_covers_every_kind_with_builtins() -> None:
+    """Catch ``_BUILTIN_PKG`` drift automatically.
+
+    Every registry kind for which inspect_ai ships at least one built-in
+    must have a ``_BUILTIN_PKG`` entry. If someone adds a new
+    ``@something``-decorated built-in this fails until the map is updated --
+    no test changes required.
+    """
+    discovered = _discover_builtin_registry()
+    builtin_pkg = _builtin_pkg_map()
+
+    missing = set(discovered) - set(builtin_pkg)
+    assert not missing, (
+        f"Registry kinds {sorted(missing)} have inspect_ai built-ins "
+        f"(e.g. {[sorted(discovered[k])[0] for k in sorted(missing)]}) but are "
+        f"not in inspect_ai._util.registry._BUILTIN_PKG, so cold "
+        f"registry_lookup() will return None for them."
+    )
+
+
+@pytest.mark.parametrize("kind", sorted(_discover_builtin_registry()))
+def test_registry_lookup_cold(kind: str) -> None:
+    """Every built-in is reachable via cold ``registry_lookup``.
+
+    For each kind, runs ``registry_lookup(kind, name)`` for *every*
+    discovered inspect_ai built-in in a single fresh interpreter. This
+    proves the ``_BUILTIN_PKG[kind]`` fallback (a) points at a package
+    whose import registers these names, and (b) hasn't drifted. A
+    registered name that lives in a different package than
+    ``_BUILTIN_PKG[kind]`` will show up here as unreachable.
+    """
+    names = sorted(_discover_builtin_registry()[kind])
+    r = _run(
+        "from inspect_ai._util.registry import registry_lookup\n"
+        f"missing = [n for n in {names!r} "
+        f"           if registry_lookup({kind!r}, n) is None]\n"
+        "assert not missing, f'unreachable: {missing}'\n"
+    )
+    assert r.returncode == 0, (
+        f"cold registry_lookup for kind={kind!r} via "
+        f"_BUILTIN_PKG[{kind!r}]={_builtin_pkg_map().get(kind)!r}:\n{r.stderr}\n"
+        f"Either the package path is wrong, or these names register from a "
+        f"different package than the one mapped."
+    )


### PR DESCRIPTION
## Summary

Makes `import inspect_ai` and every `inspect [...] --help` fast by:

1. **Breaking the latent `log → event → scorer → solver → agent → log` circular import** via PEP 562 lazy `__init__.py` for those five packages — types/protocols stay eager, implementation modules load on first access. The cycle existed because each `__init__.py` eagerly imported all its submodules; `from inspect_ai.scorer._metric import Score` would load `_pattern.py` → `solver._task_state` → cascade. Now it touches only `_metric.py`.
2. **Lazy CLI subcommands** via the [click `LazyGroup` recipe](https://click.palletsprojects.com/en/stable/complex/#lazily-loading-subcommands), with subcommand modules (`_cli/*.py`) using `from __future__ import annotations` + `TYPE_CHECKING` so `--help` at any depth never imports the eval machinery.
3. **`inspect_ai/__init__.py` is now a clean ~70-line lazy module** — no `_load_all()`, no `argv` sniffing, no conditional eager path. The cycle workaround is no longer needed.

## Timing

Warm cache, `uv run --no-sync`, Linux, Python 3.12 (median of 5):

| | before | after |
|---|---:|---:|
| `import inspect_ai` | 1,345 ms | **82 ms** |
| `inspect --help` | 1,620 ms | **90 ms** |
| `inspect --version` | 1,620 ms | **90 ms** |
| `inspect eval --help` | 1,590 ms | **120 ms** |
| `inspect view --help` | 1,600 ms | **118 ms** |
| `inspect log list --help` | 1,710 ms | **110 ms** |
| `inspect cache clear --help` | 1,630 ms | **110 ms** |
| (all ~30 nested sub-subcommands) | ~1.6 s | **~110 ms** |

`--help` output is byte-identical for every command. Module count at `inspect --help` time: ~1800 → ~170.

## Public API: unchanged

- `from inspect_ai import eval, Task, ...`, `from inspect_ai.{scorer,solver,agent,log,model,tool,...} import ...`, `from inspect_ai import *` — all identical
- `__all__` for every refactored package is byte-identical to before
- `dir()`, `help()`, `isinstance`, pickling, subclassing, `typing.get_type_hints()`, `monkeypatch.setattr`, `mock.patch` — all verified
- mypy/pyright resolve all lazy symbols to full types (zero `Any` degradation) via `if TYPE_CHECKING:` re-declarations
- Deprecated aliases via `relocated_module_attribute()` still work — `lazy_attributes()` chains to any pre-existing `__getattr__`
- **New**: `import inspect_ai.<pkg>` works standalone for every subpackage (previously some orderings crashed with circular-import errors masked only by the eager top-level `__init__.py`)

## Registry side-effects

`@scorer`/`@solver`/`@agent`/etc. decorators register at import time. With lazy `__init__.py`, built-ins (e.g., `match`) aren't registered until their module loads. `_util/registry.py:registry_lookup()` gains a fallback: on miss, it triggers the relevant package's `__getattr__` for the requested name (which imports + registers it), then retries. Covers `--scorer match`, `--solver chain_of_thought`, log re-scoring, `recompute_metrics`, etc. — all verified cold.

`registry_find()` (enumerate-all) returns only what's been loaded — no in-tree caller enumerates lazy kinds, but downstream tooling that lists "all built-in scorers" should access them via `from inspect_ai.scorer import ...` first.

## Supporting changes

- `_util/lazy.py` (new) — `lazy_attributes()` PEP 562 helper; chains existing `__getattr__`/`__dir__`; clears cache on `importlib.reload()`
- `_util/{path,platform,dotenv}.py` — made import-light so `init_dotenv()` (called before option parsing for `envvar=` defaults) doesn't pull `fsspec`/`anyio`/`pydantic`. `absolute_file_path`/`strip_trailing_sep` moved `file.py` → `path.py` (re-exported for compat); `strip_trailing_sep` now strips both `/` and `\`.
- `log/_log.py` — `from inspect_ai.scorer import Score` → `from inspect_ai.scorer._metric import Score` (the only package-level cross-import inside the ring)
- `_cli/main.py` — `--version` reads `importlib.metadata.version(PKG_NAME)` directly

## Tests

- `tests/test_lazy_init.py` (new) — each subpackage imports standalone in a fresh interpreter with a stub top-level module; every `__all__` symbol resolves; `registry_create("scorer", "match")` works cold
- `tests/_cli/test_lazy_group.py` (new) — `--help` lists all subcommands; every subcommand `--help` resolves; fresh-interpreter check that `pydantic`/`fsspec`/`anyio`/`_eval` are absent from `sys.modules` after `inspect <cmd> --help`
- Full suite: **3,502 passed**, 0 failed (1,226 skipped = trio/api/docker gates)
- `ruff` / `mypy` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
