### PR TITLE
test: xfail span-balance check for checkpoint resume

### DIFF
--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -30,7 +30,7 @@ from test_helpers.utils import skip_if_no_docker
 from inspect_ai import Task, eval, eval_retry, task
 from inspect_ai.agent import react
 from inspect_ai.dataset import Sample
-from inspect_ai.event import SpanBeginEvent, SpanEndEvent, ToolEvent
+from inspect_ai.event import Event, SpanBeginEvent, SpanEndEvent, ToolEvent
 from inspect_ai.event._checkpoint import CheckpointEvent
 from inspect_ai.log import read_eval_log
 from inspect_ai.log._samples import sample_active
@@ -54,6 +54,28 @@ WRITE_CMD = (
     f"printf '{LAYER1_CONTENT}' > /workspace/decoded/layer1.txt"
 )
 SCRIPTED_MODEL = "scripteddecode/model"
+
+
+def assert_spans_balanced(events: list[Event]) -> None:
+    """Assert the event stream's spans are well-formed (LIFO-nested).
+
+    Treats ``span_begin``/``span_end`` as brackets: every end must close
+    the innermost open span, and nothing may be left open at the end.
+    Presence/membership assertions can't catch an *additive* structural
+    corruption (extra unbalanced spans wrapped around otherwise-correct
+    content) — this can. See ``test_checkpoint_resume_spans_balanced``.
+    """
+    stack: list[str] = []
+    for e in events:
+        if isinstance(e, SpanBeginEvent):
+            stack.append(e.id)
+        elif isinstance(e, SpanEndEvent):
+            assert stack, f"span_end {e.id} with no open span"
+            top = stack.pop()
+            assert top == e.id, (
+                f"span_end {e.id} closes out of order; innermost open span is {top}"
+            )
+    assert not stack, f"{len(stack)} unclosed span(s): {stack}"
 
 
 class _ResumeState:
@@ -260,3 +282,50 @@ def test_checkpoint_resume_runs_to_completion(
         if isinstance(e, CheckpointEvent) and not (begin_idx < i < end_idx)
     }
     assert new_checkpoint_ids == {3}
+
+
+@skip_if_no_docker
+@pytest.mark.slow
+@pytest.mark.xfail(
+    reason="resume rehydrates the prior run's still-open structural spans "
+    "(solvers/react, open at checkpoint-fire time) as raw span_begins with "
+    "no matching span_end, so the `prior_run` wrap closes out of order. "
+    "Regressed in #4062 (bounded transcript store dropped the "
+    "checkpoint-spans-only capture boundary). Remove xfail once the "
+    "rehydrated wrap is span-balanced again.",
+    strict=True,
+)
+def test_checkpoint_resume_spans_balanced(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The resumed run's committed transcript must be span-balanced.
+
+    Same cancel-then-retry flow as
+    ``test_checkpoint_resume_runs_to_completion``, but asserts structural
+    well-formedness of the event stream rather than content presence — the
+    one check that catches the rehydration regression.
+    """
+    monkeypatch.setenv("INSPECT_CHECKPOINTING", "1")
+    _resume_state.cancelled = False
+    _resume_state.generates = 0
+
+    log_dir = str(tmp_path / "logs")
+
+    # initial attempt: cancels mid-run after checkpoints commit
+    log = eval(resume_decode_task(), model=SCRIPTED_MODEL, log_dir=log_dir)[0]
+    assert log.status == "error"
+
+    # the cancelled run's own transcript closes its spans on interrupt unwind
+    initial = read_eval_log(log.location)
+    assert initial.samples is not None
+    assert_spans_balanced(initial.samples[0].events)
+
+    # retry: resume from checkpoint and run to completion
+    retry_log = eval_retry(log, log_dir=log_dir)[0]
+    assert retry_log.status == "success"
+
+    # the rehydrated `prior_run` wrap must be a self-contained, balanced
+    # subtree — not closed while restored structural spans are still open
+    completed = read_eval_log(retry_log.location)
+    assert completed.samples is not None
+    assert_spans_balanced(completed.samples[0].events)


### PR DESCRIPTION
## What

Adds a structural well-formedness check for the checkpoint resume path:

- `assert_spans_balanced(events)` — a bracket-matcher over `span_begin`/`span_end` (LIFO stack: push on begin, pop-and-match on end, assert empty at end).
- `test_checkpoint_resume_spans_balanced` — same cancel-then-retry flow as the existing `test_checkpoint_resume_runs_to_completion`, but asserts the resumed run's committed `.eval` transcript is span-balanced rather than checking content presence.

Marked `@pytest.mark.xfail(strict=True)` because it currently fails — it documents a live regression and will flip to a real failure (XPASS) the moment the bug is fixed, forcing the marker's removal.

## The regression it pins (#4062)

A checkpoint fires at the **start of a turn, deep inside the react loop**, so the prior run's structural spans (`solvers` / `react [solver]` / `react [agent]`) are open at fire time. On resume those rehydrate as raw `span_begin`s with no matching `span_end`, so the `prior_run` ("checkpoint restore") wrap closes **out of order** — an ill-formed event tree.

Before #4062 the checkpointer captured events only from the first `span_begin: checkpoint` onward, so `events.json` was checkpoint-spans-only and the wrap was naturally balanced. #4062 ("Bound transcript memory for long-running samples") replaced that with a `TranscriptEventStore` seeded from the **full** `history.resident_events` and a `write_transcript_files` that dumps everything — dropping the capture boundary.

Confirmed by bisection: this test (with the balance assertions) **passes on the commit immediately prior to #4062** and **fails on current `main`**.

## Why presence assertions missed it

The existing test only makes presence/membership assertions (checkpoint-id sets, tool names). The corruption is purely *additive* — extra unbalanced spans wrapped around otherwise-correct content — so every existing assertion stays true. Only a structural balance check catches it.

## Notes

- The fix itself is **not** in this PR — this is the regression-pinning test only.
- The cancelled-run balance assertion passes (interrupt unwind closes spans correctly); the corruption is isolated to the rehydration path.