### PR TITLE
various cleanups on --run-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Unreleased
 
-- Add [run-config](https://inspect.aisi.org.uk/task-configuration.html#run-config) option to `inspect eval` for single-file run configuration. A YAML or JSON file can specify task, model, model roles, generate config, solver, and eval config in one place; explicit CLI flags override values from the file. Mutually exclusive with `--generate-config`, `--task-config`, and `--solver-config`.
 - OpenAI: Add GPT 5.5 as computer use model and exclude 'chat' and 'instant' models from computer use.
 - OpenAI Compatible: Parse OpenRouter-style `reasoning_details` in OpenAI-compatible responses.
 - Anthropic: Capture `extra_body` fields from `Message` response.
@@ -22,6 +21,7 @@
 - Scoring: `match(numeric=True, location="exact")` is now strict — values like `"5 some text"` no longer match target `"5"`.
 - Analysis: Use score reducer in `evals_df()` column name when there are multiple reducers.
 - Hooks: Cache list of registered hooks (invalidate cache on `registry_add()`).
+- Config: Add `--run-config` option to `inspect eval` for single-file run configuration.
 - Eval Set: Run [Inspect Scout](https://meridianlabs-ai.github.io/inspect_scout/) scanners over each task's logs as part of `eval_set` (CLI `--scanner` / `EvalScannerConfig`). Scans incrementally as logs land, reuses prior results across resumes, and renders progress alongside the existing eval view.
 - Eval Set: Add `score_display` argument to `eval_set()` function.
 - Eval Log: Preflight ETag check on S3 conditional write (required for S3 backends that don't implement conditional writes).

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -818,11 +818,25 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 def eval_command(ctx: click.Context, /, **params: Any) -> None:
     """Evaluate tasks."""
     # When --run-config is used, env-sourced CLI values (INSPECT_EVAL_*) defer
-    # to the run config — only explicit CLI flags override. Common-options env
-    # vars (INSPECT_LOG_LEVEL, INSPECT_LOG_DIR, ...) are not cleared because
+    # to the run config _for fields the run config actually provides_. Env
+    # values still apply to fields the run config leaves unset. Common-options
+    # env vars (INSPECT_LOG_LEVEL, INSPECT_LOG_DIR, ...) are never cleared —
     # they describe how the run is logged/displayed, not what is run.
     if params.get("run_config"):
         from click.core import ParameterSource
+
+        run_params = parse_run_config(params["run_config"])
+
+        # Map Click parameter name -> the cli_params key it ultimately produces
+        # in eval_exec. Most are identity; these are the exceptions.
+        click_to_cli_key = {
+            "m": "model_args",
+            "t": "task_args",
+            "model_role": "model_roles",
+            "no_sandbox_cleanup": "sandbox_cleanup",
+            "s": "solver",
+            "solver_config": "solver",
+        }
 
         for param in ctx.command.params:
             name = param.name
@@ -832,6 +846,9 @@ def eval_command(ctx: click.Context, /, **params: Any) -> None:
             if not (isinstance(envvar, str) and envvar.startswith("INSPECT_EVAL_")):
                 continue
             if ctx.get_parameter_source(name) != ParameterSource.ENVIRONMENT:
+                continue
+            cli_key = click_to_cli_key.get(name, name)
+            if cli_key not in run_params:
                 continue
             value = params.get(name)
             params[name] = () if isinstance(value, tuple) else None

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -5,7 +5,14 @@ from typing import Any, Literal, cast
 
 import click
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    TypeAdapter,
+    ValidationError,
+    field_validator,
+)
 from typing_extensions import Unpack
 
 from inspect_ai import Epochs, eval, eval_retry
@@ -807,7 +814,32 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 @click.command("eval", cls=EvalCommand)
 @click.argument("tasks", nargs=-1)
 @eval_options
-def eval_command(
+@click.pass_context
+def eval_command(ctx: click.Context, /, **params: Any) -> None:
+    """Evaluate tasks."""
+    # When --run-config is used, env-sourced CLI values (INSPECT_EVAL_*) defer
+    # to the run config — only explicit CLI flags override. Common-options env
+    # vars (INSPECT_LOG_LEVEL, INSPECT_LOG_DIR, ...) are not cleared because
+    # they describe how the run is logged/displayed, not what is run.
+    if params.get("run_config"):
+        from click.core import ParameterSource
+
+        for param in ctx.command.params:
+            name = param.name
+            if name is None or name == "run_config":
+                continue
+            envvar = getattr(param, "envvar", None)
+            if not (isinstance(envvar, str) and envvar.startswith("INSPECT_EVAL_")):
+                continue
+            if ctx.get_parameter_source(name) != ParameterSource.ENVIRONMENT:
+                continue
+            value = params.get(name)
+            params[name] = () if isinstance(value, tuple) else None
+
+    _eval_command_impl(**params)
+
+
+def _eval_command_impl(
     tasks: tuple[str, ...] | None,
     solver: str | None,
     model: str | None,
@@ -910,7 +942,6 @@ def eval_command(
     log_level_transcript: str,
     **common: Unpack[CommonOptions],
 ) -> None:
-    """Evaluate tasks."""
     # read config
     config = config_from_locals(dict(locals()))
 
@@ -1388,7 +1419,25 @@ class RunConfigInput(BaseModel):
 
 
 def parse_run_config(config: str) -> dict[str, Any]:
-    run_config = RunConfigInput.model_validate(resolve_args(config))
+    from jsonschema import Draft7Validator
+
+    config_dict = resolve_args(config)
+    try:
+        run_config = RunConfigInput.model_validate(config_dict)
+    except ValidationError as ex:
+        # Surface a more readable error via Draft7Validator. Fall back to
+        # pydantic's message when the JSON schema doesn't capture the
+        # failure (e.g. custom field_validators on generate_config/eval_config).
+        schema = RunConfigInput.model_json_schema()
+        errors = list(Draft7Validator(schema).iter_errors(config_dict))
+        if errors:
+            message = "\n".join(
+                [f"Invalid run config '{config}':"]
+                + [f" - {error.message}" for error in errors]
+            )
+        else:
+            message = f"Invalid run config '{config}': {ex}"
+        raise PrerequisiteError(message)
     return run_config.to_params()
 
 

--- a/tests/test_eval_config.py
+++ b/tests/test_eval_config.py
@@ -1,3 +1,4 @@
+import os
 import subprocess
 import tempfile
 from pathlib import Path
@@ -160,6 +161,70 @@ eval_config:
         assert log.eval.model_roles["grader"].model == "mockllm/model"
         assert log.eval.model_roles["grader"].config.temperature == 0.5
         assert log.eval.model_roles["grader"].config.max_tokens == 1000
+
+
+def test_eval_run_config_cli_env_var_overridden_by_run_config():
+    """INSPECT_EVAL_MODEL must not override a model set in --run-config."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        log_dir = temp_path / "logs"
+        run_config = temp_path / "run.yaml"
+        run_config.write_text(
+            """
+task: tests/test_eval_config.py@eval_config_task
+model: mockllm/model
+eval_config:
+  limit: 1
+""".strip()
+        )
+
+        subprocess.run(
+            [
+                "inspect",
+                "eval",
+                "--run-config",
+                run_config.as_posix(),
+                "--log-dir",
+                log_dir.as_posix(),
+            ],
+            env={**os.environ, "INSPECT_EVAL_MODEL": "anthropic/claude-sonnet-4-6"},
+            check=True,
+        )
+        log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
+        assert log.eval.model == "mockllm/model"
+
+
+def test_eval_run_config_cli_env_var_overridden_by_explicit_flag():
+    """An explicit --model flag must beat both INSPECT_EVAL_MODEL and --run-config."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        log_dir = temp_path / "logs"
+        run_config = temp_path / "run.yaml"
+        run_config.write_text(
+            """
+task: tests/test_eval_config.py@eval_config_task
+model: mockllm/from_run_config
+eval_config:
+  limit: 1
+""".strip()
+        )
+
+        subprocess.run(
+            [
+                "inspect",
+                "eval",
+                "--run-config",
+                run_config.as_posix(),
+                "--model",
+                "mockllm/from_cli",
+                "--log-dir",
+                log_dir.as_posix(),
+            ],
+            env={**os.environ, "INSPECT_EVAL_MODEL": "mockllm/from_env"},
+            check=True,
+        )
+        log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
+        assert log.eval.model == "mockllm/from_cli"
 
 
 def test_eval_run_config_cli_paper_config():

--- a/tests/test_eval_config.py
+++ b/tests/test_eval_config.py
@@ -227,6 +227,56 @@ eval_config:
         assert log.eval.model == "mockllm/from_cli"
 
 
+def test_eval_run_config_cli_env_var_used_when_run_config_missing_field():
+    """INSPECT_EVAL_MODEL still applies when --run-config doesn't set `model`."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp_path = Path(temp_dir)
+        log_dir = temp_path / "logs"
+        run_config = temp_path / "run.yaml"
+        # run config provides task + eval_config but NO top-level model
+        run_config.write_text(
+            """
+task: tests/test_eval_config.py@eval_config_task
+eval_config:
+  limit: 1
+""".strip()
+        )
+
+        # Defeat VSCode-mode .env override (inspect's init_dotenv uses
+        # override=True when TERM_PROGRAM=vscode, which would overwrite
+        # INSPECT_EVAL_MODEL from the repo .env and mask the env value
+        # this test is checking).
+        test_env = {
+            k: v
+            for k, v in os.environ.items()
+            if k
+            not in (
+                "VSCODE_IPYTHON_KERNEL",
+                "VSCODE_CLI_REQUIRE_TOKEN",
+                "VSCODE_PID",
+                "VSCODE_CWD",
+            )
+        }
+        if test_env.get("TERM_PROGRAM") == "vscode":
+            test_env["TERM_PROGRAM"] = "xterm"
+        test_env["INSPECT_EVAL_MODEL"] = "mockllm/from_env"
+
+        subprocess.run(
+            [
+                "inspect",
+                "eval",
+                "--run-config",
+                run_config.as_posix(),
+                "--log-dir",
+                log_dir.as_posix(),
+            ],
+            env=test_env,
+            check=True,
+        )
+        log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
+        assert log.eval.model == "mockllm/from_env"
+
+
 def test_eval_run_config_cli_paper_config():
     """Task and model supplied on CLI; run config provides the rest (the 'paper config' use case)."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
- use draft7validator for clearer error message
- run config values override environment variables.
