### PR TITLE
Scope adaptive connection pool per-model for Anthropic/OpenAI/Google

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -989,7 +989,11 @@ class AnthropicAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        return str(self.api_key)
+        # Anthropic rate-limits per (org, model) on TPM/RPM, so each model
+        # gets its own adaptive controller — otherwise a tight-quota model
+        # (e.g. sonnet under heavy TPM) throttles loose-quota models (opus)
+        # sharing the same key.
+        return f"{self.api_key}:{self.service_model_name()}"
 
     def service_model_name(self) -> str:
         """Model name without any service prefix."""

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -989,10 +989,7 @@ class AnthropicAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        # Anthropic rate-limits per (org, model) on TPM/RPM, so each model
-        # gets its own adaptive controller — otherwise a tight-quota model
-        # (e.g. sonnet under heavy TPM) throttles loose-quota models (opus)
-        # sharing the same key.
+        """Anthropic rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
         return f"{self.api_key}:{self.service_model_name()}"
 
     def service_model_name(self) -> str:

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -704,8 +704,12 @@ class GoogleGenAIAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        """Scope for enforcing max_connections."""
-        return str(self.api_key)
+        """Scope for enforcing max_connections.
+
+        Google rate-limits per model, so each model gets its own adaptive
+        controller rather than one shared per key.
+        """
+        return f"{self.api_key}:{self.model_name}"
 
     @override
     def tool_result_images(self) -> bool:

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -704,11 +704,7 @@ class GoogleGenAIAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        """Scope for enforcing max_connections.
-
-        Google rate-limits per model, so each model gets its own adaptive
-        controller rather than one shared per key.
-        """
+        """Google rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
         return f"{self.api_key}:{self.model_name}"
 
     @override

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -304,12 +304,8 @@ class GrokAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        """Scope max_connections per API key.
-
-        Without this override Grok would inherit the default `"default"` and
-        every Grok request would globally share one concurrency slot.
-        """
-        return str(self.api_key)
+        """xAI rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
+        return f"{self.api_key}:{self.model_name}"
 
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, grpc.RpcError):

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -304,7 +304,7 @@ class GrokAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        """xAI rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
+        """Scope per (key, model) since xAI rate-limits per model, not per key."""
         return f"{self.api_key}:{self.model_name}"
 
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -257,7 +257,8 @@ class GroqAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        return str(self.api_key)
+        """Groq rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
+        return f"{self.api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -283,7 +283,8 @@ class MistralAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        return str(self.api_key)
+        """Mistral rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
+        return f"{self.api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -488,11 +488,7 @@ class OpenAIAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        """Scope for enforcing max_connections.
-
-        OpenAI rate-limits per model (RPM/TPM), so each model gets its own
-        adaptive controller rather than one shared per key.
-        """
+        """OpenAI rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
         return f"{self.api_key}:{self.model_name}"
 
     @override

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -488,8 +488,12 @@ class OpenAIAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        """Scope for enforcing max_connections (could also use endpoint)."""
-        return str(self.api_key)
+        """Scope for enforcing max_connections.
+
+        OpenAI rate-limits per model (RPM/TPM), so each model gets its own
+        adaptive controller rather than one shared per key.
+        """
+        return f"{self.api_key}:{self.model_name}"
 
     @override
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -323,8 +323,8 @@ class OpenAICompatibleAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        """Scope for enforcing max_connections (could also use endpoint)."""
-        return str(self.api_key)
+        """Most backends rate-limit per model, so each model gets its own adaptive controller rather than one shared per key."""
+        return f"{self.api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -298,10 +298,10 @@ class TogetherRESTAPI(ModelAPI):
             return ex.response.status_code == 401
         return False
 
-    # cloudflare enforces rate limits by model for each account
     @override
     def connection_key(self) -> str:
-        return f"{self.api_key}"
+        """Together rate-limits per model, so each model gets its own adaptive controller rather than one shared per key."""
+        return f"{self.api_key}:{self.model_name}"
 
     # Together uses a default of 512 so we bump it up
     @override


### PR DESCRIPTION
## Summary

`AnthropicAPI.connection_key()` (and OpenAI/Google) currently returns `str(self.api_key)`, so all models on one key share a single `AdaptiveConcurrencyController`. In a multi-model task (e.g. `target=claude-opus-4-6`, `auditor=claude-sonnet-4-6`), 429s from the tighter-quota model call `controller.report_retry()` and throttle the looser one — we observed opus pinned at ~7 conn while sonnet was TPM-bound, despite opus having 100+ headroom on the same key.

These providers all rate-limit **per model** (TPM/RPM), not per key, so per-key client-side pooling is over-conservative. This change includes the model name in `connection_key()`, matching what `azureai.py:318`, `bedrock.py:313`, `sagemaker.py:135`, and `cloudflare.py:62` already do.

The display (`_concurrency.py:280-302`) and log history (`_eval/task/log.py:410-424`) already key on the controller's `name` (model string), so multiple controllers per provider render as separate model rows with no other changes needed.

## Test plan
- [x] Verified empirically: same key, separate processes — opus-4-6 ran needham at 100 conn / 6 retries while sonnet-4-6 sat at 4 conn / 2300 retries (proxy limits per-model)
- [ ] Multi-model single-process eval with adaptive shows separate `anthropic/claude-opus-*` and `anthropic/claude-sonnet-*` rows in the connection display

🤖 Generated with [Claude Code](https://claude.com/claude-code)