### PR TITLE
checkpointer: only warn about WIP gate when config is set

### DIFF
--- a/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
@@ -75,10 +75,6 @@ async def build_impl() -> Checkpointer:
     development — the function returns a no-op session unless the
     ``INSPECT_CHECKPOINTING`` env var is set to ``"1"``.
     """
-    if os.environ.get("INSPECT_CHECKPOINTING") != "1":
-        warn_once(logger, "Checkpointing is still not yet fully implemented")
-        return _NoopCheckpointer()
-
     # TODO(checkpointing-phase-3): capture the sample-level retry /
     # attempt index. `ActiveSample` does not currently carry it; the
     # value is published via the `on_sample_attempt_start` hook with
@@ -90,6 +86,10 @@ async def build_impl() -> Checkpointer:
     if active is None or active.checkpoint is None:
         return _NoopCheckpointer()
     config = active.checkpoint
+
+    if os.environ.get("INSPECT_CHECKPOINTING") != "1":
+        warn_once(logger, "Checkpointing is still not yet fully implemented")
+        return _NoopCheckpointer()
 
     if active.eval_id is None:
         raise RuntimeError(


### PR DESCRIPTION
## Summary
- `build_impl()` was emitting the "Checkpointing is still not yet fully implemented" warning even when no `CheckpointConfig` was set on the active sample.
- Move the env-gate check below the active/config check so the warning only fires when checkpointing was actually requested.