### PR TITLE
fix(tests): move max_messages off GenerateConfig in test_mcp_tools

### DIFF
--- a/tests/tools/test_mcp_tools.py
+++ b/tests/tools/test_mcp_tools.py
@@ -15,7 +15,7 @@ from inspect_ai import Task, eval, task
 from inspect_ai._util.environ import environ_var
 from inspect_ai.agent import react
 from inspect_ai.dataset import MemoryDataset, Sample
-from inspect_ai.model import GenerateConfig, get_model
+from inspect_ai.model import get_model
 from inspect_ai.solver import solver
 from inspect_ai.tool import (
     MCPServer,
@@ -204,7 +204,7 @@ def react_mcp_task():
             prompt="Use the available tools to solve the problem.",
             tools=[mcp_tools(server)],
         ),
-        config=GenerateConfig(max_messages=10),
+        message_limit=10,
     )
 
 


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

`tests/tools/test_mcp_tools.py::test_react_mcp_connection` fails on main with:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for GenerateConfig
  Value error, Unknown GenerateConfig field(s): max_messages.
```

`max_messages` is not (and never was) a `GenerateConfig` field — it's a deprecated `Task` parameter migrated to `message_limit`. The test's `GenerateConfig(max_messages=10)` was a silent no-op until #3924 added strict validation that now raises on unknown fields.

Triage: meridianlabs-ai/actions#29.

### What is the new behavior?

Pass `message_limit=10` to `Task` directly (the non-deprecated spelling) and drop the now-unused `GenerateConfig` import. The test still asserts a 10-message limit; previously it was effectively unbounded.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Verified locally with `pytest tests/tools/test_mcp_tools.py::test_react_mcp_connection --runapi`.