### PR TITLE
Add OrcaRouter model provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Add [OrcaRouter](https://inspect.aisi.org.uk/providers.html#orcarouter) model provider (`orcarouter/<vendor>/<model>`), with `models` fallback list, attribution headers (`HTTP-Referer` / `X-Title`), and error-body / empty-response retry handling.
+
 ## 0.3.227 (26 May 2026)
 
 - [`ask_user()`](https://inspect.aisi.org.uk/tools-standard.html#ask-user) tool: model can solicit a structured answer from the operator.

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -1326,6 +1326,39 @@ The following environment variables are supported by the OpenRouter AI provider
 | `OPENROUTER_API_KEY` | API key credentials (required). |
 | `OPENROUTER_BASE_URL` | Base URL for requests (optional, defaults to `https://openrouter.ai/api/v1`) |
 
+## OrcaRouter
+
+To use the [OrcaRouter](https://www.orcarouter.ai/) provider, install the `openai` package (OrcaRouter offers an OpenAI-compatible endpoint), set your credentials, and specify a model using the `--model` option:
+
+``` bash
+pip install openai
+export ORCAROUTER_API_KEY=your-orcarouter-api-key
+inspect eval arc.py --model orcarouter/openai/gpt-4o-mini
+```
+
+Model ids use the upstream `<vendor>/<model>` form (e.g. `orcarouter/anthropic/claude-opus-4.7`). The virtual router id `orcarouter/auto` selects an upstream per-request via OrcaRouter's adaptive router (see the [console](https://www.orcarouter.ai/console/routing) for strategy configuration). A full catalog is available at <https://www.orcarouter.ai/models>.
+
+For the `orcarouter` provider, the following custom model args (`-M`) are supported:
+
+| Argument | Example |
+|------------------------------------|------------------------------------|
+| `models` | `-M "models=['openai/gpt-4o', 'anthropic/claude-opus-4.7']"` — fallback list (forwarded as `extra_body.models` with `route="fallback"`) |
+| `referer` | `-M "referer=https://my-org.example/"` — overrides the `HTTP-Referer` attribution header (defaults to the Inspect docs URL) |
+| `app_title` | `-M "app_title=My Eval Harness"` — overrides the `X-Title` attribution header |
+
+: {tbl-colwidths=\[20,85\]}
+
+Reasoning options (`--reasoning-effort`, `--reasoning-tokens`) are forwarded as the standard OpenAI-compatible top-level fields. OrcaRouter passes requests through to the selected upstream using that upstream's native protocol, so `reasoning_effort` is honored by upstreams that accept that shape (OpenAI o-series / gpt-5, Gemini, Grok, Qwen, Kimi reasoning families). For Anthropic models that need the native `thinking` block, pass it via `GenerateConfig.extra_body`. Note that some Anthropic and OpenAI reasoning models reject `temperature` upstream — omit it for those models.
+
+In addition, [Tool Emulation](#tool-emulation-openai) is available for models that don't support tool calling in their API.
+
+The following environment variables are supported by the OrcaRouter provider:
+
+| Variable | Description |
+|----------------------------|--------------------------------------------|
+| `ORCAROUTER_API_KEY` | API key credentials (required). |
+| `ORCAROUTER_BASE_URL` | Base URL for requests (optional, defaults to `https://api.orcarouter.ai/v1`). |
+
 ## Hugging Face Inference Providers
 
 To use [Hugging Face Inference Providers](https://huggingface.co/docs/inference-providers), install the `openai` package (which provides the compatibility layer), set your Hugging Face token, and specify a model using the `--model` option:

--- a/src/inspect_ai/model/_providers/orcarouter.py
+++ b/src/inspect_ai/model/_providers/orcarouter.py
@@ -1,0 +1,150 @@
+import json
+from logging import getLogger
+from typing import Any
+
+from openai.types.chat import ChatCompletion
+from typing_extensions import NotRequired, TypedDict, override
+
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai.model._model import RetryDecision
+from inspect_ai.model._openai import OpenAIResponseError
+
+from .._generate_config import GenerateConfig
+from .openai_compatible import OpenAICompatibleAPI
+
+ORCAROUTER_API_KEY = "ORCAROUTER_API_KEY"
+
+logger = getLogger(__name__)
+
+
+class ErrorResponse(TypedDict):
+    code: int
+    message: str
+    metadata: NotRequired[dict[str, Any]]
+
+
+class OrcaRouterError(Exception):
+    def __init__(self, response: ErrorResponse) -> None:
+        self.response = response
+
+    @property
+    def message(self) -> str:
+        return f"Error {self.response['code']} - {self.response['message']}"
+
+    def __str__(self) -> str:
+        return (
+            self.message + ("\n" + json.dumps(self.response["metadata"], indent=2))
+            if "metadata" in self.response
+            else self.message
+        )
+
+
+class OrcaRouterAPI(OpenAICompatibleAPI):
+    """OpenAI-compatible client for the OrcaRouter inference router.
+
+    OrcaRouter (https://www.orcarouter.ai) is a multi-provider LLM router
+    exposed through an OpenAI-compatible API. Requests are forwarded by
+    OrcaRouter to the selected upstream using that upstream's native protocol;
+    Inspect's standard `reasoning_effort` / `reasoning_tokens` are forwarded as
+    top-level OpenAI-compatible fields and so work for upstreams that accept
+    that shape (OpenAI o-series / gpt-5 / Gemini / Grok / Qwen / Kimi reasoning
+    families). For Anthropic models, pass the Anthropic-native `thinking`
+    block via `GenerateConfig.extra_body` instead.
+
+    Custom model args (`-M`):
+      * `models`     — list[str], fallback model ids (sent via `extra_body.models`
+                       with `route="fallback"`).
+      * `referer`    — override the `HTTP-Referer` attribution header.
+      * `app_title`  — override the `X-Title` attribution header.
+    """
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        emulate_tools: bool = False,
+        **model_args: Any,
+    ) -> None:
+        def collect_model_arg(name: str) -> Any | None:
+            nonlocal model_args
+            value = model_args.get(name, None)
+            if value is not None:
+                model_args.pop(name)
+            return value
+
+        self.models = collect_model_arg("models")
+        if self.models is not None and not isinstance(self.models, list):
+            raise PrerequisiteError("models must be a list of strings")
+
+        self.referer = collect_model_arg("referer") or "https://inspect.aisi.org.uk/"
+        self.app_title = collect_model_arg("app_title") or "Inspect AI"
+
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="OrcaRouter",
+            service_base_url="https://api.orcarouter.ai/v1",
+            emulate_tools=emulate_tools,
+            **model_args,
+        )
+
+    @override
+    def should_retry(self, ex: BaseException) -> bool | RetryDecision:
+        decision = super().should_retry(ex)
+        if isinstance(decision, RetryDecision):
+            if decision.retry:
+                return decision
+        elif decision:
+            return RetryDecision.transient()
+        if isinstance(ex, json.JSONDecodeError):
+            return RetryDecision.transient()
+        return RetryDecision.no()
+
+    @override
+    def on_response(self, response: dict[str, Any]) -> None:
+        """Handle OrcaRouter-shaped error bodies returned with HTTP 200."""
+        error: ErrorResponse | None = response.get("error", None)
+        if error is not None:
+            if error["code"] == 429:
+                raise OpenAIResponseError("rate_limit_exceeded", error["message"])
+            elif error["code"] in [408, 500, 502, 504]:
+                raise OpenAIResponseError("server_error", error["message"])
+            else:
+                raise OrcaRouterError(error)
+
+        if response.get("choices", None) is None:
+            raise OpenAIResponseError(
+                "server_error",
+                "Empty response from OrcaRouter; retry after upstream warmup.",
+            )
+
+    @override
+    async def _generate_completion(
+        self, request: dict[str, Any], config: GenerateConfig
+    ) -> ChatCompletion:
+        # inject attribution headers so the OrcaRouter console can attribute
+        # traffic to Inspect. Mirrors the convention used by OpenAI-compatible
+        # meta-routers (HTTP-Referer + X-Title). User-supplied values via
+        # `referer` / `app_title` model args, or config.extra_headers, win.
+        extra_headers = request.get("extra_headers") or {}
+        extra_headers.setdefault("HTTP-Referer", self.referer)
+        extra_headers.setdefault("X-Title", self.app_title)
+        request["extra_headers"] = extra_headers
+        return await super()._generate_completion(request, config)
+
+    @override
+    def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        params = super().completion_params(config, tools)
+
+        # forward fallback model list via extra_body
+        if self.models:
+            extra_body = params.get("extra_body") or {}
+            extra_body["models"] = self.models
+            extra_body.setdefault("route", "fallback")
+            params["extra_body"] = extra_body
+
+        return params

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -206,6 +206,17 @@ def openrouter() -> type[ModelAPI]:
     return OpenRouterAPI
 
 
+@modelapi(name="orcarouter")
+def orcarouter() -> type[ModelAPI]:
+    # validate
+    validate_openai_client("OrcaRouter API")
+
+    # in the clear
+    from .orcarouter import OrcaRouterAPI
+
+    return OrcaRouterAPI
+
+
 @modelapi(name="perplexity")
 def perplexity() -> type[ModelAPI]:
     # validate

--- a/tests/model/providers/test_orcarouter.py
+++ b/tests/model/providers/test_orcarouter.py
@@ -1,0 +1,98 @@
+"""Tests for the OrcaRouter provider."""
+
+from typing import Any
+
+import pytest
+
+from inspect_ai._util.error import PrerequisiteError
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._openai import OpenAIResponseError
+from inspect_ai.model._providers.orcarouter import (
+    OrcaRouterAPI,
+    OrcaRouterError,
+)
+
+
+def _make_api(
+    model_name: str = "orcarouter/openai/gpt-4o-mini", **kwargs: Any
+) -> OrcaRouterAPI:
+    return OrcaRouterAPI(model_name=model_name, api_key="test-key", **kwargs)
+
+
+def test_default_base_url_and_api_key() -> None:
+    api = _make_api()
+    assert api.base_url == "https://api.orcarouter.ai/v1"
+    assert api.api_key == "test-key"
+    assert api.service == "OrcaRouter"
+
+
+def test_models_arg_accepted_as_list() -> None:
+    api = _make_api(models=["openai/gpt-4o", "anthropic/claude-opus-4.7"])
+    assert api.models == ["openai/gpt-4o", "anthropic/claude-opus-4.7"]
+
+
+def test_models_arg_must_be_list() -> None:
+    with pytest.raises(PrerequisiteError):
+        _make_api(models="not-a-list")
+
+
+def test_completion_params_injects_fallback_models() -> None:
+    api = _make_api(models=["openai/gpt-4o", "anthropic/claude-opus-4.7"])
+    params = api.completion_params(GenerateConfig(), tools=False)
+    assert params["extra_body"]["models"] == [
+        "openai/gpt-4o",
+        "anthropic/claude-opus-4.7",
+    ]
+    assert params["extra_body"]["route"] == "fallback"
+
+
+def test_completion_params_no_extra_body_without_models() -> None:
+    api = _make_api()
+    params = api.completion_params(GenerateConfig(), tools=False)
+    assert "extra_body" not in params or "models" not in params.get("extra_body", {})
+
+
+def test_default_attribution_headers() -> None:
+    api = _make_api()
+    assert api.referer == "https://inspect.aisi.org.uk/"
+    assert api.app_title == "Inspect AI"
+
+
+def test_custom_attribution_headers() -> None:
+    api = _make_api(referer="https://my-org.example/", app_title="My Eval Harness")
+    assert api.referer == "https://my-org.example/"
+    assert api.app_title == "My Eval Harness"
+
+
+def test_on_response_raises_rate_limit_on_429() -> None:
+    api = _make_api()
+    with pytest.raises(OpenAIResponseError) as info:
+        api.on_response({"error": {"code": 429, "message": "slow down"}})
+    assert "rate_limit_exceeded" in str(info.value.code)
+
+
+@pytest.mark.parametrize("code", [408, 500, 502, 504])
+def test_on_response_raises_server_error_on_5xx(code: int) -> None:
+    api = _make_api()
+    with pytest.raises(OpenAIResponseError) as info:
+        api.on_response({"error": {"code": code, "message": "boom"}})
+    assert info.value.code == "server_error"
+
+
+def test_on_response_raises_orcarouter_error_on_other_codes() -> None:
+    api = _make_api()
+    with pytest.raises(OrcaRouterError):
+        api.on_response({"error": {"code": 400, "message": "bad request"}})
+
+
+def test_on_response_raises_server_error_on_empty_choices() -> None:
+    api = _make_api()
+    with pytest.raises(OpenAIResponseError) as info:
+        api.on_response({})
+    assert info.value.code == "server_error"
+
+
+def test_on_response_passes_on_success() -> None:
+    api = _make_api()
+    # no error + non-empty choices → no raise
+    api.on_response({"choices": [{"index": 0}]})


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Inspect AI does not currently ship a built-in provider for [OrcaRouter](https://www.orcarouter.ai/), an OpenAI-compatible multi-vendor inference router (adaptive routing across OpenAI / Anthropic / Google / DeepSeek / xAI / Qwen / Kimi / MiniMax / Z.ai upstreams). Users have to either fall back to the generic `openai-api` provider (losing per-router defaults and error/retry handling) or fork the codebase.

### What is the new behavior?

Adds a new `orcarouter` provider that subclasses `OpenAICompatibleAPI` and is wired into the model API registry alongside the existing `openrouter` entry. Usage:

pip install openai
export ORCAROUTER_API_KEY=sk-orca-...
inspect eval arc.py --model orcarouter/openai/gpt-4o-mini
# or the virtual adaptive router:
inspect eval arc.py --model orcarouter/auto


Highlights:

- **Default endpoint**: `https://api.orcarouter.ai/v1`, with `ORCAROUTER_API_KEY` / `ORCAROUTER_BASE_URL` env vars.
- **Custom model args (`-M`)**:
  - `models` — list of fallback model ids (forwarded as `extra_body.models` with `route="fallback"`).
  - `referer` / `app_title` — override attribution headers (`HTTP-Referer` / `X-Title`) so OrcaRouter's console can attribute traffic.
- **Reasoning**: forwards Inspect's standard `reasoning_effort` / `reasoning_tokens` as the OpenAI-compatible top-level fields. OrcaRouter passes them through to the selected upstream, so they work for upstreams that accept that shape (OpenAI o-series / gpt-5, Gemini, Grok, Qwen, Kimi reasoning families). For Anthropic models that need the native `thinking` block, pass it via `GenerateConfig.extra_body`.
- **Error handling**: parses OrcaRouter's HTTP-200-with-`error` body shape — 429 → `rate_limit_exceeded`, 408/500/502/504 → `server_error` (retried), other codes → `OrcaRouterError`; empty `choices` is treated as a transient warmup → retry.
- **Docs**: new `## OrcaRouter` section in `docs/providers.qmd` (immediately after OpenRouter).
- **Tests**: 15 unit tests in `tests/model/providers/test_orcarouter.py` covering defaults, model-args validation, fallback-models injection, attribution headers, and all `on_response` error branches.

Locally verified: `pytest tests/model/providers/test_orcarouter.py` → 15 passed; `ruff check` / `ruff format --check` clean.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This is purely additive — a new provider name (`orcarouter`) and module. No existing provider, model id, env var, or public API is modified.

### Other information:

I'm an engineer on the OrcaRouter team. OrcaRouter is OpenAI-compatible, so most of the heavy lifting comes from `OpenAICompatibleAPI`; this PR adds only the router-specific glue (default endpoint, attribution, fallback-models arg, OrcaRouter-shaped error parsing). All code is freshly written against the OpenAI-compatible request/response shapes already used by the existing `openrouter` provider — no upstream / OrcaRouter-internal source is vendored, so there are no license-compatibility concerns.

Happy to adjust scope / split the docs out / drop the attribution-header default if maintainers prefer a leaner first cut.
