### PR TITLE
feat: accept memswap_limit in ComposeService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Docker Compose: accept `memswap_limit` in ComposeService.
+
 ## 0.3.232 (31 May 2026)
 
 - OpenAI: Support `tool_search` tool type from native scaffolds (e.g. Codex CLI).

--- a/src/inspect_ai/util/_sandbox/compose.py
+++ b/src/inspect_ai/util/_sandbox/compose.py
@@ -289,6 +289,9 @@ class ComposeService(ComposeModel):
     mem_reservation: str | None = Field(default=None)
     """Memory reservation (shortcut for deploy.resources.reservations.memory)."""
 
+    memswap_limit: str | int | None = Field(default=None)
+    """Total memory + swap limit (e.g. ``20g``, ``256m``, or bytes as int)."""
+
     cpus: float | None = Field(default=None)
     """CPU limit (shortcut for deploy.resources.limits.cpus)."""
 

--- a/tests/util/sandbox/test_compose.py
+++ b/tests/util/sandbox/test_compose.py
@@ -157,6 +157,19 @@ services:
     }
 
 
+def test_parse_compose_yaml_accepts_memswap_limit(tmp_path):
+    compose_file = tmp_path / "compose.yaml"
+    compose_file.write_text("""
+services:
+  default:
+    image: ubuntu
+    mem_limit: 12g
+    memswap_limit: 20g
+""")
+    config = parse_compose_yaml(str(compose_file))
+    assert config.services["default"].memswap_limit == "20g"
+
+
 def test_parse_compose_yaml_rejects_unknown_field(tmp_path):
     compose_file = tmp_path / "compose.yaml"
     compose_file.write_text("""


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Closes #4099. Follow-up to #3880.

### What is the current behavior? (You can also link to an open issue here)

`ComposeService` rejects `memswap_limit`, a standard Docker Compose service key (total memory + swap limit — the sibling of `mem_limit`). A `ComposeConfig` carrying it fails validation with `Unknown field: 'memswap_limit'`. This also breaks the `model_dump()` → `model_validate()` round-trip that Inspect performs when re-validating a `SandboxEnvironmentSpec` whose `config` is a `ComposeConfig` (`SandboxEnvironmentSpec.load_config_model` → `deserialize_sandbox_specific_config`, e.g. on eval-log readback) — the auto-deserialize falls through to `NotImplementedError: ... config_deserialize`.

Surfaced while doing UKGovernmentBEIS/inspect_evals#900 (porting SWE-Lancer to the programmatic `ComposeConfig` API): SWE-Lancer's sandbox sets `mem_limit: 12g` + `memswap_limit: 20g`, and the object form is unusable until `memswap_limit` round-trips.

### What is the new behavior?

`memswap_limit: str | int | None` is modeled on `ComposeService`, beside `mem_limit` / `mem_reservation`. Pure passthrough — stored on the model, interpretation left to sandbox providers, mirroring the existing memory fields (and the fields added in #3880). It now parses from a compose file and round-trips through `model_dump` / `model_validate`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. New optional field defaulting to `None`; input that was previously rejected is now accepted.

### Other information:

- `make check` (ruff + mypy, full repo) clean; `tests/util/sandbox/test_compose.py` passes, including the added `test_parse_compose_yaml_accepts_memswap_limit`.
- CHANGELOG updated.

---

*Implemented with the help of a coding agent (Claude Code) and reviewed locally by the author.*
