### PR TITLE
fix(bedrock): route Nova top_k correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Anthropic: Capture `extra_body` fields from `Message` response.
 - VLLM: Preserve dotted vLLM server arg keys.
 - Bedrock: Drop unsupported sampling params for Claude 4.7+.
+- Bedrock: Route `top_k` correctly for Nova models.
 - SageMaker: Add `prompt_logprobs` support in chat mode via `GenerateConfig`, parse prompt logprobs from completion mode responses, enabling `perplexity()` and `target_perplexity()` scorers end-to-end.
 - Model API: `--adaptive-connections` is now enabled by default (defaults to 100 per model connection).
 - Model API: Cache lookup of openai and anthropic packages at sample initialization.

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -490,19 +490,10 @@ class BedrockAPI(ModelAPI):
             # in the native anthropic provider. See issue #3766.
             forbid_sampling_params = self.is_claude_4_7_or_later()
 
-            def _sampling_param_warning(parameter: str) -> str:
-                return (
-                    f"bedrock model '{self.model_name}' does not support the "
-                    f"'{parameter}' parameter (adaptive thinking only)."
-                )
-
             # additional model request fields
-            additionalModelRequestFields: dict[str, Any] = {}
-            if config.top_k:
-                if forbid_sampling_params:
-                    warn_once(logger, _sampling_param_warning("top_k"))
-                else:
-                    additionalModelRequestFields["top_k"] = config.top_k
+            additionalModelRequestFields = self._additional_model_request_fields(
+                config, forbid_sampling_params
+            )
             reasoning_cfg = self.reasoning_config(config)
             additionalModelRequestFields = additionalModelRequestFields | reasoning_cfg
 
@@ -517,13 +508,13 @@ class BedrockAPI(ModelAPI):
 
             # Gate temperature / top_p for adaptive-thinking-only models.
             if forbid_sampling_params and config.temperature is not None:
-                warn_once(logger, _sampling_param_warning("temperature"))
+                warn_once(logger, self._sampling_param_warning("temperature"))
                 inference_temperature: float | None = None
             else:
                 inference_temperature = config.temperature
 
             if forbid_sampling_params and config.top_p is not None:
-                warn_once(logger, _sampling_param_warning("top_p"))
+                warn_once(logger, self._sampling_param_warning("top_p"))
                 inference_top_p: float | None = None
             else:
                 inference_top_p = config.top_p
@@ -587,6 +578,27 @@ class BedrockAPI(ModelAPI):
 
         # return
         return output, model_call
+
+    def _sampling_param_warning(self, parameter: str) -> str:
+        return (
+            f"bedrock model '{self.model_name}' does not support the "
+            f"'{parameter}' parameter (adaptive thinking only)."
+        )
+
+    def _additional_model_request_fields(
+        self, config: GenerateConfig, forbid_sampling_params: bool
+    ) -> dict[str, Any]:
+        fields: dict[str, Any] = {}
+
+        if config.top_k:
+            if forbid_sampling_params:
+                warn_once(logger, self._sampling_param_warning("top_k"))
+            elif self.is_nova():
+                fields["inferenceConfig"] = {"topK": config.top_k}
+            else:
+                fields["top_k"] = config.top_k
+
+        return fields
 
     def reasoning_config(self, config: GenerateConfig) -> dict[str, Any]:
         if self.is_gpt_oss():

--- a/tests/model/providers/test_bedrock_nova_max_tokens.py
+++ b/tests/model/providers/test_bedrock_nova_max_tokens.py
@@ -75,3 +75,24 @@ def test_claude_high_effort_keeps_max_tokens():
     api = _make_claude_api()
     config = GenerateConfig(reasoning_effort="high", max_tokens=2048)
     assert _nova_high_effort_reasoning(api, config) is False
+
+
+def test_nova_top_k_uses_nova_inference_config_extension():
+    api = _make_nova_api()
+    config = GenerateConfig(top_k=50)
+    fields = api._additional_model_request_fields(config, False)
+    assert fields == {"inferenceConfig": {"topK": 50}}
+
+
+def test_claude_top_k_keeps_existing_bedrock_shape():
+    api = _make_claude_api()
+    config = GenerateConfig(top_k=50)
+    fields = api._additional_model_request_fields(config, False)
+    assert fields == {"top_k": 50}
+
+
+def test_adaptive_thinking_model_omits_top_k():
+    api = _make_claude_api()
+    config = GenerateConfig(top_k=50)
+    fields = api._additional_model_request_fields(config, True)
+    assert fields == {}


### PR DESCRIPTION
## Summary

Closes #3939.

Bedrock Nova rejects `additionalModelRequestFields.top_k`, while Claude-on-Bedrock accepts that existing shape. Nova expects the model-specific extension shape instead:

```python
additionalModelRequestFields={
    "inferenceConfig": {"topK": 50},
}
```

This keeps the existing Claude shape, keeps the adaptive-thinking suppression path, and routes Nova `top_k` through the Nova-specific `inferenceConfig.topK` extension.

## Tests

```text
.\.venv\Scripts\python.exe -m py_compile src\inspect_ai\model\_providers\bedrock.py tests\model\providers\test_bedrock_nova_max_tokens.py
.\.venv\Scripts\python.exe -m ruff check src\inspect_ai\model\_providers\bedrock.py tests\model\providers\test_bedrock_nova_max_tokens.py
.\.venv\Scripts\python.exe -m pytest tests\model\providers\test_bedrock_nova_max_tokens.py -q --basetemp .tmp\pytest -p no:cacheprovider
git diff --check
```

Result: `8 passed`.
