### PR TITLE
feat(scorer): add pass_k reducer (τ-bench pass^k consistency metric)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
+## Unreleased
+
+- Scoring: Add `pass_k` reducer for computing the probability that all `k` epoch attempts succeed (τ-bench reliability metric).
+
 ## 0.3.223 (18 May 2026)
 
 - Config: Add `inspect log export-config` command to export a run config from an existing log file.
 - Anthropic: Skip thinking blocks when placing lookback cache_control.
 - AsyncFilesystem: Add `get_file()` and `exists()` methods.
-- Scoring: Add `pass_k` reducer for computing the probability that all `k` epoch attempts succeed (τ-bench reliability metric).
 - Inspect View: Fix regression where switching task tabs would reload log, causing latency.
 
 ## 0.3.222 (16 May 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Config: Add `inspect log export-config` command to export a run config from an existing log file.
 - Anthropic: Skip thinking blocks when placing lookback cache_control.
 - AsyncFilesystem: Add `get_file()` and `exists()` methods.
+- Scoring: Add `pass_k` reducer for computing the probability that all `k` epoch attempts succeed (τ-bench reliability metric).
 
 ## 0.3.222 (16 May 2026)
 

--- a/docs/options.qmd
+++ b/docs/options.qmd
@@ -124,7 +124,7 @@ For a complete matrix of which task, solver, and runtime settings can be configu
 | `--limit` | Limit samples to evaluate by specifying a maximum (e.g. `10`) or range (e.g. `10-20`) |
 | `--sample-id` | Evaluate a specific sample (e.g. `44`) or list of samples (e.g. `44,63,91`) |
 | `--epochs` | Number of times to repeat each sample (defaults to 1) |
-| `--epochs-reducer` | Method for reducing per-epoch sample scores into a single score. Built in reducers include `mean`, `median`, `mode`, `max`, `at_least_{n}`, and `pass_at_{k}`. |
+| `--epochs-reducer` | Method for reducing per-epoch sample scores into a single score. Built in reducers include `mean`, `median`, `mode`, `max`, `at_least_{n}`, `pass_at_{k}`, and `pass_k_{k}`. |
 | `--no-epochs-reducer` | Do not reduce epochs across samples (compute metrics across all samples and epochs together). |
 
 ## Parallelism

--- a/docs/reference/inspect_ai.scorer.qmd
+++ b/docs/reference/inspect_ai.scorer.qmd
@@ -33,6 +33,7 @@ description: Task scoring and metrics.
 
 ### at_least
 ### pass_at
+### pass_k
 ### max_score
 ### mean_score
 ### median_score

