### PR TITLE
Isolate view server pending-samples test fixture paths

### DIFF
--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -788,8 +788,7 @@ def write_fake_eval_log_buffer(
 @pytest.fixture
 def mock_s3_eval_file(tmp_path: Path) -> str:
     file_path = (
-        f"mocked_eval_set/{tmp_path.name}_"
-        "2025-01-01T00-00-00+00-00_task_taskid.eval"
+        f"mocked_eval_set/{tmp_path.name}_2025-01-01T00-00-00+00-00_task_taskid.eval"
     )
     write_fake_eval_log(file_path)
     return file_path

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -786,8 +786,11 @@ def write_fake_eval_log_buffer(
 
 
 @pytest.fixture
-def mock_s3_eval_file() -> str:
-    file_path = "mocked_eval_set/2025-01-01T00-00-00+00-00_task_taskid.eval"
+def mock_s3_eval_file(tmp_path: Path) -> str:
+    file_path = (
+        f"mocked_eval_set/{tmp_path.name}_"
+        "2025-01-01T00-00-00+00-00_task_taskid.eval"
+    )
     write_fake_eval_log(file_path)
     return file_path
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? 

The view server pending-samples tests can fail depending on test order.

`test_fastapi_pending_samples_no_buffer` expects `/pending-samples` to return `404` when no pending-samples buffer exists for the eval log. Other tests using the same `mock_s3_eval_file` fixture write a pending-samples buffer for that same `memory://` path.

Because `fsspec` memory storage is process-global, the buffer written by one test can remain visible to later tests using the same path. This makes the no-buffer test order-dependent.

Before this change, this command failed:

```bash
python -m pytest -q --randomly-dont-reorganize \
  tests/_view/test_view_server.py::test_fastapi_pending_samples_etag \
  tests/_view/test_view_server.py::test_fastapi_pending_samples_no_buffer \
  -vv --tb=short
```

Result before fix: `FAILED ... assert 200 == 404`

The reverse order passed, confirming order dependence.

Focused randomized validation also reproduced the issue before the fix: 3/10 seeds failed.

### What is the new behavior?

`mock_s3_eval_file` now gives each test a function-scoped unique eval filename while preserving the existing `mocked_eval_set/` prefix used by access-policy tests.

This keeps the tests on the same memory-backed storage path family, but prevents pending-samples buffer state written by one test from affecting another test.

After this change, the former failing order passes: `2 passed`.

Additional validation:
- `tests/_view/test_view_server.py`: 98 passed
- focused xdist randomized validation: 10/10 seeds passed, 31 passed each seed
- affected FastAPI subset: 12 passed

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This only changes test fixture path isolation.

### Other information:

I did not find an open issue or PR covering `mock_s3_eval_file` / `memory://` pending-samples test isolation before opening this PR.