### PR TITLE
AsyncFilesystem: add `iter_files` and `iter_dirs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- AsyncFilesystem: Add `iter_files()` and `iter_dirs()` methods.
 - Scoring: Add `pass_k` reducer for computing the probability that all `k` epoch attempts succeed (τ-bench reliability metric).
 - Model Roles: Preserve overrides of config when calling `get_model()` with `role`.
 - OpenAI Compatible: Add support for `responses_phase` parameter.

--- a/src/inspect_ai/_util/asyncfiles.py
+++ b/src/inspect_ai/_util/asyncfiles.py
@@ -6,8 +6,9 @@ import shutil
 from contextlib import AbstractAsyncContextManager
 from contextvars import ContextVar
 from dataclasses import dataclass
+from fnmatch import fnmatchcase
 from types import TracebackType
-from typing import Any, BinaryIO, Callable, Coroutine, TypeVar, cast
+from typing import Any, AsyncIterator, BinaryIO, Callable, Coroutine, TypeVar, cast
 from urllib.parse import urlparse
 
 import anyio
@@ -348,6 +349,126 @@ class AsyncFilesystem(AbstractAsyncContextManager["AsyncFilesystem"]):
         else:
             filesystem(remote).get_file(remote, local)
 
+    async def iter_files(
+        self, base: str, pattern: str = "*", *, recursive: bool = False
+    ) -> AsyncIterator[str]:
+        """Yield URIs of files under `base`.
+
+        Matching is fnmatch-on-basename (case-sensitive). When `recursive`
+        is False, only direct children of `base` are considered; otherwise
+        any file at any depth under `base` is considered.
+
+        The `pattern` argument matches the basename only; it must not
+        contain `/`.
+        """
+        if is_s3_filename(base):
+            bucket, prefix = s3_bucket_and_key(base)
+            prefix = prefix.rstrip("/") + "/" if prefix else ""
+            if current_async_backend() == "asyncio":
+                client = await self.s3_client_async()
+                paginator = client.get_paginator("list_objects_v2")
+                kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix}
+                if not recursive:
+                    kwargs["Delimiter"] = "/"
+                async for page in paginator.paginate(**kwargs):
+                    for obj in page.get("Contents", []):
+                        key = obj["Key"]
+                        if fnmatchcase(key.rsplit("/", 1)[-1], pattern):
+                            yield f"s3://{bucket}/{key}"
+            else:
+                results = await anyio.to_thread.run_sync(
+                    s3_iter_files,
+                    self.s3_client(),
+                    bucket,
+                    prefix,
+                    pattern,
+                    recursive,
+                )
+                for r in results:
+                    yield r
+        else:
+            fs = filesystem(base).fs
+            if recursive:
+                paths = fs.find(base)
+                if isinstance(paths, dict):
+                    paths = list(paths.keys())
+                for path in paths:
+                    if fnmatchcase(path.rsplit("/", 1)[-1], pattern):
+                        yield path
+            else:
+                for entry in fs.ls(base, detail=True):
+                    if entry["type"] == "file":
+                        name = entry["name"]
+                        if fnmatchcase(name.rsplit("/", 1)[-1], pattern):
+                            yield name
+
+    async def iter_dirs(
+        self, base: str, pattern: str = "*", *, recursive: bool = False
+    ) -> AsyncIterator[str]:
+        """Yield URIs (ending in `/`) of directory-like entries under `base`.
+
+        Matching is fnmatch-on-terminal-name (case-sensitive). When
+        `recursive` is False, only direct subdirectories of `base` are
+        considered; otherwise matching directories at any depth are
+        yielded once (deduplicated).
+
+        The `pattern` argument matches the terminal name only; it must
+        not contain `/`.
+        """
+        if is_s3_filename(base):
+            bucket, prefix = s3_bucket_and_key(base)
+            prefix = prefix.rstrip("/") + "/" if prefix else ""
+            if current_async_backend() == "asyncio":
+                client = await self.s3_client_async()
+                paginator = client.get_paginator("list_objects_v2")
+                if not recursive:
+                    async for page in paginator.paginate(
+                        Bucket=bucket, Prefix=prefix, Delimiter="/"
+                    ):
+                        for cp in page.get("CommonPrefixes", []):
+                            cp_key = cp["Prefix"]
+                            name = cp_key.rstrip("/").rsplit("/", 1)[-1]
+                            if fnmatchcase(name, pattern):
+                                yield f"s3://{bucket}/{cp_key}"
+                else:
+                    base_depth = len(prefix.rstrip("/").split("/")) if prefix else 0
+                    seen: set[str] = set()
+                    async for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+                        for obj in page.get("Contents", []):
+                            key = obj["Key"]
+                            parts = key.split("/")
+                            for i in range(base_depth, len(parts) - 1):
+                                if fnmatchcase(parts[i], pattern):
+                                    dir_path = "/".join(parts[: i + 1])
+                                    if dir_path not in seen:
+                                        seen.add(dir_path)
+                                        yield f"s3://{bucket}/{dir_path}/"
+            else:
+                results = await anyio.to_thread.run_sync(
+                    s3_iter_dirs,
+                    self.s3_client(),
+                    bucket,
+                    prefix,
+                    pattern,
+                    recursive,
+                )
+                for r in results:
+                    yield r
+        else:
+            fs = filesystem(base).fs
+            if not recursive:
+                for entry in fs.ls(base, detail=True):
+                    if entry["type"] == "directory":
+                        name = entry["name"]
+                        terminal = name.rstrip("/").rsplit("/", 1)[-1]
+                        if fnmatchcase(terminal, pattern):
+                            yield name.rstrip("/") + "/"
+            else:
+                for dirpath, dirnames, _ in fs.walk(base):
+                    for dirname in dirnames:
+                        if fnmatchcase(dirname, pattern):
+                            yield f"{dirpath.rstrip('/')}/{dirname}/"
+
     @override
     async def __aenter__(self) -> "AsyncFilesystem":
         existing = _current_async_fs.get()
@@ -485,6 +606,50 @@ def s3_write_file_streaming(s3: Any, bucket: str, key: str, source: BinaryIO) ->
 
 def s3_get_file(s3: Any, bucket: str, key: str, filename: str) -> None:
     s3.download_file(Bucket=bucket, Key=key, Filename=filename)
+
+
+def s3_iter_files(
+    s3: Any, bucket: str, prefix: str, pattern: str, recursive: bool
+) -> list[str]:
+    paginator = s3.get_paginator("list_objects_v2")
+    kwargs: dict[str, Any] = {"Bucket": bucket, "Prefix": prefix}
+    if not recursive:
+        kwargs["Delimiter"] = "/"
+    results: list[str] = []
+    for page in paginator.paginate(**kwargs):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if fnmatchcase(key.rsplit("/", 1)[-1], pattern):
+                results.append(f"s3://{bucket}/{key}")
+    return results
+
+
+def s3_iter_dirs(
+    s3: Any, bucket: str, prefix: str, pattern: str, recursive: bool
+) -> list[str]:
+    paginator = s3.get_paginator("list_objects_v2")
+    results: list[str] = []
+    if not recursive:
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/"):
+            for cp in page.get("CommonPrefixes", []):
+                cp_key = cp["Prefix"]
+                name = cp_key.rstrip("/").rsplit("/", 1)[-1]
+                if fnmatchcase(name, pattern):
+                    results.append(f"s3://{bucket}/{cp_key}")
+    else:
+        base_depth = len(prefix.rstrip("/").split("/")) if prefix else 0
+        seen: set[str] = set()
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                key = obj["Key"]
+                parts = key.split("/")
+                for i in range(base_depth, len(parts) - 1):
+                    if fnmatchcase(parts[i], pattern):
+                        dir_path = "/".join(parts[: i + 1])
+                        if dir_path not in seen:
+                            seen.add(dir_path)
+                            results.append(f"s3://{bucket}/{dir_path}/")
+    return results
 
 
 def s3_exists(s3: Any, bucket: str, key: str) -> bool:

--- a/src/inspect_ai/_util/event_loop_monitor.py
+++ b/src/inspect_ai/_util/event_loop_monitor.py
@@ -1,0 +1,86 @@
+"""Background watchdog that detects event loop stalls.
+
+Wakes up at a fixed cadence and logs whenever the actual wake-up
+arrives later than expected by more than a threshold. Useful for
+catching sync I/O or other blocking work that's pinning the loop.
+
+Usage:
+    from inspect_ai._util.event_loop_monitor import event_loop_monitor
+
+    async with event_loop_monitor():
+        await do_work()
+
+    # Custom cadence/threshold (seconds):
+    async with event_loop_monitor(interval=0.05, threshold=0.25):
+        await do_work()
+
+`interval` controls how often the watchdog checks the loop; `threshold`
+is the lateness (in seconds) above which a warning is logged. Warnings
+go to the module logger (`inspect_ai._util.event_loop_monitor`) at
+WARNING level — ensure logging is configured to surface them.
+"""
+
+import asyncio
+import logging
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass
+from typing import AsyncIterator
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _EventLoopMonitor:
+    """Handle for a running event-loop monitor task."""
+
+    _task: asyncio.Task[None]
+    _stop: asyncio.Event
+
+    async def stop(self) -> None:
+        self._stop.set()
+        await self._task
+
+
+async def _monitor_loop(interval: float, threshold: float, stop: asyncio.Event) -> None:
+    next_tick = time.monotonic()
+    while not stop.is_set():
+        next_tick += interval
+        delay = next_tick - time.monotonic()
+        if delay > 0:
+            await asyncio.sleep(delay)
+        if stop.is_set():
+            return
+        lateness = time.monotonic() - next_tick
+        if lateness > threshold:
+            logger.warning(
+                "event loop blocked for ~%.0fms (threshold=%.0fms)",
+                lateness * 1000,
+                threshold * 1000,
+            )
+            # Reset baseline so a single stall doesn't generate
+            # a cascade of catch-up warnings.
+            next_tick = time.monotonic()
+
+
+def _start_event_loop_monitor(
+    interval: float = 0.1,
+    threshold: float = 1.0,
+) -> _EventLoopMonitor:
+    """Start a background monitor; returns a handle for stopping."""
+    stop = asyncio.Event()
+    task = asyncio.create_task(_monitor_loop(interval, threshold, stop))
+    return _EventLoopMonitor(_task=task, _stop=stop)
+
+
+@asynccontextmanager
+async def event_loop_monitor(
+    interval: float = 0.1,
+    threshold: float = 1.0,
+) -> AsyncIterator[None]:
+    """Scoped event-loop monitor."""
+    monitor = _start_event_loop_monitor(interval, threshold)
+    try:
+        yield
+    finally:
+        await monitor.stop()

--- a/src/inspect_ai/_util/s3_monitor.py
+++ b/src/inspect_ai/_util/s3_monitor.py
@@ -1,0 +1,181 @@
+"""Optional S3 traffic monitor for saturation diagnostics.
+
+Enabled by setting ``INSPECT_S3_MONITOR=1`` (or ``true``/``yes``). When
+enabled, monkey-patches ``AsyncFilesystem._create_s3_client_async`` so
+that every newly-created aioboto3 S3 client (across all
+``AsyncFilesystem`` instances in this process) has ``before-call`` /
+``after-call`` event hooks attached. Counters accumulate into a single
+per-process ``S3Stats``; a background ticker prints a snapshot every
+``interval`` seconds and a FINAL summary on exit.
+
+Useful signals:
+- ``in_flight`` and ``peak`` vs. ``max_pool_connections`` (50 by default)
+  tell you whether you're saturating the connection pool.
+- ``MB/s`` vs. expected S3 bandwidth tells you whether you're saturating
+  the network.
+- ``ops`` distribution shows which operations are doing the work.
+"""
+
+import asyncio
+import os
+import threading
+import time
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any, AsyncIterator
+
+from .asyncfiles import AsyncFilesystem
+
+_ENABLED_ENV = "INSPECT_S3_MONITOR"
+
+
+def s3_monitor_enabled() -> bool:
+    """True if the INSPECT_S3_MONITOR env var is set to a truthy value."""
+    return os.getenv(_ENABLED_ENV, "").lower() in ("1", "true", "yes")
+
+
+@dataclass
+class S3Stats:
+    """Mutable S3 traffic counters. Internally locked for thread safety."""
+
+    label: str = ""
+    in_flight: int = 0
+    peak_in_flight: int = 0
+    total_requests: int = 0
+    total_response_bytes: int = 0
+    started_at: float = field(default_factory=time.monotonic)
+    by_operation: dict[str, int] = field(default_factory=dict)
+    _lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+def _attach_hooks(client: Any, stats: S3Stats) -> None:
+    """Register before-call/after-call event hooks on a boto3/aioboto3 client.
+
+    Handlers accept ``**kwargs`` because the hook system passes keyword
+    args that vary by event (``model``, ``params``, ``parsed``, etc.);
+    the operation name comes from ``model.name`` rather than a dedicated
+    kwarg.
+    """
+
+    def _before_call(**kwargs: Any) -> None:
+        model = kwargs.get("model")
+        op_name = getattr(model, "name", "unknown") if model is not None else "unknown"
+        with stats._lock:
+            stats.in_flight += 1
+            if stats.in_flight > stats.peak_in_flight:
+                stats.peak_in_flight = stats.in_flight
+            stats.total_requests += 1
+            stats.by_operation[op_name] = stats.by_operation.get(op_name, 0) + 1
+
+    def _after_call(**kwargs: Any) -> None:
+        parsed = kwargs.get("parsed")
+        with stats._lock:
+            if stats.in_flight > 0:
+                stats.in_flight -= 1
+            if isinstance(parsed, dict):
+                headers = parsed.get("ResponseMetadata", {}).get("HTTPHeaders", {})
+                cl = headers.get("content-length")
+                if cl:
+                    try:
+                        stats.total_response_bytes += int(cl)
+                    except (ValueError, TypeError):
+                        pass
+
+    client.meta.events.register("before-call.s3.*", _before_call)
+    client.meta.events.register("after-call.s3.*", _after_call)
+
+
+# Module-level (per-process) state for the monkey-patch
+_patch_installed = False
+_current_stats: S3Stats | None = None
+_orig_create_s3_client_async: Any = None
+
+
+def _ensure_patched() -> None:
+    """Idempotently monkey-patch AsyncFilesystem._create_s3_client_async.
+
+    The wrapper invokes the original factory, then attaches event hooks
+    that route into the current ``_current_stats``. Each process patches
+    once on first use.
+    """
+    global _patch_installed, _orig_create_s3_client_async
+    if _patch_installed:
+        return
+    _patch_installed = True
+    _orig_create_s3_client_async = AsyncFilesystem._create_s3_client_async
+
+    async def _wrapped(anonymous: bool = False, region_name: str | None = None) -> Any:
+        client = await _orig_create_s3_client_async(
+            anonymous=anonymous, region_name=region_name
+        )
+        if _current_stats is not None:
+            _attach_hooks(client, _current_stats)
+        return client
+
+    # Intentional monkey-patch for diagnostics; mypy flags it as
+    # method-assign which is expected here.
+    AsyncFilesystem._create_s3_client_async = staticmethod(_wrapped)  # type: ignore[method-assign]
+
+
+def _format(stats: S3Stats, *, final: bool = False) -> str:
+    elapsed = time.monotonic() - stats.started_at
+    with stats._lock:
+        mb = stats.total_response_bytes / 1e6
+        mbps = mb / elapsed if elapsed > 0 else 0.0
+        ops = dict(stats.by_operation)
+        in_flight = stats.in_flight
+        peak = stats.peak_in_flight
+        total = stats.total_requests
+    label_str = f"{stats.label} " if stats.label else ""
+    prefix = "FINAL " if final else ""
+    return (
+        f"[S3 monitor] {prefix}{label_str}"
+        f"t={elapsed:5.1f}s "
+        f"in_flight={in_flight} peak={peak} "
+        f"reqs={total} recv={mb:.1f}MB ({mbps:.1f}MB/s) "
+        f"ops={ops}"
+    )
+
+
+async def _ticker(stats: S3Stats, interval: float, stop: asyncio.Event) -> None:
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            pass
+        if stop.is_set():
+            return
+        print(_format(stats), flush=True)
+
+
+@asynccontextmanager
+async def monitor_s3_traffic(
+    *, interval: float = 1.0, label: str = ""
+) -> AsyncIterator[S3Stats | None]:
+    """No-op unless INSPECT_S3_MONITOR is set.
+
+    Installs a per-process monkey-patch on first use that attaches event
+    hooks to every newly-created aioboto3 S3 client. Within a process
+    only one monitor scope should be active at a time.
+    """
+    if not s3_monitor_enabled():
+        yield None
+        return
+
+    global _current_stats
+    stats = S3Stats(label=label)
+    _current_stats = stats
+    _ensure_patched()
+
+    stop = asyncio.Event()
+    task = asyncio.create_task(_ticker(stats, interval, stop))
+    try:
+        yield stats
+    finally:
+        stop.set()
+        try:
+            await task
+        except Exception:
+            pass
+        print(_format(stats, final=True), flush=True)
+        _current_stats = None

--- a/tests/util/test_asyncfiles.py
+++ b/tests/util/test_asyncfiles.py
@@ -485,6 +485,312 @@ def test_exists_s3_false(mock_s3: None) -> None:
 
 
 # =============================================================================
+# Tests for iter_files() and iter_dirs()
+# =============================================================================
+
+
+async def _collect(it):
+    return [x async for x in it]
+
+
+def _make_local_tree(root: Path) -> None:
+    """Create a fixture tree for iter_files/iter_dirs tests.
+
+    root/
+      a.txt
+      b.log
+      sub1/
+        c.txt
+        d.log
+        deep/
+          e.txt
+      sub2/
+        f.txt
+    """
+    (root / "a.txt").write_bytes(b"a")
+    (root / "b.log").write_bytes(b"b")
+    (root / "sub1").mkdir()
+    (root / "sub1" / "c.txt").write_bytes(b"c")
+    (root / "sub1" / "d.log").write_bytes(b"d")
+    (root / "sub1" / "deep").mkdir()
+    (root / "sub1" / "deep" / "e.txt").write_bytes(b"e")
+    (root / "sub2").mkdir()
+    (root / "sub2" / "f.txt").write_bytes(b"f")
+
+
+async def test_iter_files_local_one_level() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_files(str(root)))
+            names = sorted(Path(p).name for p in paths)
+            assert names == ["a.txt", "b.log"]
+
+
+async def test_iter_files_local_pattern() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_files(str(root), "*.txt"))
+            names = sorted(Path(p).name for p in paths)
+            assert names == ["a.txt"]
+
+
+async def test_iter_files_local_recursive() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_files(str(root), "*.txt", recursive=True))
+            names = sorted(Path(p).name for p in paths)
+            assert names == ["a.txt", "c.txt", "e.txt", "f.txt"]
+
+
+async def test_iter_files_local_empty_result() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_files(str(root), "*.nope", recursive=True))
+            assert paths == []
+
+
+async def test_iter_files_local_question_mark_pattern() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "a1.txt").write_bytes(b"")
+        (root / "a2.txt").write_bytes(b"")
+        (root / "ab.txt").write_bytes(b"")
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_files(str(root), "a?.txt"))
+            names = sorted(Path(p).name for p in paths)
+            assert names == ["a1.txt", "a2.txt", "ab.txt"]
+
+
+async def test_iter_files_local_bracket_pattern() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "a1.txt").write_bytes(b"")
+        (root / "a2.txt").write_bytes(b"")
+        (root / "ab.txt").write_bytes(b"")
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_files(str(root), "a[12].txt"))
+            names = sorted(Path(p).name for p in paths)
+            assert names == ["a1.txt", "a2.txt"]
+
+
+async def test_iter_dirs_local_one_level() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_dirs(str(root)))
+            terminal = sorted(p.rstrip("/").rsplit("/", 1)[-1] for p in paths)
+            assert terminal == ["sub1", "sub2"]
+            for p in paths:
+                assert p.endswith("/")
+
+
+async def test_iter_dirs_local_pattern() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_dirs(str(root), "sub1"))
+            terminal = sorted(p.rstrip("/").rsplit("/", 1)[-1] for p in paths)
+            assert terminal == ["sub1"]
+
+
+async def test_iter_dirs_local_recursive() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_dirs(str(root), "*", recursive=True))
+            terminal = sorted(p.rstrip("/").rsplit("/", 1)[-1] for p in paths)
+            assert terminal == ["deep", "sub1", "sub2"]
+
+
+async def test_iter_dirs_local_recursive_pattern() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_dirs(str(root), "deep", recursive=True))
+            terminal = sorted(p.rstrip("/").rsplit("/", 1)[-1] for p in paths)
+            assert terminal == ["deep"]
+
+
+async def test_iter_dirs_local_empty() -> None:
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        (root / "a.txt").write_bytes(b"")
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_dirs(str(root)))
+            assert paths == []
+
+
+async def test_iter_files_local_excludes_dirs() -> None:
+    """iter_files at one level returns only files, not dirs."""
+    with tempfile.TemporaryDirectory() as d:
+        root = Path(d)
+        _make_local_tree(root)
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_files(str(root)))
+            for p in paths:
+                assert not p.endswith("/")
+                assert Path(p).is_file()
+
+
+def test_iter_files_s3_one_level(mock_s3: None) -> None:
+    base = f"{S3_BUCKET}/iter_test_files_1lvl"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(f"{base}/a.txt", b"a")
+            await fs.write_file(f"{base}/b.log", b"b")
+            await fs.write_file(f"{base}/sub/c.txt", b"c")
+            paths = await _collect(fs.iter_files(base))
+            assert sorted(paths) == [
+                f"{base}/a.txt",
+                f"{base}/b.log",
+            ]
+
+    asyncio.run(run())
+
+
+def test_iter_files_s3_pattern(mock_s3: None) -> None:
+    base = f"{S3_BUCKET}/iter_test_files_pat"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(f"{base}/a.txt", b"a")
+            await fs.write_file(f"{base}/b.log", b"b")
+            paths = await _collect(fs.iter_files(base, "*.txt"))
+            assert sorted(paths) == [f"{base}/a.txt"]
+
+    asyncio.run(run())
+
+
+def test_iter_files_s3_recursive(mock_s3: None) -> None:
+    base = f"{S3_BUCKET}/iter_test_files_rec"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(f"{base}/a.txt", b"a")
+            await fs.write_file(f"{base}/sub/b.txt", b"b")
+            await fs.write_file(f"{base}/sub/deep/c.txt", b"c")
+            await fs.write_file(f"{base}/sub/d.log", b"d")
+            paths = await _collect(fs.iter_files(base, "*.txt", recursive=True))
+            assert sorted(paths) == [
+                f"{base}/a.txt",
+                f"{base}/sub/b.txt",
+                f"{base}/sub/deep/c.txt",
+            ]
+
+    asyncio.run(run())
+
+
+def test_iter_files_s3_missing_prefix(mock_s3: None) -> None:
+    """Missing prefix returns empty iterator (not an error)."""
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(
+                fs.iter_files(f"{S3_BUCKET}/never_existed", recursive=True)
+            )
+            assert paths == []
+
+    asyncio.run(run())
+
+
+def test_iter_files_s3_pagination(mock_s3: None) -> None:
+    """Pagination: >1000 keys must all be returned."""
+    base = f"{S3_BUCKET}/iter_test_files_page"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            for i in range(1050):
+                await fs.write_file(f"{base}/k{i:04d}.txt", b"x")
+            paths = await _collect(fs.iter_files(base, recursive=True))
+            assert len(paths) == 1050
+
+    asyncio.run(run())
+
+
+def test_iter_dirs_s3_one_level(mock_s3: None) -> None:
+    base = f"{S3_BUCKET}/iter_test_dirs_1lvl"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(f"{base}/sub1/a.txt", b"a")
+            await fs.write_file(f"{base}/sub1/b.txt", b"b")
+            await fs.write_file(f"{base}/sub2/c.txt", b"c")
+            await fs.write_file(f"{base}/file.txt", b"f")
+            paths = await _collect(fs.iter_dirs(base))
+            assert sorted(paths) == [f"{base}/sub1/", f"{base}/sub2/"]
+            for p in paths:
+                assert p.endswith("/")
+
+    asyncio.run(run())
+
+
+def test_iter_dirs_s3_recursive_dedup(mock_s3: None) -> None:
+    """Recursive: dir with many files yields once."""
+    base = f"{S3_BUCKET}/iter_test_dirs_dedup"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            for i in range(5):
+                await fs.write_file(f"{base}/sub/f{i}.txt", b"x")
+            paths = await _collect(fs.iter_dirs(base, "sub", recursive=True))
+            assert paths == [f"{base}/sub/"]
+
+    asyncio.run(run())
+
+
+def test_iter_dirs_s3_recursive_depth(mock_s3: None) -> None:
+    base = f"{S3_BUCKET}/iter_test_dirs_depth"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(f"{base}/sub1/deep/a.txt", b"a")
+            await fs.write_file(f"{base}/sub2/b.txt", b"b")
+            paths = await _collect(fs.iter_dirs(base, "*", recursive=True))
+            assert sorted(paths) == [
+                f"{base}/sub1/",
+                f"{base}/sub1/deep/",
+                f"{base}/sub2/",
+            ]
+
+    asyncio.run(run())
+
+
+def test_iter_dirs_s3_recursive_excludes_ancestors(mock_s3: None) -> None:
+    """Recursive iter_dirs must NOT yield ancestors of base."""
+    base = f"{S3_BUCKET}/iter_test_dirs_anc/nested"
+
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            await fs.write_file(f"{base}/inner/a.txt", b"a")
+            paths = await _collect(fs.iter_dirs(base, "*", recursive=True))
+            assert paths == [f"{base}/inner/"]
+
+    asyncio.run(run())
+
+
+def test_iter_dirs_s3_empty(mock_s3: None) -> None:
+    async def run() -> None:
+        async with AsyncFilesystem() as fs:
+            paths = await _collect(fs.iter_dirs(f"{S3_BUCKET}/iter_test_dirs_empty"))
+            assert paths == []
+
+    asyncio.run(run())
+
+
+# =============================================================================
 # Tests for AsyncFilesystem sharing via ContextVar
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Adds two async list primitives to `AsyncFilesystem`:

- `iter_files(base, pattern="*", *, recursive=False) -> AsyncIterator[str]`
- `iter_dirs(base, pattern="*", *, recursive=False) -> AsyncIterator[str]`

Pattern matches basename via `fnmatchcase` (case-sensitive). `recursive` flag controls one-level vs any-depth. Three branches per method: S3+asyncio (native aioboto3 paginator), S3+trio (sync paginator via `anyio.to_thread.run_sync`), non-S3 (sync fsspec, direct call — matching existing convention in this file).

Motivation: replaces places that currently call sync fsspec (`UPath.glob` / `UPath.rglob`) from async contexts.