### PR TITLE
fix: resolve registry task sandbox paths from module dir

### DIFF
--- a/src/inspect_ai/_eval/registry.py
+++ b/src/inspect_ai/_eval/registry.py
@@ -159,14 +159,22 @@ def task(*args: Any, name: str | None = None, **attribs: Any) -> Any:
             named_params = extract_named_params(task_type, True, *w_args, **w_kwargs)
             setattr(task_instance, TASK_ALL_PARAMS_ATTR, named_params)
 
-            # if its not from an installed package then it is a "local"
-            # module import, so set its task file and run dir
-            if get_installed_package_name(task_type) is None:
-                module = inspect.getmodule(task_type)
-                if module and hasattr(module, "__file__") and module.__file__:
-                    file = Path(getattr(module, "__file__"))
+            module = inspect.getmodule(task_type)
+            source_file = (
+                getattr(module, "__file__")
+                if module and hasattr(module, "__file__") and module.__file__
+                else inspect.getsourcefile(task_type)
+            )
+            if source_file:
+                file = Path(source_file)
+
+                # Set the run dir for all module-backed tasks so sandbox config
+                # discovery is anchored to the task source directory.
+                setattr(task_instance, TASK_RUN_DIR_ATTR, file.parent.as_posix())
+
+                # For local module imports, also record the task file in logs.
+                if get_installed_package_name(task_type) is None:
                     setattr(task_instance, TASK_FILE_ATTR, file.as_posix())
-                    setattr(task_instance, TASK_RUN_DIR_ATTR, file.parent.as_posix())
 
             # Return the task instance
             return task_instance

--- a/tests/test_task_attr.py
+++ b/tests/test_task_attr.py
@@ -1,5 +1,10 @@
+from pathlib import Path
+
+import pytest
 from test_helpers.tasks import empty_task
 
+from inspect_ai._eval.loader import load_file_tasks, resolve_task_sandbox
+from inspect_ai._eval.registry import task_create
 from inspect_ai._eval.task.constants import TASK_FILE_ATTR, TASK_RUN_DIR_ATTR
 
 
@@ -7,3 +12,46 @@ def test_local_module_attr():
     task = empty_task()
     assert getattr(task, TASK_FILE_ATTR, None)
     assert getattr(task, TASK_RUN_DIR_ATTR, None)
+
+
+def test_installed_package_task_run_dir_resolves_implicit_sandbox(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    package_dir = tmp_path / "package"
+    package_dir.mkdir()
+    module_file = package_dir / "registry_tasks.py"
+    module_file.write_text(
+        "\n".join(
+            [
+                "from inspect_ai import Task, task",
+                "",
+                "@task",
+                "def registry_sandbox_task():",
+                "    return Task(sandbox='docker')",
+                "",
+            ]
+        )
+    )
+    dockerfile = package_dir / "Dockerfile"
+    dockerfile.write_text("FROM python:3.11\n")
+
+    caller_dir = tmp_path / "caller"
+    caller_dir.mkdir()
+    monkeypatch.chdir(caller_dir)
+    monkeypatch.setattr(
+        "inspect_ai._eval.registry.get_installed_package_name",
+        lambda _obj: "sample_package",
+    )
+    monkeypatch.setattr(
+        "inspect_ai._util.registry.get_installed_package_name",
+        lambda _obj: "sample_package",
+    )
+
+    load_file_tasks(module_file)
+    task = task_create("sample_package/registry_sandbox_task")
+
+    assert getattr(task, TASK_FILE_ATTR, None) is None
+    assert getattr(task, TASK_RUN_DIR_ATTR) == package_dir.as_posix()
+    sandbox = resolve_task_sandbox(task, None)
+    assert sandbox is not None
+    assert sandbox.config == dockerfile.as_posix()


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

For tasks loaded from installed package registries, the task decorator avoids recording a task file path in the eval log. It also skipped recording the task module directory. As a result, implicit sandbox config discovery for a task such as `Task(sandbox="docker")` can fall back to the caller's current working directory instead of the package directory containing the task's `Dockerfile` or `compose.yaml`.

Closes #3372.

### What is the new behavior?

- Module-backed tasks now always record their source directory as the task run directory.
- Installed-package tasks still do not record a log-facing task file path, preserving the existing package task log behavior.
- Implicit sandbox config discovery now resolves package task `Dockerfile` / `compose.yaml` files from the task module directory rather than the caller cwd.
- The source-file lookup falls back to `inspect.getsourcefile()` when `inspect.getmodule()` cannot provide `__file__`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Local task file logging remains unchanged, installed-package tasks still avoid recording task file paths, and explicit sandbox config paths continue to be resolved the same way.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/test_task_attr.py -v`
    - Adds a regression test that simulates a registry-loaded installed package task from one directory while the caller cwd is elsewhere, then verifies implicit Dockerfile discovery uses the task module directory.
  - `uv run pytest tests/util/sandbox/test_docker_compatibility.py::TestResolveTaskSandboxDockerCompatibility -v`
    - Verifies existing task-level sandbox override and Docker-compatible config resolution behavior still passes.
- Regression:
  - `uv run make check`
    - Ran ruff, formatting, and mypy across source and tests.
  - `uv run make test`
    - Full pytest suite passed locally with 7,921 collected tests.

CI/CD coverage expected:
- Standard build, ruff, mypy, packaging, and Python 3.10/3.11 test workflows should cover this change.
- No viewer schema/dist or sandbox tool version updates are expected because this changes task metadata used for sandbox config discovery, not sandbox tool binaries.
