### PR TITLE
docs: clarify include_history grading behavior

### DIFF
--- a/docs/scorers.qmd
+++ b/docs/scorers.qmd
@@ -185,7 +185,7 @@ Model selection follows this precedence:
 There are a few ways you can customise the default behaviour:
 
 1.  Provide alternate `instructions`—the default instructions ask the model to use chain of thought reasoning and provide grades in the format `GRADE: C` or `GRADE: I`. Note that if you provide instructions that ask the model to format grades in a different way, you will also want to customise the `grade_pattern`.
-2.  Specify `include_history = True` to include the full chat history in the presented question (by default only the original sample input is presented). You may optionally instead pass a function that enables customising the presentation of the chat history.
+2.  Specify `include_history = True` to include the full chat history in the presented question (by default only the original sample input is presented). The history includes the final assistant message; the final answer is also supplied separately to the grading template. You may optionally instead pass a function that enables customising the presentation of the chat history.
 3.  Specify `partial_credit = True` to prompt the model to assign partial credit to answers that are not entirely right but come close (metrics by default convert this to a value of 0.5). Note that this parameter is only valid when using the default `instructions`.
 4.  Specify an alternate `model` to perform the grading (e.g. a more powerful model or a model fine tuned for grading). If you provide a list of models, each grades independently and the final grade is chosen by majority vote.
 5.  Bind a `model_role` (default: `"grader"`) at eval time. See [Model Roles](models.qmd#model-roles) for details.

--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -55,8 +55,11 @@ def model_graded_fact(
       include_history:
         Whether to include the full chat history in the presented
         question. Defaults to `False`, which presents only the
-        original sample input. Optionally provide a function to
-        customise how the chat history is presented.
+        original sample input. When `True`, the presented history
+        includes the final assistant message; the answer is still
+        supplied separately to the grading template. Optionally
+        provide a function to customise how the chat history is
+        presented.
       partial_credit: Whether to allow for "partial" credit for
          answers (by default assigned a score of 0.5). Defaults
          to `False`. Note that this parameter is only used
@@ -114,8 +117,11 @@ def model_graded_qa(
       include_history:
         Whether to include the full chat history in the presented
         question. Defaults to `False`, which presents only the
-        original sample input. Optionally provide a function to
-        customise how the chat history is presented.
+        original sample input. When `True`, the presented history
+        includes the final assistant message; the answer is still
+        supplied separately to the grading template. Optionally
+        provide a function to customise how the chat history is
+        presented.
       partial_credit: Whether to allow for "partial" credit for
         answers (by default assigned a score of 0.5). Defaults
         to `False`. Note that this parameter is only used
@@ -310,8 +316,9 @@ def chat_history(state: TaskState) -> str:
         if not isinstance(message, ChatMessageSystem)
     ]
 
-    # present message history (removing the final assistant message
-    # and after as it will be contained in the 'Answer:'):
+    # Present message history through the final assistant message, while
+    # dropping any later messages. The grading template still receives the
+    # final answer separately.
     messages = remove_last_match_and_after(
         messages, lambda message: isinstance(message, ChatMessageAssistant)
     )


### PR DESCRIPTION
﻿## Summary
- document that `include_history=True` keeps the final assistant message in the presented history
- update the `chat_history()` comment to match the current behavior
- note that the final answer is still passed separately to the grading template

Fixes #4017.

## To verify
- `git diff --check`
- `python -m py_compile src/inspect_ai/scorer/_model.py`
- `python -m ruff check src/inspect_ai/scorer/_model.py`
