### PR TITLE
Propagate task-level GenerateConfig.cache to non-primary models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Model: Propagate task-level `GenerateConfig.cache` to role models and ad-hoc `get_model()` calls (previously only the active/primary model inherited it).
+
 ## 0.3.232 (31 May 2026)
 
 - OpenAI: Support `tool_search` tool type from native scaffolds (e.g. Codex CLI).

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -1386,7 +1386,7 @@ class Model:
         if self == active_model():
             base_config = base_config.merge(active_config)
 
-        # otherwise merge connection-oriented config so its inherited everywhere
+        # otherwise merge operational config so its inherited everywhere
         else:
             base_config = base_config.merge(
                 GenerateConfig(
@@ -1394,6 +1394,7 @@ class Model:
                     adaptive_connections=active_config.adaptive_connections,
                     max_retries=active_config.max_retries,
                     timeout=active_config.timeout,
+                    cache=active_config.cache,
                 )
             )
 


### PR DESCRIPTION
## Summary

`Model._resolve_config` merges the full task-level `active_generate_config()` into the primary model, but only connection-oriented fields (`max_connections`, `adaptive_connections`, `max_retries`, `timeout`) into role models and ad-hoc `get_model(name)` instances. This means setting `cache=CachePolicy(...)` at the task/eval level (e.g. `eval(..., cache=CachePolicy("1M"))` or `FlowTask(config=GenerateConfig(cache=...))`) only caches the primary model's calls — target/judge/scorer roles and any ad-hoc `get_model()` inside a solver silently miss cache.

This adds `cache` to the operational fields inherited by non-primary models. Per-model (`FlowModel(config=...)`) and per-call (`generate(cache=...)`) still override via the existing merge order.

## Motivation

In a multi-role petri eval (auditor primary + target/judge/bon_scorer/bon_critic roles), we set task-level `cache=CachePolicy("1M")` expecting crash-restart to replay all model calls. Only auditor calls hit cache; target/judge/critic re-ran fresh on every restart. Workaround was to set `config=GenerateConfig(cache=...)` on every `FlowModel` individually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)