### PR TITLE
fix(recover): preserve sample uuid for crashed in-progress samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@
 - Bugfix: `grouped()` — raise instead of silently overwriting a per-group metric when a group name collides with `all_label`.
 - Bugfix: `stderr(cluster=...)` — return 0 with a single cluster (was `NaN`/`inf` from divide-by-zero).
 - Bugfix: `value_to_float()` — reject `"nan"`/`"inf"` string values so a single non-finite Score doesn't poison `accuracy()` and friends.
+- Bugfix: `inspect log recover` — preserve `sample.uuid` for crashed in-progress samples (initial buffer summary now carries `state.uuid`; recovery synthesizes a fallback uuid for legacy buffer rows).
 
 ## 0.3.220 (08 May 2026)
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -991,6 +991,7 @@ async def task_run_sample(
                 sample_summary = EvalSampleSummary(
                     id=sample_id,
                     epoch=state.epoch,
+                    uuid=state.uuid,
                     input=sample.input,
                     choices=sample.choices,
                     target=sample.target,

--- a/src/inspect_ai/log/_recover/_reconstruct.py
+++ b/src/inspect_ai/log/_recover/_reconstruct.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from logging import getLogger
 from typing import Any
 
 from pydantic import TypeAdapter
+from shortuuid import uuid as _shortuuid
 
 from inspect_ai._util.constants import get_deserializing_context
 from inspect_ai._util.error import EvalError
@@ -15,6 +17,27 @@ from inspect_ai.log._log import EvalSample, EvalSampleSummary
 from inspect_ai.log._recorders.buffer.types import SampleData
 from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._model_output import ModelOutput
+
+logger = getLogger(__name__)
+
+
+def _summary_with_uuid_fallback(summary: EvalSampleSummary) -> EvalSampleSummary:
+    """Synthesize a uuid for legacy buffer rows that lack one.
+
+    The original state.uuid wasn't persisted; the crashed sample run had no
+    external consumers, so a fresh uuid is safe.
+    """
+    if summary.uuid is not None:
+        return summary
+    fallback = _shortuuid()
+    logger.warning(
+        "Sample summary missing uuid during recovery; synthesizing %s "
+        "(sample_id=%s epoch=%s)",
+        fallback,
+        summary.id,
+        summary.epoch,
+    )
+    return summary.model_copy(update={"uuid": fallback})
 
 
 def reconstruct_eval_sample(
@@ -39,6 +62,8 @@ def reconstruct_eval_sample(
         A fully resolved EvalSample (not condensed — condensing happens
         at write time in Step 4).
     """
+    summary = _summary_with_uuid_fallback(summary)
+
     # Deserialize events from JSON dicts
     events = _deserialize_events(
         [event_data.event for event_data in sample_data.events]

--- a/src/inspect_ai/log/_recover/_stream.py
+++ b/src/inspect_ai/log/_recover/_stream.py
@@ -41,7 +41,11 @@ from inspect_ai.log._recorders.eval import ZipLogFile, _sample_filename
 from inspect_ai.model._chat_message import ChatMessage
 
 from ._attachments import StreamingAttachmentStore, write_attachments_field
-from ._reconstruct import MessageAccumulator, _deserialize_events
+from ._reconstruct import (
+    MessageAccumulator,
+    _deserialize_events,
+    _summary_with_uuid_fallback,
+)
 
 logger = getLogger(__name__)
 
@@ -98,6 +102,7 @@ def _write_sample_streaming(
     ``Sample`` payload on ``SampleInitEvent``, so we must look at raw
     events before condensing.
     """
+    summary = _summary_with_uuid_fallback(summary)
     filename = _sample_filename(summary.id, summary.epoch)
 
     # State accumulated across segments

--- a/tests/log/test_recover_e2e.py
+++ b/tests/log/test_recover_e2e.py
@@ -924,3 +924,173 @@ def test_sync_recover_eval_log() -> None:
         assert log.status == "error"
         assert log.samples is not None
         assert len(log.samples) == 2
+
+
+async def test_streaming_recovery_synthesizes_uuid_for_in_progress_sample() -> None:
+    """Filestore-based recovery synthesizes uuid for uuid-less in-progress samples.
+
+    An in-progress sample whose buffer row has no uuid should still be
+    recovered with a synthesized uuid.
+    """
+    import json
+    from zipfile import ZipFile
+
+    from pydantic_core import to_jsonable_python
+
+    from inspect_ai._util.constants import LOG_SCHEMA_VERSION
+    from inspect_ai.log._recorders.buffer.filestore import (
+        Manifest,
+        SampleManifest,
+        Segment,
+        segment_file_name,
+        segment_name,
+    )
+    from inspect_ai.log._recorders.buffer.types import EventData, SampleData
+    from inspect_ai.log._recorders.eval import LogStart
+
+    async with AsyncFilesystem():
+        with tempfile.TemporaryDirectory() as temp_dir:
+            eval_path = os.path.join(temp_dir, "fs_recover.eval")
+            output_path = os.path.join(temp_dir, "fs_recover-recovered.eval")
+
+            eval_spec = _make_eval_spec(task="fs_uuid_test", num_samples=1)
+            plan = EvalPlan()
+            log_start = LogStart(version=LOG_SCHEMA_VERSION, eval=eval_spec, plan=plan)
+
+            # Write a minimal crashed .eval file (no header.json)
+            with ZipFile(eval_path, "w") as zf:
+                zf.writestr(
+                    "_journal/start.json",
+                    json.dumps(to_jsonable_python(log_start, exclude_none=True)),
+                )
+
+            # Build a filestore buffer directory for this eval manually
+            # (mirrors _create_filestore_fixture from test_recover_filestore.py)
+            eval_name = os.path.splitext(os.path.basename(eval_path))[0]
+            buffer_dir = os.path.join(temp_dir, ".buffer", eval_name)
+            os.makedirs(buffer_dir, exist_ok=True)
+
+            # Create an in-progress summary with uuid=None (legacy row)
+            in_progress = EvalSampleSummary(
+                id=42,
+                epoch=1,
+                input="Question 42",
+                target="answer",
+                started_at=datetime.now(timezone.utc).isoformat(),
+                # uuid intentionally omitted — simulates old buffer rows
+            )
+            assert in_progress.uuid is None
+
+            # Create a model event for this sample
+            model_event = _make_model_event([ChatMessageUser(content="hi")], "hi back")
+            event_dict = to_jsonable_python(
+                model_event,
+                exclude_none=True,
+            )
+
+            # Write one segment zip for the sample
+            sample_data = SampleData(
+                events=[
+                    EventData(
+                        id=1,
+                        event_id="evt-1-0",
+                        sample_id=str(in_progress.id),
+                        epoch=in_progress.epoch,
+                        event=event_dict,
+                    )
+                ],
+                attachments=[],
+            )
+            seg_zip_path = os.path.join(buffer_dir, segment_name(1))
+            with ZipFile(seg_zip_path, "w") as zf:
+                zf.writestr(
+                    segment_file_name(in_progress.id, in_progress.epoch),
+                    json.dumps(to_jsonable_python(sample_data, exclude_none=True)),
+                )
+
+            # Write manifest listing this sample as in-progress (no completed_at)
+            manifest = Manifest(
+                samples=[
+                    SampleManifest(
+                        summary=in_progress,
+                        segments=[1],
+                    )
+                ],
+                segments=[Segment(id=1, last_event_id=1, last_attachment_id=0)],
+            )
+            with open(os.path.join(buffer_dir, "manifest.json"), "w") as f:
+                f.write(manifest.model_dump_json())
+            with open(os.path.join(buffer_dir, ".keep"), "w") as f:
+                pass
+
+            # Recover — no SQLite DB; filestore fallback kicks in
+            empty_db_dir = os.path.join(temp_dir, "empty_db_dir")
+            log = await recover_eval_log_async(
+                eval_path,
+                output=output_path,
+                cleanup=False,
+                _db_dir=empty_db_dir,
+            )
+
+            assert log.samples is not None
+            assert len(log.samples) == 1
+
+            recovered = read_eval_log(output_path, resolve_attachments=True)
+            assert recovered.samples is not None
+            target = next(s for s in recovered.samples if s.id == 42 and s.epoch == 1)
+            assert target.uuid is not None
+            assert len(target.uuid) >= 20
+
+
+async def test_recovery_preserves_uuid_from_in_progress_buffer_row() -> None:
+    """If start_sample is given a uuid, recovery preserves it (no fallback fires)."""
+    async with AsyncFilesystem():
+        with tempfile.TemporaryDirectory() as temp_dir:
+            eval_path = os.path.join(temp_dir, "uuid_roundtrip.eval")
+            output_path = os.path.join(temp_dir, "uuid_roundtrip-recovered.eval")
+
+            eval_spec = _make_eval_spec(num_samples=1)
+            plan = EvalPlan()
+            log_start = LogStart(version=LOG_SCHEMA_VERSION, eval=eval_spec, plan=plan)
+
+            zip_log = ZipLogFile(eval_path)
+            await zip_log.init(log_start=None, summary_counter=0, summaries=[])
+            await zip_log.start(log_start)
+            await zip_log.flush()
+
+            db_dir = os.path.join(temp_dir, "bufferdb")
+            buffer = SampleBufferDatabase(eval_path, create=True, db_dir=Path(db_dir))
+            try:
+                expected_uuid = "myStateUUID0123456789a"
+                in_progress = EvalSampleSummary(
+                    id=7,
+                    epoch=1,
+                    input="Q7",
+                    target="A7",
+                    uuid=expected_uuid,
+                    started_at=datetime.now(timezone.utc).isoformat(),
+                )
+                buffer.start_sample(in_progress)
+                buffer.log_events(
+                    [
+                        SampleEvent(
+                            id=7,
+                            epoch=1,
+                            event=_make_model_event(
+                                [ChatMessageUser(content="Q7")], "A7"
+                            ),
+                        )
+                    ]
+                )
+                _simulate_crashed_buffer(buffer)
+
+                await recover_eval_log_async(
+                    eval_path, output=output_path, cleanup=False, _db_dir=db_dir
+                )
+            finally:
+                buffer.cleanup()
+
+            recovered = read_eval_log(output_path, resolve_attachments=True)
+            assert recovered.samples is not None
+            target = next(s for s in recovered.samples if s.id == 7 and s.epoch == 1)
+            assert target.uuid == expected_uuid

--- a/tests/log/test_recover_reconstruct.py
+++ b/tests/log/test_recover_reconstruct.py
@@ -475,3 +475,15 @@ def test_message_accumulator_compaction_across_chunks() -> None:
     assert messages[4].text == "[Summary]"
     assert messages[6].text == "6"
     assert output.choices[0].message.content == "6"
+
+
+def test_reconstruct_in_progress_summary_without_uuid_synthesizes_one() -> None:
+    """Legacy in-flight buffer rows lack a uuid; recovery synthesizes one."""
+    summary = EvalSampleSummary(id="some-sample", epoch=1, input="2+2?", target="4")
+    assert summary.uuid is None
+
+    sample = reconstruct_eval_sample(
+        summary, SampleData(events=[], attachments=[]), cancelled=True
+    )
+
+    assert sample.uuid is not None


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`inspect log recover` emits samples with `uuid: null` when they crashed before `complete_sample()` ran. The initial `EvalSampleSummary` constructed in `_eval/task/run.py` doesn't pass `state.uuid` to `start_sample()`, so the buffer DB row never has it and recovery copies the `None` through.

### What is the new behavior?

The initial summary now carries `uuid=state.uuid`. A defensive fallback in the recovery write paths synthesizes a fresh shortuuid (with a warning log) for legacy buffer rows that pre-date the fix.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

—