### PR TITLE
Isolate disk sample store cleanup test temp files

### DIFF
--- a/tests/test_disk_sample_store.py
+++ b/tests/test_disk_sample_store.py
@@ -1,12 +1,13 @@
-import glob
 import os
-import tempfile
+from functools import partial
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
 from pydantic import JsonValue
 
 from inspect_ai import Task, eval
+from inspect_ai._eval.task import store as store_module
 from inspect_ai._eval.task.store import (
     DiskSampleStore,
     deep_getsizeof,
@@ -52,14 +53,21 @@ def test_disk_sample_store_roundtrip() -> None:
     assert not os.path.exists(store._path)
 
 
-def test_disk_sample_store_constructor_failure_cleans_up() -> None:
+def test_disk_sample_store_constructor_failure_cleans_up(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """If pickling fails in __init__, the temp file must not be leaked."""
+    monkeypatch.setattr(
+        store_module.tempfile,
+        "mkstemp",
+        partial(store_module.tempfile.mkstemp, dir=tmp_path),
+    )
     bad_sample = Sample(input="ok", metadata={"fn": lambda: None})
-    before = set(glob.glob(os.path.join(tempfile.gettempdir(), "*.pkl")))
+
     with pytest.raises(Exception):
         DiskSampleStore([bad_sample])
-    after = set(glob.glob(os.path.join(tempfile.gettempdir(), "*.pkl")))
-    leaked = after - before
+
+    leaked = list(tmp_path.glob("*.pkl"))
     assert not leaked, f"Temp file leaked: {leaked}"
 
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? 

`test_disk_sample_store_constructor_failure_cleans_up` checks for leaked `DiskSampleStore` temp files by snapshotting every `*.pkl` file under `tempfile.gettempdir()` before and after a failing constructor call.

That can falsely report unrelated `.pkl` files created by other processes as `DiskSampleStore` leaks.

I reproduced this by running the test while a background process created unrelated `/tmp/inspect-ai-tmp-noise-*.pkl` files. The test falsely reported those files as leaked `DiskSampleStore` temp files.

AssertionError: Temp file leaked: {'/tmp/inspect-ai-tmp-noise-...'}

### What is the new behavior?

The test now monkeypatches the `DiskSampleStore` `mkstemp` call so its temp file is created under pytest's `tmp_path`.

It then checks only that test-local directory for leaked `.pkl` files. This preserves the cleanup assertion while avoiding process-global tempdir noise.

No production code changed.

### Does this PR introduce a breaking change? 

No. This is a test-only isolation change.

### Other information:

Validation:

- `python -m pytest -q tests/test_disk_sample_store.py::test_disk_sample_store_constructor_failure_cleans_up`
  - 1 passed
- `python -m pytest -q tests/test_disk_sample_store.py`
  - 10 passed

