### PR TITLE
Don't drop in-flight sandbox samples on cancel

### DIFF
--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -23,7 +23,7 @@ from inspect_ai._display import (
 )
 from inspect_ai._display.core.display import TaskCancel, TaskDisplayMetric
 from inspect_ai._eval.task.scan import Scanners
-from inspect_ai._util._async import tg_collect
+from inspect_ai._util._async import aexit_shielded_when, tg_collect
 from inspect_ai._util.async_zip import AsyncZipReader
 from inspect_ai._util.asyncfiles import get_async_filesystem
 from inspect_ai._util.constants import (
@@ -907,9 +907,19 @@ async def task_run_sample(
         init_sample_assistant_internal()
 
         # use sandbox if provided
+        #
+        # The sandbox CM's `__aexit__` is wrapped so its teardown runs shielded
+        # whenever the sample's own cancel was caught upstream (`cancelled_error`
+        # set). Otherwise, the eval-level scope's still-cancelled state would
+        # re-cancel the first await inside `cleanup_sandbox_environments_sample`,
+        # propagating a fresh CancelledError out past the (already shielded)
+        # logging block and dropping the in-flight sample from the eval log.
         sandboxenv_cm = (
-            sandboxenv_context(
-                task_name, sandbox, max_sandboxes, sandbox_cleanup, sample
+            aexit_shielded_when(
+                sandboxenv_context(
+                    task_name, sandbox, max_sandboxes, sandbox_cleanup, sample
+                ),
+                lambda: cancelled_error is not None,
             )
             if sandbox or sample.sandbox is not None
             else contextlib.nullcontext()

--- a/src/inspect_ai/_util/_async.py
+++ b/src/inspect_ai/_util/_async.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 import inspect
 import os
 import sys
@@ -74,6 +75,34 @@ async def tg_collect(
             raise
         else:
             raise ex.exceptions[0] from None
+
+
+class aexit_shielded_when(contextlib.AbstractAsyncContextManager[Any]):
+    """Wrap an async context manager so its `__aexit__` runs shielded when `shield()` is True.
+
+    Lets a caller keep `async with X:` syntax while making the inner CM's
+    teardown uninterruptible under a still-cancelled enclosing scope. `shield`
+    is a callable so it can read state that is only set inside the `async with`
+    body (e.g. a `cancelled_error` local that's `None` at construction time
+    and assigned later).
+    """
+
+    def __init__(
+        self,
+        inner: contextlib.AbstractAsyncContextManager[Any],
+        shield: Callable[[], bool],
+    ) -> None:
+        self._inner = inner
+        self._shield = shield
+
+    async def __aenter__(self) -> Any:
+        return await self._inner.__aenter__()
+
+    async def __aexit__(
+        self, exc_type: Any, exc_value: Any, traceback: Any
+    ) -> Any:
+        with anyio.CancelScope(shield=self._shield()):
+            return await self._inner.__aexit__(exc_type, exc_value, traceback)
 
 
 async def coro_print_exceptions(

--- a/src/inspect_ai/_util/_async.py
+++ b/src/inspect_ai/_util/_async.py
@@ -98,9 +98,7 @@ class aexit_shielded_when(contextlib.AbstractAsyncContextManager[Any]):
     async def __aenter__(self) -> Any:
         return await self._inner.__aenter__()
 
-    async def __aexit__(
-        self, exc_type: Any, exc_value: Any, traceback: Any
-    ) -> Any:
+    async def __aexit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> Any:
         with anyio.CancelScope(shield=self._shield()):
             return await self._inner.__aexit__(exc_type, exc_value, traceback)
 

--- a/tests/test_cancellation_logging.py
+++ b/tests/test_cancellation_logging.py
@@ -5,18 +5,55 @@ with fail_on_error, or due to a KeyboardInterrupt), the cancelled samples
 are fully logged with their errors in the eval log.
 """
 
+import contextlib
 import os
 import signal
 import threading
 from pathlib import Path
 
 import anyio
+import pytest
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
 from inspect_ai.log import list_eval_logs, read_eval_log
 from inspect_ai.scorer import includes
 from inspect_ai.solver import Generate, TaskState, generate, solver, user_message
+
+
+@pytest.fixture(params=[True, False], ids=["with_sandbox", "no_sandbox"])
+def sandbox_kwarg(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> str | None:
+    """Run each cancellation test on both branches of `run.py`'s sandbox split.
+
+    `with_sandbox`: monkeypatches `sandboxenv_context` to a fake whose teardown
+    awaits, and returns `sandbox="local"` so the Task takes the `sandboxenv_cm`
+    branch -- the path whose unshielded `__aexit__` checkpoint drops in-flight
+    samples on cancel.
+
+    `no_sandbox`: returns `None` so the Task takes the `nullcontext()` branch.
+    No monkeypatch needed -- nullcontext's `__aexit__` has no await.
+
+    Each test uses `sandbox=sandbox_kwarg` on its `Task` so pytest runs it once
+    per branch, keeping the existing no-sandbox regression coverage while
+    adding the sandbox-path coverage that the bug requires.
+    """
+    if request.param:
+
+        @contextlib.asynccontextmanager
+        async def fake_sandboxenv_context(*args, **kwargs):
+            try:
+                yield
+            finally:
+                # any unshielded checkpoint here trips the still-cancelled scope
+                await anyio.sleep(0.05)
+
+        monkeypatch.setattr(
+            "inspect_ai._eval.task.run.sandboxenv_context", fake_sandboxenv_context
+        )
+        return "local"
+    return None
 
 
 @solver
@@ -63,13 +100,14 @@ def _make_samples(n: int) -> list[Sample]:
     return [Sample(input=f"Sample {i}", target="target", id=i) for i in range(1, n + 1)]
 
 
-def test_fail_on_error_logs_cancelled_samples():
+def test_fail_on_error_logs_cancelled_samples(sandbox_kwarg: str | None):
     """When fail_on_error=True and one sample errors, concurrent samples should be cancelled and all samples should appear in the log."""
     num_samples = 5
     task = Task(
         dataset=_make_samples(num_samples),
         solver=_conversation_then_error_solvers(),
         scorer=includes(),
+        sandbox=sandbox_kwarg,
         fail_on_error=True,
     )
 
@@ -105,7 +143,7 @@ def test_fail_on_error_logs_cancelled_samples():
         assert sample.error is not None
 
 
-def test_fail_on_error_threshold_logs_cancelled_samples():
+def test_fail_on_error_threshold_logs_cancelled_samples(sandbox_kwarg: str | None):
     """When fail_on_error is a count threshold and enough samples error, concurrent samples should be cancelled and logged."""
     num_samples = 6
 
@@ -126,6 +164,7 @@ def test_fail_on_error_threshold_logs_cancelled_samples():
         dataset=_make_samples(num_samples),
         solver=[error_first_three_solver()],
         scorer=includes(),
+        sandbox=sandbox_kwarg,
         # fail after 3 errors
         fail_on_error=3,
     )
@@ -148,13 +187,14 @@ def test_fail_on_error_threshold_logs_cancelled_samples():
     assert len(cancelled) > 0
 
 
-def test_all_concurrent_samples_accounted_for():
+def test_all_concurrent_samples_accounted_for(sandbox_kwarg: str | None):
     """When fail_on_error cancels concurrent samples, ALL samples should appear in the log."""
     num_samples = 5
     task = Task(
         dataset=_make_samples(num_samples),
         solver=[error_or_sleep_solver()],
         scorer=includes(),
+        sandbox=sandbox_kwarg,
         fail_on_error=True,
     )
 
@@ -176,13 +216,14 @@ def test_all_concurrent_samples_accounted_for():
     assert logged_ids == expected_ids
 
 
-def test_fail_on_error_no_retry_for_cancelled():
+def test_fail_on_error_no_retry_for_cancelled(sandbox_kwarg: str | None):
     """Cancelled samples should not be retried even when retry_on_error > 0."""
     num_samples = 3
     task = Task(
         dataset=_make_samples(num_samples),
         solver=[error_or_sleep_solver()],
         scorer=includes(),
+        sandbox=sandbox_kwarg,
         fail_on_error=True,
     )
 
@@ -195,18 +236,23 @@ def test_fail_on_error_no_retry_for_cancelled():
 
     # cancelled samples should not have retries (they should appear once)
     cancelled = [s for s in log.samples if s.id != 1 and s.error is not None]
+    # rule out vacuous pass: at least one cancelled sample must actually be present
+    assert len(cancelled) > 0
     for s in cancelled:
         # cancelled samples should have no error retries
         assert s.error_retries is None or len(s.error_retries) == 0
 
 
-def test_keyboard_interrupt_logs_cancelled_samples(tmp_path: Path):
+def test_keyboard_interrupt_logs_cancelled_samples(
+    tmp_path: Path, sandbox_kwarg: str | None
+):
     """When SIGINT (KeyboardInterrupt) occurs, all running samples should be cancelled and logged."""
     num_samples = 5
     task = Task(
         dataset=_make_samples(num_samples),
         solver=[sleep_solver()],
         scorer=includes(),
+        sandbox=sandbox_kwarg,
     )
 
     # send SIGINT from a background thread after samples have started

--- a/tests/test_cancellation_logging.py
+++ b/tests/test_cancellation_logging.py
@@ -175,14 +175,16 @@ def test_fail_on_error_threshold_logs_cancelled_samples(sandbox_kwarg: str | Non
     assert log.samples is not None
 
     # the errored samples should have ValueError
-    errored = [s for s in log.samples if s.id is not None and s.id <= 3]
+    errored = [s for s in log.samples if s.id is not None and int(s.id) <= 3]
     for s in errored:
         assert s.error is not None
         assert "Error in sample" in s.error.message
 
     # some sleeping samples should have been cancelled and logged
     cancelled = [
-        s for s in log.samples if s.id is not None and s.id > 3 and s.error is not None
+        s
+        for s in log.samples
+        if s.id is not None and int(s.id) > 3 and s.error is not None
     ]
     assert len(cancelled) > 0
 


### PR DESCRIPTION
## Summary

When a sample's `CancelledError` is caught at `task_run_sample`'s cancel handler but the enclosing scope stays cancelled (Ctrl-C, `fail_on_error`), the unshielded `sandboxenv_cm.__aexit__` awaits inside `cleanup_sandbox_environments_sample`. Because we're still cancelled, that `await` immediately raises a fresh `CancelledError`, which propagates out past the (already shielded) logging block and silently drops the in-flight sample from the eval log.

The fix wraps `sandboxenv_cm` in a new small helper `aexit_shielded_when` so its teardown runs under `anyio.CancelScope(shield=cancelled_error is not None)`. The call site keeps `async with sandboxenv_cm:` unchanged; the wrapper just decorates the inner CM's `__aexit__`. This matches the existing shielding idiom (`shield=cancelled_error is not None`) already used at three other sites in `task_run_sample` — scoring, `cleanup_span.__aexit__`, and the completion/log block — so the bug window is now uniformly shielded.

The test coverage gap that let this through is also addressed: `test_cancellation_logging.py`'s tests are now parametrized over `with_sandbox` / `no_sandbox`, so every cancellation assertion runs on both branches.