### PR TITLE
fix: make emit_sample_event thread-safe (queue + drainer) — fixes #4003

### DIFF
--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -1,10 +1,10 @@
 import math
+import queue
 from dataclasses import dataclass
 from logging import getLogger
 from typing import Awaitable, Callable, Literal, Type, TypeVar, cast
 
 import anyio
-from anyio.streams.memory import MemoryObjectReceiveStream
 
 from inspect_ai._eval.eval import EvalLogs
 from inspect_ai._eval.task.log import TaskLogger
@@ -660,6 +660,29 @@ async def emit_sample_start(
     await _emit_to_all(lambda hook: hook.on_sample_start(data))
 
 
+# Sentinel pushed onto the per-sample event queue to tell the drainer
+# task to exit cleanly. Using a module-level singleton (not a SampleEvent)
+# is safe because the queue is typed ``SampleEvent | object``.
+_SAMPLE_EVENT_QUEUE_SHUTDOWN: object = object()
+
+# Drainer worker threads block in ``queue.get`` for the lifetime of a
+# sample. With anyio's default thread limiter (typically 40), many
+# concurrent samples would queue up waiting for a thread slot, blocking
+# sample startup. Use an unbounded limiter dedicated to drainers,
+# lazily created on first use because ``anyio.CapacityLimiter`` requires
+# an active event loop at construction time.
+_drainer_thread_limiter: anyio.CapacityLimiter | None = None
+
+
+def _get_drainer_thread_limiter() -> anyio.CapacityLimiter:
+    global _drainer_thread_limiter
+    if _drainer_thread_limiter is None:
+        # ``anyio.CapacityLimiter`` validates with ``value is math.inf``,
+        # so ``float("inf")`` is rejected. Use the constant.
+        _drainer_thread_limiter = anyio.CapacityLimiter(math.inf)
+    return _drainer_thread_limiter
+
+
 def emit_sample_event(
     eval_set_id: str | None,
     run_id: str,
@@ -668,7 +691,7 @@ def emit_sample_event(
     event: Event,
 ) -> None:
     active = sample_active()
-    if active is None or active.event_send is None:
+    if active is None or active.event_queue is None:
         return
     if event.pending:
         return
@@ -679,10 +702,13 @@ def emit_sample_event(
         sample_id=sample_id,
         event=event,
     )
-    try:
-        active.event_send.send_nowait(data)
-    except (anyio.ClosedResourceError, anyio.BrokenResourceError):
-        pass
+    # ``queue.SimpleQueue.put`` is thread-safe and never blocks (unbounded),
+    # so this is safe to call from any thread — the event loop thread, an
+    # anyio worker spawned by ``to_thread.run_sync``, or a plain
+    # ``threading.Thread`` (e.g. the subprocess capture threads in
+    # ``_util/local_server.py``). The drainer task on the event loop
+    # thread is responsible for the actual hook dispatch.
+    active.event_queue.put(data)
 
 
 def start_sample_event_emitter() -> None:
@@ -694,19 +720,28 @@ def start_sample_event_emitter() -> None:
     if active is None or active.tg is None:
         return
 
-    send_stream, receive_stream = anyio.create_memory_object_stream[SampleEvent](
-        math.inf
-    )
-    active.event_send = send_stream
-    active.event_receive = receive_stream
+    event_queue: queue.SimpleQueue[SampleEvent | object] = queue.SimpleQueue()
+    active.event_queue = event_queue
     active.event_done = anyio.Event()
 
     async def _emit_loop(
-        receive: MemoryObjectReceiveStream[SampleEvent],
+        q: queue.SimpleQueue[SampleEvent | object],
         done: anyio.Event,
     ) -> None:
         try:
-            async for data in receive:
+            while True:
+                # Block a worker thread (not the event loop) on
+                # ``queue.get`` until a producer puts something on the
+                # queue. The worker round-trip is the price of being
+                # safe to call ``put`` from any thread.
+                data = await anyio.to_thread.run_sync(
+                    q.get,
+                    abandon_on_cancel=True,
+                    limiter=_get_drainer_thread_limiter(),
+                )
+                if data is _SAMPLE_EVENT_QUEUE_SHUTDOWN:
+                    return
+                assert isinstance(data, SampleEvent)
                 try:
 
                     async def _call_hook(hook: Hooks, d: SampleEvent = data) -> None:
@@ -718,7 +753,7 @@ def start_sample_event_emitter() -> None:
         finally:
             done.set()
 
-    active.tg.start_soon(_emit_loop, receive_stream, active.event_done)
+    active.tg.start_soon(_emit_loop, event_queue, active.event_done)
 
 
 async def drain_sample_events() -> None:
@@ -732,9 +767,10 @@ async def drain_sample_events() -> None:
         return
 
     try:
-        # Close the send stream to signal no more events
-        if active.event_send is not None:
-            await active.event_send.aclose()
+        # Signal the drainer to exit once it has processed everything
+        # ahead of the sentinel.
+        if active.event_queue is not None:
+            active.event_queue.put(_SAMPLE_EVENT_QUEUE_SHUTDOWN)
 
         # Wait for the background emitter to finish processing
         if active.event_done is not None:
@@ -743,25 +779,29 @@ async def drain_sample_events() -> None:
             if not active.event_done.is_set():
                 logger.warning("Timed out waiting for sample event emitter to drain")
 
-        # Process any remaining events the background emitter didn't get to
-        # (e.g. scoring events queued after the solver task group was cancelled)
-        if active.event_receive is not None:
-            try:
-                while True:
-                    data = active.event_receive.receive_nowait()
+        # Process any remaining events the drainer didn't reach (e.g.
+        # scoring events queued after the solver task group was
+        # cancelled, so the drainer task never ran the iteration that
+        # would have read them).
+        if active.event_queue is not None:
+            while True:
+                try:
+                    data = active.event_queue.get_nowait()
+                except queue.Empty:
+                    break
+                if data is _SAMPLE_EVENT_QUEUE_SHUTDOWN:
+                    continue
+                assert isinstance(data, SampleEvent)
 
-                    async def _emit_event(hook: Hooks, d: SampleEvent = data) -> None:
-                        await hook.on_sample_event(d)
+                async def _emit_event(hook: Hooks, d: SampleEvent = data) -> None:
+                    await hook.on_sample_event(d)
 
-                    await _emit_to_all(_emit_event)
-            except (anyio.WouldBlock, anyio.EndOfStream, anyio.ClosedResourceError):
-                pass
+                await _emit_to_all(_emit_event)
     except Exception as ex:
         logger.warning(f"Exception draining sample events: {ex}")
     finally:
         # Clean up regardless of success/failure
-        active.event_send = None
-        active.event_receive = None
+        active.event_queue = None
         active.event_done = None
 
 

--- a/src/inspect_ai/log/_samples.py
+++ b/src/inspect_ai/log/_samples.py
@@ -1,4 +1,5 @@
 import contextlib
+import queue
 from contextlib import AbstractAsyncContextManager
 from contextvars import ContextVar
 from datetime import datetime, timezone
@@ -14,8 +15,6 @@ from typing import (
 )
 
 if TYPE_CHECKING:
-    from anyio.streams.memory import MemoryObjectReceiveStream, MemoryObjectSendStream
-
     from inspect_ai.agent._acp.session import AcpSession
     from inspect_ai.hooks._hooks import SampleEvent
     from inspect_ai.model._model_call import ModelCall, ModelCallFilter
@@ -88,8 +87,20 @@ class ActiveSample:
         self.agent_name = agent_name
         self._interrupt_action: Literal["score", "error"] | None = None
         self._limit_exceeded_error: LimitExceededError | None = None
-        self.event_send: MemoryObjectSendStream[SampleEvent] | None = None
-        self.event_receive: MemoryObjectReceiveStream[SampleEvent] | None = None
+        # Thread-safe channel between the (possibly off-event-loop-thread)
+        # producers of sample events (notably the stdlib-logging `LogHandler`
+        # path, which can be called from anyio worker threads, subprocess
+        # capture threads, atexit, etc.) and the event-loop-side emitter
+        # task that dispatches events to hook subscribers. Use ``queue``
+        # rather than ``anyio.MemoryObjectStream`` because the latter wakes
+        # waiters via ``trio.Event.set`` → ``trio._core.reschedule``, which
+        # raises ``RuntimeError("must be called from async context")`` when
+        # invoked off the event loop thread. ``queue.SimpleQueue`` is
+        # stdlib-thread-safe with no async assumptions. The drainer side
+        # (``hooks/_hooks.py:start_sample_event_emitter``) blocks on
+        # ``queue.get`` via ``anyio.to_thread.run_sync`` so the wait does
+        # not occupy the event loop.
+        self.event_queue: "queue.SimpleQueue[SampleEvent | object] | None" = None
         self.event_done: anyio.Event | None = None
         # Live ACP session for this sample, if any. Set by
         # `LiveAcpSession.__aenter__` on entry; cleared at `__aexit__`.

--- a/tests/hooks/test_sample_events.py
+++ b/tests/hooks/test_sample_events.py
@@ -1,10 +1,16 @@
-"""Test that emit_sample_event works correctly with an unbounded stream.
+"""Tests for `emit_sample_event` and its thread-safe event channel.
 
-The stream is created with math.inf capacity, so WouldBlock can never occur
-and there is no need for a recursion guard.
+`emit_sample_event` writes onto a `queue.SimpleQueue` so it can be invoked
+from any thread (stdlib `logging` is thread-safe by contract; events may
+originate from `anyio.to_thread.run_sync` worker threads, subprocess
+capture threads, atexit handlers, etc.). The queue is unbounded, so
+puts never block.
 """
 
-import math
+import logging
+import queue
+
+import anyio
 
 from inspect_ai.dataset._dataset import Sample
 from inspect_ai.event._logger import LoggerEvent, LoggingMessage
@@ -17,8 +23,8 @@ from inspect_ai.log._transcript import Transcript, init_transcript
 from inspect_ai.util._checkpoint.checkpointer_noop import _NoopCheckpointer
 
 
-def test_emit_sample_event_unbounded_stream_never_blocks() -> None:
-    """An unbounded stream should accept many events without raising WouldBlock."""
+def test_emit_sample_event_unbounded_queue_never_blocks() -> None:
+    """Many puts succeed without blocking on the unbounded queue."""
     sample_transcript = Transcript()
     active = ActiveSample(
         task="test_task",
@@ -42,20 +48,13 @@ def test_emit_sample_event_unbounded_stream_never_blocks() -> None:
     sample_token = _sample_active.set(active)
     init_transcript(sample_transcript)
 
-    import anyio
-
-    send_stream, receive_stream = anyio.create_memory_object_stream[SampleEvent](
-        math.inf
-    )
-    active.event_send = send_stream
-    active.event_receive = receive_stream
+    active.event_queue = queue.SimpleQueue()
 
     try:
         event = LoggerEvent(
             message=LoggingMessage(level="info", message="filler", created=0.0)
         )
 
-        # Send many events — none should raise WouldBlock with an unbounded stream.
         for _ in range(2000):
             emit_sample_event(
                 eval_set_id=None,
@@ -64,6 +63,127 @@ def test_emit_sample_event_unbounded_stream_never_blocks() -> None:
                 sample_id="sample-1",
                 event=event,
             )
+
+        assert active.event_queue.qsize() == 2000
+        # Pulling them back out should also work without exceptions.
+        for _ in range(2000):
+            item = active.event_queue.get_nowait()
+            assert isinstance(item, SampleEvent)
     finally:
         _sample_active.reset(sample_token)
         init_transcript(Transcript())
+
+
+def test_emit_sample_event_thread_safe_from_worker_thread() -> None:
+    """Producing from a non-main thread must not raise.
+
+    Regression test for https://github.com/UKGovernmentBEIS/inspect_ai/issues/4003
+    — `emit_sample_event` used to call `anyio.MemoryObjectSendStream.send_nowait`,
+    which under the trio backend invokes `trio._core.reschedule` and raises
+    `RuntimeError: must be called from async context` from any thread that is
+    not the event-loop thread.
+
+    Spawns the producers via ``copy_context().run(...)`` because plain
+    ``threading.Thread`` does NOT inherit ``ContextVar``s from the parent;
+    that's the same context-copy mechanism ``anyio.to_thread.run_sync``
+    uses internally, which is precisely the call path that triggered the
+    original bug.
+    """
+    import contextvars
+    import threading
+
+    sample_transcript = Transcript()
+    active = ActiveSample(
+        task="test_task",
+        log_location="test",
+        model="test_model",
+        sample=Sample(input="test"),
+        epoch=1,
+        message_limit=None,
+        token_limit=None,
+        cost_limit=None,
+        time_limit=None,
+        working_limit=None,
+        fails_on_error=True,
+        transcript=sample_transcript,
+        sandboxes={},
+        checkpointer=_NoopCheckpointer(),
+        eval_set_id=None,
+        run_id="run-1",
+        eval_id="eval-1",
+    )
+    sample_token = _sample_active.set(active)
+    init_transcript(sample_transcript)
+
+    active.event_queue = queue.SimpleQueue()
+
+    event = LoggerEvent(
+        message=LoggingMessage(level="warning", message="from-thread", created=0.0)
+    )
+
+    errors: list[BaseException] = []
+
+    def producer() -> None:
+        try:
+            for _ in range(50):
+                emit_sample_event(
+                    eval_set_id=None,
+                    run_id="run-1",
+                    eval_id="eval-1",
+                    sample_id="sample-1",
+                    event=event,
+                )
+        except BaseException as exc:
+            errors.append(exc)
+
+    try:
+        ctx = contextvars.copy_context()
+        threads = [threading.Thread(target=ctx.run, args=(producer,)) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"emit_sample_event raised from a worker thread: {errors}"
+        assert active.event_queue.qsize() == 50 * 4
+    finally:
+        _sample_active.reset(sample_token)
+        init_transcript(Transcript())
+
+
+async def test_logging_from_worker_thread_does_not_crash_eval() -> None:
+    """End-to-end regression for issue #4003.
+
+    A solver that logs from inside ``anyio.to_thread.run_sync`` used to crash
+    the eval under the trio backend with ``RuntimeError: must be called from
+    async context``. The eval must complete with status ``success`` on both
+    asyncio and trio.
+    """
+    from inspect_ai import Task, eval_async
+    from inspect_ai.solver import solver
+
+    # Use a logger under the inspect_ai namespace so it goes through the
+    # inspect_ai LogHandler (which routes records into the active sample's
+    # transcript stream — the path that used to crash from worker threads).
+    worker_logger = logging.getLogger("inspect_ai.tests.test_sample_events.worker")
+
+    def sync_work_that_logs() -> str:
+        # WARNING (not INFO) so the record clears the root logger's default
+        # level filter (DEFAULT_LOG_LEVEL is "warning").
+        worker_logger.warning("hello from worker thread")
+        return "done"
+
+    @solver
+    def thread_logger_solver():
+        async def solve(state, generate):
+            await anyio.to_thread.run_sync(sync_work_that_logs)
+            return state
+
+        return solve
+
+    task = Task(
+        dataset=[Sample(input="x", target="x")],
+        solver=thread_logger_solver(),
+    )
+    log = (await eval_async(task, model="mockllm/model"))[0]
+    assert log.status == "success", f"status={log.status} error={log.error}"


### PR DESCRIPTION
## Human notes

This is past my oversight as it requires deeper understanding to anyio and inspect internals that I have. Feel free to discard if irrelevant / easier to implement a different skill yourself

## Summary

Fixes #4003. `emit_sample_event` previously called `anyio.MemoryObjectSendStream.send_nowait` directly, which under trio resolves to `trio._core.reschedule` and raises `RuntimeError: must be called from async context` whenever invoked off the event-loop thread. The most common trigger is a `logger.warning(...)` issued from inside an `anyio.to_thread.run_sync(...)` block during an active eval sample — for example the vLLM/sglang provider startup path. Worker threads inherit the parent context via `context.run(...)`, so they see `_sample_active` set, reach the LogHandler → transcript → `emit_sample_event` chain, and detonate.

This PR replaces the producer→drainer channel from `anyio.MemoryObjectStream` to `queue.SimpleQueue`. `queue.SimpleQueue.put` is stdlib-thread-safe with no async assumptions, so `emit_sample_event` is now callable from any thread (the event loop thread, an anyio worker thread, etc.). The drainer task on the event loop blocks on `queue.get` via `anyio.to_thread.run_sync(queue.get, limiter=...)`, so the wait does not occupy the event loop.

This matches the long-term option (Option 4) from the issue thread.

## Why this approach over a `from_thread.run_sync` bridge

A smaller fix is to special-case off-thread callers of `emit_sample_event` and bridge them via `anyio.from_thread.run_sync(send_nowait, data)`. That works for the immediate vLLM crash but requires the producer to detect on-thread-vs-off-thread, and the bridge only works for anyio-claimed worker threads (e.g. `to_thread.run_sync` callees) — not raw `threading.Thread`s. The queue-based approach makes the channel thread-safe by construction, so producers stay unchanged and don't need to reason about threading.

The cost is one worker thread per active sample, parked in `queue.get` for the sample's lifetime. To avoid sample startup blocking on the default 40-token anyio thread limiter, the drainer uses a dedicated unbounded limiter (`anyio.CapacityLimiter(math.inf)`), lazily created inside the event loop because `CapacityLimiter` requires an active backend at construction.

## Test plan
- [x] New regression test `test_logging_from_worker_thread_does_not_crash_eval` exercises the original failing pattern (`logger.warning` from inside `anyio.to_thread.run_sync` inside a solver inside `eval_async`) and passes on both asyncio and trio backends.
- [x] New unit test `test_emit_sample_event_thread_safe_from_worker_thread` verifies `emit_sample_event` does not raise when called concurrently from multiple non-event-loop threads (spawned with `contextvars.copy_context().run(...)` to mirror the anyio worker-thread context-copy semantics).
- [x] Updated capacity test `test_emit_sample_event_unbounded_queue_never_blocks` covers the new API.
- [x] `make check` (ruff + mypy) passes on changed files.
- [x] Out-of-tree reproduction: a minimal CPU-only repro (just `logger.warning` from `to_thread.run_sync` inside `eval_async`) and a vLLM-server-start repro both report `eval status: success` under trio after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
