### PR TITLE
fix: align vLLM logging with Inspect log level

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1030,6 +1030,9 @@ The following environment variables are supported by the vLLM provider:
 | `VLLM_BASE_URL` | Base URL for requests (optional, defaults to the server started by Inspect) |
 | `VLLM_API_KEY` | API key for the vLLM server (optional, defaults to "local") |
 | `VLLM_DEFAULT_SERVER_ARGS` | JSON string of default server args (e.g., '{"tensor_parallel_size": 4, "max_model_len": 8192}') |
+| `VLLM_CONFIGURE_LOGGING` | Set automatically when Inspect starts a local vLLM server. Enabled when the Inspect console log level is `info` or more verbose, unless overridden with `configure_logging`. |
+
+When Inspect starts the vLLM server, fine-grained vLLM logging follows the Inspect console log level by default. For example, `inspect eval ... --log-level debug` enables vLLM logging before server startup. You can override this with `-M configure_logging=true` or `-M configure_logging=false`.
 
 You can also access models from ModelScope rather than Hugging Face, see the [vLLM documentation](https://docs.vllm.ai/en/stable/getting_started/quickstart.html) for details on this.
 

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -121,7 +121,8 @@ class VLLMAPI(OpenAICompatibleAPI):
             - ``host`` (str): Host to bind the server to (default:
               ``"0.0.0.0"``).
             - ``configure_logging`` (bool): Enable fine-grained vLLM
-              logging (default: ``False``).
+              logging (default: follows Inspect console logging, enabled
+              when the Inspect log level is ``info`` or more verbose).
             - ``device`` / ``devices`` (str): GPU device(s) to run the
               server on, as used in ``CUDA_VISIBLE_DEVICES``. If
               ``tensor_parallel_size`` is not provided, it is set to the
@@ -274,7 +275,9 @@ class VLLMAPI(OpenAICompatibleAPI):
                 server_args.setdefault("max_lora_rank", server.max_lora_rank)
             os.environ["VLLM_ALLOW_RUNTIME_LORA_UPDATING"] = "True"
 
-        configure_logging = server_args.pop("configure_logging", False)
+        configure_logging = _configure_logging_enabled(
+            server_args.pop("configure_logging", None)
+        )
         os.environ[VLLM_CONFIGURE_LOGGING] = "1" if configure_logging else "0"
 
         server_args, env_vars = configure_devices(
@@ -543,6 +546,12 @@ def _is_dead_local_vllm_endpoint(ex: BaseException, base_url: str | None) -> boo
             return False
     except OSError:
         return True
+
+
+def _configure_logging_enabled(configure_logging: bool | None) -> bool:
+    if configure_logging is not None:
+        return configure_logging
+    return logger.isEnabledFor(logging.INFO)
 
 
 def mistral_message_reducer(

--- a/tests/model/providers/test_vllm.py
+++ b/tests/model/providers/test_vllm.py
@@ -1,3 +1,10 @@
+import logging
+import os
+import sys
+from subprocess import Popen
+from types import ModuleType
+from typing import Any, cast
+
 import pytest
 from test_helpers.utils import skip_if_github_action, skip_if_no_vllm
 
@@ -6,6 +13,97 @@ from inspect_ai.model import (
     GenerateConfig,
     get_model,
 )
+from inspect_ai.model._providers import vllm as vllm_provider
+
+
+def _mock_vllm_start(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
+
+    def start_local_server(
+        base_cmd: list[str],
+        host: str,
+        port: int | None = None,
+        api_key: str | None = None,
+        server_type: str = "server",
+        timeout: int | None = None,
+        server_args: dict[str, Any] | None = None,
+        env: dict[str, str] | None = None,
+    ) -> tuple[str, Popen[str], int]:
+        captured.update(
+            {
+                "base_cmd": base_cmd,
+                "host": host,
+                "port": port,
+                "api_key": api_key,
+                "server_type": server_type,
+                "timeout": timeout,
+                "server_args": server_args,
+                "env": env,
+            }
+        )
+        return ("http://localhost:3000/v1", cast(Popen[str], object()), 3000)
+
+    monkeypatch.setitem(sys.modules, "vllm", ModuleType("vllm"))
+    monkeypatch.setattr(vllm_provider, "start_local_server", start_local_server)
+    monkeypatch.delenv(vllm_provider.VLLM_CONFIGURE_LOGGING, raising=False)
+    return captured
+
+
+def test_vllm_configure_logging_respects_explicit_value(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(vllm_provider.logger, "isEnabledFor", lambda level: True)
+
+    assert vllm_provider._configure_logging_enabled(False) is False
+
+    monkeypatch.setattr(vllm_provider.logger, "isEnabledFor", lambda level: False)
+
+    assert vllm_provider._configure_logging_enabled(True) is True
+
+
+def test_vllm_configure_logging_follows_inspect_log_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def info_enabled(level: int) -> bool:
+        return level >= logging.INFO
+
+    monkeypatch.setattr(vllm_provider.logger, "isEnabledFor", info_enabled)
+
+    assert vllm_provider._configure_logging_enabled(None) is True
+
+    monkeypatch.setattr(vllm_provider.logger, "isEnabledFor", lambda level: False)
+
+    assert vllm_provider._configure_logging_enabled(None) is False
+
+
+def test_vllm_start_server_sets_configure_logging_from_log_level(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _mock_vllm_start(monkeypatch)
+    monkeypatch.setattr(
+        vllm_provider.logger,
+        "isEnabledFor",
+        lambda level: level == logging.INFO,
+    )
+
+    api = vllm_provider.VLLMAPI("mock/model")
+    api._start_server("mock/model")
+
+    assert os.environ[vllm_provider.VLLM_CONFIGURE_LOGGING] == "1"
+    assert captured["server_args"] == {}
+
+
+def test_vllm_start_server_respects_explicit_configure_logging_false(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _mock_vllm_start(monkeypatch)
+    monkeypatch.setattr(vllm_provider.logger, "isEnabledFor", lambda level: True)
+
+    api = vllm_provider.VLLMAPI("mock/quiet-model", configure_logging=False)
+    api._start_server("mock/quiet-model")
+
+    assert os.environ[vllm_provider.VLLM_CONFIGURE_LOGGING] == "0"
+    assert captured["server_args"] == {}
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #1883.

When Inspect starts a local vLLM server, the internal `configure_logging` control defaults to `False`. As a result, even when an evaluation is run with a verbose Inspect log level such as `--log-level debug`, vLLM's fine-grained logs are not enabled unless users pass `-M configure_logging=true` explicitly.

### What is the new behavior?

- Local vLLM server startup now defaults `configure_logging` from Inspect's effective console log level.
- `--log-level info` and `--log-level debug` enable vLLM fine-grained logging before the subprocess starts.
- Explicit model args still take precedence, so `-M configure_logging=true` and `-M configure_logging=false` keep their current override behavior.
- The vLLM provider docs now describe the default and the override path.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No API or configuration migration is required. The only behavior change is that Inspect-managed vLLM subprocesses inherit verbose logging behavior from Inspect by default. Users who want the previous quiet behavior while running Inspect at `info` or `debug` can pass `-M configure_logging=false`.

### Other information:

Validation:

- Targeted:
  - `uv run pytest tests/model/providers/test_vllm.py -v`
  - Result: 4 passed, 4 skipped locally
  - Proves explicit `configure_logging` overrides, defaulting from Inspect's effective log level, and the local server-start path setting `VLLM_CONFIGURE_LOGGING` before launch without forwarding the internal control as a CLI arg. The live vLLM generation tests skipped locally because the optional `vllm` package is not installed.
- Regression:
  - `uv run make check`
  - Result: passed
  - Covers ruff formatting/linting and mypy type checking across the repository.
  - `uv run make test`
  - Result: passed, 7,924 tests collected

CI/CD coverage expected:

- Standard PR workflows should cover package build/inspection, schema/type checks, ruff, mypy on supported Python versions, pre-commit hooks, and the Python test matrix.
- No viewer schema, frontend, sandbox-tool, or generated distribution artifacts are touched.
