### PR TITLE
fix: warn when model output is truncated by token limit

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -942,7 +942,7 @@ class Model:
         )
         from inspect_ai.hooks._legacy import send_telemetry_legacy
         from inspect_ai.log._refusal import report_refusal
-        from inspect_ai.log._samples import track_active_model_event
+        from inspect_ai.log._samples import sample_active, track_active_model_event
 
         # default to 'auto' for tool_choice (same as underlying model apis)
         tool_choice = tool_choice if tool_choice is not None else "auto"
@@ -1225,6 +1225,20 @@ class Model:
         # report refusal
         if not model_output.empty and model_output.stop_reason == "content_filter":
             report_refusal(model_output.completion)
+
+        # warn when the model's output was cut short by a token limit
+        if model_output.stop_reason in ("max_tokens", "model_length"):
+            active = sample_active()
+            sample_info = (
+                f" ({active.task}/{active.id}/{active.epoch})" if active else ""
+            )
+            limit_info = (
+                f" (max_tokens={config.max_tokens})" if config.max_tokens else ""
+            )
+            logger.warning(
+                f"Model output truncated by token limit{sample_info}{limit_info}. "
+                "Increase max_tokens in GenerateConfig if the truncation is unintended."
+            )
 
         # return results
         return model_output, event


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #3582.

When a model call hits its `max_tokens` limit the output is silently truncated. The viewer already surfaces task-level limits (message/token/time) at the sample level, but per-call limits set via `GenerateConfig.max_tokens` produce no visible signal. Users running evals against reasoning models — whose extended-thinking tokens consume the same budget — can unknowingly collect scores from truncated completions that look identical to genuine short answers.

### What is the new behavior?

When the model returns `stop_reason == "max_tokens"` or `"model_length"`, a `logger.warning` is emitted immediately after the generate call:

```
WARNING - Model output truncated by token limit (task/sample_id/epoch) (max_tokens=1024).
          Increase max_tokens in GenerateConfig if the truncation is unintended.
```

The message includes:
- The active sample context (`task / id / epoch`) when called inside a running eval.
- The `max_tokens` value from `GenerateConfig` when it was explicitly set.

The warning flows through the standard Python logging system and appears in the console at the default `WARNING` level. Users who intentionally cap tokens (e.g. to keep cost bounded) can suppress it with `--log-level error` or a logging config filter.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The warning is purely additive. It uses the existing `logger` instance in `_model.py` and follows the same pattern as the existing `content_filter` refusal warning.

### Other information:

Changed file: `src/inspect_ai/model/_model.py` — one import addition and ~12 lines.