### PR TITLE
Extract SampleRunner from task_run_sample (PR 1 of EvalSession RFC)

### DIFF
--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1,17 +1,14 @@
 import contextlib
 import functools
-import importlib
 import sys
 import time
-from copy import copy, deepcopy
+from copy import deepcopy
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from logging import getLogger
 from pathlib import PurePath
 from typing import Any, Awaitable, Callable, Literal
 
 import anyio
-from anyio.abc import TaskGroup
 from typing_extensions import Unpack
 
 from inspect_ai._display import (
@@ -33,30 +30,16 @@ from inspect_ai._util.constants import (
 )
 from inspect_ai._util.dateutil import iso_now
 from inspect_ai._util.error import exception_message
-from inspect_ai._util.exception import TerminateSampleError, TerminateTaskError
-from inspect_ai._util.json import to_json_str_safe
+from inspect_ai._util.exception import TerminateTaskError
 from inspect_ai._util.notgiven import NOT_GIVEN
 from inspect_ai._util.registry import (
-    has_registry_params,
     is_registry_object,
     registry_log_name,
-    registry_params,
-    registry_unqualified_name,
-)
-from inspect_ai._util.working import (
-    init_sample_working_time,
-    sample_start_datetime,
-    sample_waiting_time,
 )
 from inspect_ai._view.notify import view_notify_eval
 from inspect_ai.dataset import Dataset, Sample
-from inspect_ai.event._error import ErrorEvent
-from inspect_ai.event._sample_init import SampleInitEvent
-from inspect_ai.event._sample_limit import SampleLimitEvent
-from inspect_ai.event._score import ScoreEvent
 from inspect_ai.log import (
     EvalConfig,
-    EvalError,
     EvalLog,
     EvalResults,
     EvalSample,
@@ -69,20 +52,8 @@ from inspect_ai.log._file import (
     read_eval_log_sample_async,
 )
 from inspect_ai.log._log import (
-    EvalRetryError,
-    EvalSampleLimit,
     EvalSampleReductions,
-    EvalSampleSummary,
     eval_error,
-)
-from inspect_ai.log._recorders.streaming import materialize_streaming_sample
-from inspect_ai.log._samples import (
-    active_sample,
-)
-from inspect_ai.log._transcript import (
-    Transcript,
-    init_transcript,
-    transcript,
 )
 from inspect_ai.model import (
     GenerateConfig,
@@ -94,23 +65,16 @@ from inspect_ai.model import (
 from inspect_ai.model._model import (
     init_model_usage,
     init_role_usage,
-    init_sample_model_usage,
-    init_sample_role_usage,
-    sample_model_usage,
-    sample_role_usage,
 )
 from inspect_ai.model._model_output import ModelUsage
 from inspect_ai.scorer import Scorer, Target
 from inspect_ai.scorer._metric import Metric, SampleScore
 from inspect_ai.scorer._reducer.types import ScoreReducer
-from inspect_ai.scorer._score import init_scoring_context
 from inspect_ai.scorer._scorer import unique_scorer_name
-from inspect_ai.solver import Generate, Plan, TaskState
+from inspect_ai.solver import Plan, TaskState
 from inspect_ai.solver._chain import Chain, unroll
 from inspect_ai.solver._fork import set_task_generate
 from inspect_ai.solver._solver import Solver
-from inspect_ai.solver._task_state import sample_state, set_sample_state, state_jsonable
-from inspect_ai.util._anyio import inner_exception
 from inspect_ai.util._checkpoint._layout import (
     has_sample_checkpoint,
     sample_checkpoints_dir,
@@ -118,26 +82,13 @@ from inspect_ai.util._checkpoint._layout import (
 from inspect_ai.util._checkpoint.checkpointer import ResumeCheckpoint
 from inspect_ai.util._checkpoint.config import (
     CheckpointConfig,
-    merge_checkpoint_configs,
 )
 from inspect_ai.util._early_stopping import (
     EarlyStop,
-    EarlyStopping,
     EarlyStoppingSummary,
 )
-from inspect_ai.util._limit import (
-    LimitExceededError,
-    monitor_working_limit,
-    record_sample_limit_data,
-)
-from inspect_ai.util._limit import time_limit as create_time_limit
-from inspect_ai.util._limit import working_limit as create_working_limit
-from inspect_ai.util._sandbox import SandboxTimeoutError
-from inspect_ai.util._sandbox.context import sandbox_connections
 from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 from inspect_ai.util._sandbox.limits import reset_sandbox_limits, set_sandbox_limits
-from inspect_ai.util._span import span
-from inspect_ai.util._store import init_subtask_store
 
 from ..context import init_task_context
 from ..task import Task
@@ -145,16 +96,19 @@ from .error import SampleErrorHandler, _should_eval_fail
 from .generate import task_generate
 from .images import (
     sample_with_base64_content,
-    sample_without_base64_content,
-    state_without_base64_content,
-    states_with_base64_content,
 )
 from .log import TaskLogger, collect_eval_data, log_start
 from .results import eval_results
-from .sandbox import sandboxenv_context
+
+# re-exports for backward-compat with tests that import these names from
+# `_eval.task.run` (their canonical home is now `sample_helpers`).
+from .sample_helpers import (
+    init_sample_assistant_internal as init_sample_assistant_internal,
+)
+from .sample_helpers import log_sample as log_sample
+from .sample_runner import SampleRunner
 from .scan import (
     resume_scan_previous_sample,
-    scan_eval_sample,
     scanned_transcripts_for_resume,
 )
 from .store import DiskSampleStore, maybe_page_to_disk
@@ -530,7 +484,7 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
                         )
                         return sample, state
 
-                    return await task_run_sample(
+                    return await SampleRunner(
                         task_name=task.name,
                         log_location=profile.log_location,
                         create_sample_state=create_sample_state,
@@ -568,7 +522,7 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
                         run_id=logger.eval.run_id,
                         task_id=logger.eval.eval_id,
                         scan_id=options.scan_id,
-                    )
+                    ).run()
 
                 sample_results = await tg_collect(
                     [
@@ -804,774 +758,6 @@ def update_metrics_display_fn(
     return compute
 
 
-async def task_run_sample(
-    *,
-    task_name: str,
-    log_location: str,
-    create_sample_state: Callable[[str | None], Awaitable[tuple[Sample, TaskState]]],
-    sandbox: SandboxEnvironmentSpec | None,
-    checkpoint: CheckpointConfig | None,
-    eval_checkpoint: CheckpointConfig | None,
-    resume_checkpoint: ResumeCheckpoint | None,
-    max_sandboxes: int | None,
-    sandbox_cleanup: bool,
-    plan: Plan,
-    scorers: list[Scorer] | None,
-    scorer_names: list[str] | None,
-    scanner: "Scanners | None",
-    cleanup: Callable[[TaskState], Awaitable[None]] | None,
-    generate: Generate,
-    progress: Callable[[int], None],
-    logger: TaskLogger | None,
-    log_images: bool,
-    log_model_api: bool | None,
-    sample_error: SampleErrorHandler,
-    sample_complete: Callable[
-        [int | str, int, dict[str, SampleScore]], Awaitable[None]
-    ],
-    fails_on_error: bool,
-    early_stopping: EarlyStopping | None,
-    retry_on_error: int,
-    score_on_error: bool,
-    error_retries: list[EvalRetryError],
-    time_limit: int | None,
-    working_limit: int | None,
-    semaphore: contextlib.AbstractAsyncContextManager[Any],
-    eval_set_id: str | None,
-    run_id: str,
-    task_id: str,
-    scan_id: str | None = None,
-    sample_uuid: str | None = None,
-) -> dict[str, SampleScore] | EarlyStop | None:
-    from inspect_ai.event import Event
-    from inspect_ai.hooks._hooks import (
-        drain_sample_events,
-        emit_sample_attempt_end,
-        emit_sample_attempt_start,
-        emit_sample_end,
-        emit_sample_event,
-        emit_sample_init,
-        emit_sample_scoring,
-        emit_sample_start,
-        start_sample_event_emitter,
-    )
-
-    # execute under sample semaphore
-    async with semaphore:
-        # materialize sample+state lazily (deferred until semaphore acquired)
-        sample, state = await create_sample_state(sample_uuid)
-
-        # validate that we have sample_id (mostly for the typechecker)
-        sample_id = sample.id
-        if sample_id is None:
-            raise ValueError("sample must have id to run")
-
-        def on_sample_event(event: Event) -> None:
-            if logger:
-                logger.log_sample_event(sample_id, state.epoch, event)
-            emit_sample_event(
-                eval_set_id=eval_set_id,
-                run_id=run_id,
-                eval_id=task_id,
-                sample_id=state.uuid,
-                event=event,
-            )
-
-        # initialise subtask and scoring context
-        init_sample_model_usage()
-        init_sample_role_usage()
-        set_sample_state(state)
-        sample_transcript = Transcript(log_model_api=log_model_api)
-        init_transcript(sample_transcript)
-        init_subtask_store(state.store)
-        sample_transcript._subscribe(on_sample_event)
-        if scorers:
-            init_scoring_context(scorers, Target(sample.target))
-        init_sample_assistant_internal()
-
-        # use sandbox if provided
-        sandboxenv_cm = (
-            sandboxenv_context(
-                task_name, sandbox, max_sandboxes, sandbox_cleanup, sample
-            )
-            if sandbox or sample.sandbox is not None
-            else contextlib.nullcontext()
-        )
-
-        # resolve checkpoint config across all three levels with
-        # precedence eval > sample > task (per-field merge — see
-        # `merge_checkpoint_configs`).
-        resolved_checkpoint = merge_checkpoint_configs(
-            checkpoint, sample.checkpoint, eval_checkpoint
-        )
-
-        # helper to handle exceptions (will throw if we've exceeded the limit)
-        def handle_error(ex: BaseException) -> tuple[EvalError, BaseException | None]:
-            # helper to log sample error
-            def log_sample_error() -> None:
-                msg = f"Sample error (id: {sample.id}, epoch: {state.epoch}): {exception_message(ex)})"
-                if retry_on_error > 0:
-                    msg = f"{msg}. Sample will be retried."
-                elif score_on_error:
-                    msg = f"{msg}. Sample will be scored."
-                py_logger.warning(msg)
-
-            # if we have retries left then return EvalError
-            if retry_on_error > 0:
-                log_sample_error()
-                return eval_error(ex, type(ex), ex, ex.__traceback__), None
-            else:
-                err = sample_error(ex)
-                # with score_on_error, suppress the raise so we can score the
-                # sample; error_count was still incremented on sample_error()
-                # above, so the eval-level fail_on_error threshold continues
-                # to apply.
-                if score_on_error:
-                    log_sample_error()
-                    transcript()._event(ErrorEvent(error=err[0]))
-                    return err[0], None
-                # if we aren't raising the error then print a warning
-                if err[1] is None:
-                    log_sample_error()
-                transcript()._event(ErrorEvent(error=err[0]))
-                return err
-
-        # Derive agent name for the ACP picker / TUI meta row. Mirrors
-        # inspect_scout's `_agent(log)` heuristic: prefer the configured
-        # eval-level solver string, fall back to the last plan step.
-        agent_name: str | None = None
-        if logger is not None and logger.eval.solver is not None:
-            agent_name = logger.eval.solver
-        elif plan.steps:
-            agent_name = registry_log_name(plan.steps[-1])
-
-        async with active_sample(
-            task=task_name,
-            log_location=log_location,
-            model=str(state.model),
-            sample=sample,
-            epoch=state.epoch,
-            message_limit=state.message_limit,
-            token_limit=state.token_limit,
-            cost_limit=state.cost_limit,
-            time_limit=time_limit,
-            working_limit=working_limit,
-            fails_on_error=fails_on_error or (retry_on_error > 0),
-            transcript=sample_transcript,
-            checkpoint=resolved_checkpoint,
-            resume_checkpoint=resume_checkpoint,
-            eval_set_id=eval_set_id,
-            run_id=run_id,
-            eval_id=task_id,
-            agent_name=agent_name,
-        ) as active:
-            # check for early stopping
-            if early_stopping is not None and logger is not None:
-                early_stop = await early_stopping.schedule_sample(
-                    state.sample_id, state.epoch
-                )
-                if early_stop is not None:
-                    return early_stop
-
-            start_time: float | None = None
-            error: EvalError | None = None
-            raise_error: BaseException | None = None
-            cancelled_error: BaseException | None = None
-            results: dict[str, SampleScore] = {}
-            limit: EvalSampleLimit | None = None
-            sample_summary: EvalSampleSummary | None = None
-            attempt_started = False
-
-            async def emit_attempt_end(will_retry: bool) -> None:
-                if sample_summary is None or not attempt_started:
-                    return
-                await emit_sample_attempt_end(
-                    eval_set_id,
-                    run_id,
-                    task_id,
-                    state.uuid,
-                    summary=sample_summary,
-                    attempt=len(error_retries) + 1,
-                    error=error,
-                    will_retry=will_retry,
-                )
-
-            # begin init
-            init_span = span("init", type="init")
-            await init_span.__aenter__()
-            cleanup_span: contextlib.AbstractAsyncContextManager[None] | None = (
-                init_span
-            )
-
-            try:
-                # sample init event (remove file bodies as they have content or absolute paths)
-                event_sample = sample.model_copy(
-                    update=dict(files={k: "" for k in sample.files.keys()})
-                    if sample.files
-                    else None
-                )
-                transcript()._event(
-                    SampleInitEvent(sample=event_sample, state=state_jsonable(state))
-                )
-
-                # construct sample summary, used by both emit_sample_init and emit_sample_start
-                sample_summary = EvalSampleSummary(
-                    id=sample_id,
-                    epoch=state.epoch,
-                    uuid=state.uuid,
-                    input=sample.input,
-                    choices=sample.choices,
-                    target=sample.target,
-                    metadata=sample.metadata or {},
-                )
-
-                # emit sample init before sandbox creation
-                # (only on the first attempt; not re-emitted when the sample is retried after an error)
-                if not error_retries:
-                    await emit_sample_init(
-                        eval_set_id,
-                        run_id,
-                        task_id,
-                        state.uuid,
-                        sample_summary,
-                    )
-
-                async with sandboxenv_cm:
-                    try:
-                        # update active sample wth sandboxes now that we are initialised
-                        # (ensure that we still exit init context in presence of sandbox error)
-                        try:
-                            active.sandboxes = await sandbox_connections()
-                        finally:
-                            await init_span.__aexit__(None, None, None)
-                            cleanup_span = None
-
-                        # record start time
-                        start_time = time.monotonic()
-                        init_sample_working_time(start_time)
-
-                        # run sample w/ optional limits
-                        with (
-                            state._token_limit,
-                            state._cost_limit,
-                            state._message_limit,
-                            create_time_limit(time_limit),
-                            create_working_limit(working_limit),
-                        ):
-
-                            async def run(tg: TaskGroup) -> None:
-                                # access to state, limit, and errors
-                                nonlocal state, limit, error, raise_error
-
-                                try:
-                                    # start the sample
-                                    active.start(tg)
-
-                                    # monitor working limit in the background
-                                    monitor_working_limit()
-
-                                    # start background sample event emitter
-                                    start_sample_event_emitter()
-
-                                    # set progress for plan then run it
-                                    async with span("solvers"):
-                                        state = await plan(state, generate)
-
-                                # some 'cancel' exceptions are actually user interrupts or the
-                                # result of monitor_working_limit() - for these exceptions we
-                                # want to intercept them and apply the appropriate control flow
-                                # so they can continue on and be scored.
-                                except anyio.get_cancelled_exc_class() as ex:
-                                    if active.interrupt_action:
-                                        # record event
-                                        transcript()._event(
-                                            SampleLimitEvent(
-                                                type="operator",
-                                                message="Sample completed: interrupted by operator",
-                                            )
-                                        )
-
-                                        # handle the action
-                                        match active.interrupt_action:
-                                            case "score":
-                                                # continue to scoring (capture the most recent state)
-                                                state = sample_state() or state
-                                                limit = EvalSampleLimit(
-                                                    type="operator", limit=1
-                                                )
-                                            case "error":
-                                                # default error handling
-                                                error, raise_error = handle_error(ex)
-
-                                    elif active.limit_exceeded_error:
-                                        # record event
-                                        transcript()._event(
-                                            SampleLimitEvent(
-                                                type="working",
-                                                message=active.limit_exceeded_error.message,
-                                                limit=active.limit_exceeded_error.limit,
-                                            )
-                                        )
-
-                                        # capture most recent state for scoring
-                                        state = sample_state() or state
-                                        limit = EvalSampleLimit(
-                                            type=active.limit_exceeded_error.type,
-                                            limit=active.limit_exceeded_error.limit
-                                            if active.limit_exceeded_error.limit
-                                            is not None
-                                            else -1,
-                                        )
-
-                                    # this was not a user interrupt or working time limit so propagate
-                                    else:
-                                        raise
-                                finally:
-                                    # ensures that monitor_working_limit() and any coroutines
-                                    # created w/ background() are cancelled
-                                    tg.cancel_scope.cancel()
-
-                            try:
-                                # emit/log sample start
-                                if logger is not None:
-                                    await logger.start_sample(sample_summary)
-
-                                # only emit the sample start once: not on retries
-                                if not error_retries:
-                                    await emit_sample_start(
-                                        eval_set_id,
-                                        run_id,
-                                        task_id,
-                                        state.uuid,
-                                        sample_summary,
-                                    )
-
-                                await emit_sample_attempt_start(
-                                    eval_set_id,
-                                    run_id,
-                                    task_id,
-                                    state.uuid,
-                                    sample_summary,
-                                    attempt=len(error_retries) + 1,
-                                )
-                                attempt_started = True
-
-                                async with anyio.create_task_group() as tg:
-                                    tg.start_soon(run, tg)
-                            except Exception as ex:
-                                raise inner_exception(ex)
-                            finally:
-                                # capture sample limits
-                                record_sample_limit_data(
-                                    len((sample_state() or state).messages)
-                                )
-
-                    except SandboxTimeoutError as ex:
-                        raise RuntimeError(str(ex)) from ex
-
-                    except TimeoutError:
-                        # Scoped time limits manifest themselves as LimitExceededError, not
-                        # TimeoutError.
-                        py_logger.warning(
-                            "Unexpected timeout error reached top of sample stack. Are you handling TimeoutError when applying timeouts?"
-                        )
-
-                        # capture most recent state for scoring
-                        state = sample_state() or state
-
-                    except LimitExceededError as ex:
-                        # capture most recent state for scoring
-                        state = sample_state() or state
-                        limit = EvalSampleLimit(
-                            type=ex.type, limit=ex.limit if ex.limit is not None else -1
-                        )
-
-                    except TerminateSampleError as ex:
-                        # emit event
-                        transcript()._event(
-                            SampleLimitEvent(
-                                type="operator", limit=1, message=ex.reason
-                            )
-                        )
-
-                        # capture most recent state for scoring
-                        state = sample_state() or state
-                        limit = EvalSampleLimit(type="operator", limit=1)
-
-                    except anyio.get_cancelled_exc_class() as ex:
-                        with anyio.CancelScope(shield=True):
-                            cancelled_error = ex
-                            # convert to standard error
-                            error = eval_error(ex, type(ex), ex, ex.__traceback__)
-                            transcript()._event(ErrorEvent(error=error))
-
-                    except Exception as ex:
-                        error, raise_error = handle_error(ex)
-
-                    # mark completed
-                    state.completed = True
-
-                    # set timeout for scoring. if the original timeout was hit we still
-                    # want to provide opportunity for scoring, but we don't necessarily
-                    # want to wait the full timeout again (especially in the case where
-                    # the cause of the timeout is a hung container and scoring requires
-                    # interacting with the container). as a middle ground we use half
-                    # of the original timeout value for scoring.
-                    scoring_time_limit = time_limit / 2 if time_limit else None
-
-                    set_sample_state(state)
-                    if state.scores is None:
-                        state.scores = {}
-                    solver_score_names = [*state.scores]
-
-                    # scoring
-                    with anyio.CancelScope(shield=cancelled_error is not None):
-                        await emit_sample_scoring(
-                            eval_set_id,
-                            run_id,
-                            task_id,
-                            state.uuid,
-                        )
-                        try:
-                            # timeout during scoring will result in an ordinary sample error
-                            with create_time_limit(scoring_time_limit):
-                                # score on success, or when score_on_error is on
-                                # for the final attempt (no retries left, not cancelled)
-                                if error is None or (
-                                    score_on_error
-                                    and retry_on_error == 0
-                                    and cancelled_error is None
-                                ):
-                                    async with span(name="scorers"):
-                                        for scorer_idx, scorer in enumerate(
-                                            scorers or []
-                                        ):
-                                            scorer_name = (
-                                                scorer_names[scorer_idx]
-                                                if scorer_names
-                                                else unique_scorer_name(
-                                                    scorer,
-                                                    list(
-                                                        {*solver_score_names, *results}
-                                                    ),
-                                                )
-                                            )
-                                            async with span(
-                                                name=scorer_name, type="scorer"
-                                            ):
-                                                if not scorer:
-                                                    continue
-                                                score_result = await scorer(
-                                                    state, Target(sample.target)
-                                                )
-                                                if scorer_name in state.scores:
-                                                    raise RuntimeError(
-                                                        f"Scorer {scorer_name} has modified state.scores"
-                                                    )
-                                                if score_result is not None:
-                                                    state.scores[scorer_name] = (
-                                                        score_result
-                                                    )
-
-                                                    transcript()._event(
-                                                        ScoreEvent(
-                                                            score=score_result,
-                                                            target=sample.target,
-                                                            scorer=scorer_name,
-                                                            scorer_args=registry_params(
-                                                                scorer
-                                                            )
-                                                            if has_registry_params(
-                                                                scorer
-                                                            )
-                                                            else None,
-                                                            model_usage=sample_model_usage()
-                                                            or None,
-                                                            role_usage=sample_role_usage()
-                                                            or None,
-                                                        )
-                                                    )
-
-                                                    results[scorer_name] = SampleScore(
-                                                        score=score_result,
-                                                        sample_id=sample.id,
-                                                        sample_metadata=sample.metadata,
-                                                        scorer=registry_unqualified_name(
-                                                            scorer
-                                                        ),
-                                                    )
-
-                                for name in solver_score_names:
-                                    score = state.scores[name]
-                                    transcript()._event(
-                                        ScoreEvent(
-                                            score=score,
-                                            target=sample.target,
-                                            scorer=name,
-                                            model_usage=sample_model_usage() or None,
-                                            role_usage=sample_role_usage() or None,
-                                        )
-                                    )
-                                    results[name] = SampleScore(
-                                        score=score,
-                                        sample_id=state.sample_id,
-                                        sample_metadata=state.metadata,
-                                    )
-
-                        except anyio.get_cancelled_exc_class() as ex:
-                            with anyio.CancelScope(shield=True):
-                                cancelled_error = ex
-                                if active.interrupt_action:
-                                    transcript()._event(
-                                        SampleLimitEvent(
-                                            type="operator",
-                                            message="Unable to score sample due to operator interruption",
-                                        )
-                                    )
-
-                                # convert to standard error
-                                error = eval_error(ex, type(ex), ex, ex.__traceback__)
-                                transcript()._event(ErrorEvent(error=error))
-
-                        except Exception as ex:
-                            if active.interrupt_action is not None:
-                                # Operator-interrupted: log to transcript but
-                                # don't propagate to error/retry. The operator
-                                # EvalSampleLimit is set in the run() handler.
-                                scorer_error = eval_error(
-                                    ex, type(ex), ex, ex.__traceback__
-                                )
-                                transcript()._event(ErrorEvent(error=scorer_error))
-                            else:
-                                error, raise_error = handle_error(ex)
-                        finally:
-                            # run task cleanup if required (inside sandbox context)
-                            if cleanup is not None:
-                                with anyio.CancelScope(shield=True):
-                                    try:
-                                        await cleanup(state)
-                                    except Exception as ex:
-                                        py_logger.warning(
-                                            f"Exception occurred during task cleanup: {ex}",
-                                            exc_info=ex,
-                                        )
-
-            except Exception as ex:
-                error, raise_error = handle_error(ex)
-            finally:
-                # cleanup the task init span if required
-                if cleanup_span is not None:
-                    with anyio.CancelScope(shield=cancelled_error is not None):
-                        await cleanup_span.__aexit__(None, None, None)
-
-            # complete the sample if there is no error or if there is no retry_on_error in play
-            with anyio.CancelScope(shield=cancelled_error is not None):
-                # drain sample events for both completion and retry paths
-                await drain_sample_events()
-
-                if not error or (retry_on_error == 0) or (cancelled_error is not None):
-                    progress(SAMPLE_TOTAL_PROGRESS_UNITS)
-
-                    # if we are logging images then be sure to base64 images injected by solvers
-                    if log_images:
-                        state = (await states_with_base64_content([state]))[0]
-
-                    # otherwise ensure there are no base64 images in sample or messages
-                    else:
-                        sample = sample_without_base64_content(sample)
-                        state = state_without_base64_content(state)
-
-                    # emit/log sample end
-                    def make_eval_sample(include_events: bool = True) -> EvalSample:
-                        return create_eval_sample(
-                            start_time=start_time,
-                            sample=sample,
-                            state=state,
-                            scores=results,
-                            error=error,
-                            limit=limit,
-                            error_retries=error_retries,
-                            started_at=sample_start_datetime(),
-                            include_events=include_events,
-                        )
-
-                    if logger:
-                        eval_sample = await log_sample(
-                            eval_sample=make_eval_sample(
-                                include_events=logger.buffer_db is None
-                            ),
-                            logger=logger,
-                            log_images=log_images,
-                        )
-                    else:
-                        eval_sample = make_eval_sample()
-                    await scan_eval_sample(
-                        eval_sample,
-                        scanner,
-                        scan_id=scan_id,
-                        eval_id=task_id,
-                        log_location=log_location,
-                        model=str(state.model),
-                        eval_spec=logger.eval if logger else None,
-                    )
-                    await emit_attempt_end(will_retry=False)
-                    await emit_sample_end(
-                        eval_set_id, run_id, task_id, state.uuid, eval_sample
-                    )
-
-    # error that should be retried (we do this outside of the above scope so that we can
-    # retry outside of the original semaphore -- our retry will therefore go to the back
-    # of the sample queue)
-    if (
-        error
-        and retry_on_error > 0
-        and cancelled_error is None
-        and active.interrupt_action is None
-    ):
-        await emit_attempt_end(will_retry=True)
-
-        # remove any buffered sample events
-        if logger is not None:
-            logger.remove_sample(state.sample_id, state.epoch)
-
-        # recurse w/ tick down of retry_on_error and append of error to error_retries
-        return await task_run_sample(
-            task_name=task_name,
-            log_location=log_location,
-            create_sample_state=create_sample_state,
-            sandbox=sandbox,
-            checkpoint=checkpoint,
-            eval_checkpoint=eval_checkpoint,
-            resume_checkpoint=resume_checkpoint,
-            max_sandboxes=max_sandboxes,
-            sandbox_cleanup=sandbox_cleanup,
-            plan=plan,
-            scorers=scorers,
-            scorer_names=scorer_names,
-            scanner=scanner,
-            cleanup=cleanup,
-            generate=generate,
-            progress=progress,
-            logger=logger,
-            log_images=log_images,
-            log_model_api=log_model_api,
-            sample_error=sample_error,
-            sample_complete=sample_complete,
-            early_stopping=early_stopping,
-            fails_on_error=fails_on_error,
-            # tick retry count down
-            retry_on_error=retry_on_error - 1,
-            score_on_error=score_on_error,
-            # forward on error that caused retry
-            error_retries=copy(error_retries) + [_eval_retry_error(error)],
-            time_limit=time_limit,
-            working_limit=working_limit,
-            semaphore=semaphore,
-            eval_set_id=eval_set_id,
-            run_id=run_id,
-            task_id=task_id,
-            scan_id=scan_id,
-            sample_uuid=state.uuid,
-        )
-
-    # re-raise cancellation after logging to preserve structured concurrency
-    elif cancelled_error is not None:
-        raise cancelled_error
-
-    # no error
-    elif error is None:
-        # call sample_complete callback if we have score results
-        if results is not None:
-            await sample_complete(state.sample_id, state.epoch, results)
-        return results
-
-    # we have an error and should raise it
-    elif raise_error is not None:
-        raise raise_error
-
-    # we have an error and should not raise it
-    else:
-        return None
-
-
-def create_eval_sample(
-    start_time: float | None,
-    sample: Sample,
-    state: TaskState,
-    scores: dict[str, SampleScore],
-    error: EvalError | None,
-    limit: EvalSampleLimit | None,
-    error_retries: list[EvalRetryError],
-    started_at: datetime | None = None,
-    include_events: bool = True,
-) -> EvalSample:
-    # sample must have id to be logged
-    id = sample.id
-    if id is None:
-        raise ValueError(
-            f"Samples without IDs cannot be logged: {to_json_str_safe(sample)}"
-        )
-
-    # construct sample for logging
-
-    # compute total time if we can
-    total_time = time.monotonic() - start_time if start_time is not None else None
-
-    return EvalSample(
-        id=id,
-        epoch=state.epoch,
-        input=sample.input,
-        choices=sample.choices,
-        target=sample.target,
-        metadata=state.metadata or {},
-        sandbox=sample.sandbox,
-        files=list(sample.files.keys()) if sample.files else None,
-        setup=sample.setup,
-        messages=state.messages,
-        output=state.output,
-        scores={k: v.score for k, v in scores.items()},
-        store=dict(state.store.items()),
-        uuid=state.uuid,
-        events=list(transcript().events) if include_events else [],
-        timelines=list(transcript().timelines) or None,
-        attachments=dict(transcript().attachments),
-        model_usage=sample_model_usage(),
-        role_usage=sample_role_usage(),
-        started_at=started_at.isoformat() if started_at is not None else None,
-        completed_at=datetime.now(timezone.utc).isoformat(),
-        total_time=round(total_time, 3) if total_time is not None else None,
-        working_time=round(total_time - sample_waiting_time(), 3)
-        if total_time is not None
-        else None,
-        error=error,
-        error_retries=error_retries,
-        limit=limit,
-    )
-
-
-async def log_sample(
-    eval_sample: EvalSample,
-    logger: TaskLogger,
-    log_images: bool,
-) -> EvalSample:
-    if logger.buffer_db is None:
-        await logger.complete_sample(
-            condense_sample(eval_sample, log_images), flush=True
-        )
-        return eval_sample
-
-    logging_sample = condense_sample(
-        eval_sample.model_copy(update={"events": [], "events_data": None}),
-        log_images,
-    )
-    with logger.buffer_db.open_sample_history(
-        eval_sample.id, eval_sample.epoch
-    ) as history:
-        materialized_sample = materialize_streaming_sample(eval_sample, history)
-        await logger.complete_sample_streaming(logging_sample, history, flush=True)
-    return materialized_sample
-
-
 # we can reuse samples from a previous eval_log if and only if:
 #   - The datasets have not been shuffled OR the samples in the dataset have unique ids
 #   - The datasets have the exact same length
@@ -1713,51 +899,3 @@ def create_sample_semaphore(
             else DEFAULT_MAX_CONNECTIONS
         )
         return anyio.Semaphore(max_samples)
-
-
-# `importlib.util.find_spec` walks importer paths (~3 ms per call). Cache
-# at module load — package installation can't change during a process
-# lifetime, so the result is invariant. Without this, `init_sample_assistant_internal`
-# (called once per sample) was costing ~3 s per 500 samples in profiling.
-_HAS_OPENAI: bool = importlib.util.find_spec("openai") is not None
-_HAS_ANTHROPIC: bool = importlib.util.find_spec("anthropic") is not None
-
-
-def init_sample_assistant_internal() -> None:
-    if _HAS_OPENAI:
-        try:
-            from inspect_ai.model._openai_responses import (
-                init_sample_openai_assistant_internal,
-            )
-
-            init_sample_openai_assistant_internal()
-        except ImportError:
-            pass
-
-    if _HAS_ANTHROPIC:
-        try:
-            from inspect_ai.model._providers.anthropic import (
-                init_sample_anthropic_assistant_internal,
-            )
-
-            init_sample_anthropic_assistant_internal()
-        except ImportError:
-            pass
-
-
-def _eval_retry_error(error: EvalError) -> EvalRetryError:
-    """Create retry error with events from the most recent ModelEvent onward."""
-    from inspect_ai.event._model import ModelEvent
-
-    events = transcript().events
-    recent_events = list(events)
-    for i in range(len(events) - 1, -1, -1):
-        if isinstance(events[i], ModelEvent):
-            recent_events = list(events[i:])
-            break
-    return EvalRetryError(
-        message=error.message,
-        traceback=error.traceback,
-        traceback_ansi=error.traceback_ansi,
-        events=recent_events,
-    )

--- a/src/inspect_ai/_eval/task/sample_helpers.py
+++ b/src/inspect_ai/_eval/task/sample_helpers.py
@@ -1,0 +1,153 @@
+"""Per-sample helpers shared between `task_run` and `SampleRunner`.
+
+Lifted out of `_eval/task/run.py` so the dependency between `run.py` and
+`sample_runner.py` is a DAG rather than a cycle (both import from here).
+"""
+
+from __future__ import annotations
+
+import functools
+import importlib
+import time
+from datetime import datetime, timezone
+
+from inspect_ai._util.json import to_json_str_safe
+from inspect_ai._util.working import sample_waiting_time
+from inspect_ai.dataset import Sample
+from inspect_ai.log import EvalError, EvalSample
+from inspect_ai.log._condense import condense_sample
+from inspect_ai.log._log import EvalRetryError, EvalSampleLimit
+from inspect_ai.log._recorders.streaming import materialize_streaming_sample
+from inspect_ai.log._transcript import transcript
+from inspect_ai.model._model import sample_model_usage, sample_role_usage
+from inspect_ai.scorer._metric import SampleScore
+from inspect_ai.solver import TaskState
+
+from .log import TaskLogger
+
+
+def create_eval_sample(
+    start_time: float | None,
+    sample: Sample,
+    state: TaskState,
+    scores: dict[str, SampleScore],
+    error: EvalError | None,
+    limit: EvalSampleLimit | None,
+    error_retries: list[EvalRetryError],
+    started_at: datetime | None = None,
+    include_events: bool = True,
+) -> EvalSample:
+    # sample must have id to be logged
+    id = sample.id
+    if id is None:
+        raise ValueError(
+            f"Samples without IDs cannot be logged: {to_json_str_safe(sample)}"
+        )
+
+    # construct sample for logging
+
+    # compute total time if we can
+    total_time = time.monotonic() - start_time if start_time is not None else None
+
+    return EvalSample(
+        id=id,
+        epoch=state.epoch,
+        input=sample.input,
+        choices=sample.choices,
+        target=sample.target,
+        metadata=state.metadata or {},
+        sandbox=sample.sandbox,
+        files=list(sample.files.keys()) if sample.files else None,
+        setup=sample.setup,
+        messages=state.messages,
+        output=state.output,
+        scores={k: v.score for k, v in scores.items()},
+        store=dict(state.store.items()),
+        uuid=state.uuid,
+        events=list(transcript().events) if include_events else [],
+        timelines=list(transcript().timelines) or None,
+        attachments=dict(transcript().attachments),
+        model_usage=sample_model_usage(),
+        role_usage=sample_role_usage(),
+        started_at=started_at.isoformat() if started_at is not None else None,
+        completed_at=datetime.now(timezone.utc).isoformat(),
+        total_time=round(total_time, 3) if total_time is not None else None,
+        working_time=round(total_time - sample_waiting_time(), 3)
+        if total_time is not None
+        else None,
+        error=error,
+        error_retries=error_retries,
+        limit=limit,
+    )
+
+
+async def log_sample(
+    eval_sample: EvalSample,
+    logger: TaskLogger,
+    log_images: bool,
+) -> EvalSample:
+    if logger.buffer_db is None:
+        await logger.complete_sample(
+            condense_sample(eval_sample, log_images), flush=True
+        )
+        return eval_sample
+
+    logging_sample = condense_sample(
+        eval_sample.model_copy(update={"events": [], "events_data": None}),
+        log_images,
+    )
+    with logger.buffer_db.open_sample_history(
+        eval_sample.id, eval_sample.epoch
+    ) as history:
+        materialized_sample = materialize_streaming_sample(eval_sample, history)
+        await logger.complete_sample_streaming(logging_sample, history, flush=True)
+    return materialized_sample
+
+
+@functools.cache
+def _has_package(name: str) -> bool:
+    # `importlib.util.find_spec` walks importer paths (~3 ms per call). Cached
+    # because package installation can't change during a process lifetime, so
+    # the result is invariant. Without this, `init_sample_assistant_internal`
+    # (called once per sample) was costing ~3 s per 500 samples in profiling.
+    return importlib.util.find_spec(name) is not None
+
+
+def init_sample_assistant_internal() -> None:
+    if _has_package("openai"):
+        try:
+            from inspect_ai.model._openai_responses import (
+                init_sample_openai_assistant_internal,
+            )
+
+            init_sample_openai_assistant_internal()
+        except ImportError:
+            pass
+
+    if _has_package("anthropic"):
+        try:
+            from inspect_ai.model._providers.anthropic import (
+                init_sample_anthropic_assistant_internal,
+            )
+
+            init_sample_anthropic_assistant_internal()
+        except ImportError:
+            pass
+
+
+def eval_retry_error(error: EvalError) -> EvalRetryError:
+    """Create retry error with events from the most recent ModelEvent onward."""
+    from inspect_ai.event._model import ModelEvent
+
+    events = transcript().events
+    recent_events = list(events)
+    for i in range(len(events) - 1, -1, -1):
+        if isinstance(events[i], ModelEvent):
+            recent_events = list(events[i:])
+            break
+    return EvalRetryError(
+        message=error.message,
+        traceback=error.traceback,
+        traceback_ansi=error.traceback_ansi,
+        events=recent_events,
+    )

--- a/src/inspect_ai/_eval/task/sample_runner.py
+++ b/src/inspect_ai/_eval/task/sample_runner.py
@@ -1,0 +1,920 @@
+import contextlib
+import time
+from logging import getLogger
+from typing import Any, Awaitable, Callable
+
+import anyio
+from anyio.abc import TaskGroup
+
+from inspect_ai._eval.task.scan import Scanners
+from inspect_ai._util.error import exception_message
+from inspect_ai._util.exception import TerminateSampleError
+from inspect_ai._util.registry import (
+    has_registry_params,
+    registry_log_name,
+    registry_params,
+    registry_unqualified_name,
+)
+from inspect_ai._util.working import (
+    init_sample_working_time,
+    sample_start_datetime,
+)
+from inspect_ai.dataset import Sample
+from inspect_ai.event._error import ErrorEvent
+from inspect_ai.event._sample_init import SampleInitEvent
+from inspect_ai.event._sample_limit import SampleLimitEvent
+from inspect_ai.event._score import ScoreEvent
+from inspect_ai.log import EvalError, EvalSample
+from inspect_ai.log._log import (
+    EvalRetryError,
+    EvalSampleLimit,
+    EvalSampleSummary,
+    eval_error,
+)
+from inspect_ai.log._samples import active_sample
+from inspect_ai.log._transcript import (
+    Transcript,
+    init_transcript,
+    transcript,
+)
+from inspect_ai.model._model import (
+    init_sample_model_usage,
+    init_sample_role_usage,
+    sample_model_usage,
+    sample_role_usage,
+)
+from inspect_ai.scorer import Scorer, Target
+from inspect_ai.scorer._metric import SampleScore
+from inspect_ai.scorer._score import init_scoring_context
+from inspect_ai.scorer._scorer import unique_scorer_name
+from inspect_ai.solver import Generate, Plan, TaskState
+from inspect_ai.solver._task_state import sample_state, set_sample_state, state_jsonable
+from inspect_ai.util._anyio import inner_exception
+from inspect_ai.util._checkpoint.checkpointer import ResumeCheckpoint
+from inspect_ai.util._checkpoint.config import (
+    CheckpointConfig,
+    merge_checkpoint_configs,
+)
+from inspect_ai.util._early_stopping import EarlyStop, EarlyStopping
+from inspect_ai.util._limit import (
+    LimitExceededError,
+    monitor_working_limit,
+    record_sample_limit_data,
+)
+from inspect_ai.util._limit import time_limit as create_time_limit
+from inspect_ai.util._limit import working_limit as create_working_limit
+from inspect_ai.util._sandbox import SandboxTimeoutError
+from inspect_ai.util._sandbox.context import sandbox_connections
+from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
+from inspect_ai.util._span import span
+from inspect_ai.util._store import init_subtask_store
+
+from . import scan as _scan_mod
+from .error import SampleErrorHandler
+from .images import (
+    sample_without_base64_content,
+    state_without_base64_content,
+    states_with_base64_content,
+)
+from .log import TaskLogger
+from .sample_helpers import (
+    create_eval_sample,
+    eval_retry_error,
+    init_sample_assistant_internal,
+    log_sample,
+)
+from .sandbox import sandboxenv_context
+
+py_logger = getLogger(__name__)
+
+
+SAMPLE_TOTAL_PROGRESS_UNITS = 1
+
+
+class SampleRunner:
+    """Run a single sample (one attempt-chain) through plan + scoring.
+
+    The retry path constructs a fresh `SampleRunner` with `retry_on_error`
+    decremented and `error_retries` appended, then awaits its `run()`.
+    """
+
+    def __init__(
+        self,
+        *,
+        task_name: str,
+        log_location: str,
+        create_sample_state: Callable[
+            [str | None], Awaitable[tuple[Sample, TaskState]]
+        ],
+        sandbox: SandboxEnvironmentSpec | None,
+        checkpoint: CheckpointConfig | None,
+        eval_checkpoint: CheckpointConfig | None,
+        resume_checkpoint: ResumeCheckpoint | None,
+        max_sandboxes: int | None,
+        sandbox_cleanup: bool,
+        plan: Plan,
+        scorers: list[Scorer] | None,
+        scorer_names: list[str] | None,
+        scanner: "Scanners | None",
+        cleanup: Callable[[TaskState], Awaitable[None]] | None,
+        generate: Generate,
+        progress: Callable[[int], None],
+        logger: TaskLogger | None,
+        log_images: bool,
+        log_model_api: bool | None,
+        sample_error: SampleErrorHandler,
+        sample_complete: Callable[
+            [int | str, int, dict[str, SampleScore]], Awaitable[None]
+        ],
+        fails_on_error: bool,
+        early_stopping: EarlyStopping | None,
+        retry_on_error: int,
+        score_on_error: bool,
+        error_retries: list[EvalRetryError],
+        time_limit: int | None,
+        working_limit: int | None,
+        semaphore: contextlib.AbstractAsyncContextManager[Any],
+        eval_set_id: str | None,
+        run_id: str,
+        task_id: str,
+        scan_id: str | None = None,
+        sample_uuid: str | None = None,
+    ) -> None:
+        self._task_name = task_name
+        self._log_location = log_location
+        self._create_sample_state = create_sample_state
+        self._sandbox = sandbox
+        self._checkpoint = checkpoint
+        self._eval_checkpoint = eval_checkpoint
+        self._resume_checkpoint = resume_checkpoint
+        self._max_sandboxes = max_sandboxes
+        self._sandbox_cleanup = sandbox_cleanup
+        self._plan = plan
+        self._scorers = scorers
+        self._scorer_names = scorer_names
+        self._scanner = scanner
+        self._cleanup = cleanup
+        self._generate = generate
+        self._progress = progress
+        self._logger = logger
+        self._log_images = log_images
+        self._log_model_api = log_model_api
+        self._sample_error = sample_error
+        self._sample_complete = sample_complete
+        self._fails_on_error = fails_on_error
+        self._early_stopping = early_stopping
+        self._retry_on_error = retry_on_error
+        self._score_on_error = score_on_error
+        self._error_retries = error_retries
+        self._time_limit = time_limit
+        self._working_limit = working_limit
+        self._semaphore = semaphore
+        self._eval_set_id = eval_set_id
+        self._run_id = run_id
+        self._task_id = task_id
+        self._scan_id = scan_id
+        self._sample_uuid = sample_uuid
+
+        # per-run mutable state — set up inside run()
+        self._sample: Sample | None = None
+        self._state: TaskState | None = None
+        self._sample_id: int | str | None = None
+        self._error: EvalError | None = None
+        self._raise_error: BaseException | None = None
+        self._cancelled_error: BaseException | None = None
+        self._sample_summary: EvalSampleSummary | None = None
+        self._attempt_started: bool = False
+
+    def _on_sample_event(self, event: Any) -> None:
+        from inspect_ai.hooks._hooks import emit_sample_event
+
+        # _state and _sample_id are set before _on_sample_event is wired up
+        assert self._state is not None
+        assert self._sample_id is not None
+
+        if self._logger:
+            self._logger.log_sample_event(self._sample_id, self._state.epoch, event)
+        emit_sample_event(
+            eval_set_id=self._eval_set_id,
+            run_id=self._run_id,
+            eval_id=self._task_id,
+            sample_id=self._state.uuid,
+            event=event,
+        )
+
+    def _handle_error(
+        self, ex: BaseException
+    ) -> tuple[EvalError, BaseException | None]:
+        assert self._sample is not None
+        assert self._state is not None
+
+        sample = self._sample
+        state = self._state
+
+        def log_sample_error() -> None:
+            msg = (
+                f"Sample error (id: {sample.id}, epoch: {state.epoch}): "
+                f"{exception_message(ex)})"
+            )
+            if self._retry_on_error > 0:
+                msg = f"{msg}. Sample will be retried."
+            elif self._score_on_error:
+                msg = f"{msg}. Sample will be scored."
+            py_logger.warning(msg)
+
+        # if we have retries left then return EvalError
+        if self._retry_on_error > 0:
+            log_sample_error()
+            return eval_error(ex, type(ex), ex, ex.__traceback__), None
+        else:
+            err = self._sample_error(ex)
+            # with score_on_error, suppress the raise so we can score the
+            # sample; error_count was still incremented on sample_error()
+            # above, so the eval-level fail_on_error threshold continues
+            # to apply.
+            if self._score_on_error:
+                log_sample_error()
+                transcript()._event(ErrorEvent(error=err[0]))
+                return err[0], None
+            # if we aren't raising the error then print a warning
+            if err[1] is None:
+                log_sample_error()
+            transcript()._event(ErrorEvent(error=err[0]))
+            return err
+
+    async def _emit_attempt_end(self, will_retry: bool) -> None:
+        from inspect_ai.hooks._hooks import emit_sample_attempt_end
+
+        if self._sample_summary is None or not self._attempt_started:
+            return
+        assert self._state is not None
+        await emit_sample_attempt_end(
+            self._eval_set_id,
+            self._run_id,
+            self._task_id,
+            self._state.uuid,
+            summary=self._sample_summary,
+            attempt=len(self._error_retries) + 1,
+            error=self._error,
+            will_retry=will_retry,
+        )
+
+    async def run(self) -> dict[str, SampleScore] | EarlyStop | None:
+        from inspect_ai.hooks._hooks import (
+            drain_sample_events,
+            emit_sample_attempt_start,
+            emit_sample_end,
+            emit_sample_init,
+            emit_sample_scoring,
+            emit_sample_start,
+            start_sample_event_emitter,
+        )
+
+        # execute under sample semaphore
+        async with self._semaphore:
+            # materialize sample+state lazily (deferred until semaphore acquired)
+            sample, state = await self._create_sample_state(self._sample_uuid)
+            self._sample = sample
+            self._state = state
+
+            # validate that we have sample_id (mostly for the typechecker)
+            sample_id = sample.id
+            if sample_id is None:
+                raise ValueError("sample must have id to run")
+            self._sample_id = sample_id
+
+            # initialise subtask and scoring context
+            init_sample_model_usage()
+            init_sample_role_usage()
+            set_sample_state(state)
+            sample_transcript = Transcript(log_model_api=self._log_model_api)
+            init_transcript(sample_transcript)
+            init_subtask_store(state.store)
+            sample_transcript._subscribe(self._on_sample_event)
+            if self._scorers:
+                init_scoring_context(self._scorers, Target(sample.target))
+
+            init_sample_assistant_internal()
+
+            # use sandbox if provided
+            sandboxenv_cm = (
+                sandboxenv_context(
+                    self._task_name,
+                    self._sandbox,
+                    self._max_sandboxes,
+                    self._sandbox_cleanup,
+                    sample,
+                )
+                if self._sandbox or sample.sandbox is not None
+                else contextlib.nullcontext()
+            )
+
+            # resolve checkpoint config across all three levels with
+            # precedence eval > sample > task (per-field merge — see
+            # `merge_checkpoint_configs`).
+            resolved_checkpoint = merge_checkpoint_configs(
+                self._checkpoint, sample.checkpoint, self._eval_checkpoint
+            )
+
+            # Derive agent name for the ACP picker / TUI meta row. Mirrors
+            # inspect_scout's `_agent(log)` heuristic: prefer the configured
+            # eval-level solver string, fall back to the last plan step.
+            agent_name: str | None = None
+            if self._logger is not None and self._logger.eval.solver is not None:
+                agent_name = self._logger.eval.solver
+            elif self._plan.steps:
+                agent_name = registry_log_name(self._plan.steps[-1])
+
+            async with active_sample(
+                task=self._task_name,
+                log_location=self._log_location,
+                model=str(state.model),
+                sample=sample,
+                epoch=state.epoch,
+                message_limit=state.message_limit,
+                token_limit=state.token_limit,
+                cost_limit=state.cost_limit,
+                time_limit=self._time_limit,
+                working_limit=self._working_limit,
+                fails_on_error=self._fails_on_error or (self._retry_on_error > 0),
+                transcript=sample_transcript,
+                checkpoint=resolved_checkpoint,
+                resume_checkpoint=self._resume_checkpoint,
+                eval_set_id=self._eval_set_id,
+                run_id=self._run_id,
+                eval_id=self._task_id,
+                agent_name=agent_name,
+            ) as active:
+                # check for early stopping
+                if self._early_stopping is not None and self._logger is not None:
+                    early_stop = await self._early_stopping.schedule_sample(
+                        state.sample_id, state.epoch
+                    )
+                    if early_stop is not None:
+                        return early_stop
+
+                start_time: float | None = None
+                results: dict[str, SampleScore] = {}
+                limit: EvalSampleLimit | None = None
+
+                # begin init
+                init_span = span("init", type="init")
+                await init_span.__aenter__()
+                cleanup_span: contextlib.AbstractAsyncContextManager[None] | None = (
+                    init_span
+                )
+
+                try:
+                    # sample init event (remove file bodies as they have content or absolute paths)
+                    event_sample = sample.model_copy(
+                        update=dict(files={k: "" for k in sample.files.keys()})
+                        if sample.files
+                        else None
+                    )
+                    transcript()._event(
+                        SampleInitEvent(
+                            sample=event_sample, state=state_jsonable(state)
+                        )
+                    )
+
+                    # construct sample summary, used by both emit_sample_init and emit_sample_start
+                    self._sample_summary = EvalSampleSummary(
+                        id=sample_id,
+                        epoch=state.epoch,
+                        uuid=state.uuid,
+                        input=sample.input,
+                        choices=sample.choices,
+                        target=sample.target,
+                        metadata=sample.metadata or {},
+                    )
+
+                    # emit sample init before sandbox creation
+                    # (only on the first attempt; not re-emitted when the sample is retried after an error)
+                    if not self._error_retries:
+                        await emit_sample_init(
+                            self._eval_set_id,
+                            self._run_id,
+                            self._task_id,
+                            state.uuid,
+                            self._sample_summary,
+                        )
+
+                    async with sandboxenv_cm:
+                        try:
+                            # update active sample wth sandboxes now that we are initialised
+                            # (ensure that we still exit init context in presence of sandbox error)
+                            try:
+                                active.sandboxes = await sandbox_connections()
+                            finally:
+                                await init_span.__aexit__(None, None, None)
+                                cleanup_span = None
+
+                            # record start time
+                            start_time = time.monotonic()
+                            init_sample_working_time(start_time)
+
+                            # run sample w/ optional limits
+                            with (
+                                state._token_limit,
+                                state._cost_limit,
+                                state._message_limit,
+                                create_time_limit(self._time_limit),
+                                create_working_limit(self._working_limit),
+                            ):
+
+                                async def run(tg: TaskGroup) -> None:
+                                    nonlocal limit
+                                    # access to state via outer scope (via self._state too)
+                                    assert self._state is not None
+                                    try:
+                                        # start the sample
+                                        active.start(tg)
+
+                                        # monitor working limit in the background
+                                        monitor_working_limit()
+
+                                        # start background sample event emitter
+                                        start_sample_event_emitter()
+
+                                        # set progress for plan then run it
+                                        async with span("solvers"):
+                                            self._state = await self._plan(
+                                                self._state, self._generate
+                                            )
+
+                                    # some 'cancel' exceptions are actually user interrupts or the
+                                    # result of monitor_working_limit() - for these exceptions we
+                                    # want to intercept them and apply the appropriate control flow
+                                    # so they can continue on and be scored.
+                                    except anyio.get_cancelled_exc_class() as ex:
+                                        if active.interrupt_action:
+                                            # record event
+                                            transcript()._event(
+                                                SampleLimitEvent(
+                                                    type="operator",
+                                                    message="Sample completed: interrupted by operator",
+                                                )
+                                            )
+
+                                            # handle the action
+                                            match active.interrupt_action:
+                                                case "score":
+                                                    # continue to scoring (capture the most recent state)
+                                                    self._state = (
+                                                        sample_state() or self._state
+                                                    )
+                                                    limit = EvalSampleLimit(
+                                                        type="operator", limit=1
+                                                    )
+                                                case "error":
+                                                    # default error handling
+                                                    (
+                                                        self._error,
+                                                        self._raise_error,
+                                                    ) = self._handle_error(ex)
+
+                                        elif active.limit_exceeded_error:
+                                            # record event
+                                            transcript()._event(
+                                                SampleLimitEvent(
+                                                    type="working",
+                                                    message=active.limit_exceeded_error.message,
+                                                    limit=active.limit_exceeded_error.limit,
+                                                )
+                                            )
+
+                                            # capture most recent state for scoring
+                                            self._state = sample_state() or self._state
+                                            limit = EvalSampleLimit(
+                                                type=active.limit_exceeded_error.type,
+                                                limit=active.limit_exceeded_error.limit
+                                                if active.limit_exceeded_error.limit
+                                                is not None
+                                                else -1,
+                                            )
+
+                                        # this was not a user interrupt or working time limit so propagate
+                                        else:
+                                            raise
+                                    finally:
+                                        # ensures that monitor_working_limit() and any coroutines
+                                        # created w/ background() are cancelled
+                                        tg.cancel_scope.cancel()
+
+                                try:
+                                    # emit/log sample start
+                                    if self._logger is not None:
+                                        await self._logger.start_sample(
+                                            self._sample_summary
+                                        )
+
+                                    # only emit the sample start once: not on retries
+                                    if not self._error_retries:
+                                        await emit_sample_start(
+                                            self._eval_set_id,
+                                            self._run_id,
+                                            self._task_id,
+                                            state.uuid,
+                                            self._sample_summary,
+                                        )
+
+                                    await emit_sample_attempt_start(
+                                        self._eval_set_id,
+                                        self._run_id,
+                                        self._task_id,
+                                        state.uuid,
+                                        self._sample_summary,
+                                        attempt=len(self._error_retries) + 1,
+                                    )
+                                    self._attempt_started = True
+
+                                    async with anyio.create_task_group() as tg:
+                                        tg.start_soon(run, tg)
+                                except Exception as ex:
+                                    raise inner_exception(ex)
+                                finally:
+                                    # capture sample limits
+                                    record_sample_limit_data(
+                                        len((sample_state() or self._state).messages)
+                                    )
+
+                        except SandboxTimeoutError as ex:
+                            raise RuntimeError(str(ex)) from ex
+
+                        except TimeoutError:
+                            # Scoped time limits manifest themselves as LimitExceededError, not
+                            # TimeoutError.
+                            py_logger.warning(
+                                "Unexpected timeout error reached top of sample stack. Are you handling TimeoutError when applying timeouts?"
+                            )
+
+                            # capture most recent state for scoring
+                            self._state = sample_state() or self._state
+
+                        except LimitExceededError as ex:
+                            # capture most recent state for scoring
+                            self._state = sample_state() or self._state
+                            limit = EvalSampleLimit(
+                                type=ex.type,
+                                limit=ex.limit if ex.limit is not None else -1,
+                            )
+
+                        except TerminateSampleError as ex:
+                            # emit event
+                            transcript()._event(
+                                SampleLimitEvent(
+                                    type="operator", limit=1, message=ex.reason
+                                )
+                            )
+
+                            # capture most recent state for scoring
+                            self._state = sample_state() or self._state
+                            limit = EvalSampleLimit(type="operator", limit=1)
+
+                        except anyio.get_cancelled_exc_class() as ex:
+                            with anyio.CancelScope(shield=True):
+                                self._cancelled_error = ex
+                                # convert to standard error
+                                self._error = eval_error(
+                                    ex, type(ex), ex, ex.__traceback__
+                                )
+                                transcript()._event(ErrorEvent(error=self._error))
+
+                        except Exception as ex:
+                            self._error, self._raise_error = self._handle_error(ex)
+
+                        # mark completed
+                        assert self._state is not None
+                        self._state.completed = True
+
+                        # set timeout for scoring. if the original timeout was hit we still
+                        # want to provide opportunity for scoring, but we don't necessarily
+                        # want to wait the full timeout again (especially in the case where
+                        # the cause of the timeout is a hung container and scoring requires
+                        # interacting with the container). as a middle ground we use half
+                        # of the original timeout value for scoring.
+                        scoring_time_limit = (
+                            self._time_limit / 2 if self._time_limit else None
+                        )
+
+                        set_sample_state(self._state)
+                        if self._state.scores is None:
+                            self._state.scores = {}
+                        solver_score_names = [*self._state.scores]
+
+                        # scoring
+                        with anyio.CancelScope(
+                            shield=self._cancelled_error is not None
+                        ):
+                            await emit_sample_scoring(
+                                self._eval_set_id,
+                                self._run_id,
+                                self._task_id,
+                                self._state.uuid,
+                            )
+                            try:
+                                # timeout during scoring will result in an ordinary sample error
+                                with create_time_limit(scoring_time_limit):
+                                    # score on success, or when score_on_error is on
+                                    # for the final attempt (no retries left, not cancelled)
+                                    if self._error is None or (
+                                        self._score_on_error
+                                        and self._retry_on_error == 0
+                                        and self._cancelled_error is None
+                                    ):
+                                        async with span(name="scorers"):
+                                            for scorer_idx, scorer in enumerate(
+                                                self._scorers or []
+                                            ):
+                                                scorer_name = (
+                                                    self._scorer_names[scorer_idx]
+                                                    if self._scorer_names
+                                                    else unique_scorer_name(
+                                                        scorer,
+                                                        list(
+                                                            {
+                                                                *solver_score_names,
+                                                                *results,
+                                                            }
+                                                        ),
+                                                    )
+                                                )
+                                                async with span(
+                                                    name=scorer_name, type="scorer"
+                                                ):
+                                                    if not scorer:
+                                                        continue
+                                                    score_result = await scorer(
+                                                        self._state,
+                                                        Target(sample.target),
+                                                    )
+                                                    if (
+                                                        scorer_name
+                                                        in self._state.scores
+                                                    ):
+                                                        raise RuntimeError(
+                                                            f"Scorer {scorer_name} has modified state.scores"
+                                                        )
+                                                    if score_result is not None:
+                                                        self._state.scores[
+                                                            scorer_name
+                                                        ] = score_result
+
+                                                        transcript()._event(
+                                                            ScoreEvent(
+                                                                score=score_result,
+                                                                target=sample.target,
+                                                                scorer=scorer_name,
+                                                                scorer_args=registry_params(
+                                                                    scorer
+                                                                )
+                                                                if has_registry_params(
+                                                                    scorer
+                                                                )
+                                                                else None,
+                                                                model_usage=sample_model_usage()
+                                                                or None,
+                                                                role_usage=sample_role_usage()
+                                                                or None,
+                                                            )
+                                                        )
+
+                                                        results[scorer_name] = (
+                                                            SampleScore(
+                                                                score=score_result,
+                                                                sample_id=sample.id,
+                                                                sample_metadata=sample.metadata,
+                                                                scorer=registry_unqualified_name(
+                                                                    scorer
+                                                                ),
+                                                            )
+                                                        )
+
+                                    for name in solver_score_names:
+                                        score = self._state.scores[name]
+                                        transcript()._event(
+                                            ScoreEvent(
+                                                score=score,
+                                                target=sample.target,
+                                                scorer=name,
+                                                model_usage=sample_model_usage()
+                                                or None,
+                                                role_usage=sample_role_usage() or None,
+                                            )
+                                        )
+                                        results[name] = SampleScore(
+                                            score=score,
+                                            sample_id=self._state.sample_id,
+                                            sample_metadata=self._state.metadata,
+                                        )
+
+                            except anyio.get_cancelled_exc_class() as ex:
+                                with anyio.CancelScope(shield=True):
+                                    self._cancelled_error = ex
+                                    if active.interrupt_action:
+                                        transcript()._event(
+                                            SampleLimitEvent(
+                                                type="operator",
+                                                message="Unable to score sample due to operator interruption",
+                                            )
+                                        )
+
+                                    # convert to standard error
+                                    self._error = eval_error(
+                                        ex, type(ex), ex, ex.__traceback__
+                                    )
+                                    transcript()._event(ErrorEvent(error=self._error))
+
+                            except Exception as ex:
+                                if active.interrupt_action is not None:
+                                    # Operator-interrupted: log to transcript but
+                                    # don't propagate to error/retry. The operator
+                                    # EvalSampleLimit is set in the run() handler.
+                                    scorer_error = eval_error(
+                                        ex, type(ex), ex, ex.__traceback__
+                                    )
+                                    transcript()._event(ErrorEvent(error=scorer_error))
+                                else:
+                                    self._error, self._raise_error = self._handle_error(
+                                        ex
+                                    )
+                            finally:
+                                # run task cleanup if required (inside sandbox context)
+                                if self._cleanup is not None:
+                                    with anyio.CancelScope(shield=True):
+                                        try:
+                                            await self._cleanup(self._state)
+                                        except Exception as ex:
+                                            py_logger.warning(
+                                                f"Exception occurred during task cleanup: {ex}",
+                                                exc_info=ex,
+                                            )
+
+                except Exception as ex:
+                    self._error, self._raise_error = self._handle_error(ex)
+                finally:
+                    # cleanup the task init span if required
+                    if cleanup_span is not None:
+                        with anyio.CancelScope(
+                            shield=self._cancelled_error is not None
+                        ):
+                            await cleanup_span.__aexit__(None, None, None)
+
+                # complete the sample if there is no error or if there is no retry_on_error in play
+                with anyio.CancelScope(shield=self._cancelled_error is not None):
+                    # drain sample events for both completion and retry paths
+                    await drain_sample_events()
+
+                    if (
+                        not self._error
+                        or (self._retry_on_error == 0)
+                        or (self._cancelled_error is not None)
+                    ):
+                        self._progress(SAMPLE_TOTAL_PROGRESS_UNITS)
+
+                        assert self._state is not None
+                        sample = self._sample
+                        state = self._state
+
+                        # if we are logging images then be sure to base64 images injected by solvers
+                        if self._log_images:
+                            state = (await states_with_base64_content([state]))[0]
+
+                        # otherwise ensure there are no base64 images in sample or messages
+                        else:
+                            sample = sample_without_base64_content(sample)
+                            state = state_without_base64_content(state)
+
+                        # publish back so post-loop branches see the cleaned versions
+                        self._sample = sample
+                        self._state = state
+
+                        # emit/log sample end
+                        def make_eval_sample(
+                            include_events: bool = True,
+                        ) -> EvalSample:
+                            return create_eval_sample(
+                                start_time=start_time,
+                                sample=sample,
+                                state=state,
+                                scores=results,
+                                error=self._error,
+                                limit=limit,
+                                error_retries=self._error_retries,
+                                started_at=sample_start_datetime(),
+                                include_events=include_events,
+                            )
+
+                        if self._logger:
+                            eval_sample = await log_sample(
+                                eval_sample=make_eval_sample(
+                                    include_events=self._logger.buffer_db is None
+                                ),
+                                logger=self._logger,
+                                log_images=self._log_images,
+                            )
+                        else:
+                            eval_sample = make_eval_sample()
+                        # Call via module attribute so tests can monkey-patch
+                        # `inspect_ai._eval.task.scan.scan_eval_sample` to
+                        # inject crash/error behaviour. See e.g.
+                        # tests/test_eval_set_scanner.py::
+                        # test_eval_set_resume_scans_when_intermediate_run_crashed_after_clean_finalize
+                        # — a `from .scan import scan_eval_sample` here would
+                        # bind the symbol at import time and bypass the patch.
+                        await _scan_mod.scan_eval_sample(
+                            eval_sample,
+                            self._scanner,
+                            scan_id=self._scan_id,
+                            eval_id=self._task_id,
+                            log_location=self._log_location,
+                            model=str(state.model),
+                            eval_spec=self._logger.eval if self._logger else None,
+                        )
+                        await self._emit_attempt_end(will_retry=False)
+                        await emit_sample_end(
+                            self._eval_set_id,
+                            self._run_id,
+                            self._task_id,
+                            state.uuid,
+                            eval_sample,
+                        )
+
+        # error that should be retried (we do this outside of the above scope so that we can
+        # retry outside of the original semaphore -- our retry will therefore go to the back
+        # of the sample queue)
+        if (
+            self._error
+            and self._retry_on_error > 0
+            and self._cancelled_error is None
+            and active.interrupt_action is None
+        ):
+            await self._emit_attempt_end(will_retry=True)
+
+            assert self._state is not None
+
+            # remove any buffered sample events
+            if self._logger is not None:
+                self._logger.remove_sample(self._state.sample_id, self._state.epoch)
+
+            # recurse w/ tick down of retry_on_error and append of error to error_retries
+            return await SampleRunner(
+                task_name=self._task_name,
+                log_location=self._log_location,
+                create_sample_state=self._create_sample_state,
+                sandbox=self._sandbox,
+                checkpoint=self._checkpoint,
+                eval_checkpoint=self._eval_checkpoint,
+                resume_checkpoint=self._resume_checkpoint,
+                max_sandboxes=self._max_sandboxes,
+                sandbox_cleanup=self._sandbox_cleanup,
+                plan=self._plan,
+                scorers=self._scorers,
+                scorer_names=self._scorer_names,
+                scanner=self._scanner,
+                cleanup=self._cleanup,
+                generate=self._generate,
+                progress=self._progress,
+                logger=self._logger,
+                log_images=self._log_images,
+                log_model_api=self._log_model_api,
+                sample_error=self._sample_error,
+                sample_complete=self._sample_complete,
+                early_stopping=self._early_stopping,
+                fails_on_error=self._fails_on_error,
+                # tick retry count down
+                retry_on_error=self._retry_on_error - 1,
+                score_on_error=self._score_on_error,
+                # forward on error that caused retry
+                error_retries=[*self._error_retries, eval_retry_error(self._error)],
+                time_limit=self._time_limit,
+                working_limit=self._working_limit,
+                semaphore=self._semaphore,
+                eval_set_id=self._eval_set_id,
+                run_id=self._run_id,
+                task_id=self._task_id,
+                scan_id=self._scan_id,
+                sample_uuid=self._state.uuid,
+            ).run()
+
+        # re-raise cancellation after logging to preserve structured concurrency
+        elif self._cancelled_error is not None:
+            raise self._cancelled_error
+
+        # no error
+        elif self._error is None:
+            # call sample_complete callback if we have score results
+            assert self._state is not None
+            if results is not None:
+                await self._sample_complete(
+                    self._state.sample_id, self._state.epoch, results
+                )
+            return results
+
+        # we have an error and should raise it
+        elif self._raise_error is not None:
+            raise self._raise_error
+
+        # we have an error and should not raise it
+        else:
+            return None

--- a/tests/_eval/task/test_sample_runner.py
+++ b/tests/_eval/task/test_sample_runner.py
@@ -1,0 +1,611 @@
+"""Integration tests for `SampleRunner` (PR 1 of the EvalSession RFC).
+
+Driven via the public `eval()` entry point — `task_run` now instantiates one
+`SampleRunner` per (sample, epoch) pair, so this is the realistic path the
+runner takes in production. Tests cover the four invariants the plan names:
+
+1. Three-class exception taxonomy + early-stop.
+2. Hook firing order on every exit path.
+3. Per-sample contextvar isolation under concurrent `tg_collect`.
+4. `DiskSampleStore` deferred sample materialisation.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Generator, Type, TypeVar
+
+import pytest
+from pydantic import JsonValue
+
+import inspect_ai.hooks._startup as hooks_startup_module
+from inspect_ai import Task, eval
+from inspect_ai._util.registry import _registry, registry_lookup
+from inspect_ai.dataset import MemoryDataset, Sample
+from inspect_ai.hooks._hooks import (
+    Hooks,
+    SampleAttemptEnd,
+    SampleAttemptStart,
+    SampleEnd,
+    SampleEvent,
+    SampleInit,
+    SampleStart,
+    hooks,
+)
+from inspect_ai.scorer import Score, Scorer, Target, mean, scorer, stderr
+from inspect_ai.solver import Generate, Solver, TaskState, solver
+from inspect_ai.solver._solver import generate
+from inspect_ai.solver._task_state import sample_state, set_sample_state
+from inspect_ai.util._early_stopping import EarlyStop
+
+# `failing_solver_deterministic` lives in the repo's shared test_helpers package
+# (see e.g. tests/test_score_on_error.py:4). Import it the same way.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1].parent))
+from test_helpers.utils import failing_solver_deterministic  # noqa: E402
+
+if TYPE_CHECKING:
+    from inspect_ai.log._log import EvalSpec
+    from inspect_ai.scorer._metric import SampleScore as _SampleScoreType
+
+
+# -- shared fixtures / hook recorder --------------------------------------------------
+
+
+class _RecordingHooks(Hooks):
+    """Captures every sample-level hook call in firing order across all samples."""
+
+    def __init__(self) -> None:
+        self.timeline: list[tuple[str, str | int | None]] = []
+        self.sample_init_events: list[SampleInit] = []
+        self.sample_start_events: list[SampleStart] = []
+        self.sample_attempt_start_events: list[SampleAttemptStart] = []
+        self.sample_attempt_end_events: list[SampleAttemptEnd] = []
+        self.sample_event_events: list[SampleEvent] = []
+        self.sample_end_events: list[SampleEnd] = []
+
+    def enabled(self) -> bool:
+        return True
+
+    async def on_sample_init(self, data: SampleInit) -> None:
+        self.timeline.append(("init", data.summary.id))
+        self.sample_init_events.append(data)
+
+    async def on_sample_start(self, data: SampleStart) -> None:
+        self.timeline.append(("start", data.summary.id))
+        self.sample_start_events.append(data)
+
+    async def on_sample_attempt_start(self, data: SampleAttemptStart) -> None:
+        self.timeline.append(("attempt_start", data.summary.id))
+        self.sample_attempt_start_events.append(data)
+
+    async def on_sample_attempt_end(self, data: SampleAttemptEnd) -> None:
+        self.timeline.append(("attempt_end", data.summary.id))
+        self.sample_attempt_end_events.append(data)
+
+    async def on_sample_event(self, data: SampleEvent) -> None:
+        self.sample_event_events.append(data)
+
+    async def on_sample_end(self, data: SampleEnd) -> None:
+        self.timeline.append(("end", data.sample.id))
+        self.sample_end_events.append(data)
+
+    def attempt_count(self, sample_id: str | int) -> int:
+        return sum(
+            1
+            for kind, sid in self.timeline
+            if kind == "attempt_start" and sid == sample_id
+        )
+
+    def kinds_for(self, sample_id: str | int) -> list[str]:
+        return [kind for kind, sid in self.timeline if sid == sample_id]
+
+
+T = TypeVar("T", bound=Hooks)
+
+
+def _create_recorder(name: str, cls: Type[T]) -> Generator[T, None, None]:
+    @hooks(name, description=f"{name}-description")
+    def _get() -> type[T]:
+        return cls
+
+    hook = registry_lookup("hooks", name)
+    assert isinstance(hook, cls)
+    try:
+        yield hook
+    finally:
+        del _registry[f"hooks:{name}"]
+
+
+@pytest.fixture(autouse=True)
+def _reset_hooks() -> None:
+    hooks_startup_module._registry_hooks_loaded = False
+
+
+@pytest.fixture
+def recorder() -> Generator[_RecordingHooks, None, None]:
+    yield from _create_recorder("test_sample_runner_recorder", _RecordingHooks)
+
+
+# -- shared scorer --------------------------------------------------------------------
+
+
+@scorer(metrics=[mean(), stderr()])
+def constant_scorer(value: float = 1.0) -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        return Score(value=value)
+
+    return score
+
+
+# -- (1) Three-class exception taxonomy + early-stop ---------------------------------
+
+
+def test_runner_returns_scores_on_success() -> None:
+    log = eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=generate(),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+    )[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    assert log.samples[0].error is None
+    assert log.samples[0].scores is not None
+    assert len(log.samples[0].scores) == 1
+
+
+def test_runner_retries_on_recoverable_error_then_succeeds() -> None:
+    """retry_on_error > 0 → recurse; the retry is recorded in error_retries."""
+    log = eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=failing_solver_deterministic([True, False]),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+        retry_on_error=3,
+    )[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    sample = log.samples[0]
+    assert sample.error is None
+    # error_retries records each prior failed attempt
+    assert sample.error_retries is not None
+    assert len(sample.error_retries) == 1
+    assert "Eval failed!" in sample.error_retries[0].message
+
+
+def test_runner_raises_on_terminal_error_with_fail_on_error_true() -> None:
+    log = eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=failing_solver_deterministic([True]),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+        retry_on_error=0,
+        fail_on_error=True,
+    )[0]
+    # fail_on_error=True turns a sample error into an eval-level error
+    assert log.status == "error"
+
+
+def test_runner_returns_none_on_terminal_error_with_score_on_error() -> None:
+    """Score the failing sample but keep the eval running.
+
+    retry_on_error=0, score_on_error=True → runner returns the dict from
+    error-path scoring, errored=True. Eval continues; sample has both error
+    and scores.
+    """
+    log = eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=failing_solver_deterministic([True]),
+            scorer=constant_scorer(),
+            score_on_error=True,
+            fail_on_error=False,
+        ),
+        model="mockllm/model",
+        retry_on_error=0,
+    )[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    sample = log.samples[0]
+    assert sample.error is not None
+    assert sample.scores is not None and len(sample.scores) > 0
+
+
+def test_runner_emits_early_stop_when_early_stopping_returns_directive() -> None:
+    """Stopping a single sample short-circuits its runner without errors.
+
+    An EarlyStopping that fires for sample 2 → the runner short-circuits
+    that sample and the eval finalises cleanly.
+    """
+
+    class _StopSampleTwo:
+        async def start_task(
+            self, task: "EvalSpec", samples: list[Sample], epochs: int
+        ) -> str:
+            return "stop_two"
+
+        async def schedule_sample(self, id: str | int, epoch: int) -> EarlyStop | None:
+            if id == 2:
+                return EarlyStop(id=id, epoch=epoch, reason="stop sample 2")
+            return None
+
+        async def complete_sample(
+            self,
+            id: str | int,
+            epoch: int,
+            scores: dict[str, "_SampleScoreType"],
+        ) -> None:
+            pass
+
+        async def complete_task(self) -> dict[str, JsonValue]:
+            return {}
+
+    log = eval(
+        Task(
+            dataset=MemoryDataset(
+                [
+                    Sample(id=1, input="hi", target="hi"),
+                    Sample(id=2, input="hi", target="hi"),
+                    Sample(id=3, input="hi", target="hi"),
+                ]
+            ),
+            solver=generate(),
+            scorer=constant_scorer(),
+            early_stopping=_StopSampleTwo(),
+        ),
+        model="mockllm/model",
+    )[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    # sample 2 was stopped early; samples 1 and 3 ran normally
+    ran_ids = {s.id for s in log.samples}
+    assert 1 in ran_ids and 3 in ran_ids
+    # the early-stopping summary records the stop
+    assert log.results is not None
+    assert log.results.early_stopping is not None
+    stops = log.results.early_stopping.early_stops
+    assert any(s.id == 2 for s in stops)
+
+
+# -- (2) Hook firing order on every exit path ---------------------------------------
+
+
+def test_hooks_success_path(recorder: _RecordingHooks) -> None:
+    """Success: init → start → attempt_start → attempt_end → end."""
+    eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=generate(),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+    )
+    assert recorder.kinds_for(1) == [
+        "init",
+        "start",
+        "attempt_start",
+        "attempt_end",
+        "end",
+    ]
+
+
+def test_hooks_retry_path(recorder: _RecordingHooks) -> None:
+    """Hook firing across retry attempts.
+
+    init/start fire once; attempt_start/attempt_end fire per attempt;
+    end fires once at the terminal attempt.
+    """
+    eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=failing_solver_deterministic([True, True, False]),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+        retry_on_error=5,
+    )
+    kinds = recorder.kinds_for(1)
+    assert kinds.count("init") == 1
+    assert kinds.count("start") == 1
+    assert kinds.count("end") == 1
+    assert kinds.count("attempt_start") == 3
+    assert kinds.count("attempt_end") == 3
+    # init/start come first; end comes last
+    assert kinds[0] == "init"
+    assert kinds[1] == "start"
+    assert kinds[-1] == "end"
+
+
+def test_hooks_terminal_error_path(recorder: _RecordingHooks) -> None:
+    """Terminal error (fail_on_error=False) still fires the full terminal sequence."""
+    eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=failing_solver_deterministic([True]),
+            scorer=constant_scorer(),
+            score_on_error=True,
+            fail_on_error=False,
+        ),
+        model="mockllm/model",
+        retry_on_error=0,
+    )
+    kinds = recorder.kinds_for(1)
+    # both attempt_end AND end fire on the terminal-error path
+    assert kinds.count("init") == 1
+    assert kinds.count("start") == 1
+    assert kinds.count("attempt_start") == 1
+    assert kinds.count("attempt_end") == 1
+    assert kinds.count("end") == 1
+
+
+def test_hooks_early_stop_path(recorder: _RecordingHooks) -> None:
+    """Early stop: terminal sequence still completes for the stopped sample."""
+
+    class _StopAll:
+        async def start_task(
+            self, task: "EvalSpec", samples: list[Sample], epochs: int
+        ) -> str:
+            return "stop"
+
+        async def schedule_sample(self, id: str | int, epoch: int) -> EarlyStop | None:
+            return EarlyStop(id=id, epoch=epoch, reason="stop")
+
+        async def complete_sample(
+            self,
+            id: str | int,
+            epoch: int,
+            scores: dict[str, "_SampleScoreType"],
+        ) -> None:
+            pass
+
+        async def complete_task(self) -> dict[str, JsonValue]:
+            return {}
+
+    eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=generate(),
+            scorer=constant_scorer(),
+            early_stopping=_StopAll(),
+        ),
+        model="mockllm/model",
+    )
+    # An early-stopped sample never enters init/start/attempt — it is short-
+    # circuited before the runner is awarded the semaphore. We just assert no
+    # spurious end events fired without matching attempt_starts.
+    kinds = recorder.kinds_for(1)
+    assert kinds.count("attempt_end") == kinds.count("attempt_start")
+    assert kinds.count("end") <= kinds.count("init")
+
+
+def test_hooks_uuid_stable_across_attempts(recorder: _RecordingHooks) -> None:
+    """sample_uuid is stable across retry attempts.
+
+    The constructor-injected `sample_uuid` flows through retries — every
+    attempt_start/attempt_end carries the same id as the init/end.
+    """
+    eval(
+        Task(
+            dataset=MemoryDataset([Sample(id=1, input="hi", target="hi")]),
+            solver=failing_solver_deterministic([True, False]),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+        retry_on_error=3,
+    )
+    init_uuid = recorder.sample_init_events[0].sample_id
+    assert recorder.sample_end_events[0].sample_id == init_uuid
+    for start_evt in recorder.sample_attempt_start_events:
+        assert start_evt.sample_id == init_uuid
+    for end_evt in recorder.sample_attempt_end_events:
+        assert end_evt.sample_id == init_uuid
+
+
+# -- (3) Per-sample contextvar isolation under concurrent tg_collect ----------------
+
+
+@solver
+def assert_distinct_state_solver() -> Solver:
+    """Verify `sample_state()` resolves to this sample's own TaskState.
+
+    Returns the same TaskState that was set at the top of this sample's run,
+    even after an `await`. If contextvars leaked across concurrent runners
+    we'd see another sample's state here.
+    """
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        # Tag the current sample's state with a unique marker derived from its
+        # input — this guards against a TaskState shared across coroutines.
+        marker = f"marker_{state.sample_id}"
+        state.metadata["marker"] = marker
+        set_sample_state(state)
+
+        import anyio
+
+        await anyio.sleep(0.01)
+        # Verify the contextvar still resolves to OUR state, not a sibling's
+        retrieved = sample_state()
+        assert retrieved is state, (
+            f"contextvar leak: expected state for sample {state.sample_id}, "
+            f"got {retrieved.sample_id if retrieved else None}"
+        )
+        assert retrieved.metadata.get("marker") == marker
+        return state
+
+    return solve
+
+
+def test_per_sample_contextvar_isolation_concurrent() -> None:
+    """Concurrent samples never see each other's contextvar state.
+
+    N samples run concurrently via tg_collect; each must see its own
+    contextvar state across an await without cross-talk.
+    """
+    n = 8
+    log = eval(
+        Task(
+            dataset=MemoryDataset(
+                [Sample(id=i, input=f"q{i}", target="hi") for i in range(1, n + 1)]
+            ),
+            solver=assert_distinct_state_solver(),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+        max_samples=n,
+    )[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    assert len(log.samples) == n
+    # If the asserts inside the solver had failed, status would be "error"
+    for s in log.samples:
+        assert s.error is None
+
+
+# -- (4) DiskSampleStore deferred sample materialisation ----------------------------
+
+
+def test_disk_sample_store_deferred_materialisation() -> None:
+    """An eval paged through disk completes successfully.
+
+    When a `DiskSampleStore` is used, `create_sample_state` must defer the
+    actual sample read until after the semaphore is acquired — the eval
+    completes successfully even when paged through disk. (`max_dataset_memory=0`
+    forces every sample through `DiskSampleStore`.)
+    """
+    samples = [Sample(input=f"Say {i}", target=str(i)) for i in range(3)]
+    log = eval(
+        Task(
+            dataset=samples,
+            solver=generate(),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+        max_dataset_memory=0,
+    )[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    assert len(log.samples) == 3
+
+
+def test_disk_sample_store_deferred_materialisation_with_retry() -> None:
+    """Retry path is also lazy-materialisation safe.
+
+    The recursive SampleRunner construction in the retry path must re-use
+    the same lazy `create_sample_state` callable.
+    """
+    samples = [Sample(id=1, input="hi", target="hi")]
+    log = eval(
+        Task(
+            dataset=samples,
+            solver=failing_solver_deterministic([True, False]),
+            scorer=constant_scorer(),
+        ),
+        model="mockllm/model",
+        max_dataset_memory=0,
+        retry_on_error=3,
+    )[0]
+    assert log.status == "success"
+    assert log.samples is not None
+    sample = log.samples[0]
+    assert sample.error is None
+    assert sample.error_retries is not None
+    assert len(sample.error_retries) == 1
+
+
+# -- (5) Cancellation propagates through the runner ---------------------------------
+
+
+def test_runner_cancellation_via_task_cancel() -> None:
+    """Cancelling a sample mid-solve via TaskCancel.cancel_task('abort') unwinds.
+
+    The reviewer's RFC notes cancellation as a v1 risk path. The runner
+    handles cancellation by re-raising at the `tg_collect` boundary; this
+    test asserts the eval finalises with status='error' and the cancel
+    propagates rather than hanging.
+    """
+    import tempfile
+    from unittest.mock import patch
+
+    import anyio
+
+    from inspect_ai._display.core.display import TaskCancel
+    from inspect_ai._eval.evalset import eval_set
+    from inspect_ai._eval.task.run import task_run as original_task_run
+
+    cancel_holder: list[TaskCancel] = []
+
+    async def capturing_task_run(
+        options: object, task_cancel: TaskCancel | None = None
+    ) -> object:
+        if task_cancel is not None:
+            cancel_holder.append(task_cancel)
+        return await original_task_run(options, task_cancel=task_cancel)  # type: ignore[arg-type]
+
+    solver_id = id(cancel_holder)
+
+    @solver(name=f"runner_cancel_solver_{solver_id}")
+    def cancelling_solver() -> Any:
+        async def solve(state: TaskState, gen: Generate) -> TaskState:
+            # wait until we've captured the TaskCancel handle
+            while not cancel_holder:
+                await anyio.sleep(0.01)
+            cancel_holder[0].cancel_task("abort")
+            await anyio.sleep(5)  # give cancellation time to propagate
+            return state
+
+        return solve
+
+    with tempfile.TemporaryDirectory() as log_dir:
+        with patch("inspect_ai._eval.run.task_run", capturing_task_run):
+            success, logs = eval_set(
+                tasks=[
+                    Task(
+                        dataset=[Sample(id=1, input="hi", target="hi")],
+                        solver=[cancelling_solver()],
+                        scorer=constant_scorer(),
+                        name="task_runner_cancel",
+                    )
+                ],
+                log_dir=log_dir,
+                model="mockllm/model",
+                retry_attempts=1,
+                retry_immediate=True,
+                max_tasks=1,
+            )
+
+    # eval_set returns normally (does not raise) — the runner handled the
+    # cancellation cleanly rather than letting an exception group escape.
+    assert not success
+    assert len(logs) == 1
+    assert logs[0].status == "error"
+
+
+# -- (bonus) regression: SampleRunner constructor signature stays mechanical --------
+
+
+def test_sample_runner_class_is_used_by_task_run() -> None:
+    """task_run uses SampleRunner, not the deleted task_run_sample.
+
+    Guards against an accidental fallback to the now-deleted helper.
+    """
+    import inspect
+
+    from inspect_ai._eval.task import run as run_mod
+    from inspect_ai._eval.task.sample_runner import SampleRunner
+
+    src = inspect.getsource(run_mod.task_run)
+    assert "SampleRunner(" in src, (
+        "task_run should construct SampleRunner instead of calling task_run_sample"
+    )
+    # And the deleted symbol must not have come back
+    assert not hasattr(run_mod, "task_run_sample")
+    # And the runner has the documented public surface
+    assert hasattr(SampleRunner, "run")
+    assert callable(SampleRunner.run)

--- a/tests/test_eval_set_scanner.py
+++ b/tests/test_eval_set_scanner.py
@@ -1178,11 +1178,11 @@ def test_eval_set_resume_scans_when_finalize_did_not_run_cleanly() -> None:
     Final state — parquet rows: [1, 2 (error), 3, 4, 5]; all 5 ids
     present. summary.scans == 5, summary.errors == 1 (still just id 2).
     """
-    import inspect_ai._eval.task.run as run_mod
+    import inspect_ai._eval.task.scan as scan_mod
     from inspect_ai import ScannerConfig
 
     n = 5
-    orig_scan_eval_sample = run_mod.scan_eval_sample  # type: ignore[attr-defined]
+    orig_scan_eval_sample = scan_mod.scan_eval_sample
 
     async def skip_sample_3(eval_sample, scanner, **kwargs):
         # simulate a crash in the window between log_sample and
@@ -1210,7 +1210,7 @@ def test_eval_set_resume_scans_when_finalize_did_not_run_cleanly() -> None:
         # never started" gap); scanner naturally errors on id 2 (the
         # "scan started, errored" case); ids 4, 5 fail solver and are
         # filtered out of scanning entirely.
-        run_mod.scan_eval_sample = skip_sample_3  # type: ignore[attr-defined]
+        scan_mod.scan_eval_sample = skip_sample_3
         try:
             eval_set(
                 tasks=make_task(),
@@ -1223,7 +1223,7 @@ def test_eval_set_resume_scans_when_finalize_did_not_run_cleanly() -> None:
                 display="none",
             )
         finally:
-            run_mod.scan_eval_sample = orig_scan_eval_sample  # type: ignore[attr-defined]
+            scan_mod.scan_eval_sample = orig_scan_eval_sample
 
         scan_dir = _scan_dir(log_dir)
         summary_1 = _read_summary(scan_dir)
@@ -1362,7 +1362,6 @@ def test_eval_set_resume_scans_when_intermediate_run_crashed_after_clean_finaliz
     parquet/buffer state per sample rather than trusting the stale
     summary.
     """
-    import inspect_ai._eval.task.run as run_mod
     import inspect_ai._eval.task.scan as scan_mod
     from inspect_ai import ScannerConfig
 
@@ -1406,7 +1405,7 @@ def test_eval_set_resume_scans_when_intermediate_run_crashed_after_clean_finaliz
         # - scan_eval_sample is no-op for id 4 (sample logged, scan
         #   never started — the gap)
         # - scan_finalize is no-op (process killed before sync ran)
-        orig_scan_eval_sample = run_mod.scan_eval_sample  # type: ignore[attr-defined]
+        orig_scan_eval_sample = scan_mod.scan_eval_sample
         orig_scan_finalize = scan_mod.scan_finalize
 
         async def skip_sample_4(eval_sample, scanner, **kwargs):
@@ -1417,7 +1416,6 @@ def test_eval_set_resume_scans_when_intermediate_run_crashed_after_clean_finaliz
         async def no_finalize(*args, **kwargs):
             return
 
-        run_mod.scan_eval_sample = skip_sample_4  # type: ignore[attr-defined]
         scan_mod.scan_eval_sample = skip_sample_4
         scan_mod.scan_finalize = no_finalize
         try:
@@ -1431,7 +1429,6 @@ def test_eval_set_resume_scans_when_intermediate_run_crashed_after_clean_finaliz
                 display="none",
             )
         finally:
-            run_mod.scan_eval_sample = orig_scan_eval_sample  # type: ignore[attr-defined]
             scan_mod.scan_eval_sample = orig_scan_eval_sample
             scan_mod.scan_finalize = orig_scan_finalize
 
@@ -1542,8 +1539,6 @@ def test_eval_set_resume_short_circuits_when_prior_scan_clean() -> None:
     the success-logs → PreviousTask routing entirely. The scanner is
     never invoked again — confirms the fast-path optimization works.
     """
-    from unittest.mock import patch
-
     n = 3
 
     def make_task() -> Task:
@@ -1573,17 +1568,15 @@ def test_eval_set_resume_short_circuits_when_prior_scan_clean() -> None:
         # success_logs are returned directly and the scanner is never
         # called. We assert this by patching scan_eval_sample to track
         # invocations: it must NOT be called during run 2.
-        import inspect_ai._eval.task.run as run_mod
         import inspect_ai._eval.task.scan as scan_mod
 
         invocations: list[str] = []
-        orig = run_mod.scan_eval_sample  # type: ignore[attr-defined]
+        orig = scan_mod.scan_eval_sample
 
         async def tracking(eval_sample, scanner, **kwargs):
             invocations.append(str(eval_sample.id))
             return await orig(eval_sample, scanner, **kwargs)
 
-        run_mod.scan_eval_sample = tracking  # type: ignore[attr-defined]
         scan_mod.scan_eval_sample = tracking
         try:
             eval_set(
@@ -1595,7 +1588,6 @@ def test_eval_set_resume_short_circuits_when_prior_scan_clean() -> None:
                 display="none",
             )
         finally:
-            run_mod.scan_eval_sample = orig  # type: ignore[attr-defined]
             scan_mod.scan_eval_sample = orig
 
         assert invocations == [], (
@@ -1606,8 +1598,6 @@ def test_eval_set_resume_short_circuits_when_prior_scan_clean() -> None:
         # also: the on-disk scan output is unchanged (no extra rows)
         pf = _read_parquet(scan_dir / "echo_scanner.parquet")
         assert pf.metadata.num_rows == n
-        # silence unused-import warning
-        del patch
 
 
 def test_summary_complete_flips_to_false_when_resume_introduces_scan_errors() -> None:


### PR DESCRIPTION
Part of #4067 (the RFC for an online/streaming evaluation primitive). First of three PRs; this one ships the shared per-sample execution unit the other two depend on. Does not close the issue — that happens after PRs 2 and 3 land.

## Summary

Extract the per-sample execution body (`task_run_sample`, ~688 lines / ~30 keyword params) out of `_eval/task/run.py` into a new `SampleRunner` class. The two follow-up PRs in #4067 — extending `eval_async` to accept `AsyncIterable[Sample]` (option **(d)** in the RFC), and a thin `EvalSession` async-context wrapper (option **(a)**) — both need a single reusable per-sample execution unit; this PR is that unit.

**No public API change.** `eval()` / `eval_async()` / `eval_set()` still route through the runner via the existing `task_run` call site. Hook firing order, retry semantics, and per-sample contextvar isolation are preserved.

## What changed

- **New** `src/inspect_ai/_eval/task/sample_runner.py` — `SampleRunner` class with one public coroutine, `run() -> dict[str, SampleScore] | EarlyStop | None`. The closures `on_sample_event` / `handle_error` / `emit_attempt_end` become private methods. Retry recursion constructs a fresh `SampleRunner` with `retry_on_error - 1` and the appended `error_retries`.
- **New** `src/inspect_ai/_eval/task/sample_helpers.py` — hosts `create_eval_sample`, `log_sample`, `init_sample_assistant_internal`, and `eval_retry_error` (renamed from `_eval_retry_error`). Both `run.py` and `sample_runner.py` import from here so the dependency is a DAG, not a cycle. `find_spec` for `openai` / `anthropic` is wrapped in a `@functools.cache`d `_has_package` accessor.
- **Modified** `src/inspect_ai/_eval/task/run.py` — `task_run_sample` deleted; the inner `run_sample` closure now `await`s `SampleRunner(...).run()`. Re-exports `init_sample_assistant_internal` and `log_sample` from `sample_helpers` for external import-path compatibility (`tests/_eval/test_init_sample_assistant_internal.py`, `tests/log/test_streaming_completion.py`).
- **New** `tests/_eval/task/test_sample_runner.py` — 15 property / integration tests covering:
  - the three-class exception taxonomy (success / retry / terminal-error / cancel / early-stop),
  - hook firing order on every exit path,
  - per-sample contextvar isolation under concurrent `tg_collect`,
  - `DiskSampleStore` lazy materialisation,
  - `TaskCancel.cancel_task('abort')` cancellation through the runner.
- **Modified** `tests/test_eval_set_scanner.py` — drop orphaned `unittest.mock.patch` imports left behind by an earlier edit.

## Deliberately deferred

These are tracked in companion docs and will land before / during PR 2:

- Replacing `self._error` / `self._sample` / etc. (per-run state on `self.*` with `None`-init) with a `_RunState` dataclass — same shape change for every field, easier as its own commit before PR 2 begins.
- A direct-construction `SampleRunner(...).run()` test — the constructor takes 30+ kwargs tightly coupled to `task_run` setup; PR 3's `EvalSession.__aenter__` becomes the real external caller and its tests exercise that boundary.
- `agent_name` derivation duplicated between runner and `inspect_scout` (pre-existing in `main`).
- `KeyboardInterrupt`-from-solver shielding — explicitly PR 3 (`EvalSession.__aexit__` shielded scope per the RFC).

## Test plan

- [ ] `ruff format` + `ruff check` clean
- [ ] `mypy --exclude tests/test_package src tests` — clean
- [ ] `pytest tests/_eval/task/test_sample_runner.py -v` — 15 pass
- [ ] Broader sweep: `tests/_eval/`, `tests/test_task_cancel.py`, `tests/test_eval_set_scanner.py`, `tests/test_disk_sample_store.py`, `tests/test_score_on_error.py`, `tests/test_fail_on_error.py`, `tests/checkpoint/`, `tests/hooks/test_hooks.py`, `tests/log/test_streaming_completion.py`, `tests/_eval/test_init_sample_assistant_internal.py` — 282 pass
- [ ] Full suite green on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
