### PR TITLE
fix: preserve Score.answer/explanation in reduced scores when epochs differ

### DIFF
--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -454,37 +454,32 @@ def _reduced_score(value: Value, scores: list[Score]) -> Score:
 
     Args:
         value: the reduced Value
-        scores: ths list of scores being reduced
+        scores: the list of scores being reduced
     """
+    answers = [score.answer for score in scores]
+    explanations = [score.explanation for score in scores]
+    rep = _closest_epoch_score(value, scores)
     return Score(
         value=value,
-        # retain remaining fields only if equal across all Scores
-        answer=scores[0].answer
-        if len(set(score.answer for score in scores)) == 1
-        else None,
-        explanation=scores[0].explanation
-        if len(set(score.explanation for score in scores)) == 1
-        else None,
+        answer=answers[0] if len(set(answers)) == 1 else rep.answer,
+        explanation=explanations[0] if len(set(explanations)) == 1 else rep.explanation,
         metadata=scores[0].metadata,
     )
 
 
 def _nan_score(scores: list[Score]) -> Score:
-    r"""Create a NaN Score based upon a single Value and list of Scores that produced it
+    r"""Create a NaN Score based upon a list of Scores that produced it
 
     Args:
-        value: the reduced Value
-        scores: ths list of scores being reduced
+        scores: the list of scores being reduced
     """
+    answers = [score.answer for score in scores]
+    explanations = [score.explanation for score in scores]
+    rep = _first_scored(scores) or scores[0]
     return Score(
         value=float("nan"),
-        # retain remaining fields only if equal across all Scores
-        answer=scores[0].answer
-        if len(set(score.answer for score in scores)) == 1
-        else None,
-        explanation=scores[0].explanation
-        if len(set(score.explanation for score in scores)) == 1
-        else None,
+        answer=answers[0] if len(set(answers)) == 1 else rep.answer,
+        explanation=explanations[0] if len(set(explanations)) == 1 else rep.explanation,
         metadata=scores[0].metadata,
     )
 
@@ -492,3 +487,31 @@ def _nan_score(scores: list[Score]) -> Score:
 def _is_reducible(value: str | int | float | bool) -> bool:
     """Check if a value is reducible (not a NaN float)."""
     return not (isinstance(value, float) and math.isnan(value))
+
+
+def _closest_epoch_score(value: Value, scores: list[Score]) -> Score:
+    r"""Return the epoch Score whose value is numerically closest to `value`.
+
+    When answer/explanation differ across epochs, the reduced score inherits
+    these fields from the epoch that most closely represents the reduced value
+    (e.g. the max-value epoch for max_score, the epoch nearest the mean for
+    mean_score). Falls back to the first scored (non-NaN) epoch, or scores[0]
+    when value is non-numeric or all epochs are unscored.
+
+    Args:
+        value: the reduced Value to match against
+        scores: the list of per-epoch Scores
+    """
+    if isinstance(value, (int, float)) and not _is_unscored(value):
+        target = float(value)
+        best: Score | None = None
+        best_diff = float("inf")
+        for score in scores:
+            if isinstance(score.value, (int, float)) and not _is_unscored(score.value):
+                diff = abs(float(score.value) - target)
+                if diff < best_diff:
+                    best = score
+                    best_diff = diff
+        if best is not None:
+            return best
+    return _first_scored(scores) or scores[0]

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -277,12 +277,21 @@ def test_reducer_preserve_metadata() -> None:
         pass_at_2_no_threshhold,
     ]
 
-    # verify that other fields are set only if equal across all samples
+    # When answers/explanations differ across epochs, the reduced score
+    # inherits them from the epoch whose value is closest to the reduced
+    # value (rather than dropping them to None).
     for reducer in reducers:
         # reduce all scores _including_ the last one that's different
         reduced = reducer(simple_scores)
-        assert reduced.answer is None
-        assert reduced.explanation is None
+        if reducer is max_reducer:
+            # max_score reduces to 2; the epoch with value=2 is closest.
+            assert reduced.answer == simple_scores[-1].answer
+            assert reduced.explanation == simple_scores[-1].explanation
+        else:
+            # All other reducers (mean≈1.17, median=1, mode=1, at_least=1,
+            # pass_at=1) reduce to a value ≤1.5, closest to value=1 epochs.
+            assert reduced.answer == simple_scores[0].answer
+            assert reduced.explanation == simple_scores[0].explanation
         assert reduced.metadata == simple_scores[0].metadata
         # reduce all scores _except_ the last one
         reduced = reducer(simple_scores[:-1])


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #3840.

When `epochs > 1`, built-in reducers (`mean`, `median`, `mode`, `max`, `at_least`, `pass_at`) set `Score.answer` and `Score.explanation` to `None` whenever the values differ across epochs. Custom metrics that rely on these fields silently receive `None`, even though every individual epoch score had them fully populated.

The root cause is in `_reduced_score()` and `_nan_score()` in `scorer/_reducer/reducer.py`:

```python
answer=scores[0].answer if len(set(score.answer for score in scores)) == 1 else None
```

### What is the new behavior?

Instead of discarding `answer`/`explanation` when they differ, the reduced `Score` now inherits them from the epoch whose numeric value is closest to the reduced value — the most representative epoch:

- `max_score` reduces to the highest value, so the epoch with the highest score provides the context.
- `mean_score` / `median_score` pick the epoch nearest the computed statistic.
- `mode_score` / `at_least` / `pass_at` similarly use the closest-matching epoch.

When values are non-numeric (dict/list) or all epochs are unscored (NaN), the first scored epoch is used as the fallback. When `answer`/`explanation` are identical across all epochs the existing behaviour (preserve as-is) is unchanged.

The selection logic lives in the new private helper `_closest_epoch_score(value, scores)`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `answer` and `explanation` were previously `None` when epochs differed; they are now non-`None`. Code that checked `if score.answer is None` to detect the multi-epoch case should instead rely on `Score.metadata` or disable reduction with `Epochs(n, [])` if raw per-epoch scores are needed.

### Other information:

All 30 existing reducer tests pass. The `test_reducer_preserve_metadata` assertions are updated to reflect the new representative-epoch semantics.