### PR TITLE
Fix header_only writes for JSON and remote .eval logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Bugfix: Prevent transcript subscriber-failure warnings from re-entering the subscriber loop and fanning out.
 - Bugfix: Align CLI --display and --effort type annotations with their choices.
 - Bugfix: Don't enter prompt mode when a sample is globally cancelled.
+- Bugfix: `write_eval_log(..., header_only=True)` now preserves on-disk samples for JSON logs and remote `.eval` logs (previously a header-only write to either erased the samples). On non-local filesystems the `.eval` zip is rewritten cleanly so old header bytes don't accumulate across edits.
 
 ## 0.3.228 (27 May 2026)
 

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -6,6 +6,7 @@ import os
 import tempfile
 from collections.abc import Generator, Sequence
 from contextlib import contextmanager
+from io import BytesIO
 from logging import getLogger
 from typing import (
     IO,
@@ -33,7 +34,7 @@ from inspect_ai._util.constants import (
     get_deserializing_context,
 )
 from inspect_ai._util.error import EvalError, WriteConflictError
-from inspect_ai._util.file import FileSystem, dirname, filesystem, local_path
+from inspect_ai._util.file import FileSystem, dirname, file, filesystem, local_path
 from inspect_ai._util.json import is_ijson_nan_inf_error, to_json_safe
 from inspect_ai._util.trace import trace_action
 from inspect_ai._util.zip_common import ZipEntry
@@ -419,7 +420,9 @@ class EvalRecorder(FileRecorder):
     ) -> None:
         if filesystem(location).is_s3() and if_match_etag:
             # Use S3 conditional write
