### PR TITLE
AsyncFilesystem: add `get_file` and `exists`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- AsyncFilesystem: Add `get_file()` and `exists()` methods.
+
 ## 0.3.222 (16 May 2026)
 
 - Scanners: Declare Scanner import in a way that's compatible with pyright type checking.

--- a/src/inspect_ai/_util/asyncfiles.py
+++ b/src/inspect_ai/_util/asyncfiles.py
@@ -165,6 +165,32 @@ class AsyncFilesystem(AbstractAsyncContextManager["AsyncFilesystem"]):
         else:
             return filesystem(filename).info(filename)
 
+    async def exists(self, filename: str) -> bool:
+        """Return True if `filename` exists, False otherwise."""
+        if is_s3_filename(filename):
+            bucket, key = s3_bucket_and_key(filename)
+            if current_async_backend() == "asyncio":
+                from botocore.exceptions import ClientError
+
+                try:
+                    await (await self.s3_client_async()).head_object(
+                        Bucket=bucket, Key=key
+                    )
+                    return True
+                except ClientError as e:
+                    if e.response.get("Error", {}).get("Code") in (
+                        "404",
+                        "NoSuchKey",
+                        "NotFound",
+                    ):
+                        return False
+                    raise
+            return await anyio.to_thread.run_sync(
+                s3_exists, self.s3_client(), bucket, key
+            )
+        else:
+            return filesystem(filename).exists(filename)
+
     async def read_file(self, filename: str) -> bytes:
         if is_s3_filename(filename):
             bucket, key = s3_bucket_and_key(filename)
@@ -308,6 +334,20 @@ class AsyncFilesystem(AbstractAsyncContextManager["AsyncFilesystem"]):
             ) as f:
                 shutil.copyfileobj(source, f, length=_STREAMING_COPY_BUFSIZE)
 
+    async def get_file(self, remote: str, local: str) -> None:
+        """Download `remote` to local path `local`."""
+        if is_s3_filename(remote):
+            bucket, key = s3_bucket_and_key(remote)
+            if current_async_backend() == "asyncio":
+                client = await self.s3_client_async()
+                await client.download_file(Bucket=bucket, Key=key, Filename=local)
+            else:
+                await anyio.to_thread.run_sync(
+                    s3_get_file, self.s3_client(), bucket, key, local
+                )
+        else:
+            filesystem(remote).get_file(remote, local)
+
     @override
     async def __aenter__(self) -> "AsyncFilesystem":
         existing = _current_async_fs.get()
@@ -441,6 +481,22 @@ def s3_write_file_streaming(s3: Any, bucket: str, key: str, source: BinaryIO) ->
     s3.upload_fileobj(
         Fileobj=source, Bucket=bucket, Key=key, Config=_s3_transfer_config()
     )
+
+
+def s3_get_file(s3: Any, bucket: str, key: str, filename: str) -> None:
+    s3.download_file(Bucket=bucket, Key=key, Filename=filename)
+
+
+def s3_exists(s3: Any, bucket: str, key: str) -> bool:
+    from botocore.exceptions import ClientError
+
+    try:
+        s3.head_object(Bucket=bucket, Key=key)
+        return True
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") in ("404", "NoSuchKey", "NotFound"):
+            return False
+        raise
 
 
 def s3_bucket_and_key(filename: str) -> tuple[str, str]:

--- a/tests/util/test_asyncfiles.py
+++ b/tests/util/test_asyncfiles.py
@@ -400,6 +400,91 @@ def test_write_file_streaming_s3(mock_s3: None) -> None:
 
 
 # =============================================================================
+# Tests for get_file()
+# =============================================================================
+
+
+async def test_get_file_local() -> None:
+    """get_file copies a local source to a local destination."""
+    test_data = b"local get_file payload"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        src = Path(temp_dir) / "src.bin"
+        dst = Path(temp_dir) / "dst.bin"
+        src.write_bytes(test_data)
+
+        async with AsyncFilesystem() as fs:
+            await fs.get_file(str(src), str(dst))
+
+        assert dst.read_bytes() == test_data
+
+
+def test_get_file_s3(mock_s3: None) -> None:
+    """get_file downloads an S3 source to a local destination."""
+    test_data = b"s3 get_file payload"
+    s3_path = f"{S3_BUCKET}/get_file_test/file.bin"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(s3_path, test_data)
+            with tempfile.TemporaryDirectory() as temp_dir:
+                dst = Path(temp_dir) / "downloaded.bin"
+                await fs.get_file(s3_path, str(dst))
+                assert dst.read_bytes() == test_data
+
+    asyncio.run(run())
+
+
+# =============================================================================
+# Tests for exists()
+# =============================================================================
+
+
+async def test_exists_local_true() -> None:
+    """Existing local file returns True."""
+    with tempfile.NamedTemporaryFile(mode="wb", delete=False) as f:
+        f.write(b"x")
+        temp_path = f.name
+
+    try:
+        async with AsyncFilesystem() as fs:
+            assert await fs.exists(temp_path) is True
+    finally:
+        Path(temp_path).unlink()
+
+
+async def test_exists_local_false() -> None:
+    """Missing local file returns False."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        missing = Path(temp_dir) / "does_not_exist.bin"
+        async with AsyncFilesystem() as fs:
+            assert await fs.exists(str(missing)) is False
+
+
+def test_exists_s3_true(mock_s3: None) -> None:
+    """Existing S3 key returns True."""
+    s3_path = f"{S3_BUCKET}/exists_test/present.bin"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(s3_path, b"data")
+            assert await fs.exists(s3_path) is True
+
+    asyncio.run(run())
+
+
+def test_exists_s3_false(mock_s3: None) -> None:
+    """Missing S3 key returns False."""
+    s3_path = f"{S3_BUCKET}/exists_test/absent.bin"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            assert await fs.exists(s3_path) is False
+
+    asyncio.run(run())
+
+
+# =============================================================================
 # Tests for AsyncFilesystem sharing via ContextVar
 # =============================================================================
 


### PR DESCRIPTION
## Summary
- Add `AsyncFilesystem.get_file(remote, local)` — downloads to a local path; native asyncio via aioboto3 `download_file`, trio via sync boto3 through `anyio.to_thread`, non-S3 via sync fsspec.
- Add `AsyncFilesystem.exists(filename) -> bool` — S3 `head_object` with 404/NoSuchKey/NotFound swallowed; non-S3 via fsspec `exists`.
- New sync helpers `s3_get_file` and `s3_exists` alongside the other `s3_*` helpers.