### PR TITLE
Fix scanner test under pandas 3.0 nullable-string NaN sentinel

### DIFF
--- a/tests/test_eval_set_scanner.py
+++ b/tests/test_eval_set_scanner.py
@@ -1278,7 +1278,12 @@ def test_eval_set_resume_scans_when_finalize_did_not_run_cleanly() -> None:
         assert id2_rows.iloc[0]["scan_error"]
         id3_rows = df[df["transcript_task_id"] == "3"]
         assert len(id3_rows) == 1
-        assert not id3_rows.iloc[0]["scan_error"]
+        # scan_error is null for a successful scan. Use pd.isna so this works
+        # under both pandas 2.x (object dtype, None) and pandas 3.0+ (str
+        # dtype, NaN sentinel) where `not <missing>` is no longer reliable.
+        import pandas as pd
+
+        assert pd.isna(id3_rows.iloc[0]["scan_error"])
 
 
 def test_eval_set_resume_scans_when_scanner_added_on_resume() -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`tests/test_eval_set_scanner.py::test_eval_set_resume_scans_when_finalize_did_not_run_cleanly` fails under pandas 3.0.

pandas 3.0 changed the default string dtype to the new `StringDtype`, which uses `NaN` (not `None`) as the missing-value sentinel. The assertion `assert not id3_rows.iloc[0]["scan_error"]` relied on pandas 2.x preserving `None` in an object-dtype column; under pandas 3.0 the value is `NaN` and `bool(nan)` is `True`, so `not nan` is `False` and the assertion fails.

Fixes meridianlabs-ai/actions#39

### What is the new behavior?

The assertion uses `pd.isna(...)`, which correctly detects the missing value under both pandas 2.x (`None`) and pandas 3.0+ (`NaN`).

This is the only `scan_error` truthy-on-missing check in the file. The nearby `assert id2_rows.iloc[0]["scan_error"]` (present non-empty string) and the `transcript_error` truthy checks (lines 777, 832, 1090) assert on present values and are unaffected.

Verified locally with `pandas==3.0.3` + `inspect-scout==0.4.39`:

```
pytest tests/test_eval_set_scanner.py::test_eval_set_resume_scans_when_finalize_did_not_run_cleanly
1 passed
```

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Test-only change.

### Other information:

🤖 Generated with [Claude Code](https://claude.com/claude-code)