### PR TITLE
checkpoint: sample is customize-only; CLI token trigger + 500k default

### DIFF
--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -131,7 +131,7 @@ TIMEOUT_HELP = "Model API request timeout in seconds (defaults to no timeout)"
 ATTEMPT_TIMEOUT_HELP = "Timeout (in seconds) for any given attempt (if exceeded, will abandon attempt and retry according to max_retries)."
 CACHE_HELP = "Policy for caching of model generations. Specify --cache to cache with 7 day expiration (7D). Specify an explicit duration (e.g. (e.g. 1h, 3d, 6M) to set the expiration explicitly (durations can be expressed as s, m, h, D, W, M, or Y). Alternatively, pass the file path to a YAML or JSON config file with a full `CachePolicy` configuration."
 BATCH_HELP = "Batch requests together to reduce API calls when using a model that supports batching (by default, no batching). Specify --batch to batch with default configuration,  specify a batch size e.g. `--batch=1000` to configure batches of 1000 requests, or pass the file path to a YAML or JSON config file with batch configuration."
-CHECKPOINT_HELP = "Periodically checkpoint sample state so the eval can be resumed via `inspect eval retry`. Specify --checkpoint for default (every 5 turns), --checkpoint=turn:N / time:Ns/m/h/d / manual for a shorthand trigger, or pass a YAML/JSON file path for a full CheckpointConfig."
+CHECKPOINT_HELP = "Periodically checkpoint sample state so the eval can be resumed via `inspect eval retry`. Specify --checkpoint for the default (every 500k tokens), --checkpoint=token:N{k,m,b} / time:N{s,m,h,d} / turn:N / manual for a shorthand trigger, or pass a YAML/JSON file path for a full CheckpointConfig."
 
 
 def _notification_callback(
@@ -401,7 +401,7 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
     @click.option(
         "--checkpoint",
         is_flag=False,
-        flag_value="turn:5",
+        flag_value="default",
         default=None,
         help=CHECKPOINT_HELP,
         envvar="INSPECT_EVAL_CHECKPOINT",
@@ -2177,7 +2177,7 @@ def parse_comma_separated(value: str | None) -> list[str] | None:
 @click.option(
     "--checkpoint",
     is_flag=False,
-    flag_value="turn:5",
+    flag_value="default",
     default=None,
     help=CHECKPOINT_HELP
     + " For resume to find checkpoint files, pass the same `--checkpoint` value used on the original eval.",

--- a/src/inspect_ai/_eval/eval.py
+++ b/src/inspect_ai/_eval/eval.py
@@ -69,7 +69,7 @@ from inspect_ai.scorer._reducer import reducer_log_names
 from inspect_ai.solver._chain import chain
 from inspect_ai.solver._solver import Solver, SolverSpec
 from inspect_ai.util import SandboxEnvironmentType
-from inspect_ai.util._checkpoint import CheckpointConfig
+from inspect_ai.util._checkpoint import CheckpointConfig, normalize_checkpoint
 from inspect_ai.util._concurrency import AdaptiveConcurrency
 from inspect_ai.util._display import (
     DisplayType,
@@ -98,7 +98,7 @@ def eval(
     task_args: dict[str, Any] | str = dict(),
     sandbox: SandboxEnvironmentType | None = None,
     sandbox_cleanup: bool | None = None,
-    checkpoint: CheckpointConfig | None = None,
+    checkpoint: CheckpointConfig | bool | None = None,
     acp_server: bool | int | str | None = None,
     solver: Solver | SolverSpec | Agent | list[Solver] | None = None,
     scanner: "Scanners | None" = None,
@@ -167,8 +167,10 @@ def eval(
             (or optionally a str or tuple with a shorthand spec)
         sandbox_cleanup: Cleanup sandbox environments after task completes
             (defaults to True)
-        checkpoint: Checkpoint configuration for this eval. Overrides
-            any task- or sample-level `checkpoint` when set.
+        checkpoint: Checkpoint configuration for this eval, or `True` to
+            enable checkpointing with the default trigger (every 500k
+            tokens) — equivalent to the bare `--checkpoint` CLI flag.
+            Overrides any task- or sample-level `checkpoint` when set.
         acp_server: Expose this eval over an Agent Client Protocol server.
             `True` enables a default AF_UNIX socket at `<inspect_data_dir>/acp/<run_id>.sock`;
             an integer binds a TCP loopback port; a string is taken as a custom
@@ -368,7 +370,7 @@ async def eval_async(
     task_args: dict[str, Any] | str = dict(),
     sandbox: SandboxEnvironmentType | None = None,
     sandbox_cleanup: bool | None = None,
-    checkpoint: CheckpointConfig | None = None,
+    checkpoint: CheckpointConfig | bool | None = None,
     acp_server: bool | int | str | None = None,
     solver: Solver | SolverSpec | Agent | list[Solver] | None = None,
     scanner: "Scanners | None" = None,
@@ -430,7 +432,7 @@ async def eval_async(
         task_args: Task creation arguments (as a dictionary or as a path to a JSON or YAML config file)
         sandbox: Sandbox environment type (or optionally a str or tuple with a shorthand spec)
         sandbox_cleanup: Cleanup sandbox environments after task completes (defaults to True)
-        checkpoint: Checkpoint configuration for this eval. Overrides any task- or sample-level `checkpoint` when set.
+        checkpoint: Checkpoint configuration for this eval, or `True` to enable checkpointing with the default trigger (every 500k tokens), equivalent to the bare `--checkpoint` CLI flag. Overrides any task- or sample-level `checkpoint` when set.
         acp_server: Expose this eval over an Agent Client Protocol server.
             `True` enables a default AF_UNIX socket at `<inspect_data_dir>/acp/<run_id>.sock`;
             an integer binds a TCP loopback port; a string is taken as a custom
@@ -510,6 +512,11 @@ async def eval_async(
     Returns:
         List of EvalLog (one for each task)
     """
+    # normalize `checkpoint=True` (enable, defer trigger) to a config;
+    # this is the single choke point for the eval layer — `eval`,
+    # `eval_set`, `eval_retry`, and `eval_retry_async` all funnel here.
+    checkpoint = normalize_checkpoint(checkpoint)
+
     result: list[EvalLog] | None = None
 
     async def run(tg: TaskGroup) -> None:
@@ -981,7 +988,7 @@ def eval_retry(
     attempt_timeout: int | None = None,
     max_connections: int | None = None,
     adaptive_connections: bool | int | AdaptiveConcurrency | None = None,
-    checkpoint: CheckpointConfig | None = None,
+    checkpoint: CheckpointConfig | bool | None = None,
 ) -> list[EvalLog]:
     """Retry a previously failed evaluation task.
 
@@ -1060,10 +1067,11 @@ def eval_retry(
             scale_up_percent). An explicit `max_connections` or `batch=True`
             takes precedence and uses static concurrency.
         checkpoint:
-            Checkpoint configuration for this retry. Must match the config
-            used on the original eval for resume detection to find the
-            checkpoint files (the original `--checkpoint` is not recorded in the
-            log file).
+            Checkpoint configuration for this retry, or `True` to enable
+            checkpointing with the default trigger (every 500k tokens).
+            Must match the config used on the original eval for resume
+            detection to find the checkpoint files (the original
+            `--checkpoint` is not recorded in the log file).
 
     Returns:
         List of EvalLog (one for each task)
@@ -1158,7 +1166,7 @@ async def eval_retry_async(
     attempt_timeout: int | None = None,
     max_connections: int | None = None,
     adaptive_connections: bool | int | AdaptiveConcurrency | None = None,
-    checkpoint: CheckpointConfig | None = None,
+    checkpoint: CheckpointConfig | bool | None = None,
 ) -> list[EvalLog]:
     """Retry a previously failed evaluation task.
 
@@ -1217,7 +1225,7 @@ async def eval_retry_async(
         attempt_timeout: Timeout (in seconds) for any given attempt (if exceeded, will abandon attempt and retry according to max_retries).
         max_connections: Maximum number of concurrent connections to Model API (default is per Model API)
         adaptive_connections: Adaptive concurrency for Model API connections. Defaults to enabled (resolves to `AdaptiveConcurrency()` defaults: min=4, start=20, max=100). Pass `False` to opt out, an integer `N` as shorthand for `AdaptiveConcurrency(max=N)`, or an `AdaptiveConcurrency` to fully customize bounds and tuning (cooldown_seconds, decrease_factor, scale_up_percent). An explicit `max_connections` or `batch=True` takes precedence and uses static concurrency.
-        checkpoint: Checkpoint configuration for this retry. Must match the config used on the original eval for resume detection to find the checkpoint files (the original `--checkpoint` is not recorded in the log file).
+        checkpoint: Checkpoint configuration for this retry, or `True` to enable checkpointing with the default trigger (every 500k tokens). Must match the config used on the original eval for resume detection to find the checkpoint files (the original `--checkpoint` is not recorded in the log file).
 
     Returns:
         List of EvalLog (one for each task)

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -115,7 +115,7 @@ def eval_set(
     task_args: dict[str, Any] | str = dict(),
     sandbox: SandboxEnvironmentType | None = None,
     sandbox_cleanup: bool | None = None,
-    checkpoint: CheckpointConfig | None = None,
+    checkpoint: CheckpointConfig | bool | None = None,
     acp_server: bool | int | str | None = None,
     solver: Solver | SolverSpec | Agent | list[Solver] | None = None,
     scanner: "Scanners | None" = None,
@@ -197,8 +197,10 @@ def eval_set(
             (or optionally a str or tuple with a shorthand spec)
         sandbox_cleanup: Cleanup sandbox environments after task completes
             (defaults to True)
-        checkpoint: Checkpoint configuration for this eval set. Overrides
-            any task- or sample-level `checkpoint` when set.
+        checkpoint: Checkpoint configuration for this eval set, or `True`
+            to enable checkpointing with the default trigger (every 500k
+            tokens). Overrides any task- or sample-level `checkpoint`
+            when set.
         acp_server: Override the original eval's ACP server transport on retry.
             `True` enables a default AF_UNIX socket; an integer binds a TCP
             loopback port; a string is taken as a custom UNIX socket path;

--- a/src/inspect_ai/_eval/task/task.py
+++ b/src/inspect_ai/_eval/task/task.py
@@ -38,7 +38,7 @@ from inspect_ai.scorer._reducer import ScoreReducers, create_reducers
 from inspect_ai.solver import Plan, Solver, generate
 from inspect_ai.solver._chain import chain
 from inspect_ai.solver._task_state import TaskState
-from inspect_ai.util._checkpoint.config import CheckpointConfig
+from inspect_ai.util._checkpoint.config import CheckpointConfig, normalize_checkpoint
 from inspect_ai.util._sandbox.environment import (
     SandboxEnvironmentSpec,
     SandboxEnvironmentType,
@@ -78,7 +78,7 @@ class Task:
         config: GenerateConfig = GenerateConfig(),
         model_roles: dict[str, str | Model] | None = None,
         sandbox: SandboxEnvironmentType | None = None,
-        checkpoint: CheckpointConfig | None = None,
+        checkpoint: CheckpointConfig | bool | None = None,
         approval: str | ApprovalPolicyConfig | list[ApprovalPolicy] | None = None,
         epochs: int | Epochs | None = None,
         fail_on_error: bool | float | None = None,
@@ -113,9 +113,10 @@ class Task:
             config: Model generation config for default model (does not apply to model roles)
             model_roles: Named roles for use in `get_model()`.
             sandbox: Sandbox environment type (or optionally a str or tuple with a shorthand spec)
-            checkpoint: Checkpoint configuration for this task. Overridden by
-                eval-level `checkpoint` when set; overrides any sample-level
-                `checkpoint`.
+            checkpoint: Checkpoint configuration for this task, or `True` to
+                enable checkpointing with the default trigger (every 500k
+                tokens). Overridden by eval-level `checkpoint` when set;
+                overrides any sample-level `checkpoint`.
             approval: Tool use approval policies.
                 Either a path to an approval policy config file, an ApprovalPolicyConfig, or a list of approval policies. Defaults to no approval policy.
             epochs: Epochs to repeat samples for and optional score
@@ -183,7 +184,7 @@ class Task:
         self.config = config
         self.model_roles = resolve_model_roles(model_roles)
         self.sandbox = resolve_sandbox_environment(sandbox)
-        self.checkpoint = checkpoint
+        self.checkpoint = normalize_checkpoint(checkpoint)
         self.approval = resolve_approval(approval)
         epochs = resolve_epochs(epochs)
         self.epochs = epochs.epochs if epochs else None
@@ -255,7 +256,7 @@ def task_with(
     config: GenerateConfig | NotGiven = NOT_GIVEN,
     model_roles: dict[str, str | Model] | NotGiven = NOT_GIVEN,
     sandbox: SandboxEnvironmentType | None | NotGiven = NOT_GIVEN,
-    checkpoint: CheckpointConfig | None | NotGiven = NOT_GIVEN,
+    checkpoint: CheckpointConfig | bool | None | NotGiven = NOT_GIVEN,
     approval: str
     | ApprovalPolicyConfig
     | list[ApprovalPolicy]
@@ -297,9 +298,10 @@ def task_with(
         config: Model generation config for default model (does not apply to model roles)
         model_roles: Named roles for use in `get_model()`.
         sandbox: Sandbox environment type (or optionally a str or tuple with a shorthand spec)
-        checkpoint: Checkpoint configuration for this task. Overridden by
-            eval-level `checkpoint` when set; overrides any sample-level
-            `checkpoint`.
+        checkpoint: Checkpoint configuration for this task, or `True` to
+            enable checkpointing with the default trigger (every 500k
+            tokens). Overridden by eval-level `checkpoint` when set;
+            overrides any sample-level `checkpoint`.
         approval: Tool use approval policies.
             Either a path to an approval policy config file, an ApprovalPolicyConfig, or a list of approval policies. Defaults to no approval policy.
         epochs: Epochs to repeat samples for and optional score
@@ -357,7 +359,7 @@ def task_with(
     if not isinstance(sandbox, NotGiven):
         task.sandbox = resolve_sandbox_environment(sandbox)
     if not isinstance(checkpoint, NotGiven):
-        task.checkpoint = checkpoint
+        task.checkpoint = normalize_checkpoint(checkpoint)
     if not isinstance(approval, NotGiven):
         task.approval = resolve_approval(approval)
     if not isinstance(epochs, NotGiven):

--- a/src/inspect_ai/dataset/_dataset.py
+++ b/src/inspect_ai/dataset/_dataset.py
@@ -56,8 +56,10 @@ class Sample(BaseModel):
                 SandboxEnvironment). Files can be paths, inline text, or inline binary (base64 encoded data URL).
             setup: Optional. Setup script to run for sample (run
                 within default SandboxEnvironment).
-            checkpoint: Optional. Checkpoint configuration for this sample
-                (overridden by task- or eval-level `checkpoint`).
+            checkpoint: Optional. Checkpoint configuration for this sample.
+                Customize-only — it does not enable checkpointing by itself
+                (that is turned on at the task or eval level) and is ignored
+                when nothing enabled it.
         """
         super().__init__(
             input=input,
@@ -113,8 +115,9 @@ class Sample(BaseModel):
     """Checkpoint configuration for this sample. Per-sample configs are
     restricted to the :class:`CheckpointSampleConfig` base class — the
     eval-wide fields (``checkpoints_dir``, ``retention``) live only on
-    :class:`CheckpointConfig` at the task / eval layers. Overridden by
-    task- or eval-level `checkpoint` when set."""
+    :class:`CheckpointConfig` at the task / eval layers. Customize-only:
+    a sample config never enables checkpointing (that happens at the task
+    or eval layer) and is ignored when nothing enabled it."""
 
 
 def sample_input_len(sample: Sample) -> int:

--- a/src/inspect_ai/util/_checkpoint/README.md
+++ b/src/inspect_ai/util/_checkpoint/README.md
@@ -12,17 +12,18 @@ Checkpointing snapshots **filesystem state** (configured paths inside each sandb
 
 ## Enabling Checkpointing
 
-Checkpointing can be configured at any of three layers — **sample**, **task**, or **eval / CLI**. The layers are merged per-field at sample-run time, with precedence **eval > sample > task** (see [Configuration Layers](#configuration-layers)). When unset at every layer, checkpointing is disabled.
+Checkpointing is **enabled** by a config at the **task** or **eval / CLI** layer. The **sample** layer is customize-only — it refines an already-enabled policy but never turns checkpointing on by itself, and is silently ignored when neither task nor eval enabled it. Once enabled, the layers are merged per-field at sample-run time, with precedence **eval > sample > task** (see [Configuration Layers](#configuration-layers)). When neither task nor eval supplies a config, checkpointing is disabled.
 
 ### Eval / CLI layer
 
 Pass the `--checkpoint` CLI option or `checkpoint=...` to `eval()`. The `--checkpoint` option supports several formats:
 
 ``` bash
-# Enable with the default trigger (every 5 turns)
+# Enable with the default trigger (every 500k tokens)
 inspect eval arc.py --model openai/gpt-4o --checkpoint
 
 # Shorthand triggers
+inspect eval arc.py --model openai/gpt-4o --checkpoint=token:500k
 inspect eval arc.py --model openai/gpt-4o --checkpoint=turn:10
 inspect eval arc.py --model openai/gpt-4o --checkpoint=time:15m
 inspect eval arc.py --model openai/gpt-4o --checkpoint=manual
@@ -31,7 +32,7 @@ inspect eval arc.py --model openai/gpt-4o --checkpoint=manual
 inspect eval arc.py --model openai/gpt-4o --checkpoint=checkpoint.yaml
 ```
 
-Time-value suffixes are `s`, `m`, `h`, `d` (case-insensitive); a bare integer is seconds.
+Time-value suffixes are `s`, `m`, `h`, `d` and token-value suffixes are `k`, `m`, `b` (all case-insensitive). A suffix is **required** in both cases — a bare number is rejected. Token values may be fractional as long as they resolve to a whole token count (e.g. `token:1.5m`). The bare `--checkpoint` flag enables checkpointing without pinning a trigger; the concrete default (`token:500k`) is filled in per-sample only when no layer — including the sample — set one.
 
 Or from Python:
 
@@ -42,6 +43,12 @@ from inspect_ai.util import CheckpointConfig, TurnInterval
 eval("arc.py", model="openai/gpt-4o", checkpoint=CheckpointConfig(
     trigger=TurnInterval(every=10),
 ))
+```
+
+Passing `checkpoint=True` is the Python-API equivalent of the bare `--checkpoint` flag — it enables checkpointing with the default trigger (every 500k tokens), deferring the trigger so a sample can still override it. `checkpoint=False` / `None` disable it. `True` is accepted anywhere a `CheckpointConfig` is (the `eval()` family, `eval_set()`, `Task`, and `task_with()`).
+
+``` python
+eval("arc.py", model="openai/gpt-4o", checkpoint=True)
 ```
 
 ### Task layer
@@ -67,7 +74,7 @@ def my_task():
 
 ### Sample layer
 
-An individual sample can specialize the task's default — e.g. when one sample needs an extra directory captured that the rest of the task's samples don't. Sample-layer configs use `CheckpointSampleConfig`, which omits the eval-wide fields (`checkpoints_location`, `retention`) that a sample physically cannot influence:
+An individual sample can specialize an already-enabled policy — e.g. when one sample needs an extra directory captured that the rest of the task's samples don't, or supplies its own trigger when the eval/CLI layer enabled checkpointing without pinning one. A sample config never enables checkpointing on its own; if neither task nor eval enabled it, the sample config is ignored. Sample-layer configs use `CheckpointSampleConfig`, which omits the eval-wide fields (`checkpoints_location`, `retention`) that a sample physically cannot influence:
 
 ``` python
 from inspect_ai.dataset import Sample
@@ -107,7 +114,7 @@ Additional trigger types — including cost-based and budget-percentage triggers
 
 | Field | Description |
 |----|----|
-| `trigger` | The trigger that decides when to fire. Required (must be set at some layer). |
+| `trigger` | The trigger that decides when to fire. When unset at every layer (while checkpointing is enabled by task/eval), defaults to `TokenInterval(every=500_000)`. |
 | `sandbox_paths` | Per-sandbox-name map of absolute paths inside the sandbox to capture. Empty/omitted = host-only checkpointing (no sandbox repos). See [Sandbox Paths](#sandbox-paths) below. |
 | `checkpoints_location` | Override the parent directory under which the per-eval checkpoint dir lands. Defaults to a sibling of the eval log file. Any fsspec-resolvable path (`s3://`, `gs://`, local, …). Settable only at the task or eval layer. |
 | `max_consecutive_failures` | If set, fail the sample after N consecutive failed checkpoint attempts. `None` (default) = unlimited tolerance; `0` = any single failure is fatal. |
@@ -153,7 +160,7 @@ When more than one of the sample / task / eval layers supplies a config, Inspect
 
 `sandbox_paths` is treated as a single whole-dict value, not key-wise merged. To add a path to one sandbox while inheriting others, the higher-priority layer must redeclare the full map.
 
-If at least one layer supplies a config but no layer sets a `trigger`, merge raises a `ValueError`.
+When checkpointing is enabled (task or eval) but no layer — including the sample — sets a `trigger`, the trigger defaults to `TokenInterval(every=500_000)` (every 500k tokens).
 
 ## Sandbox Paths
 

--- a/src/inspect_ai/util/_checkpoint/__init__.py
+++ b/src/inspect_ai/util/_checkpoint/__init__.py
@@ -19,6 +19,7 @@ from .checkpointer import Checkpointer, checkpointer
 from .config import (
     CheckpointConfig,
     CheckpointSampleConfig,
+    normalize_checkpoint,
 )
 
 __all__ = [
@@ -31,4 +32,5 @@ __all__ = [
     "TurnInterval",
     "checkpointer",
     "Checkpointer",
+    "normalize_checkpoint",
 ]

--- a/src/inspect_ai/util/_checkpoint/config.py
+++ b/src/inspect_ai/util/_checkpoint/config.py
@@ -20,7 +20,10 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal
 
-from ._triggers import CheckpointTrigger
+from ._triggers import CheckpointTrigger, TokenInterval
+
+DEFAULT_CHECKPOINT_TRIGGER = TokenInterval(every=500_000)
+"""Trigger used when checkpointing is enabled but no layer set a trigger."""
 
 
 @dataclass
@@ -42,8 +45,9 @@ class CheckpointSampleConfig:
     trigger: CheckpointTrigger | None = None
     """Checkpoint trigger strategy — any implementer of
     :class:`CheckpointTrigger` (see :mod:`.triggers`). ``None`` means
-    "inherit from a lower-priority layer"; the final merged config
-    must have a non-None trigger or resolution raises."""
+    "inherit from a lower-priority layer"; when no layer sets a
+    trigger, resolution falls back to
+    :data:`DEFAULT_CHECKPOINT_TRIGGER`."""
 
     sandbox_paths: dict[str, list[str]] | None = None
     """Per-sandbox-name list of absolute paths to capture inside the
@@ -130,15 +134,20 @@ def merge_checkpoint_configs(
     ``sandbox_paths`` is treated as a single value (whole-dict
     replacement), not key-wise merged.
 
-    Returns ``None`` if no layer supplied a config (checkpointing
-    disabled). Otherwise returns a :class:`ResolvedCheckpointConfig`
-    with ``trigger`` guaranteed non-None and ``sandbox_paths`` /
-    ``retention`` filled with canonical defaults.
+    The sample layer is **customize-only** — it never enables
+    checkpointing. Only the task or eval layer turns it on. When
+    neither task nor eval supplied a config, this returns ``None``
+    (checkpointing disabled) and any sample-level config is silently
+    ignored. Once enabled, the sample layer participates in the
+    per-field merge like any other layer.
 
-    Raises ``ValueError`` if at least one layer was supplied but no
-    layer set a ``trigger``.
+    Otherwise returns a :class:`ResolvedCheckpointConfig` with
+    ``trigger`` guaranteed non-None and ``sandbox_paths`` /
+    ``retention`` filled with canonical defaults. When checkpointing
+    is enabled but no layer (including the sample) set a ``trigger``,
+    the trigger defaults to :data:`DEFAULT_CHECKPOINT_TRIGGER`.
     """
-    if task is None and sample is None and eval_ is None:
+    if task is None and eval_ is None:
         return None
 
     trigger: CheckpointTrigger | None = None
@@ -165,9 +174,7 @@ def merge_checkpoint_configs(
             retention = layer.retention
 
     if trigger is None:
-        raise ValueError(
-            "checkpoint config provided but no trigger was set at any level"
-        )
+        trigger = DEFAULT_CHECKPOINT_TRIGGER
 
     return ResolvedCheckpointConfig(
         trigger=trigger,
@@ -176,3 +183,21 @@ def merge_checkpoint_configs(
         checkpoints_location=checkpoints_location,
         max_consecutive_failures=max_consecutive_failures,
     )
+
+
+def normalize_checkpoint(
+    checkpoint: CheckpointConfig | bool | None,
+) -> CheckpointConfig | None:
+    """Normalize a public ``checkpoint=`` argument to a ``CheckpointConfig``.
+
+    ``True`` enables checkpointing without pinning a trigger — the
+    concrete default (:data:`DEFAULT_CHECKPOINT_TRIGGER`) is resolved
+    per-sample by :func:`merge_checkpoint_configs`, exactly matching the
+    bare ``--checkpoint`` CLI flag. ``False`` / ``None`` disable it. A
+    :class:`CheckpointConfig` is returned unchanged.
+    """
+    if checkpoint is True:
+        return CheckpointConfig(trigger=None)
+    if checkpoint is False or checkpoint is None:
+        return None
+    return checkpoint

--- a/src/inspect_ai/util/_checkpoint/parse_cli.py
+++ b/src/inspect_ai/util/_checkpoint/parse_cli.py
@@ -3,16 +3,20 @@
 Accepted forms (in order of detection):
 
 - ``None`` / empty → ``None`` (checkpointing disabled).
-- ``"<kind>:<value>"`` shorthand where ``kind`` ∈ ``{turn, time}`` →
-  parsed shorthand trigger.
+- The literal ``"default"`` → ``CheckpointConfig(trigger=None)`` —
+  enable checkpointing without pinning a trigger, deferring the
+  trigger to a sample-level config or the merge-time default.
+- ``"<kind>:<value>"`` shorthand where ``kind`` ∈ ``{turn, time,
+  token}`` → parsed shorthand trigger.
 - The literal ``"manual"`` → ``trigger=Manual()``.
 - Otherwise → treat as a file path; load YAML/JSON via
   :func:`inspect_ai._util.config.resolve_args` and validate against
   :class:`_CheckpointConfigModel`.
 
-The CLI's bare ``--checkpoint`` flag is mapped to a concrete shorthand
-(``"turn:5"``) by Click's ``flag_value``; this parser has no
-default-policy knowledge.
+The CLI's bare ``--checkpoint`` flag is mapped to ``"default"`` by
+Click's ``flag_value``; the merge resolver supplies the concrete
+default trigger (see ``DEFAULT_CHECKPOINT_TRIGGER``) once a sample is
+in hand.
 """
 
 from __future__ import annotations
@@ -25,16 +29,28 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from inspect_ai._util.config import resolve_args
 
-from ._triggers import CheckpointTrigger, Manual, TimeInterval, TurnInterval
+from ._triggers import (
+    CheckpointTrigger,
+    Manual,
+    TimeInterval,
+    TokenInterval,
+    TurnInterval,
+)
 from .config import CheckpointConfig
 
-_DURATION_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhd]?)\s*$", re.IGNORECASE)
+_DURATION_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([smhd])\s*$", re.IGNORECASE)
 _DURATION_UNITS_S: dict[str, float] = {
-    "": 1.0,
     "s": 1.0,
     "m": 60.0,
     "h": 3600.0,
     "d": 86400.0,
+}
+
+_TOKEN_RE = re.compile(r"^\s*(\d+(?:\.\d+)?)\s*([kmb])\s*$", re.IGNORECASE)
+_TOKEN_UNITS: dict[str, int] = {
+    "k": 1_000,
+    "m": 1_000_000,
+    "b": 1_000_000_000,
 }
 
 
@@ -45,6 +61,8 @@ def parse_checkpoint(value: str | None) -> CheckpointConfig | None:
     """
     if not value:
         return None
+    if value == "default":
+        return CheckpointConfig(trigger=None)
     if value == "manual":
         return CheckpointConfig(trigger=Manual())
     match value.partition(":"):
@@ -56,6 +74,12 @@ def parse_checkpoint(value: str | None) -> CheckpointConfig | None:
             return CheckpointConfig(
                 trigger=TimeInterval(
                     every=_parse_duration(rest, error_prefix="--checkpoint time")
+                )
+            )
+        case ("token", ":", rest):
+            return CheckpointConfig(
+                trigger=TokenInterval(
+                    every=_parse_tokens(rest, error_prefix="--checkpoint token")
                 )
             )
         case _:
@@ -74,6 +98,26 @@ def _parse_positive_int(value: str, kind: str) -> int:
     return n
 
 
+def _parse_tokens(value: str, *, error_prefix: str = "tokens") -> int:
+    """Parse ``500k`` / ``2m`` / ``1.5m`` / ``1b`` into a token count.
+
+    A ``k``/``m``/``b`` suffix is required (no bare integer). Decimals
+    are allowed as long as the result is a whole, positive number of
+    tokens.
+    """
+    m = _TOKEN_RE.match(value)
+    if m is None:
+        raise ValueError(f"{error_prefix}: expected <number><k|m|b>, got {value!r}")
+    tokens = float(m.group(1)) * _TOKEN_UNITS[m.group(2).lower()]
+    if tokens <= 0:
+        raise ValueError(f"{error_prefix}: value must be > 0, got {value!r}")
+    if not tokens.is_integer():
+        raise ValueError(
+            f"{error_prefix}: must resolve to a whole number of tokens, got {value!r}"
+        )
+    return int(tokens)
+
+
 # --- YAML/JSON config loader ----------------------------------------
 
 
@@ -86,11 +130,21 @@ class _TurnTriggerModel(BaseModel):
 class _TimeTriggerModel(BaseModel):
     model_config = ConfigDict(extra="forbid")
     type: Literal["time"]
-    every: int | float | str
+    every: str
+    """Suffixed duration string (``"30s"`` / ``"15m"`` / ``"2h"`` /
+    ``"1d"``). A bare numeric value is rejected — the unit is required."""
+
+
+class _TokenTriggerModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    type: Literal["token"]
+    every: int | str
+    """Raw token count (``500000``) or a suffixed string (``"500k"`` /
+    ``"1.5m"`` / ``"1b"``)."""
 
 
 _TriggerModel = Annotated[
-    _TurnTriggerModel | _TimeTriggerModel,
+    _TurnTriggerModel | _TimeTriggerModel | _TokenTriggerModel,
     Field(discriminator="type"),
 ]
 
@@ -131,15 +185,15 @@ def _trigger_model_to_strategy(
         case _TurnTriggerModel(every=n):
             return TurnInterval(every=n)
         case _TimeTriggerModel(every=v):
-            return TimeInterval(every=_coerce_duration(v))
-
-
-def _coerce_duration(value: int | float | str) -> timedelta:
-    return (
-        _parse_duration(value, error_prefix="checkpoint time")
-        if isinstance(value, str)
-        else timedelta(seconds=float(value))
-    )
+            return TimeInterval(
+                every=_parse_duration(v, error_prefix="checkpoint time")
+            )
+        case _TokenTriggerModel(every=v):
+            return TokenInterval(
+                every=v
+                if isinstance(v, int)
+                else _parse_tokens(v, error_prefix="checkpoint token")
+            )
 
 
 def _parse_config_file(path: str) -> CheckpointConfig:
@@ -151,9 +205,11 @@ def _parse_config_file(path: str) -> CheckpointConfig:
 
 
 def _parse_duration(value: str, *, error_prefix: str = "duration") -> timedelta:
-    """Parse ``15m`` / ``30s`` / ``2h`` / ``1d``, or a bare integer (seconds).
+    """Parse ``15m`` / ``30s`` / ``2h`` / ``1d`` into a ``timedelta``.
 
-    Raises ``ValueError`` on a malformed string or a non-positive result.
+    A ``s``/``m``/``h``/``d`` suffix is required — a bare number is
+    rejected. Raises ``ValueError`` on a malformed string or a
+    non-positive result.
     ``error_prefix`` is used to tag the raised message (e.g. the CLI flag
     name) so the diagnostic is meaningful to the caller's audience.
     """

--- a/tests/_cli/test_checkpoint_flag.py
+++ b/tests/_cli/test_checkpoint_flag.py
@@ -1,0 +1,87 @@
+"""Tests for the `--checkpoint` CLI option wiring.
+
+The flag uses Click's optional-value form (``is_flag=False`` +
+``flag_value="default"``): a bare ``--checkpoint`` yields the sentinel
+``"default"`` (enable checkpointing, defer the trigger), while
+``--checkpoint=<shorthand>`` passes the value through verbatim. The
+sentinel is resolved to the concrete default trigger
+(``TokenInterval(every=500_000)``) at merge time, once a sample is in
+hand. These tests cover the bare-flag → default → 500k seam that the
+parse/merge unit tests exercise only as separate halves.
+"""
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from inspect_ai._cli.eval import eval_command, eval_retry_command
+from inspect_ai.util._checkpoint import TokenInterval
+from inspect_ai.util._checkpoint.config import merge_checkpoint_configs
+from inspect_ai.util._checkpoint.parse_cli import parse_checkpoint
+
+
+def _build_cmd() -> click.Command:
+    """Minimal click command mirroring the real --checkpoint option."""
+
+    @click.command()
+    @click.option(
+        "--checkpoint",
+        is_flag=False,
+        flag_value="default",
+        default=None,
+        envvar="INSPECT_EVAL_CHECKPOINT",
+    )
+    def cmd(checkpoint: str | None) -> None:
+        click.echo(repr(checkpoint))
+
+    return cmd
+
+
+def _parsed(args: list[str], env: dict[str, str] | None = None) -> object:
+    runner = CliRunner()
+    result = runner.invoke(_build_cmd(), args, env=env, standalone_mode=False)
+    assert result.exit_code == 0, result.output
+    return eval(result.output.strip())
+
+
+@pytest.mark.parametrize("command", [eval_command, eval_retry_command])
+def test_real_option_uses_default_sentinel(command: click.Command) -> None:
+    """Guard against drift: the real CLI option maps the bare flag to "default".
+
+    The rebuilt command below mirrors this; this test ties the mirror to
+    the actual `inspect eval` / `inspect eval retry` options.
+    """
+    param = next(p for p in command.params if p.name == "checkpoint")
+    assert isinstance(param, click.Option)
+    assert param.is_flag is False
+    assert param.flag_value == "default"
+
+
+def test_bare_flag_maps_to_default_sentinel() -> None:
+    """`--checkpoint` with no value → the "default" sentinel string."""
+    assert _parsed(["--checkpoint"]) == "default"
+
+
+def test_explicit_shorthand_passes_through() -> None:
+    assert _parsed(["--checkpoint=turn:5"]) == "turn:5"
+
+
+def test_omitted_returns_none() -> None:
+    assert _parsed([]) is None
+
+
+def test_env_var_passes_through() -> None:
+    assert _parsed([], env={"INSPECT_EVAL_CHECKPOINT": "token:500k"}) == "token:500k"
+
+
+def test_bare_flag_resolves_to_500k_tokens() -> None:
+    """End-to-end: bare `--checkpoint` enables and defaults to 500k tokens.
+
+    The bare flag must NOT pin a trigger at the eval layer (so a sample
+    can still supply one); the 500k default is filled in by the merge.
+    """
+    cfg = parse_checkpoint("default")
+    assert cfg is not None and cfg.trigger is None  # enable, no trigger pinned
+    out = merge_checkpoint_configs(eval_=cfg)
+    assert out is not None
+    assert out.trigger == TokenInterval(every=500_000)

--- a/tests/checkpoint/test_normalize.py
+++ b/tests/checkpoint/test_normalize.py
@@ -1,0 +1,83 @@
+"""Tests for `checkpoint=True` in the Python API.
+
+Passing ``True`` to a ``checkpoint=`` argument is the Python-API
+equivalent of the bare ``--checkpoint`` CLI flag: it enables
+checkpointing without pinning a trigger, and the concrete default
+(``TokenInterval(every=500_000)``) is resolved per-sample by
+``merge_checkpoint_configs``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from inspect_ai import Task
+from inspect_ai._eval.task.task import task_with
+from inspect_ai.util._checkpoint import TokenInterval, TurnInterval
+from inspect_ai.util._checkpoint.config import (
+    CheckpointConfig,
+    merge_checkpoint_configs,
+    normalize_checkpoint,
+)
+from inspect_ai.util._checkpoint.parse_cli import parse_checkpoint
+
+
+def test_normalize_true_enables_without_trigger() -> None:
+    assert normalize_checkpoint(True) == CheckpointConfig(trigger=None)
+
+
+@pytest.mark.parametrize("value", [False, None])
+def test_normalize_falsey_disables(value: bool | None) -> None:
+    assert normalize_checkpoint(value) is None
+
+
+def test_normalize_passes_config_through_unchanged() -> None:
+    cfg = CheckpointConfig(trigger=TurnInterval(every=3))
+    assert normalize_checkpoint(cfg) is cfg
+
+
+def test_true_matches_bare_cli_flag() -> None:
+    """`checkpoint=True` and the bare `--checkpoint` flag resolve identically."""
+    assert normalize_checkpoint(True) == parse_checkpoint("default")
+
+
+def test_true_resolves_to_500k_tokens() -> None:
+    out = merge_checkpoint_configs(eval_=normalize_checkpoint(True))
+    assert out is not None
+    assert out.trigger == TokenInterval(every=500_000)
+
+
+def test_true_defers_trigger_to_sample() -> None:
+    """`True` enables without pinning a trigger, so a sample can still win."""
+    from inspect_ai.util._checkpoint import CheckpointSampleConfig
+
+    out = merge_checkpoint_configs(
+        eval_=normalize_checkpoint(True),
+        sample=CheckpointSampleConfig(trigger=TurnInterval(every=2)),
+    )
+    assert out is not None
+    assert out.trigger == TurnInterval(every=2)
+
+
+def test_task_checkpoint_true_enables() -> None:
+    task = Task(checkpoint=True)
+    assert task.checkpoint == CheckpointConfig(trigger=None)
+    out = merge_checkpoint_configs(task=task.checkpoint)
+    assert out is not None
+    assert out.trigger == TokenInterval(every=500_000)
+
+
+@pytest.mark.parametrize("value", [False, None])
+def test_task_checkpoint_falsey_disables(value: bool | None) -> None:
+    assert Task(checkpoint=value).checkpoint is None
+
+
+def test_task_with_checkpoint_true_enables() -> None:
+    task = task_with(Task(), checkpoint=True)
+    assert task.checkpoint == CheckpointConfig(trigger=None)
+
+
+def test_task_with_checkpoint_omitted_leaves_unchanged() -> None:
+    original = CheckpointConfig(trigger=TurnInterval(every=4))
+    task = task_with(Task(checkpoint=original))
+    assert task.checkpoint == original

--- a/tests/checkpoint/test_parse.py
+++ b/tests/checkpoint/test_parse.py
@@ -12,6 +12,7 @@ from inspect_ai.util._checkpoint import (
     CheckpointConfig,
     Manual,
     TimeInterval,
+    TokenInterval,
     TurnInterval,
 )
 from inspect_ai.util._checkpoint.parse_cli import parse_checkpoint
@@ -36,7 +37,6 @@ def test_turn_shorthand() -> None:
 @pytest.mark.parametrize(
     "spec, expected",
     [
-        ("time:30", timedelta(seconds=30)),
         ("time:30s", timedelta(seconds=30)),
         ("time:15m", timedelta(minutes=15)),
         ("time:2h", timedelta(hours=2)),
@@ -47,6 +47,38 @@ def test_time_shorthand(spec: str, expected: timedelta) -> None:
     cfg = _parse(spec)
     assert isinstance(cfg.trigger, TimeInterval)
     assert cfg.trigger.every == expected
+
+
+def test_bare_time_rejected() -> None:
+    """A bare numeric duration (no unit) is no longer accepted."""
+    with pytest.raises(ValueError, match="time"):
+        parse_checkpoint("time:30")
+
+
+@pytest.mark.parametrize(
+    "spec, expected",
+    [
+        ("token:500k", 500_000),
+        ("token:2m", 2_000_000),
+        ("token:1b", 1_000_000_000),
+        ("token:1.5m", 1_500_000),
+    ],
+)
+def test_token_shorthand(spec: str, expected: int) -> None:
+    cfg = _parse(spec)
+    assert isinstance(cfg.trigger, TokenInterval)
+    assert cfg.trigger.every == expected
+
+
+@pytest.mark.parametrize("spec", ["token:500000", "token:0k", "token:0.0001k"])
+def test_bad_token_value(spec: str) -> None:
+    with pytest.raises(ValueError, match="token"):
+        parse_checkpoint(spec)
+
+
+def test_default_sentinel_enables_without_trigger() -> None:
+    cfg = _parse("default")
+    assert cfg.trigger is None
 
 
 def test_manual_literal() -> None:
@@ -97,6 +129,28 @@ def test_yaml_file_time_trigger_with_suffix(tmp_path: Path) -> None:
     cfg = _parse(str(path))
     assert isinstance(cfg.trigger, TimeInterval)
     assert cfg.trigger.every == timedelta(minutes=45)
+
+
+def test_yaml_file_token_trigger(tmp_path: Path) -> None:
+    path = tmp_path / "ckpt.yaml"
+    path.write_text("trigger:\n  type: token\n  every: 500000\n")
+    cfg = _parse(str(path))
+    assert isinstance(cfg.trigger, TokenInterval) and cfg.trigger.every == 500_000
+
+
+def test_yaml_file_token_trigger_suffixed(tmp_path: Path) -> None:
+    path = tmp_path / "ckpt.yaml"
+    path.write_text('trigger:\n  type: token\n  every: "1.5m"\n')
+    cfg = _parse(str(path))
+    assert isinstance(cfg.trigger, TokenInterval) and cfg.trigger.every == 1_500_000
+
+
+def test_yaml_file_time_numeric_rejected(tmp_path: Path) -> None:
+    """Bare numeric seconds are rejected; a suffixed string is required."""
+    path = tmp_path / "ckpt.yaml"
+    path.write_text("trigger:\n  type: time\n  every: 30\n")
+    with pytest.raises(ValueError):
+        parse_checkpoint(str(path))
 
 
 def test_json_file(tmp_path: Path) -> None:

--- a/tests/checkpoint/test_resolve.py
+++ b/tests/checkpoint/test_resolve.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Literal
 
 import pytest
 
@@ -10,9 +11,30 @@ from inspect_ai.util._checkpoint import (
     CheckpointConfig,
     CheckpointSampleConfig,
     TimeInterval,
+    TokenInterval,
     TurnInterval,
 )
-from inspect_ai.util._checkpoint.config import merge_checkpoint_configs
+from inspect_ai.util._checkpoint.config import (
+    DEFAULT_CHECKPOINT_TRIGGER,
+    merge_checkpoint_configs,
+)
+
+# --- builders -------------------------------------------------------
+
+
+def _cfg(field: str, value: object) -> CheckpointConfig:
+    cfg = CheckpointConfig()
+    setattr(cfg, field, value)
+    return cfg
+
+
+def _sample_cfg(field: str, value: object) -> CheckpointSampleConfig:
+    cfg = CheckpointSampleConfig()
+    setattr(cfg, field, value)
+    return cfg
+
+
+# --- enable predicate + defaults ------------------------------------
 
 
 def test_no_layers_returns_none() -> None:
@@ -22,8 +44,7 @@ def test_no_layers_returns_none() -> None:
 
 
 def test_single_layer_passes_through() -> None:
-    cfg = CheckpointConfig(trigger=TurnInterval(every=5))
-    out = merge_checkpoint_configs(cfg)
+    out = merge_checkpoint_configs(CheckpointConfig(trigger=TurnInterval(every=5)))
     assert out is not None
     assert out.trigger == TurnInterval(every=5)
     # Defaults are materialized.
@@ -31,80 +52,100 @@ def test_single_layer_passes_through() -> None:
     assert out.retention == "delete"
 
 
-def test_layer_without_trigger_raises() -> None:
-    with pytest.raises(ValueError, match="no trigger"):
-        merge_checkpoint_configs(CheckpointConfig(checkpoints_location="/tmp"))
+def test_enabled_without_trigger_defaults_to_500k_tokens() -> None:
+    out = merge_checkpoint_configs(CheckpointConfig(checkpoints_location="/tmp"))
+    assert out is not None
+    assert out.trigger == DEFAULT_CHECKPOINT_TRIGGER == TokenInterval(every=500_000)
+    assert out.checkpoints_location == "/tmp"
+
+
+def test_sample_only_does_not_enable() -> None:
+    """A sample-layer config never enables checkpointing — it is ignored."""
+    assert (
+        merge_checkpoint_configs(
+            None, CheckpointSampleConfig(trigger=TurnInterval(every=2)), None
+        )
+        is None
+    )
+    # Even with no trigger, a lone sample config is silently ignored (no raise).
+    assert merge_checkpoint_configs(None, CheckpointSampleConfig(), None) is None
+
+
+def test_sample_supplies_trigger_when_eval_has_none() -> None:
+    """Eval enables (no trigger); sample customizes the trigger."""
+    out = merge_checkpoint_configs(
+        task=None,
+        sample=CheckpointSampleConfig(trigger=TurnInterval(every=2)),
+        eval_=CheckpointConfig(sandbox_paths={"default": ["/workspace"]}),
+    )
+    assert out is not None
+    assert out.trigger == TurnInterval(every=2)  # from sample
+    assert out.sandbox_paths == {"default": ["/workspace"]}  # from eval
 
 
 def test_sample_layer_uses_sample_config_type() -> None:
-    """Sample-layer configs are typed CheckpointSampleConfig — no checkpoints_dir field."""
+    """Sample-layer configs are typed CheckpointSampleConfig — no eval-wide fields."""
     sample = CheckpointSampleConfig(trigger=TurnInterval(every=2))
-    assert not hasattr(sample, "checkpoints_dir")
+    assert not hasattr(sample, "checkpoints_location")
     assert not hasattr(sample, "retention")
 
-    out = merge_checkpoint_configs(
-        task=CheckpointConfig(
-            trigger=TurnInterval(every=5), checkpoints_location="/tmp"
-        ),
-        sample=sample,
-    )
-    assert out is not None
-    assert out.checkpoints_location == "/tmp"  # from task
-    assert out.trigger == TurnInterval(every=2)  # from sample
+
+# --- per-field precedence (eval > sample > task) --------------------
+
+# Distinct value per layer for each mergeable field, so the winner is
+# unambiguous. The sample value lives on both config types (these fields
+# are shared with CheckpointSampleConfig).
+_MERGEABLE_VALUES: dict[str, dict[str, object]] = {
+    "trigger": {
+        "task": TurnInterval(every=5),
+        "sample": TurnInterval(every=2),
+        "eval": TimeInterval(every=timedelta(minutes=15)),
+    },
+    "sandbox_paths": {
+        "task": {"task": ["/t"]},
+        "sample": {"sample": ["/s"]},
+        "eval": {"eval": ["/e"]},
+    },
+    "max_consecutive_failures": {"task": 3, "sample": 10, "eval": 7},
+}
+
+# (present layers, winning layer) under precedence eval > sample > task.
+# Sample-only is excluded — it never enables, covered separately.
+_PRECEDENCE_COMBOS = [
+    (("task", "sample", "eval"), "eval"),
+    (("task", "sample"), "sample"),
+    (("task", "eval"), "eval"),
+    (("sample", "eval"), "eval"),
+    (("task",), "task"),
+    (("eval",), "eval"),
+]
 
 
-def test_higher_priority_overrides_trigger() -> None:
-    task = CheckpointConfig(trigger=TurnInterval(every=5))
-    sample = CheckpointConfig(trigger=TurnInterval(every=2))
-    eval_ = CheckpointConfig(trigger=TimeInterval(every=timedelta(minutes=15)))
+@pytest.mark.parametrize("field", list(_MERGEABLE_VALUES))
+@pytest.mark.parametrize("present, winner", _PRECEDENCE_COMBOS)
+def test_mergeable_field_precedence(
+    field: str, present: tuple[str, ...], winner: str
+) -> None:
+    vals = _MERGEABLE_VALUES[field]
+    task = _cfg(field, vals["task"]) if "task" in present else None
+    sample = _sample_cfg(field, vals["sample"]) if "sample" in present else None
+    eval_ = _cfg(field, vals["eval"]) if "eval" in present else None
 
-    # task < sample < eval (left to right priority increases)
     out = merge_checkpoint_configs(task, sample, eval_)
     assert out is not None
-    assert out.trigger == TimeInterval(every=timedelta(minutes=15))
+    # Distinct keys mean a winning sandbox_paths dict also proves
+    # whole-dict replacement (no key-wise merge).
+    assert getattr(out, field) == vals[winner]
 
 
-def test_sample_overrides_task_when_eval_absent() -> None:
-    task = CheckpointConfig(trigger=TurnInterval(every=5))
-    sample = CheckpointConfig(trigger=TurnInterval(every=2))
-    out = merge_checkpoint_configs(task, sample, None)
-    assert out is not None
-    assert out.trigger == TurnInterval(every=2)
-
-
-def test_lower_layer_supplies_default_for_unset_field() -> None:
-    """Task provides paths; sample overrides only trigger; merged has both."""
-    task = CheckpointConfig(
-        trigger=TurnInterval(every=5),
-        sandbox_paths={"default": ["/workspace"]},
-    )
-    sample = CheckpointConfig(trigger=TurnInterval(every=2))
-    out = merge_checkpoint_configs(task, sample, None)
-    assert out is not None
-    assert out.trigger == TurnInterval(every=2)
-    assert out.sandbox_paths == {"default": ["/workspace"]}
-
-
-def test_sandbox_paths_whole_dict_replacement() -> None:
-    """Higher layer's sandbox_paths replaces the whole dict (no per-key merge)."""
-    task = CheckpointConfig(
-        trigger=TurnInterval(every=5),
-        sandbox_paths={"default": ["/workspace"]},
-    )
-    sample = CheckpointConfig(sandbox_paths={"tools": ["/data"]})
-    out = merge_checkpoint_configs(task, sample, None)
-    assert out is not None
-    assert out.sandbox_paths == {"tools": ["/data"]}
-
-
-def test_per_field_layering() -> None:
-    """Different fields can come from different layers."""
+def test_cross_field_layering() -> None:
+    """Different fields resolve from different layers in one merge."""
     task = CheckpointConfig(
         trigger=TurnInterval(every=5),
         sandbox_paths={"default": ["/workspace"]},
         max_consecutive_failures=3,
     )
-    sample = CheckpointConfig(max_consecutive_failures=10)
+    sample = CheckpointSampleConfig(max_consecutive_failures=10)
     eval_ = CheckpointConfig(checkpoints_location="s3://bucket/checkpoints")
     out = merge_checkpoint_configs(task, sample, eval_)
     assert out is not None
@@ -127,12 +168,88 @@ def test_eval_only_with_partial_config_completes_from_task() -> None:
     assert out.sandbox_paths == {"default": ["/workspace"]}
 
 
-def test_retention_inherits() -> None:
-    task = CheckpointConfig(
-        trigger=TurnInterval(every=5),
-        retention="retain",
+# --- eval-wide field precedence (task / eval only) ------------------
+
+_LOCATION = {"task": "/task/ckpt", "eval": "s3://bucket/eval"}
+
+
+@pytest.mark.parametrize(
+    "present, winner",
+    [(("task", "eval"), "eval"), (("task",), "task"), (("eval",), "eval")],
+)
+def test_checkpoints_location_eval_wide_precedence(
+    present: tuple[str, ...], winner: str
+) -> None:
+    task = (
+        CheckpointConfig(
+            trigger=TurnInterval(every=5), checkpoints_location=_LOCATION["task"]
+        )
+        if "task" in present
+        else None
     )
-    sample = CheckpointConfig(trigger=TurnInterval(every=2))
-    out = merge_checkpoint_configs(task, sample, None)
+    eval_ = (
+        CheckpointConfig(
+            trigger=TurnInterval(every=5), checkpoints_location=_LOCATION["eval"]
+        )
+        if "eval" in present
+        else None
+    )
+    out = merge_checkpoint_configs(task, None, eval_)
+    assert out is not None
+    assert out.checkpoints_location == _LOCATION[winner]
+
+
+@pytest.mark.parametrize(
+    "task_r, eval_r",
+    [
+        ("retain", None),  # task inherits (eval absent)
+        ("delete", "retain"),  # eval wins
+        (None, "retain"),  # eval only
+    ],
+)
+def test_retention_eval_wide_precedence(
+    task_r: Literal["delete", "retain"] | None,
+    eval_r: Literal["delete", "retain"] | None,
+) -> None:
+    # The expected winner is always "retain" (non-default), so a result
+    # of "retain" cannot be confused with the materialized default.
+    task = (
+        CheckpointConfig(trigger=TurnInterval(every=5), retention=task_r)
+        if task_r is not None
+        else None
+    )
+    eval_ = (
+        CheckpointConfig(trigger=TurnInterval(every=5), retention=eval_r)
+        if eval_r is not None
+        else None
+    )
+    out = merge_checkpoint_configs(task, None, eval_)
     assert out is not None
     assert out.retention == "retain"
+
+
+# --- falsy-but-set edges (None means inherit, not 0 / {}) -----------
+
+
+def test_explicit_empty_sandbox_paths_overrides_lower() -> None:
+    """An explicit empty dict replaces a lower layer's paths (host-only)."""
+    out = merge_checkpoint_configs(
+        task=CheckpointConfig(
+            trigger=TurnInterval(every=5), sandbox_paths={"default": ["/workspace"]}
+        ),
+        sample=CheckpointSampleConfig(sandbox_paths={}),
+    )
+    assert out is not None
+    assert out.sandbox_paths == {}
+
+
+def test_zero_max_consecutive_failures_is_set_not_inherited() -> None:
+    """``0`` (any failure fatal) is honored, not treated as unset."""
+    out = merge_checkpoint_configs(
+        task=CheckpointConfig(
+            trigger=TurnInterval(every=5), max_consecutive_failures=5
+        ),
+        sample=CheckpointSampleConfig(max_consecutive_failures=0),
+    )
+    assert out is not None
+    assert out.max_consecutive_failures == 0


### PR DESCRIPTION
## Summary

Refines checkpoint config resolution and the `--checkpoint` CLI surface.

### Sample config is customize-only
Previously a checkpoint config at *any* layer (sample, task, or eval) enabled checkpointing. Now only the **task** or **eval/CLI** layer enables it. A **sample** config never turns checkpointing on by itself — it refines an already-enabled policy (e.g. supplies the trigger) and is silently ignored when nothing enabled it. Once enabled, the existing per-field merge (`eval > sample > task`) is unchanged.

### Default trigger = 500k tokens
When checkpointing is enabled but no layer set a `trigger`, the trigger now defaults to `TokenInterval(every=500_000)` instead of raising. This is resolved inside `merge_checkpoint_configs`, which runs once per sample — so a sample-supplied trigger still wins over the default when eval/CLI left it unset. The bare `--checkpoint` flag maps to a `"default"` sentinel (`CheckpointConfig(trigger=None)`): it enables checkpointing without pinning a trigger, deferring resolution until a sample is in hand.

### CLI trigger syntax
- New `token:N{k,m,b}` shorthand (e.g. `token:500k`, `token:1.5m`, `token:1b`). Decimals are allowed as long as they resolve to a whole token count; a suffix is required.
- `time:N` now **requires** an `s|m|h|d` suffix — a bare number is rejected (previously treated as seconds).
- YAML/JSON loader: the `time` trigger's `every` is a suffixed string only (numeric seconds rejected); added a `token` trigger model.

## Tests
- `tests/checkpoint/test_resolve.py`: sample-only is ignored; sample supplies trigger when eval enabled without one; enabled-without-trigger defaults to 500k tokens.
- `tests/checkpoint/test_parse.py`: token shorthand + rejections, bare `time:` rejection, `default` sentinel, YAML token trigger, numeric-time rejection.
- Plus pre-existing checkpoint resume e2e tests on this branch.

## Verification
`pytest tests/checkpoint` (119 passed, 50 skipped) · `mypy` clean · `ruff format`/`check` clean.