### PR TITLE
Fix bash_session crash on realtime logging caused by sandbox object in store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Inspect View: Migrated the sample transcript to a virtualized list for smoother rendering of long transcripts.
 - Bugfix: Inspect View sample-list columns now expand to fill the available width.
 - Bugfix: Avoid emitting empty assistant output messages when converting Chat Completions tool-call with reasoning into Responses API input items.
+- Bugfix: Fix crash when running `bash_session` with realtime logging enabled (the default), caused by a non-serializable sandbox object being written to the sample store. The sandbox is now re-resolved per call rather than cached in the store.
 
 ## 0.3.233 (01 June 2026)
 

--- a/src/inspect_ai/tool/_tools/_bash_session.py
+++ b/src/inspect_ai/tool/_tools/_bash_session.py
@@ -11,7 +11,6 @@ from inspect_ai.tool._sandbox_tools_utils.sandbox import sandbox_with_injected_t
 from inspect_ai.util import StoreModel, store_as
 from inspect_ai.util._sandbox._cli import SANDBOX_CLI
 from inspect_ai.util._sandbox._json_rpc_transport import SandboxJSONRPCTransport
-from inspect_ai.util._sandbox.environment import SandboxEnvironment
 
 from .._tool import Tool, ToolParsingError, tool
 
@@ -30,7 +29,6 @@ class BashRestartResult(BaseModel):
 
 class BashSessionStore(StoreModel):
     session_id: str = Field(default_factory=str)
-    sandbox: SandboxEnvironment | None = Field(default=None)
 
 
 # Action-specific parameter models
@@ -194,7 +192,7 @@ def bash_session(
                     )
 
         store = store_as(BashSessionStore, instance=instance)
-        sandbox = await _get_sandbox(store)
+        sandbox = await sandbox_with_injected_tools()
 
         # Create transport for all RPC calls
         transport = SandboxJSONRPCTransport(sandbox, SANDBOX_CLI)
@@ -245,10 +243,3 @@ def bash_session(
         )
 
     return execute
-
-
-async def _get_sandbox(store: BashSessionStore) -> SandboxEnvironment:
-    if not store.sandbox:
-        store.sandbox = await sandbox_with_injected_tools()
-
-    return store.sandbox


### PR DESCRIPTION
## Summary

`bash_session` cached the live `SandboxEnvironment` proxy in its `BashSessionStore` (`StoreModel`). Because store-model fields write through to the sample store, the proxy ended up in `state.store` and was copied into the logged `EvalSample`. The realtime streaming sample writer serializes via a raw `model_dump(mode="json")` with no fallback, so the non-serializable proxy crashed any `bash_session` eval with realtime logging enabled (the default). Other write paths route through `to_json_safe` (`fallback=lambda _x: None`), which silently logged the field as `null` instead of crashing.

## Fix

Re-resolve the sandbox per call via `sandbox_with_injected_tools()` instead of caching it in the store — matching the `web_browser` pattern, where only the serializable `session_id` persists. No live object ever lands in the sample store, which fixes the crash and the prior `sandbox: null` corruption.

## Notes

- Behavioral change: each `bash_session` action now runs the (idempotent) injection probe to re-resolve the sandbox, the same trade-off `web_browser` already makes.
- Refs #4120 (does not close it — that issue also tracks the streaming-writer serialization-safety gap and the pytest realtime-buffer coverage gap, addressed separately).