### PR TITLE
Bound transcript memory for long-running samples

### DIFF
--- a/docs/superpowers/plans/2026-05-21-bounded-checkpointer.md
+++ b/docs/superpowers/plans/2026-05-21-bounded-checkpointer.md
@@ -1,0 +1,1142 @@
+# Bounded-Memory Checkpointer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move checkpoint cumulative event/pool/attachment state out of `_Checkpointer` Python lists and into a checkpoint-local SQLite store while preserving existing checkpoint snapshot files.
+
+**Architecture:** Add a private `CheckpointEventStore` under `inspect_ai.util._checkpoint` that merges one transcript event/update at a time into SQLite. `_Checkpointer` delegates event accumulation and snapshot file export to this store, retaining only orchestration state for triggers, restic, sidecars, and agent-state callbacks. The existing exported files (`events.json`, `events_data.json`, `attachments.json`, `store.json`, `agent_state.json`) remain the checkpoint artifact for this round.
+
+**Tech Stack:** Python 3.13, SQLite via stdlib `sqlite3`, Pydantic event models, existing `inspect_ai.log._pool` expansion semantics, `pytest`, `ruff`, `mypy`.
+
+---
+
+## File Structure
+
+- Create `src/inspect_ai/util/_checkpoint/event_store.py`
+  - Defines `CheckpointEventStore` and `CheckpointEventStoreCounts`.
+  - Owns SQLite schema, event merge/update collapse, DB-backed pool lookup, cumulative attachments, and snapshot JSON export.
+- Modify `src/inspect_ai/util/_checkpoint/checkpointer_impl.py`
+  - Replace `_condensed_events`, `_condensed_event_index`, `_msg_pool`, `_msg_index`, `_call_pool`, `_call_index` with `CheckpointEventStore`.
+  - Pass transcript attachments into event-store merge calls.
+  - Export host context through event store.
+  - Update TEMPORARY diagnostics to report store counts.
+- Modify `src/inspect_ai/log/_pool.py`
+  - Add small reusable helpers for hashing/condensing one event with callback-based pool lookup, or expose the existing hash/ref primitives needed by `CheckpointEventStore`.
+- Modify `src/inspect_ai/log/_transcript.py` only if late provider-backed seeding needs a streaming history method. Prefer not to widen this API unless tests prove it necessary.
+- Modify `tests/checkpoint/test_checkpointer.py`
+  - Update tests that inspect private `_Checkpointer` cumulative lists.
+  - Add bounded-memory/checkpoint-store integration tests.
+- Create `tests/checkpoint/test_checkpoint_event_store.py`
+  - Store-level unit tests for merge, update collapse, pool stability, attachments, and export round-trip.
+
+---
+
+### Task 1: Add Store Skeleton and Schema
+
+**Files:**
+- Create: `src/inspect_ai/util/_checkpoint/event_store.py`
+- Create: `tests/checkpoint/test_checkpoint_event_store.py`
+
+- [ ] **Step 1: Write failing schema/counts tests**
+
+Add this test file:
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+
+from inspect_ai.util._checkpoint.event_store import CheckpointEventStore
+
+
+def test_checkpoint_event_store_initializes_schema(tmp_path: Path) -> None:
+    store = CheckpointEventStore(tmp_path / "checkpoint-state.sqlite")
+
+    counts = store.counts()
+
+    assert counts.events == 0
+    assert counts.message_pool == 0
+    assert counts.call_pool == 0
+    assert counts.attachments == 0
+    assert (tmp_path / "checkpoint-state.sqlite").exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py::test_checkpoint_event_store_initializes_schema -q
+```
+
+Expected: FAIL with `ModuleNotFoundError` or missing `CheckpointEventStore`.
+
+- [ ] **Step 3: Implement store skeleton**
+
+Create `src/inspect_ai/util/_checkpoint/event_store.py`:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from sqlite3 import Connection, connect
+
+
+@dataclass(frozen=True)
+class CheckpointEventStoreCounts:
+    events: int
+    message_pool: int
+    call_pool: int
+    attachments: int
+    db_bytes: int
+
+
+class CheckpointEventStore:
+    def __init__(self, path: str | Path) -> None:
+        self._path = Path(path)
+        self._conn = connect(self._path)
+        self._conn.row_factory = None
+        self._init_schema(self._conn)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def counts(self) -> CheckpointEventStoreCounts:
+        return CheckpointEventStoreCounts(
+            events=self._count_rows("events"),
+            message_pool=self._count_rows("message_pool"),
+            call_pool=self._count_rows("call_pool"),
+            attachments=self._count_rows("attachments"),
+            db_bytes=self._path.stat().st_size if self._path.exists() else 0,
+        )
+
+    def close(self) -> None:
+        self._conn.close()
+
+    def _count_rows(self, table: str) -> int:
+        row = self._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+        assert row is not None
+        return int(row[0])
+
+    @staticmethod
+    def _init_schema(conn: Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS events (
+                logical_id TEXT PRIMARY KEY,
+                first_seq INTEGER NOT NULL UNIQUE,
+                latest_json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS message_pool (
+                pos INTEGER PRIMARY KEY,
+                hash TEXT NOT NULL UNIQUE,
+                json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS call_pool (
+                pos INTEGER PRIMARY KEY,
+                hash TEXT NOT NULL UNIQUE,
+                json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS attachments (
+                hash TEXT PRIMARY KEY,
+                content TEXT NOT NULL
+            );
+            """
+        )
+        conn.commit()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py::test_checkpoint_event_store_initializes_schema -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpoint_event_store.py
+git commit -m "feat(checkpoint): add SQLite event store skeleton"
+```
+
+---
+
+### Task 2: Implement Event Merge and Update Collapse
+
+**Files:**
+- Modify: `src/inspect_ai/util/_checkpoint/event_store.py`
+- Modify: `tests/checkpoint/test_checkpoint_event_store.py`
+
+- [ ] **Step 1: Add failing tests for order and update collapse**
+
+Append to `tests/checkpoint/test_checkpoint_event_store.py`:
+
+```python
+import json
+
+from inspect_ai.event._info import InfoEvent
+
+
+def _exported_events(work_dir: Path) -> list[dict[str, object]]:
+    return json.loads((work_dir / "events.json").read_text())
+
+
+def test_checkpoint_event_store_exports_events_in_first_seen_order(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / "checkpoint-state.sqlite")
+    first = InfoEvent(data="first")
+    second = InfoEvent(data="second")
+
+    event_store.merge_event(first, attachments={})
+    event_store.merge_event(second, attachments={})
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events = _exported_events(tmp_path)
+    assert [event["data"] for event in events] == ["first", "second"]
+    assert [event["uuid"] for event in events] == [first.uuid, second.uuid]
+
+
+def test_checkpoint_event_store_updates_existing_logical_event(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / "checkpoint-state.sqlite")
+    event = InfoEvent(data="first")
+
+    event_store.merge_event(event, attachments={})
+    event.data = "updated"
+    event_store.merge_event(event, attachments={})
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events = _exported_events(tmp_path)
+    assert len(events) == 1
+    assert events[0]["uuid"] == event.uuid
+    assert events[0]["data"] == "updated"
+    assert event_store.counts().events == 1
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py -q
+```
+
+Expected: FAIL because `merge_event()` and `export_snapshot_files()` are missing.
+
+- [ ] **Step 3: Implement event merge/export without pools**
+
+Update `event_store.py` imports and class:
+
+```python
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from pydantic_core import to_jsonable_python
+from shortuuid import uuid
+
+from inspect_ai.event._event import Event
+```
+
+Add methods inside `CheckpointEventStore`:
+
+```python
+    def merge_event(self, event: Event, attachments: Mapping[str, str]) -> None:
+        if event.uuid is None:
+            event.uuid = uuid()
+        event_json = json.dumps(
+            to_jsonable_python(event, exclude_none=True, fallback=lambda _: None),
+            separators=(",", ":"),
+        )
+        with self._conn:
+            row = self._conn.execute(
+                "SELECT first_seq FROM events WHERE logical_id = ?",
+                (event.uuid,),
+            ).fetchone()
+            if row is None:
+                first_seq = self._next_event_seq()
+                self._conn.execute(
+                    "INSERT INTO events(logical_id, first_seq, latest_json) VALUES (?, ?, ?)",
+                    (event.uuid, first_seq, event_json),
+                )
+            else:
+                self._conn.execute(
+                    "UPDATE events SET latest_json = ? WHERE logical_id = ?",
+                    (event_json, event.uuid),
+                )
+            for ref in self._attachment_refs(event):
+                content = attachments.get(ref)
+                if content is not None:
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO attachments(hash, content) VALUES (?, ?)",
+                        (ref, content),
+                    )
+
+    def merge_events(self, events: list[Event], attachments: Mapping[str, str]) -> None:
+        for event in events:
+            self.merge_event(event, attachments)
+
+    def export_snapshot_files(
+        self,
+        sample_working_dir: str | Path,
+        *,
+        store_json: object,
+        agent_state: Mapping[str, object] | None,
+    ) -> None:
+        sample_dir = Path(sample_working_dir)
+        self._write_json_array(
+            sample_dir / "events.json",
+            self._conn.execute("SELECT latest_json FROM events ORDER BY first_seq"),
+        )
+        (sample_dir / "events_data.json").write_text('{"messages":[],"calls":[]}\n')
+        self._write_json_object_from_rows(
+            sample_dir / "attachments.json",
+            self._conn.execute("SELECT hash, content FROM attachments ORDER BY hash"),
+        )
+        (sample_dir / "store.json").write_text(json.dumps(store_json) + "\n")
+        if agent_state is not None:
+            (sample_dir / "agent_state.json").write_text(json.dumps(agent_state) + "\n")
+
+    def _next_event_seq(self) -> int:
+        row = self._conn.execute("SELECT COALESCE(MAX(first_seq), -1) + 1 FROM events").fetchone()
+        assert row is not None
+        return int(row[0])
+
+    @staticmethod
+    def _attachment_refs(event: Event) -> set[str]:
+        refs: set[str] = set()
+
+        def collect(value: object) -> None:
+            if isinstance(value, str):
+                if value.startswith("attachment://"):
+                    refs.add(value.removeprefix("attachment://"))
+            elif isinstance(value, dict):
+                for item in value.values():
+                    collect(item)
+            elif isinstance(value, list):
+                for item in value:
+                    collect(item)
+
+        collect(event.model_dump(mode="python"))
+        return refs
+
+    @staticmethod
+    def _write_json_array(path: Path, rows: object) -> None:
+        with path.open("w") as file:
+            file.write("[")
+            first = True
+            for (json_text,) in rows:  # type: ignore[assignment]
+                if not first:
+                    file.write(",")
+                file.write(str(json_text))
+                first = False
+            file.write("]\n")
+
+    @staticmethod
+    def _write_json_object_from_rows(path: Path, rows: object) -> None:
+        with path.open("w") as file:
+            file.write("{")
+            first = True
+            for key, value in rows:  # type: ignore[assignment]
+                if not first:
+                    file.write(",")
+                file.write(json.dumps(str(key)))
+                file.write(":")
+                file.write(json.dumps(value))
+                first = False
+            file.write("}\n")
+```
+
+- [ ] **Step 4: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py -q
+```
+
+Expected: PASS for current tests.
+
+- [ ] **Step 5: Run type/lint and fix only issues in touched files**
+
+Run:
+
+```bash
+uv run ruff check src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpoint_event_store.py
+uv run mypy src/inspect_ai/util/_checkpoint/event_store.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpoint_event_store.py
+git commit -m "feat(checkpoint): store latest event versions on disk"
+```
+
+---
+
+### Task 3: Add DB-Backed Pool Condensing
+
+**Files:**
+- Modify: `src/inspect_ai/log/_pool.py`
+- Modify: `src/inspect_ai/util/_checkpoint/event_store.py`
+- Modify: `tests/checkpoint/test_checkpoint_event_store.py`
+
+- [ ] **Step 1: Add failing pool round-trip test**
+
+Append to `tests/checkpoint/test_checkpoint_event_store.py`:
+
+```python
+from inspect_ai.log import expand_events
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.model._chat_message import ChatMessageAssistant, ChatMessageSystem, ChatMessageUser
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_output import ModelOutput
+
+
+def _model_event(messages: list[object]) -> ModelEvent:
+    return ModelEvent(
+        model="test",
+        input=messages,
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput(),
+        call=None,
+    )
+
+
+def test_checkpoint_event_store_exports_stable_message_pool(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / "checkpoint-state.sqlite")
+    sys = ChatMessageSystem(content="sys")
+    user = ChatMessageUser(content="question")
+    assistant = ChatMessageAssistant(content="answer")
+
+    event_store.merge_event(_model_event([sys, user]), attachments={})
+    event_store.merge_event(_model_event([sys, user, assistant]), attachments={})
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events_data = json.loads((tmp_path / "events_data.json").read_text())
+    events = json.loads((tmp_path / "events.json").read_text())
+    assert len(events_data["messages"]) == 3
+    assert events[0]["input_refs"] == [[0, 1]]
+    assert events[1]["input_refs"] == [[0, 2]]
+
+    expanded = expand_events(
+        (tmp_path / "events.json").read_text(),
+        (tmp_path / "events_data.json").read_text(),
+    )
+    model_events = [event for event in expanded if isinstance(event, ModelEvent)]
+    assert [len(event.input) for event in model_events] == [2, 3]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py::test_checkpoint_event_store_exports_stable_message_pool -q
+```
+
+Expected: FAIL because `events_data.messages` is empty and events are uncondensed.
+
+- [ ] **Step 3: Expose callback-based condense helpers**
+
+In `src/inspect_ai/log/_pool.py`, add imports if needed:
+
+```python
+from collections.abc import Callable
+```
+
+Add helper functions near existing condense functions:
+
+```python
+def condense_model_event_inputs_with_lookup(
+    event: Event,
+    lookup_message: Callable[[ChatMessage], int],
+) -> Event:
+    if isinstance(event, ModelEvent) and event.input:
+        raw_indices = [lookup_message(message) for message in event.input]
+        return event.model_copy(
+            update={
+                "input": [],
+                "input_refs": _compress_refs(raw_indices),
+            }
+        )
+    return event
+
+
+def condense_model_event_calls_with_lookup(
+    event: Event,
+    lookup_call: Callable[[JsonValue], int],
+) -> Event:
+    if isinstance(event, ModelEvent) and event.call and event.call.request:
+        msg_key = "messages" if "messages" in event.call.request else "contents"
+        msgs = event.call.request.get(msg_key)
+        if isinstance(msgs, list):
+            raw_indices = [lookup_call(msg) for msg in msgs]
+            new_request = {k: v for k, v in event.call.request.items() if k != msg_key}
+            new_call = event.call.model_copy(
+                update={
+                    "request": new_request,
+                    "call_refs": _compress_refs(raw_indices),
+                    "call_key": msg_key,
+                }
+            )
+            return event.model_copy(update={"call": new_call})
+    return event
+```
+
+Use the existing private `_compress_refs()` and existing `ChatMessage`, `JsonValue`, `Event`, `ModelEvent` imports already in `_pool.py`.
+
+- [ ] **Step 4: Wire message pool lookup in event store**
+
+Update `event_store.py` imports:
+
+```python
+from pydantic_core import to_jsonable_python
+from inspect_ai._util.hash import mm3_hash
+from inspect_ai.log._pool import condense_model_event_inputs_with_lookup, condense_model_event_calls_with_lookup
+from inspect_ai.model._chat_message import ChatMessage
+from pydantic import JsonValue
+```
+
+Add methods:
+
+```python
+    def _condense_event(self, event: Event) -> Event:
+        event = condense_model_event_inputs_with_lookup(event, self._message_pos)
+        event = condense_model_event_calls_with_lookup(event, self._call_pos)
+        return event
+
+    def _message_pos(self, message: ChatMessage) -> int:
+        message_jsonable = to_jsonable_python(message, exclude_none=True, fallback=lambda _: None)
+        message_json = json.dumps(message_jsonable, sort_keys=True)
+        return self._pool_pos("message_pool", mm3_hash(message_json), message_json)
+
+    def _call_pos(self, call_message: JsonValue) -> int:
+        call_json = json.dumps(call_message, sort_keys=True)
+        return self._pool_pos("call_pool", mm3_hash(call_json), call_json)
+
+    def _pool_pos(self, table: str, hash_value: str, json_text: str) -> int:
+        row = self._conn.execute(f"SELECT pos FROM {table} WHERE hash = ?", (hash_value,)).fetchone()
+        if row is not None:
+            return int(row[0])
+        pos_row = self._conn.execute(f"SELECT COALESCE(MAX(pos), -1) + 1 FROM {table}").fetchone()
+        assert pos_row is not None
+        pos = int(pos_row[0])
+        self._conn.execute(
+            f"INSERT INTO {table}(pos, hash, json) VALUES (?, ?, ?)",
+            (pos, hash_value, json_text),
+        )
+        return pos
+```
+
+In `merge_event()`, before serializing:
+
+```python
+        event = self._condense_event(event)
+```
+
+Update `export_snapshot_files()` to write real events data:
+
+```python
+        self._write_events_data(sample_dir / "events_data.json")
+```
+
+Add:
+
+```python
+    def _write_events_data(self, path: Path) -> None:
+        with path.open("w") as file:
+            file.write('{"messages":')
+            self._write_json_array_to_file(
+                file,
+                self._conn.execute("SELECT json FROM message_pool ORDER BY pos"),
+            )
+            file.write(',"calls":')
+            self._write_json_array_to_file(
+                file,
+                self._conn.execute("SELECT json FROM call_pool ORDER BY pos"),
+            )
+            file.write("}\n")
+
+    @staticmethod
+    def _write_json_array_to_file(file: object, rows: object) -> None:
+        file.write("[")
+        first = True
+        for (json_text,) in rows:  # type: ignore[assignment]
+            if not first:
+                file.write(",")
+            file.write(str(json_text))
+            first = False
+        file.write("]")
+```
+
+Then make `_write_json_array()` delegate to `_write_json_array_to_file()`.
+
+- [ ] **Step 5: Run pool test**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py::test_checkpoint_event_store_exports_stable_message_pool -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Add and pass call pool test**
+
+Append a second test:
+
+```python
+from inspect_ai.model._model_call import ModelCall
+
+
+def test_checkpoint_event_store_exports_stable_call_pool(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / "checkpoint-state.sqlite")
+    event = _model_event([ChatMessageUser(content="visible")])
+    event.call = ModelCall.create(
+        request={"messages": [{"role": "user", "content": "hidden"}]},
+        response={"ok": True},
+    )
+
+    event_store.merge_event(event, attachments={})
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events_data = json.loads((tmp_path / "events_data.json").read_text())
+    events = json.loads((tmp_path / "events.json").read_text())
+    assert events_data["calls"] == [{"role": "user", "content": "hidden"}]
+    assert events[0]["call"]["call_refs"] == [[0, 0]]
+    assert "messages" not in events[0]["call"]["request"]
+```
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py::test_checkpoint_event_store_exports_stable_call_pool -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run full store tests and type/lint**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py -q
+uv run ruff check src/inspect_ai/log/_pool.py src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpoint_event_store.py
+uv run mypy src/inspect_ai/log/_pool.py src/inspect_ai/util/_checkpoint/event_store.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/inspect_ai/log/_pool.py src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpoint_event_store.py
+git commit -m "feat(checkpoint): condense event pools on disk"
+```
+
+---
+
+### Task 4: Export Attachments and Host Context Files
+
+**Files:**
+- Modify: `src/inspect_ai/util/_checkpoint/event_store.py`
+- Modify: `tests/checkpoint/test_checkpoint_event_store.py`
+
+- [ ] **Step 1: Add failing attachment and host-context tests**
+
+Append:
+
+```python
+from inspect_ai.event._model import ModelEvent
+
+
+def test_checkpoint_event_store_retains_cumulative_attachments(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / "checkpoint-state.sqlite")
+    event = InfoEvent(data={"blob": "attachment://abc"})
+
+    event_store.merge_event(event, attachments={"abc": "payload"})
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    assert json.loads((tmp_path / "attachments.json").read_text()) == {"abc": "payload"}
+
+    event_store.merge_event(InfoEvent(data="later"), attachments={})
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    assert json.loads((tmp_path / "attachments.json").read_text()) == {"abc": "payload"}
+
+
+def test_checkpoint_event_store_writes_store_and_agent_state(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / "checkpoint-state.sqlite")
+    event_store.export_snapshot_files(
+        tmp_path,
+        store_json={"x": 1},
+        agent_state={"agent": {"step": 2}},
+    )
+
+    assert json.loads((tmp_path / "store.json").read_text()) == {"x": 1}
+    assert json.loads((tmp_path / "agent_state.json").read_text()) == {
+        "agent": {"step": 2}
+    }
+```
+
+- [ ] **Step 2: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py::test_checkpoint_event_store_retains_cumulative_attachments tests/checkpoint/test_checkpoint_event_store.py::test_checkpoint_event_store_writes_store_and_agent_state -q
+```
+
+Expected: attachment test may already pass; host context should pass if Task 2 implemented it. If both pass, continue; these tests lock behavior.
+
+- [ ] **Step 3: If needed, fix attachment scanning/export**
+
+Ensure `_attachment_refs()` scans condensed events and nested dict/list structures. Keep cumulative rows with `INSERT OR IGNORE`.
+
+- [ ] **Step 4: Run store tests**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpoint_event_store.py
+git commit -m "feat(checkpoint): retain checkpoint attachments on disk"
+```
+
+---
+
+### Task 5: Wire `_Checkpointer` to `CheckpointEventStore`
+
+**Files:**
+- Modify: `src/inspect_ai/util/_checkpoint/checkpointer_impl.py`
+- Modify: `tests/checkpoint/test_checkpointer.py`
+
+- [ ] **Step 1: Update tests to assert store-backed state**
+
+In `tests/checkpoint/test_checkpointer.py`, add a test near existing checkpoint stream tests:
+
+```python
+async def test_checkpointer_uses_store_instead_of_cumulative_python_lists(tmp_path: Path) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    cp = _Checkpointer(
+        config=CheckpointConfig(trigger=TurnInterval(every=1)),
+        sample_checkpoints_dir=str(tmp_path / "ckpts"),
+        sample_working_dir=str(work),
+        host_restic=Path("/fake"),
+        restic_password="pwd",
+    )
+
+    assert not hasattr(cp, "_condensed_events")
+    assert not hasattr(cp, "_msg_pool")
+    assert not hasattr(cp, "_call_pool")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpointer.py::test_checkpointer_uses_store_instead_of_cumulative_python_lists -q
+```
+
+Expected: FAIL because `_Checkpointer` still has cumulative lists.
+
+- [ ] **Step 3: Replace cumulative fields with event store**
+
+In `checkpointer_impl.py`:
+
+- Remove imports of `EventsData`, `condense_model_event_calls`, `condense_model_event_inputs`, `ChatMessage`, and `JsonValue` if no longer used.
+- Import:
+
+```python
+from pydantic_core import to_jsonable_python
+from .event_store import CheckpointEventStore
+```
+
+In `_Checkpointer.__init__`, replace the cumulative fields with:
+
+```python
+        self._event_store = CheckpointEventStore(
+            Path(self._sample_working_dir) / "checkpoint-state.sqlite"
+        )
+```
+
+Remove `_merge_events_into_checkpoint_stream()` and `_merge_event_into_checkpoint_stream()` or leave as thin wrappers temporarily:
+
+```python
+    def _merge_events_into_checkpoint_stream(
+        self, events: Sequence[Event], attachments: Mapping[str, str] | None = None
+    ) -> None:
+        self._event_store.merge_events(events, attachments or {})
+```
+
+Update `_track_transcript_event()`:
+
+```python
+    def _track_transcript_event(self, event: Event) -> None:
+        self._event_store.merge_event(event, transcript().attachments)
+        self._events_since_diagnostic += 1
+        if self._events_since_diagnostic >= _TEMPORARY_CHECKPOINT_DIAGNOSTIC_INTERVAL:
+            self._events_since_diagnostic = 0
+            self._log_temporary_diagnostics("event")
+```
+
+Update seeding:
+
+```python
+            seed_events = list(ts.events)
+            self._event_store.merge_events(seed_events, ts.attachments)
+```
+
+Update `_write_host_context()`:
+
+```python
+        if events:
+            self._event_store.merge_events(events, attachments)
+        agent_state = None
+        if self._on_checkpoint_callbacks:
+            agent_state = {key: cb() for key, cb in self._on_checkpoint_callbacks.items()}
+        self._event_store.export_snapshot_files(
+            sample_working_dir,
+            store_json=store_jsonable(store),
+            agent_state=agent_state,
+        )
+```
+
+- [ ] **Step 4: Update diagnostics to use counts**
+
+Replace `_log_temporary_diagnostics()` body with:
+
+```python
+        extra = extra or {}
+        counts = self._event_store.counts()
+        logger.info(
+            "TEMPORARY checkpoint: source=%s events=%s message_pool=%s call_pool=%s attachments=%s db_bytes=%s callbacks=%s next_checkpoint_id=%s turns_since_fire=%s extra=%s",
+            source,
+            counts.events,
+            counts.message_pool,
+            counts.call_pool,
+            counts.attachments,
+            counts.db_bytes,
+            len(self._on_checkpoint_callbacks),
+            self._next_checkpoint_id,
+            self._turns_since_fire,
+            dict(extra),
+        )
+```
+
+- [ ] **Step 5: Run focused checkpointer tests**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpointer.py::test_checkpointer_uses_store_instead_of_cumulative_python_lists tests/checkpoint/test_checkpointer.py::test_write_host_context_accumulates_across_fires tests/checkpoint/test_checkpointer.py::test_fire_collapses_same_cycle_event_updates -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run all checkpoint tests**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpointer.py tests/checkpoint/test_checkpoint_event_store.py -q
+```
+
+Expected: PASS for asyncio tests; trio variants may skip as usual.
+
+- [ ] **Step 7: Type/lint**
+
+Run:
+
+```bash
+uv run ruff check src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpointer.py
+uv run mypy src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/util/_checkpoint/event_store.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/util/_checkpoint/event_store.py tests/checkpoint/test_checkpointer.py
+git commit -m "feat(checkpoint): back checkpoint stream with SQLite"
+```
+
+---
+
+### Task 6: Add Bounded Transcript Attachment Regression
+
+**Files:**
+- Modify: `tests/checkpoint/test_checkpointer.py`
+
+- [ ] **Step 1: Add failing regression test**
+
+Append near bounded transcript/checkpoint tests:
+
+```python
+async def test_checkpoint_retains_attachment_after_transcript_eviction(tmp_path: Path) -> None:
+    work = tmp_path / "work"
+    work.mkdir()
+    transcript = Transcript(bounded=True, resident_tail=1)
+    cp = _Checkpointer(
+        config=CheckpointConfig(trigger=TurnInterval(every=1)),
+        sample_checkpoints_dir=str(tmp_path / "ckpts"),
+        sample_working_dir=str(work),
+        host_restic=Path("/fake"),
+        restic_password="pwd",
+    )
+
+    first = InfoEvent(data={"blob": "attachment://abc"})
+    transcript.attachments["abc"] = "payload"
+
+    with patch(
+        "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+        return_value=transcript,
+    ):
+        cp._ensure_transcript_subscription()
+        transcript._event(first)
+        transcript._event(InfoEvent(data="evict first"))
+        await cp._write_host_context(str(work), [], transcript.attachments, Store())
+
+    assert first not in transcript.resident_events
+    assert json.loads((work / "attachments.json").read_text()) == {"abc": "payload"}
+```
+
+- [ ] **Step 2: Run test**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpointer.py::test_checkpoint_retains_attachment_after_transcript_eviction -q
+```
+
+Expected: PASS if Task 5 copied attachments during merge. If it fails, update `_track_transcript_event()` to pass `transcript().attachments` before eviction can prune content, or update transcript notification ordering only if necessary and covered by tests.
+
+- [ ] **Step 3: Run related tests**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpointer.py tests/log/test_transcript_bounded.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/checkpoint/test_checkpointer.py src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/util/_checkpoint/event_store.py
+git commit -m "test(checkpoint): retain attachments after transcript eviction"
+```
+
+---
+
+### Task 7: Fix Late Provider-Backed Seeding Without Full List Materialization
+
+**Files:**
+- Modify: `src/inspect_ai/log/_transcript.py`
+- Modify: `src/inspect_ai/log/_recorders/buffer/history_provider.py`
+- Modify: `src/inspect_ai/util/_checkpoint/checkpointer_impl.py`
+- Modify: `tests/checkpoint/test_checkpointer.py`
+- Modify: `tests/test_helpers/transcript.py`
+
+- [ ] **Step 1: Add provider streaming protocol method**
+
+In `TranscriptHistoryProvider` in `src/inspect_ai/log/_transcript.py`, add:
+
+```python
+    def iter_events(self) -> Iterator[Event]: ...
+```
+
+In `_TranscriptEventsView.__iter__()`, keep existing behavior or call `provider.iter_events()` if implemented. In `BufferTranscriptHistoryProvider`, implement:
+
+```python
+    def iter_events(self) -> Iterator[Event]:
+        with self._buffer_db.open_sample_history(self._sample_id, self._epoch) as history:
+            yield from materialize_events_from_history(history)
+```
+
+If no existing `materialize_events_from_history()` exists, use the same helper/path as `events()` but yield incrementally. Do not return a list.
+
+- [ ] **Step 2: Update fake providers**
+
+In `tests/test_helpers/transcript.py`, add `iter_events()` to `FakeTranscriptHistoryProvider`:
+
+```python
+    def iter_events(self) -> Iterator[Event]:
+        return iter(self._events)
+```
+
+- [ ] **Step 3: Add failing no-materialize seed test**
+
+In `tests/checkpoint/test_checkpointer.py`, add:
+
+```python
+class _SeedOnlyProvider(FakeTranscriptHistoryProvider):
+    def events(self) -> list[Event]:
+        raise AssertionError("checkpoint seed must not materialize provider.events()")
+
+    def iter_events(self) -> Iterator[Event]:
+        return iter(self._events)
+
+
+async def test_late_checkpointer_provider_seed_does_not_materialize_events(tmp_path: Path) -> None:
+    full_history: list[Event] = [InfoEvent(data="evicted"), InfoEvent(data="resident")]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=_SeedOnlyProvider(full_history),
+    )
+    for event in full_history:
+        transcript._event(event)
+
+    cp = _Checkpointer(
+        config=CheckpointConfig(trigger=TurnInterval(every=1)),
+        sample_checkpoints_dir=str(tmp_path / "ckpts"),
+        sample_working_dir=str(tmp_path / "work"),
+        host_restic=Path("/fake"),
+        restic_password="pwd",
+    )
+
+    with patch(
+        "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+        return_value=transcript,
+    ):
+        cp._ensure_transcript_subscription()
+        await cp._write_host_context(str(tmp_path / "work"), [], transcript.attachments, Store())
+
+    events = json.loads((tmp_path / "work" / "events.json").read_text())
+    assert [event["data"] for event in events] == ["evicted", "resident"]
+```
+
+- [ ] **Step 4: Update checkpointer seeding**
+
+In `_ensure_transcript_subscription()`:
+
+```python
+            if ts.resident_events_truncated and ts.full_history_available:
+                seed_events_iter = ts._history_provider.iter_events()
+            else:
+                seed_events_iter = iter(ts.events)
+            seed_count = 0
+            for event in seed_events_iter:
+                self._event_store.merge_event(event, ts.attachments)
+                seed_count += 1
+```
+
+Avoid `list(...)` in this path. Preserve existing RuntimeError for truncated/no-provider transcripts.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpointer.py::test_late_checkpointer_provider_seed_does_not_materialize_events tests/checkpoint/test_checkpointer.py::test_late_checkpointer_subscription_seeds_provider_backed_history -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run type/lint**
+
+Run:
+
+```bash
+uv run ruff check src/inspect_ai/log/_transcript.py src/inspect_ai/log/_recorders/buffer/history_provider.py src/inspect_ai/util/_checkpoint/checkpointer_impl.py tests/checkpoint/test_checkpointer.py tests/test_helpers/transcript.py
+uv run mypy src/inspect_ai/log/_transcript.py src/inspect_ai/log/_recorders/buffer/history_provider.py src/inspect_ai/util/_checkpoint/checkpointer_impl.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/inspect_ai/log/_transcript.py src/inspect_ai/log/_recorders/buffer/history_provider.py src/inspect_ai/util/_checkpoint/checkpointer_impl.py tests/checkpoint/test_checkpointer.py tests/test_helpers/transcript.py
+git commit -m "feat(checkpoint): stream provider-backed checkpoint seed"
+```
+
+---
+
+### Task 8: Final Validation and Squash
+
+**Files:**
+- Review all touched files.
+
+- [ ] **Step 1: Run focused test suite**
+
+Run:
+
+```bash
+uv run pytest tests/checkpoint/test_checkpoint_event_store.py tests/checkpoint/test_checkpointer.py tests/log/test_transcript_bounded.py tests/log/test_sample_history.py tests/log/test_streaming_completion.py tests/_eval/test_retry_error_events.py tests/display/test_textual_transcript.py -q
+```
+
+Expected: PASS, with known trio skips if not running trio.
+
+- [ ] **Step 2: Run type/lint for touched code**
+
+Run:
+
+```bash
+uv run ruff check src/inspect_ai/util/_checkpoint/event_store.py src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/log/_pool.py src/inspect_ai/log/_transcript.py src/inspect_ai/log/_recorders/buffer/history_provider.py tests/checkpoint/test_checkpoint_event_store.py tests/checkpoint/test_checkpointer.py
+uv run mypy src/inspect_ai/util/_checkpoint/event_store.py src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/log/_pool.py src/inspect_ai/log/_transcript.py src/inspect_ai/log/_recorders/buffer/history_provider.py
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Inspect for accidental cumulative fields**
+
+Run:
+
+```bash
+rg -n "_condensed_events|_condensed_event_index|_msg_pool|_msg_index|_call_pool|_call_index" src/inspect_ai/util/_checkpoint tests/checkpoint
+```
+
+Expected: no `_Checkpointer` cumulative list ownership remains. It is acceptable if tests mention the old names only in negative assertions.
+
+- [ ] **Step 4: Inspect for full materialization in checkpoint seed**
+
+Run:
+
+```bash
+rg -n "list\(ts\.events\)|list\(transcript\(\)\.events\)|seed_events = list" src/inspect_ai/util/_checkpoint src/inspect_ai/log
+```
+
+Expected: no checkpoint seed path materializes full transcript history.
+
+- [ ] **Step 5: Squash implementation commits if requested**
+
+If this work should remain one feature commit on top of the current event-store branch, run an interactive rebase over the checkpoint implementation commits only. Do not squash the existing event-store feature commit unless the user explicitly asks.
+
+- [ ] **Step 6: Push branch**
+
+```bash
+git push --force-with-lease metr event-store-transcript
+```
+
+Expected: branch updates on `metr/event-store-transcript`.

