### PR TITLE
viewer config: accept legacy `view` key as alias for SampleScoreView.default

### DIFF
--- a/src/inspect_ai/viewer/_config.py
+++ b/src/inspect_ai/viewer/_config.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 
 class ScannerResultField(BaseModel):
@@ -69,9 +69,12 @@ class SampleScoreViewSort(BaseModel):
 class SampleScoreView(BaseModel):
     """How the sample-header score panel should render when there are 3 or more scores."""
 
-    default: Literal["chips", "grid"] | None = None
+    default: Literal["chips", "grid"] | None = Field(
+        default=None, validation_alias=AliasChoices("default", "view")
+    )
     """Default rendering mode. `chips` = wrapping pills; `grid` = sortable
-    table. When None, the viewer picks based on score count."""
+    table. When None, the viewer picks based on score count. (The legacy
+    `view` key is still accepted on input.)"""
 
     sort: SampleScoreViewSort | None = None
     """Default sort. When None, scores render in their natural order."""

--- a/tests/view/test_viewer_config.py
+++ b/tests/view/test_viewer_config.py
@@ -265,6 +265,15 @@ def test_sample_score_view_rejects_unknown_view() -> None:
         SampleScoreView(default="table")  # type: ignore[arg-type]
 
 
+def test_sample_score_view_accepts_legacy_view_alias() -> None:
+    """Pre-rename `view` key populates `default`; output stays canonical."""
+    from_kwarg = SampleScoreView(view="chips")  # type: ignore[call-arg]
+    from_json = SampleScoreView.model_validate({"view": "grid"})
+    assert from_kwarg.default == "chips"
+    assert from_json.default == "grid"
+    assert from_kwarg.model_dump() == {"default": "chips", "sort": None}
+
+
 def test_viewer_config_sample_score_view_defaults_to_none() -> None:
     """Existing logs / unconfigured callers must keep working unchanged."""
     cfg = ViewerConfig()


### PR DESCRIPTION
## Summary

#4110 renamed `SampleScoreView.view` → `default`. Because the model uses `extra="ignore"`, a pre-rename `view` key — in user code or a serialized config — is **silently dropped** rather than populating `default` (no error, just `default=None`).

This adds a validation alias so both keys are accepted on input:

```python
default: Literal["chips", "grid"] | None = Field(
    default=None, validation_alias=AliasChoices("default", "view")
)
```

- Accepts `view` and `default` as Python kwargs **and** in JSON/dict deserialization.
- Serialization and the JSON schema still emit only `default` — verified that both `mode="validation"` and `mode="serialization"` schemas keep the property named `default`, so `inspect-openapi.json` and the TS viewer contract are unchanged (no Input/Output schema split).

It's a backward-compat shim for the deprecation window, mirroring the relocated-name shims (`SamplesView` → `TaskSamplesView`, etc.); remove at 0.4.

## Test

Adds `test_sample_score_view_accepts_legacy_view_alias` covering the `view` kwarg, the `view` JSON key, and that `model_dump()` round-trips as `default`.

`pytest tests/view/test_viewer_config.py` (61 passed), `ruff`, and `mypy` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)