### PR TITLE
feat: add OpenRouter app attribution headers

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1547,8 +1547,11 @@ For the `openrouter` provider, the following custom model args (`-M`) are suppor
 | [`provider`](https://openrouter.ai/docs/features/provider-routing) | `-M "provider={ 'quantizations': ['int8'] }"` |
 | [`transforms`](https://openrouter.ai/docs/features/message-transforms) | `-M "transforms=['middle-out']"` |
 | [`reasoning_enabled`](https://openrouter.ai/docs/use-cases/reasoning-tokens) | `-M "reasoning_enabled=false"` |
+| [`app_attribution`](https://openrouter.ai/docs/app-attribution) | `-M app_attribution=false` |
 
 : {tbl-colwidths=\[20,85\]}
+
+Inspect sends OpenRouter [app attribution](https://openrouter.ai/docs/app-attribution) headers by default (`HTTP-Referer: https://inspect.aisi.org.uk/` and `X-OpenRouter-Title: Inspect AI`). To attribute requests to your own application, pass `default_headers` as a model arg; user-supplied headers override Inspect's defaults. To disable the default attribution headers entirely, set `app_attribution=false`.
 
 In addition, [Tool Emulation](#tool-emulation-openai) is available for models that don't yet support tool calling in their API.
 

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Mapping
 from logging import getLogger
 from typing import Any, cast
 
@@ -33,6 +34,10 @@ from .._generate_config import GenerateConfig
 from .openai_compatible import OpenAICompatibleAPI
 
 OPENROUTER_API_KEY = "OPENROUTER_API_KEY"
+OPENROUTER_APP_ATTRIBUTION_HEADERS = {
+    "HTTP-Referer": "https://inspect.aisi.org.uk/",
+    "X-OpenRouter-Title": "Inspect AI",
+}
 
 logger = getLogger(__name__)
 
@@ -67,6 +72,21 @@ class OpenRouterError(Exception):
             if "metadata" in self.response
             else ""
         )
+
+
+def _apply_app_attribution_headers(model_args: dict[str, Any]) -> None:
+    default_headers = model_args.get("default_headers")
+    if default_headers is None:
+        model_args["default_headers"] = OPENROUTER_APP_ATTRIBUTION_HEADERS.copy()
+        return
+
+    if not isinstance(default_headers, Mapping):
+        raise PrerequisiteError("default_headers must be a mapping")
+
+    merged_headers = OPENROUTER_APP_ATTRIBUTION_HEADERS | dict(default_headers)
+    if "X-Title" in default_headers and "X-OpenRouter-Title" not in default_headers:
+        merged_headers.pop("X-OpenRouter-Title", None)
+    model_args["default_headers"] = merged_headers
 
 
 class OpenRouterAPI(OpenAICompatibleAPI):
@@ -121,6 +141,14 @@ class OpenRouterAPI(OpenAICompatibleAPI):
         if self.reasoning_enabled is not None:
             if not isinstance(self.reasoning_enabled, bool):
                 raise PrerequisiteError("reasoning_enabled must be a boolean")
+
+        self.app_attribution = collect_model_arg("app_attribution")
+        if self.app_attribution is None:
+            self.app_attribution = True
+        if not isinstance(self.app_attribution, bool):
+            raise PrerequisiteError("app_attribution must be a boolean")
+        if self.app_attribution:
+            _apply_app_attribution_headers(model_args)
 
         # call super
         super().__init__(

--- a/tests/model/providers/test_openrouter.py
+++ b/tests/model/providers/test_openrouter.py
@@ -8,6 +8,7 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput, ModelUsage
 from inspect_ai.model._providers.openrouter import (
+    OPENROUTER_APP_ATTRIBUTION_HEADERS,
     OpenRouterAPI,
     _add_anthropic_cache_markers,
     _apply_cache_creation_usage,
@@ -40,6 +41,50 @@ def _make_output(
             input_tokens_cache_read=input_tokens_cache_read,
         ),
     )
+
+
+def test_app_attribution_headers_enabled_by_default() -> None:
+    api = _make_api("openrouter/openai/gpt-4o-mini")
+
+    assert api.model_args["default_headers"] == OPENROUTER_APP_ATTRIBUTION_HEADERS
+
+
+def test_app_attribution_headers_preserve_user_default_headers() -> None:
+    api = _make_api(
+        "openrouter/openai/gpt-4o-mini",
+        default_headers={
+            "HTTP-Referer": "https://example.com/evals",
+            "X-OpenRouter-Title": "Custom Eval Runner",
+            "X-Custom": "present",
+        },
+    )
+
+    assert api.model_args["default_headers"] == {
+        "HTTP-Referer": "https://example.com/evals",
+        "X-OpenRouter-Title": "Custom Eval Runner",
+        "X-Custom": "present",
+    }
+
+
+def test_app_attribution_headers_respect_legacy_title_header() -> None:
+    api = _make_api(
+        "openrouter/openai/gpt-4o-mini",
+        default_headers={
+            "HTTP-Referer": "https://example.com/evals",
+            "X-Title": "Legacy Title",
+        },
+    )
+
+    assert api.model_args["default_headers"] == {
+        "HTTP-Referer": "https://example.com/evals",
+        "X-Title": "Legacy Title",
+    }
+
+
+def test_app_attribution_headers_can_be_disabled() -> None:
+    api = _make_api("openrouter/openai/gpt-4o-mini", app_attribution=False)
+
+    assert "default_headers" not in api.model_args
 
 
 def test_add_cache_markers_system_tool_and_penultimate_block() -> None:


### PR DESCRIPTION
## Summary

Closes #2690.

Adds OpenRouter app-attribution headers by default so requests made through the OpenRouter provider are attributed to Inspect AI:

- `HTTP-Referer: https://inspect.aisi.org.uk/`
- `X-OpenRouter-Title: Inspect AI`

User-supplied `default_headers` continue to take precedence, including custom attribution values. The legacy `X-Title` header is preserved without also injecting `X-OpenRouter-Title`, and `app_attribution=false` disables the default headers entirely.

## Validation

Targeted provider regression coverage:

- `uv run pytest tests/model/providers/test_openrouter.py -v`
- Result: 25 passed, 2 skipped
- Covers default attribution header injection, user override behavior, legacy `X-Title` compatibility, explicit opt-out via `app_attribution=false`, and existing OpenRouter cache/reasoning behavior.

Repository validation:

- `uv run make check`
- Result: passed
- Covers ruff formatting/linting and mypy type checking across the repository.

Full regression suite:

- `uv run make test`
- Result: passed, 7,924 tests collected

## CI/CD Coverage

The standard pull request workflows should exercise package build/inspection, schema and type checks, ruff, mypy on supported Python versions, pre-commit hooks, and the Python test matrix. This change is limited to the OpenRouter provider, provider tests, and provider docs, so no viewer, sandbox, or tool-path workflow changes are expected.

## Compatibility

This adds default HTTP headers for OpenRouter requests only. Existing callers can override attribution through `default_headers` or disable it with `app_attribution=false`.
