### PR TITLE
_call_tools: except exec with nul in command

### DIFF
--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -177,6 +177,14 @@ async def _execute_tools_impl(
                     "unicode_decode",
                     f"Error decoding bytes to {ex.encoding}: {ex.reason}",
                 )
+            except ValueError as ex:
+                if "embedded null byte" in str(ex):
+                    tool_error = ToolCallError(
+                        "unknown",
+                        "A command argument contained an embedded null byte.",
+                    )
+                else:
+                    raise
             except PermissionError as ex:
                 err = f"{ex.strerror or str(ex)}."
                 if isinstance(ex.filename, str):

--- a/tests/tools/test_bash_tool.py
+++ b/tests/tools/test_bash_tool.py
@@ -106,3 +106,60 @@ def test_bash_null_byte() -> None:
     assert tool_response is not None
     assert tool_response.error is not None
     assert "embedded null byte" in tool_response.error.message
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_bash_chmodless_script() -> None:
+    """Running a non-executable script surfaces as a tool response with stderr, not a sample crash."""
+    task = minimal_task_for_tool_use(bash())
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name=bash.__name__,
+                    tool_arguments={
+                        "command": "echo 'true' > /tmp/myscript && /tmp/myscript"
+                    },
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    sample = result.samples[0]
+    assert sample.error is None, f"unexpected sample error: {sample.error}"
+    tool_call = get_tool_call(sample.messages, bash.__name__)
+    assert tool_call is not None
+    tool_response = get_tool_response(sample.messages, tool_call)
+    assert tool_response is not None
+    assert "Permission denied" in str(tool_response.content)
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_bash_invalid_utf8() -> None:
+    """Non-UTF-8 command output does not crash the sample."""
+    task = minimal_task_for_tool_use(bash())
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name=bash.__name__,
+                    tool_arguments={"command": "printf '\\xff'"},
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    sample = result.samples[0]
+    assert sample.error is None
+    # The sandbox interface allows `exec` to raise UnicodeDecodeError (which
+    # the tool call framework converts to a friendly result), but built-in
+    # sandboxes use lossy decoding instead of raising. This test does not
+    # insist on either behavior.

--- a/tests/tools/test_bash_tool.py
+++ b/tests/tools/test_bash_tool.py
@@ -77,3 +77,32 @@ def test_bash_profile() -> None:
     tool_call_response = get_tool_response(messages, tool_call)
     assert tool_call_response is not None
     assert tool_call_response.content == "custom_value\n"
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+def test_bash_null_byte() -> None:
+    """A null byte in a bash command surfaces as a tool error, not a sample crash."""
+    task = minimal_task_for_tool_use(bash())
+    result = eval(
+        task,
+        model=get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.for_tool_call(
+                    model="mockllm/model",
+                    tool_name=bash.__name__,
+                    tool_arguments={"command": "echo -n '\x00' > /tmp/poc"},
+                ),
+            ],
+        ),
+    )[0]
+    assert result.samples
+    sample = result.samples[0]
+    assert sample.error is None
+    tool_call = get_tool_call(sample.messages, bash.__name__)
+    assert tool_call is not None
+    tool_response = get_tool_response(sample.messages, tool_call)
+    assert tool_response is not None
+    assert tool_response.error is not None
+    assert "embedded null byte" in tool_response.error.message


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
sample ends with error

### What is the new behavior?
tool call fails with "A command argument contained an embedded null byte."

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
no

### Other information:
fixes https://github.com/UKGovernmentBEIS/inspect_evals/issues/1643