### PR TITLE
transcript: reuse a persistent per-thread SQLite connection in the realtime sample buffer database

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Transcript: Reuse a persistent per-thread SQLite connection in the realtime sample buffer database.
 - Eval Logs: Support for writing to Hugging Face Storage Buckets.
 - S3: Retry when requests have stale signatures.
 

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -156,6 +156,25 @@ class SampleBufferDatabase(SampleBuffer):
         # warn at most once per database if WAL journal mode can't be enabled
         self._wal_checked = False
 
+        # Persistent per-thread SQLite connections. Each thread reuses one
+        # connection across operations instead of opening/closing per call
+        # (a large throughput win, especially under WAL). Connections are
+        # tracked so they can all be closed at cleanup. Initialized before the
+        # schema-creation _get_connection() call below.
+        #
+        # Safety rests on two invariants (see _get_connection): (a) all writes
+        # and explicit-transaction reads run on the single anyio event-loop
+        # thread; the only other DB-touching thread is the read-only filestore
+        # sync worker, so no two threads ever touch the same connection
+        # concurrently. (b) _get_connection() bodies are await-free, so no other
+        # task can interleave a statement onto the shared connection mid-txn.
+        # check_same_thread=False is set purely so cleanup can close a (dead)
+        # thread's handle, not to enable concurrent use.
+        self._local = threading.local()
+        self._connections: list[Connection] = []
+        self._connections_lock = threading.Lock()
+        self._closed = False
+
         # location subdir and file
         dir, file = location_dir_and_file(self.location)
 
@@ -407,9 +426,26 @@ class SampleBufferDatabase(SampleBuffer):
         return True
 
     def _cleanup_now(self) -> None:
+        # Close all persistent connections BEFORE unlinking. This is required
+        # for correctness on Windows (unlink fails on an open file) and to allow
+        # removal of the WAL -wal/-shm sidecars, which stay open as long as a
+        # connection is open. The sync worker is already joined by this point
+        # (see cleanup -> _close_sync_worker_for_cleanup), so closing its handle
+        # cross-thread is safe.
+        self._close_all_connections()
         cleanup_sample_buffer_db(self.db_path)
         if self._sync_filestore is not None:
             self._sync_filestore.cleanup()
+
+    def __del__(self) -> None:
+        # Best-effort close in case cleanup() was never called (e.g. tests that
+        # construct a database without tearing it down). Guard against partial
+        # __init__ where connection state may not exist yet.
+        if getattr(self, "_connections", None) is not None:
+            try:
+                self._close_all_connections()
+            except Exception:
+                pass
 
     @classmethod
     @override
@@ -737,14 +773,14 @@ class SampleBufferDatabase(SampleBuffer):
             if cleanup_ready:
                 self._cleanup_now()
 
-    @contextmanager
-    def _get_connection(
-        self,
-        *,
-        write: bool = False,
-        on_rollback: Callable[[], None] | None = None,
-    ) -> Iterator[Connection]:
-        """Get a database connection."""
+    def _open_connection(self) -> Connection:
+        """Open and configure a new SQLite connection (with connect-time retry).
+
+        Opened with check_same_thread=False so the cleanup/finalizer path can
+        close a connection owned by another (by then dead) thread. This does
+        NOT make the connection safe for concurrent use across threads — each
+        connection is only ever used by the thread that opened it.
+        """
         max_retries = 5
         retry_delay = 0.1
 
@@ -753,7 +789,9 @@ class SampleBufferDatabase(SampleBuffer):
 
         for attempt in range(max_retries):
             try:
-                conn = sqlite3.connect(self.db_path, timeout=30)
+                conn = sqlite3.connect(
+                    self.db_path, timeout=30, check_same_thread=False
+                )
                 conn.row_factory = sqlite3.Row  # enable row factory for named columns
 
                 # Enable foreign key constraints
@@ -797,22 +835,101 @@ class SampleBufferDatabase(SampleBuffer):
                 conn.execute("PRAGMA cache_size=-64000")
                 conn.execute("PRAGMA temp_store=MEMORY")
 
-                break
+                return conn
 
             except sqlite3.OperationalError as e:
                 last_error = e
