### PR TITLE
Retry stale S3 write signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - ACP: Substitute `{{param}}` placeholders in tool-call views.
 - ACP: Keep the optimistic `user · queued` chip visible when agents are idle mid-turn.
 - Limits: Fix a spurious, mislabeled `working` limit event recorded alongside the real one when a message/token/cost limit is hit inside a sandboxed agent bridge (e.g. `claude_code`).
+- S3: Retry when requests have stale signatures
 - Inspect View: Improve model event rendering - add INFO tab (usage + stop reason) and a Stop Reason display
 - Inspect View: Fix: stop VirtualList from fighting deep-link scroll in WebKit
 - Inspect View: Fix: collapse the timeline by default when only main + scoring lanes exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- S3: Retry when requests have stale signatures.
+
 ## 0.3.238 (08 June 2026)
 
 - Transcript: Continue using the realtime sample buffer database when WAL journal mode cannot be enabled.
@@ -5,7 +9,6 @@
 - ACP: Substitute `{{param}}` placeholders in tool-call views.
 - ACP: Keep the optimistic `user · queued` chip visible when agents are idle mid-turn.
 - Limits: Fix a spurious, mislabeled `working` limit event recorded alongside the real one when a message/token/cost limit is hit inside a sandboxed agent bridge (e.g. `claude_code`).
-- S3: Retry when requests have stale signatures
 - Inspect View: Improve model event rendering - add INFO tab (usage + stop reason) and a Stop Reason display
 - Inspect View: Fix: stop VirtualList from fighting deep-link scroll in WebKit
 - Inspect View: Fix: collapse the timeline by default when only main + scoring lanes exist

--- a/src/inspect_ai/_util/asyncfiles.py
+++ b/src/inspect_ai/_util/asyncfiles.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import functools
 import io
+import logging
 import shutil
 from contextlib import AbstractAsyncContextManager
 from contextvars import ContextVar
@@ -15,6 +16,15 @@ import anyio
 import anyio.to_thread
 from anyio import AsyncFile, EndOfStream, open_file
 from anyio.abc import ByteReceiveStream
+from botocore.exceptions import ClientError
+from tenacity import (
+    AsyncRetrying,
+    RetryCallState,
+    retry_if_exception,
+    stop_after_attempt,
+    stop_after_delay,
+    wait_exponential_jitter,
+)
 from typing_extensions import TYPE_CHECKING, override
 
 if TYPE_CHECKING:
@@ -22,7 +32,10 @@ if TYPE_CHECKING:
     from boto3.s3.transfer import TransferConfig
 
 from inspect_ai._util._async import current_async_backend
+from inspect_ai._util.constants import HTTP
 from inspect_ai._util.file import FileInfo, file, filesystem, local_path
+
+logger = logging.getLogger(__name__)
 
 
 class _BytesByteReceiveStream(ByteReceiveStream):
@@ -287,15 +300,19 @@ class AsyncFilesystem(AbstractAsyncContextManager["AsyncFilesystem"]):
     async def write_file(self, filename: str, content: bytes) -> None:
         if is_s3_filename(filename):
             bucket, key = s3_bucket_and_key(filename)
-            if current_async_backend() == "asyncio":
-                client = await self.s3_client_async()
-                await client.upload_fileobj(
-                    Fileobj=io.BytesIO(content), Bucket=bucket, Key=key
-                )
-            else:
-                await anyio.to_thread.run_sync(
-                    s3_write_file, self.s3_client(), bucket, key, content
-                )
+
+            async def do_put() -> None:
+                if current_async_backend() == "asyncio":
+                    client = await self.s3_client_async()
+                    await client.upload_fileobj(
+                        Fileobj=io.BytesIO(content), Bucket=bucket, Key=key
+                    )
+                else:
+                    await anyio.to_thread.run_sync(
+                        s3_write_file, self.s3_client(), bucket, key, content
+                    )
+
+            await _s3_put_with_retry(do_put, location=filename)
         else:
             with file(filename, "wb") as f:
                 f.write(content)
