### PR TITLE
OpenRouter: enable Anthropic prompt caching for anthropic/* models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 - OpenAI: Add GPT 5.5 as computer use model and exclude 'chat' and 'instant' models from computer use.
 - OpenAI Compatible: Parse OpenRouter-style `reasoning_details` in OpenAI-compatible responses.
-- OpenRouter: Enable Anthropic prompt caching by default for `openrouter/anthropic/*` models via per-block `cache_control` markers (works across Anthropic-direct, Bedrock, and Vertex routing). Cache writes (`cache_creation_input_tokens`) are parsed into `ModelUsage.input_tokens_cache_write`. Set `cache_prompt=False` in `GenerateConfig` to disable.
 - Anthropic: Capture `extra_body` fields from `Message` response.
+- OpenRouter: Enable Anthropic prompt caching by default for `openrouter/anthropic/*` models.
 - VLLM: Preserve dotted vLLM server arg keys.
 - Bedrock: Drop unsupported sampling params for Claude 4.7+.
 - Bedrock: Route `top_k` correctly for Nova models.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Add [run-config](https://inspect.aisi.org.uk/task-configuration.html#run-config) option to `inspect eval` for single-file run configuration. A YAML or JSON file can specify task, model, model roles, generate config, solver, and eval config in one place; explicit CLI flags override values from the file. Mutually exclusive with `--generate-config`, `--task-config`, and `--solver-config`.
 - OpenAI: Add GPT 5.5 as computer use model and exclude 'chat' and 'instant' models from computer use.
 - OpenAI Compatible: Parse OpenRouter-style `reasoning_details` in OpenAI-compatible responses.
+- OpenRouter: Enable Anthropic prompt caching by default for `openrouter/anthropic/*` models via per-block `cache_control` markers (works across Anthropic-direct, Bedrock, and Vertex routing). Cache writes (`cache_creation_input_tokens`) are parsed into `ModelUsage.input_tokens_cache_write`. Set `cache_prompt=False` in `GenerateConfig` to disable.
 - Anthropic: Capture `extra_body` fields from `Message` response.
 - VLLM: Preserve dotted vLLM server arg keys.
 - Bedrock: Drop unsupported sampling params for Claude 4.7+.

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1269,9 +1269,11 @@ For the `openrouter` provider, the following custom model args (`-M`) are suppor
 
 In addition, [Tool Emulation](#tool-emulation-openai) is available for models that don't yet support tool calling in their API.
 
-For `openrouter/anthropic/*` models, Anthropic [prompt caching](https://docs.claude.com/en/docs/build-with-claude/prompt-caching) is enabled by default: per-block `cache_control` markers are inserted on the last system block, the last tool definition, and a rolling pair of message-level breakpoints (mirroring the placement used by the direct `anthropic` provider). The markers are accepted by OpenRouter across Anthropic-direct, Bedrock, and Vertex routing. Cache writes returned upstream are surfaced as `ModelUsage.input_tokens_cache_write`. Pass `--cache-prompt=false` (or set `cache_prompt=False` in `GenerateConfig`) to disable.
+For `openrouter/anthropic/*` models, Anthropic [prompt caching](https://docs.claude.com/en/docs/build-with-claude/prompt-caching) is enabled by default: per-block `cache_control` markers are inserted on the last system block, the last tool definition, and a rolling pair of message-level breakpoints (mirroring the placement used by the direct `anthropic` provider). The markers are accepted by OpenRouter across Anthropic-direct, Bedrock, and Vertex routing. Cache writes returned upstream are surfaced as `ModelUsage.input_tokens_cache_write`. Pass `--cache-prompt=false` (or set `cache_prompt=False` in `GenerateConfig`) to disable. Single-turn evaluations that never re-issue the same prefix pay a small premium (Anthropic charges ~1.25× for cache writes) with no offsetting cache reads — disable caching for those workloads.
 
 Note that OpenRouter may distribute consecutive requests for the same model across multiple Anthropic-compatible backends (Anthropic-direct, Bedrock, Vertex), and each backend maintains its own prompt cache. To maximise the cache hit rate across a multi-turn run, pin routing to a single backend via the `provider` model-arg, for example `-M provider='{"order":["anthropic"],"allow_fallbacks":false}'`.
+
+The `cache_control` markers are injected just before the request reaches OpenRouter and so will not appear in the request snapshot recorded in `.eval` log files. Verify caching is active by inspecting the usage line (cache reads/writes) on returned `ModelOutput`s.
 
 The following environment variables are supported by the OpenRouter AI provider
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1269,6 +1269,10 @@ For the `openrouter` provider, the following custom model args (`-M`) are suppor
 
 In addition, [Tool Emulation](#tool-emulation-openai) is available for models that don't yet support tool calling in their API.
 
+For `openrouter/anthropic/*` models, Anthropic [prompt caching](https://docs.claude.com/en/docs/build-with-claude/prompt-caching) is enabled by default: per-block `cache_control` markers are inserted on the last system block, the last tool definition, and a rolling pair of message-level breakpoints (mirroring the placement used by the direct `anthropic` provider). The markers are accepted by OpenRouter across Anthropic-direct, Bedrock, and Vertex routing. Cache writes returned upstream are surfaced as `ModelUsage.input_tokens_cache_write`. Pass `--cache-prompt=false` (or set `cache_prompt=False` in `GenerateConfig`) to disable.
+
+Note that OpenRouter may distribute consecutive requests for the same model across multiple Anthropic-compatible backends (Anthropic-direct, Bedrock, Vertex), and each backend maintains its own prompt cache. To maximise the cache hit rate across a multi-turn run, pin routing to a single backend via the `provider` model-arg, for example `-M provider='{"order":["anthropic"],"allow_fallbacks":false}'`.
+
 The following environment variables are supported by the OpenRouter AI provider
 
 | Variable | Description |

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -15,7 +15,8 @@ from inspect_ai._util.logger import warn_once
 from inspect_ai.model import _openrouter_reasoning
 from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._model import RetryDecision
-from inspect_ai.model._model_output import ChatCompletionChoice
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ChatCompletionChoice, ModelOutput
 from inspect_ai.model._openai import (
     CompletionsReasoningContent,
     OpenAIResponseError,
@@ -25,6 +26,7 @@ from inspect_ai.model._openai import (
 from inspect_ai.model._reasoning import (
     reasoning_to_think_tag,
 )
+from inspect_ai.tool import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
 
 from .._generate_config import GenerateConfig
@@ -68,6 +70,18 @@ class OpenRouterError(Exception):
 
 
 class OpenRouterAPI(OpenAICompatibleAPI):
+    """OpenAI-compatible client for the OpenRouter inference router.
+
+    For `openrouter/anthropic/*` models, Anthropic prompt caching is enabled
+    by default: this provider inserts per-block `cache_control: {"type":
+    "ephemeral"}` markers on the last system block, the last tool definition,
+    and a rolling pair of message-level breakpoints (mirroring the placement
+    used by the direct Anthropic provider). The markers are accepted by
+    OpenRouter across Anthropic-direct, Bedrock, and Vertex routing. Set
+    `cache_prompt=False` in `GenerateConfig` to disable. Cache writes returned
+    by the upstream provider are surfaced as `ModelUsage.input_tokens_cache_write`.
+    """
+
     def __init__(
         self,
         model_name: str,
@@ -246,6 +260,52 @@ class OpenRouterAPI(OpenAICompatibleAPI):
             )
 
     @override
+    async def generate(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
+        # Delegate to the OpenAI-compatible base and post-process usage to
+        # surface Anthropic-style cache_creation_input_tokens (which OpenRouter
+        # passes through for Anthropic-routed models but the base does not parse).
+        result = await super().generate(input, tools, tool_choice, config)
+        if isinstance(result, tuple):
+            output, call = result
+            if isinstance(output, ModelOutput):
+                _apply_cache_creation_usage(output, call)
+        return result
+
+    async def _generate_completion(
+        self, request: dict[str, Any], config: GenerateConfig
+    ) -> ChatCompletion:
+        # Inject Anthropic per-block cache_control markers when routing to
+        # an anthropic/* model. OpenRouter forwards these markers to all
+        # Anthropic-compatible backends (Anthropic-direct, Bedrock, Vertex).
+        if self._cache_prompt_enabled(config):
+            _add_anthropic_cache_markers(request)
+        return await super()._generate_completion(request, config)
+
+    def _cache_prompt_enabled(self, config: GenerateConfig) -> bool:
+        # service_model_name() may not strip the "openrouter/" prefix because
+        # self.service is mixed-case ("OpenRouter") while user-supplied model
+        # names are lowercase — fall back to manual prefix-strip.
+        name = self.service_model_name().removeprefix("openrouter/")
+        if not name.startswith("anthropic/"):
+            return False
+        cache_prompt = (
+            config.cache_prompt if isinstance(config.cache_prompt, bool) else True
+        )
+        if not cache_prompt:
+            return False
+        # Mirror the legacy-Claude gate from the direct anthropic provider.
+        bare = name.split(":", 1)[0]
+        if "claude-3-sonnet" in bare or "claude-2" in bare or "claude-instant" in bare:
+            return False
+        return True
+
+    @override
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         # default params
         params = super().completion_params(config, tools)
@@ -291,3 +351,105 @@ class OpenRouterAPI(OpenAICompatibleAPI):
                 params[EXTRA_BODY]["reasoning"] = reasoning
 
         return params
+
+
+def _ephemeral() -> dict[str, str]:
+    return {"type": "ephemeral"}
+
+
+def _add_anthropic_cache_markers(request: dict[str, Any]) -> None:
+    """Insert Anthropic per-block cache_control markers in an OpenAI-format request.
+
+    Mirrors the breakpoint placement used by inspect_ai's direct anthropic
+    provider: last system block, last tool definition, and the penultimate
+    content block of the last message (with fallback to the last block of the
+    previous message when the last message has fewer than 2 blocks). Anthropic
+    enforces a maximum of 4 cache_control breakpoints per request; this scheme
+    uses at most 3.
+
+    Note: the OpenAI-compatible base snapshots the ModelCall request before
+    _generate_completion runs, so cache_control markers will NOT appear in the
+    request as logged to ``.eval`` files even when they are sent on the wire.
+    Verify caching via the returned usage line (CW/CR > 0) or the OpenRouter
+    dashboard's Generation viewer, not the Inspect log.
+    """
+    messages = request.get("messages")
+    if isinstance(messages, list) and messages:
+        # mark the last system message's last content block
+        for msg in reversed(messages):
+            if isinstance(msg, dict) and msg.get("role") == "system":
+                _mark_last_content_block(msg)
+                break
+
+        # mark a rolling pair of message-level breakpoints. auto-cache marks the
+        # last block; this gives lookback a fallback when the final block changes.
+        last = messages[-1]
+        if isinstance(last, dict):
+            last_content = last.get("content")
+            if isinstance(last_content, list) and len(last_content) >= 2:
+                _mark_block(last_content[-2])
+            elif len(messages) >= 2:
+                prev = messages[-2]
+                if isinstance(prev, dict):
+                    _mark_last_content_block(prev)
+
+    # mark the last tool definition (cache_control at the top of the tool dict,
+    # alongside "type": "function" — OpenRouter forwards this through to
+    # Anthropic's tool param where the marker lives at the same logical level).
+    tools = request.get("tools")
+    if isinstance(tools, list) and tools:
+        last_tool = tools[-1]
+        if isinstance(last_tool, dict):
+            cast(dict[str, Any], last_tool)["cache_control"] = _ephemeral()
+
+
+def _mark_last_content_block(msg: dict[str, Any]) -> None:
+    """Mark the last content block of a message with cache_control.
+
+    If content is a plain string, convert to a single-block list so we can
+    attach the marker.
+    """
+    content = msg.get("content")
+    if isinstance(content, list) and content:
+        last_block = content[-1]
+        if isinstance(last_block, dict):
+            _mark_block(last_block)
+    elif isinstance(content, str) and content:
+        msg["content"] = [
+            {"type": "text", "text": content, "cache_control": _ephemeral()}
+        ]
+
+
+def _mark_block(block: dict[str, Any]) -> None:
+    block["cache_control"] = _ephemeral()
+
+
+def _apply_cache_creation_usage(output: ModelOutput, call: ModelCall | None) -> None:
+    """Surface Anthropic's cache_creation_input_tokens in ModelUsage.
+
+    OpenRouter passes this field through on the raw response usage object for
+    Anthropic-routed models; the OpenAI-compatible base does not parse it.
+    Mirrors the input_tokens accounting convention used by the base for cache
+    reads: the count is subtracted from input_tokens so the usage line reads
+    `input + cache_write + cache_read = total tokens charged this turn`.
+    """
+    if call is None or output.usage is None:
+        return
+    raw = call.response if isinstance(call.response, dict) else None
+    if not raw:
+        return
+    usage = raw.get("usage")
+    if not isinstance(usage, dict):
+        return
+    # OpenRouter surfaces cache-write counts under
+    # prompt_tokens_details.cache_write_tokens (OpenAI-extension shape);
+    # also accept cache_creation_input_tokens for safety in case a future
+    # upstream switches to the Anthropic-native key at the top of usage.
+    ptd = usage.get("prompt_tokens_details")
+    cw = usage.get("cache_creation_input_tokens")
+    if (not isinstance(cw, int) or cw <= 0) and isinstance(ptd, dict):
+        cw = ptd.get("cache_write_tokens")
+    if not isinstance(cw, int) or cw <= 0:
+        return
+    output.usage.input_tokens_cache_write = cw
+    output.usage.input_tokens = max(0, output.usage.input_tokens - cw)

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -277,6 +277,7 @@ class OpenRouterAPI(OpenAICompatibleAPI):
                 _apply_cache_creation_usage(output, call)
         return result
 
+    @override
     async def _generate_completion(
         self, request: dict[str, Any], config: GenerateConfig
     ) -> ChatCompletion:
@@ -288,16 +289,15 @@ class OpenRouterAPI(OpenAICompatibleAPI):
         return await super()._generate_completion(request, config)
 
     def _cache_prompt_enabled(self, config: GenerateConfig) -> bool:
-        # service_model_name() may not strip the "openrouter/" prefix because
-        # self.service is mixed-case ("OpenRouter") while user-supplied model
-        # names are lowercase — fall back to manual prefix-strip.
+        # service_model_name() does case-sensitive prefix-strip against
+        # self.service ("OpenRouter"), so it does NOT remove the lowercase
+        # "openrouter/" prefix from user-supplied model names. Strip manually.
         name = self.service_model_name().removeprefix("openrouter/")
         if not name.startswith("anthropic/"):
             return False
-        cache_prompt = (
-            config.cache_prompt if isinstance(config.cache_prompt, bool) else True
-        )
-        if not cache_prompt:
+        # Matches direct anthropic provider: only explicit False disables;
+        # None, True, and "auto" all enable.
+        if config.cache_prompt is False:
             return False
         # Mirror the legacy-Claude gate from the direct anthropic provider.
         bare = name.split(":", 1)[0]
@@ -375,7 +375,8 @@ def _add_anthropic_cache_markers(request: dict[str, Any]) -> None:
     """
     messages = request.get("messages")
     if isinstance(messages, list) and messages:
-        # mark the last system message's last content block
+        # mark the last system message's last content block (string-content
+        # system messages are safe to convert to list form)
         for msg in reversed(messages):
             if isinstance(msg, dict) and msg.get("role") == "system":
                 _mark_last_content_block(msg)
@@ -383,45 +384,49 @@ def _add_anthropic_cache_markers(request: dict[str, Any]) -> None:
 
         # mark a rolling pair of message-level breakpoints. auto-cache marks the
         # last block; this gives lookback a fallback when the final block changes.
+        # In the fallback branch we deliberately do NOT convert string-content
+        # to list form (mirroring anthropic.py:1208-1211): the previous message
+        # may be a role:"tool" message whose string content must stay a string
+        # for upstream tool_result translation.
         last = messages[-1]
         if isinstance(last, dict):
             last_content = last.get("content")
             if isinstance(last_content, list) and len(last_content) >= 2:
-                _mark_block(last_content[-2])
+                last_content[-2]["cache_control"] = _ephemeral()
             elif len(messages) >= 2:
                 prev = messages[-2]
                 if isinstance(prev, dict):
-                    _mark_last_content_block(prev)
+                    prev_content = prev.get("content")
+                    if isinstance(prev_content, list) and prev_content:
+                        last_block = prev_content[-1]
+                        if isinstance(last_block, dict):
+                            last_block["cache_control"] = _ephemeral()
 
     # mark the last tool definition (cache_control at the top of the tool dict,
-    # alongside "type": "function" — OpenRouter forwards this through to
-    # Anthropic's tool param where the marker lives at the same logical level).
+    # alongside "type": "function" — empirically verified against OpenRouter;
+    # nesting inside tool["function"] is silently tokenized as schema content).
     tools = request.get("tools")
     if isinstance(tools, list) and tools:
         last_tool = tools[-1]
         if isinstance(last_tool, dict):
-            cast(dict[str, Any], last_tool)["cache_control"] = _ephemeral()
+            last_tool["cache_control"] = _ephemeral()
 
 
 def _mark_last_content_block(msg: dict[str, Any]) -> None:
     """Mark the last content block of a message with cache_control.
 
     If content is a plain string, convert to a single-block list so we can
-    attach the marker.
+    attach the marker. Only safe for system messages — see caller.
     """
     content = msg.get("content")
     if isinstance(content, list) and content:
         last_block = content[-1]
         if isinstance(last_block, dict):
-            _mark_block(last_block)
+            last_block["cache_control"] = _ephemeral()
     elif isinstance(content, str) and content:
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": _ephemeral()}
         ]
-
-
-def _mark_block(block: dict[str, Any]) -> None:
-    block["cache_control"] = _ephemeral()
 
 
 def _apply_cache_creation_usage(output: ModelOutput, call: ModelCall | None) -> None:
@@ -436,20 +441,20 @@ def _apply_cache_creation_usage(output: ModelOutput, call: ModelCall | None) -> 
     if call is None or output.usage is None:
         return
     raw = call.response if isinstance(call.response, dict) else None
-    if not raw:
-        return
-    usage = raw.get("usage")
+    usage = raw.get("usage") if raw else None
     if not isinstance(usage, dict):
         return
-    # OpenRouter surfaces cache-write counts under
-    # prompt_tokens_details.cache_write_tokens (OpenAI-extension shape);
-    # also accept cache_creation_input_tokens for safety in case a future
-    # upstream switches to the Anthropic-native key at the top of usage.
-    ptd = usage.get("prompt_tokens_details")
+    # Prefer Anthropic-native key for future-proofing; fall back to the
+    # OpenAI-extension shape that OpenRouter currently uses in practice.
     cw = usage.get("cache_creation_input_tokens")
-    if (not isinstance(cw, int) or cw <= 0) and isinstance(ptd, dict):
-        cw = ptd.get("cache_write_tokens")
     if not isinstance(cw, int) or cw <= 0:
+        ptd = usage.get("prompt_tokens_details")
+        cw = ptd.get("cache_write_tokens") if isinstance(ptd, dict) else None
+    if not isinstance(cw, int) or cw <= 0:
+        return
+    # Guard against double-application (e.g. if a future base parses cache
+    # writes natively): only set when the field hasn't been populated yet.
+    if output.usage.input_tokens_cache_write is not None:
         return
     output.usage.input_tokens_cache_write = cw
     output.usage.input_tokens = max(0, output.usage.input_tokens - cw)

--- a/tests/model/providers/test_openrouter.py
+++ b/tests/model/providers/test_openrouter.py
@@ -20,6 +20,28 @@ def _has_cache_control(block: Any) -> bool:
     return isinstance(block, dict) and block.get("cache_control") == EPHEMERAL
 
 
+def _make_api(model_name: str, **kwargs: Any) -> OpenRouterAPI:
+    return OpenRouterAPI(model_name=model_name, api_key="test-key", **kwargs)
+
+
+def _make_output(
+    input_tokens: int = 500,
+    output_tokens: int = 20,
+    total_tokens: int = 520,
+    input_tokens_cache_read: int | None = None,
+) -> ModelOutput:
+    return ModelOutput(
+        model="claude-sonnet-4-5",
+        choices=[],
+        usage=ModelUsage(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total_tokens,
+            input_tokens_cache_read=input_tokens_cache_read,
+        ),
+    )
+
+
 def test_add_cache_markers_system_tool_and_penultimate_block() -> None:
     """System + tools + multi-block last user message: 3 markers placed."""
     request: dict[str, Any] = {
@@ -109,6 +131,35 @@ def test_add_cache_markers_string_content_converted_to_list() -> None:
     assert sys_content[0]["cache_control"] == EPHEMERAL
 
 
+def test_add_cache_markers_fallback_does_not_convert_string_content() -> None:
+    """Fallback branch must NOT convert string content on the previous message.
+
+    Mirrors `anthropic.py:1208-1211`: when the last message has fewer than 2
+    blocks and we fall back to marking the previous message, the previous
+    message's string content must stay a string (it may be a `role:"tool"`
+    message whose content shape matters for upstream tool_result translation).
+    """
+    request: dict[str, Any] = {
+        "messages": [
+            {"role": "user", "content": "do the thing"},
+            {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "calling tool"}],
+                "tool_calls": [{"id": "call_1"}],
+            },
+            {"role": "tool", "tool_call_id": "call_1", "content": "tool result"},
+            {"role": "user", "content": "thanks"},
+        ]
+    }
+
+    _add_anthropic_cache_markers(request)
+
+    # the previous (tool) message's string content must remain a string
+    assert request["messages"][2]["content"] == "tool result"
+    # and no marker is placed on it (fallback only marks list content)
+    assert "cache_control" not in request["messages"][2]
+
+
 def test_add_cache_markers_single_message_no_marker() -> None:
     """Single message with single block (no previous message) → no marker placed."""
     request: dict[str, Any] = {
@@ -126,10 +177,6 @@ def test_add_cache_markers_no_tools_no_messages() -> None:
     request: dict[str, Any] = {}
     _add_anthropic_cache_markers(request)
     assert request == {}
-
-
-def _make_api(model_name: str, **kwargs: Any) -> OpenRouterAPI:
-    return OpenRouterAPI(model_name=model_name, api_key="test-key", **kwargs)
 
 
 def test_cache_prompt_enabled_for_anthropic_model_by_default() -> None:
@@ -153,6 +200,12 @@ def test_cache_prompt_disabled_when_config_false() -> None:
     assert api._cache_prompt_enabled(GenerateConfig(cache_prompt=False)) is False
 
 
+def test_cache_prompt_enabled_when_config_auto() -> None:
+    """`cache_prompt="auto"` enables caching (matches direct anthropic provider)."""
+    api = _make_api("openrouter/anthropic/claude-sonnet-4-5")
+    assert api._cache_prompt_enabled(GenerateConfig(cache_prompt="auto")) is True
+
+
 @pytest.mark.parametrize(
     "model",
     [
@@ -167,16 +220,7 @@ def test_cache_prompt_disabled_for_legacy_claude(model: str) -> None:
 
 
 def test_apply_cache_creation_usage_sets_write_and_adjusts_input() -> None:
-    output = ModelOutput(
-        model="claude-sonnet-4-5",
-        choices=[],
-        usage=ModelUsage(
-            input_tokens=500,
-            output_tokens=20,
-            total_tokens=520,
-            input_tokens_cache_read=100,
-        ),
-    )
+    output = _make_output(input_tokens_cache_read=100)
     call = ModelCall(
         request={}, response={"usage": {"cache_creation_input_tokens": 80}}
     )
@@ -196,16 +240,7 @@ def test_apply_cache_creation_usage_reads_openrouter_shape() -> None:
     OpenAI-extension shape rather than Anthropic's native `cache_creation_input_tokens`
     key, so the helper must read both.
     """
-    output = ModelOutput(
-        model="claude-sonnet-4-5",
-        choices=[],
-        usage=ModelUsage(
-            input_tokens=500,
-            output_tokens=20,
-            total_tokens=520,
-            input_tokens_cache_read=100,
-        ),
-    )
+    output = _make_output(input_tokens_cache_read=100)
     call = ModelCall(
         request={},
         response={"usage": {"prompt_tokens_details": {"cache_write_tokens": 80}}},
@@ -220,11 +255,7 @@ def test_apply_cache_creation_usage_reads_openrouter_shape() -> None:
 
 def test_apply_cache_creation_usage_prefers_anthropic_native_key() -> None:
     """When both shapes are present, the Anthropic-native key wins (future-proofing)."""
-    output = ModelOutput(
-        model="claude-sonnet-4-5",
-        choices=[],
-        usage=ModelUsage(input_tokens=500, output_tokens=20, total_tokens=520),
-    )
+    output = _make_output()
     call = ModelCall(
         request={},
         response={
@@ -242,11 +273,7 @@ def test_apply_cache_creation_usage_prefers_anthropic_native_key() -> None:
 
 
 def test_apply_cache_creation_usage_noop_when_field_missing() -> None:
-    output = ModelOutput(
-        model="claude-sonnet-4-5",
-        choices=[],
-        usage=ModelUsage(input_tokens=500, output_tokens=20, total_tokens=520),
-    )
+    output = _make_output()
     call = ModelCall(request={}, response={"usage": {"prompt_tokens": 500}})
 
     _apply_cache_creation_usage(output, call)
@@ -257,11 +284,7 @@ def test_apply_cache_creation_usage_noop_when_field_missing() -> None:
 
 
 def test_apply_cache_creation_usage_noop_when_no_call() -> None:
-    output = ModelOutput(
-        model="claude-sonnet-4-5",
-        choices=[],
-        usage=ModelUsage(input_tokens=500, output_tokens=20, total_tokens=520),
-    )
+    output = _make_output()
 
     _apply_cache_creation_usage(output, None)
 

--- a/tests/model/providers/test_openrouter.py
+++ b/tests/model/providers/test_openrouter.py
@@ -1,0 +1,270 @@
+"""Tests for the OpenRouter provider's Anthropic prompt-caching support."""
+
+from typing import Any
+
+import pytest
+
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput, ModelUsage
+from inspect_ai.model._providers.openrouter import (
+    OpenRouterAPI,
+    _add_anthropic_cache_markers,
+    _apply_cache_creation_usage,
+)
+
+EPHEMERAL: dict[str, str] = {"type": "ephemeral"}
+
+
+def _has_cache_control(block: Any) -> bool:
+    return isinstance(block, dict) and block.get("cache_control") == EPHEMERAL
+
+
+def test_add_cache_markers_system_tool_and_penultimate_block() -> None:
+    """System + tools + multi-block last user message: 3 markers placed."""
+    request: dict[str, Any] = {
+        "messages": [
+            {
+                "role": "system",
+                "content": [
+                    {"type": "text", "text": "system part 1"},
+                    {"type": "text", "text": "system part 2"},
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "user block 0"},
+                    {"type": "text", "text": "user block 1"},
+                    {"type": "text", "text": "user block 2"},
+                ],
+            },
+        ],
+        "tools": [
+            {"type": "function", "function": {"name": "a"}},
+            {"type": "function", "function": {"name": "b"}},
+        ],
+    }
+
+    _add_anthropic_cache_markers(request)
+
+    # last system block marked
+    assert _has_cache_control(request["messages"][0]["content"][-1])
+    assert "cache_control" not in request["messages"][0]["content"][0]
+    # penultimate block of last (user) message marked
+    user_blocks = request["messages"][1]["content"]
+    assert _has_cache_control(user_blocks[-2])  # block 1 (penultimate)
+    assert "cache_control" not in user_blocks[-1]  # auto-cache covers the last
+    assert "cache_control" not in user_blocks[0]
+    # last tool marked at top level (alongside "type": "function")
+    assert request["tools"][1]["cache_control"] == EPHEMERAL
+    assert "cache_control" not in request["tools"][0]
+
+
+def test_add_cache_markers_fallback_to_previous_message() -> None:
+    """Single-block last message → mark the last block of the previous message."""
+    request: dict[str, Any] = {
+        "messages": [
+            {"role": "user", "content": "earlier context"},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "reply part 1"},
+                    {"type": "text", "text": "reply part 2"},
+                ],
+            },
+            {"role": "user", "content": "follow-up"},
+        ]
+    }
+
+    _add_anthropic_cache_markers(request)
+
+    # last block of the previous (assistant) message marked
+    assistant_blocks = request["messages"][1]["content"]
+    assert _has_cache_control(assistant_blocks[-1])
+    assert "cache_control" not in assistant_blocks[0]
+
+
+def test_add_cache_markers_string_content_converted_to_list() -> None:
+    """String-content system message gets converted to a single-block list with marker."""
+    request: dict[str, Any] = {
+        "messages": [
+            {"role": "system", "content": "you are helpful"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "block 0"},
+                    {"type": "text", "text": "block 1"},
+                ],
+            },
+        ]
+    }
+
+    _add_anthropic_cache_markers(request)
+
+    sys_content = request["messages"][0]["content"]
+    assert isinstance(sys_content, list)
+    assert len(sys_content) == 1
+    assert sys_content[0]["text"] == "you are helpful"
+    assert sys_content[0]["cache_control"] == EPHEMERAL
+
+
+def test_add_cache_markers_single_message_no_marker() -> None:
+    """Single message with single block (no previous message) → no marker placed."""
+    request: dict[str, Any] = {
+        "messages": [{"role": "user", "content": "lone message"}]
+    }
+
+    _add_anthropic_cache_markers(request)
+
+    # content stays as a string (no list conversion since nothing to mark)
+    assert request["messages"][0]["content"] == "lone message"
+
+
+def test_add_cache_markers_no_tools_no_messages() -> None:
+    """Empty/missing fields handled without error."""
+    request: dict[str, Any] = {}
+    _add_anthropic_cache_markers(request)
+    assert request == {}
+
+
+def _make_api(model_name: str, **kwargs: Any) -> OpenRouterAPI:
+    return OpenRouterAPI(model_name=model_name, api_key="test-key", **kwargs)
+
+
+def test_cache_prompt_enabled_for_anthropic_model_by_default() -> None:
+    api = _make_api("openrouter/anthropic/claude-sonnet-4-5")
+    assert api._cache_prompt_enabled(GenerateConfig()) is True
+
+
+def test_cache_prompt_enabled_handles_openrouter_suffix() -> None:
+    """`:thinking` and similar suffixes don't break the gating."""
+    api = _make_api("openrouter/anthropic/claude-opus-4.1:thinking")
+    assert api._cache_prompt_enabled(GenerateConfig()) is True
+
+
+def test_cache_prompt_disabled_for_non_anthropic_model() -> None:
+    api = _make_api("openrouter/openai/gpt-4o-mini")
+    assert api._cache_prompt_enabled(GenerateConfig()) is False
+
+
+def test_cache_prompt_disabled_when_config_false() -> None:
+    api = _make_api("openrouter/anthropic/claude-sonnet-4-5")
+    assert api._cache_prompt_enabled(GenerateConfig(cache_prompt=False)) is False
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "openrouter/anthropic/claude-3-sonnet-20240229",
+        "openrouter/anthropic/claude-2.1",
+        "openrouter/anthropic/claude-instant-1.2",
+    ],
+)
+def test_cache_prompt_disabled_for_legacy_claude(model: str) -> None:
+    api = _make_api(model)
+    assert api._cache_prompt_enabled(GenerateConfig()) is False
+
+
+def test_apply_cache_creation_usage_sets_write_and_adjusts_input() -> None:
+    output = ModelOutput(
+        model="claude-sonnet-4-5",
+        choices=[],
+        usage=ModelUsage(
+            input_tokens=500,
+            output_tokens=20,
+            total_tokens=520,
+            input_tokens_cache_read=100,
+        ),
+    )
+    call = ModelCall(
+        request={}, response={"usage": {"cache_creation_input_tokens": 80}}
+    )
+
+    _apply_cache_creation_usage(output, call)
+
+    assert output.usage is not None
+    assert output.usage.input_tokens_cache_write == 80
+    # 500 - 80 = 420 (the base already subtracted cache_read from input_tokens)
+    assert output.usage.input_tokens == 420
+
+
+def test_apply_cache_creation_usage_reads_openrouter_shape() -> None:
+    """OpenRouter surfaces cache writes under prompt_tokens_details.cache_write_tokens.
+
+    Live runs against `openrouter/anthropic/*` returned the cache-write count in
+    OpenAI-extension shape rather than Anthropic's native `cache_creation_input_tokens`
+    key, so the helper must read both.
+    """
+    output = ModelOutput(
+        model="claude-sonnet-4-5",
+        choices=[],
+        usage=ModelUsage(
+            input_tokens=500,
+            output_tokens=20,
+            total_tokens=520,
+            input_tokens_cache_read=100,
+        ),
+    )
+    call = ModelCall(
+        request={},
+        response={"usage": {"prompt_tokens_details": {"cache_write_tokens": 80}}},
+    )
+
+    _apply_cache_creation_usage(output, call)
+
+    assert output.usage is not None
+    assert output.usage.input_tokens_cache_write == 80
+    assert output.usage.input_tokens == 420
+
+
+def test_apply_cache_creation_usage_prefers_anthropic_native_key() -> None:
+    """When both shapes are present, the Anthropic-native key wins (future-proofing)."""
+    output = ModelOutput(
+        model="claude-sonnet-4-5",
+        choices=[],
+        usage=ModelUsage(input_tokens=500, output_tokens=20, total_tokens=520),
+    )
+    call = ModelCall(
+        request={},
+        response={
+            "usage": {
+                "cache_creation_input_tokens": 80,
+                "prompt_tokens_details": {"cache_write_tokens": 999},
+            }
+        },
+    )
+
+    _apply_cache_creation_usage(output, call)
+
+    assert output.usage is not None
+    assert output.usage.input_tokens_cache_write == 80
+
+
+def test_apply_cache_creation_usage_noop_when_field_missing() -> None:
+    output = ModelOutput(
+        model="claude-sonnet-4-5",
+        choices=[],
+        usage=ModelUsage(input_tokens=500, output_tokens=20, total_tokens=520),
+    )
+    call = ModelCall(request={}, response={"usage": {"prompt_tokens": 500}})
+
+    _apply_cache_creation_usage(output, call)
+
+    assert output.usage is not None
+    assert output.usage.input_tokens_cache_write is None
+    assert output.usage.input_tokens == 500
+
+
+def test_apply_cache_creation_usage_noop_when_no_call() -> None:
+    output = ModelOutput(
+        model="claude-sonnet-4-5",
+        choices=[],
+        usage=ModelUsage(input_tokens=500, output_tokens=20, total_tokens=520),
+    )
+
+    _apply_cache_creation_usage(output, None)
+
+    assert output.usage is not None
+    assert output.usage.input_tokens_cache_write is None
+    assert output.usage.input_tokens == 500


### PR DESCRIPTION
## Summary

Inspect's direct `anthropic/` provider enables Anthropic prompt caching by default; the `openrouter/` provider doesn't, so `openrouter/anthropic/*` runs report `CW=0, CR=0` and pay full input-token price every turn on multi-turn evals.

This PR injects per-block `cache_control: {"type": "ephemeral"}` markers on outgoing OpenRouter requests when the model routes to `anthropic/*`, mirroring the breakpoint placement used by the direct anthropic provider (last system block, last tool definition, rolling pair of message-level breakpoints). Per-block markers are accepted across Anthropic-direct, Bedrock, and Vertex routing. Cache writes from upstream are parsed back into `ModelUsage.input_tokens_cache_write`.

Gated on `GenerateConfig.cache_prompt` (default on); pass `--cache-prompt=false` to disable. Legacy Claude models (`claude-3-sonnet`, `claude-2`, `claude-instant`) are excluded to mirror the direct provider.

See the explanatory comment below for validation numbers, the routing caveat, and notes for reviewers.

## Test plan

- [ ] CI green
- [ ] Maintainer review of marker placement and cache-write accounting
- [ ] Optional: live smoke against an `openrouter/anthropic/*` model — expect `CW > 0` on first turn, `CR > 0` on subsequent turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)