### PR TITLE
fix(log): normalize buffer task directory URI

### DIFF
--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -484,7 +484,7 @@ class SampleBufferDatabase(SampleBuffer):
     @classmethod
     @override
     def running_tasks(cls, log_dir: str) -> list[str] | None:
-        log_subdir = log_dir_hash(log_dir)
+        log_subdir = log_dir_hash(filesystem(log_dir).path_as_uri(log_dir))
         db_dir = resolve_db_dir() / log_subdir
 
         if db_dir.exists():

--- a/tests/log/test_log_eventdb.py
+++ b/tests/log/test_log_eventdb.py
@@ -561,6 +561,22 @@ def test_running_tasks():
             assert len(SampleBufferFilestore.running_tasks(log_dir)) == 2
 
 
+def test_running_tasks_hashes_canonical_log_uri(tmp_path, monkeypatch):
+    class StubFileSystem:
+        def path_as_uri(self, path: str) -> str:
+            assert path == "raw-log-dir"
+            return "canonical-log-dir"
+
+    db_dir = tmp_path / database_module.log_dir_hash("canonical-log-dir")
+    db_dir.mkdir()
+    (db_dir / "task.eval.123.db").touch()
+
+    monkeypatch.setattr(database_module, "filesystem", lambda _: StubFileSystem())
+    monkeypatch.setattr(database_module, "resolve_db_dir", lambda: tmp_path)
+
+    assert SampleBufferDatabase.running_tasks("raw-log-dir") == ["task.eval"]
+
+
 def test_connection_is_reused_within_thread(
     db: SampleBufferDatabase, sample: EvalSampleSummary
 ) -> None:


### PR DESCRIPTION
## Summary

- normalize `running_tasks()` input with the same filesystem URI conversion used when creating buffer databases
- add a regression test that ensures the task lookup hashes the canonical log URI, not the raw caller input

## Why

On Windows, the buffer database is created under the hash of `file://C:/...`, because `SampleBufferDatabase.__init__()` normalizes the location through `filesystem(...).path_as_uri(...)`.

`running_tasks()` currently hashes the caller-provided directory directly. A caller passing `Path(...).as_uri()` gets `file:///C:/...`, so the lookup checks a different hash directory and returns `None` even while buffer database files exist.

## To verify

- `PYTHONPATH=src python -m pytest tests/log/test_log_eventdb.py -q -k "running_tasks"`
- `python -m py_compile src/inspect_ai/log/_recorders/buffer/database.py tests/log/test_log_eventdb.py`
- `python -m ruff check src/inspect_ai/log/_recorders/buffer/database.py tests/log/test_log_eventdb.py`
- `python -m ruff format --check src/inspect_ai/log/_recorders/buffer/database.py tests/log/test_log_eventdb.py`
- `git diff --check`
