### PR TITLE
fix: warn on unbounded message conversations

### DIFF
--- a/docs/_message_limits.md
+++ b/docs/_message_limits.md
@@ -5,3 +5,5 @@ Message limits are checked:
 * Whenever you call `generate()` on any model. A `LimitExceededError` will be raised if the number of messages passed in `input` parameter to `generate()` is equal to or exceeds the limit. This is to avoid proceeding to another (wasteful) generate call if we're already at the limit.
 
 * Whenever `TaskState.messages` or `AgentState.messages` is mutated, but a `LimitExceededError` is only raised if the count exceeds the limit.
+
+If `message_limit` is unset, Inspect does not impose a default cap. It will warn once when an unbounded conversation reaches 1,000 messages so that runaway loops are easier to notice before they continue consuming model calls.

--- a/src/inspect_ai/util/_limit.py
+++ b/src/inspect_ai/util/_limit.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 TNode = TypeVar("TNode", bound="_Node")
 
+UNBOUNDED_MESSAGE_WARNING_THRESHOLD = 1_000
+
 
 class LimitExceededError(Exception):
     """Exception raised when a limit is exceeded.
@@ -1274,6 +1276,7 @@ class _MessageLimit(Limit, _Node):
         super().__init__()
         self._validate_message_limit(limit)
         self._limit = limit
+        self._unbounded_warning_issued = False
 
     def __enter__(self) -> Limit:
         super()._check_reuse()
@@ -1322,6 +1325,7 @@ class _MessageLimit(Limit, _Node):
         from inspect_ai.log._transcript import transcript
 
         if self.limit is None:
+            self._warn_if_unbounded(count)
             return
         if count > self.limit or (raise_for_equal and count == self.limit):
             reached_or_exceeded = "reached" if count == self.limit else "exceeded"
@@ -1341,6 +1345,19 @@ class _MessageLimit(Limit, _Node):
             raise ValueError(
                 f"Message limit value must be a non-negative integer or None: {value}"
             )
+
+    def _warn_if_unbounded(self, count: int) -> None:
+        if (
+            not self._unbounded_warning_issued
+            and count >= UNBOUNDED_MESSAGE_WARNING_THRESHOLD
+        ):
+            logger.warning(
+                "Message count has reached %s with no message_limit set. "
+                "This can cause unbounded generation loops and unexpected API costs; "
+                "set message_limit=... to bound the conversation.",
+                f"{UNBOUNDED_MESSAGE_WARNING_THRESHOLD:,}",
+            )
+            self._unbounded_warning_issued = True
 
 
 class _TimeLimit(Limit, _Node):

--- a/tests/util/test_limit_message.py
+++ b/tests/util/test_limit_message.py
@@ -1,12 +1,40 @@
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+
 import anyio
 import pytest
 
 from inspect_ai._util._async import tg_collect
 from inspect_ai.util._limit import (
+    UNBOUNDED_MESSAGE_WARNING_THRESHOLD,
     LimitExceededError,
     check_message_limit,
     message_limit,
 )
+
+
+@contextmanager
+def _capture_limit_warnings() -> Iterator[list[str]]:
+    messages: list[str] = []
+
+    class CaptureHandler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            messages.append(record.getMessage())
+
+    logger = logging.getLogger("inspect_ai.util._limit")
+    handler = CaptureHandler(level=logging.WARNING)
+    previous_level = logger.level
+    previous_propagate = logger.propagate
+    logger.addHandler(handler)
+    logger.setLevel(logging.WARNING)
+    logger.propagate = False
+    try:
+        yield messages
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous_level)
+        logger.propagate = previous_propagate
 
 
 def test_validates_limit_parameter() -> None:
@@ -17,6 +45,40 @@ def test_validates_limit_parameter() -> None:
 def test_can_create_with_none_limit() -> None:
     with message_limit(None):
         check_message_limit(10, raise_for_equal=False)
+
+
+def test_warns_once_when_none_limit_reaches_high_message_count() -> None:
+    with _capture_limit_warnings() as warning_messages:
+        with message_limit(None):
+            check_message_limit(
+                UNBOUNDED_MESSAGE_WARNING_THRESHOLD - 1,
+                raise_for_equal=False,
+            )
+            check_message_limit(
+                UNBOUNDED_MESSAGE_WARNING_THRESHOLD,
+                raise_for_equal=False,
+            )
+            check_message_limit(
+                UNBOUNDED_MESSAGE_WARNING_THRESHOLD + 1,
+                raise_for_equal=False,
+            )
+
+    assert warning_messages == [
+        "Message count has reached 1,000 with no message_limit set. "
+        "This can cause unbounded generation loops and unexpected API costs; "
+        "set message_limit=... to bound the conversation."
+    ]
+
+
+def test_does_not_warn_when_finite_limit_is_set() -> None:
+    with _capture_limit_warnings() as warning_messages:
+        with message_limit(UNBOUNDED_MESSAGE_WARNING_THRESHOLD + 1):
+            check_message_limit(
+                UNBOUNDED_MESSAGE_WARNING_THRESHOLD,
+                raise_for_equal=False,
+            )
+
+    assert not warning_messages
 
 
 def test_can_create_with_zero_limit() -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When `message_limit=None`, Inspect applies no message cap and gives no signal if an agent or solver conversation grows very large. A runaway loop can therefore continue making model calls without an obvious warning.

Closes #2747.

### What is the new behavior?

- Unbounded message limits now emit a warning once a conversation reaches 1,000 messages.
- Finite message limits keep the existing behavior and still raise `LimitExceededError` at the configured threshold.
- The message limit docs now call out that `message_limit=None` remains uncapped, but warns once at the high-message threshold.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This does not impose a new default cap or change `LimitExceededError` behavior. It only adds a warning for unbounded conversations after they become unusually large.

### Other information:

Validation:
- Targeted:
  - `uv run pytest tests/util/test_limit_message.py -v`
    - 19 passed, 1 skipped.
    - Covers the new once-only warning at 1,000 messages, no warning below the threshold, no repeated warning after the threshold, no warning when a finite `message_limit` is configured, and the existing message-limit regression tests.
- Regression:
  - `uv run make check`
    - Ruff fixed formatting/import order and mypy passed with no issues across 1,114 source files.
  - `uv run make test`
    - 5,469 passed, 2,453 skipped, 4 warnings.

CI/CD coverage expected:
- Standard Python checks should cover this change through ruff, mypy, package build, and the pytest matrix.
- No viewer schema, frontend bundle, sandbox-tools, or package-lock artifacts are touched, so the specialized viewer/sandbox gates should not require additional generated output for this PR.
