### PR TITLE
fix: accept Anthropic system role messages

### DIFF
--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -342,7 +342,21 @@ async def messages_from_anthropic_input(
     tool_names: dict[str, str] = {}
 
     for param in input:
-        if param["role"] == "assistant":
+        if param["role"] == "system":
+            if isinstance(param["content"], str):
+                messages.append(ChatMessageSystem(content=param["content"]))
+            else:
+                messages.append(
+                    ChatMessageSystem(
+                        content=[
+                            content_block_to_content(c)
+                            for c in param["content"]
+                            if isinstance(c, dict) and c["type"] == "text"
+                        ]
+                    )
+                )
+
+        elif param["role"] == "assistant":
             # resolve str to block
             if isinstance(param["content"], str):
                 param_content: list[ContentBlockParam | ContentBlock] = [

--- a/tests/model/test_anthropic_chat_messages.py
+++ b/tests/model/test_anthropic_chat_messages.py
@@ -1,0 +1,29 @@
+from typing import Any, cast
+
+from inspect_ai._util.content import ContentText
+from inspect_ai.agent._bridge.anthropic_api_impl import messages_from_anthropic_input
+from inspect_ai.model import ChatMessageSystem, ChatMessageUser
+
+
+async def test_anthropic_input_accepts_inline_system_messages() -> None:
+    messages = await messages_from_anthropic_input(
+        cast(
+            Any,
+            [
+                {"role": "user", "content": "hello"},
+                {
+                    "role": "system",
+                    "content": [
+                        {"type": "text", "text": "answer in French"},
+                    ],
+                },
+            ],
+        ),
+        tools=[],
+    )
+
+    assert isinstance(messages[0], ChatMessageUser)
+    assert messages[0].content == "hello"
+    assert isinstance(messages[1], ChatMessageSystem)
+    assert isinstance(messages[1].content, list)
+    assert messages[1].content == [ContentText(text="answer in French")]


### PR DESCRIPTION
## Summary

- accept inline Anthropic `role: "system"` messages in the agent bridge input converter
- preserve text-block system content as `ChatMessageSystem`
- add a regression test for Anthropic input containing a mid-conversation system turn

## To verify

- `uv run pytest tests\model\test_anthropic_chat_messages.py -q`
- `uv run pytest tests\model\providers\test_anthropic_mid_conversation_system.py -q`
- `uv run ruff check src\inspect_ai\agent\_bridge\anthropic_api_impl.py tests\model\test_anthropic_chat_messages.py`
- `uv run ruff format --check src\inspect_ai\agent\_bridge\anthropic_api_impl.py tests\model\test_anthropic_chat_messages.py`
- `uv run mypy src\inspect_ai\agent\_bridge\anthropic_api_impl.py tests\model\test_anthropic_chat_messages.py`
- `git diff --check`
