### PR TITLE
fix: support explicit Azure OpenAI AD token auth

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -156,6 +156,21 @@ export AZUREAI_OPENAI_API_VERSION=2025-03-01-preview
 inspect eval math.py --model openai/azure/gpt-4o-mini
 ```
 
+If your application obtains an Azure AD token directly, pass it as an OpenAI model arg. Other Azure OpenAI SDK constructor args, including `default_headers`, are forwarded to the client.
+
+``` python
+eval(
+    "math.py",
+    model="openai/azure/gpt-4o-mini",
+    model_args={
+        "azure_ad_token": token,
+        "default_headers": {"projectID": "your-project-id"},
+    },
+)
+```
+
+You can also pass `azure_ad_token_provider` as a model arg when you want the OpenAI SDK to call a token provider function for each request.
+
 Note that if the `AZUREAI_OPENAI_API_VERSION` is not specified, Inspect will generally default to the latest deployed version, which as of this writing is `2025-03-01-preview`. When using managed identity for authentication, install the `azure-identity` package and leave `AZUREAI_OPENAI_API_KEY` undefined.
 
 ### OpenAI on AWS Bedrock {#openai-on-aws-bedrock}

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -206,14 +206,21 @@ class OpenAIAPI(ModelAPI):
         if self.is_bedrock():
             self.aws_region = resolve_bedrock_region(model_args.pop("aws_region", None))
 
-        # resolve api_key, managed identity (Azure), or AWS credentials (Bedrock)
-        self.token_provider = None
+        # resolve api_key, explicit Azure AD auth, managed identity (Azure),
+        # or AWS credentials (Bedrock)
+        self.token_provider = (
+            model_args.pop("azure_ad_token_provider", None) if self.is_azure() else None
+        )
+        has_azure_ad_token = (
+            self.is_azure() and model_args.get("azure_ad_token") is not None
+        )
+        has_azure_ad_auth = has_azure_ad_token or self.token_provider is not None
         if not self.api_key:
             if self.is_azure():
                 self.api_key = resolve_api_key(
                     [AZUREAI_OPENAI_API_KEY, AZURE_OPENAI_API_KEY]
                 )
-                if not self.api_key:
+                if not self.api_key and not has_azure_ad_auth:
                     # try managed identity (Microsoft Entra ID)
                     self.token_provider = resolve_azure_token_provider("OpenAI")
             elif self.is_bedrock():
@@ -228,7 +235,7 @@ class OpenAIAPI(ModelAPI):
             else:
                 self.api_key = os.environ.get(OPENAI_API_KEY, None)
 
-            if not self.api_key and not self.token_provider:
+            if not self.api_key and not self.token_provider and not has_azure_ad_token:
                 raise environment_prerequisite_error(
                     "OpenAI",
                     [

--- a/tests/model/providers/test_openai.py
+++ b/tests/model/providers/test_openai.py
@@ -14,6 +14,7 @@ from inspect_ai.model import (
 from inspect_ai.model._chat_message import ChatMessageSystem
 from inspect_ai.model._internal import parse_content_with_internal
 from inspect_ai.model._openai import openai_completion_params
+from inspect_ai.model._providers.openai import OpenAIAPI
 
 
 @pytest.mark.anyio
@@ -60,6 +61,82 @@ def test_openai_completion_params_extra_body_not_mutated() -> None:
             "metadata": {"source": "test"},
             "reasoning": {"effort": "low"},
         }
+
+
+def test_azure_openai_ad_token_forwards_headers_without_managed_identity(
+    monkeypatch, mocker
+) -> None:
+    _clear_openai_auth_env(monkeypatch)
+    resolve_azure_token_provider = mocker.patch(
+        "inspect_ai.model._providers.openai.resolve_azure_token_provider",
+        side_effect=AssertionError("managed identity should not be resolved"),
+    )
+    azure_client = mocker.patch("inspect_ai.model._providers.openai.AsyncAzureOpenAI")
+    http_client = mocker.Mock(is_closed=False)
+
+    api = OpenAIAPI(
+        "azure/gpt-4o",
+        base_url="https://example.openai.azure.com",
+        azure_ad_token="entra-token",
+        default_headers={"projectID": "project-123"},
+        http_client=http_client,
+    )
+
+    resolve_azure_token_provider.assert_not_called()
+    azure_client.assert_called_once()
+    kwargs = azure_client.call_args.kwargs
+    assert api.api_key is None
+    assert api.token_provider is None
+    assert kwargs["api_key"] is None
+    assert kwargs["azure_ad_token_provider"] is None
+    assert kwargs["azure_ad_token"] == "entra-token"
+    assert kwargs["default_headers"] == {"projectID": "project-123"}
+    assert kwargs["azure_endpoint"] == "https://example.openai.azure.com"
+    assert kwargs["http_client"] is http_client
+
+
+def test_azure_openai_ad_token_provider_does_not_duplicate_sdk_arg(
+    monkeypatch, mocker
+) -> None:
+    _clear_openai_auth_env(monkeypatch)
+    resolve_azure_token_provider = mocker.patch(
+        "inspect_ai.model._providers.openai.resolve_azure_token_provider",
+        side_effect=AssertionError("managed identity should not be resolved"),
+    )
+    azure_client = mocker.patch("inspect_ai.model._providers.openai.AsyncAzureOpenAI")
+    http_client = mocker.Mock(is_closed=False)
+
+    def token_provider() -> str:
+        return "entra-token"
+
+    api = OpenAIAPI(
+        "azure/gpt-4o",
+        base_url="https://example.openai.azure.com",
+        azure_ad_token_provider=token_provider,
+        http_client=http_client,
+    )
+
+    resolve_azure_token_provider.assert_not_called()
+    azure_client.assert_called_once()
+    kwargs = azure_client.call_args.kwargs
+    assert api.api_key is None
+    assert api.token_provider is token_provider
+    assert "azure_ad_token_provider" not in api.model_args
+    assert kwargs["api_key"] is None
+    assert kwargs["azure_ad_token_provider"] is token_provider
+    assert kwargs["azure_endpoint"] == "https://example.openai.azure.com"
+
+
+def _clear_openai_auth_env(monkeypatch) -> None:
+    for name in [
+        "OPENAI_API_KEY",
+        "AZUREAI_OPENAI_API_KEY",
+        "AZURE_OPENAI_API_KEY",
+        "AZUREAI_OPENAI_BASE_URL",
+        "AZURE_OPENAI_BASE_URL",
+        "AZURE_OPENAI_ENDPOINT",
+    ]:
+        monkeypatch.delenv(name, raising=False)
 
 
 @skip_if_no_openai


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When using `openai/azure/...` without an API key, the OpenAI provider attempts managed identity resolution before caller-provided Azure AD model args are used. That means `azure_ad_token` still falls through to managed identity setup, and `azure_ad_token_provider` can collide with the provider's own `azure_ad_token_provider` argument when the Azure client is constructed.

This also makes it hard to use Azure OpenAI deployments that require a caller-supplied Azure AD token plus custom constructor args such as `default_headers`.

Closes #2293.

### What is the new behavior?

- Treats explicit `azure_ad_token` and `azure_ad_token_provider` model args as valid Azure OpenAI authentication.
- Skips managed identity fallback when explicit Azure AD auth is supplied.
- Stores caller-provided `azure_ad_token_provider` on the provider so the Azure client receives it once, avoiding duplicate SDK keyword arguments.
- Continues forwarding other Azure OpenAI SDK constructor args, including `default_headers`.
- Documents the Azure AD token and custom header pattern in the OpenAI on Azure provider docs.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Existing API key and managed identity flows are preserved. This only adds support for explicit Azure AD auth model args and documents the existing custom constructor-arg forwarding path.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/model/providers/test_openai.py::test_azure_openai_ad_token_forwards_headers_without_managed_identity tests/model/providers/test_openai.py::test_azure_openai_ad_token_provider_does_not_duplicate_sdk_arg -v`
    - Verifies `azure_ad_token` avoids managed identity fallback, `default_headers` are forwarded to `AsyncAzureOpenAI`, and `azure_ad_token_provider` is passed without duplicate SDK kwargs.
  - `uv run pytest tests/model/providers/test_openai.py -v`
    - Verifies the new Azure constructor tests alongside the existing OpenAI provider tests. Live OpenAI cases are skipped locally because credentials are not configured.
- Regression:
  - `uv run make check`
    - Ran ruff, formatting, and mypy across source and tests.
  - `uv run make test`
    - Full pytest suite passed locally with 7,922 collected tests.

CI/CD coverage expected:
- Standard build, ruff, mypy, schema/type, packaging, and Python 3.10/3.11 test workflows should cover this change.
- No viewer schema/dist or sandbox tool version updates are expected because this only touches provider auth handling, provider tests, and docs.