+                if conn is not None:
+                    conn.close()
+                    conn = None
                 if "locked" in str(e) and attempt < max_retries - 1:
-                    if conn:
-                        conn.close()
                     time.sleep(retry_delay * (2**attempt))
                     continue
                 raise
+            except BaseException:
+                # close any half-open connection before propagating a
+                # non-retryable error raised during connect/PRAGMA setup
+                if conn is not None:
+                    conn.close()
+                raise
 
-        # ensure we have a connection
+        raise sqlite3.OperationalError(
+            f"Failed to establish connection after {max_retries} attempts"
+        ) from last_error
+
+    def _thread_connection(self) -> Connection:
+        """Return this thread's persistent connection, opening one if needed."""
+        if self._closed:
+            raise RuntimeError("SampleBufferDatabase used after cleanup")
+        conn: Connection | None = getattr(self._local, "conn", None)
         if conn is None:
-            raise sqlite3.OperationalError(
-                f"Failed to establish connection after {max_retries} attempts"
-            ) from last_error
+            conn = self._open_connection()
+            with self._connections_lock:
+                # re-check under the lock: if cleanup() won the race while we
+                # were opening, discard this connection rather than tracking and
+                # using a handle to an already-unlinked database
+                if self._closed:
+                    conn.close()
+                    raise RuntimeError("SampleBufferDatabase used after cleanup")
+                self._local.conn = conn
+                self._connections.append(conn)
+        return conn
+
+    def _discard_thread_connection(self, conn: Connection) -> None:
+        """Drop a (possibly poisoned) connection so the next op reopens a fresh one."""
+        if getattr(self._local, "conn", None) is conn:
+            self._local.conn = None
+        with self._connections_lock:
+            try:
+                self._connections.remove(conn)
+            except ValueError:
+                pass
+        try:
+            conn.close()
+        except Exception:
+            pass
+
+    def _close_all_connections(self) -> None:
+        """Close every tracked connection (cleanup/finalizer).
+
+        Precondition: no other thread may be mid-operation on a tracked
+        connection when this runs (closing a connection in use from another
+        thread is undefined even with check_same_thread=False). This holds
+        because callers either (a) join the filestore sync worker first
+        (_close_sync_worker_for_cleanup, which aborts cleanup if the join times
+        out) and (b) run on the single event-loop thread that performs all other
+        DB access — so that thread is never mid-op while calling cleanup. The
+        _closed flag (set here, re-checked under the lock in _thread_connection)
+        closes the remaining "open racing with close" window. Offloading a DB
+        operation to another non-joined thread would break this precondition.
+        """
+        with self._connections_lock:
+            self._closed = True
+            conns, self._connections = self._connections, []
+        for conn in conns:
+            try:
+                conn.close()
+            except Exception:
+                pass
+        # clear the calling thread's handle (other threads are no longer running)
+        self._local.conn = None
+
+    @contextmanager
+    def _get_connection(
+        self,
+        *,
+        write: bool = False,
+        on_rollback: Callable[[], None] | None = None,
+    ) -> Iterator[Connection]:
+        """Get this thread's persistent database connection.
+
+        The connection is reused across operations rather than opened/closed per
+        call. IMPORTANT: the body of a `with _get_connection()` block must remain
+        await-free — an `await` between acquiring the connection and committing
+        would let another anyio task run a statement on the same shared
+        connection mid-transaction.
+        """
+        conn = self._thread_connection()
 
         try:
             # do work
@@ -830,18 +947,24 @@ class SampleBufferDatabase(SampleBuffer):
             conn.commit()
 
         except Exception:
-            # rollback on any error
+            # roll back, then self-heal by discarding the connection so the next
+            # op on this thread transparently reopens a fresh one. Buffer-write
+            # errors are swallowed by the caller (Transcript._notify_subscribers),
+            # so a wedged connection would otherwise silently disable realtime
+            # logging for the rest of the run. on_rollback always fires (even if
+            # rollback() raises) and the original exception is re-raised.
             try:
                 conn.rollback()
+            except Exception:
+                pass
             finally:
+                self._discard_thread_connection(conn)
                 if on_rollback is not None:
                     on_rollback()
             raise
         finally:
-            # close the connection
-            conn.close()
-
-            # if this was for write then sync (throttled)
+            # if this was for write then sync (throttled). Note: no conn.close()
+            # here — the connection persists and is closed at cleanup.
             if write:
                 self._sync()
 
@@ -897,13 +1020,6 @@ class SampleBufferDatabase(SampleBuffer):
                     self._sync_pending = False
                     self._sync_thread = None
                 raise
-
-    def _increment_version(self, conn: Connection) -> None:
-        conn.execute("""
-        UPDATE task_database
-        SET version = version + 1,
-            last_updated = CURRENT_TIMESTAMP;
-        """)
 
     def _get_task_data(self, conn: Connection) -> TaskData:
         row = conn.execute("SELECT version, metrics FROM task_database").fetchone()

--- a/tests/log/test_log_eventdb.py
+++ b/tests/log/test_log_eventdb.py
@@ -3,6 +3,7 @@ import os
 import re
 import sqlite3
 import tempfile
+import threading
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Generator, Iterator, cast
@@ -558,3 +559,178 @@ def test_running_tasks():
             log_uri = Path(log_dir).absolute().as_uri()
             assert len(SampleBufferDatabase.running_tasks(log_uri)) == 2
             assert len(SampleBufferFilestore.running_tasks(log_dir)) == 2
