### PR TITLE
docs(scorer): document percent handling in match(numeric=True)

### DIFF
--- a/src/inspect_ai/scorer/_match.py
+++ b/src/inspect_ai/scorer/_match.py
@@ -19,9 +19,15 @@ def match(
           output; "exact" requires the output be exactly
           equal to the target (module whitespace, etc.)
        ignore_case: Do case insensitive comparison.
-       numeric: Is this a numeric match? (in this
-          case different punctuation removal rules are
-          used and numbers are normalized before comparison).
+       numeric: Is this a numeric match? When True, currency symbols
+          (`$`, `€`, `£`), thousands separators (`,`), and formatting
+          markers (`*`, `_`) are stripped before numbers are normalized
+          and compared. The percent sign is not stripped: `60%` is
+          ambiguous (it could mean `60` or `0.6`), so an answer of `60%`
+          will not match a numeric target of `60`. To accept a
+          percentage-formatted answer, pass both forms as targets, e.g.
+          `Target(["60", "60%"])`, where the non-numeric `"60%"` is
+          matched as a string.
     """
 
     def check(value: str, target: str) -> tuple[str, bool]:

--- a/tests/util/test_text.py
+++ b/tests/util/test_text.py
@@ -1,0 +1,36 @@
+import pytest
+
+from inspect_ai._util.text import strip_numeric_punctuation
+
+
+@pytest.mark.parametrize(
+    "input_str,expected",
+    [
+        # Currency symbols and thousands separators are stripped: they are
+        # value-preserving labels ("$20" denotes the quantity 20).
+        ("$20", "20"),
+        ("£20", "20"),
+        ("€20", "20"),
+        ("1,234", "1234"),
+        # LLM formatting markers (markdown bold/italic) are also stripped.
+        ("*20*", "20"),
+        ("_20_", "20"),
+        # The percent sign is deliberately NOT stripped.
+        # Unlike the symbols above, "%" is a divide-by-100 operator:
+        # "20%" is the quantity 0.2, not 20.
+        # Stripping it to face value would make match(numeric=True)
+        # both over- and under-count: a "20%" answer would score CORRECT
+        # against target "20" for a question whose answer is 20 (false positive),
+        # and a correct "60%" answer would score INCORRECT against
+        # target "0.6" (false negative). Datasets that accept a percentage-
+        # formatted answer should pass both forms as targets, e.g.
+        # Target(["60", "60%"]), where the non-numeric "60%" is compared as a
+        # string. This was settled in #838 / #939 and re-confirmed in #1622 /
+        # #3782. Please don't add "%" to the strip set without revisiting that
+        # discussion.
+        ("20%", "20%"),
+        ("60%", "60%"),
+    ],
+)
+def test_strip_numeric_punctuation(input_str: str, expected: str) -> None:
+    assert strip_numeric_punctuation(input_str) == expected


### PR DESCRIPTION

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Closes #1622.

The `match()` docstring describes `numeric=True` as using "different punctuation removal rules" without saying what they are. In particular it doesn't mention that `%` is not stripped, so `match(numeric=True)` scores an answer of `60%` as INCORRECT against a numeric target of `60`. This surprised the reporter of #1622, who asked for either a behaviour or a documentation change.

As discussed in #3782, stripping `%` to compare face value is not a safe default: `%` is a divide-by-100 operator (unlike the value-preserving `$ € £ ,`), so `60%` is ambiguous (it could mean `60` or `0.6`). Resolving that ambiguity belongs with the dataset author, which is the approach established in #838 / #939.

### What is the new behavior?
Documentation only, no behaviour change:
- The `match()` docstring now enumerates what `numeric=True` strips (`$ € £ , * _`), states that `%` is intentionally not stripped, and documents the recommended pattern for accepting percentage-formatted answers: pass both forms as targets, e.g. `Target(["60", "60%"])`, where the non-numeric target is compared as a string.
- A regression test in `tests/util/test_text.py` asserts `%` stays unstripped (alongside the value-preserving symbols that are stripped), with a comment linking #838 / #939 / #1622 so the rationale is discoverable and the decision isn't re-litigated.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. Documentation and a test only, no runtime behaviour changes.

### Other information:
Supersedes #3782 (closed).