--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -861,6 +861,7 @@ Inspect includes several built in reducers which are summarised below.
 | mode | Reduce to the most common score. |
 | max | Reduce to the maximum of all scores. |
 | pass_at\_{k} | Probability of at least 1 correct sample given `k` epochs (<https://arxiv.org/pdf/2107.03374>) |
+| pass_k\_{k} | Probability that all `k` epoch attempts succeed (<https://arxiv.org/pdf/2406.12045>) |
 | at_least\_{k} | `1` if at least `k` samples are correct, else `0`. |
 
 : {tbl-colwidths="\[30,70\]"}

--- a/src/inspect_ai/scorer/__init__.py
+++ b/src/inspect_ai/scorer/__init__.py
@@ -39,6 +39,7 @@ from ._reducer import (
     median_score,
     mode_score,
     pass_at,
+    pass_k,
     score_reducer,
 )
 from ._score import score
@@ -85,6 +86,7 @@ __all__ = [
     "model_graded_qa",
     "multi_scorer",
     "pass_at",
+    "pass_k",
     "pattern",
     "perplexity",
     "perplexity_per_seq",

--- a/src/inspect_ai/scorer/_reducer/__init__.py
+++ b/src/inspect_ai/scorer/_reducer/__init__.py
@@ -1,4 +1,12 @@
-from .reducer import at_least, max_score, mean_score, median_score, mode_score, pass_at
+from .reducer import (
+    at_least,
+    max_score,
+    mean_score,
+    median_score,
+    mode_score,
+    pass_at,
+    pass_k,
+)
 from .registry import (
     create_reducers,
     reducer_log_name,
@@ -21,5 +29,6 @@ __all__ = [
     "max_score",
     "at_least",
     "pass_at",
+    "pass_k",
     "validate_reducer",
 ]

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -163,6 +163,46 @@ def pass_at(
     return reduce
 
 
+@score_reducer
+def pass_k(
+    k: int, value: float = 1.0, value_to_float: ValueToFloat = value_to_float()
+) -> ScoreReducer:
+    r"""Probability that all `k` epoch attempts succeed (<https://arxiv.org/pdf/2406.12045>).
+
+    Computed as the draw-without-replacement estimator
+    `C(correct, k) / C(total, k)`, dual to `pass_at`'s Chen 2021 estimator.
+
+    Args:
+       k: Epochs to compute probability for.
+       value: Score value threshold.
+       value_to_float: Function to convert score values to float.
+    """
+
+    def reduce(scores: list[Score]) -> Score:
+        def pass_k_k(values: list[float]) -> float:
+            total = len(values)
+            if total < k:
+                # NaN-filtering left fewer than k scored epochs, so the
+                # pass^k estimator is undefined; surface the unscored
+                # sentinel.
+                return float("nan")
+            correct = sum(1 for v in values if v >= value)
+            return math.comb(correct, k) / math.comb(total, k)
+
+        representative = _first_scored(scores)
+        if representative is None:
+            return _nan_score(scores)
+        if isinstance(representative.value, dict):
+            return _compute_dict_stat(scores, value_to_float, pass_k_k)
+        elif isinstance(representative.value, list):
+            return _compute_list_stat(scores, value_to_float, pass_k_k)
+        else:
+            return _compute_scalar_stat(scores, value_to_float, pass_k_k)
+
+    setattr(reduce, REDUCER_NAME, f"pass_k_{k}")
+    return reduce
+
+
 @score_reducer(name="max")
 def max_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
     r"""Take the maximum value from a list of scores.

--- a/src/inspect_ai/scorer/_reducer/registry.py
+++ b/src/inspect_ai/scorer/_reducer/registry.py
@@ -184,7 +184,11 @@ def validate_reducer(epochs: int, reducer: ScoreReducer) -> None:
         if k > epochs:
             name = registry_log_name(reducer)
             # don't interfere w/ unknown uses of 'k' (i.e. only validate built in)
-            if name.startswith("pass_at") or name.startswith("at_least"):
+            if (
+                name.startswith("pass_at")
+                or name.startswith("pass_k")
+                or name.startswith("at_least")
+            ):
                 raise PrerequisiteError(
                     f"Reducer '{reducer_log_name(reducer)}' requires {k} epochs however evaluation has only {epochs} epochs."
                 )

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -25,7 +25,7 @@ from inspect_ai.scorer import (
     value_to_float,
 )
 from inspect_ai.scorer._reducer import create_reducers
-from inspect_ai.scorer._reducer.reducer import pass_at
+from inspect_ai.scorer._reducer.reducer import pass_at, pass_k
 from inspect_ai.scorer._reducer.registry import REDUCER_NAME, reducer_log_name
 
 avg_reducer = mean_score()
@@ -39,6 +39,10 @@ pass_at_2_no_threshhold = pass_at(2)
 pass_at_3_threshhold = pass_at(3, 2)
 pass_at_5_no_threshhold = pass_at(5)
 pass_at_5_threshhold = pass_at(5, 2)
+pass_k_2_no_threshold = pass_k(2)
+pass_k_3_threshold = pass_k(3, 2)
+pass_k_5_no_threshold = pass_k(5)
+pass_k_5_threshold = pass_k(5, 2)
 
 
 def test_simple_reducers() -> None:
@@ -65,6 +69,10 @@ def test_all_nan_simple_reducers() -> None:
     assert _is_nan(pass_at_3_threshhold(simple_scores).value)
     assert _is_nan(pass_at_5_no_threshhold(simple_scores).value)
     assert _is_nan(pass_at_5_threshhold(simple_scores).value)
+    assert _is_nan(pass_k_2_no_threshold(simple_scores).value)
+    assert _is_nan(pass_k_3_threshold(simple_scores).value)
+    assert _is_nan(pass_k_5_no_threshold(simple_scores).value)
+    assert _is_nan(pass_k_5_threshold(simple_scores).value)
 
 
 def test_list_reducers() -> None:
@@ -97,6 +105,8 @@ def test_all_nan_list_reducers() -> None:
     assert_list_nan(reduced)
     reduced = pass_at_2_no_threshhold(list_scores).value
     assert_list_nan(reduced)
+    reduced = pass_k_2_no_threshold(list_scores).value
+    assert_list_nan(reduced)
 
 
 def test_nan_root_list_reducers() -> None:
@@ -119,6 +129,7 @@ def test_nan_root_list_reducers() -> None:
     assert max_reducer(list_scores).value == [4, 3]
     assert at_least_3_reducer(list_scores).value == [1, 1]
     assert pass_at_2_no_threshhold(list_scores).value == [1, 1]
+    assert pass_k_2_no_threshold(list_scores).value == [1, 1]
 
 
 def test_all_nan_root_list_reducers() -> None:
@@ -136,6 +147,7 @@ def test_all_nan_root_list_reducers() -> None:
     assert _is_nan(max_reducer(list_scores).value)
     assert _is_nan(at_least_3_reducer(list_scores).value)
     assert _is_nan(pass_at_2_no_threshhold(list_scores).value)
+    assert _is_nan(pass_k_2_no_threshold(list_scores).value)
 
 
 def test_dict_reducers() -> None:
@@ -172,6 +184,8 @@ def test_all_nan_dict_reducers() -> None:
     assert_dict_nan(reduced)
     reduced = pass_at_2_no_threshhold(dict_scores).value
     assert_dict_nan(reduced)
+    reduced = pass_k_2_no_threshold(dict_scores).value
+    assert_dict_nan(reduced)
 
 
 def test_nan_root_dict_reducers() -> None:
@@ -196,6 +210,7 @@ def test_nan_root_dict_reducers() -> None:
     assert at_least_4_reducer(dict_scores).value == {"coolness": 1, "spiciness": 1}
     assert at_least_5_reducer(dict_scores).value == {"coolness": 0, "spiciness": 0}
     assert pass_at_2_no_threshhold(dict_scores).value == {"coolness": 1, "spiciness": 1}
+    assert pass_k_2_no_threshold(dict_scores).value == {"coolness": 1, "spiciness": 1}
 
 
 def test_all_nan_root_dict_reducers() -> None:
@@ -213,6 +228,7 @@ def test_all_nan_root_dict_reducers() -> None:
     assert _is_nan(max_reducer(scores).value)
     assert _is_nan(at_least_3_reducer(scores).value)
     assert _is_nan(pass_at_2_no_threshhold(scores).value)
+    assert _is_nan(pass_k_2_no_threshold(scores).value)
 
 
 def test_nan_root_first_score_dict_reducers() -> None:
@@ -275,6 +291,7 @@ def test_reducer_preserve_metadata() -> None:
         max_reducer,
         at_least_3_reducer,
         pass_at_2_no_threshhold,
+        pass_k_2_no_threshold,
     ]
 
     # verify that other fields are set only if equal across all samples
@@ -411,6 +428,7 @@ def test_create_reducers_exact_name_with_trailing_digits() -> None:
     # built-in `_<k>` shorthand must still work
     assert create_reducers("at_least_2")
     assert create_reducers("pass_at_3")
+    assert create_reducers("pass_k_3")
 
 
 def test_at_least_reducer_name_includes_k() -> None:
@@ -428,6 +446,8 @@ def test_at_least_reducer_name_includes_k() -> None:
     # log name must not double-append the suffix
     assert reducer_log_name(r3) == "at_least_3"
     assert reducer_log_name(pass_at(4)) == "pass_at_4"
+    assert reducer_log_name(pass_k(4)) == "pass_k_4"
+    assert not hasattr(pass_k, REDUCER_NAME)
 
 
 def test_max_reducer_dict_per_key_nan_order_independent() -> None:
@@ -472,6 +492,38 @@ def test_pass_at_k_insufficient_scored_epochs() -> None:
     assert pass_at(3)([Score(value=0.0)] * 4).value == 0.0
 
 
+def test_pass_k_insufficient_scored_epochs() -> None:
+    # pass_k mirrors pass_at: when NaN-filtering shrinks the valid count
+    # below k, the estimator is undefined and the reducer yields the
+    # unscored NaN sentinel rather than a spurious 0.0 from comb(c, k)=0.
+    scores = [
+        Score(value=1.0),
+        Score(value=1.0),
+        Score(value=float("nan")),
+        Score(value=float("nan")),
+    ]
+    result = pass_k(3)(scores).value
+    assert _is_nan(result), f"expected NaN for <k scored epochs, got {result!r}"
+
+    # sanity: with k scored epochs and all correct, pass^k is 1.0
+    assert pass_k(3)([Score(value=1.0)] * 3).value == 1.0
+
+
+def test_validate_pass_k_reducer() -> None:
+    import pytest
+
+    from inspect_ai._util.error import PrerequisiteError
+    from inspect_ai.scorer._reducer.registry import validate_reducer
+
+    # k <= epochs: ok
+    validate_reducer(5, pass_k(5))
+    validate_reducer(8, pass_k(3))
+
+    # k > epochs: raises with the reducer's logged name in the message
+    with pytest.raises(PrerequisiteError, match="pass_k_5"):
+        validate_reducer(3, pass_k(5))
+
+
 def eval_with_reducer():
     task = Task(dataset=[Sample(input="Say hello.", target="Hello")], scorer=match())
     return eval(task, model="mockllm/model", epochs=Epochs(5, max_score()))[0]
@@ -486,6 +538,12 @@ def test_reducer_by_name():
     task = Task(dataset=[Sample(input="Say hello.", target="Hello")], scorer=match())
     log = eval(task, model="mockllm/model", epochs=Epochs(5, "at_least_2"))[0]
     assert log.eval.config.epochs_reducer == ["at_least_2"]
+
+
+def test_pass_k_reducer_by_name():
+    task = Task(dataset=[Sample(input="Say hello.", target="Hello")], scorer=match())
+    log = eval(task, model="mockllm/model", epochs=Epochs(5, "pass_k_2"))[0]
+    assert log.eval.config.epochs_reducer == ["pass_k_2"]
 
 
 def test_no_reducer():
@@ -565,6 +623,13 @@ def _test_simple_reducers_impl(include_nan: bool = False) -> None:
     assert pass_at_3_threshhold(simple_scores).value == 0.95
     assert pass_at_5_no_threshhold(simple_scores).value == 1.0
     assert pass_at_5_threshhold(simple_scores).value == 1.0
+    # pass_k = comb(correct, k) / comb(total, k). For simple_scores
+    # (correct=3, total=6): pass_k(2)=3/15=0.2; pass_k(3, value=2)=1/20=0.05;
+    # pass_k(5,*)=0/6=0.0 since correct < k.
+    assert pass_k_2_no_threshold(simple_scores).value == 0.2
+    assert pass_k_3_threshold(simple_scores).value == 0.05
+    assert pass_k_5_no_threshold(simple_scores).value == 0.0
+    assert pass_k_5_threshold(simple_scores).value == 0.0
 
 
 def _test_list_reducers_impl(include_nan: bool = False) -> None:
@@ -585,6 +650,7 @@ def _test_list_reducers_impl(include_nan: bool = False) -> None:
     assert at_least_3_reducer(list_scores).value == [1, 1]
     assert at_least_4_reducer(list_scores).value == [1, 1]
     assert pass_at_2_no_threshhold(list_scores).value == [1, 1]
+    assert pass_k_2_no_threshold(list_scores).value == [1, 1]
 
 
 def _test_dict_reducers_impl(include_nan: bool = False) -> None:
@@ -608,6 +674,7 @@ def _test_dict_reducers_impl(include_nan: bool = False) -> None:
     assert at_least_4_reducer(dict_scores).value == {"coolness": 1, "spiciness": 1}
     assert at_least_5_reducer(dict_scores).value == {"coolness": 0, "spiciness": 0}
     assert pass_at_2_no_threshhold(dict_scores).value == {"coolness": 1, "spiciness": 1}
+    assert pass_k_2_no_threshold(dict_scores).value == {"coolness": 1, "spiciness": 1}
 
 
 def _is_nan(x: Any) -> bool:


### PR DESCRIPTION
## Summary

Adds a new built-in epoch reducer `pass_k` that returns the probability all `k` epoch attempts succeed — the τ-bench reliability metric (Yao et al. 2024, [arxiv 2406.12045](https://arxiv.org/abs/2406.12045)). Mirrors the existing `pass_at` reducer in API shape; uses the draw-without-replacement estimator `C(correct, k) / C(total, k)`, mathematically dual to `pass_at`'s Chen 2021 estimator.

```python
# pass_at: probability at least one of k attempts succeeds
epochs=Epochs(8, ["mean", "pass_at_1", "pass_at_8"])

# pass_k: probability all k attempts succeed (NEW)
epochs=Epochs(8, ["mean", "pass_k_1", "pass_k_8"])
```

`pass_at` and `pass_k` are conceptually distinct — at-least-one vs all-of-k — so a separate factory keeps registered names clean (`pass_k_{k}` mirrors `pass_at_{k}` / `at_least_{k}`).

### Why this primitive

`pass^k` is the canonical reliability metric for agent benchmarks where a single failure is costly (e.g. GPT-4o on τ-retail drops from `pass^1 ≈ 61%` to `pass^8 ≈ 25%`). Without a framework-level reducer, ports have been rolling their own — `inspect_evals/zerobench/reducer.py` already implements an ad-hoc `reliability_at(k)` with the same combinatorial formula. A built-in lets τ-bench / τ²-bench (currently unwired) and SWE-bench / KernelBench / BigCodeBench / LiveCodeBench adopt it with a one-line `epochs=` change.

### Files changed

- `src/inspect_ai/scorer/_reducer/reducer.py` — new `pass_k` factory (~30 LOC) mirroring `pass_at` exactly
- `src/inspect_ai/scorer/_reducer/registry.py` — one-line extension of `validate_reducer`'s startswith check
- `src/inspect_ai/scorer/{_reducer,}/__init__.py` — exports
- `tests/scorer/test_reducers.py` — new fixtures + assertions in the existing scalar/list/dict/NaN helpers, two net-new tests (`test_pass_k_insufficient_scored_epochs`, `test_validate_pass_k_reducer` — note: this is the file's first `validate_reducer` test), name-resolution roundtrip (`test_pass_k_reducer_by_name`)
- `docs/scorers.qmd`, `docs/options.qmd`, `docs/reference/inspect_ai.scorer.qmd` — reducer-table row, options enumeration, reference heading
- `CHANGELOG.md` — `Scoring:` entry under `Unreleased`

## Test Plan

- [x] `pytest tests/scorer/test_reducers.py -v` → 33 passed (29 existing + extended assertions in shared helpers + 4 net-new tests)
- [x] `pytest tests/` (excluding `tools/`, `test_package/`) → 3976 passed, 1488 skipped (trio-only / vllm-gated), 0 failed
- [x] `make check` clean for `src/inspect_ai/scorer/_reducer/` and `tests/scorer/test_reducers.py` (ruff lint + format + mypy)
- [x] Numerical anchor: `pass_k(3)` on `[1,1,1,0,0]` = `comb(3,3)/comb(5,3)` = `0.1`
- [x] Registry roundtrip: `create_reducers("pass_k_3")` → `reducer_log_name` → `"pass_k_3"`
- [x] Validation: `validate_reducer(3, pass_k(5))` raises `PrerequisiteError("'pass_k_5' requires 5 epochs however evaluation has only 3 epochs.")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)