### PR TITLE
pytest: parallelize in CI only; add make test-parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -117,7 +117,7 @@ jobs:
           uv pip install .[dev]
 
       - name: Test with pytest
-        run: uv run pytest -rA --doctest-modules --color=yes --cov=inspect_ai
+        run: uv run pytest -rA --doctest-modules --color=yes -n auto --cov=inspect_ai
 
       - name: Minimize uv cache
         if: ${{ !cancelled() }}

--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,8 @@ check: ruff mypy
 test:
 	pytest
 
+.PHONY: test-parallel
+test-parallel:
+	pytest -n auto
+
 include docs/evals/inspect-evals.mk

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ convention = "google"
 
 [tool.pytest.ini_options]
 minversion = "7.0"
-addopts = "-rA --doctest-modules --color=yes -n auto"
+addopts = "-rA --doctest-modules --color=yes"
 testpaths = ["tests"]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
 norecursedirs = [


### PR DESCRIPTION
## Summary

Parallelization stays on in CI but is off by default for local `pytest` / `make test`. Devs can opt back in with `pytest -n auto` or `make test-parallel`.

## Why

Some of our tests aren't fully isolated and can fail under xdist. Rather than force an immediate, broad fix-up of every flaky-under-parallel test, we're keeping the speedup where it matters (CI) and giving local runs a stable default. Tests can be hardened against parallel execution incrementally; in the meantime, developers (and coding agents driving pytest) aren't fighting spurious failures.

## Changes

- `pyproject.toml`: drop `-n auto` from `addopts`
- `.github/workflows/build.yml`: add `-n auto` to the CI pytest command
- `Makefile`: add `test-parallel` target