### PR TITLE
docs: clarify ReAct loop depth controls

### DIFF
--- a/docs/react-agent.qmd
+++ b/docs/react-agent.qmd
@@ -189,6 +189,66 @@ You can pass a different continuation message, or alternatively pass an `AgentCo
   - `AgentState`: Agent loop continues and the agent state is updated to the returned value.
 
 
+## Controlling Loop Depth
+
+There are two common ways to keep a ReAct agent from working longer than you want:
+
+1.  Let an outer workflow control turn-taking by disabling the submit tool.
+
+2.  Keep the submit tool, but bound the loop with `on_continue` and sample limits.
+
+For fixed-turn conversations, such as a client agent talking to a customer-service agent, `submit=False` is often the simplest option. With no submit tool, `react()` returns when the model stops calling tools, so the outer workflow can decide when the next agent gets a turn:
+
+``` python
+from inspect_ai.agent import AgentState, react, run
+from inspect_ai.model import ChatMessageUser
+
+client = react(
+    prompt="You are an airline customer. Answer one question at a time.",
+    submit=False,
+)
+service = react(
+    prompt="You are a customer-service agent. Ask one concise follow-up.",
+    submit=False,
+)
+
+state = AgentState(
+    messages=[
+        ChatMessageUser(
+            content="Hello, I have a baggage check-in question about my flight."
+        )
+    ]
+)
+
+for _ in range(2):
+    state = await run(service, state)
+    state = await run(client, state)
+```
+
+Use the default submit tool when the agent should decide when it has completed the task. In that mode, you can use `on_continue` to stop after a bounded number of agent turns or to send a more specific continuation message:
+
+``` python
+from inspect_ai.agent import AgentState, react
+
+
+async def stop_after_two_turns(state: AgentState) -> bool | str:
+    assistant_turns = sum(
+        1 for message in state.messages if message.role == "assistant"
+    )
+    if assistant_turns >= 2:
+        return False
+    return "Ask one concise follow-up question, then wait for the client."
+
+
+service = react(
+    prompt="You are a customer-service agent. Submit when the exchange is complete.",
+    on_continue=stop_after_two_turns,
+)
+```
+
+For hard safety bounds, also set [message, token, or time limits](setting-limits.qmd#sample-limits) at the task level or apply scoped limits when invoking an agent with `run()`.
+
+
 ## Submit Tool
 
 As described above, the `react()` agent uses a special `submit()` tool internally to enable the model to signal explicitly when it is complete and has an answer. The use of a `submit()` tool has a couple of benefits:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The ReAct agent documentation explains continuation handling and the submit tool separately, but it does not give users a direct pattern for bounding a ReAct agent's loop depth. In fixed-turn agent conversations, this makes it hard to tell whether to disable `submit()`, rely on `on_continue`, or use sample limits.

Closes #2716.

### What is the new behavior?

- Adds a "Controlling Loop Depth" section to the ReAct agent docs.
- Shows a fixed-turn client/service-agent pattern that disables the submit tool with `submit=False` and lets the outer workflow decide turn order with `run()`.
- Shows how to keep the default submit tool while using an `on_continue` callback to stop after a bounded number of assistant turns or send a targeted continuation message.
- Points readers to task-level and scoped message/token/time limits for hard safety bounds.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This is a docs-only change and does not alter runtime behavior.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/agent/test_agent_react.py -v`
    - 21 passed.
    - Exercises the ReAct behaviors described by the new docs section, including `submit=False`, custom submit tools, string and callable `on_continue`, retry/refusal handling, and truncation paths.
- Regression:
  - `uv run make check`
    - Passed ruff, formatting, tool-support checks, and mypy over 1114 source files.
  - `uv run make test`
    - Passed the full local pytest suite: 7920 tests collected.

CI/CD coverage expected:
- Standard Build workflow should cover ruff, mypy, package, and pytest checks.
- Log Viewer workflow is not expected to require generated artifact changes because this PR only edits docs.
