### PR TITLE
Checkpoint resume: fix event layout regression and change testing to use `SIGKILL` (vs coorperative)

### DIFF
--- a/src/inspect_ai/util/_checkpoint/_layout/eval_checkpoints_dir.py
+++ b/src/inspect_ai/util/_checkpoint/_layout/eval_checkpoints_dir.py
@@ -17,19 +17,23 @@ from inspect_ai._util.file import basename, dirname
 from ..config import CheckpointConfig
 
 _LOG_SUFFIX = ".eval"
+_RECOVERED_SUFFIX = "-recovered"
 
 
 def log_basename(log_location: str) -> str:
-    """Return the log's basename with any trailing ``.eval`` stripped.
+    """Return the log's basename with recovery and log suffixes stripped.
 
     Used to derive the per-eval ``<log-base>.checkpoints/`` directory
     name (durable, alongside the log) and the matching per-eval working
     dir under ``inspect_cache_dir("checkpoints")/`` (ephemeral, host
-    cache). Single owner of the ``.eval`` suffix convention.
+    cache). Single owner of the ``.eval`` / ``-recovered`` suffix
+    conventions.
     """
     base = basename(log_location)
     if base.endswith(_LOG_SUFFIX):
         base = base[: -len(_LOG_SUFFIX)]
+    if base.endswith(_RECOVERED_SUFFIX):
+        base = base[: -len(_RECOVERED_SUFFIX)]
     return base
 
 

--- a/src/inspect_ai/util/_checkpoint/dump_events.py
+++ b/src/inspect_ai/util/_checkpoint/dump_events.py
@@ -1,0 +1,155 @@
+"""Dump a sample's events from an eval log, flat and as a span hierarchy.
+
+Usage:
+    python scripts/dump_events.py <path-to-.eval> [--sample ID] [--epoch N]
+
+Opens the given eval log, selects one sample, and prints its events twice:
+once as a flat ordered list, once nested by span. With no ``--sample`` /
+``--epoch`` the first sample in the log is used; ``--sample`` selects by
+sample id and ``--epoch`` by epoch (combine them to disambiguate a sample
+that ran for multiple epochs). Most events render as
+``<event.event> <name-or-identifier>``; spans also show a short id and parent
+id so the flat and hierarchical views can be correlated.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from inspect_ai.event import EventTreeSpan, event_tree
+from inspect_ai.event._event import Event
+from inspect_ai.log import EvalSample, read_eval_log
+
+
+def _sid(span_id: str | None) -> str:
+    """Short, stable rendering of a span id for eyeballing."""
+    return span_id[:4] if span_id else "----"
+
+
+# For events with no `name`, surface the natural identifier (first match
+# wins) so busy leaf events stay legible: tool->function, model->model,
+# sandbox->action, info->source.
+_ID_FIELDS = ("function", "model", "action", "source")
+
+
+def _event_label(e: Event) -> str:
+    """``<event> <name-or-identifier>`` for most events; id/parent for spans."""
+    name = getattr(e, "name", None)
+    type_ = getattr(e, "type", None)
+    label: str = e.event
+    if name is not None:
+        label += f" {name!r}"
+    else:
+        for field in _ID_FIELDS:
+            value = getattr(e, field, None)
+            if value is not None:
+                label += f" {value!r}"
+                break
+    # checkpoint events render as `checkpoint N`
+    if e.event == "checkpoint":
+        cid = getattr(e, "checkpoint_id", None)
+        if cid is not None:
+            label += f" {cid}"
+    # for sandbox exec, show the first 50 chars of the command line
+    cmd = getattr(e, "cmd", None)
+    if e.event == "sandbox" and cmd:
+        label += f" {cmd[:50]!r}" + ("…" if len(cmd) > 50 else "")
+    # for a tool call, show the error (if it failed) or the first 50 chars of
+    # the result
+    if e.event == "tool":
+        error = getattr(e, "error", None)
+        if error is not None:
+            label += f" ERROR:{error.type}"
+        else:
+            result = str(getattr(e, "result", "")).replace("\n", " ")
+            if result:
+                label += f" -> {result[:50]!r}" + ("…" if len(result) > 50 else "")
+    # `[function]` on tool events is noise; keep `[type]` for span markers
+    if type_ is not None and type_ != name and e.event != "tool":
+        label += f" [{type_}]"
+    # span markers carry the span identity the tree is built from
+    if e.event in ("span_begin", "span_end"):
+        eid = getattr(e, "id", None)
+        parent = getattr(e, "parent_id", None)
+        label += f"  id={_sid(eid)}"
+        if e.event == "span_begin":
+            label += f" parent={_sid(parent)}"
+    return label
+
+
+def dump_flat(events: list[Event]) -> None:
+    print("=" * 70)
+    print(f"FLAT  ({len(events)} events)")
+    print("=" * 70)
+    for i, e in enumerate(events):
+        print(f"{i:>4}  span={_sid(e.span_id)}  {_event_label(e)}")
+
+
+def dump_tree(events: list[Event]) -> None:
+    print()
+    print("=" * 70)
+    print("HIERARCHY (by span)")
+    print("=" * 70)
+
+    def walk(nodes: list[EventTreeSpan | Event], depth: int) -> None:
+        indent = "  " * depth
+        for node in nodes:
+            if isinstance(node, EventTreeSpan):
+                open_marker = "" if node.end is not None else "  (unclosed)"
+                print(
+                    f"{indent}SPAN {node.type!r} {node.name!r} "
+                    f"id={_sid(node.id)} parent={_sid(node.parent_id)}{open_marker}"
+                )
+                walk(node.children, depth + 1)
+            else:
+                print(f"{indent}{_event_label(node)}")
+
+    walk(event_tree(events), 0)
+
+
+def _select_sample(
+    samples: list[EvalSample], sample_id: str | None, epoch: int | None
+) -> EvalSample:
+    """Pick a sample by id and/or epoch; default to the first sample.
+
+    ``sample_id`` is matched against ``str(sample.id)`` (ids may be int or
+    str). With both unset the first sample is returned.
+    """
+    matches = [
+        s
+        for s in samples
+        if (sample_id is None or str(s.id) == sample_id)
+        and (epoch is None or s.epoch == epoch)
+    ]
+    if not matches:
+        want = f"id={sample_id!r} epoch={epoch}"
+        have = ", ".join(f"(id={s.id!r}, epoch={s.epoch})" for s in samples)
+        raise SystemExit(f"no sample matching {want}; log has: {have}")
+    return matches[0]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Dump a sample's events.")
+    parser.add_argument("path", help="path to the .eval log")
+    parser.add_argument(
+        "--sample", "-s", help="sample id (default: first sample in the log)"
+    )
+    parser.add_argument(
+        "--epoch", "-e", type=int, help="epoch (combine with --sample to disambiguate)"
+    )
+    args = parser.parse_args()
+
+    log = read_eval_log(args.path)
+    if not log.samples:
+        raise SystemExit(f"no samples in {args.path}")
+    sample = _select_sample(log.samples, args.sample, args.epoch)
+    events = list(sample.events)
+
+    print(f"log:    {args.path}")
+    print(f"sample: id={sample.id!r} epoch={sample.epoch}")
+    dump_flat(events)
+    dump_tree(events)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/inspect_ai/util/_checkpoint/hydrate.py
+++ b/src/inspect_ai/util/_checkpoint/hydrate.py
@@ -550,6 +550,14 @@ def _load_host_state(
         synthesized = _synthesize_trailing_checkpoint_event(
             sample_root, latest_committed_id
         )
+        # Stamp the synthesized event with the restored session's active
+        # span (the innermost still-open span), matching the span the
+        # prior checkpoint events carry. Constructing the event live
+        # otherwise stamps `current_span_id()` — the *resuming* session's
+        # span, which lives outside the `prior_run` wrap and would dangle
+        # the checkpoint under the current agent instead of nesting it as
+        # a peer of the other restored checkpoints.
+        synthesized.span_id = _innermost_open_span_id(rehydrated_events)
         rehydrated_events.append(synthesized)
 
     rehydrated_events = materialize_pooled_events(
@@ -703,6 +711,21 @@ def _synthesize_trailing_checkpoint_event(
     return CheckpointEvent.from_details(checkpoint).model_copy(
         update={"timestamp": checkpoint.created_at}
     )
+
+
+def _innermost_open_span_id(events: list[Event]) -> str | None:
+    """Return the id of the innermost span still open at the end of ``events``.
+
+    This is the restored session's active span at context-write time — the
+    agent span the checkpoints fire within. ``None`` if no span is open.
+    """
+    open_span_ids: list[str] = []
+    for e in events:
+        if isinstance(e, SpanBeginEvent):
+            open_span_ids.append(e.id)
+        elif isinstance(e, SpanEndEvent) and e.id in open_span_ids:
+            open_span_ids.remove(e.id)
+    return open_span_ids[-1] if open_span_ids else None
 
 
 def _validate_resume_state(

--- a/src/inspect_ai/util/_checkpoint/hydrate.py
+++ b/src/inspect_ai/util/_checkpoint/hydrate.py
@@ -63,6 +63,7 @@ from inspect_ai.solver._task_state import sample_state
 from inspect_ai.util._restic import init_repo, resolve_restic, restore_repo
 from inspect_ai.util._restic.ops import restic_env
 from inspect_ai.util._sandbox.context import sandbox
+from inspect_ai.util._span import current_span_id
 
 from ._host_egress import seed_manifest
 from ._layout import host_context
@@ -322,12 +323,16 @@ async def _hydrate_host(
         )
     with trace_action(logger, action, "host restore"):
         await restore_repo(host_restic, host_repo, restic_password, context_dir)
+    # Capture the live span id here (loop thread); the `_current_span_id`
+    # ContextVar isn't propagated into the worker thread below.
+    parent_span_id = current_span_id()
     result = await anyio.to_thread.run_sync(
         partial(
             _load_host_state,
             context_dir,
             sample_root,
             latest_committed_id,
+            parent_span_id,
         )
     )
     result = _push_host_state(result, sample_root, latest_committed_id)
@@ -520,6 +525,7 @@ def _load_host_state(
     context_dir: str,
     sample_root: str,
     latest_committed_id: int | None,
+    parent_span_id: str | None,
 ) -> _HostHydrationResult:
     """Read restored host context and prepare resume state.
 
@@ -555,7 +561,7 @@ def _load_host_state(
     # session ends up as a sibling wrap inside this attempt's events.
     # See `_wrap_prior_run` for the slicing + reparenting
     # mechanics.
-    pushed_events = _wrap_prior_run(rehydrated_events)
+    pushed_events = _wrap_prior_run(rehydrated_events, parent_span_id)
 
     return _HostHydrationResult(
         agent_state=ctx.agent_state,
@@ -594,7 +600,7 @@ def _push_host_state(
     return result
 
 
-def _wrap_prior_run(events: list[Event]) -> list[Event]:
+def _wrap_prior_run(events: list[Event], parent_span_id: str | None) -> list[Event]:
     """Wrap the trailing unwrapped checkpoint spans in a new ``prior_run`` span.
 
     The "tail" is the slice of ``events`` after the last existing
@@ -609,9 +615,9 @@ def _wrap_prior_run(events: list[Event]) -> list[Event]:
     hierarchy reflects the new structure rather than carrying stale
     parent ids from the prior session's transcript. ``span_end`` events
     carry no ``parent_id``, so they pass through unchanged. The wrap's
-    own ``parent_id`` is ``None`` (sibling at the sample root,
-    alongside other prior wraps and the current session's checkpoint
-    spans).
+    own ``parent_id`` is ``parent_span_id`` — the live span id captured
+    at hydrate time — so the wrap nests under the current session's
+    span rather than dangling at the transcript root.
 
     Wrap numbering (``checkpoint restore 1``, ``2``, …) is the count
     of existing wraps plus one, so each resume adds one numbered
@@ -640,7 +646,7 @@ def _wrap_prior_run(events: list[Event]) -> list[Event]:
     wrap_id = shortuuid()
     wrap_begin = SpanBeginEvent(
         id=wrap_id,
-        parent_id=None,
+        parent_id=parent_span_id,
         type="prior_run",
         name=f"checkpoint restore {next_n}",
     )

--- a/src/inspect_ai/util/_checkpoint/hydrate.py
+++ b/src/inspect_ai/util/_checkpoint/hydrate.py
@@ -611,21 +611,37 @@ def _push_host_state(
 def _wrap_prior_run(events: list[Event], parent_span_id: str | None) -> list[Event]:
     """Wrap the trailing unwrapped checkpoint spans in a new ``prior_run`` span.
 
-    The "tail" is the slice of ``events`` after the last existing
-    ``prior_run`` ``span_end`` (or the whole list if there are
-    no prior wraps). That tail is the most-recent prior session's
-    checkpoint spans, which haven't been wrapped yet — the current
-    session wraps them at hydrate time.
+    The buffer stores the full cumulative transcript (``init`` /
+    ``solvers`` / ``solver`` / ``agent`` structural spans plus setup
+    execs), but a ``prior_run`` wrap should contain only checkpoint
+    work — checkpoint spans as its direct children. We reproduce that by
+    discarding the resumed session's structural scaffolding in two
+    places:
 
-    Top-level ``span_begin`` events in the tail (depth 0 relative to the
-    new wrap — in practice the checkpoint span_begins) get their
-    ``parent_id`` rewritten to point at the new wrap's id, so the span
-    hierarchy reflects the new structure rather than carrying stale
-    parent ids from the prior session's transcript. ``span_end`` events
-    carry no ``parent_id``, so they pass through unchanged. The wrap's
-    own ``parent_id`` is ``parent_span_id`` — the live span id captured
-    at hydrate time — so the wrap nests under the current session's
-    span rather than dangling at the transcript root.
+    - A leading slice drops everything before the first
+      checkpoint-related ``span_begin`` — an existing ``prior_run`` wrap
+      (from an earlier resume) or this session's first ``checkpoint``
+      span.
+    - A tail slice drops the resumed session's own ancestor spans that
+      sit between the last prior wrap and its first *new* checkpoint
+      span. The cumulative buffer records seeded prior wraps *before*
+      the live session's ancestor spans, so that scaffolding lands in
+      the tail rather than ahead of the leading slice.
+
+    Re-parenting fixes the stale parent ids the slices expose:
+
+    - Surviving ``prior_run`` wraps in the head pointed at a prior
+      session's (now-sliced) ``agent`` span; rewrite them to
+      ``parent_span_id`` so they sit as siblings under the current span.
+    - Depth-0 ``span_begin`` events in the tail (the checkpoint spans)
+      get ``parent_id`` rewritten to the new wrap; other depth-0 events
+      (``CheckpointEvent``s, inter-checkpoint execs) get ``span_id``
+      rewritten to it. ``span_end`` events carry no ``parent_id`` and
+      pass through unchanged.
+
+    The new wrap's own ``parent_id`` is ``parent_span_id`` — the live
+    span id captured at hydrate time — so the wrap nests under the
+    current session's span rather than dangling at the transcript root.
 
     Wrap numbering (``checkpoint restore 1``, ``2``, …) is the count
     of existing wraps plus one, so each resume adds one numbered
@@ -636,6 +652,22 @@ def _wrap_prior_run(events: list[Event], parent_span_id: str | None) -> list[Eve
     rehydrating rather than the work being rehydrated; the contained
     checkpoint spans carry their original timestamps.
     """
+    # Slice away the live session's scaffolding ahead of the first
+    # `prior_run` wrap or `checkpoint` span.
+    first_relevant = next(
+        (
+            i
+            for i, e in enumerate(events)
+            if isinstance(e, SpanBeginEvent) and e.type in ("prior_run", "checkpoint")
+        ),
+        None,
+    )
+    if first_relevant is None:
+        # Degenerate resume with no checkpoint structure; leave the events
+        # untouched and let `_validate_resume_state` surface the problem.
+        return list(events)
+    events = events[first_relevant:]
+
     prior_ids: set[str] = set()
     last_prior_end_idx = -1
     for i, e in enumerate(events):
@@ -644,11 +676,33 @@ def _wrap_prior_run(events: list[Event], parent_span_id: str | None) -> list[Eve
         elif isinstance(e, SpanEndEvent) and e.id in prior_ids:
             last_prior_end_idx = i
 
-    head = events[: last_prior_end_idx + 1]
+    # Re-parent surviving `prior_run` wraps onto the current session's span;
+    # their stored `parent_id` pointed at the now-sliced prior `agent` span.
+    head = [
+        e.model_copy(update={"parent_id": parent_span_id})
+        if isinstance(e, SpanBeginEvent) and e.type == "prior_run"
+        else e
+        for e in events[: last_prior_end_idx + 1]
+    ]
     tail = events[last_prior_end_idx + 1 :]
 
-    if not tail:
+    # Slice the tail to its first *new* `checkpoint` span, dropping the
+    # resumed session's own structural scaffolding (`init` / `solvers` /
+    # `solver` / `agent` spans + setup execs). The new checkpoint span's
+    # `parent_id` points at the (now-dropped) `agent` span; the depth-0
+    # reparenting below rewrites it to the new wrap.
+    first_new_ckpt = next(
+        (
+            i
+            for i, e in enumerate(tail)
+            if isinstance(e, SpanBeginEvent) and e.type == "checkpoint"
+        ),
+        None,
+    )
+    if first_new_ckpt is None:
+        # No unwrapped checkpoint spans; nothing new to wrap this resume.
         return list(head)
+    tail = tail[first_new_ckpt:]
 
     next_n = len(prior_ids) + 1
     wrap_id = shortuuid()

--- a/tests/checkpoint/resume_kill_harness.py
+++ b/tests/checkpoint/resume_kill_harness.py
@@ -1,15 +1,16 @@
-"""Importable harness for the checkpoint resume-after-hard-kill e2e test.
+"""Harness for the checkpoint resume-after-hard-kill e2e test.
 
-Lives in ``test_helpers`` (not the test file) so it can be both imported by
-the test — registering the ``@task`` / ``@modelapi`` so the final in-process
-resume works, and exposing shared constants — and run as a **subprocess**::
+Lives alongside the e2e test in ``tests/checkpoint/`` and serves two roles:
 
-    python -c "from test_helpers.checkpoint_resume_kill import main; main()" <log_dir> [<retry_from>]
+1. **Importable** by the test — registering the ``@task`` / ``@modelapi`` so
+   the final in-process resume works, and exposing shared constants.
+2. **Runnable as a script** by the test for each killed attempt::
+
+       python resume_kill_harness.py <log_dir> [<retry_from>]
 
 Running the killed attempts in child processes is what lets the test issue a
 *real* ``SIGKILL`` of the eval without taking down pytest. The ``crash`` tool
-``os.kill``s its own (child) process at the same point the cooperative
-``cancel`` tool used to ``interrupt`` — abruptly, with no graceful unwind, no
+``os.kill``s its own (child) process — abruptly, with no graceful unwind, no
 ``finally``, no log finalize — exercising recovery from an unanticipated death
 (power loss / OOM / preemption), which is the whole point of checkpointing.
 

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -4,7 +4,7 @@ Drives a ``react()`` agent through tool-calling turns with
 ``TurnInterval(every=1)``, so a checkpoint fires at the start of each turn
 after the first; the agent then calls a ``cancel`` tool that interrupts the
 sample mid-run, leaving committed checkpoints on disk.
-``test_checkpoint_resume_runs_to_completion`` then ``eval_retry``s the
+``test_checkpoint_resume_rehydrated_event_layout`` then ``eval_retry``s the
 cancelled run and asserts it resumes and completes successfully. It checks,
 via the public ``.eval`` log: the restored checkpoints appear as
 ``CheckpointEvent``s inside the ``prior_run`` ("checkpoint restore") span, a
@@ -20,6 +20,7 @@ binary inside the sandbox, which only works with a Linux container
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
@@ -89,19 +90,48 @@ def assert_spans_balanced(events: list[Event]) -> None:
 class _ResumeState:
     """Module-level state shared by the scripted provider and the cancel tool.
 
-    ``cancelled`` lets the scripted model emit a ``cancel`` call on the
-    first attempt and continue past it on resume (the cancel leaves no trace
-    in the restored conversation, so an out-of-band flag is needed to
-    distinguish the two). ``generates`` counts model calls so the resume test
-    can prove the conversation was restored (only the remaining turns run)
-    rather than re-run from scratch.
+    ``generates`` counts model calls so the resume test can prove the
+    conversation was restored (only the remaining turns run) rather than
+    re-run from scratch.
+
+    The cancel *count* and *target* deliberately do NOT live here: on
+    ``eval_retry`` the cancel tool is rebuilt from a re-imported copy of
+    this module, so a module-global counter mutated by the tool and read
+    by the model would be two different instances. They're kept in a host
+    file / env var instead (process-global, re-import-proof) — see
+    ``_cancels_done`` / ``_bump_cancels`` / ``_target_cancels``.
     """
 
-    cancelled: bool = False
     generates: int = 0
+
+    @property
+    def cancelled(self) -> bool:
+        return _cancels_done() > 0
 
 
 _resume_state = _ResumeState()
+
+# Env vars set per test. The cancel count is persisted to the file named by
+# `_CANCEL_FILE_ENV` so it survives `eval_retry`'s module re-import.
+_CANCEL_FILE_ENV = "INSPECT_TEST_RESUME_CANCEL_FILE"
+_TARGET_ENV = "INSPECT_TEST_RESUME_TARGET_CANCELS"
+
+
+def _cancels_done() -> int:
+    f = os.environ.get(_CANCEL_FILE_ENV)
+    return int(Path(f).read_text() or "0") if f and Path(f).exists() else 0
+
+
+def _bump_cancels() -> int:
+    n = _cancels_done() + 1
+    f = os.environ.get(_CANCEL_FILE_ENV)
+    if f:
+        Path(f).write_text(str(n))
+    return n
+
+
+def _target_cancels() -> int:
+    return int(os.environ.get(_TARGET_ENV, "1"))
 
 
 @tool
@@ -128,7 +158,7 @@ def cancel() -> Tool:
         """Cancel the run immediately (interrupts the sample)."""
         active = sample_active()
         assert active is not None, "expected an active sample"
-        _resume_state.cancelled = True
+        _bump_cancels()
         active.interrupt("error")
         # interrupt cancels the surrounding scope; never return normally.
         await anyio.sleep_forever()
@@ -163,18 +193,23 @@ def _scripted_outputs(
     config: GenerateConfig,
 ) -> ModelOutput:
     _resume_state.generates += 1
-    completed_tool_turns = sum(1 for m in input if isinstance(m, ChatMessageTool))
-    if completed_tool_turns == 0:
+    n = sum(1 for m in input if isinstance(m, ChatMessageTool))
+    cancels_done = _cancels_done()
+    target = _target_cancels()
+    if n == 0:
         return ModelOutput.for_tool_call(SCRIPTED_MODEL, "bash", {"command": WRITE_CMD})
-    if completed_tool_turns == 1:
+    if n == 1:
         return ModelOutput.for_tool_call(
             SCRIPTED_MODEL, "remember", {"key": STORE_KEY, "value": LAYER1_CONTENT}
         )
-    if completed_tool_turns == 2 and not _resume_state.cancelled:
+    # Each resume cycle does one work turn (commits a fresh checkpoint) and
+    # then cancels, until `target` cancels are reached. The k-th cancel
+    # (k = cancels_done) lands at turn `2 + cancels_done`; the work turn for
+    # the cycle that *doesn't* cancel writes a new sandbox file (so the new
+    # checkpoint has a non-empty diff vs its parent).
+    if cancels_done < target and n == 2 + cancels_done:
         return ModelOutput.for_tool_call(SCRIPTED_MODEL, "cancel", {})
-    if completed_tool_turns == 2:
-        # post-resume turn: write a new sandbox file so ckpt-3 commits on
-        # retry with a non-empty diff vs its parent.
+    if n < 2 + target:
         return ModelOutput.for_tool_call(
             SCRIPTED_MODEL, "bash", {"command": RESUME_WRITE_CMD}
         )
@@ -214,7 +249,7 @@ def resume_decode_task() -> Task:
 
 @skip_if_no_docker
 @pytest.mark.slow
-def test_checkpoint_resume_runs_to_completion(
+def test_checkpoint_resume_rehydrated_event_layout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("INSPECT_CHECKPOINTING", "1")
@@ -222,7 +257,8 @@ def test_checkpoint_resume_runs_to_completion(
     # sandbox file paths (exercises host-side `restic ls` on the egressed
     # sandbox repo).
     monkeypatch.setenv("INSPECT_CHECKPOINT_LIST_FILES", "1")
-    _resume_state.cancelled = False
+    monkeypatch.setenv(_CANCEL_FILE_ENV, str(tmp_path / "cancels.txt"))
+    monkeypatch.setenv(_TARGET_ENV, "1")
     _resume_state.generates = 0
 
     log_dir = str(tmp_path / "logs")
@@ -330,32 +366,27 @@ def test_checkpoint_resume_runs_to_completion(
 
 @skip_if_no_docker
 @pytest.mark.slow
-@pytest.mark.xfail(
-    reason="resume rehydrates the prior run's still-open structural spans "
-    "(solvers/react, open at checkpoint-fire time) as raw span_begins with "
-    "no matching span_end, so the `prior_run` wrap closes out of order. "
-    "Regressed in #4062 (bounded transcript store dropped the "
-    "checkpoint-spans-only capture boundary). Remove xfail once the "
-    "rehydrated wrap is span-balanced again.",
-    strict=True,
-)
 def test_checkpoint_resume_spans_balanced(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The resumed run's committed transcript must be span-balanced.
+    """Two resume cycles must yield a span-balanced final transcript.
 
-    Same cancel-then-retry flow as
-    ``test_checkpoint_resume_runs_to_completion``, but asserts structural
-    well-formedness of the event stream rather than content presence — the
-    one check that catches the rehydration regression.
+    Like ``test_checkpoint_resume_rehydrated_event_layout`` but cancels
+    *twice*: cancel mid-run, resume (work one turn, cancel again), resume
+    again to completion. The second resume hydrates a buffer that already
+    contains the first resume's ``prior_run`` wrap, so it exercises the
+    wrap-reparenting path — the case that catches the rehydration
+    regression. Asserts structural balance plus two sequentially-numbered
+    sibling restore wraps.
     """
     monkeypatch.setenv("INSPECT_CHECKPOINTING", "1")
-    _resume_state.cancelled = False
+    monkeypatch.setenv(_CANCEL_FILE_ENV, str(tmp_path / "cancels.txt"))
+    monkeypatch.setenv(_TARGET_ENV, "2")
     _resume_state.generates = 0
 
     log_dir = str(tmp_path / "logs")
 
-    # initial attempt: cancels mid-run after checkpoints commit
+    # initial attempt: cancels mid-run after ckpt-1/ckpt-2 commit
     log = eval(resume_decode_task(), model=SCRIPTED_MODEL, log_dir=log_dir)[0]
     assert log.status == "error"
 
@@ -364,12 +395,25 @@ def test_checkpoint_resume_spans_balanced(
     assert initial.samples is not None
     assert_spans_balanced(initial.samples[0].events)
 
-    # retry: resume from checkpoint and run to completion
-    retry_log = eval_retry(log, log_dir=log_dir)[0]
-    assert retry_log.status == "success"
+    # first resume: one work turn commits a fresh checkpoint, then cancels
+    resume1 = eval_retry(log, log_dir=log_dir)[0]
+    assert resume1.status == "error"
 
-    # the rehydrated `prior_run` wrap must be a self-contained, balanced
-    # subtree — not closed while restored structural spans are still open
-    completed = read_eval_log(retry_log.location)
+    # second resume: hydrates a buffer that already holds the first wrap
+    resume2 = eval_retry(resume1, log_dir=log_dir)[0]
+    assert resume2.status == "success"
+
+    # the rehydrated `prior_run` wraps must form self-contained, balanced
+    # subtrees — not closed while restored structural spans are still open
+    completed = read_eval_log(resume2.location)
     assert completed.samples is not None
-    assert_spans_balanced(completed.samples[0].events)
+    events = completed.samples[0].events
+    assert_spans_balanced(events)
+
+    # two sibling restore wraps, sequentially numbered
+    wrap_names = [
+        e.name
+        for e in events
+        if isinstance(e, SpanBeginEvent) and e.type == "prior_run"
+    ]
+    assert wrap_names == ["checkpoint restore 1", "checkpoint restore 2"]

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -10,7 +10,7 @@ the point of checkpointing.
 
 Because a real ``SIGKILL`` can't kill the pytest process and let it continue,
 each killed attempt runs in a **child process** (the harness in
-``test_helpers/checkpoint_resume_kill.py``, run via ``python -c``); the
+``tests/checkpoint/resume_kill_harness.py``, run as a script); the
 ``crash`` tool kills that child. ``test_checkpoint_resume_rehydrated_event_layout``
 kills a fresh attempt (after ck1/ck2 commit), resumes and kills again (after
 ck3), then resumes a final time *in-process* to completion. It checks, via
@@ -31,22 +31,21 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
 import signal
 import subprocess
 import sys
 from pathlib import Path
 
 import pytest
-from test_helpers.checkpoint_resume_kill import (
+from test_helpers.utils import skip_if_no_docker
+
+from checkpoint.resume_kill_harness import (
     CANCEL_FILE_ENV,
     LAYER1_CONTENT,
     TARGET_ENV,
     generates,
     reset_generates,
 )
-from test_helpers.utils import skip_if_no_docker
-
 from inspect_ai import eval_retry
 from inspect_ai.event import Event, SpanBeginEvent, SpanEndEvent, ToolEvent
 from inspect_ai.event._checkpoint import CheckpointEvent
@@ -93,19 +92,13 @@ def _run_killed_attempt(log_dir: str, retry_from: str | None, tests_dir: Path) -
     """
     env = {
         **os.environ,
-        # the child needs `tests/` on the path to import `test_helpers`
         "PYTHONPATH": os.pathsep.join(
             p for p in (str(tests_dir), os.environ.get("PYTHONPATH", "")) if p
         ),
     }
+    harness = str(tests_dir / "checkpoint" / "resume_kill_harness.py")
     proc = subprocess.run(
-        [
-            sys.executable,
-            "-c",
-            "from test_helpers.checkpoint_resume_kill import main; main()",
-            log_dir,
-            retry_from or "",
-        ],
+        [sys.executable, harness, log_dir, retry_from or ""],
         env=env,
         timeout=600,
     )
@@ -113,13 +106,6 @@ def _run_killed_attempt(log_dir: str, retry_from: str | None, tests_dir: Path) -
         f"expected the child to die by SIGKILL (-{signal.SIGKILL}); "
         f"got returncode {proc.returncode}"
     )
-    # The hard kill orphans the realtime-view sample buffer (`<log_dir>/.buffer`,
-    # a streaming UI cache distinct from the durable .eval log + checkpoints).
-    # inspect only auto-prunes buffers of *finished* evals, so this killed
-    # ("started") one lingers and its stale recovery data shadows checkpoint
-    # resume on the next attempt. A real crash-recovery orchestrator restores
-    # from the log + checkpoints, not this cache, so drop it before resuming.
-    shutil.rmtree(Path(log_dir) / ".buffer", ignore_errors=True)
 
 
 def _inspect_projects() -> set[str]:
@@ -167,12 +153,6 @@ def test_checkpoint_resume_rehydrated_event_layout(
 
     log_dir = str(tmp_path / "logs")
     tests_dir = Path(__file__).parent.parent
-
-    # This test is auto-wrapped in flaky_retry (docker), which re-invokes it
-    # with the *same* tmp_path. Reset the per-run state so a retry starts clean
-    # (a stale crash count would make the fresh attempt never crash).
-    shutil.rmtree(tmp_path / "logs", ignore_errors=True)
-    (tmp_path / "cancels.txt").unlink(missing_ok=True)
 
     # A hard kill skips sandbox teardown, so each killed attempt leaks its
     # sandbox container. Track inspect projects before/after and force-remove

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -1,16 +1,18 @@
-"""End-to-end checkpoint resume test: cancel an attempt, then retry it.
+"""End-to-end checkpoint resume test: cancel an attempt, then retry — twice.
 
 Drives a ``react()`` agent through tool-calling turns with
 ``TurnInterval(every=1)``, so a checkpoint fires at the start of each turn
 after the first; the agent then calls a ``cancel`` tool that interrupts the
 sample mid-run, leaving committed checkpoints on disk.
-``test_checkpoint_resume_rehydrated_event_layout`` then ``eval_retry``s the
-cancelled run and asserts it resumes and completes successfully. It checks,
-via the public ``.eval`` log: the restored checkpoints appear as
-``CheckpointEvent``s inside the ``prior_run`` ("checkpoint restore") span, a
-new checkpoint commits *during* the retry (a ``CheckpointEvent`` outside that
-span, continuing the numbering), and resume restored the prior conversation
-(only the remaining turns run, not a replay from scratch).
+``test_checkpoint_resume_rehydrated_event_layout`` ``eval_retry``s the
+cancelled run, has it work one turn and cancel again, then ``eval_retry``s a
+second time to completion. It checks, via the public ``.eval`` log: each
+resume's restored checkpoints appear as ``CheckpointEvent``s inside its own
+``prior_run`` ("checkpoint restore N") span; the wraps are sequentially
+numbered, span-balanced siblings; a new checkpoint commits *during* the final
+resume (a ``CheckpointEvent`` outside the wraps, continuing the numbering);
+and resume restored the prior conversation (only the remaining turns run, not
+a replay from scratch).
 
 Requires Docker: the sandbox backup path injects/execs a Linux restic
 binary inside the sandbox, which only works with a Linux container
@@ -72,7 +74,7 @@ def assert_spans_balanced(events: list[Event]) -> None:
     the innermost open span, and nothing may be left open at the end.
     Presence/membership assertions can't catch an *additive* structural
     corruption (extra unbalanced spans wrapped around otherwise-correct
-    content) — this can. See ``test_checkpoint_resume_spans_balanced``.
+    content) — this can.
     """
     stack: list[str] = []
     for e in events:
@@ -92,14 +94,15 @@ class _ResumeState:
 
     ``generates`` counts model calls so the resume test can prove the
     conversation was restored (only the remaining turns run) rather than
-    re-run from scratch.
+    re-run from scratch. ``cancelled`` reflects whether the cancel tool has
+    fired.
 
-    The cancel *count* and *target* deliberately do NOT live here: on
-    ``eval_retry`` the cancel tool is rebuilt from a re-imported copy of
-    this module, so a module-global counter mutated by the tool and read
-    by the model would be two different instances. They're kept in a host
-    file / env var instead (process-global, re-import-proof) — see
-    ``_cancels_done`` / ``_bump_cancels`` / ``_target_cancels``.
+    The cancel *count* and *target* do NOT live here: on ``eval_retry`` the
+    cancel tool is rebuilt from a re-imported copy of this module, so a
+    module-global counter mutated by the tool and read by the model would be
+    two different instances. They're kept in a host file / env var instead
+    (process-global, re-import-proof) — see ``_cancels_done`` /
+    ``_bump_cancels`` / ``_target_cancels``.
     """
 
     generates: int = 0
@@ -111,8 +114,6 @@ class _ResumeState:
 
 _resume_state = _ResumeState()
 
-# Env vars set per test. The cancel count is persisted to the file named by
-# `_CANCEL_FILE_ENV` so it survives `eval_retry`'s module re-import.
 _CANCEL_FILE_ENV = "INSPECT_TEST_RESUME_CANCEL_FILE"
 _TARGET_ENV = "INSPECT_TEST_RESUME_TARGET_CANCELS"
 
@@ -258,29 +259,33 @@ def test_checkpoint_resume_rehydrated_event_layout(
     # sandbox repo).
     monkeypatch.setenv("INSPECT_CHECKPOINT_LIST_FILES", "1")
     monkeypatch.setenv(_CANCEL_FILE_ENV, str(tmp_path / "cancels.txt"))
-    monkeypatch.setenv(_TARGET_ENV, "1")
+    monkeypatch.setenv(_TARGET_ENV, "2")
     _resume_state.generates = 0
 
     log_dir = str(tmp_path / "logs")
 
-    # --- initial attempt: cancels mid-run after checkpoints commit ---------
+    # --- initial attempt: ckpt-1/ckpt-2 commit, then cancels mid-run -------
     log = eval(resume_decode_task(), model=SCRIPTED_MODEL, log_dir=log_dir)[0]
     assert log.status == "error"
     assert _resume_state.cancelled is True
     assert _resume_state.generates >= 3  # bash, remember, cancel
 
-    # --- retry: resume from checkpoint and run to completion ---------------
-    _resume_state.generates = 0
-    retry_log = eval_retry(log, log_dir=log_dir)[0]
+    # --- first resume: one work turn commits ckpt-3, then cancels again ----
+    resume1 = eval_retry(log, log_dir=log_dir)[0]
+    assert resume1.status == "error"
 
-    assert retry_log.status == "success"
-    assert retry_log.samples is not None and len(retry_log.samples) == 1
-    sample = retry_log.samples[0]
+    # --- second resume: commits ckpt-4, then runs to completion ------------
+    _resume_state.generates = 0
+    resume2 = eval_retry(resume1, log_dir=log_dir)[0]
+
+    assert resume2.status == "success"
+    assert resume2.samples is not None and len(resume2.samples) == 1
+    sample = resume2.samples[0]
     assert sample.error is None
 
-    # resume restored the prior conversation, so only the remaining turns ran
-    # (one bash + submit = 2 generates; a fresh re-run would have redone the
-    # turn-0 bash + turn-1 remember as well).
+    # the final resume restored the full prior conversation, so only the
+    # remaining turns ran (one bash + submit = 2 generates; a fresh re-run
+    # would have redone the earlier turns as well).
     assert _resume_state.generates == 2
 
     # the restored + completed run scored correct
@@ -288,53 +293,69 @@ def test_checkpoint_resume_rehydrated_event_layout(
     assert sample.scores["includes"].value == CORRECT
     assert LAYER1_CONTENT in sample.output.completion
 
-    # --- examine the completed .eval: restore span + checkpoint events -----
-    completed = read_eval_log(retry_log.location)
+    # --- examine the completed .eval: restore spans + checkpoint events ----
+    completed = read_eval_log(resume2.location)
     assert completed.samples is not None
     events = completed.samples[0].events
 
-    # the rehydrated history is wrapped in a single "checkpoint restore" span
-    # (type "prior_run")
+    # the rehydrated wraps must be self-contained, balanced subtrees — not
+    # closed while restored structural spans are still open (the regression)
+    assert_spans_balanced(events)
+
+    # each resume contributed one "checkpoint restore" (prior_run) wrap,
+    # sequentially numbered
     restore_spans = [
         e for e in events if isinstance(e, SpanBeginEvent) and e.type == "prior_run"
     ]
-    assert len(restore_spans) == 1
-    restore_span = restore_spans[0]
-    assert restore_span.name.startswith("checkpoint restore")
+    assert [s.name for s in restore_spans] == [
+        "checkpoint restore 1",
+        "checkpoint restore 2",
+    ]
 
-    # events contained by that span (between its begin and matching end)
-    begin_idx = next(
-        i
-        for i, e in enumerate(events)
-        if isinstance(e, SpanBeginEvent) and e.id == restore_span.id
-    )
-    end_idx = next(
-        i
-        for i, e in enumerate(events)
-        if isinstance(e, SpanEndEvent) and e.id == restore_span.id
-    )
-    restored = events[begin_idx + 1 : end_idx]
+    # index range each wrap spans (begin..matching end)
+    def _span_range(span_id: str) -> tuple[int, int]:
+        begin_idx = next(
+            i
+            for i, e in enumerate(events)
+            if isinstance(e, SpanBeginEvent) and e.id == span_id
+        )
+        end_idx = next(
+            i
+            for i, e in enumerate(events)
+            if isinstance(e, SpanEndEvent) and e.id == span_id
+        )
+        return begin_idx, end_idx
 
-    # a CheckpointEvent for each checkpoint that fired in the initial attempt,
-    # all rehydrated inside the restore span
+    wrap_ranges = [_span_range(s.id) for s in restore_spans]
+
+    def _in_wrap(i: int) -> bool:
+        return any(begin < i < end for begin, end in wrap_ranges)
+
+    # every checkpoint that fired before a cancel is rehydrated inside a wrap:
+    # ckpt-1/ckpt-2 (initial attempt) and ckpt-3 (first resume).
     restored_checkpoint_ids = {
-        e.checkpoint_id for e in restored if isinstance(e, CheckpointEvent)
+        e.checkpoint_id
+        for i, e in enumerate(events)
+        if isinstance(e, CheckpointEvent) and _in_wrap(i)
     }
-    assert restored_checkpoint_ids == {1, 2}
+    assert restored_checkpoint_ids == {1, 2, 3}
 
-    # the prior tool activity was rehydrated inside the span too
-    restored_tools = {e.function for e in restored if isinstance(e, ToolEvent)}
+    # the prior tool activity was rehydrated inside the wraps too
+    restored_tools = {
+        e.function
+        for i, e in enumerate(events)
+        if isinstance(e, ToolEvent) and _in_wrap(i)
+    }
     assert {"bash", "remember"} <= restored_tools
 
-    # a checkpoint committed *during* the retry shows up as a CheckpointEvent
-    # outside the restore span (the live resumed session), continuing the
-    # numbering past the restored ones.
+    # the checkpoint committed *during* the final resume is live — outside any
+    # wrap — and continues the numbering past the restored ones.
     new_checkpoint_ids = {
         e.checkpoint_id
         for i, e in enumerate(events)
-        if isinstance(e, CheckpointEvent) and not (begin_idx < i < end_idx)
+        if isinstance(e, CheckpointEvent) and not _in_wrap(i)
     }
-    assert new_checkpoint_ids == {3}
+    assert new_checkpoint_ids == {4}
 
     # File listing (opt-in) records each sandbox snapshot's added/changed
     # files (diff vs parent), not the whole tree.
@@ -362,58 +383,3 @@ def test_checkpoint_resume_rehydrated_event_layout(
         p.endswith("workspace/decoded/layer1.txt") for p in ckpt3_details.files
     )
     assert ckpt3_details.additional_files is None
-
-
-@skip_if_no_docker
-@pytest.mark.slow
-def test_checkpoint_resume_spans_balanced(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Two resume cycles must yield a span-balanced final transcript.
-
-    Like ``test_checkpoint_resume_rehydrated_event_layout`` but cancels
-    *twice*: cancel mid-run, resume (work one turn, cancel again), resume
-    again to completion. The second resume hydrates a buffer that already
-    contains the first resume's ``prior_run`` wrap, so it exercises the
-    wrap-reparenting path — the case that catches the rehydration
-    regression. Asserts structural balance plus two sequentially-numbered
-    sibling restore wraps.
-    """
-    monkeypatch.setenv("INSPECT_CHECKPOINTING", "1")
-    monkeypatch.setenv(_CANCEL_FILE_ENV, str(tmp_path / "cancels.txt"))
-    monkeypatch.setenv(_TARGET_ENV, "2")
-    _resume_state.generates = 0
-
-    log_dir = str(tmp_path / "logs")
-
-    # initial attempt: cancels mid-run after ckpt-1/ckpt-2 commit
-    log = eval(resume_decode_task(), model=SCRIPTED_MODEL, log_dir=log_dir)[0]
-    assert log.status == "error"
-
-    # the cancelled run's own transcript closes its spans on interrupt unwind
-    initial = read_eval_log(log.location)
-    assert initial.samples is not None
-    assert_spans_balanced(initial.samples[0].events)
-
-    # first resume: one work turn commits a fresh checkpoint, then cancels
-    resume1 = eval_retry(log, log_dir=log_dir)[0]
-    assert resume1.status == "error"
-
-    # second resume: hydrates a buffer that already holds the first wrap
-    resume2 = eval_retry(resume1, log_dir=log_dir)[0]
-    assert resume2.status == "success"
-
-    # the rehydrated `prior_run` wraps must form self-contained, balanced
-    # subtrees — not closed while restored structural spans are still open
-    completed = read_eval_log(resume2.location)
-    assert completed.samples is not None
-    events = completed.samples[0].events
-    assert_spans_balanced(events)
-
-    # two sibling restore wraps, sequentially numbered
-    wrap_names = [
-        e.name
-        for e in events
-        if isinstance(e, SpanBeginEvent) and e.type == "prior_run"
-    ]
-    assert wrap_names == ["checkpoint restore 1", "checkpoint restore 2"]

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -1,18 +1,25 @@
-"""End-to-end checkpoint resume test: cancel an attempt, then retry — twice.
+"""End-to-end checkpoint resume test: hard-kill an attempt, then retry — twice.
 
 Drives a ``react()`` agent through tool-calling turns with
 ``TurnInterval(every=1)``, so a checkpoint fires at the start of each turn
-after the first; the agent then calls a ``cancel`` tool that interrupts the
-sample mid-run, leaving committed checkpoints on disk.
-``test_checkpoint_resume_rehydrated_event_layout`` ``eval_retry``s the
-cancelled run, has it work one turn and cancel again, then ``eval_retry``s a
-second time to completion. It checks, via the public ``.eval`` log: each
-resume's restored checkpoints appear as ``CheckpointEvent``s inside its own
-``prior_run`` ("checkpoint restore N") span; the wraps are sequentially
-numbered, span-balanced siblings; a new checkpoint commits *during* the final
-resume (a ``CheckpointEvent`` outside the wraps, continuing the numbering);
-and resume restored the prior conversation (only the remaining turns run, not
-a replay from scratch).
+after the first. Instead of cooperatively cancelling, the agent calls a
+``crash`` tool that ``SIGKILL``s its own process mid-run — an *unanticipated*
+death (power loss / OOM / preemption) with no graceful unwind, no log
+finalize, and an orphaned sandbox container. Recovering from exactly that is
+the point of checkpointing.
+
+Because a real ``SIGKILL`` can't kill the pytest process and let it continue,
+each killed attempt runs in a **child process** (the harness in
+``test_helpers/checkpoint_resume_kill.py``, run via ``python -c``); the
+``crash`` tool kills that child. ``test_checkpoint_resume_rehydrated_event_layout``
+kills a fresh attempt (after ck1/ck2 commit), resumes and kills again (after
+ck3), then resumes a final time *in-process* to completion. It checks, via
+the public ``.eval`` log: each resume's restored checkpoints appear as
+``CheckpointEvent``s inside its own ``prior_run`` ("checkpoint restore N")
+span; the wraps are sequentially numbered, span-balanced siblings; a new
+checkpoint commits *during* the final resume (a ``CheckpointEvent`` outside
+the wraps, continuing the numbering); and resume restored the prior
+conversation (only the remaining turns run, not a replay from scratch).
 
 Requires Docker: the sandbox backup path injects/execs a Linux restic
 binary inside the sandbox, which only works with a Linux container
@@ -22,49 +29,29 @@ binary inside the sandbox, which only works with a Linux container
 
 from __future__ import annotations
 
+import json
 import os
+import shutil
+import signal
+import subprocess
+import sys
 from pathlib import Path
-from typing import Any
 
-import anyio
 import pytest
+from test_helpers.checkpoint_resume_kill import (
+    CANCEL_FILE_ENV,
+    LAYER1_CONTENT,
+    TARGET_ENV,
+    generates,
+    reset_generates,
+)
 from test_helpers.utils import skip_if_no_docker
 
-from inspect_ai import Task, eval, eval_retry, task
-from inspect_ai.agent import react
-from inspect_ai.dataset import Sample
+from inspect_ai import eval_retry
 from inspect_ai.event import Event, SpanBeginEvent, SpanEndEvent, ToolEvent
 from inspect_ai.event._checkpoint import CheckpointEvent
-from inspect_ai.log import read_eval_log
-from inspect_ai.log._samples import sample_active
-from inspect_ai.model import (
-    ChatMessage,
-    ChatMessageTool,
-    GenerateConfig,
-    ModelOutput,
-    modelapi,
-)
-from inspect_ai.model._providers.mockllm import MockLLM
-from inspect_ai.scorer import CORRECT, includes
-from inspect_ai.tool import Tool, ToolChoice, ToolInfo, bash, tool
-from inspect_ai.util import CheckpointConfig, TurnInterval, store
-
-LAYER1_CONTENT = "plain1"
-STORE_KEY = "answer"
-# Write under $HOME (not /workspace) so the default-user home-dir auto-backup
-# captures it — the task declares no `sandbox_paths`, exercising
-# `resolve_sandbox_backup_paths` / `_resolve_home_and_cache`. Also drop a file
-# under the XDG cache dir ($HOME/.cache) to prove auto-home mode excludes it.
-WRITE_CMD = (
-    'mkdir -p "$HOME/workspace/decoded" "$HOME/.cache" && '
-    f"printf '{LAYER1_CONTENT}' > \"$HOME/workspace/decoded/layer1.txt\" && "
-    'printf cache > "$HOME/.cache/junk.txt"'
-)
-# Written on the post-resume turn so the ckpt-3 snapshot has a non-empty
-# diff vs its parent (ckpt-2) — used to assert file listing records the
-# *changed* file, not the unchanged `layer1.txt`.
-RESUME_WRITE_CMD = 'printf resumed > "$HOME/workspace/resumed.txt"'
-SCRIPTED_MODEL = "scripteddecode/model"
+from inspect_ai.log import list_eval_logs, read_eval_log
+from inspect_ai.scorer import CORRECT
 
 
 def assert_spans_balanced(events: list[Event]) -> None:
@@ -89,163 +76,79 @@ def assert_spans_balanced(events: list[Event]) -> None:
     assert not stack, f"{len(stack)} unclosed span(s): {stack}"
 
 
-class _ResumeState:
-    """Module-level state shared by the scripted provider and the cancel tool.
+def _latest_log(log_dir: str) -> str:
+    """Location of the most recently written eval log.
 
-    ``generates`` counts model calls so the resume test can prove the
-    conversation was restored (only the remaining turns run) rather than
-    re-run from scratch. ``cancelled`` reflects whether the cancel tool has
-    fired.
-
-    The cancel *count* and *target* do NOT live here: on ``eval_retry`` the
-    cancel tool is rebuilt from a re-imported copy of this module, so a
-    module-global counter mutated by the tool and read by the model would be
-    two different instances. They're kept in a host file / env var instead
-    (process-global, re-import-proof) — see ``_cancels_done`` /
-    ``_bump_cancels`` / ``_target_cancels``.
+    Filenames are timestamp-prefixed, so lexicographic max is newest.
     """
-
-    generates: int = 0
-
-    @property
-    def cancelled(self) -> bool:
-        return _cancels_done() > 0
+    logs = list_eval_logs(log_dir)
+    assert logs, f"no eval logs under {log_dir}"
+    return max(logs, key=lambda info: info.name).name
 
 
-_resume_state = _ResumeState()
+def _run_killed_attempt(log_dir: str, retry_from: str | None, tests_dir: Path) -> None:
+    """Run an eval in a child process that ``SIGKILL``s itself mid-run.
 
-_CANCEL_FILE_ENV = "INSPECT_TEST_RESUME_CANCEL_FILE"
-_TARGET_ENV = "INSPECT_TEST_RESUME_TARGET_CANCELS"
-
-
-def _cancels_done() -> int:
-    f = os.environ.get(_CANCEL_FILE_ENV)
-    return int(Path(f).read_text() or "0") if f and Path(f).exists() else 0
-
-
-def _bump_cancels() -> int:
-    n = _cancels_done() + 1
-    f = os.environ.get(_CANCEL_FILE_ENV)
-    if f:
-        Path(f).write_text(str(n))
-    return n
-
-
-def _target_cancels() -> int:
-    return int(os.environ.get(_TARGET_ENV, "1"))
-
-
-@tool
-def remember() -> Tool:
-    async def execute(key: str, value: str) -> str:
-        """Record a key/value note in the sample store.
-
-        Args:
-            key: short label for the note.
-            value: the value to remember.
-
-        Returns:
-            Confirmation string.
-        """
-        store().set(key, value)
-        return f"remembered: {key}"
-
-    return execute
-
-
-@tool
-def cancel() -> Tool:
-    async def execute() -> str:
-        """Cancel the run immediately (interrupts the sample)."""
-        active = sample_active()
-        assert active is not None, "expected an active sample"
-        _bump_cancels()
-        active.interrupt("error")
-        # interrupt cancels the surrounding scope; never return normally.
-        await anyio.sleep_forever()
-        return "cancelled"
-
-    return execute
-
-
-# eval_retry reconstructs the task by registry name and rebuilds the model by
-# name from the log — so the task must be a registered @task and the scripted
-# behavior must live in a registered model provider (a plain mockllm
-# custom_outputs object would not survive the round-trip). The provider drives
-# a linear script keyed off the number of completed tool turns in the restored
-# conversation, plus `_resume_state`:
-#
-#   turn 0: bash (write a sandbox file)          -> ckpt-1 fires next turn
-#   turn 1: remember (write the store)           -> ckpt-2 fires next turn
-#   turn 2: cancel (first attempt) ............... interrupt, then resume
-#           bash (write a *new* sandbox file)    -> ckpt-3 fires next turn
-#   turn 3: submit
-#
-# The post-resume bash turn exists so a *new* checkpoint (ckpt-3) fires during
-# the retry — the trigger resets on resume, so a single submit turn alone would
-# commit nothing. It writes a new file (not the one from turn 0) so ckpt-3's
-# diff-vs-parent file listing has a deterministic changed file to assert on.
-
-
-def _scripted_outputs(
-    input: list[ChatMessage],
-    tools: list[ToolInfo],
-    tool_choice: ToolChoice,
-    config: GenerateConfig,
-) -> ModelOutput:
-    _resume_state.generates += 1
-    n = sum(1 for m in input if isinstance(m, ChatMessageTool))
-    cancels_done = _cancels_done()
-    target = _target_cancels()
-    if n == 0:
-        return ModelOutput.for_tool_call(SCRIPTED_MODEL, "bash", {"command": WRITE_CMD})
-    if n == 1:
-        return ModelOutput.for_tool_call(
-            SCRIPTED_MODEL, "remember", {"key": STORE_KEY, "value": LAYER1_CONTENT}
-        )
-    # Each resume cycle does one work turn (commits a fresh checkpoint) and
-    # then cancels, until `target` cancels are reached. The k-th cancel
-    # (k = cancels_done) lands at turn `2 + cancels_done`; the work turn for
-    # the cycle that *doesn't* cancel writes a new sandbox file (so the new
-    # checkpoint has a non-empty diff vs its parent).
-    if cancels_done < target and n == 2 + cancels_done:
-        return ModelOutput.for_tool_call(SCRIPTED_MODEL, "cancel", {})
-    if n < 2 + target:
-        return ModelOutput.for_tool_call(
-            SCRIPTED_MODEL, "bash", {"command": RESUME_WRITE_CMD}
-        )
-    return ModelOutput.for_tool_call(
-        SCRIPTED_MODEL, "submit", {"answer": LAYER1_CONTENT}
-    )
-
-
-@modelapi(name="scripteddecode")
-def _scripteddecode_provider() -> type[MockLLM]:
-    class ScriptedDecode(MockLLM):
-        def __init__(self, model_name: str, **kwargs: Any) -> None:
-            # ignore any persisted custom_outputs; drive from _scripted_outputs
-            kwargs.pop("custom_outputs", None)
-            super().__init__(model_name, custom_outputs=_scripted_outputs, **kwargs)
-
-    return ScriptedDecode
-
-
-@task
-def resume_decode_task() -> Task:
-    return Task(
-        dataset=[Sample(id="resume", input="decode the layers", target=LAYER1_CONTENT)],
-        solver=react(tools=[bash(timeout=60), remember(), cancel()]),
-        scorer=includes(),
-        # Default sandbox image: its ~955 MB /root is mostly /root/.cache,
-        # which auto-home mode excludes — so the egress stays small without a
-        # custom small-home image, and this exercises that exclude for real.
-        sandbox="docker",
-        checkpoint=CheckpointConfig(
-            trigger=TurnInterval(every=1),
-            # No sandbox_paths: the default sandbox's $HOME is auto-captured.
-            retention="retain",
+    Asserts the child died by signal rather than exiting normally.
+    """
+    env = {
+        **os.environ,
+        # the child needs `tests/` on the path to import `test_helpers`
+        "PYTHONPATH": os.pathsep.join(
+            p for p in (str(tests_dir), os.environ.get("PYTHONPATH", "")) if p
         ),
+    }
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from test_helpers.checkpoint_resume_kill import main; main()",
+            log_dir,
+            retry_from or "",
+        ],
+        env=env,
+        timeout=600,
     )
+    assert proc.returncode == -signal.SIGKILL, (
+        f"expected the child to die by SIGKILL (-{signal.SIGKILL}); "
+        f"got returncode {proc.returncode}"
+    )
+    # The hard kill orphans the realtime-view sample buffer (`<log_dir>/.buffer`,
+    # a streaming UI cache distinct from the durable .eval log + checkpoints).
+    # inspect only auto-prunes buffers of *finished* evals, so this killed
+    # ("started") one lingers and its stale recovery data shadows checkpoint
+    # resume on the next attempt. A real crash-recovery orchestrator restores
+    # from the log + checkpoints, not this cache, so drop it before resuming.
+    shutil.rmtree(Path(log_dir) / ".buffer", ignore_errors=True)
+
+
+def _inspect_projects() -> set[str]:
+    """Names of inspect docker compose projects currently known to docker."""
+    result = subprocess.run(
+        ["docker", "compose", "ls", "--all", "--format", "json"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        return set()
+    try:
+        projects = json.loads(result.stdout or "[]")
+    except json.JSONDecodeError:
+        return set()
+    return {
+        p.get("Name", "") for p in projects if p.get("Name", "").startswith("inspect-")
+    }
+
+
+def _force_remove_project(name: str) -> None:
+    """Best-effort force-remove the containers of a leaked compose project."""
+    ids = subprocess.run(
+        ["docker", "ps", "-aq", "--filter", f"label=com.docker.compose.project={name}"],
+        capture_output=True,
+        text=True,
+    ).stdout.split()
+    if ids:
+        subprocess.run(["docker", "rm", "-f", *ids], capture_output=True)
 
 
 @skip_if_no_docker
@@ -258,35 +161,46 @@ def test_checkpoint_resume_rehydrated_event_layout(
     # sandbox file paths (exercises host-side `restic ls` on the egressed
     # sandbox repo).
     monkeypatch.setenv("INSPECT_CHECKPOINT_LIST_FILES", "1")
-    monkeypatch.setenv(_CANCEL_FILE_ENV, str(tmp_path / "cancels.txt"))
-    monkeypatch.setenv(_TARGET_ENV, "2")
-    _resume_state.generates = 0
+    # Crash count (host file) + target are inherited by the child processes.
+    monkeypatch.setenv(CANCEL_FILE_ENV, str(tmp_path / "cancels.txt"))
+    monkeypatch.setenv(TARGET_ENV, "2")
 
     log_dir = str(tmp_path / "logs")
+    tests_dir = Path(__file__).parent.parent
 
-    # --- initial attempt: ckpt-1/ckpt-2 commit, then cancels mid-run -------
-    log = eval(resume_decode_task(), model=SCRIPTED_MODEL, log_dir=log_dir)[0]
-    assert log.status == "error"
-    assert _resume_state.cancelled is True
-    assert _resume_state.generates >= 3  # bash, remember, cancel
+    # This test is auto-wrapped in flaky_retry (docker), which re-invokes it
+    # with the *same* tmp_path. Reset the per-run state so a retry starts clean
+    # (a stale crash count would make the fresh attempt never crash).
+    shutil.rmtree(tmp_path / "logs", ignore_errors=True)
+    (tmp_path / "cancels.txt").unlink(missing_ok=True)
 
-    # --- first resume: one work turn commits ckpt-3, then cancels again ----
-    resume1 = eval_retry(log, log_dir=log_dir)[0]
-    assert resume1.status == "error"
+    # A hard kill skips sandbox teardown, so each killed attempt leaks its
+    # sandbox container. Track inspect projects before/after and force-remove
+    # the ones this test leaks (the final resume cleans up its own).
+    projects_before = _inspect_projects()
+    try:
+        # --- attempt #0: fresh eval, hard-killed at turn 2 (after ck1/ck2) --
+        _run_killed_attempt(log_dir, None, tests_dir)
 
-    # --- second resume: commits ckpt-4, then runs to completion ------------
-    _resume_state.generates = 0
-    resume2 = eval_retry(resume1, log_dir=log_dir)[0]
+        # --- attempt #1: resume, work one turn (ck3), hard-kill at turn 3 ---
+        _run_killed_attempt(log_dir, _latest_log(log_dir), tests_dir)
 
-    assert resume2.status == "success"
-    assert resume2.samples is not None and len(resume2.samples) == 1
-    sample = resume2.samples[0]
+        # --- final resume: runs in this process, to completion --------------
+        reset_generates()
+        resume = eval_retry(read_eval_log(_latest_log(log_dir)), log_dir=log_dir)[0]
+    finally:
+        for name in _inspect_projects() - projects_before:
+            _force_remove_project(name)
+
+    assert resume.status == "success"
+    assert resume.samples is not None and len(resume.samples) == 1
+    sample = resume.samples[0]
     assert sample.error is None
 
     # the final resume restored the full prior conversation, so only the
     # remaining turns ran (one bash + submit = 2 generates; a fresh re-run
     # would have redone the earlier turns as well).
-    assert _resume_state.generates == 2
+    assert generates() == 2
 
     # the restored + completed run scored correct
     assert sample.scores is not None
@@ -294,7 +208,7 @@ def test_checkpoint_resume_rehydrated_event_layout(
     assert LAYER1_CONTENT in sample.output.completion
 
     # --- examine the completed .eval: restore spans + checkpoint events ----
-    completed = read_eval_log(resume2.location)
+    completed = read_eval_log(resume.location)
     assert completed.samples is not None
     events = completed.samples[0].events
 
@@ -331,7 +245,7 @@ def test_checkpoint_resume_rehydrated_event_layout(
     def _in_wrap(i: int) -> bool:
         return any(begin < i < end for begin, end in wrap_ranges)
 
-    # every checkpoint that fired before a cancel is rehydrated inside a wrap:
+    # every checkpoint that fired before a kill is rehydrated inside a wrap:
     # ckpt-1/ckpt-2 (initial attempt) and ckpt-3 (first resume).
     restored_checkpoint_ids = {
         e.checkpoint_id

--- a/tests/checkpoint/test_checkpointer.py
+++ b/tests/checkpoint/test_checkpointer.py
@@ -453,6 +453,109 @@ def test_synthesize_trailing_checkpoint_event(tmp_path: Path) -> None:
     assert event.timestamp == checkpoint.created_at
 
 
+def _assert_spans_balanced(events: list[Event]) -> None:
+    """Assert span_begin/span_end nest LIFO with nothing left open."""
+    from inspect_ai.event._span import SpanBeginEvent, SpanEndEvent
+
+    stack: list[str] = []
+    for e in events:
+        if isinstance(e, SpanBeginEvent):
+            stack.append(e.id)
+        elif isinstance(e, SpanEndEvent):
+            assert stack and stack[-1] == e.id, f"unbalanced span_end {e.id}"
+            stack.pop()
+    assert not stack, f"unclosed spans: {stack}"
+
+
+def test_wrap_prior_run_reparents_existing_wraps_across_resumes() -> None:
+    """A second resume keeps prior wraps as clean siblings under the current span.
+
+    Models the cumulative buffer a second resume hydrates. Insertion
+    order puts the seeded earlier ``prior_run`` wrap *first*, then the
+    resumed session's own (still-open) structural ancestry, then a fresh
+    unwrapped checkpoint span nested under that ancestry's ``agent``
+    span. Both layers of scaffolding — leading (before the first wrap)
+    and trailing (between the wrap and the new checkpoint) — must be
+    sliced away: the surviving wrap is re-parented onto the current
+    span, and the new checkpoint span becomes a second sibling wrap with
+    nothing else inside it.
+    """
+    from inspect_ai.event._span import SpanBeginEvent, SpanEndEvent
+    from inspect_ai.util._checkpoint.hydrate import _wrap_prior_run
+
+    restored_events: list[Event] = [
+        # leading scaffolding before the first wrap — dropped by the slice
+        SpanBeginEvent(id="agent0", name="react", type="agent"),
+        InfoEvent(data="leading-setup"),
+        # the wrap hydrated during the prior resume (seeded first in the
+        # buffer), parented to that resume's now-gone agent span
+        SpanBeginEvent(
+            id="restore-1",
+            name="checkpoint restore 1",
+            type="prior_run",
+            parent_id="agent0",
+        ),
+        SpanBeginEvent(
+            id="checkpoint-1",
+            name="checkpoint 1",
+            type="checkpoint",
+            parent_id="restore-1",
+        ),
+        SpanEndEvent(id="checkpoint-1"),
+        SpanEndEvent(id="restore-1"),
+        # the resumed session's OWN structural ancestry, recorded after the
+        # seeded wrap and still open at fire time — trailing scaffolding
+        SpanBeginEvent(id="init1", name="init", type="init"),
+        SpanEndEvent(id="init1"),
+        SpanBeginEvent(id="solvers1", name="solvers"),
+        SpanBeginEvent(id="solver1", name="react", type="solver", parent_id="solvers1"),
+        SpanBeginEvent(id="agent1", name="react", type="agent", parent_id="solver1"),
+        InfoEvent(data="trailing-setup"),
+        # the new, still-unwrapped checkpoint span nested under that agent
+        SpanBeginEvent(
+            id="checkpoint-2",
+            name="checkpoint 2",
+            type="checkpoint",
+            parent_id="agent1",
+        ),
+        SpanEndEvent(id="checkpoint-2"),
+    ]
+
+    wrapped = _wrap_prior_run(restored_events, parent_span_id="current")
+
+    # all structural ancestry (leading and trailing) is gone
+    span_ids = {
+        event.id
+        for event in wrapped
+        if isinstance(event, (SpanBeginEvent, SpanEndEvent))
+    }
+    assert {"agent0", "init1", "solvers1", "solver1", "agent1"}.isdisjoint(span_ids)
+
+    wrap_begins = [
+        event
+        for event in wrapped
+        if isinstance(event, SpanBeginEvent) and event.type == "prior_run"
+    ]
+    assert [w.name for w in wrap_begins] == [
+        "checkpoint restore 1",
+        "checkpoint restore 2",
+    ]
+    # both wraps sit under the current session's span as siblings
+    assert wrap_begins[0].id == "restore-1"
+    assert wrap_begins[0].parent_id == "current"
+    assert wrap_begins[1].parent_id == "current"
+
+    # the new wrap's first child is checkpoint-2, re-parented onto it — the
+    # wrap contains the checkpoint span and nothing else
+    new_wrap = wrap_begins[1]
+    new_wrap_idx = next(i for i, e in enumerate(wrapped) if e is new_wrap)
+    first_child = wrapped[new_wrap_idx + 1]
+    assert isinstance(first_child, SpanBeginEvent)
+    assert first_child.id == "checkpoint-2"
+    assert first_child.parent_id == new_wrap.id
+    _assert_spans_balanced(wrapped)
+
+
 # --- tracing (inspect trace anomalies / dump --filter checkpoint) ---------
 
 

--- a/tests/checkpoint/test_eval_checkpoints.py
+++ b/tests/checkpoint/test_eval_checkpoints.py
@@ -9,6 +9,13 @@ def test_eval_checkpoints_dir_strips_eval_suffix() -> None:
     assert eval_checkpoints_dir("/logs/foo.eval", None) == "/logs/foo.checkpoints"
 
 
+def test_eval_checkpoints_dir_strips_recovered_suffix() -> None:
+    assert (
+        eval_checkpoints_dir("/logs/foo-recovered.eval", None)
+        == "/logs/foo.checkpoints"
+    )
+
+
 def test_eval_checkpoints_dir_passthrough_when_no_eval_suffix() -> None:
     assert eval_checkpoints_dir("/logs/raw_name", None) == "/logs/raw_name.checkpoints"
 
@@ -20,10 +27,24 @@ def test_eval_checkpoints_dir_handles_s3_uri() -> None:
     )
 
 
+def test_eval_checkpoints_dir_handles_recovered_s3_uri() -> None:
+    assert (
+        eval_checkpoints_dir("s3://bucket/path/foo-recovered.eval", None)
+        == "s3://bucket/path/foo.checkpoints"
+    )
+
+
 def test_eval_checkpoints_dir_with_override_root() -> None:
     """Override repoints the parent; the per-eval subdir name is unchanged."""
     assert (
         eval_checkpoints_dir("/logs/foo.eval", "/scratch/ckpts")
+        == "/scratch/ckpts/foo.checkpoints"
+    )
+
+
+def test_eval_checkpoints_dir_with_recovered_override_root() -> None:
+    assert (
+        eval_checkpoints_dir("/logs/foo-recovered.eval", "/scratch/ckpts")
         == "/scratch/ckpts/foo.checkpoints"
     )
 

--- a/tests/test_helpers/checkpoint_resume_kill.py
+++ b/tests/test_helpers/checkpoint_resume_kill.py
@@ -1,0 +1,238 @@
+"""Importable harness for the checkpoint resume-after-hard-kill e2e test.
+
+Lives in ``test_helpers`` (not the test file) so it can be both imported by
+the test — registering the ``@task`` / ``@modelapi`` so the final in-process
+resume works, and exposing shared constants — and run as a **subprocess**::
+
+    python -c "from test_helpers.checkpoint_resume_kill import main; main()" <log_dir> [<retry_from>]
+
+Running the killed attempts in child processes is what lets the test issue a
+*real* ``SIGKILL`` of the eval without taking down pytest. The ``crash`` tool
+``os.kill``s its own (child) process at the same point the cooperative
+``cancel`` tool used to ``interrupt`` — abruptly, with no graceful unwind, no
+``finally``, no log finalize — exercising recovery from an unanticipated death
+(power loss / OOM / preemption), which is the whole point of checkpointing.
+
+Requires Docker (the sandbox backup path injects a Linux restic binary).
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+from pathlib import Path
+from typing import Any
+
+import anyio
+
+from inspect_ai import Task, eval, eval_retry, task
+from inspect_ai.agent import react
+from inspect_ai.dataset import Sample
+from inspect_ai.log import read_eval_log
+from inspect_ai.model import (
+    ChatMessage,
+    ChatMessageTool,
+    GenerateConfig,
+    ModelOutput,
+    modelapi,
+)
+from inspect_ai.model._providers.mockllm import MockLLM
+from inspect_ai.scorer import includes
+from inspect_ai.tool import Tool, ToolChoice, ToolInfo, bash, tool
+from inspect_ai.util import CheckpointConfig, TurnInterval, store
+
+LAYER1_CONTENT = "plain1"
+STORE_KEY = "answer"
+SCRIPTED_MODEL = "scripteddecode/model"
+
+# Write under $HOME (not /workspace) so the default-user home-dir auto-backup
+# captures it — the task declares no `sandbox_paths`, exercising
+# `resolve_sandbox_backup_paths` / `_resolve_home_and_cache`. Also drop a file
+# under the XDG cache dir ($HOME/.cache) to prove auto-home mode excludes it.
+WRITE_CMD = (
+    'mkdir -p "$HOME/workspace/decoded" "$HOME/.cache" && '
+    f"printf '{LAYER1_CONTENT}' > \"$HOME/workspace/decoded/layer1.txt\" && "
+    'printf cache > "$HOME/.cache/junk.txt"'
+)
+# Written on each post-resume turn so the new snapshot has a non-empty diff vs
+# its parent — used to assert file listing records the *changed* file.
+RESUME_WRITE_CMD = 'printf resumed > "$HOME/workspace/resumed.txt"'
+
+# The crash count + target live in a host file named by an env var, not module
+# state: each killed attempt is a fresh process, and the count must survive
+# both the kill and the next process's startup. The file is read by the
+# scripted model (to decide when to crash vs work vs submit) and bumped by the
+# crash tool just before it kills the process.
+CANCEL_FILE_ENV = "INSPECT_TEST_RESUME_CANCEL_FILE"
+TARGET_ENV = "INSPECT_TEST_RESUME_TARGET_CANCELS"
+
+
+def cancels_done() -> int:
+    f = os.environ.get(CANCEL_FILE_ENV)
+    return int(Path(f).read_text() or "0") if f and Path(f).exists() else 0
+
+
+def bump_cancels() -> int:
+    n = cancels_done() + 1
+    f = os.environ.get(CANCEL_FILE_ENV)
+    if f:
+        Path(f).write_text(str(n))
+    return n
+
+
+def target_cancels() -> int:
+    return int(os.environ.get(TARGET_ENV, "1"))
+
+
+class _ResumeState:
+    """In-process model-call counter.
+
+    Meaningful only for the resume that runs in the test process; killed
+    attempts run in their own process.
+    """
+
+    generates: int = 0
+
+
+_resume_state = _ResumeState()
+
+
+def generates() -> int:
+    return _resume_state.generates
+
+
+def reset_generates() -> None:
+    _resume_state.generates = 0
+
+
+@tool
+def remember() -> Tool:
+    async def execute(key: str, value: str) -> str:
+        """Record a key/value note in the sample store.
+
+        Args:
+            key: short label for the note.
+            value: the value to remember.
+
+        Returns:
+            Confirmation string.
+        """
+        store().set(key, value)
+        return f"remembered: {key}"
+
+    return execute
+
+
+@tool
+def crash() -> Tool:
+    async def execute() -> str:
+        """Kill the eval process immediately (uncatchable, no cleanup)."""
+        # Record the crash before dying (flushed to disk), then SIGKILL our own
+        # process. Running inside the child, this is the child's PID — an
+        # abrupt death with no unwind, mimicking a power loss / OOM / preempt.
+        bump_cancels()
+        os.kill(os.getpid(), signal.SIGKILL)
+        await anyio.sleep_forever()  # unreachable; SIGKILL is immediate
+        return "crashed"
+
+    return execute
+
+
+# eval_retry reconstructs the task by registry name and rebuilds the model by
+# name from the log — so the task must be a registered @task and the scripted
+# behavior must live in a registered model provider. The provider drives a
+# linear script keyed off the number of completed tool turns in the restored
+# conversation, plus the host-file crash count:
+#
+#   turn 0: bash (write a sandbox file)        -> ckpt-1 fires next turn
+#   turn 1: remember (write the store)         -> ckpt-2 fires next turn
+#   turn 2: crash (1st kill) ..................... SIGKILL, then resume
+#           bash (write a new sandbox file)    -> ckpt-3 fires next turn
+#   turn 3: crash (2nd kill) ..................... SIGKILL, then resume
+#           bash (write a new sandbox file)    -> ckpt-4 fires next turn
+#   turn 4: submit
+#
+# Each resume cycle does one work turn (so a fresh checkpoint commits) before
+# crashing, until `target` crashes are reached; the final resume submits.
+
+
+def _scripted_outputs(
+    input: list[ChatMessage],
+    tools: list[ToolInfo],
+    tool_choice: ToolChoice,
+    config: GenerateConfig,
+) -> ModelOutput:
+    _resume_state.generates += 1
+    n = sum(1 for m in input if isinstance(m, ChatMessageTool))
+    done = cancels_done()
+    target = target_cancels()
+    if n == 0:
+        return ModelOutput.for_tool_call(SCRIPTED_MODEL, "bash", {"command": WRITE_CMD})
+    if n == 1:
+        return ModelOutput.for_tool_call(
+            SCRIPTED_MODEL, "remember", {"key": STORE_KEY, "value": LAYER1_CONTENT}
+        )
+    # The k-th crash (k = done) lands at turn `2 + done`; cycles that don't
+    # crash do a work turn that writes a new sandbox file (non-empty diff vs
+    # parent), then the final resume submits.
+    if done < target and n == 2 + done:
+        return ModelOutput.for_tool_call(SCRIPTED_MODEL, "crash", {})
+    if n < 2 + target:
+        return ModelOutput.for_tool_call(
+            SCRIPTED_MODEL, "bash", {"command": RESUME_WRITE_CMD}
+        )
+    return ModelOutput.for_tool_call(
+        SCRIPTED_MODEL, "submit", {"answer": LAYER1_CONTENT}
+    )
+
+
+@modelapi(name="scripteddecode")
+def _scripteddecode_provider() -> type[MockLLM]:
+    class ScriptedDecode(MockLLM):
+        def __init__(self, model_name: str, **kwargs: Any) -> None:
+            # ignore any persisted custom_outputs; drive from _scripted_outputs
+            kwargs.pop("custom_outputs", None)
+            super().__init__(model_name, custom_outputs=_scripted_outputs, **kwargs)
+
+    return ScriptedDecode
+
+
+@task
+def resume_decode_task() -> Task:
+    return Task(
+        dataset=[Sample(id="resume", input="decode the layers", target=LAYER1_CONTENT)],
+        solver=react(tools=[bash(timeout=60), remember(), crash()]),
+        scorer=includes(),
+        # Default sandbox image: its ~955 MB /root is mostly /root/.cache,
+        # which auto-home mode excludes — so the egress stays small without a
+        # custom small-home image, and this exercises that exclude for real.
+        sandbox="docker",
+        checkpoint=CheckpointConfig(
+            trigger=TurnInterval(every=1),
+            # No sandbox_paths: the default sandbox's $HOME is auto-captured.
+            retention="retain",
+        ),
+    )
+
+
+def run_eval(log_dir: str, retry_from: str | None = None) -> None:
+    """Run a fresh eval, or resume one from a prior log.
+
+    Never returns when the scripted run is due to crash — the ``crash`` tool
+    ``SIGKILL``s the process.
+    """
+    if retry_from is None:
+        eval(resume_decode_task(), model=SCRIPTED_MODEL, log_dir=log_dir)
+    else:
+        eval_retry(read_eval_log(retry_from), log_dir=log_dir)
+
+
+def main() -> None:
+    log_dir = sys.argv[1]
+    retry_from = sys.argv[2] if len(sys.argv) > 2 and sys.argv[2] else None
+    run_eval(log_dir, retry_from)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Fixes checkpoint-resume rehydration so each `prior_run` ("checkpoint restore N") span contains only its checkpoint spans as direct children, for an arbitrary number of resumes. Before this, the wrap re-nested the prior session's full `init / solvers / solver / agent` structural ancestry, burying the checkpoint spans.

This is a regression from #4062, which moved checkpoint capture from the transcript's in-memory event list (held only events from the first `checkpoint` span onward) to the buffer-db transcript store (holds the entire transcript, scaffolding included). This PR restores the earlier hydration result without unwinding that move, by re-applying the checkpoint-spans-only boundary in the hydration layer.

## Motivating principle

The buffer-db transcript store's contract is to expose a complete, properly-structured transcript — the right behavior for a general-purpose store. Checkpoint resume needs something different: a selective slice of prior events spliced into a new run's live transcript. Teaching the store to emit a checkpoint-shaped subset would corrupt its contract. The pruning belongs in the hydration layer: the store stays "proper"; `_wrap_prior_run` slices out what it needs.

## Fixes / significant changes

- **`_wrap_prior_run` — scope prior_run wraps to checkpoint events only.** Leading slice drops everything before the first `prior_run` or `checkpoint` span_begin. Tail slice drops the resumed session's ancestor spans (which the buffer records after seeded prior wraps, landing them between the last wrap and the new checkpoint work). Surviving prior wraps are reparented onto the current span and numbered sequentially. Generalizes to any resume depth.

- **`eval_checkpoints_dir` — fix checkpoint dir derivation after a hard kill.** When `eval_retry` resumes a hard-killed (`status=started`) eval, crash recovery writes the log to `X-recovered.eval`. The checkpoint dir was derived as `X-recovered.checkpoints` (empty) instead of `X.checkpoints`, so `has_sample_checkpoint` returned false and the eval re-ran from scratch. Fix: `log_basename` strips `-recovered` after `.eval`. Invisible under cooperative cancellation (`Ctrl-C`, `interrupt()`), which finalizes as `error` and never triggers crash recovery.

- **Synthesized trailing `CheckpointEvent` — correct span parenting.** Parent to the restored session's innermost open span, not the resuming session's span.

- **`test_checkpoint_resume_rehydrated_event_layout` — SIGKILL instead of cooperative cancel.** Cooperative cancel is a graceful shutdown that finalizes the log as `error` and never triggers crash recovery — not a real hard failure. The test now issues a real `SIGKILL` via a child subprocess (`resume_kill_harness.py`), with two kill cycles and a final in-process resume. This is what exposed the `eval_checkpoints_dir` bug.

- **Removed `test_checkpoint_resume_spans_balanced`** — subsumed by the two-resume test, which now also asserts span balance.

- **Added unit tests** for `eval_checkpoints_dir` (`-recovered` suffix: local, S3, with override) and `_wrap_prior_run` (scaffolding removal, multi-wrap reparenting).

## Notes

- Does not include the span-balance branch's synthetic-span-end infrastructure — once the tail slice is in place, no structural spans remain open inside the wrap.
- `dump_events.py` is a temporary debugging aid (expected lifetime: a few weeks).
