### PR TITLE
test: invoke inspect CLI directly in eval log config round-trip test

### DIFF
--- a/tests/log/test_eval_log_config.py
+++ b/tests/log/test_eval_log_config.py
@@ -118,8 +118,6 @@ def test_eval_log_run_config_round_trip() -> None:
 
         subprocess.run(
             [
-                "uv",
-                "run",
                 "inspect",
                 "eval",
                 "--run-config",


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip` shells out via `["uv", "run", "inspect", "eval", ...]`. This requires `uv` to be on `PATH`. inspect_ai's own CI installs `uv` via `astral-sh/setup-uv@v7`, so it passes there, but downstream test runners that install dependencies via pip (e.g. the meridianlabs `slow-tests` workflow) do not have `uv` available and the test fails with `FileNotFoundError: [Errno 2] No such file or directory: 'uv'`.

### What is the new behavior?

The test invokes `inspect` directly, matching the precedent set by other subprocess CLI tests in this repo (e.g. `tests/test_eval_config.py`). The `inspect` console script is already on `PATH` whenever the package is installed.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Test passes locally.