### PR TITLE
providers: surface api_key_vars as ClassVar for introspection

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass, field
 from logging import getLogger
 from typing import (
     Any,
+    ClassVar,
     Iterable,
     Literal,
     Sequence,
@@ -203,6 +204,12 @@ INTERNAL_COMPUTER_TOOL_NAME = "computer"
 
 
 class AnthropicAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (
+        ANTHROPIC_API_KEY,
+        AZUREAI_ANTHROPIC_API_KEY,
+        AZURE_ANTHROPIC_API_KEY,
+    )
+
     def __init__(
         self,
         model_name: str,
@@ -239,11 +246,7 @@ class AnthropicAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[
-                ANTHROPIC_API_KEY,
-                AZUREAI_ANTHROPIC_API_KEY,
-                AZURE_ANTHROPIC_API_KEY,
-            ],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -2,7 +2,7 @@ import functools
 import json
 import os
 from copy import copy
-from typing import Any
+from typing import Any, ClassVar
 
 from azure.ai.inference.aio import ChatCompletionsClient
 from azure.ai.inference.models import (
@@ -86,6 +86,8 @@ AZURE_ENDPOINT_URL = "AZURE_ENDPOINT_URL"
 
 
 class AzureAIAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (AZURE_API_KEY, AZUREAI_ENDPOINT_KEY)
+
     def __init__(
         self,
         model_name: str,
@@ -105,7 +107,7 @@ class AzureAIAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[AZURE_API_KEY, AZUREAI_ENDPOINT_KEY],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -1,7 +1,7 @@
 import base64
 import re
 from logging import getLogger
-from typing import Any, Literal, Tuple, Union, cast
+from typing import Any, ClassVar, Literal, Tuple, Union, cast
 
 from pydantic import BaseModel, Field
 from typing_extensions import override
@@ -253,6 +253,8 @@ class ConverseClientConverseRequest(BaseModel):
 
 
 class BedrockAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = ()
+
     def __init__(
         self,
         model_name: str,
@@ -265,7 +267,7 @@ class BedrockAPI(ModelAPI):
             model_name=model_name,
             base_url=model_base_url(base_url, "BEDROCK_BASE_URL"),
             api_key=api_key,
-            api_key_vars=[],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -7,7 +7,7 @@ from copy import copy
 from io import BytesIO
 from logging import getLogger
 from textwrap import dedent
-from typing import Any, Literal, NamedTuple, cast
+from typing import Any, ClassVar, Literal, NamedTuple, cast
 
 # SDK Docs: https://googleapis.github.io/python-genai/
 import anyio
@@ -171,6 +171,8 @@ class CategorizedTools(NamedTuple):
 
 
 class GoogleGenAIAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (GOOGLE_API_KEY, VERTEX_API_KEY)
+
     def __init__(
         self,
         model_name: str,
@@ -184,7 +186,7 @@ class GoogleGenAIAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[GOOGLE_API_KEY, VERTEX_API_KEY],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -2,7 +2,7 @@ import json
 import os
 import time
 from copy import copy
-from typing import Any, Literal, cast
+from typing import Any, ClassVar, Literal, cast
 
 import grpc
 from google.protobuf.json_format import MessageToDict
@@ -79,6 +79,8 @@ GROK_BASE_URL = "GROK_BASE_URL"
 
 
 class GrokAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (XAI_API_KEY, GROK_API_KEY)
+
     def __init__(
         self,
         model_name: str,
@@ -93,7 +95,7 @@ class GrokAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[XAI_API_KEY, GROK_API_KEY],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -1,7 +1,7 @@
 import json
 import os
 from copy import copy
-from typing import Any, Dict, Iterable, List, Optional
+from typing import Any, ClassVar, Dict, Iterable, List, Optional
 
 import httpx
 from groq import (
@@ -67,6 +67,8 @@ GROQ_API_KEY = "GROQ_API_KEY"
 
 
 class GroqAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (GROQ_API_KEY,)
+
     def __init__(
         self,
         model_name: str,
@@ -79,7 +81,7 @@ class GroqAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[GROQ_API_KEY],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 from logging import getLogger
 from queue import Empty, Queue
 from threading import Thread
-from typing import Any, Literal, Protocol, cast
+from typing import Any, ClassVar, Literal, Protocol, cast
 
 import anyio
 import numpy as np
@@ -60,6 +60,8 @@ HF_TOKEN = "HF_TOKEN"
 
 
 class HuggingFaceAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (HF_TOKEN,)
+
     def __init__(
         self,
         model_name: str,
@@ -72,7 +74,7 @@ class HuggingFaceAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[HF_TOKEN],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -1,7 +1,7 @@
 import functools
 import json
 import os
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from mistralai.client import Mistral
 from mistralai.client.errors import SDKError
@@ -93,6 +93,12 @@ AZURE_MISTRAL_BASE_URL_VARS = ["AZUREAI_MISTRAL_BASE_URL", "AZURE_MISTRAL_BASE_U
 
 
 class MistralAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (
+        MISTRAL_API_KEY,
+        AZURE_MISTRAL_API_KEY,
+        AZUREAI_MISTRAL_API_KEY,
+    )
+
     def __init__(
         self,
         model_name: str,
@@ -113,11 +119,7 @@ class MistralAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[
-                MISTRAL_API_KEY,
-                AZURE_MISTRAL_API_KEY,
-                AZUREAI_MISTRAL_API_KEY,
-            ],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/nnterp.py
+++ b/src/inspect_ai/model/_providers/nnterp.py
@@ -1,6 +1,6 @@
 import gc
 import time
-from typing import Any
+from typing import Any, ClassVar
 
 import torch  # type: ignore
 from nnterp import StandardizedTransformer  # type: ignore
@@ -30,6 +30,8 @@ from inspect_ai.tool import (
 
 
 class NNterpAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = ("HF_TOKEN",)
+
     def __init__(
         self,
         model_name: str,
@@ -42,7 +44,7 @@ class NNterpAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=["HF_TOKEN"],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -1,6 +1,6 @@
 import os
 from logging import getLogger
-from typing import Any
+from typing import Any, ClassVar
 
 import anyio
 from openai import (
@@ -74,6 +74,12 @@ AZURE_OPENAI_BASE_URL_VARS = [
 
 
 class OpenAIAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (
+        OPENAI_API_KEY,
+        AZURE_OPENAI_API_KEY,
+        AZUREAI_OPENAI_API_KEY,
+    )
+
     def __init__(
         self,
         model_name: str,
@@ -128,7 +134,7 @@ class OpenAIAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[OPENAI_API_KEY, AZURE_OPENAI_API_KEY, AZUREAI_OPENAI_API_KEY],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/sagemaker.py
+++ b/src/inspect_ai/model/_providers/sagemaker.py
@@ -1,6 +1,6 @@
 import json
 from logging import getLogger
-from typing import Any
+from typing import Any, ClassVar
 
 from botocore.config import Config  # type: ignore[import-untyped]
 from botocore.exceptions import ClientError  # type: ignore[import-untyped]
@@ -59,6 +59,8 @@ SAGEMAKER_RETRY_ERROR_CODES = {
 
 
 class SagemakerAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = ()
+
     def __init__(
         self,
         model_name: str,
@@ -69,7 +71,7 @@ class SagemakerAPI(ModelAPI):
             model_name=model_name,
             base_url=None,
             api_key=None,
-            api_key_vars=[],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -1,6 +1,6 @@
 import os
 from json import dumps
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import httpx
 from openai import APIStatusError
@@ -194,6 +194,8 @@ TOGETHER_API_KEY = "TOGETHER_API_KEY"
 
 
 class TogetherRESTAPI(ModelAPI):
+    API_KEY_VARS: ClassVar[tuple[str, ...]] = (TOGETHER_API_KEY,)
+
     def __init__(
         self,
         model_name: str,
@@ -212,7 +214,7 @@ class TogetherRESTAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[TOGETHER_API_KEY],
+            api_key_vars=list(self.API_KEY_VARS),
             config=config,
         )
 


### PR DESCRIPTION
Each provider now declares API_KEY_VARS as a class-level `ClassVar[tuple[str, ...]]` alongside the existing api_key_vars init-arg pattern.

The class attribute enables introspection of provider env-var requirements without instantiating the provider.    

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [X] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Programmatically reading the required env vars metadata requires initialisation of the provider (including runtime checks, optional dependencies, other random potential side effects)

### What is the new behavior?

Easier/safer to do introspection on a provider's env vars without init'ing --> triggering validation etc. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

AFAIK, no.

### Other information:

Somewhat related: there is some documentation drift in: https://github.com/UKGovernmentBEIS/inspect_ai/blob/main/docs/providers.qmd

^ this PR does not solve for it. But a couple stale vars missing from docs are `GROK_API_KEY`, `VERTEX_API_KEY`, `AZUREAI_ENDPOINT_KEY`, `AZURE_API_KEY`,  `AZURE_OPENAI_API_KEY`, `AZURE_ANTHROPIC_API_KEY`. 

