### PR TITLE
fix(openrouter): strip reasoning_details replay for Gemini models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Model Roles: Preserve overrides of config when calling `get_model()` with `role`.
 - OpenAI: Set `redacted=False` when reasoning content, summary, and encrypted exists.
 - OpenAI Compatible: Add support for `responses_phase` parameter.
+- OpenRouter: Strip reasoning_details replay for Gemini models (they currently cause a runtime error due to OpenRouter not handling the `id` properly).
 - Docker: Retry docker compose commands on BrokenResourceError.
 - Inspect View: Replaced the aiohttp server with a FastAPI server. `fastapi` and `uvicorn` are now required dependencies.
 

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -218,10 +218,25 @@ class OpenRouterAPI(OpenAICompatibleAPI):
     async def messages_to_openai(
         self, input: list[ChatMessage]
     ) -> list[ChatCompletionMessageParam]:
+        # For Gemini-family models, do not replay stored reasoning_details
+        # back to OpenRouter. Gemini's openai-compat translation produces
+        # reasoning_details whose `id` field is missing or stale relative to
+        # the new tool_calls[].id on sequential function-call retries; the
+        # upstream Gemini provider then rejects with HTTP 200 + body
+        # {code:400, message:"Provider returned error"} (raw upstream error:
+        # "function call ... missing a thought_signature"). Falling through
+        # to the `<think>` tag path keeps assistant CoT visible to the model
+        # without triggering signature validation. Non-Gemini providers
+        # (Anthropic / Grok / OpenAI reasoning models) retain reasoning
+        # replay since they require it for correct CoT continuation.
+        _strip_reasoning_details = "gemini" in self.model_name.lower()
+
         # convert reasoning_details to an extra body parameter
         def handle_reasoning_details(
             content: ContentReasoning,
         ) -> dict[str, JsonValue] | str:
+            if _strip_reasoning_details:
+                return reasoning_to_think_tag(content)
             details = reasoning_to_openrouter_reasoning_details(content)
             if details is not None:
                 return details

--- a/tests/model/providers/test_openrouter.py
+++ b/tests/model/providers/test_openrouter.py
@@ -291,3 +291,64 @@ def test_apply_cache_creation_usage_noop_when_no_call() -> None:
     assert output.usage is not None
     assert output.usage.input_tokens_cache_write is None
     assert output.usage.input_tokens == 500
+
+
+@pytest.mark.anyio
+async def test_messages_to_openai_strips_reasoning_details_for_gemini() -> None:
+    """Gemini-family models must not get reasoning_details replayed.
+
+    OpenRouter's openai-compat translation of Gemini sequential function-call
+    thoughtSignatures produces reasoning_details whose ``id`` is missing or
+    stale vs the new tool_calls[].id, causing HTTP 200 + body
+    ``{code:400, message:"Provider returned error"}`` (upstream Gemini
+    rejects with "function call ... missing a thought_signature"). The
+    provider should fall through to the ``<think>`` tag path for Gemini.
+    """
+    from inspect_ai._util.content import ContentReasoning
+    from inspect_ai.model._chat_message import ChatMessageAssistant
+    from inspect_ai.model._providers.openrouter import (
+        OPENROUTER_REASONING_DETAILS_SIGNATURE,
+    )
+
+    signature = OPENROUTER_REASONING_DETAILS_SIGNATURE + (
+        '[{"type": "reasoning.encrypted", "data": "ENCRYPTED", "id": "tool_X"}]'
+    )
+    msg = ChatMessageAssistant(
+        content=[ContentReasoning(reasoning="thinking...", signature=signature)],
+    )
+
+    api = _make_api("google/gemini-3-pro-preview")
+    converted = await api.messages_to_openai([msg])
+
+    # No reasoning_details echoed; content carries <think> tag instead.
+    payload = converted[0]
+    assert "reasoning_details" not in payload
+    content = payload.get("content")
+    if isinstance(content, list):
+        text = "".join(b.get("text", "") for b in content if isinstance(b, dict))
+    else:
+        text = content or ""
+    assert "<think" in text and "thinking..." in text and "</think>" in text
+
+
+@pytest.mark.anyio
+async def test_messages_to_openai_preserves_reasoning_details_for_non_gemini() -> None:
+    """Anthropic/Grok/OpenAI reasoning replay must be left intact."""
+    from inspect_ai._util.content import ContentReasoning
+    from inspect_ai.model._chat_message import ChatMessageAssistant
+    from inspect_ai.model._providers.openrouter import (
+        OPENROUTER_REASONING_DETAILS_SIGNATURE,
+    )
+
+    signature = OPENROUTER_REASONING_DETAILS_SIGNATURE + (
+        '[{"type": "reasoning.text", "text": "considered options", "id": "r1"}]'
+    )
+    msg = ChatMessageAssistant(
+        content=[ContentReasoning(reasoning="considered options", signature=signature)],
+    )
+
+    api = _make_api("anthropic/claude-sonnet-4-5")
+    converted = await api.messages_to_openai([msg])
+
+    payload = converted[0]
+    assert "reasoning_details" in payload


