### PR TITLE
agent bridge: preserve wrapped OpenAI reasoning payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - OpenAI: Set `redacted=False` when reasoning content, summary, and encrypted exists.
 - OpenAI Compatible: Add support for `responses_phase` parameter.
 - OpenRouter: Strip reasoning_details replay for Gemini models (they currently cause a runtime error due to OpenRouter not handling the `id` properly).
+- Agent Bridge: Preserve wrapped OpenAI reasoning payloads.
 - Docker: Retry docker compose commands on BrokenResourceError.
 - Inspect View: Replaced the aiohttp server with a FastAPI server. `fastapi` and `uvicorn` are now required dependencies.
 

--- a/src/inspect_ai/model/_reasoning.py
+++ b/src/inspect_ai/model/_reasoning.py
@@ -48,6 +48,11 @@ def parse_content_with_reasoning(content: str) -> tuple[str, ReasoningCapsule | 
 
         # Extract nested <summary> tag from content
         reasoning, summary = _parse_summary(reasoning)
+        if redacted and signature and signature.startswith("rs_"):
+            # Redacted reasoning bodies carry opaque provider payloads such as
+            # encrypted_content. Some text scaffolds wrap long lines; whitespace
+            # inserted there is not part of the payload.
+            reasoning = re.sub(r"\s+", "", reasoning)
 
         # Remove the matched <think>...</think> from the input
         start, end = match.span()

--- a/tests/model/test_reasoning_parse.py
+++ b/tests/model/test_reasoning_parse.py
@@ -403,3 +403,17 @@ def test_reasoning_parse_with_invalid_internal_json():
     assert reasoning is not None
     assert reasoning.internal is None  # Invalid JSON should result in None
     assert reasoning.reasoning == "Reasoning"
+
+
+def test_reasoning_parse_redacted_collapses_wrapped_payload():
+    encrypted = "abcDEF123+/=" * 50
+    wrapped = "\n".join(encrypted[i : i + 17] for i in range(0, len(encrypted), 17))
+
+    content, reasoning = parse_content_with_reasoning(
+        f'<think signature="rs_123" redacted="true">\n{wrapped}\n</think>Content'
+    )
+
+    assert reasoning is not None
+    assert reasoning.reasoning == encrypted
+    assert reasoning.redacted is True
+    assert content == "Content"


### PR DESCRIPTION
﻿## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #3978

When redacted OpenAI Responses reasoning items are carried through a text scaffold, the `<think>` body contains the opaque `encrypted_content` payload. Some scaffolds can wrap long text before replay. For OpenAI reasoning item ids (`rs_*`), whitespace inserted into that opaque payload is not semantically meaningful text; it corrupts the encrypted blob and can surface later as `invalid_encrypted_content`.

### What is the new behavior?

When parsing a redacted `<think>` capsule whose signature is an OpenAI reasoning item id (`rs_*`), whitespace inside the restored reasoning payload is removed. Non-OpenAI redacted reasoning keeps the existing behavior, so human-readable redacted tests and non-`rs_*` signatures are unchanged.

A regression test covers a wrapped encrypted-style payload and verifies that it is restored byte-for-byte after removing scaffold line breaks.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### To verify
- `uv run pytest tests\model\test_reasoning_parse.py -q`
- `uv run ruff check src\inspect_ai\model\_reasoning.py tests\model\test_reasoning_parse.py`
- `uv run ruff format --check src\inspect_ai\model\_reasoning.py tests\model\test_reasoning_parse.py`
- `python -m py_compile src\inspect_ai\model\_reasoning.py tests\model\test_reasoning_parse.py`
