### PR TITLE
Agent Bridge: accept inline role="system" in Anthropic API requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Agent Bridge: Accept inline `role: "system"` messages from bridged Anthropic-API clients (Claude 4.8+ mid-conversation system messages).
+
 ## 0.3.232 (31 May 2026)
 
 - OpenAI: Support `tool_search` tool type from native scaffolds (e.g. Codex CLI).

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -180,7 +180,9 @@ def anthropic_system_to_text(value: Any) -> str:
     if isinstance(value, str):
         return value
     return "\n\n".join(
-        str(b.get("text", "")) for b in value if isinstance(b, dict) and b.get("type") == "text"
+        str(b.get("text", ""))
+        for b in value
+        if isinstance(b, dict) and b.get("type") == "text"
     )
 
 

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -175,11 +175,21 @@ def debug_log(caption: str, o: Any) -> None:
     pass
 
 
+def anthropic_system_to_text(value: Any) -> str:
+    """Flatten an Anthropic ``system`` value (``str`` or ``list[TextBlockParam]``) to text."""
+    if isinstance(value, str):
+        return value
+    return "\n\n".join(
+        str(b.get("text", "")) for b in value if isinstance(b, dict) and b.get("type") == "text"
+    )
+
+
 def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
     config = GenerateConfig()
     config.max_tokens = json_data.get("max_tokens", None)
     config.stop_seqs = json_data.get("stop_sequences", None) or None
-    config.system_message = json_data.get("system", None)
+    if (system := json_data.get("system")) is not None:
+        config.system_message = anthropic_system_to_text(system)
     config.temperature = json_data.get("temperature", None)
     config.top_k = json_data.get("top_k", None)
     config.top_p = json_data.get("top_p", None)
@@ -425,19 +435,9 @@ async def messages_from_anthropic_input(
                 flush_pending_user_content()
 
         elif param["role"] == "system":
-            if isinstance(param["content"], str):
-                messages.append(ChatMessageSystem(content=param["content"]))
-            else:
-                text_blocks = [
-                    cast(TextBlockParam, c)
-                    for c in param["content"]
-                    if isinstance(c, dict) and c.get("type") == "text"
-                ]
-                messages.append(
-                    ChatMessageSystem(
-                        content=[content_block_to_content(b) for b in text_blocks]
-                    )
-                )
+            messages.append(
+                ChatMessageSystem(content=anthropic_system_to_text(param["content"]))
+            )
 
         else:
             raise RuntimeError(f"Unexpected message role: {param['role']}")

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -424,6 +424,21 @@ async def messages_from_anthropic_input(
 
                 flush_pending_user_content()
 
+        elif param["role"] == "system":
+            if isinstance(param["content"], str):
+                messages.append(ChatMessageSystem(content=param["content"]))
+            else:
+                text_blocks = [
+                    cast(TextBlockParam, c)
+                    for c in param["content"]
+                    if isinstance(c, dict) and c.get("type") == "text"
+                ]
+                messages.append(
+                    ChatMessageSystem(
+                        content=[content_block_to_content(b) for b in text_blocks]
+                    )
+                )
+
         else:
             raise RuntimeError(f"Unexpected message role: {param['role']}")
 

--- a/tests/agent/test_bridge_anthropic_messages.py
+++ b/tests/agent/test_bridge_anthropic_messages.py
@@ -1,0 +1,45 @@
+import pytest
+
+from inspect_ai.agent._bridge.anthropic_api_impl import messages_from_anthropic_input
+from inspect_ai.model._chat_message import (
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+
+
+@pytest.mark.anyio
+async def test_inline_system_role_str_content() -> None:
+    """Claude 4.8+ clients may send role="system" inside the messages array."""
+    messages = await messages_from_anthropic_input(
+        [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi"},
+            {"role": "system", "content": "<system-reminder>note</system-reminder>"},
+            {"role": "user", "content": "continue"},
+        ],
+        tools=[],
+    )
+    assert [type(m) for m in messages] == [
+        ChatMessageUser,
+        ChatMessageAssistant,
+        ChatMessageSystem,
+        ChatMessageUser,
+    ]
+    assert messages[2].text == "<system-reminder>note</system-reminder>"
+
+
+@pytest.mark.anyio
+async def test_inline_system_role_block_content() -> None:
+    messages = await messages_from_anthropic_input(
+        [
+            {"role": "user", "content": "hello"},
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "reminder"}],
+            },
+        ],
+        tools=[],
+    )
+    assert isinstance(messages[1], ChatMessageSystem)
+    assert messages[1].text == "reminder"

--- a/tests/agent/test_bridge_anthropic_messages.py
+++ b/tests/agent/test_bridge_anthropic_messages.py
@@ -1,6 +1,9 @@
 import pytest
 
-from inspect_ai.agent._bridge.anthropic_api_impl import messages_from_anthropic_input
+from inspect_ai.agent._bridge.anthropic_api_impl import (
+    anthropic_system_to_text,
+    messages_from_anthropic_input,
+)
 from inspect_ai.model._chat_message import (
     ChatMessageAssistant,
     ChatMessageSystem,
@@ -43,3 +46,13 @@ async def test_inline_system_role_block_content() -> None:
     )
     assert isinstance(messages[1], ChatMessageSystem)
     assert messages[1].text == "reminder"
+
+
+def test_anthropic_system_to_text() -> None:
+    assert anthropic_system_to_text("plain") == "plain"
+    assert (
+        anthropic_system_to_text(
+            [{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]
+        )
+        == "a\n\nb"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -10,6 +10,15 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "2027-01-01T00:00:00Z"
+
+[options.exclude-newer-package]
+inspect-petri = false
+inspect-ai = false
+inspect-scout = false
+inspect-swe = false
+
 [[package]]
 name = "adlfs"
 version = "2026.4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -10,15 +10,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "2027-01-01T00:00:00Z"
-
-[options.exclude-newer-package]
-inspect-petri = false
-inspect-ai = false
-inspect-scout = false
-inspect-swe = false
-
 [[package]]
 name = "adlfs"
 version = "2026.4.0"


### PR DESCRIPTION
## Summary

- `messages_from_anthropic_input()` now maps `role: "system"` → `ChatMessageSystem` (previously raised `RuntimeError: Unexpected message role: system`).
- Claude 4.8+ supports [mid-conversation system messages](https://platform.claude.com/docs/en/build-with-claude/mid-conversation-system-messages); the newer `claude-agent-sdk` (bundled in `@agentclientprotocol/claude-agent-acp`, used by inspect_swe ≥0.2.56) sends `<system-reminder>` injections this way, so bridged `claude_code` agents currently crash on the first reminder.
- The outbound Anthropic provider already handles inline `ChatMessageSystem` (`anthropic.py:_split_for_mid_conversation_system` for 4.8+; `split_system_messages` hoists all to the top-level `system` param for older models), so this just closes the inbound gap.

## Test plan

- [x] `tests/agent/test_bridge_anthropic_messages.py` — string and block-list `role: "system"` content
- [x] `mypy` / `ruff` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)