### PR TITLE
fix: resolve database lock contention by implementing WAL mode and re…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Bugfix: Avoid emitting empty assistant output messages when converting Chat Completions tool-call with reasoning into Responses API input items.
 - Bugfix: Preserve OpenAI Responses API encrypted reasoning through agent bridge round-trips and replay reasoning input items with empty `content` to avoid server validation errors.
 - Bugfix: Agent bridge checks for google.genai more defensively (ensure that module not found is raised).
+- Bugfix: Avoid `OperationalError: database is locked` when writing to the log buffer. The sample buffer database now uses WAL journal mode so the viewer and background sync no longer block writes, and write transactions retry briefly on lock contention.
 
 ## 0.3.235 (03 June 2026)
 

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -207,94 +207,107 @@ class SampleBufferDatabase(SampleBuffer):
         self._sync_requested = False
 
     def start_sample(self, sample: EvalSampleSummary) -> None:
-        with self._get_connection(write=True) as conn:
-            sample = self._condense_sample(conn, sample)
-            conn.execute(
-                """
-                INSERT INTO samples (id, epoch, data)
-                VALUES (?, ?, ?)
-            """,
-                (str(sample.id), sample.epoch, to_json_str_safe(sample)),
-            )
-
-    def log_events(self, events: list[SampleEvent]) -> None:
-        index_snapshots: dict[
-            tuple[str, int], tuple[dict[str, int] | None, dict[str, int] | None]
-        ] = {}
-
-        def restore_index_snapshots() -> None:
-            for key, (msg_index, call_index) in index_snapshots.items():
-                if msg_index is None:
-                    self._msg_indices.pop(key, None)
-                else:
-                    self._msg_indices[key] = msg_index
-
-                if call_index is None:
-                    self._call_indices.pop(key, None)
-                else:
-                    self._call_indices[key] = call_index
-
-        with self._get_connection(
-            write=True, on_rollback=restore_index_snapshots
-        ) as conn:
-            # collect the values for all events
-            values: list[str | int] = []
-            for event in events:
-                if isinstance(event.event, ModelEvent):
-                    key = (str(event.id), event.epoch)
-                    if key not in index_snapshots:
-                        msg_index = self._msg_indices.get(key)
-                        call_index = self._call_indices.get(key)
-                        index_snapshots[key] = (
-                            None if msg_index is None else dict(msg_index),
-                            None if call_index is None else dict(call_index),
-                        )
-
-                event = self._condense_event(conn, event)
-                values.extend(
-                    (
-                        event.event.uuid or uuid(),
-                        str(event.id),
-                        event.epoch,
-                        to_json_str_safe(event.event),
-                    )
+        def _op() -> None:
+            with self._get_connection(write=True) as conn:
+                condensed = self._condense_sample(conn, sample)
+                conn.execute(
+                    """
+                    INSERT INTO samples (id, epoch, data)
+                    VALUES (?, ?, ?)
+                """,
+                    (str(condensed.id), condensed.epoch, to_json_str_safe(condensed)),
                 )
 
-            # dynamically create the SQL query
-            placeholders = ", ".join(["(?, ?, ?, ?)"] * len(events))
-            sql = f"""
-            INSERT INTO events (event_id, sample_id, sample_epoch, data)
-            VALUES {placeholders}
-            """
+        self._retry_on_locked(_op)
 
-            # Insert all rows
-            conn.execute(sql, values)
+    def log_events(self, events: list[SampleEvent]) -> None:
+        def _op() -> None:
+            index_snapshots: dict[
+                tuple[str, int], tuple[dict[str, int] | None, dict[str, int] | None]
+            ] = {}
+
+            def restore_index_snapshots() -> None:
+                for key, (msg_index, call_index) in index_snapshots.items():
+                    if msg_index is None:
+                        self._msg_indices.pop(key, None)
+                    else:
+                        self._msg_indices[key] = msg_index
+
+                    if call_index is None:
+                        self._call_indices.pop(key, None)
+                    else:
+                        self._call_indices[key] = call_index
+
+            with self._get_connection(
+                write=True, on_rollback=restore_index_snapshots
+            ) as conn:
+                # collect the values for all events
+                values: list[str | int] = []
+                for event in events:
+                    if isinstance(event.event, ModelEvent):
+                        key = (str(event.id), event.epoch)
+                        if key not in index_snapshots:
+                            msg_index = self._msg_indices.get(key)
+                            call_index = self._call_indices.get(key)
+                            index_snapshots[key] = (
+                                None if msg_index is None else dict(msg_index),
+                                None if call_index is None else dict(call_index),
+                            )
+
+                    event = self._condense_event(conn, event)
+                    values.extend(
+                        (
+                            event.event.uuid or uuid(),
+                            str(event.id),
+                            event.epoch,
+                            to_json_str_safe(event.event),
+                        )
+                    )
+
+                # dynamically create the SQL query
+                placeholders = ", ".join(["(?, ?, ?, ?)"] * len(events))
+                sql = f"""
+                INSERT INTO events (event_id, sample_id, sample_epoch, data)
+                VALUES {placeholders}
+                """
+
+                # Insert all rows
+                conn.execute(sql, values)
+
+        self._retry_on_locked(_op)
 
     def complete_sample(self, summary: EvalSampleSummary) -> None:
-        with self._get_connection(write=True) as conn:
-            summary = self._condense_sample(conn, summary)
-            conn.execute(
-                """
-                UPDATE samples SET data = ? WHERE id = ? and epoch = ?
-            """,
-                (to_json_str_safe(summary), str(summary.id), summary.epoch),
-            )
+        def _op() -> None:
+            with self._get_connection(write=True) as conn:
+                condensed = self._condense_sample(conn, summary)
+                conn.execute(
+                    """
+                    UPDATE samples SET data = ? WHERE id = ? and epoch = ?
+                """,
+                    (to_json_str_safe(condensed), str(condensed.id), condensed.epoch),
+                )
 
-            key = (str(summary.id), summary.epoch)
-            self._msg_indices.pop(key, None)
-            self._call_indices.pop(key, None)
-            self._completed_samples.add(key)
+        self._retry_on_locked(_op)
+
+        # mark the sample complete only once the write has committed
+        key = (str(summary.id), summary.epoch)
+        self._msg_indices.pop(key, None)
+        self._call_indices.pop(key, None)
+        self._completed_samples.add(key)
 
     def update_metrics(self, metrics: list[TaskDisplayMetric]) -> None:
-        with self._get_connection(write=True) as conn:
-            conn.execute(
-                """
-                UPDATE task_database
-                SET metrics = ?,
-                    last_updated = CURRENT_TIMESTAMP;
-                """,
-                [to_json_str_safe(metrics)],
-            )
+        def _op() -> None:
+            with self._get_connection(write=True) as conn:
+                conn.execute(
+                    """
+                    UPDATE task_database
+                    SET metrics = ?,
+                        last_updated = CURRENT_TIMESTAMP;
+                    """,
+                    [to_json_str_safe(metrics)],
+                )
+
+        self._retry_on_locked(_op)
 
     def remove_samples(self, samples: list[tuple[str | int, int]]) -> None:
         ready: list[tuple[str, int]] = []
@@ -734,6 +747,21 @@ class SampleBufferDatabase(SampleBuffer):
             if cleanup_ready:
                 self._cleanup_now()
 
+    def _retry_on_locked(self, op: Callable[[], None]) -> None:
+        # _get_connection only retries opening the connection; the lock can also
+        # surface at commit, so retry the whole write (each attempt rolls back).
+        max_retries = 5
+        retry_delay = 0.1
+        for attempt in range(max_retries):
+            try:
+                op()
+                return
+            except OperationalError as e:
+                if "locked" in str(e).lower() and attempt < max_retries - 1:
+                    time.sleep(retry_delay * (2**attempt))
+                    continue
+                raise
+
     @contextmanager
     def _get_connection(
         self,
@@ -753,12 +781,19 @@ class SampleBufferDatabase(SampleBuffer):
                 conn = sqlite3.connect(self.db_path, timeout=30)
                 conn.row_factory = sqlite3.Row  # enable row factory for named columns
 
+                # wait for a held lock rather than failing immediately; set
+                # first so the WAL switch below also honors it
+                conn.execute("PRAGMA busy_timeout=30000")
+
                 # Enable foreign key constraints
                 conn.execute("PRAGMA foreign_keys = ON")
 
-                # concurrency setup
-                conn.execute("PRAGMA busy_timeout=30000")
-                conn.execute("PRAGMA synchronous=OFF")
+                # WAL lets readers (the sync thread and the view process) read
+                # without blocking writes. Set it outside any transaction.
+                conn.execute("PRAGMA journal_mode=WAL")
+
+                # concurrency setup (NORMAL is the durable pairing for WAL)
+                conn.execute("PRAGMA synchronous=NORMAL")
                 conn.execute("PRAGMA cache_size=-64000")
                 conn.execute("PRAGMA temp_store=MEMORY")
 
@@ -1461,7 +1496,13 @@ def cleanup_sample_buffer_databases(db_dir: Path | None = None) -> None:
 
 def cleanup_sample_buffer_db(path: Path) -> None:
     try:
-        path.unlink(missing_ok=True)
+        # also remove the WAL sidecars, else the rmdir below fails
+        for p in (
+            path,
+            path.with_name(f"{path.name}-wal"),
+            path.with_name(f"{path.name}-shm"),
+        ):
+            p.unlink(missing_ok=True)
         try:
             # Remove the directory if it's empty
             path.parent.rmdir()

--- a/tests/log/test_buffer_db_wal.py
+++ b/tests/log/test_buffer_db_wal.py
@@ -1,6 +1,7 @@
 """Tests for SampleBufferDatabase WAL mode and write retry (issue #4148)."""
 
 import threading
+import time
 from pathlib import Path
 from sqlite3 import OperationalError
 
@@ -8,7 +9,6 @@ import pytest
 
 from inspect_ai.event._info import InfoEvent
 from inspect_ai.log._log import EvalSampleSummary
-from inspect_ai.log._recorders.buffer import database as database_module
 from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
 from inspect_ai.log._recorders.types import SampleEvent
 
@@ -105,7 +105,7 @@ def test_retry_on_locked_retries_then_succeeds(
     """A transient lock error is retried, then the write succeeds."""
     db = _make_db(tmp_path)
     try:
-        monkeypatch.setattr(database_module.time, "sleep", lambda *_: None)
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
         calls = {"n": 0}
 
         def op() -> None:
@@ -125,7 +125,7 @@ def test_retry_on_locked_propagates_non_lock_errors(
     """Non-lock errors propagate without retrying."""
     db = _make_db(tmp_path)
     try:
-        monkeypatch.setattr(database_module.time, "sleep", lambda *_: None)
+        monkeypatch.setattr(time, "sleep", lambda *_: None)
         calls = {"n": 0}
 
         def op() -> None:

--- a/tests/log/test_buffer_db_wal.py
+++ b/tests/log/test_buffer_db_wal.py
@@ -1,0 +1,139 @@
+"""Tests for SampleBufferDatabase WAL mode and write retry (issue #4148)."""
+
+import threading
+from pathlib import Path
+from sqlite3 import OperationalError
+
+import pytest
+
+from inspect_ai.event._info import InfoEvent
+from inspect_ai.log._log import EvalSampleSummary
+from inspect_ai.log._recorders.buffer import database as database_module
+from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+from inspect_ai.log._recorders.types import SampleEvent
+
+
+def _make_db(tmp_path: Path) -> SampleBufferDatabase:
+    return SampleBufferDatabase(location="wal_test", create=True, db_dir=tmp_path)
+
+
+def _summary(id: str = "s", epoch: int = 1) -> EvalSampleSummary:
+    return EvalSampleSummary(id=id, epoch=epoch, input="in", target="out")
+
+
+def test_journal_mode_is_wal(tmp_path: Path) -> None:
+    """The database runs in WAL mode."""
+    db = _make_db(tmp_path)
+    try:
+        db.start_sample(_summary())
+        with db._get_connection() as conn:
+            mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+            assert str(mode).lower() == "wal"
+            # -shm exists while a WAL connection is open
+            shm = db.db_path.with_name(f"{db.db_path.name}-shm")
+            assert shm.exists()
+    finally:
+        db.cleanup()
+
+
+def test_concurrent_readers_writer_no_lock(tmp_path: Path) -> None:
+    """Concurrent readers and a writer don't raise "database is locked"."""
+    db = _make_db(tmp_path)
+    db.start_sample(_summary())
+
+    errors: list[BaseException] = []
+    stop = threading.Event()
+
+    def writer() -> None:
+        try:
+            for i in range(150):
+                db.log_events(
+                    [SampleEvent(id="s", epoch=1, event=InfoEvent(data=f"e{i}"))]
+                )
+        except BaseException as exc:
+            errors.append(exc)
+        finally:
+            stop.set()
+
+    def reader() -> None:
+        try:
+            while not stop.is_set():
+                db.get_sample_data("s", 1)
+                db.get_samples()
+                db.sample_event_count("s", 1)
+        except BaseException as exc:
+            errors.append(exc)
+
+    threads = [threading.Thread(target=writer)] + [
+        threading.Thread(target=reader) for _ in range(4)
+    ]
+    try:
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        assert not any(t.is_alive() for t in threads), "threads did not finish in time"
+        assert errors == [], f"unexpected contention errors: {errors!r}"
+    finally:
+        stop.set()
+        db.cleanup()
+
+
+def test_cleanup_removes_wal_sidecars_and_dir(tmp_path: Path) -> None:
+    """Cleanup removes the db plus -wal/-shm sidecars and the (now empty) dir."""
+    db = _make_db(tmp_path)
+    db.start_sample(_summary())
+
+    wal = db.db_path.with_name(f"{db.db_path.name}-wal")
+    shm = db.db_path.with_name(f"{db.db_path.name}-shm")
+    # touch the sidecars so there's something for cleanup to remove
+    wal.touch()
+    shm.touch()
+    parent = db.db_path.parent
+
+    db.cleanup()
+
+    assert not db.db_path.exists()
+    assert not wal.exists()
+    assert not shm.exists()
+    assert not parent.exists()
+
+
+def test_retry_on_locked_retries_then_succeeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A transient lock error is retried, then the write succeeds."""
+    db = _make_db(tmp_path)
+    try:
+        monkeypatch.setattr(database_module.time, "sleep", lambda *_: None)
+        calls = {"n": 0}
+
+        def op() -> None:
+            calls["n"] += 1
+            if calls["n"] < 3:
+                raise OperationalError("database is locked")
+
+        db._retry_on_locked(op)
+        assert calls["n"] == 3
+    finally:
+        db.cleanup()
+
+
+def test_retry_on_locked_propagates_non_lock_errors(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Non-lock errors propagate without retrying."""
+    db = _make_db(tmp_path)
+    try:
+        monkeypatch.setattr(database_module.time, "sleep", lambda *_: None)
+        calls = {"n": 0}
+
+        def op() -> None:
+            calls["n"] += 1
+            raise OperationalError("no such table: events")
+
+        with pytest.raises(OperationalError, match="no such table"):
+            db._retry_on_locked(op)
+        assert calls["n"] == 1
+    finally:
+        db.cleanup()


### PR DESCRIPTION
**This PR contains:**
  - [ ] New features
  - [ ] Changes to dev-tools e.g. CI config / github tooling
  - [ ] Docs
  - [x] Bug fixes
  - [ ] Code refactor

  **What is the current behavior? (You can also link to an open issue here)**

  Writing events to the log buffer occasionally throws OperationalError: database is locked and takes the sample down with it (#4148).

  The buffer db uses SQLite's default rollback-journal mode, where a reader and a writer can't be active at once. While a sample is running there are readers around (the background sync thread, plus inspect view if it's open in another process), and when one of them is mid-read the writer can't commit, so after the busy timeout it errors out. The retry that's already in _get_connection doesn't help here because it only wraps opening the connection, not the commit that actually fails.

  **What is the new behavior?**

  Switched the buffer db to WAL mode, which lets readers and the (single) writer run at the same time. That's the real fix. The rest is cleanup around it:

  - bumped synchronous from OFF to NORMAL, since OFF isn't safe with WAL
  - the write retry now wraps the whole operation so it covers the commit (still only retries on "database is locked", anything else propagates)
  - WAL leaves -wal/-shm files next to the db, so cleanup deletes those too

  There's only ever one writer per process (the event loop) and the db is a per-pid file on a local dir, so WAL is safe here: no cross-process writers, and no network fs to worry about.

  **Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)**

  No.

  **Other information:**

  Added tests in tests/log/test_buffer_db_wal.py and ran the full tests/log suite.