### PR TITLE
fix: flush streamed score samples periodically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Task Display: Add column to indicate the agent/solver for each task.
 - Transcript: Various improvements to transcript event subscriber delivery.
 - Transcript: Complete samples from buffer history database rather than in-memory list.
+- Scoring: Flush the output recorder after each `--stream N` batch of scored samples.
 - Bugfix: Show View Log button on top right of sample display.
 - Bugfix: Prevent transcript subscriber-failure warnings from re-entering the subscriber loop and fanning out.
 - Bugfix: Don't mutate plan when calling `resolve_plan()`.

--- a/src/inspect_ai/_cli/score.py
+++ b/src/inspect_ai/_cli/score.py
@@ -163,7 +163,9 @@ async def score(
     read_sample = None
     if stream:
         sample_map = await recorder.read_log_sample_ids(log_file)
-        semaphore = anyio.Semaphore(len(sample_map) if stream is True else stream)
+        stream_batch = len(sample_map) if stream is True else stream
+        semaphore = anyio.Semaphore(stream_batch)
+        samples_written = 0
 
         @contextlib.asynccontextmanager
         async def _read_sample(idx_sample: int) -> AsyncGenerator[EvalSample, None]:
@@ -173,6 +175,10 @@ async def score(
                 )
                 yield sample
                 await write_recorder.log_sample(eval_log.eval, sample)
+                nonlocal samples_written
+                samples_written += 1
+                if samples_written % stream_batch == 0:
+                    await write_recorder.flush(eval_log.eval)
                 del sample
 
         read_sample = _read_sample

--- a/tests/_cli/test_score.py
+++ b/tests/_cli/test_score.py
@@ -13,6 +13,7 @@ from inspect_ai.log._edit import (
     edit_eval_log,
 )
 from inspect_ai.log._file import read_eval_log, read_eval_log_async, write_eval_log
+from inspect_ai.log._recorders import create_recorder_for_location
 
 LOGS_DIR = pathlib.Path(__file__).parents[1] / "scorer/logs"
 LOG_SCORED = (
@@ -163,3 +164,63 @@ async def test_score_stream_preserves_log_updates(
     assert rescored_log.log_updates == log.log_updates
     assert rescored_log.tags == log.tags
     assert rescored_log.metadata == log.metadata
+
+
+@pytest.mark.anyio
+async def test_score_stream_flushes_periodically(
+    tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    output_file = tmp_path / "rescored.eval"
+    flush_counts: list[int] = []
+
+    class FlushTrackingRecorder:
+        def __init__(self, recorder):
+            self.recorder = recorder
+            self.flush_count = 0
+
+        def __getattr__(self, name):
+            return getattr(self.recorder, name)
+
+        async def flush(self, eval):
+            self.flush_count += 1
+            flush_counts.append(self.flush_count)
+            await self.recorder.flush(eval)
+
+    def create_recorder(location: str, log_dir: str):
+        recorder = create_recorder_for_location(location, log_dir)
+        if pathlib.Path(location) == output_file:
+            return FlushTrackingRecorder(recorder)
+        return recorder
+
+    monkeypatch.setattr(
+        "inspect_ai._cli.score.create_recorder_for_location", create_recorder
+    )
+    monkeypatch.setattr(score_cli, "init_eval_context", lambda *args, **kwargs: None)
+    monkeypatch.setattr(score_cli, "print_results", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        score_cli, "resolve_scorers", lambda *args, **kwargs: [object()]
+    )
+
+    async def fake_score_async(*, log, scorers, metrics, action, copy, samples):
+        assert samples is not None
+        for idx in range(10):
+            async with samples(idx):
+                pass
+        return log
+
+    monkeypatch.setattr(score_cli, "score_async", fake_score_async)
+
+    await score(
+        log_dir="",
+        log_file=str(LOG_SCORED),
+        action="overwrite",
+        log_level=None,
+        output_file=str(output_file),
+        overwrite=True,
+        scorer="match",
+        s=(),
+        metric=None,
+        stream=3,
+    )
+
+    assert flush_counts == [1, 2, 3]


### PR DESCRIPTION
﻿## Summary
- flush the streamed score output recorder after each `--stream N` batch of written samples
- keep the existing concurrency limit and final `log_finish()` path unchanged
- add a CLI regression test that consumes ten streamed samples with `stream=3` and verifies three periodic flushes

Fixes #4065

## Test Plan
- `python -m py_compile src\inspect_ai\_cli\score.py tests\_cli\test_score.py`
- `uv run pytest tests/_cli/test_score.py::test_score_stream_flushes_periodically -q --basetemp .tmp\pytest-4065 -p no:cacheprovider`
- `uv run pytest tests/_cli/test_score.py -q --basetemp .tmp\pytest-score-file -p no:cacheprovider`
- `uv run ruff check src/inspect_ai/_cli/score.py tests/_cli/test_score.py`
- `git diff --check`
