### PR TITLE
anthropic: skip thinking blocks when placing lookback cache_control

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1197,18 +1197,14 @@ class AnthropicAPI(ModelAPI):
             # tools
             if tools_params:
                 add_cache_control(tools_params[-1])
-            # mark the second-to-last block. auto-cache marks the last; this
-            # write gives lookback a fallback when that block changes (RAG,
-            # scorers, approvers, branching evals). harmless extra write for
-            # append-only growth where auto-cache alone suffices.
+            # mark the second-to-last cacheable block. auto-cache marks the
+            # last; this write gives lookback a fallback when that block
+            # changes (RAG, scorers, approvers, branching evals). harmless
+            # extra write for append-only growth where auto-cache alone
+            # suffices. Skip thinking/redacted_thinking blocks — the API
+            # rejects cache_control on those.
             if message_params:
-                last_content = message_params[-1]["content"]
-                if isinstance(last_content, list) and len(last_content) >= 2:
-                    add_cache_control(cast(dict[str, Any], last_content[-2]))
-                elif len(message_params) >= 2:
-                    prev_content = message_params[-2]["content"]
-                    if isinstance(prev_content, list) and prev_content:
-                        add_cache_control(cast(dict[str, Any], prev_content[-1]))
+                add_lookback_cache_control(message_params)
 
         # return chat input
         return (
@@ -1618,6 +1614,43 @@ def is_code_execution_tool(
     param: ToolParamDef,
 ) -> TypeGuard[BetaCodeExecutionTool20250825Param]:
     return param.get("name") == "code_execution" and not is_tool_param(param)
+
+
+_NON_CACHEABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+
+
+def add_lookback_cache_control(message_params: list[MessageParam]) -> None:
+    """Tag the second-to-last cacheable content block across `message_params`.
+
+    Walks blocks in reverse (last message first), skipping
+    thinking/redacted_thinking (the API rejects `cache_control` on those with
+    `Extra inputs are not permitted`), and tags the second cacheable block
+    found. Tagging the *second*-to-last rather than the last gives lookback
+    caching a fallback when the final block changes (RAG, scorers, approvers,
+    branching) — auto-cache already covers the very last block.
+
+    Bare-string content counts as one cacheable block for position purposes
+    (it is the "last block" that auto-cache covers) but cannot itself carry
+    a `cache_control` field, so it is counted but never tagged.
+    """
+    seen_cacheable = 0
+    for msg in reversed(message_params):
+        content = msg["content"]
+        if isinstance(content, str):
+            seen_cacheable += 1
+            if seen_cacheable >= 2:
+                return
+        elif isinstance(content, list):
+            for block in reversed(content):
+                if (
+                    isinstance(block, dict)
+                    and block.get("type") in _NON_CACHEABLE_BLOCK_TYPES
+                ):
+                    continue
+                seen_cacheable += 1
+                if seen_cacheable == 2:
+                    add_cache_control(cast(dict[str, Any], block))
+                    return
 
 
 def add_cache_control(

--- a/tests/model/providers/test_anthropic_cache_control.py
+++ b/tests/model/providers/test_anthropic_cache_control.py
@@ -1,0 +1,200 @@
+"""Unit tests for lookback cache_control placement in the Anthropic provider.
+
+These exercise `add_lookback_cache_control` directly with hand-built
+`MessageParam` dicts — no API calls. The function must place
+`cache_control: {type: "ephemeral"}` on the second-to-last *cacheable*
+content block, skipping `thinking` / `redacted_thinking` blocks (which the
+API rejects with `'thinking.cache_control: Extra inputs are not permitted'`).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from inspect_ai.model._providers.anthropic import add_lookback_cache_control
+
+CACHE = {"type": "ephemeral"}
+
+
+def text(s: str) -> dict[str, Any]:
+    return {"type": "text", "text": s}
+
+
+def thinking(s: str = "hmm") -> dict[str, Any]:
+    return {"type": "thinking", "thinking": s, "signature": "sig"}
+
+
+def redacted() -> dict[str, Any]:
+    return {"type": "redacted_thinking", "data": "xxx"}
+
+
+def tool_use(tid: str = "t1") -> dict[str, Any]:
+    return {"type": "tool_use", "id": tid, "name": "f", "input": {}}
+
+
+def tool_result(tid: str = "t1") -> dict[str, Any]:
+    return {"type": "tool_result", "tool_use_id": tid, "content": "ok"}
+
+
+def tagged(msgs: list[dict[str, Any]]) -> list[tuple[int, int]]:
+    """Return (msg_idx, block_idx) for every block carrying cache_control."""
+    out: list[tuple[int, int]] = []
+    for mi, m in enumerate(msgs):
+        if isinstance(m["content"], list):
+            for bi, b in enumerate(m["content"]):
+                if isinstance(b, dict) and "cache_control" in b:
+                    out.append((mi, bi))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# (a) no-thinking cases: must behave identically to the original logic
+#     original: last[-2] if last is list len>=2, else prev[-1] if prev is list
+# ---------------------------------------------------------------------------
+
+
+def test_no_thinking_last_message_two_blocks_tags_second_to_last() -> None:
+    msgs = [{"role": "user", "content": [text("a"), text("b")]}]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == [(0, 0)]
+    assert msgs[0]["content"][0]["cache_control"] == CACHE
+
+
+def test_no_thinking_last_message_three_blocks_tags_index_minus_two() -> None:
+    msgs = [{"role": "user", "content": [text("a"), text("b"), text("c")]}]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == [(0, 1)]
+
+
+def test_no_thinking_last_single_block_falls_back_to_prev_last() -> None:
+    msgs = [
+        {"role": "assistant", "content": [text("x"), tool_use()]},
+        {"role": "user", "content": [tool_result()]},
+    ]
+    add_lookback_cache_control(msgs)
+    # original: last has len 1 → prev[-1]
+    assert tagged(msgs) == [(0, 1)]
+
+
+def test_no_thinking_last_string_content_tags_prev_last() -> None:
+    # plain-string user content is produced by message_param() for str input
+    msgs = [
+        {"role": "assistant", "content": [text("x"), text("y")]},
+        {"role": "user", "content": "hello"},
+    ]
+    add_lookback_cache_control(msgs)
+    # original: last not a list → prev[-1]
+    assert tagged(msgs) == [(0, 1)]
+
+
+# ---------------------------------------------------------------------------
+# (b)/(c)/(d) thinking blocks present: must skip them
+# ---------------------------------------------------------------------------
+
+
+def test_thinking_at_minus_two_skipped() -> None:
+    # the motivating bug: last[-2] is a thinking block
+    msgs = [
+        {"role": "assistant", "content": [text("a"), thinking(), text("b")]},
+    ]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == [(0, 0)]
+    assert "cache_control" not in msgs[0]["content"][1]
+
+
+def test_redacted_thinking_at_minus_two_skipped() -> None:
+    msgs = [
+        {"role": "assistant", "content": [text("a"), redacted(), text("b")]},
+    ]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == [(0, 0)]
+
+
+def test_thinking_at_prev_minus_one_skipped() -> None:
+    # last has 1 block → fall back to prev; prev[-1] is thinking → skip to prev[-2]
+    msgs = [
+        {"role": "assistant", "content": [text("x"), thinking()]},
+        {"role": "user", "content": [text("q")]},
+    ]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == [(0, 0)]
+
+
+def test_all_thinking_last_message_falls_back_to_earlier_message() -> None:
+    msgs = [
+        {"role": "user", "content": [text("u1"), text("u2")]},
+        {"role": "assistant", "content": [thinking(), redacted()]},
+    ]
+    add_lookback_cache_control(msgs)
+    # last msg contributes 0 cacheable blocks → 2nd-to-last cacheable is u1
+    assert tagged(msgs) == [(0, 0)]
+
+
+def test_thinking_then_tool_use_tags_prev_tool_result() -> None:
+    # realistic interleaved-thinking agent loop
+    msgs = [
+        {"role": "user", "content": [text("task")]},
+        {"role": "assistant", "content": [thinking(), tool_use("t1")]},
+        {"role": "user", "content": [tool_result("t1")]},
+        {"role": "assistant", "content": [thinking(), tool_use("t2")]},
+    ]
+    add_lookback_cache_control(msgs)
+    # last cacheable = tool_use t2; second-to-last cacheable = tool_result t1
+    assert tagged(msgs) == [(2, 0)]
+
+
+# ---------------------------------------------------------------------------
+# (e) edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_single_cacheable_block_no_tag() -> None:
+    msgs = [{"role": "user", "content": [text("only")]}]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == []
+
+
+def test_single_string_message_no_tag() -> None:
+    msgs = [{"role": "user", "content": "only"}]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == []
+
+
+def test_second_cacheable_is_string_no_tag() -> None:
+    # last has 1 block, prev is bare string → can't tag a string, stop
+    msgs = [
+        {"role": "user", "content": "sys-ish"},
+        {"role": "user", "content": [text("q")]},
+    ]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == []
+
+
+def test_empty_messages_noop() -> None:
+    msgs: list[dict[str, Any]] = []
+    add_lookback_cache_control(msgs)
+    assert msgs == []
+
+
+def test_only_thinking_blocks_no_tag() -> None:
+    msgs = [
+        {"role": "assistant", "content": [thinking(), redacted(), thinking()]},
+    ]
+    add_lookback_cache_control(msgs)
+    assert tagged(msgs) == []
+
+
+@pytest.mark.parametrize("block_type", ["thinking", "redacted_thinking"])
+def test_never_tags_thinking_block(block_type: str) -> None:
+    blk = thinking() if block_type == "thinking" else redacted()
+    msgs = [
+        {"role": "user", "content": [text("a")]},
+        {"role": "assistant", "content": [blk, blk, text("b"), blk]},
+    ]
+    add_lookback_cache_control(msgs)
+    for m in msgs:
+        for b in m["content"]:
+            if b.get("type") in ("thinking", "redacted_thinking"):
+                assert "cache_control" not in b


### PR DESCRIPTION
## Summary

The provider tags the second-to-last content block of the message list with `cache_control: {type: "ephemeral"}` so prompt-cache lookback has a stable fallback when the very last block changes (RAG, scorers, branching). With interleaved/extended thinking enabled, that position can land on a `thinking` or `redacted_thinking` block, and the API rejects the request with:

```
'thinking.cache_control: Extra inputs are not permitted'
```

This PR extracts the placement into `add_lookback_cache_control`, which walks blocks in reverse across messages, skips `thinking` / `redacted_thinking`, and tags the second *cacheable* block found. Bare-string content is counted as one block position (so `[assistant(list), user(str)]` still tags `prev[-1]` as before) but is never tagged itself. Behaviour for conversations without thinking blocks is unchanged.

`add_cache_control` is intentionally left unguarded — silently no-opping there would mask placement bugs.

## Test plan

- [x] `tests/model/providers/test_anthropic_cache_control.py` (16 cases, no API calls): no-thinking parity with the old `last[-2]` / `prev[-1]` logic; thinking at `[-2]`, at `prev[-1]`, all-thinking last message, realistic interleaved agent loop; edge cases (single block, string content, empty, all-thinking → no tag)
- [x] `pytest tests/model/providers/ -k cache`
- [x] `ruff check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)