### PR TITLE
fix: preserve role model config defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Scoring: Add `pass_k` reducer for computing the probability that all `k` epoch attempts succeed (τ-bench reliability metric).
+- Model Roles: Preserve overrides of config when calling `get_model()` with `role`.
 
 ## 0.3.223 (18 May 2026)
 

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1622,6 +1622,10 @@ def get_model(
     if role is not None:
         model_for_role = model_roles().get(role, None)
         if model_for_role is not None:
+            if config.model_dump(exclude_none=True):
+                model_for_role = copy(model_for_role)
+                model_for_role.config = config.merge(model_for_role.config)
+                model_for_role._set_role(role)
             return model_for_role
 
         # raise if required and not found

--- a/tests/model/test_model_roles.py
+++ b/tests/model/test_model_roles.py
@@ -9,7 +9,7 @@ from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.dataset._dataset import Sample
 from inspect_ai.log._file import read_eval_log
 from inspect_ai.log._log import EvalLog
-from inspect_ai.model import Model, get_model
+from inspect_ai.model import GenerateConfig, Model, get_model
 from inspect_ai.solver import solver
 
 RED_TEAM = "red_team"
@@ -325,3 +325,33 @@ def test_model_role_merge_preserves_unspecified() -> None:
     model_events = [e for e in log.samples[0].events if e.event == "model"]
     reviewer_event = next(e for e in model_events if e.role == REVIEWER)
     assert reviewer_event.model == MOCK_B
+
+
+def test_model_role_merge_preserves_get_model_config_defaults() -> None:
+    """Role overrides should not drop defaults supplied at the get_model call site."""
+
+    @solver
+    def configured_grader_solver():
+        async def solve(state, generate):
+            model = get_model(
+                role=GRADER,
+                default=MOCK_A,
+                config=GenerateConfig(max_tokens=17, reasoning_effort="low"),
+            )
+            state.output = await model.generate(state.messages)
+            state.messages.append(state.output.message)
+            return state
+
+        return solve
+
+    log = eval(
+        Task(solver=configured_grader_solver()),
+        model_roles={GRADER: MOCK_B},
+    )[0]
+    assert log.status == "success"
+    check_model_role(log, GRADER, MOCK_B)
+
+    assert log.samples
+    model_event = next(e for e in log.samples[0].events if e.event == "model")
+    assert model_event.config.max_tokens == 17
+    assert model_event.config.reasoning_effort == "low"


### PR DESCRIPTION
## Summary

- Preserve get_model role call-site defaults when a model role override is supplied
- Merge the call-site GenerateConfig into a shallow copy of the role model so the shared role object is not mutated
- Add a mockllm regression test for issue #3665

Fixes #3665

## To verify

- .\.venv\Scripts\python.exe -m pytest tests\model\test_model_roles.py -q
- .\.venv\Scripts\python.exe -m pytest tests\model\test_model_roles.py tests\model\test_get_model.py -q
- .\.venv\Scripts\python.exe -m ruff check src\inspect_ai\model\_model.py tests\model\test_model_roles.py
- .\.venv\Scripts\python.exe -m ruff format --check src\inspect_ai\model\_model.py tests\model\test_model_roles.py
- git diff --check

The skipped tests in the local pytest runs were the existing real-provider/API-key or trio-gated cases.
