### PR TITLE
test: remove flaky test_web_browser_displays_error

### DIFF
--- a/tests/tools/test_web_browser.py
+++ b/tests/tools/test_web_browser.py
@@ -282,29 +282,6 @@ def test_web_browser_input():
     assert type_call
 
 
-@skip_if_no_docker
-@skip_if_no_openai
-@pytest.mark.slow
-def test_web_browser_displays_error():
-    """This should return an error, because the web-browsing tool cannot access pdfs."""
-    task = Task(
-        dataset=[
-            Sample(
-                input="Please use the web browser tool to navigate to https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf."
-            )
-        ],
-        solver=[use_tools(web_browser()), generate()],
-        sandbox=web_browser_sandbox(),
-    )
-
-    log = eval(task, model="openai/gpt-4o")[0]
-    response = get_tool_response(
-        log.samples[0].messages,
-        get_tool_call(log.samples[0].messages, "web_browser_go"),
-    )
-    assert response.error is not None
-
-
 def web_browser_sandbox() -> tuple[str, str]:
     return (
         "docker",


### PR DESCRIPTION
Test premise ("web browser tool cannot access PDFs") is false. The URL under test sits behind Cloudflare bot mitigation, so headless-shell intermittently gets a 403 HTML challenge instead of the PDF -- which page.goto treats as a successful navigation and the assertion fires. web_browser is borderline deprecated; not worth keeping working.