### PR TITLE
Timeline: don't render primitive solvers as sub-agents

### DIFF
--- a/src/inspect_ai/event/_timeline.py
+++ b/src/inspect_ai/event/_timeline.py
@@ -395,7 +395,8 @@ def timeline_build(
     Span type                       Result
     ==============================  =======================================
     ``type="agent"``                ``TimelineSpan(span_type="agent")``
-    ``type="solver"``               ``TimelineSpan(span_type="agent")``
+    ``type="solver"`` wrapping agent ``TimelineSpan(span_type="agent")``
+    ``type="solver"`` (primitive)   Unrolled into parent
     ``type="tool"`` + ModelEvents   ``TimelineSpan(span_type="agent")``
     ToolEvent with ``agent`` field  ``TimelineSpan(span_type="agent")``
     ``type="tool"`` (no models)     Unrolled into parent
@@ -685,8 +686,12 @@ def _is_agent_span(span: EventTreeSpan) -> bool:
 
     Agent spans are:
     - Explicit agent spans (type="agent")
-    - Solver spans (type="solver")
+    - Solver spans that wrap a genuine agent (e.g. an @agent run via as_solver)
     - Tool spans containing model events (tool-spawned agents)
+
+    Primitive solver spans (system_message, generate, use_tools, ...) wrap no
+    agent of their own, so they are not agent trajectories — they get unrolled
+    into their parent rather than occupying a swimlane.
 
     Args:
         span: The EventTreeSpan to check.
@@ -694,8 +699,10 @@ def _is_agent_span(span: EventTreeSpan) -> bool:
     Returns:
         True if the span represents an agent trajectory.
     """
-    if span.type in ("agent", "solver"):
+    if span.type == "agent":
         return True
+    if span.type == "solver":
+        return _contains_agent_span(span)
     if (
         span.type == "tool"
         and _contains_model_events(span)

--- a/tests/timeline/generate.py
+++ b/tests/timeline/generate.py
@@ -32,6 +32,7 @@ from inspect_ai.event._timeline import TimelineSpan
 from inspect_ai.log import EvalLog
 from inspect_ai.model import ModelOutput, get_model
 from inspect_ai.scorer import includes
+from inspect_ai.solver import generate, system_message
 from inspect_ai.tool import tool
 from inspect_ai.util import collect
 
@@ -111,6 +112,23 @@ def scenario_simple_agent() -> tuple[str, Task, Any]:
         scorer=includes(),
     )
     return "simple_agent", task, model
+
+
+def scenario_primitive_solvers() -> tuple[str, Task, Any]:
+    """Plain solver plan (system_message + generate) with no agents.
+
+    Primitive solver spans should be unrolled into the 'main' lane rather than
+    each occupying their own swimlane.
+    """
+    outputs = [ModelOutput.from_content(MODEL, "2")]
+    model = get_model(MODEL, custom_outputs=outputs)
+    task = Task(
+        name="primitive_solvers",
+        dataset=DATASET,
+        solver=[system_message("You are a helpful assistant."), generate()],
+        scorer=includes(),
+    )
+    return "primitive_solvers", task, model
 
 
 def scenario_multi_turn_agent() -> tuple[str, Task, Any]:
@@ -783,6 +801,26 @@ def validate_simple_agent(timeline: Timeline) -> None:
         f"root should have no agent sub-spans: {agent_children}"
     )
     assert_repr_labels(timeline, "main")
+
+
+def validate_primitive_solvers(timeline: Timeline) -> None:
+    root = timeline.root
+    children = child_span_names(root)
+    # Primitive solvers (system_message, generate) must not become sub-lanes;
+    # only init/scoring remain as child spans.
+    agent_children = [s for s in children if s not in ("init", "scoring")]
+    assert agent_children == [], (
+        f"primitive solvers should not be sub-spans: {agent_children}"
+    )
+    # The generate solver's model event must be unrolled directly into 'main'.
+    model_events = [
+        item
+        for item in root.content
+        if not isinstance(item, TimelineSpan) and item.event.event == "model"
+    ]
+    assert model_events, "expected generate's model event unrolled into 'main'"
+    assert_repr_labels(timeline, "main")
+    assert_repr_not_contains(timeline, "system_message", "generate")
 
 
 def validate_multi_turn_agent(timeline: Timeline) -> None:

--- a/tests/timeline/test_timeline.py
+++ b/tests/timeline/test_timeline.py
@@ -17,6 +17,7 @@ from .generate import (
     scenario_parallel_collect,
     scenario_parallel_heterogeneous,
     scenario_parallel_with_nesting,
+    scenario_primitive_solvers,
     scenario_sequential_and_parallel,
     scenario_sequential_run,
     scenario_simple_agent,
@@ -29,6 +30,7 @@ from .generate import (
     validate_parallel_collect,
     validate_parallel_heterogeneous,
     validate_parallel_with_nesting,
+    validate_primitive_solvers,
     validate_sequential_and_parallel,
     validate_sequential_run,
     validate_simple_agent,
@@ -51,6 +53,10 @@ def _run_and_validate(
 
 def test_timeline_simple_agent() -> None:
     _run_and_validate(scenario_simple_agent, validate_simple_agent)
+
+
+def test_timeline_primitive_solvers() -> None:
+    _run_and_validate(scenario_primitive_solvers, validate_primitive_solvers)
 
 
 def test_timeline_multi_turn_agent() -> None:


### PR DESCRIPTION
## Problem

A plain solver plan like `[system_message, generate]` rendered `generate` (and `system_message`) as **sub-agent swimlanes** under a synthetic `main` lane, instead of `generate` activity appearing in the `main` lane itself.

## Cause

`_is_agent_span` treated **every** `type="solver"` span as an agent trajectory. With two solver spans under `solvers`, the builder took the "multiple agent spans" path and wrapped them in a synthetic `main`, pushing each solver down a level.

## Fix

Treat a `type="solver"` span as an agent trajectory **only when it wraps a genuine agent** (`_contains_agent_span`). Primitive solvers (`system_message`, `generate`, `use_tools`, …) wrap no agent of their own, so the existing unroll machinery dissolves them into the parent rather than giving them a swimlane.

Result: a plain generate plan collapses into a single `main` lane with the model event inline. Behavior preserved for single agent-as-solver (still promoted to `main`), multiple agents (still separate lanes), and scoring.

## Testing

- New `test_timeline_primitive_solvers` asserts a `[system_message, generate]` plan produces no solver sub-lanes and that `generate`'s model event is unrolled into `main`.
- All 16 `tests/timeline` tests pass; ruff + mypy clean.

> Note: this classification is mirrored in the `ts-mono` timeline builder (`core.ts`); the matching TS change is in meridianlabs-ai/ts-mono#287 so client- and server-built timelines stay in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)