### PR TITLE
MCP: Raise ToolError when timeout error occurs in MCP tool call in sandbox

### DIFF
--- a/src/inspect_ai/tool/_mcp/_sandbox.py
+++ b/src/inspect_ai/tool/_mcp/_sandbox.py
@@ -1,12 +1,19 @@
 import sys
 from contextlib import asynccontextmanager
+from logging import getLogger
 from typing import TextIO
 
 import anyio
 from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
 from mcp import JSONRPCRequest, StdioServerParameters
 from mcp.shared.message import SessionMessage
-from mcp.types import JSONRPCMessage, JSONRPCNotification
+from mcp.types import (
+    INTERNAL_ERROR,
+    ErrorData,
+    JSONRPCError,
+    JSONRPCMessage,
+    JSONRPCNotification,
+)
 
 from inspect_ai._util._json_rpc import (
     exec_model_request,
@@ -21,6 +28,8 @@ from inspect_ai.util._sandbox._cli import SANDBOX_CLI
 from inspect_ai.util._sandbox._json_rpc_transport import SandboxJSONRPCTransport
 
 from ._context import MCPServerContext
+
+logger = getLogger(__name__)
 
 
 # Pardon the type: ignore's here. This code is a modified clone of Anthropic code
@@ -68,37 +77,75 @@ async def sandbox_client(  # type: ignore
         pass
 
     async def stdin_writer() -> None:
+        async def send_to_read_stream(item: SessionMessage) -> None:
+            try:
+                await read_stream_writer.send(item)
+            except anyio.ClosedResourceError:
+                await anyio.lowlevel.checkpoint()
+
         try:
             async with write_stream_reader:
                 # This reads messages until the stream is closed
                 async for message in write_stream_reader:
                     root = message.message.root
                     if isinstance(root, JSONRPCRequest):
-                        await read_stream_writer.send(
-                            SessionMessage(
-                                message=await exec_model_request(
-                                    method="mcp_send_request",
-                                    params={
-                                        "session_id": session_id,
-                                        "request": root.model_dump(),
-                                    },
-                                    result_type=JSONRPCMessage,
-                                    transport=transport,
-                                    error_mapper=SandboxToolsErrorMapper,
-                                    timeout=timeout,
+                        try:
+                            response = await exec_model_request(
+                                method="mcp_send_request",
+                                params={
+                                    "session_id": session_id,
+                                    "request": root.model_dump(),
+                                },
+                                result_type=JSONRPCMessage,
+                                transport=transport,
+                                error_mapper=SandboxToolsErrorMapper,
+                                timeout=timeout,
+                            )
+                        except TimeoutError as ex:
+                            # Do not let this propagate: it would collapse the task
+                            # group and cancel the MCP client, which surfaces as a bare
+                            # CancelledError on call_tool. Turn it into a JSON-RPC error
+                            # on the same request id so ClientSession raises McpError and
+                            # _local.py can map it to ToolError.
+                            await send_to_read_stream(
+                                SessionMessage(
+                                    message=JSONRPCMessage(
+                                        JSONRPCError(
+                                            jsonrpc="2.0",
+                                            id=root.id,
+                                            error=ErrorData(
+                                                code=INTERNAL_ERROR,
+                                                message=(
+                                                    "MCP request timed out "
+                                                    f"before completing: {ex}"
+                                                ),
+                                                data=None,
+                                            ),
+                                        )
+                                    )
                                 )
                             )
+                            continue
+                        await send_to_read_stream(
+                            SessionMessage(message=response),
                         )
                     elif isinstance(root, JSONRPCNotification):
-                        await exec_notification(
-                            method="mcp_send_notification",
-                            params={
-                                "session_id": session_id,
-                                "notification": root.model_dump(),
-                            },
-                            transport=transport,
-                            timeout=timeout,
-                        )
+                        try:
+                            await exec_notification(
+                                method="mcp_send_notification",
+                                params={
+                                    "session_id": session_id,
+                                    "notification": root.model_dump(),
+                                },
+                                transport=transport,
+                                timeout=timeout,
+                            )
+                        except TimeoutError as ex:
+                            logger.warning(
+                                "Sandbox MCP notification dropped after transport "
+                                "timeout: %s",
+                                ex,
+                            )
                     else:
                         assert False, f"Unexpected message type {message=}"
 

--- a/tests/tools/test_mcp_tools.py
+++ b/tests/tools/test_mcp_tools.py
@@ -69,25 +69,38 @@ async def test_mcp_filter():
 
 @skip_if_no_mcp_package
 async def test_mcp_tool_call_timeout_becomes_tool_error():
-    """A timeout in the underlying transport should surface as ToolError.
+    """A sandbox-style transport timeout should surface as ToolError.
 
-    Regression test: previously a TimeoutError raised by the sandbox MCP
-    transport (or similar) bubbled up to the top of the sample stack
-    instead of being converted to a ToolError visible to the model.
+    Sandbox MCP must not raise TimeoutError from the writer task: that collapses
+    the task group and the client sees CancelledError. Instead the writer sends
+    a JSON-RPC error for the pending request (see ``sandbox_client``); the MCP
+    client raises ``McpError``, which ``_local.py`` maps to ``ToolError``.
     """
     from anyio.streams.memory import (
         MemoryObjectReceiveStream,
         MemoryObjectSendStream,
     )
-    from mcp.types import JSONRPCRequest
+    from mcp.shared.message import SessionMessage
+    from mcp.types import (
+        INTERNAL_ERROR,
+        ErrorData,
+        InitializeResult,
+        Implementation,
+        JSONRPCError,
+        JSONRPCMessage,
+        JSONRPCNotification,
+        JSONRPCRequest,
+        JSONRPCResponse,
+        LATEST_PROTOCOL_VERSION,
+        ServerCapabilities,
+    )
     from mcp.types import Tool as MCPTool
 
     from inspect_ai.tool._mcp._local import MCPServerLocalSession
 
     @contextlib.asynccontextmanager
     async def timing_out_client() -> AsyncIterator[Any]:
-        # Mirrors the structure of sandbox_client: a task group with a
-        # writer task that raises TimeoutError when forwarding requests.
+        # Mirrors sandbox_client: writer forwards or injects JSON-RPC errors.
         read_stream_writer: MemoryObjectSendStream
         read_stream: MemoryObjectReceiveStream
         write_stream: MemoryObjectSendStream
@@ -100,9 +113,52 @@ async def test_mcp_tool_call_timeout_becomes_tool_error():
             try:
                 async with write_stream_reader:
                     async for message in write_stream_reader:
-                        if isinstance(message.message.root, JSONRPCRequest):
-                            await anyio.sleep(0.05)
-                            raise TimeoutError("simulated transport timeout")
+                        root = message.message.root
+                        if isinstance(root, JSONRPCRequest):
+                            if root.method == "initialize":
+                                init = InitializeResult(
+                                    protocolVersion=LATEST_PROTOCOL_VERSION,
+                                    capabilities=ServerCapabilities(),
+                                    serverInfo=Implementation(name="test", version="1"),
+                                )
+                                await read_stream_writer.send(
+                                    SessionMessage(
+                                        message=JSONRPCMessage(
+                                            JSONRPCResponse(
+                                                jsonrpc="2.0",
+                                                id=root.id,
+                                                result=init.model_dump(
+                                                    by_alias=True, exclude_none=True
+                                                ),
+                                            )
+                                        )
+                                    )
+                                )
+                            elif root.method == "tools/call":
+                                await anyio.sleep(0.05)
+                                await read_stream_writer.send(
+                                    SessionMessage(
+                                        message=JSONRPCMessage(
+                                            JSONRPCError(
+                                                jsonrpc="2.0",
+                                                id=root.id,
+                                                error=ErrorData(
+                                                    code=INTERNAL_ERROR,
+                                                    message="simulated transport timeout",
+                                                    data=None,
+                                                ),
+                                            )
+                                        )
+                                    )
+                                )
+                            else:
+                                pytest.fail(
+                                    f"unexpected JSON-RPC method {root.method!r}"
+                                )
+                        elif isinstance(root, JSONRPCNotification):
+                            pass
+                        else:
+                            pytest.fail(f"unexpected message type {message!r}")
             except anyio.ClosedResourceError:
                 pass
 
@@ -125,8 +181,17 @@ async def test_mcp_tool_call_timeout_becomes_tool_error():
     )
     tool_def = session._tool_def_from_mcp_tool(fake_tool)
 
-    with pytest.raises(ToolError, match="slow_tool.*timed out"):
+    def _flatten(exc: BaseException) -> list[BaseException]:
+        if isinstance(exc, BaseExceptionGroup):
+            return [leaf for sub in exc.exceptions for leaf in _flatten(sub)]
+        return [exc]
+
+    with pytest.raises(BaseExceptionGroup) as exc_info:
         await tool_def.tool()
+    assert any(
+        isinstance(exc, ToolError) and "simulated transport timeout" in str(exc)
+        for exc in _flatten(exc_info.value)
+    )
 
 
 @skip_if_no_mcp_package


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Agents using MCP calls that result in servers being executed in a sandbox results in TimeoutErrors not being passed back to the tool.

### What is the new behavior?

The TimeoutError is now caught, and passed back to the tool to be raised as a ToolError, so the model can react to this and proceed.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.