### PR TITLE
openai-api: add use_max_completion_tokens escape hatch

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1282,6 +1282,14 @@ Or using the `eval()` function:
 eval("arc.py", model="openai-api/<provider>/<model>", model_args=dict(strict_tools=False))
 ```
 
+### `max_completion_tokens` {#max-completion-tokens-openai-compatible}
+
+Some OpenAI-compatible providers require `max_completion_tokens` (and reject `max_tokens`) even when they use non-standard model names that Inspect can't reliably detect. You can force Inspect to send `max_completion_tokens` (Chat Completions API only; ignored when using `responses_api=true`) by passing the `use_max_completion_tokens` model arg:
+
+``` bash
+inspect eval my_task.py --model openai-api/<provider>/<model> -M use_max_completion_tokens=true
+```
+
 ### Streaming {#streaming-openai-compatible}
 
 You can enable the use of the streaming with the `openai-api` provider by passing the `stream` model arg. For example:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -122,6 +122,12 @@ class OpenAICompatibleAPI(ModelAPI):
         if not isinstance(responses_phase, bool):
             raise ValueError("responses_phase must be a bool")
         self.responses_phase: bool = responses_phase
+
+        use_max_completion_tokens = model_args.pop("use_max_completion_tokens", False)
+        if not isinstance(use_max_completion_tokens, bool):
+            raise ValueError("use_max_completion_tokens must be a bool")
+        self.use_max_completion_tokens: bool = use_max_completion_tokens
+
         if self.emulate_tools and self.responses_api:
             raise ValueError(
                 "emulate_tools is not compatible with using the responses_api"
@@ -349,17 +355,17 @@ class OpenAICompatibleAPI(ModelAPI):
         return JSON_SCHEMA_EXTENDED_FIELDS
 
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        service_model = self.service_model_name()
         params = openai_completion_params(
-            model=self.service_model_name(),
+            model=service_model,
             config=config,
             tools=tools,
             schema_exclude=self.schema_exclude_fields,
         )
 
         if (
-            needs_max_completion_tokens(self.service_model_name())
-            and "max_tokens" in params
-        ):
+            self.use_max_completion_tokens or needs_max_completion_tokens(service_model)
+        ) and "max_tokens" in params:
             params["max_completion_tokens"] = params.pop("max_tokens")
 
         return params

--- a/tests/model/test_openai_compatible_max_completion_tokens.py
+++ b/tests/model/test_openai_compatible_max_completion_tokens.py
@@ -1,0 +1,28 @@
+import pytest
+
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+
+
+def test_openai_compatible_use_max_completion_tokens_rewrites_max_tokens():
+    api = OpenAICompatibleAPI(
+        model_name="acme/custom-model",
+        base_url="http://localhost:9999/v1",
+        api_key="test-key",
+        use_max_completion_tokens=True,
+    )
+
+    params = api.completion_params(GenerateConfig(max_tokens=123), tools=False)
+
+    assert "max_tokens" not in params
+    assert params["max_completion_tokens"] == 123
+
+
+def test_openai_compatible_use_max_completion_tokens_requires_bool():
+    with pytest.raises(ValueError, match="use_max_completion_tokens must be a bool"):
+        OpenAICompatibleAPI(
+            model_name="acme/custom-model",
+            base_url="http://localhost:9999/v1",
+            api_key="test-key",
+            use_max_completion_tokens="true",
+        )


### PR DESCRIPTION
## What
Add a `use_max_completion_tokens` boolean model arg to the `openai-api` (OpenAI-compatible) provider that forces `max_tokens` -> `max_completion_tokens` for Chat Completions requests.

## Why
Some OpenAI-compatible deployments with non-standard model names reject `max_tokens` and require `max_completion_tokens`, and the current model-name heuristic can't cover all custom names. This provides an explicit per-deployment escape hatch (e.g. `-M use_max_completion_tokens=true`).

## Changes
- `OpenAICompatibleAPI`: parse/validate `use_max_completion_tokens` and apply it in request param construction
- Docs: document the new model arg under the `openai-api` provider
- Tests: add a unit test covering the rewrite + type validation

## Notes
- Applies to Chat Completions parameter building; when `responses_api=true` the Responses API uses `max_output_tokens` instead (no `max_tokens` is sent).