-            await cls._write_log_s3_conditional(location, log, if_match_etag)
+            await cls._write_log_s3_conditional(
+                location, log, if_match_etag, header_only=header_only
+            )
         else:
             # Standard write using the recorder (so we get all of the extra streams)
             await _write_eval_log_with_recorder(
@@ -428,26 +431,33 @@ class EvalRecorder(FileRecorder):
 
     @classmethod
     async def _write_log_s3_conditional(
-        cls, location: str, log: EvalLog, etag: str
+        cls,
+        location: str,
+        log: EvalLog,
+        etag: str,
+        header_only: bool = False,
     ) -> None:
         """Perform S3 conditional write for .eval format using boto3."""
-        import tempfile
-
         bucket, key = _s3_bucket_and_key(location)
 
-        # create the eval log in a temporary directory first
-        import os
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # create a temporary eval file name
-            temp_eval_file = os.path.join(tmpdir, "temp_log.eval")
-
-            # write using the normal recorder to get proper .eval format
-            await _write_eval_log_with_recorder(log, tmpdir, temp_eval_file)
-
-            # read the created file in bytes
-            with open(temp_eval_file, "rb") as f:
-                log_bytes = f.read()
+        if header_only:
+            # Download the existing object, rewrite the zip in memory with a
+            # fresh header.json. Sample entries are untouched; any sample
+            # mutations on the in-memory log are discarded, matching the
+            # local .eval contract.
+            async with AsyncFilesystem() as async_fs:
+                s3_client = await async_fs.s3_client_async()
+                response = await s3_client.get_object(Bucket=bucket, Key=key)
+                body = await response["Body"].read()
+            log_bytes = _rewrite_eval_zip_with_new_header(body, log)
+        else:
+            # Full recreate goes through the recorder, which needs a
+            # filesystem path; read the result back into memory for upload.
+            with tempfile.TemporaryDirectory() as tmpdir:
+                temp_eval_file = os.path.join(tmpdir, "temp_log.eval")
+                await _write_eval_log_with_recorder(log, tmpdir, temp_eval_file)
+                with open(temp_eval_file, "rb") as f:
+                    log_bytes = f.read()
 
         async with AsyncFilesystem() as async_fs:
             await _write_s3_conditional(
@@ -461,31 +471,86 @@ class EvalRecorder(FileRecorder):
             )
 
 
+def _replace_eval_header_in_place(zip_path: str, log: EvalLog) -> None:
+    """Replace `header.json` inside a local `.eval` zip in place.
+
+    Opens the zip in append mode, drops the old header entry from the
+    central directory, then writes the new one. The old header bytes
+    become unreferenced — a small size leak that's acceptable for local
+    files since we're not paying for a re-upload on every edit. Sample
+    entries are untouched.
+    """
+    eval_header = _eval_log_header(log)
+    with ZipFile(zip_path, "a", **zipfile_compress_kwargs) as zf:
+        zf.filelist = [i for i in zf.filelist if i.filename != HEADER_JSON]
+        zf.NameToInfo.pop(HEADER_JSON, None)
+        zf.writestr(HEADER_JSON, to_json_safe(eval_header, indent=None))
+
+
+def _rewrite_eval_zip_with_new_header(zip_bytes: bytes, log: EvalLog) -> bytes:
+    """Return new zip bytes with header.json replaced; no dead bytes.
+
+    Copies every non-header entry from the source zip and appends a fresh
+    header.json at the end. Used for remote-filesystem header_only writes
+    where dead bytes would otherwise accumulate across re-uploads.
+    """
+    eval_header = _eval_log_header(log)
+    out = BytesIO()
+    with (
+        ZipFile(BytesIO(zip_bytes), "r") as src,
+        ZipFile(out, "w", **zipfile_compress_kwargs) as dst,
+    ):
+        for info in src.infolist():
+            if info.filename == HEADER_JSON:
+                continue
+            # writestr with a ZipInfo preserves the original compression
+            # type / date_time / external_attr. The data still round-trips
+            # through decompress + recompress, but member metadata is
+            # carried over verbatim.
+            dst.writestr(info, src.read(info.filename))
+        dst.writestr(HEADER_JSON, to_json_safe(eval_header, indent=None))
+    return out.getvalue()
+
+
+def _eval_log_header(log: EvalLog) -> EvalLog:
+    """Build a header-only EvalLog (no samples / reductions) for header.json."""
+    return EvalLog(
+        version=log.version,
+        invalidated=log.invalidated,
+        log_updates=log.log_updates,
+        eval=log.eval,
+        plan=log.plan,
+        results=log.results,
+        stats=log.stats,
+        status=log.status,
+        error=log.error,
+    )
+
+
+def _rewrite_eval_zip_via_filesystem(location: str, log: EvalLog) -> None:
+    """Read a remote .eval, rewrite zip with a new header, write it back.
+
+    Works for any fsspec-backed filesystem (S3, GCS, abfs, …). Used by the
+    unconditional header_only write path — the S3 conditional path inlines
+    the equivalent steps so it can route the upload through
+    `_write_s3_conditional` with `If-Match`.
+    """
+    with file(location, "rb") as f:
+        existing_bytes = f.read()
+    new_bytes = _rewrite_eval_zip_with_new_header(existing_bytes, log)
+    with file(location, "wb") as f:
+        f.write(new_bytes)
+
+
 async def _write_eval_log_with_recorder(
     log: EvalLog, recorder_dir: str, output_file: str, header_only: bool = False
 ) -> None:
     """Helper function to write EvalLog using EvalRecorder pattern."""
-    if header_only and filesystem(output_file).is_local():
-        # Replace the header entry in the existing zip without rewriting
-        # sample data. Opens in append mode, removes the old header.json
-        # from the central directory, then writes the new one. The old
-        # header bytes become unreferenced but sample entries are untouched.
-        eval_header = EvalLog(
-            version=log.version,
-            invalidated=log.invalidated,
-            log_updates=log.log_updates,
-            eval=log.eval,
-            plan=log.plan,
-            results=log.results,
-            stats=log.stats,
-            status=log.status,
-            error=log.error,
-        )
-        with ZipFile(local_path(output_file), "a", **zipfile_compress_kwargs) as zf:
-            # Remove old header entry from the central directory
-            zf.filelist = [i for i in zf.filelist if i.filename != HEADER_JSON]
-            zf.NameToInfo.pop(HEADER_JSON, None)
-            zf.writestr(HEADER_JSON, to_json_safe(eval_header, indent=None))
+    if header_only:
+        if filesystem(output_file).is_local():
+            _replace_eval_header_in_place(local_path(output_file), log)
+        else:
+            _rewrite_eval_zip_via_filesystem(output_file, log)
         return
 
     recorder = EvalRecorder(recorder_dir)

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -218,6 +218,15 @@ class JSONRecorder(FileRecorder):
     ) -> None:
         from inspect_ai.log._file import eval_log_json
 
+        if header_only:
+            # header_only contract: do not let sample-level state from the
+            # in-memory log reach disk. JSON has no in-place header swap, so
+            # read the on-disk samples and reductions and graft them onto
+            # the in-memory header before serializing. If the file doesn't
+            # exist yet, clear samples / reductions so the result is truly
+            # header-only.
+            log = await cls._merge_disk_samples_for_header_only(location, log)
+
         # sort samples before writing as they can come in out of order
         if log.samples:
             sort_samples(log.samples)
