### PR TITLE
docs: fix typo in tools basics docs (ipmort -> import)

### DIFF
--- a/docs/_tools-basics.md
+++ b/docs/_tools-basics.md
@@ -34,7 +34,7 @@ We can use the `addition()` tool in an evaluation by passing it to the `use_tool
 
 ``` python
 from inspect_ai import Task, task
-from inspect_ai.dataset ipmort Sample
+from inspect_ai.dataset import Sample
 from inspect_ai.solver import generate, use_tools
 from inspect_ai.scorer import match
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The tools basics documentation (`docs/_tools-basics.md`) has a typo in a code example: the import statement reads `from inspect_ai.dataset ipmort Sample`, where `import` is misspelled as `ipmort`. As written, the example would raise a error if copied and run.

### What is the new behavior?
Corrected the typo so the line reads `from inspect_ai.dataset import Sample`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
Documentation-only change; no code or tests affected.
