### PR TITLE
refinements to buffer backed sample history

### DIFF
--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -215,29 +215,56 @@ class SampleBufferDatabase(SampleBuffer):
             )
 
     def log_events(self, events: list[SampleEvent]) -> None:
-        with self._get_connection(write=True) as conn:
-            # collect the values for all events
-            values: list[str | int] = []
-            for event in events:
-                event = self._condense_event(conn, event)
-                values.extend(
-                    (
-                        event.event.uuid or uuid(),
-                        str(event.id),
-                        event.epoch,
-                        to_json_str_safe(event.event),
+        index_snapshots: dict[
+            tuple[str, int], tuple[dict[str, int] | None, dict[str, int] | None]
+        ] = {}
+
+        try:
+            with self._get_connection(write=True) as conn:
+                # collect the values for all events
+                values: list[str | int] = []
+                for event in events:
+                    if isinstance(event.event, ModelEvent):
+                        key = (str(event.id), event.epoch)
+                        if key not in index_snapshots:
+                            msg_index = self._msg_indices.get(key)
+                            call_index = self._call_indices.get(key)
+                            index_snapshots[key] = (
+                                None if msg_index is None else dict(msg_index),
+                                None if call_index is None else dict(call_index),
+                            )
+
+                    event = self._condense_event(conn, event)
+                    values.extend(
+                        (
+                            event.event.uuid or uuid(),
+                            str(event.id),
+                            event.epoch,
+                            to_json_str_safe(event.event),
+                        )
                     )
-                )
 
-            # dynamically create the SQL query
-            placeholders = ", ".join(["(?, ?, ?, ?)"] * len(events))
-            sql = f"""
-            INSERT INTO events (event_id, sample_id, sample_epoch, data)
-            VALUES {placeholders}
-            """
+                # dynamically create the SQL query
+                placeholders = ", ".join(["(?, ?, ?, ?)"] * len(events))
+                sql = f"""
+                INSERT INTO events (event_id, sample_id, sample_epoch, data)
+                VALUES {placeholders}
+                """
 
-            # Insert all rows
-            conn.execute(sql, values)
+                # Insert all rows
+                conn.execute(sql, values)
+        except Exception:
+            for key, (msg_index, call_index) in index_snapshots.items():
+                if msg_index is None:
+                    self._msg_indices.pop(key, None)
+                else:
+                    self._msg_indices[key] = msg_index
+
+                if call_index is None:
+                    self._call_indices.pop(key, None)
+                else:
+                    self._call_indices[key] = call_index
+            raise
 
     def complete_sample(self, summary: EvalSampleSummary) -> None:
         with self._get_connection(write=True) as conn:
@@ -459,7 +486,7 @@ class SampleBufferDatabase(SampleBuffer):
     def sample_event_count(self, id: str | int, epoch: int) -> int:
         with self._acquire_sample_read_lease(id, epoch):
             with self._get_connection() as conn:
-                conn.execute("BEGIN IMMEDIATE")
+                conn.execute("BEGIN")
                 try:
                     cursor = conn.execute(
                         """
@@ -479,7 +506,7 @@ class SampleBufferDatabase(SampleBuffer):
     def sample_attachment(self, id: str | int, epoch: int, hash: str) -> str | None:
         with self._acquire_sample_read_lease(id, epoch):
             with self._get_connection() as conn:
-                conn.execute("BEGIN IMMEDIATE")
+                conn.execute("BEGIN")
                 try:
                     row = conn.execute(
                         """
@@ -507,7 +534,7 @@ class SampleBufferDatabase(SampleBuffer):
 
         with self._acquire_sample_read_lease(id, epoch):
             with self._get_connection() as conn:
-                conn.execute("BEGIN IMMEDIATE")
+                conn.execute("BEGIN")
                 history = self._sample_history(
                     conn, id, epoch, self._get_events_tail(conn, id, epoch, n)
                 )
@@ -523,7 +550,7 @@ class SampleBufferDatabase(SampleBuffer):
     ) -> Iterator[SampleHistory]:
         with self._acquire_sample_read_lease(id, epoch):
             with self._get_connection() as conn:
-                conn.execute("BEGIN IMMEDIATE")
+                conn.execute("BEGIN")
                 history = self._sample_history(
                     conn, id, epoch, self._get_events_from(conn, id, epoch, start)
                 )
@@ -538,7 +565,7 @@ class SampleBufferDatabase(SampleBuffer):
     ) -> Iterator[SampleHistory]:
         with self._acquire_sample_read_lease(id, epoch):
             with self._get_connection() as conn:
-                conn.execute("BEGIN IMMEDIATE")
+                conn.execute("BEGIN")
                 history = self._sample_history(
                     conn,
                     id,
@@ -821,7 +848,7 @@ class SampleBufferDatabase(SampleBuffer):
                 WHERE sample_id = ? AND sample_epoch = ?
                 GROUP BY COALESCE(NULLIF(event_id, ''), CAST(id AS TEXT))
             ), tail_rows AS (
-                SELECT logical_id, latest_id
+                SELECT logical_id, first_id, latest_id
                 FROM first_rows
                 ORDER BY first_id DESC
                 LIMIT ?
@@ -829,7 +856,7 @@ class SampleBufferDatabase(SampleBuffer):
             SELECT e.id, tr.logical_id AS event_id, e.data
             FROM tail_rows tr
             JOIN events e ON e.id = tr.latest_id
-            ORDER BY e.id
+            ORDER BY tr.first_id
         """
         cursor = conn.execute(query, [str(id), epoch, n])
 

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -219,41 +219,7 @@ class SampleBufferDatabase(SampleBuffer):
             tuple[str, int], tuple[dict[str, int] | None, dict[str, int] | None]
         ] = {}
 
-        try:
-            with self._get_connection(write=True) as conn:
-                # collect the values for all events
-                values: list[str | int] = []
-                for event in events:
-                    if isinstance(event.event, ModelEvent):
-                        key = (str(event.id), event.epoch)
-                        if key not in index_snapshots:
-                            msg_index = self._msg_indices.get(key)
-                            call_index = self._call_indices.get(key)
-                            index_snapshots[key] = (
-                                None if msg_index is None else dict(msg_index),
-                                None if call_index is None else dict(call_index),
-                            )
-
-                    event = self._condense_event(conn, event)
-                    values.extend(
-                        (
-                            event.event.uuid or uuid(),
-                            str(event.id),
-                            event.epoch,
-                            to_json_str_safe(event.event),
-                        )
-                    )
-
-                # dynamically create the SQL query
-                placeholders = ", ".join(["(?, ?, ?, ?)"] * len(events))
-                sql = f"""
-                INSERT INTO events (event_id, sample_id, sample_epoch, data)
-                VALUES {placeholders}
-                """
-
-                # Insert all rows
-                conn.execute(sql, values)
-        except Exception:
+        def restore_index_snapshots() -> None:
             for key, (msg_index, call_index) in index_snapshots.items():
                 if msg_index is None:
                     self._msg_indices.pop(key, None)
@@ -264,7 +230,42 @@ class SampleBufferDatabase(SampleBuffer):
                     self._call_indices.pop(key, None)
                 else:
                     self._call_indices[key] = call_index
-            raise
+
+        with self._get_connection(
+            write=True, on_rollback=restore_index_snapshots
+        ) as conn:
+            # collect the values for all events
+            values: list[str | int] = []
+            for event in events:
+                if isinstance(event.event, ModelEvent):
+                    key = (str(event.id), event.epoch)
+                    if key not in index_snapshots:
+                        msg_index = self._msg_indices.get(key)
+                        call_index = self._call_indices.get(key)
+                        index_snapshots[key] = (
+                            None if msg_index is None else dict(msg_index),
+                            None if call_index is None else dict(call_index),
+                        )
+
+                event = self._condense_event(conn, event)
+                values.extend(
+                    (
+                        event.event.uuid or uuid(),
+                        str(event.id),
+                        event.epoch,
+                        to_json_str_safe(event.event),
+                    )
+                )
+
+            # dynamically create the SQL query
+            placeholders = ", ".join(["(?, ?, ?, ?)"] * len(events))
+            sql = f"""
+            INSERT INTO events (event_id, sample_id, sample_epoch, data)
+            VALUES {placeholders}
+            """
+
+            # Insert all rows
+            conn.execute(sql, values)
 
     def complete_sample(self, summary: EvalSampleSummary) -> None:
         with self._get_connection(write=True) as conn:
@@ -626,7 +627,12 @@ class SampleBufferDatabase(SampleBuffer):
                 self._cleanup_now()
 
     @contextmanager
-    def _get_connection(self, *, write: bool = False) -> Iterator[Connection]:
+    def _get_connection(
+        self,
+        *,
+        write: bool = False,
+        on_rollback: Callable[[], None] | None = None,
+    ) -> Iterator[Connection]:
         """Get a database connection."""
         max_retries = 5
         retry_delay = 0.1
@@ -682,7 +688,11 @@ class SampleBufferDatabase(SampleBuffer):
 
         except Exception:
             # rollback on any error
-            conn.rollback()
+            try:
+                conn.rollback()
+            finally:
+                if on_rollback is not None:
+                    on_rollback()
             raise
         finally:
             # close the connection

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -284,9 +284,7 @@ def test_open_sample_history_releases_write_lock_after_snapshot(tmp_path):
         assert [event["data"] for event in history.iter_events()] == ["hello"]
 
 
-def test_sample_history_read_methods_use_deferred_transactions(
-    tmp_path, monkeypatch
-):
+def test_sample_history_read_methods_use_deferred_transactions(tmp_path, monkeypatch):
     db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
     db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
 

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -284,7 +284,9 @@ def test_open_sample_history_releases_write_lock_after_snapshot(tmp_path):
         assert [event["data"] for event in history.iter_events()] == ["hello"]
 
 
-def test_sample_history_read_methods_use_deferred_transactions(tmp_path, monkeypatch):
+def test_sample_history_read_methods_use_deferred_transactions(
+    tmp_path, monkeypatch
+) -> None:
     db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
     db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
 

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -228,6 +228,50 @@ def test_log_events_restores_pool_indices_when_transaction_rolls_back(
     ]
 
 
+def test_log_events_keeps_pool_indices_when_sync_fails_after_commit(
+    tmp_path, monkeypatch
+):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+
+    def model_event(uuid: str, content: str) -> ModelEvent:
+        return _model(uuid, f"answer {content}").model_copy(
+            update={"input": [ChatMessageUser(id=f"{uuid}-input", content=content)]}
+        )
+
+    db.log_events(
+        [SampleEvent(id="sample", epoch=1, event=model_event("event-1", "a"))]
+    )
+
+    original_sync = db._sync
+
+    def fail_sync():
+        raise RuntimeError("sync failed")
+
+    monkeypatch.setattr(db, "_sync", fail_sync)
+    with pytest.raises(RuntimeError, match="sync failed"):
+        db.log_events(
+            [SampleEvent(id="sample", epoch=1, event=model_event("event-2", "b"))]
+        )
+
+    monkeypatch.setattr(db, "_sync", original_sync)
+    db.log_events(
+        [SampleEvent(id="sample", epoch=1, event=model_event("event-3", "c"))]
+    )
+
+    with db.open_sample_history("sample", 1) as history:
+        materialized = materialize_streaming_sample(
+            EvalSample(id="sample", epoch=1, input="question", target="answer"),
+            history,
+        )
+
+    inputs = [
+        event.input[0].content
+        for event in materialized.events
+        if isinstance(event, ModelEvent)
+    ]
+    assert inputs == ["a", "b", "c"]
+
+
 def test_open_sample_history_defers_remove_samples_until_release(tmp_path):
     db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
     db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -6,11 +6,17 @@ from inspect_ai._util.json import to_json_str_safe
 from inspect_ai.event import InfoEvent, ModelEvent
 from inspect_ai.log._log import EvalSample, EventsData
 from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+from inspect_ai.log._recorders.streaming import materialize_streaming_sample
 from inspect_ai.log._recorders.types import SampleEvent
-from inspect_ai.model import ChatMessageUser, GenerateConfig, ModelOutput
+from inspect_ai.model import ChatMessageUser, GenerateConfig, ModelCall, ModelOutput
 
 
-def _model(uuid: str, completion: str, pending: bool | None = None) -> ModelEvent:
+def _model(
+    uuid: str,
+    completion: str,
+    pending: bool | None = None,
+    call: ModelCall | None = None,
+) -> ModelEvent:
     return ModelEvent(
         uuid=uuid,
         model="mockllm/model",
@@ -20,6 +26,7 @@ def _model(uuid: str, completion: str, pending: bool | None = None) -> ModelEven
         config=GenerateConfig(),
         output=ModelOutput.from_content("mockllm/model", completion),
         pending=pending,
+        call=call,
     )
 
 
@@ -44,6 +51,32 @@ def test_open_sample_history_latest_payload_first_insert_order(tmp_path):
     assert rows[0].event["output"]["completion"] == "complete"
     assert rows[0].event.get("pending") is None
     assert rows[1].event["data"] == "middle"
+
+
+def test_open_sample_history_tail_preserves_logical_order(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    first = _model("event-1", "pending", pending=True)
+    other = InfoEvent(uuid="event-2", data="middle")
+    latest = _model("event-1", "complete", pending=None)
+
+    db.log_events(
+        [
+            SampleEvent(id="sample", epoch=1, event=first),
+            SampleEvent(id="sample", epoch=1, event=other),
+            SampleEvent(id="sample", epoch=1, event=latest),
+        ]
+    )
+
+    with db.open_sample_history("sample", 1) as history:
+        full_rows = history.raw_event_rows
+
+    with db.open_sample_history_tail("sample", 1, 2) as history:
+        tail_rows = history.raw_event_rows
+
+    assert [row.event_id for row in full_rows] == ["event-1", "event-2"]
+    assert [row.event_id for row in tail_rows] == ["event-1", "event-2"]
+    assert tail_rows[0].event["output"]["completion"] == "complete"
+    assert tail_rows[1].event["data"] == "middle"
 
 
 @pytest.mark.parametrize("event_id_literal", ["NULL", "''"])
@@ -151,6 +184,50 @@ def test_sample_history_translates_buffer_pool_refs_to_eval_positions(tmp_path):
     )
 
 
+def test_log_events_restores_pool_indices_when_transaction_rolls_back(
+    tmp_path, monkeypatch
+):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    event = _model(
+        "event-1",
+        "answer",
+        call=ModelCall(
+            request={"messages": [{"role": "user", "content": "question"}]},
+            response={},
+        ),
+    )
+    original_condense_event = db._condense_event
+
+    def fail_after_condense(conn, sample_event):
+        original_condense_event(conn, sample_event)
+        raise RuntimeError("forced rollback")
+
+    monkeypatch.setattr(db, "_condense_event", fail_after_condense)
+    with pytest.raises(RuntimeError, match="forced rollback"):
+        db.log_events([SampleEvent(id="sample", epoch=1, event=event)])
+
+    monkeypatch.setattr(db, "_condense_event", original_condense_event)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=event)])
+
+    with db.open_sample_history("sample", 1) as history:
+        assert len(history.message_pool) == 1
+        assert len(history.call_pool) == 1
+        materialized = materialize_streaming_sample(
+            EvalSample(id="sample", epoch=1, input="question", target="answer"),
+            history,
+        )
+
+    model_event = materialized.events[0]
+    assert isinstance(model_event, ModelEvent)
+    assert model_event.input_refs is None
+    assert model_event.input[0].content == "question"
+    assert model_event.call is not None
+    assert model_event.call.call_refs is None
+    assert model_event.call.request["messages"] == [
+        {"role": "user", "content": "question"}
+    ]
+
+
 def test_open_sample_history_defers_remove_samples_until_release(tmp_path):
     db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
     db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
@@ -205,3 +282,40 @@ def test_open_sample_history_releases_write_lock_after_snapshot(tmp_path):
 
         assert lock_available is True
         assert [event["data"] for event in history.iter_events()] == ["hello"]
+
+
+def test_sample_history_read_methods_use_deferred_transactions(
+    tmp_path, monkeypatch
+):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
+
+    statements: list[str] = []
+    original_connect = sqlite3.connect
+
+    class RecordingConnection(sqlite3.Connection):
+        def execute(self, sql, *args, **kwargs):
+            statements.append(str(sql))
+            return super().execute(sql, *args, **kwargs)
+
+    def connect(*args, **kwargs):
+        kwargs["factory"] = RecordingConnection
+        return original_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+
+    assert db.sample_event_count("sample", 1) == 1
+    assert db.sample_attachment("sample", 1, "missing") is None
+    with db.open_sample_history_tail("sample", 1, 1):
+        pass
+    with db.open_sample_history_from("sample", 1, 0):
+        pass
+    with db.open_sample_history("sample", 1):
+        pass
+
+    begin_statements = [
+        statement.strip().upper()
+        for statement in statements
+        if statement.strip().upper().startswith("BEGIN")
+    ]
+    assert begin_statements == ["BEGIN", "BEGIN", "BEGIN", "BEGIN", "BEGIN"]


### PR DESCRIPTION
This is a follow-up hardening change for buffer-backed sample history after PR 4037.

The original diagnosis found three narrow issues:

1. Buffer pool indices can diverge from SQLite after a failed write transaction.

   `SampleBufferDatabase.log_events()` condenses `ModelEvent` payloads before inserting event rows. Condensing updates the in-memory `_msg_indices` and `_call_indices` maps as it writes new entries to `message_pool` and `call_pool`. If an exception occurs after those maps are advanced but before the SQLite transaction commits, SQLite rolls back while the in-memory indices keep pointing past rows that no longer exist.

   A later successful `log_events()` call for the same sample can then emit `input_refs` or `call_refs` that reference missing pool positions. Streaming materialization can consequently fail to restore `ModelEvent.input` or raw call request messages correctly.

2. `open_sample_history_tail()` can return logical events in the wrong order.

   The tail query correctly selects the latest physical row for each logical event ID, but it previously ordered the final rows by latest physical row ID. For an event updated later, this changes logical history order. For example, with rows `event-1 pending`, `event-2`, `event-1 complete`, `tail(2)` should return `event-1 complete` followed by `event-2`, matching the logical first-seen order used by full history.

3. Read-only history helpers take unnecessary SQLite write locks.

   The sample history read helpers use explicit transactions so each returned history snapshot is internally consistent. They did this with `BEGIN IMMEDIATE`, which acquires a write-reserved lock even though the methods only read. That can unnecessarily block concurrent buffer writes while history is being read.

### What is the new behavior?

`log_events()` now snapshots the current message and call pool index maps for every sample key touched by `ModelEvent` condensation. If any exception escapes the write transaction, the snapshots are restored so in-memory indices remain consistent with the rolled-back database state. Successful writes keep the updated indices.

`open_sample_history_tail()` now carries each logical event's `first_id` through the tail CTE. It still selects the latest payload for each logical event, but orders the final result by original logical position rather than latest physical row ID.

The read-only sample history methods now use deferred `BEGIN` instead of `BEGIN IMMEDIATE`:

- `sample_event_count()`
- `sample_attachment()`
- `open_sample_history_tail()`
- `open_sample_history_from()`
- `open_sample_history()`

This preserves explicit snapshot transactions without taking a write-reserved lock for pure reads.

### Rationale for the proposed fixes

The pool-index fix keeps the existing fast in-memory index design while making it transaction-safe. Rebuilding indices from SQLite on every event write would avoid this class of bug, but would add avoidable read work to the streaming hot path. Snapshot-and-restore is scoped to the mutation boundary that can fail, keeps successful behavior unchanged, and leaves realtime transcript subscriber behavior unchanged.

The tail-order fix aligns `open_sample_history_tail()` with the logical ordering contract already used by `open_sample_history()`: event updates replace payloads, but they do not move an event's position in sample history. Ordering by `first_id` is the direct representation of that contract.

The transaction-mode fix preserves the reason explicit read transactions were introduced: the event rows, message pool, call pool, and attachments for a history object should be read from one consistent snapshot. Deferred `BEGIN` provides that consistency for reads without reserving write access up front. This is intentionally limited to the read helpers and does not introduce WAL mode or broader SQLite connection policy changes.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This does not change public APIs, eval log structure, or filestore behavior.

### Other information:

Regression coverage added:

- Failed `log_events()` after pool condensation restores `_msg_indices` and `_call_indices`, and a later successful write materializes both `ModelEvent.input` and `ModelCall.request` correctly.
- `open_sample_history_tail(..., 2)` preserves logical history order for updated event IDs.
- Read-only sample history helpers issue deferred `BEGIN`, not `BEGIN IMMEDIATE`.

Validation run:

```bash
.venv/bin/pytest tests/log/test_sample_history.py tests/log/test_streaming_completion.py -q
.venv/bin/pytest tests/log/test_log_eventdb.py tests/log/test_buffer_pool_dedup.py tests/log/test_message_pool.py -q
.venv/bin/ruff check src/inspect_ai/log/_recorders/buffer/database.py tests/log/test_sample_history.py
```
