### PR TITLE
misc fixes discovered during claude_code acp testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 - Transcript: Continue using the realtime sample buffer database when WAL journal mode cannot be enabled.
 - ACP: Render tool calls for agent-bridge agents (e.g. `claude_code`, `codex_cli`). 
+- ACP: Substitute `{{param}}` placeholders in tool-call views.
+- ACP: Keep the optimistic `user · queued` chip visible when agents are idle mid-turn.
+- Limits: Fix a spurious, mislabeled `working` limit event recorded alongside the real one when a message/token/cost limit is hit inside a sandboxed agent bridge (e.g. `claude_code`).
 - Inspect View: Improve model event rendering - add INFO tab (usage + stop reason) and a Stop Reason display
 - Inspect View: Fix: stop VirtualList from fighting deep-link scroll in WebKit
 - Inspect View: Fix: collapse the timeline by default when only main + scoring lanes exist

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1154,22 +1154,32 @@ async def task_run_sample(
                                                 error, raise_error = handle_error(ex)
 
                                     elif active.limit_exceeded_error:
-                                        # record event
-                                        transcript()._event(
-                                            SampleLimitEvent(
-                                                type="working",
-                                                message=active.limit_exceeded_error.message,
-                                                limit=active.limit_exceeded_error.limit,
+                                        err = active.limit_exceeded_error
+                                        # Record a SampleLimitEvent ONLY for a working-time
+                                        # limit. `sample.limit_exceeded()` (which set
+                                        # `limit_exceeded_error` and cancelled us) has two
+                                        # callers: monitor_working_limit(), which records no
+                                        # event of its own — so here we are its sole recorder
+                                        # — and the sandbox service, which surfaces a bridged
+                                        # message/token/cost limit that ALREADY recorded its
+                                        # own event at its detection point (e.g.
+                                        # check_message_limit). Recording the latter here would
+                                        # both duplicate that event and mislabel it "working".
+                                        if err.type == "working":
+                                            transcript()._event(
+                                                SampleLimitEvent(
+                                                    type=err.type,
+                                                    message=err.message,
+                                                    limit=err.limit,
+                                                )
                                             )
-                                        )
 
                                         # capture most recent state for scoring
                                         state = sample_state() or state
                                         limit = EvalSampleLimit(
-                                            type=active.limit_exceeded_error.type,
-                                            limit=active.limit_exceeded_error.limit
-                                            if active.limit_exceeded_error.limit
-                                            is not None
+                                            type=err.type,
+                                            limit=err.limit
+                                            if err.limit is not None
                                             else -1,
                                         )
 

--- a/src/inspect_ai/agent/_acp/tool_content.py
+++ b/src/inspect_ai/agent/_acp/tool_content.py
@@ -40,7 +40,7 @@ from inspect_ai._util.url import (
     is_http_url,
 )
 from inspect_ai.event._tool import ToolEvent
-from inspect_ai.tool._tool_call import ToolCallContent
+from inspect_ai.tool._tool_call import ToolCallContent, substitute_tool_call_content
 
 # Built-in Inspect tool name → ACP ``ToolKind`` mapping. The kind
 # is what tells the editor "render this row with a file icon" vs
@@ -262,8 +262,20 @@ def content_blocks_from_view(
 
 
 def _content_from_view(event: ToolEvent) -> list[ContentToolCallContent] | None:
-    """ToolEvent-flavored adapter around :func:`content_blocks_from_view`."""
-    return content_blocks_from_view(event.view)
+    """ToolEvent-flavored adapter around :func:`content_blocks_from_view`.
+
+    Substitutes ``{{param}}`` placeholders in the view from the call's
+    ``arguments`` first. Tool viewers emit placeholders (e.g. ``{{content}}``
+    in the Write card) that the web viewer fills in via
+    ``substituteToolCallContent`` (``tool.ts``); the ACP path must do the same
+    or editors/TUI render the literal ``{{content}}``. This covers both real
+    ``ToolEvent``s and the synthesized bridged tool cards (claude_code/codex),
+    which both flow through here via ``_content_for_start`` / ``_content_for_update``.
+    """
+    view = event.view
+    if view is not None:
+        view = substitute_tool_call_content(view, event.arguments)
+    return content_blocks_from_view(view)
 
 
 # Cap result-as-content payloads so a multi-megabyte tool output

--- a/src/inspect_ai/agent/_acp/tui/session_screen.py
+++ b/src/inspect_ai/agent/_acp/tui/session_screen.py
@@ -1031,12 +1031,27 @@ class SessionScreen(Screen[None]):
         # popped when the server echoes the real chunk back. Subsequent
         # sends-while-busy APPEND to the existing ephemeral (single
         # bucket) so the row matches the server-side coalesced merge
-        # — the user sees exactly what the model will see. Skip while
-        # ``idle``: the agent is parked in ``before_turn`` and the
-        # chunk arrives within ms, so an ephemeral would just flash.
+        # — the user sees exactly what the model will see.
+        #
+        # Shown whenever the session is live (idle / running /
+        # interrupted / approval); suppressed only once the agent loop
+        # is done (``scoring`` / ``complete``), where the server rejects
+        # new prompts anyway (and the send-failure rollback below covers
+        # a racing rejection). We deliberately do NOT skip on ``idle``:
+        # for a bridged agent (claude_code / codex) ``idle`` can occur
+        # mid-turn — during scaffold startup / ``--resume`` relaunch or
+        # an inter-model-call gap — where the message is NOT drained
+        # within ms but waits for the next turn boundary, so the chip is
+        # exactly what the operator needs. For a native agent parked in
+        # ``before_turn`` the message does drain within ms, but the
+        # queued→real swap is atomic (the pop and the real group's
+        # append land in the same ``consume()`` tick — see
+        # ``SessionState._consume_chunk``), so the worst case is a
+        # sub-perceptible dim→solid flicker of the same text, not a
+        # vanish/reappear glitch.
         # See :attr:`state.MessageGroup.is_queued` for the lifecycle.
         handle: _QueuedEnqueueHandle | None = None
-        if self._state.lifecycle != "idle":
+        if self._state.lifecycle not in ("complete", "scoring"):
             handle = self._state.enqueue_queued_user_message(text)
         try:
             await connection.send_request(

--- a/tests/agent/test_acp/test_router_bridge_tools.py
+++ b/tests/agent/test_acp/test_router_bridge_tools.py
@@ -409,6 +409,90 @@ def test_bridge_start_without_view_falls_back_to_title() -> None:
         _transcript.reset(token)
 
 
+def _write_call(
+    tool_id: str = "tc1",
+    *,
+    content: str = "hello world",
+    view_content: str = "```text\n{{content}}\n```\n",
+) -> ToolCall:
+    """A bridged Write call whose viewer emits a ``{{content}}`` placeholder."""
+    return ToolCall(
+        id=tool_id,
+        function="Write",
+        arguments={"file_path": "/tmp/x.txt", "content": content},
+        view=ToolCallContent(title="Write", format="markdown", content=view_content),
+    )
+
+
+def test_bridge_tool_view_substitutes_param_placeholders() -> None:
+    """Viewer ``{{param}}`` placeholders are filled from the call args.
+
+    inspect_swe's Write/Edit viewers emit ``{{content}}`` placeholders that the
+    web viewer fills via ``substituteToolCallContent`` (tool.ts). The ACP path
+    must do the same or editors/TUI render the literal ``{{content}}``.
+    """
+    tr = Transcript()
+    token = _transcript.set(tr)
+    try:
+        _, published = _attach_router(_new_session())
+        with bridge_model_generate():
+            tr._event(_tool_call_event(_write_call(content="hello world")))
+        starts = _starts(published)
+        assert len(starts) == 1
+        text = _content_text(starts[0])
+        assert "hello world" in text
+        assert "{{content}}" not in text
+    finally:
+        _transcript.reset(token)
+
+
+def test_bridge_tool_view_leaves_unknown_placeholder_literal() -> None:
+    """A ``{{param}}`` with no matching arg is left as-is (not blanked)."""
+    tr = Transcript()
+    token = _transcript.set(tr)
+    try:
+        _, published = _attach_router(_new_session())
+        with bridge_model_generate():
+            tr._event(
+                _tool_call_event(_write_call(view_content="{{content}} {{missing}}"))
+            )
+        starts = _starts(published)
+        assert len(starts) == 1
+        text = _content_text(starts[0])
+        assert "hello world" in text  # known key substituted
+        assert "{{missing}}" in text  # unknown key preserved
+    finally:
+        _transcript.reset(token)
+
+
+def test_bridge_tool_view_substitution_preserved_on_completion() -> None:
+    """The settled (completed) card also has placeholders substituted.
+
+    The update path runs through the same ``_content_from_view``, so the result
+    card must show the file body, not the literal ``{{content}}``.
+    """
+    tr = Transcript()
+    token = _transcript.set(tr)
+    try:
+        _, published = _attach_router(_new_session())
+        with bridge_model_generate():
+            tr._event(_tool_call_event(_write_call(content="hello world")))
+            tr._event(
+                _result_event(
+                    ChatMessageTool(
+                        tool_call_id="tc1", function="Write", content="wrote 1 file"
+                    )
+                )
+            )
+        progress = _progress(published)
+        assert len(progress) == 1
+        text = _content_text(progress[0])
+        assert "hello world" in text  # view preserved + substituted
+        assert "{{content}}" not in text
+    finally:
+        _transcript.reset(token)
+
+
 # ---------------------------------------------------------------------------
 # Replay (late-attach) — structural detection, no bridge context
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_acp/test_tui/test_queued_messages_pilot.py
+++ b/tests/agent/test_acp/test_tui/test_queued_messages_pilot.py
@@ -146,15 +146,18 @@ async def test_send_during_running_appends_queued_ephemeral_and_clears_composer(
 
 @skip_if_trio
 @pytest.mark.anyio
-async def test_send_during_idle_does_not_create_ephemeral(
+async def test_send_during_idle_creates_ephemeral(
     sample_rows: list[SessionRow],
 ) -> None:
-    """Send during ``idle`` skips the optimistic ephemeral.
+    """Send during ``idle`` still mounts the optimistic ephemeral.
 
-    The agent is parked in ``before_turn`` and the chunk usually
-    round-trips within milliseconds, so an ephemeral would just flash.
-    Skipping the optimistic echo on idle keeps the transcript steady
-    on the common case.
+    We deliberately do NOT skip on idle: for a bridged agent (claude_code
+    / codex) ``idle`` can occur mid-turn — scaffold startup / ``--resume``
+    relaunch or an inter-model-call gap — where the message is NOT drained
+    within ms but waits for the next turn boundary, so the operator needs
+    the ``user · queued`` chip. The only cost on a native agent that does
+    drain instantly is a sub-perceptible dim→solid flicker (the queued→real
+    swap is atomic). Only ``scoring`` / ``complete`` suppress the echo.
     """
     client = make_fake_client(sample_rows)
     app = InspectAcpApp(eval_id=None, server=None, client=client)
@@ -167,11 +170,14 @@ async def test_send_during_idle_does_not_create_ephemeral(
         await screen.action_submit()
         await pilot.pause()
 
-        # Request was sent, composer cleared, NO ephemeral mounted.
+        # Request was sent, composer cleared, AND the ephemeral is mounted.
         assert composer.text == ""
         conn = cast(Any, screen._session.connection)
         assert len(conn.requests) == 1
-        assert _queued(screen) == []
+        queued = _queued(screen)
+        assert len(queued) == 1
+        assert queued[0].text == "kick off"
+        assert queued[0].user_source == "operator"
 
 
 @skip_if_trio


### PR DESCRIPTION
- ACP: Substitute `{{param}}` placeholders in tool-call views.
- ACP: Keep the optimistic `user · queued` chip visible when agents are idle mid-turn.
- Limits: Fix a spurious, mislabeled `working` limit event recorded alongside the real one when a message/token/cost limit is hit inside a sandboxed agent bridge (e.g. `claude_code`).

