### PR TITLE
fix: agent bridge correctly checks for google.genai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Bugfix: Inspect View sample-list columns now expand to fill the available width.
 - Bugfix: Avoid emitting empty assistant output messages when converting Chat Completions tool-call with reasoning into Responses API input items.
 - Bugfix: Preserve OpenAI Responses API encrypted reasoning through agent bridge round-trips and replay reasoning input items with empty `content` to avoid server validation errors.
+- Bugfix: Agent bridge checks for google.genai more defensively (ensure that module not found is raised).
 
 ## 0.3.235 (03 June 2026)
 

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -1,5 +1,5 @@
 import contextlib
-import importlib
+import importlib.util
 import re
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -355,8 +355,10 @@ def init_anthropic_request_patch() -> None:
 
 
 def init_google_request_patch() -> None:
-    # don't patch if no google genai
-    if not importlib.util.find_spec("google.genai"):
+    try:
+        if not importlib.util.find_spec("google.genai"):
+            return
+    except ModuleNotFoundError:
         return
 
     from google.genai._api_client import BaseApiClient


### PR DESCRIPTION
## This PR contains:
  - [ ] New features
  - [ ] Changes to dev-tools e.g. CI config / github tooling
  - [ ] Docs
  - [x] Bug fixes
  - [ ] Code refactor

### What is the current behavior? (#4144)

I recently opened the issue #4144 pointing out that the agent bridge fails to initialize with `ModuleNotFoundError: No module named 'google'` whenever the `google` package is not installed, even for users who only use the OpenAI or Anthropic clients. However, `init_google_request_patch()` detects the SDK via `importlib.util.find_spec("google.genai")` and, for a dotted submodule name, this causes `find_spec` to import the parent package (`google`) and raise `ModuleNotFoundError` instead of returning `None` when it's absent. Since the function runs on every bridge init, the bridge breaks for everyone without `google` installed.

### What is the new behavior?

The detection check is wrapped in `try/except ModuleNotFoundError`, so a missing package skips patching (matching the OpenAI/Anthropic providers) instead of crashing. `importlib.util` is also imported explicitly so the submodule reference resolves for static type checkers.

### Does this PR introduce a breaking change?

No.

### Other information:

None.
