### PR TITLE
anthropic: fix sample-killing bugs on multi-turn server-tool traces

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -726,8 +726,22 @@ class AnthropicAPI(ModelAPI):
 
         if continuation_required:
             tail_request = dict(request)
+            # Strip `citations` from each content block before echoing
+            # head_message.content back as input. Anthropic's response models
+            # have `extra='allow'`, so web_fetch_tool_result and similar
+            # response blocks carry `citations` fields on the way in but the
+            # API rejects them as "Extra inputs are not permitted" on the
+            # way back out. See `_drop_citations` below.
+            tail_head_content = [
+                _drop_citations(
+                    block.model_dump(exclude_none=True)
+                    if hasattr(block, "model_dump")
+                    else dict(block)
+                )
+                for block in head_message.content
+            ]
             tail_request["messages"] = request["messages"] + [
-                MessageParam(role=head_message.role, content=head_message.content)
+                MessageParam(role=head_message.role, content=tail_head_content)
             ]
             _, tail_model_output = await self._perform_request_and_continuations(
                 tail_request,
@@ -1961,6 +1975,35 @@ def _strip_text_block_citations(block: MessageBlockParam) -> MessageBlockParam:
         block = cast(TextBlockParam | DocumentBlockParam, block.copy())
         del block["citations"]
     return block
+
+
+def _drop_citations(obj: Any) -> Any:
+    """Recursively remove every ``citations`` key from a dict/list structure.
+
+    Anthropic's response models for tool result blocks
+    (``BetaWebFetchToolResultBlock``, ``BetaWebFetchBlock``, ...) are
+    configured with ``extra='allow'``, so any extra fields the API returns
+    — ``citations`` among them, despite not being declared on the model —
+    round-trip through ``model_dump(exclude_none=True)``. When the block is
+    then replayed as input on a subsequent ``/v1/messages`` request, the
+    API rejects the extra field with::
+
+      {"type": "invalid_request_error",
+       "message": "messages.N.content.M.web_fetch_tool_result.citations:
+                   Extra inputs are not permitted"}
+
+    Recursive because the field has been observed at the outer block level
+    AND nested inside ``content`` on successful fetches. Mutates ``obj``
+    in place and returns it for convenience.
+    """
+    if isinstance(obj, dict):
+        obj.pop("citations", None)
+        for v in obj.values():
+            _drop_citations(v)
+    elif isinstance(obj, list):
+        for v in obj:
+            _drop_citations(v)
+    return obj
 
 
 async def assistant_message_blocks(

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1977,6 +1977,77 @@ def _strip_text_block_citations(block: MessageBlockParam) -> MessageBlockParam:
     return block
 
 
+def _resolve_or_synthesize_tool_use(
+    *,
+    tool_use_id: str,
+    pending_tool_uses: dict[str, ServerToolUseBlock],
+    server_store: dict[
+        str, tuple[ServerToolUseBlockParam, Any]
+    ],
+    fallback_tool_name: str,
+) -> tuple[ServerToolUseBlockParam, str, dict[str, Any]]:
+    """Resolve the matching ServerToolUseBlock for an incoming tool_result.
+
+    Three cases, in order:
+
+    1. **Local message** — the tool_use is in ``pending_tool_uses`` (the
+       common case where ``server_tool_use`` and its result block appear
+       in the same assistant turn). Pop and return.
+
+    2. **pause_turn continuation** — when the model uses a server-side
+       tool that pauses mid-execution (e.g. a long web_fetch), the next
+       assistant turn starts with the tool_result block. The tool_use
+       was emitted in the *previous* turn and lives in
+       ``server_store`` (e.g. ``server_web_fetches``) keyed by the same
+       tool_use_id, populated when the prior turn was parsed.
+
+    3. **Synthesized fallback** — if the tool_use is in neither, log a
+       warning and return a minimal ``ServerToolUseBlockParam`` so the
+       sample completes. This handles rare edge cases such as
+       server-side context compaction stripping the original tool_use
+       detail blocks while leaving tool_result references.
+
+    Returns ``(tool_use_param, name, input)`` regardless of the source so
+    callers can use a uniform construction site.
+    """
+    pending = pending_tool_uses.pop(tool_use_id, None)
+    if pending is not None:
+        return (
+            cast(ServerToolUseBlockParam, pending.model_dump(exclude_none=True)),
+            pending.name,
+            pending.input,
+        )
+
+    stored = server_store.get(tool_use_id)
+    if stored is not None:
+        prior_use_param, _ = stored
+        return (
+            prior_use_param,
+            prior_use_param.get("name", fallback_tool_name),
+            prior_use_param.get("input", {}),
+        )
+
+    logger.warning(
+        "anthropic: synthesizing fallback tool_use for orphan %s result "
+        "(id=%r). The matching server_tool_use block was not in the "
+        "current message and was not previously stored in "
+        "assistant_internal — most commonly seen with server-side "
+        "context compaction stripping the tool_use detail block.",
+        fallback_tool_name,
+        tool_use_id,
+    )
+    return (
+        cast(ServerToolUseBlockParam, {
+            "id": tool_use_id,
+            "name": fallback_tool_name,
+            "type": "server_tool_use",
+            "input": {},
+        }),
+        fallback_tool_name,
+        {},
+    )
+
+
 def _drop_citations(obj: Any) -> Any:
     """Recursively remove every ``citations`` key from a dict/list structure.
 
@@ -2360,19 +2431,18 @@ def content_and_tool_calls_from_assistant_content_blocks(
                 )
             )
         elif content_block.type == "web_fetch_tool_result":
-            # confirm that there is a pending tool use
-            pending_tool_use = pending_tool_uses.pop(content_block.tool_use_id, None)
-            if pending_tool_use is None:
-                raise RuntimeError(
-                    "BetaWebFetchToolResultBlock without previous ServerToolUseBlock"
+            tool_use_param, tool_use_name, tool_use_input = (
+                _resolve_or_synthesize_tool_use(
+                    tool_use_id=content_block.tool_use_id,
+                    pending_tool_uses=pending_tool_uses,
+                    server_store=assistant_internal().server_web_fetches,
+                    fallback_tool_name="web_fetch",
                 )
+            )
 
             # record in internal
-            assistant_internal().server_web_fetches[pending_tool_use.id] = (
-                cast(
-                    ServerToolUseBlockParam,
-                    pending_tool_use.model_dump(exclude_none=True),
-                ),
+            assistant_internal().server_web_fetches[content_block.tool_use_id] = (
+                tool_use_param,
                 cast(
                     BetaWebFetchToolResultBlockParam,
                     content_block.model_dump(exclude_none=True),
@@ -2383,9 +2453,9 @@ def content_and_tool_calls_from_assistant_content_blocks(
             content.append(
                 ContentToolUse(
                     tool_type="web_search",
-                    id=pending_tool_use.id,
-                    name="web_fetch",
-                    arguments=to_json_str_safe(pending_tool_use.input),
+                    id=content_block.tool_use_id,
+                    name=tool_use_name,
+                    arguments=to_json_str_safe(tool_use_input),
                     result=to_json_tool_result_safe(content_block),
                 )
             )
@@ -2394,19 +2464,18 @@ def content_and_tool_calls_from_assistant_content_blocks(
             content_block.type == "bash_code_execution_tool_result"
             or content_block.type == "text_editor_code_execution_tool_result"
         ):
-            # confirm that there is a pending tool use
-            pending_tool_use = pending_tool_uses.pop(content_block.tool_use_id, None)
-            if pending_tool_use is None:
-                raise RuntimeError(
-                    "CodeExecutionToolResultBlock without previous ServerToolUseBlock"
+            tool_use_param, tool_use_name, tool_use_input = (
+                _resolve_or_synthesize_tool_use(
+                    tool_use_id=content_block.tool_use_id,
+                    pending_tool_uses=pending_tool_uses,
+                    server_store=assistant_internal().server_code_executions,
+                    fallback_tool_name="code_execution",
                 )
+            )
 
             # record in internal
-            assistant_internal().server_code_executions[pending_tool_use.id] = (
-                cast(
-                    ServerToolUseBlockParam,
-                    pending_tool_use.model_dump(exclude_none=True),
-                ),
+            assistant_internal().server_code_executions[content_block.tool_use_id] = (
+                tool_use_param,
                 cast(
                     BetaBashCodeExecutionToolResultBlockParam
                     | BetaTextEditorCodeExecutionToolResultBlockParam,
@@ -2418,9 +2487,9 @@ def content_and_tool_calls_from_assistant_content_blocks(
             content.append(
                 ContentToolUse(
                     tool_type="code_execution",
-                    id=pending_tool_use.id,
-                    name=pending_tool_use.name,
-                    arguments=to_json_str_safe(pending_tool_use.input),
+                    id=content_block.tool_use_id,
+                    name=tool_use_name,
+                    arguments=to_json_str_safe(tool_use_input),
                     result=to_json_tool_result_safe(content_block),
                 )
             )
@@ -2476,18 +2545,18 @@ def content_and_tool_calls_from_assistant_content_blocks(
         elif isinstance(
             content_block, (WebSearchToolResultBlock, BetaWebSearchToolResultBlock)
         ):
-            pending_tool_use = pending_tool_uses.pop(content_block.tool_use_id, None)
-            if pending_tool_use is None:
-                raise RuntimeError(
-                    "WebSearchToolResultBlock without previous ServerToolUseBlock"
+            tool_use_param, tool_use_name, tool_use_input = (
+                _resolve_or_synthesize_tool_use(
+                    tool_use_id=content_block.tool_use_id,
+                    pending_tool_uses=pending_tool_uses,
+                    server_store=assistant_internal().server_web_searches,
+                    fallback_tool_name="web_search",
                 )
+            )
 
             # record in internal
-            assistant_internal().server_web_searches[pending_tool_use.id] = (
-                cast(
-                    ServerToolUseBlockParam,
-                    pending_tool_use.model_dump(exclude_none=True),
-                ),
+            assistant_internal().server_web_searches[content_block.tool_use_id] = (
+                tool_use_param,
                 cast(
                     WebSearchToolResultBlockParam,
                     content_block.model_dump(exclude_none=True),
@@ -2497,9 +2566,9 @@ def content_and_tool_calls_from_assistant_content_blocks(
             content.append(
                 ContentToolUse(
                     tool_type="web_search",
-                    id=pending_tool_use.id,
-                    name=pending_tool_use.name,
-                    arguments=to_json_str_safe(pending_tool_use.input),
+                    id=content_block.tool_use_id,
+                    name=tool_use_name,
+                    arguments=to_json_str_safe(tool_use_input),
                     result=web_search_result_block_adapter.dump_json(
                         content_block.content, exclude_none=True
                     ).decode(),


### PR DESCRIPTION
## Summary

Fixes three classes of sample-killing bugs in the anthropic provider that surface on long multi-turn traces using server-side tools (`web_search`, `web_fetch`, `code_execution`), commonly with `claude-opus-4-7` and the new `compact-2026-01-12` context-management beta.

## What's broken today (at `main`)

### 1. `citations` field rejected on continuation replay

When a response requires continuation, `_perform_request_and_continuations` appends `head_message.content` verbatim into `tail_request[\"messages\"]`:

```python
tail_request[\"messages\"] = request[\"messages\"] + [
    MessageParam(role=head_message.role, content=head_message.content)
]
```

But Anthropic's response models for tool result blocks (`BetaWebFetchToolResultBlock`, `BetaWebFetchBlock`) are configured with `extra='allow'`, so any extra fields the API returns — `citations` among them, despite not being declared on the model — round-trip through `model_dump(exclude_none=True)`. When that content is replayed as input on the tail request, the API rejects it:

```
{\"type\": \"invalid_request_error\",
 \"message\": \"messages.N.content.M.web_fetch_tool_result.citations:
             Extra inputs are not permitted\"}
```

### 2. `pause_turn` — tool_result from prior turn raises RuntimeError

When the model uses a server-side tool that pauses mid-execution (e.g. a long web_fetch), the next assistant turn *starts* with the tool_result block. The matching `server_tool_use` was emitted in the prior turn, so the local `pending_tool_uses` dict in `content_and_tool_calls_from_assistant_content_blocks` doesn't have it, and the code raises:

```
RuntimeError(\"BetaWebFetchToolResultBlock without previous ServerToolUseBlock\")
RuntimeError(\"WebSearchToolResultBlock without previous ServerToolUseBlock\")
RuntimeError(\"CodeExecutionToolResultBlock without previous ServerToolUseBlock\")
```

The tool_use IS in `assistant_internal().server_web_fetches` / `server_web_searches` / `server_code_executions` (populated when the prior turn was parsed) — we just never look there.

### 3. Compaction can produce truly-orphan tool_result blocks

With `context_management.edits = [{type: \"compact_20260112\", ...}]`, older turns are replaced by a compaction summary block. The model can then echo `tool_use_id`s whose detail blocks were stripped — they're in neither `pending_tool_uses` nor `assistant_internal`. Same RuntimeError, sample killed.

## What this PR does

### Commit 1: strip citations from continuation replay

Adds a small `_drop_citations(obj)` helper that recursively pops `citations` keys from a dict/list structure. Calls it on each content block dump before re-wrapping into `MessageParam` in `_perform_request_and_continuations`. The strip is recursive because the field has been observed at the outer block level AND nested inside `content` on successful fetches.

### Commit 2: fall back to assistant_internal for orphan tool_result blocks

Adds `_resolve_or_synthesize_tool_use(...)` that tries, in order:

1. `pending_tool_uses.pop(tool_use_id)` — the existing local-message case.
2. `server_store.get(tool_use_id)` — the pause_turn case. The store (`server_web_fetches` / `server_web_searches` / `server_code_executions`) is keyed by the same `tool_use_id`, populated on the prior turn's parse.
3. Synthesize a minimal `ServerToolUseBlockParam` and emit a warning — last-resort fallback for the compaction case so the sample completes with the result content visible to the agent (input args unknown but rarely affects the final answer).

Applied at all three raise sites: `web_fetch_tool_result`, `bash_code_execution_tool_result` / `text_editor_code_execution_tool_result`, and the `WebSearchToolResultBlock` isinstance branch.

## Observed impact

On `claude-opus-4-7` dsqa runs with native `web_search` + `web_fetch` + `code_execution` + auto-compaction (`context_management.edits` with `compact_20260112`):

| | Before this PR | After this PR |
|---|---|---|
| citations errors | ~20% of samples | 0 |
| pause_turn / orphan errors | ~25% of samples (additional) | 0 |
| Total fatal sample errors | ~30%+ | 0 |

Mean score on a dsqa-100 verify run climbed from 0.55 (depressed by sample failures) to 0.70 (the model's actual capability).

## Test plan

- [x] Sanity: helpers and patched paths import and parse cleanly.
- [x] End-to-end: 100-sample anthropic-direct eval against claude-opus-4-7 with `web_search` + `web_fetch` + `code_execution` + `effort=high` + `compact-2026-01-12` beta — confirmed zero `RuntimeError`s and zero `Extra inputs are not permitted` errors over multiple runs.
- [ ] Unit tests for the new helpers — happy to add these if you'd like; the surface is small (3 cases for `_resolve_or_synthesize_tool_use`, 2 cases for `_drop_citations`).

## Notes for reviewers

- The synthesized fallback in commit 2 is the most opinionated piece. If you prefer strict raise behavior over graceful synthesis, I can split it out so the PR adds only the pause_turn fallback and leaves the compaction-orphan case raising. Let me know your preference.
- I've held off on touching the `MCPToolResultBlock without previous MCPToolUseBlock` raise site since I haven't reproduced it in our usage. The same pattern would apply if you want it covered.