+
+
+def test_connection_is_reused_within_thread(
+    db: SampleBufferDatabase, sample: EvalSampleSummary
+) -> None:
+    """Operations on one thread reuse a single persistent connection."""
+    db.start_sample(sample=sample)
+
+    with db._get_connection() as conn1:
+        pass
+    with db._get_connection() as conn2:
+        pass
+
+    assert conn1 is conn2
+    assert conn1 is db._local.conn
+    # only the one per-thread connection is tracked
+    assert len(db._connections) == 1
+
+
+def test_connection_self_heals_after_error(
+    db: SampleBufferDatabase, sample: EvalSampleSummary
+) -> None:
+    """A failed operation discards the connection; the next op reopens cleanly."""
+    db.start_sample(sample=sample)
+    conn_before = db._local.conn
+
+    # force a failure inside a write transaction
+    with pytest.raises(sqlite3.OperationalError):
+        with db._get_connection(write=True) as conn:
+            conn.execute("INSERT INTO nonexistent_table VALUES (1)")
+
+    # the poisoned connection was discarded (self-heal)
+    assert getattr(db._local, "conn", None) is None
+    assert conn_before not in db._connections
+
+    # subsequent operations succeed with a fresh connection
+    db.log_events(
+        [SampleEvent(id="sample1", epoch=1, event=InfoEvent(data="after-error"))]
+    )
+    conn_after = db._local.conn
+    assert conn_after is not None
+    assert conn_after is not conn_before
+
+    with db._get_connection() as conn:
+        events = list(db._get_events(conn, id="sample1", epoch=1))
+    assert len(events) == 1
+
+
+def test_cleanup_closes_all_connections(
+    db: SampleBufferDatabase, sample: EvalSampleSummary
+) -> None:
+    """Cleanup closes every tracked connection before unlinking the db."""
+    db.start_sample(sample=sample)
+    tracked = list(db._connections)
+    assert len(tracked) >= 1
+
+    db.cleanup()
+
+    assert db._connections == []
+    assert db._closed is True
+    for conn in tracked:
+        with pytest.raises(sqlite3.ProgrammingError):
+            conn.execute("SELECT 1")
+
+
+def test_use_after_cleanup_raises_and_does_not_resurrect_db(
+    db: SampleBufferDatabase, sample: EvalSampleSummary
+) -> None:
+    """After cleanup, operations raise rather than recreating the db files."""
+    db.start_sample(sample=sample)
+    db.cleanup()
+    assert not os.path.exists(db.db_path)
+
+    with pytest.raises(RuntimeError):
+        db.start_sample(sample=sample)
+
+    # the unlinked db (and WAL sidecars) were not resurrected
+    assert not os.path.exists(db.db_path)
+    assert not os.path.exists(f"{db.db_path}-wal")
+    assert not os.path.exists(f"{db.db_path}-shm")
+
+
+def test_per_thread_connections_and_cross_thread_cleanup(
+    db: SampleBufferDatabase, sample: EvalSampleSummary
+) -> None:
+    """Each thread gets its own connection; cleanup closes them cross-thread."""
+    db.start_sample(sample=sample)
+    main_conn = db._local.conn
+
+    worker_conn: list[sqlite3.Connection] = []
+
+    def worker() -> None:
+        # a write from another thread opens that thread's own connection
+        db.log_events(
+            [SampleEvent(id="sample1", epoch=1, event=InfoEvent(data="from-worker"))]
+        )
+        worker_conn.append(db._local.conn)
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    assert len(worker_conn) == 1
+    assert worker_conn[0] is not main_conn
+    assert main_conn in db._connections
+    assert worker_conn[0] in db._connections
+    assert len(db._connections) == 2
+
+    # cleanup on the main thread closes the (now dead) worker thread's
+    # connection without raising, thanks to check_same_thread=False
+    db.cleanup()
+    assert db._connections == []
+    with pytest.raises(sqlite3.ProgrammingError):
+        worker_conn[0].execute("SELECT 1")
+
+
+def test_thread_connection_discards_on_cleanup_race(
+    db: SampleBufferDatabase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If cleanup wins the race during open, the new connection is discarded.
+
+    The used-after-cleanup guard re-checks ``_closed`` under the lock after
+    opening, so a connection opened concurrently with cleanup is closed and not
+    tracked (rather than left pointing at an unlinked database).
+    """
+    real_open = db._open_connection
+    opened: list[sqlite3.Connection] = []
+
+    def open_then_cleanup_wins() -> sqlite3.Connection:
+        conn = real_open()
+        opened.append(conn)
+        db._closed = True  # simulate cleanup completing while we were opening
+        return conn
+
+    monkeypatch.setattr(db, "_open_connection", open_then_cleanup_wins)
+    db._local.conn = None  # force a fresh open on this thread
+
+    with pytest.raises(RuntimeError):
+        db._thread_connection()
+
+    # the just-opened connection was closed and never tracked
+    assert len(opened) == 1
+    assert opened[0] not in db._connections
+    with pytest.raises(sqlite3.ProgrammingError):
+        opened[0].execute("SELECT 1")
+
+
+def test_open_connection_closes_conn_on_non_operational_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-OperationalError during PRAGMA setup must not leak the connection."""
+    original_connect = sqlite3.connect
+    closed: list[bool] = []
+
+    class FailingConnection(sqlite3.Connection):
+        def execute(self, sql: str, *args: Any, **kwargs: Any) -> sqlite3.Cursor:
+            if sql.strip().upper() == "PRAGMA SYNCHRONOUS=OFF":
+                raise ValueError("boom during PRAGMA setup")
+            return super().execute(sql, *args, **kwargs)
+
+        def close(self) -> None:
+            closed.append(True)
+            super().close()
+
+    def connect(*args: Any, **kwargs: Any) -> sqlite3.Connection:
+        kwargs["factory"] = FailingConnection
+        return original_connect(*args, **kwargs)
+
+    monkeypatch.setattr(sqlite3, "connect", connect)
+
+    with pytest.raises(ValueError):
+        SampleBufferDatabase(location="test_location", db_dir=tmp_path)
+
+    # the half-open connection was closed before the error propagated
+    assert closed

--- a/tests/log/test_recover_api.py
+++ b/tests/log/test_recover_api.py
@@ -9,6 +9,7 @@ from zipfile import ZipFile
 
 import pytest
 from pydantic_core import to_jsonable_python
+from test_helpers.buffer import simulate_crashed_buffer_db
 
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.constants import LOG_SCHEMA_VERSION
@@ -101,9 +102,6 @@ def _write_crashed_eval(
     return log_start
 
 
-_DEAD_PID = 99999999  # PID that doesn't exist
-
-
 def _create_buffer_db(
     location: str,
     completed_ids: list[int],
@@ -150,13 +148,8 @@ def _create_buffer_db(
             [SampleEvent(id=id, epoch=1, event=_make_model_event(f"partial {id}"))]
         )
 
-    # Rename DB file to use a dead PID (simulating a crashed process)
-    old_path = buffer.db_path
-    new_path = old_path.parent / old_path.name.replace(
-        f".{os.getpid()}.", f".{_DEAD_PID}."
-    )
-    old_path.rename(new_path)
-    buffer.db_path = new_path
+    # simulate a crashed process: snapshot the DB (incl. hot WAL) under a dead PID
+    simulate_crashed_buffer_db(buffer)
 
     return buffer
 

--- a/tests/log/test_recover_buffer.py
+++ b/tests/log/test_recover_buffer.py
@@ -5,6 +5,8 @@ import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
+from test_helpers.buffer import DEAD_PID, simulate_crashed_buffer_db
+
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.log._log import EvalSampleSummary
 from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
@@ -53,9 +55,6 @@ def _make_model_event(content: str = "test response") -> ModelEvent:
     )
 
 
-_DEAD_PID = 99999999
-
-
 def _create_test_buffer(
     location: str,
     completed_ids: list[int],
@@ -83,13 +82,8 @@ def _create_test_buffer(
             [SampleEvent(id=id, epoch=1, event=_make_model_event(f"partial {id}"))]
         )
 
-    # Rename DB to dead PID to simulate crashed process
-    old_path = buffer.db_path
-    new_path = old_path.parent / old_path.name.replace(
-        f".{os.getpid()}.", f".{_DEAD_PID}."
-    )
-    old_path.rename(new_path)
-    buffer.db_path = new_path
+    # simulate a crashed process: snapshot the DB (incl. hot WAL) under a dead PID
+    simulate_crashed_buffer_db(buffer)
 
     return buffer
 
@@ -170,11 +164,7 @@ def test_read_buffer_recovery_data_empty() -> None:
 
         # Create DB but don't add any samples, simulate dead PID
         buffer = SampleBufferDatabase(location, create=True, db_dir=Path(db_dir))
-        old_path = buffer.db_path
-        new_path = old_path.parent / old_path.name.replace(
-            f".{os.getpid()}.", f".{_DEAD_PID}."
-        )
-        old_path.rename(new_path)
+        simulate_crashed_buffer_db(buffer)
 
         recovery = read_buffer_recovery_data(location, db_dir=db_dir)
         assert recovery is not None
@@ -224,44 +214,24 @@ def test_read_buffer_recovery_data_picks_newest_db() -> None:
     """Test that when multiple dead-PID DBs exist, the newest one is used."""
     import time
 
-    from inspect_ai._util.file import filesystem
-    from inspect_ai.log._recorders.buffer.database import (
-        location_dir_and_file,
-        resolve_db_dir,
-    )
-
     with tempfile.TemporaryDirectory() as temp_dir:
         db_dir = os.path.join(temp_dir, "bufferdb")
         location = os.path.join(temp_dir, "test.eval")
 
-        # Resolve the subdirectory where DBs are stored
-        resolved_dir = resolve_db_dir(Path(db_dir))
-        uri = filesystem(location).path_as_uri(location)
-        dir_hash, file = location_dir_and_file(uri)
-        log_subdir = resolved_dir / dir_hash
-        log_subdir.mkdir(parents=True, exist_ok=True)
-
-        # Create an older DB with dead PID 99999998
-        older_pid = 99999998
-        older_db = log_subdir / f"{file}.{older_pid}.db"
+        # Create an older crashed DB (dead PID 99999998)
         older_buffer = SampleBufferDatabase(location, create=True, db_dir=Path(db_dir))
-        # Add a sample to the older DB
         older_buffer.start_sample(_make_started_summary(1))
         older_buffer.log_events(
             [SampleEvent(id=1, epoch=1, event=_make_model_event("old response"))]
         )
         older_buffer.complete_sample(_make_completed_summary(1))
-        # Rename to dead PID
-        older_buffer.db_path.rename(older_db)
+        simulate_crashed_buffer_db(older_buffer, pid=99999998)
 
-        # Small delay to ensure different mtime
+        # Small delay to ensure the newer snapshot has a later mtime
         time.sleep(0.1)
 
-        # Create a newer DB with dead PID 99999999
-        newer_pid = _DEAD_PID
-        newer_db = log_subdir / f"{file}.{newer_pid}.db"
+        # Create a newer crashed DB (dead PID 99999999)
         newer_buffer = SampleBufferDatabase(location, create=True, db_dir=Path(db_dir))
-        # Add different samples to the newer DB
         newer_buffer.start_sample(_make_started_summary(10))
         newer_buffer.log_events(
             [SampleEvent(id=10, epoch=1, event=_make_model_event("new response"))]
@@ -271,8 +241,7 @@ def test_read_buffer_recovery_data_picks_newest_db() -> None:
         newer_buffer.log_events(
             [SampleEvent(id=11, epoch=1, event=_make_model_event("new partial"))]
         )
-        # Rename to dead PID
-        newer_buffer.db_path.rename(newer_db)
+        simulate_crashed_buffer_db(newer_buffer, pid=DEAD_PID)
 
         # Read recovery data — should pick the newer DB
         recovery = read_buffer_recovery_data(location, db_dir=db_dir)

--- a/tests/log/test_recover_e2e.py
+++ b/tests/log/test_recover_e2e.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
+from test_helpers.buffer import simulate_crashed_buffer_db
 
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.constants import LOG_SCHEMA_VERSION
@@ -88,17 +89,9 @@ def _make_realistic_sample(
     )
 
 
-_DEAD_PID = 99999999
-
-
 def _simulate_crashed_buffer(buffer: SampleBufferDatabase) -> None:
-    """Rename the buffer DB to use a dead PID, simulating a crashed process."""
-    old_path = buffer.db_path
-    new_path = old_path.parent / old_path.name.replace(
-        f".{os.getpid()}.", f".{_DEAD_PID}."
-    )
-    old_path.rename(new_path)
-    buffer.db_path = new_path
+    """Snapshot the buffer DB (incl. hot WAL) under a dead PID, simulating a crash."""
+    simulate_crashed_buffer_db(buffer)
 
 
 def _make_model_event(input_msgs: list[ChatMessage], output_content: str) -> ModelEvent:

--- a/tests/log/test_recover_filestore.py
+++ b/tests/log/test_recover_filestore.py
@@ -10,6 +10,7 @@ from zipfile import ZipFile
 import pytest
 from pydantic import JsonValue
 from pydantic_core import to_jsonable_python
+from test_helpers.buffer import simulate_crashed_buffer_db
 
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.constants import LOG_SCHEMA_VERSION
@@ -383,13 +384,8 @@ def test_db_takes_priority_over_filestore() -> None:
             output=ModelOutput.from_content(model="mockllm/model", content="db output"),
         )
         buffer.log_events([SampleEvent(id=99, epoch=1, event=event)])
-        # Rename to dead PID
-        old_path = buffer.db_path
-        new_path = old_path.parent / old_path.name.replace(
-            f".{os.getpid()}.", ".99999999."
-        )
-        old_path.rename(new_path)
-        buffer.db_path = new_path
+        # simulate a crashed process: snapshot the DB (incl. hot WAL) under a dead PID
+        simulate_crashed_buffer_db(buffer)
 
         recovery = read_buffer_recovery_data(eval_path, db_dir=db_dir)
 

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -360,9 +360,6 @@ def test_open_sample_history_releases_write_lock_after_snapshot(tmp_path):
 def test_sample_history_read_methods_use_deferred_transactions(
     tmp_path, monkeypatch
 ) -> None:
-    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
-    db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
-
     statements: list[str] = []
     original_connect = sqlite3.connect
 
@@ -375,7 +372,15 @@ def test_sample_history_read_methods_use_deferred_transactions(
         kwargs["factory"] = RecordingConnection
         return original_connect(*args, **kwargs)
 
+    # patch before constructing the db so its persistent per-thread connection
+    # records statements; reads reuse that connection rather than opening anew
     monkeypatch.setattr(sqlite3, "connect", connect)
+
+    db = SampleBufferDatabase(str(tmp_path / "test.eval"), db_dir=tmp_path)
+    db.log_events([SampleEvent(id="sample", epoch=1, event=InfoEvent(data="hello"))])
+
+    # only capture statements issued by the read methods exercised below
+    statements.clear()
 
     assert db.sample_event_count("sample", 1) == 1
     assert db.sample_attachment("sample", 1, "missing") is None

--- a/tests/test_helpers/buffer.py
+++ b/tests/test_helpers/buffer.py
@@ -1,0 +1,56 @@
+"""Test helpers for sample-buffer database recovery flows."""
+
+import os
+import shutil
+from pathlib import Path
+
+from inspect_ai.log._recorders.buffer.database import SampleBufferDatabase
+
+# A PID that does not correspond to a live process, so the recovery flow treats
+# the snapshot as belonging to a crashed (not running) eval.
+DEAD_PID = 99999999
+
+
+def simulate_crashed_buffer_db(
+    buffer: SampleBufferDatabase, *, pid: int = DEAD_PID
+) -> Path:
+    """Simulate an eval process crashing with this buffer database still open.
+
+    A real crash leaves the ``.db`` plus its *hot* (uncheckpointed) ``-wal`` /
+    ``-shm`` sidecars on disk under the crashed process's PID. With persistent
+    per-thread connections the committed data lives in the ``-wal`` until a
+    checkpoint, so we snapshot the whole file set to a dead-PID name *without*
+    checkpointing first — reproducing a hot-WAL crash (the common case now).
+
+    The live buffer's handles are then released and its (live-PID) files removed,
+    leaving only the dead-PID snapshot, which the recovery flow discovers via
+    ``psutil`` liveness filtering.
+
+    Args:
+        buffer: the live buffer database to "crash".
+        pid: the dead PID to use in the snapshot filename.
+
+    Returns:
+        Path to the dead-PID ``.db`` snapshot (also assigned to
+        ``buffer.db_path``).
+    """
+    src = buffer.db_path
+    dst = src.parent / src.name.replace(f".{os.getpid()}.", f".{pid}.")
+
+    # snapshot the main db + hot WAL sidecars. copy (not move) avoids disturbing
+    # the still-open connection's files; plain copy gives the snapshot a fresh
+    # mtime so callers that create several crashed DBs get recency ordering that
+    # matches call order (the recovery flow picks the newest by mtime).
+    for suffix in ("", "-wal", "-shm"):
+        source = Path(f"{src}{suffix}")
+        if source.exists():
+            shutil.copy(source, f"{dst}{suffix}")
+
+    # the crashed process is gone: drop its handles and remove the live-PID files
+    # so only the dead-PID snapshot remains (and the name is free for reuse)
+    buffer._close_all_connections()
+    for suffix in ("", "-wal", "-shm"):
+        Path(f"{src}{suffix}").unlink(missing_ok=True)
+
+    buffer.db_path = dst
+    return dst


### PR DESCRIPTION

Closes #4159. Builds on the WAL fix (#4148); see also #1775 and #2038.

## Summary

The realtime sample buffer database (`src/inspect_ai/log/_recorders/buffer/database.py`)
opened a **fresh SQLite connection on every operation** (`log_events`, `start_sample`,
`complete_sample`, `get_samples`, …) and closed it on exit. This switches to **one
persistent connection per thread** (`threading.local`), reused across operations — a large
event-logging throughput win that also makes write throughput independent of journal mode.
The connection lifecycle is the only thing that changes; commit/rollback/version-bump
semantics are preserved.

Because realtime buffer-write errors are **silently swallowed** by the transcript
subscriber loop (`Transcript._notify_subscribers`), a persistent connection that became
poisoned would otherwise disable realtime logging for the rest of a run. To preserve the
self-healing the per-call model gave for free, `_get_connection()` now **discards the
connection on any error** so the next operation transparently reopens.

## Why

`_get_connection()` did `sqlite3.connect()` + a handful of `PRAGMA`s + `close()` on every
call. That per-operation cost is significant in both journal modes and pathological under
WAL (each open maps the `-shm` file and recovers the WAL index; the last close triggers a
checkpoint), which is what made plain per-call WAL *slower* than rollback mode with no
reader. A persistent connection pays connect/PRAGMA/shm-mapping once per thread and lets
WAL amortize commits as intended.

## Benchmarks

Real app code (`benchmarks/buffer_db_journal_mode.py`, 20k events/trial × 3 trials, 0 lock
errors throughout):

| scenario | before (per-call) | after (persistent) | speedup |
| --- | --- | --- | --- |
| single writer, WAL | 1,935 ev/s | **23,828 ev/s** | **~12.3×** |
| single writer, delete | 3,050 ev/s | 5,372 ev/s | ~1.8× |
| writer + concurrent reader, WAL | 636 ev/s | **2,479 ev/s** | **~3.9×** |
| writer + concurrent reader, delete | 798 ev/s | 1,745 ev/s | ~2.2× |

Versus the state **before WAL was enabled at all** (per-call + delete journal): ~7.8×
unobserved and ~3.1× when a reader (bounded transcript or the live viewer) is attached. The
per-call WAL throughput regression is eliminated (WAL was 0.63× delete before; 4.44× after),
and throughput no longer depends on journal mode or whether a reader is attached.

(Absolute numbers are below the raw-SQLite figures in #4159 because they include the
per-event app work — event condensing, JSON, pool dedup, version bump.)

## What changed (`database.py`)

- **Per-thread reuse.** `_open_connection()` factors out the existing connect/retry/PRAGMA
  logic (now opened with `check_same_thread=False`). `_thread_connection()` returns the
  thread's cached connection, opening + tracking one on first use.
- **Self-heal on error.** On any exception, `_get_connection()` rolls back, then discards
  the connection (`_discard_thread_connection`) so the next op on that thread reopens a
  fresh one. `on_rollback` still always fires and the original exception is re-raised.
- **Lifecycle hardening.**
  - All connections are closed in `_cleanup_now()` **before** unlinking the DB — required on
    Windows and to remove the WAL `-wal`/`-shm` sidecars.
  - A used-after-cleanup guard (`_closed`) prevents resurrecting an unlinked DB; it is
    re-checked **under the connections lock** after opening to close the "open races with
    cleanup" window.
  - `_open_connection()` closes any half-open connection on *any* error during
    connect/PRAGMA setup (not just `OperationalError`).
  - A `__del__` finalizer closes handles when `cleanup()` is never called (tests / GC).
- **Documented invariants.** Safety rests on (a) all writes and explicit-transaction reads
  running on the single event-loop thread (the only other DB thread, the filestore sync
  worker, is read-only and is joined before cleanup closes anything), and (b)
  `_get_connection()` blocks staying await-free. These are spelled out in comments at the
  points that depend on them.
- Removed the dead `_increment_version` helper (duplicated the inline version bump).

## Recovery tests

Persistent connections keep committed data in a **hot (uncheckpointed) WAL**, whereas
per-call connections checkpointed on every close. The recovery tests simulated a crash by
renaming only the `.db` file, which left the data stranded in the orphaned `-wal` and broke
21 tests. This was a **test-fidelity issue, not a production regression** — real recovery
reads the crashed files in place with their sidecars present, and SQLite replays the WAL.

The four duplicated crash-simulation helpers are consolidated into a single
`tests/test_helpers/buffer.py::simulate_crashed_buffer_db`, which snapshots the **full file
set** (`.db` + `-wal` + `-shm`) to a dead-PID name with the WAL still hot — so the recovery
suite now exercises the realistic hot-WAL crash path (previously uncovered).

## Tests

- 113 buffer + recovery tests pass (was 21 failing on the recovery side before the helper
  fix).
- New robustness tests: connection reuse, self-heal-after-error, cleanup closes handles,
  used-after-cleanup guard, per-thread isolation + cross-thread cleanup, the open/cleanup
  race, and the half-open-connection leak.
- `ruff format`/`ruff check` clean; `mypy --exclude tests/test_package src tests` clean.

## Durability note

Persistent connections enlarge the window in which committed events live only in the WAL
(checkpointing is now amortized rather than per-op). A **clean process crash** is
unaffected — recovery replays the hot WAL. A hard **power loss** under the existing
`synchronous=OFF` setting can lose more recent events than before; this is the same
durability tradeoff accepted in #1775/#4148, just with a larger window.

## Follow-up (not in this PR)

High-throughput mode (#3173) currently force-disables `log_realtime` partly due to this
overhead. Now that realtime logging is much cheaper, it's worth re-measuring whether it can
be left on at scale — an experiment plan is sketched in
`benchmarks/high_throughput_realtime_experiment.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
