### PR TITLE
fix: isolate transcript in checkpointer pre-construction test

### DIFF
--- a/tests/checkpoint/test_checkpointer.py
+++ b/tests/checkpoint/test_checkpointer.py
@@ -26,7 +26,7 @@ from inspect_ai.event._event import Event
 from inspect_ai.event._info import InfoEvent
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.log import Transcript, expand_events
-from inspect_ai.log._transcript import init_transcript, transcript
+from inspect_ai.log._transcript import init_transcript
 from inspect_ai.log._transcript_store import TranscriptEventStore
 from inspect_ai.model._chat_message import (
     ChatMessage,
@@ -377,7 +377,10 @@ async def test_fire_includes_events_emitted_before_checkpointer_construction(
     dirs: _Dirs,
 ) -> None:
     preexisting = InfoEvent(data="before-checkpointer")
-    active_transcript = transcript()
+    # Fresh transcript, not the ambient `transcript()`: in a full-suite run
+    # the shared ContextVar transcript holds leftover events from prior tests,
+    # which would sort ahead of `preexisting` in the dumped events.json.
+    active_transcript = Transcript(bounded=False)
     active_transcript._event(preexisting)
 
     with patch(


### PR DESCRIPTION
## Problem

`test_checkpointer.py::test_fire_includes_events_emitted_before_checkpointer_construction` fails in the full-suite CI run but passes locally / in isolation:

```
assert events[0]["uuid"] == preexisting.uuid
AssertionError: assert '9wNLkg3GdTfuTmX6VZnwwc' == 'fjQeswCuHynJmyBJ6cZa7S'
```

## Cause

The test seeded the **ambient** transcript via `transcript()`, which returns the shared `_transcript` ContextVar. The checkpointer dumps the entire transcript event store to `events.json`, so the assert only holds if that transcript contains nothing but the seeded event. In a full-suite run an earlier test leaves events in the ambient transcript, which sort ahead of `preexisting` — hence `events[0]` is stale. In isolation the ambient transcript is clean, so it passes.

## Fix

Seed a fresh `Transcript(bounded=False)` instead of the ambient global (matching the existing `_patch_sample_runtime` helper). Drops the now-unused `transcript` import.

Note: this is **not** the `test_checkpoint_e2e.py` test — that one passes.