### PR TITLE
misc fixes discovered during claude_code acp testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 ## Unreleased
 
-- Transcript: Continue using the realtime sample buffer database when WAL journal mode cannot be enabled, warning once and falling back to the current journal mode.
 - Transcript: Continue using the realtime sample buffer database when WAL journal mode cannot be enabled.
 - ACP: Render tool calls for agent-bridge agents (e.g. `claude_code`, `codex_cli`). 
+- ACP: Substitute `{{param}}` placeholders in tool-call views.
+- ACP: Keep the optimistic `user · queued` chip visible when agents are idle mid-turn.
+- Limits: Fix a spurious, mislabeled `working` limit event recorded alongside the real one when a message/token/cost limit is hit inside a sandboxed agent bridge (e.g. `claude_code`).
 - Inspect View: Improve model event rendering - add INFO tab (usage + stop reason) and a Stop Reason display
 - Inspect View: Fix: stop VirtualList from fighting deep-link scroll in WebKit
 - Inspect View: Fix: collapse the timeline by default when only main + scoring lanes exist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - ACP: Render tool calls for agent-bridge agents (e.g. `claude_code`, `codex_cli`). 
 - ACP: Substitute `{{param}}` placeholders in tool-call views.
 - ACP: Keep the optimistic `user · queued` chip visible when agents are idle mid-turn.
