### PR TITLE
perf(log): reuse buffer database connections

### DIFF
--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -155,6 +155,9 @@ class SampleBufferDatabase(SampleBuffer):
 
         # warn at most once per database if WAL journal mode can't be enabled
         self._wal_checked = False
+        self._connection_local = threading.local()
+        self._connections: list[Connection] = []
+        self._connections_lock = threading.Lock()
 
         # location subdir and file
         dir, file = location_dir_and_file(self.location)
@@ -407,6 +410,7 @@ class SampleBufferDatabase(SampleBuffer):
         return True
 
     def _cleanup_now(self) -> None:
+        self._close_connections()
         cleanup_sample_buffer_db(self.db_path)
         if self._sync_filestore is not None:
             self._sync_filestore.cleanup()
@@ -745,6 +749,46 @@ class SampleBufferDatabase(SampleBuffer):
         on_rollback: Callable[[], None] | None = None,
     ) -> Iterator[Connection]:
         """Get a database connection."""
+        conn = self._thread_connection()
+
+        try:
+            # do work
+            yield conn
+
+            # if this was for a write then bump the version
+            if write:
+                conn.execute("""
+                UPDATE task_database
+                SET version = version + 1,
+                    last_updated = CURRENT_TIMESTAMP;
+                """)
+
+            # commit
+            conn.commit()
+
+        except Exception:
+            # rollback on any error
+            try:
+                conn.rollback()
+            finally:
+                if on_rollback is not None:
+                    on_rollback()
+            raise
+        finally:
+            # if this was for write then sync (throttled)
+            if write:
+                self._sync()
+
+    def _thread_connection(self) -> Connection:
+        conn = getattr(self._connection_local, "conn", None)
+        if conn is None:
+            conn = self._open_connection()
+            self._connection_local.conn = conn
+            with self._connections_lock:
+                self._connections.append(conn)
+        return cast(Connection, conn)
+
+    def _open_connection(self) -> Connection:
         max_retries = 5
         retry_delay = 0.1
 
@@ -753,7 +797,9 @@ class SampleBufferDatabase(SampleBuffer):
 
         for attempt in range(max_retries):
             try:
-                conn = sqlite3.connect(self.db_path, timeout=30)
+                conn = sqlite3.connect(
+                    self.db_path, timeout=30, check_same_thread=False
+                )
                 conn.row_factory = sqlite3.Row  # enable row factory for named columns
 
                 # Enable foreign key constraints
@@ -808,36 +854,24 @@ class SampleBufferDatabase(SampleBuffer):
                 f"Failed to establish connection after {max_retries} attempts"
             ) from last_error
 
-        try:
-            # do work
-            yield conn
+        return conn
 
-            # if this was for a write then bump the version
-            if write:
-                conn.execute("""
-                UPDATE task_database
-                SET version = version + 1,
-                    last_updated = CURRENT_TIMESTAMP;
-                """)
+    def _close_connections(self) -> None:
+        with self._connections_lock:
+            connections = self._connections
+            self._connections = []
 
-            # commit
-            conn.commit()
-
-        except Exception:
-            # rollback on any error
+        current = getattr(self._connection_local, "conn", None)
+        for conn in connections:
             try:
-                conn.rollback()
-            finally:
-                if on_rollback is not None:
-                    on_rollback()
-            raise
-        finally:
-            # close the connection
-            conn.close()
+                conn.close()
+            except Exception as ex:
+                logger.warning(
+                    "Error closing sample buffer database connection: %s", ex
+                )
 
-            # if this was for write then sync (throttled)
-            if write:
-                self._sync()
+            if conn is current:
+                delattr(self._connection_local, "conn")
 
     def _sync(self) -> None:
         sync_filestore = self._sync_filestore

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -327,6 +327,40 @@ def test_cleanup_defers_while_sample_history_is_open(tmp_path):
     assert not db.db_path.exists()
 
 
+def test_buffer_database_reuses_thread_connection(tmp_path, monkeypatch):
+    connects = 0
+    original_connect = sqlite3.connect
+
+    def connect(*args, **kwargs):
+        nonlocal connects
+        connects += 1
+        return original_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
+    assert db.sample_event_count("sample", 1) == 1
+
+    assert connects == 1
+
+
+def test_cleanup_closes_persistent_database_connections(tmp_path):
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+
+    with db._get_connection() as conn:
+        assert conn.execute("SELECT 1").fetchone()[0] == 1
+
+    assert db._connections == [conn]
+
+    db.cleanup()
+
+    assert db._connections == []
+    assert not db.db_path.exists()
+    with pytest.raises(sqlite3.ProgrammingError, match="closed database"):
+        conn.execute("SELECT 1")
+
+
 def test_sample_history_event_rows_are_private(tmp_path):
     db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
     db.log_events([SampleEvent(id="sample", epoch=1, event=_model("event-1", "first"))])
@@ -376,6 +410,7 @@ def test_sample_history_read_methods_use_deferred_transactions(
         return original_connect(*args, **kwargs)
 
     monkeypatch.setattr(sqlite3, "connect", connect)
+    db._close_connections()
 
     assert db.sample_event_count("sample", 1) == 1
     assert db.sample_attachment("sample", 1, "missing") is None


### PR DESCRIPTION
## Summary
- reuse one sample-buffer SQLite connection per thread instead of opening and closing a connection on every operation
- close cached connections before destructive cleanup removes the database and WAL sidecar files
- keep the existing commit, rollback, version bump, and sync scheduling behavior

## Why
Issue #4159 identified connection churn as the remaining throughput bottleneck after WAL was restored for the realtime sample buffer database. The previous `_get_connection()` path paid `connect()`, PRAGMA setup, and close/checkpoint overhead for every read or write. This patch pays that setup once per thread and keeps the hot path focused on the actual transaction.

## Notes
- Connections are still thread-local, so normal operations do not share a handle across threads.
- Connections are opened with `check_same_thread=False` only so cleanup can close handles owned by other threads before unlinking the DB, `-wal`, and `-shm` files.
- `_get_connection()` keeps the same context-manager shape for existing tests and callers.

## To verify
- `PYTHONPATH=src python -m pytest tests/log/test_sample_history.py tests/log/test_buffer_sync_thread.py tests/log/test_buffer_pool_dedup.py -q`
- `python -m ruff check src/inspect_ai/log/_recorders/buffer/database.py tests/log/test_sample_history.py`
- `python -m ruff format --check src/inspect_ai/log/_recorders/buffer/database.py tests/log/test_sample_history.py`
- `python -m py_compile src/inspect_ai/log/_recorders/buffer/database.py`

I also ran `PYTHONPATH=src python -m pytest tests/log/test_log_eventdb.py -q`; the unrelated `test_running_tasks` case fails locally on Windows because the test constructs the database from a Windows path but calls `running_tasks()` with `Path.as_uri()`, producing different log-dir hashes. The other 18 cases in that file pass.

Closes #4159
