### PR TITLE
Fix package task sandbox path resolution

### DIFF
--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -11,7 +11,11 @@ from typing import Any, Callable, Tuple, cast
 from shortuuid import uuid
 
 from inspect_ai._eval.task.resolved import ResolvedTask
-from inspect_ai._eval.task.util import split_spec, task_file, task_run_dir, task_source_dir
+from inspect_ai._eval.task.util import (
+    split_spec,
+    task_file,
+    task_source_dir,
+)
 from inspect_ai._util.decorator import parse_decorators
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.logger import warn_once

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -14,6 +14,7 @@ from inspect_ai._eval.task.resolved import ResolvedTask
 from inspect_ai._eval.task.util import (
     split_spec,
     task_file,
+    task_run_dir,
     task_source_dir,
 )
 from inspect_ai._util.decorator import parse_decorators
@@ -244,6 +245,9 @@ def resolve_task_sandbox(
 ) -> SandboxEnvironmentSpec | None:
     # do the resolution
     resolved_sandbox = resolve_sandbox_environment(sandbox) or task.sandbox
+    config_base_dir = (
+        task_run_dir(task) if sandbox is not None else task_source_dir(task)
+    )
 
     # if we have a sandbox with no config, see if there are implcit
     # config files available for the provider
@@ -265,6 +269,7 @@ def resolve_task_sandbox(
                     resolved_sandbox = SandboxEnvironmentSpec(
                         resolved_sandbox.type, config_file
                     )
+                    config_base_dir = src_dir
                     break
 
             # if we found an override without a config then we may still
@@ -279,12 +284,13 @@ def resolve_task_sandbox(
                 resolved_sandbox = SandboxEnvironmentSpec(
                     resolved_sandbox.type, task.sandbox.config
                 )
+                config_base_dir = task_source_dir(task)
 
         # resolve relative paths
         if isinstance(resolved_sandbox.config, str):
             file_path = Path(resolved_sandbox.config)
             if not file_path.is_absolute():
-                file_path = Path(task_source_dir(task)) / file_path
+                file_path = Path(config_base_dir) / file_path
                 resolved_sandbox = SandboxEnvironmentSpec(
                     resolved_sandbox.type, file_path.as_posix()
                 )

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -112,10 +112,6 @@ def resolve_tasks(
     if isinstance(tasks, PreviousTask):
         tasks = [tasks]
     if isinstance(tasks, list) and isinstance(tasks[0], (ResolvedTask, PreviousTask)):
-        tasks = cast(
-            list[PreviousTask] | list[ResolvedTask] | list[ResolvedTask | PreviousTask],
-            tasks,
-        )
         return resolve_previous_tasks(
             tasks, sample_shuffle=sample_shuffle, model=model, model_roles=model_roles
         )
@@ -124,13 +120,13 @@ def resolve_tasks(
     if isinstance(tasks, Task):
         return as_resolved_tasks([tasks])
     elif isinstance(tasks, list) and isinstance(tasks[0], Task):
-        return as_resolved_tasks(cast(list[Task], tasks))
+        return as_resolved_tasks(tasks)
 
     # convert TaskInfo to str
     if isinstance(tasks, TaskInfo):
         tasks = [tasks]
     if isinstance(tasks, list) and isinstance(tasks[0], TaskInfo):
-        tasks = [f"{task.file}@{task.name}" for task in cast(list[TaskInfo], tasks)]
+        tasks = [f"{task.file}@{task.name}" for task in tasks]
 
     # handle functions that return tasks (we get their registry name)
     if isinstance(tasks, list) and callable(tasks[0]):

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -120,13 +120,15 @@ def resolve_tasks(
     if isinstance(tasks, Task):
         return as_resolved_tasks([tasks])
     elif isinstance(tasks, list) and isinstance(tasks[0], Task):
-        return as_resolved_tasks(tasks)
+        return as_resolved_tasks([t for t in tasks if isinstance(t, Task)])
 
     # convert TaskInfo to str
     if isinstance(tasks, TaskInfo):
         tasks = [tasks]
     if isinstance(tasks, list) and isinstance(tasks[0], TaskInfo):
-        tasks = [f"{task.file}@{task.name}" for task in tasks]
+        tasks = [
+            f"{task.file}@{task.name}" for task in tasks if isinstance(task, TaskInfo)
+        ]
 
     # handle functions that return tasks (we get their registry name)
     if isinstance(tasks, list) and callable(tasks[0]):

--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Tuple, cast
 from shortuuid import uuid
 
 from inspect_ai._eval.task.resolved import ResolvedTask
-from inspect_ai._eval.task.util import split_spec, task_file, task_run_dir
+from inspect_ai._eval.task.util import split_spec, task_file, task_run_dir, task_source_dir
 from inspect_ai._util.decorator import parse_decorators
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.logger import warn_once
@@ -45,7 +45,7 @@ from inspect_ai.util._sandbox.registry import registry_find_sandboxenv
 from .list import task_files
 from .registry import task_create
 from .task import PreviousTask, Task, TaskInfo
-from .task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
+from .task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR, TASK_SRC_DIR_ATTR
 from .task.hf import task_create_from_hf
 from .task.run import eval_log_sample_source
 from .task.tasks import Tasks
@@ -254,7 +254,7 @@ def resolve_task_sandbox(
             config_files = config_files_fn()
 
             # probe for them in task src dir
-            src_dir = task_run_dir(task)
+            src_dir = task_source_dir(task)
             for config_file in config_files:
                 config_file_path = os.path.join(src_dir, config_file)
                 if os.path.isfile(config_file_path):
@@ -280,7 +280,7 @@ def resolve_task_sandbox(
         if isinstance(resolved_sandbox.config, str):
             file_path = Path(resolved_sandbox.config)
             if not file_path.is_absolute():
-                file_path = Path(task_run_dir(task)) / file_path
+                file_path = Path(task_source_dir(task)) / file_path
                 resolved_sandbox = SandboxEnvironmentSpec(
                     resolved_sandbox.type, file_path.as_posix()
                 )
@@ -392,6 +392,7 @@ def create_file_tasks(
             task = task_create(task_spec, **task_args)
             setattr(task, TASK_FILE_ATTR, file.as_posix())
             setattr(task, TASK_RUN_DIR_ATTR, run_dir)
+            setattr(task, TASK_SRC_DIR_ATTR, run_dir)
             tasks.append(task)
 
             # warn that chdir has been removed

--- a/src/inspect_ai/_eval/registry.py
+++ b/src/inspect_ai/_eval/registry.py
@@ -18,7 +18,12 @@ from inspect_ai._util.registry import (
 )
 
 from .task import Task
-from .task.constants import TASK_ALL_PARAMS_ATTR, TASK_FILE_ATTR, TASK_RUN_DIR_ATTR, TASK_SRC_DIR_ATTR
+from .task.constants import (
+    TASK_ALL_PARAMS_ATTR,
+    TASK_FILE_ATTR,
+    TASK_RUN_DIR_ATTR,
+    TASK_SRC_DIR_ATTR,
+)
 
 MODEL_PARAM = "model"
 

--- a/src/inspect_ai/_eval/registry.py
+++ b/src/inspect_ai/_eval/registry.py
@@ -18,7 +18,7 @@ from inspect_ai._util.registry import (
 )
 
 from .task import Task
-from .task.constants import TASK_ALL_PARAMS_ATTR, TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
+from .task.constants import TASK_ALL_PARAMS_ATTR, TASK_FILE_ATTR, TASK_RUN_DIR_ATTR, TASK_SRC_DIR_ATTR
 
 MODEL_PARAM = "model"
 
@@ -138,12 +138,14 @@ def task(*args: Any, name: str | None = None, **attribs: Any) -> Any:
             named_params = extract_named_params(task_type, True, *w_args, **w_kwargs)
             setattr(task_instance, TASK_ALL_PARAMS_ATTR, named_params)
 
-            # if its not from an installed package then it is a "local"
-            # module import, so set its task file and run dir
-            if get_installed_package_name(task_type) is None:
-                module = inspect.getmodule(task_type)
-                if module and hasattr(module, "__file__") and module.__file__:
-                    file = Path(getattr(module, "__file__"))
+            module = inspect.getmodule(task_type)
+            if module and hasattr(module, "__file__") and module.__file__:
+                file = Path(getattr(module, "__file__"))
+                setattr(task_instance, TASK_SRC_DIR_ATTR, file.parent.as_posix())
+
+                # if its not from an installed package then it is a "local"
+                # module import, so set its task file and run dir
+                if get_installed_package_name(task_type) is None:
                     setattr(task_instance, TASK_FILE_ATTR, file.as_posix())
                     setattr(task_instance, TASK_RUN_DIR_ATTR, file.parent.as_posix())
 

--- a/src/inspect_ai/_eval/task/constants.py
+++ b/src/inspect_ai/_eval/task/constants.py
@@ -1,3 +1,4 @@
 TASK_FILE_ATTR = "__task_file__"
 TASK_RUN_DIR_ATTR = "__task_run_dir__"
+TASK_SRC_DIR_ATTR = "__task_src_dir__"
 TASK_ALL_PARAMS_ATTR = "__task_all_params__"

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -143,8 +143,11 @@ class TaskLogger:
         # redact authentication oriented model_args
         model_args = model_args_for_log(model_args)
 
-        # cwd_relative_path for sandbox config
-        if sandbox and isinstance(sandbox.config, str):
+        # cwd_relative_path for sandbox config when we can later recover the
+        # source location used to resolve relative configs (i.e. file-based tasks).
+        # Package tasks do not have task_file metadata, so preserving an absolute
+        # config path avoids making eval-retry cwd-dependent.
+        if sandbox and isinstance(sandbox.config, str) and task_file is not None:
             sandbox = SandboxEnvironmentSpec(
                 sandbox.type, cwd_relative_path(sandbox.config)
             )

--- a/src/inspect_ai/_eval/task/util.py
+++ b/src/inspect_ai/_eval/task/util.py
@@ -1,9 +1,9 @@
 import os
 import reprlib
-from pathlib import Path
 from copy import deepcopy
 from fnmatch import fnmatch
 from logging import getLogger
+from pathlib import Path
 from typing import cast
 
 from inspect_ai._util.error import PrerequisiteError

--- a/src/inspect_ai/_eval/task/util.py
+++ b/src/inspect_ai/_eval/task/util.py
@@ -1,5 +1,6 @@
 import os
 import reprlib
+from pathlib import Path
 from copy import deepcopy
 from fnmatch import fnmatch
 from logging import getLogger
@@ -14,7 +15,7 @@ from inspect_ai.dataset._util import normalise_sample_id
 from inspect_ai.model import ChatMessage, ChatMessageUser
 
 from ..task import Task
-from .constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
+from .constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR, TASK_SRC_DIR_ATTR
 
 logger = getLogger(__name__)
 
@@ -31,6 +32,18 @@ def sample_messages(sample: Sample) -> list[ChatMessage]:
 
 def task_run_dir(task: Task) -> str:
     return getattr(task, TASK_RUN_DIR_ATTR, os.getcwd())
+
+
+def task_source_dir(task: Task) -> str:
+    src_dir = cast(str | None, getattr(task, TASK_SRC_DIR_ATTR, None))
+    if src_dir is not None:
+        return src_dir
+
+    file = cast(str | None, getattr(task, TASK_FILE_ATTR, None))
+    if file is not None:
+        return Path(file).parent.as_posix()
+
+    return task_run_dir(task)
 
 
 def task_file(task: Task, relative: bool = False) -> str | None:

--- a/tests/test_package/inspect_package/Dockerfile
+++ b/tests/test_package/inspect_package/Dockerfile
@@ -1,0 +1,2 @@
+FROM alpine:3.20
+RUN printf package-docker-proof > /package_marker

--- a/tests/test_package/inspect_package/_registry.py
+++ b/tests/test_package/inspect_package/_registry.py
@@ -8,6 +8,7 @@ from inspect_ai.util import sandboxenv
 from .approvers.renamer import renamer
 from .score.scorer import simple_score
 from .solvers.cot import cot
+from .tasks import implicit_sandbox_task, relative_sandbox_task
 
 # delayed import for the model and sandbox allows us to only resolve the imports
 # when they are actually requeasted (so that we don't end up requiring all

--- a/tests/test_package/inspect_package/podman.yaml
+++ b/tests/test_package/inspect_package/podman.yaml
@@ -1,0 +1,1 @@
+socket_path: /tmp/inspect-package-podman.sock

--- a/tests/test_package/inspect_package/sandboxenv/podman.py
+++ b/tests/test_package/inspect_package/sandboxenv/podman.py
@@ -22,6 +22,10 @@ class PodmanSandboxEnvironment(SandboxEnvironment):
         return {"default": PodmanSandboxEnvironment(None)}
 
     @classmethod
+    def config_files(cls) -> list[str]:
+        return ["podman.yaml"]
+
+    @classmethod
     async def sample_cleanup(
         cls,
         task_name: str,

--- a/tests/test_package/inspect_package/tasks.py
+++ b/tests/test_package/inspect_package/tasks.py
@@ -1,4 +1,6 @@
 from inspect_ai import Task, task
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+from inspect_ai.util import sandbox
 
 
 @task
@@ -9,3 +11,20 @@ def implicit_sandbox_task() -> Task:
 @task
 def relative_sandbox_task() -> Task:
     return Task(sandbox=("podman", "podman.yaml"))
+
+
+@solver
+def docker_marker_solver() -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        result = await sandbox().exec(["sh", "-lc", "cat /package_marker"])
+        state.store.set("package_marker", result.stdout.strip())
+        if not result.success:
+            raise RuntimeError(result.stderr)
+        return state
+
+    return solve
+
+
+@task
+def docker_implicit_task() -> Task:
+    return Task(solver=docker_marker_solver(), sandbox="docker")

--- a/tests/test_package/inspect_package/tasks.py
+++ b/tests/test_package/inspect_package/tasks.py
@@ -1,0 +1,11 @@
+from inspect_ai import Task, task
+
+
+@task
+def implicit_sandbox_task() -> Task:
+    return Task(sandbox="podman")
+
+
+@task
+def relative_sandbox_task() -> Task:
+    return Task(sandbox=("podman", "podman.yaml"))

--- a/tests/test_package/pyproject.toml
+++ b/tests/test_package/pyproject.toml
@@ -19,3 +19,6 @@ build-backend = "setuptools.build_meta"
 [project.entry-points.inspect_ai]
 inspect_package = "inspect_package._registry"
 
+
+[tool.setuptools.package-data]
+inspect_package = ["*.yaml"]

--- a/tests/test_package/pyproject.toml
+++ b/tests/test_package/pyproject.toml
@@ -21,4 +21,4 @@ inspect_package = "inspect_package._registry"
 
 
 [tool.setuptools.package-data]
-inspect_package = ["*.yaml"]
+inspect_package = ["*.yaml", "Dockerfile"]

--- a/tests/test_task_attr.py
+++ b/tests/test_task_attr.py
@@ -56,6 +56,16 @@ def test_package_task_uses_source_dir_without_changing_run_dir():
     assert task_run_dir(task) == str(Path.cwd())
 
 
+def test_package_task_override_sandbox_resolves_relative_to_run_dir():
+    ensure_test_package_installed()
+
+    task = task_create("inspect_package/implicit_sandbox_task")
+    resolved = resolve_task_sandbox(task, ("podman", "override.yaml"))
+
+    assert resolved is not None
+    assert resolved.config == str(Path.cwd() / "override.yaml")
+
+
 @skip_if_no_docker
 def test_package_task_implicit_docker_build_uses_package_dockerfile():
     ensure_test_package_installed()

--- a/tests/test_task_attr.py
+++ b/tests/test_task_attr.py
@@ -1,9 +1,50 @@
-from test_helpers.tasks import empty_task
+from pathlib import Path
 
+from test_helpers.tasks import empty_task
+from test_helpers.utils import ensure_test_package_installed
+
+from inspect_ai._eval.loader import resolve_task_sandbox
+from inspect_ai._eval.registry import task_create
 from inspect_ai._eval.task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
+from inspect_ai._eval.task.util import task_run_dir, task_source_dir
 
 
 def test_local_module_attr():
     task = empty_task()
     assert getattr(task, TASK_FILE_ATTR, None)
     assert getattr(task, TASK_RUN_DIR_ATTR, None)
+
+
+def test_package_task_implicit_sandbox_resolves_relative_to_package_dir():
+    ensure_test_package_installed()
+
+    import inspect_package
+
+    task = task_create("inspect_package/implicit_sandbox_task")
+    resolved = resolve_task_sandbox(task, None)
+
+    assert resolved is not None
+    assert resolved.config == str(Path(inspect_package.__file__).parent / "podman.yaml")
+
+
+def test_package_task_relative_sandbox_config_resolves_relative_to_package_dir():
+    ensure_test_package_installed()
+
+    import inspect_package
+
+    task = task_create("inspect_package/relative_sandbox_task")
+    resolved = resolve_task_sandbox(task, None)
+
+    assert resolved is not None
+    assert resolved.config == str(Path(inspect_package.__file__).parent / "podman.yaml")
+
+
+def test_package_task_uses_source_dir_without_changing_run_dir():
+    ensure_test_package_installed()
+
+    import inspect_package
+
+    task = task_create("inspect_package/implicit_sandbox_task")
+
+    assert task_source_dir(task) == str(Path(inspect_package.__file__).parent)
+    assert task_run_dir(task) == str(Path.cwd())

--- a/tests/test_task_attr.py
+++ b/tests/test_task_attr.py
@@ -1,8 +1,10 @@
+import importlib
 from pathlib import Path
 
 from test_helpers.tasks import empty_task
-from test_helpers.utils import ensure_test_package_installed
+from test_helpers.utils import ensure_test_package_installed, skip_if_no_docker
 
+from inspect_ai import eval
 from inspect_ai._eval.loader import resolve_task_sandbox
 from inspect_ai._eval.registry import task_create
 from inspect_ai._eval.task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
@@ -18,33 +20,50 @@ def test_local_module_attr():
 def test_package_task_implicit_sandbox_resolves_relative_to_package_dir():
     ensure_test_package_installed()
 
-    import inspect_package
+    inspect_package = importlib.import_module("inspect_package")
 
     task = task_create("inspect_package/implicit_sandbox_task")
     resolved = resolve_task_sandbox(task, None)
 
     assert resolved is not None
-    assert resolved.config == str(Path(inspect_package.__file__).parent / "podman.yaml")
+    assert resolved.config == str(
+        Path(str(inspect_package.__file__)).parent / "podman.yaml"
+    )
 
 
 def test_package_task_relative_sandbox_config_resolves_relative_to_package_dir():
     ensure_test_package_installed()
 
-    import inspect_package
+    inspect_package = importlib.import_module("inspect_package")
 
     task = task_create("inspect_package/relative_sandbox_task")
     resolved = resolve_task_sandbox(task, None)
 
     assert resolved is not None
-    assert resolved.config == str(Path(inspect_package.__file__).parent / "podman.yaml")
+    assert resolved.config == str(
+        Path(str(inspect_package.__file__)).parent / "podman.yaml"
+    )
 
 
 def test_package_task_uses_source_dir_without_changing_run_dir():
     ensure_test_package_installed()
 
-    import inspect_package
+    inspect_package = importlib.import_module("inspect_package")
 
     task = task_create("inspect_package/implicit_sandbox_task")
 
-    assert task_source_dir(task) == str(Path(inspect_package.__file__).parent)
+    assert task_source_dir(task) == str(Path(str(inspect_package.__file__)).parent)
     assert task_run_dir(task) == str(Path.cwd())
+
+
+@skip_if_no_docker
+def test_package_task_implicit_docker_build_uses_package_dockerfile():
+    ensure_test_package_installed()
+
+    task = task_create("inspect_package/docker_implicit_task")
+    log = eval(task, model="mockllm/model")[0]
+
+    assert log.status == "success"
+    assert log.samples
+    sample = log.samples[0]
+    assert sample.store.get("package_marker") == "package-docker-proof"

--- a/tests/test_task_attr.py
+++ b/tests/test_task_attr.py
@@ -76,7 +76,9 @@ def test_package_task_logs_absolute_sandbox_config_for_retry(monkeypatch, tmp_pa
 
     inspect_package = importlib.import_module("inspect_package")
 
-    monkeypatch.chdir("/home/claw/.openclaw/workspace/repos/inspect_ai")
+    initial_cwd = tmp_path / "initial-cwd"
+    initial_cwd.mkdir()
+    monkeypatch.chdir(initial_cwd)
 
     task = task_create("inspect_package/implicit_sandbox_task")
     sandbox = resolve_task_sandbox(task, None)
@@ -115,7 +117,9 @@ def test_package_task_logs_absolute_sandbox_config_for_retry(monkeypatch, tmp_pa
     assert logger.eval.sandbox is not None
     assert logger.eval.sandbox.config == expected
 
-    monkeypatch.chdir(tmp_path)
+    retry_cwd = tmp_path / "retry-cwd"
+    retry_cwd.mkdir()
+    monkeypatch.chdir(retry_cwd)
     retried = resolve_task_file_sandbox(logger.eval.task_file, logger.eval.sandbox)
     assert retried is not None
     assert retried.config == expected

--- a/tests/test_task_attr.py
+++ b/tests/test_task_attr.py
@@ -5,10 +5,15 @@ from test_helpers.tasks import empty_task
 from test_helpers.utils import ensure_test_package_installed, skip_if_no_docker
 
 from inspect_ai import eval
-from inspect_ai._eval.loader import resolve_task_sandbox
+from inspect_ai._eval.loader import resolve_task_file_sandbox, resolve_task_sandbox
 from inspect_ai._eval.registry import task_create
 from inspect_ai._eval.task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
+from inspect_ai._eval.task.log import TaskLogger
 from inspect_ai._eval.task.util import task_run_dir, task_source_dir
+from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.log import EvalConfig
+from inspect_ai.log._recorders.eval import EvalRecorder
+from inspect_ai.model import get_model
 
 
 def test_local_module_attr():
@@ -64,6 +69,56 @@ def test_package_task_override_sandbox_resolves_relative_to_run_dir():
 
     assert resolved is not None
     assert resolved.config == str(Path.cwd() / "override.yaml")
+
+
+def test_package_task_logs_absolute_sandbox_config_for_retry(monkeypatch, tmp_path):
+    ensure_test_package_installed()
+
+    inspect_package = importlib.import_module("inspect_package")
+
+    monkeypatch.chdir("/home/claw/.openclaw/workspace/repos/inspect_ai")
+
+    task = task_create("inspect_package/implicit_sandbox_task")
+    sandbox = resolve_task_sandbox(task, None)
+
+    assert sandbox is not None
+
+    logger = TaskLogger(
+        task_name=task.name,
+        task_version=task.version,
+        task_file=None,
+        task_registry_name=task.registry_name,
+        task_display_name=task.display_name,
+        task_id=None,
+        eval_set_id=None,
+        run_id="run-id",
+        solver=None,
+        tags=None,
+        model=get_model("mockllm/model"),
+        model_roles=None,
+        dataset=MemoryDataset([Sample(input="hi", id=1)], name="dataset"),
+        scorer=None,
+        metrics=None,
+        sandbox=sandbox,
+        task_attribs=task.attribs,
+        task_args={},
+        task_args_passed={},
+        model_args={},
+        eval_config=EvalConfig(),
+        metadata=None,
+        viewer=None,
+        recorder=EvalRecorder(tmp_path.as_posix()),
+        header_only=False,
+    )
+
+    expected = str(Path(str(inspect_package.__file__)).parent / "podman.yaml")
+    assert logger.eval.sandbox is not None
+    assert logger.eval.sandbox.config == expected
+
+    monkeypatch.chdir(tmp_path)
+    retried = resolve_task_file_sandbox(logger.eval.task_file, logger.eval.sandbox)
+    assert retried is not None
+    assert retried.config == expected
 
 
 @skip_if_no_docker


### PR DESCRIPTION
Fixes #3372.

## Summary
- fix sandbox config resolution for package-installed tasks without changing task runtime cwd semantics
- preserve explicit override semantics for relative sandbox config paths
- preserve package sandbox config paths in eval logs so retry remains cwd-independent
- add regression coverage for implicit package sandbox discovery, explicit relative overrides, run-dir/source-dir separation, retry logging, and the Docker-backed package task path

## Problem
Registry-loaded package tasks could resolve implicit or relative Docker sandbox configs relative to the caller cwd instead of the installed task package directory. In practice that meant package tasks could silently fall back to the default sandbox image instead of using the package-local Dockerfile/config intended by the task author.

There was also a follow-on robustness gap: for package tasks without a `task_file`, the logged sandbox config path could remain relative to the original cwd, which made retry behavior cwd-dependent.

## Approach
The fix separates task source-directory semantics from task run-directory semantics.

- stamp a dedicated task source-dir attribute from the module file for package-installed tasks
- keep existing task run-dir behavior unchanged so runtime cwd semantics do not shift
- resolve implicit package sandbox configs and docker-forwarded relative paths from the task source dir
- continue resolving explicit override sandbox arguments from the task run dir
- preserve absolute sandbox config paths in eval logs for package tasks so retry remains stable

This avoids the riskier alternative of mutating task run-dir behavior for installed-package tasks.

## Validation
Whole-repo regression rerun during the revisit:

```bash
cd /home/claw/.openclaw/workspace/repos/inspect_ai
PATH=/home/claw/.openclaw/workspace/repos/inspect_ai/.venv/bin:$PATH make test
```

Observed result:
- `4359 passed, 1646 skipped, 12 warnings in 319.34s (0:05:19)`

Targeted non-Docker regression set:

```bash
PYTHONPATH=/tmp/inspect_ai_issue3372_revisit/src \
PATH=/home/claw/.openclaw/workspace/repos/inspect_ai/.venv/bin:$PATH \
/home/claw/.openclaw/workspace/repos/inspect_ai/.venv/bin/python -m pytest -q \
  tests/test_task_attr.py \
  tests/test_extensions.py \
  tests/solver/test_solver_spec.py \
  tests/scorer/test_scorer.py
```

Observed result:
- `22 passed, 6 skipped in 16.12s`

Docker-backed proof on a Docker-capable host:

```bash
PYTHONPATH=/home/claw/work/inspect_ai-3372/src \
PATH=/home/claw/work/inspect_ai/.venv/bin:$PATH \
/home/claw/work/inspect_ai/.venv/bin/python -m pytest -q \
  tests/test_task_attr.py::test_package_task_implicit_docker_build_uses_package_dockerfile
```

Observed result:
- `1 passed in 11.43s`

## Merge note
A squash merge is preferred for this branch.
