### PR TITLE
[Docs] Document running vLLM solver and judge on separate servers

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -842,6 +842,41 @@ You can also access models from ModelScope rather than Hugging Face, see the [vL
 
 vLLM is generally much faster than the Hugging Face provider as the library is designed entirely for inference speed whereas the Hugging Face library is more general purpose.
 
+### Multiple Servers
+
+`VLLM_BASE_URL` sets a single global endpoint, but a vLLM server only serves one model. If you need different models for different purposes — for example, a small model for the solver and a larger one as a judge for [model-graded scoring](scorers.qmd#model-graded) — start a vLLM server per model and pass a per-model `base_url` rather than relying on the env var.
+
+The most ergonomic path is [model roles](models.qmd#model-roles), which lets the built-in `model_graded_*` scorers automatically resolve their judge from the `grader` role:
+
+``` bash
+inspect eval task.py \
+    --model vllm/meta-llama/Llama-3-8B \
+    --model-base-url http://gpu1:8000/v1 \
+    --model-role 'grader={model: vllm/meta-llama/Llama-3-70B-Instruct, base_url: http://gpu2:8000/v1}'
+```
+
+Equivalent from Python:
+
+``` python
+from inspect_ai import eval
+from inspect_ai.model import get_model
+
+eval(
+    "task.py",
+    model=get_model("vllm/meta-llama/Llama-3-8B", base_url="http://gpu1:8000/v1"),
+    model_roles={
+        "grader": get_model(
+            "vllm/meta-llama/Llama-3-70B-Instruct",
+            base_url="http://gpu2:8000/v1",
+        ),
+    },
+)
+```
+
+Any number of roles can be defined this way (e.g. a separate `critic` or `red_team` model); each one can point at its own vLLM server. `VLLM_API_KEY` is also accepted as a per-model `api_key=` argument if your servers use different keys.
+
+Note: Inspect reuses a single server entry per base model name, so two `vllm/<same-model>` instances pointed at different URLs will collapse to the first URL. This caveat does not apply to the typical solver-vs-judge setup since the two models are different.
+
 ### Batching
 
 vLLM automatically handles batching, so you generally don't have to worry about selecting the optimal batch size. However, you can still use the `max_connections` option to control the number of concurrent requests which defaults to 32. If the server has saturated the GPU it may reject requests---these are by default retried after 5 seconds (you can customize this using the `retry_delay` model args, e.g. `-M retry_delay=3`).


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Refs #3605.

The vLLM provider docs (`docs/providers.qmd`) only describe a single global `VLLM_BASE_URL` environment variable. Since a vLLM server only serves one model, users reading the docs reasonably conclude that they cannot use a small solver model and a separate larger judge model — both backed by vLLM — in the same eval. The capability already exists (`get_model("vllm/...", base_url=...)` and `--model-role grader={model: vllm/..., base_url: ...}` both flow through `ModelConfig` and reach `VLLMAPI.__init__` as a per-model `base_url`), but it isn't documented anywhere in the vLLM section, so it's effectively invisible.

### What is the new behavior?

Adds a new **Multiple Servers** subsection to the vLLM provider docs, placed directly under the env-var table where the question naturally arises. It:

- Explains why a single `VLLM_BASE_URL` is limiting.
- Shows the **CLI** form using `--model-base-url` + `--model-role 'grader={model: vllm/..., base_url: ...}'`, and links to model-graded scoring so readers understand why `grader` is the right role name (built-in `model_graded_*` scorers resolve their judge from it by default).
- Shows the equivalent **Python** form using `get_model(base_url=...)` + `eval(..., model_roles={...})`.
- Notes that any number of named roles (e.g. `critic`, `red_team`) can be configured the same way, and that `VLLM_API_KEY` can be supplied per-model via `api_key=`.
- Flags the per-base-model server-cache caveat: two `vllm/<same-model>` instances pointed at different URLs collapse to the first URL. This does not affect the typical solver-vs-judge case (different models) but is worth knowing for edge cases.

No code changes — purely additive documentation reflecting the framework's existing behavior.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Docs-only addition; no public API, behavior, defaults, or config schema is changed. Existing users continue to work exactly as before; readers who hit the multi-server question now have a documented path that already works.

### Other information:

Verified locally on macOS (no GPU, no real vLLM package needed) that the documented configuration works end-to-end:

- `get_model("vllm/...", base_url=...)` propagates the URL through to the resolved OpenAI-compatible client (`api.base_url` matches after `_resolve_server()`).
- Two `ModelConfig`s with different vLLM model names and different `base_url`s produce two distinct cached server entries; each instance's `api.base_url` matches what was passed.
- End-to-end: a full `eval()` with `model_graded_qa()` against two stub OpenAI-compatible HTTP servers on `127.0.0.1:18091` and `:18092` confirmed exactly one request per server, each carrying the expected model name; eval completed with `status: success`.
- Renders cleanly in the existing `docs/providers.qmd` Quarto file — the new subsection sits between the env-var table and the existing `### Batching` section, matching surrounding heading depth and prose style.
