### PR TITLE
docs: add LLM-to-LLM conversation eval example

### DIFF
--- a/docs/multi-agent.qmd
+++ b/docs/multi-agent.qmd
@@ -98,6 +98,81 @@ def research_solver() -> Solver:
 Alternatively, if you don't need custom per-sample logic around the agent, use `as_solver()` to convert the agent into a solver that updates the `TaskState` automatically.
 
 
+### LLM-to-LLM Conversations
+
+Fixed-turn conversations between two models are another good fit for an explicit workflow. In the example below, a client agent and a service agent take turns appending to the same conversation history, then a third model scores the full transcript:
+
+``` python
+from inspect_ai import Task, task
+from inspect_ai.agent import Agent, AgentState, react, run
+from inspect_ai.dataset import Sample
+from inspect_ai.model import ChatMessageSystem, ChatMessageUser, get_model
+from inspect_ai.scorer import Score, Scorer, Target, mean, scorer
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+
+
+@solver
+def conversation(client: Agent, service: Agent, turns: int = 3) -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        agent_state = AgentState(messages=list(state.messages))
+
+        for _ in range(turns):
+            agent_state = await run(client, agent_state)
+            agent_state = await run(service, agent_state)
+
+        state.messages = agent_state.messages
+        state.output = agent_state.output
+        return state
+
+    return solve
+
+
+@scorer(metrics=[mean()])
+def conversation_judge(model: str | None = None) -> Scorer:
+    judge = get_model(model)
+
+    async def score(state: TaskState, target: Target) -> Score:
+        transcript = "\n".join(
+            f"{message.role}: {message.text}" for message in state.messages
+        )
+        result = await judge.generate(
+            [
+                ChatMessageSystem(
+                    content="Judge whether the conversation resolved the request. "
+                    "Respond with PASS or FAIL, then explain briefly."
+                ),
+                ChatMessageUser(content=transcript),
+            ]
+        )
+        passed = result.completion.upper().startswith("PASS")
+        return Score(value=1.0 if passed else 0.0, explanation=result.completion)
+
+    return score
+
+
+@task
+def baggage_dialogue():
+    client = react(
+        prompt="You are an airline customer. Answer one question at a time.",
+        submit=False,
+    )
+    service = react(
+        prompt="You are a customer-service agent. Ask only for details you need.",
+        submit=False,
+    )
+
+    return Task(
+        dataset=[
+            Sample(input="I have a baggage check-in question about my flight.")
+        ],
+        solver=conversation(client, service, turns=2),
+        scorer=conversation_judge(model="openai/gpt-4o-mini"),
+    )
+```
+
+Using `submit=False` makes each `react()` agent return when it stops calling tools, which is often what you want when the outer workflow controls turn-taking. If either agent has tools and might keep working for too long, add a [message, token, or time limit](setting-limits.qmd#sample-limits) to the task or agent invocation.
+
+
 ## Tools
 
 You can make agents available as a standard tool call. In this case, the agent sees only a single input string and returns the output of its last assistant message.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #2803.

The multi-agent docs describe handoffs, tools, and explicit agent workflows, but they do not include a compact example for fixed-turn LLM-to-LLM evaluations where two agents converse and a third model judges the transcript. Users trying to build client-agent/customer-service-agent style evals have to infer the pattern from lower-level agent APIs.

### What is the new behavior?

The multi-agent docs now include an LLM-to-LLM conversation example that:

- Alternates a client agent and service agent through an explicit solver workflow.
- Uses `AgentState` and `run()` so the two agents share and extend the same conversation history.
- Adds a third judge model scorer over the transcript.
- Notes that `submit=False` is useful when the outer workflow controls turn-taking, and points users to message/token/time limits for tool-using agents that may run too long.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This is a docs-only addition for existing agent and scorer APIs.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/agent/test_agent_execute.py -v`
    - 31 passed, 6 skipped locally.
    - Confirms the `run()` execution path used by the example.
    - Confirms agent invocation as solver/tool/handoff and limit handling, which supports the guidance about bounded agent runs.
  - Reviewed the docs example against the current `react`, `run`, `AgentState`, `solver`, and `scorer` APIs after rebasing onto current `origin/main`.
- Regression:
  - `uv run make check`
  - `uv run make test`
  - Commit-time pre-commit hooks passed: large-file, JSON/YAML, debug-statement, private-key, requirements, and docs typo checks.

CI/CD coverage expected:
- Standard Build workflow should cover ruff, ruff format, mypy, pre-commit, package build, and pytest on Python 3.10 and 3.11.
- Docs are excluded from ruff's source lint, but the pre-commit typos hook covers markdown/docs text.
- Log viewer and sandbox-tools special gates should not require extra artifacts because this PR only changes multi-agent docs.

Closes #2803.
