### PR TITLE
Close web search HTTP clients after provider calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Config: Add `inspect log export-config` command to export a run config from an existing log file.
+- Web Search: Close web search HTTP clients after provider calls.
 
 ## 0.3.222 (16 May 2026)
 

--- a/src/inspect_ai/tool/_tools/_web_search/_base_http_provider.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_base_http_provider.py
@@ -36,7 +36,6 @@ class BaseHttpProvider(ABC):
         self.max_connections = self._extract_max_connections(options)
         self.api_options = self._prepare_api_options(options)
         self.api_key = self._validate_api_key()
-        self.client = httpx.AsyncClient(timeout=30)
 
     @abstractmethod
     def prepare_headers(self, api_key: str) -> dict[str, str]:
@@ -90,8 +89,8 @@ class BaseHttpProvider(ABC):
             retry=retry_if_exception(httpx_should_retry),
             before_sleep=log_httpx_retry_attempt(self.api_endpoint),
         )
-        async def _search() -> httpx.Response:
-            response = await self.client.post(
+        async def _search(client: httpx.AsyncClient) -> httpx.Response:
+            response = await client.post(
                 self.api_endpoint,
                 headers=self.prepare_headers(self.api_key),
                 json={"query": query, **self.api_options},
@@ -100,5 +99,6 @@ class BaseHttpProvider(ABC):
             return response
 
         async with concurrency(self.concurrency_key, self.max_connections):
-            response_data = (await _search()).json()
-            return self.parse_response(response_data)
+            async with httpx.AsyncClient(timeout=30) as client:
+                response_data = (await _search(client)).json()
+                return self.parse_response(response_data)

--- a/src/inspect_ai/tool/_tools/_web_search/_google.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_google.py
@@ -69,39 +69,41 @@ def google_search_provider(
         )
     google_api_key, google_cse_id = keys
 
-    # Create the client within the provider
-    client = httpx.AsyncClient()
-
     async def search(query: str) -> list[ContentText] | None:
-        # limit number of concurrent searches
-        results: list[ContentText] = []
-        search_calls = 0
+        async with httpx.AsyncClient() as client:
+            # limit number of concurrent searches
+            results: list[ContentText] = []
+            search_calls = 0
 
-        # Paginate through search results until we have successfully extracted num_results pages or we have reached max_provider_calls
-        while len(results) < num_results and search_calls < max_provider_calls:
-            async with concurrency("google_web_search", max_connections):
-                links = await _search(query, start_idx=search_calls * 10)
+            # Paginate through search results until we have successfully extracted num_results pages or we have reached max_provider_calls
+            while len(results) < num_results and search_calls < max_provider_calls:
+                async with concurrency("google_web_search", max_connections):
+                    links = await _search(
+                        query, start_idx=search_calls * 10, client=client
+                    )
 
-            async with anyio.create_task_group() as tg:
+                async with anyio.create_task_group() as tg:
 
-                async def process_link(link: SearchLink) -> None:
-                    try:
-                        if page := await page_if_relevant(
-                            link.url, query, model, client
-                        ):
-                            results.append(page)
-                    # exceptions fetching pages are very common!
-                    except Exception:
-                        pass
+                    async def process_link(link: SearchLink) -> None:
+                        try:
+                            if page := await page_if_relevant(
+                                link.url, query, model, client
+                            ):
+                                results.append(page)
+                        # exceptions fetching pages are very common!
+                        except Exception:
+                            pass
 
-                for lk in links:
-                    tg.start_soon(process_link, lk)
+                    for lk in links:
+                        tg.start_soon(process_link, lk)
 
-            search_calls += 1
+                search_calls += 1
 
-        return results or None
+            return results or None
 
-    async def _search(query: str, start_idx: int) -> list[SearchLink]:
+    async def _search(
+        query: str, start_idx: int, client: httpx.AsyncClient
+    ) -> list[SearchLink]:
         # List of allowed parameters can be found https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list
         search_params = {
             "q": query,

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -25,6 +25,46 @@ ALL_INTERNAL_PROVIDERS: _NormalizedProviders = {
 }
 
 
+class _MockResponse:
+    def __init__(self, data):
+        self._data = data
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._data
+
+
+def _mock_async_client_class(response_data):
+    class MockAsyncClient:
+        instances = []
+
+        def __init__(self, *args, **kwargs):
+            self.args = args
+            self.kwargs = kwargs
+            self.closed = False
+            self.posts = []
+            self.gets = []
+            type(self).instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            self.closed = True
+
+        async def post(self, *args, **kwargs):
+            self.posts.append((args, kwargs))
+            return _MockResponse(response_data)
+
+        async def get(self, *args, **kwargs):
+            self.gets.append((args, kwargs))
+            return _MockResponse(response_data)
+
+    return MockAsyncClient
+
+
 class TestNormalizeConfig:
     """Tests for the _normalize_config function in _web_search.py."""
 
@@ -342,6 +382,103 @@ class TestCreateExternalProvider:
     def test_exa_provider_with_bogus_config(self, mock_environ_get) -> None:
         with pytest.raises(ValidationError):
             _create_external_provider({"exa": {"text": "bogus"}})
+
+    async def test_tavily_provider_closes_http_client(self, monkeypatch) -> None:
+        monkeypatch.setenv("TAVILY_API_KEY", "fake-key")
+        mock_client = _mock_async_client_class(
+            {
+                "query": "query",
+                "answer": "answer",
+                "images": [],
+                "results": [
+                    {
+                        "title": "Example",
+                        "url": "https://example.com",
+                        "content": "content",
+                        "score": 1.0,
+                    }
+                ],
+                "response_time": 0.1,
+            }
+        )
+        monkeypatch.setattr(
+            "inspect_ai.tool._tools._web_search._base_http_provider.httpx.AsyncClient",
+            mock_client,
+        )
+
+        provider = _create_external_provider({"tavily": {}})
+        result = await provider("query")
+
+        assert result is not None
+        assert len(mock_client.instances) == 1
+        assert mock_client.instances[0].closed
+
+    async def test_exa_provider_closes_http_client(self, monkeypatch) -> None:
+        monkeypatch.setenv("EXA_API_KEY", "fake-key")
+        mock_client = _mock_async_client_class(
+            {
+                "answer": "answer",
+                "citations": [
+                    {
+                        "id": "1",
+                        "url": "https://example.com",
+                        "title": "Example",
+                        "text": "content",
+                    }
+                ],
+            }
+        )
+        monkeypatch.setattr(
+            "inspect_ai.tool._tools._web_search._base_http_provider.httpx.AsyncClient",
+            mock_client,
+        )
+
+        provider = _create_external_provider({"exa": {}})
+        result = await provider("query")
+
+        assert result is not None
+        assert len(mock_client.instances) == 1
+        assert mock_client.instances[0].closed
+
+    async def test_google_provider_closes_http_client(self, monkeypatch) -> None:
+        mock_client = _mock_async_client_class(
+            {
+                "items": [
+                    {
+                        "link": "https://example.com",
+                        "snippet": "snippet",
+                        "title": "Example",
+                    }
+                ]
+            }
+        )
+        monkeypatch.setattr(
+            "inspect_ai.tool._tools._web_search._google.maybe_get_google_api_keys",
+            lambda: ("fake-key", "fake-cse-id"),
+        )
+        monkeypatch.setattr(
+            "inspect_ai.tool._tools._web_search._google.httpx.AsyncClient",
+            mock_client,
+        )
+
+        async def page_if_relevant(url, query, relevance_model, client):
+            assert client is mock_client.instances[0]
+            assert not client.closed
+            return "fake result"
+
+        monkeypatch.setattr(
+            "inspect_ai.tool._tools._web_search._google.page_if_relevant",
+            page_if_relevant,
+        )
+
+        provider = _create_external_provider(
+            {"google": {"num_results": 1, "max_provider_calls": 1}}
+        )
+        result = await provider("query")
+
+        assert result == ["fake result"]
+        assert len(mock_client.instances) == 1
+        assert mock_client.instances[0].closed
 
 
 class TestOldSignatureVariants:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

External `web_search` providers created `httpx.AsyncClient` instances without a deterministic close path.

Tavily and Exa inherited a client created in `BaseHttpProvider.__init__()`, while Google created one in the provider closure. The provider API returns only a callable, so callers had no exposed way to close those clients after use.

I did not find an open issue covering this external `web_search` provider client lifecycle case.

### What is the new behavior?

Each external provider now scopes its `AsyncClient` to the provider call with `async with`.

This preserves the existing request/retry behavior while ensuring the HTTP client is closed after Tavily, Exa, or Google provider execution.

Regression tests cover all three external providers and assert that the mocked async client is closed after the provider call.

### Does this PR introduce a breaking change?

No.

### Other information:

Validation:

- `python -m pytest -q tests/tools/test_web_search.py`
  - 76 passed, 3 skipped
- `python -m pytest -q tests/tools/test_web_search.py::TestCreateExternalProvider`
  - 11 passed, 3 skipped
- `python -m pytest -q tests/tools/test_web_search_tavily.py`
  - 4 passed, 4 skipped
- `python -m pytest -q tests/tools/test_web_search.py tests/tools/test_web_search_tavily.py`
  - 80 passed, 7 skipped
- `python -m pytest -q --runtrio tests/tools/test_web_search.py::TestCreateExternalProvider::test_tavily_provider_closes_http_client tests/tools/test_web_search.py::TestCreateExternalProvider::test_exa_provider_closes_http_client tests/tools/test_web_search.py::TestCreateExternalProvider::test_google_provider_closes_http_client tests/tools/test_web_search_tavily.py`
  - 7 passed, 7 skipped
- `rg -n 'self\.client|\.client' src/inspect_ai/tool/_tools/_web_search tests/tools/test_web_search.py tests/tools/test_web_search_tavily.py`
  - no matches
- `ruff format --check src/inspect_ai/tool/_tools/_web_search/_base_http_provider.py src/inspect_ai/tool/_tools/_web_search/_google.py tests/tools/test_web_search.py`
  - 3 files already formatted
- `ruff check src/inspect_ai/tool/_tools/_web_search/_base_http_provider.py src/inspect_ai/tool/_tools/_web_search/_google.py tests/tools/test_web_search.py`
  - All checks passed