+- ACP: Preserve `operator` provenance for user messages a bridged agent round-trips through its own store.
 - Limits: Fix a spurious, mislabeled `working` limit event recorded alongside the real one when a message/token/cost limit is hit inside a sandboxed agent bridge (e.g. `claude_code`).
 - Inspect View: Improve model event rendering - add INFO tab (usage + stop reason) and a Stop Reason display
 - Inspect View: Fix: stop VirtualList from fighting deep-link scroll in WebKit

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1154,22 +1154,32 @@ async def task_run_sample(
                                                 error, raise_error = handle_error(ex)
 
                                     elif active.limit_exceeded_error:
-                                        # record event
-                                        transcript()._event(
-                                            SampleLimitEvent(
-                                                type="working",
-                                                message=active.limit_exceeded_error.message,
-                                                limit=active.limit_exceeded_error.limit,
+                                        err = active.limit_exceeded_error
+                                        # Record a SampleLimitEvent ONLY for a working-time
+                                        # limit. `sample.limit_exceeded()` (which set
+                                        # `limit_exceeded_error` and cancelled us) has two
+                                        # callers: monitor_working_limit(), which records no
+                                        # event of its own — so here we are its sole recorder
+                                        # — and the sandbox service, which surfaces a bridged
+                                        # message/token/cost limit that ALREADY recorded its
+                                        # own event at its detection point (e.g.
+                                        # check_message_limit). Recording the latter here would
+                                        # both duplicate that event and mislabel it "working".
+                                        if err.type == "working":
+                                            transcript()._event(
+                                                SampleLimitEvent(
+                                                    type=err.type,
+                                                    message=err.message,
+                                                    limit=err.limit,
+                                                )
                                             )
-                                        )
 
                                         # capture most recent state for scoring
                                         state = sample_state() or state
                                         limit = EvalSampleLimit(
-                                            type=active.limit_exceeded_error.type,
-                                            limit=active.limit_exceeded_error.limit
-                                            if active.limit_exceeded_error.limit
-                                            is not None
+                                            type=err.type,
+                                            limit=err.limit
+                                            if err.limit is not None
                                             else -1,
                                         )
 

--- a/src/inspect_ai/agent/_acp/event_mapping.py
+++ b/src/inspect_ai/agent/_acp/event_mapping.py
@@ -520,14 +520,19 @@ def _user_message_text(msg: ChatMessageUser | ChatMessageSystem) -> str:
     is a follow-on alongside the message widget's image content-block
     handling.
     """
+    # Strip outer whitespace: a bridged scaffold may re-emit an operator
+    # message with cosmetic leading/trailing whitespace (e.g. Claude Code
+    # prepends a newline on ``--resume``), which would otherwise render as a
+    # blank line above the message body. Display-only — the stored
+    # ChatMessageUser content is left untouched.
     content = msg.content
     if isinstance(content, str):
-        return content
+        return content.strip()
     parts: list[str] = []
     for block in content:
         if isinstance(block, ContentText) and block.text:
             parts.append(block.text)
-    return "\n".join(parts)
+    return "\n".join(parts).strip()
 
 
 def _map_model_event(

--- a/src/inspect_ai/agent/_acp/tool_content.py
+++ b/src/inspect_ai/agent/_acp/tool_content.py
@@ -40,7 +40,7 @@ from inspect_ai._util.url import (
     is_http_url,
 )
 from inspect_ai.event._tool import ToolEvent
-from inspect_ai.tool._tool_call import ToolCallContent
+from inspect_ai.tool._tool_call import ToolCallContent, substitute_tool_call_content
 
 # Built-in Inspect tool name → ACP ``ToolKind`` mapping. The kind
 # is what tells the editor "render this row with a file icon" vs
@@ -262,8 +262,20 @@ def content_blocks_from_view(
 
 
 def _content_from_view(event: ToolEvent) -> list[ContentToolCallContent] | None:
-    """ToolEvent-flavored adapter around :func:`content_blocks_from_view`."""
-    return content_blocks_from_view(event.view)
+    """ToolEvent-flavored adapter around :func:`content_blocks_from_view`.
+
+    Substitutes ``{{param}}`` placeholders in the view from the call's
+    ``arguments`` first. Tool viewers emit placeholders (e.g. ``{{content}}``
+    in the Write card) that the web viewer fills in via
+    ``substituteToolCallContent`` (``tool.ts``); the ACP path must do the same
+    or editors/TUI render the literal ``{{content}}``. This covers both real
+    ``ToolEvent``s and the synthesized bridged tool cards (claude_code/codex),
+    which both flow through here via ``_content_for_start`` / ``_content_for_update``.
+    """
+    view = event.view
+    if view is not None:
+        view = substitute_tool_call_content(view, event.arguments)
+    return content_blocks_from_view(view)
 
 
 # Cap result-as-content payloads so a multi-megabyte tool output

--- a/src/inspect_ai/agent/_acp/transport.py
+++ b/src/inspect_ai/agent/_acp/transport.py
@@ -37,6 +37,7 @@ from typing import (
 
 from anyio.streams.memory import MemoryObjectReceiveStream
 
+from inspect_ai._util.content import ContentText
 from inspect_ai.model._chat_message import ChatMessageUser
 
 if TYPE_CHECKING:
@@ -723,6 +724,28 @@ async def acp_session() -> AsyncIterator[AcpTransport]:
         finally:
             _acp_var.reset(token_var)
             _acp_live_active.reset(token_live)
+
+
+def operator_text_candidates(message: ChatMessageUser) -> set[str]:
+    """Whitespace-normalized texts a round-tripped operator message could match on.
+
+    A bridged scaffold (claude_code, codex, …) re-emits an operator
+    intervention through its own conversation store, and Claude Code in
+    particular returns the user turn as MULTIPLE ``ContentText`` blocks —
+    ``<system-reminder>`` / skills content as their own blocks alongside the
+    operator's actual text as a separate block. So the whole-message
+    ``.text`` (which concatenates all blocks) never equals the submitted
+    operator text. Match against the individual blocks as well: the candidate
+    set is the stripped whole ``.text`` (handles ``str`` content) plus each
+    ``ContentText`` block's stripped text. Empty strings are dropped.
+    """
+    candidates = {message.text.strip()}
+    content = message.content
+    if not isinstance(content, str):
+        for block in content:
+            if isinstance(block, ContentText):
+                candidates.add(block.text.strip())
+    return {candidate for candidate in candidates if candidate}
 
 
 def current_acp_transport() -> AcpTransport:

--- a/src/inspect_ai/agent/_acp/transport.py
+++ b/src/inspect_ai/agent/_acp/transport.py
@@ -278,6 +278,21 @@ class AcpTransport(Protocol):
         """
         ...
 
+    def consume_operator_message(self, message: ChatMessageUser) -> bool:
+        """Pop ``message`` from the set of operator messages awaiting recognition.
+
+        Lets the agent bridge restore ``source="operator"`` the first time a
+        bridged scaffold's round-tripped copy of an operator intervention
+        re-enters — the scaffold (claude_code, codex, …) re-emits the message
+        through its own conversation store (e.g. Claude Code's ``--resume``)
+        as a plain ``ChatMessageUser`` with no source. Implementations match
+        (and remove, one-shot) against the messages seen by
+        :meth:`submit_user_message`; the bridge carries provenance forward on
+        later turns from its own tracked conversation, so this stays bounded
+        by in-flight submissions. The no-op session always returns False.
+        """
+        ...
+
     def cancel_current_turn(
         self,
         cause: Literal["user_cancel", "limit", "system"] = "user_cancel",

--- a/src/inspect_ai/agent/_acp/transport.py
+++ b/src/inspect_ai/agent/_acp/transport.py
@@ -37,7 +37,6 @@ from typing import (
 
 from anyio.streams.memory import MemoryObjectReceiveStream
 
-from inspect_ai._util.content import ContentText
 from inspect_ai.model._chat_message import ChatMessageUser
 
 if TYPE_CHECKING:
@@ -279,18 +278,27 @@ class AcpTransport(Protocol):
         """
         ...
 
-    def consume_operator_message(self, message: ChatMessageUser) -> bool:
-        """Pop ``message`` from the set of operator messages awaiting recognition.
+    @property
+    def pending_operator_count(self) -> int:
+        """Number of operator messages submitted but not yet recognized.
 
-        Lets the agent bridge restore ``source="operator"`` the first time a
-        bridged scaffold's round-tripped copy of an operator intervention
-        re-enters — the scaffold (claude_code, codex, …) re-emits the message
-        through its own conversation store (e.g. Claude Code's ``--resume``)
-        as a plain ``ChatMessageUser`` with no source. Implementations match
-        (and remove, one-shot) against the messages seen by
-        :meth:`submit_user_message`; the bridge carries provenance forward on
-        later turns from its own tracked conversation, so this stays bounded
-        by in-flight submissions. The no-op session always returns False.
+        Incremented by :meth:`submit_user_message`. The agent bridge reads
+        this to restore ``source="operator"`` when an operator intervention
+        round-trips back through a bridged scaffold (claude_code, codex, …)
+        as a plain ``ChatMessageUser`` with no source — the scaffold re-emits
+        it through its own conversation store (e.g. Claude Code's
+        ``--resume``). A positive count gates stamping the just-arrived user
+        turn as operator; the bridge then calls :meth:`clear_pending_operators`
+        to consume it. The no-op session always returns 0.
+        """
+        ...
+
+    def clear_pending_operators(self) -> None:
+        """Reset :attr:`pending_operator_count` to 0.
+
+        Called by the bridge once it has recognized the arrived operator turn
+        (one coalesced turn represents every queued submission). The no-op
+        session does nothing.
         """
         ...
 
@@ -724,28 +732,6 @@ async def acp_session() -> AsyncIterator[AcpTransport]:
         finally:
             _acp_var.reset(token_var)
             _acp_live_active.reset(token_live)
-
-
-def operator_text_candidates(message: ChatMessageUser) -> set[str]:
-    """Whitespace-normalized texts a round-tripped operator message could match on.
-
-    A bridged scaffold (claude_code, codex, …) re-emits an operator
-    intervention through its own conversation store, and Claude Code in
-    particular returns the user turn as MULTIPLE ``ContentText`` blocks —
-    ``<system-reminder>`` / skills content as their own blocks alongside the
-    operator's actual text as a separate block. So the whole-message
-    ``.text`` (which concatenates all blocks) never equals the submitted
-    operator text. Match against the individual blocks as well: the candidate
-    set is the stripped whole ``.text`` (handles ``str`` content) plus each
-    ``ContentText`` block's stripped text. Empty strings are dropped.
-    """
-    candidates = {message.text.strip()}
-    content = message.content
-    if not isinstance(content, str):
-        for block in content:
-            if isinstance(block, ContentText):
-                candidates.add(block.text.strip())
-    return {candidate for candidate in candidates if candidate}
 
 
 def current_acp_transport() -> AcpTransport:

--- a/src/inspect_ai/agent/_acp/transport_live.py
+++ b/src/inspect_ai/agent/_acp/transport_live.py
@@ -41,6 +41,7 @@ from inspect_ai.agent._acp.transport import (
     AcpUpdate,
     ApproverClient,
     ElicitationClient,
+    operator_text_candidates,
 )
 from inspect_ai.log._transcript import transcript
 from inspect_ai.model._chat_message import (
@@ -1052,12 +1053,15 @@ class LiveAcpTransport:
         recognition the bridge carries operator provenance forward from its
         own tracked conversation, so this set stays bounded by in-flight
         submissions rather than growing without bound. Matches on
-        whitespace-normalized text.
+        whitespace-normalized text, per ``ContentText`` block (Claude Code
+        re-emits the operator turn as its own block alongside reminder /
+        skills blocks, so the concatenated ``.text`` would never match) —
+        see :func:`operator_text_candidates`.
         """
-        text = message.text.strip()
-        if text in self._pending_operator_texts:
-            self._pending_operator_texts.discard(text)
-            return True
+        for candidate in operator_text_candidates(message):
+            if candidate in self._pending_operator_texts:
+                self._pending_operator_texts.discard(candidate)
+                return True
         return False
 
     @property

--- a/src/inspect_ai/agent/_acp/transport_live.py
+++ b/src/inspect_ai/agent/_acp/transport_live.py
@@ -593,6 +593,18 @@ class LiveAcpTransport:
         # (drivable). Named ``_attachable_override`` for historical
         # reasons; it governs the interactivity axis.
         self._attachable_override: bool | None = None
+        # Normalized text of operator-submitted user messages awaiting first
+        # recognition by the bridge. A bridged scaffold (claude_code, codex,
+        # …) round-trips operator interventions through its own conversation
+        # store (e.g. Claude Code's ``--resume``), so the message re-enters
+        # the bridge as a plain ``ChatMessageUser`` (``source=None``),
+        # losing the provenance stamped at submit time. ``bridge_generate``
+        # re-stamps it the FIRST time it re-enters (via
+        # :meth:`consume_operator_message`, which pops the match) and
+        # thereafter carries the source forward from the bridge's tracked
+        # conversation — so this set holds only in-flight, not-yet-seen
+        # submissions, never a permanent, ever-growing ledger.
+        self._pending_operator_texts: set[str] = set()
 
     @property
     def session_id(self) -> str:
@@ -1017,11 +1029,36 @@ class LiveAcpTransport:
         with acp_guard("ACP submit_user_message raised; message dropped"):
             if msg.source != "operator":
                 msg = msg.model_copy(update={"source": "operator"})
+            # Mark the text pending recognition so a bridged scaffold's
+            # round-tripped copy (which loses ``source``) can be re-stamped
+            # operator the first time it re-enters ``bridge_generate``.
+            # Normalized (stripped) to tolerate cosmetic whitespace the
+            # scaffold may add on re-emit.
+            op_text = msg.text.strip()
+            if op_text:
+                self._pending_operator_texts.add(op_text)
             self._interrupt.resolve_if_pending()
             if self._ref is not None:
                 from inspect_ai.agent._channel import UserMessage as _ChannelUserMessage
 
                 self._ref.post(_ChannelUserMessage(message=msg))
+
+    def consume_operator_message(self, message: ChatMessageUser) -> bool:
+        """Pop ``message`` from the pending operator-submission set.
+
+        Returns True (and removes the entry) iff ``message`` matches an
+        operator message submitted via :meth:`submit_user_message` that the
+        bridge hasn't recognized yet. One-shot by design: after first
+        recognition the bridge carries operator provenance forward from its
+        own tracked conversation, so this set stays bounded by in-flight
+        submissions rather than growing without bound. Matches on
+        whitespace-normalized text.
+        """
+        text = message.text.strip()
+        if text in self._pending_operator_texts:
+            self._pending_operator_texts.discard(text)
+            return True
+        return False
 
     @property
     def interrupt_pending(self) -> bool:

--- a/src/inspect_ai/agent/_acp/transport_live.py
+++ b/src/inspect_ai/agent/_acp/transport_live.py
@@ -41,7 +41,6 @@ from inspect_ai.agent._acp.transport import (
     AcpUpdate,
     ApproverClient,
     ElicitationClient,
-    operator_text_candidates,
 )
 from inspect_ai.log._transcript import transcript
 from inspect_ai.model._chat_message import (
@@ -594,18 +593,18 @@ class LiveAcpTransport:
         # (drivable). Named ``_attachable_override`` for historical
         # reasons; it governs the interactivity axis.
         self._attachable_override: bool | None = None
-        # Normalized text of operator-submitted user messages awaiting first
-        # recognition by the bridge. A bridged scaffold (claude_code, codex,
-        # …) round-trips operator interventions through its own conversation
-        # store (e.g. Claude Code's ``--resume``), so the message re-enters
-        # the bridge as a plain ``ChatMessageUser`` (``source=None``),
-        # losing the provenance stamped at submit time. ``bridge_generate``
-        # re-stamps it the FIRST time it re-enters (via
-        # :meth:`consume_operator_message`, which pops the match) and
-        # thereafter carries the source forward from the bridge's tracked
-        # conversation — so this set holds only in-flight, not-yet-seen
-        # submissions, never a permanent, ever-growing ledger.
-        self._pending_operator_texts: set[str] = set()
+        # Count of operator-submitted user messages awaiting first recognition
+        # by the bridge. A bridged scaffold (claude_code, codex, …) round-trips
+        # operator interventions through its own conversation store (e.g. Claude
+        # Code's ``--resume``), so the message re-enters the bridge as a plain
+        # ``ChatMessageUser`` (``source=None``), losing the provenance stamped
+        # at submit time. ``bridge_generate`` reads this count to gate stamping
+        # the just-arrived user turn as operator, then clears it (one coalesced
+        # turn represents every queued submission); thereafter it carries the
+        # source forward from the bridge's tracked conversation. A bare count
+        # (not a text ledger) means recognition is structural, not content-
+        # matched — robust to the scaffold reformatting / coalescing the turn.
+        self._pending_operator_count: int = 0
 
     @property
     def session_id(self) -> str:
@@ -694,6 +693,13 @@ class LiveAcpTransport:
         """
         if self._ref is ref:
             self._ref = None
+            # Reset pending-operator recognition state on consumer handoff: the
+            # count is only meaningful to the consumer that received the
+            # submissions. A react consumer never calls ``bridge_generate`` to
+            # consume it, so without this a stale count could survive into a
+            # successor (e.g. bridged) consumer bound in the same sample and
+            # mis-stamp an unrelated new user message as operator.
+            self._pending_operator_count = 0
             if self._unsubscribe_drained is not None:
                 self._unsubscribe_drained()
                 self._unsubscribe_drained = None
@@ -837,6 +843,10 @@ class LiveAcpTransport:
         if bound:
             # Split-phase: park the session for the scoring window.
             self._agent_completed = True
+            # No more generations will run, so any operator submission still
+            # pending recognition is stale — drop it so it can't outlive the
+            # agent loop.
+            self._pending_operator_count = 0
             # The interrupt coordinator and approver-client registry only
             # make sense while the agent loop is running; drop their
             # subscribers / clients so a late listener can't fire into a
@@ -1030,39 +1040,34 @@ class LiveAcpTransport:
         with acp_guard("ACP submit_user_message raised; message dropped"):
             if msg.source != "operator":
                 msg = msg.model_copy(update={"source": "operator"})
-            # Mark the text pending recognition so a bridged scaffold's
-            # round-tripped copy (which loses ``source``) can be re-stamped
-            # operator the first time it re-enters ``bridge_generate``.
-            # Normalized (stripped) to tolerate cosmetic whitespace the
-            # scaffold may add on re-emit.
-            op_text = msg.text.strip()
-            if op_text:
-                self._pending_operator_texts.add(op_text)
             self._interrupt.resolve_if_pending()
             if self._ref is not None:
+                # Count this submission pending recognition — but only once it
+                # is actually posted to a bound channel. A message dropped for
+                # lack of a channel never round-trips through a bridge, so it
+                # must not leave a phantom pending count that could later
+                # mis-stamp an unrelated turn. A count (not the text) suffices:
+                # the bridge identifies the operator turn structurally (a newly
+                # arrived user message), tolerating the scaffold reformatting /
+                # coalescing the turn on re-emit.
+                self._pending_operator_count += 1
                 from inspect_ai.agent._channel import UserMessage as _ChannelUserMessage
 
                 self._ref.post(_ChannelUserMessage(message=msg))
 
-    def consume_operator_message(self, message: ChatMessageUser) -> bool:
-        """Pop ``message`` from the pending operator-submission set.
+    @property
+    def pending_operator_count(self) -> int:
+        """Operator submissions awaiting first recognition by the bridge.
 
-        Returns True (and removes the entry) iff ``message`` matches an
-        operator message submitted via :meth:`submit_user_message` that the
-        bridge hasn't recognized yet. One-shot by design: after first
-        recognition the bridge carries operator provenance forward from its
-        own tracked conversation, so this set stays bounded by in-flight
-        submissions rather than growing without bound. Matches on
-        whitespace-normalized text, per ``ContentText`` block (Claude Code
-        re-emits the operator turn as its own block alongside reminder /
-        skills blocks, so the concatenated ``.text`` would never match) —
-        see :func:`operator_text_candidates`.
+        Incremented by :meth:`submit_user_message`; read by
+        ``bridge_generate`` to gate stamping the just-arrived user turn as
+        operator, then zeroed via :meth:`clear_pending_operators`.
         """
-        for candidate in operator_text_candidates(message):
-            if candidate in self._pending_operator_texts:
-                self._pending_operator_texts.discard(candidate)
-                return True
-        return False
+        return self._pending_operator_count
+
+    def clear_pending_operators(self) -> None:
+        """Reset :attr:`pending_operator_count` to 0 (consume all pending)."""
+        self._pending_operator_count = 0
 
     @property
     def interrupt_pending(self) -> bool:

--- a/src/inspect_ai/agent/_acp/transport_noop.py
+++ b/src/inspect_ai/agent/_acp/transport_noop.py
@@ -84,9 +84,14 @@ class NoOpAcpTransport:
         """No-op submit — message is discarded."""
         return None
 
-    def consume_operator_message(self, message: ChatMessageUser) -> bool:
-        """No-op session never has pending operator messages — always False."""
-        return False
+    @property
+    def pending_operator_count(self) -> int:
+        """No-op session never has pending operator messages — always 0."""
+        return 0
+
+    def clear_pending_operators(self) -> None:
+        """No-op session has no pending operator count to clear."""
+        return None
 
     def cancel_current_turn(
         self,

--- a/src/inspect_ai/agent/_acp/transport_noop.py
+++ b/src/inspect_ai/agent/_acp/transport_noop.py
@@ -84,6 +84,10 @@ class NoOpAcpTransport:
         """No-op submit — message is discarded."""
         return None
 
+    def consume_operator_message(self, message: ChatMessageUser) -> bool:
+        """No-op session never has pending operator messages — always False."""
+        return False
+
     def cancel_current_turn(
         self,
         cause: Literal["user_cancel", "limit", "system"] = "user_cancel",

--- a/src/inspect_ai/agent/_acp/tui/session_screen.py
+++ b/src/inspect_ai/agent/_acp/tui/session_screen.py
@@ -1031,12 +1031,27 @@ class SessionScreen(Screen[None]):
         # popped when the server echoes the real chunk back. Subsequent
         # sends-while-busy APPEND to the existing ephemeral (single
         # bucket) so the row matches the server-side coalesced merge
-        # — the user sees exactly what the model will see. Skip while
-        # ``idle``: the agent is parked in ``before_turn`` and the
-        # chunk arrives within ms, so an ephemeral would just flash.
+        # — the user sees exactly what the model will see.
+        #
+        # Shown whenever the session is live (idle / running /
+        # interrupted / approval); suppressed only once the agent loop
+        # is done (``scoring`` / ``complete``), where the server rejects
+        # new prompts anyway (and the send-failure rollback below covers
+        # a racing rejection). We deliberately do NOT skip on ``idle``:
+        # for a bridged agent (claude_code / codex) ``idle`` can occur
+        # mid-turn — during scaffold startup / ``--resume`` relaunch or
+        # an inter-model-call gap — where the message is NOT drained
+        # within ms but waits for the next turn boundary, so the chip is
+        # exactly what the operator needs. For a native agent parked in
+        # ``before_turn`` the message does drain within ms, but the
+        # queued→real swap is atomic (the pop and the real group's
+        # append land in the same ``consume()`` tick — see
+        # ``SessionState._consume_chunk``), so the worst case is a
+        # sub-perceptible dim→solid flicker of the same text, not a
+        # vanish/reappear glitch.
         # See :attr:`state.MessageGroup.is_queued` for the lifecycle.
         handle: _QueuedEnqueueHandle | None = None
-        if self._state.lifecycle != "idle":
+        if self._state.lifecycle not in ("complete", "scoring"):
             handle = self._state.enqueue_queued_user_message(text)
         try:
             await connection.send_request(

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -136,6 +136,52 @@ def _is_model_filter(fn: GenerateFilter) -> TypeIs[ModelGenerateFilter]:
     return result
 
 
+def _restore_operator_message_source(
+    bridge: AgentBridge, input: list[ChatMessage]
+) -> None:
+    """Restore ``source="operator"`` on operator messages re-entering via a bridge.
+
+    A bridged scaffold (claude_code, codex, …) round-trips operator
+    interventions through its own conversation store (e.g. Claude Code's
+    ``--resume``), so an operator message comes back as a plain
+    ``ChatMessageUser`` (``source=None``) — losing the provenance the ACP
+    transport stamped at submit time. Re-stamp it here, at the single bridge
+    generate chokepoint shared by every bridged agent. ``input`` is the same
+    list the caller records as the ``ModelEvent`` input and tracks into
+    ``state.messages``, and messages are mutated in place, so the restored
+    source persists in both the events and the final messages (and the ACP
+    TUI's operator-keyed rendering + queued-echo reconciliation then work
+    without further special-casing).
+
+    Scoped recognition (no global ledger): a message is recognized ONCE, the
+    first time it re-enters — matched against the transport's small set of
+    submitted-but-not-yet-seen operator messages, which is consumed on match.
+    Thereafter the source is carried forward from the bridge's own tracked
+    conversation (``bridge.state.messages``), bounded by the live conversation
+    and pruned with compaction. No match leaves the message untouched.
+    """
+    # Local import to avoid a load-order cycle (_acp imports from _bridge).
+    from inspect_ai.agent._acp.transport import current_acp_transport
+
+    # operator messages already established in the tracked conversation
+    known_operator_text = {
+        message.text.strip()
+        for message in bridge.state.messages
+        if isinstance(message, ChatMessageUser) and message.source == "operator"
+    }
+    transport = current_acp_transport()
+    for message in input:
+        if not isinstance(message, ChatMessageUser) or message.source == "operator":
+            continue
+        # ``consume_operator_message`` first so a still-pending entry is always
+        # cleared; fall back to carry-forward for messages already in state.
+        if (
+            transport.consume_operator_message(message)
+            or message.text.strip() in known_operator_text
+        ):
+            message.source = "operator"
+
+
 async def bridge_generate(
     bridge: AgentBridge,
     model: Model,
@@ -152,6 +198,12 @@ async def bridge_generate(
     retries up to bridge.retry_refusals times, with inputs reset to original values for
     each retry to ensure clean state.
     """
+    # restore operator provenance lost to a bridged scaffold's round-trip
+    # (e.g. claude_code --resume re-emits an operator message as a plain
+    # user message). Done before compaction/recording so the restored
+    # source persists in both the ModelEvent input and state.messages.
+    _restore_operator_message_source(bridge, input)
+
     # get compaction function and run compaction once before retry loop
     compact = bridge.compaction(tools, model)
     if compact is not None:

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -136,10 +136,8 @@ def _is_model_filter(fn: GenerateFilter) -> TypeIs[ModelGenerateFilter]:
     return result
 
 
-def _restore_operator_message_source(
-    bridge: AgentBridge, input: list[ChatMessage]
-) -> None:
-    """Restore ``source="operator"`` on operator messages re-entering via a bridge.
+def _restore_operator_message_source(input: list[ChatMessage]) -> None:
+    """Restore ``source="operator"`` on an operator message re-entering via a bridge.
 
     A bridged scaffold (claude_code, codex, …) round-trips operator
     interventions through its own conversation store (e.g. Claude Code's
@@ -148,45 +146,51 @@ def _restore_operator_message_source(
     transport stamped at submit time. Re-stamp it here, at the single bridge
     generate chokepoint shared by every bridged agent. ``input`` is the same
     list the caller records as the ``ModelEvent`` input and tracks into
-    ``state.messages``, and messages are mutated in place, so the restored
-    source persists in both the events and the final messages (and the ACP
-    TUI's operator-keyed rendering + queued-echo reconciliation then work
-    without further special-casing).
+    ``state.messages``, and the message is mutated in place, so the restored
+    source persists in both the event and the final messages.
 
-    Scoped recognition (no global ledger): a message is recognized ONCE, the
-    first time it re-enters — matched against the transport's small set of
-    submitted-but-not-yet-seen operator messages, which is consumed on match.
-    Thereafter the source is carried forward from the bridge's own tracked
-    conversation (``bridge.state.messages``), bounded by the live conversation
-    and pruned with compaction. No match leaves the message untouched.
+    Recognition is positional, gated on transport ground truth:
+
+    - The transport's pending-operator count is the ONE thing we know for
+      certain — operator messages enter via the ACP channel, so a positive
+      count means an operator was actually submitted (and, by the time the
+      scaffold calls back into ``bridge_generate``, has been resumed into this
+      ``input``). When the count is 0 nothing is stamped, so the task and a
+      history-taking bridge's ordinary multi-message input are never touched.
+    - The operator turn is the LATEST user message: any queued operator submits
+      coalesce into one newline-joined message, and the scaffold never emits a
+      user-role message after it (the task sits at the head behind an assistant
+      turn; a compaction summary likewise sits at the head). So we stamp the
+      last ``ChatMessageUser`` and consume all pending.
+
+    We do NOT re-stamp on later turns: the ACP TUI latches a message's operator
+    provenance on first sight (stable content-hash message id + per-id input
+    dedup + first-chunk-wins), so stamping once is sufficient and per-turn
+    carry-forward would be redundant. Timing-independent — no dependency on
+    ``CompactionEvent``.
     """
     # Local import to avoid a load-order cycle (_acp imports from _bridge).
     from inspect_ai.agent._acp.transport import current_acp_transport
+    from inspect_ai.agent._acp.transport_noop import NoOpAcpTransport
 
-    # Operator messages already established in the tracked conversation, keyed by
-    # whole-text. Carry-forward deliberately matches the FULL ``.text`` (not the
-    # per-block candidates ``consume_operator_message`` uses): Claude Code keeps
-    # a user turn's representation stable once it is history (reminder / skills
-    # blocks included), so the same operator message re-enters every later turn
-    # with an identical, distinctive whole text. Matching per-block here instead
-    # would risk a false positive — the shared reminder / skills blocks also
-    # appear on the dataset task message, which must NOT be stamped operator.
-    known_operator_text = {
-        message.text.strip()
-        for message in bridge.state.messages
-        if isinstance(message, ChatMessageUser) and message.source == "operator"
-    }
     transport = current_acp_transport()
-    for message in input:
-        if not isinstance(message, ChatMessageUser) or message.source == "operator":
-            continue
-        # ``consume_operator_message`` first so a still-pending entry is always
-        # cleared; fall back to carry-forward for messages already in state.
-        if (
-            transport.consume_operator_message(message)
-            or message.text.strip() in known_operator_text
-        ):
+    if isinstance(transport, NoOpAcpTransport):
+        # operator injections only exist within a live ACP session
+        return
+    if transport.pending_operator_count == 0:
+        # no operator was submitted: leave the task / ordinary input untouched
+        return
+
+    # The just-arrived operator turn (queued submits coalesce into one message)
+    # is the latest user message; stamp it and consume all pending. Stamp
+    # unconditionally — re-stamping an already-operator message is a no-op,
+    # whereas skipping one (e.g. an in-process bridge that preserved the source)
+    # would wrongly fall through to the earlier task.
+    for message in reversed(input):
+        if isinstance(message, ChatMessageUser):
             message.source = "operator"
+            break
+    transport.clear_pending_operators()
 
 
 async def bridge_generate(
@@ -209,7 +213,7 @@ async def bridge_generate(
     # (e.g. claude_code --resume re-emits an operator message as a plain
     # user message). Done before compaction/recording so the restored
     # source persists in both the ModelEvent input and state.messages.
-    _restore_operator_message_source(bridge, input)
+    _restore_operator_message_source(input)
 
     # get compaction function and run compaction once before retry loop
     compact = bridge.compaction(tools, model)

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -163,7 +163,14 @@ def _restore_operator_message_source(
     # Local import to avoid a load-order cycle (_acp imports from _bridge).
     from inspect_ai.agent._acp.transport import current_acp_transport
 
-    # operator messages already established in the tracked conversation
+    # Operator messages already established in the tracked conversation, keyed by
+    # whole-text. Carry-forward deliberately matches the FULL ``.text`` (not the
+    # per-block candidates ``consume_operator_message`` uses): Claude Code keeps
+    # a user turn's representation stable once it is history (reminder / skills
+    # blocks included), so the same operator message re-enters every later turn
+    # with an identical, distinctive whole text. Matching per-block here instead
+    # would risk a false positive — the shared reminder / skills blocks also
+    # appear on the dataset task message, which must NOT be stamped operator.
     known_operator_text = {
         message.text.strip()
         for message in bridge.state.messages

--- a/tests/agent/test_acp/test_operator_provenance.py
+++ b/tests/agent/test_acp/test_operator_provenance.py
@@ -5,14 +5,20 @@ interventions through its own conversation store (e.g. Claude Code's
 ``--resume``), so an operator message re-enters the bridge as a plain
 ``ChatMessageUser`` (``source=None``) — losing the ``"operator"``
 provenance the ACP transport stamped at submit time. The single
-``bridge_generate`` chokepoint restores it so the source survives in BOTH
-the recorded ``ModelEvent`` input and the final ``state.messages`` — for
-every bridged agent, regardless of its live consumption technique.
+``bridge_generate`` chokepoint restores it so the source survives in the
+recorded ``ModelEvent`` input (and thus the final ``state.messages``).
 
-Recognition is scoped, not a global ledger: the transport holds only
-submitted-but-not-yet-seen operator messages (consumed on first match),
-and thereafter provenance is carried forward from the bridge's own tracked
-conversation (``bridge.state.messages``).
+Recognition is positional, gated on transport ground truth. The transport's
+pending-operator COUNT is the one thing known for certain — operator messages
+enter via the ACP channel, so a positive count means an operator was actually
+submitted and (by the time the scaffold calls back) resumed into the input.
+When the count is positive the operator turn is the LATEST user message
+(queued submits coalesce into one), so it is stamped and all pending consumed;
+when the count is 0 nothing is stamped, leaving the task and a history-taking
+bridge's ordinary multi-message input untouched. The restore is NOT repeated
+on later turns: the ACP TUI latches a message's operator provenance on first
+sight (stable content-hash id + per-id input dedup + first-chunk-wins), so a
+single stamp suffices.
 """
 
 from __future__ import annotations
@@ -31,14 +37,35 @@ from inspect_ai.agent._bridge.util import (
     bridge_generate,
 )
 from inspect_ai.log._transcript import Transcript, _transcript
-from inspect_ai.model import ChatMessageSystem, ChatMessageUser, get_model
+from inspect_ai.model import (
+    ChatMessageAssistant,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+    get_model,
+)
 from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ModelOutput
 
 
-def _bridge(*messages: ChatMessageUser) -> AgentBridge:
-    return AgentBridge(AgentState(messages=list(messages)))
+class _FakeRef:
+    """Minimal channel-producer sink so ``submit_user_message`` records pending.
+
+    A real ``submit_user_message`` only counts a submission once it is posted
+    to a bound channel; tests that need a pending count therefore attach this
+    stand-in via :func:`_live`.
+    """
+
+    def post(self, item: object) -> None:
+        pass
+
+
+def _live() -> LiveAcpTransport:
+    """A LiveAcpTransport with a bound channel sink (so submits accrue pending)."""
+    transport = LiveAcpTransport()
+    transport._ref = _FakeRef()  # type: ignore[assignment]
+    return transport
 
 
 def _cc_user(*texts: str, source: str | None = None) -> ChatMessageUser:
@@ -61,125 +88,290 @@ _REMINDER = (
 
 
 # ---------------------------------------------------------------------------
-# Transport pending set (consume-on-match)
+# Transport pending-operator count
 # ---------------------------------------------------------------------------
 
 
-def test_consume_operator_message_is_one_shot_and_normalized() -> None:
-    transport = LiveAcpTransport()
-    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
-    # whitespace-normalized match
-    assert transport.consume_operator_message(
-        ChatMessageUser(content="\n  let's continue working  \n")
-    )
-    # one-shot: the entry was popped, so a second match fails
-    assert not transport.consume_operator_message(
-        ChatMessageUser(content="let's continue working")
-    )
+def test_submit_user_message_increments_pending_operator_count() -> None:
+    transport = _live()
+    assert transport.pending_operator_count == 0
+    transport.submit_user_message(ChatMessageUser(content="first"))
+    assert transport.pending_operator_count == 1
+    transport.submit_user_message(ChatMessageUser(content="second"))
+    assert transport.pending_operator_count == 2
 
 
-def test_consume_operator_message_no_match() -> None:
-    transport = LiveAcpTransport()
-    transport.submit_user_message(ChatMessageUser(content="alpha"))
-    assert not transport.consume_operator_message(ChatMessageUser(content="beta"))
+def test_submit_without_bound_channel_does_not_count() -> None:
+    # A message dropped for lack of a bound channel never round-trips through a
+    # bridge, so it must NOT leave a phantom pending count.
+    transport = LiveAcpTransport()  # no _ref bound
+    transport.submit_user_message(ChatMessageUser(content="dropped"))
+    assert transport.pending_operator_count == 0
 
 
-def test_consume_operator_message_matches_multiblock_round_trip() -> None:
-    # The pending set holds the SHORT submitted text; Claude Code re-emits the
-    # turn as multiple blocks (reminder/skills + the operator text as its own
-    # block). The concatenated ``.text`` won't match, but the per-block
-    # candidate does.
-    transport = LiveAcpTransport()
-    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
-    round_tripped = _cc_user(_REMINDER, "let's continue working")
-    assert round_tripped.text.strip() != "let's continue working"  # sanity
-    assert transport.consume_operator_message(round_tripped)
-    # one-shot: the matched candidate was popped
-    assert not transport.consume_operator_message(
-        _cc_user(_REMINDER, "let's continue working")
-    )
+def test_clear_pending_operators_zeroes_count() -> None:
+    transport = _live()
+    transport.submit_user_message(ChatMessageUser(content="first"))
+    assert transport.pending_operator_count == 1
+    transport.clear_pending_operators()
+    assert transport.pending_operator_count == 0
 
 
-def test_noop_transport_never_consumes_operator_message() -> None:
-    assert (
-        NoOpAcpTransport().consume_operator_message(ChatMessageUser(content="anything"))
-        is False
-    )
+def test_pending_count_cleared_on_unbind() -> None:
+    # A posted submission's pending count must not survive a consumer handoff:
+    # unbind() resets it so a successor (e.g. bridged) consumer bound in the
+    # same sample starts clean and can't be mis-stamped by a stale count.
+    transport = _live()
+    ref = transport._ref
+    transport.submit_user_message(ChatMessageUser(content="op"))
+    assert transport.pending_operator_count == 1
+    transport.unbind(ref)  # type: ignore[arg-type]
+    assert transport.pending_operator_count == 0
+
+
+def test_noop_transport_pending_operator_count_is_zero() -> None:
+    transport = NoOpAcpTransport()
+    transport.submit_user_message(ChatMessageUser(content="anything"))
+    assert transport.pending_operator_count == 0
+    transport.clear_pending_operators()  # no-op, must not raise
+    assert transport.pending_operator_count == 0
 
 
 # ---------------------------------------------------------------------------
-# _restore_operator_message_source (the bridge helper)
+# _restore_operator_message_source — stamping when an operator is pending
 # ---------------------------------------------------------------------------
 
 
-def test_restore_recognizes_pending_message_first_time() -> None:
-    transport = LiveAcpTransport()
+def test_restore_stamps_last_user_when_pending() -> None:
+    transport = _live()
     transport.submit_user_message(ChatMessageUser(content="let's continue working"))
     token = _acp_var.set(transport)
     try:
-        dataset = ChatMessageUser(content="solve the task")
-        # round-tripped operator message: source lost, leading newline added
-        redirect = ChatMessageUser(content="\nlet's continue working")
-        system = ChatMessageSystem(content="let's continue working")  # not a user msg
-        _restore_operator_message_source(_bridge(), [dataset, redirect, system])
+        task = ChatMessageUser(content="solve the task")
+        operator = ChatMessageUser(content="let's continue working")
+        input: list[ChatMessage] = [task, ChatMessageAssistant(content="..."), operator]
+        _restore_operator_message_source(input)
 
-        assert redirect.source == "operator"  # recognized via pending set
-        assert dataset.source is None  # non-operator user message untouched
-        assert system.source is None  # system messages are never stamped
+        assert operator.source == "operator"  # latest user message, pending > 0
+        assert task.source is None  # the task sits behind an assistant turn
+        assert transport.pending_operator_count == 0  # consumed
     finally:
         _acp_var.reset(token)
 
 
-def test_restore_recognizes_multiblock_pending_first_time() -> None:
-    # A multi-block redirect (operator text as a non-first block) is recognized
-    # via the pending set; a sibling dataset message that shares the SAME
-    # reminder block must NOT be stamped (the pending set only holds operator
-    # texts, never reminders, so per-block matching is safe here).
-    transport = LiveAcpTransport()
+def test_restore_stamps_multiblock_operator() -> None:
+    # A round-tripped operator message arrives as multiple ContentText blocks
+    # (reminder / skills + prompt). It is still recognized purely positionally
+    # (latest user message + pending) — no content matching of any kind.
+    transport = _live()
     transport.submit_user_message(ChatMessageUser(content="let's continue working"))
     token = _acp_var.set(transport)
     try:
+        task = ChatMessageUser(content="solve the task")
         redirect = _cc_user(_REMINDER, "let's continue working")
-        dataset = _cc_user(_REMINDER, "solve the original task")  # shares reminder
-        _restore_operator_message_source(_bridge(), [dataset, redirect])
+        system = ChatMessageSystem(content="system prompt")
+        input: list[ChatMessage] = [system, task, redirect]
+        _restore_operator_message_source(input)
+
         assert redirect.source == "operator"
-        assert dataset.source is None
+        assert task.source is None
+        assert system.source is None
     finally:
         _acp_var.reset(token)
 
 
-def test_restore_carry_forward_multiblock_no_reminder_false_positive() -> None:
-    # No pending entry (already consumed on a prior turn). Carry-forward matches
-    # the FULL ``.text`` of a prior operator message — Claude Code keeps a user
-    # turn's representation stable once it is history, so the same operator
-    # message re-enters with an identical whole text. A dataset message that
-    # shares only the reminder block must NOT be falsely stamped operator.
-    transport = LiveAcpTransport()
+def test_restore_operator_text_colliding_with_task_is_irrelevant() -> None:
+    # Positional stamping does not look at content, so an operator whose text
+    # happens to equal the task's is still correctly identified as the latest
+    # user message; the earlier (same-text) task is left untouched.
+    transport = _live()
+    transport.submit_user_message(ChatMessageUser(content="repeat"))
     token = _acp_var.set(transport)
     try:
-        prior = _cc_user(_REMINDER, "let's continue working", source="operator")
-        this_turn = _cc_user(_REMINDER, "let's continue working")  # same whole text
-        dataset = _cc_user(_REMINDER, "solve the original task")  # shares reminder
-        _restore_operator_message_source(_bridge(prior), [dataset, this_turn])
-        assert this_turn.source == "operator"
-        assert dataset.source is None
+        input_task = ChatMessageUser(content="repeat")  # earlier turn
+        operator = ChatMessageUser(content="repeat")  # operator, same text, latest
+        input: list[ChatMessage] = [
+            input_task,
+            ChatMessageAssistant(content="..."),
+            operator,
+        ]
+        _restore_operator_message_source(input)
+
+        assert operator.source == "operator"
+        assert input_task.source is None
+        assert transport.pending_operator_count == 0
     finally:
         _acp_var.reset(token)
 
 
-def test_restore_carries_forward_from_bridge_state() -> None:
-    # No pending transport entry (already consumed on a prior turn); the
-    # operator message is recognized purely from the tracked conversation.
-    transport = LiveAcpTransport()
+def test_restore_coalesced_operator_stamped() -> None:
+    # Several queued sends coalesce into one "first\n\nsecond" turn; the bridge
+    # stamps the single arrived message and consumes ALL pending.
+    transport = _live()
+    transport.submit_user_message(ChatMessageUser(content="first"))
+    transport.submit_user_message(ChatMessageUser(content="second"))
     token = _acp_var.set(transport)
     try:
-        prior = ChatMessageUser(content="let's continue working", source="operator")
-        # fresh same-text message rebuilt by the bridge this turn (source lost)
-        this_turn = ChatMessageUser(content="let's continue working")
-        _restore_operator_message_source(_bridge(prior), [this_turn])
-        assert this_turn.source == "operator"
+        task = ChatMessageUser(content="solve the task")
+        coalesced = ChatMessageUser(content="first\n\nsecond")
+        input: list[ChatMessage] = [
+            task,
+            ChatMessageAssistant(content="..."),
+            coalesced,
+        ]
+        _restore_operator_message_source(input)
+
+        assert coalesced.source == "operator"
+        assert task.source is None
+        assert transport.pending_operator_count == 0
     finally:
         _acp_var.reset(token)
+
+
+def test_restore_tool_messages_skipped() -> None:
+    # Tool results are ChatMessageTool, not ChatMessageUser; the latest USER
+    # message (the operator) is stamped even when tool results sit between it
+    # and the preceding assistant turn.
+    transport = _live()
+    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
+    token = _acp_var.set(transport)
+    try:
+        task = ChatMessageUser(content="solve the task")
+        tool = ChatMessageTool(content="tool output", tool_call_id="t1")
+        operator = ChatMessageUser(content="let's continue working")
+        input: list[ChatMessage] = [
+            task,
+            ChatMessageAssistant(content="calling tool"),
+            tool,
+            operator,
+        ]
+        _restore_operator_message_source(input)
+
+        assert operator.source == "operator"
+        assert task.source is None
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_does_not_downgrade_existing_operator_source() -> None:
+    # Stamping the latest user message is a no-op when it is already operator.
+    transport = _live()
+    transport.submit_user_message(ChatMessageUser(content="hi"))
+    token = _acp_var.set(transport)
+    try:
+        task = ChatMessageUser(content="solve the task")
+        operator = ChatMessageUser(content="hi", source="operator")
+        input: list[ChatMessage] = [task, ChatMessageAssistant(content="..."), operator]
+        _restore_operator_message_source(input)
+
+        assert operator.source == "operator"
+        assert task.source is None  # not stamped via fall-through
+        assert transport.pending_operator_count == 0
+    finally:
+        _acp_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# _restore_operator_message_source — the pending gate (nothing stamped at 0)
+# ---------------------------------------------------------------------------
+
+
+def test_restore_no_stamp_without_pending() -> None:
+    # No operator submission is pending → the latest user message is NOT stamped
+    # (the count gates recognition).
+    transport = _live()
+    token = _acp_var.set(transport)
+    try:
+        task = ChatMessageUser(content="solve the task")
+        newish = ChatMessageUser(content="a fresh user message")
+        input: list[ChatMessage] = [task, ChatMessageAssistant(content="..."), newish]
+        _restore_operator_message_source(input)
+
+        assert newish.source is None
+        assert task.source is None
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_multi_message_history_not_stamped() -> None:
+    # Key robustness case for non-claude_code / history-taking bridges: an
+    # ordinary multi-message conversation input (ending in a user turn) with no
+    # operator pending must be left entirely untouched.
+    transport = _live()
+    token = _acp_var.set(transport)
+    try:
+        user_a = ChatMessageUser(content="first user turn")
+        user_b = ChatMessageUser(content="second user turn")
+        input: list[ChatMessage] = [
+            user_a,
+            ChatMessageAssistant(content="..."),
+            user_b,
+        ]
+        _restore_operator_message_source(input)
+
+        assert user_a.source is None
+        assert user_b.source is None
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_does_not_stamp_task_from_unposted_submission() -> None:
+    # Reviewer probe: a submission dropped for lack of a channel must not leave
+    # a pending count that later marks an unrelated bridged task as operator.
+    transport = LiveAcpTransport()  # no _ref bound → submit is dropped, no count
+    transport.submit_user_message(ChatMessageUser(content="op"))
+    token = _acp_var.set(transport)
+    try:
+        task = ChatMessageUser(content="solve the task")
+        _restore_operator_message_source([task])
+        assert task.source is None
+        assert transport.pending_operator_count == 0
+    finally:
+        _acp_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# _restore_operator_message_source — compaction summary safety
+# ---------------------------------------------------------------------------
+
+
+def test_restore_compaction_summary_not_stamped_without_pending() -> None:
+    # A scaffold auto-compaction summary arrives as a synthetic user message
+    # with no operator submission pending → never stamped.
+    transport = _live()
+    token = _acp_var.set(transport)
+    try:
+        summary = ChatMessageUser(content="[CONTEXT COMPACTION SUMMARY] ...")
+        input: list[ChatMessage] = [summary, ChatMessageAssistant(content="...")]
+        _restore_operator_message_source(input)
+        assert summary.source is None
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_compaction_summary_spared_when_operator_follows() -> None:
+    # Post-compaction shape [summary, operator] with a pending submission: the
+    # operator is the LATEST user message and gets stamped; the summary (ahead
+    # of it) is spared.
+    transport = _live()
+    transport.submit_user_message(ChatMessageUser(content="please refocus"))
+    token = _acp_var.set(transport)
+    try:
+        summary = ChatMessageUser(content="[CONTEXT COMPACTION SUMMARY] ...")
+        operator = ChatMessageUser(content="please refocus")
+        input: list[ChatMessage] = [summary, operator]
+        _restore_operator_message_source(input)
+
+        assert operator.source == "operator"
+        assert summary.source is None
+        assert transport.pending_operator_count == 0
+    finally:
+        _acp_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# _restore_operator_message_source — ACP-session gate
+# ---------------------------------------------------------------------------
 
 
 def test_restore_is_noop_without_active_transport() -> None:
@@ -187,19 +379,19 @@ def test_restore_is_noop_without_active_transport() -> None:
     # singleton → nothing is stamped (graceful no-op for non-ACP evals).
     assert isinstance(current_acp_transport(), NoOpAcpTransport)
     msg = ChatMessageUser(content="let's continue working")
-    _restore_operator_message_source(_bridge(), [msg])
+    _restore_operator_message_source([msg])
     assert msg.source is None
 
 
-def test_restore_does_not_downgrade_existing_operator_source() -> None:
-    transport = LiveAcpTransport()
-    token = _acp_var.set(transport)
-    try:
-        msg = ChatMessageUser(content="hi", source="operator")
-        _restore_operator_message_source(_bridge(), [msg])
-        assert msg.source == "operator"
-    finally:
-        _acp_var.reset(token)
+def test_restore_skips_when_noop_even_with_subsequent_users() -> None:
+    # Even a multi-user input is left untouched outside an ACP session.
+    assert isinstance(current_acp_transport(), NoOpAcpTransport)
+    task = ChatMessageUser(content="solve the task")
+    op = ChatMessageUser(content="follow-up")
+    input: list[ChatMessage] = [task, ChatMessageAssistant(content="..."), op]
+    _restore_operator_message_source(input)
+    assert task.source is None
+    assert op.source is None
 
 
 # ---------------------------------------------------------------------------
@@ -212,15 +404,15 @@ def test_restore_does_not_downgrade_existing_operator_source() -> None:
 async def test_bridge_generate_restores_operator_source() -> None:
     """The restore runs inside the shared ``bridge_generate`` chokepoint.
 
-    Proves the wiring: an operator message submitted to the transport, then
-    re-entering ``bridge_generate`` as a plain (source-less) user message, is
-    re-stamped ``operator`` in place — so the same object the caller records
-    as the ``ModelEvent`` input and tracks into ``state.messages`` carries
-    the restored source.
+    Proves the wiring: an operator message submitted to the transport (bumping
+    the pending count), then re-entering ``bridge_generate`` as a plain
+    (source-less) user message, is re-stamped ``operator`` in place — so the
+    same object the caller records as the ``ModelEvent`` input and tracks into
+    ``state.messages`` carries the restored source.
     """
     tr = Transcript()
     tok_tr = _transcript.set(tr)
-    transport = LiveAcpTransport()
+    transport = _live()
     transport.submit_user_message(ChatMessageUser(content="let's continue working"))
     tok_acp = _acp_var.set(transport)
     try:
@@ -231,14 +423,16 @@ async def test_bridge_generate_restores_operator_source() -> None:
             ],
         )
         bridge = AgentBridge(AgentState(messages=[]))
-        redirect = ChatMessageUser(content="\nlet's continue working")
+        redirect = ChatMessageUser(content="let's continue working")
         input_messages: list[ChatMessage] = [
             ChatMessageUser(content="solve the task"),
+            ChatMessageAssistant(content="working"),
             redirect,
         ]
         await bridge_generate(bridge, model, input_messages, [], None, GenerateConfig())
         assert redirect.source == "operator"
         assert input_messages[0].source is None
+        assert transport.pending_operator_count == 0
     finally:
         _acp_var.reset(tok_acp)
         _transcript.reset(tok_tr)

--- a/tests/agent/test_acp/test_operator_provenance.py
+++ b/tests/agent/test_acp/test_operator_provenance.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import pytest
 from test_helpers.utils import skip_if_trio
 
+from inspect_ai._util.content import ContentText
 from inspect_ai.agent import AgentState
 from inspect_ai.agent._acp.transport import _acp_var, current_acp_transport
 from inspect_ai.agent._acp.transport_live import LiveAcpTransport
@@ -37,6 +38,25 @@ from inspect_ai.model._model_output import ModelOutput
 
 def _bridge(*messages: ChatMessageUser) -> AgentBridge:
     return AgentBridge(AgentState(messages=list(messages)))
+
+
+def _cc_user(*texts: str, source: str | None = None) -> ChatMessageUser:
+    """A Claude Code-style multi-block user message.
+
+    Claude Code returns a user turn as multiple ``ContentText`` blocks —
+    ``<system-reminder>`` / skills content as their own blocks alongside the
+    actual prompt text as a separate block — so the concatenated ``.text``
+    never equals any single block's text.
+    """
+    return ChatMessageUser(
+        content=[ContentText(text=text) for text in texts],
+        source=source,  # type: ignore[arg-type]
+    )
+
+
+_REMINDER = (
+    "<system-reminder>\nThe following skills are available...\n</system-reminder>"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +81,22 @@ def test_consume_operator_message_no_match() -> None:
     transport = LiveAcpTransport()
     transport.submit_user_message(ChatMessageUser(content="alpha"))
     assert not transport.consume_operator_message(ChatMessageUser(content="beta"))
+
+
+def test_consume_operator_message_matches_multiblock_round_trip() -> None:
+    # The pending set holds the SHORT submitted text; Claude Code re-emits the
+    # turn as multiple blocks (reminder/skills + the operator text as its own
+    # block). The concatenated ``.text`` won't match, but the per-block
+    # candidate does.
+    transport = LiveAcpTransport()
+    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
+    round_tripped = _cc_user(_REMINDER, "let's continue working")
+    assert round_tripped.text.strip() != "let's continue working"  # sanity
+    assert transport.consume_operator_message(round_tripped)
+    # one-shot: the matched candidate was popped
+    assert not transport.consume_operator_message(
+        _cc_user(_REMINDER, "let's continue working")
+    )
 
 
 def test_noop_transport_never_consumes_operator_message() -> None:
@@ -89,6 +125,43 @@ def test_restore_recognizes_pending_message_first_time() -> None:
         assert redirect.source == "operator"  # recognized via pending set
         assert dataset.source is None  # non-operator user message untouched
         assert system.source is None  # system messages are never stamped
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_recognizes_multiblock_pending_first_time() -> None:
+    # A multi-block redirect (operator text as a non-first block) is recognized
+    # via the pending set; a sibling dataset message that shares the SAME
+    # reminder block must NOT be stamped (the pending set only holds operator
+    # texts, never reminders, so per-block matching is safe here).
+    transport = LiveAcpTransport()
+    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
+    token = _acp_var.set(transport)
+    try:
+        redirect = _cc_user(_REMINDER, "let's continue working")
+        dataset = _cc_user(_REMINDER, "solve the original task")  # shares reminder
+        _restore_operator_message_source(_bridge(), [dataset, redirect])
+        assert redirect.source == "operator"
+        assert dataset.source is None
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_carry_forward_multiblock_no_reminder_false_positive() -> None:
+    # No pending entry (already consumed on a prior turn). Carry-forward matches
+    # the FULL ``.text`` of a prior operator message — Claude Code keeps a user
+    # turn's representation stable once it is history, so the same operator
+    # message re-enters with an identical whole text. A dataset message that
+    # shares only the reminder block must NOT be falsely stamped operator.
+    transport = LiveAcpTransport()
+    token = _acp_var.set(transport)
+    try:
+        prior = _cc_user(_REMINDER, "let's continue working", source="operator")
+        this_turn = _cc_user(_REMINDER, "let's continue working")  # same whole text
+        dataset = _cc_user(_REMINDER, "solve the original task")  # shares reminder
+        _restore_operator_message_source(_bridge(prior), [dataset, this_turn])
+        assert this_turn.source == "operator"
+        assert dataset.source is None
     finally:
         _acp_var.reset(token)
 

--- a/tests/agent/test_acp/test_operator_provenance.py
+++ b/tests/agent/test_acp/test_operator_provenance.py
@@ -32,6 +32,7 @@ from inspect_ai.agent._bridge.util import (
 )
 from inspect_ai.log._transcript import Transcript, _transcript
 from inspect_ai.model import ChatMessageSystem, ChatMessageUser, get_model
+from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ModelOutput
 
@@ -231,7 +232,10 @@ async def test_bridge_generate_restores_operator_source() -> None:
         )
         bridge = AgentBridge(AgentState(messages=[]))
         redirect = ChatMessageUser(content="\nlet's continue working")
-        input_messages = [ChatMessageUser(content="solve the task"), redirect]
+        input_messages: list[ChatMessage] = [
+            ChatMessageUser(content="solve the task"),
+            redirect,
+        ]
         await bridge_generate(bridge, model, input_messages, [], None, GenerateConfig())
         assert redirect.source == "operator"
         assert input_messages[0].source is None

--- a/tests/agent/test_acp/test_operator_provenance.py
+++ b/tests/agent/test_acp/test_operator_provenance.py
@@ -1,0 +1,167 @@
+"""Operator-provenance restoration for bridged agents.
+
+A bridged scaffold (claude_code, codex, …) round-trips operator
+interventions through its own conversation store (e.g. Claude Code's
+``--resume``), so an operator message re-enters the bridge as a plain
+``ChatMessageUser`` (``source=None``) — losing the ``"operator"``
+provenance the ACP transport stamped at submit time. The single
+``bridge_generate`` chokepoint restores it so the source survives in BOTH
+the recorded ``ModelEvent`` input and the final ``state.messages`` — for
+every bridged agent, regardless of its live consumption technique.
+
+Recognition is scoped, not a global ledger: the transport holds only
+submitted-but-not-yet-seen operator messages (consumed on first match),
+and thereafter provenance is carried forward from the bridge's own tracked
+conversation (``bridge.state.messages``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from test_helpers.utils import skip_if_trio
+
+from inspect_ai.agent import AgentState
+from inspect_ai.agent._acp.transport import _acp_var, current_acp_transport
+from inspect_ai.agent._acp.transport_live import LiveAcpTransport
+from inspect_ai.agent._acp.transport_noop import NoOpAcpTransport
+from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.util import (
+    _restore_operator_message_source,
+    bridge_generate,
+)
+from inspect_ai.log._transcript import Transcript, _transcript
+from inspect_ai.model import ChatMessageSystem, ChatMessageUser, get_model
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_output import ModelOutput
+
+
+def _bridge(*messages: ChatMessageUser) -> AgentBridge:
+    return AgentBridge(AgentState(messages=list(messages)))
+
+
+# ---------------------------------------------------------------------------
+# Transport pending set (consume-on-match)
+# ---------------------------------------------------------------------------
+
+
+def test_consume_operator_message_is_one_shot_and_normalized() -> None:
+    transport = LiveAcpTransport()
+    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
+    # whitespace-normalized match
+    assert transport.consume_operator_message(
+        ChatMessageUser(content="\n  let's continue working  \n")
+    )
+    # one-shot: the entry was popped, so a second match fails
+    assert not transport.consume_operator_message(
+        ChatMessageUser(content="let's continue working")
+    )
+
+
+def test_consume_operator_message_no_match() -> None:
+    transport = LiveAcpTransport()
+    transport.submit_user_message(ChatMessageUser(content="alpha"))
+    assert not transport.consume_operator_message(ChatMessageUser(content="beta"))
+
+
+def test_noop_transport_never_consumes_operator_message() -> None:
+    assert (
+        NoOpAcpTransport().consume_operator_message(ChatMessageUser(content="anything"))
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# _restore_operator_message_source (the bridge helper)
+# ---------------------------------------------------------------------------
+
+
+def test_restore_recognizes_pending_message_first_time() -> None:
+    transport = LiveAcpTransport()
+    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
+    token = _acp_var.set(transport)
+    try:
+        dataset = ChatMessageUser(content="solve the task")
+        # round-tripped operator message: source lost, leading newline added
+        redirect = ChatMessageUser(content="\nlet's continue working")
+        system = ChatMessageSystem(content="let's continue working")  # not a user msg
+        _restore_operator_message_source(_bridge(), [dataset, redirect, system])
+
+        assert redirect.source == "operator"  # recognized via pending set
+        assert dataset.source is None  # non-operator user message untouched
+        assert system.source is None  # system messages are never stamped
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_carries_forward_from_bridge_state() -> None:
+    # No pending transport entry (already consumed on a prior turn); the
+    # operator message is recognized purely from the tracked conversation.
+    transport = LiveAcpTransport()
+    token = _acp_var.set(transport)
+    try:
+        prior = ChatMessageUser(content="let's continue working", source="operator")
+        # fresh same-text message rebuilt by the bridge this turn (source lost)
+        this_turn = ChatMessageUser(content="let's continue working")
+        _restore_operator_message_source(_bridge(prior), [this_turn])
+        assert this_turn.source == "operator"
+    finally:
+        _acp_var.reset(token)
+
+
+def test_restore_is_noop_without_active_transport() -> None:
+    # No ACP transport installed → current_acp_transport() is the no-op
+    # singleton → nothing is stamped (graceful no-op for non-ACP evals).
+    assert isinstance(current_acp_transport(), NoOpAcpTransport)
+    msg = ChatMessageUser(content="let's continue working")
+    _restore_operator_message_source(_bridge(), [msg])
+    assert msg.source is None
+
+
+def test_restore_does_not_downgrade_existing_operator_source() -> None:
+    transport = LiveAcpTransport()
+    token = _acp_var.set(transport)
+    try:
+        msg = ChatMessageUser(content="hi", source="operator")
+        _restore_operator_message_source(_bridge(), [msg])
+        assert msg.source == "operator"
+    finally:
+        _acp_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# Integration: bridge_generate restores provenance end to end
+# ---------------------------------------------------------------------------
+
+
+@skip_if_trio
+@pytest.mark.anyio
+async def test_bridge_generate_restores_operator_source() -> None:
+    """The restore runs inside the shared ``bridge_generate`` chokepoint.
+
+    Proves the wiring: an operator message submitted to the transport, then
+    re-entering ``bridge_generate`` as a plain (source-less) user message, is
+    re-stamped ``operator`` in place — so the same object the caller records
+    as the ``ModelEvent`` input and tracks into ``state.messages`` carries
+    the restored source.
+    """
+    tr = Transcript()
+    tok_tr = _transcript.set(tr)
+    transport = LiveAcpTransport()
+    transport.submit_user_message(ChatMessageUser(content="let's continue working"))
+    tok_acp = _acp_var.set(transport)
+    try:
+        model = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.from_content(model="mockllm/model", content="ok")
+            ],
+        )
+        bridge = AgentBridge(AgentState(messages=[]))
+        redirect = ChatMessageUser(content="\nlet's continue working")
+        input_messages = [ChatMessageUser(content="solve the task"), redirect]
+        await bridge_generate(bridge, model, input_messages, [], None, GenerateConfig())
+        assert redirect.source == "operator"
+        assert input_messages[0].source is None
+    finally:
+        _acp_var.reset(tok_acp)
+        _transcript.reset(tok_tr)

--- a/tests/agent/test_acp/test_router_bridge_tools.py
+++ b/tests/agent/test_acp/test_router_bridge_tools.py
@@ -409,6 +409,90 @@ def test_bridge_start_without_view_falls_back_to_title() -> None:
         _transcript.reset(token)
 
 
+def _write_call(
+    tool_id: str = "tc1",
+    *,
+    content: str = "hello world",
+    view_content: str = "```text\n{{content}}\n```\n",
+) -> ToolCall:
+    """A bridged Write call whose viewer emits a ``{{content}}`` placeholder."""
+    return ToolCall(
+        id=tool_id,
+        function="Write",
+        arguments={"file_path": "/tmp/x.txt", "content": content},
+        view=ToolCallContent(title="Write", format="markdown", content=view_content),
+    )
+
+
+def test_bridge_tool_view_substitutes_param_placeholders() -> None:
+    """Viewer ``{{param}}`` placeholders are filled from the call args.
+
+    inspect_swe's Write/Edit viewers emit ``{{content}}`` placeholders that the
+    web viewer fills via ``substituteToolCallContent`` (tool.ts). The ACP path
+    must do the same or editors/TUI render the literal ``{{content}}``.
+    """
+    tr = Transcript()
+    token = _transcript.set(tr)
+    try:
+        _, published = _attach_router(_new_session())
+        with bridge_model_generate():
+            tr._event(_tool_call_event(_write_call(content="hello world")))
+        starts = _starts(published)
+        assert len(starts) == 1
+        text = _content_text(starts[0])
+        assert "hello world" in text
+        assert "{{content}}" not in text
+    finally:
+        _transcript.reset(token)
+
+
+def test_bridge_tool_view_leaves_unknown_placeholder_literal() -> None:
+    """A ``{{param}}`` with no matching arg is left as-is (not blanked)."""
+    tr = Transcript()
+    token = _transcript.set(tr)
+    try:
+        _, published = _attach_router(_new_session())
+        with bridge_model_generate():
+            tr._event(
+                _tool_call_event(_write_call(view_content="{{content}} {{missing}}"))
+            )
+        starts = _starts(published)
+        assert len(starts) == 1
+        text = _content_text(starts[0])
+        assert "hello world" in text  # known key substituted
+        assert "{{missing}}" in text  # unknown key preserved
+    finally:
+        _transcript.reset(token)
+
+
+def test_bridge_tool_view_substitution_preserved_on_completion() -> None:
+    """The settled (completed) card also has placeholders substituted.
+
+    The update path runs through the same ``_content_from_view``, so the result
+    card must show the file body, not the literal ``{{content}}``.
+    """
+    tr = Transcript()
+    token = _transcript.set(tr)
+    try:
+        _, published = _attach_router(_new_session())
+        with bridge_model_generate():
+            tr._event(_tool_call_event(_write_call(content="hello world")))
+            tr._event(
+                _result_event(
+                    ChatMessageTool(
+                        tool_call_id="tc1", function="Write", content="wrote 1 file"
+                    )
+                )
+            )
+        progress = _progress(published)
+        assert len(progress) == 1
+        text = _content_text(progress[0])
+        assert "hello world" in text  # view preserved + substituted
+        assert "{{content}}" not in text
+    finally:
+        _transcript.reset(token)
+
+
 # ---------------------------------------------------------------------------
 # Replay (late-attach) — structural detection, no bridge context
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_acp/test_tui/test_queued_messages_pilot.py
+++ b/tests/agent/test_acp/test_tui/test_queued_messages_pilot.py
@@ -146,15 +146,18 @@ async def test_send_during_running_appends_queued_ephemeral_and_clears_composer(
 
 @skip_if_trio
 @pytest.mark.anyio
-async def test_send_during_idle_does_not_create_ephemeral(
+async def test_send_during_idle_creates_ephemeral(
     sample_rows: list[SessionRow],
 ) -> None:
-    """Send during ``idle`` skips the optimistic ephemeral.
+    """Send during ``idle`` still mounts the optimistic ephemeral.
 
-    The agent is parked in ``before_turn`` and the chunk usually
-    round-trips within milliseconds, so an ephemeral would just flash.
-    Skipping the optimistic echo on idle keeps the transcript steady
-    on the common case.
+    We deliberately do NOT skip on idle: for a bridged agent (claude_code
+    / codex) ``idle`` can occur mid-turn — scaffold startup / ``--resume``
+    relaunch or an inter-model-call gap — where the message is NOT drained
+    within ms but waits for the next turn boundary, so the operator needs
+    the ``user · queued`` chip. The only cost on a native agent that does
+    drain instantly is a sub-perceptible dim→solid flicker (the queued→real
+    swap is atomic). Only ``scoring`` / ``complete`` suppress the echo.
     """
     client = make_fake_client(sample_rows)
     app = InspectAcpApp(eval_id=None, server=None, client=client)
@@ -167,11 +170,14 @@ async def test_send_during_idle_does_not_create_ephemeral(
         await screen.action_submit()
         await pilot.pause()
 
-        # Request was sent, composer cleared, NO ephemeral mounted.
+        # Request was sent, composer cleared, AND the ephemeral is mounted.
         assert composer.text == ""
         conn = cast(Any, screen._session.connection)
         assert len(conn.requests) == 1
-        assert _queued(screen) == []
+        queued = _queued(screen)
+        assert len(queued) == 1
+        assert queued[0].text == "kick off"
+        assert queued[0].user_source == "operator"
 
 
 @skip_if_trio


### PR DESCRIPTION
- ACP: Substitute `{{param}}` placeholders in tool-call views.
- ACP: Keep the optimistic `user · queued` chip visible when agents are idle mid-turn.
- Limits: Fix a spurious, mislabeled `working` limit event recorded alongside the real one when a message/token/cost limit is hit inside a sandboxed agent bridge (e.g. `claude_code`).