### PR DESCRIPTION
Fixes #3986.

## Summary

OpenRouter's openai-compat translation of Gemini sequential function-call thoughtSignatures produces `reasoning_details` whose `id` field is missing or stale relative to the new `tool_calls[].id` on tool-retry turns. Replaying those `reasoning_details` triggers Gemini-side signature validation, which OpenRouter surfaces as HTTP 200 + body `{code:400, message:"Provider returned error"}`. A single non-{429,408,500,502,504} OpenRouterError is fatal to the run, so this presents as sporadic batch aborts (~3–5%/sample) on Gemini reasoning models with tool use.

## Change

In `OpenRouterAPI.messages_to_openai`, route Gemini-family models through the existing `reasoning_to_think_tag` path instead of replaying stored `reasoning_details`. CoT continuity is preserved as inline `<think>` tags; signature validation no longer fires. Non-Gemini providers (Anthropic / Grok / OpenAI reasoning models) keep `reasoning_details` replay since they require it.

```python
_strip_reasoning_details = "gemini" in self.model_name.lower()

def handle_reasoning_details(content: ContentReasoning) -> dict[str, JsonValue] | str:
    if _strip_reasoning_details:
        return reasoning_to_think_tag(content)
    details = reasoning_to_openrouter_reasoning_details(content)
    ...
```

## Validation

Re-ran an agentic task that previously hit the 400 (3 epochs, agency=true, executive_assistant on `openrouter/google/gemini-3.1-pro-preview`): 3/3 samples completed, 0 model errors, no new entries in the request-dump log.

## Tests

Two new tests in `tests/model/providers/test_openrouter.py`:
- `test_messages_to_openai_strips_reasoning_details_for_gemini` — asserts no `reasoning_details` in outgoing payload, `<think>` tag carries CoT
- `test_messages_to_openai_preserves_reasoning_details_for_non_gemini` — asserts Anthropic models still get `reasoning_details`

`make check` and `pytest tests/model/providers/test_openrouter.py tests/model/test_reasoning_openrouter.py` pass.

## Caveats

- Lossy: Gemini no longer sees its prior encrypted reasoning blob; it redoes reasoning each turn. Acceptable trade-off vs aborted runs.
- A more invasive fix would teach the OpenRouter provider to rebind `reasoning_details[].id` to the current `tool_calls[].id` (mirroring native `_providers/google.py:1100-1141`'s `Part.thought_signature` handling), but the encrypted blob is cryptographically signed by Gemini — rewriting `id` does not necessarily revalidate. The strip path is the smallest change that restores correctness.

## Test plan

- [x] `make check` (ruff lint + format) on touched files
- [x] `pytest tests/model/providers/test_openrouter.py tests/model/test_reasoning_openrouter.py` — 17 pass, 2 skipped (trio-only)
- [x] End-to-end: 3-epoch agentic run on `openrouter/google/gemini-3.1-pro-preview`, no 400s

🤖 Generated with [Claude Code](https://claude.com/claude-code)