### PR TITLE
dataset: retry transient HTTP/connection errors in csv_dataset and json_dataset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Model Info: Cache model info database lookup results so that failed lookups don't repeat fuzzy model name search.
 - Limits: Added `suspend_token_limit()` context manager for suspending token tracking and limit enforcement within a scope.
 - Datasets: `hf_dataset` retries transient Hugging Face errors (rate limits, timeouts, Hub-unreachable cache misses) up to 3 times (5 in CI) with exponential backoff. Pass `retry=False` to disable.
+- Datasets: `csv_dataset` and `json_dataset` retry transient HTTP/connection failures (rate limits, timeouts, transient 5xx) up to 3 times (5 in CI) with exponential backoff. Pass `retry=False` to disable.
 - Datasets: Reject sample ids that collide under `str()` coercion.
 - Datasets: Treat NaN from HuggingFace dataset as `None` is treated (converted to `""`).
 - Datasets: Use HuggingFace revision in cache key for downloaded datasets.

--- a/src/inspect_ai/dataset/_sources/_retry.py
+++ b/src/inspect_ai/dataset/_sources/_retry.py
@@ -1,0 +1,164 @@
+"""Retry helpers for csv_dataset / json_dataset.
+
+Mirrors the structure of the HF retry helper in `hf.py` but classifies generic
+HTTP/connection failure modes raised by the fsspec/urllib/requests/aiohttp
+backends used by `inspect_ai._util.file.file`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Callable, TypeVar
+
+logger = logging.getLogger(__name__)
+
+# HTTP statuses worth retrying. 408 (request timeout), 429 (rate limit), and the
+# 5xx family covered by the standard cloud-storage providers.
+_RETRYABLE_HTTP_STATUSES: frozenset[int] = frozenset({408, 429, 500, 502, 503, 504})
+
+# Exponential backoff bounds. Kept short relative to `hf.py` since CSV/JSON
+# loads are typically small individual requests rather than multi-file HF
+# dataset downloads.
+_INITIAL_WAIT_SECS = 1.0
+_MAX_WAIT_SECS = 60.0
+_MAX_TRIES_DEFAULT = 3
+_MAX_TRIES_CI = 5
+
+
+def _dataset_max_tries() -> int:
+    return _MAX_TRIES_CI if os.getenv("CI") else _MAX_TRIES_DEFAULT
+
+
+def _http_status_of(err: BaseException) -> int | None:
+    """Best-effort HTTP status extraction.
+
+    Reads the status off any of the common HTTP client exception shapes
+    (aiohttp, requests, urllib, generic duck-typed `status`/`code`).
+    """
+    # urllib.error.HTTPError exposes `.code`
+    code = getattr(err, "code", None)
+    if isinstance(code, int):
+        return code
+    # aiohttp.ClientResponseError exposes `.status`
+    status = getattr(err, "status", None)
+    if isinstance(status, int):
+        return status
+    # requests.exceptions.HTTPError holds the response on `.response`
+    response = getattr(err, "response", None)
+    if response is not None:
+        rstatus = getattr(response, "status_code", None)
+        if isinstance(rstatus, int):
+            return rstatus
+    return None
+
+
+def _should_retry_dataset_io_error(err: BaseException) -> bool:
+    """Return True if `err` is a transient network failure worth retrying.
+
+    Covers the four backends `inspect_ai._util.file.file` can dispatch to:
+    direct local filesystem, fsspec HTTP (aiohttp), fsspec S3/GCS/Azure
+    (which surface as either aiohttp or requests errors depending on the
+    backend), and bare urllib for direct HTTP.
+
+    Intentionally narrow: does not retry `FileNotFoundError`,
+    `PermissionError`, `IsADirectoryError`, `ValueError`, decode errors,
+    or any other non-network failure mode.
+    """
+    # Built-in network errors raised by the standard library and fsspec.
+    if isinstance(err, (ConnectionError, TimeoutError)):
+        return True
+
+    # aiohttp errors (fsspec's HTTPFileSystem and some S3/GCS backends).
+    try:
+        from aiohttp import ClientConnectionError, ClientResponseError
+
+        if isinstance(err, ClientConnectionError):
+            return True
+        if isinstance(err, ClientResponseError):
+            return err.status in _RETRYABLE_HTTP_STATUSES
+    except ImportError:
+        pass
+
+    # requests-based backends (some fsspec implementations, urllib3 wrappers).
+    try:
+        from requests.exceptions import ConnectionError as RequestsConnectionError
+        from requests.exceptions import HTTPError as RequestsHTTPError
+        from requests.exceptions import Timeout as RequestsTimeout
+
+        if isinstance(err, (RequestsConnectionError, RequestsTimeout)):
+            return True
+        if isinstance(err, RequestsHTTPError):
+            status = _http_status_of(err)
+            if status is not None:
+                return status in _RETRYABLE_HTTP_STATUSES
+    except ImportError:
+        pass
+
+    # urllib stdlib errors (used by some fsspec backends as a fallback).
+    import urllib.error
+
+    if isinstance(err, urllib.error.HTTPError):
+        return err.code in _RETRYABLE_HTTP_STATUSES
+    if isinstance(err, urllib.error.URLError):
+        # URLError wraps lower-level network failures (DNS, connection reset).
+        reason = getattr(err, "reason", None)
+        if isinstance(reason, (ConnectionError, TimeoutError, OSError)):
+            return True
+
+    return False
+
+
+_T = TypeVar("_T")
+
+
+def _call_with_dataset_retry(
+    fn: Callable[[], _T],
+    *,
+    label: str = "dataset",
+) -> _T:
+    """Run `fn` with exponential-backoff retry on transient I/O failures.
+
+    Args:
+        fn: Zero-argument callable that performs the dataset read.
+        label: Human-readable label used in the warning log line.
+
+    Returns:
+        The successful return value of `fn`.
+
+    Raises:
+        Whatever `fn` raises after exhausting retries, or the first
+        non-retryable error.
+    """
+    import tenacity.nap
+    from tenacity import (
+        RetryCallState,
+        Retrying,
+        retry_if_exception,
+        stop_after_attempt,
+        wait_random_exponential,
+    )
+
+    def log_before_sleep(rs: RetryCallState) -> None:
+        if rs.outcome is None:
+            return
+        ex = rs.outcome.exception()
+        if ex is None:
+            return
+        logger.warning(
+            "%s read failed with %s (attempt %d); retrying in %.1fs",
+            label,
+            type(ex).__name__,
+            rs.attempt_number,
+            rs.upcoming_sleep,
+        )
+
+    retrier = Retrying(
+        sleep=tenacity.nap.sleep,
+        retry=retry_if_exception(_should_retry_dataset_io_error),
+        wait=wait_random_exponential(multiplier=_INITIAL_WAIT_SECS, max=_MAX_WAIT_SECS),
+        stop=stop_after_attempt(_dataset_max_tries()),
+        before_sleep=log_before_sleep,
+        reraise=True,
+    )
+    return retrier(fn)

--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from inspect_ai._util.asyncfiles import is_s3_filename
 from inspect_ai._util.file import file
+from inspect_ai.dataset._sources._retry import _call_with_dataset_retry
 from inspect_ai.dataset._sources.util import resolve_sample_files
 
 from .._dataset import (
@@ -32,6 +33,7 @@ def csv_dataset(
     fs_options: dict[str, Any] | None = None,
     fieldnames: list[str] | None = None,
     delimiter: str = ",",
+    retry: bool = True,
 ) -> Dataset:
     r"""Read dataset from CSV file.
 
