### PR TITLE
test(tools): assert tool args/response instead of model accuracy

### DIFF
--- a/tests/tools/test_tools.py
+++ b/tests/tools/test_tools.py
@@ -8,7 +8,6 @@ from test_helpers.tool_call_utils import (
 )
 from test_helpers.tools import addition, raise_error, read_file
 from test_helpers.utils import (
-    flaky_retry,
     skip_if_no_anthropic,
     skip_if_no_google,
     skip_if_no_mistral,
@@ -109,17 +108,22 @@ def check_tools_calls(model: Model, **model_args) -> None:
     # evaluate the task
     log: list[EvalLog] = eval(task, model=model, model_args=model_args)
 
-    # check that we got the answer right
-    assert log[0].results and log[0].results.scores[0].metrics["accuracy"].value == 1
-
-    # check that there is a tool_call
+    # check that the forced tool_call was made with the expected arguments. we
+    # deliberately do NOT assert on accuracy of the final model response: a
+    # forced tool call followed by free-form text is non-deterministic across
+    # providers (models occasionally return empty content or phrasing the
+    # match scorer doesn't pick up), and this test is about tool-call plumbing
+    # rather than the model's natural-language behavior.
     assert log[0].samples
     messages = log[0].samples[0].messages
     tool_call = get_tool_call(messages, "addition")
     assert tool_call
+    assert int(tool_call.arguments["x"]) + int(tool_call.arguments["y"]) == 2
 
-    # check that there is a tool response for this call
-    assert get_tool_response(messages, tool_call)
+    # check that the tool produced and returned the correct result
+    response = get_tool_response(messages, tool_call)
+    assert response
+    assert "2" in response.text
 
 
 def check_tools_none(model: Model, **model_args) -> None:
@@ -192,9 +196,6 @@ def test_mistral_tools():
 
 
 @skip_if_no_google
-# Rarely, but reproducibly, gemini will respond with '' after the tool call returns '2'?!?
-# In my testing, it failed on the order of a couple times per 100 attempts
-@flaky_retry(max_retries=3)
 def test_google_tools():
     check_tools("google/gemini-2.5-pro")
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`tests/tools/test_tools.py::test_anthropic_tools` (and previously `test_google_tools`) flakes on its accuracy assertion. The `check_tools_calls` helper asserted `accuracy == 1`, which required the model's free-form text response after a forced tool call to contain `"2"`, `"2.0"`, or `"Two"`. Models occasionally return empty content or phrasing the `match("any", numeric=True)` scorer doesn't pick up. This is what the `@flaky_retry` decorator on `test_google_tools` was working around.

Note: every API test already gets `flaky_retry(max_retries=3)` applied implicitly by `tests/conftest.py` via the `_needs_flaky_retry` flag on `skip_if_no_*` decorators — so retries weren't a real backstop here. The Anthropic failure had already burned all 4 attempts.

### What is the new behavior?

`check_tools_calls` now asserts on the tool-call plumbing it is named for, not on the model's natural-language behavior:

- the forced tool was called with arguments that sum to 2 (deterministic — the prompt is `"What is 1 + 1?"` and the tool is forced via `tool_choice`)
- the tool response message contains `"2"` (deterministic — the test `addition()` tool returns `str(x + y)` directly)

The brittle `accuracy == 1` assertion is dropped. The now-redundant `@flaky_retry` on `test_google_tools` is removed.

### Does this PR introduce a breaking change?

No.

### Other information:

Fixes the recurring flake tracked in meridianlabs-ai/actions#28.