### PR TITLE
fix: map metrics to solver score names

### DIFF
--- a/docs/solvers.qmd
+++ b/docs/solvers.qmd
@@ -469,6 +469,23 @@ async def solve(state: TaskState, generate: Generate):
 
 Note that scores yielded by a `Solver` are combined with scores from the normal scoring provided by the scorer(s) defined for a `Task`.
 
+By default, scalar scores yielded by a solver use the standard `accuracy` and `stderr` metrics. You can assign different metrics to these scores with `Task(metrics=...)`:
+
+``` python
+from inspect_ai.scorer import mean, stderr
+
+Task(
+    dataset=dataset,
+    solver=duration_solver(),
+    metrics={
+        "duration_of_generate": [mean(), stderr()],
+        "first_token_duration": [mean()],
+    },
+)
+```
+
+Metric dictionary keys match the names used in `state.scores` and support globs, so `"*_duration": [mean()]` applies to every matching solver score. For solver scores whose `Score.value` is itself a dictionary, metric dictionary keys continue to match the keys inside that score value as described in [Scorer with Multiple Values](scorers.qmd#scorer-with-multiple-values).
+
 ### Intermediate Scoring
 
 In some cases it is useful for a solver to score a task directly to generate an intermediate score or assist in deciding whether or how to continue. You can do this using the `score` function:

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -137,7 +137,9 @@ def eval_results(
 
                 # resolve the task scores
                 if metrics is not None:
-                    scorer_info.metrics = metrics
+                    scorer_info.metrics = resolve_solver_score_metrics(
+                        metrics, name, sample_score.score
+                    )
 
                 # capture the scorer information
                 scorers_info.append(scorer_info)
@@ -189,6 +191,12 @@ def compute_eval_scores_for_views(
 ) -> tuple[list[EvalScore], list[EvalSampleReductions]]:
     result_scores: list[EvalScore] = []
     sample_reductions: list[EvalSampleReductions] = []
+
+    if isinstance(metrics, list) and len(metrics) == 0:
+        result_scores.extend(
+            compute_eval_scores(scores, metrics, scorer_name, scorer_info, None)
+        )
+        return result_scores, sample_reductions
 
     if isinstance(reducers, list) and len(reducers) == 0:
         if _has_explicit_reduced_metrics(metrics) and _has_repeated_sample_ids(scores):
@@ -317,6 +325,17 @@ def _flatten_metrics(
                 yield m
 
 
+def resolve_solver_score_metrics(
+    metrics: Metrics,
+    score_name: str,
+    score: Score,
+) -> Metrics:
+    if isinstance(metrics, dict) and not isinstance(score.value, dict):
+        return resolve_glob_score_metrics(metrics, score_name)
+    else:
+        return metrics
+
+
 def _filter_metrics_by_scores(
     metrics: Metrics, modes: set[MetricScores]
 ) -> Metrics | None:
@@ -382,6 +401,24 @@ def split_metrics(
             dict_list.append(metric)
 
     return metric_list, dict_list
+
+
+def resolve_glob_score_metrics(
+    metrics: dict[str, list[Metric]], score_name: str
+) -> list[Metric | dict[str, list[Metric]]]:
+    resolved_metrics: list[Metric | dict[str, list[Metric]]] = []
+    existing_metric_names: set[str] = set()
+
+    for metric_key, metric_list in metrics.items():
+        key_glob_re = re.compile(fnmatch.translate(metric_key))
+        if key_glob_re.match(score_name):
+            for metric in metric_list:
+                metric_name = registry_log_name(metric)
+                if metric_name not in existing_metric_names:
+                    resolved_metrics.append(metric)
+                    existing_metric_names.add(metric_name)
+
+    return resolved_metrics
 
 
 def scorer_for_metrics(

--- a/tests/scorer/test_score_from_solver.py
+++ b/tests/scorer/test_score_from_solver.py
@@ -1,6 +1,6 @@
 from inspect_ai import Task, eval
 from inspect_ai.dataset import MemoryDataset, Sample
-from inspect_ai.scorer import Score, mean
+from inspect_ai.scorer import Score, mean, stderr
 from inspect_ai.solver import Generate, TaskState, solver
 from inspect_ai.solver._solver import Solver
 
@@ -50,6 +50,37 @@ def test_solver_simple_score():
     assert eval_log.results.scores[0].name == "simple"
     assert len(eval_log.results.scores[0].metrics) == 1
     assert eval_log.results.scores[0].metrics["mean"].value == 1.0
+
+
+@solver
+def no_scorer_solver_named_scores() -> Solver:
+    async def run(state: TaskState, generate: Generate) -> TaskState:
+        state.scores = {
+            "duration_of_generate": Score(value=1),
+            "first_token_duration": Score(value=2),
+            "unmatched_duration": Score(value=3),
+        }
+        return state
+
+    return run
+
+
+def test_solver_simple_score_named_metrics():
+    task = Task(
+        dataset=MemoryDataset([Sample(input="")]),
+        solver=no_scorer_solver_named_scores(),
+        metrics={
+            "duration_of_generate": [mean()],
+            "first_token_*": [mean(), stderr()],
+        },
+    )
+
+    eval_log = eval(tasks=task, model="mockllm/model")[0]
+    scores = {score.name: score for score in eval_log.results.scores}
+
+    assert [*scores["duration_of_generate"].metrics] == ["mean"]
+    assert [*scores["first_token_duration"].metrics] == ["mean", "stderr"]
+    assert scores["unmatched_duration"].metrics == {}
 
 
 def test_solver_score_event_scorer_name():


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Solver-defined scores can be written directly to `state.scores`, but scalar solver scores cannot currently use a `Task(metrics={...})` dictionary to assign metrics by score name. That makes it hard to give timing or instrumentation scores custom metrics without also affecting unrelated scorer output.

Closes #2215.

### What is the new behavior?

- When a solver sets scalar scores in `state.scores`, `Task(metrics={...})` now matches dictionary keys against the solver score names.
- Glob keys are supported for solver score names, matching the existing metric glob behavior for dictionary-valued score values.
- Existing dictionary-valued score behavior is preserved: when `Score.value` is a dictionary, metric dictionary keys still match the keys inside the score value.
- The solvers documentation now shows how to assign metrics to solver-defined scalar scores and clarifies the distinction from dictionary-valued score metrics.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Existing list-based metrics and dictionary-valued score metric behavior are preserved. The new behavior only enables `Task(metrics={...})` to target scalar scores that solvers write into `state.scores`.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/scorer/test_score_from_solver.py -v`
    - 4 passed.
    - Covers existing dict-valued solver scores, existing list metrics on scalar solver scores, new score-name metric mapping for scalar solver scores, glob matching, unmatched scalar scores, and score event naming.
- Regression:
  - `uv run make check`
    - Passed ruff, formatting, tool-support checks, and mypy over 1114 source files.
  - `uv run make test`
    - Passed the full local pytest suite: 7921 tests collected.

CI/CD coverage expected:
- Standard Build workflow should cover ruff, mypy, package, and pytest checks.
- Log Viewer workflow is not expected to require generated artifact changes because this PR does not touch viewer schema or frontend assets.
