### PR TITLE
Fix npm publish workflow (npm 11 self-upgrade fails on Node 22)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -49,8 +49,10 @@ jobs:
 
       - name: Upgrade npm (for Trusted Publishing)
         run: |
-          npm i -g npm@^11.5.1
-          npm --version
+          # Install via prefix to avoid npm self-upgrade rebuild bug on Node 22.
+          npm install --prefix "$RUNNER_TEMP/npm-upgrade" --no-audit --no-fund npm@^11.5.1
+          echo "$RUNNER_TEMP/npm-upgrade/node_modules/.bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/npm-upgrade/node_modules/.bin/npm" --version
 
       - name: Install dependencies
         working-directory: src/inspect_ai/_view/ts-mono


### PR DESCRIPTION
## Summary
- The `Publish React Viewer Lib` workflow has been failing on every release since at least 0.3.214 (Apr 29) — see [run 26063225319](https://github.com/UKGovernmentBEIS/inspect_ai/actions/runs/26063225319/job/76628104815).
- Root cause: `npm i -g npm@^11.5.1` (added so the publish step can use Trusted Publishing, which requires npm >= 11.5.1) crashes on Node 22 with `Cannot find module 'promise-retry'`. The new npm tarball overwrites the live npm's `node_modules` before arborist's rebuild phase finishes, so a `require('promise-retry')` from `@npmcli/arborist/lib/arborist/rebuild.js` fails.
- Fix: install `npm@^11.5.1` into a scratch prefix (`$RUNNER_TEMP/npm-upgrade`) instead of upgrading global npm in place. Prepend its bin to `$GITHUB_PATH` so the later `npm publish` steps pick up the upgraded npm. The global npm is never touched, so there's no half-overwritten state.

## Test plan
- [x] Trigger this workflow via `workflow_dispatch` against this branch with `dry-run: true` and confirm the `Upgrade npm (for Trusted Publishing)` step succeeds and `npm publish --dry-run` runs end-to-end.
- [ ] After merge, the next tagged release should publish successfully without manual intervention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)