### PR TITLE
fix(model): record cached usage in per-sample and eval model_usage

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1081,6 +1081,9 @@ class Model:
 
                     _request_was_cache_hit.set(True)
                     if existing.usage:
+                        record_and_check_model_usage(
+                            f"{self}", existing.usage, role=self.role
+                        )
                         await emit_model_cache_usage(
                             model_name=str(self), usage=existing.usage
                         )

--- a/tests/model/test_cache.py
+++ b/tests/model/test_cache.py
@@ -6,7 +6,8 @@ from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.log import EvalSample
-from inspect_ai.solver import generate
+from inspect_ai.model import get_model
+from inspect_ai.solver import Generate, TaskState, generate, solver
 
 
 def test_cache_examples():
@@ -42,3 +43,68 @@ def test_cache():
     # first eval should miss the cache and the second should hit it
     check_eval_with_cache(False)
     check_eval_with_cache(True)
+
+
+def test_cache_hit_records_model_usage():
+    """Cache hits must update per-sample and eval-level model_usage.
+
+    Regression test for a bug where the cache-hit branch of `Model._generate`
+    returned early without calling `record_and_check_model_usage`, so cached
+    usage was missing from both `sample.model_usage` and `EvalStats.model_usage`
+    even though `ModelEvent`s were emitted correctly. The omission showed up
+    most visibly with multi-model evals: a per-sample bucket could end up
+    empty while the corresponding events were all present.
+    """
+
+    @solver
+    def two_model_solver():
+        sonnet = get_model("mockllm/sonnet")
+        opus = get_model("mockllm/opus")
+
+        async def solve(state: TaskState, generate_: Generate) -> TaskState:
+            for _ in range(3):
+                await sonnet.generate(state.input_text, cache=True)
+            await opus.generate(state.input_text, cache=True)
+            return state
+
+        return solve
+
+    # use a stable input so the second eval gets cache hits on every call
+    timestamp = str(datetime.now(timezone.utc))
+    task = Task(
+        dataset=[
+            Sample(input=f"sample-a {timestamp}"),
+            Sample(input=f"sample-b {timestamp}"),
+        ],
+        solver=two_model_solver(),
+    )
+
+    def assert_per_sample_usage_matches_events(log):
+        assert log.samples is not None
+        for sample in log.samples:
+            event_models = {
+                ev.model for ev in sample.events if isinstance(ev, ModelEvent)
+            }
+            usage_models = set((sample.model_usage or {}).keys())
+            assert event_models == usage_models, (
+                f"sample {sample.id}: events have models {event_models} "
+                f"but model_usage has {usage_models}"
+            )
+
+    # first run warms the cache; sample 2's repeated input will already hit
+    # the cache that sample 1 populated
+    log_warm = eval(task, model="mockllm/driver")[0]
+    assert_per_sample_usage_matches_events(log_warm)
+
+    # second run: every call is a cache hit
+    log_cached = eval(task, model="mockllm/driver")[0]
+    assert_per_sample_usage_matches_events(log_cached)
+
+    # eval-level model_usage must include both models even when everything
+    # came from cache
+    assert set(log_cached.stats.model_usage.keys()) == {
+        "mockllm/sonnet",
+        "mockllm/opus",
+    }
+    for model_usage in log_cached.stats.model_usage.values():
+        assert model_usage.total_tokens > 0


### PR DESCRIPTION
## Summary

The cache-hit branch of `Model._generate` returned early after emitting the `ModelEvent` and a hooks notification, but never called `record_and_check_model_usage`. Cached calls were therefore missing from:

- `sample.model_usage`
- `EvalStats.model_usage` (eval-level totals)
- the token-limit tree (`record_model_usage` / `check_token_limit` / `check_cost_limit`)
- the per-role buckets (`sample_role_usage_context_var` / `role_usage_context_var`)

— even though the corresponding `ModelEvent` was correctly attached to the sample's transcript. This made per-sample cost attribution and token-budget alarms unreliable for any eval that uses model caching.

The mismatch is most visible on multi-model or multi-sample evals: a sample whose calls all hit the cache can end up with several `ModelEvent`s but an empty `model_usage` dict. The bug was originally observed on a SHADE/Control-Arena run, where sample 2 carried 81 sonnet `ModelEvent`s but had no sonnet entry in `sample.model_usage`. A plain-Inspect repro confirmed the same pattern with `mockllm`, ruling out anything Control-Arena-specific.

The fix is a single call: on a cache hit, call `record_and_check_model_usage(f\"{self}\", existing.usage, role=self.role)` before the existing `emit_model_cache_usage` hook, matching the ordering on the non-cache path.

## Reproducer (before the fix)

```python
from inspect_ai import Task, eval
from inspect_ai.dataset import Sample
from inspect_ai.model import get_model
from inspect_ai.solver import Generate, TaskState, solver

@solver
def two_model_solver():
    sonnet = get_model(\"mockllm/sonnet\")
    opus = get_model(\"mockllm/opus\")
    async def solve(state: TaskState, generate_: Generate) -> TaskState:
        for _ in range(3):
            await sonnet.generate(state.input_text, cache=True)
        await opus.generate(state.input_text, cache=True)
        return state
    return solve

task = Task(dataset=[Sample(input=\"hello\"), Sample(input=\"hello\")],
            solver=two_model_solver())
eval(task, model=\"mockllm/driver\")  # warm
log = eval(task, model=\"mockllm/driver\")[0]  # all cache hits

for s in log.samples:
    print(s.id, list((s.model_usage or {}).keys()),
          {ev.model for ev in s.events if hasattr(ev, \"model\")})
# Before the fix: model_usage_keys = [] for both samples
# After the fix:  model_usage_keys = ['mockllm/sonnet', 'mockllm/opus']
```

## Behavior change

Cache hits now exercise token-limit and cost-limit checks the same way non-cached calls do. This matches the documented field semantics on `ModelUsage` (cache-read tokens are part of the usage object) and the implicit expectation that `model_usage` reflects every `ModelEvent`. Evals running near a hard token/cost limit and previously relying on cache hits being uncounted will start hitting those limits sooner — flagged here for reviewer awareness.

## Test plan

- [x] `pytest tests/model/test_cache.py -v` (new test fails without the source fix, passes with it)
- [x] `pytest tests/model/` (610 passed)
- [x] `pytest tests/util/test_limit_token.py tests/util/test_limit.py tests/test_sample_limits.py tests/hooks/test_hooks.py tests/agent/test_agent_execute.py` (140 passed)
- [x] `ruff format` / `ruff check --fix` clean
- [x] `mypy --exclude tests/test_package src tests` clean

## Out of scope

- The `default={}` mutable-dict defaults on the four usage `ContextVar`s in `src/inspect_ai/model/_model.py`. A code smell, but all recording call sites use `.get(None)` which overrides the constructor default, so they are not the source of any per-sample leak. Happy to clean up in a follow-up if desired.