### PR TITLE
Add responses_phase to openai-api provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Scoring: Add `pass_k` reducer for computing the probability that all `k` epoch attempts succeed (τ-bench reliability metric).
 - Model Roles: Preserve overrides of config when calling `get_model()` with `role`.
+- OpenAI Compatible: Add support for `responses_phase` parameter.
 
 ## 0.3.223 (18 May 2026)
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1249,6 +1249,8 @@ Or using the `eval()` function:
 eval("arc.py", model="openai-api/<provider>/<model>", model_args=dict(responses_api=True))
 ```
 
+When using the Responses API, `openai-api` also supports the `responses_phase` model arg to synthesize missing assistant message `phase` values when replaying Responses API histories.
+
 ### Tool Emulation {#tool-emulation-openai}
 
 When using OpenAI compatible model providers, tool calling support can be 'emulated' for models that don't yet support it. Use the `emulate_tools` model arg to force tool emulation:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -118,6 +118,10 @@ class OpenAICompatibleAPI(ModelAPI):
         self.emulate_tools = emulate_tools
         self.responses_api = responses_api
         self.responses_store = responses_store
+        responses_phase = model_args.pop("responses_phase", False)
+        if not isinstance(responses_phase, bool):
+            raise ValueError("responses_phase must be a bool")
+        self.responses_phase: bool = responses_phase
         if self.emulate_tools and self.responses_api:
             raise ValueError(
                 "emulate_tools is not compatible with using the responses_api"
@@ -188,7 +192,7 @@ class OpenAICompatibleAPI(ModelAPI):
                 prompt_cache_retention=NOT_GIVEN,
                 safety_identifier=NOT_GIVEN,
                 responses_store=self.responses_store,
-                synthesize_phase=False,
+                synthesize_phase=self.responses_phase,
                 model_info=ModelInfo(),
                 batcher=None,
                 handle_bad_request=self.handle_bad_request,

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import httpx
 import pytest
 from openai import APIStatusError
@@ -63,6 +65,40 @@ def test_strict_tools_default_true() -> None:
 
     tools = api.tools_to_openai([ToolInfo(name="test_tool", description="Test tool")])
     assert tools[0]["function"]["strict"] is True
+
+
+async def test_responses_phase_model_arg(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test responses_phase is an openai-api model arg, not an SDK arg."""
+    captured: dict[str, Any] = {}
+
+    async def mock_generate_responses(**kwargs: Any) -> ModelOutput:
+        captured.update(kwargs)
+        return ModelOutput.from_content(model="gpt-5", content="ok")
+
+    monkeypatch.setattr(
+        "inspect_ai.model._providers.openai_compatible.generate_responses",
+        mock_generate_responses,
+    )
+    api = OpenAICompatibleAPI(
+        model_name="openai-api/openai/gpt-5",
+        api_key="test",
+        base_url="https://example.com",
+        responses_api=True,
+        responses_phase=True,
+    )
+    try:
+        assert api.responses_phase is True
+        assert "responses_phase" not in api.model_args
+
+        await api.generate(
+            input=[ChatMessageUser(content="hi")],
+            tools=[],
+            tool_choice="auto",
+            config=GenerateConfig(),
+        )
+        assert captured["synthesize_phase"] is True
+    finally:
+        await api.aclose()
 
 
 @skip_if_no_openai


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The behavior addressed by `responses_phase` task variable is not available to `openai-api`.

### What is the new behavior?

Add the implementation of `responses_phase` from `openai` provider to `openai-api`. Now if a model exhibits similar behavioral characteristics in openai-api, the task variable can be provided to address them.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No