### PR TITLE
Support OpenAI models on AWS Bedrock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## Unreleased
 
+- OpenAI: Support [OpenAI models on AWS Bedrock](https://inspect.aisi.org.uk/providers.html#openai-on-aws-bedrock) via the `openai/bedrock/<model>` qualifier.
 - Together: Support the `stream` model arg (e.g. `-M stream=true`) to stream completions. A length-truncated streaming response (with structured output or tools) now degrades gracefully to `stop_reason="max_tokens"` instead of raising.
 - Bedrock: Support `response_schema` (structured output) for Claude models via `output_config.format`.
-- Sandbox: Allow `sandbox_service()` instances running as different users in the same sandbox
-  to share `/var/tmp/sandbox-services`.
+- Sandbox: Allow `sandbox_service()` instances running as different users in the same sandbox to share `/var/tmp/sandbox-services`.
 - Agent Intervention: Support connecting to all samples (disabling interruption and user messages if the agent doesn't explicitly support ACP).
 - Docker Compose: accept `platform`, `extra_hosts`, `cap_add`, `cap_drop`, `security_opt`, and `tmpfs` in ComposeService.
 - Docker Sandbox: `SandboxTimeoutError` now carries `truncated_output` with the partial command output captured before a timeout (surfaced to tool callers), instead of discarding it.

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -145,6 +145,59 @@ inspect eval math.py --model openai/azure/gpt-4o-mini
 
 Note that if the `AZUREAI_OPENAI_API_VERSION` is not specified, Inspect will generally default to the latest deployed version, which as of this writing is `2025-03-01-preview`. When using managed identity for authentication, install the `azure-identity` package and leave `AZUREAI_OPENAI_API_KEY` undefined.
 
+### OpenAI on AWS Bedrock {#openai-on-aws-bedrock}
+
+::: {.callout-note appearance="simple"}
+OpenAI models on Amazon Bedrock require the development version of Inspect. You can install the development version from GitHub with:
+
+```bash
+pip install git+https://github.com/UKGovernmentBEIS/inspect_ai
+```
+:::
+
+The `openai` provider supports OpenAI models served through [Amazon Bedrock](https://aws.amazon.com/bedrock/). Use the normal `openai` provider with the `bedrock` qualifier, and use a standard OpenAI model identifier (Inspect automatically adds prefixes and suffixes required by Bedrock). For example:
+
+``` bash
+export AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key
+inspect eval arc.py --model openai/bedrock/gpt-5.5
+```
+
+You don't need to set a region for the example above — Inspect defaults to `us-east-2`. The available model ids (e.g. `gpt-5.5`, `gpt-oss-120b`) and the regions they're offered in vary over time and by account; the [`bedrock-mantle` documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) lists the supported regions.
+
+#### Region
+
+The AWS region is resolved with the following precedence: the `aws_region` model arg (`-M aws_region`), then `AWS_REGION`, then `AWS_DEFAULT_REGION`, and finally a default of `us-east-2`. Region availability varies by model (for example, at the time of writing `gpt-5.5` is only offered in `us-east-2`. Note that Bedrock API keys are region-bound (a key only works in the region it was created in).
+
+If your environment sets a global `AWS_REGION` for other AWS services, you can target a specific region for this model only — without changing that global — using the model arg:
+
+``` bash
+inspect eval arc.py --model openai/bedrock/gpt-5.5 -M aws_region=us-east-2
+```
+
+#### Authentication
+
+Authentication uses an AWS Bedrock bearer token. There are two ways to provide one:
+
+| Variable | Description |
+|---------------------------|---------------------------------------------|
+| `AWS_BEARER_TOKEN_BEDROCK` | Bedrock bearer API key — the AWS-standard name, as used in the AWS and OpenAI documentation. |
+| `BEDROCK_OPENAI_API_KEY` | Bedrock bearer API key — Inspect-convention alias (takes precedence if both are set). |
+| `BEDROCK_OPENAI_BASE_URL` | Custom endpoint override (optional; the AWS-standard `AWS_BEDROCK_BASE_URL` is also accepted). By default Inspect targets the region's Mantle endpoint, choosing the model-appropriate path automatically (`/openai/v1` for frontier models like GPT-5.x and Codex, `/v1` for open-weight models like gpt-oss). |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | AWS region (optional; defaults to `us-east-2`). |
+
+The first option is a static bearer key. Generate an [Amazon Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) and set it via `AWS_BEARER_TOKEN_BEDROCK` (the name used in the AWS and OpenAI docs; Inspect also accepts `BEDROCK_OPENAI_API_KEY`).
+
+The second option uses your standard AWS credentials (IAM roles, instance profiles, SSO, AssumeRole, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or a configured `AWS_PROFILE`). If no bearer key is set, Inspect generates short-lived bearer tokens from these credentials. This requires the `aws-bedrock-token-generator` package:
+
+``` bash
+pip install aws-bedrock-token-generator
+export AWS_PROFILE=your-profile           # or any standard AWS credential source
+inspect eval arc.py --model openai/bedrock/gpt-5.5
+```
+
+If the package is not installed and no bearer key is available, Inspect raises an error explaining how to proceed.
+
+
 ## Anthropic {#anthropic}
 
 To use the [Anthropic](https://www.anthropic.com/api) provider, install the `anthropic` package, set your credentials, and specify a model using the `--model` option:
@@ -440,7 +493,7 @@ Note that all models on AWS Bedrock require that you [request model access](http
 
 You should be also sure that you have the appropriate AWS credentials before accessing models on Bedrock. You aren't likely to need to, but you can also specify a custom base URL for AWS Bedrock using the `BEDROCK_BASE_URL` environment variable.
 
-If you are using Anthropic models on Bedrock, you can alternatively use the [Anthropic provider](#anthropic-on-aws-bedrock) as your means of access.
+If you are using Anthropic models on Bedrock, you can alternatively use the [Anthropic provider](#anthropic-on-aws-bedrock) as your means of access. If you are using OpenAI models on Bedrock, access them via the `openai` provider with the `bedrock` qualifier — see [OpenAI on AWS Bedrock](#openai-on-aws-bedrock).
 
 ## AWS SageMaker {#aws-sagemaker}
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 adlfs>=2025.8.0
 anthropic>=0.105.0
 apprise
+aws-bedrock-token-generator
 azure-ai-inference
 azure-identity
 google-genai>=1.69.0
@@ -16,7 +17,7 @@ mistralai>=2.4.5,
 moto[server]>=5.1.5
 mypy>=1.17.0
 nbformat
-openai>=2.26.0
+openai>=2.40.0
 pandas>=2.0.0
 pandas-stubs
 panflute

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -6,6 +6,7 @@ import anyio
 from openai import (
     APIStatusError,
     AsyncAzureOpenAI,
+    AsyncBedrockOpenAI,
     AsyncOpenAI,
     NotFoundError,
     NotGiven,
@@ -54,6 +55,9 @@ from .util import (
     require_azure_base_url,
     resolve_api_key,
     resolve_azure_token_provider,
+    resolve_bedrock_base_url,
+    resolve_bedrock_region,
+    resolve_bedrock_token_provider,
 )
 
 logger = getLogger(__name__)
@@ -63,11 +67,23 @@ OPENAI_SAFETY_IDENTIFIER = "OPENAI_SAFETY_IDENTIFIER"
 AZURE_OPENAI_API_KEY = "AZURE_OPENAI_API_KEY"
 AZUREAI_OPENAI_API_KEY = "AZUREAI_OPENAI_API_KEY"
 
+# Bedrock environment variables
+BEDROCK_OPENAI_API_KEY = "BEDROCK_OPENAI_API_KEY"
+AWS_BEARER_TOKEN_BEDROCK = "AWS_BEARER_TOKEN_BEDROCK"
+
 # Azure base URL environment variables
 AZURE_OPENAI_BASE_URL_VARS = [
     "AZUREAI_OPENAI_BASE_URL",
     "AZURE_OPENAI_BASE_URL",
     "AZURE_OPENAI_ENDPOINT",
+]
+
+# Bedrock base URL environment variables (BEDROCK_OPENAI_BASE_URL is the
+# Inspect-convention name; AWS_BEDROCK_BASE_URL is the AWS-standard name, also
+# read natively by the OpenAI SDK)
+BEDROCK_OPENAI_BASE_URL_VARS = [
+    "BEDROCK_OPENAI_BASE_URL",
+    "AWS_BEDROCK_BASE_URL",
 ]
 
 
@@ -92,7 +108,7 @@ class OpenAIAPI(ModelAPI):
         # that subclass from us like together expect to have the qualifier
         # in the model name e.g. google/gemma-2b-it)
         parts = model_name.split("/")
-        if parts[0] == "azure" and len(parts) > 1:
+        if parts[0] in ("azure", "bedrock") and len(parts) > 1:
             self.service: str | None = parts[0]
         else:
             self.service = None
@@ -134,7 +150,13 @@ class OpenAIAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[OPENAI_API_KEY, AZURE_OPENAI_API_KEY, AZUREAI_OPENAI_API_KEY],
+            api_key_vars=[
+                OPENAI_API_KEY,
+                AZURE_OPENAI_API_KEY,
+                AZUREAI_OPENAI_API_KEY,
+                BEDROCK_OPENAI_API_KEY,
+                AWS_BEARER_TOKEN_BEDROCK,
+            ],
             config=config,
         )
 
@@ -175,7 +197,13 @@ class OpenAIAPI(ModelAPI):
             900.0 if self.service_tier == "flex" else None
         )
 
-        # resolve api_key or managed identity (for Azure)
+        # resolve the AWS region for Bedrock (also pop the aws_region model arg
+        # so it isn't double-passed to AsyncBedrockOpenAI via **model_args)
+        self.aws_region: str | None = None
+        if self.is_bedrock():
+            self.aws_region = resolve_bedrock_region(model_args.pop("aws_region", None))
+
+        # resolve api_key, managed identity (Azure), or AWS credentials (Bedrock)
         self.token_provider = None
         if not self.api_key:
             if self.is_azure():
@@ -185,6 +213,15 @@ class OpenAIAPI(ModelAPI):
                 if not self.api_key:
                     # try managed identity (Microsoft Entra ID)
                     self.token_provider = resolve_azure_token_provider("OpenAI")
+            elif self.is_bedrock():
+                self.api_key = resolve_api_key(
+                    [BEDROCK_OPENAI_API_KEY, AWS_BEARER_TOKEN_BEDROCK]
+                )
+                if not self.api_key:
+                    # generate short-lived bearer tokens from AWS credentials
+                    self.token_provider = resolve_bedrock_token_provider(
+                        self.aws_region
+                    )
             else:
                 self.api_key = os.environ.get(OPENAI_API_KEY, None)
 
@@ -221,7 +258,7 @@ class OpenAIAPI(ModelAPI):
         self.model_args = model_args
         self.initialize()
 
-    def _create_client(self) -> AsyncAzureOpenAI | AsyncOpenAI:
+    def _create_client(self) -> AsyncAzureOpenAI | AsyncBedrockOpenAI | AsyncOpenAI:
         # azure client
         if self.is_azure():
             # resolve base_url (required for Azure)
@@ -235,6 +272,26 @@ class OpenAIAPI(ModelAPI):
                 azure_ad_token_provider=self.token_provider,
                 api_version=self.api_version,
                 azure_endpoint=base_url,
+                http_client=self.http_client,
+                timeout=self.client_timeout
+                if self.client_timeout is not None
+                else NOT_GIVEN,
+                **self.model_args,
+            )
+        elif self.is_bedrock():
+            # exactly one of api_key / bedrock_token_provider is set; pass
+            # api_key as None (not "") when using the token provider so we
+            # don't trip the SDK's mutually-exclusive credentials check
+            return AsyncBedrockOpenAI(
+                api_key=self.api_key or None,
+                bedrock_token_provider=self.token_provider,
+                aws_region=self.aws_region,
+                base_url=resolve_bedrock_base_url(
+                    self.base_url,
+                    BEDROCK_OPENAI_BASE_URL_VARS,
+                    self.aws_region or "",
+                    self.bedrock_mantle_path(),
+                ),
                 http_client=self.http_client,
                 timeout=self.client_timeout
                 if self.client_timeout is not None
@@ -332,7 +389,7 @@ class OpenAIAPI(ModelAPI):
 
         # Call the input_tokens endpoint with reasoning settings
         response = await self.client.responses.input_tokens.count(
-            model=self.service_model_name(),
+            model=self.api_model_name(),
             input=padded_items,
             reasoning=self._get_reasoning_params_for_config(config),
         )
@@ -341,6 +398,17 @@ class OpenAIAPI(ModelAPI):
 
     def is_azure(self) -> bool:
         return self.service == "azure"
+
+    def is_bedrock(self) -> bool:
+        return self.service == "bedrock"
+
+    def bedrock_mantle_path(self) -> str:
+        """Mantle API path for this model.
+
+        Frontier OpenAI models (gpt-5.x, codex) are served on the `/openai/v1`
+        path; open-weight models (e.g. gpt-oss) and others use `/v1`.
+        """
+        return "openai/v1" if (self.is_gpt_5() or self.is_codex()) else "v1"
 
     def has_reasoning_options(self) -> bool:
         return (
@@ -395,7 +463,8 @@ class OpenAIAPI(ModelAPI):
 
     @override
     def supports_remote_mcp(self) -> bool:
-        return True
+        # the OpenAI-on-Bedrock endpoint does not support remote MCP servers
+        return not self.is_bedrock()
 
     @override
     def tool_result_images(self) -> bool:
@@ -435,7 +504,7 @@ class OpenAIAPI(ModelAPI):
             generate_responses(
                 client=self.client,
                 http_hooks=self._http_hooks,
-                model_name=self.service_model_name(),
+                model_name=self.api_model_name(),
                 input=input,
                 tools=tools,
                 tool_choice=tool_choice,
@@ -454,7 +523,7 @@ class OpenAIAPI(ModelAPI):
             else generate_completions(
                 client=self.client,
                 http_hooks=self._http_hooks,
-                model_name=self.service_model_name(),
+                model_name=self.api_model_name(),
                 input=input,
                 tools=tools,
                 tool_choice=tool_choice,
@@ -470,6 +539,18 @@ class OpenAIAPI(ModelAPI):
     def service_model_name(self) -> str:
         """Model name without any service prefix."""
         return self.model_name.replace(f"{self.service}/", "", 1)
+
+    def api_model_name(self) -> str:
+        """Model id to send to the API.
+
+        Bedrock requires an `openai.` prefix on the model id (e.g.
+        `openai.gpt-5.5`); we add it here so model-family detection and the
+        model-info canonical name can keep operating on the plain name.
+        """
+        name = self.service_model_name()
+        if self.is_bedrock() and not name.startswith("openai."):
+            return f"openai.{name}"
+        return name
 
     def canonical_name(self) -> str:
         """Canonical model name for model info database lookup."""
@@ -524,7 +605,7 @@ class OpenAIAPI(ModelAPI):
                 if self.responses_api and self.has_reasoning_options():
                     try:
                         await self.client.responses.create(
-                            model=self.service_model_name(),
+                            model=self.api_model_name(),
                             input="Please say 'hello, world'",
                             reasoning={"effort": "low", "summary": "auto"},
                         )
@@ -603,7 +684,7 @@ class OpenAIAPI(ModelAPI):
         # Call compact endpoint (note: compact() doesn't accept reasoning params)
         try:
             response = await self.client.responses.compact(
-                model=self.service_model_name(),
+                model=self.api_model_name(),
                 input=input_params,
                 instructions=instructions if instructions is not None else omit,
             )

--- a/src/inspect_ai/model/_providers/openai_completions.py
+++ b/src/inspect_ai/model/_providers/openai_completions.py
@@ -121,7 +121,7 @@ def completion_params_completions(
     openai_api: "OpenAIAPI", config: GenerateConfig, tools: bool
 ) -> dict[str, Any]:
     # first call the default processing
-    params = openai_completion_params(openai_api.service_model_name(), config, tools)
+    params = openai_completion_params(openai_api.api_model_name(), config, tools)
 
     # add service_tier if specified
     if openai_api.service_tier is not None:

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -332,7 +332,7 @@ def hf_inference_providers() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "2.26.0"
+    MIN_VERSION = "2.40.0"
 
     # verify we have the package
     try:

--- a/src/inspect_ai/model/_providers/util/__init__.py
+++ b/src/inspect_ai/model/_providers/util/__init__.py
@@ -5,6 +5,11 @@ from .azure_hosting import (
     require_azure_base_url,
     resolve_azure_token_provider,
 )
+from .bedrock_hosting import (
+    resolve_bedrock_base_url,
+    resolve_bedrock_region,
+    resolve_bedrock_token_provider,
+)
 from .chatapi import (
     ChatAPIHandler,
     ChatAPIMessage,
@@ -29,6 +34,9 @@ __all__ = [
     "require_azure_base_url",
     "resolve_api_key",
     "resolve_azure_token_provider",
+    "resolve_bedrock_base_url",
+    "resolve_bedrock_region",
+    "resolve_bedrock_token_provider",
     "check_azure_deployment_mismatch",
     "tool_parse_error_message",
     "ChatAPIHandler",

--- a/src/inspect_ai/model/_providers/util/bedrock_hosting.py
+++ b/src/inspect_ai/model/_providers/util/bedrock_hosting.py
@@ -1,0 +1,97 @@
+"""Common Amazon Bedrock utilities for model providers."""
+
+import os
+from logging import getLogger
+from typing import Callable
+
+from inspect_ai._util.error import PrerequisiteError
+
+from .util import model_base_url
+
+logger = getLogger(__name__)
+
+# OpenAI models on Bedrock are currently only available in us-east-2, so we
+# default to it when no region is otherwise specified (revisit when more
+# regions become available).
+DEFAULT_BEDROCK_REGION = "us-east-2"
+
+
+def resolve_bedrock_base_url(
+    base_url: str | None, base_url_vars: list[str], region: str, path: str = "v1"
+) -> str:
+    """Resolve the Bedrock Mantle (OpenAI-compatible) endpoint base URL.
+
+    Uses an explicit `base_url` or one of `base_url_vars` if provided, otherwise
+    derives the region-specific Mantle endpoint. We derive the endpoint ourselves
+    (rather than relying on the OpenAI SDK) because the correct path is
+    model-dependent: frontier OpenAI models (gpt-5.x, codex) are served at
+    `/openai/v1`, while open-weight models (e.g. gpt-oss) and others are served
+    at `/v1` (the OpenAI SDK always derives `/openai/v1`).
+
+    Args:
+        base_url: Explicitly provided base URL (or None).
+        base_url_vars: Environment variable names to check for a base URL.
+        region: The resolved AWS region.
+        path: API path for the Mantle endpoint (`"v1"` or `"openai/v1"`).
+
+    Returns:
+        The resolved base URL.
+    """
+    return (
+        model_base_url(base_url, base_url_vars)
+        or f"https://bedrock-mantle.{region}.api.aws/{path}"
+    )
+
+
+def resolve_bedrock_region(region: str | None) -> str:
+    """Resolve the AWS region for Bedrock.
+
+    Precedence: explicit `region` arg, then `AWS_REGION`, then
+    `AWS_DEFAULT_REGION`, then the `DEFAULT_BEDROCK_REGION` fallback. Always
+    returns a region (never raises).
+
+    Args:
+        region: Explicitly provided region (or None).
+
+    Returns:
+        The resolved AWS region.
+    """
+    return (
+        region
+        or os.environ.get("AWS_REGION")
+        or os.environ.get("AWS_DEFAULT_REGION")
+        or DEFAULT_BEDROCK_REGION
+    )
+
+
+def resolve_bedrock_token_provider(region: str | None) -> Callable[[], str]:
+    """Resolve a Bedrock bearer-token provider from the AWS credential chain.
+
+    Generates short-lived Bedrock bearer tokens from standard AWS credentials
+    (IAM roles, instance profiles, SSO, AssumeRole, env credentials, profiles)
+    via the `aws-bedrock-token-generator` package.
+
+    Args:
+        region: AWS region the generated token should be scoped to.
+
+    Returns:
+        A callable token provider function.
+
+    Raises:
+        PrerequisiteError: If the `aws-bedrock-token-generator` package is not
+            installed.
+    """
+    try:
+        from aws_bedrock_token_generator import (  # type: ignore[import-untyped]
+            provide_token,
+        )
+    except ImportError:
+        raise PrerequisiteError(
+            "ERROR: Using OpenAI on Bedrock with AWS credentials requires the "
+            "`aws-bedrock-token-generator` package.\n\n"
+            "Install it with: pip install aws-bedrock-token-generator\n\n"
+            "Alternatively, provide a Bedrock API key via the BEDROCK_OPENAI_API_KEY "
+            "or AWS_BEARER_TOKEN_BEDROCK environment variable."
+        )
+
+    return lambda: provide_token(region=region)

--- a/tests/model/providers/test_openai_bedrock.py
+++ b/tests/model/providers/test_openai_bedrock.py
@@ -1,0 +1,162 @@
+from typing import cast
+
+import pytest
+from openai import AsyncBedrockOpenAI
+from test_helpers.utils import skip_if_no_openai_bedrock
+
+from inspect_ai.model import GenerateConfig, get_model
+from inspect_ai.model._providers.openai import OpenAIAPI
+
+# Bedrock auth/region env vars that must be cleared so tests don't pick up a
+# developer's real environment.
+BEDROCK_ENV_VARS = [
+    "BEDROCK_OPENAI_API_KEY",
+    "AWS_BEARER_TOKEN_BEDROCK",
+    "BEDROCK_OPENAI_BASE_URL",
+    "AWS_BEDROCK_BASE_URL",
+    "AWS_REGION",
+    "AWS_DEFAULT_REGION",
+]
+
+
+@pytest.fixture
+def clean_bedrock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    for var in BEDROCK_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+
+
+def bedrock_api(model_name: str = "openai/bedrock/gpt-5.5", **kwargs) -> OpenAIAPI:
+    # memoize=False so each test gets a fresh instance that re-reads the
+    # monkeypatched environment rather than a cached one
+    return cast(OpenAIAPI, get_model(model_name, memoize=False, **kwargs).api)
+
+
+def test_bedrock_prefix_parsing(clean_bedrock_env: None) -> None:
+    api = bedrock_api(api_key="test-key")
+    assert api.service == "bedrock"
+    assert api.is_bedrock() is True
+    assert api.service_model_name() == "gpt-5.5"
+    # the openai. prefix is added only at the API boundary
+    assert api.api_model_name() == "openai.gpt-5.5"
+    # canonical name (for model-info lookup) keeps the plain name
+    assert api.canonical_name() == "openai/gpt-5.5"
+
+
+def test_bedrock_region_default(clean_bedrock_env: None) -> None:
+    # with nothing set, region defaults to us-east-2 (the only region offering
+    # these models today)
+    api = bedrock_api(api_key="test-key")
+    assert api.aws_region == "us-east-2"
+    assert "us-east-2" in str(api.client.base_url)
+
+
+def test_bedrock_base_url_path_frontier(clean_bedrock_env: None) -> None:
+    # frontier models (gpt-5.x, codex) are served on the /openai/v1 path
+    api = bedrock_api("openai/bedrock/gpt-5.5", api_key="test-key")
+    base_url = str(api.client.base_url).rstrip("/")
+    assert base_url == "https://bedrock-mantle.us-east-2.api.aws/openai/v1"
+
+
+def test_bedrock_base_url_path_open_weight(clean_bedrock_env: None) -> None:
+    # open-weight models (e.g. gpt-oss) are served on the /v1 path
+    api = bedrock_api("openai/bedrock/gpt-oss-120b", api_key="test-key")
+    base_url = str(api.client.base_url).rstrip("/")
+    assert base_url == "https://bedrock-mantle.us-east-2.api.aws/v1"
+    assert "/openai/v1" not in base_url
+
+
+def test_bedrock_region_env_override(
+    clean_bedrock_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AWS_REGION", "us-west-2")
+    api = bedrock_api(api_key="test-key")
+    assert api.aws_region == "us-west-2"
+
+
+def test_bedrock_aws_region_model_arg(clean_bedrock_env: None) -> None:
+    # the aws_region model arg wins and must not leak into model_args (which
+    # would otherwise be double-passed to AsyncBedrockOpenAI)
+    api = bedrock_api(api_key="test-key", aws_region="eu-west-1")
+    assert api.aws_region == "eu-west-1"
+    assert "aws_region" not in api.model_args
+
+
+def test_bedrock_static_key_inspect_var(
+    clean_bedrock_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("BEDROCK_OPENAI_API_KEY", "inspect-key")
+    api = bedrock_api()
+    assert api.api_key == "inspect-key"
+    assert api.token_provider is None
+
+
+def test_bedrock_static_key_aws_var_fallback(
+    clean_bedrock_env: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # AWS-standard name resolves when the Inspect-convention name is unset
+    monkeypatch.setenv("AWS_BEARER_TOKEN_BEDROCK", "aws-key")
+    api = bedrock_api()
+    assert api.api_key == "aws-key"
+    assert api.token_provider is None
+
+
+def test_bedrock_token_provider_path(clean_bedrock_env: None) -> None:
+    # no static key anywhere -> fall through to the AWS credential-chain token
+    # provider (mutually exclusive with api_key)
+    api = bedrock_api()
+    assert not api.api_key
+    assert callable(api.token_provider)
+
+
+def test_bedrock_client_type(clean_bedrock_env: None) -> None:
+    api = bedrock_api(api_key="test-key")
+    assert isinstance(api.client, AsyncBedrockOpenAI)
+
+
+def test_bedrock_responses_api_default(clean_bedrock_env: None) -> None:
+    # family detection runs on the plain name, so gpt-5.5 prefers the
+    # Responses API (which Bedrock supports)
+    api = bedrock_api(api_key="test-key")
+    assert api.responses_api is True
+
+
+def test_bedrock_disables_remote_mcp(clean_bedrock_env: None) -> None:
+    api = bedrock_api(api_key="test-key")
+    assert api.supports_remote_mcp() is False
+
+
+@pytest.mark.parametrize("env_var", ["BEDROCK_OPENAI_BASE_URL", "AWS_BEDROCK_BASE_URL"])
+def test_bedrock_base_url_env(
+    clean_bedrock_env: None, monkeypatch: pytest.MonkeyPatch, env_var: str
+) -> None:
+    # both the Inspect-convention and AWS-standard base URL env vars are honored
+    monkeypatch.setenv(env_var, "https://custom.example.com/openai/v1")
+    api = bedrock_api(api_key="test-key")
+    assert "custom.example.com" in str(api.client.base_url)
+
+
+@pytest.mark.anyio
+@skip_if_no_openai_bedrock
+@pytest.mark.parametrize(
+    "model_name,aws_region",
+    [
+        # open-weight model: served on the /v1 path, broadly available across
+        # regions, so use the tester's own region resolution
+        ("openai/bedrock/gpt-oss-120b", None),
+        # frontier model: served on the /openai/v1 path via the Responses API;
+        # gpt-5.5 is currently only available in us-east-2, so pin the region
+        ("openai/bedrock/gpt-5.5", "us-east-2"),
+    ],
+)
+async def test_bedrock_generate(model_name: str, aws_region: str | None) -> None:
+    # We assert on output token usage rather than completion text: some models
+    # (e.g. gpt-oss) can route their entire response through a reasoning channel,
+    # leaving completion text empty even on a successful call. Bedrock bearer
+    # keys are region-bound, so the tester's key must be valid for the region.
+    kwargs: dict = dict(config=GenerateConfig(max_tokens=200))
+    if aws_region is not None:
+        kwargs["aws_region"] = aws_region
+    model = get_model(model_name, **kwargs)
+    response = await model.generate(input="Say hello in three words.")
+    assert response.usage is not None
+    assert response.usage.output_tokens > 0

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -216,6 +216,20 @@ def skip_if_no_openai_azure(func):
     )(func)
 
 
+def skip_if_no_openai_bedrock(func):
+    func._needs_flaky_retry = True
+    return pytest.mark.api(
+        pytest.mark.skipif(
+            importlib.util.find_spec("openai") is None
+            or (
+                os.environ.get("BEDROCK_OPENAI_API_KEY") is None
+                and os.environ.get("AWS_BEARER_TOKEN_BEDROCK") is None
+            ),
+            reason="Test requires the OpenAI package and a Bedrock bearer key (BEDROCK_OPENAI_API_KEY or AWS_BEARER_TOKEN_BEDROCK)",
+        )(func)
+    )
+
+
 def skip_if_no_mistral_azure(func):
     func._needs_flaky_retry = True
     return pytest.mark.skipif(

--- a/uv.lock
+++ b/uv.lock
@@ -475,6 +475,18 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-bedrock-token-generator"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/39/cf1c2e12bc5a84af0f96a546481213f81fa6e7927d2bbabd81758c6558ca/aws_bedrock_token_generator-1.1.0.tar.gz", hash = "sha256:95ccb07f63a91ac486561f6df05cc4e04784c8ff5086dc687ed9c5fd3ab1b5ba", size = 19123, upload-time = "2025-07-29T19:53:19.511Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/fd/745ece98870c3824d294bcdce5dc5e15381188a41bc80832c246b205e40e/aws_bedrock_token_generator-1.1.0-py3-none-any.whl", hash = "sha256:bd12854f7c7e52dde5d980d369379f12d0cc5f0855099d87f38688b0f9de5cd4", size = 10291, upload-time = "2025-07-29T19:53:18.704Z" },
+]
+
+[[package]]
 name = "aws-sam-translator"
 version = "1.106.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2002,6 +2014,7 @@ dev = [
     { name = "adlfs" },
     { name = "anthropic" },
     { name = "apprise" },
+    { name = "aws-bedrock-token-generator" },
     { name = "azure-ai-inference" },
     { name = "azure-identity" },
     { name = "google-genai" },
@@ -2084,6 +2097,7 @@ requires-dist = [
     { name = "anthropic", marker = "extra == 'dev'", specifier = ">=0.105.0" },
     { name = "anyio", specifier = ">=4.8.0" },
     { name = "apprise", marker = "extra == 'dev'" },
+    { name = "aws-bedrock-token-generator", marker = "extra == 'dev'" },
     { name = "azure-ai-inference", marker = "extra == 'dev'" },
     { name = "azure-identity", marker = "extra == 'dev'" },
     { name = "beautifulsoup4", specifier = ">=4.10.0" },
@@ -2123,7 +2137,7 @@ requires-dist = [
     { name = "nbformat", marker = "extra == 'dev'" },
     { name = "nest-asyncio2", specifier = ">=1.7.2" },
     { name = "numpy" },
-    { name = "openai", marker = "extra == 'dev'", specifier = ">=2.26.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=2.40.0" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "panflute", marker = "extra == 'dev'" },
@@ -4155,7 +4169,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.32.0"
+version = "2.40.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4167,9 +4181,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ed/59/bdcc6b759b8c42dd73afaf5bf8f902c04b37987a5514dbc1c64dba390fef/openai-2.32.0.tar.gz", hash = "sha256:c54b27a9e4cb8d51f0dd94972ffd1a04437efeb259a9e60d8922b8bd26fe55e0", size = 693286, upload-time = "2026-04-15T22:28:19.434Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/9f/136562ec6c3b1a50fe06eb0bb34ed21f0d7426ec0140e5cc43ac785b69a5/openai-2.40.0.tar.gz", hash = "sha256:9a756f91f274a24ad6026cbcb2042fd356c8d4a10e8f347b08d34465e585f7a2", size = 781177, upload-time = "2026-06-01T21:48:23.878Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/c1/d6e64ccd0536bf616556f0cad2b6d94a8125f508d25cfd814b1d2db4e2f1/openai-2.32.0-py3-none-any.whl", hash = "sha256:4dcc9badeb4bf54ad0d187453742f290226d30150890b7890711bda4f32f192f", size = 1162570, upload-time = "2026-04-15T22:28:17.714Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/46/180e14be801a75bc13f234cb1b594b232adeb9c84e60a9ab1832e8333591/openai-2.40.0-py3-none-any.whl", hash = "sha256:2b205637ff214477f9ce9ab035e9f494db0e3fa8f1e599008953735fbf6ff1ff", size = 1350935, upload-time = "2026-06-01T21:48:21.462Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The `openai` provider now supports OpenAI models served through [Amazon Bedrock](https://aws.amazon.com/bedrock/). Use the normal `openai` provider with the `bedrock` qualifier, and use a standard OpenAI model identifier (Inspect automatically adds prefixes and suffixes required by Bedrock). For example:

``` bash
export AWS_BEARER_TOKEN_BEDROCK=your-bedrock-api-key
inspect eval arc.py --model openai/bedrock/gpt-5.5
```

You don't need to set a region for the example above — Inspect defaults to `us-east-2`. The available model ids (e.g. `gpt-5.5`, `gpt-oss-120b`) and the regions they're offered in vary over time and by account; the [`bedrock-mantle` documentation](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-mantle.html) lists the supported regions.

#### Region

The AWS region is resolved with the following precedence: the `aws_region` model arg (`-M aws_region`), then `AWS_REGION`, then `AWS_DEFAULT_REGION`, and finally a default of `us-east-2`. Region availability varies by model (for example, at the time of writing `gpt-5.5` is only offered in `us-east-2`. Note that Bedrock API keys are region-bound (a key only works in the region it was created in).

If your environment sets a global `AWS_REGION` for other AWS services, you can target a specific region for this model only — without changing that global — using the model arg:

``` bash
inspect eval arc.py --model openai/bedrock/gpt-5.5 -M aws_region=us-east-2
```

#### Authentication

Authentication uses an AWS Bedrock bearer token. There are two ways to provide one:

| Variable | Description |
|---------------------------|---------------------------------------------|
| `AWS_BEARER_TOKEN_BEDROCK` | Bedrock bearer API key — the AWS-standard name, as used in the AWS and OpenAI documentation. |
| `BEDROCK_OPENAI_API_KEY` | Bedrock bearer API key — Inspect-convention alias (takes precedence if both are set). |
| `BEDROCK_OPENAI_BASE_URL` | Custom endpoint override (optional; the AWS-standard `AWS_BEDROCK_BASE_URL` is also accepted). By default Inspect targets the region's Mantle endpoint, choosing the model-appropriate path automatically (`/openai/v1` for frontier models like GPT-5.x and Codex, `/v1` for open-weight models like gpt-oss). |
| `AWS_REGION` / `AWS_DEFAULT_REGION` | AWS region (optional; defaults to `us-east-2`). |

The first option is a static bearer key. Generate an [Amazon Bedrock API key](https://docs.aws.amazon.com/bedrock/latest/userguide/api-keys.html) and set it via `AWS_BEARER_TOKEN_BEDROCK` (the name used in the AWS and OpenAI docs; Inspect also accepts `BEDROCK_OPENAI_API_KEY`).

The second option uses your standard AWS credentials (IAM roles, instance profiles, SSO, AssumeRole, `AWS_ACCESS_KEY_ID`/`AWS_SECRET_ACCESS_KEY`, or a configured `AWS_PROFILE`). If no bearer key is set, Inspect generates short-lived bearer tokens from these credentials. This requires the `aws-bedrock-token-generator` package:

``` bash
pip install aws-bedrock-token-generator
export AWS_PROFILE=your-profile           # or any standard AWS credential source
inspect eval arc.py --model openai/bedrock/gpt-5.5
```

If the package is not installed and no bearer key is available, Inspect raises an error explaining how to proceed.