### PR TITLE
Checkpoint: update compaction to use checkpointer for state tracking.

### DIFF
--- a/src/inspect_ai/agent/_react.py
+++ b/src/inspect_ai/agent/_react.py
@@ -26,7 +26,7 @@ from inspect_ai.tool._mcp.connection import mcp_connection
 from inspect_ai.tool._tool import Tool, ToolResult, ToolSource, tool
 from inspect_ai.tool._tool_def import ToolDef
 from inspect_ai.tool._tool_info import parse_tool_info
-from inspect_ai.util._checkpoint import checkpointer
+from inspect_ai.util._checkpoint import Checkpointer, checkpointer
 
 from ._agent import Agent, AgentState, agent, agent_with, is_agent
 from ._channel import (
@@ -212,7 +212,7 @@ def react(
             overflow = _resolve_overflow(truncation)
 
             # create compact function
-            compact = _agent_compact(compaction, state.messages, tools, model)
+            compact = _agent_compact(compaction, state.messages, tools, model, cp)
 
             # track attempts (recovered from checkpoint state on resume)
             attempt_count = cp.track("attempt_count", lambda: attempt_count, 0)
@@ -414,7 +414,7 @@ def react_no_submit(
             overflow = _resolve_overflow(truncation)
 
             # create compact function
-            compact = _agent_compact(compaction, state.messages, tools, model)
+            compact = _agent_compact(compaction, state.messages, tools, model, cp)
 
             # track consecutive content_filter responses
             consecutive_content_filter = 0
@@ -596,6 +596,7 @@ def _agent_compact(
     prefix: list[ChatMessage],
     tools: Sequence[Tool | ToolDef | ToolSource] | None,
     model: str | Model | Agent | None,
+    checkpointer: Checkpointer,
 ) -> Compact | None:
     # create compact function
     if compaction is not None:
@@ -604,6 +605,7 @@ def _agent_compact(
             prefix=prefix,
             tools=tools,
             model=model if isinstance(model, str | Model | None) else None,
+            checkpointer=checkpointer,
         )
     else:
         return None

--- a/src/inspect_ai/model/_compaction/_compaction.py
+++ b/src/inspect_ai/model/_compaction/_compaction.py
@@ -4,9 +4,12 @@ from logging import getLogger
 from typing import Sequence
 
 import anyio
+from pydantic import BaseModel, Field
 
 from inspect_ai._util.content import ContentReasoning
 from inspect_ai.tool import Tool, ToolDef, ToolInfo, ToolSource
+from inspect_ai.util._checkpoint import Checkpointer
+from inspect_ai.util._checkpoint.checkpointer_noop import _NoopCheckpointer
 
 from .._call_tools import get_tools_info, resolve_tools
 from .._chat_message import ChatMessage, ChatMessageAssistant, ChatMessageUser
@@ -23,12 +26,42 @@ from .types import Compact, CompactionStrategy
 
 logger = getLogger(__name__)
 
+# stateless no-op session used when the caller has no checkpointer; its
+# track() returns initial_value and never registers, so the compaction
+# handler needs no special-casing
+_NOOP_CHECKPOINTER: Checkpointer = _NoopCheckpointer()
+
+
+class _CompactionState(BaseModel):
+    """Checkpointable state held by a `compaction()` handler.
+
+    Captured at each checkpoint fire and restored on resume so a resumed
+    session continues from the prior compacted view rather than re-deriving
+    (and, for summary strategies, re-invoking the model) from scratch.
+    """
+
+    compacted_input: list[ChatMessage] = Field(default_factory=list)
+    """Reduced input actually sent to the model."""
+
+    processed_message_ids: set[str] = Field(default_factory=set)
+    """IDs of messages already folded into the input."""
+
+    baseline_tokens: int | None = None
+    """Token baseline from the last `record_output` call."""
+
+    baseline_message_ids: set[str] = Field(default_factory=set)
+    """IDs of messages that produced `baseline_tokens`."""
+
+    memory_warning_issued: bool = False
+    """Whether a pre-compaction memory warning was issued for the window."""
+
 
 def compaction(
     strategy: CompactionStrategy,
     prefix: list[ChatMessage],
     tools: Sequence[Tool | ToolDef | ToolInfo | ToolSource] | ToolSource | None = None,
     model: str | Model | None = None,
+    checkpointer: Checkpointer = _NOOP_CHECKPOINTER,
 ) -> Compact:
     """Create a conversation compaction handler.
 
@@ -44,28 +77,26 @@ def compaction(
         prefix: Chat messages to always preserve in compacted conversations.
         tools: Tool definitions (included in token count as they consume context).
         model: Target model for compacted input (defaults to active model).
+        checkpointer: Session checkpointer. The handler's internal state is
+            captured at each checkpoint fire and restored on resume so the
+            resumed session continues from the prior compacted view rather
+            than re-deriving from scratch. Defaults to a no-op session.
 
     Returns:
         `Compact` handler with `compact_input()` and `record_output()` methods.
     """
     from inspect_ai.log._transcript import transcript
 
-    # state: compacted input to send to the model
-    compacted_input: list[ChatMessage] = []
-
-    # state: whether we've issued a memory warning for the current window
-    memory_warning_issued: bool = False
-
-    # state: IDs of messages we've already processed (added to input)
-    processed_message_ids: set[str] = set()
-
-    # state: baseline token count from the last generate call
-    # This is the most accurate count since it comes directly from the API
-    # and includes all overhead (tools, system messages, thinking config, etc.)
-    baseline_tokens: int | None = None
-
-    # state: IDs of messages that were included in the baseline count
-    baseline_message_ids: set[str] = set()
+    # mutable per-session state (see _CompactionState for field docs). The
+    # closure mutates `state` in place; it is the single source of truth.
+    #
+    # `track` registers the state for checkpointing and returns either the
+    # fresh instance passed as initial_value (no checkpointer / fresh run) or
+    # the value captured at the last fire (resume). The `lambda: state`
+    # callback hands the live instance to each fire; track never invokes it
+    # during registration, so closing over `state` before this assignment
+    # completes is safe.
+    state = checkpointer.track("compaction", lambda: state, _CompactionState())
 
     # snapshot the prefix in case it changes
     prefix = prefix.copy()
@@ -94,8 +125,6 @@ def compaction(
 
     async def record_output_fn(input: list[ChatMessage], output: ModelOutput) -> None:
         """Record output from generate call to calibrate token baseline."""
-        nonlocal baseline_tokens, baseline_message_ids
-
         if output.usage is None:
             return
 
@@ -108,10 +137,10 @@ def compaction(
                 input_tokens += output.usage.input_tokens_cache_write
 
             # `input` is the messages that produced output.usage; under
-            # concurrent bridge use the closure's `compacted_input` may
-            # already reflect a later call
-            baseline_tokens = input_tokens
-            baseline_message_ids = {message_id(m) for m in input}
+            # concurrent bridge use `state.compacted_input` may already
+            # reflect a later call
+            state.baseline_tokens = input_tokens
+            state.baseline_message_ids = {message_id(m) for m in input}
 
     async def compact_fn(
         messages: list[ChatMessage],
@@ -119,9 +148,8 @@ def compaction(
     ) -> tuple[list[ChatMessage], ChatMessageUser | None]:
         from inspect_ai.event._compaction import CompactionEvent
 
-        # state variables we modify
-        nonlocal tool_tokens, tools_info, prefix_tokens, memory_warning_issued
-        nonlocal baseline_tokens, baseline_message_ids
+        # derived caches we lazily resolve (not part of checkpointed state)
+        nonlocal tool_tokens, tools_info, prefix_tokens
 
         async with _lock:
             # one time resolution of tool_tokens and prefix_tokens
@@ -136,11 +164,11 @@ def compaction(
             # we allow unprocessed messages to accumulate in the input until
             # the compaction 'threshold' is reached.
             unprocessed: list[ChatMessage] = [
-                m for m in messages if message_id(m) not in processed_message_ids
+                m for m in messages if message_id(m) not in state.processed_message_ids
             ]
 
             # estimate total tokens using the most accurate method available
-            target_messages = compacted_input + unprocessed
+            target_messages = state.compacted_input + unprocessed
             target_message_ids = {message_id(m) for m in target_messages}
 
             # On providers whose usage.input_tokens omits redacted reasoning
@@ -153,8 +181,9 @@ def compaction(
                 target_messages, target_model
             )
 
-            if baseline_tokens is not None and baseline_message_ids.issubset(
-                target_message_ids
+            if (
+                state.baseline_tokens is not None
+                and state.baseline_message_ids.issubset(target_message_ids)
             ):
                 # Use the baseline from the last generate call (most accurate).
                 # The baseline already includes tool definitions, system messages,
@@ -163,14 +192,16 @@ def compaction(
                 new_since_baseline = [
                     m
                     for m in target_messages
-                    if message_id(m) not in baseline_message_ids
+                    if message_id(m) not in state.baseline_message_ids
                 ]
                 new_tokens = (
                     await target_model.count_tokens(new_since_baseline)
                     if new_since_baseline
                     else 0
                 )
-                total_tokens = baseline_tokens + new_tokens + hidden_reasoning_tokens
+                total_tokens = (
+                    state.baseline_tokens + new_tokens + hidden_reasoning_tokens
+                )
             else:
                 # No baseline yet (first call). Fall back to per-message counting.
                 message_tokens = await target_model.count_tokens(target_messages)
@@ -189,13 +220,13 @@ def compaction(
                 )
 
                 # track all messages that were processed in this compaction pass
-                for m in compacted_input + unprocessed:
-                    processed_message_ids.add(message_id(m))
+                for m in state.compacted_input + unprocessed:
+                    state.processed_message_ids.add(message_id(m))
 
                 # c_message is a compaction side effect to append to the history
                 # (e.g. a summary). track it as processed as well
                 if c_message is not None:
-                    processed_message_ids.add(message_id(c_message))
+                    state.processed_message_ids.add(message_id(c_message))
 
                 # Preserve prefix messages based on strategy type
                 if strategy.preserve_prefix:
@@ -219,13 +250,15 @@ def compaction(
                     c_message = None
 
                 # update input
-                compacted_input.clear()
-                compacted_input.extend(c_input)
+                state.compacted_input.clear()
+                state.compacted_input.extend(c_input)
 
                 # log compaction
-                compacted_tokens = await target_model.count_tokens(compacted_input)
+                compacted_tokens = await target_model.count_tokens(
+                    state.compacted_input
+                )
                 compacted_hidden = _redacted_reasoning_tokens_total(
-                    compacted_input, target_model
+                    state.compacted_input, target_model
                 )
                 transcript()._event(
                     CompactionEvent(
@@ -236,18 +269,18 @@ def compaction(
                         metadata={
                             "strategy": strategy.__class__.__name__,
                             "messages_before": len(target_messages),
-                            "messages_after": len(compacted_input),
+                            "messages_after": len(state.compacted_input),
                             "trigger": "forced" if force else "threshold",
                         },
                     )
                 )
 
                 # clear memory warning state
-                memory_warning_issued = False
+                state.memory_warning_issued = False
 
                 # invalidate baseline (compaction changed the messages)
-                baseline_tokens = None
-                baseline_message_ids = set()
+                state.baseline_tokens = None
+                state.baseline_message_ids = set()
 
                 # return input and any extra message to append
                 return list(c_input), c_message
@@ -255,25 +288,25 @@ def compaction(
             else:
                 # track unprocessed messages as now processed
                 for m in unprocessed:
-                    processed_message_ids.add(message_id(m))
+                    state.processed_message_ids.add(message_id(m))
 
                 # extend input with unprocessed messages
-                compacted_input.extend(unprocessed)
+                state.compacted_input.extend(unprocessed)
 
                 # check if we need to do a memory warning
                 if (
                     strategy.memory is True
                     and MEMORY_TOOL in [t.name for t in tools_info]
                     and total_tokens > memory_warning_threshold
-                    and not memory_warning_issued
+                    and not state.memory_warning_issued
                 ):
                     memory_message = memory_warning_message()
-                    compacted_input.append(memory_message)
-                    processed_message_ids.add(message_id(memory_message))
-                    memory_warning_issued = True
+                    state.compacted_input.append(memory_message)
+                    state.processed_message_ids.add(message_id(memory_message))
+                    state.memory_warning_issued = True
 
                 # return
-                return list(compacted_input), None
+                return list(state.compacted_input), None
 
     class _CompactHandler:
         async def compact_input(

--- a/tests/agent/test_agent_compaction.py
+++ b/tests/agent/test_agent_compaction.py
@@ -310,3 +310,26 @@ def test_compaction_event_emitted() -> None:
     assert event.metadata is not None
     assert "strategy" in event.metadata
     assert event.metadata["strategy"] == "CompactionEdit"
+
+
+def test_react_threads_checkpointer_into_compaction() -> None:
+    """React wires the session checkpointer into the compaction handler.
+
+    The handler registers its state under the 'compaction' track key when a
+    strategy is configured, and registers nothing when compaction is off.
+    Guards the one-line threading that the round-trip tests can't see.
+    """
+    from test_helpers.checkpoint import RecordingCheckpointer
+
+    from inspect_ai.agent._react import _agent_compact
+
+    model = get_model("mockllm/model")
+
+    cp = RecordingCheckpointer()
+    compact = _agent_compact(CompactionEdit(threshold=500), [], None, model, cp)
+    assert compact is not None
+    assert "compaction" in cp.callbacks
+
+    cp_off = RecordingCheckpointer()
+    assert _agent_compact(None, [], None, model, cp_off) is None
+    assert "compaction" not in cp_off.callbacks

--- a/tests/model/test_compaction.py
+++ b/tests/model/test_compaction.py
@@ -3,6 +3,7 @@
 from typing import Literal
 
 import pytest
+from test_helpers.checkpoint import RecordingCheckpointer
 
 from inspect_ai._util.citation import UrlCitation
 from inspect_ai._util.content import ContentImage, ContentReasoning, ContentText
@@ -13,7 +14,7 @@ from inspect_ai.model import (
     ChatMessageTool,
     ChatMessageUser,
 )
-from inspect_ai.model._compaction._compaction import compaction
+from inspect_ai.model._compaction._compaction import _CompactionState, compaction
 from inspect_ai.model._compaction.edit import CompactionEdit
 from inspect_ai.model._compaction.memory import MEMORY_TOOL
 from inspect_ai.model._compaction.summary import CompactionSummary
@@ -21,7 +22,7 @@ from inspect_ai.model._compaction.trim import CompactionTrim
 from inspect_ai.model._model import Model, get_model
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.model._trim import partition_messages, strip_citations
-from inspect_ai.tool import ToolInfo
+from inspect_ai.tool import ToolCall, ToolInfo
 
 
 class ConsecutiveUserCompaction(CompactionSummary):
@@ -1334,3 +1335,99 @@ async def test_baseline_shortcut_trips_only_with_redacted_reasoning_correction(
         f"flag on: baseline + redacted_reasoning_tokens should exceed threshold "
         f"and trigger compaction; expected fewer than {n_in} messages, got {n_out}"
     )
+
+
+# ==============================================================================
+# Checkpointing support
+# ==============================================================================
+async def test_checkpoint_state_survives_round_trip() -> None:
+    """Handler state serializes and restores faithfully on resume.
+
+    The edit strategy replaces the tool result with a synthesized
+    "(Tool result removed)" message that has its own id, absent from the
+    full history. Such messages live only in `compacted_input`, so they
+    can't be rebuilt from the tracked `messages` by id — the state must be
+    persisted in full and survive the JSON round-trip intact.
+    """
+    model = get_model("mockllm/model")
+    strategy = CompactionEdit(threshold=300, keep_tool_uses=0)
+    prefix: list[ChatMessage] = [system_msg("S", "sys1")]
+
+    tool_call = ToolCall(id="t1", function="bash", arguments={"command": "A" * 200})
+    messages: list[ChatMessage] = [
+        system_msg("S", "sys1"),
+        user_msg("Question", "msg1"),
+        ChatMessageAssistant(content="Using tool", id="msg2", tool_calls=[tool_call]),
+        ChatMessageTool(
+            content="B" * 200, tool_call_id="t1", function="bash", id="msg3"
+        ),
+        user_msg("Follow up", "msg4"),
+        assistant_msg("Done", "msg5"),
+    ]
+
+    cp = RecordingCheckpointer()
+    compact = compaction(
+        strategy, prefix=prefix, tools=None, model=model, checkpointer=cp
+    )
+    # force=True so the edit runs deterministically (content is under threshold)
+    await compact.compact_input(messages, force=True)
+
+    snap = cp.callbacks["compaction"]()
+    assert isinstance(snap, _CompactionState)
+    assert snap.processed_message_ids  # state was captured
+
+    # compacted_input contains a synthesized message whose id is NOT in the
+    # full history — proof it can't be reconstructed from ids and must be
+    # serialized in full.
+    history_ids = {m.id for m in messages}
+    novel = [m for m in snap.compacted_input if m.id not in history_ids]
+    assert novel, "expected edit strategy to introduce a message absent from history"
+
+    # round-trip through JSON exactly as the checkpointer would, then resume
+    restored = _CompactionState.model_validate(snap.model_dump(mode="json"))
+    cp2 = RecordingCheckpointer(restored={"compaction": restored})
+    compaction(strategy, prefix=prefix, tools=None, model=model, checkpointer=cp2)
+    snap2 = cp2.callbacks["compaction"]()
+
+    assert snap2 == snap  # synthesized content and bookkeeping intact across resume
+
+
+async def test_resumed_compaction_does_not_resummarize() -> None:
+    """A resumed summary handler skips re-summarizing already-processed history.
+
+    Without restored state the resumed handler treats the whole history as
+    unprocessed and re-invokes the model; with it, the prior compacted view
+    is honored and no compaction runs.
+    """
+    model = get_model("mockllm/model")
+    strategy = CompactionSummary(threshold=200)
+    prefix: list[ChatMessage] = [system_msg("S", "sys1")]
+    # large enough to exceed threshold and trigger a summary on the first pass
+    messages: list[ChatMessage] = [
+        system_msg("S", "sys1"),
+        user_msg("A" * 800, "u1", source="input"),
+        assistant_msg("B" * 800, "a1"),
+        user_msg("C" * 800, "u2"),
+    ]
+
+    cp = RecordingCheckpointer()
+    compact = compaction(
+        strategy, prefix=prefix, tools=None, model=model, checkpointer=cp
+    )
+    _, summary1 = await compact.compact_input(messages)
+    assert summary1 is not None  # first pass summarized
+    # the agent appends the summary to the full history
+    history: list[ChatMessage] = messages + [summary1]
+
+    snap = cp.callbacks["compaction"]()
+    assert isinstance(snap, _CompactionState)
+    restored = _CompactionState.model_validate(snap.model_dump(mode="json"))
+
+    cp2 = RecordingCheckpointer(restored={"compaction": restored})
+    compact2 = compaction(
+        strategy, prefix=prefix, tools=None, model=model, checkpointer=cp2
+    )
+    # everything in `history` was processed before the fire, so the resumed
+    # handler must not re-summarize.
+    _, summary2 = await compact2.compact_input(history)
+    assert summary2 is None

--- a/tests/test_helpers/checkpoint.py
+++ b/tests/test_helpers/checkpoint.py
@@ -1,0 +1,58 @@
+"""Lightweight checkpointer test doubles."""
+
+import contextlib
+from collections.abc import AsyncIterator, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+@contextlib.asynccontextmanager
+async def _noop_span() -> AsyncIterator[None]:
+    yield
+
+
+class RecordingCheckpointer:
+    """Minimal in-memory `Checkpointer` for tests.
+
+    Records the callbacks registered via `track()` so a test can fire a
+    snapshot on demand (`cp.callbacks[key]()`), and optionally seeds
+    `restored` state to simulate a resume. All lifecycle methods are inert,
+    so it exercises agent/handler wiring without the real checkpointer's
+    restic/transcript machinery.
+    """
+
+    def __init__(self, restored: dict[str, object] | None = None) -> None:
+        self._restored = restored or {}
+        self.callbacks: dict[str, Callable[[], object]] = {}
+
+    @property
+    def is_resuming(self) -> bool:
+        return bool(self._restored)
+
+    async def tick(self) -> None:
+        return None
+
+    async def checkpoint(self) -> None:
+        return None
+
+    def span_session(self) -> contextlib.AbstractAsyncContextManager[None]:
+        return _noop_span()
+
+    def track(
+        self,
+        key: str,
+        callback: Callable[[], T],
+        initial_value: T,
+        *,
+        value_type: type[T] | None = None,
+    ) -> T:
+        self.callbacks[key] = callback
+        if key not in self._restored:
+            return initial_value
+        restored = self._restored[key]
+        assert isinstance(restored, type(initial_value)), (
+            f"restored {key!r} is {type(restored).__name__}, "
+            f"expected {type(initial_value).__name__}"
+        )
+        return restored


### PR DESCRIPTION
## Change

- **`CompactionState`** (new Pydantic model in `_compaction/types.py`) holds the five mutable closure fields.
- **`compaction()`** gains a `checkpointer` param which is used to retain state under a `"compaction"` track key and applies the restored value back into its closure locals — so the state is captured at each fire and rehydrated on resume.
- **react** threads `cp` through `_agent_compact` → `create_compaction(checkpointer=...)` in both `execute` bodies.

`compacted_input` is serialized in full (not as IDs) because edit/summary strategies produce messages absent from the tracked `"messages"` history, so ID-based reconstruction isn't possible.

## Tests

Two integration tests in `tests/checkpoint/test_checkpointer.py` using the real `_EnteredCheckpointer` harness:

- `test_compaction_state_round_trips_through_fire` — `CompactionState` survives a fire → resume cycle and restores identically.
- `test_resumed_compaction_does_not_resummarize` — a resumed summary handler skips re-invoking the model on already-processed history (discriminating: the assertion fails under the pre-fix behavior).