--- a/docs/superpowers/specs/2026-05-21-bounded-checkpointer-design.md
+++ b/docs/superpowers/specs/2026-05-21-bounded-checkpointer-design.md
@@ -1,0 +1,270 @@
+# Bounded-Memory Checkpointer Design
+
+## Context
+
+The bounded transcript work limits resident `Transcript` memory by evicting old events and reading full history from a provider when needed. Checkpointing currently defeats that goal when enabled: `_Checkpointer` subscribes to transcript events, condenses each event, and keeps the cumulative checkpoint stream in Python lists and dictionaries for the lifetime of the sample.
+
+The hard requirement for this update is bounded Python memory with checkpointing enabled. Bounded checkpoint duration, bounded disk use, and avoiding cumulative checkpoint rewrites are not hard requirements for this round.
+
+Checkpointing is not live yet, so the on-disk format can change if it substantially simplifies the design. The preferred design below keeps the existing snapshot files initially because it satisfies the memory goal while preserving the current resume/checkpoint compatibility story.
+
+## Goals
+
+- Keep checkpointer Python memory bounded by current event/update size plus small export buffers.
+- Preserve checkpoint semantics: stable event order, latest-update collapse by logical event id, stable positional event pools, and self-contained attachment snapshots.
+- Keep `_Checkpointer` focused on policy, sidecars, restic backup, and `Checkpointer.track()` callbacks.
+- Avoid depending on the log buffer DB for correctness; checkpointing should work with or without bounded transcript logging.
+- Keep existing host snapshot files unless a later implementation step proves a DB artifact is simpler.
+
+## Non-Goals
+
+- Bounded checkpoint export time. Exporting cumulative `events.json` can remain O(total history).
+- Bounded checkpoint artifact size. Cumulative snapshot files can keep growing.
+- A public checkpoint store API.
+- A general replacement for the eval log buffer DB.
+
+## Current Problem
+
+`src/inspect_ai/util/_checkpoint/checkpointer_impl.py` currently stores cumulative state in memory:
+
+- `_condensed_events: list[Event]`
+- `_condensed_event_index: dict[str | int, int]`
+- `_msg_pool: list[ChatMessage]`
+- `_msg_index: dict[str, int]`
+- `_call_pool: list[JsonValue]`
+- `_call_index: dict[str, int]`
+
+These structures grow with total event history. Bounded transcript eviction does not help because the checkpointer has already copied the cumulative condensed stream into its own Python objects.
+
+The current late-seed path also does `list(ts.events)`. With a provider-backed bounded transcript this can materialize full history in memory.
+
+A separate correctness issue exists under bounded transcripts: `_write_host_context()` writes cumulative checkpoint events but receives attachments from `ts.attachments`. Bounded transcript may prune attachments for evicted events, so checkpoint snapshots must retain cumulative attachments independently.
+
+## Chosen Approach
+
+Add a checkpoint-local SQLite store in the sample working directory. `_Checkpointer` writes event deltas into this store as transcript notifications arrive. On checkpoint fire, the store exports the existing snapshot files into the sample working directory, then restic backs up the directory as today.
+
+This gives bounded runtime memory without tying checkpointing to buffer logging internals.
+
+## Components
+
+### `_Checkpointer`
+
+`_Checkpointer` remains the orchestration layer. It should own:
+
+- checkpoint trigger policy;
+- restic repo setup and backup calls;
+- sidecar writes;
+- `Checkpointer.track()` callback registration;
+- subscription lifecycle.
+
+It should no longer own cumulative event or pool state. Replace the cumulative lists/dicts with a private `CheckpointEventStore` instance.
+
+### `CheckpointEventStore`
+
+A new private class, likely in `src/inspect_ai/util/_checkpoint/event_store.py`, owns durable checkpoint transcript state for one sample attempt.
+
+Core methods:
+
+- `merge_event(event: Event) -> None`
+- `merge_events(events: Iterable[Event]) -> None`
+- `export_snapshot_files(sample_working_dir: str, store: Store, agent_state: Mapping[str, JsonValue] | None) -> None`
+- `counts() -> CheckpointEventStoreCounts` for TEMPORARY diagnostics and tests
+- `close() -> None` if needed
+
+The store is private to checkpointing and can be synchronous. `_Checkpointer` can call it from synchronous transcript callbacks because each merge is one event/update.
+
+## Store Schema
+
+Use a small SQLite DB under the sample working dir, e.g. `checkpoint-state.sqlite`.
+
+### `events`
+
+One row per logical event.
+
+- `logical_id TEXT PRIMARY KEY`
+- `first_seq INTEGER NOT NULL UNIQUE`
+- `latest_json TEXT NOT NULL`
+
+`logical_id` should be `event.uuid` when present. If an event lacks a uuid, assign one before storage, matching `Transcript._event_key()` behavior. `first_seq` preserves first-seen event order. Later updates overwrite `latest_json` for the same logical id without changing `first_seq`.
+
+### `message_pool`
+
+Stable positional pool for `ModelEvent.input_refs`.
+
+- `pos INTEGER PRIMARY KEY`
+- `hash TEXT NOT NULL UNIQUE`
+- `json TEXT NOT NULL`
+
+`pos` is zero-based and never changes. Hash input must match the current `condense_model_event_inputs()` semantics so existing event expansion behavior remains equivalent.
+
+### `call_pool`
+
+Stable positional pool for `ModelEvent.call.call_refs`.
+
+- `pos INTEGER PRIMARY KEY`
+- `hash TEXT NOT NULL UNIQUE`
+- `json TEXT NOT NULL`
+
+`pos` is zero-based and never changes. Hash input must match current `condense_model_event_calls()` semantics.
+
+### `attachments`
+
+Cumulative attachment content needed by checkpointed events.
+
+- `hash TEXT PRIMARY KEY`
+- `content TEXT NOT NULL`
+
+Start with cumulative retention. Do not refcount or prune in the first version; checkpoint snapshots are cumulative, and correctness matters more than disk minimization.
+
+### `metadata`
+
+Small store metadata.
+
+- `key TEXT PRIMARY KEY`
+- `value TEXT NOT NULL`
+
+Use this for schema version and next sequence if needed. Alternatively compute next sequence from `MAX(first_seq) + 1` inside a transaction.
+
+## Event Condensing
+
+Do not reuse `condense_model_event_inputs()` and `condense_model_event_calls()` directly if doing so requires full in-memory hash indexes. Instead add lower-level helpers or a small adapter that performs lookup-or-insert through the checkpoint store.
+
+The desired shape is:
+
+- walk one event;
+- for each model input message, compute the same hash as today;
+- look up or insert the message in `message_pool` and return its stable `pos`;
+- replace `ModelEvent.input` with compressed `input_refs`;
+- for each call request message, compute the same hash as today;
+- look up or insert the call entry in `call_pool` and return its stable `pos`;
+- replace `ModelEvent.call.request[messages]` with compressed `call_refs`/`call_key`;
+- store the condensed event JSON in `events.latest_json`.
+
+The existing list/dict condense helpers can remain for eval logging. Checkpointing needs DB-backed pool lookup to avoid growing Python indexes.
+
+## Attachment Handling
+
+Checkpoint attachments must be independent of `Transcript.attachments`.
+
+When `merge_event()` sees an event, it should collect `attachment://<hash>` refs from the event after transcript processing has rewritten heavy payloads into attachment refs. For each newly referenced hash, copy the content from the current transcript attachment map into the checkpoint attachment table during the same merge. This is safe only while the attachment is still resident in the transcript.
+
+If an event arrives from a late provider-backed seed, attachment content must come from the provider/import source rather than `ts.attachments`, because the bounded transcript may already have pruned old attachments. The store must not rely on `ts.attachments` at checkpoint fire for cumulative correctness.
+
+Export writes all rows in `attachments` to `attachments.json`.
+
+## Snapshot Export
+
+On checkpoint fire:
+
+1. `_Checkpointer` calls `_ensure_transcript_subscription()`.
+2. `_write_host_context()` merges any explicit `events` argument into the store.
+3. The store exports snapshot files into the sample working dir.
+4. `_Checkpointer` writes `store.json` and optional `agent_state.json`, or delegates those writes to the store export method.
+5. `_Checkpointer` releases any SQLite transaction before running restic backup.
+6. Restic backup and sidecar write proceed as today.
+
+Export should avoid building cumulative Python lists. It should stream rows ordered by `first_seq` / `pos` into JSON files. It is acceptable for export to be O(total history) in time and output bytes.
+
+The first implementation can use simple manual JSON writing:
+
+- write `[`;
+- iterate rows;
+- write comma-separated JSON object strings;
+- write `]` or object wrappers as needed.
+
+`events_data.json` should preserve the existing shape: `{"messages": [...], "calls": [...]}` with positional arrays.
+
+## Late Subscription and Seeding
+
+The normal path should subscribe before meaningful transcript eviction starts. Late subscription still needs defined behavior.
+
+- If the transcript is untruncated, seed from the in-memory events sequence.
+- If the transcript is truncated and has no full-history provider, keep raising a clear `RuntimeError`.
+- If the transcript is truncated and provider-backed, do not call `list(ts.events)`. Add a streaming provider path or a checkpoint-specific import path that feeds events to `CheckpointEventStore.merge_event()` incrementally.
+
+For the first implementation, it is acceptable to make provider-backed late seed a focused method rather than a broad public API. The key requirement is that it must not materialize full history in one Python list.
+
+## Concurrency and Transactions
+
+Transcript subscription callbacks are synchronous. Each `merge_event()` should use a short transaction and commit quickly.
+
+Snapshot export should use a read transaction or a clear high-water mark so `events.json`, `events_data.json`, and `attachments.json` are mutually consistent. The transaction must not remain open across restic backup or other awaits.
+
+Restic should only see complete snapshot files. Preserve the current sidecar-as-commit-point behavior: write host context, run backups, then write the sidecar.
+
+## Diagnostics
+
+Keep TEMPORARY checkpoint diagnostics during the memory investigation, but change them to report store counts instead of Python list sizes:
+
+- event rows;
+- message pool rows;
+- call pool rows;
+- attachment rows;
+- optional DB file size;
+- merge count since last diagnostic;
+- export duration and row counts.
+
+The diagnostic line should remain scalar-only and include `TEMPORARY` for easy removal.
+
+## Testing
+
+### Store Unit Tests
+
+- New events export in first-seen order.
+- Repeated uuid updates overwrite the exported event and do not duplicate it.
+- Events without uuid get stable assigned ids.
+- Message pool positions are stable across repeated merges and updates.
+- Call pool positions are stable across repeated merges and updates.
+- Exported `events.json` + `events_data.json` expands to the same events as the current in-memory checkpointer path.
+- Attachment refs from old events remain available after many later merges.
+
+### Checkpointer Tests
+
+Update existing tests to assert behavior, not private list internals:
+
+- repeated fires accumulate cumulative output;
+- same-cycle event updates serialize once with the final state;
+- checkpointer unsubscribes on close;
+- late truncated/no-provider seed still raises;
+- late provider-backed seed streams/imports without calling the materializing `events` path.
+
+### Bounded-Memory Regression Tests
+
+- Emit many events into a bounded transcript with checkpointing enabled and assert `_Checkpointer` no longer has cumulative Python event/pool lists.
+- Assert store counts grow while resident transcript counts stay bounded.
+- Add an attachment regression where the event that introduced an attachment is evicted before checkpoint fire; the checkpoint export still contains the attachment.
+
+## Risks and Mitigations
+
+### Pool Index Mismatch
+
+Pool refs are positional. If DB `id` values are not zero-based dense positions, exported refs will be wrong. Store explicit `pos` values and order by `pos`.
+
+### Update Ordering Bugs
+
+Event updates must preserve first-seen order while exporting latest content. Use `logical_id` primary key and `first_seq` stored only on first insert.
+
+### Attachment Loss
+
+Bounded transcript prunes attachments. The checkpoint store must retain cumulative attachment content independently.
+
+### Export Memory Spikes
+
+A naive export that builds full lists reintroduces the problem. Export JSON incrementally from DB cursors.
+
+### Late Provider Seed
+
+`list(ts.events)` is not acceptable under bounded mode. Add tests with a provider that raises on materializing `events()` and supports only streaming/suffix import.
+
+### SQLite Lock Scope
+
+Do not hold locks across awaits/restic. Use short merge transactions and short export transactions.
+
+## Implementation Notes
+
+- Keep the existing checkpoint file format initially.
+- Keep the store private and checkpoint-specific.
+- Prefer deterministic JSON serialization compatible with current `_json_dump()` output where practical.
+- The store DB itself does not need to be included in the restic snapshot initially if exported files remain the checkpoint artifact.
+- If exporting cumulative JSON becomes awkward or memory-prone, revisit using the SQLite DB itself as the checkpoint artifact; checkpointing is not live, so that remains negotiable.

--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -81,7 +81,7 @@ class TranscriptView(ScrollableContainer):
             # if we have either a new sample or a new event count then proceed
             if (
                 sample.id != self._sample_id
-                or len(sample.transcript.events) != self._sample_events
+                or sample.transcript.event_count != self._sample_events
             ):
                 # update (scrolling to end if we are already close to it)
                 new_sample = sample.id != self._sample_id
@@ -92,14 +92,14 @@ class TranscriptView(ScrollableContainer):
                 async with self.batch():
                     await self.remove_children()
                     await self.mount_all(
-                        self._widgets_for_events(sample.transcript.events)
+                        self._widgets_for_events(sample.transcript.resident_events)
                     )
                 if scroll_to_end:
                     self.scroll_end(animate=not new_sample)
 
                 # set members
                 self._sample_id = sample.id
