### PR TITLE
anthropic: convert mid-stream content_filter APIStatusError to refusal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Model Roles: Preserve overrides of config when calling `get_model()` with `role`.
 - OpenAI: Set `redacted=False` when reasoning content, summary, and encrypted exists.
 - OpenAI Compatible: Add support for `responses_phase` parameter.
+- Anthropic: Convert mid-stream content_filter APIStatusError to refusal.
 - Google: Add a default 1 hour SDK transport timeout for GenAI requests.
 - OpenRouter: Strip reasoning_details replay for Gemini models (they currently cause a runtime error due to OpenRouter not handling the `id` properly).
 - Agent Bridge: Preserve wrapped OpenAI reasoning payloads.

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -525,8 +525,14 @@ class AnthropicAPI(ModelAPI):
                     stop_reason="model_length",
                     error=ex.message,
                 ), model_call or ModelCall(request={})
-            else:
-                raise ex
+            # Content-filter errors that arrive mid-stream surface as a plain
+            # APIStatusError (the SDK can't infer the 400 subclass once the
+            # HTTP response was 200), so route through handle_bad_request to
+            # convert them into a content_filter refusal.
+            handled = self.handle_bad_request(ex)
+            if isinstance(handled, ModelOutput):
+                return handled, model_call or ModelCall(request={})
+            raise ex
 
     @override
     async def count_tokens(
@@ -1078,8 +1084,8 @@ class AnthropicAPI(ModelAPI):
     def force_reasoning_history(self) -> Literal["none", "all", "last"] | None:
         return "all"
 
-    # convert some common BadRequestError states into 'refusal' model output
-    def handle_bad_request(self, ex: BadRequestError) -> ModelOutput | Exception:
+    # convert some common APIStatusError states into 'refusal' model output
+    def handle_bad_request(self, ex: APIStatusError) -> ModelOutput | Exception:
         error = exception_message(ex).lower()
         content: str | None = None
         stop_reason: StopReason | None = None

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -188,6 +188,92 @@ def test_anthropic_should_retry():
     assert not model.api.should_retry(ex)
 
 
+def test_anthropic_handle_bad_request_content_filter_apistatuserror() -> None:
+    """Mid-stream content-filter errors arrive as a plain APIStatusError.
+
+    The Anthropic SDK raises errors that occur after streaming has begun via
+    `_make_status_error`; because the HTTP response was already 200, the SDK
+    can't infer the 400 subclass, so the exception is the base APIStatusError
+    rather than BadRequestError. handle_bad_request() must still convert
+    "content filtering" messages into a content_filter refusal.
+    """
+    import httpx
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._model_output import ModelOutput
+
+    api = AnthropicAPI(model_name="claude-opus-4-6", api_key="test-key")
+    ex = APIStatusError(
+        "Output blocked by content filtering policy",
+        response=httpx.Response(
+            status_code=200,
+            request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+        ),
+        body={
+            "type": "error",
+            "error": {
+                "type": "invalid_request_error",
+                "message": "Output blocked by content filtering policy",
+            },
+        },
+    )
+
+    result = api.handle_bad_request(ex)
+    assert isinstance(result, ModelOutput)
+    assert result.stop_reason == "content_filter"
+
+
+@pytest.mark.anyio
+async def test_anthropic_generate_handles_midstream_content_filter() -> None:
+    """generate() must convert a mid-stream APIStatusError into a content_filter refusal.
+
+    Regression: the outer `except APIStatusError` block previously only handled
+    status_code == 413 and re-raised everything else, so content-filter errors
+    that surfaced mid-stream killed the eval instead of becoming a refusal.
+    """
+    import httpx
+    from anthropic import APIStatusError
+
+    from inspect_ai.model._model_output import ModelOutput
+
+    api = AnthropicAPI(model_name="claude-opus-4-6", api_key="test-key")
+
+    async def fake_perform(
+        request: dict[str, Any],
+        streaming: bool,
+        tools: list[Any],
+        config: GenerateConfig,
+        pending_tool_uses: Any = None,
+        pending_mcp_tool_uses: Any = None,
+    ) -> tuple[dict[str, Any], ModelOutput]:
+        raise APIStatusError(
+            "Output blocked by content filtering policy",
+            response=httpx.Response(
+                status_code=200,
+                request=httpx.Request("POST", "https://api.anthropic.com/v1/messages"),
+            ),
+            body={
+                "type": "error",
+                "error": {
+                    "type": "invalid_request_error",
+                    "message": "Output blocked by content filtering policy",
+                },
+            },
+        )
+
+    api._perform_request_and_continuations = fake_perform  # type: ignore[method-assign]
+
+    output, _model_call = await api.generate(
+        input=[ChatMessageUser(content="hello")],
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(max_tokens=64),
+    )
+
+    assert isinstance(output, ModelOutput)
+    assert output.stop_reason == "content_filter"
+
+
 @skip_if_no_anthropic
 async def test_anthropic_count_tokens_single_tool_call() -> None:
     """Test counting tokens for a single assistant message with one tool call."""


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Anthropic content-filter errors that arrive *mid-stream* — after the HTTP response has already returned 200 — surface as a plain `APIStatusError`, not the 400 subclass `BadRequestError` (the SDK's `_make_status_error` can't infer a subclass from a 200 response). The existing `"content filtering"` → `stop_reason=content_filter` conversion in `handle_bad_request` was only reachable from the `except BadRequestError` branch, so streaming refusals raised through and killed the eval.

Observed on `claude-opus-4-6` running `inspect_evals/lab_bench_cloning_scenarios`:

```
anthropic.APIStatusError: {'type': 'error', 'error': {'details': None, 'type': 'invalid_request_error', 'message': 'Output blocked by content filtering policy'}, 'request_id': 'req_011CbE6GZ3rrqd2oB7oJyXQ4'}
```

raised from `_capture_compaction_from_stream` → `anthropic._streaming.__stream__`.

### What is the new behavior?

`handle_bad_request`'s parameter type is widened to `APIStatusError` (a no-op for existing callers since `BadRequestError` is a subclass; also matches the signature already used by `openai_compatible.py`, `vllm.py`, `groq.py`, `cloudflare.py`, `together.py`, and `sglang.py`). The outer `except APIStatusError` branch in `generate()` now routes through `handle_bad_request` for any non-413 error, so mid-stream content-filter errors become a `ModelOutput` with `stop_reason=content_filter` instead of crashing the eval.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `handle_bad_request` still returns the original exception for `APIStatusError`s it doesn't recognize, which the outer block re-raises — preserving prior behavior for non-content-filter, non-413 errors.

### Other information:

- Two regression tests added in `tests/model/providers/test_anthropic.py`: one unit test against `handle_bad_request` directly, one integration test that mocks `_perform_request_and_continuations` to raise the mid-stream form and verifies `generate()` returns a refusal.
- Verified end-to-end by re-running the failed eval with `inspect eval-retry` against a patched local install: 4 of the first 12 retried samples surfaced `stop_reason=content_filter` (previously each one would have crashed the eval).
- `make check` (ruff + mypy) clean on changed files.