### PR TITLE
Thread exclude_fields through eval log readers

### DIFF
--- a/src/inspect_ai/analysis/_dataframe/samples/table.py
+++ b/src/inspect_ai/analysis/_dataframe/samples/table.py
@@ -64,6 +64,7 @@ def samples_df(
     strict: Literal[True] = True,
     parallel: bool | int = False,
     quiet: bool | None = None,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame": ...
 
 
@@ -75,6 +76,7 @@ def samples_df(
     strict: Literal[False] = False,
     parallel: bool | int = False,
     quiet: bool | None = None,
+    exclude_fields: set[str] | None = None,
 ) -> tuple["pd.DataFrame", list[ColumnError]]: ...
 
 
@@ -85,6 +87,7 @@ def samples_df(
     strict: bool = True,
     parallel: bool | int = False,
     quiet: bool | None = None,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame" | tuple["pd.DataFrame", list[ColumnError]]:
     """Read a dataframe containing samples from a set of evals.
 
@@ -105,6 +108,8 @@ def samples_df(
           do not read in parallel.
        quiet: If `True`, do not show any output or progress. Defaults to `False`
           for terminal environments, and `True` for notebooks.
+       exclude_fields: Set of top-level sample field names to exclude when reading
+          full samples.
 
     Returns:
        For `strict`, a Pandas `DataFrame` with information for the specified logs.
@@ -123,6 +128,7 @@ def samples_df(
         strict=strict,
         progress=not quiet,
         parallel=parallel,
+        exclude_fields=exclude_fields,
     )
 
 
@@ -149,6 +155,7 @@ def _read_samples_df(
     detail: MessagesDetail | EventsDetail | None = None,
     progress: bool = True,
     parallel: bool | int = False,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame" | tuple["pd.DataFrame", list[ColumnError]]:
     import pandas as pd
 
@@ -185,6 +192,7 @@ def _read_samples_df(
                         strict=strict,
                         detail=detail,
                         progress=False,
+                        exclude_fields=exclude_fields,
                     ): idx
                     for idx, log_path in enumerate(log_paths)
                 }
@@ -236,6 +244,7 @@ def _read_samples_df(
             strict=strict,
             detail=detail,
             progress=progress,
+            exclude_fields=exclude_fields,
         )
 
 
@@ -247,6 +256,7 @@ def _read_samples_df_serial(
     strict: bool = True,
     detail: MessagesDetail | EventsDetail | None = None,
     progress: bool = True,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame" | tuple["pd.DataFrame", list[ColumnError]]:
     # split columns by type
     columns_eval: list[Column] = []
@@ -318,7 +328,9 @@ def _read_samples_df_serial(
                 samples: Iterable[EvalSample | EvalSampleSummary] = eval_log.samples
             elif require_full_samples:
                 full_log = await read_eval_log_async(
-                    eval_log.location, resolve_attachments=True
+                    eval_log.location,
+                    resolve_attachments=True,
+                    exclude_fields=exclude_fields,
                 )
                 samples = full_log.samples or []
             else:

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -266,6 +266,7 @@ def read_eval_log(
     header_only: bool = False,
     resolve_attachments: bool | Literal["full", "core"] = False,
     format: Literal["eval", "json", "auto"] = "auto",
+    exclude_fields: set[str] | None = None,
 ) -> EvalLog:
     """Read an evaluation log.
 
@@ -279,6 +280,8 @@ def read_eval_log(
           to their full content.
        format (Literal["eval", "json", "auto"]): Read from format
           (defaults to 'auto' based on `log_file` extension).
+       exclude_fields (set[str] | None): Set of top-level sample field names to
+          exclude when reading samples.
 
     Returns:
        EvalLog object read from file.
@@ -297,6 +300,7 @@ def read_eval_log(
             header_only,
             resolve_attachments,
             format,
+            exclude_fields,
         )
     )
 
@@ -306,6 +310,7 @@ async def read_eval_log_async(
     header_only: bool = False,
     resolve_attachments: bool | Literal["full", "core"] = False,
     format: Literal["eval", "json", "auto"] = "auto",
+    exclude_fields: set[str] | None = None,
 ) -> EvalLog:
     """Read an evaluation log.
 
@@ -319,6 +324,8 @@ async def read_eval_log_async(
           to their full content.
        format (Literal["eval", "json", "auto"]): Read from format
           (defaults to 'auto' based on `log_file` extension).
+       exclude_fields (set[str] | None): Set of top-level sample field names to
+          exclude when reading samples.
 
     Returns:
        EvalLog object read from file.
@@ -332,7 +339,9 @@ async def read_eval_log_async(
             recorder_type = recorder_type_for_format(format)
 
         logger.debug("Reading eval log from stream")
-        log = await recorder_type.read_log_bytes(log_bytes, header_only)
+        log = await recorder_type.read_log_bytes(
+            log_bytes, header_only, exclude_fields
+        )
     else:
         # resolve to file path
         log_file = (
@@ -349,7 +358,7 @@ async def read_eval_log_async(
             recorder_type = recorder_type_for_location(log_file)
         else:
             recorder_type = recorder_type_for_format(format)
-        log = await recorder_type.read_log(log_file, header_only)
+        log = await recorder_type.read_log(log_file, header_only, exclude_fields)
 
     if log.samples:
         log.samples = [

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -225,6 +225,7 @@ class EvalRecorder(FileRecorder):
         cls,
         location: str,
         header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog:
         async with AsyncFilesystem() as async_fs:
             # if the log is not stored in the local filesystem then download it
@@ -250,7 +251,9 @@ class EvalRecorder(FileRecorder):
                 read_location = temp_log or location
                 reader = AsyncZipReader(async_fs, read_location)
                 cd = await reader.entries()
-                log = await _read_log(reader, cd.entries, location, header_only)
+                log = await _read_log(
+                    reader, cd.entries, location, header_only, exclude_fields
+                )
 
                 if etag is not None:
                     log.etag = etag
@@ -267,9 +270,17 @@ class EvalRecorder(FileRecorder):
     @override
     @classmethod
     async def read_log_bytes(
-        cls, log_bytes: IO[bytes], header_only: bool = False
+        cls,
+        log_bytes: IO[bytes],
+        header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog:
-        return _read_log_from_bytes(log_bytes, location="", header_only=header_only)
+        return _read_log_from_bytes(
+            log_bytes,
+            location="",
+            header_only=header_only,
+            exclude_fields=exclude_fields,
+        )
 
     @override
     @classmethod
@@ -318,66 +329,9 @@ class EvalRecorder(FileRecorder):
                 epoch = sample.epoch
 
             if exclude_fields:
-                # Stream the sample JSON using low-level parse events.
-                # An ObjectBuilder accumulates events only for included fields;
-                # excluded fields are read as raw events and never allocated
-                # as Python objects, keeping peak memory proportional to the
-                # data we actually keep.
-                import ijson  # type: ignore
-                from ijson import IncompleteJSONError, ObjectBuilder
-                from ijson.backends.python import (  # type: ignore[import-untyped]
-                    UnexpectedSymbol,
+                data = await _read_sample_json(
+                    reader, _sample_filename(id, epoch), exclude_fields
                 )
-
-                try:
-                    data: dict[str, Any] = {}
-                    async with await reader.open_member(
-                        _sample_filename(id, epoch)
-                    ) as f:
-                        depth = 0
-                        current_key: str = ""
-                        builder: ObjectBuilder | None = None
-                        async for prefix, event, value in ijson.parse_async(
-                            adapt_to_reader(f), use_float=True
-                        ):
-                            # Depth must be updated before the completion check
-                            # so that a closing bracket that returns depth to 1
-                            # is recognised as completing the current value.
-                            if event in ("start_map", "start_array"):
-                                depth += 1
-                            elif event in ("end_map", "end_array"):
-                                depth -= 1
-
-                            if depth == 1 and event == "map_key":
-                                current_key = value
-                                builder = (
-                                    None
-                                    if current_key in exclude_fields
-                                    else ObjectBuilder()
-                                )
-                            elif builder is not None:
-                                builder.event(event, value)
-                                # Depth 1 means we have returned to the top-level
-                                # object, so the current field's value is complete.
-                                if depth == 1:
-                                    data[current_key] = builder.value
-                                    builder = None
-                except (
-                    ValueError,
-                    IncompleteJSONError,
-                    UnexpectedSymbol,
-                ) as ex:
-                    # ijson doesn't support NaN/Inf which are valid in
-                    # Python's JSON. Fall back to standard json.load
-                    # and manually remove excluded fields.
-                    if is_ijson_nan_inf_error(ex):
-                        data = json.loads(
-                            await reader.read_member_fully(_sample_filename(id, epoch))
-                        )
-                        for field in exclude_fields:
-                            data.pop(field, None)
-                    else:
-                        raise
             else:
                 data = json.loads(
                     await reader.read_member_fully(_sample_filename(id, epoch))
@@ -734,6 +688,7 @@ async def _read_log(
     entries: list[ZipEntry],
     location: str,
     header_only: bool = False,
+    exclude_fields: set[str] | None = None,
 ) -> EvalLog:
     entry_names = {e.filename for e in entries}
 
@@ -756,7 +711,7 @@ async def _read_log(
             if entry.filename.startswith(f"{SAMPLES_DIR}/") and entry.filename.endswith(
                 ".json"
             ):
-                data = await _read_member_json(reader, entry.filename)
+                data = await _read_sample_json(reader, entry.filename, exclude_fields)
                 samples.append(
                     EvalSample.model_validate(
                         data, context=get_deserializing_context()
@@ -769,7 +724,10 @@ async def _read_log(
 
 
 def _read_log_from_bytes(
-    log: IO[bytes], location: str, header_only: bool = False
+    log: IO[bytes],
+    location: str,
+    header_only: bool = False,
+    exclude_fields: set[str] | None = None,
 ) -> EvalLog:
     with ZipFile(log, mode="r") as zip:
         eval_log = _read_header(zip, location)
@@ -790,9 +748,13 @@ def _read_log_from_bytes(
             for name in zip.namelist():
                 if name.startswith(f"{SAMPLES_DIR}/") and name.endswith(".json"):
                     with zip.open(name, "r") as f:
+                        data = json.load(f)
+                        if exclude_fields:
+                            for field in exclude_fields:
+                                data.pop(field, None)
                         samples_list.append(
                             EvalSample.model_validate(
-                                json.load(f), context=get_deserializing_context()
+                                data, context=get_deserializing_context()
                             ),
                         )
             sort_samples(samples_list)
@@ -805,6 +767,60 @@ def _read_log_from_bytes(
 
 async def _read_member_json(reader: AsyncZipReader, member: str) -> Any:
     return json.loads(await reader.read_member_fully(member))
+
+
+async def _read_sample_json(
+    reader: AsyncZipReader,
+    member: str,
+    exclude_fields: set[str] | None = None,
+) -> dict[str, Any]:
+    if not exclude_fields:
+        return json.loads(await reader.read_member_fully(member))
+
+    # Stream the sample JSON using low-level parse events. An ObjectBuilder
+    # accumulates included fields only; excluded fields are read as raw events
+    # and never allocated as Python objects.
+    import ijson  # type: ignore
+    from ijson import IncompleteJSONError, ObjectBuilder
+    from ijson.backends.python import UnexpectedSymbol  # type: ignore[import-untyped]
+
+    try:
+        data: dict[str, Any] = {}
+        async with await reader.open_member(member) as f:
+            depth = 0
+            current_key: str = ""
+            builder: ObjectBuilder | None = None
+            async for _prefix, event, value in ijson.parse_async(
+                adapt_to_reader(f), use_float=True
+            ):
+                # Depth must be updated before the completion check so that a
+                # closing bracket that returns depth to 1 completes the field.
+                if event in ("start_map", "start_array"):
+                    depth += 1
+                elif event in ("end_map", "end_array"):
+                    depth -= 1
+
+                if depth == 1 and event == "map_key":
+                    current_key = value
+                    builder = (
+                        None if current_key in exclude_fields else ObjectBuilder()
+                    )
+                elif builder is not None:
+                    builder.event(event, value)
+                    if depth == 1:
+                        data[current_key] = builder.value
+                        builder = None
+        return data
+    except (ValueError, IncompleteJSONError, UnexpectedSymbol) as ex:
+        # ijson doesn't support NaN/Inf which are valid in Python's JSON.
+        # Fall back to standard json.load and manually remove excluded fields.
+        if is_ijson_nan_inf_error(ex):
+            data = json.loads(await reader.read_member_fully(member))
+            for field in exclude_fields:
+                data.pop(field, None)
+            return data
+        else:
+            raise
 
 
 async def _read_header_async(

--- a/src/inspect_ai/log/_recorders/file.py
+++ b/src/inspect_ai/log/_recorders/file.py
@@ -74,7 +74,13 @@ class FileRecorder(Recorder):
                 f"Sample id {id} for epoch {epoch} not found in log {location}"
             )
         else:
-            return eval_sample
+            if exclude_fields:
+                data = eval_sample.model_dump(mode="json")
+                for field in exclude_fields:
+                    data.pop(field, None)
+                return EvalSample.model_validate(data)
+            else:
+                return eval_sample
 
     @classmethod
     @override

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -161,6 +161,7 @@ class JSONRecorder(FileRecorder):
         cls,
         location: str,
         header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog:
         fs = filesystem(location)
 
@@ -193,7 +194,7 @@ class JSONRecorder(FileRecorder):
                 raw_data = from_json(f.read())
             etag = None
 
-        log = _parse_json_log(raw_data, header_only)
+        log = _parse_json_log(raw_data, header_only, exclude_fields)
         log.location = location
         if etag:
             log.etag = etag
@@ -203,9 +204,12 @@ class JSONRecorder(FileRecorder):
     @override
     @classmethod
     async def read_log_bytes(
-        cls, log_bytes: IO[bytes], header_only: bool = False
+        cls,
+        log_bytes: IO[bytes],
+        header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog:
-        return _parse_json_log(from_json(log_bytes.read()), header_only)
+        return _parse_json_log(from_json(log_bytes.read()), header_only, exclude_fields)
 
     @override
     @classmethod
@@ -264,8 +268,18 @@ def _validate_version(ver: int) -> None:
         raise ValueError(f"Unable to read version {ver} of log format.")
 
 
-def _parse_json_log(raw_data: Any, header_only: bool) -> EvalLog:
+def _parse_json_log(
+    raw_data: Any, header_only: bool, exclude_fields: set[str] | None = None
+) -> EvalLog:
     """Parse raw JSON data into an EvalLog, validating version and pruning if header_only."""
+    if exclude_fields and not header_only and isinstance(raw_data, dict):
+        samples = raw_data.get("samples")
+        if isinstance(samples, list):
+            for sample in samples:
+                if isinstance(sample, dict):
+                    for field in exclude_fields:
+                        sample.pop(field, None)
+
     log = EvalLog.model_validate(raw_data, context=get_deserializing_context())
 
     # fail for unknown version

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -64,12 +64,16 @@ class Recorder(abc.ABC):
         cls,
         location: str,
         header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog: ...
 
     @classmethod
     @abc.abstractmethod
     async def read_log_bytes(
-        cls, log_bytes: IO[bytes], header_only: bool = False
+        cls,
+        log_bytes: IO[bytes],
+        header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog: ...
 
     @classmethod

--- a/tests/analysis/test_df.py
+++ b/tests/analysis/test_df.py
@@ -19,7 +19,7 @@ from inspect_ai.analysis import (
     samples_df,
 )
 from inspect_ai.analysis._dataframe.evals.columns import EvalTask
-from inspect_ai.analysis._dataframe.samples.columns import SampleScores
+from inspect_ai.analysis._dataframe.samples.columns import SampleColumn, SampleScores
 from inspect_ai.log import (
     EvalLog,
     MetadataEdit,
@@ -174,6 +174,14 @@ def test_samples_df_columns():
     assert "eval_id" in df.columns
     assert "sample_id" in df.columns
     assert "log" in df.columns
+
+
+def test_samples_df_exclude_fields_with_full_sample_read():
+    log_file = Path("tests/log/test_eval_log/log_read_sample.eval")
+    column = SampleColumn("events", path="events", full=True)
+    df = samples_df(log_file, columns=[column], exclude_fields={"events"})
+    assert len(df) == 1
+    assert df["events"].iloc[0] == "[]"
 
 
 def test_messages_df():

--- a/tests/log/test_eval_log.py
+++ b/tests/log/test_eval_log.py
@@ -148,6 +148,19 @@ def test_read_sample_with_exclude_fields():
     assert not sample.events
 
 
+def test_read_log_with_exclude_fields():
+    eval_log_file = os.path.join(
+        "tests", "log", "test_eval_log", "log_read_sample.eval"
+    )
+    log = read_eval_log(eval_log_file, exclude_fields={"store", "events"})
+    assert log.samples
+    sample = log.samples[0]
+    assert sample.id == 1
+    assert sample.input is not None
+    assert not sample.store
+    assert not sample.events
+
+
 def test_log_location():
     json_log_file = os.path.join("tests", "log", "test_eval_log", "log_formats.json")
     check_log_location(json_log_file)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #3815.

`exclude_fields` is supported for `read_eval_log_sample`, but it is not threaded through full log reads or `samples_df`. As a result, callers that need full samples for analysis still load large top-level sample fields such as `events` even when they want to exclude them.

### What is the new behavior?

- Adds `exclude_fields` to `read_eval_log` and `read_eval_log_async`.
- Threads `exclude_fields` through recorder `read_log` / `read_log_bytes` implementations.
- Reuses the existing streaming exclusion path for `.eval` sample members so excluded fields are not allocated during full `.eval` log reads.
- Adds `exclude_fields` to `samples_df` and passes it into full sample reads.
- Covers full log and dataframe exclusion with tests.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Validation:

- `python -m ruff check src/inspect_ai/log/_file.py src/inspect_ai/log/_recorders/recorder.py src/inspect_ai/log/_recorders/file.py src/inspect_ai/log/_recorders/json.py src/inspect_ai/log/_recorders/eval.py src/inspect_ai/analysis/_dataframe/samples/table.py tests/log/test_eval_log.py tests/analysis/test_df.py`
- `python -m pytest tests/log/test_eval_log.py::test_read_sample_with_exclude_fields tests/log/test_eval_log.py::test_read_log_with_exclude_fields tests/analysis/test_df.py::test_samples_df_exclude_fields_with_full_sample_read -q`
- `python -m pytest tests/log/test_eval_log.py tests/analysis/test_df.py -q`
