### PR TITLE
Agent Bridge: By default the bridge no longer forwards client generation-tuning parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bedrock: Support `response_schema` (structured output) for Claude models via `output_config.format`.
 - Deep Agent: Subagent `submit()` calls are retained in the subagent transcript (previously stripped) and rendered as markdown, so a submit is distinguishable from a normal assistant message. The parent's result is unchanged.
 - Sandbox: Allow `sandbox_service()` instances running as different users in the same sandbox to share `/var/tmp/sandbox-services`.
+- Agent Bridge: By default the bridge no longer forwards client generation-tuning parameters (e.g. `max_tokens`, `temperature`, reasoning effort/tokens) to the resolved Inspect model, leaving these parameters entirely determined by the evaluation config. Pass `forward_generation_config=True` to `agent_bridge()`/`sandbox_agent_bridge()` to restore previous behavior.
 - Agent Intervention: Support connecting to all samples (disabling interruption and user messages if the agent doesn't explicitly support ACP).
 - Docker Compose: accept `platform`, `extra_hosts`, `cap_add`, `cap_drop`, `security_opt`, and `tmpfs` in ComposeService.
 - Docker Sandbox: `SandboxTimeoutError` now carries `truncated_output` with the partial command output captured before a timeout (surfaced to tool callers), instead of discarding it.

--- a/docs/agent-bridge.qmd
+++ b/docs/agent-bridge.qmd
@@ -178,6 +178,23 @@ For example, in a LangChain agent, you would do this to utilise the Inspect inte
 model = ChatOpenAI(model="inspect/google/gemini-1.5-pro")
 ```
 
+## Generation Config
+
+Bridged agents typically tune their requests (e.g. `max_tokens`, `temperature`, reasoning effort) for the model named in their own configuration, which is _not_ the Inspect model actually serving the request. Those values are therefore targeted for the wrong model, and forwarding them can produce incorrect or even failing requests (for example a small `max_tokens` combined with reasoning being enabled on the real model).
+
+For this reason, by default the bridge does not forward client generation parameters. Instead, the resolved Inspect model configuration and the provider's defaults govern generation. Structural parameters that express the agent's intent — the system prompt, tools, tool choice, response format, `stop` sequences, and `seed` — are always forwarded.
+
+The generation parameters dropped by default are: `max_tokens`, `temperature`, `top_p`, `top_k`, `frequency_penalty`, `presence_penalty`, `n`/`num_choices`, `logprobs`, `top_logprobs`, `logit_bias`, and reasoning effort/tokens/summary.
+
+If you want the bridge to act as a faithful proxy where the agent's generation parameters are authoritative, pass `forward_generation_config=True`:
+
+``` python
+async with agent_bridge(state, forward_generation_config=True) as bridge:
+    ...
+```
+
+This option is available on both `agent_bridge()` and `sandbox_agent_bridge()`.
+
 ## Transcript
 
 Custom agents run through a bridge still get most of the benefit of the Inspect transcript and log viewer. All model calls are captured and produce the same transcript output as when using conventional agents.

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -78,6 +78,7 @@ from .types import AgentBridge
 from .util import (
     apply_message_ids,
     bridge_generate,
+    clear_generation_params,
     resolve_generate_config,
     resolve_inspect_model,
 )
@@ -128,6 +129,8 @@ async def inspect_anthropic_api_request_impl(
 
     # extract generate config (hoist instructions into system_message)
     config = generate_config_from_anthropic(json_data)
+    if not bridge.forward_generation_config:
+        clear_generation_params(config)
     config.extra_headers = headers
     if config.system_message is not None:
         messages.insert(0, ChatMessageSystem(content=config.system_message))

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -91,6 +91,7 @@ async def agent_bridge(
     web_search: WebSearchProviders | None = None,
     code_execution: CodeExecutionProviders | None = None,
     model_event_sink: ModelEventSink | None = None,
+    forward_generation_config: bool = False,
 ) -> AsyncGenerator[AgentBridge, None]:
     """Agent bridge.
 
@@ -126,6 +127,13 @@ async def agent_bridge(
           emission for calls routed through the bridge. When set, the bridge
           installs it around `model.generate()` so the sink decides when and
           under which span each event is emitted to the transcript.
+       forward_generation_config: Forward client generation parameters (e.g.
+          `max_tokens`, `temperature`, reasoning effort) to the model. Defaults
+          to `False`, in which case those parameters are dropped and the resolved
+          Inspect model config and provider defaults govern generation (structural
+          parameters like the system prompt, tools, and response format are always
+          forwarded). Set `True` for faithful-proxy behavior where the client's
+          generation parameters are authoritative.
     """
     # ensure one time init
     init_bridge_request_patch()
@@ -144,6 +152,7 @@ async def agent_bridge(
         retry_refusals,
         compaction,
         model_event_sink=model_event_sink,
+        forward_generation_config=forward_generation_config,
     )
 
     # set the patch config for this context and child coroutines

--- a/src/inspect_ai/agent/_bridge/completions.py
+++ b/src/inspect_ai/agent/_bridge/completions.py
@@ -22,6 +22,7 @@ from inspect_ai.util._json import JSONSchema
 from .util import (
     apply_message_ids,
     bridge_generate,
+    clear_generation_params,
     resolve_generate_config,
     resolve_inspect_model,
 )
@@ -64,6 +65,8 @@ async def inspect_completions_api_request(
 
     # extract generate config (hoist instructions into system_message)
     config = generate_config_from_openai_completions(json_data)
+    if not bridge.forward_generation_config:
+        clear_generation_params(config)
     config.extra_headers = headers
     if config.system_message is not None:
         messages.insert(0, ChatMessageSystem(content=config.system_message))

--- a/src/inspect_ai/agent/_bridge/google_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/google_api_impl.py
@@ -50,6 +50,7 @@ from .types import AgentBridge
 from .util import (
     apply_message_ids,
     bridge_generate,
+    clear_generation_params,
     resolve_generate_config,
     resolve_inspect_model,
 )
@@ -106,6 +107,8 @@ async def inspect_google_api_request_impl(
 
     # extract generate config
     config = generate_config_from_google(generation_config)
+    if not bridge.forward_generation_config:
+        clear_generation_params(config)
 
     # try to maintain id stability
     apply_message_ids(bridge, messages)

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -171,6 +171,7 @@ from inspect_ai.util._json import JSONSchema
 from .util import (
     apply_message_ids,
     bridge_generate,
+    clear_generation_params,
     resolve_generate_config,
     resolve_inspect_model,
 )
@@ -263,6 +264,8 @@ async def inspect_responses_api_request_impl(
 
     # extract generate config (hoist instructions into system_message)
     config = generate_config_from_openai_responses(json_data)
+    if not bridge.forward_generation_config:
+        clear_generation_params(config)
     config.extra_headers = headers
     if config.system_message:
         messages.insert(0, ChatMessageSystem(content=config.system_message))

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -48,6 +48,7 @@ async def sandbox_agent_bridge(
     code_execution: CodeExecutionProviders | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
     model_event_sink: ModelEventSink | None = None,
+    forward_generation_config: bool = False,
 ) -> AsyncIterator[SandboxAgentBridge]:
     """Sandbox agent bridge.
 
@@ -95,6 +96,13 @@ async def sandbox_agent_bridge(
             emission for calls routed through the bridge. When set, the bridge
             installs it around `model.generate()` so the sink decides when and
             under which span each event is emitted to the transcript.
+        forward_generation_config: Forward client generation parameters (e.g.
+            `max_tokens`, `temperature`, reasoning effort) to the model. Defaults
+            to `False`, in which case those parameters are dropped and the resolved
+            Inspect model config and provider defaults govern generation (structural
+            parameters like the system prompt, tools, and response format are always
+            forwarded). Set `True` for faithful-proxy behavior where the client's
+            generation parameters are authoritative.
     """
     # instance id for this bridge
     instance = f"proxy_{uuid()}"
@@ -128,6 +136,7 @@ async def sandbox_agent_bridge(
                 model=model,
                 model_aliases=model_aliases,
                 model_event_sink=model_event_sink,
+                forward_generation_config=forward_generation_config,
             )
 
             # register bridged tools with the bridge

--- a/src/inspect_ai/agent/_bridge/sandbox/types.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/types.py
@@ -21,6 +21,7 @@ class SandboxAgentBridge(AgentBridge):
         mcp_server_configs: list[MCPServerConfigHTTP] | None = None,
         bridged_tools: dict[str, dict[str, Tool]] | None = None,
         model_event_sink: ModelEventSink | None = None,
+        forward_generation_config: bool = False,
     ) -> None:
         super().__init__(
             state,
@@ -30,6 +31,7 @@ class SandboxAgentBridge(AgentBridge):
             model=model,
             model_aliases=model_aliases,
             model_event_sink=model_event_sink,
+            forward_generation_config=forward_generation_config,
         )
         self.port = port
         self.mcp_server_configs = mcp_server_configs or []

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -32,6 +32,7 @@ class AgentBridge:
         model: str | None = None,
         model_aliases: dict[str, str | Model] | None = None,
         model_event_sink: ModelEventSink | None = None,
+        forward_generation_config: bool = False,
     ) -> None:
         self.state = state
         self.filter = filter
@@ -39,6 +40,7 @@ class AgentBridge:
         self.model = model
         self.model_aliases: dict[str, str | Model] = model_aliases or {}
         self.model_event_sink = model_event_sink
+        self.forward_generation_config = forward_generation_config
         self._compaction = compaction
         self._compaction_prefix = state.messages.copy()
         self._compact: Compact | None = None
@@ -73,6 +75,19 @@ class AgentBridge:
     complete events to the sink instead of emitting them to the transcript.
     Use this to attribute bridge model events to externally-managed agent
     spans (e.g. spans driven by a side-channel event stream).
+    """
+
+    forward_generation_config: bool
+    """Whether to forward client generation parameters to the model.
+
+    When `False` (the default), generation-tuning parameters from the incoming
+    request (e.g. `max_tokens`, `temperature`, `top_p`/`top_k`, reasoning effort /
+    thinking budget, penalties, `n`, logprobs) are dropped; the resolved Inspect
+    model config and provider defaults govern generation. This prevents a scaffold
+    from imposing parameters it computed for a different model than the one actually
+    serving the request. Structural parameters (system prompt, tools, tool choice,
+    response format, stop sequences) are always forwarded. Set `True` to forward
+    the client's generation parameters (faithful-proxy behavior).
     """
 
     def compaction(

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -27,6 +27,42 @@ from inspect_ai.tool._tools._web_search._web_search import (
     _normalize_config,
 )
 
+# Generation-tuning fields a scaffold may set on a bridged request that describe
+# *how* the underlying model generates. These are the Inspect model's province
+# (the scaffold computes them for its assumed --model, not the model actually
+# serving the request), so by default the bridge drops them and lets the model
+# config / provider defaults govern generation. Structural fields the scaffold
+# legitimately controls (system_message, stop_seqs, response_schema,
+# parallel_tool_calls, seed, extra_body/headers) are deliberately NOT listed here.
+_GENERATION_PARAM_FIELDS: tuple[str, ...] = (
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    "frequency_penalty",
+    "presence_penalty",
+    "num_choices",
+    "logprobs",
+    "top_logprobs",
+    "prompt_logprobs",
+    "logit_bias",
+    "reasoning_effort",
+    "reasoning_tokens",
+    "reasoning_summary",
+)
+
+
+def clear_generation_params(config: GenerateConfig) -> None:
+    """Clear generation-tuning params from a bridged request config (in place).
+
+    Used when a bridge is configured not to forward client generation parameters
+    (the default): the dropped fields then fall back to the resolved Inspect model
+    config and provider defaults during ``resolve_generate_config``.
+    """
+    for field in _GENERATION_PARAM_FIELDS:
+        setattr(config, field, None)
+
+
 _filter_type_cache: dict[int, bool] = {}
 
 

--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -39,7 +39,7 @@ from inspect_ai.util._json import json_schema
 @agent
 def completions_agent(tools: bool) -> Agent:
     async def execute(state: AgentState) -> AgentState:
-        async with agent_bridge():
+        async with agent_bridge(forward_generation_config=True):
 
             class Message(BaseModel):
                 text: str
@@ -141,7 +141,7 @@ def bridge_filter_agent(type: Literal["output", "config"]) -> Agent:
 @agent
 def responses_agent(tools: bool) -> Agent:
     async def execute(state: AgentState) -> AgentState:
-        async with agent_bridge():
+        async with agent_bridge(forward_generation_config=True):
             async with AsyncOpenAI() as client:
                 responses_tools = (
                     [
@@ -372,7 +372,7 @@ def anthropic_agent(tools: bool) -> Agent:
             else:
                 return None
 
-        async with agent_bridge(state) as bridge:
+        async with agent_bridge(state, forward_generation_config=True) as bridge:
             async with AsyncAnthropic() as client:
                 await client.messages.create(  # type: ignore[call-overload]
                     model="inspect",
@@ -514,7 +514,7 @@ def google_agent(tools: bool) -> Agent:
             else:
                 return None
 
-        async with agent_bridge(state) as bridge:
+        async with agent_bridge(state, forward_generation_config=True) as bridge:
             client = genai.Client(api_key="inspect")
 
             generation_config: dict[str, Any] = {

--- a/tests/agent/test_bridge_generation_config.py
+++ b/tests/agent/test_bridge_generation_config.py
@@ -1,0 +1,187 @@
+"""Unit tests for bridge generation-parameter forwarding.
+
+These exercise the per-format `generate_config_from_*` extractors together with
+`clear_generation_params` (the helper applied when a bridge is configured not to
+forward client generation parameters, the default). They are fast and require no
+provider SDKs or API keys.
+"""
+
+from inspect_ai.agent._bridge.anthropic_api_impl import generate_config_from_anthropic
+from inspect_ai.agent._bridge.completions import (
+    generate_config_from_openai_completions,
+)
+from inspect_ai.agent._bridge.google_api_impl import generate_config_from_google
+from inspect_ai.agent._bridge.responses_impl import (
+    generate_config_from_openai_responses,
+)
+from inspect_ai.agent._bridge.util import (
+    _GENERATION_PARAM_FIELDS,
+    clear_generation_params,
+)
+
+# generation-tuning fields that must be dropped when not forwarding.
+# Hard-coded (not derived from the implementation's list) so this test fails if
+# the helper's field list drifts from what we expect to be cleared.
+GENERATION_FIELDS = {
+    "max_tokens",
+    "temperature",
+    "top_p",
+    "top_k",
+    "frequency_penalty",
+    "presence_penalty",
+    "num_choices",
+    "logprobs",
+    "top_logprobs",
+    "prompt_logprobs",
+    "logit_bias",
+    "reasoning_effort",
+    "reasoning_tokens",
+    "reasoning_summary",
+}
+
+
+def test_generation_param_fields_match_expected():
+    # guard against the helper's cleared-field list drifting from this test's
+    # expectations in either direction
+    assert set(_GENERATION_PARAM_FIELDS) == GENERATION_FIELDS
+
+# structural fields that must always survive clearing
+STRUCTURAL_FIELDS = (
+    "system_message",
+    "stop_seqs",
+    "response_schema",
+    "parallel_tool_calls",
+    "seed",
+)
+
+
+def _assert_cleared(config) -> None:
+    for field in GENERATION_FIELDS:
+        assert getattr(config, field) is None, f"{field} should be cleared"
+
+
+def test_openai_completions_forward_then_clear():
+    json_data = {
+        "model": "inspect",
+        "max_tokens": 256,
+        "temperature": 0.8,
+        "top_p": 0.9,
+        "frequency_penalty": 1.0,
+        "presence_penalty": 1.5,
+        "n": 3,
+        "logprobs": True,
+        "top_logprobs": 3,
+        "logit_bias": {42: 10},
+        "reasoning_effort": "low",
+        # structural
+        "stop": ["foo"],
+        "seed": 42,
+        "parallel_tool_calls": True,
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {"name": "message", "schema": {"type": "object"}},
+        },
+    }
+
+    # raw extraction forwards the generation-tuning params
+    config = generate_config_from_openai_completions(json_data)
+    assert config.max_tokens == 256
+    assert config.temperature == 0.8
+    assert config.num_choices == 3
+    assert config.logprobs is True
+    assert config.reasoning_effort == "low"
+
+    # clearing drops gen-tuning, keeps structural
+    clear_generation_params(config)
+    _assert_cleared(config)
+    assert config.stop_seqs == ["foo"]
+    assert config.seed == 42
+    assert config.parallel_tool_calls is True
+    assert config.response_schema is not None
+
+
+def test_openai_responses_forward_then_clear():
+    json_data = {
+        "model": "inspect",
+        "instructions": "You are a dope model.",
+        "max_output_tokens": 2048,
+        "temperature": 0.8,
+        "top_p": 0.9,
+        "top_logprobs": 3,
+        "include": ["message.output_text.logprobs"],
+        "reasoning": {"effort": "low", "summary": "auto"},
+        # structural
+        "parallel_tool_calls": True,
+        "text": {
+            "format": {
+                "type": "json_schema",
+                "name": "message",
+                "schema": {"type": "object"},
+            }
+        },
+    }
+
+    config = generate_config_from_openai_responses(json_data)
+    assert config.max_tokens == 2048
+    assert config.temperature == 0.8
+    assert config.reasoning_effort == "low"
+    assert config.reasoning_summary == "auto"
+    assert config.logprobs is True
+    assert config.top_logprobs == 3
+
+    clear_generation_params(config)
+    _assert_cleared(config)
+    assert config.system_message == "You are a dope model."
+    assert config.parallel_tool_calls is True
+    assert config.response_schema is not None
+
+
+def test_anthropic_forward_then_clear():
+    json_data = {
+        "model": "inspect",
+        "max_tokens": 4096,
+        "temperature": 0.8,
+        "top_k": 2,
+        "top_p": 0.9,
+        "thinking": {"type": "enabled", "budget_tokens": 2048},
+        # structural
+        "system": "You are a dope model.",
+        "stop_sequences": ["foo"],
+        "tool_choice": {"type": "auto", "disable_parallel_tool_use": True},
+    }
+
+    config = generate_config_from_anthropic(json_data)
+    assert config.max_tokens == 4096
+    assert config.temperature == 0.8
+    assert config.top_k == 2
+    # anthropic thinking budget maps to reasoning_tokens
+    assert config.reasoning_tokens == 2048
+
+    clear_generation_params(config)
+    _assert_cleared(config)
+    # reasoning_tokens specifically must be among the cleared fields
+    assert config.reasoning_tokens is None
+    assert config.system_message == "You are a dope model."
+    assert config.stop_seqs == ["foo"]
+    assert config.parallel_tool_calls is False
+
+
+def test_google_forward_then_clear():
+    generation_config = {
+        "temperature": 0.8,
+        "maxOutputTokens": 2048,
+        "topP": 0.9,
+        "topK": 2,
+        # structural
+        "stopSequences": ["foo"],
+    }
+
+    config = generate_config_from_google(generation_config)
+    assert config.temperature == 0.8
+    assert config.max_tokens == 2048
+    assert config.top_p == 0.9
+    assert config.top_k == 2
+
+    clear_generation_params(config)
+    _assert_cleared(config)
+    assert config.stop_seqs == ["foo"]

--- a/tests/agent/test_bridge_generation_config.py
+++ b/tests/agent/test_bridge_generation_config.py
@@ -45,6 +45,7 @@ def test_generation_param_fields_match_expected():
     # expectations in either direction
     assert set(_GENERATION_PARAM_FIELDS) == GENERATION_FIELDS
 
+
 # structural fields that must always survive clearing
 STRUCTURAL_FIELDS = (
     "system_message",


### PR DESCRIPTION
Bridged agents typically tune their requests (e.g. `max_tokens`, `temperature`, reasoning effort) for the model named in their own configuration, which is _not_ the Inspect model actually serving the request. Those values are therefore targeted for the wrong model, and forwarding them can produce incorrect or even failing requests (for example a small `max_tokens` combined with reasoning being enabled on the real model).

For this reason, by default the bridge does not forward client generation parameters. Instead, the resolved Inspect model configuration and the provider's defaults govern generation. Structural parameters that express the agent's intent — the system prompt, tools, tool choice, response format, `stop` sequences, and `seed` — are always forwarded.

The generation parameters dropped by default are: `max_tokens`, `temperature`, `top_p`, `top_k`, `frequency_penalty`, `presence_penalty`, `n`/`num_choices`, `logprobs`, `top_logprobs`, `logit_bias`, and reasoning effort/tokens/summary.

If you want the bridge to act as a faithful proxy where the agent's generation parameters are authoritative, pass `forward_generation_config=True`:

``` python
async with agent_bridge(state, forward_generation_config=True) as bridge:
    ...
```

This option is available on both `agent_bridge()` and `sandbox_agent_bridge()`.
