### PR TITLE
Add `inspect log export-config` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Analysis: Use score reducer in `evals_df()` column name when there are multiple reducers.
 - Hooks: Cache list of registered hooks (invalidate cache on `registry_add()`).
 - Config: Add `--run-config` option to `inspect eval` for single-file run configuration.
+- Config: Add `inspect log export-config` command to export a run config from an existing log file, enabling round-trip reproduction of evaluations.
 - Eval Set: Run [Inspect Scout](https://meridianlabs-ai.github.io/inspect_scout/) scanners over each task's logs as part of `eval_set` (CLI `--scanner` / `EvalScannerConfig`). Scans incrementally as logs land, reuses prior results across resumes, and renders progress alongside the existing eval view.
 - Eval Set: Fail fast with "No inspect tasks were found at the specified paths." when a task spec resolves to nothing (e.g. uninstalled package); previously crashed with `IndexError` inside `resolve_tasks` after passing an empty task list to `eval`.
 - Eval Set: Add `score_display` argument to `eval_set()` function.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Config: Add `inspect log export-config` command to export a run config from an existing log file.
+
 ## 0.3.222 (16 May 2026)
 
 - Scanners: Declare Scanner import in a way that's compatible with pyright type checking.
@@ -29,7 +33,6 @@
 - Analysis: Use score reducer in `evals_df()` column name when there are multiple reducers.
 - Hooks: Cache list of registered hooks (invalidate cache on `registry_add()`).
 - Config: Add `--run-config` option to `inspect eval` for single-file run configuration.
-- Config: Add `inspect log export-config` command to export a run config from an existing log file, enabling round-trip reproduction of evaluations.
 - Eval Set: Run [Inspect Scout](https://meridianlabs-ai.github.io/inspect_scout/) scanners over each task's logs as part of `eval_set` (CLI `--scanner` / `ScannerConfig`). Scans incrementally as logs land, reuses prior results across resumes, and renders progress alongside the existing eval view.
 - Eval Set: Fail fast with "No inspect tasks were found at the specified paths." when a task spec resolves to nothing (e.g. uninstalled package); previously crashed with `IndexError` inside `resolve_tasks` after passing an empty task list to `eval`.
 - Eval Set: Add `score_display` argument to `eval_set()` function.

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -565,12 +565,13 @@ As with other log file oriented environment variables, you may find it convenien
 
 We've shown a number of Python functions that let you work with eval logs from code. However, you may be writing an orchestration or visualisation tool in another language (e.g. TypeScript) where its not particularly convenient to call the Python API. The Inspect CLI has a few commands intended to make it easier to work with Inspect logs from other languages:
 
-| Command               | Description                         |
-|-----------------------|-------------------------------------|
-| `inspect log list`    | List all logs in the log directory. |
-| `inspect log dump`    | Print log file contents as JSON.    |
-| `inspect log convert` | Convert between log file formats.   |
-| `inspect log schema`  | Print JSON schema for log files.    |
+| Command                      | Description                                        |
+|------------------------------|----------------------------------------------------|
+| `inspect log list`           | List all logs in the log directory.                |
+| `inspect log dump`           | Print log file contents as JSON.                   |
+| `inspect log convert`        | Convert between log file formats.                  |
+| `inspect log export-config`  | Export a run config YAML from a log file.          |
+| `inspect log schema`         | Print JSON schema for log files.                   |
 
 ### Listing Logs
 
@@ -607,6 +608,19 @@ For example, here we read a local log file and a log file on Amazon S3:
 $ inspect log dump file:///home/user/log/logfile.json
 $ inspect log dump s3://my-evals-bucket/logfile.json
 ```
+
+### Exporting Run Config {#exporting-run-config}
+
+The `inspect log export-config` command reads a log file and writes a YAML (or JSON) file that captures the complete configuration used for that run — task, model, model roles, generation parameters, solver, and eval settings. The output can be passed directly to `inspect eval --run-config` to reproduce the run:
+
+``` bash
+$ inspect log export-config logs/my_run.eval > run.yaml
+$ inspect eval --run-config run.yaml
+```
+
+This closes the round-trip: `eval → log → export-config → eval`. By default output goes to stdout; use `--output` to write to a file, and `--format json` for JSON instead of YAML.
+
+See [Run Config File](task-configuration.qmd#run-config) for the full schema that `--run-config` accepts.
 
 ### Converting Logs {#converting-logs}
 

--- a/docs/eval-logs.qmd
+++ b/docs/eval-logs.qmd
@@ -609,19 +609,6 @@ $ inspect log dump file:///home/user/log/logfile.json
 $ inspect log dump s3://my-evals-bucket/logfile.json
 ```
 
-### Exporting Run Config {#exporting-run-config}
-
-The `inspect log export-config` command reads a log file and writes a YAML (or JSON) file that captures the complete configuration used for that run — task, model, model roles, generation parameters, solver, and eval settings. The output can be passed directly to `inspect eval --run-config` to reproduce the run:
-
-``` bash
-$ inspect log export-config logs/my_run.eval > run.yaml
-$ inspect eval --run-config run.yaml
-```
-
-This closes the round-trip: `eval → log → export-config → eval`. By default output goes to stdout; use `--output` to write to a file, and `--format json` for JSON instead of YAML.
-
-See [Run Config File](task-configuration.qmd#run-config) for the full schema that `--run-config` accepts.
-
 ### Converting Logs {#converting-logs}
 
 You can convert between the two underlying [log formats](#sec-log-format) using the `inspect log convert` command. The convert command takes a source path (with either a log file or a directory of log files) along with two required arguments that specify the conversion (`--to` and `--output-dir`). For example:
@@ -639,6 +626,19 @@ $ inspect log convert logs --to eval --output-dir logs-eval
 Logs that are already in the target format are simply copied to the output directory. By default, log files in the target directory will not be overwritten, however you can add the `--overwrite` flag to force an overwrite.
 
 Note that the output directory is always required to enforce the practice of not doing conversions that result in side-by-side log files that are identical save for their format.
+
+### Exporting Run Config {#exporting-run-config}
+
+The `inspect log export-config` command reads a log file and writes a YAML (or JSON) file that captures the complete configuration used for that run — task, model, model roles, generation parameters, solver, and eval settings. The output can be passed directly to `inspect eval --run-config` to reproduce the run:
+
+``` bash
+$ inspect log export-config logs/my_run.eval > run.yaml
+$ inspect eval --run-config run.yaml
+```
+
+This closes the round-trip: `eval → log → export-config → eval`. By default output goes to stdout; use `--output` to write to a file, and `--format json` for JSON instead of YAML.
+
+See [Run Config File](task-configuration.qmd#run-config) for the full schema that `--run-config` accepts.
 
 ### Log Schema
 

--- a/docs/task-configuration.qmd
+++ b/docs/task-configuration.qmd
@@ -391,6 +391,15 @@ inspect eval --run-config run.yaml --temperature 0.9
 
 `--run-config` cannot be combined with `--generate-config`, `--task-config`, or `--solver-config`. Use `--run-config` when you want a single file; use the individual options when you want to compose configuration from multiple files.
 
+To generate a run config from an existing eval log, use `inspect log export-config`. This extracts the complete realised configuration and writes it as a `--run-config`-compatible YAML:
+
+``` bash
+inspect log export-config logs/my_run.eval > run.yaml
+inspect eval --run-config run.yaml
+```
+
+See [Exporting Run Config](eval-logs.qmd#exporting-run-config) for details.
+
 ## Solver Override {#solver-override}
 
 The solver can be overridden at every layer:

--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -265,12 +265,13 @@ def types() -> None:
 )
 @click.option(
     "--format",
+    "fmt",
     type=click.Choice(["yaml", "json"], case_sensitive=False),
     default="yaml",
     show_default=True,
     help="Output format.",
 )
-def export_config_command(log_file: str, output: str | None, format: str) -> None:
+def export_config_command(log_file: str, output: str | None, fmt: str) -> None:
     """Export the run configuration from a log file.
 
     Reads LOG_FILE and writes a YAML (or JSON) file that can be passed directly
@@ -289,7 +290,7 @@ def export_config_command(log_file: str, output: str | None, format: str) -> Non
     log = read_eval_log(log_file, header_only=True)
     d = eval_log_to_run_config_dict(log)
 
-    if format == "json":
+    if fmt == "json":
         from json import dumps
 
         text = dumps(d, indent=2)

--- a/src/inspect_ai/_cli/log.py
+++ b/src/inspect_ai/_cli/log.py
@@ -255,6 +255,56 @@ def types() -> None:
     print(view_type_resource("generated.ts"))
 
 
+@log_command.command("export-config")
+@click.argument("log_file")
+@click.option(
+    "--output",
+    type=str,
+    default=None,
+    help="Write output to this file instead of stdout.",
+)
+@click.option(
+    "--format",
+    type=click.Choice(["yaml", "json"], case_sensitive=False),
+    default="yaml",
+    show_default=True,
+    help="Output format.",
+)
+def export_config_command(log_file: str, output: str | None, format: str) -> None:
+    """Export the run configuration from a log file.
+
+    Reads LOG_FILE and writes a YAML (or JSON) file that can be passed directly
+    to 'inspect eval --run-config' to reproduce the run.
+
+    Example:
+        inspect log export-config logs/my_run.eval > run.yaml
+
+        inspect eval --run-config run.yaml
+    """
+    import yaml
+
+    from inspect_ai.log._config import eval_log_to_run_config_dict
+    from inspect_ai.log._file import read_eval_log
+
+    log = read_eval_log(log_file, header_only=True)
+    d = eval_log_to_run_config_dict(log)
+
+    if format == "json":
+        from json import dumps
+
+        text = dumps(d, indent=2)
+    else:
+        text = yaml.dump(
+            d, default_flow_style=False, sort_keys=False, allow_unicode=True
+        )
+
+    if output:
+        with open(output, "w", encoding="utf-8") as f:
+            f.write(text)
+    else:
+        print(text, end="")
+
+
 @log_command.command("recover")
 @click.argument("log_file", required=False)
 @click.option(

--- a/src/inspect_ai/log/_config.py
+++ b/src/inspect_ai/log/_config.py
@@ -96,6 +96,16 @@ def eval_log_to_run_config_dict(log: EvalLog) -> dict[str, Any]:
             cfg = spec.sandbox.config
             if isinstance(cfg, str) and cfg:
                 out["sandbox"] = f"{spec.sandbox.type}:{cfg}"
+            elif hasattr(cfg, "model_dump"):
+                import sys
+
+                print(
+                    f"Warning: sandbox config is a Python object ({type(cfg).__name__}) "
+                    "and cannot be fully exported. Only the sandbox type has been included — "
+                    "you will need to supply the sandbox config manually when re-running.",
+                    file=sys.stderr,
+                )
+                out["sandbox"] = spec.sandbox.type
             else:
                 out["sandbox"] = spec.sandbox.type
         elif isinstance(spec.sandbox, str):

--- a/src/inspect_ai/log/_config.py
+++ b/src/inspect_ai/log/_config.py
@@ -1,0 +1,110 @@
+from typing import Any
+
+from inspect_ai.log._log import EvalLog
+
+# EvalConfig fields that control logging, display, and parallelism — not the
+# scientific conditions of the eval. Omitted from exported run configs so that
+# users can apply their own operational preferences when re-running.
+_OPERATIONAL_EVAL_CONFIG_FIELDS = {
+    "log_samples",
+    "log_realtime",
+    "log_images",
+    "log_model_api",
+    "log_buffer",
+    "log_shared",
+    "score_display",
+    "sandbox_cleanup",
+    "max_samples",
+    "max_dataset_memory",
+    "max_tasks",
+    "max_subprocesses",
+    "max_sandboxes",
+}
+
+
+def eval_log_to_run_config_dict(log: EvalLog) -> dict[str, Any]:
+    """Produce a --run-config compatible dict from an eval log.
+
+    All resolved task and solver args are included (not just args_passed) so
+    the exported config is self-contained even if defaults change in future.
+    """
+    spec = log.eval
+    plan = log.plan
+    out: dict[str, Any] = {}
+
+    # Task
+    task_name = spec.task_registry_name or spec.task
+    task_ref = f"{spec.task_file}@{task_name}" if spec.task_file else task_name
+    task_entry: dict[str, Any] = {"task": task_ref}
+    if spec.task_args:
+        task_entry["args"] = spec.task_args
+    out["task"] = task_entry
+
+    # Model
+    model_entry: dict[str, Any] = {"model": spec.model}
+    if spec.model_base_url:
+        model_entry["base_url"] = spec.model_base_url
+    if spec.model_args:
+        model_entry["args"] = spec.model_args
+    model_gc = spec.model_generate_config.model_dump(exclude_none=True)
+    if model_gc:
+        model_entry["config"] = model_gc
+    out["model"] = model_entry
+
+    # Model roles (dict[str, ModelConfig])
+    if spec.model_roles:
+        roles: dict[str, Any] = {}
+        for name, mc in spec.model_roles.items():
+            role_entry: dict[str, Any] = {"model": mc.model}
+            if mc.base_url:
+                role_entry["base_url"] = mc.base_url
+            role_gc = mc.config.model_dump(exclude_none=True)
+            if role_gc:
+                role_entry["config"] = role_gc
+            if mc.args:
+                role_entry["args"] = mc.args
+            roles[name] = role_entry
+        out["model_roles"] = roles
+
+    # Generate config (plan-level)
+    if plan is not None:
+        gc = plan.config.model_dump(exclude_none=True)
+        if gc:
+            out["generate_config"] = gc
+
+    # Solver
+    if spec.solver:
+        solver_entry: dict[str, Any] = {"solver": spec.solver}
+        if spec.solver_args:
+            solver_entry["args"] = spec.solver_args
+        out["solver"] = solver_entry
+
+    # Eval config — drop operational fields (logging, display, parallelism)
+    ec = {
+        k: v
+        for k, v in spec.config.model_dump(exclude_none=True).items()
+        if k not in _OPERATIONAL_EVAL_CONFIG_FIELDS
+    }
+    if ec:
+        out["eval_config"] = ec
+
+    # Sandbox
+    if spec.sandbox is not None:
+        from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+
+        if isinstance(spec.sandbox, SandboxEnvironmentSpec):
+            cfg = spec.sandbox.config
+            if isinstance(cfg, str) and cfg:
+                out["sandbox"] = f"{spec.sandbox.type}:{cfg}"
+            else:
+                out["sandbox"] = spec.sandbox.type
+        elif isinstance(spec.sandbox, str):
+            out["sandbox"] = spec.sandbox
+
+    # Tags and metadata
+    if spec.tags:
+        out["tags"] = spec.tags
+    if spec.metadata:
+        out["metadata"] = spec.metadata
+
+    return out

--- a/tests/log/test_eval_log_config.py
+++ b/tests/log/test_eval_log_config.py
@@ -3,13 +3,29 @@ import tempfile
 from pathlib import Path
 
 import yaml
+from pydantic import BaseModel
 
 from inspect_ai import Task, eval, task
 from inspect_ai.dataset import Sample
 from inspect_ai.log._config import eval_log_to_run_config_dict
 from inspect_ai.log._file import list_eval_logs, read_eval_log
+from inspect_ai.log._log import EvalConfig, EvalDataset, EvalLog, EvalSpec
 from inspect_ai.model import GenerateConfig, get_model
 from inspect_ai.solver import SolverSpec, solver
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+
+
+def _make_log(sandbox: SandboxEnvironmentSpec | None = None) -> EvalLog:
+    return EvalLog(
+        eval=EvalSpec(
+            task="test_task",
+            model="mockllm/model",
+            created="2024-01-01T00:00:00Z",
+            dataset=EvalDataset(),
+            config=EvalConfig(),
+            sandbox=sandbox,
+        )
+    )
 
 
 @solver
@@ -126,3 +142,27 @@ def test_eval_log_run_config_round_trip() -> None:
     assert log2.eval.model_roles["grader"].model == "mockllm/model"
     assert log2.eval.model_roles["grader"].config.temperature == 0.3
     assert log2.eval.model_roles["grader"].config.max_tokens == 500
+
+
+def test_sandbox_string_config() -> None:
+    log = _make_log(SandboxEnvironmentSpec(type="docker", config="compose.yaml"))
+    d = eval_log_to_run_config_dict(log)
+    assert d["sandbox"] == "docker:compose.yaml"
+
+
+def test_sandbox_no_config() -> None:
+    log = _make_log(SandboxEnvironmentSpec(type="local"))
+    d = eval_log_to_run_config_dict(log)
+    assert d["sandbox"] == "local"
+
+
+def test_sandbox_basemodel_config(capsys) -> None:
+    class DockerConfig(BaseModel):
+        image: str
+        memory: str = "2g"
+
+    log = _make_log(SandboxEnvironmentSpec(type="docker", config=DockerConfig(image="ubuntu")))
+    d = eval_log_to_run_config_dict(log)
+
+    assert d["sandbox"] == "docker"
+    assert "DockerConfig" in capsys.readouterr().err

--- a/tests/log/test_eval_log_config.py
+++ b/tests/log/test_eval_log_config.py
@@ -1,0 +1,128 @@
+import subprocess
+import tempfile
+from pathlib import Path
+
+import yaml
+
+from inspect_ai import Task, eval, task
+from inspect_ai.dataset import Sample
+from inspect_ai.log._config import eval_log_to_run_config_dict
+from inspect_ai.log._file import list_eval_logs, read_eval_log
+from inspect_ai.model import GenerateConfig, get_model
+from inspect_ai.solver import SolverSpec, solver
+
+
+@solver
+def config_test_solver(shape: str = "square", size: int = 1):
+    async def solve(state, generate):
+        return state
+
+    return solve
+
+
+@task
+def config_test_task(color: str = "red", count: int = 1) -> Task:
+    return Task(
+        dataset=[Sample(input="input", target="target")],
+        solver=config_test_solver(),
+        model_roles={"grader": get_model(role="grader")},
+    )
+
+
+def test_eval_log_to_run_config_dict() -> None:
+    grader = get_model(
+        "mockllm/model",
+        config=GenerateConfig(temperature=0.5, max_tokens=1000),
+    )
+    log = eval(
+        config_test_task,
+        model="mockllm/model",
+        model_roles={"grader": grader},
+        task_args={"color": "blue"},
+        max_tokens=256,
+        temperature=0.7,
+        limit=1,
+    )[0]
+
+    d = eval_log_to_run_config_dict(log)
+
+    assert d["task"]["task"].endswith("config_test_task")
+    assert d["task"]["args"] == {"color": "blue", "count": 1}
+    assert d["model"]["model"] == "mockllm/model"
+    assert d["generate_config"]["temperature"] == 0.7
+    assert d["generate_config"]["max_tokens"] == 256
+    assert d["model_roles"]["grader"]["model"] == "mockllm/model"
+    assert d["model_roles"]["grader"]["config"]["temperature"] == 0.5
+    assert d["model_roles"]["grader"]["config"]["max_tokens"] == 1000
+    assert d["eval_config"]["limit"] == 1
+
+
+def test_eval_log_to_run_config_dict_solver_override() -> None:
+    log = eval(
+        config_test_task,
+        model="mockllm/model",
+        solver=SolverSpec(
+            "config_test_solver",
+            args={"shape": "circle", "size": 1},
+            args_passed={"shape": "circle"},
+        ),
+        limit=1,
+    )[0]
+
+    d = eval_log_to_run_config_dict(log)
+
+    assert d["solver"]["solver"] == "config_test_solver"
+    assert d["solver"]["args"] == {"shape": "circle", "size": 1}
+
+
+def test_eval_log_run_config_round_trip() -> None:
+    """Round-trip: eval → export-config → re-eval produces the same effective configuration."""
+    grader = get_model(
+        "mockllm/model",
+        config=GenerateConfig(temperature=0.3, max_tokens=500),
+    )
+    log1 = eval(
+        config_test_task,
+        model="mockllm/model",
+        model_roles={"grader": grader},
+        task_args={"color": "blue"},
+        temperature=0.7,
+        max_tokens=256,
+        seed=42,
+        limit=1,
+    )[0]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        run_config = tmp_path / "run.yaml"
+        log_dir = tmp_path / "logs"
+
+        d = eval_log_to_run_config_dict(log1)
+        run_config.write_text(yaml.dump(d, default_flow_style=False, sort_keys=False))
+
+        subprocess.run(
+            [
+                "uv",
+                "run",
+                "inspect",
+                "eval",
+                "--run-config",
+                run_config.as_posix(),
+                "--log-dir",
+                log_dir.as_posix(),
+            ],
+            check=True,
+        )
+
+        log2 = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
+
+    assert log2.eval.task == log1.eval.task
+    assert log2.eval.model == log1.eval.model
+    assert log2.plan.config.temperature == log1.plan.config.temperature
+    assert log2.plan.config.max_tokens == log1.plan.config.max_tokens
+    assert log2.plan.config.seed == log1.plan.config.seed
+    assert log2.eval.config.limit == log1.eval.config.limit
+    assert log2.eval.model_roles is not None
+    assert log2.eval.model_roles["grader"].model == "mockllm/model"
+    assert log2.eval.model_roles["grader"].config.temperature == 0.3
+    assert log2.eval.model_roles["grader"].config.max_tokens == 500

--- a/tests/log/test_eval_log_config.py
+++ b/tests/log/test_eval_log_config.py
@@ -161,7 +161,9 @@ def test_sandbox_basemodel_config(capsys) -> None:
         image: str
         memory: str = "2g"
 
-    log = _make_log(SandboxEnvironmentSpec(type="docker", config=DockerConfig(image="ubuntu")))
+    log = _make_log(
+        SandboxEnvironmentSpec(type="docker", config=DockerConfig(image="ubuntu"))
+    )
     d = eval_log_to_run_config_dict(log)
 
     assert d["sandbox"] == "docker"


### PR DESCRIPTION
Adds a new `inspect log export-config` CLI command that reads the header of an existing log file and emits a `--run-config`-compatible YAML (or JSON) file, enabling round-trip reproduction of evaluations.

## Usage

```bash
# Export config from a log file
inspect log export-config logs/my_run.eval > run.yaml

# Re-run using the exported config
inspect eval --run-config run.yaml
```

The `--format json` flag switches to JSON output. The `--output` flag writes to a file instead of stdout.

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

There is no way to reproduce an evaluation from its log file without manually reconstructing the command-line arguments.

### What is the new behavior?

`inspect log export-config <log_file>` reads the log header and produces a YAML (or JSON) run config that can be passed directly to `inspect eval --run-config` to reproduce the run with the same task, model, solver, generate config, and eval config.

Operational fields that don't affect scientific outcomes (`log_samples`, `log_realtime`, `max_tasks`, etc.) are excluded from the export so users can apply their own operational preferences when re-running. Currently `fail_on_error`, `continue_on_fail` and `score_on_error` will be included if they appear in the log.

When a sandbox was configured with a programmatic `BaseModel` config (generated at runtime), a warning is emitted to stderr and only the sandbox type is included — the user is told they need to supply the sandbox config manually.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No breaking changes. The new command is additive.

### Other information:

- `eval_log_to_run_config_dict()` in `src/inspect_ai/log/_config.py` is the core function; it is also importable for programmatic use.
- Tests cover the main round-trip case, solver override, and all three sandbox config variants (string, none, BaseModel).