### PR TITLE
test: update OpenAI audio test to use gpt-audio model

### DIFF
--- a/tests/util/test_media.py
+++ b/tests/util/test_media.py
@@ -55,4 +55,4 @@ def test_media_google_video():
 
 @skip_if_no_openai
 def test_media_openai_audio():
-    check_audio("openai/gpt-4o-audio-preview")
+    check_audio("openai/gpt-audio")


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`tests/util/test_media.py::test_media_openai_audio` fails because OpenAI has retired `gpt-4o-audio-preview`. The API now returns:

```
NotFoundError: Error code: 404 - {'error': {'message': 'The model `gpt-4o-audio-preview` does not exist or you do not have access to it.', 'type': 'invalid_request_error', 'code': 'model_not_found'}}
```

### What is the new behavior?

The test points at `gpt-audio`, the GA successor (confirmed available in `GET /v1/models`). Verified passing locally.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information: