### PR TITLE
Arena: Add pairwise comparison with win rate and Elo metrics

### DIFF
--- a/src/inspect_ai/arena/__init__.py
+++ b/src/inspect_ai/arena/__init__.py
@@ -1,0 +1,25 @@
+"""Arena-style pairwise evaluation for inspect_ai.
+
+This module defines the core abstractions used to compose arena-style
+evaluation on top of the standard `Task` pipeline:
+
+- `ArenaState`: per-sample storage shared between solver and scorer.
+- `Judge` / `JudgeVerdict`: the contract any judging strategy implements.
+
+First-party implementations (`arena_solver`, `llm_judge`, `pairwise_scorer`,
+`win_rate`, `elo`) build on these contracts and are added separately.
+
+See https://github.com/UKGovernmentBEIS/inspect_ai/issues/3994 for the
+design proposal and rationale.
+"""
+
+from ._judge import Judge
+from ._state import ArenaState
+from ._verdict import JudgeVerdict, Winner
+
+__all__ = [
+    "ArenaState",
+    "Judge",
+    "JudgeVerdict",
+    "Winner",
+]

--- a/src/inspect_ai/arena/__init__.py
+++ b/src/inspect_ai/arena/__init__.py
@@ -6,20 +6,42 @@ evaluation on top of the standard `Task` pipeline:
 - `ArenaState`: per-sample storage shared between solver and scorer.
 - `Judge` / `JudgeVerdict`: the contract any judging strategy implements.
 
-First-party implementations (`arena_solver`, `llm_judge`, `pairwise_scorer`,
-`win_rate`, `elo`) build on these contracts and are added separately.
+It also ships first-party implementations that plug into the standard
+`Task` slots:
+
+- `arena_solver`: fans out to multiple contestants on the same input.
+- `llm_judge`: model-backed `Judge` with position-bias controls.
+- `pairwise_scorer`: generates all pairs and runs the judge.
+- `win_rate`, `elo`: metrics that aggregate pairwise verdicts.
 
 See https://github.com/UKGovernmentBEIS/inspect_ai/issues/3994 for the
 design proposal and rationale.
 """
 
 from ._judge import Judge
+from ._llm_judge import (
+    DEFAULT_JUDGE_INSTRUCTIONS,
+    DEFAULT_JUDGE_TEMPLATE,
+    DEFAULT_VERDICT_PATTERN,
+    llm_judge,
+)
+from ._metrics import elo, win_rate
+from ._scorer import pairwise_scorer
+from ._solver import arena_solver
 from ._state import ArenaState
 from ._verdict import JudgeVerdict, Winner
 
 __all__ = [
     "ArenaState",
+    "DEFAULT_JUDGE_INSTRUCTIONS",
+    "DEFAULT_JUDGE_TEMPLATE",
+    "DEFAULT_VERDICT_PATTERN",
     "Judge",
     "JudgeVerdict",
     "Winner",
+    "arena_solver",
+    "elo",
+    "llm_judge",
+    "pairwise_scorer",
+    "win_rate",
 ]

--- a/src/inspect_ai/arena/_judge.py
+++ b/src/inspect_ai/arena/_judge.py
@@ -1,0 +1,21 @@
+from typing import Protocol, runtime_checkable
+
+from ._verdict import JudgeVerdict
+
+
+@runtime_checkable
+class Judge(Protocol):
+    """Callable that compares two responses to the same prompt.
+
+    Implementations may use a model (`llm_judge`), a human, or any other
+    strategy. The protocol intentionally sees only the prompt and the two
+    candidate responses — contestant identities are kept inside
+    `pairwise_scorer` to avoid biasing the judge.
+    """
+
+    async def __call__(
+        self,
+        prompt: str,
+        response_a: str,
+        response_b: str,
+    ) -> JudgeVerdict: ...

--- a/src/inspect_ai/arena/_llm_judge.py
+++ b/src/inspect_ai/arena/_llm_judge.py
@@ -1,0 +1,131 @@
+import random
+import re
+
+from inspect_ai.model import Model, get_model
+from inspect_ai.util import resource
+
+from ._judge import Judge
+from ._verdict import JudgeVerdict, Winner
+
+DEFAULT_JUDGE_TEMPLATE = """\
+You are an impartial judge comparing two responses to the same prompt.
+
+[PROMPT]
+{prompt}
+
+[RESPONSE A]
+{response_a}
+
+[RESPONSE B]
+{response_b}
+
+{instructions}
+"""
+
+DEFAULT_JUDGE_INSTRUCTIONS = """\
+Decide which response better addresses the prompt. Briefly justify your choice,
+then end your reply on a new line with exactly one of:
+
+  VERDICT: A
+  VERDICT: B
+  VERDICT: TIE
+
+Use TIE only when neither response is meaningfully better than the other.
+"""
+
+DEFAULT_VERDICT_PATTERN = r"(?is).*VERDICT\s*:\s*(A|B|TIE)"
+
+
+def llm_judge(
+    template: str | None = None,
+    instructions: str | None = None,
+    verdict_pattern: str | None = None,
+    randomize_order: bool = True,
+    both_orders: bool = False,
+    model: str | Model | None = None,
+    model_role: str | None = "judge",
+) -> Judge:
+    """Built-in `Judge` backed by an LLM.
+
+    Follows the conventions of `model_graded_qa`: customisable template /
+    instructions / verdict regex, and `model_role` binding via the
+    `model_roles` argument to `eval()`.
+
+    Position-bias controls (mutually exclusive — `both_orders` wins):
+
+    - `randomize_order` (default): swap the two responses with probability
+      0.5 per call. The verdict is un-swapped before returning, so position
+      bias averages out across many samples without doubling cost.
+    - `both_orders`: invoke the judge twice with swapped orderings and
+      aggregate. Agreement on a winner returns that winner; disagreement
+      returns a tie. Doubles judge calls per pair.
+    """
+    template_str = template if template else DEFAULT_JUDGE_TEMPLATE
+    judge_template = resource(template_str)
+    judge_instructions = instructions if instructions else DEFAULT_JUDGE_INSTRUCTIONS
+    pattern = verdict_pattern or DEFAULT_VERDICT_PATTERN
+
+    async def _ask(
+        judge_model: Model, prompt: str, resp_a: str, resp_b: str
+    ) -> JudgeVerdict:
+        rendered = judge_template.format(
+            prompt=prompt,
+            response_a=resp_a,
+            response_b=resp_b,
+            instructions=judge_instructions,
+        )
+        result = await judge_model.generate(rendered)
+        match = re.search(pattern, result.completion)
+        if match is None:
+            return JudgeVerdict(
+                winner="tie",
+                explanation=result.completion,
+                metadata={"reason": "verdict_pattern_not_matched"},
+            )
+        letter = match.group(1).upper()
+        winner: Winner = "a" if letter == "A" else "b" if letter == "B" else "tie"
+        return JudgeVerdict(winner=winner, explanation=result.completion)
+
+    def _flip(verdict: JudgeVerdict) -> JudgeVerdict:
+        flipped: Winner = (
+            "a" if verdict.winner == "b" else "b" if verdict.winner == "a" else "tie"
+        )
+        return JudgeVerdict(
+            winner=flipped,
+            explanation=verdict.explanation,
+            metadata=verdict.metadata,
+        )
+
+    async def judge(prompt: str, response_a: str, response_b: str) -> JudgeVerdict:
+        # Resolve the judge model lazily, mirroring model_graded_qa.
+        if model is not None:
+            judge_model = model if isinstance(model, Model) else get_model(model)
+        elif model_role is not None:
+            judge_model = get_model(role=model_role)
+        else:
+            judge_model = get_model()
+
+        if both_orders:
+            # Show each ordering to the judge once. The second verdict comes
+            # back in the swapped coordinate system, so flip it before
+            # comparing to the first.
+            v1 = await _ask(judge_model, prompt, response_a, response_b)
+            v2_swapped = await _ask(judge_model, prompt, response_b, response_a)
+            v2 = _flip(v2_swapped)
+            if v1.winner == v2.winner:
+                return JudgeVerdict(winner=v1.winner)
+            return JudgeVerdict(
+                winner="tie",
+                metadata={"reason": "both_orders_disagree"},
+            )
+
+        if randomize_order and random.random() < 0.5:
+            # Show the judge the swapped order to neutralise position bias,
+            # then flip the verdict back so callers always see "a"/"b" in
+            # the original (response_a, response_b) coordinates.
+            verdict = await _ask(judge_model, prompt, response_b, response_a)
+            return _flip(verdict)
+
+        return await _ask(judge_model, prompt, response_a, response_b)
+
+    return judge

--- a/src/inspect_ai/arena/_metrics.py
+++ b/src/inspect_ai/arena/_metrics.py
@@ -1,0 +1,152 @@
+import random
+from collections import defaultdict
+from typing import Any, cast
+
+from inspect_ai.scorer import Metric, SampleScore, Value, metric
+
+
+def _iter_comparisons(scores: list[SampleScore]) -> list[dict[str, str]]:
+    """Flatten the `comparisons` lists from each sample's metadata into one stream.
+
+    `pairwise_scorer` stores the structured per-pair verdicts on
+    `Score.metadata["comparisons"]` (not `value`, which only allows flat
+    `Mapping[str, scalar]`). This helper hides the access path so metric
+    implementations stay focused on the aggregation logic.
+    """
+    out: list[dict[str, str]] = []
+    for sample in scores:
+        metadata = sample.score.metadata
+        if not metadata:
+            continue
+        comparisons = metadata.get("comparisons")
+        if not isinstance(comparisons, list):
+            continue
+        for cmp in comparisons:
+            if isinstance(cmp, dict) and {"a", "b", "winner"} <= cmp.keys():
+                out.append(cast(dict[str, str], cmp))
+    return out
+
+
+@metric
+def win_rate(include_ties: bool = True) -> Metric:
+    """Average win rate per contestant across all pairwise comparisons.
+
+    A win contributes 1.0; a loss contributes 0.0. Ties contribute 0.5 to each
+    side when `include_ties=True` (the default), and are excluded from both
+    numerator and denominator otherwise.
+
+    Returns a `dict[contestant_name, rate]`. Contestants with zero
+    comparisons are omitted.
+    """
+
+    def compute(scores: list[SampleScore]) -> Value:
+        wins: dict[str, float] = defaultdict(float)
+        total: dict[str, float] = defaultdict(float)
+
+        for cmp in _iter_comparisons(scores):
+            a, b, winner = cmp["a"], cmp["b"], cmp["winner"]
+            if winner == "tie" and not include_ties:
+                continue
+            total[a] += 1
+            total[b] += 1
+            if winner == "a":
+                wins[a] += 1
+            elif winner == "b":
+                wins[b] += 1
+            else:
+                wins[a] += 0.5
+                wins[b] += 0.5
+
+        return cast(Value, {name: wins[name] / total[name] for name in total})
+
+    return compute
+
+
+def _expected(rating_a: float, rating_b: float, base: float = 400.0) -> float:
+    return 1.0 / (1.0 + 10 ** ((rating_b - rating_a) / base))
+
+
+def _run_elo(
+    comparisons: list[dict[str, str]],
+    contestants: list[str],
+    k: float,
+    initial: float,
+    order: list[int],
+) -> dict[str, float]:
+    ratings = {c: initial for c in contestants}
+    for idx in order:
+        cmp = comparisons[idx]
+        a, b, winner = cmp["a"], cmp["b"], cmp["winner"]
+        ea = _expected(ratings[a], ratings[b])
+        sa = 1.0 if winner == "a" else 0.0 if winner == "b" else 0.5
+        delta = k * (sa - ea)
+        ratings[a] += delta
+        ratings[b] -= delta
+    return ratings
+
+
+@metric
+def elo(
+    k: float = 32.0,
+    initial: float = 1000.0,
+    n_bootstrap: int = 1000,
+    seed: int | None = None,
+) -> Metric:
+    """Elo rating per contestant with bootstrap-based confidence intervals.
+
+    Standard Elo update with scale `k` against `initial` rating. Because
+    sequential Elo is order-dependent, the metric repeats the full update
+    sweep over `n_bootstrap` random shuffles of the comparison list and
+    reports the mean rating and 2.5th / 97.5th percentile bounds.
+
+    Returns `{contestant_name: {"rating": float, "low": float, "high": float}}`.
+    Contestants that never appeared in a comparison are omitted.
+    """
+
+    def compute(scores: list[SampleScore]) -> Value:
+        comparisons = _iter_comparisons(scores)
+        if not comparisons:
+            return cast(Value, {})
+
+        contestants = sorted(
+            {cmp["a"] for cmp in comparisons} | {cmp["b"] for cmp in comparisons}
+        )
+
+        rng = random.Random(seed)
+        samples: dict[str, list[float]] = {c: [] for c in contestants}
+        indices = list(range(len(comparisons)))
+
+        for _ in range(n_bootstrap):
+            rng.shuffle(indices)
+            run = _run_elo(comparisons, contestants, k, initial, indices)
+            for c, r in run.items():
+                samples[c].append(r)
+
+        result: dict[str, dict[str, float]] = {}
+        for c, ratings in samples.items():
+            sorted_ratings = sorted(ratings)
+            n = len(sorted_ratings)
+            mean = sum(sorted_ratings) / n
+            lo = sorted_ratings[max(0, int(0.025 * n))]
+            hi = sorted_ratings[min(n - 1, int(0.975 * n))]
+            result[c] = {"rating": mean, "low": lo, "high": hi}
+
+        return cast(Value, _flatten_for_value(result))
+
+    return compute
+
+
+def _flatten_for_value(
+    nested: dict[str, dict[str, float]],
+) -> dict[str, Any]:
+    """Flatten per-contestant stats into a single-level dict.
+
+    Score `Value` is `Mapping[str, scalar]`, so nested per-contestant stats
+    are encoded as flat keys (`{name}.rating`, `{name}.low`, `{name}.high`) —
+    the result is valid `Value` while remaining round-trippable.
+    """
+    out: dict[str, Any] = {}
+    for name, stats in nested.items():
+        for k, v in stats.items():
+            out[f"{name}.{k}"] = v
+    return out

--- a/src/inspect_ai/arena/_scorer.py
+++ b/src/inspect_ai/arena/_scorer.py
@@ -1,0 +1,78 @@
+from collections import defaultdict
+from itertools import combinations
+
+from inspect_ai.scorer import Score, Scorer, Target, scorer
+from inspect_ai.solver import TaskState
+from inspect_ai.util import collect
+
+from ._judge import Judge
+from ._metrics import elo, win_rate
+from ._state import ArenaState
+
+
+@scorer(metrics=[win_rate(), elo()])
+def pairwise_scorer(judge: Judge) -> Scorer:
+    """Generate pairwise comparisons across contestants and run the judge.
+
+    Reads contestant responses from `ArenaState` (populated by `arena_solver`),
+    constructs all N×(N−1)/2 unordered pairs of non-failed contestants, and
+    awaits the judge on each pair concurrently.
+
+    Each sample's `Score.value` is `{contestant_name: win_points}` — each
+    contestant's contribution to this sample (1.0 per win, 0.5 per tie). The
+    full structured list of verdicts is preserved on `Score.metadata` under
+    the `"comparisons"` key for downstream metrics to consume:
+
+        metadata = {
+            "comparisons": [
+                {"a": "<name_a>", "b": "<name_b>", "winner": "a"|"b"|"tie"},
+                ...
+            ],
+            "failed": ["<contestant>", ...],
+        }
+    """
+
+    async def score(state: TaskState, target: Target) -> Score:
+        arena = state.store_as(ArenaState)
+        names = list(arena.responses.keys())
+
+        if len(names) < 2:
+            return Score(
+                value={name: 0.0 for name in names},
+                metadata={"comparisons": [], "failed": list(arena.failed)},
+                explanation="Fewer than 2 successful contestants; no pairs to judge.",
+            )
+
+        prompt = state.input_text
+        pairs = list(combinations(names, 2))
+
+        verdicts = await collect(
+            *(judge(prompt, arena.responses[a], arena.responses[b]) for a, b in pairs)
+        )
+
+        comparisons = [
+            {"a": a, "b": b, "winner": v.winner} for (a, b), v in zip(pairs, verdicts)
+        ]
+
+        points: dict[str, float] = defaultdict(float)
+        for cmp in comparisons:
+            a, b, winner = cmp["a"], cmp["b"], cmp["winner"]
+            if winner == "a":
+                points[a] += 1.0
+            elif winner == "b":
+                points[b] += 1.0
+            else:
+                points[a] += 0.5
+                points[b] += 0.5
+        # Ensure every contestant appears in value even with no wins.
+        value: dict[str, float] = {name: points[name] for name in names}
+
+        return Score(
+            value=value,
+            metadata={
+                "comparisons": comparisons,
+                "failed": list(arena.failed),
+            },
+        )
+
+    return score

--- a/src/inspect_ai/arena/_solver.py
+++ b/src/inspect_ai/arena/_solver.py
@@ -1,0 +1,63 @@
+from typing import Literal
+
+from inspect_ai.model import Model, get_model
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+from inspect_ai.util import collect
+
+from ._state import ArenaState
+
+
+@solver
+def arena_solver(
+    contestants: list[str | Model],
+    parallel: bool = True,
+    on_contestant_error: Literal["skip", "raise"] = "skip",
+) -> Solver:
+    """Fan out to multiple contestants on the same input.
+
+    Each contestant generates a response from `state.input`. Responses are
+    written into `ArenaState` for downstream consumption by `pairwise_scorer`.
+
+    Args:
+        contestants: List of model specs (strings like `"openai/gpt-4o"`) or
+            pre-resolved `Model` instances. Contestant identity in the
+            resulting `ArenaState` is the canonical name (`str(model)`).
+        parallel: If `True` (default), all contestants generate concurrently
+            via `collect()`. Set `False` for deterministic sequential runs.
+        on_contestant_error: `"skip"` (default) records the failure in
+            `ArenaState.failed` and continues with remaining contestants.
+            `"raise"` propagates the first exception, failing the sample.
+    """
+    resolved: list[Model] = [
+        c if isinstance(c, Model) else get_model(c) for c in contestants
+    ]
+    names = [str(m) for m in resolved]
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        arena = state.store_as(ArenaState)
+
+        async def call(name: str, model: Model) -> tuple[str, str | None]:
+            try:
+                output = await model.generate(state.input)
+                return name, output.completion
+            except Exception:
+                if on_contestant_error == "raise":
+                    raise
+                return name, None
+
+        if parallel:
+            results = await collect(
+                *(call(name, model) for name, model in zip(names, resolved))
+            )
+        else:
+            results = [await call(name, model) for name, model in zip(names, resolved)]
+
+        for name, completion in results:
+            if completion is None:
+                arena.failed.append(name)
+            else:
+                arena.responses[name] = completion
+
+        return state
+
+    return solve

--- a/src/inspect_ai/arena/_state.py
+++ b/src/inspect_ai/arena/_state.py
@@ -1,0 +1,17 @@
+from pydantic import Field
+
+from inspect_ai.util import StoreModel
+
+
+class ArenaState(StoreModel):
+    """Per-sample state for arena evaluation.
+
+    Populated by `arena_solver` (one entry per contestant) and consumed by
+    `pairwise_scorer` to generate the set of pairs for judging.
+    """
+
+    responses: dict[str, str] = Field(default_factory=dict)
+    """Map of contestant name to generated response."""
+
+    failed: list[str] = Field(default_factory=list)
+    """Contestants that raised during generation for this sample."""

--- a/src/inspect_ai/arena/_verdict.py
+++ b/src/inspect_ai/arena/_verdict.py
@@ -1,0 +1,18 @@
+from dataclasses import dataclass
+from typing import Any, Literal
+
+Winner = Literal["a", "b", "tie"]
+
+
+@dataclass
+class JudgeVerdict:
+    """Outcome of a single pairwise judgment.
+
+    `winner` is positional (`"a"` or `"b"`) because the `Judge` sees only two
+    anonymized responses. The `pairwise_scorer` is responsible for mapping
+    positions back to contestant names when assembling the `Score`.
+    """
+
+    winner: Winner
+    explanation: str | None = None
+    metadata: dict[str, Any] | None = None

--- a/tests/arena/test_metrics.py
+++ b/tests/arena/test_metrics.py
@@ -1,0 +1,99 @@
+from typing import Any, cast
+
+from inspect_ai.arena import elo, win_rate
+from inspect_ai.scorer import MetricProtocol, SampleScore, Score
+
+
+def _sample(comparisons: list[dict[str, str]]) -> SampleScore:
+    return SampleScore(
+        score=Score(value={}, metadata={"comparisons": comparisons, "failed": []}),
+        sample_id="s",
+    )
+
+
+def _wr(*args: Any, **kwargs: Any) -> MetricProtocol:
+    # `Metric` is a union of new/deprecated protocols — the deprecated arm wins
+    # mypy's resolution and rejects `list[SampleScore]`. Cast to the modern
+    # protocol so test call sites stay clean and well-typed.
+    return cast(MetricProtocol, win_rate(*args, **kwargs))
+
+
+def _elo(*args: Any, **kwargs: Any) -> MetricProtocol:
+    return cast(MetricProtocol, elo(*args, **kwargs))
+
+
+def test_win_rate_basic() -> None:
+    # A beats B, A ties C, B loses to C → A=0.75, B=0.0, C=0.75
+    samples = [
+        _sample(
+            [
+                {"a": "A", "b": "B", "winner": "a"},
+                {"a": "A", "b": "C", "winner": "tie"},
+                {"a": "B", "b": "C", "winner": "b"},
+            ]
+        )
+    ]
+    result = cast(dict[str, Any], _wr()(samples))
+    assert result == {"A": 0.75, "B": 0.0, "C": 0.75}
+
+
+def test_win_rate_excludes_ties() -> None:
+    samples = [
+        _sample(
+            [
+                {"a": "A", "b": "B", "winner": "a"},
+                {"a": "A", "b": "C", "winner": "tie"},
+            ]
+        )
+    ]
+    result = cast(dict[str, Any], _wr(include_ties=False)(samples))
+    # A's tie excluded; only one decisive comparison: A vs B → A=1.0, B=0.0
+    assert result == {"A": 1.0, "B": 0.0}
+
+
+def test_win_rate_empty() -> None:
+    assert _wr()([]) == {}
+
+
+def test_elo_orders_contestants_correctly() -> None:
+    # Lopsided: A wins every comparison vs B across many samples
+    cmp = [{"a": "A", "b": "B", "winner": "a"}]
+    samples = [_sample(cmp) for _ in range(50)]
+    result = cast(dict[str, Any], _elo(n_bootstrap=100, seed=42)(samples))
+    assert result["A.rating"] > result["B.rating"]
+    # CIs span the mean
+    assert result["A.low"] <= result["A.rating"] <= result["A.high"]
+    assert result["B.low"] <= result["B.rating"] <= result["B.high"]
+
+
+def test_elo_is_deterministic_with_seed() -> None:
+    cmp = [
+        {"a": "A", "b": "B", "winner": "a"},
+        {"a": "A", "b": "C", "winner": "tie"},
+        {"a": "B", "b": "C", "winner": "b"},
+    ]
+    samples = [_sample(cmp)] * 5
+    r1 = cast(dict[str, Any], _elo(n_bootstrap=200, seed=7)(samples))
+    r2 = cast(dict[str, Any], _elo(n_bootstrap=200, seed=7)(samples))
+    assert r1 == r2
+
+
+def test_elo_empty() -> None:
+    assert _elo()([]) == {}
+
+
+def test_metrics_ignore_malformed_metadata() -> None:
+    # Empty metadata, missing comparisons, wrong types — should be skipped silently
+    bad_samples = [
+        SampleScore(score=Score(value={}), sample_id="s1"),
+        SampleScore(
+            score=Score(value={}, metadata={"comparisons": "not a list"}),
+            sample_id="s2",
+        ),
+        SampleScore(
+            score=Score(value={}, metadata={"comparisons": [{"missing": "keys"}]}),
+            sample_id="s3",
+        ),
+    ]
+    assert _wr()(bad_samples) == {}
+    assert _elo()(bad_samples) == {}

--- a/tests/arena/test_scorer.py
+++ b/tests/arena/test_scorer.py
@@ -1,0 +1,100 @@
+from typing import Any, cast
+
+import pytest
+
+from inspect_ai.arena import ArenaState, JudgeVerdict, Winner, pairwise_scorer
+from inspect_ai.model import ModelName
+from inspect_ai.scorer import Target
+from inspect_ai.solver import TaskState
+
+
+def _make_state(input_text: str, responses: dict[str, str]) -> TaskState:
+    state = TaskState(
+        model=ModelName("openai/gpt-4o"),
+        sample_id="s1",
+        epoch=1,
+        input=input_text,
+        messages=[],
+    )
+    arena = state.store_as(ArenaState)
+    arena.responses = dict(responses)
+    return state
+
+
+def _stub_judge(verdicts: dict[tuple[str, str], Winner]):
+    """Return a Judge that picks winners from a pre-populated lookup."""
+
+    async def judge(prompt: str, response_a: str, response_b: str) -> JudgeVerdict:
+        # We map by the response strings since our state uses names as values.
+        return JudgeVerdict(winner=verdicts[(response_a, response_b)])
+
+    return judge
+
+
+async def test_pairwise_scorer_generates_all_pairs() -> None:
+    state = _make_state(
+        "the question",
+        {"A": "ra", "B": "rb", "C": "rc"},
+    )
+
+    # 3 contestants → 3 pairs in combinations() order: (A,B), (A,C), (B,C)
+    # Verdicts in pair-local "a"/"b" positions:
+    #   (A,B) winner=a → A wins
+    #   (A,C) winner=tie
+    #   (B,C) winner=a → B wins
+    judge = _stub_judge(
+        {
+            ("ra", "rb"): "a",
+            ("ra", "rc"): "tie",
+            ("rb", "rc"): "a",
+        }
+    )
+
+    scorer = pairwise_scorer(judge)
+    score = await scorer(state, Target(""))
+    assert score is not None
+
+    metadata = score.metadata or {}
+    comparisons = metadata["comparisons"]
+    assert comparisons == [
+        {"a": "A", "b": "B", "winner": "a"},
+        {"a": "A", "b": "C", "winner": "tie"},
+        {"a": "B", "b": "C", "winner": "a"},
+    ]
+
+    # value carries per-contestant win points for this sample:
+    # A: 1 (vs B) + 0.5 (tie vs C) = 1.5
+    # B: 1 (vs C)                  = 1.0
+    # C: 0.5 (tie vs A)            = 0.5
+    value = cast(dict[str, Any], score.value)
+    assert value == {"A": 1.5, "B": 1.0, "C": 0.5}
+
+
+async def test_pairwise_scorer_with_one_contestant_returns_empty() -> None:
+    state = _make_state("q", {"only": "response"})
+
+    # Should not raise even though no pair exists; judge must not be called.
+    async def boom(*args: object, **kwargs: object) -> JudgeVerdict:
+        pytest.fail("judge should not be invoked when fewer than 2 contestants")
+
+    scorer = pairwise_scorer(boom)
+    score = await scorer(state, Target(""))
+    assert score is not None
+
+    metadata = score.metadata or {}
+    assert metadata["comparisons"] == []
+    assert score.value == {"only": 0.0}
+
+
+async def test_pairwise_scorer_surfaces_failed_contestants() -> None:
+    state = _make_state("q", {"A": "ra", "B": "rb"})
+    arena = state.store_as(ArenaState)
+    arena.failed = ["C", "D"]
+
+    judge = _stub_judge({("ra", "rb"): "a"})
+    scorer = pairwise_scorer(judge)
+    score = await scorer(state, Target(""))
+    assert score is not None
+
+    metadata = score.metadata or {}
+    assert metadata["failed"] == ["C", "D"]


### PR DESCRIPTION
**Status: Draft — looking for design feedback before completing.**

Implements #3994. Opening as Draft to make the design concrete for code review
while the open questions in the issue are still being discussed.

## What's in this branch

Split into two commits to ease review:

1. **`Arena: Add core abstractions for pairwise evaluation`** —
   contracts only (`ArenaState`, `Judge` protocol, `JudgeVerdict`).
   These are the extension points that future-work items in #3994 build on.
2. **`Arena: Add first-party solver, judge, scorer, and metrics`** —
   the concrete pipeline (`arena_solver`, `llm_judge`,
   `pairwise_scorer`, `win_rate`, `elo`) plus unit tests.

Everything fits the standard `Task` workflow — no protocol changes, no new
entry point. Usage stays:

```python
Task(
    dataset=...,
    solver=arena_solver(contestants=[...]),
    scorer=pairwise_scorer(judge=llm_judge(...)),
    metrics=[win_rate(), elo()],
)
```

## UI validation (local)

Ran an end-to-end task with two contestants and a judge against a
local OpenAI-compatible endpoint and viewed the result in `inspect view`:

- Top-level metrics render correctly: `win_rate` shows per-contestant
  rates, `elo` shows `<name>.rating` / `.low` / `.high` triples.
- Per-sample contestant points appear as score columns.
- Transcript view groups each contestant's call and the per-pair judge
  call into nested tasks (via `collect()` spans) — readable out of the
  box.

Two cosmetic notes from this run, both fixable in follow-up if
maintainers prefer different defaults:

- `inspect view` derives the "Scorer" label from `Score.value` dict
  keys, so the contestant names appear there instead of `pairwise_scorer`.
- Flat `<name>.rating/.low/.high` keys from `elo()` get verbose with
  many contestants. An alternative is to split `elo()` (mean only) and
  `elo_ci()` (bounds) — happy to go either way.

## One intentional divergence from the issue

The issue draft suggested storing the structured per-pair verdict list
directly in `Score.value`:

```python
Score(value={
    "comparisons": [
        {"a": "...", "b": "...", "winner": "..."},
        ...
    ]
})
```

This doesn't fit the framework's `Value` type, which is

```python
Mapping[str, str | int | float | bool | None]
```

— a flat dict of scalars, no nested lists/dicts. So `value` cannot
carry the comparisons list directly.

The implementation puts the structured list under
`Score.metadata["comparisons"]` (which has no type restriction) and
keeps `Score.value` populated with each contestant's win points for
that sample (`{name: 1.0 per win, 0.5 per tie}`). Two reasons for this
choice:

1. `win_rate` and `elo` read from `metadata["comparisons"]` — they
   need the full pair structure for aggregation, and metadata is the
   natural place for it.
2. `Score.value` still being a meaningful per-sample dict means default
   inspect_ai metric machinery (`{"*": [mean()]}`, glob patterns)
   still produces a useful summary even if users override the metrics.

Open to other shapes if maintainers prefer a different split.

## Intentionally deferred

To keep this PR scoped to the abstractions and core implementations
until the direction is confirmed:

- Integration tests for `arena_solver` and `llm_judge` (require model
  mocking infrastructure).
- Documentation page under `docs/`.
- Runnable example under `examples/`.

These are easy follow-ups once the API is settled.

## Open questions from #3994

Still open and would benefit from maintainer input:

1. Should sub-sample contestant failures count toward `fail_on_error`?
2. What role should `Sample.target` play in pairwise scoring?
3. How should `Task.epochs` interact with arena tasks (re-run all
   contestants, or only re-judge)?