-                self._sample_events = len(sample.transcript.events)
+                self._sample_events = sample.transcript.event_count
 
         # if we aren't active then save as a pending sample
         else:

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -371,7 +371,7 @@ async def _run_score_task(
     init_subtask_store(state.store)
 
     # load a copy of the current sample events into the transcript
-    init_transcript(Transcript([*sample.events], log_model_api=False))
+    init_transcript(Transcript([*sample.events], log_model_api=False, bounded=False))
 
     if state.scores is None:
         state.scores = {}

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from importlib import metadata as importlib_metadata
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from shortuuid import uuid
 
@@ -61,6 +61,9 @@ from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 from inspect_ai.viewer import ViewerConfig
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from inspect_ai.log._recorders.buffer.history import SampleHistory
 
 
 def resolve_revision() -> EvalRevision | None:
@@ -301,6 +304,10 @@ class TaskLogger:
     def samples_completed(self) -> int:
         return self._samples_completed
 
+    @property
+    def buffer_db(self) -> SampleBufferDatabase | None:
+        return self._buffer_db
+
     async def log_start(self, plan: EvalPlan) -> None:
         await self.recorder.log_start(self.eval, plan)
         await self.recorder.flush(self.eval)
@@ -319,28 +326,29 @@ class TaskLogger:
             self._buffer_db.remove_samples([(id, epoch)])
 
     async def complete_sample(self, sample: EvalSample, *, flush: bool) -> None:
-        # log the sample
         await self.recorder.log_sample(self.eval, sample)
+        await self._finalize_sample(sample, flush=flush)
 
-        # mark complete
+    async def complete_sample_streaming(
+        self, sample: EvalSample, history: "SampleHistory", *, flush: bool
+    ) -> None:
+        await self.recorder.log_sample_streaming(self.eval, sample, history)
+        await self._finalize_sample(sample, flush=flush)
+
+    async def _finalize_sample(self, sample: EvalSample, *, flush: bool) -> None:
         if self._buffer_db is not None:
             self._buffer_db.complete_sample(sample.summary())
 
-        # flush if requested
         if flush:
             self.flush_pending.append((sample.id, sample.epoch))
             if len(self.flush_pending) >= self.flush_buffer:
-                # flush to disk
                 await self.recorder.flush(self.eval)
 
-                # notify the event db it can remove these
                 if self._buffer_db is not None:
                     self._buffer_db.remove_samples(self.flush_pending)
 
-                # Clear
                 self.flush_pending.clear()
 
-        # track sucessful samples logged
         if sample.error is None:
             self._samples_completed += 1
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -75,13 +75,22 @@ from inspect_ai.log._log import (
     EvalSampleSummary,
     eval_error,
 )
+from inspect_ai.log._recorders.buffer.history_provider import (
+    BufferTranscriptHistoryProvider,
+)
+from inspect_ai.log._recorders.streaming import (
+    eval_retry_error_from_history,
+    materialize_streaming_sample,
+)
 from inspect_ai.log._samples import (
     active_sample,
 )
 from inspect_ai.log._transcript import (
     Transcript,
+    TranscriptHistoryProvider,
     init_transcript,
     transcript,
+    transcript_bounded_enabled,
 )
 from inspect_ai.model import (
     GenerateConfig,
@@ -171,6 +180,18 @@ EvalSampleSource = Callable[
 # the remainder are increments of progress within a sample (and
 # must sum to the total_progress_units when the sample is complete)
 SAMPLE_TOTAL_PROGRESS_UNITS = 1
+
+
+def _sample_transcript_config(
+    logger: TaskLogger | None, sample_id: str | int, epoch: int
+) -> tuple[bool, TranscriptHistoryProvider | None]:
+    if logger is not None and logger.buffer_db is not None:
+        return (
+            transcript_bounded_enabled(),
+            BufferTranscriptHistoryProvider(logger.buffer_db, sample_id, epoch),
+        )
+    else:
+        return False, None
 
 
 @dataclass
@@ -880,10 +901,18 @@ async def task_run_sample(
         init_sample_model_usage()
         init_sample_role_usage()
         set_sample_state(state)
-        sample_transcript = Transcript(log_model_api=log_model_api)
+        sample_transcript_bounded, history_provider = _sample_transcript_config(
+            logger, sample_id, state.epoch
+        )
+        sample_transcript = Transcript(
+            log_model_api=log_model_api,
+            bounded=sample_transcript_bounded,
+            resident_tail=100,
+            history_provider=history_provider,
+        )
         init_transcript(sample_transcript)
         init_subtask_store(state.store)
-        sample_transcript._subscribe(on_sample_event)
+        sample_transcript.subscribe(on_sample_event)
         if scorers:
             init_scoring_context(scorers, Target(sample.target))
         init_sample_assistant_internal()
@@ -1381,22 +1410,29 @@ async def task_run_sample(
                         state = state_without_base64_content(state)
 
                     # emit/log sample end
-                    eval_sample = create_eval_sample(
-                        start_time=start_time,
-                        sample=sample,
-                        state=state,
-                        scores=results,
-                        error=error,
-                        limit=limit,
-                        error_retries=error_retries,
-                        started_at=sample_start_datetime(),
-                    )
+                    def make_eval_sample(include_events: bool = True) -> EvalSample:
+                        return create_eval_sample(
+                            start_time=start_time,
+                            sample=sample,
+                            state=state,
+                            scores=results,
+                            error=error,
+                            limit=limit,
+                            error_retries=error_retries,
+                            started_at=sample_start_datetime(),
+                            include_events=include_events,
+                        )
+
                     if logger:
-                        await log_sample(
-                            eval_sample=eval_sample,
+                        eval_sample = await log_sample(
+                            eval_sample=make_eval_sample(
+                                include_events=logger.buffer_db is None
+                            ),
                             logger=logger,
                             log_images=log_images,
                         )
+                    else:
+                        eval_sample = make_eval_sample()
                     await scan_eval_sample(
                         eval_sample,
                         scanner,
@@ -1421,6 +1457,8 @@ async def task_run_sample(
         and active.interrupt_action is None
     ):
         await emit_attempt_end(will_retry=True)
+
+        retry_error = _eval_retry_error(error, logger, state.sample_id, state.epoch)
 
         # remove any buffered sample events
         if logger is not None:
@@ -1455,7 +1493,7 @@ async def task_run_sample(
             retry_on_error=retry_on_error - 1,
             score_on_error=score_on_error,
             # forward on error that caused retry
-            error_retries=copy(error_retries) + [_eval_retry_error(error)],
+            error_retries=copy(error_retries) + [retry_error],
             time_limit=time_limit,
             working_limit=working_limit,
             semaphore=semaphore,
@@ -1495,6 +1533,7 @@ def create_eval_sample(
     limit: EvalSampleLimit | None,
     error_retries: list[EvalRetryError],
     started_at: datetime | None = None,
+    include_events: bool = True,
 ) -> EvalSample:
     # sample must have id to be logged
     id = sample.id
@@ -1523,7 +1562,7 @@ def create_eval_sample(
         scores={k: v.score for k, v in scores.items()},
         store=dict(state.store.items()),
         uuid=state.uuid,
-        events=list(transcript().events),
+        events=list(transcript().events) if include_events else [],
         timelines=list(transcript().timelines) or None,
         attachments=dict(transcript().attachments),
         model_usage=sample_model_usage(),
@@ -1541,9 +1580,26 @@ def create_eval_sample(
 
 
 async def log_sample(
-    eval_sample: EvalSample, logger: TaskLogger, log_images: bool
-) -> None:
-    await logger.complete_sample(condense_sample(eval_sample, log_images), flush=True)
+    eval_sample: EvalSample,
+    logger: TaskLogger,
+    log_images: bool,
+) -> EvalSample:
+    if logger.buffer_db is None:
+        await logger.complete_sample(
+            condense_sample(eval_sample, log_images), flush=True
+        )
+        return eval_sample
+
+    logging_sample = condense_sample(
+        eval_sample.model_copy(update={"events": [], "events_data": None}),
+        log_images,
+    )
+    with logger.buffer_db.open_sample_history(
+        eval_sample.id, eval_sample.epoch
+    ) as history:
+        materialized_sample = materialize_streaming_sample(eval_sample, history)
+        await logger.complete_sample_streaming(logging_sample, history, flush=True)
+    return materialized_sample
 
 
 # we can reuse samples from a previous eval_log if and only if:
@@ -1719,16 +1775,29 @@ def init_sample_assistant_internal() -> None:
             pass
 
 
-def _eval_retry_error(error: EvalError) -> EvalRetryError:
+def _eval_retry_error(
+    error: EvalError,
+    logger: TaskLogger | None = None,
+    sample_id: str | int | None = None,
+    epoch: int | None = None,
+) -> EvalRetryError:
     """Create retry error with events from the most recent ModelEvent onward."""
     from inspect_ai.event._model import ModelEvent
 
-    events = transcript().events
-    recent_events = list(events)
-    for i in range(len(events) - 1, -1, -1):
-        if isinstance(events[i], ModelEvent):
-            recent_events = list(events[i:])
-            break
+    if logger is not None and logger.buffer_db is not None and sample_id is not None:
+        if epoch is None:
+            raise ValueError(
+                "epoch is required when reading retry events from buffer DB"
+            )
+        with logger.buffer_db.open_sample_history(sample_id, epoch) as history:
+            return eval_retry_error_from_history(error, history)
+
+    sample_transcript = transcript()
+    recent_events = (
+        sample_transcript.events_since_last(ModelEvent)
+        if sample_transcript.full_history_available
+        else []
+    )
     return EvalRetryError(
         message=error.message,
         traceback=error.traceback,

--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import string
+import threading
 import unicodedata
 from contextlib import contextmanager
 from copy import deepcopy
@@ -182,6 +183,16 @@ class FileSystem:
 
     def touch(self, path: str) -> None:
         self.fs.touch(path)
+
+    def open(
+        self,
+        path: str,
+        mode: OpenTextMode | OpenBinaryMode,
+        encoding: str = "utf-8",
+    ) -> Any:
+        if "b" in mode:
+            return self.fs.open(path, mode=mode)
+        return self.fs.open(path, mode=mode, encoding=encoding)
 
     def rm(
         self, path: str, recursive: bool = False, maxdepth: int | None = None
@@ -579,6 +590,26 @@ async def cleanup_s3_sessions() -> None:
                 "Cleaned up %d cached S3FileSystem instance(s)",
                 len(instances),
             )
+
+
+def s3_filesystem_cache_diagnostics() -> dict[str, int | str] | None:
+    """Return lightweight S3FileSystem cache diagnostics if s3fs is loaded."""
+    import sys
+
+    if "s3fs" not in sys.modules:
+        return None
+
+    from s3fs import S3FileSystem  # type: ignore
+
+    cache = getattr(S3FileSystem, "_cache", None)
+    if cache is None:
+        return None
+    return {
+        "cache_size": len(cache),
+        "cache_type": type(cache).__name__,
+        "thread_id": threading.get_ident(),
+        "thread_name": threading.current_thread().name,
+    }
 
 
 DEFAULT_FS_OPTIONS: dict[str, dict[str, Any]] = dict(

--- a/src/inspect_ai/_util/json.py
+++ b/src/inspect_ai/_util/json.py
@@ -1,3 +1,4 @@
+import json
 import re
 from copy import deepcopy
 from typing import (
@@ -54,6 +55,10 @@ JSONType = Literal["string", "integer", "number", "boolean", "array", "object", 
 
 def jsonable_python(x: Any) -> Any:
     return to_jsonable_python(x, exclude_none=True, fallback=lambda _x: None)
+
+
+def json_dump(x: Any) -> str:
+    return json.dumps(jsonable_python(x)) + "\n"
 
 
 def jsonable_dict(x: Any) -> dict[str, JsonValue]:

--- a/src/inspect_ai/agent/_acp/transport_live.py
+++ b/src/inspect_ai/agent/_acp/transport_live.py
@@ -263,9 +263,9 @@ class _TranscriptCapture:
     def snapshot(self) -> Sequence[Any]:
         if self._captured is None:
             return []
-        # list() the events sequence so callers iterating concurrently
-        # with new ``_event`` appends don't see size changes mid-iteration.
-        return list(self._captured.events)[self._attach_index :]
+        # Slice the transcript view directly so bounded/provider-backed
+        # transcripts can read only the suffix since attach.
+        return self._captured.events[self._attach_index :]
 
 
 class _CancelSnapshot:

--- a/src/inspect_ai/event/_pool.py
+++ b/src/inspect_ai/event/_pool.py
@@ -15,25 +15,30 @@ content by definition).
 """
 
 import json
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Final, TypeVar
 
 from pydantic import JsonValue
 
 from inspect_ai._util.hash import mm3_hash
+from inspect_ai.event._validate import validate_events
 from inspect_ai.model._chat_message import ChatMessage
 
-from ..event._event import Event
-from ..event._model import ModelEvent
-from ._log import EvalSample
+from ._event import Event
+from ._model import ModelEvent
+
+
+def materialize_pooled_events(
+    events: Iterable[object],
+    message_pool: list[ChatMessage],
+    call_pool: list[JsonValue],
+) -> list[Event]:
+    materialized = validate_events(list(events))
+    materialized = resolve_model_event_inputs(materialized, message_pool)
+    return resolve_model_event_calls(materialized, call_pool)
 
 
 def _msg_hash(msg: ChatMessage) -> str:
-    """Compute a content hash for dedup keying.
-
-    Excludes the ``id`` field so that messages with identical content
-    but different UUIDs are treated as duplicates.
-    """
     data = json.loads(msg.model_dump_json(exclude={"id"}))
     return mm3_hash(json.dumps(data, sort_keys=True))
 
@@ -52,6 +57,24 @@ def _build_call_index(pool: list[JsonValue]) -> dict[str, int]:
     for i, call_msg in enumerate(pool):
         index[mm3_hash(json.dumps(call_msg, sort_keys=True))] = i
     return index
+
+
+def condense_model_event_inputs_with_lookup(
+    event: Event,
+    lookup_message: Callable[[ChatMessage], int],
+) -> Event:
+    """Replace a single ModelEvent.input with message_pool references."""
+    if not isinstance(event, ModelEvent):
+        return event
+    if event.input_refs is not None and not event.input:
+        return event
+    if not event.input:
+        return event
+
+    raw_indices = [lookup_message(message) for message in event.input]
+    return event.model_copy(
+        update={"input": [], "input_refs": _compress_refs(raw_indices)}
+    )
 
 
 def condense_model_event_inputs(
@@ -157,6 +180,33 @@ def _expand_refs(
     return result
 
 
+def condense_model_event_calls_with_lookup(
+    event: Event,
+    lookup_call: Callable[[JsonValue], int],
+) -> Event:
+    """Replace a single ModelEvent call request message list with call_refs."""
+    if not isinstance(event, ModelEvent) or event.call is None:
+        return event
+    if event.call.call_refs is not None:
+        return event
+
+    msg_key = next((k for k in _CALL_MESSAGE_KEYS if k in event.call.request), None)
+    msgs = event.call.request.get(msg_key) if msg_key else None
+    if not isinstance(msgs, list) or not msgs:
+        return event
+
+    raw_indices = [lookup_call(message) for message in msgs]
+    new_request = {k: v for k, v in event.call.request.items() if k != msg_key}
+    new_call = event.call.model_copy(
+        update={
+            "request": new_request,
+            "call_refs": _compress_refs(raw_indices),
+            "call_key": msg_key,
+        }
+    )
+    return event.model_copy(update={"call": new_call})
+
+
 def condense_model_event_calls(
     events: Sequence[Event],
     next_index: int,
@@ -258,40 +308,3 @@ def resolve_model_event_inputs(
             )
         result.append(event)
     return result
-
-
-def resolve_sample_events_data(sample: EvalSample) -> EvalSample:
-    """Resolve events_data pool references in model events.
-
-    Always called on read to ensure ModelEvent.input is populated,
-    regardless of the resolve_attachments setting.
-    """
-    if sample.events_data is None:
-        return sample
-    msg_pool = sample.events_data["messages"]
-    call_pool = sample.events_data["calls"]
-    resolved_events = resolve_model_event_inputs(sample.events, msg_pool)
-    resolved_events = resolve_model_event_calls(resolved_events, call_pool)
-    return sample.model_copy(
-        update={
-            "events": resolved_events,
-            "events_data": None,
-        }
-    )
-
-
-def rebind_sample_timelines(sample: EvalSample) -> EvalSample:
-    """Rebind timelines to the sample's current event objects."""
-    if not sample.timelines:
-        return sample
-
-    from inspect_ai.event._timeline import timeline_dump, timeline_load
-
-    return sample.model_copy(
-        update={
-            "timelines": [
-                timeline_load(timeline_dump(timeline), sample.events)
-                for timeline in sample.timelines
-            ],
-        }
-    )

--- a/src/inspect_ai/event/_validate.py
+++ b/src/inspect_ai/event/_validate.py
@@ -1,0 +1,29 @@
+from pydantic import TypeAdapter
+
+from inspect_ai._util.constants import get_deserializing_context
+from inspect_ai.model._chat_message import ChatMessage
+
+from ._event import Event
+
+_chat_message_list_adapter: TypeAdapter[list[ChatMessage]] = TypeAdapter(
+    list[ChatMessage]
+)
+_event_list_adapter: TypeAdapter[list[Event]] = TypeAdapter(list[Event])
+
+
+def validate_chat_messages(
+    messages: object, *, context: dict[str, object] | None = None
+) -> list[ChatMessage]:
+    return _chat_message_list_adapter.validate_python(messages, context=context)
+
+
+def validate_events(events: object) -> list[Event]:
+    return _event_list_adapter.validate_python(
+        events, context=get_deserializing_context()
+    )
+
+
+def validate_events_json(events: str) -> list[Event]:
+    return _event_list_adapter.validate_json(
+        events, context=get_deserializing_context()
+    )

--- a/src/inspect_ai/log/__init__.py
+++ b/src/inspect_ai/log/__init__.py
@@ -54,13 +54,13 @@ from ._log import (
     EventsData,
 )
 from ._metric import recompute_metrics
-from ._pool import resolve_sample_events_data
 from ._recover import (
     RecoverableEvalLog,
     RecoveryNotAvailable,
     recover_eval_log,
     recoverable_eval_logs,
 )
+from ._resolve import resolve_sample_events_data
 from ._retry import retryable_eval_logs
 from ._score import edit_score
 from ._transcript import (

--- a/src/inspect_ai/log/_condense.py
+++ b/src/inspect_ai/log/_condense.py
@@ -1,6 +1,5 @@
 import json
 from collections.abc import MutableMapping
-from functools import lru_cache
 from logging import getLogger
 from typing import (
     Callable,
@@ -8,7 +7,7 @@ from typing import (
     Sequence,
 )
 
-from pydantic import JsonValue, TypeAdapter
+from pydantic import JsonValue
 from typing_extensions import TypedDict
 
 from inspect_ai._util.constants import BASE_64_DATA_REMOVED
@@ -27,6 +26,15 @@ from inspect_ai._util.hash import mm3_hash
 from inspect_ai._util.json import JsonChange
 from inspect_ai._util.url import is_data_uri
 from inspect_ai.dataset._dataset import Sample
+from inspect_ai.event._pool import (
+    _build_call_index,
+    _build_msg_index,
+    condense_model_event_calls,
+    condense_model_event_inputs,
+    resolve_model_event_calls,
+    resolve_model_event_inputs,
+)
+from inspect_ai.event._validate import validate_chat_messages, validate_events_json
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageAssistant
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
@@ -44,25 +52,6 @@ from ..event._store import StoreEvent
 from ..event._subtask import SubtaskEvent
 from ..event._tool import ToolEvent
 from ._log import EvalSample, EventsData
-from ._pool import (
-    _build_call_index,
-    _build_msg_index,
-    condense_model_event_calls,
-    condense_model_event_inputs,
-    resolve_model_event_calls,
-    resolve_model_event_inputs,
-)
-
-
-@lru_cache(maxsize=1)
-def _events_adapter() -> TypeAdapter[list[Event]]:
-    return TypeAdapter(list[Event])
-
-
-@lru_cache(maxsize=1)
-def _chat_messages_adapter() -> TypeAdapter[list[ChatMessage]]:
-    return TypeAdapter(list[ChatMessage])
-
 
 logger = getLogger(__name__)
 
@@ -73,6 +62,24 @@ ATTACHMENT_PROTOCOL = "attachment://"
 class WalkContext(TypedDict):
     message_cache: dict[str, ChatMessage]
     only_core: bool
+
+
+def attachment_refs_from_value(value: object) -> set[str]:
+    refs: set[str] = set()
+
+    def collect(value: object) -> None:
+        if isinstance(value, str):
+            if value.startswith(ATTACHMENT_PROTOCOL):
+                refs.add(value.removeprefix(ATTACHMENT_PROTOCOL))
+        elif isinstance(value, dict):
+            for item in value.values():
+                collect(item)
+        elif isinstance(value, (list, tuple, set)):
+            for item in value:
+                collect(item)
+
+    collect(value)
+    return refs
 
 
 def condense_events(
@@ -112,11 +119,11 @@ def expand_events(
         Events with full message inputs and call request messages restored.
     """
     if isinstance(events, str):
-        events = _events_adapter().validate_json(events)
+        events = validate_events_json(events)
     if isinstance(data, str):
         raw = json.loads(data)
         data = EventsData(
-            messages=_chat_messages_adapter().validate_python(raw.get("messages", [])),
+            messages=validate_chat_messages(raw.get("messages", [])),
             calls=raw.get("calls", []),
         )
     result = resolve_model_event_inputs(list(events), data["messages"])

--- a/src/inspect_ai/log/_convert.py
+++ b/src/inspect_ai/log/_convert.py
@@ -14,9 +14,9 @@ from inspect_ai.log._file import (
     read_eval_log_async,
     write_eval_log,
 )
-from inspect_ai.log._pool import resolve_sample_events_data
 from inspect_ai.log._recorders import create_recorder_for_location
 from inspect_ai.log._recorders.create import recorder_type_for_location
+from inspect_ai.log._resolve import resolve_sample_events_data
 
 
 def convert_eval_logs(

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -24,7 +24,7 @@ from inspect_ai._util.file import (
 from inspect_ai._util.json import to_json_safe
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.log._log import EvalSampleSummary
-from inspect_ai.log._pool import rebind_sample_timelines, resolve_sample_events_data
+from inspect_ai.log._resolve import rebind_sample_timelines, resolve_sample_events_data
 
 from ._log import EvalLog, EvalMetric, EvalSample, EvalStatus
 from ._recorders import (

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -5,11 +5,12 @@ import os
 import sqlite3
 import threading
 import time
+from collections.abc import Sequence
 from contextlib import contextmanager
 from logging import getLogger
 from pathlib import Path
 from sqlite3 import Connection, OperationalError
-from typing import Callable, Iterator, Literal
+from typing import TYPE_CHECKING, Callable, Iterable, Iterator, Literal, cast
 
 import psutil
 from pydantic import BaseModel, JsonValue
@@ -19,10 +20,20 @@ from typing_extensions import override
 from inspect_ai._display.core.display import TaskDisplayMetric
 from inspect_ai._util.appdirs import inspect_data_dir
 from inspect_ai._util.dateutil import is_file_older_than
-from inspect_ai._util.file import basename, dirname, filesystem
+from inspect_ai._util.file import (
+    basename,
+    dirname,
+    filesystem,
+)
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.trace import trace_action
 from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._pool import (
+    _compress_refs,
+    condense_model_event_calls,
+    condense_model_event_inputs,
+)
+from inspect_ai.log._recorders.buffer.history import SampleHistory
 from inspect_ai.model import ChatMessage
 
 from ..._condense import (
@@ -34,10 +45,6 @@ from ..._condense import (
     walk_json_dict,
 )
 from ..._log import EvalSampleSummary
-from ..._pool import (
-    condense_model_event_calls,
-    condense_model_event_inputs,
-)
 from ..types import SampleEvent
 from .filestore import (
     Manifest,
@@ -56,6 +63,10 @@ from .types import (
     SampleData,
     Samples,
 )
+
+if TYPE_CHECKING:
+    from inspect_ai.util._checkpoint._event_store import CheckpointEventStore
+
 
 logger = getLogger(__name__)
 SYNC_CLEANUP_TIMEOUT = 30
@@ -89,6 +100,9 @@ class SampleBufferDatabase(SampleBuffer):
         sample_epoch INTEGER,
         data TEXT -- JSON containing full event
     );
+
+    CREATE INDEX IF NOT EXISTS idx_events_sample_uuid
+        ON events(sample_id, sample_epoch, event_id, id);
 
     CREATE TABLE attachments (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -168,11 +182,16 @@ class SampleBufferDatabase(SampleBuffer):
                 raise FileNotFoundError("Log database for '{location}' not found.")
 
         # Per-sample hash → pool index maps; full pool entries live in SQLite.
-        self._msg_indices: dict[tuple[str | int, int], dict[str, int]] = {}
-        self._call_indices: dict[tuple[str | int, int], dict[str, int]] = {}
+        self._msg_indices: dict[tuple[str, int], dict[str, int]] = {}
+        self._call_indices: dict[tuple[str, int], dict[str, int]] = {}
 
         # Prevent late ModelEvents from restarting indices at 0 after completion.
-        self._completed_samples: set[tuple[str | int, int]] = set()
+        self._completed_samples: set[tuple[str, int]] = set()
+
+        self._sample_read_leases: dict[tuple[str, int], int] = {}
+        self._pending_sample_removals: set[tuple[str, int]] = set()
+        self._cleanup_pending = False
+        self._lease_lock = threading.Lock()
 
         # create sync filestore if log_shared
         self._sync_filestore = (
@@ -186,6 +205,7 @@ class SampleBufferDatabase(SampleBuffer):
         self._sync_thread: threading.Thread | None = None
         self._sync_pending = False
         self._sync_closed = False
+        self._sync_requested = False
 
     def start_sample(self, sample: EvalSampleSummary) -> None:
         with self._get_connection(write=True) as conn:
@@ -233,7 +253,7 @@ class SampleBufferDatabase(SampleBuffer):
                 (to_json_str_safe(summary), str(summary.id), summary.epoch),
             )
 
-            key = (summary.id, summary.epoch)
+            key = (str(summary.id), summary.epoch)
             self._msg_indices.pop(key, None)
             self._call_indices.pop(key, None)
             self._completed_samples.add(key)
@@ -250,6 +270,20 @@ class SampleBufferDatabase(SampleBuffer):
             )
 
     def remove_samples(self, samples: list[tuple[str | int, int]]) -> None:
+        ready: list[tuple[str, int]] = []
+
+        with self._lease_lock:
+            for sample_id, epoch in samples:
+                key = (str(sample_id), epoch)
+                if key in self._sample_read_leases:
+                    self._pending_sample_removals.add(key)
+                else:
+                    ready.append(key)
+
+        if ready:
+            self._remove_samples_now(ready)
+
+    def _remove_samples_now(self, samples: list[tuple[str, int]]) -> None:
         # short circuit no samples
         if len(samples) == 0:
             return
@@ -301,6 +335,17 @@ class SampleBufferDatabase(SampleBuffer):
 
     @override
     def cleanup(self) -> None:
+        if not self._close_sync_worker_for_cleanup():
+            return
+
+        with self._lease_lock:
+            if self._sample_read_leases:
+                self._cleanup_pending = True
+                return
+
+        self._cleanup_now()
+
+    def _close_sync_worker_for_cleanup(self) -> bool:
         sync_thread: threading.Thread | None = None
         with self._sync_lock:
             self._sync_closed = True
@@ -312,7 +357,7 @@ class SampleBufferDatabase(SampleBuffer):
                 "Skipping log buffer cleanup from active sync worker for %s",
                 self.location,
             )
-            return
+            return False
 
         if sync_thread is not None and sync_thread.is_alive():
             sync_thread.join(timeout=SYNC_CLEANUP_TIMEOUT)
@@ -321,8 +366,11 @@ class SampleBufferDatabase(SampleBuffer):
                     "Timed out waiting for log buffer sync; skipping cleanup for %s",
                     self.location,
                 )
-                return
+                return False
 
+        return True
+
+    def _cleanup_now(self) -> None:
         cleanup_sample_buffer_db(self.db_path)
         if self._sync_filestore is not None:
             self._sync_filestore.cleanup()
@@ -406,6 +454,226 @@ class SampleBufferDatabase(SampleBuffer):
         except FileNotFoundError:
             return None
 
+    def sample_event_count(self, id: str | int, epoch: int) -> int:
+        with self._acquire_sample_read_lease(id, epoch):
+            with self._get_connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    cursor = conn.execute(
+                        """
+                        SELECT COUNT(DISTINCT COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT)))
+                        FROM events
+                        WHERE sample_id = ? AND sample_epoch = ?
+                        """,
+                        [str(id), epoch],
+                    )
+                    count = int(cursor.fetchone()[0])
+                    conn.commit()
+                    return count
+                except Exception:
+                    conn.rollback()
+                    raise
+
+    def sample_attachment(self, id: str | int, epoch: int, hash: str) -> str | None:
+        with self._acquire_sample_read_lease(id, epoch):
+            with self._get_connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    row = conn.execute(
+                        """
+                        SELECT content FROM attachments
+                        WHERE sample_id = ? AND sample_epoch = ? AND hash = ?
+                        """,
+                        [str(id), epoch, hash],
+                    ).fetchone()
+                    conn.commit()
+                    return None if row is None else str(row["content"])
+                except Exception:
+                    conn.rollback()
+                    raise
+
+    def import_checkpoint_events(
+        self, id: str | int, epoch: int, event_store: "CheckpointEventStore"
+    ) -> int:
+        seed_count = 0
+        with self._acquire_sample_read_lease(id, epoch):
+            with self._get_connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    pool_attachment_refs: set[str] = set()
+                    message_pos_map: dict[int, int] = {}
+                    for pos, message_entry in enumerate(
+                        self._get_message_pool(conn, id, epoch)
+                    ):
+                        message_pos_map[pos] = event_store.merge_message_pool_entry(
+                            message_entry.msg_id, message_entry.data
+                        )
+                        pool_attachment_refs.update(
+                            event_store.attachment_refs_from_json(message_entry.data)
+                        )
+                    call_pos_map: dict[int, int] = {}
+                    for pos, call_entry in enumerate(
+                        self._get_call_pool(conn, id, epoch)
+                    ):
+                        call_pos_map[pos] = event_store.merge_call_pool_entry(
+                            call_entry.hash, call_entry.data
+                        )
+                        pool_attachment_refs.update(
+                            event_store.attachment_refs_from_json(call_entry.data)
+                        )
+
+                    def attachment_lookup(hash: str) -> str | None:
+                        row = conn.execute(
+                            """
+                            SELECT content FROM attachments
+                            WHERE sample_id = ? AND sample_epoch = ? AND hash = ?
+                            """,
+                            [str(id), epoch, hash],
+                        ).fetchone()
+                        return None if row is None else str(row["content"])
+
+                    event_store.merge_attachment_refs(
+                        pool_attachment_refs, attachment_lookup
+                    )
+                    for row in self._get_events(conn, id, epoch, latest_only=True):
+                        event_store.merge_condensed_event(
+                            row.event_id,
+                            self._remap_pool_refs(
+                                row.event, message_pos_map, call_pos_map
+                            ),
+                            attachment_lookup,
+                        )
+                        seed_count += 1
+                    conn.commit()
+                    return seed_count
+                except Exception:
+                    conn.rollback()
+                    raise
+
+    @staticmethod
+    def _remap_pool_refs(
+        event: JsonData, message_pos_map: dict[int, int], call_pos_map: dict[int, int]
+    ) -> JsonData:
+        remapped = dict(event)
+        input_refs = remapped.get("input_refs")
+        if isinstance(input_refs, list):
+            remapped["input_refs"] = cast(
+                JsonValue, _remap_refs(input_refs, message_pos_map)
+            )
+        call = remapped.get("call")
+        if isinstance(call, dict):
+            call_refs = call.get("call_refs")
+            if isinstance(call_refs, list):
+                remapped["call"] = {
+                    **call,
+                    "call_refs": cast(JsonValue, _remap_refs(call_refs, call_pos_map)),
+                }
+        return remapped
+
+    @contextmanager
+    def open_sample_history_tail(
+        self,
+        id: str | int,
+        epoch: int,
+        n: int,
+    ) -> Iterator[SampleHistory]:
+        if n <= 0:
+            yield SampleHistory([], [], [], {})
+            return
+
+        with self._acquire_sample_read_lease(id, epoch):
+            with self._get_connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                history = self._sample_history(
+                    conn, id, epoch, self._get_events_tail(conn, id, epoch, n)
+                )
+                conn.commit()
+            yield history
+
+    @contextmanager
+    def open_sample_history_from(
+        self,
+        id: str | int,
+        epoch: int,
+        start: int,
+    ) -> Iterator[SampleHistory]:
+        with self._acquire_sample_read_lease(id, epoch):
+            with self._get_connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                history = self._sample_history(
+                    conn, id, epoch, self._get_events_from(conn, id, epoch, start)
+                )
+                conn.commit()
+            yield history
+
+    @contextmanager
+    def open_sample_history(
+        self,
+        id: str | int,
+        epoch: int,
+    ) -> Iterator[SampleHistory]:
+        with self._acquire_sample_read_lease(id, epoch):
+            with self._get_connection() as conn:
+                conn.execute("BEGIN IMMEDIATE")
+                history = self._sample_history(
+                    conn,
+                    id,
+                    epoch,
+                    self._get_events(conn, id, epoch, latest_only=True),
+                )
+                conn.commit()
+            yield history
+
+    def _sample_history(
+        self,
+        conn: Connection,
+        id: str | int,
+        epoch: int,
+        events: Iterable[EventData],
+    ) -> SampleHistory:
+        message_pool = [
+            json.loads(entry.data) for entry in self._get_message_pool(conn, id, epoch)
+        ]
+        call_pool = [
+            json.loads(entry.data) for entry in self._get_call_pool(conn, id, epoch)
+        ]
+        attachments = {
+            entry.hash: entry.content
+            for entry in self._get_attachments(conn, id, epoch)
+        }
+        return SampleHistory(list(events), message_pool, call_pool, attachments)
+
+    @contextmanager
+    def _acquire_sample_read_lease(
+        self,
+        id: str | int,
+        epoch: int,
+    ) -> Iterator[None]:
+        key = (str(id), epoch)
+        with self._lease_lock:
+            self._sample_read_leases[key] = self._sample_read_leases.get(key, 0) + 1
+        try:
+            yield
+        finally:
+            ready_remove = False
+            cleanup_ready = False
+            with self._lease_lock:
+                lease_count = self._sample_read_leases[key] - 1
+                if lease_count > 0:
+                    self._sample_read_leases[key] = lease_count
+                else:
+                    del self._sample_read_leases[key]
+                    if key in self._pending_sample_removals:
+                        self._pending_sample_removals.remove(key)
+                        ready_remove = True
+                    if self._cleanup_pending and not self._sample_read_leases:
+                        self._cleanup_pending = False
+                        cleanup_ready = True
+            if ready_remove:
+                self._remove_samples_now([key])
+            if cleanup_ready:
+                self._cleanup_now()
+
     @contextmanager
     def _get_connection(self, *, write: bool = False) -> Iterator[Connection]:
         """Get a database connection."""
@@ -482,24 +750,38 @@ class SampleBufferDatabase(SampleBuffer):
             if self._sync_closed:
                 return
 
-            if self._sync_thread is not None:
-                self._sync_pending = True
-                return
+            self._sync_requested = True
+            self._sync_pending = True
 
-            if (time.monotonic() - self._sync_time) <= self.log_shared:
-                return
+            if self._sync_thread is None or not self._sync_thread.is_alive():
+                self._sync_thread = threading.Thread(
+                    target=self._sync_to_filestore,
+                    args=(sync_filestore,),
+                    daemon=True,
+                    name="inspect-buffer-sync",
+                )
+                self._sync_thread.start()
 
-            self._sync_time = time.monotonic()
-            self._sync_thread = threading.Thread(
-                target=self._sync_to_filestore,
-                args=(sync_filestore,),
-                daemon=True,
-                name="inspect-buffer-sync",
-            )
-            self._sync_thread.start()
+            self._sync_wakeup.notify_all()
 
     def _sync_to_filestore(self, sync_filestore: SampleBufferFilestore) -> None:
         while True:
+            with self._sync_lock:
+                while not self._sync_closed:
+                    assert self.log_shared is not None
+                    remaining = self.log_shared - (time.monotonic() - self._sync_time)
+                    if self._sync_requested and remaining <= 0:
+                        self._sync_requested = False
+                        self._sync_pending = False
+                        self._sync_time = time.monotonic()
+                        break
+
+                    timeout = max(remaining, 0) if self._sync_requested else None
+                    self._sync_wakeup.wait(timeout=timeout)
+                else:
+                    self._sync_thread = None
+                    return
+
             try:
                 with trace_action(logger, "Log Sync", self.location):
                     sync_to_filestore(self, sync_filestore)
@@ -507,31 +789,10 @@ class SampleBufferDatabase(SampleBuffer):
                 logger.exception("Log Sync failed for %s", self.location)
             except BaseException:
                 with self._sync_lock:
+                    self._sync_requested = False
                     self._sync_pending = False
                     self._sync_thread = None
                 raise
-
-            with self._sync_lock:
-                if self._sync_closed or not self._sync_pending:
-                    self._sync_pending = False
-                    self._sync_thread = None
-                    return
-
-                assert self.log_shared is not None
-                while True:
-                    if self._sync_closed:
-                        self._sync_pending = False
-                        self._sync_thread = None
-                        return
-
-                    remaining = self.log_shared - (time.monotonic() - self._sync_time)
-                    if remaining <= 0:
-                        break
-
-                    self._sync_wakeup.wait(timeout=remaining)
-
-                self._sync_pending = False
-                self._sync_time = time.monotonic()
 
     def _increment_version(self, conn: Connection) -> None:
         conn.execute("""
@@ -571,18 +832,37 @@ class SampleBufferDatabase(SampleBuffer):
         epoch: int,
         after_event_id: int | None = None,
         resolve_attachments: bool | Literal["full", "core"] = False,
+        latest_only: bool = False,
     ) -> Iterator[EventData]:
-        query = """
-            SELECT id, event_id, data
-            FROM events e WHERE sample_id = ? AND sample_epoch = ?
-        """
-        params: list[str | int] = [str(id), epoch]
+        if latest_only:
+            query = """
+                WITH first_rows AS (
+                    SELECT
+                        COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT)) AS logical_id,
+                        MIN(id) AS first_id,
+                        MAX(id) AS latest_id
+                    FROM events
+                    WHERE sample_id = ? AND sample_epoch = ?
+                    GROUP BY COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT))
+                )
+                SELECT e.id, fr.logical_id AS event_id, e.data
+                FROM first_rows fr
+                JOIN events e ON e.id = fr.latest_id
+                ORDER BY fr.first_id
+            """
+            params: list[str | int] = [str(id), epoch]
+        else:
+            query = """
+                SELECT id, COALESCE(NULLIF(e.event_id, ''), CAST(e.id AS TEXT)) AS event_id, data
+                FROM events e WHERE sample_id = ? AND sample_epoch = ?
+            """
+            params = [str(id), epoch]
 
-        if after_event_id is not None:
-            query += " AND e.id > ?"
-            params.append(after_event_id)
+            if after_event_id is not None:
+                query += " AND e.id > ?"
+                params.append(after_event_id)
 
-        query += " ORDER BY e.id"
+            query += " ORDER BY e.id"
 
         cursor = conn.execute(query, params)
 
@@ -592,6 +872,83 @@ class SampleBufferDatabase(SampleBuffer):
             event = json.loads(row["data"])
             if resolve_attachments is True or resolve_attachments == "full":
                 event = self._resolve_event_attachments(conn, event, message_cache)
+            yield EventData(
+                id=row["id"],
+                event_id=row["event_id"],
+                sample_id=str(id),
+                epoch=epoch,
+                event=event,
+            )
+
+    def _get_events_tail(
+        self,
+        conn: Connection,
+        id: str | int,
+        epoch: int,
+        n: int,
+    ) -> Iterator[EventData]:
+        query = """
+            WITH first_rows AS (
+                SELECT
+                    COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT)) AS logical_id,
+                    MIN(id) AS first_id,
+                    MAX(id) AS latest_id
+                FROM events
+                WHERE sample_id = ? AND sample_epoch = ?
+                GROUP BY COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT))
+            ), tail_rows AS (
+                SELECT logical_id, latest_id
+                FROM first_rows
+                ORDER BY first_id DESC
+                LIMIT ?
+            )
+            SELECT e.id, tr.logical_id AS event_id, e.data
+            FROM tail_rows tr
+            JOIN events e ON e.id = tr.latest_id
+            ORDER BY e.id
+        """
+        cursor = conn.execute(query, [str(id), epoch, n])
+
+        for row in cursor:
+            event = json.loads(row["data"])
+            yield EventData(
+                id=row["id"],
+                event_id=row["event_id"],
+                sample_id=str(id),
+                epoch=epoch,
+                event=event,
+            )
+
+    def _get_events_from(
+        self,
+        conn: Connection,
+        id: str | int,
+        epoch: int,
+        start: int,
+    ) -> Iterator[EventData]:
+        query = """
+            WITH first_rows AS (
+                SELECT
+                    COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT)) AS logical_id,
+                    MIN(id) AS first_id,
+                    MAX(id) AS latest_id
+                FROM events
+                WHERE sample_id = ? AND sample_epoch = ?
+                GROUP BY COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT))
+            ), ordered_rows AS (
+                SELECT logical_id, latest_id, ROW_NUMBER() OVER (ORDER BY first_id) AS row_num
+                FROM first_rows
+            )
+            SELECT e.id, ordered_rows.logical_id AS event_id, e.data
+            FROM ordered_rows
+            JOIN events e ON e.id = ordered_rows.latest_id
+            WHERE ordered_rows.row_num > ?
+            ORDER BY ordered_rows.row_num
+        """
+        cursor = conn.execute(query, [str(id), epoch, start])
+
+        for row in cursor:
+            event = json.loads(row["data"])
             yield EventData(
                 id=row["id"],
                 event_id=row["event_id"],
@@ -728,7 +1085,7 @@ class SampleBufferDatabase(SampleBuffer):
 
         # message/call pool dedup for ModelEvents
         if isinstance(event.event, ModelEvent):
-            key = (event.id, event.epoch)
+            key = (str(event.id), event.epoch)
             if key in self._completed_samples:
                 raise RuntimeError(
                     f"ModelEvent for sample {key} arrived after "
@@ -996,6 +1353,20 @@ def maximum_ids(
     if sample_data.call_pool:
         call_pool_id = max(call_pool_id, sample_data.call_pool[-1].id)
     return event_id, attachment_id, message_pool_id, call_pool_id
+
+
+def _remap_refs(
+    refs: Sequence[object], pos_map: dict[int, int]
+) -> list[tuple[int, int]]:
+    indices: list[int] = []
+    for ref in refs:
+        if not isinstance(ref, (list, tuple)) or len(ref) != 2:
+            continue
+        start, end = ref
+        if not isinstance(start, int) or not isinstance(end, int):
+            continue
+        indices.extend(pos_map[index] for index in range(start, end))
+    return _compress_refs(indices)
 
 
 def cleanup_sample_buffer_databases(db_dir: Path | None = None) -> None:

--- a/src/inspect_ai/log/_recorders/buffer/filestore.py
+++ b/src/inspect_ai/log/_recorders/buffer/filestore.py
@@ -1,25 +1,32 @@
 import os
 import tempfile
+from contextlib import AbstractContextManager
 from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
-from typing import Iterator, Literal
-from zipfile import ZipFile
+from typing import IO, TYPE_CHECKING, Iterator, Literal
+from zipfile import ZipFile, ZipInfo
 
 from pydantic import BaseModel, Field
 from typing_extensions import override
 
 from inspect_ai._display.core.display import TaskDisplayMetric
 from inspect_ai._util.constants import DEFAULT_LOG_SHARED, EVAL_LOG_FORMAT
-from inspect_ai._util.file import FileSystem, basename, dirname, file, filesystem
-from inspect_ai._util.json import to_json_safe, to_json_str_safe
+from inspect_ai._util.file import FileSystem, basename, dirname, filesystem
+from inspect_ai._util.json import to_json_safe
 from inspect_ai._util.zipfile import zipfile_compress_kwargs
 from inspect_ai.log._file import read_eval_log
 
 from ..._log import EvalSampleSummary
 from .types import SampleBuffer, SampleData, Samples
 
+if TYPE_CHECKING:
+    from .history import SampleHistory
+
+
 logger = getLogger(__name__)
+
+_SEGMENT_WRITE_CHUNK_SIZE = 16 * 1024 * 1024
 
 
 class Segment(BaseModel):
@@ -147,7 +154,7 @@ class SampleBufferFilestore(SampleBuffer):
             self._fs.touch(f"{self._dir}.keep")
 
     def write_manifest(self, manifest: Manifest) -> None:
-        with file(self._manifest_file(), "wb") as f:
+        with self._fs.open(self._manifest_file(), "wb") as f:
             f.write(to_json_safe(manifest))
 
     def write_segment(self, id: int, files: list[SegmentFile]) -> None:
@@ -156,9 +163,11 @@ class SampleBufferFilestore(SampleBuffer):
             name = segment_file.name
             with ZipFile(segment_file, mode="w", **zipfile_compress_kwargs) as zip:
                 for sf in files:
-                    zip.writestr(
+                    data = to_json_safe(sf.data, indent=None)
+                    _write_member_chunked(
+                        zip,
                         segment_file_name(sf.id, sf.epoch),
-                        to_json_str_safe(sf.data),
+                        data,
                     )
             segment_file.flush()
             os.fsync(segment_file.fileno())
@@ -166,7 +175,7 @@ class SampleBufferFilestore(SampleBuffer):
         # write then move for atomicity
         try:
             with open(name, "rb") as zf:
-                with file(f"{self._dir}{segment_name(id)}", "wb") as f:
+                with self._fs.open(f"{self._dir}{segment_name(id)}", "wb") as f:
                     f.write(zf.read())
                     f.flush()
         finally:
@@ -174,7 +183,7 @@ class SampleBufferFilestore(SampleBuffer):
 
     def read_manifest(self) -> Manifest | None:
         try:
-            with file(self._manifest_file(), "r") as f:
+            with self._fs.open(self._manifest_file(), "r") as f:
                 contents = f.read()
                 return Manifest.model_validate_json(contents)
         except FileNotFoundError:
@@ -184,7 +193,7 @@ class SampleBufferFilestore(SampleBuffer):
         self, id: int, sample_id: str | int, epoch_id: int
     ) -> SampleData:
         segment_file = f"{self._dir}{segment_name(id)}"
-        with file(segment_file, "rb") as f:
+        with self._fs.open(segment_file, "rb") as f:
             with ZipFile(f, mode="r") as zip:
                 with zip.open(segment_file_name(sample_id, epoch_id), "r") as sf:
                     return SampleData.model_validate_json(sf.read())
@@ -340,6 +349,36 @@ class SampleBufferFilestore(SampleBuffer):
 
         return sample_data
 
+    @override
+    def sample_event_count(self, id: str | int, epoch: int) -> int:
+        raise NotImplementedError("Sample history is only available for buffer DBs")
+
+    @override
+    def open_sample_history_tail(
+        self,
+        id: str | int,
+        epoch: int,
+        n: int,
+    ) -> AbstractContextManager["SampleHistory"]:
+        raise NotImplementedError("Sample history is only available for buffer DBs")
+
+    @override
+    def open_sample_history_from(
+        self,
+        id: str | int,
+        epoch: int,
+        start: int,
+    ) -> AbstractContextManager["SampleHistory"]:
+        raise NotImplementedError("Sample history is only available for buffer DBs")
+
+    @override
+    def open_sample_history(
+        self,
+        id: str | int,
+        epoch: int,
+    ) -> AbstractContextManager["SampleHistory"]:
+        raise NotImplementedError("Sample history is only available for buffer DBs")
+
     def get_pending_segments(
         self,
         id: str | int,
@@ -404,6 +443,16 @@ class SampleBufferFilestore(SampleBuffer):
 
     def _manifest_file(self) -> str:
         return f"{self._dir}{MANIFEST}"
+
+
+def _write_member_chunked(zip: ZipFile, name: str | ZipInfo, data: bytes) -> None:
+    with zip.open(name, "w", force_zip64=True) as member:
+        _write_chunked(member, data)
+
+
+def _write_chunked(member: IO[bytes], data: bytes) -> None:
+    for offset in range(0, len(data), _SEGMENT_WRITE_CHUNK_SIZE):
+        member.write(data[offset : offset + _SEGMENT_WRITE_CHUNK_SIZE])
 
 
 def cleanup_sample_buffer_filestores(log_dir: str) -> None:

--- a/src/inspect_ai/log/_recorders/buffer/history.py
+++ b/src/inspect_ai/log/_recorders/buffer/history.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass, field
+from typing import TypeAlias
+
+from pydantic import JsonValue, TypeAdapter
+
+from inspect_ai.event._validate import validate_chat_messages
+from inspect_ai.log._log import EventsData
+from inspect_ai.log._recorders.buffer.types import EventData, JsonData
+from inspect_ai.model import ChatMessage
+
+_json_value_list_adapter: TypeAdapter[list[JsonValue]] = TypeAdapter(list[JsonValue])
+
+RawEvent: TypeAlias = JsonData
+"""Event payload deserialized from JSON but not validated into a typed Event.
+
+The raw form is the cheap path for consumers that either re-serialize directly
+or inspect discriminator fields before validating a subset.
+"""
+
+
+@dataclass
+class SampleHistory:
+    """Latest logical sample history with .eval positional pool refs."""
+
+    raw_event_rows: list[EventData]
+    message_pool: list[ChatMessage]
+    call_pool: list[JsonValue]
+    attachments: dict[str, str]
+    events_data: EventsData = field(init=False)
+
+    def __post_init__(self) -> None:
+        self.message_pool = validate_chat_messages(
+            self.message_pool, context={"deserializing": True}
+        )
+        self.call_pool = _json_value_list_adapter.validate_python(self.call_pool)
+        self.events_data = EventsData(messages=self.message_pool, calls=self.call_pool)
+
+    @property
+    def event_count(self) -> int:
+        return len(self.raw_event_rows)
+
+    def iter_events(self) -> Iterator[RawEvent]:
+        """Iterate raw event payloads.
+
+        Raw-by-design consumers include the streaming recorder, which writes
+        condensed events directly, and retry-error construction, which scans
+        event discriminators before validating only the suffix.
+        """
+        for row in self.raw_event_rows:
+            yield row.event
+
+    def attachment(self, hash: str) -> str | None:
+        return self.attachments.get(hash)

--- a/src/inspect_ai/log/_recorders/buffer/history_provider.py
+++ b/src/inspect_ai/log/_recorders/buffer/history_provider.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping, Sequence
+from typing import TYPE_CHECKING
+
+from inspect_ai._util.list import find_last_match
+from inspect_ai.event._event import Event
+from inspect_ai.event._pool import (
+    materialize_pooled_events,
+    resolve_model_event_calls,
+    resolve_model_event_inputs,
+)
+from inspect_ai.event._validate import validate_events
+
+if TYPE_CHECKING:
+    from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+    from inspect_ai.log._recorders.buffer.history import SampleHistory
+    from inspect_ai.log._transcript import TranscriptHistoryProvider
+    from inspect_ai.util._checkpoint._event_store import CheckpointEventStore
+
+
+class BufferTranscriptHistoryProvider:
+    def __init__(
+        self,
+        buffer_db: SampleBufferDatabase,
+        sample_id: str | int,
+        epoch: int,
+    ) -> None:
+        self._buffer_db = buffer_db
+        self._sample_id = sample_id
+        self._epoch = epoch
+
+    @property
+    def event_count(self) -> int:
+        return self._buffer_db.sample_event_count(self._sample_id, self._epoch)
+
+    def events(self) -> Sequence[Event]:
+        return self._events()
+
+    def iter_events(self) -> Iterator[Event]:
+        return iter(self._events())
+
+    def recent_events(self, n: int | None = None) -> Sequence[Event]:
+        if n is None:
+            return self._events()
+        if n <= 0:
+            return []
+        with self._buffer_db.open_sample_history_tail(
+            self._sample_id, self._epoch, n
+        ) as history:
+            return _materialize_events(history)
+
+    def events_from(self, start: int) -> Sequence[Event]:
+        if start <= 0:
+            return self._events()
+        with self._buffer_db.open_sample_history_from(
+            self._sample_id, self._epoch, start
+        ) as history:
+            return _materialize_events(history)
+
+    def events_since_last(self, event_type: type[Event]) -> list[Event]:
+        events = self._events()
+        index = find_last_match(events, lambda event: isinstance(event, event_type))
+        if index is not None:
+            return events[index:]
+        return events
+
+    def attachments(self) -> Mapping[str, str]:
+        with self._buffer_db.open_sample_history(
+            self._sample_id, self._epoch
+        ) as history:
+            return dict(history.attachments)
+
+    def attachment(self, hash: str) -> str | None:
+        return self._buffer_db.sample_attachment(self._sample_id, self._epoch, hash)
+
+    def import_checkpoint_events(self, event_store: "CheckpointEventStore") -> int:
+        return self._buffer_db.import_checkpoint_events(
+            self._sample_id, self._epoch, event_store
+        )
+
+    def _events(self) -> list[Event]:
+        with self._buffer_db.open_sample_history(
+            self._sample_id, self._epoch
+        ) as history:
+            return _materialize_events(history)
+
+
+def _materialize_events(history: SampleHistory) -> list[Event]:
+    return materialize_pooled_events(
+        history.iter_events(),
+        history.events_data["messages"],
+        history.events_data["calls"],
+    )
+
+
+def _iter_materialized_events(history: SampleHistory) -> Iterator[Event]:
+    message_pool = history.events_data["messages"]
+    call_pool = history.events_data["calls"]
+    for raw_event in history.iter_events():
+        event = validate_events([raw_event])[0]
+        event = resolve_model_event_inputs([event], message_pool)[0]
+        yield resolve_model_event_calls([event], call_pool)[0]
+
+
+if TYPE_CHECKING:
+    _buffer_transcript_history_provider: type[TranscriptHistoryProvider] = (
+        BufferTranscriptHistoryProvider
+    )

--- a/src/inspect_ai/log/_recorders/buffer/types.py
+++ b/src/inspect_ai/log/_recorders/buffer/types.py
@@ -1,11 +1,15 @@
 import abc
-from typing import Literal, TypeAlias
+from contextlib import AbstractContextManager
+from typing import TYPE_CHECKING, Literal, TypeAlias
 
 from pydantic import BaseModel, JsonValue
 
 from inspect_ai._display.core.display import TaskDisplayMetric
 
 from ..._log import EvalSampleSummary
+
+if TYPE_CHECKING:
+    from .history import SampleHistory
 
 JsonData: TypeAlias = dict[str, JsonValue]
 
@@ -121,6 +125,40 @@ class SampleBuffer(abc.ABC):
           - `SampleData` with event, attachment, and pool data.
           - None if the database no longer exists
         """
+        ...
+
+    @abc.abstractmethod
+    def sample_event_count(self, id: str | int, epoch: int) -> int:
+        """Return the number of distinct events recorded for a sample."""
+        ...
+
+    @abc.abstractmethod
+    def open_sample_history_tail(
+        self,
+        id: str | int,
+        epoch: int,
+        n: int,
+    ) -> AbstractContextManager["SampleHistory"]:
+        """Open a consistent snapshot of the last ``n`` sample events."""
+        ...
+
+    @abc.abstractmethod
+    def open_sample_history_from(
+        self,
+        id: str | int,
+        epoch: int,
+        start: int,
+    ) -> AbstractContextManager["SampleHistory"]:
+        """Open a consistent sample-history snapshot from ``start`` onward."""
+        ...
+
+    @abc.abstractmethod
+    def open_sample_history(
+        self,
+        id: str | int,
+        epoch: int,
+    ) -> AbstractContextManager["SampleHistory"]:
+        """Open a consistent snapshot of the full sample history."""
         ...
 
     @abc.abstractmethod

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -4,11 +4,12 @@ import logging
 import math
 import os
 import tempfile
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from logging import getLogger
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     BinaryIO,
     Generic,
@@ -21,7 +22,7 @@ from typing import (
 from zipfile import ZipFile
 
 import anyio
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, JsonValue
 from typing_extensions import override
 
 from inspect_ai._util.async_bytes_reader import adapt_to_reader
@@ -38,7 +39,7 @@ from inspect_ai._util.trace import trace_action
 from inspect_ai._util.zip_common import ZipEntry
 from inspect_ai._util.zipfile import zipfile_compress_kwargs
 
-from .._condense import condense_sample
+from .._condense import ATTACHMENT_PROTOCOL, condense_sample
 from .._edit import LogUpdate
 from .._log import (
     EvalLog,
@@ -50,12 +51,16 @@ from .._log import (
     EvalSpec,
     EvalStats,
     EvalStatus,
+    EventsData,
     sort_samples,
 )
-from .._pool import rebind_sample_timelines, resolve_sample_events_data
+from .._resolve import rebind_sample_timelines, resolve_sample_events_data
 from .file import FileRecorder
 
 logger = getLogger(__name__)
+
+if TYPE_CHECKING:
+    from inspect_ai.log._recorders.buffer.history import SampleHistory
 
 
 class LogStart(BaseModel):
@@ -148,6 +153,13 @@ class EvalRecorder(FileRecorder):
     async def log_sample(self, eval: EvalSpec, sample: EvalSample) -> None:
         log = self.data[self._log_file_key(eval)]
         await log.buffer_sample(sample)
+
+    @override
+    async def log_sample_streaming(
+        self, eval: EvalSpec, sample: EvalSample, history: "SampleHistory"
+    ) -> None:
+        log = self.data[self._log_file_key(eval)]
+        await log.buffer_sample_streaming(sample, history)
 
     @override
     async def flush(self, eval: EvalSpec) -> None:
@@ -613,6 +625,42 @@ class ZipLogFile:
         async with self._lock:
             self._samples.append(sample)
 
+    async def buffer_sample_streaming(
+        self, sample: EvalSample, history: "SampleHistory"
+    ) -> None:
+        async with self._lock:
+            events = list(history.iter_events())
+            events_data = history.events_data
+            attachments = _sample_history_attachments(
+                sample, history, events, events_data
+            )
+            sample_data = sample.model_dump(
+                mode="json",
+                exclude_none=True,
+                exclude={"events", "events_data", "attachments"},
+            )
+            sample_data.update(
+                {
+                    "events": events,
+                    "attachments": attachments,
+                    "events_data": events_data,
+                }
+            )
+
+            self._zip_writestr(_sample_filename(sample.id, sample.epoch), sample_data)
+
+            self._summary_counter += 1
+            summary = sample.summary()
+            summary_file = _journal_summary_file(self._summary_counter)
+            summary_path = _journal_summary_path(summary_file)
+            self._zip_writestr(summary_path, [summary])
+            self._summaries = [
+                s
+                for s in self._summaries
+                if (s.id, s.epoch) != (summary.id, summary.epoch)
+            ]
+            self._summaries.append(summary)
+
     async def write_buffered_samples(self) -> None:
         async with self._lock:
             # Write the buffered samples
@@ -727,6 +775,38 @@ class ZipLogFile:
         assert self._zip
         with self._zip.open(filename, "w", force_zip64=True) as stream:
             yield stream
+
+
+def _sample_history_attachments(
+    sample: EvalSample,
+    history: "SampleHistory",
+    events: Sequence[JsonValue],
+    events_data: EventsData,
+) -> dict[str, str]:
+    attachments = dict(sample.attachments)
+    for hash in _attachment_hashes(events):
+        content = history.attachment(hash)
+        if content is not None:
+            attachments[hash] = content
+    for hash in _attachment_hashes(events_data):
+        content = history.attachment(hash)
+        if content is not None:
+            attachments[hash] = content
+    return attachments
+
+
+def _attachment_hashes(value: object) -> Iterator[str]:
+    if isinstance(value, str):
+        if value.startswith(ATTACHMENT_PROTOCOL):
+            yield value.replace(ATTACHMENT_PROTOCOL, "", 1)
+    elif isinstance(value, BaseModel):
+        yield from _attachment_hashes(value.model_dump(mode="python"))
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _attachment_hashes(item)
+    elif isinstance(value, list | tuple):
+        for item in value:
+            yield from _attachment_hashes(item)
 
 
 async def _read_log(

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -30,7 +30,7 @@ from .._log import (
     EvalStatus,
     sort_samples,
 )
-from .._pool import rebind_sample_timelines, resolve_sample_events_data
+from .._resolve import rebind_sample_timelines, resolve_sample_events_data
 from .eval import _s3_bucket_and_key, _write_s3_conditional
 from .file import FileRecorder
 

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -1,5 +1,5 @@
 import abc
-from typing import IO
+from typing import IO, TYPE_CHECKING
 
 from inspect_ai._util.async_zip import AsyncZipReader
 from inspect_ai._util.error import EvalError
@@ -15,6 +15,10 @@ from inspect_ai.log._log import (
     EvalStats,
     EvalStatus,
 )
+from inspect_ai.log._recorders.streaming import materialize_streaming_sample
+
+if TYPE_CHECKING:
+    from inspect_ai.log._recorders.buffer.history import SampleHistory
 
 
 class Recorder(abc.ABC):
@@ -40,6 +44,11 @@ class Recorder(abc.ABC):
 
     @abc.abstractmethod
     async def log_sample(self, eval: EvalSpec, sample: EvalSample) -> None: ...
+
+    async def log_sample_streaming(
+        self, eval: EvalSpec, sample: EvalSample, history: "SampleHistory"
+    ) -> None:
+        await self.log_sample(eval, materialize_streaming_sample(sample, history))
 
     @abc.abstractmethod
     async def flush(self, eval: EvalSpec) -> None: ...

--- a/src/inspect_ai/log/_recorders/streaming.py
+++ b/src/inspect_ai/log/_recorders/streaming.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from inspect_ai._util.error import EvalError
+from inspect_ai.event._pool import materialize_pooled_events
+from inspect_ai.event._validate import validate_events
+from inspect_ai.log._log import EvalRetryError, EvalSample
+from inspect_ai.log._resolve import resolve_sample_events_data
+
+if TYPE_CHECKING:
+    from inspect_ai.log._recorders.buffer.history import SampleHistory
+
+
+def materialize_streaming_sample(
+    sample: EvalSample, history: "SampleHistory"
+) -> EvalSample:
+    events = validate_events(list(history.iter_events()))
+    materialized = resolve_sample_events_data(
+        sample.model_copy(update={"events": events, "events_data": history.events_data})
+    )
+    return materialized.model_copy(
+        update={
+            "attachments": {
+                **materialized.attachments,
+                **history.attachments,
+            }
+        }
+    )
+
+
+def eval_retry_error_from_history(
+    error: EvalError, history: "SampleHistory"
+) -> EvalRetryError:
+    """Create retry error from full history since the latest ModelEvent."""
+    suffix: list[object] = []
+    for event in history.iter_events():
+        if event.get("event") == "model":
+            suffix = [event]
+        elif suffix:
+            suffix.append(event)
+
+    events = materialize_pooled_events(
+        suffix,
+        history.events_data["messages"],
+        history.events_data["calls"],
+    )
+
+    return EvalRetryError(
+        message=error.message,
+        traceback=error.traceback,
+        traceback_ansi=error.traceback_ansi,
+        events=events,
+    )

--- a/src/inspect_ai/log/_recover/_read.py
+++ b/src/inspect_ai/log/_recover/_read.py
@@ -8,7 +8,6 @@ from inspect_ai._util.async_zip import AsyncZipReader
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.constants import get_deserializing_context
 from inspect_ai.log._log import EvalPlan, EvalSample, EvalSampleSummary, EvalSpec
-from inspect_ai.log._pool import rebind_sample_timelines, resolve_sample_events_data
 from inspect_ai.log._recorders.eval import (
     HEADER_JSON,
     JOURNAL_DIR,
@@ -18,6 +17,7 @@ from inspect_ai.log._recorders.eval import (
     SUMMARY_DIR,
     LogStart,
 )
+from inspect_ai.log._resolve import rebind_sample_timelines, resolve_sample_events_data
 
 
 @dataclass

--- a/src/inspect_ai/log/_recover/_reconstruct.py
+++ b/src/inspect_ai/log/_recover/_reconstruct.py
@@ -14,11 +14,11 @@ from inspect_ai._util.error import EvalError
 from inspect_ai.event._compaction import CompactionEvent
 from inspect_ai.event._event import Event
 from inspect_ai.event._model import ModelEvent
-from inspect_ai.log._log import EvalSample, EvalSampleSummary
-from inspect_ai.log._pool import (
+from inspect_ai.event._pool import (
     resolve_model_event_calls,
     resolve_model_event_inputs,
 )
+from inspect_ai.log._log import EvalSample, EvalSampleSummary
 from inspect_ai.log._recorders.buffer.types import (
     CallPoolData,
     EventData,

--- a/src/inspect_ai/log/_recover/_stream.py
+++ b/src/inspect_ai/log/_recover/_stream.py
@@ -8,13 +8,22 @@ import tempfile
 from logging import getLogger
 from typing import IO
 
-from pydantic import JsonValue, TypeAdapter
+from pydantic import JsonValue
 
 from inspect_ai._util.constants import get_deserializing_context
 from inspect_ai._util.error import EvalError
 from inspect_ai._util.json import to_json_safe
+from inspect_ai.event._pool import (
+    _build_call_index,
+    _build_msg_index,
+    condense_model_event_calls,
+    condense_model_event_inputs,
+    resolve_model_event_calls,
+    resolve_model_event_inputs,
+)
 from inspect_ai.event._sample_init import SampleInitEvent
 from inspect_ai.event._sample_limit import SampleLimitEvent
+from inspect_ai.event._validate import validate_chat_messages
 from inspect_ai.log._condense import (
     WalkContext,
     condense_event,
@@ -27,14 +36,6 @@ from inspect_ai.log._log import (
     EvalSampleSummary,
     EvalSpec,
     EventsData,
-)
-from inspect_ai.log._pool import (
-    _build_call_index,
-    _build_msg_index,
-    condense_model_event_calls,
-    condense_model_event_inputs,
-    resolve_model_event_calls,
-    resolve_model_event_inputs,
 )
 from inspect_ai.log._recorders.buffer.filestore import Manifest, SampleBufferFilestore
 from inspect_ai.log._recorders.eval import ZipLogFile, _sample_filename
@@ -49,8 +50,6 @@ from ._reconstruct import (
 )
 
 logger = getLogger(__name__)
-
-_CHAT_MESSAGES_ADAPTER: TypeAdapter[list[ChatMessage]] = TypeAdapter(list[ChatMessage])
 
 
 def _write_json_field(
@@ -179,7 +178,7 @@ def _write_sample_streaming(
                 # Segment files written by sync_to_filestore already carry
                 # condensed events; their pools live alongside the events.
                 if seg_data.message_pool:
-                    new_messages = _CHAT_MESSAGES_ADAPTER.validate_python(
+                    new_messages = validate_chat_messages(
                         [
                             json_module.loads(entry.data)
                             for entry in sorted(

--- a/src/inspect_ai/log/_resolve.py
+++ b/src/inspect_ai/log/_resolve.py
@@ -1,0 +1,46 @@
+from inspect_ai.event._pool import (
+    resolve_model_event_calls,
+    resolve_model_event_inputs,
+)
+from inspect_ai.event._validate import validate_chat_messages
+
+from ._log import EvalSample
+
+
+def resolve_sample_events_data(sample: EvalSample) -> EvalSample:
+    """Resolve events_data pool references in model events.
+
+    Always called on read to ensure ModelEvent.input is populated,
+    regardless of the resolve_attachments setting.
+    """
+    if sample.events_data is None:
+        return sample
+    msg_pool = validate_chat_messages(
+        sample.events_data["messages"], context={"deserializing": True}
+    )
+    call_pool = sample.events_data["calls"]
+    resolved_events = resolve_model_event_inputs(sample.events, msg_pool)
+    resolved_events = resolve_model_event_calls(resolved_events, call_pool)
+    return sample.model_copy(
+        update={
+            "events": resolved_events,
+            "events_data": None,
+        }
+    )
+
+
+def rebind_sample_timelines(sample: EvalSample) -> EvalSample:
+    """Rebind timelines to the sample's current event objects."""
+    if not sample.timelines:
+        return sample
+
+    from inspect_ai.event._timeline import timeline_dump, timeline_load
+
+    return sample.model_copy(
+        update={
+            "timelines": [
+                timeline_load(timeline_dump(timeline), sample.events)
+                for timeline in sample.timelines
+            ],
+        }
+    )

--- a/src/inspect_ai/log/_samples.py
+++ b/src/inspect_ai/log/_samples.py
@@ -1,5 +1,4 @@
 import contextlib
-from contextlib import AbstractAsyncContextManager
 from contextvars import ContextVar
 from datetime import datetime, timezone
 from logging import getLogger
@@ -26,7 +25,7 @@ from anyio.abc import TaskGroup
 from shortuuid import uuid
 
 from inspect_ai.dataset._dataset import Sample
-from inspect_ai.util._checkpoint.checkpointer import Checkpointer, ResumeCheckpoint
+from inspect_ai.util._checkpoint.checkpointer import CheckpointerSetup, ResumeCheckpoint
 from inspect_ai.util._checkpoint.checkpointer_factory import create_checkpointer
 from inspect_ai.util._checkpoint.config import ResolvedCheckpointConfig
 from inspect_ai.util._limit import LimitExceededError
@@ -56,7 +55,7 @@ class ActiveSample:
         fails_on_error: bool,
         transcript: Transcript,
         sandboxes: dict[str, SandboxConnection],
-        checkpointer: AbstractAsyncContextManager[Checkpointer],
+        checkpointer: CheckpointerSetup,
         eval_id: str,
         eval_set_id: str | None = None,
         run_id: str | None = None,
@@ -283,6 +282,7 @@ async def active_sample(
                         "ActiveSample on_complete hook raised",
                         exc_info=True,
                     )
+        active.checkpointer.close()
         active.complete()
         _active_samples.remove(active)
         _sample_active.set(None)

--- a/src/inspect_ai/log/_transcript.py
+++ b/src/inspect_ai/log/_transcript.py
@@ -1,10 +1,16 @@
 import contextlib
+import os
+from collections import deque
 from contextvars import ContextVar
 from logging import getLogger
 from typing import (
+    TYPE_CHECKING,
     Callable,
+    Deque,
     Iterator,
     Literal,
+    Mapping,
+    Protocol,
     Sequence,
     TypeVar,
     overload,
@@ -13,21 +19,28 @@ from typing import (
 from pydantic import (
     JsonValue,
 )
+from shortuuid import uuid
 
+from inspect_ai._util.list import find_last_match
 from inspect_ai._util.logger import warn_once
 from inspect_ai.event._base import BaseEvent
 from inspect_ai.event._event import Event
 from inspect_ai.event._info import InfoEvent
 from inspect_ai.event._interrupt import InterruptEvent
 from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._sample_init import SampleInitEvent
 from inspect_ai.event._store import StoreEvent
 from inspect_ai.event._timeline import Timeline
 from inspect_ai.log._condense import (
     WalkContext,
+    attachment_refs_from_value,
     events_attachment_fn,
     walk_model_call,
 )
 from inspect_ai.util._store import store, store_changes, store_jsonable
+
+if TYPE_CHECKING:
+    from inspect_ai.util._checkpoint._event_store import CheckpointEventStore
 
 logger = getLogger(__name__)
 
@@ -35,53 +48,187 @@ logger = getLogger(__name__)
 ET = TypeVar("ET", bound=BaseEvent)
 
 
+def transcript_bounded_enabled() -> bool:
+    value = os.environ.get("INSPECT_TRANSCRIPT_BOUNDED")
+    if value is None:
+        return False
+    return value.strip().lower() not in ("0", "false", "no", "off")
+
+
+class TranscriptHistoryProvider(Protocol):
+    @property
+    def event_count(self) -> int: ...
+
+    def iter_events(self) -> Iterator[Event]: ...
+
+    def events(self) -> Sequence[Event]: ...
+
+    def recent_events(self, n: int | None = None) -> Sequence[Event]: ...
+
+    def events_from(self, start: int) -> Sequence[Event]: ...
+
+    def events_since_last(self, event_type: type[Event]) -> list[Event]: ...
+
+    def attachments(self) -> Mapping[str, str]: ...
+
+    def attachment(self, hash: str) -> str | None: ...
+
+    def import_checkpoint_events(self, event_store: "CheckpointEventStore") -> int: ...
+
+
+class _TranscriptEventsView(Sequence[Event]):
+    def __init__(self, transcript: "Transcript") -> None:
+        self._transcript = transcript
+
+    def __len__(self) -> int:
+        return self._transcript.event_count
+
+    def __iter__(self) -> Iterator[Event]:
+        provider = self._transcript._history_provider
+        if provider is None:
+            return iter(self._transcript._events)
+        return provider.iter_events()
+
+    def __contains__(self, item: object) -> bool:
+        if not isinstance(item, BaseEvent):
+            return False
+        item_key = item.uuid
+        if item_key is None:
+            return any(event is item for event in self._transcript._events)
+        return any(event.uuid == item_key for event in self._transcript._events)
+
+    @overload
+    def __getitem__(self, index: int) -> Event: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[Event]: ...
+
+    def __getitem__(self, index: int | slice) -> Event | Sequence[Event]:
+        if isinstance(index, slice):
+            return self._slice(index)
+        if index == -1:
+            provider = self._transcript._history_provider
+            if provider is not None:
+                recent_events = provider.recent_events(1)
+                if not recent_events:
+                    raise IndexError("Transcript events index out of range")
+                return recent_events[-1]
+            last_event = self._transcript.last_event
+            if last_event is None:
+                raise IndexError("Transcript events index out of range")
+            return last_event
+        if index >= 0:
+            provider = self._transcript._history_provider
+            if provider is not None:
+                for event_index, event in enumerate(provider.iter_events()):
+                    if event_index == index:
+                        return event
+                raise IndexError("Transcript events index out of range")
+        events = self._materialize()
+        return events[index]
+
+    def _slice(self, index: slice) -> Sequence[Event]:
+        if index == slice(None, None, None):
+            provider = self._transcript._history_provider
+            if provider is None:
+                return self._transcript._events[:]
+            return provider.events()
+        if index.step is None and index.stop is None and index.start is not None:
+            start = index.start
+            provider = self._transcript._history_provider
+            if provider is not None:
+                if start >= 0:
+                    return provider.events_from(start)
+                return provider.recent_events(-start)
+        return self._materialize()[index]
+
+    def _materialize(self) -> list[Event]:
+        provider = self._transcript._history_provider
+        if provider is None:
+            return list(self._transcript._events)
+        return list(provider.events())
+
+
 class Transcript:
     """Transcript of events."""
 
     _event_logger: Callable[[Event], None] | None
+    _event_loggers: list[Callable[[Event], None]]
+    _additional_subscribers: list[Callable[[Event], None]]
+    _notifying_subscribers: set[int]
     _context: WalkContext
 
     @overload
-    def __init__(self, *, log_model_api: bool | None = None) -> None: ...
+    def __init__(
+        self,
+        *,
+        log_model_api: bool | None = None,
+        bounded: bool = False,
+        resident_tail: int = 100,
+        history_provider: TranscriptHistoryProvider | None = None,
+    ) -> None: ...
 
     @overload
     def __init__(
-        self, events: list[Event], log_model_api: bool | None = None
+        self,
+        events: list[Event],
+        log_model_api: bool | None = None,
+        bounded: bool = False,
+        resident_tail: int = 100,
+        history_provider: TranscriptHistoryProvider | None = None,
     ) -> None: ...
 
     def __init__(
-        self, events: list[Event] | None = None, log_model_api: bool | None = None
+        self,
+        events: list[Event] | None = None,
+        log_model_api: bool | None = None,
+        bounded: bool = False,
+        resident_tail: int = 100,
+        history_provider: TranscriptHistoryProvider | None = None,
     ) -> None:
         self._event_logger = None
+        self._event_loggers = []
+        self._additional_subscribers = self._event_loggers
         self._log_model_api = log_model_api
         self._context = WalkContext(message_cache={}, only_core=False)
-        self._events: list[Event] = events if events is not None else []
+        self._events: list[Event] = self._copy_uuidless_events(events or [])
+        self._history_provider = history_provider
+        self._events_view = _TranscriptEventsView(self)
         self._attachments: dict[str, str] = {}
+        self._attachment_refcount: dict[str, int] = {}
+        self._event_attachment_refs: dict[str, set[str]] = {}
         self._timelines: list[Timeline] = []
         self._model_call_counts: dict[str, int] = {}
-        self._kept_event_ids: set[int] = set()
-        self._additional_subscribers: list[Callable[[Event], None]] = []
-        # Sidecar of currently-pending events keyed by ``event.uuid`` so
-        # consumers (live TUI toolbar, future DB-backed transcripts) can
-        # query in-flight state in O(in-flight) without scanning all
-        # events. Maintained by ``_event``/``_event_updated``. Insertion
-        # order = declared order; dict preserves it so the "earliest
-        # pending" is the first value.
-        self._pending_events: dict[str, Event] = {}
-        if events is not None:
-            for ev in events:
-                if ev.pending and ev.uuid is not None:
-                    self._pending_events[ev.uuid] = ev
-        # Re-entry guard for the subscriber loop. A subscriber that
-        # raises causes :data:`logger.exception` to run, which (when
-        # ``inspect_ai``'s ``LogHandler`` is installed by eval) feeds
-        # a fresh ``LoggerEvent`` back through ``_event`` → straight
-        # into this method again. Without the guard, a consistently
-        # broken subscriber would recurse infinitely. We still want
-        # the recursive event to land in ``_events`` and reach the
-        # single-slot ``_event_logger`` (log writer), but skip the
-        # subscriber loop to break the cycle.
-        self._notifying_subscribers: bool = False
+        self._kept_event_ids: set[str] = set()
+        self._bounded = bounded
+        self._resident_tail = resident_tail
+        self._event_count = len(self._events)
+        self._events_truncated = False
+        self._pinned_event_ids: set[str] = {
+            self._event_key(event)
+            for event in self._events
+            if isinstance(event, SampleInitEvent)
+        }
+        self._pending_event_ids: set[str] = {
+            self._event_key(event) for event in self._events if event.pending
+        }
+        self._pending_events: dict[str, Event] = {
+            self._event_key(event): event for event in self._events if event.pending
+        }
+        self._resident_event_ids: set[str] = {
+            self._event_key(event) for event in self._events
+        }
+        self._evictable_event_ids: Deque[str] = deque(
+            event_key
+            for event in self._events
+            if (event_key := self._event_key(event))
+            not in self._pinned_event_ids | self._pending_event_ids
+        )
+        # Re-entry guard for subscriber callbacks. If a subscriber logs while
+        # handling an event, the resulting LoggerEvent should still reach all
+        # other subscribers, but not recursively notify the same subscriber.
+        self._notifying_subscribers = set()
+        self._evict_events()
 
     def info(self, data: JsonValue, *, source: str | None = None) -> None:
         """Add an `InfoEvent` to the transcript.
@@ -113,19 +260,65 @@ class Transcript:
 
     @property
     def events(self) -> Sequence[Event]:
+        """Compatibility view of the logical event history.
+
+        For unbounded or provider-free transcripts this returns resident events.
+        For bounded transcripts with a history provider this returns a lazy view
+        over the full logical history. Iteration, random indexing, and some slices
+        may read and materialize events from the provider; hot paths should use
+        `resident_events`, `event_count`, `last_event`, or `recent_events()`.
+        """
+        if self._history_provider is None:
+            return self._events
+        return self._events_view
+
+    @property
+    def resident_events(self) -> Sequence[Event]:
+        """Events currently resident in memory for live/hot-path consumers."""
         return self._events
 
     @property
     def pending_events(self) -> Sequence[Event]:
-        """Currently-pending events in declared (insertion) order.
-
-        Returns a snapshot of events with ``pending=True`` keyed by
-        their ``uuid``. Updates whenever ``_event`` records a new
-        pending event or ``_event_updated`` flips one to a terminal
-        state. Bounded by the number of in-flight operations
-        (typically 0-1, up to the stage size under parallel tools).
-        """
+        """Currently-pending events in insertion order."""
         return list(self._pending_events.values())
+
+    @property
+    def event_count(self) -> int:
+        return self._event_count
+
+    @property
+    def resident_events_truncated(self) -> bool:
+        return self._events_truncated
+
+    @property
+    def full_history_available(self) -> bool:
+        return not self._events_truncated or self._history_provider is not None
+
+    @property
+    def last_event(self) -> Event | None:
+        return self._events[-1] if self._events else None
+
+    def recent_events(self, n: int | None = None) -> Sequence[Event]:
+        if n is not None and n <= 0:
+            return []
+        if self._history_provider is None:
+            return self._events if n is None else self._events[-n:]
+        if not self._events_truncated and n is not None and n <= len(self._events):
+            return self._events[-n:]
+        return self._history_provider.recent_events(n)
+
+    def events_since_last(self, event_type: type[Event]) -> list[Event]:
+        if self._events_truncated:
+            if self._history_provider is not None:
+                return self._history_provider.events_since_last(event_type)
+            raise RuntimeError(
+                "Full transcript history is not available from this Transcript"
+            )
+        events = list(self._events)
+        index = find_last_match(events, lambda event: isinstance(event, event_type))
+        if index is not None:
+            return events[index:]
+        return events
 
     @property
     def attachments(self) -> dict[str, str]:
@@ -152,31 +345,65 @@ class Transcript:
         self._timelines.append(timeline)
 
     def _event(self, event: Event) -> None:
+        event_key = self._ensure_event_key(event)
+        if event_key in self._resident_event_ids:
+            raise ValueError(f"Duplicate event uuid: {event_key}")
         self._process_event(event)
         self._events.append(event)
+        self._resident_event_ids.add(event_key)
+        self._set_attachment_refs(event)
+        self._event_count += 1
+        self._update_pin_state(event)
         self._update_pending(event)
+        self._update_evictable_state(event)
+        self._evict_events()
+
+    def _extend_restored_events(
+        self, events: Sequence[Event], attachments: Mapping[str, str]
+    ) -> None:
+        events = self._copy_uuidless_events(events)
+        event_keys: list[str] = []
+        new_event_keys: set[str] = set()
+        for event in events:
+            event_key = self._ensure_event_key(event)
+            if event_key in self._resident_event_ids or event_key in new_event_keys:
+                raise ValueError(f"Duplicate event uuid: {event_key}")
+            event_keys.append(event_key)
+            new_event_keys.add(event_key)
+
+        self._attachments.update(attachments)
+        for event, event_key in zip(events, event_keys):
+            self._events.append(event)
+            self._resident_event_ids.add(event_key)
+            self._set_attachment_refs(event)
+            self._event_count += 1
+            self._update_pin_state(event)
+            self._update_pending(event)
+            self._update_evictable_state(event)
+        self._evict_events()
 
     def _event_updated(self, event: Event) -> None:
-        self._process_event(event)
-        self._update_pending(event)
+        if self._is_resident(event):
+            self._process_event(event)
+            self._set_attachment_refs(event)
+            self._update_pin_state(event)
+            self._update_pending(event)
+            self._update_evictable_state(event)
+            self._evict_events()
+        else:
+            self._process_event(event, retain_attachments=False)
+            self._update_pending(event)
+            self._prune_unreferenced_attachments()
 
     def _update_pending(self, event: Event) -> None:
-        """Reflect ``event``'s current pending state in the sidecar.
-
-        Adds the event on first emission with ``pending=True``; removes
-        on the subsequent ``_event_updated`` that flips it to a terminal
-        state. Events without a ``uuid`` (synthetic step/span events)
-        are skipped — they can't be deduplicated and don't represent
-        an in-flight operation.
-        """
-        if event.uuid is None:
-            return
+        """Reflect ``event``'s current pending state in the sidecar."""
+        event_key = self._event_key(event)
         if event.pending:
-            self._pending_events[event.uuid] = event
+            self._pending_events[event_key] = event
         else:
-            self._pending_events.pop(event.uuid, None)
+            self._pending_events.pop(event_key, None)
 
-    def _process_event(self, event: Event) -> None:
+    def _process_event(self, event: Event, *, retain_attachments: bool = True) -> None:
         if isinstance(event, ModelEvent) and event.call is not None:
             is_error = bool(event.call.error)
             if not is_error:
@@ -185,8 +412,8 @@ class Transcript:
                 elif self._log_model_api is False:
                     event.call = None
                 else:
-                    event_id = id(event)
-                    if event_id not in self._kept_event_ids:
+                    event_key = self._event_key(event)
+                    if event_key not in self._kept_event_ids:
                         from inspect_ai._util.constants import (
                             DEFAULT_LOG_MODEL_API_CALLS,
                         )
@@ -194,61 +421,190 @@ class Transcript:
                         count = self._model_call_counts.get(event.model, 0)
                         if count < DEFAULT_LOG_MODEL_API_CALLS:
                             self._model_call_counts[event.model] = count + 1
-                            self._kept_event_ids.add(event_id)
+                            self._kept_event_ids.add(event_key)
                         else:
                             event.call = None
 
-        if self._event_logger:
-            self._event_logger(event)
+            if retain_attachments and event.call is not None:
+                event_fn = events_attachment_fn(self.attachments)
+                event.call = walk_model_call(event.call, event_fn, self._context)
 
-        # Re-entrant call (a subscriber's logger.exception fed a
-        # LoggerEvent back through here). Skip the subscriber loop
-        # to avoid infinite recursion with a consistently broken
-        # subscriber — the outer call's loop is the one that
-        # delivers events anyway.
-        if not self._notifying_subscribers:
-            self._notifying_subscribers = True
+        for event_logger in list(self._event_loggers):
+            subscriber_id = id(event_logger)
+            if subscriber_id in self._notifying_subscribers:
+                continue
+            self._notifying_subscribers.add(subscriber_id)
             try:
-                for sub in self._additional_subscribers:
-                    try:
-                        sub(event)
-                    except Exception:
-                        logger.exception("Transcript subscriber raised; continuing")
+                try:
+                    event_logger(event)
+                except Exception:
+                    logger.warning("Transcript subscriber failed", exc_info=True)
             finally:
-                self._notifying_subscribers = False
+                self._notifying_subscribers.remove(subscriber_id)
 
-        # condense model event calls immediately to prevent O(N) memory usage
-        if isinstance(event, ModelEvent) and event.call is not None:
-            event_fn = events_attachment_fn(self.attachments)
-            event.call = walk_model_call(event.call, event_fn, self._context)
+    def _set_attachment_refs(self, event: Event) -> None:
+        if not self._bounded:
+            return
 
-    def _subscribe(self, event_logger: Callable[[Event], None]) -> None:
-        self._event_logger = event_logger
+        event_key = self._event_key(event)
+        previous_refs = self._event_attachment_refs.get(event_key, set())
+        current_refs = self._attachment_refs(event)
+        for ref in previous_refs - current_refs:
+            self._decrement_attachment_ref(ref)
+        for ref in current_refs - previous_refs:
+            self._attachment_refcount[ref] = self._attachment_refcount.get(ref, 0) + 1
+        if current_refs:
+            self._event_attachment_refs[event_key] = current_refs
+        else:
+            self._event_attachment_refs.pop(event_key, None)
 
-    def _add_subscriber(self, callback: Callable[[Event], None]) -> Callable[[], None]:
-        """Register an additive event subscriber.
+    def _attachment_refs(self, event: Event) -> set[str]:
+        return attachment_refs_from_value(event.model_dump(mode="python"))
 
-        Unlike :meth:`_subscribe` (single-slot, used by the eval runner's
-        log writer), multiple subscribers coexist and all fire on every
-        event. Each subscriber runs in a try/except so one failing
-        subscriber does not block others or interrupt the agent loop.
+    def _decrement_attachment_ref(self, ref: str) -> None:
+        count = self._attachment_refcount.get(ref, 0) - 1
+        if count > 0:
+            self._attachment_refcount[ref] = count
+        else:
+            self._attachment_refcount.pop(ref, None)
+            self._attachments.pop(ref, None)
 
-        Returns an idempotent unsubscribe callable.
+    def _prune_unreferenced_attachments(self) -> None:
+        if not self._bounded:
+            return
+
+        for ref in list(self._attachments):
+            if ref not in self._attachment_refcount:
+                self._attachments.pop(ref, None)
+
+    def _evict_events(self) -> None:
+        if not self._bounded:
+            return
+
+        resident_tail = max(self._resident_tail, 0)
+        evicted_event_ids: set[str] = set()
+        while len(self._evictable_event_ids) > resident_tail:
+            event_key = self._evictable_event_ids.popleft()
+            if not self._is_evictable_event_key(event_key):
+                continue
+            evicted_event_ids.add(event_key)
+
+        if evicted_event_ids:
+            self._events = [
+                event
+                for event in self._events
+                if self._event_key(event) not in evicted_event_ids
+            ]
+            self._resident_event_ids.difference_update(evicted_event_ids)
+            self._events_truncated = True
+            self._prune_pin_state()
+
+    def _prune_pin_state(self) -> None:
+        resident_event_keys = self._resident_event_ids
+        self._pinned_event_ids.intersection_update(resident_event_keys)
+        self._pending_event_ids.intersection_update(resident_event_keys)
+        self._evictable_event_ids = deque(
+            event_key
+            for event_key in self._evictable_event_ids
+            if self._is_evictable_event_key(event_key)
+        )
+        if self._bounded:
+            self._kept_event_ids.intersection_update(resident_event_keys)
+            self._prune_attachment_refs(resident_event_keys)
+
+    def _prune_attachment_refs(self, resident_event_keys: set[str]) -> None:
+        for event_key in list(self._event_attachment_refs):
+            if event_key in resident_event_keys:
+                continue
+            for ref in self._event_attachment_refs.pop(event_key):
+                self._decrement_attachment_ref(ref)
+
+    def _is_resident(self, event: Event) -> bool:
+        return event.uuid is not None and event.uuid in self._resident_event_ids
+
+    def _update_pin_state(self, event: Event) -> None:
+        event_key = self._event_key(event)
+        if isinstance(event, SampleInitEvent):
+            self._pinned_event_ids.add(event_key)
+        if event.pending:
+            self._pending_event_ids.add(event_key)
+        else:
+            self._pending_event_ids.discard(event_key)
+
+    def _update_evictable_state(self, event: Event) -> None:
+        event_key = self._event_key(event)
+        if not self._is_evictable_event_key(event_key):
+            return
+        if event_key in self._evictable_event_ids:
+            return
+
+        for index, resident_event in enumerate(self._events):
+            if resident_event is event:
+                self._evictable_event_ids.insert(index, event_key)
+                return
+        self._evictable_event_ids.append(event_key)
+
+    def _is_evictable_event_key(self, event_key: str) -> bool:
+        return (
+            event_key in self._resident_event_ids
+            and event_key not in self._pinned_event_ids
+            and event_key not in self._pending_event_ids
+        )
+
+    def _event_key(self, event: Event) -> str:
+        if event.uuid is None:
+            raise ValueError("Transcript event is missing uuid")
+        return event.uuid
+
+    def _ensure_event_key(self, event: Event) -> str:
+        if event.uuid is None:
+            event.uuid = uuid()
+        return event.uuid
+
+    @staticmethod
+    def _copy_uuidless_events(events: Sequence[Event]) -> list[Event]:
+        copied_events: list[Event] = []
+        for event in events:
+            if event.uuid is None:
+                event = event.model_copy()
+                event.uuid = uuid()
+            copied_events.append(event)
+        return copied_events
+
+    def subscribe(self, event_logger: Callable[[Event], None]) -> Callable[[], None]:
+        """Subscribe to transcript event notifications.
+
+        The callback is invoked when an event is added and when a resident event
+        is updated. Subscriber exceptions are logged and do not prevent other
+        subscribers or normal transcript processing. Returns an unsubscribe
+        callback that removes the subscription.
         """
-        self._additional_subscribers.append(callback)
+        self._event_loggers.append(event_logger)
 
         def unsubscribe() -> None:
-            try:
-                self._additional_subscribers.remove(callback)
-            except ValueError:
-                pass
+            if event_logger in self._event_loggers:
+                self._event_loggers.remove(event_logger)
 
         return unsubscribe
+
+    def _subscribe(self, event_logger: Callable[[Event], None]) -> None:
+        """Legacy subscription API for eval logging."""
+        if self._event_logger is not None and self._event_logger in self._event_loggers:
+            self._event_loggers.remove(self._event_logger)
+        self._event_logger = event_logger
+        self._event_loggers.append(event_logger)
+
+    def _add_subscriber(self, callback: Callable[[Event], None]) -> Callable[[], None]:
+        return self.subscribe(callback)
 
 
 def transcript() -> Transcript:
     """Get the current `Transcript`."""
-    return _transcript.get()
+    active_transcript = _transcript.get()
+    if active_transcript is None:
+        active_transcript = Transcript()
+        _transcript.set(active_transcript)
+    return active_transcript
 
 
 def record_interrupt_event(
@@ -263,15 +619,6 @@ def record_interrupt_event(
     Internal helper used by Inspect's cancellation machinery — the ACP
     `cancel_current_turn` path, sample-level limit handlers, and system
     shutdown. Not a public API for agent authors.
-
-    Args:
-        source: What caused the interrupt — an ACP client cancel,
-            a sample limit, or system shutdown.
-        interrupted: What was running at the moment of the interrupt.
-        interrupted_tool_call_id: ``ToolEvent.id`` of the in-flight
-            tool call, if any.
-        interrupted_model_event_id: ``ModelEvent.uuid`` of the
-            in-flight model call, if any.
     """
     transcript()._event(
         InterruptEvent(
@@ -298,6 +645,6 @@ def init_transcript(transcript: Transcript) -> None:
     _transcript.set(transcript)
 
 
-_transcript: ContextVar[Transcript] = ContextVar(
-    "subtask_transcript", default=Transcript()
+_transcript: ContextVar[Transcript | None] = ContextVar(
+    "subtask_transcript", default=None
 )

--- a/src/inspect_ai/util/_checkpoint/_event_store.py
+++ b/src/inspect_ai/util/_checkpoint/_event_store.py
@@ -1,0 +1,452 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from sqlite3 import Connection, connect
+from threading import RLock
+from typing import TextIO
+
+from pydantic import JsonValue
+from pydantic_core import to_jsonable_python
+from shortuuid import uuid
+
+from inspect_ai._util.hash import mm3_hash
+from inspect_ai._util.json import json_dump
+from inspect_ai.event._event import Event
+from inspect_ai.event._pool import (
+    _msg_hash,
+    condense_model_event_calls_with_lookup,
+    condense_model_event_inputs_with_lookup,
+)
+from inspect_ai.log._condense import (
+    attachment_refs_from_value,
+    condense_event,
+)
+from inspect_ai.model._chat_message import ChatMessage
+
+logger = logging.getLogger(__name__)
+
+CHECKPOINT_EVENT_STORE = "checkpoint_events.sqlite"
+
+
+@dataclass(frozen=True)
+class CheckpointEventStoreCounts:
+    events: int
+    message_pool: int
+    call_pool: int
+    attachments: int
+    db_bytes: int
+
+
+class CheckpointEventStore:
+    def __init__(self, path: str | Path, *, reset: bool = False) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        if reset:
+            self._reset_files()
+        self._conn = connect(self._path, check_same_thread=False)
+        self._lock = RLock()
+        self._pending_message_pos_by_event: dict[str, dict[int, int]] = {}
+        self._pending_call_pos_by_event: dict[str, dict[int, int]] = {}
+        self._conn.row_factory = None
+        self._init_schema(self._conn)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def counts(self) -> CheckpointEventStoreCounts:
+        with self._lock:
+            return CheckpointEventStoreCounts(
+                events=self._count_rows("events"),
+                message_pool=self._count_rows("message_pool"),
+                call_pool=self._count_rows("call_pool"),
+                attachments=self._count_rows("attachments"),
+                db_bytes=self._path.stat().st_size if self._path.exists() else 0,
+            )
+
+    def close(self) -> None:
+        with self._lock:
+            self._conn.close()
+
+    def merge_event(
+        self, event: Event, attachment_lookup: Callable[[str], str | None]
+    ) -> None:
+        with self._lock:
+            if event.uuid is None:
+                event.uuid = uuid()
+            logical_id = event.uuid
+
+            with self._conn:
+                event_attachments: dict[str, str] = {}
+                event = condense_event(event, event_attachments)
+                condensed_event = self._condense_event(logical_id, event)
+                event_json = json.dumps(
+                    to_jsonable_python(
+                        condensed_event, exclude_none=True, fallback=lambda _: None
+                    ),
+                    separators=(",", ":"),
+                )
+                self._upsert_event(logical_id, event_json)
+                self._insert_attachments(event_attachments)
+                self._merge_attachment_refs(
+                    self._attachment_refs(event),
+                    lambda ref: event_attachments.get(ref) or attachment_lookup(ref),
+                )
+
+    def merge_condensed_event(
+        self,
+        logical_id: str,
+        event: Mapping[str, JsonValue],
+        attachment_lookup: Callable[[str], str | None],
+    ) -> None:
+        event_jsonable = dict(event)
+        event_jsonable.setdefault("uuid", logical_id)
+        event_json = json.dumps(event_jsonable, separators=(",", ":"))
+        with self._lock:
+            with self._conn:
+                self._upsert_event(logical_id, event_json)
+                self._merge_attachment_refs(
+                    attachment_refs_from_value(event_jsonable), attachment_lookup
+                )
+
+    def merge_message_pool_entry(self, hash_value: str, json_text: str) -> int:
+        with self._lock:
+            with self._conn:
+                return self._pool_pos("message_pool", hash_value, json_text)
+
+    def merge_message_pool(self, messages: Iterable[ChatMessage]) -> None:
+        with self._lock:
+            with self._conn:
+                for message in messages:
+                    self._message_pos(message)
+
+    def merge_call_pool_entry(self, hash_value: str, json_text: str) -> int:
+        with self._lock:
+            with self._conn:
+                return self._pool_pos("call_pool", hash_value, json_text)
+
+    def merge_call_pool(self, calls: Iterable[JsonValue]) -> None:
+        with self._lock:
+            with self._conn:
+                for call in calls:
+                    self._call_pos(call)
+
+    def _upsert_event(self, logical_id: str, event_json: str) -> None:
+        row = self._conn.execute(
+            "SELECT first_seq FROM events WHERE logical_id = ?",
+            (logical_id,),
+        ).fetchone()
+        if row is None:
+            first_seq = self._next_event_seq()
+            self._conn.execute(
+                "INSERT INTO events(logical_id, first_seq, latest_json) VALUES (?, ?, ?)",
+                (logical_id, first_seq, event_json),
+            )
+        else:
+            self._conn.execute(
+                "UPDATE events SET latest_json = ? WHERE logical_id = ?",
+                (event_json, logical_id),
+            )
+
+    def _merge_attachment_refs(
+        self, refs: Iterable[str], attachment_lookup: Callable[[str], str | None]
+    ) -> None:
+        for ref in refs:
+            content = attachment_lookup(ref)
+            if content is not None:
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO attachments(hash, content) VALUES (?, ?)",
+                    (ref, content),
+                )
+            elif not self._has_attachment(ref):
+                logger.warning(
+                    "Checkpoint event references missing attachment: %s", ref
+                )
+
+    def _has_attachment(self, ref: str) -> bool:
+        row = self._conn.execute(
+            "SELECT 1 FROM attachments WHERE hash = ?",
+            (ref,),
+        ).fetchone()
+        return row is not None
+
+    def merge_events(
+        self, events: Iterable[Event], attachments: Mapping[str, str]
+    ) -> None:
+        with self._lock:
+            for event in events:
+                self.merge_event(event, attachments.get)
+
+    def merge_attachments(self, attachments: Mapping[str, str]) -> None:
+        if not attachments:
+            return
+        with self._lock:
+            with self._conn:
+                self._insert_attachments(attachments)
+
+    def _insert_attachments(self, attachments: Mapping[str, str]) -> None:
+        if not attachments:
+            return
+        self._conn.executemany(
+            "INSERT OR IGNORE INTO attachments(hash, content) VALUES (?, ?)",
+            attachments.items(),
+        )
+
+    def merge_attachment_refs(
+        self, refs: Iterable[str], attachment_lookup: Callable[[str], str | None]
+    ) -> None:
+        with self._lock:
+            with self._conn:
+                self._merge_attachment_refs(refs, attachment_lookup)
+
+    @staticmethod
+    def attachment_refs_from_json(json_text: str) -> set[str]:
+        return attachment_refs_from_value(json.loads(json_text))
+
+    def _reset_files(self) -> None:
+        for path in (
+            self._path,
+            self._path.with_name(f"{self._path.name}-wal"),
+            self._path.with_name(f"{self._path.name}-shm"),
+        ):
+            path.unlink(missing_ok=True)
+
+    def export_snapshot_files(
+        self,
+        sample_working_dir: str | Path,
+        *,
+        store_json: object,
+        agent_state: Mapping[str, object] | None,
+    ) -> None:
+        sample_dir = Path(sample_working_dir)
+        with self._lock:
+            self._write_text_atomic(sample_dir / "store.json", json_dump(store_json))
+            if agent_state is not None:
+                self._write_text_atomic(
+                    sample_dir / "agent_state.json", json_dump(agent_state)
+                )
+            with self._conn:
+                self._write_events_data(sample_dir / "events_data.json")
+                self._write_json_object_from_rows(
+                    sample_dir / "attachments.json",
+                    self._conn.execute(
+                        "SELECT hash, content FROM attachments ORDER BY hash"
+                    ),
+                )
+                self._write_json_array(
+                    sample_dir / "events.json",
+                    self._conn.execute(
+                        "SELECT latest_json FROM events ORDER BY first_seq"
+                    ),
+                )
+
+    def _count_rows(self, table: str) -> int:
+        row = self._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def _next_event_seq(self) -> int:
+        row = self._conn.execute(
+            "SELECT COALESCE(MAX(first_seq), -1) + 1 FROM events"
+        ).fetchone()
+        assert row is not None
+        return int(row[0])
+
+    def _condense_event(self, logical_id: str, event: Event) -> Event:
+        message_cache = self._pending_message_pos_by_event.get(logical_id)
+        call_cache = self._pending_call_pos_by_event.get(logical_id)
+        if event.pending:
+            message_cache = message_cache if message_cache is not None else {}
+            call_cache = call_cache if call_cache is not None else {}
+            self._pending_message_pos_by_event[logical_id] = message_cache
+            self._pending_call_pos_by_event[logical_id] = call_cache
+
+        event = condense_model_event_inputs_with_lookup(
+            event, lambda message: self._message_pos(message, message_cache)
+        )
+        event = condense_model_event_calls_with_lookup(
+            event, lambda call_message: self._call_pos(call_message, call_cache)
+        )
+        if not event.pending:
+            self._pending_message_pos_by_event.pop(logical_id, None)
+            self._pending_call_pos_by_event.pop(logical_id, None)
+        return event
+
+    def _message_pos(
+        self, message: ChatMessage, cache: dict[int, int] | None = None
+    ) -> int:
+        message_id = id(message)
+        if cache is not None:
+            cached_pos = cache.get(message_id)
+            if cached_pos is not None:
+                return cached_pos
+
+        message_jsonable = to_jsonable_python(
+            message,
+            exclude_none=True,
+            fallback=lambda _: None,
+        )
+        pos = self._pool_pos(
+            "message_pool",
+            _msg_hash(message),
+            json.dumps(message_jsonable, sort_keys=True),
+        )
+        if cache is not None:
+            cache[message_id] = pos
+        return pos
+
+    def _call_pos(
+        self, call_message: JsonValue, cache: dict[int, int] | None = None
+    ) -> int:
+        call_message_id = id(call_message)
+        if cache is not None:
+            cached_pos = cache.get(call_message_id)
+            if cached_pos is not None:
+                return cached_pos
+
+        call_json = json.dumps(call_message, sort_keys=True)
+        pos = self._pool_pos("call_pool", mm3_hash(call_json), call_json)
+        if cache is not None:
+            cache[call_message_id] = pos
+        return pos
+
+    def _pool_pos(self, table: str, hash_value: str, json_text: str) -> int:
+        row = self._conn.execute(
+            f"SELECT pos FROM {table} WHERE hash = ?",
+            (hash_value,),
+        ).fetchone()
+        if row is not None:
+            return int(row[0])
+
+        pos_row = self._conn.execute(
+            f"SELECT COALESCE(MAX(pos), -1) + 1 FROM {table}"
+        ).fetchone()
+        assert pos_row is not None
+        pos = int(pos_row[0])
+        self._conn.execute(
+            f"INSERT INTO {table}(pos, hash, json) VALUES (?, ?, ?)",
+            (pos, hash_value, json_text),
+        )
+        return pos
+
+    @staticmethod
+    def _attachment_refs(event: Event) -> set[str]:
+        return attachment_refs_from_value(event.model_dump(mode="python"))
+
+    @staticmethod
+    def _write_text_atomic(path: Path, content: str) -> None:
+        CheckpointEventStore._write_atomic(path, lambda file: file.write(content))
+
+    @staticmethod
+    def _write_json_array(path: Path, rows: Iterable[tuple[str]]) -> None:
+        def write(file: TextIO) -> None:
+            CheckpointEventStore._write_json_array_to_file(file, rows)
+            file.write("\n")
+
+        CheckpointEventStore._write_atomic(path, write)
+
+    @staticmethod
+    def _write_json_object_from_rows(
+        path: Path, rows: Iterable[tuple[str, str]]
+    ) -> None:
+        def write(file: TextIO) -> None:
+            file.write("{")
+            first = True
+            for key, value in rows:
+                if not first:
+                    file.write(",")
+                file.write(json.dumps(str(key)))
+                file.write(":")
+                file.write(json.dumps(value))
+                first = False
+            file.write("}\n")
+
+        CheckpointEventStore._write_atomic(path, write)
+
+    def _write_events_data(self, path: Path) -> None:
+        def write(file: TextIO) -> None:
+            file.write('{"messages":')
+            self._write_json_array_to_file(
+                file,
+                self._conn.execute("SELECT json FROM message_pool ORDER BY pos"),
+            )
+            file.write(',"calls":')
+            self._write_json_array_to_file(
+                file,
+                self._conn.execute("SELECT json FROM call_pool ORDER BY pos"),
+            )
+            file.write("}\n")
+
+        self._write_atomic(path, write)
+
+    @staticmethod
+    def _write_atomic(path: Path, write: Callable[[TextIO], object]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd, tmp_name = tempfile.mkstemp(
+            dir=path.parent,
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            text=True,
+        )
+        tmp_path = Path(tmp_name)
+        try:
+            with open(fd, "w") as file:
+                write(file)
+                file.flush()
+                os.fsync(file.fileno())
+            os.replace(tmp_path, path)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    @staticmethod
+    def _write_json_array_to_file(file: TextIO, rows: Iterable[tuple[str]]) -> None:
+        file.write("[")
+        first = True
+        for (json_text,) in rows:
+            if not first:
+                file.write(",")
+            file.write(str(json_text))
+            first = False
+        file.write("]")
+
+    @staticmethod
+    def _init_schema(conn: Connection) -> None:
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS events (
+                logical_id TEXT PRIMARY KEY,
+                first_seq INTEGER NOT NULL UNIQUE,
+                latest_json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS message_pool (
+                pos INTEGER PRIMARY KEY,
+                hash TEXT NOT NULL UNIQUE,
+                json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS call_pool (
+                pos INTEGER PRIMARY KEY,
+                hash TEXT NOT NULL UNIQUE,
+                json TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS attachments (
+                hash TEXT PRIMARY KEY,
+                content TEXT NOT NULL
+            );
+            """
+        )
+        conn.commit()

--- a/src/inspect_ai/util/_checkpoint/_layout/host_context.py
+++ b/src/inspect_ai/util/_checkpoint/_layout/host_context.py
@@ -24,13 +24,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import anyio
 from pydantic import JsonValue
-from pydantic_core import to_jsonable_python
 
 from inspect_ai.event._event import Event
-from inspect_ai.log import EventsData
-from inspect_ai.log._condense import _chat_messages_adapter, _events_adapter
+from inspect_ai.event._validate import validate_chat_messages, validate_events_json
 from inspect_ai.model._chat_message import ChatMessage
 
 EVENTS = "events.json"
@@ -55,31 +52,15 @@ class HostContext:
     ``None`` is returned when the file is absent."""
 
 
-async def write(working_dir: str, ctx: HostContext) -> None:
-    """Write all host-context files to ``working_dir``, overwriting in place."""
-    sample_dir = anyio.Path(working_dir)
-    await (sample_dir / EVENTS).write_text(_json_dump(ctx.condensed_events))
-    events_data = EventsData(messages=ctx.msg_pool, calls=ctx.call_pool)
-    await (sample_dir / EVENTS_DATA).write_text(_json_dump(events_data))
-    await (sample_dir / ATTACHMENTS).write_text(_json_dump(ctx.attachments))
-    await (sample_dir / STORE).write_text(_json_dump(ctx.store))
-    if ctx.agent_state is not None:
-        await (sample_dir / AGENT_STATE).write_text(_json_dump(ctx.agent_state))
-
-
 def read(working_dir: str) -> HostContext:
     """Read all host-context files from ``working_dir``.
 
     Synchronous (caller wraps in ``anyio.to_thread.run_sync`` if needed).
     """
     p = Path(working_dir)
-    condensed_events: list[Event] = _events_adapter().validate_json(
-        (p / EVENTS).read_text()
-    )
+    condensed_events: list[Event] = validate_events_json((p / EVENTS).read_text())
     raw_data = json.loads((p / EVENTS_DATA).read_text())
-    msg_pool: list[ChatMessage] = _chat_messages_adapter().validate_python(
-        raw_data.get("messages", [])
-    )
+    msg_pool: list[ChatMessage] = validate_chat_messages(raw_data.get("messages", []))
     call_pool: list[JsonValue] = raw_data.get("calls", [])
     attachments: dict[str, str] = json.loads((p / ATTACHMENTS).read_text())
     store_data: dict[str, Any] = json.loads((p / STORE).read_text())
@@ -94,12 +75,4 @@ def read(working_dir: str) -> HostContext:
         attachments=attachments,
         store=store_data,
         agent_state=agent_state,
-    )
-
-
-def _json_dump(obj: object) -> str:
-    """Serialize ``obj`` to JSON, excluding ``None`` fields, with a trailing newline."""
-    return (
-        json.dumps(to_jsonable_python(obj, exclude_none=True, fallback=lambda _: None))
-        + "\n"
     )

--- a/src/inspect_ai/util/_checkpoint/checkpointer.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer.py
@@ -134,6 +134,21 @@ class Checkpointer(Protocol):
         ...
 
 
+class CheckpointerSetup(Protocol):
+    """Per-sample setup object stored on ActiveSample.
+
+    Enters to yield the agent-facing :class:`Checkpointer` and closes any
+    cached resources at sample teardown. ``close()`` is intentionally here,
+    not on ``Checkpointer``, so agents don't see lifecycle concerns.
+    """
+
+    async def __aenter__(self) -> Checkpointer: ...
+
+    async def __aexit__(self, *exc: object) -> None: ...
+
+    def close(self) -> None: ...
+
+
 @contextlib.asynccontextmanager
 async def checkpointer() -> AsyncIterator[Checkpointer]:
     """Enter the checkpointer bound to the active sample.

--- a/src/inspect_ai/util/_checkpoint/checkpointer_factory.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_factory.py
@@ -1,8 +1,7 @@
 import os
-from contextlib import AbstractAsyncContextManager
 
 from inspect_ai._util.logger import warn_once
-from inspect_ai.util._checkpoint.checkpointer import Checkpointer, ResumeCheckpoint
+from inspect_ai.util._checkpoint.checkpointer import CheckpointerSetup, ResumeCheckpoint
 from inspect_ai.util._checkpoint.checkpointer_impl import _CheckpointerSetup, logger
 from inspect_ai.util._checkpoint.checkpointer_noop import _NoopCheckpointer
 from inspect_ai.util._checkpoint.config import ResolvedCheckpointConfig
@@ -15,7 +14,7 @@ def create_checkpointer(
     sample_id: int | str,
     epoch: int,
     resume_checkpoint: ResumeCheckpoint | None = None,
-) -> AbstractAsyncContextManager[Checkpointer]:
+) -> CheckpointerSetup:
     """Build the per-sample checkpointer setup.
 
     Returns a :class:`_NoopCheckpointer` when ``config`` is ``None`` or

--- a/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
@@ -13,7 +13,13 @@ from __future__ import annotations
 
 import contextlib
 import time
-from collections.abc import AsyncIterator, Awaitable, Callable, Mapping, Sequence
+from collections.abc import (
+    AsyncIterator,
+    Awaitable,
+    Callable,
+    Mapping,
+    Sequence,
+)
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timezone
 from functools import partial
@@ -22,26 +28,23 @@ from pathlib import Path
 from typing import Any, TypeVar
 
 import anyio
-from pydantic import BaseModel, JsonValue, TypeAdapter
+from pydantic import BaseModel, TypeAdapter
 
 from inspect_ai._util._async import tg_collect
 from inspect_ai.event._checkpoint import CheckpointEvent
 from inspect_ai.event._event import Event
-from inspect_ai.log._pool import (
-    _build_call_index,
-    _build_msg_index,
-    condense_model_event_calls,
-    condense_model_event_inputs,
-)
 from inspect_ai.log._transcript import transcript
-from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.solver._task_state import sample_state
+from inspect_ai.util._checkpoint._event_store import (
+    CHECKPOINT_EVENT_STORE,
+    CheckpointEventStore,
+)
 from inspect_ai.util._restic import ResticBackupSummary, run_backup
 from inspect_ai.util._sandbox.context import sandbox
 from inspect_ai.util._span import span
 from inspect_ai.util._store import Store, store_jsonable
 
-from ._layout import CheckpointDetails, SnapshotDetails, host_context, write_sidecar
+from ._layout import CheckpointDetails, SnapshotDetails, write_sidecar
 from ._sandbox_restic import egress_sandbox, run_sandbox_backup
 from ._triggers import CheckpointTriggerKind, create_trigger
 from .checkpointer import (
@@ -86,6 +89,7 @@ class _CheckpointerSetup(AbstractAsyncContextManager[Checkpointer]):
         self._epoch = epoch
         self._resume_checkpoint = resume_checkpoint
         self._cached: _EnteredCheckpointer | None = None
+        self._reset_event_store_on_next_enter = True
 
     async def __aenter__(self) -> Checkpointer:
         if self._cached is not None:
@@ -97,15 +101,23 @@ class _CheckpointerSetup(AbstractAsyncContextManager[Checkpointer]):
             epoch=self._epoch,
             resume_checkpoint=self._resume_checkpoint,
         )
+        reset_event_store = self._reset_event_store_on_next_enter
         self._cached = _EnteredCheckpointer(
             config=self._config,
             hydration=result,
             resume_checkpoint=self._resume_checkpoint,
+            reset_event_store=reset_event_store,
         )
+        self._reset_event_store_on_next_enter = False
         return self._cached
 
     async def __aexit__(self, *exc: object) -> None:
         return None
+
+    def close(self) -> None:
+        if self._cached is not None:
+            self._cached.close()
+            self._cached = None
 
 
 class _EnteredCheckpointer:
@@ -123,6 +135,7 @@ class _EnteredCheckpointer:
         config: ResolvedCheckpointConfig,
         hydration: HydrationResult,
         resume_checkpoint: ResumeCheckpoint | None,
+        reset_event_store: bool,
     ) -> None:
         self._config = config
         self._sample_checkpoints_dir = hydration.sample_checkpoints_dir
@@ -146,30 +159,24 @@ class _EnteredCheckpointer:
         # work-between-fires window. Owned across `span_session()`'s
         # enter/exit and rotated inside `_fire()`.
         self._current_span_cm: AbstractAsyncContextManager[None] | None = None
-        # Persisted across fires: each fire processes only the new event slice
-        # and appends to these accumulators. Safe because checkpoints fire at
-        # turn boundaries, after which prior events are immutable.
-        #
-        # The accumulator + `_events_consumed` exist for performance — the
-        # next condense uses the prior pool as a starting point rather than
-        # re-walking the full transcript each fire. Revisit if profiling
-        # later shows the from-scratch alternative is fine at expected scale.
-        #
-        # `_events_consumed` is set lazily by the first `_open_next_span()`
-        # call to the transcript index where that first `span_begin:
-        # checkpoint` will land — so pre-first-span setup events (system
-        # message, sample init chatter) never enter the accumulator, and
-        # the persisted snapshot contains only checkpoint spans + contents.
-        # On resume, hydrate seeds the pools and pushes prior span content
-        # into the transcript; the lazy init then captures the index of the
-        # new `span_begin checkpoint M+1` so the next fire's slice is just
-        # the new span.
-        self._condensed_events: list[Event] = list(hydration.host.condensed_events)
-        self._msg_pool: list[ChatMessage] = list(hydration.host.msg_pool)
-        self._msg_index: dict[str, int] = _build_msg_index(self._msg_pool)
-        self._call_pool: list[JsonValue] = list(hydration.host.call_pool)
-        self._call_index: dict[str, int] = _build_call_index(self._call_pool)
-        self._events_consumed: int | None = None
+        self._event_store = CheckpointEventStore(
+            Path(self._sample_working_dir) / CHECKPOINT_EVENT_STORE,
+            reset=reset_event_store,
+        )
+        self._transcript_subscription: Callable[[], None] | None = None
+        self._closed = False
+        self._transcript_seeded = False
+        self._seed_event_store(hydration)
+        self._ensure_transcript_subscription()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        if self._transcript_subscription is not None:
+            self._transcript_subscription()
+            self._transcript_subscription = None
+        self._event_store.close()
+        self._closed = True
 
     @property
     def is_resuming(self) -> bool:
@@ -201,11 +208,6 @@ class _EnteredCheckpointer:
         next_id = await anyio.to_thread.run_sync(
             _scan_next_checkpoint_id, self._sample_checkpoints_dir
         )
-        # First-span lazy init for `_events_consumed`: capture the
-        # transcript index where the about-to-open `span_begin` will land
-        # so the persisted snapshot starts at the first checkpoint span.
-        if self._events_consumed is None:
-            self._events_consumed = len(transcript().events)
         cm = span(name=f"checkpoint {next_id}", type="checkpoint")
         await cm.__aenter__()
         self._current_span_cm = cm
@@ -242,7 +244,7 @@ class _EnteredCheckpointer:
             )
         self._on_checkpoint_callbacks[key] = callback
         if key in self._agent_state:
-            raw = self._agent_state[key]
+            raw = self._agent_state.pop(key)
             if value_type is not None:
                 return TypeAdapter(value_type).validate_python(raw)
             if isinstance(initial_value, BaseModel):
@@ -280,73 +282,76 @@ class _EnteredCheckpointer:
         # ``SpanEndEvent`` lands in this checkpoint's ``events.json`` —
         # the persisted snapshot must show the span closing within it.
         await self._close_current_span()
+        try:
+            state = sample_state()
+            if not state:
+                raise RuntimeError("Checkpointer must find sample state")
+            ts = transcript()
+            await self._write_host_context(
+                self._sample_working_dir,
+                ts.resident_events,
+                ts.attachments,
+                state.store,
+            )
 
-        state = sample_state()
-        if not state:
-            raise RuntimeError("Checkpointer must find sample state")
-        ts = transcript()
-        await self._write_host_context(
-            self._sample_working_dir,
-            ts.events,
-            ts.attachments,
-            state.store,
-        )
+            # Host + each sandbox (backup → egress) in parallel. The
+            # backup-then-egress pair for a given sandbox is sequential
+            # (egress diffs against what backup just wrote), but the pairs
+            # are independent across sandboxes and from the host backup.
+            # `tg_collect` takes thunks (zero-arg callables) so coroutines
+            # are only created at task-group start time.
+            sandbox_items = list((self._config.sandbox_paths or {}).items())
+            backup_funcs: list[Callable[[], Awaitable[ResticBackupSummary]]] = [
+                partial(self._backup_host, next_checkpoint_id),
+                *[
+                    partial(
+                        self._backup_and_egress_sandbox,
+                        name,
+                        paths,
+                        next_checkpoint_id,
+                    )
+                    for name, paths in sandbox_items
+                ],
+            ]
+            summaries = await tg_collect(backup_funcs)
+            host_info = _snapshot_info(summaries[0])
+            sandbox_infos = {
+                name: _snapshot_info(summary)
+                for (name, _), summary in zip(sandbox_items, summaries[1:])
+            }
 
-        # Host + each sandbox (backup → egress) in parallel. The
-        # backup-then-egress pair for a given sandbox is sequential
-        # (egress diffs against what backup just wrote), but the pairs
-        # are independent across sandboxes and from the host backup.
-        # `tg_collect` takes thunks (zero-arg callables) so coroutines
-        # are only created at task-group start time.
-        sandbox_items = list((self._config.sandbox_paths or {}).items())
-        backup_funcs: list[Callable[[], Awaitable[ResticBackupSummary]]] = [
-            partial(self._backup_host, next_checkpoint_id),
-            *[
-                partial(
-                    self._backup_and_egress_sandbox, name, paths, next_checkpoint_id
-                )
-                for name, paths in sandbox_items
-            ],
-        ]
-        summaries = await tg_collect(backup_funcs)
-        host_info = _snapshot_info(summaries[0])
-        sandbox_infos = {
-            name: _snapshot_info(summary)
-            for (name, _), summary in zip(sandbox_items, summaries[1:])
-        }
+            # Cycle duration measured up to the sidecar write — the write
+            # itself is the commit point, so its cost lands on the next
+            # cycle's clock if anywhere.
+            duration_ms = int((time.monotonic() - cycle_start) * 1000)
 
-        # Cycle duration measured up to the sidecar write — the write
-        # itself is the commit point, so its cost lands on the next
-        # cycle's clock if anywhere.
-        duration_ms = int((time.monotonic() - cycle_start) * 1000)
+            sidecar = CheckpointDetails(
+                checkpoint_id=next_checkpoint_id,
+                trigger=trigger,
+                turn=self._turn,
+                created_at=datetime.now(timezone.utc),
+                duration_ms=duration_ms,
+                size_bytes=host_info.size_bytes
+                + sum(s.size_bytes for s in sandbox_infos.values()),
+                host=host_info,
+                sandboxes=sandbox_infos,
+            )
 
-        sidecar = CheckpointDetails(
-            checkpoint_id=next_checkpoint_id,
-            trigger=trigger,
-            turn=self._turn,
-            created_at=datetime.now(timezone.utc),
-            duration_ms=duration_ms,
-            size_bytes=host_info.size_bytes
-            + sum(s.size_bytes for s in sandbox_infos.values()),
-            host=host_info,
-            sandboxes=sandbox_infos,
-        )
+            await write_sidecar(
+                sample_checkpoints_dir=self._sample_checkpoints_dir,
+                sidecar=sidecar,
+            )
 
-        await write_sidecar(
-            sample_checkpoints_dir=self._sample_checkpoints_dir,
-            sidecar=sidecar,
-        )
-
-        # Emit the CheckpointEvent now that the sidecar is committed.
-        # By construction the event is NOT in this fire's events.json
-        # (already written above); it IS captured in the next fire's
-        # events.json. On resume, hydrate synthesizes the trailing
-        # event from the latest sidecar (working.md §8a).
-        transcript()._event(CheckpointEvent.from_details(sidecar))
-
-        # Sidecar is committed; open the next `checkpoint N+1` span so
-        # subsequent agent events nest under it.
-        await self._open_next_span()
+            # Emit the CheckpointEvent now that the sidecar is committed.
+            # By construction the event is NOT in this fire's events.json
+            # (already written above); it IS captured in the next fire's
+            # events.json. On resume, hydrate synthesizes the trailing
+            # event from the latest sidecar (working.md §8a).
+            transcript()._event(CheckpointEvent.from_details(sidecar))
+        finally:
+            # Reopen even if checkpointing fails after closing the prior span;
+            # subsequent agent events should stay nested under a checkpoint span.
+            await self._open_next_span()
 
     async def _write_host_context(
         self,
@@ -355,74 +360,64 @@ class _EnteredCheckpointer:
         attachments: Mapping[str, str],
         store: Store,
     ) -> None:
-        """Write the host context across up to five files.
-
-        - ``events.json`` — condensed events; ModelEvent inputs / calls
-          replaced with refs into the pools below.
-        - ``events_data.json`` — ``{messages, calls}`` dedup pools.
-        - ``attachments.json`` — hash → original-content pool that
-          ``ModelEvent.call`` refs (`attachment://<hash>`) point into.
-          Captured live by ``Transcript._process_event``; serialized
-          here so the snapshot is self-contained.
-        - ``store.json`` — Store key/value as a single JSON object.
-        - ``agent_state.json`` — agent-defined property bag, written
-          only when the agent registered at least one callback via
-          :meth:`Checkpointer.track`. Each registered key becomes a
-          top-level field in the dict. The agent's conversation
-          messages typically live here (e.g. under the ``"messages"``
-          key) — the protocol no longer privileges them as a top-level
-          file. Presence on disk signals opt-in.
-        """
-        # Pool ModelEvent input + call messages — the big O(N²) redundancy.
-        # We process only the new event slice each fire and append to the
-        # accumulators on the session, so total hashing work is O(N) over a
-        # sample rather than O(N) per fire. Safe because checkpoints fire at
-        # turn boundaries, after which prior events are immutable.
-        # Attachments come pre-extracted on the transcript (call payloads
-        # >100 chars are rewritten to attachment:// refs as events flow in,
-        # with originals in transcript.attachments) — we persist that pool
-        # here so resume can resolve the refs.
-        # `_events_consumed` is set lazily by the first `_open_next_span()`,
-        # which runs in `span_session().__aenter__()` before any fire can
-        # happen — so it's guaranteed non-None here.
-        assert self._events_consumed is not None
-        # Filter the new slice: persisted events.json contains only events
-        # inside checkpoint / prior_run spans (inclusive of begin/end) plus
-        # CheckpointEvents. Stray events that land between checkpoint spans
-        # (e.g. `sandbox:exec` / `sandbox:read_file` emitted by restic
-        # operations during the fire's backup phase) stay in the live
-        # transcript but don't get persisted. See working.md §5.
-        new = _filter_persisted_events(events[self._events_consumed :])
-        if new:
-            cond, self._msg_index, new_msgs = condense_model_event_inputs(
-                new, len(self._msg_pool), self._msg_index
-            )
-            self._msg_pool.extend(m for _, m in new_msgs)
-            cond, self._call_index, new_calls = condense_model_event_calls(
-                cond, len(self._call_pool), self._call_index
-            )
-            self._call_pool.extend(c for _, c in new_calls)
-            self._condensed_events.extend(cond)
-        # Advance regardless of whether the filtered slice was empty:
-        # this fire's events have been consumed from the live transcript's
-        # perspective even if none made it into the persisted snapshot.
-        self._events_consumed = len(events)
+        """Write the host context snapshot files."""
         agent_state = (
             {key: cb() for key, cb in self._on_checkpoint_callbacks.items()}
             if self._on_checkpoint_callbacks
             else None
         )
-        await host_context.write(
+        self._event_store.export_snapshot_files(
             sample_working_dir,
-            host_context.HostContext(
-                condensed_events=self._condensed_events,
-                msg_pool=self._msg_pool,
-                call_pool=self._call_pool,
-                attachments=dict(attachments),
-                store=store_jsonable(store),
-                agent_state=agent_state,
-            ),
+            store_json=store_jsonable(store),
+            agent_state=agent_state,
         )
+
+    def _seed_event_store(self, hydration: HydrationResult) -> None:
+        if self._transcript_seeded:
+            return
+        ts = transcript()
+        try:
+            attachments = ts.attachments
+            self._event_store.merge_message_pool(hydration.host.msg_pool)
+            self._event_store.merge_call_pool(hydration.host.call_pool)
+            seeded_event_ids: set[str] = set()
+            if hydration.host.condensed_events:
+                self._event_store.merge_events(
+                    hydration.host.condensed_events, attachments
+                )
+                seeded_event_ids = {
+                    event.uuid
+                    for event in hydration.host.condensed_events
+                    if event.uuid is not None
+                }
+            if ts.resident_events_truncated:
+                history_provider = ts._history_provider
+                if history_provider is None:
+                    raise RuntimeError(
+                        "Cannot seed checkpoint events from a truncated Transcript. "
+                        "Create the checkpointer before bounded transcript eviction starts."
+                    )
+                history_provider.import_checkpoint_events(self._event_store)
+            else:
+                for event in ts.resident_events:
+                    if event.uuid in seeded_event_ids:
+                        continue
+                    self._event_store.merge_event(event, attachments.get)
+            self._event_store.merge_attachments(attachments)
+            self._transcript_seeded = True
+        except Exception:
+            self.close()
+            raise
+
+    def _ensure_transcript_subscription(self) -> None:
+        if self._transcript_subscription is not None:
+            return
+        self._transcript_subscription = transcript().subscribe(
+            self._track_transcript_event
+        )
+
+    def _track_transcript_event(self, event: Event) -> None:
+        self._event_store.merge_event(event, transcript().attachments.get)
 
     async def _backup_host(self, checkpoint_id: int) -> ResticBackupSummary:
         return await run_backup(
@@ -481,55 +476,3 @@ def _snapshot_info(summary: ResticBackupSummary) -> SnapshotDetails:
         size_bytes=summary.data_added_packed,
         duration_ms=int(summary.total_duration * 1000),
     )
-
-
-def _filter_persisted_events(events: Sequence[Event]) -> list[Event]:
-    r"""Keep only events that belong in the persisted ``events.json``.
-
-    Three things pass through:
-
-    - Events inside a ``type="checkpoint"`` span (inclusive of the
-      span_begin/span_end).
-    - Events inside a ``type="prior_run"`` span (inclusive).
-    - ``CheckpointEvent``\ s, even when between checkpoint spans.
-
-    Everything else is dropped — in practice the ``sandbox:exec`` and
-    ``sandbox:read_file`` events emitted by restic operations during
-    the fire's backup phase, which land in the live transcript between
-    ``span_end checkpoint N`` and ``span_begin checkpoint N+1``. They
-    stay in the live transcript (visible in ``inspect view`` of the
-    running eval) but don't get persisted.
-    """
-    result: list[Event] = []
-    # Track currently-open tracked-span ids. Depth = len(tracked_open_ids).
-    # We track checkpoint + prior_run spans; everything inside (including
-    # nested non-tracked spans like bash/tool) is kept.
-    tracked_open_ids: set[str] = set()
-    for e in events:
-        if e.event == "span_begin":
-            type_ = getattr(e, "type", None)
-            if type_ in ("checkpoint", "prior_run"):
-                tracked_open_ids.add(e.id)
-                result.append(e)
-            elif tracked_open_ids:
-                # Nested non-tracked span inside a tracked one — keep.
-                result.append(e)
-            # else: stray span_begin outside any tracked span — drop.
-        elif e.event == "span_end":
-            id_ = getattr(e, "id", None)
-            if id_ in tracked_open_ids:
-                tracked_open_ids.discard(id_)
-                result.append(e)
-            elif tracked_open_ids:
-                # Inner span_end inside a tracked span — keep.
-                result.append(e)
-            # else: stray span_end outside any tracked span — drop.
-        elif e.event == "checkpoint":
-            # CheckpointEvent — always keep, whether inside a tracked
-            # span or not (in practice it lands between checkpoint spans).
-            result.append(e)
-        elif tracked_open_ids:
-            # Inside a tracked span — keep.
-            result.append(e)
-        # else: stray event outside any tracked span — drop.
-    return result

--- a/src/inspect_ai/util/_checkpoint/checkpointer_noop.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_noop.py
@@ -32,6 +32,9 @@ class _NoopCheckpointer(contextlib.AbstractAsyncContextManager[Checkpointer]):
     def span_session(self) -> contextlib.AbstractAsyncContextManager[None]:
         return contextlib.nullcontext()
 
+    def close(self) -> None:
+        return None
+
     def track(
         self,
         key: str,

--- a/src/inspect_ai/util/_checkpoint/hydrate.py
+++ b/src/inspect_ai/util/_checkpoint/hydrate.py
@@ -103,6 +103,12 @@ class _HostHydrationResult:
     call_pool: list[JsonValue] = field(default_factory=list)
     """From ``events_data.json[calls]`` — seeds the dedup pool."""
 
+    attachments: dict[str, str] = field(default_factory=dict)
+    """From ``attachments.json`` — pushed into the live transcript on resume."""
+
+    store: dict[str, Any] = field(default_factory=dict)
+    """From ``store.json`` — pushed into the live sample state on resume."""
+
 
 @dataclass
 class HydrationResult:
@@ -260,12 +266,13 @@ async def _hydrate_host(
     sample_checkpoints_dir = str(Path(host_repo).parent)
     result = await anyio.to_thread.run_sync(
         partial(
-            _load_and_push_host_state,
+            _load_host_state,
             sample_working_dir,
             sample_checkpoints_dir,
             latest_committed_id,
         )
     )
+    result = _push_host_state(result, sample_checkpoints_dir, latest_committed_id)
     _debug(
         f"[hydrate.host] resume done: "
         f"events={len(result.condensed_events)} "
@@ -441,26 +448,12 @@ def _fs_copy_repo(
     _debug(f"[hydrate.copy] {label} repo: {src} -> {new_repo} ({file_count} files)")
 
 
-def _load_and_push_host_state(
+def _load_host_state(
     sample_working_dir: str,
     sample_checkpoints_dir: str,
     latest_committed_id: int | None,
 ) -> _HostHydrationResult:
-    """Read the restored host context and push framework state.
-
-    Loads via :mod:`host_context`, pushes events/attachments/store into
-    the live ``Transcript`` and ``Store`` (so the agent's continued run
-    sees the cumulative history), and returns the parts the agent-facing
-    :class:`_EnteredCheckpointer` needs at construction:
-
-    - ``agent_state`` — for ``track()`` to return persisted values.
-    - ``condensed_events``, ``msg_pool``, ``call_pool`` — seeds for the
-      checkpointer's pools so the next fire writes a cumulative snapshot.
-
-    Validates the loaded events against expected resume invariants
-    (checkpoint span structure, sidecar parity) so a broken resume
-    fails loudly here rather than cascading into the agent loop.
-    """
+    """Read restored host context and prepare it for loop-thread hydration."""
     ctx = host_context.read(local_path(sample_working_dir))
 
     _debug(
@@ -496,25 +489,32 @@ def _load_and_push_host_state(
     # mechanics.
     pushed_events = _wrap_prior_run(rehydrated_events)
 
-    # Push framework-owned state into the live transcript + store so the
-    # agent's continued run appends to (rather than replaces) the prior
-    # history. Direct mutation of the internal lists bypasses
-    # ``_process_event`` — the events are already in their condensed,
-    # attachment-ref form and must not be reprocessed. The persisted
-    # `condensed_events` is already span-only (the writer's accumulator
-    # only ever captured events from the first `span_begin: checkpoint`
-    # onward), and the prior-session wrap we just added is balanced.
+    return _HostHydrationResult(
+        agent_state=ctx.agent_state,
+        condensed_events=pushed_events,
+        msg_pool=ctx.msg_pool,
+        call_pool=ctx.call_pool,
+        attachments=ctx.attachments,
+        store=ctx.store,
+    )
+
+
+def _push_host_state(
+    result: _HostHydrationResult,
+    sample_checkpoints_dir: str,
+    latest_committed_id: int | None,
+) -> _HostHydrationResult:
+    """Push loaded host state into loop-owned Transcript and Store."""
     ts = transcript()
     pre = [_event_label(e) for e in ts._events]
-    restored = [_event_label(e) for e in pushed_events]
+    restored = [_event_label(e) for e in result.condensed_events]
     _debug(f"[hydrate.host] pre-hydration transcript.events (n={len(pre)}): {pre}")
     _debug(f"[hydrate.host] restored events to push (n={len(restored)}): {restored}")
-    ts._events.extend(pushed_events)
-    ts._attachments.update(ctx.attachments)
+    ts._extend_restored_events(result.condensed_events, result.attachments)
     state = sample_state()
     if state is None:
         raise RuntimeError("_hydrate_host: no active sample state to populate Store")
-    for key, value in ctx.store.items():
+    for key, value in result.store.items():
         state.store.set(key, value)
     _debug(
         f"[hydrate.host] pushed: transcript.events={len(ts._events)} "
@@ -522,14 +522,10 @@ def _load_and_push_host_state(
         f"store_keys={len(list(state.store.keys()))}"
     )
 
-    _validate_resume_state(pushed_events, sample_checkpoints_dir, latest_committed_id)
-
-    return _HostHydrationResult(
-        agent_state=ctx.agent_state,
-        condensed_events=pushed_events,
-        msg_pool=ctx.msg_pool,
-        call_pool=ctx.call_pool,
+    _validate_resume_state(
+        result.condensed_events, sample_checkpoints_dir, latest_committed_id
     )
+    return result
 
 
 def _wrap_prior_run(events: list[Event]) -> list[Event]:

--- a/tests/_eval/test_retry_error_events.py
+++ b/tests/_eval/test_retry_error_events.py
@@ -1,0 +1,233 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from inspect_ai._eval.task.log import TaskLogger
+from inspect_ai._eval.task.run import _eval_retry_error, _sample_transcript_config
+from inspect_ai.event import Event, InfoEvent, ModelEvent
+from inspect_ai.log import EvalError, Transcript
+from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+from inspect_ai.log._recorders.buffer.history_provider import (
+    BufferTranscriptHistoryProvider,
+)
+from inspect_ai.log._recorders.streaming import eval_retry_error_from_history
+from inspect_ai.log._recorders.types import SampleEvent
+from inspect_ai.log._transcript import init_transcript
+from inspect_ai.model import ChatMessageUser, GenerateConfig, ModelOutput
+
+
+def _model(uuid: str, content: str) -> ModelEvent:
+    output = ModelOutput.from_content("mockllm/model", content)
+    return ModelEvent(
+        uuid=uuid,
+        timestamp=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        working_start=0.0,
+        model="mockllm/model",
+        input=[ChatMessageUser(content="question")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=output,
+    )
+
+
+def _error() -> EvalError:
+    return EvalError(message="boom", traceback="traceback", traceback_ansi="ansi")
+
+
+def test_transcript_events_since_last_returns_suffix_from_latest_type() -> None:
+    first_info = InfoEvent(uuid="info-1", data={"note": "before"})
+    first_model = _model("model-1", "first")
+    second_info = InfoEvent(uuid="info-2", data={"note": "middle"})
+    second_model = _model("model-2", "second")
+    tail_info = InfoEvent(uuid="info-3", data={"note": "after"})
+    transcript = Transcript(
+        [first_info, first_model, second_info, second_model, tail_info]
+    )
+
+    assert transcript.events_since_last(ModelEvent) == [second_model, tail_info]
+
+
+def test_eval_retry_error_uses_latest_resident_model_event_suffix() -> None:
+    first_model = _model("model-1", "first")
+    middle_info = InfoEvent(uuid="info-1", data={"note": "middle"})
+    second_model = _model("model-2", "second")
+    tail_info = InfoEvent(uuid="info-2", data={"note": "after"})
+    init_transcript(Transcript([first_model, middle_info, second_model, tail_info]))
+
+    retry = _eval_retry_error(_error())
+
+    assert retry.events == [second_model, tail_info]
+
+
+def test_eval_retry_error_does_not_claim_evicted_bounded_history() -> None:
+    first_model = _model("model-1", "first")
+    middle_info = InfoEvent(uuid="info-1", data={"note": "middle"})
+    tail_info = InfoEvent(uuid="info-2", data={"note": "after"})
+    bounded = Transcript(bounded=True, resident_tail=2)
+    init_transcript(bounded)
+    bounded._event(first_model)
+    bounded._event(middle_info)
+    bounded._event(tail_info)
+
+    retry = _eval_retry_error(_error())
+
+    assert bounded.resident_events_truncated is True
+    assert retry.events == []
+
+
+def test_eval_retry_error_uses_buffer_history_when_transcript_truncated(
+    tmp_path,
+) -> None:
+    first_model = _model("model-1", "first")
+    middle_info = InfoEvent(uuid="info-1", data={"note": "middle"})
+    second_model = _model("model-2", "second")
+    tail_info = InfoEvent(uuid="info-2", data={"note": "after"})
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=first_model),
+            SampleEvent(id="sample", epoch=1, event=middle_info),
+            SampleEvent(id="sample", epoch=1, event=second_model),
+            SampleEvent(id="sample", epoch=1, event=tail_info),
+        ]
+    )
+
+    bounded = Transcript(bounded=True, resident_tail=1)
+    init_transcript(bounded)
+    bounded._event(first_model)
+    bounded._event(middle_info)
+    bounded._event(second_model)
+    bounded._event(tail_info)
+    assert bounded.resident_events_truncated is True
+
+    with db.open_sample_history("sample", 1) as history:
+        retry = eval_retry_error_from_history(_error(), history)
+
+    assert retry.events is not None
+    assert [event.uuid for event in retry.events] == ["model-2", "info-2"]
+    assert isinstance(retry.events[0], ModelEvent)
+    assert len(retry.events[0].input) == 1
+    assert isinstance(retry.events[0].input[0], ChatMessageUser)
+    assert retry.events[0].input[0].content == "question"
+    assert retry.events[0].input_refs is None
+
+
+def test_bounded_transcript_events_since_last_uses_buffer_provider(tmp_path) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    first_model = ModelEvent(
+        uuid="model-1",
+        model="mockllm/model",
+        input=[ChatMessageUser(content="first")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "first"),
+    )
+    middle = InfoEvent(uuid="info-1", data="middle")
+    second_model = ModelEvent(
+        uuid="model-2",
+        model="mockllm/model",
+        input=[ChatMessageUser(content="second")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "second"),
+    )
+    tail = InfoEvent(uuid="info-2", data="tail")
+    events: list[Event] = [first_model, middle, second_model, tail]
+    db.log_events([SampleEvent(id="sample", epoch=0, event=event) for event in events])
+
+    provider = BufferTranscriptHistoryProvider(db, "sample", 0)
+    transcript = Transcript(bounded=True, resident_tail=1, history_provider=provider)
+    for event in events:
+        transcript._event(event)
+
+    assert transcript.resident_events_truncated is True
+    assert transcript.events_since_last(ModelEvent) == [second_model, tail]
+
+
+def test_eval_retry_error_uses_provider_when_transcript_resident_tail_truncated(
+    tmp_path,
+) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    first_model = _model("model-1", "first")
+    middle = InfoEvent(uuid="info-1", data="middle")
+    second_model = _model("model-2", "second")
+    tail = InfoEvent(uuid="info-2", data="tail")
+    events: list[Event] = [first_model, middle, second_model, tail]
+    db.log_events([SampleEvent(id="sample", epoch=0, event=event) for event in events])
+
+    provider = BufferTranscriptHistoryProvider(db, "sample", 0)
+    transcript = Transcript(bounded=True, resident_tail=1, history_provider=provider)
+    init_transcript(transcript)
+    for event in events:
+        transcript._event(event)
+
+    retry = _eval_retry_error(_error())
+
+    assert transcript.resident_events_truncated is True
+    assert transcript.full_history_available is True
+    assert retry.events is not None
+    assert [event.uuid for event in retry.events] == ["model-2", "info-2"]
+
+
+def test_eval_retry_error_preserves_epoch_zero(tmp_path) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=0, event=_model("model-0", "zero")),
+            SampleEvent(id="sample", epoch=1, event=_model("model-1", "one")),
+        ]
+    )
+    logger = _TaskLoggerShim(db)
+
+    retry = _eval_retry_error(_error(), logger, "sample", 0)
+
+    assert retry.events is not None
+    assert [event.uuid for event in retry.events] == ["model-0"]
+
+
+def test_eval_retry_error_requires_epoch_for_buffer_history(tmp_path) -> None:
+    logger = _TaskLoggerShim(
+        SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    )
+
+    with pytest.raises(
+        ValueError, match="epoch is required when reading retry events from buffer DB"
+    ):
+        _eval_retry_error(_error(), logger, "sample")
+
+
+def test_sample_transcript_config_requires_buffer_for_bounded_mode(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("INSPECT_TRANSCRIPT_BOUNDED", "true")
+
+    bounded, history_provider = _sample_transcript_config(
+        logger=_TaskLoggerShim(buffer_db=None), sample_id="sample", epoch=0
+    )
+
+    assert bounded is False
+    assert history_provider is None
+
+
+def test_sample_transcript_config_defaults_to_unbounded_with_buffer(
+    monkeypatch, tmp_path
+) -> None:
+    monkeypatch.delenv("INSPECT_TRANSCRIPT_BOUNDED", raising=False)
+    logger = _TaskLoggerShim(
+        SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    )
+
+    bounded, history_provider = _sample_transcript_config(
+        logger=logger, sample_id="sample", epoch=0
+    )
+
+    assert bounded is False
+    assert history_provider is not None
+
+
+class _TaskLoggerShim(TaskLogger):
+    def __init__(self, buffer_db: SampleBufferDatabase | None) -> None:
+        self._buffer_db = buffer_db

--- a/tests/agent/test_agent_execute.py
+++ b/tests/agent/test_agent_execute.py
@@ -10,7 +10,7 @@ from inspect_ai.agent import Agent, AgentState, agent, as_solver, as_tool
 from inspect_ai.agent._handoff import handoff
 from inspect_ai.agent._run import run
 from inspect_ai.event._span import SpanBeginEvent
-from inspect_ai.log._transcript import transcript
+from inspect_ai.log._transcript import Transcript, init_transcript, transcript
 from inspect_ai.model._call_tools import execute_tools
 from inspect_ai.model._chat_message import ChatMessageAssistant, ChatMessageTool
 from inspect_ai.model._model import get_model
@@ -379,6 +379,7 @@ def test_agent_as_solver_respects_sample_limits() -> None:
 
 @pytest.mark.anyio
 async def test_agent_run():
+    init_transcript(Transcript())
     state = await run(web_surfer(), "This is the input", max_searches=22)
     assert state.output.completion == "22"
     assert any(
@@ -389,6 +390,7 @@ async def test_agent_run():
 
 @pytest.mark.anyio
 async def test_agent_run_with_name_param():
+    init_transcript(Transcript())
     await run(web_surfer(), "This is the input", name="my-agent", max_searches=22)
 
     assert any(

--- a/tests/checkpoint/test_checkpoint_event_store.py
+++ b/tests/checkpoint/test_checkpoint_event_store.py
@@ -1,0 +1,447 @@
+from __future__ import annotations
+
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import cast
+
+import pytest
+from pydantic import JsonValue
+
+from inspect_ai._util.constants import get_deserializing_context
+from inspect_ai.event._info import InfoEvent
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.log import expand_events
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.util._checkpoint._event_store import (
+    CHECKPOINT_EVENT_STORE,
+    CheckpointEventStore,
+)
+
+
+def _exported_events(work_dir: Path) -> list[dict[str, object]]:
+    return json.loads((work_dir / "events.json").read_text())
+
+
+def _no_attachment(_: str) -> str | None:
+    return None
+
+
+def _model_event(
+    messages: list[ChatMessage], call: ModelCall | None = None
+) -> ModelEvent:
+    return ModelEvent(
+        model="test",
+        input=messages,
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput(),
+        call=call,
+    )
+
+
+def test_checkpoint_event_store_initializes_schema(tmp_path: Path) -> None:
+    store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+
+    counts = store.counts()
+
+    assert counts.events == 0
+    assert counts.message_pool == 0
+    assert counts.call_pool == 0
+    assert counts.attachments == 0
+    assert (tmp_path / CHECKPOINT_EVENT_STORE).exists()
+
+
+def test_checkpoint_event_store_exports_events_in_first_seen_order(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    first = InfoEvent(data="first")
+    second = InfoEvent(data="second")
+
+    first_id = first.uuid
+    second_id = second.uuid
+
+    event_store.merge_event(first, attachment_lookup=_no_attachment)
+    event_store.merge_event(second, attachment_lookup=_no_attachment)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events = _exported_events(tmp_path)
+    assert [event["data"] for event in events] == ["first", "second"]
+    assert [event["uuid"] for event in events] == [first_id, second_id]
+
+
+def test_checkpoint_event_store_updates_existing_logical_event(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event = InfoEvent(data="first")
+
+    event_id = event.uuid
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event.data = "updated"
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events = _exported_events(tmp_path)
+    assert len(events) == 1
+    assert events[0]["uuid"] == event_id
+    assert events[0]["data"] == "updated"
+    assert event_store.counts().events == 1
+
+
+def test_checkpoint_event_store_accepts_cross_thread_events(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    input_events = [InfoEvent(data=f"from-thread-{index}") for index in range(8)]
+
+    with ThreadPoolExecutor(max_workers=4) as executor:
+        futures = [
+            executor.submit(event_store.merge_event, event, _no_attachment)
+            for event in input_events
+        ]
+        for future in futures:
+            future.result()
+
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    exported_events = _exported_events(tmp_path)
+    assert {event["data"] for event in exported_events} == {
+        f"from-thread-{index}" for index in range(8)
+    }
+
+
+def test_checkpoint_event_store_assigns_uuid_to_uuidless_events(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event = InfoEvent.model_validate(
+        {"event": "info", "data": "uuidless"}, context=get_deserializing_context()
+    )
+    assert event.uuid is None
+
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    assert isinstance(event.uuid, str)
+    events = _exported_events(tmp_path)
+    assert len(events) == 1
+    assert events[0]["uuid"] == event.uuid
+
+
+def test_checkpoint_event_store_assigns_uuid_for_uuidless_event_updates(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event = InfoEvent.model_validate(
+        {"event": "info", "data": "pending", "pending": True},
+        context=get_deserializing_context(),
+    )
+    assert event.uuid is None
+
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event.pending = False
+    event.data = "done"
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events = _exported_events(tmp_path)
+    assert len(events) == 1
+    assert events[0]["uuid"] == event.uuid
+    assert events[0]["data"] == "done"
+
+
+def test_checkpoint_event_store_serializes_agent_state_models(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+
+    event_store.export_snapshot_files(
+        tmp_path,
+        store_json={"store_message": ChatMessageSystem(content="store")},
+        agent_state={
+            "messages": [
+                ChatMessageSystem(content="sys"),
+                ChatMessageUser(content="user"),
+            ]
+        },
+    )
+
+    store_json = json.loads((tmp_path / "store.json").read_text())
+    agent_state = json.loads((tmp_path / "agent_state.json").read_text())
+
+    assert store_json["store_message"]["role"] == "system"
+    assert store_json["store_message"]["content"] == "store"
+    assert agent_state["messages"][0]["role"] == "system"
+    assert agent_state["messages"][0]["content"] == "sys"
+    assert agent_state["messages"][1]["role"] == "user"
+    assert agent_state["messages"][1]["content"] == "user"
+
+
+def test_checkpoint_event_store_writes_store_and_agent_state(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event_store.export_snapshot_files(
+        tmp_path,
+        store_json={"x": 1},
+        agent_state={"agent": {"step": 2}},
+    )
+
+    assert json.loads((tmp_path / "store.json").read_text()) == {"x": 1}
+    assert json.loads((tmp_path / "agent_state.json").read_text()) == {
+        "agent": {"step": 2}
+    }
+
+
+def test_checkpoint_event_store_exports_only_referenced_attachments(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event_store.merge_event(
+        InfoEvent(data={"blob": "attachment://kept"}),
+        attachment_lookup={"kept": "payload", "unused": "ignore me"}.get,
+    )
+
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    assert json.loads((tmp_path / "attachments.json").read_text()) == {
+        "kept": "payload"
+    }
+    assert not (tmp_path / "agent_state.json").exists()
+
+
+def test_checkpoint_event_store_warns_for_missing_attachment_ref(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+
+    with caplog.at_level(
+        logging.WARNING, logger="inspect_ai.util._checkpoint._event_store"
+    ):
+        event_store.merge_event(
+            InfoEvent(data={"blob": "attachment://missing"}),
+            attachment_lookup=_no_attachment,
+        )
+
+    assert "Checkpoint event references missing attachment: missing" in caplog.text
+
+
+def test_checkpoint_event_store_attachment_refs_follow_condense_protocol() -> None:
+    from inspect_ai.log._condense import ATTACHMENT_PROTOCOL
+
+    refs = CheckpointEventStore.attachment_refs_from_json(
+        json.dumps({"blob": f"{ATTACHMENT_PROTOCOL}kept"})
+    )
+
+    assert refs == {"kept"}
+
+
+def test_checkpoint_event_store_retains_cumulative_attachments(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    first_event = InfoEvent(data={"blob": "attachment://abc"})
+    second_event = InfoEvent(data={"blob": "attachment://def"})
+
+    event_store.merge_event(first_event, attachment_lookup={"abc": "payload"}.get)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    assert json.loads((tmp_path / "attachments.json").read_text()) == {"abc": "payload"}
+
+    event_store.merge_event(second_event, attachment_lookup={"def": "payload2"}.get)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    assert json.loads((tmp_path / "attachments.json").read_text()) == {
+        "abc": "payload",
+        "def": "payload2",
+    }
+
+
+def test_checkpoint_event_store_retains_attachment_on_event_update(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event = InfoEvent(data={"blob": "attachment://abc"})
+
+    event_store.merge_event(event, attachment_lookup={"abc": "payload"}.get)
+    event.data = {"blob": "attachment://abc", "status": "done"}
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    assert json.loads((tmp_path / "attachments.json").read_text()) == {"abc": "payload"}
+
+
+def test_checkpoint_event_store_attaches_raw_model_call_update(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event = _model_event(
+        [ChatMessageUser(content="question")],
+        call=ModelCall.create(
+            {"messages": [{"role": "user", "content": "short"}]}, None
+        ),
+    )
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+
+    raw_payload = "late payload" * 100
+    event.call = ModelCall.create(
+        {"messages": [{"role": "user", "content": raw_payload}]}, None
+    )
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    attachments = json.loads((tmp_path / "attachments.json").read_text())
+
+    assert raw_payload in attachments.values()
+    events_data = json.loads((tmp_path / "events_data.json").read_text())
+    call = events_data["calls"][-1]
+    assert isinstance(call, dict)
+    content = call["content"]
+    assert isinstance(content, str)
+    assert content.startswith("attachment://")
+
+
+def test_checkpoint_event_store_attaches_raw_model_input(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    raw_payload = "input payload" * 100
+
+    event_store.merge_event(
+        _model_event([ChatMessageUser(content=raw_payload)]),
+        attachment_lookup=_no_attachment,
+    )
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    attachments = json.loads((tmp_path / "attachments.json").read_text())
+    events_data = json.loads((tmp_path / "events_data.json").read_text())
+
+    assert raw_payload in attachments.values()
+    content = events_data["messages"][0]["content"]
+    assert isinstance(content, str)
+    assert content.startswith("attachment://")
+
+
+def test_checkpoint_event_store_exports_stable_message_pool(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    sys = ChatMessageSystem(content="sys")
+    user = ChatMessageUser(content="question")
+    assistant = ChatMessageAssistant(content="answer")
+
+    event_store.merge_event(_model_event([sys, user]), attachment_lookup=_no_attachment)
+    event_store.merge_event(
+        _model_event([sys, user, assistant]), attachment_lookup=_no_attachment
+    )
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events_data = json.loads((tmp_path / "events_data.json").read_text())
+    events = json.loads((tmp_path / "events.json").read_text())
+
+    assert len(events_data["messages"]) == 3
+    assert events[0]["input_refs"] == [[0, 2]]
+    assert events[1]["input_refs"] == [[0, 3]]
+
+    expanded = expand_events(
+        (tmp_path / "events.json").read_text(),
+        (tmp_path / "events_data.json").read_text(),
+    )
+    model_events = [event for event in expanded if isinstance(event, ModelEvent)]
+    assert [len(event.input) for event in model_events] == [2, 3]
+
+
+def test_checkpoint_event_store_import_pool_entry_returns_canonical_position(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+
+    first_pos = event_store.merge_message_pool_entry(
+        "first-hash", ChatMessageUser(content="first").model_dump_json()
+    )
+    duplicate_pos = event_store.merge_message_pool_entry(
+        "first-hash", ChatMessageUser(content="first").model_dump_json()
+    )
+    second_pos = event_store.merge_message_pool_entry(
+        "second-hash", ChatMessageUser(content="second").model_dump_json()
+    )
+
+    assert first_pos == 0
+    assert duplicate_pos == first_pos
+    assert second_pos == 1
+
+
+def test_checkpoint_event_store_exports_stable_call_pool(tmp_path: Path) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    request_message = cast(
+        dict[str, JsonValue],
+        {"role": "user", "content": "question"},
+    )
+
+    event_store.merge_event(
+        _model_event(
+            [],
+            call=ModelCall(
+                request={"model": "test", "messages": [request_message]},
+                response=None,
+            ),
+        ),
+        attachment_lookup=_no_attachment,
+    )
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events_data = json.loads((tmp_path / "events_data.json").read_text())
+    events = json.loads((tmp_path / "events.json").read_text())
+
+    assert events_data["calls"] == [request_message]
+    assert events[0]["call"]["call_refs"] == [[0, 1]]
+    assert "messages" not in events[0]["call"]["request"]
+
+    expanded = expand_events(
+        (tmp_path / "events.json").read_text(),
+        (tmp_path / "events_data.json").read_text(),
+    )
+    model_events = [event for event in expanded if isinstance(event, ModelEvent)]
+    assert model_events[0].call is not None
+    assert model_events[0].call.request["messages"] == [request_message]
+
+
+def test_checkpoint_event_store_reuses_pending_message_positions_on_update(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    message = ChatMessageUser(content="question")
+    event = _model_event([message])
+    event.pending = True
+
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+    event.pending = False
+    event_store.merge_event(event, attachment_lookup=_no_attachment)
+
+    assert event_store.counts().message_pool == 1
+
+
+def test_checkpoint_event_store_deduplicates_messages_using_pool_hash(
+    tmp_path: Path,
+) -> None:
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    first = ChatMessageUser(content="same")
+    second = ChatMessageUser(content="same")
+    assert first.id != second.id
+
+    event_store.merge_event(_model_event([first]), attachment_lookup=_no_attachment)
+    event_store.merge_event(_model_event([second]), attachment_lookup=_no_attachment)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    events_data = json.loads((tmp_path / "events_data.json").read_text())
+    events = json.loads((tmp_path / "events.json").read_text())
+
+    assert len(events_data["messages"]) == 1
+    assert events[0]["input_refs"] == [[0, 1]]
+    assert events[1]["input_refs"] == [[0, 1]]

--- a/tests/checkpoint/test_checkpointer.py
+++ b/tests/checkpoint/test_checkpointer.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import json
 import os
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import timedelta
@@ -19,11 +19,13 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
+from test_helpers.transcript import FakeTranscriptHistoryProvider
 
 from inspect_ai.event._event import Event
+from inspect_ai.event._info import InfoEvent
 from inspect_ai.event._model import ModelEvent
-from inspect_ai.event._span import SpanBeginEvent, SpanEndEvent
-from inspect_ai.log import expand_events
+from inspect_ai.log import Transcript, expand_events
+from inspect_ai.log._transcript import transcript
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -31,6 +33,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageUser,
 )
 from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.util._checkpoint import (
     Manual,
@@ -39,7 +42,9 @@ from inspect_ai.util._checkpoint import (
     TurnInterval,
     checkpointer,
 )
+from inspect_ai.util._checkpoint._event_store import CheckpointEventStore
 from inspect_ai.util._checkpoint._triggers import CheckpointTriggerKind
+from inspect_ai.util._checkpoint.checkpointer import ResumeCheckpoint
 from inspect_ai.util._checkpoint.checkpointer_impl import (
     _CheckpointerSetup,
     _EnteredCheckpointer,
@@ -88,26 +93,14 @@ class _Dirs:
 
 @contextmanager
 def _patch_sample_runtime(events: list[object]) -> Iterator[None]:
-    """Patch sample_state() and transcript() for tests that drive _fire.
-
-    `_CheckpointerSetup._fire` reads ``sample_state().store`` and
-    ``transcript().events`` directly from ContextVars. Tests that
-    construct `_CheckpointerSetup` outside a real sample run need stand-ins.
-
-    ``events`` is the externally-owned event-collection list — the fake
-    transcript's ``events`` attribute and ``_event`` callable both wire
-    to it so tests can inspect emit behavior.
-    """
+    """Patch sample_state() and transcript() for tests that drive _fire."""
     from types import SimpleNamespace
 
     from inspect_ai.util._store import Store
 
     fake_state = SimpleNamespace(store=Store())
-    fake_transcript = SimpleNamespace(
-        events=events,
-        attachments={},
-        _event=events.append,
-    )
+    fake_transcript = Transcript(bounded=False)
+    fake_transcript.subscribe(events.append)
     with (
         patch(
             "inspect_ai.util._checkpoint.checkpointer_impl.sample_state",
@@ -164,11 +157,8 @@ def _counting(config: ResolvedCheckpointConfig, dirs: _Dirs) -> _CountingCheckpo
         config=config,
         hydration=_fake_hydration(dirs.checkpoints, dirs.working),
         resume_checkpoint=None,
+        reset_event_store=True,
     )
-    # Policy tests drive `tick()`/`checkpoint()` without going through
-    # `span_session()`, so the first-span lazy init for `_events_consumed`
-    # never fires. Seed it here so `_write_host_context` can slice.
-    cp._events_consumed = 0
     return cp
 
 
@@ -323,6 +313,44 @@ async def test_fire_emits_checkpoint_event(dirs: _Dirs) -> None:
     # restic the stub values from `_CountingCheckpointer._backup_host`
     # round-trip.
     assert first.host.snapshot_id.startswith("fake-snap-")
+
+
+async def test_fire_includes_events_emitted_before_checkpointer_construction(
+    dirs: _Dirs,
+) -> None:
+    preexisting = InfoEvent(data="before-checkpointer")
+    active_transcript = transcript()
+    active_transcript._event(preexisting)
+
+    with patch(
+        "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+        return_value=active_transcript,
+    ):
+        cp = _counting(ResolvedCheckpointConfig(trigger=Manual()), dirs)
+        await cp.checkpoint()
+
+    events = json.loads((Path(dirs.working) / "events.json").read_text())
+    assert events[0]["uuid"] == preexisting.uuid
+    assert events[0]["data"] == "before-checkpointer"
+
+
+async def test_fire_reopens_checkpoint_span_after_failure(dirs: _Dirs) -> None:
+    cp = _counting(ResolvedCheckpointConfig(trigger=Manual()), dirs)
+    assert cp._current_span_cm is None
+    await cp._open_next_span()
+    open_before = cp._current_span_cm
+    assert open_before is not None
+
+    async def fail_write_host_context(*_args: object) -> None:
+        raise RuntimeError("write failed")
+
+    with patch.object(cp, "_write_host_context", side_effect=fail_write_host_context):
+        with pytest.raises(RuntimeError, match="write failed"):
+            await cp.checkpoint()
+
+    assert cp._current_span_cm is not None
+    assert cp._current_span_cm is not open_before
+    await cp._close_current_span()
 
 
 def test_synthesize_trailing_checkpoint_event(tmp_path: Path) -> None:
@@ -516,24 +544,6 @@ async def test_fire_writes_sample_json_and_sidecars(
 # === _write_host_context: condensed events round-trip =======================
 
 
-def _wrap_in_checkpoint_span(checkpoint_id: int, events: list[Event]) -> list[Event]:
-    """Wrap a list of events in `span_begin/span_end` of type "checkpoint".
-
-    `_write_host_context`'s filter (`_filter_persisted_events`) keeps only
-    events inside checkpoint / prior_run spans + CheckpointEvents. Tests
-    that drive `_write_host_context` directly with raw events need to
-    bracket them so they survive the filter.
-    """
-    span_id = f"test-ckpt-{checkpoint_id}"
-    return [
-        SpanBeginEvent(
-            id=span_id, name=f"checkpoint {checkpoint_id}", type="checkpoint"
-        ),
-        *events,
-        SpanEndEvent(id=span_id),
-    ]
-
-
 async def test_write_host_context_condenses_and_round_trips(tmp_path: Path) -> None:
     """Pooled ModelEvent inputs round-trip via expand_events; pool < total slots."""
     msg_sys: ChatMessage = ChatMessageSystem(content="sys")
@@ -554,16 +564,12 @@ async def test_write_host_context_condenses_and_round_trips(tmp_path: Path) -> N
         )
 
     # Each ModelEvent carries the full prior history — 2 + 4 + 5 = 11 input
-    # slots across 5 unique messages. Wrapped in a checkpoint span so the
-    # write_host_context filter keeps them.
-    events: list[Event] = _wrap_in_checkpoint_span(
-        1,
-        [
-            _model_event([msg_sys, msg_u1]),
-            _model_event([msg_sys, msg_u1, msg_a1, msg_u2]),
-            _model_event(messages),
-        ],
-    )
+    # slots across 5 unique messages.
+    events: list[Event] = [
+        _model_event([msg_sys, msg_u1]),
+        _model_event([msg_sys, msg_u1, msg_a1, msg_u2]),
+        _model_event(messages),
+    ]
 
     work = tmp_path / "work"
     work.mkdir()
@@ -571,9 +577,11 @@ async def test_write_host_context_condenses_and_round_trips(tmp_path: Path) -> N
         config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
         hydration=_fake_hydration("/tmp/cp-test/ckpts", "/tmp/cp-test/work"),
         resume_checkpoint=None,
+        reset_event_store=True,
     )
-    cp._events_consumed = 0
-    await cp._write_host_context(str(work), events, {}, Store())
+    for event in events:
+        cp._track_transcript_event(event)
+    await cp._write_host_context(str(work), [], {}, Store())
 
     assert (work / "events.json").is_file()
     assert (work / "events_data.json").is_file()
@@ -599,13 +607,10 @@ def _make_cp(**kwargs: object) -> _EnteredCheckpointer:
         "config": ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
         "hydration": _fake_hydration(str(base / "ckpts"), str(base / "work")),
         "resume_checkpoint": None,
+        "reset_event_store": True,
     }
     defaults.update(kwargs)
     cp = _EnteredCheckpointer(**defaults)  # type: ignore[arg-type]
-    # In real use, `_events_consumed` is set lazily by the first
-    # `_open_next_span()` call. Tests bypass that by driving
-    # `_write_host_context` directly, so seed the precondition here.
-    cp._events_consumed = 0
     return cp
 
 
@@ -623,21 +628,29 @@ def test_track_duplicate_key_raises(tmp_path: Path) -> None:
         cp.track("attempt_count", lambda: 2, 0)
 
 
-async def test_track_single_key_writes_file(tmp_path: Path) -> None:
-    """Registered callback's return value lands in agent_state.json."""
+async def _write_agent_state(
+    tmp_path: Path, cp: _EnteredCheckpointer
+) -> dict[str, object] | None:
     work = tmp_path / "work"
     work.mkdir()
+    await cp._write_host_context(str(work), [], {}, Store())
+    agent_state = work / "agent_state.json"
+    if not agent_state.exists():
+        return None
+    return json.loads(agent_state.read_text())
+
+
+async def test_track_single_key_writes_file(tmp_path: Path) -> None:
+    """Registered callback's return value lands in agent_state.json."""
     cp = _make_cp()
     value = 3
     cp.track("attempt_count", lambda: value, 0)
-    await cp._write_host_context(str(work), [], {}, Store())
-    assert json.loads((work / "agent_state.json").read_text()) == {"attempt_count": 3}
+
+    assert await _write_agent_state(tmp_path, cp) == {"attempt_count": 3}
 
 
 async def test_track_messages_via_track(tmp_path: Path) -> None:
     """Messages persist via `track('messages', ...)` — Pydantic model lists serialize."""
-    work = tmp_path / "work"
-    work.mkdir()
     cp = _make_cp()
     messages: list[ChatMessage] = [
         ChatMessageSystem(content="sys"),
@@ -649,23 +662,23 @@ async def test_track_messages_via_track(tmp_path: Path) -> None:
         messages,
         value_type=list[ChatMessage],
     )
-    await cp._write_host_context(str(work), [], {}, Store())
 
-    state = json.loads((work / "agent_state.json").read_text())
+    state = await _write_agent_state(tmp_path, cp)
+    assert state is not None
     assert "messages" in state
-    assert [m["role"] for m in state["messages"]] == ["system", "user"]
-    assert [m["content"] for m in state["messages"]] == ["sys", "hi"]
+    messages_state = state["messages"]
+    assert isinstance(messages_state, list)
+    assert [m["role"] for m in messages_state] == ["system", "user"]
+    assert [m["content"] for m in messages_state] == ["sys", "hi"]
 
 
 async def test_track_multiple_keys_merge(tmp_path: Path) -> None:
     """Multiple registered keys merge into one top-level dict."""
-    work = tmp_path / "work"
-    work.mkdir()
     cp = _make_cp()
     cp.track("attempt_count", lambda: 3, 0)
     cp.track("phase", lambda: "explore", "")
-    await cp._write_host_context(str(work), [], {}, Store())
-    assert json.loads((work / "agent_state.json").read_text()) == {
+
+    assert await _write_agent_state(tmp_path, cp) == {
         "attempt_count": 3,
         "phase": "explore",
     }
@@ -673,11 +686,9 @@ async def test_track_multiple_keys_merge(tmp_path: Path) -> None:
 
 async def test_track_not_registered_no_file(tmp_path: Path) -> None:
     """Without any callback, agent_state.json is not written."""
-    work = tmp_path / "work"
-    work.mkdir()
     cp = _make_cp()
-    await cp._write_host_context(str(work), [], {}, Store())
-    assert not (work / "agent_state.json").exists()
+
+    assert await _write_agent_state(tmp_path, cp) is None
 
 
 def test_track_noop_session() -> None:
@@ -692,8 +703,6 @@ def test_is_resuming_noop_false() -> None:
 
 
 def test_is_resuming_reflects_resume_checkpoint() -> None:
-    from inspect_ai.util._checkpoint.checkpointer import ResumeCheckpoint
-
     assert _make_cp().is_resuming is False
     assert (
         _make_cp(
@@ -786,8 +795,9 @@ async def test_setup_aenter_defers_io_setup(tmp_path: Path) -> None:
             init_sandbox.assert_awaited_once()
 
 
-async def test_write_host_context_persists_attachments(tmp_path: Path) -> None:
-    """transcript.attachments survives the checkpoint as attachments.json."""
+async def test_write_host_context_exports_event_store_attachments(
+    tmp_path: Path,
+) -> None:
     attachments = {"abc123": "data:image/png;base64,iVBORw0", "def456": "long-text"}
 
     work = tmp_path / "work"
@@ -796,9 +806,10 @@ async def test_write_host_context_persists_attachments(tmp_path: Path) -> None:
         config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
         hydration=_fake_hydration("/tmp/cp-test/ckpts", "/tmp/cp-test/work"),
         resume_checkpoint=None,
+        reset_event_store=True,
     )
-    cp._events_consumed = 0
-    await cp._write_host_context(str(work), [], attachments, Store())
+    cp._event_store.merge_attachments(attachments)
+    await cp._write_host_context(str(work), [], {}, Store())
 
     assert json.loads((work / "attachments.json").read_text()) == attachments
 
@@ -820,20 +831,12 @@ async def test_write_host_context_accumulates_across_fires(tmp_path: Path) -> No
             output=ModelOutput(),
         )
 
-    # Each fire's events wrapped in a checkpoint span so the
-    # write_host_context filter keeps them.
-    fire1_events: list[Event] = _wrap_in_checkpoint_span(
-        1,
-        [
-            _model_event([msg_sys, msg_u1]),
-            _model_event([msg_sys, msg_u1, msg_a1]),
-        ],
-    )
-    # Fire 2 cumulatively contains fire 1's events + a new checkpoint span
-    # with one more model event. The two prior events stay condensed-as-is.
+    fire1_events: list[Event] = [
+        _model_event([msg_sys, msg_u1]),
+        _model_event([msg_sys, msg_u1, msg_a1]),
+    ]
     fire2_events: list[Event] = [
-        *fire1_events,
-        *_wrap_in_checkpoint_span(2, [_model_event([msg_sys, msg_u1, msg_a1, msg_u2])]),
+        _model_event([msg_sys, msg_u1, msg_a1, msg_u2]),
     ]
 
     work = tmp_path / "work"
@@ -842,28 +845,26 @@ async def test_write_host_context_accumulates_across_fires(tmp_path: Path) -> No
         config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
         hydration=_fake_hydration("/tmp/cp-test/ckpts", "/tmp/cp-test/work"),
         resume_checkpoint=None,
+        reset_event_store=True,
     )
-    cp._events_consumed = 0
-
-    await cp._write_host_context(str(work), fire1_events, {}, Store())
+    for event in fire1_events:
+        cp._track_transcript_event(event)
+    await cp._write_host_context(str(work), [], {}, Store())
     pool_after_1 = json.loads((work / "events_data.json").read_text())["messages"]
     events_after_1 = json.loads((work / "events.json").read_text())
     assert len(pool_after_1) == 3  # sys, u1, a1
-    # Fire 1's persisted events: [span_begin_1, model_1, model_2, span_end_1].
-    assert len(events_after_1) == 4
-    assert cp._events_consumed == len(fire1_events)
+    assert len(events_after_1) == 2
 
-    await cp._write_host_context(str(work), fire2_events, {}, Store())
+    for event in fire2_events:
+        cp._track_transcript_event(event)
+    await cp._write_host_context(str(work), [], {}, Store())
     pool_after_2 = json.loads((work / "events_data.json").read_text())["messages"]
     events_after_2 = json.loads((work / "events.json").read_text())
     # Append-only: pool grew by exactly one (u2); first 3 entries unchanged.
     assert pool_after_2[:3] == pool_after_1
     assert len(pool_after_2) == 4
-    # Events grew by 3 (span_begin_2 + model_3 + span_end_2 = checkpoint 2's
-    # wrap); the first 4 are byte-identical to fire 1's persisted output.
-    assert events_after_2[:4] == events_after_1
-    assert len(events_after_2) == 7
-    assert cp._events_consumed == len(fire2_events)
+    assert events_after_2[:2] == events_after_1
+    assert len(events_after_2) == 3
 
     # Full round-trip still works on the cumulative output.
     expanded = expand_events(
@@ -872,3 +873,425 @@ async def test_write_host_context_accumulates_across_fires(tmp_path: Path) -> No
     )
     model_events = [e for e in expanded if isinstance(e, ModelEvent)]
     assert [len(e.input) for e in model_events] == [2, 3, 4]
+
+
+def test_track_consumes_hydrated_agent_state() -> None:
+    hydration = _fake_hydration("/tmp/cp-test/ckpts", "/tmp/cp-test/work")
+    hydration.host.agent_state = {"phase": "resume", "other": "kept"}
+    cp = _make_cp(hydration=hydration)
+
+    assert cp.track("phase", lambda: "fresh", "fresh") == "resume"
+
+    assert "phase" not in cp._agent_state
+    assert cp._agent_state == {"other": "kept"}
+
+
+def test_seed_event_store_uses_history_provider_for_truncated_transcript(
+    tmp_path: Path,
+) -> None:
+    provider_events = [
+        InfoEvent(uuid=f"provider-event-{index}", data=f"from-provider-{index}")
+        for index in range(3)
+    ]
+    provider = FakeTranscriptHistoryProvider(provider_events)
+    fake_transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=provider,
+    )
+    for event in provider_events:
+        fake_transcript._event(event)
+    assert fake_transcript.resident_events_truncated is True
+
+    with patch(
+        "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+        return_value=fake_transcript,
+    ):
+        cp = _make_cp(
+            hydration=_fake_hydration(str(tmp_path / "ckpts"), str(tmp_path / "work")),
+        )
+
+    work = tmp_path / "snapshot"
+    work.mkdir()
+    cp._event_store.export_snapshot_files(work, store_json={}, agent_state=None)
+    cp.close()
+
+    events = json.loads((work / "events.json").read_text())
+    assert [event["data"] for event in events] == [
+        "from-provider-0",
+        "from-provider-1",
+        "from-provider-2",
+    ]
+
+
+def test_checkpointer_closes_store_when_transcript_seed_fails(tmp_path: Path) -> None:
+    fake_transcript = Transcript(bounded=True, resident_tail=0)
+    fake_transcript._event(InfoEvent(data="evicted"))
+    assert fake_transcript.resident_events_truncated is True
+
+    with patch(
+        "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+        return_value=fake_transcript,
+    ):
+        with pytest.raises(RuntimeError, match="Cannot seed checkpoint events"):
+            _make_cp(
+                hydration=_fake_hydration("/tmp/cp-test/ckpts", str(tmp_path / "work")),
+            )
+
+
+async def test_checkpointer_setup_resets_event_store_after_seed_failure(
+    tmp_path: Path,
+) -> None:
+    work = tmp_path / "work"
+    checkpoints = tmp_path / "ckpts"
+    work.mkdir()
+    checkpoints.mkdir()
+    fake_transcript = Transcript(bounded=False)
+    fake_transcript._event(InfoEvent(uuid="seeded", data="seeded"))
+    hydration = _fake_hydration(str(checkpoints), str(work))
+    calls = 0
+
+    def fail_once_merge_event(self: CheckpointEventStore, *args: object) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            original_merge_event(self, *args)  # type: ignore[arg-type]
+            raise RuntimeError("seed failed")
+        original_merge_event(self, *args)  # type: ignore[arg-type]
+
+    original_merge_event = CheckpointEventStore.merge_event
+    setup = _CheckpointerSetup(
+        config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
+        log_location=str(tmp_path / "t.eval"),
+        sample_id="s",
+        epoch=0,
+    )
+
+    with (
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.hydrate",
+            return_value=hydration,
+        ),
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+            return_value=fake_transcript,
+        ),
+        patch.object(CheckpointEventStore, "merge_event", fail_once_merge_event),
+    ):
+        with pytest.raises(RuntimeError, match="seed failed"):
+            await setup.__aenter__()
+
+        cp = await setup.__aenter__()
+        assert isinstance(cp, _EnteredCheckpointer)
+        snapshot = tmp_path / "snapshot"
+        snapshot.mkdir()
+        await cp._write_host_context(str(snapshot), [], {}, Store())
+        setup.close()
+
+    events = json.loads((snapshot / "events.json").read_text())
+    assert [event["data"] for event in events] == ["seeded"]
+
+
+async def test_fire_retains_attachment_from_evicted_event(
+    tmp_path: Path,
+) -> None:
+    transcript = Transcript(bounded=True, resident_tail=1, log_model_api=True)
+    cp = _make_cp(
+        hydration=_fake_hydration(str(tmp_path / "ckpts"), str(tmp_path / "work"))
+    )
+    payload = "evicted payload" * 100
+    evicted = ModelEvent(
+        uuid="evicted",
+        model="mockllm/model",
+        input=[ChatMessageUser(content="question")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "answer"),
+    )
+    evicted.call = ModelCall.create(
+        {"messages": [{"role": "user", "content": payload}]}, None
+    )
+
+    with patch(
+        "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+        return_value=transcript,
+    ):
+        transcript.subscribe(cp._track_transcript_event)
+        transcript._event(evicted)
+        transcript._event(InfoEvent(data="resident"))
+
+    assert transcript.resident_events == [transcript.last_event]
+    assert transcript.attachments == {}
+
+    work = tmp_path / "snapshot"
+    work.mkdir()
+    await cp._write_host_context(str(work), [], {}, Store())
+    cp.close()
+
+    attachments = json.loads((work / "attachments.json").read_text())
+    assert payload in attachments.values()
+
+
+async def test_checkpointer_setup_close_unsubscribes_and_closes_store(
+    tmp_path: Path,
+) -> None:
+    callbacks: list[Callable[[Event], None]] = []
+
+    def subscribe(callback: Callable[[Event], None]) -> Callable[[], None]:
+        callbacks.append(callback)
+
+        def unsubscribe() -> None:
+            callbacks.remove(callback)
+
+        return unsubscribe
+
+    from types import SimpleNamespace
+
+    fake_transcript = SimpleNamespace(
+        attachments={},
+        resident_events=[],
+        resident_events_truncated=False,
+        full_history_available=True,
+        subscribe=subscribe,
+    )
+
+    setup = _CheckpointerSetup(
+        config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
+        log_location=str(tmp_path / "t.eval"),
+        sample_id="s",
+        epoch=0,
+    )
+    hydration = _fake_hydration(str(tmp_path / "ckpts"), str(tmp_path / "work"))
+    Path(hydration.sample_checkpoints_dir).mkdir(parents=True)
+    Path(hydration.sample_working_dir).mkdir(parents=True)
+
+    with (
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.hydrate",
+            return_value=hydration,
+        ),
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+            return_value=fake_transcript,
+        ),
+    ):
+        async with setup as cp:
+            assert isinstance(cp, _EnteredCheckpointer)
+            assert len(callbacks) == 1
+        assert len(callbacks) == 1
+
+        async with setup as cp2:
+            assert cp2 is cp
+            assert len(callbacks) == 1
+
+        setup.close()
+        assert callbacks == []
+        assert setup._cached is None
+        setup.close()
+
+
+async def test_checkpointer_setup_reconstruct_preserves_event_store(
+    tmp_path: Path,
+) -> None:
+    from types import SimpleNamespace
+
+    callbacks: list[Callable[[Event], None]] = []
+
+    def subscribe(callback: Callable[[Event], None]) -> Callable[[], None]:
+        callbacks.append(callback)
+
+        def unsubscribe() -> None:
+            callbacks.remove(callback)
+
+        return unsubscribe
+
+    fake_transcript = SimpleNamespace(
+        attachments={},
+        resident_events=[],
+        resident_events_truncated=False,
+        full_history_available=True,
+        subscribe=subscribe,
+    )
+    hydration = _fake_hydration(str(tmp_path / "ckpts"), str(tmp_path / "work"))
+    Path(hydration.sample_checkpoints_dir).mkdir(parents=True)
+    Path(hydration.sample_working_dir).mkdir(parents=True)
+    setup = _CheckpointerSetup(
+        config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
+        log_location=str(tmp_path / "t.eval"),
+        sample_id="s",
+        epoch=0,
+    )
+
+    with (
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.hydrate",
+            return_value=hydration,
+        ),
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+            return_value=fake_transcript,
+        ),
+    ):
+        async with setup as first:
+            assert isinstance(first, _EnteredCheckpointer)
+            first._track_transcript_event(InfoEvent(data="first"))
+
+        async with setup as second:
+            assert isinstance(second, _EnteredCheckpointer)
+            second._track_transcript_event(InfoEvent(data="second"))
+            work = tmp_path / "snapshot"
+            work.mkdir()
+            await second._write_host_context(str(work), [], {}, Store())
+
+    events = json.loads((work / "events.json").read_text())
+    assert [event["data"] for event in events] == ["first", "second"]
+
+
+async def test_resume_resets_restored_event_store_before_seeding(
+    tmp_path: Path,
+) -> None:
+    from types import SimpleNamespace
+
+    callbacks: list[Callable[[Event], None]] = []
+
+    def subscribe(callback: Callable[[Event], None]) -> Callable[[], None]:
+        callbacks.append(callback)
+        return lambda: callbacks.remove(callback)
+
+    work = tmp_path / "work"
+    work.mkdir()
+    restored_store = CheckpointEventStore(work / "checkpoint_events.sqlite", reset=True)
+    restored_store.merge_event(InfoEvent(data="orphan"), lambda _: None)
+    restored_store.close()
+
+    hydration = _fake_hydration(str(tmp_path / "ckpts"), str(work))
+    hydration.host.condensed_events = [InfoEvent(data="committed")]
+    fake_transcript = SimpleNamespace(
+        attachments={},
+        resident_events=[],
+        resident_events_truncated=False,
+        full_history_available=True,
+        subscribe=subscribe,
+    )
+    setup = _CheckpointerSetup(
+        config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
+        log_location=str(tmp_path / "t.eval"),
+        sample_id="s",
+        epoch=0,
+        resume_checkpoint=ResumeCheckpoint(
+            sample_checkpoints_dir=str(tmp_path / "prior-ckpts")
+        ),
+    )
+
+    with (
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.hydrate",
+            return_value=hydration,
+        ),
+        patch(
+            "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+            return_value=fake_transcript,
+        ),
+    ):
+        cp = await setup.__aenter__()
+        assert isinstance(cp, _EnteredCheckpointer)
+        cp._track_transcript_event(InfoEvent(data="new"))
+        snapshot = tmp_path / "snapshot"
+        snapshot.mkdir()
+        await cp._write_host_context(str(snapshot), [], {}, Store())
+        setup.close()
+
+    events = json.loads((snapshot / "events.json").read_text())
+    assert [event["data"] for event in events] == ["committed", "new"]
+
+
+def test_resume_seed_skips_restored_resident_events(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    restored = InfoEvent(uuid="restored", data="committed")
+    fake_transcript = Transcript([restored], bounded=False)
+    hydration = _fake_hydration(str(tmp_path / "ckpts"), str(tmp_path / "work"))
+    hydration.host.condensed_events = [restored]
+
+    monkeypatch.setattr(
+        "inspect_ai.util._checkpoint.checkpointer_impl.transcript",
+        lambda: fake_transcript,
+    )
+
+    cp = _EnteredCheckpointer(
+        config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
+        hydration=hydration,
+        resume_checkpoint=ResumeCheckpoint(
+            sample_checkpoints_dir=str(tmp_path / "old")
+        ),
+        reset_event_store=True,
+    )
+    snapshot = tmp_path / "snapshot"
+    snapshot.mkdir()
+    cp._event_store.export_snapshot_files(snapshot, store_json={}, agent_state=None)
+    cp.close()
+
+    events = json.loads((snapshot / "events.json").read_text())
+    assert [event["uuid"] for event in events] == ["restored"]
+    assert [event["data"] for event in events] == ["committed"]
+
+
+async def test_resume_seed_preserves_message_pool_positions(tmp_path: Path) -> None:
+    msg_sys: ChatMessage = ChatMessageSystem(content="sys")
+    msg_u1: ChatMessage = ChatMessageUser(content="q1")
+    msg_a1: ChatMessage = ChatMessageAssistant(content="a1")
+    msg_u2: ChatMessage = ChatMessageUser(content="q2")
+
+    def _model_event(input_msgs: list[ChatMessage]) -> ModelEvent:
+        return ModelEvent(
+            model="test",
+            input=input_msgs,
+            tools=[],
+            tool_choice="auto",
+            config=GenerateConfig(),
+            output=ModelOutput(),
+        )
+
+    first_work = tmp_path / "first"
+    first_work.mkdir()
+    first_cp = _EnteredCheckpointer(
+        config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
+        hydration=_fake_hydration(str(tmp_path / "ckpts"), str(tmp_path / "state1")),
+        resume_checkpoint=None,
+        reset_event_store=True,
+    )
+    first_cp._track_transcript_event(_model_event([msg_sys, msg_u1, msg_a1]))
+    await first_cp._write_host_context(str(first_work), [], {}, Store())
+
+    from inspect_ai.util._checkpoint._layout import host_context
+
+    first_context = host_context.read(str(first_work))
+    assert len(first_context.condensed_events) == 1
+
+    hydration = _fake_hydration(str(tmp_path / "ckpts"), str(tmp_path / "state2"))
+    hydration.host.condensed_events = first_context.condensed_events
+    hydration.host.msg_pool = first_context.msg_pool
+    hydration.host.call_pool = first_context.call_pool
+    resumed_cp = _EnteredCheckpointer(
+        config=ResolvedCheckpointConfig(trigger=TurnInterval(every=1)),
+        hydration=hydration,
+        resume_checkpoint=None,
+        reset_event_store=True,
+    )
+
+    resumed_work = tmp_path / "resumed"
+    resumed_work.mkdir()
+    resumed_cp._track_transcript_event(_model_event([msg_u2]))
+    await resumed_cp._write_host_context(str(resumed_work), [], {}, Store())
+
+    resumed_data = json.loads((resumed_work / "events_data.json").read_text())
+    assert len(resumed_data["messages"]) == 4
+    expanded = expand_events(
+        (resumed_work / "events.json").read_text(),
+        (resumed_work / "events_data.json").read_text(),
+    )
+    model_events = [event for event in expanded if isinstance(event, ModelEvent)]
+    assert [len(event.input) for event in model_events] == [3, 1]
+    assert [message.content for message in model_events[0].input] == ["sys", "q1", "a1"]
+    assert [message.content for message in model_events[1].input] == ["q2"]

--- a/tests/display/test_textual_transcript.py
+++ b/tests/display/test_textual_transcript.py
@@ -1,0 +1,86 @@
+from collections.abc import AsyncIterator, Sequence
+from contextlib import asynccontextmanager
+from typing import cast
+
+import pytest
+
+from inspect_ai._display.textual.widgets.transcript import TranscriptView
+from inspect_ai.dataset import Sample
+from inspect_ai.event import Event, InfoEvent
+from inspect_ai.event._sample_init import SampleInitEvent
+from inspect_ai.log import Transcript
+from inspect_ai.log._samples import ActiveSample
+
+
+class _RaisingHistoryProvider:
+    def __init__(self) -> None:
+        self.event_count_calls = 0
+
+    @property
+    def event_count(self) -> int:
+        self.event_count_calls += 1
+        return 3
+
+    def events(self) -> Sequence[Event]:
+        raise AssertionError("textual transcript view should use resident events")
+
+    def recent_events(self, n: int | None = None) -> Sequence[Event]:
+        raise AssertionError("textual transcript view should use resident events")
+
+    def events_from(self, start: int) -> Sequence[Event]:
+        raise AssertionError("textual transcript view should use resident events")
+
+    def events_since_last(self, event_type: type[Event]) -> list[Event]:
+        raise AssertionError("textual transcript view should use resident events")
+
+
+class _Sample:
+    id = "sample"
+
+    def __init__(self, transcript: Transcript) -> None:
+        self.transcript = transcript
+
+
+@pytest.mark.anyio
+async def test_textual_transcript_view_uses_resident_events(monkeypatch) -> None:
+    provider = _RaisingHistoryProvider()
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=provider,
+    )
+    sample_init = SampleInitEvent(sample=Sample(input="input", id="sample"), state={})
+    transcript._event(sample_init)
+    transcript._event(InfoEvent(data="evicted"))
+    transcript._event(InfoEvent(data="resident"))
+
+    async def remove_children(self: TranscriptView) -> None:
+        pass
+
+    async def mount_all(self: TranscriptView, widgets: object) -> None:
+        pass
+
+    @asynccontextmanager
+    async def batch(self: TranscriptView) -> AsyncIterator[None]:
+        yield
+
+    def scroll_end(self: TranscriptView, animate: bool = False) -> None:
+        pass
+
+    def widgets_for_events(
+        self: TranscriptView, events: Sequence[Event]
+    ) -> list[object]:
+        return []
+
+    monkeypatch.setattr(TranscriptView, "remove_children", remove_children)
+    monkeypatch.setattr(TranscriptView, "mount_all", mount_all)
+    monkeypatch.setattr(TranscriptView, "_widgets_for_events", widgets_for_events)
+    monkeypatch.setattr(TranscriptView, "batch", batch)
+    monkeypatch.setattr(TranscriptView, "scroll_end", scroll_end)
+
+    view = TranscriptView()
+    view._active = True
+
+    await view.sync_sample(cast(ActiveSample, _Sample(transcript)))
+
+    assert provider.event_count_calls == 0

--- a/tests/log/test_buffer_sync_thread.py
+++ b/tests/log/test_buffer_sync_thread.py
@@ -258,6 +258,37 @@ def test_pending_sync_respects_log_shared_interval(
     assert sync_times[1] - sync_times[0] >= throttle_interval * 0.9
 
 
+def test_sync_worker_thread_identity_is_reused(
+    shared_db: SampleBufferDatabase,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    first_call = threading.Event()
+    second_call = threading.Event()
+    sync_threads: list[threading.Thread] = []
+    recorder = SyncRecorder()
+
+    def recording_sync(
+        db: SampleBufferDatabase,
+        filestore: SampleBufferFilestore,
+    ) -> None:
+        sync_threads.append(threading.current_thread())
+        if recorder.next_call() == 1:
+            first_call.set()
+        else:
+            second_call.set()
+
+    monkeypatch.setattr(database_module, "sync_to_filestore", recording_sync)
+
+    _request_sync(shared_db, "first")
+    _assert_event(first_call, "first sync did not run")
+
+    _request_sync(shared_db, "second")
+    _assert_event(second_call, "second sync did not run")
+
+    assert len(sync_threads) == 2
+    assert sync_threads[0] is sync_threads[1]
+
+
 def test_sync_exception_does_not_prevent_later_sync(
     shared_db: SampleBufferDatabase,
     monkeypatch: pytest.MonkeyPatch,
@@ -277,13 +308,15 @@ def test_sync_exception_does_not_prevent_later_sync(
 
     _request_sync(shared_db, "first")
     _wait_until(
-        lambda: recorder.calls >= 1 and shared_db._sync_thread is None,
-        "sync worker did not recover after exception",
+        lambda: recorder.calls >= 1 and shared_db._sync_thread is not None,
+        "sync worker did not remain available after exception",
     )
+    first_thread = shared_db._sync_thread
 
     _request_sync(shared_db, "second")
 
     _assert_event(second_call, "second sync did not run")
+    assert shared_db._sync_thread is first_thread
 
 
 def test_sync_request_pending_when_thread_reference_exists_but_not_alive(

--- a/tests/log/test_log_eventdb_sync.py
+++ b/tests/log/test_log_eventdb_sync.py
@@ -1,10 +1,12 @@
 import tempfile
 from pathlib import Path
+from typing import IO, cast
 
 import pytest
 
 from inspect_ai.event._info import InfoEvent
 from inspect_ai.log._log import EvalSampleSummary
+from inspect_ai.log._recorders.buffer import filestore as filestore_module
 from inspect_ai.log._recorders.buffer.database import (
     SampleBufferDatabase,
     sync_to_filestore,
@@ -217,3 +219,44 @@ def test_sync_incremental(
     # Confirm filestore returns all 4 events
     sample_data = filestore.get_sample_data("inc", 1)
     assert sample_data is not None
+
+
+def test_sync_writes_segment_members_in_bounded_chunks(
+    db_and_filestore: tuple[SampleBufferDatabase, SampleBufferFilestore],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    db, filestore = db_and_filestore
+    monkeypatch.setattr(filestore_module, "_SEGMENT_WRITE_CHUNK_SIZE", 128)
+
+    sample = EvalSampleSummary(id="chunked", epoch=1, input="foo", target="bar")
+    db.start_sample(sample)
+    db.log_events(
+        [SampleEvent(id="chunked", epoch=1, event=InfoEvent(data="x" * 1024))]
+    )
+
+    sync_to_filestore(db, filestore)
+
+    sample_data = filestore.get_sample_data("chunked", 1)
+    assert sample_data is not None
+    assert len(sample_data.events) == 1
+    event_data = sample_data.events[0].event["data"]
+    assert isinstance(event_data, str)
+    assert event_data.startswith("attachment://")
+    assert len(sample_data.attachments) == 1
+    assert sample_data.attachments[0].content == "x" * 1024
+
+
+def test_chunked_writer_bounds_individual_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    writes: list[bytes] = []
+
+    class Member:
+        def write(self, data: bytes) -> int:
+            writes.append(data)
+            return len(data)
+
+    monkeypatch.setattr(filestore_module, "_SEGMENT_WRITE_CHUNK_SIZE", 4)
+    filestore_module._write_chunked(cast(IO[bytes], Member()), b"0123456789")
+
+    assert writes == [b"0123", b"4567", b"89"]

--- a/tests/log/test_message_pool.py
+++ b/tests/log/test_message_pool.py
@@ -12,6 +12,7 @@ from inspect_ai._util.constants import LOG_SCHEMA_VERSION
 from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai.event import Event, Timeline, TimelineEvent, TimelineSpan
 from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._pool import _compress_refs, _expand_refs
 from inspect_ai.log._condense import (
     condense_events,
     condense_sample,
@@ -29,11 +30,7 @@ from inspect_ai.log._log import (
     EvalSpec,
     EvalStats,
 )
-from inspect_ai.log._pool import (
-    _compress_refs,
-    _expand_refs,
-    resolve_sample_events_data,
-)
+from inspect_ai.log._resolve import resolve_sample_events_data
 from inspect_ai.model._chat_message import (
     ChatMessageAssistant,
     ChatMessageSystem,
@@ -1020,7 +1017,7 @@ def test_resolve_call_empty_refs_preserves_request():
     then sets request[default_key] = [], adding a spurious 'messages' key
     and potentially masking the original 'input' field.
     """
-    from inspect_ai.log._pool import resolve_model_event_calls
+    from inspect_ai.event._pool import resolve_model_event_calls
 
     call = ModelCall(
         request={"model": "test", "input": "What is 2+2?"},

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -1,0 +1,362 @@
+import sqlite3
+
+import pytest
+
+from inspect_ai._util.json import to_json_str_safe
+from inspect_ai.event import InfoEvent, ModelEvent
+from inspect_ai.log import expand_events
+from inspect_ai.log._log import EvalSample, EventsData
+from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+from inspect_ai.log._recorders.types import SampleEvent
+from inspect_ai.log._transcript import Transcript
+from inspect_ai.model import ChatMessageUser, GenerateConfig, ModelOutput
+from inspect_ai.util._checkpoint._event_store import (
+    CHECKPOINT_EVENT_STORE,
+    CheckpointEventStore,
+)
+
+
+def _model(uuid: str, completion: str, pending: bool | None = None) -> ModelEvent:
+    return ModelEvent(
+        uuid=uuid,
+        model="mockllm/model",
+        input=[ChatMessageUser(id="input-message", content="question")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", completion),
+        pending=pending,
+    )
+
+
+def test_open_sample_history_latest_payload_first_insert_order(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    first = _model("event-1", "pending", pending=True)
+    other = InfoEvent(uuid="event-2", data="middle")
+    latest = _model("event-1", "complete", pending=None)
+
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=first),
+            SampleEvent(id="sample", epoch=1, event=other),
+            SampleEvent(id="sample", epoch=1, event=latest),
+        ]
+    )
+
+    with db.open_sample_history("sample", 1) as history:
+        rows = history.raw_event_rows
+
+    assert [row.event_id for row in rows] == ["event-1", "event-2"]
+    assert rows[0].event["output"]["completion"] == "complete"
+    assert rows[0].event.get("pending") is None
+    assert rows[1].event["data"] == "middle"
+
+
+@pytest.mark.parametrize("event_id_literal", ["NULL", "''"])
+def test_open_sample_history_blank_event_id_is_unique(tmp_path, event_id_literal):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    with db._get_connection(write=True) as conn:
+        conn.executemany(
+            f"""
+            INSERT INTO events (event_id, sample_id, sample_epoch, data)
+            VALUES ({event_id_literal}, ?, ?, ?)
+            """,
+            [
+                ("sample", 1, to_json_str_safe({"event": "info", "data": "first"})),
+                ("sample", 1, to_json_str_safe({"event": "info", "data": "second"})),
+            ],
+        )
+
+    with db.open_sample_history("sample", 1) as history:
+        rows = history.raw_event_rows
+
+    assert [row.event["data"] for row in rows] == ["first", "second"]
+    assert len({row.event_id for row in rows}) == 2
+    assert all(row.event_id for row in rows)
+
+
+def test_get_events_synthesizes_missing_event_id(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    with db._get_connection(write=True) as conn:
+        conn.execute(
+            """
+            INSERT INTO events (event_id, sample_id, sample_epoch, data)
+            VALUES (NULL, ?, ?, ?)
+            """,
+            ("sample", 1, to_json_str_safe({"event": "info", "data": "legacy"})),
+        )
+
+        rows = list(db._get_events(conn, "sample", 1))
+
+    assert [row.event["data"] for row in rows] == ["legacy"]
+    assert rows[0].event_id
+
+
+def test_sample_event_count_counts_logical_events_without_materializing_json(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    with db._get_connection(write=True) as conn:
+        conn.executemany(
+            """
+            INSERT INTO events (event_id, sample_id, sample_epoch, data)
+            VALUES (?, ?, ?, ?)
+            """,
+            [
+                ("event-1", "sample", 1, "not json"),
+                ("event-1", "sample", 1, "still not json"),
+                (None, "sample", 1, "also not json"),
+                ("", "sample", 1, "not json either"),
+                ("event-other-epoch", "sample", 2, "not json"),
+            ],
+        )
+
+    assert db.sample_event_count("sample", 1) == 3
+
+
+def test_sample_history_translates_buffer_pool_refs_to_eval_positions(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    first = _model("event-1", "first")
+    second = _model("event-2", "second")
+
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=first),
+            SampleEvent(id="sample", epoch=1, event=second),
+        ]
+    )
+
+    with db.open_sample_history("sample", 1) as history:
+        events = list(history.iter_events())
+        events_data = history.events_data
+
+    sample = EvalSample(
+        id="sample",
+        epoch=1,
+        input="question",
+        target="answer",
+        events=events,
+        events_data=events_data,
+    )
+
+    assert isinstance(events_data, dict)
+    assert set(events_data.keys()) == set(EventsData.__annotations__.keys())
+    model_events = [event for event in sample.events if event.event == "model"]
+    assert len(model_events) == 2
+    assert model_events[0].input_refs is not None
+    assert model_events[1].input_refs is not None
+    assert len(events_data["messages"]) == 1
+    assert events_data["messages"][0].content == "question"
+    assert model_events[0].input_refs == [(0, 1)]
+    assert model_events[1].input_refs == [(0, 1)]
+    assert all(
+        end <= len(sample.events_data["messages"])
+        for start, end in model_events[0].input_refs
+    )
+    assert all(
+        end <= len(sample.events_data["messages"])
+        for start, end in model_events[1].input_refs
+    )
+
+
+def test_import_checkpoint_events_translates_buffer_pool_positions(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    first = ChatMessageUser(id="first", content="first")
+    second = ChatMessageUser(id="second", content="second")
+    event = ModelEvent(
+        uuid="event-1",
+        model="mockllm/model",
+        input=[first, second],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "completion"),
+    )
+    db.log_events([SampleEvent(id="sample", epoch=1, event=event)])
+
+    event_store = CheckpointEventStore(tmp_path / CHECKPOINT_EVENT_STORE)
+    event_store.merge_message_pool_entry("placeholder", first.model_dump_json())
+
+    db.import_checkpoint_events("sample", 1, event_store)
+    event_store.export_snapshot_files(tmp_path, store_json={}, agent_state=None)
+
+    expanded = expand_events(
+        (tmp_path / "events.json").read_text(),
+        (tmp_path / "events_data.json").read_text(),
+    )
+    model_events = [event for event in expanded if isinstance(event, ModelEvent)]
+    assert [message.content for message in model_events[0].input] == [
+        "first",
+        "second",
+    ]
+
+
+def test_open_sample_history_defers_remove_samples_until_release(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
+
+    with db.open_sample_history("sample", 1) as history:
+        db.remove_samples([("sample", 1)])
+        assert [event["data"] for event in history.iter_events()] == ["hello"]
+        with db._get_connection() as conn:
+            assert list(db._get_events(conn, "sample", 1))
+
+    with db._get_connection() as conn:
+        assert not list(db._get_events(conn, "sample", 1))
+
+
+def test_cleanup_defers_while_sample_history_is_open(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
+
+    with db.open_sample_history("sample", 1) as history:
+        db.cleanup()
+        assert db.db_path.exists()
+        assert [event["data"] for event in history.iter_events()] == ["hello"]
+
+    assert not db.db_path.exists()
+
+
+def test_sample_history_event_rows_are_private(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=_model("event-1", "first"))])
+
+    with db.open_sample_history("sample", 1) as history:
+        assert not hasattr(history, "events")
+        assert history.raw_event_rows
+
+
+def test_open_sample_history_releases_write_lock_after_snapshot(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
+
+    with db.open_sample_history("sample", 1) as history:
+        conn = sqlite3.connect(db.db_path, timeout=0)
+        try:
+            conn.execute("PRAGMA busy_timeout=0")
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                lock_available = True
+            except sqlite3.OperationalError as exc:
+                assert "locked" in str(exc)
+                lock_available = False
+        finally:
+            conn.close()
+
+        assert lock_available is True
+        assert [event["data"] for event in history.iter_events()] == ["hello"]
+
+
+def test_buffer_transcript_history_provider_materializes_full_events(tmp_path) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    first = InfoEvent(uuid="event-1", data="first")
+    model = _model("event-2", "answer")
+    tail = InfoEvent(uuid="event-3", data="tail")
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=first),
+            SampleEvent(id="sample", epoch=1, event=model),
+            SampleEvent(id="sample", epoch=1, event=tail),
+        ]
+    )
+
+    from inspect_ai.log._recorders.buffer.history_provider import (
+        BufferTranscriptHistoryProvider,
+    )
+
+    provider = BufferTranscriptHistoryProvider(db, "sample", 1)
+
+    events = provider.events()
+    assert [event.uuid for event in events] == ["event-1", "event-2", "event-3"]
+    assert isinstance(events[1], ModelEvent)
+    assert events[1].input == [ChatMessageUser(id="input-message", content="question")]
+    assert events[1].input_refs is None
+    assert provider.event_count == 3
+    assert provider.recent_events(2) == events[-2:]
+    assert provider.recent_events(0) == []
+    assert provider.events_since_last(ModelEvent) == events[1:]
+
+    iterator = provider.iter_events()
+    assert next(iterator).uuid == "event-1"
+    db.remove_samples([("sample", 1)])
+    with db._get_connection() as conn:
+        assert not list(db._get_events(conn, "sample", 1))
+
+
+def test_buffer_transcript_history_provider_collapses_pending_updates(tmp_path) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    pending = _model("event-1", "pending", pending=True)
+    complete = _model("event-1", "complete", pending=None)
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=pending),
+            SampleEvent(id="sample", epoch=1, event=complete),
+        ]
+    )
+
+    from inspect_ai.log._recorders.buffer.history_provider import (
+        BufferTranscriptHistoryProvider,
+    )
+
+    provider = BufferTranscriptHistoryProvider(db, "sample", 1)
+
+    events = provider.events()
+    assert provider.event_count == 1
+    assert len(events) == 1
+    assert isinstance(events[0], ModelEvent)
+    assert events[0].output.completion == "complete"
+    assert events[0].pending is None
+
+
+def test_buffer_transcript_history_provider_recent_events_reads_only_tail(
+    tmp_path,
+) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=InfoEvent(uuid="old", data="old")),
+            SampleEvent(id="sample", epoch=1, event=InfoEvent(uuid="new", data="new")),
+        ]
+    )
+    with db._get_connection(write=True) as conn:
+        conn.execute(
+            "UPDATE events SET data = ? WHERE event_id = ?",
+            ("not json", "old"),
+        )
+
+    from inspect_ai.log._recorders.buffer.history_provider import (
+        BufferTranscriptHistoryProvider,
+    )
+
+    provider = BufferTranscriptHistoryProvider(db, "sample", 1)
+
+    recent = provider.recent_events(1)
+
+    assert len(recent) == 1
+    assert recent[0].uuid == "new"
+
+
+def test_transcript_events_iteration_uses_provider_iterator(tmp_path) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=InfoEvent(uuid="old", data="old")),
+            SampleEvent(id="sample", epoch=1, event=InfoEvent(uuid="new", data="new")),
+        ]
+    )
+
+    from inspect_ai.log._recorders.buffer.history_provider import (
+        BufferTranscriptHistoryProvider,
+    )
+
+    class IteratorOnlyProvider(BufferTranscriptHistoryProvider):
+        def events(self):
+            raise AssertionError("iteration must not materialize provider.events()")
+
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=IteratorOnlyProvider(db, "sample", 1),
+    )
+    transcript._event(InfoEvent(uuid="old", data="old"))
+    transcript._event(InfoEvent(uuid="new", data="new"))
+
+    assert [event.uuid for event in transcript.events] == ["old", "new"]

--- a/tests/log/test_streaming_completion.py
+++ b/tests/log/test_streaming_completion.py
@@ -1,0 +1,353 @@
+from collections.abc import Sequence
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from inspect_ai._eval.task.log import TaskLogger
+from inspect_ai._eval.task.run import log_sample
+from inspect_ai.event import InfoEvent, ModelEvent
+from inspect_ai.log._condense import condense_sample
+from inspect_ai.log._file import read_eval_log_async
+from inspect_ai.log._log import (
+    EvalConfig,
+    EvalDataset,
+    EvalPlan,
+    EvalResults,
+    EvalSample,
+    EvalSpec,
+    EvalStats,
+)
+from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+from inspect_ai.log._recorders.eval import EvalRecorder
+from inspect_ai.log._recorders.json import JSONRecorder
+from inspect_ai.log._recorders.types import SampleEvent
+from inspect_ai.model import ChatMessageUser, GenerateConfig, ModelOutput
+
+
+def _model(uuid: str, content: str) -> ModelEvent:
+    output = ModelOutput.from_content("mockllm/model", content)
+    output.choices[0].message.id = "output-message"
+    return ModelEvent(
+        uuid=uuid,
+        timestamp=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        working_start=0.0,
+        model="mockllm/model",
+        input=[ChatMessageUser(id="input-message", content="question")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=output,
+    )
+
+
+def _long_content() -> str:
+    return "long answer " * 20
+
+
+def _data_uri() -> str:
+    return "data:image/png;base64," + ("A" * 120)
+
+
+async def test_log_sample_returns_materialized_streaming_sample(
+    tmp_path,
+) -> None:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    sample = _sample().model_copy(
+        update={"events": [InfoEvent(uuid="resident", data={})]}
+    )
+    db.start_sample(sample.summary())
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=_model("event-1", "answer-1")),
+            SampleEvent(id="sample", epoch=1, event=_model("event-2", "answer-2")),
+        ]
+    )
+    recorder = EvalRecorder(str(tmp_path))
+    spec = _eval_spec()
+    logger = _TaskLoggerShim(db)
+    logger.recorder = recorder
+    logger.eval = spec
+    logger.flush_buffer = 1
+    logger.flush_pending = []
+    logger._samples_completed = 0
+    await recorder.log_init(spec, str(tmp_path / "streaming.eval"), clean=True)
+    await recorder.log_start(spec, EvalPlan())
+
+    materialized = await log_sample(
+        sample.model_copy(update={"events": []}), logger, log_images=True
+    )
+    await _finish_eval(recorder, spec)
+
+    assert [event.uuid for event in materialized.events] == ["event-1", "event-2"]
+    assert all(isinstance(event, ModelEvent) for event in materialized.events)
+    first_event = materialized.events[0]
+    assert isinstance(first_event, ModelEvent)
+    assert materialized.events_data is None
+    assert first_event.input[0].content == "question"
+    assert first_event.input_refs is None
+
+
+async def _finish_eval(recorder: EvalRecorder, spec: EvalSpec):
+    return await recorder.log_finish(
+        spec, "success", EvalStats(), EvalResults(), reductions=None
+    )
+
+
+async def _write_eval_with_materialized_sample(path) -> object:
+    recorder = EvalRecorder(str(path.parent))
+    spec = _eval_spec()
+    await recorder.log_init(spec, str(path), clean=True)
+    await recorder.log_start(spec, EvalPlan())
+
+    sample = _sample().model_copy(
+        update={"events": [_model("event-1", _long_content())]}
+    )
+    await recorder.log_sample(spec, condense_sample(sample))
+
+    await _finish_eval(recorder, spec)
+    return await read_eval_log_async(str(path))
+
+
+async def _write_eval_with_streaming_sample(path) -> object:
+    recorder = EvalRecorder(str(path.parent))
+    spec = _eval_spec()
+    await recorder.log_init(spec, str(path), clean=True)
+    await recorder.log_start(spec, EvalPlan())
+
+    db = SampleBufferDatabase(
+        str(path.parent / "streaming-buffer.eval"), db_dir=path.parent
+    )
+    db.start_sample(_sample().summary())
+    db.log_events(
+        [SampleEvent(id="sample", epoch=1, event=_model("event-1", _long_content()))]
+    )
+
+    with db.open_sample_history("sample", 1) as history:
+        await recorder.log_sample_streaming(spec, _sample(), history)
+
+    await _finish_eval(recorder, spec)
+    return await read_eval_log_async(str(path))
+
+
+@pytest.mark.anyio
+async def test_streaming_completion_eval_output_matches_materialized(tmp_path):
+    materialized_path = tmp_path / "materialized.eval"
+    streaming_path = tmp_path / "streaming.eval"
+
+    materialized_log = await _write_eval_with_materialized_sample(materialized_path)
+    streaming_log = await _write_eval_with_streaming_sample(streaming_path)
+
+    assert materialized_log.samples is not None
+    assert streaming_log.samples is not None
+    assert materialized_log.samples[0].events == streaming_log.samples[0].events
+    assert (
+        materialized_log.samples[0].attachments == streaming_log.samples[0].attachments
+    )
+
+
+@pytest.mark.anyio
+async def test_eval_recorder_log_sample_streaming_writes_sample(
+    tmp_path,
+) -> None:
+    recorder = EvalRecorder(str(tmp_path))
+    spec = _eval_spec()
+    await recorder.log_init(spec, clean=True)
+    await recorder.log_start(spec, EvalPlan())
+
+    with _history(tmp_path) as history:
+        await recorder.log_sample_streaming(spec, _sample(), history)
+
+    log = await recorder.log_finish(
+        spec, "success", EvalStats(), EvalResults(), reductions=None
+    )
+    log = await read_eval_log_async(log.location)
+
+    assert log.samples is not None
+    assert len(log.samples[0].events) == 1
+
+
+def _sample() -> EvalSample:
+    return EvalSample(id="sample", epoch=1, input="question", target="answer")
+
+
+def _sample_with_core_attachments() -> EvalSample:
+    data_uri = _data_uri()
+    return EvalSample(
+        id="sample",
+        epoch=1,
+        input=[ChatMessageUser(content=data_uri)],
+        target="answer",
+        messages=[ChatMessageUser(content=data_uri)],
+    )
+
+
+def _eval_spec() -> EvalSpec:
+    return EvalSpec(
+        created="2026-05-18T00:00:00+00:00",
+        task="streaming_completion_test",
+        model="mockllm/model",
+        dataset=EvalDataset(),
+        config=EvalConfig(),
+    )
+
+
+def _history(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.start_sample(_sample().summary())
+    db.log_events(
+        [SampleEvent(id="sample", epoch=1, event=_model("event-1", "answer"))]
+    )
+    return db.open_sample_history("sample", 1)
+
+
+def _buffer_db(
+    tmp_path: Path, events: Sequence[ModelEvent | InfoEvent]
+) -> SampleBufferDatabase:
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.start_sample(_sample().summary())
+    db.log_events([SampleEvent(id="sample", epoch=1, event=event) for event in events])
+    return db
+
+
+async def _start_eval_recorder(tmp_path: Path) -> tuple[EvalRecorder, EvalSpec]:
+    recorder = EvalRecorder(str(tmp_path))
+    spec = _eval_spec()
+    await recorder.log_init(spec, str(tmp_path / "streaming.eval"), clean=True)
+    await recorder.log_start(spec, EvalPlan())
+    return recorder, spec
+
+
+async def _log_sample_with_buffer(
+    tmp_path: Path,
+    sample: EvalSample,
+    events: Sequence[ModelEvent | InfoEvent],
+    *,
+    log_images: bool,
+) -> tuple[EvalSample, EvalSample]:
+    db = _buffer_db(tmp_path, events)
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    logger = _TaskLoggerShim(db)
+    logger.recorder = recorder
+    logger.eval = spec
+    logger.flush_buffer = 1
+    logger.flush_pending = []
+    logger._samples_completed = 0
+
+    returned = await log_sample(sample, logger, log_images=log_images)
+    await _finish_eval(recorder, spec)
+
+    logged_samples = (
+        await read_eval_log_async(str(tmp_path / "streaming.eval"))
+    ).samples
+    assert logged_samples is not None
+    return returned, logged_samples[0]
+
+
+class _TaskLoggerShim(TaskLogger):
+    def __init__(self, buffer_db: SampleBufferDatabase) -> None:
+        self._buffer_db = buffer_db
+
+
+@pytest.mark.anyio
+async def test_log_sample_writes_streamed_buffer_events_to_eval(tmp_path) -> None:
+    sample = _sample().model_copy(
+        update={"events": [InfoEvent(uuid="resident", data={})]}
+    )
+    returned, logged = await _log_sample_with_buffer(
+        tmp_path, sample, [_model("event-1", "answer")], log_images=False
+    )
+
+    assert [event.uuid for event in returned.events] == ["event-1"]
+    returned_event = returned.events[0]
+    assert isinstance(returned_event, ModelEvent)
+    assert returned_event.input[0].content == "question"
+    assert [event.uuid for event in logged.events] == ["event-1"]
+    logged_event = logged.events[0]
+    assert isinstance(logged_event, ModelEvent)
+    assert logged_event.input[0].content == "question"
+
+
+@pytest.mark.anyio
+async def test_log_sample_streaming_condenses_core_sample_fields_and_merges_history_attachments(
+    tmp_path,
+) -> None:
+    sample = _sample_with_core_attachments()
+    event_content = _long_content()
+    returned, logged = await _log_sample_with_buffer(
+        tmp_path, sample, [_model("event-1", event_content)], log_images=True
+    )
+
+    assert returned.events_data is None
+    assert event_content in returned.attachments.values()
+    logged_input = logged.input[0]
+    assert isinstance(logged_input, ChatMessageUser)
+    assert isinstance(logged_input.content, str)
+    assert logged_input.content.startswith("attachment://")
+    logged_message = logged.messages[0]
+    assert isinstance(logged_message, ChatMessageUser)
+    assert isinstance(logged_message.content, str)
+    assert logged_message.content.startswith("attachment://")
+    assert event_content in logged.attachments.values()
+    assert logged.events_data is None
+
+
+@pytest.mark.anyio
+async def test_json_recorder_log_sample_streaming_includes_history_attachments(
+    tmp_path,
+) -> None:
+    recorder = JSONRecorder(str(tmp_path))
+    spec = _eval_spec()
+    await recorder.log_init(spec)
+    await recorder.log_start(spec, EvalPlan())
+
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.start_sample(_sample().summary())
+    long_content = _long_content()
+    db.log_events(
+        [
+            SampleEvent(
+                id="sample",
+                epoch=1,
+                event=_model("event-1", "answer"),
+            ),
+            SampleEvent(
+                id="sample",
+                epoch=1,
+                event=InfoEvent(uuid="event-2", data={"content": long_content}),
+            ),
+        ]
+    )
+
+    with db.open_sample_history("sample", 1) as history:
+        await recorder.log_sample_streaming(spec, _sample(), history)
+
+    samples = recorder.data[recorder._log_file_key(spec)].data.samples
+    assert samples is not None
+    buffered_sample = samples[0]
+    assert len(buffered_sample.events) == 2
+    assert buffered_sample.events_data is None
+    buffered_model_event = buffered_sample.events[0]
+    assert isinstance(buffered_model_event, ModelEvent)
+    assert buffered_model_event.input[0].content == "question"
+    buffered_info_event = buffered_sample.events[1]
+    assert isinstance(buffered_info_event, InfoEvent)
+    assert isinstance(buffered_info_event.data, dict)
+    assert isinstance(buffered_info_event.data["content"], str)
+    assert buffered_info_event.data["content"].startswith("attachment://")
+    assert long_content in buffered_sample.attachments.values()
+
+    log = await recorder.log_finish(
+        spec, "success", EvalStats(), EvalResults(), reductions=None
+    )
+
+    assert log.samples is not None
+    assert len(log.samples[0].events) == 2
+    logged_model_event = log.samples[0].events[0]
+    assert isinstance(logged_model_event, ModelEvent)
+    assert logged_model_event.input[0].content == "question"
+    logged_info_event = log.samples[0].events[1]
+    assert isinstance(logged_info_event, InfoEvent)
+    assert isinstance(logged_info_event.data, dict)
+    assert logged_info_event.data["content"] == buffered_info_event.data["content"]
+    assert long_content in log.samples[0].attachments.values()

--- a/tests/log/test_transcript_bounded.py
+++ b/tests/log/test_transcript_bounded.py
@@ -1,0 +1,660 @@
+import contextvars
+import logging
+from typing import Sequence
+
+import pytest
+from test_helpers.transcript import FakeTranscriptHistoryProvider
+
+from inspect_ai.dataset._dataset import Sample
+from inspect_ai.event._event import Event
+from inspect_ai.event._info import InfoEvent
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._sample_init import SampleInitEvent
+from inspect_ai.log._transcript import (
+    Transcript,
+    transcript,
+    transcript_bounded_enabled,
+)
+from inspect_ai.model import GenerateConfig
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput
+
+
+class _RaisingEventCountProvider(FakeTranscriptHistoryProvider):
+    @property
+    def event_count(self) -> int:
+        raise AssertionError("Transcript.event_count should be in-memory")
+
+
+class _SliceOnlyProvider(FakeTranscriptHistoryProvider):
+    @property
+    def event_count(self) -> int:
+        raise AssertionError("Transcript slice should not read event_count")
+
+    def recent_events(self, n: int | None = None) -> Sequence[Event]:
+        raise AssertionError("Transcript positive slice should not read recent_events")
+
+
+class _NoIterProvider(FakeTranscriptHistoryProvider):
+    def iter_events(self):
+        raise AssertionError(
+            "Transcript membership should not iterate provider history"
+        )
+
+
+class _CountingIterProvider(FakeTranscriptHistoryProvider):
+    iterated: int = 0
+
+    def iter_events(self):
+        for event in self._events:
+            self.iterated += 1
+            yield event
+
+
+def _data(events):
+    return [event.data for event in events]
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, False),
+        ("true", True),
+        ("1", True),
+        ("false", False),
+        (" FALSE ", False),
+        ("Off", False),
+    ],
+)
+def test_transcript_bounded_env_escape_hatch(
+    monkeypatch: pytest.MonkeyPatch, value: str | None, expected: bool
+) -> None:
+    monkeypatch.delenv("INSPECT_TRANSCRIPT_BOUNDED", raising=False)
+    if value is not None:
+        monkeypatch.setenv("INSPECT_TRANSCRIPT_BOUNDED", value)
+    assert transcript_bounded_enabled() is expected
+
+
+def test_transcript_context_default_is_lazy_and_isolated() -> None:
+    first_context = contextvars.Context()
+    second_context = contextvars.Context()
+
+    first = first_context.run(transcript)
+    second = second_context.run(transcript)
+
+    assert first is first_context.run(transcript)
+    assert second is second_context.run(transcript)
+    assert first is not second
+
+
+def test_bounded_transcript_assigns_keys_to_uuidless_events() -> None:
+    first = InfoEvent.model_validate(
+        {"event": "info", "data": "first"}, context={"deserializing": True}
+    )
+    second = InfoEvent.model_validate(
+        {"event": "info", "data": "second"}, context={"deserializing": True}
+    )
+    transcript = Transcript(bounded=True, resident_tail=1)
+
+    transcript._event(first)
+    transcript._event(second)
+
+    assert first.uuid is not None
+    assert second.uuid is not None
+    assert first.uuid != second.uuid
+    assert _data(transcript.events) == ["second"]
+
+
+def test_bounded_transcript_evictable_queue_stays_bounded() -> None:
+    transcript = Transcript(bounded=True, resident_tail=3)
+
+    for index in range(20):
+        transcript._event(InfoEvent(data=index))
+
+    assert _data(transcript.resident_events) == [17, 18, 19]
+    assert len(transcript._evictable_event_ids) == 3
+
+
+def test_bounded_transcript_does_not_prune_when_no_event_is_evicted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transcript = Transcript(bounded=True, resident_tail=3)
+    prune_calls = 0
+    original_prune = transcript._prune_pin_state
+
+    def count_prune() -> None:
+        nonlocal prune_calls
+        prune_calls += 1
+        original_prune()
+
+    monkeypatch.setattr(transcript, "_prune_pin_state", count_prune)
+
+    transcript._event(InfoEvent(data=1))
+    transcript._event(InfoEvent(data=2))
+    transcript._event(InfoEvent(data=3))
+
+    assert prune_calls == 0
+
+
+def test_bounded_transcript_evicts_to_resident_tail():
+    transcript = Transcript(bounded=True, resident_tail=3)
+
+    for data in range(5):
+        transcript._event(InfoEvent(data=data))
+
+    assert transcript.event_count == 5
+    assert transcript.resident_events_truncated is True
+    assert _data(transcript.events) == [2, 3, 4]
+    assert _data(transcript.recent_events(2)) == [3, 4]
+    assert transcript.recent_events(0) == []
+    assert transcript.last_event is not None
+    assert transcript.last_event.data == 4
+
+
+def test_bounded_transcript_events_uses_provider_for_full_history() -> None:
+    full_history: list[Event] = [
+        InfoEvent(data=0),
+        InfoEvent(data=1),
+        InfoEvent(data=2),
+    ]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=FakeTranscriptHistoryProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    assert transcript.resident_events_truncated is True
+    assert transcript.resident_events_truncated is True
+    assert transcript.full_history_available is True
+    assert _data(transcript.resident_events) == [2]
+    assert _data(transcript.events) == [0, 1, 2]
+    assert len(transcript.events) == 3
+    assert transcript.events[-1] is transcript.last_event
+    assert _data(transcript.events[1:]) == [1, 2]
+
+
+def test_bounded_transcript_event_count_is_in_memory_with_provider() -> None:
+    full_history: list[Event] = [InfoEvent(data=0), InfoEvent(data=1)]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=_RaisingEventCountProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    assert transcript.resident_events_truncated is True
+    assert transcript.event_count == 2
+
+
+def test_provider_backed_events_len_uses_in_memory_event_count() -> None:
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=_RaisingEventCountProvider([InfoEvent(data=1)]),
+    )
+    transcript._event(InfoEvent(data=1))
+    transcript._event(InfoEvent(data=2))
+
+    assert len(transcript.events) == 2
+
+
+def test_full_history_available_distinguishes_provider_from_resident_truncation() -> (
+    None
+):
+    provider_backed = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=FakeTranscriptHistoryProvider(
+            [InfoEvent(data=0), InfoEvent(data=1)]
+        ),
+    )
+    provider_backed._event(InfoEvent(data=0))
+    provider_backed._event(InfoEvent(data=1))
+
+    no_provider = Transcript(bounded=True, resident_tail=1)
+    no_provider._event(InfoEvent(data=0))
+    no_provider._event(InfoEvent(data=1))
+
+    assert provider_backed.resident_events_truncated is True
+    assert provider_backed.full_history_available is True
+    assert no_provider.resident_events_truncated is True
+    assert no_provider.full_history_available is False
+
+
+def test_provider_backed_events_supports_score_suffix_slice() -> None:
+    full_history: list[Event] = [
+        InfoEvent(data=0),
+        InfoEvent(data=1),
+        InfoEvent(data=2),
+    ]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=FakeTranscriptHistoryProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    existing_sample_events = [full_history[0]]
+    suffix = transcript.events[len(existing_sample_events) :]
+
+    assert _data(suffix) == [1, 2]
+
+
+def test_provider_backed_events_suffix_slice_uses_single_provider_operation() -> None:
+    full_history: list[Event] = [
+        InfoEvent(data=0),
+        InfoEvent(data=1),
+        InfoEvent(data=2),
+    ]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=_SliceOnlyProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    assert _data(transcript.events[1:]) == [1, 2]
+
+
+def test_provider_backed_events_membership_checks_resident_events_only() -> None:
+    evicted = InfoEvent(data="evicted")
+    resident = InfoEvent(data="resident")
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=_NoIterProvider([evicted, resident]),
+    )
+
+    transcript._event(evicted)
+    transcript._event(resident)
+
+    assert resident in transcript.events
+    assert evicted not in transcript.events
+
+
+def test_provider_backed_positive_index_streams_until_match() -> None:
+    full_history: list[Event] = [
+        InfoEvent(data=0),
+        InfoEvent(data=1),
+        InfoEvent(data=2),
+    ]
+    provider = _CountingIterProvider(full_history)
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=provider,
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    event = transcript.events[1]
+
+    assert isinstance(event, InfoEvent)
+    assert event.data == 1
+    assert provider.iterated == 2
+
+
+def test_bounded_transcript_recent_events_uses_provider_when_resident_tail_insufficient() -> (
+    None
+):
+    full_history: list[Event] = [
+        InfoEvent(data=0),
+        InfoEvent(data=1),
+        InfoEvent(data=2),
+    ]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=FakeTranscriptHistoryProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    assert _data(transcript.recent_events(2)) == [1, 2]
+    assert transcript.recent_events(0) == []
+    assert _data(transcript.recent_events()) == [0, 1, 2]
+
+
+def test_bounded_transcript_recent_events_uses_provider_with_pinned_gap() -> None:
+    sample_init = SampleInitEvent(
+        sample=Sample(input="input", id="sample"),
+        state={},
+    )
+    full_history: list[Event] = [sample_init, InfoEvent(data=1), InfoEvent(data=2)]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=FakeTranscriptHistoryProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    assert transcript.resident_events == [sample_init, full_history[-1]]
+    assert _data(transcript.recent_events(2)) == [1, 2]
+
+
+def test_bounded_transcript_events_negative_index_uses_provider_with_pinned_tail() -> (
+    None
+):
+    sample_init = SampleInitEvent(
+        sample=Sample(input="input", id="sample"),
+        state={},
+    )
+    tail = InfoEvent(data="tail")
+    full_history: list[Event] = [sample_init, tail]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=0,
+        history_provider=FakeTranscriptHistoryProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    assert transcript.resident_events == [sample_init]
+    assert transcript.last_event is sample_init
+    assert transcript.events[-1] is tail
+    assert list(transcript.events)[-1] is tail
+
+
+def test_bounded_transcript_events_since_last_uses_provider_after_eviction() -> None:
+    first_model = ModelEvent(
+        model="mockllm/model",
+        input=[ChatMessageUser(content="first")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "first"),
+    )
+    middle = InfoEvent(data="middle")
+    second_model = ModelEvent(
+        model="mockllm/model",
+        input=[ChatMessageUser(content="second")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "second"),
+    )
+    tail = InfoEvent(data="tail")
+    full_history: list[Event] = [first_model, middle, second_model, tail]
+    transcript = Transcript(
+        bounded=True,
+        resident_tail=1,
+        history_provider=FakeTranscriptHistoryProvider(full_history),
+    )
+
+    for event in full_history:
+        transcript._event(event)
+
+    assert transcript.events_since_last(ModelEvent) == [second_model, tail]
+
+
+def test_events_since_last_raises_when_transcript_truncated() -> None:
+    transcript = Transcript(bounded=True, resident_tail=1)
+    transcript._event(InfoEvent(data="first"))
+    transcript._event(InfoEvent(data="second"))
+
+    with pytest.raises(RuntimeError, match="Full transcript history is not available"):
+        transcript.events_since_last(ModelEvent)
+
+
+def test_seeded_transcript_defaults_to_unbounded():
+    transcript = Transcript([InfoEvent(data=1)], resident_tail=0)
+
+    transcript._event(InfoEvent(data=2))
+
+    assert transcript.event_count == 2
+    assert transcript.resident_events_truncated is False
+    assert _data(transcript.events) == [1, 2]
+
+
+def test_sample_init_event_is_pinned_in_bounded_transcript():
+    transcript = Transcript(bounded=True, resident_tail=1)
+    sample_init = SampleInitEvent(
+        sample=Sample(input="input", id="sample"),
+        state={},
+    )
+
+    transcript._event(sample_init)
+    transcript._event(InfoEvent(data=1))
+    transcript._event(InfoEvent(data=2))
+
+    assert transcript.event_count == 3
+    assert transcript.resident_events_truncated is True
+    assert transcript.events == [sample_init, transcript.last_event]
+
+
+def test_pending_event_is_pinned_in_bounded_transcript():
+    transcript = Transcript(bounded=True, resident_tail=1)
+    pending = InfoEvent(data="pending", pending=True)
+
+    transcript._event(pending)
+    transcript._event(InfoEvent(data=1))
+    transcript._event(InfoEvent(data=2))
+
+    assert transcript.event_count == 3
+    assert transcript.resident_events_truncated is True
+    assert transcript.events == [pending, transcript.last_event]
+
+
+def test_completed_pending_event_is_evictable_on_update():
+    transcript = Transcript(bounded=True, resident_tail=1)
+    pending = InfoEvent(data="pending", pending=True)
+
+    transcript._event(pending)
+    transcript._event(InfoEvent(data=1))
+    pending.pending = False
+    transcript._event_updated(pending)
+
+    assert transcript.event_count == 2
+    assert transcript.resident_events_truncated is True
+    assert _data(transcript.events) == [1]
+
+
+def test_transcript_subscribe_receives_events_and_updates() -> None:
+    transcript = Transcript()
+    received: list[Event] = []
+    unsubscribe = transcript.subscribe(received.append)
+    event = InfoEvent(data="first")
+
+    transcript._event(event)
+    event.data = "updated"
+    transcript._event_updated(event)
+    unsubscribe()
+    transcript._event(InfoEvent(data="after"))
+
+    assert received == [event, event]
+
+
+def test_transcript_subscriber_exception_does_not_skip_processing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    transcript = Transcript(bounded=True, resident_tail=0, log_model_api=True)
+    received: list[Event] = []
+
+    def bad_subscriber(event: Event) -> None:
+        raise RuntimeError("subscriber failed")
+
+    transcript.subscribe(bad_subscriber)
+    transcript.subscribe(received.append)
+    event = _model_event_with_call_payload("event-1", "large payload" * 100)
+
+    transcript_logger = logging.getLogger("inspect_ai.log._transcript")
+    transcript_logger.addHandler(caplog.handler)
+    original_propagate = transcript_logger.propagate
+    transcript_logger.propagate = False
+    try:
+        with caplog.at_level("WARNING", logger="inspect_ai.log._transcript"):
+            transcript._event(event)
+    finally:
+        transcript_logger.propagate = original_propagate
+        transcript_logger.removeHandler(caplog.handler)
+
+    assert received == [event]
+    assert "Transcript subscriber failed" in caplog.text
+    assert event.call is not None
+    messages = event.call.request["messages"]
+    assert isinstance(messages, list)
+    message = messages[0]
+    assert isinstance(message, dict)
+    content = message["content"]
+    assert isinstance(content, str)
+    assert content.startswith("attachment://")
+    assert transcript.events == []
+    assert transcript.resident_events_truncated is True
+    assert transcript.attachments == {}
+
+
+def test_bounded_transcript_evicts_unreferenced_attachments() -> None:
+    transcript = Transcript(bounded=True, resident_tail=1, log_model_api=True)
+    first = _model_event_with_call_payload("event-1", "first large payload" * 100)
+    second = _model_event_with_call_payload("event-2", "second large payload" * 100)
+
+    transcript._event(first)
+    first_attachments = set(transcript.attachments)
+    assert first_attachments
+
+    transcript._event(second)
+
+    assert not first_attachments.intersection(transcript.attachments)
+    assert transcript.attachments
+
+
+def test_bounded_transcript_update_rebuilds_attachment_refs() -> None:
+    transcript = Transcript(bounded=True, resident_tail=1, log_model_api=True)
+    event = _model_event_with_call_payload("event-1", "first payload" * 100)
+
+    transcript._event(event)
+    first_attachments = set(transcript.attachments)
+    event.call = ModelCall.create(
+        {"messages": [{"role": "user", "content": "second payload" * 100}]}, None
+    )
+    transcript._event_updated(event)
+
+    assert not first_attachments.intersection(transcript.attachments)
+    assert transcript.attachments
+
+
+def test_bounded_transcript_accepts_non_json_metadata() -> None:
+    transcript = Transcript(bounded=True)
+
+    transcript._event(InfoEvent(data="ok", metadata={"x": object()}))
+
+    assert transcript.last_event is not None
+    assert isinstance(transcript.last_event, InfoEvent)
+    assert transcript.last_event.data == "ok"
+
+
+def test_bounded_transcript_update_of_evicted_event_does_not_retain_attachments() -> (
+    None
+):
+    transcript = Transcript(bounded=True, resident_tail=1, log_model_api=True)
+    evicted = _model_event_with_call_payload("event-1", "evicted payload" * 100)
+    resident = InfoEvent(data="resident")
+
+    transcript._event(evicted)
+    transcript._event(resident)
+    assert transcript.events == [resident]
+
+    for index in range(3):
+        evicted.call = ModelCall.create(
+            {"messages": [{"role": "user", "content": f"late payload {index}" * 100}]},
+            None,
+        )
+        transcript._event_updated(evicted)
+
+    assert transcript.events == [resident]
+    assert evicted.call is not None
+    messages = evicted.call.request["messages"]
+    assert isinstance(messages, list)
+    message = messages[0]
+    assert isinstance(message, dict)
+    content = message["content"]
+    assert isinstance(content, str)
+    assert not content.startswith("attachment://")
+    assert transcript.attachments == {}
+
+
+def _model_event_with_call_payload(uuid: str, payload: str) -> ModelEvent:
+    event = ModelEvent(
+        uuid=uuid,
+        model="mockllm/model",
+        input=[ChatMessageUser(content="question")],
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "answer"),
+    )
+    event.call = ModelCall.create(
+        {"messages": [{"role": "user", "content": payload}]}, None
+    )
+    return event
+
+
+def test_bounded_transcript_external_mutation_keeps_original_attachment_ref() -> None:
+    transcript = Transcript(bounded=True, resident_tail=1, log_model_api=True)
+    first = _model_event_with_call_payload("event-1", "first payload" * 100)
+    second = InfoEvent(data="second")
+
+    transcript._event(first)
+    first_attachments = dict(transcript.attachments)
+    assert first_attachments
+
+    first.call = ModelCall.create(
+        {"messages": [{"role": "user", "content": "mutated payload" * 100}]}, None
+    )
+    transcript._event(second)
+
+    assert transcript.events == [second]
+    assert not any(hash in transcript.attachments for hash in first_attachments)
+
+
+def test_restored_events_update_bounded_bookkeeping_and_evict() -> None:
+    transcript = Transcript(bounded=True, resident_tail=2)
+    events = [InfoEvent(data=i) for i in range(5)]
+
+    transcript._extend_restored_events(events, {})
+
+    assert transcript.event_count == 5
+    assert transcript.resident_events_truncated is True
+    assert _data(transcript.resident_events) == [3, 4]
+    assert _data(transcript.recent_events(2)) == [3, 4]
+
+
+def test_restored_events_reject_duplicate_uuid() -> None:
+    transcript = Transcript(bounded=True, resident_tail=10)
+    first = InfoEvent(data="first", uuid="same")
+    duplicate = InfoEvent(data="duplicate", uuid="same")
+
+    transcript._extend_restored_events([first], {})
+
+    with pytest.raises(ValueError, match="Duplicate event uuid"):
+        transcript._extend_restored_events([duplicate], {})
+
+
+def test_bounded_transcript_allows_duplicate_uuid_after_eviction() -> None:
+    transcript = Transcript(bounded=True, resident_tail=1)
+    first = InfoEvent(data="first", uuid="same")
+    second = InfoEvent(data="second", uuid="other")
+    duplicate = InfoEvent(data="duplicate", uuid="same")
+
+    transcript._event(first)
+    transcript._event(second)
+    assert _data(transcript.resident_events) == ["second"]
+
+    transcript._event(duplicate)
+
+    assert _data(transcript.resident_events) == ["duplicate"]

--- a/tests/log/test_transcript_pending.py
+++ b/tests/log/test_transcript_pending.py
@@ -83,19 +83,14 @@ def test_non_pending_event_does_not_enter_sidecar() -> None:
     assert list(t.pending_events) == []
 
 
-def test_event_without_uuid_skipped() -> None:
-    """Events whose uuid is None can't be deduped; skip the sidecar.
-
-    ``BaseEvent.model_post_init`` auto-generates a uuid for live events,
-    so this case only arises during deserialization (or if a future
-    event-type opts out of uuid generation). The guard exists in
-    ``_update_pending`` for safety; this asserts it holds.
-    """
+def test_event_without_uuid_is_assigned_key() -> None:
+    """UUID-less events are normalized before pending bookkeeping."""
     t = Transcript()
     ev = _tool_event(id="tc-1", uuid="uuid-1", pending=True)
     ev.uuid = None
     t._event(ev)
-    assert list(t.pending_events) == []
+    assert ev.uuid is not None
+    assert list(t.pending_events) == [ev]
 
 
 def test_hydration_from_constructor_events_populates_sidecar() -> None:
@@ -110,6 +105,17 @@ def test_hydration_from_constructor_events_populates_sidecar() -> None:
     info = InfoEvent(source=None, data={"k": "v"})
     t = Transcript(events=[done, pending, info])
     assert [e.uuid for e in t.pending_events] == ["uuid-pending"]
+
+
+def test_constructor_does_not_mutate_uuidless_seed_events() -> None:
+    ev = _tool_event(id="tc-1", uuid="uuid-1", pending=True)
+    ev.uuid = None
+
+    t = Transcript(events=[ev])
+
+    assert ev.uuid is None
+    assert list(t.pending_events)[0] is not ev
+    assert list(t.pending_events)[0].uuid is not None
 
 
 def test_pending_and_non_pending_interleaved() -> None:

--- a/tests/log/test_transcript_subscribers.py
+++ b/tests/log/test_transcript_subscribers.py
@@ -1,10 +1,3 @@
-"""Tests for the additive `Transcript._add_subscriber` API.
-
-Independent of ACP: ``_add_subscriber`` is general-purpose multi-cast
-plumbing used by the Phase 6 router and (potentially) future hooks /
-tooling consumers.
-"""
-
 from inspect_ai.event import Event
 from inspect_ai.event._info import InfoEvent
 from inspect_ai.log._transcript import Transcript
@@ -15,7 +8,6 @@ def _info(data: str) -> InfoEvent:
 
 
 def _info_data(events: list[Event]) -> list[str]:
-    """Project a list of (Info)Events to their string `data` for assertion."""
     out: list[str] = []
     for e in events:
         assert isinstance(e, InfoEvent)
@@ -25,7 +17,6 @@ def _info_data(events: list[Event]) -> list[str]:
 
 
 def test_add_subscriber_receives_events_in_order() -> None:
-    """Subscriber receives events in the order they were appended."""
     tr = Transcript()
     received: list[Event] = []
     tr._add_subscriber(received.append)
@@ -38,7 +29,6 @@ def test_add_subscriber_receives_events_in_order() -> None:
 
 
 def test_add_subscriber_multi_cast_to_two_subscribers() -> None:
-    """Two subscribers added in turn both receive every event."""
     tr = Transcript()
     a: list[Event] = []
     b: list[Event] = []
@@ -53,7 +43,6 @@ def test_add_subscriber_multi_cast_to_two_subscribers() -> None:
 
 
 def test_add_subscriber_coexists_with_legacy_subscribe() -> None:
-    """The legacy single-slot ``_subscribe`` and ``_add_subscriber`` both fire."""
     tr = Transcript()
     legacy: list[Event] = []
     additive: list[Event] = []
@@ -67,7 +56,6 @@ def test_add_subscriber_coexists_with_legacy_subscribe() -> None:
 
 
 def test_unsubscribe_handle_stops_delivery() -> None:
-    """The returned unsubscribe callable removes the subscriber."""
     tr = Transcript()
     received: list[Event] = []
     unsubscribe = tr._add_subscriber(received.append)
@@ -78,12 +66,10 @@ def test_unsubscribe_handle_stops_delivery() -> None:
 
     assert _info_data(received) == ["before"]
 
-    # Double-unsubscribe must be a no-op.
     unsubscribe()
 
 
 def test_subscriber_exception_does_not_block_other_subscribers() -> None:
-    """A raising subscriber is logged but does not block siblings or the loop."""
     tr = Transcript()
     received: list[Event] = []
 
@@ -93,7 +79,25 @@ def test_subscriber_exception_does_not_block_other_subscribers() -> None:
     tr._add_subscriber(raises)
     tr._add_subscriber(received.append)
 
-    # _event itself must not raise even though `raises` does.
     tr._event(_info("survivor"))
 
     assert _info_data(received) == ["survivor"]
+
+
+def test_reentrant_event_reaches_other_subscribers_once() -> None:
+    tr = Transcript()
+    first_seen: list[Event] = []
+    second_seen: list[Event] = []
+
+    def reentrant(event: Event) -> None:
+        first_seen.append(event)
+        if isinstance(event, InfoEvent) and event.data == "outer":
+            tr._event(_info("inner"))
+
+    tr._add_subscriber(reentrant)
+    tr._add_subscriber(second_seen.append)
+
+    tr._event(_info("outer"))
+
+    assert _info_data(first_seen) == ["outer"]
+    assert _info_data(second_seen) == ["inner", "outer"]

--- a/tests/test_helpers/transcript.py
+++ b/tests/test_helpers/transcript.py
@@ -1,0 +1,52 @@
+from collections.abc import Iterator, Sequence
+
+from inspect_ai._util.list import find_last_match
+from inspect_ai.event._event import Event
+from inspect_ai.util._checkpoint._event_store import CheckpointEventStore
+
+
+class FakeTranscriptHistoryProvider:
+    def __init__(
+        self, events: Sequence[Event], attachments: dict[str, str] | None = None
+    ) -> None:
+        self._events = list(events)
+        self._attachments = dict(attachments or {})
+
+    @property
+    def event_count(self) -> int:
+        return len(self._events)
+
+    def events(self) -> Sequence[Event]:
+        return list(self._events)
+
+    def iter_events(self) -> Iterator[Event]:
+        return iter(self._events)
+
+    def recent_events(self, n: int | None = None) -> Sequence[Event]:
+        if n is None:
+            return list(self._events)
+        if n <= 0:
+            return []
+        return list(self._events[-n:])
+
+    def events_from(self, start: int) -> Sequence[Event]:
+        return list(self._events[start:])
+
+    def events_since_last(self, event_type: type[Event]) -> list[Event]:
+        events = list(self._events)
+        index = find_last_match(events, lambda event: isinstance(event, event_type))
+        if index is not None:
+            return events[index:]
+        return events
+
+    def attachments(self) -> dict[str, str]:
+        return dict(self._attachments)
+
+    def attachment(self, hash: str) -> str | None:
+        return self._attachments.get(hash)
+
+    def import_checkpoint_events(self, event_store: CheckpointEventStore) -> int:
+        for event in self._events:
+            event_store.merge_event(event, self._attachments.get)
+        event_store.merge_attachments(self._attachments)
+        return len(self._events)

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -8,6 +8,7 @@ from inspect_ai._util.file import (
     basename,
     cleanup_s3_sessions,
     filesystem,
+    s3_filesystem_cache_diagnostics,
     strip_trailing_sep,
     to_uri,
 )
@@ -119,6 +120,18 @@ async def test_cleanup_s3_sessions_no_instances() -> None:
         mock_s3fs._cache = {}
         await cleanup_s3_sessions()
         mock_s3fs.clear_instance_cache.assert_not_called()
+
+
+def test_s3_filesystem_cache_diagnostics_reports_cache() -> None:
+    with patch("s3fs.S3FileSystem") as mock_s3fs:
+        mock_s3fs._cache = {"key": object()}
+
+        diagnostics = s3_filesystem_cache_diagnostics()
+
+    assert diagnostics is not None
+    assert diagnostics["cache_size"] == 1
+    assert diagnostics["cache_type"] == "dict"
+    assert diagnostics["thread_name"] == "MainThread"
 
 
 async def test_cleanup_s3_sessions_closes_creator() -> None:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Long-running samples can retain too much transcript state in memory. Bounded transcript eviction reduces the live event list, but completion logging, retry errors, checkpointing, and buffer-history reads still had places that assumed all events were resident or kept their own unbounded copies.

### What is the new behavior?

Bounded transcript mode can keep only a resident tail while completion and retry paths read complete logical sample history from the buffer database. The buffer-backed history view provides `.eval`-compatible event/pool data for streaming completion and retry-error suffixes, so consumers no longer need to materialize `Transcript.events` for the full sample.

The surrounding state now follows the same bounded-memory contract: transcript side indexes are pruned with evicted events, checkpoint subscriptions no longer keep raw pending events, and sample-history reads take a consistent event/pool/attachment snapshot before releasing the database for final sample completion.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No intended user-facing breaking change. Bounded transcript mode remains opt-in behind `INSPECT_TRANSCRIPT_BOUNDED`, and unbounded transcripts continue to expose full resident event history.

### Other information:

`Transcript.events` and `Transcript.materialize_events()` remain resident-history APIs. Code that needs full history under bounded mode should use the buffer-backed sample history path.
