### PR TITLE
Add /app-config endpoint to view server

### DIFF
--- a/src/inspect_ai/_view/common.py
+++ b/src/inspect_ai/_view/common.py
@@ -5,6 +5,7 @@ import os
 import urllib.parse
 from collections.abc import AsyncIterable
 from functools import partial
+from importlib.metadata import PackageNotFoundError, version
 from io import BytesIO
 from logging import getLogger
 from typing import Any, AsyncIterator, Literal, NamedTuple, Tuple, cast
@@ -18,6 +19,7 @@ from s3fs import S3FileSystem  # type: ignore
 from s3fs.core import _error_wrapper, version_id_kw  # type: ignore
 
 from inspect_ai._util._async import tg_collect
+from inspect_ai._util.constants import PKG_NAME
 from inspect_ai._util.file import default_fs_options, dirname, filesystem, size_in_mb
 from inspect_ai._view.azure import (
     azure_warning_hint,
@@ -63,6 +65,29 @@ def normalize_uri(uri: str) -> str:
             path = path[1:]
 
         return f"file://{path}"
+
+
+class AppConfig(BaseModel):
+    """Application configuration returned by GET /app-config."""
+
+    inspect_version: str
+    scout_version: str | None = None
+
+
+def get_app_config() -> AppConfig:
+    """Return app config, including installed inspect and scout versions.
+
+    `inspect_scout` is an optional dependency, so `scout_version` is None when
+    it isn't installed.
+    """
+    try:
+        scout_version: str | None = version("inspect_scout")
+    except PackageNotFoundError:
+        scout_version = None
+    return AppConfig(
+        inspect_version=version(PKG_NAME),
+        scout_version=scout_version,
+    )
 
 
 class LogDirResponse(BaseModel):

--- a/src/inspect_ai/_view/dist/assets/index.css
+++ b/src/inspect_ai/_view/dist/assets/index.css
@@ -15709,15 +15709,11 @@ pre[class*="language-"] {
   padding: 1em;
   margin: 0.5em 0;
   overflow: auto;
-  /* border: 0.3em solid #7a6651; */
   border-radius: 0.5em;
-  box-shadow: 1px 1px 0.5em #000 inset;
 }
 .vscode-dark :not(pre) > code[class*="language-"] {
   padding: 0.15em 0.2em 0.05em;
   border-radius: 0.3em;
-  /* border: 0.13em solid #7a6651; */
-  box-shadow: 1px 1px 0.3em -0.1em #000 inset;
   white-space: normal;
 }
 .vscode-dark .token.cdata,

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -32,6 +32,7 @@ from inspect_ai._util.local_server import get_machine_ip
 from inspect_ai._view import notify
 from inspect_ai._view._dist import resolve_dist_directory
 from inspect_ai._view.common import (
+    AppConfig,
     LogDirResponse,
     LogFilesResponse,
     LogInfo,
@@ -40,6 +41,7 @@ from inspect_ai._view.common import (
     apply_log_edits,
     build_pending_sample_urls,
     delete_log,
+    get_app_config,
     get_log_dir,
     get_log_file,
     get_log_files,
@@ -524,6 +526,10 @@ def view_server_app(
         if body is None:
             return Response(status_code=HTTP_404_NOT_FOUND)
         return body
+
+    @app.get("/app-config", response_model=AppConfig)
+    async def api_app_config() -> AppConfig:
+        return get_app_config()
 
     scout_router = get_scout_search_router()
     if scout_router is not None:

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -133,6 +133,31 @@
         "title": "AnchorEvent",
         "type": "object"
       },
+      "AppConfig": {
+        "description": "Application configuration returned by GET /app-config.",
+        "properties": {
+          "inspect_version": {
+            "title": "Inspect Version",
+            "type": "string"
+          },
+          "scout_version": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scout Version"
+          }
+        },
+        "required": [
+          "inspect_version"
+        ],
+        "title": "AppConfig",
+        "type": "object"
+      },
       "ApprovalEvent": {
         "description": "Tool approval.",
         "properties": {
@@ -10732,6 +10757,24 @@
   },
   "openapi": "3.1.0",
   "paths": {
+    "/app-config": {
+      "get": {
+        "operationId": "api_app_config_app_config_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AppConfig"
+                }
+              }
+            },
+            "description": "Successful Response"
+          }
+        },
+        "summary": "Api App Config"
+      }
+    },
     "/chat-message": {
       "get": {
         "operationId": "_chat_message_chat_message_get",

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -323,6 +323,17 @@ def test_api_log(view_client: ViewTestClient) -> None:
     assert resp.json()["eval"]["task"] == "task"
 
 
+def test_api_app_config(view_client: ViewTestClient) -> None:
+    resp = view_client.request("GET", "/app-config")
+    resp.raise_for_status()
+    config = resp.json()
+    assert config["inspect_version"] == inspect_ai.__version__
+    # scout is an optional dependency: present as a string when installed,
+    # otherwise null.
+    assert "scout_version" in config
+    assert config["scout_version"] is None or isinstance(config["scout_version"], str)
+
+
 def test_api_log_info(view_client: ViewTestClient) -> None:
     fname = "2025-01-01T00-00-00+00-00_task_taskid.eval"
     write_eval_log(view_client.log_dir, fname)


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

`/app-config` returns an object with the installed Inspect version and the optional Scout version (None when inspect_scout is not installed), mirroring Scout's /app-config endpoint. 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:

I'll merge https://github.com/meridianlabs-ai/ts-mono/pull/285 and point the submodule to it once this has been approved.