@@ -60,6 +62,10 @@ def csv_dataset(
             If None, the values in the first row of the file will be used as the fieldnames.
             Useful for files without a header.
         delimiter: Optional. The delimiter to use when parsing the file. Defaults to ",".
+        retry: Retry transient HTTP/connection failures (rate limits, timeouts,
+            transient 5xx) with exponential backoff. Pass `False` to disable.
+            Defaults to `True`. Non-network failures (`FileNotFoundError`,
+            parsing errors, etc.) are never retried.
 
     Returns:
         Dataset read from CSV file.
@@ -71,35 +77,42 @@ def csv_dataset(
     if fs_options is None and is_s3_filename(csv_file):
         fs_options = dict(default_fill_cache=True, default_cache_type="readahead")
 
-    # read and convert samples
-    with file(csv_file, "r", encoding=encoding, fs_options=fs_options or {}) as f:
-        # filter out rows with empty values
-        valid_data = [
-            data
-            for data in csv_dataset_reader(f, dialect, fieldnames, delimiter)
-            if data and any(value.strip() for value in data.values())
-        ]
-        name = name if name else Path(csv_file).stem
-        dataset = MemoryDataset(
-            samples=data_to_samples(valid_data, data_to_sample, auto_id),
-            name=name,
-            location=os.path.abspath(csv_file),
-        )
+    resolved_fs_options = fs_options or {}
+    resolved_name = name if name else Path(csv_file).stem
 
-        # resolve relative file paths
-        resolve_sample_files(dataset)
+    def _load() -> Dataset:
+        # read and convert samples
+        with file(
+            csv_file, "r", encoding=encoding, fs_options=resolved_fs_options
+        ) as f:
+            # filter out rows with empty values
+            valid_data = [
+                data
+                for data in csv_dataset_reader(f, dialect, fieldnames, delimiter)
+                if data and any(value.strip() for value in data.values())
+            ]
+            dataset = MemoryDataset(
+                samples=data_to_samples(valid_data, data_to_sample, auto_id),
+                name=resolved_name,
+                location=os.path.abspath(csv_file),
+            )
 
-        # shuffle if requested
-        if shuffle:
-            dataset.shuffle(seed=seed)
+            # resolve relative file paths
+            resolve_sample_files(dataset)
 
-        shuffle_choices_if_requested(dataset, shuffle_choices)
+            # shuffle if requested
+            if shuffle:
+                dataset.shuffle(seed=seed)
 
-        # limit if requested
-        if limit:
-            return dataset[0:limit]
+            shuffle_choices_if_requested(dataset, shuffle_choices)
 
-        return dataset
+            # limit if requested
+            if limit:
+                return dataset[0:limit]
+
+            return dataset
+
+    return _call_with_dataset_retry(_load, label="csv_dataset") if retry else _load()
 
 
 def csv_dataset_reader(

--- a/src/inspect_ai/dataset/_sources/json.py
+++ b/src/inspect_ai/dataset/_sources/json.py
@@ -8,6 +8,7 @@ import jsonlines
 
 from inspect_ai._util.asyncfiles import is_s3_filename
 from inspect_ai._util.file import file
+from inspect_ai.dataset._sources._retry import _call_with_dataset_retry
 
 from .._dataset import (
     Dataset,
@@ -31,6 +32,7 @@ def json_dataset(
     encoding: str = "utf-8",
     name: str | None = None,
     fs_options: dict[str, Any] | None = None,
+    retry: bool = True,
     **reader_kwargs: Any,
 ) -> Dataset:
     r"""Read dataset from a JSON file.
@@ -60,6 +62,10 @@ def json_dataset(
       fs_options: Optional. Additional arguments to pass through
         to the filesystem provider (e.g. `S3FileSystem`). Use `{"anon": True }`
         if you are accessing a public S3 bucket with no credentials.
+      retry: Retry transient HTTP/connection failures (rate limits, timeouts,
+        transient 5xx) with exponential backoff. Pass `False` to disable.
+        Defaults to `True`. Non-network failures (`FileNotFoundError`,
+        parsing errors, etc.) are never retried.
       **reader_kwargs: Optional JSON reader options.
 
     Returns:
@@ -79,31 +85,38 @@ def json_dataset(
     if fs_options is None and is_s3_filename(json_file):
         fs_options = dict(default_fill_cache=True, default_cache_type="readahead")
 
-    # read and convert samples
-    with file(json_file, "r", encoding=encoding, fs_options=fs_options or {}) as f:
-        name = name if name else Path(json_file).stem
-        dataset = MemoryDataset(
-            samples=data_to_samples(
-                dataset_reader(f, **reader_kwargs), data_to_sample, auto_id
-            ),
-            name=name,
-            location=os.path.abspath(json_file),
-        )
+    resolved_fs_options = fs_options or {}
+    resolved_name = name if name else Path(json_file).stem
 
-        # resolve relative file paths
-        resolve_sample_files(dataset)
+    def _load() -> Dataset:
+        # read and convert samples
+        with file(
+            json_file, "r", encoding=encoding, fs_options=resolved_fs_options
+        ) as f:
+            dataset = MemoryDataset(
+                samples=data_to_samples(
+                    dataset_reader(f, **reader_kwargs), data_to_sample, auto_id
+                ),
+                name=resolved_name,
+                location=os.path.abspath(json_file),
+            )
 
-        # shuffle if requested
-        if shuffle:
-            dataset.shuffle(seed=seed)
+            # resolve relative file paths
+            resolve_sample_files(dataset)
 
-        shuffle_choices_if_requested(dataset, shuffle_choices)
+            # shuffle if requested
+            if shuffle:
+                dataset.shuffle(seed=seed)
 
-        # limit if requested
-        if limit:
-            return dataset[0:limit]
+            shuffle_choices_if_requested(dataset, shuffle_choices)
 
-    return dataset
+            # limit if requested
+            if limit:
+                return dataset[0:limit]
+
+        return dataset
+
+    return _call_with_dataset_retry(_load, label="json_dataset") if retry else _load()
 
 
 def jsonlines_dataset_reader(file: TextIOWrapper, **kwargs: Any) -> DatasetReader:

--- a/tests/dataset/test_dataset_retry.py
+++ b/tests/dataset/test_dataset_retry.py
@@ -1,0 +1,326 @@
+"""Tests for the transient-I/O retry layer in csv_dataset / json_dataset.
+
+Mirrors the structure of tests/dataset/test_hf_dataset.py for the parallel
+`hf_dataset` retry pattern introduced in PR #3836.
+
+Two layers of coverage:
+
+1. `_should_retry_dataset_io_error` — exception-classification unit tests
+   that exercise the four HTTP-client backend shapes fsspec can dispatch to
+   (built-in, aiohttp, requests, urllib).
+
+2. `csv_dataset` / `json_dataset` integration — patches `file()` to raise a
+   sequence of transient errors followed by a successful open, and asserts
+   that the wrapper retries and ultimately succeeds (or, for the negative
+   cases, that non-transient errors are raised on the first attempt).
+"""
+
+from __future__ import annotations
+
+import urllib.error
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from test_helpers.utils import skip_if_no_package
+
+from inspect_ai.dataset._sources._retry import (
+    _call_with_dataset_retry,
+    _should_retry_dataset_io_error,
+)
+
+# ---------------------------------------------------------------------------
+# Predicate tests — _should_retry_dataset_io_error
+# ---------------------------------------------------------------------------
+
+
+def test_retry_connection_error():
+    assert _should_retry_dataset_io_error(ConnectionError("reset")) is True
+
+
+def test_retry_timeout_error():
+    assert _should_retry_dataset_io_error(TimeoutError("slow")) is True
+
+
+def test_no_retry_filenotfound():
+    assert _should_retry_dataset_io_error(FileNotFoundError("/tmp/nope")) is False
+
+
+def test_no_retry_permission_error():
+    assert _should_retry_dataset_io_error(PermissionError("denied")) is False
+
+
+def test_no_retry_value_error():
+    assert _should_retry_dataset_io_error(ValueError("bad value")) is False
+
+
+def test_no_retry_keyboard_interrupt():
+    assert _should_retry_dataset_io_error(KeyboardInterrupt()) is False
+
+
+@pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+def test_retry_urllib_http_retryable_status(status: int):
+    err = urllib.error.HTTPError(
+        "https://example.com/data.csv", status, "err", None, None
+    )
+    assert _should_retry_dataset_io_error(err) is True
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 404, 405])
+def test_no_retry_urllib_http_client_error(status: int):
+    err = urllib.error.HTTPError(
+        "https://example.com/data.csv", status, "err", None, None
+    )
+    assert _should_retry_dataset_io_error(err) is False
+
+
+def test_retry_urllib_urlerror_with_connection_reason():
+    err = urllib.error.URLError(ConnectionError("network down"))
+    assert _should_retry_dataset_io_error(err) is True
+
+
+def test_no_retry_urllib_urlerror_with_unrelated_reason():
+    err = urllib.error.URLError(ValueError("bad url shape"))
+    assert _should_retry_dataset_io_error(err) is False
+
+
+@skip_if_no_package("aiohttp")
+@pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+def test_retry_aiohttp_client_response_error(status: int):
+    from aiohttp import ClientResponseError, RequestInfo
+    from yarl import URL
+
+    request_info = RequestInfo(
+        url=URL("https://example.com/data.csv"),
+        method="GET",
+        headers={},  # type: ignore[arg-type]
+        real_url=URL("https://example.com/data.csv"),
+    )
+    err = ClientResponseError(
+        request_info=request_info, history=(), status=status, message="err"
+    )
+    assert _should_retry_dataset_io_error(err) is True
+
+
+@skip_if_no_package("aiohttp")
+def test_no_retry_aiohttp_client_response_error_404():
+    from aiohttp import ClientResponseError, RequestInfo
+    from yarl import URL
+
+    request_info = RequestInfo(
+        url=URL("https://example.com/data.csv"),
+        method="GET",
+        headers={},  # type: ignore[arg-type]
+        real_url=URL("https://example.com/data.csv"),
+    )
+    err = ClientResponseError(
+        request_info=request_info, history=(), status=404, message="err"
+    )
+    assert _should_retry_dataset_io_error(err) is False
+
+
+@skip_if_no_package("aiohttp")
+def test_retry_aiohttp_client_connection_error():
+    from aiohttp import ClientConnectionError
+
+    assert _should_retry_dataset_io_error(ClientConnectionError()) is True
+
+
+@skip_if_no_package("requests")
+def test_retry_requests_connection_error():
+    from requests.exceptions import ConnectionError as RequestsConnectionError
+
+    assert _should_retry_dataset_io_error(RequestsConnectionError("reset")) is True
+
+
+@skip_if_no_package("requests")
+def test_retry_requests_timeout():
+    from requests.exceptions import Timeout
+
+    assert _should_retry_dataset_io_error(Timeout("slow")) is True
+
+
+@skip_if_no_package("requests")
+@pytest.mark.parametrize("status", [408, 429, 500, 502, 503, 504])
+def test_retry_requests_http_error(status: int):
+    from requests.exceptions import HTTPError
+
+    response = SimpleNamespace(status_code=status)
+    err = HTTPError("err")
+    err.response = response  # type: ignore[assignment]
+    assert _should_retry_dataset_io_error(err) is True
+
+
+@skip_if_no_package("requests")
+def test_no_retry_requests_http_error_404():
+    from requests.exceptions import HTTPError
+
+    response = SimpleNamespace(status_code=404)
+    err = HTTPError("err")
+    err.response = response  # type: ignore[assignment]
+    assert _should_retry_dataset_io_error(err) is False
+
+
+# ---------------------------------------------------------------------------
+# Helper-level tests — _call_with_dataset_retry
+# ---------------------------------------------------------------------------
+
+
+def test_helper_retries_then_succeeds(monkeypatch: pytest.MonkeyPatch):
+    # Drive the helper through 2 transient failures + 1 success without
+    # actually sleeping between attempts.
+    # _call_with_dataset_retry constructs a tenacity Retrying with
+    # `sleep=tenacity.nap.sleep` at call time, so patching the module
+    # attribute directly is sufficient to short-circuit the wait.
+    monkeypatch.setattr("tenacity.nap.sleep", lambda _: None)
+
+    calls = {"n": 0}
+
+    def flaky() -> str:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise ConnectionError(f"attempt {calls['n']}")
+        return "ok"
+
+    # _MAX_TRIES_DEFAULT is 3; helper should reach attempt 3 and succeed.
+    assert _call_with_dataset_retry(flaky) == "ok"
+    assert calls["n"] == 3
+
+
+def test_helper_non_transient_raises_immediately():
+    calls = {"n": 0}
+
+    def boom() -> None:
+        calls["n"] += 1
+        raise ValueError("not transient")
+
+    with pytest.raises(ValueError):
+        _call_with_dataset_retry(boom)
+    # Predicate says no-retry → exactly one attempt.
+    assert calls["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration — csv_dataset / json_dataset behavior end-to-end
+# ---------------------------------------------------------------------------
+
+
+_CSV_CONTENT = "input,target\nhello,world\nfoo,bar\n"
+_JSON_CONTENT = '[{"input":"hello","target":"world"},{"input":"foo","target":"bar"}]'
+
+
+class _FakeFileCM:
+    """Context manager that yields a `StringIO` for the given text content."""
+
+    def __init__(self, content: str):
+        self._content = content
+        self._buf: StringIO | None = None
+
+    def __enter__(self) -> StringIO:
+        self._buf = StringIO(self._content)
+        return self._buf
+
+    def __exit__(self, *exc: object) -> None:
+        if self._buf is not None:
+            self._buf.close()
+
+
+def _make_flaky_file_factory(fails: int, content: str):
+    """Build a flaky `file()` replacement.
+
+    Returns a callable that raises ConnectionError `fails` times and then
+    yields a context manager wrapping `content`.
+    """
+    calls = {"n": 0}
+
+    def factory(*args, **kwargs) -> _FakeFileCM:
+        calls["n"] += 1
+        if calls["n"] <= fails:
+            raise ConnectionError(f"simulated transient (call {calls['n']})")
+        return _FakeFileCM(content)
+
+    factory.calls = calls  # type: ignore[attr-defined]
+    return factory
+
+
+def test_csv_dataset_retries_on_transient_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from inspect_ai.dataset import csv_dataset
+
+    # _call_with_dataset_retry constructs a tenacity Retrying with
+    # `sleep=tenacity.nap.sleep` at call time, so patching the module
+    # attribute directly is sufficient to short-circuit the wait.
+    monkeypatch.setattr("tenacity.nap.sleep", lambda _: None)
+    factory = _make_flaky_file_factory(fails=2, content=_CSV_CONTENT)
+
+    with patch("inspect_ai.dataset._sources.csv.file", side_effect=factory):
+        dataset = csv_dataset("https://example.com/data.csv")
+
+    assert len(dataset) == 2
+    assert dataset[0].input == "hello"
+    assert dataset[0].target == "world"
+    assert factory.calls["n"] == 3  # 2 transient + 1 success
+
+
+def test_csv_dataset_does_not_retry_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    from inspect_ai.dataset import csv_dataset
+
+    factory = _make_flaky_file_factory(fails=2, content=_CSV_CONTENT)
+
+    with patch("inspect_ai.dataset._sources.csv.file", side_effect=factory):
+        with pytest.raises(ConnectionError):
+            csv_dataset("https://example.com/data.csv", retry=False)
+
+    # retry=False → single attempt only.
+    assert factory.calls["n"] == 1
+
+
+def test_csv_dataset_does_not_retry_non_transient(monkeypatch: pytest.MonkeyPatch):
+    from inspect_ai.dataset import csv_dataset
+
+    calls = {"n": 0}
+
+    def always_missing(*args, **kwargs) -> _FakeFileCM:
+        calls["n"] += 1
+        raise FileNotFoundError("/tmp/does/not/exist")
+
+    with patch("inspect_ai.dataset._sources.csv.file", side_effect=always_missing):
+        with pytest.raises(FileNotFoundError):
+            csv_dataset("/tmp/does/not/exist")
+
+    # FileNotFoundError is non-transient → single attempt even with retry=True.
+    assert calls["n"] == 1
+
+
+def test_json_dataset_retries_on_transient_then_succeeds(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from inspect_ai.dataset import json_dataset
+
+    # _call_with_dataset_retry constructs a tenacity Retrying with
+    # `sleep=tenacity.nap.sleep` at call time, so patching the module
+    # attribute directly is sufficient to short-circuit the wait.
+    monkeypatch.setattr("tenacity.nap.sleep", lambda _: None)
+    factory = _make_flaky_file_factory(fails=2, content=_JSON_CONTENT)
+
+    with patch("inspect_ai.dataset._sources.json.file", side_effect=factory):
+        dataset = json_dataset("https://example.com/data.json")
+
+    assert len(dataset) == 2
+    assert dataset[0].input == "hello"
+    assert dataset[1].target == "bar"
+    assert factory.calls["n"] == 3
+
+
+def test_json_dataset_does_not_retry_when_disabled():
+    from inspect_ai.dataset import json_dataset
+
+    factory = _make_flaky_file_factory(fails=2, content=_JSON_CONTENT)
+
+    with patch("inspect_ai.dataset._sources.json.file", side_effect=factory):
+        with pytest.raises(ConnectionError):
+            json_dataset("https://example.com/data.json", retry=False)
+
+    assert factory.calls["n"] == 1


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [X] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Partially addresses #3734.

`csv_dataset` and `json_dataset` surface any transient network failure (HTTP 429/5xx, connection reset, read timeout) as a hard error. `hf_dataset` gained an exponential-backoff retry layer in #3836; this PR brings the same behavior to the CSV and JSON sources.

### What is the new behavior?

`csv_dataset(..., retry=True)` and `json_dataset(..., retry=True)` (default `True`) retry transient HTTP/connection failures with exponential backoff: up to 3 attempts locally, 5 in CI (mirrors `hf_dataset`). Pass `retry=False` to disable. Non-network failures (`FileNotFoundError`, `PermissionError`, `ValueError`, parse errors) are never retried.

The retry classifier covers the four backends `inspect_ai._util.file.file` can dispatch to:
- Built-in: `ConnectionError`, `TimeoutError`
- aiohttp (fsspec's `HTTPFileSystem`): `ClientConnectionError`, `ClientResponseError` with status in {408, 429, 500, 502, 503, 504}
- requests (some fsspec backends): `ConnectionError`, `Timeout`, `HTTPError` with the same retryable statuses
- urllib stdlib: `HTTPError`, `URLError` wrapping `ConnectionError`/`TimeoutError`/`OSError`

### Scope (intentionally limited)

Issue #3734 has three sub-features: retry, caching, and broader fsspec protocol surface. Of those:

- **Retry** is well-defined now that #3836 has landed and provides a template. This PR.
- **Caching** has open design questions in the issue body (cache-location semantics, kwarg shape) that deserve maintainer alignment in a follow-up.
- **fsspec multi-protocol** is already supported in `csv_dataset` today via `inspect_ai._util.file.file()`.

Keeping this PR to the retry piece closes the immediate observability gap without prejudging the caching design.

### Does this PR introduce a breaking change?

No. `retry=True` is the new default (matching `hf_dataset`), but the retry layer only activates on transient errors that previously bubbled as exceptions — well-behaved local reads complete on the first attempt with no observable change.

### Implementation summary

- New module `src/inspect_ai/dataset/_sources/_retry.py` with:
  - `_should_retry_dataset_io_error(err)` — predicate (~50 LOC, optional-imports for aiohttp / requests)
  - `_call_with_dataset_retry(fn, *, label)` — tenacity-based retrier mirroring `_call_with_hf_retry`
- `csv.py` / `json.py`: hoist the `with file(...)` block into a `_load` closure; wrap with the retry helper when `retry=True`. The closure captures resolved `fs_options` and `name` so each retry produces an identical read.
- 43 tests in `tests/dataset/test_dataset_retry.py`:
  - Predicate parameterized across retryable + non-retryable HTTP statuses for each backend exception shape.
  - Helper-level retry-then-succeed and non-transient-raises-once paths.
  - End-to-end csv/json integration: `file()` patched to raise transient errors N times then succeed; asserts read succeeds and `retry=False` disables the loop.
- `CHANGELOG.md` entry under "Unreleased" alongside the existing `hf_dataset` retry entry.

### Test plan

Tested locally on macOS 25.4 / Python 3.13 / inspect_ai @ `feat/csv-json-dataset-retry`:

```
python3 -m pytest tests/dataset/test_dataset_retry.py tests/dataset/test_dataset.py tests/dataset/test_hf_dataset.py -q
# 97 passed in 1.15s
```

Ruff format + check on `dataset/_sources/_retry.py`, `dataset/_sources/csv.py`, `dataset/_sources/json.py`, `tests/dataset/test_dataset_retry.py` is clean.

---
*Disclosure: this PR was prepared with AI assistance. Diff was hand-reviewed end-to-end; tests were run locally on the cited platform. The submitter takes full responsibility for the change.*