@@ -313,22 +330,41 @@ class AsyncFilesystem(AbstractAsyncContextManager["AsyncFilesystem"]):
         """
         if is_s3_filename(filename):
             bucket, key = s3_bucket_and_key(filename)
-            if current_async_backend() == "asyncio":
-                client = await self.s3_client_async()
-                await client.upload_fileobj(
-                    Fileobj=source,
-                    Bucket=bucket,
-                    Key=key,
-                    Config=_s3_transfer_config(),
-                )
+
+            try:
+                # Only retry streams we can replay exactly from their current offset.
+                # Non-seekable streams use one upload attempt because a retry after a
+                # partial read could otherwise write a truncated object.
+                start = source.tell() if source.seekable() else None
+                if start is not None:
+                    source.seek(start)
+            except (AttributeError, OSError):
+                start = None
+
+            async def do_put() -> None:
+                if start is not None:
+                    source.seek(start)
+                if current_async_backend() == "asyncio":
+                    client = await self.s3_client_async()
+                    await client.upload_fileobj(
+                        Fileobj=source,
+                        Bucket=bucket,
+                        Key=key,
+                        Config=_s3_transfer_config(),
+                    )
+                else:
+                    await anyio.to_thread.run_sync(
+                        s3_write_file_streaming,
+                        self.s3_client(),
+                        bucket,
+                        key,
+                        source,
+                    )
+
+            if start is None:
+                await do_put()
             else:
-                await anyio.to_thread.run_sync(
-                    s3_write_file_streaming,
-                    self.s3_client(),
-                    bucket,
-                    key,
-                    source,
-                )
+                await _s3_put_with_retry(do_put, location=filename)
         else:
             with file(
                 filename, "wb", fs_options={"block_size": _FSSPEC_WRITE_BLOCK_SIZE}
@@ -602,6 +638,52 @@ def s3_write_file_streaming(s3: Any, bucket: str, key: str, source: BinaryIO) ->
     s3.upload_fileobj(
         Fileobj=source, Bucket=bucket, Key=key, Config=_s3_transfer_config()
     )
+
+
+def _is_stale_signature_error(ex: BaseException) -> bool:
+    return (
+        isinstance(ex, ClientError)
+        and ex.response.get("Error", {}).get("Code") == "RequestTimeTooSkewed"
+    )
+
+
+def _log_s3_retry_attempt(location: str) -> Callable[[RetryCallState], None]:
+    def log_attempt(retry_state: RetryCallState) -> None:
+        from inspect_ai._util.retry import report_http_retry, sample_context_prefix
+
+        ex = retry_state.outcome.exception() if retry_state.outcome else None
+        request_id = ""
+        if isinstance(ex, ClientError):
+            request_id = ex.response.get("ResponseMetadata", {}).get("RequestId", "")
+
+        report_http_retry("transient")
+        logger.log(
+            HTTP,
+            "%sS3 write to %s hit RequestTimeTooSkewed on attempt %d; "
+            "retrying in %.0fs (request id %s)",
+            sample_context_prefix(),
+            location,
+            retry_state.attempt_number,
+            retry_state.upcoming_sleep,
+            request_id or "unknown",
+        )
+
+    return log_attempt
+
+
+async def _s3_put_with_retry(
+    do_put: Callable[[], Coroutine[Any, Any, None]], *, location: str
+) -> None:
+    async for attempt in AsyncRetrying(
+        retry=retry_if_exception(_is_stale_signature_error),
+        wait=wait_exponential_jitter(),
+        stop=stop_after_attempt(5) | stop_after_delay(60),
+        sleep=anyio.sleep,
+        before_sleep=_log_s3_retry_attempt(location),
+        reraise=True,
+    ):
+        with attempt:
+            await do_put()
 
 
 def s3_get_file(s3: Any, bucket: str, key: str, filename: str) -> None:

--- a/tests/util/test_asyncfiles.py
+++ b/tests/util/test_asyncfiles.py
@@ -2,9 +2,11 @@ import asyncio
 import io
 import tempfile
 from pathlib import Path
+from typing import Any, cast
 
 import pytest
 from anyio import EndOfStream
+from botocore.exceptions import ClientError
 
 from inspect_ai._util._async import run_coroutine, tg_collect
 from inspect_ai._util.asyncfiles import (
@@ -397,6 +399,151 @@ def test_write_file_streaming_s3(mock_s3: None) -> None:
             assert result == test_data
 
     asyncio.run(run())
+
+
+class _RetryingUploadClient:
+    def __init__(self) -> None:
+        self.calls = 0
+        self.uploaded: list[bytes] = []
+
+    def upload_fileobj_sync(
+        self, Fileobj: Any, Bucket: str, Key: str, **kwargs: Any
+    ) -> None:
+        self.calls += 1
+        data = Fileobj.read()
+        if self.calls == 1:
+            raise ClientError(
+                cast(
+                    Any,
+                    {
+                        "Error": {"Code": "RequestTimeTooSkewed", "Message": "skewed"},
+                        "ResponseMetadata": {"RequestId": "request-1"},
+                    },
+                ),
+                "PutObject",
+            )
+        self.uploaded.append(data)
+
+    async def upload_fileobj(
+        self, Fileobj: Any, Bucket: str, Key: str, **kwargs: Any
+    ) -> None:
+        self.upload_fileobj_sync(Fileobj, Bucket, Key, **kwargs)
+
+
+class _FailingUploadClient:
+    def __init__(self, code: str) -> None:
+        self.code = code
+        self.calls = 0
+
+    def upload_fileobj_sync(
+        self, Fileobj: Any, Bucket: str, Key: str, **kwargs: Any
+    ) -> None:
+        self.calls += 1
+        Fileobj.read()
+        raise ClientError(
+            cast(
+                Any,
+                {
+                    "Error": {"Code": self.code, "Message": self.code},
+                    "ResponseMetadata": {"RequestId": "request-1"},
+                },
+            ),
+            "PutObject",
+        )
+
+    async def upload_fileobj(
+        self, Fileobj: Any, Bucket: str, Key: str, **kwargs: Any
+    ) -> None:
+        self.upload_fileobj_sync(Fileobj, Bucket, Key, **kwargs)
+
+
+class _SyncUploadClient:
+    def __init__(self, client: Any) -> None:
+        self._client = client
+
+    def upload_fileobj(
+        self, Fileobj: Any, Bucket: str, Key: str, **kwargs: Any
+    ) -> None:
+        self._client.upload_fileobj_sync(Fileobj, Bucket, Key, **kwargs)
+
+
+class _NonSeekableBytesIO(io.BytesIO):
+    def seekable(self) -> bool:
+        return False
+
+
+async def test_write_file_streaming_s3_retries_stale_signature_from_start(
+    monkeypatch,
+):
+    client = _RetryingUploadClient()
+
+    async def s3_client_async(self):
+        return client
+
+    def s3_client(self):
+        return _SyncUploadClient(client)
+
+    async def no_sleep(seconds: float) -> None:
+        pass
+
+    monkeypatch.setattr(AsyncFilesystem, "s3_client_async", s3_client_async)
+    monkeypatch.setattr(AsyncFilesystem, "s3_client", s3_client)
+    monkeypatch.setattr("inspect_ai._util.asyncfiles.anyio.sleep", no_sleep)
+
+    content = b"full eval log contents"
+    async with AsyncFilesystem() as fs:
+        await fs.write_file_streaming("s3://bucket/path/log.eval", io.BytesIO(content))
+
+    assert client.calls == 2
+    assert client.uploaded == [content]
+
+
+async def test_write_file_streaming_s3_does_not_retry_non_seekable_source(
+    monkeypatch,
+):
+    client = _FailingUploadClient("RequestTimeTooSkewed")
+
+    async def s3_client_async(self):
+        return client
+
+    def s3_client(self):
+        return _SyncUploadClient(client)
+
+    monkeypatch.setattr(AsyncFilesystem, "s3_client_async", s3_client_async)
+    monkeypatch.setattr(AsyncFilesystem, "s3_client", s3_client)
+
+    async with AsyncFilesystem() as fs:
+        with pytest.raises(ClientError) as exc_info:
+            await fs.write_file_streaming(
+                "s3://bucket/path/log.eval", _NonSeekableBytesIO(b"contents")
+            )
+
+    assert exc_info.value.response["Error"]["Code"] == "RequestTimeTooSkewed"
+    assert client.calls == 1
+
+
+async def test_write_file_streaming_s3_does_not_retry_non_retryable_error(
+    monkeypatch,
+):
+    client = _FailingUploadClient("AccessDenied")
+
+    async def s3_client_async(self):
+        return client
+
+    def s3_client(self):
+        return _SyncUploadClient(client)
+
+    monkeypatch.setattr(AsyncFilesystem, "s3_client_async", s3_client_async)
+    monkeypatch.setattr(AsyncFilesystem, "s3_client", s3_client)
+
+    async with AsyncFilesystem() as fs:
+        with pytest.raises(ClientError) as exc_info:
+            await fs.write_file_streaming(
+                "s3://bucket/path/log.eval", io.BytesIO(b"contents")
+            )
+
+    assert exc_info.value.response["Error"]["Code"] == "AccessDenied"
+    assert client.calls == 1
 
 
 # =============================================================================


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Long-running evals can fail during S3 log writes if S3 rejects an aged request signature with `RequestTimeTooSkewed`. The existing botocore adaptive retry policy handles common transient S3 failures, but it does not retry this code, so a single stale signature can propagate out of final log flush.

We have seen this fail in production at least once.

### What is the new behavior?

Inspect retries S3 writes only for exact `RequestTimeTooSkewed` failures, rebuilding the request so it gets a fresh signature. Streaming writes retry only when the source is seekable and reset to the original offset before each attempt, avoiding truncated uploads after a partial failed attempt.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Draft while CI runs.