@@ -234,6 +243,29 @@ class JSONRecorder(FileRecorder):
             with trace_action(logger, "Log Write", location):
                 with file(location, "wb") as f:
                     f.write(log_bytes)
+
+    @classmethod
+    async def _merge_disk_samples_for_header_only(
+        cls, location: str, log: EvalLog
+    ) -> EvalLog:
+        """Return a copy of `log` whose samples come from the on-disk file.
+
+        If the target doesn't exist, returns a copy with samples and
+        reductions cleared so the resulting write is genuinely header-only.
+        """
+        fs = filesystem(location)
+        if not fs.exists(location):
+            return log.model_copy(
+                update={"samples": None, "reductions": None}, deep=False
+            )
+        existing = await cls.read_log(location, header_only=False)
+        return log.model_copy(
+            update={
+                "samples": existing.samples,
+                "reductions": existing.reductions,
+            },
+            deep=False,
+        )
 
     @classmethod
     async def _write_log_s3_conditional(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -164,6 +164,13 @@ def mock_s3():
     os.environ["AWS_SECRET_ACCESS_KEY"] = "unused_key_mock_s3"
     os.environ["AWS_DEFAULT_REGION"] = "us-west-1"
 
+    # Drop any cached fsspec S3FileSystem instance from a previous module's
+    # mock_s3 fixture — its baked-in client points at a moto server that
+    # was already torn down, and reuse causes EndpointConnectionError.
+    from s3fs import S3FileSystem
+
+    S3FileSystem.clear_instance_cache()
+
     s3_client = boto3.client("s3")
     s3_client.create_bucket(
         Bucket="test-bucket",
@@ -187,6 +194,9 @@ def mock_s3():
     s3_client.delete_bucket(Bucket="test-bucket")
 
     server.stop()
+    # Clear again on teardown so a later non-mock_s3 caller doesn't grab
+    # the stale instance either.
+    S3FileSystem.clear_instance_cache()
     for key, value in existing_env.items():
         if value is None:
             del os.environ[key]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -167,7 +167,7 @@ def mock_s3():
     # Drop any cached fsspec S3FileSystem instance from a previous module's
     # mock_s3 fixture — its baked-in client points at a moto server that
     # was already torn down, and reuse causes EndpointConnectionError.
-    from s3fs import S3FileSystem
+    from s3fs import S3FileSystem  # type: ignore
 
     S3FileSystem.clear_instance_cache()
 

--- a/tests/log/test_log_formats.py
+++ b/tests/log/test_log_formats.py
@@ -283,6 +283,275 @@ def test_write_header_only_with_file_uri(original_log, temp_dir):
     assert len(restored.samples) == len(original_log.samples)
 
 
+def test_write_json_header_only_no_samples(original_log, temp_dir):
+    """Writing a JSON log whose EvalLog carries only a header must succeed.
+
+    Build a header-only EvalLog (samples=None) and write it as JSON, then
+    read it back. The on-disk file must be parseable and round-trip with
+    samples still None — no spurious empty list, no exception on write.
+    """
+    header_only_log = original_log.model_copy(update={"samples": None})
+
+    json_log_path = (temp_dir / "header_only_fresh.json").as_posix()
+    write_eval_log(header_only_log, json_log_path, format="json")
+
+    restored = read_eval_log(json_log_path, format="json")
+    assert restored.samples is None
+    assert restored.eval.task == original_log.eval.task
+    assert restored.status == original_log.status
+
+
+def test_write_json_header_only_to_new_file_drops_samples(original_log, temp_dir):
+    """A header_only write to a new JSON file must not persist in-memory samples.
+
+    If the caller passes `header_only=True`, the resulting file should contain
+    only the header — sample data carried on the in-memory EvalLog must be
+    dropped, not serialized. Today JSONRecorder.write_log ignores `header_only`
+    and writes the full object, so the new file would contain every sample.
+    """
+    assert original_log.samples is not None and len(original_log.samples) > 0
+
+    json_log_path = (temp_dir / "json_header_only_new.json").as_posix()
+    write_eval_log(original_log, json_log_path, format="json", header_only=True)
+
+    restored = read_eval_log(json_log_path, format="json")
+    assert restored.samples is None, (
+        "header_only write to a new JSON file wrote samples to disk"
+    )
+    # Sanity: the rest of the header is still there.
+    assert restored.eval.task == original_log.eval.task
+    assert restored.status == original_log.status
+
+
+def test_write_json_header_only_preserves_samples(original_log, temp_dir):
+    """JSON regression: header_only write must not erase existing samples.
+
+    Reproduces the destructive chain reported on PR #4014:
+      1. Write a full JSON log with samples.
+      2. Read it with header_only=True (samples becomes None on the in-memory log).
+      3. Write that header-only log back with header_only=True.
+      4. Re-read the file in full.
+
+    The samples on disk must be untouched. Today JSONRecorder.write_log ignores
+    `header_only` and serializes the (sample-less) in-memory object, erasing
+    the samples on disk.
+    """
+    json_log_path = (temp_dir / "json_header_only.json").as_posix()
+
+    write_eval_log(original_log, json_log_path, format="json")
+    assert original_log.samples is not None and len(original_log.samples) > 0
+    original_sample_count = len(original_log.samples)
+
+    header = read_eval_log(json_log_path, header_only=True, format="json")
+    assert header.samples is None
+
+    header = edit_eval_log(
+        header,
+        [TagsEdit(tags_add=["json_header_only_tag"])],
+        ProvenanceData(author="test", reason="test json header_only"),
+    )
+    write_eval_log(header, json_log_path, format="json", header_only=True)
+
+    restored = read_eval_log(json_log_path, format="json")
+    assert "json_header_only_tag" in restored.tags
+    assert restored.samples is not None, "header_only write erased samples on disk"
+    assert len(restored.samples) == original_sample_count
+    for orig, rest in zip(original_log.samples, restored.samples):
+        assert orig.id == rest.id
+        assert orig.epoch == rest.epoch
+
+
+@pytest.mark.parametrize("format", ["json", "eval"])
+def test_write_header_only_ignores_in_memory_sample_changes(
+    original_log, temp_dir, format
+):
+    """header_only writes must use on-disk samples, not the in-memory log's.
+
+    Contract guard for the JSON read-modify-write fix and the .eval in-place
+    header swap: if a caller mutates `log.samples` in memory before a
+    header_only write, those mutations must NOT leak to disk. Only a
+    subsequent header_only=False write should persist sample changes.
+
+    The risk is a "helpful" fix that grabs samples off the in-memory object
+    when they're present (instead of from disk), silently honoring caller
+    mutations that the header_only contract says to discard.
+    """
+    assert original_log.samples is not None and len(original_log.samples) > 0
+    original_input = original_log.samples[0].input
+
+    log_path = (temp_dir / f"in_memory_mutation.{format}").as_posix()
+    write_eval_log(original_log, log_path, format=format)
+
+    # Read back as a full log (so samples are loaded), then mutate both the
+    # header (via edit_eval_log) and the in-memory samples.
+    log = read_eval_log(log_path, format=format)
+    log = edit_eval_log(
+        log,
+        [TagsEdit(tags_add=["mutation_tag"])],
+        ProvenanceData(author="test", reason="mutation guard"),
+    )
+    sentinel = "MUTATED IN MEMORY — must not reach disk on header_only write"
+    log.samples[0].input = sentinel
+
+    # header_only write: header lands on disk, sample mutation does NOT.
+    write_eval_log(log, log_path, format=format, header_only=True)
+
+    after_header_only = read_eval_log(log_path, format=format)
+    assert "mutation_tag" in after_header_only.tags
+    assert after_header_only.samples is not None
+    assert len(after_header_only.samples) == len(original_log.samples)
+    assert after_header_only.samples[0].input == original_input, (
+        "header_only write leaked in-memory sample mutation to disk"
+    )
+
+    # full write of the same in-memory log: sample mutation now lands.
+    write_eval_log(log, log_path, format=format, header_only=False)
+
+    after_full = read_eval_log(log_path, format=format)
+    assert "mutation_tag" in after_full.tags
+    assert after_full.samples is not None
+    assert after_full.samples[0].input == sentinel
+
+
+def test_write_s3_eval_header_only_ignores_in_memory_sample_changes(
+    original_log, mock_s3
+):
+    """Same in-memory-mutation guard as the local-format test, but on S3 .eval.
+
+    The S3 fix (download → in-place header swap → upload) must read samples
+    from the downloaded copy, not from the in-memory log handed in.
+    """
+    assert original_log.samples is not None and len(original_log.samples) > 0
+    original_input = original_log.samples[0].input
+
+    log_path = "s3://test-bucket/s3_in_memory_mutation.eval"
+    write_eval_log(original_log, log_path, format="eval")
+
+    log = read_eval_log(log_path, format="eval")
+    log = edit_eval_log(
+        log,
+        [TagsEdit(tags_add=["s3_mutation_tag"])],
+        ProvenanceData(author="test", reason="s3 mutation guard"),
+    )
+    sentinel = "MUTATED IN MEMORY (S3) — must not reach disk on header_only write"
+    log.samples[0].input = sentinel
+
+    write_eval_log(
+        log, log_path, format="eval", header_only=True, if_match_etag=log.etag
+    )
+
+    after_header_only = read_eval_log(log_path, format="eval")
+    assert "s3_mutation_tag" in after_header_only.tags
+    assert after_header_only.samples is not None
+    assert len(after_header_only.samples) == len(original_log.samples)
+    assert after_header_only.samples[0].input == original_input, (
+        "S3 header_only write leaked in-memory sample mutation to disk"
+    )
+
+    # full write should persist the in-memory sample mutation.
+    write_eval_log(
+        log,
+        log_path,
+        format="eval",
+        header_only=False,
+        if_match_etag=after_header_only.etag,
+    )
+
+    after_full = read_eval_log(log_path, format="eval")
+    assert "s3_mutation_tag" in after_full.tags
+    assert after_full.samples is not None
+    assert after_full.samples[0].input == sentinel
+
+
+def test_write_s3_eval_header_only_compacts_zip(original_log, mock_s3):
+    """S3 header_only write must compact the .eval zip, not leave dead bytes.
+
+    The local in-place trick uses `ZipFile(..., "a")` which removes the old
+    `header.json` from the central directory but leaves its compressed bytes
+    in the file. That's a tolerable size leak locally. On S3 we re-upload
+    the whole object on every edit, so dead bytes accumulate across the
+    network — the rewrite there should produce a compact zip with no
+    orphan data.
+
+    The test compares the post-edit file size to a baseline written from
+    scratch with the same final state. They should match within a small
+    tolerance (zip timestamps / entry ordering).
+    """
+    from inspect_ai._util.file import filesystem
+
+    edits = [TagsEdit(tags_add=["compact_tag"])]
+    provenance = ProvenanceData(author="test", reason="compaction test")
+
+    # Baseline: write the final log state directly.
+    baseline_path = "s3://test-bucket/compact_baseline.eval"
+    baseline_log = edit_eval_log(original_log, edits, provenance)
+    write_eval_log(baseline_log, baseline_path, format="eval")
+    fs = filesystem(baseline_path)
+    baseline_size = fs.info(baseline_path).size
+
+    # Test: write original, header_only-swap to the same final state.
+    test_path = "s3://test-bucket/compact_test.eval"
+    write_eval_log(original_log, test_path, format="eval")
+    header = read_eval_log(test_path, header_only=True, format="eval")
+    header = edit_eval_log(header, edits, provenance)
+    write_eval_log(
+        header, test_path, format="eval", header_only=True, if_match_etag=header.etag
+    )
+    test_size = fs.info(test_path).size
+
+    # Allow a small tolerance for zip metadata jitter; the test fixture's
+    # header is ~1.5KB compressed, so any dead-header leak will easily
+    # exceed this threshold.
+    growth = test_size - baseline_size
+    assert growth < 256, (
+        f"after header_only edit on S3, file is {growth} bytes larger "
+        f"than the from-scratch baseline ({test_size} vs {baseline_size}) "
+        f"— old header.json bytes are likely retained as dead data"
+    )
+
+
+def test_write_s3_eval_header_only_preserves_samples(original_log, mock_s3):
+    """S3 .eval regression: header_only write must not erase existing samples.
+
+    Same destructive chain as the JSON case, but on S3 with an `If-Match`
+    ETag. The S3 conditional write path in EvalRecorder ignores `header_only`
+    and rewrites the object from the in-memory header-only EvalLog, writing
+    `log.samples or []` (= zero samples) into the new object.
+    """
+    log_path = "s3://test-bucket/s3_eval_header_only.eval"
+
+    write_eval_log(original_log, log_path, format="eval")
+    assert original_log.samples is not None and len(original_log.samples) > 0
+    original_sample_count = len(original_log.samples)
+
+    header = read_eval_log(log_path, header_only=True, format="eval")
+    assert header.samples is None
+    assert header.etag is not None, (
+        "S3 header_only read should return an ETag for conditional write"
+    )
+
+    header = edit_eval_log(
+        header,
+        [TagsEdit(tags_add=["s3_header_only_tag"])],
+        ProvenanceData(author="test", reason="test s3 eval header_only"),
+    )
+    write_eval_log(
+        header,
+        log_path,
+        format="eval",
+        header_only=True,
+        if_match_etag=header.etag,
+    )
+
+    restored = read_eval_log(log_path, format="eval")
+    assert "s3_header_only_tag" in restored.tags
+    assert restored.samples is not None, "header_only S3 write erased samples on disk"
+    assert len(restored.samples) == original_sample_count
+    for orig, rest in zip(original_log.samples, restored.samples):
+        assert orig.id == rest.id
+        assert orig.epoch == rest.epoch
+
+
 def compare_zip_contents(zip_file1: Path, zip_file2: Path) -> bool:
     """Compare the contents of two zip files."""
     with (


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`write_eval_log(..., header_only=True)` erases on-disk samples in two cases:

- **JSON logs.** `JSONRecorder.write_log` ignores \`header_only\` and serializes the in-memory \`EvalLog\` as-is. After a \`header_only=True\` read (which sets \`samples=None\`), writing back with \`header_only=True\` overwrites the file with no samples.
- **Remote \`.eval\` logs.** \`_write_eval_log_with_recorder\` only honors the in-place header swap when the target is local (\`filesystem(...).is_local()\`). For S3 (and any other non-local fsspec target) the path falls through to a full recreate that writes \`log.samples or []\` — zero entries — back over the existing object.

Discovered while reviewing #4014 (viewer-side log editing): \`apply_log_edits\` reads with \`header_only=True\` and writes back with \`header_only=True\`, so editing a tag or metadata field in the viewer destroys the samples for both JSON and S3-backed logs.

Independently, the local \`.eval\` in-place trick uses \`ZipFile(..., \"a\")\`, which leaves the old \`header.json\` bytes as unreferenced data in the zip. Acceptable locally; on S3 those dead bytes accumulate across re-uploads.

### What is the new behavior?

\`write_eval_log(..., header_only=True)\` matches the local \`.eval\` contract everywhere: the header is updated on disk and sample data is not touched. Sample mutations on the in-memory log are discarded.

- **JSON.** When the target exists, read the on-disk samples and reductions back into the in-memory header before serializing. When it doesn't, write a header-only file (samples / reductions cleared).
- **Remote \`.eval\` (any fsspec filesystem).** Download the existing object, rewrite the zip with a fresh \`header.json\`, write back via \`file(...)\`. The local path keeps the fast in-place ZipFile append.
- **S3 conditional path.** Same in-memory rewrite, then routed through \`_write_s3_conditional\` for \`If-Match\`.
- **Compaction.** The remote rewrite produces a clean zip — no orphan bytes from the previous header.

New tests in \`tests/log/test_log_formats.py\`:

- \`test_write_json_header_only_no_samples\` — fresh header-only JSON write round-trips.
- \`test_write_json_header_only_to_new_file_drops_samples\` — \`header_only=True\` to a new JSON file drops in-memory samples.
- \`test_write_json_header_only_preserves_samples\` — JSON header-only-after-header-only-read keeps on-disk samples.
- \`test_write_s3_eval_header_only_preserves_samples\` — same for S3 \`.eval\`.
- \`test_write_header_only_ignores_in_memory_sample_changes[json|eval]\` and \`test_write_s3_eval_header_only_ignores_in_memory_sample_changes\` — in-memory sample mutations are discarded on \`header_only\` write.
- \`test_write_s3_eval_header_only_compacts_zip\` — post-edit S3 file size matches a from-scratch baseline (no dead header bytes).

Also bundled (separate commit): \`tests/conftest.py\` clears \`s3fs.S3FileSystem.clear_instance_cache()\` around the \`mock_s3\` fixture. Two modules both using \`mock_s3\` in one pytest invocation were hitting \`EndpointConnectionError\` because fsspec was caching a client bound to the previous module's (stopped) moto server. Reproducible on \`main\` with \`pytest tests/test_eval_set.py::test_eval_set_s3 tests/log/test_s3_conditional_writes.py\`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The fix tightens the existing \`header_only=True\` contract; callers that relied on the destructive behavior would already have been losing data.

### Other information:

Stacks on top of \`main\`; independent of #4014.