### PR TITLE
fix(groq): map tool_choice="any" to "required" so forced tool calls are forced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Model API: Add `ModelInfo.family` and `ModelAPI.model_family()`. Provider capability and request-shape checks now consult a registered `ModelInfo.family` before falling back to model-name matching, while preserving the configured model name for provider requests.
 - Together: Support the `stream` model arg (e.g. `-M stream=true`) to stream completions. A length-truncated streaming response (with structured output or tools) now degrades gracefully to `stop_reason="max_tokens"` instead of raising.
+- Groq: Map tool_choice="any" to "required" for forced tool calls.
 - Bedrock: Support `response_schema` (structured output) for Claude models via `output_config.format`.
 - Deep Agent: Subagent `submit()` calls are retained in the subagent transcript (previously stripped) and rendered as markdown, so a submit is distinguishable from a normal assistant message. The parent's result is unchanged.
 - Sandbox: Allow `sandbox_service()` instances running as different users in the same sandbox to share `/var/tmp/sandbox-services`.

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -407,7 +407,7 @@ def chat_tool_choice(tool_choice: ToolChoice) -> str | Dict[str, Any]:
     if isinstance(tool_choice, ToolFunction):
         return {"type": "function", "function": {"name": tool_choice.name}}
     elif tool_choice == "any":
-        return "auto"
+        return "required"
     else:
         return tool_choice
 

--- a/tests/model/providers/test_groq.py
+++ b/tests/model/providers/test_groq.py
@@ -7,6 +7,8 @@ from inspect_ai.model import (
     ResponseSchema,
     get_model,
 )
+from inspect_ai.model._providers.groq import chat_tool_choice
+from inspect_ai.tool import ToolFunction
 from inspect_ai.util import json_schema
 
 
@@ -23,6 +25,22 @@ async def test_core_groq_api() -> None:
     message = ChatMessageUser(content="This is a test string. What are you?")
     response = await model.generate(input=[message])
     assert len(response.completion) >= 1
+
+
+def test_chat_tool_choice_any_maps_to_required() -> None:
+    # Inspect's tool_choice "any" means "use at least one tool" (force a tool call). Groq is
+    # OpenAI-compatible, where the value that forces a call is "required" ("auto" lets the
+    # model skip the tool), matching the openai/azureai/bedrock/mistral providers.
+    assert chat_tool_choice("any") == "required"
+
+
+def test_chat_tool_choice_other_values_pass_through() -> None:
+    assert chat_tool_choice("auto") == "auto"
+    assert chat_tool_choice("none") == "none"
+    assert chat_tool_choice(ToolFunction(name="my_tool")) == {
+        "type": "function",
+        "function": {"name": "my_tool"},
+    }
 
 
 class NounPhrase(BaseModel):


### PR DESCRIPTION
Closes #4156

## Summary

`chat_tool_choice` in `src/inspect_ai/model/_providers/groq.py` mapped `tool_choice="any"` to `"auto"`. Inspect's `ToolChoice` `"any"` means *"use at least one tool"* (force a tool call). Groq is OpenAI-compatible, where forcing a tool call is `"required"` and `"auto"` lets the model skip the tool — so on Groq a forced tool call (`tool_choice="any"`) could be silently skipped, with no error and quietly degraded results (e.g. forced structured output, the react agent's forced-submission path).

Every sibling provider already maps `"any"` correctly — `_openai.py` → `"required"`, plus azureai/bedrock/mistral equivalents. Groq was the lone outlier.

## Fix

One line: map `"any"` to `"required"` in `chat_tool_choice`. The result is passed straight to `client.chat.completions.create(tool_choice=...)`, so no other change is needed.

## Verification

Added pure-function unit tests in `tests/model/providers/test_groq.py` (no network): `chat_tool_choice("any") == "required"`, plus the `"auto"`/`"none"`/`ToolFunction` pass-through cases. Verified red before the fix (returned `"auto"`) and green after. `ruff check` and `ruff format --check` clean.