### PR TITLE
resolve content attachments when reading transcript events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Model API: `ChatCompletionChoice.stop_details` (`StopDetails`/`StopCategory`) surfaces a model's refusal/safety category and explanation when available.
+- Transcript: `transcript().events` now resolves content attachments (large text, images) instead of returning bare `attachment://` references when reads are served from the bounded-history provider.
 - Transcript: Use WAL journal mode for the realtime sample buffer database so concurrent reads and writes no longer raise `OperationalError: database is locked`.
 - Remove ACP patch for connection initialization order issue (resolved in ACP 0.10.1).
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -87,6 +87,7 @@ from inspect_ai.log._samples import (
     active_sample,
 )
 from inspect_ai.log._transcript import (
+    DEFAULT_RESIDENT_TAIL,
     Transcript,
     TranscriptHistoryProvider,
     init_transcript,
@@ -924,7 +925,7 @@ async def task_run_sample(
         sample_transcript = Transcript(
             log_model_api=log_model_api,
             bounded=sample_transcript_bounded,
-            resident_tail=100,
+            resident_tail=DEFAULT_RESIDENT_TAIL,
             history_provider=history_provider,
         )
         init_transcript(sample_transcript)

--- a/src/inspect_ai/agent/_acp/connection.py
+++ b/src/inspect_ai/agent/_acp/connection.py
@@ -686,7 +686,13 @@ class ConnectionHandler:
         if sample is None:
             # Sample finished — nothing to cancel. Idempotent.
             return {"cancelled": False}
-        for event in sample.transcript.events:
+        # Scan pending events only (a pending ToolEvent is what we can
+        # cancel) rather than the full `events` history — scoped, and it
+        # avoids materializing / re-inflating evicted history on a bounded
+        # transcript. Pending events are never evicted, and nested
+        # sub-agent tool calls (task / as_tool / handoff) record into this
+        # same sample transcript, so they remain reachable here.
+        for event in sample.transcript.pending_events:
             if (
                 isinstance(event, ToolEvent)
                 and event.id == tool_call_id

--- a/src/inspect_ai/agent/_acp/session_router.py
+++ b/src/inspect_ai/agent/_acp/session_router.py
@@ -35,6 +35,7 @@ from inspect_ai.agent._acp.inspect_ext import (
     PlanPolicyTransformer,
     RawEventForwarder,
 )
+from inspect_ai.log._transcript import DEFAULT_RESIDENT_TAIL
 
 if TYPE_CHECKING:
     from inspect_ai.agent._acp.connection import ConnectionState
@@ -51,8 +52,13 @@ _SESSION_UPDATE_METHOD = CLIENT_METHODS["session_update"]
 
 # ``REPLAY_MAX_EVENTS`` caps replay payload size on late attach so a
 # very long-running sample doesn't dump thousands of events on every
-# new connection.
-REPLAY_MAX_EVENTS = 100
+# new connection. Aligned with the sample transcript's resident window
+# (``DEFAULT_RESIDENT_TAIL``): the replay snapshot is read from resident,
+# attachment-resolved memory (see ``_TranscriptCapture.snapshot``), so
+# capping at the resident size means replay never needs to reach past what
+# is held in memory (which would surface unresolved ``attachment://``
+# refs). Keep ``REPLAY_MAX_EVENTS <= DEFAULT_RESIDENT_TAIL``.
+REPLAY_MAX_EVENTS = DEFAULT_RESIDENT_TAIL
 
 # How long :meth:`Forwarders.stop` waits for the semantic task to
 # finish its EOF cleanup naturally before falling through to cancel.

--- a/src/inspect_ai/agent/_acp/transport_live.py
+++ b/src/inspect_ai/agent/_acp/transport_live.py
@@ -265,9 +265,25 @@ class _TranscriptCapture:
     def snapshot(self) -> Sequence[Any]:
         if self._captured is None:
             return []
-        # Slice the transcript view directly so bounded/provider-backed
-        # transcripts can read only the suffix since attach.
-        return self._captured.events[self._attach_index :]
+        # Read ONLY the resident (in-memory) window via the history
+        # accessor — never the provider-backed `events` view. Resident
+        # events keep their message / input content un-condensed, so
+        # replay forwards real content rather than `attachment://` refs;
+        # going through the provider would re-materialize evicted history
+        # from the buffer DB with content still condensed. The resident
+        # window equals `resident_tail`, which `REPLAY_MAX_EVENTS` is
+        # aligned to (see session_router), so this loses nothing replay
+        # would have shown. `list()` snapshots a copy so a concurrent
+        # `_event` append can't change size mid-iteration downstream.
+        history = self._captured.history
+        resident = list(history.resident_events)
+        # Translate the absolute attach index into the resident window,
+        # accounting for any evicted prefix in bounded mode (the floor
+        # drops pre-attach events the live router never saw — chiefly the
+        # eval framework's outer AGENT_SPAN begin).
+        first_resident_index = history.event_count - len(resident)
+        floor = max(self._attach_index - first_resident_index, 0)
+        return resident[floor:]
 
 
 class _CancelSnapshot:

--- a/src/inspect_ai/log/_condense.py
+++ b/src/inspect_ai/log/_condense.py
@@ -1,5 +1,5 @@
 import json
-from collections.abc import MutableMapping
+from collections.abc import Mapping, MutableMapping
 from logging import getLogger
 from typing import (
     Callable,
@@ -312,6 +312,50 @@ def resolve_sample_attachments(
             "events_data": None,
         }
     )
+
+
+def resolve_events_attachments(
+    events: list[Event],
+    attachments: Mapping[str, str],
+    resolve_attachments: bool | Literal["full", "core"] = "core",
+) -> list[Event]:
+    """Resolve ``attachment://`` references in a list of events.
+
+    The events must already have their message / call *pools* resolved
+    (the buffer history provider does this via
+    ``materialize_pooled_events``); this only swaps ``attachment://<hash>``
+    content references back to their underlying values from
+    ``attachments``.
+
+    Args:
+       events: Events (pool-resolved) that may carry ``attachment://`` refs.
+       attachments: Mapping of attachment hash -> underlying content.
+       resolve_attachments: Which fields to resolve. ``"core"`` (default)
+           leaves ``ModelEvent.call`` condensed — matching resident
+           in-memory events, whose model-call payloads stay condensed
+           after ``Transcript._process_event``. ``"full"`` / ``True``
+           also resolves the model call. ``False`` is a no-op.
+
+    Returns:
+       Events with attachment content resolved (a new list; inputs are
+       not mutated). Returns ``events`` unchanged when
+       ``resolve_attachments`` is ``False``.
+    """
+    if resolve_attachments is False:
+        return events
+
+    def content_fn(text: str) -> str:
+        # migrate previous flavor of content reference
+        CONTENT_PROTOCOL = "tc://"
+        if text.startswith(CONTENT_PROTOCOL):
+            text = text.replace(CONTENT_PROTOCOL, ATTACHMENT_PROTOCOL, 1)
+        if text.startswith(ATTACHMENT_PROTOCOL):
+            return attachments.get(text.replace(ATTACHMENT_PROTOCOL, "", 1), text)
+        else:
+            return text
+
+    context = WalkContext(message_cache={}, only_core=resolve_attachments == "core")
+    return walk_events(events, content_fn, context)
 
 
 def attachments_content_fn(

--- a/src/inspect_ai/log/_recorders/buffer/transcript_history_provider.py
+++ b/src/inspect_ai/log/_recorders/buffer/transcript_history_provider.py
@@ -12,6 +12,7 @@ from inspect_ai.event._pool import (
     resolve_model_event_inputs,
 )
 from inspect_ai.event._validate import validate_events
+from inspect_ai.log._condense import resolve_events_attachments
 from inspect_ai.log._log import EventsData
 from inspect_ai.log._recorders.buffer.types import JsonData
 
@@ -134,16 +135,22 @@ class BufferTranscriptHistoryProvider:
 
 
 def _materialize_events(history: SampleHistoryLike) -> list[Event]:
-    return materialize_pooled_events(
+    events = materialize_pooled_events(
         history.iter_events(),
         history.events_data["messages"],
         history.events_data["calls"],
     )
+    # Resolve content attachments (large text / images) back to their
+    # underlying values so callers get usable events, not bare
+    # `attachment://<hash>` references. "core" leaves ModelEvent.call
+    # condensed, matching resident in-memory events.
+    return resolve_events_attachments(events, history.attachments)
 
 
 def _iter_materialized_events(history: SampleHistoryLike) -> Iterator[Event]:
     message_pool = history.events_data["messages"]
     call_pool = history.events_data["calls"]
+    attachments = history.attachments
     for raw_event in history.iter_events():
         event = (
             raw_event
@@ -151,7 +158,9 @@ def _iter_materialized_events(history: SampleHistoryLike) -> Iterator[Event]:
             else validate_events([raw_event])[0]
         )
         event = resolve_model_event_inputs([event], message_pool)[0]
-        yield resolve_model_event_calls([event], call_pool)[0]
+        event = resolve_model_event_calls([event], call_pool)[0]
+        # Resolve attachments per-event so streaming/index reads stay lazy.
+        yield resolve_events_attachments([event], attachments)[0]
 
 
 if TYPE_CHECKING:

--- a/src/inspect_ai/log/_transcript.py
+++ b/src/inspect_ai/log/_transcript.py
@@ -59,6 +59,17 @@ def transcript_bounded_enabled() -> bool:
     return value.strip().lower() not in ("0", "false", "no", "off")
 
 
+DEFAULT_RESIDENT_TAIL = 100
+"""Default number of most-recent events a bounded transcript keeps in memory.
+
+Shared source of truth for the resident window. Consumers that read a
+recent slice of history (e.g. the ACP replay-on-attach in
+``agent/_acp/session_router.py``, whose ``REPLAY_MAX_EVENTS`` is aligned to
+this value) can rely on that slice being served from resident,
+attachment-resolved memory rather than re-materialized from the buffer DB.
+"""
+
+
 class TranscriptHistoryProvider(Protocol):
     @property
     def event_count(self) -> int: ...
@@ -421,7 +432,7 @@ class Transcript:
         `history.resident_events`, `history.event_count`, `history.last_event`, or
         `history.recent_events()`.
         """
-        if self._history_provider is None:
+        if self._history_provider is None or not self._events_truncated:
             return self._events
         return self._events_view
 

--- a/tests/agent/test_acp/test_replay_snapshot.py
+++ b/tests/agent/test_acp/test_replay_snapshot.py
@@ -1,0 +1,111 @@
+"""ACP replay snapshot reads the resident, un-condensed event window.
+
+Part B / C of the attachment-resolution fix: the replay-on-attach snapshot
+reads only the resident (in-memory) event window via the history accessor,
+never the provider-backed ``events`` view. Resident events keep their message
+content un-condensed, so replay forwards real content instead of
+``attachment://`` references — and it stays off the buffer DB even on a
+bounded, already-evicted transcript. ``REPLAY_MAX_EVENTS`` is aligned to the
+resident window so capping never reaches past what is held in memory.
+"""
+
+from typing import Sequence
+
+from inspect_ai.agent._acp.session_router import REPLAY_MAX_EVENTS
+from inspect_ai.agent._acp.transport_live import LiveAcpTransport
+from inspect_ai.event._event import Event
+from inspect_ai.event._info import InfoEvent
+from inspect_ai.log._transcript import DEFAULT_RESIDENT_TAIL, Transcript
+
+
+class _RaisingReadProvider:
+    """History provider that fails if any event-read method is touched.
+
+    The snapshot must serve everything from the resident window, so reaching
+    the provider at all is a bug.
+    """
+
+    @property
+    def event_count(self) -> int:
+        raise AssertionError("snapshot must not read provider.event_count")
+
+    def iter_events(self):
+        raise AssertionError("snapshot must not read provider.iter_events")
+
+    def events(self) -> Sequence[Event]:
+        raise AssertionError("snapshot must not read provider.events")
+
+    def recent_events(self, n: int | None = None) -> Sequence[Event]:
+        raise AssertionError("snapshot must not read provider.recent_events")
+
+    def events_from(self, start: int) -> Sequence[Event]:
+        raise AssertionError("snapshot must not read provider.events_from")
+
+    def events_since_last(self, event_type: type[Event]) -> list[Event]:
+        raise AssertionError("snapshot must not read provider.events_since_last")
+
+    def contains_event(self, event_id: str) -> bool:
+        raise AssertionError("snapshot must not read provider.contains_event")
+
+    def attachments(self):
+        return {}
+
+    def attachment(self, hash: str) -> str | None:
+        return None
+
+    def export_transcript_events(self, transcript_store) -> int:
+        return 0
+
+
+def _capture(transcript: Transcript, attach_index: int) -> LiveAcpTransport:
+    acp = LiveAcpTransport()
+    acp._transcript_capture.captured = transcript
+    acp._transcript_capture.attach_index = attach_index
+    return acp
+
+
+def test_snapshot_uses_resident_window_not_provider() -> None:
+    # Bounded transcript with only the last 2 events resident; older events
+    # are evicted and would be served (condensed) by the provider.
+    tr = Transcript(
+        bounded=True, resident_tail=2, history_provider=_RaisingReadProvider()
+    )
+    for i in range(5):
+        tr._event(InfoEvent(data=i))
+    assert tr.history.resident_events_truncated is True
+
+    snap = _capture(tr, attach_index=0).transcript_events_snapshot()
+
+    # Resident window (last 2) — read without touching the raising provider.
+    assert [e.data for e in snap] == [3, 4]
+
+
+def test_snapshot_applies_attach_index_floor() -> None:
+    tr = Transcript()
+    for i in range(5):
+        tr._event(InfoEvent(data=i))
+
+    snap = _capture(tr, attach_index=2).transcript_events_snapshot()
+
+    assert [e.data for e in snap] == [2, 3, 4]
+
+
+def test_snapshot_attach_index_predating_eviction_returns_resident() -> None:
+    # attach_index points at an event that has since been evicted; the floor
+    # clamps into the resident window rather than going negative.
+    tr = Transcript(
+        bounded=True, resident_tail=2, history_provider=_RaisingReadProvider()
+    )
+    for i in range(5):
+        tr._event(InfoEvent(data=i))
+
+    # first resident event is logical index 3; attach_index 1 predates it.
+    snap = _capture(tr, attach_index=1).transcript_events_snapshot()
+
+    assert [e.data for e in snap] == [3, 4]
+
+
+def test_replay_window_aligned_with_resident_tail() -> None:
+    # Replay must never need to read past the resident window (which would
+    # surface unresolved attachment refs from the provider).
+    assert REPLAY_MAX_EVENTS <= DEFAULT_RESIDENT_TAIL

--- a/tests/log/test_resolve_events_attachments.py
+++ b/tests/log/test_resolve_events_attachments.py
@@ -1,0 +1,146 @@
+"""Attachment resolution when reading transcript events.
+
+Regression coverage for the bounded-transcript work (#4062), which routed
+``Transcript.events`` reads through the buffer history provider. The provider
+returned events whose content was still condensed to ``attachment://<hash>``
+references, and nothing downstream resolved them — so consumers that display
+content (notably the ACP client) showed bare ``attachment://`` refs in place
+of system / user / assistant message text.
+
+The fix resolves attachments at the provider boundary (so every ``events``
+reader gets usable content) and reads the ACP replay snapshot from the
+resident, un-condensed window (so it never touches the provider at all).
+"""
+
+from inspect_ai._util.content import ContentText
+from inspect_ai.event._event import Event
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.log._condense import ATTACHMENT_PROTOCOL, resolve_events_attachments
+from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+from inspect_ai.log._recorders.buffer.transcript_history_provider import (
+    BufferTranscriptHistoryProvider,
+)
+from inspect_ai.log._recorders.types import SampleEvent
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageSystem,
+    ChatMessageUser,
+)
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput
+
+
+def _model_event(
+    input_messages: list[ChatMessage],
+    *,
+    uuid: str | None = None,
+    call: ModelCall | None = None,
+) -> ModelEvent:
+    return ModelEvent(
+        uuid=uuid,
+        model="mockllm/model",
+        input=input_messages,
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", "ok"),
+        call=call,
+    )
+
+
+def test_resolve_events_attachments_resolves_message_content() -> None:
+    attachments = {"h1": "SYSTEM PROMPT", "h2": "USER PROMPT"}
+    event = _model_event(
+        [
+            ChatMessageSystem(content=f"{ATTACHMENT_PROTOCOL}h1"),
+            ChatMessageUser(
+                content=[
+                    ContentText(text=f"{ATTACHMENT_PROTOCOL}h2"),
+                    ContentText(text="plain tail"),
+                ]
+            ),
+        ]
+    )
+
+    events: list[Event] = [event]
+    [resolved] = resolve_events_attachments(events, attachments)
+
+    assert isinstance(resolved, ModelEvent)
+    assert resolved.input[0].content == "SYSTEM PROMPT"
+    user_content = resolved.input[1].content
+    assert isinstance(user_content, list)
+    assert isinstance(user_content[0], ContentText)
+    assert user_content[0].text == "USER PROMPT"
+    assert isinstance(user_content[1], ContentText)
+    assert user_content[1].text == "plain tail"
+    # input event is not mutated in place
+    assert event.input[0].content == f"{ATTACHMENT_PROTOCOL}h1"
+
+
+def test_resolve_events_attachments_unknown_ref_passes_through() -> None:
+    event = _model_event([ChatMessageUser(content=f"{ATTACHMENT_PROTOCOL}missing")])
+    events: list[Event] = [event]
+    [resolved] = resolve_events_attachments(events, {})
+    # No matching attachment -> ref is left as-is rather than dropped.
+    assert isinstance(resolved, ModelEvent)
+    assert resolved.input[0].content == f"{ATTACHMENT_PROTOCOL}missing"
+
+
+def test_resolve_events_attachments_core_vs_full_model_call() -> None:
+    call = ModelCall.create(
+        {"messages": [{"role": "user", "content": f"{ATTACHMENT_PROTOCOL}h1"}]}, None
+    )
+    event = _model_event([ChatMessageUser(content="hi")], call=call)
+    events: list[Event] = [event]
+
+    # "core" (default) leaves ModelEvent.call condensed, matching the resident
+    # in-memory representation.
+    [core] = resolve_events_attachments(events, {"h1": "BIG CALL"})
+    assert isinstance(core, ModelEvent) and core.call is not None
+    assert f"{ATTACHMENT_PROTOCOL}h1" in core.call.model_dump_json()
+    assert "BIG CALL" not in core.call.model_dump_json()
+
+    # "full" also resolves the model call payload.
+    [full] = resolve_events_attachments(
+        events, {"h1": "BIG CALL"}, resolve_attachments="full"
+    )
+    assert isinstance(full, ModelEvent) and full.call is not None
+    assert "BIG CALL" in full.call.model_dump_json()
+
+
+def test_resolve_events_attachments_false_is_noop() -> None:
+    events: list[Event] = [
+        _model_event([ChatMessageUser(content=f"{ATTACHMENT_PROTOCOL}h1")])
+    ]
+    result = resolve_events_attachments(events, {"h1": "X"}, resolve_attachments=False)
+    assert result is events
+
+
+def test_buffer_history_provider_resolves_attachments(tmp_path) -> None:
+    # Long content (> the buffer's 100-char condense threshold) is extracted to
+    # an attachment when written to the buffer DB.
+    big_system = "SYS-" + "y" * 300
+    big_user = "USER-" + "x" * 300
+    event = _model_event(
+        [
+            ChatMessageSystem(id="sys-msg", content=big_system),
+            ChatMessageUser(id="usr-msg", content=big_user),
+        ],
+        uuid="e1",
+    )
+
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="s", epoch=1, event=event)])
+    provider = BufferTranscriptHistoryProvider(db, "s", 1)
+
+    # events() resolves attachments back to the underlying content.
+    [me] = [e for e in provider.events() if isinstance(e, ModelEvent)]
+    assert me.input[0].content == big_system
+    assert me.input[1].content == big_user
+    assert ATTACHMENT_PROTOCOL not in me.model_dump_json()
+
+    # iter_events() (the lazy/streaming path) resolves per-event too.
+    [me_iter] = [e for e in provider.iter_events() if isinstance(e, ModelEvent)]
+    assert me_iter.input[0].content == big_system
+    assert me_iter.input[1].content == big_user


### PR DESCRIPTION

## Summary

The ACP client was rendering bare `attachment://<hash>` references in place of
replayed system / user / assistant message content (see below). This fixes the
underlying `transcript().events` contract so all readers get **resolved**
content, and makes the ACP replay read only the resident, un-condensed window.

```
user
  attachment://ff300e9fadd403df4ace1c7748d9c98c attachment://aba0a0c140d…  Find the content of the flag.txt file on the target.
```

## Root cause

Regression from #4062 ("Bound transcript memory for long-running samples").
That change introduced a buffer-backed history provider and routed
`Transcript.events` through it:

- A `BufferTranscriptHistoryProvider` is attached for **all** normal runs
  (whenever a buffer DB is present), not just bounded ones.
- `Transcript.events` returned the provider-backed view whenever a provider was
  attached, regardless of the `bounded` flag.
- The provider materializes events through the message/call **pool** but did
  **not** resolve **attachments** — large text and images stayed as
  `attachment://<hash>`, with the real bytes in a separate attachments map.
- Nothing downstream resolved them. ACP's replay-on-attach reads the transcript
  snapshot (which went through the provider) and forwarded the refs verbatim.

Before #4062, `events` returned the resident, in-memory events, whose message
content is never condensed — so the refs never surfaced.

Live forwarding was unaffected (subscribers receive the resident, un-condensed
event object at notify time); only **replay-on-attach** leaked refs, which
matches the screenshot (early/replayed messages condensed, later live content
intact).

## The fix

Three parts, in one change:

1. **Resolve attachments at the provider boundary** so every `transcript().events`
   reader gets usable content (not just ACP). `BufferTranscriptHistoryProvider`
   now resolves `attachment://` refs as it materializes events (both the eager
   and lazy/streaming paths). Resolution uses a new reusable
   `resolve_events_attachments()` helper in `log/_condense.py`, defaulting to
   `"core"` (leaves `ModelEvent.call` condensed, matching resident events).
   `Transcript.events` returns resident events directly when nothing has been
   evicted (the common case — zero provider round-trip), and the lazy
   provider-backed view otherwise; the lazy view's contract (streaming index,
   `len` via in-memory count, resident-tail shortcuts, membership) is preserved.

2. **ACP replay reads the resident window** via the `history` accessor rather
   than `transcript().events`. Resident events are un-condensed and in memory,
   so replay forwards real content and never re-materializes evicted history
   from the buffer DB. `inspect/cancel_tool_call` likewise switched from a full
   `events` scan to the scoped `pending_events` accessor.

3. **Aligned the replay window with the resident window.** `REPLAY_MAX_EVENTS`
   now derives from a shared `DEFAULT_RESIDENT_TAIL` constant, with the invariant
   `REPLAY_MAX_EVENTS <= DEFAULT_RESIDENT_TAIL`, so a replay never needs to read
   past what is held in memory (which would re-introduce unresolved refs).

## Scope / compatibility

- **Non-bounded runs (the default):** identical to pre-#4062 — `events` returns
  resident, un-condensed events; no provider round-trip.
- **Bounded + evicted:** reading the full `events` history re-inflates content
  into memory (the documented convenience-view trade-off). Memory-sensitive
  callers should use the narrow `history.*` APIs (`recent_events`,
  `resident_events`, `last_event`), which stay on the resident window. The ACP
  path always uses these and never re-inflates.
- Log serialization is unaffected: `create_eval_sample` only reads
  `transcript().events` when no buffer DB is present; with a buffer the log
  events come from the buffer stream (condensed + attachments map), as before.

## Tests

- `tests/log/test_resolve_events_attachments.py` — `resolve_events_attachments`
  (message content, unknown-ref passthrough, core-vs-full model call, no-op);
  real buffer-DB round-trip proving `BufferTranscriptHistoryProvider` returns
  resolved content (the direct regression repro).
- `tests/agent/test_acp/test_replay_snapshot.py` — replay snapshot serves the
  resident window without touching the provider (raises if it does), applies the
  attach-index floor (including when the attach point predates eviction), and
  asserts `REPLAY_MAX_EVENTS <= DEFAULT_RESIDENT_TAIL`.
- Full `tests/log/` (570) and `tests/agent/test_acp/` (871) suites pass; `ruff`
  clean; `mypy --exclude tests/test_package src tests` clean (1196 files).

## Note for #4062 authors

cc @rasmusfaber @eric.patey — this changes the semantics of `Transcript.events`
from your bounded-transcript work: it now returns resident events when nothing
is evicted, and resolves attachments when serving evicted history from the
provider. The lazy provider-view behavior your tests pin (streaming index,
in-memory `len`, resident-tail shortcuts, membership) is preserved. Flagging in
case it interacts with anything you have in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
