### PR TITLE
logging: complete samples by logging the resident in-memory events di…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Transcript: Reuse a persistent per-thread SQLite connection in the realtime sample buffer database.
+- Logging: Complete samples by logging the resident in-memory events directly rather than reading every event back out of the realtime buffer database.
+- Logging: Re-enable realtime logging and score display for large runs (≥1000 samples) — the buffer-database and sample-completion improvements make them inexpensive enough to leave on.
 - Eval Logs: Support for writing to Hugging Face Storage Buckets.
 - S3: Retry when requests have stale signatures.
 

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -166,13 +166,15 @@ class TaskLogger:
         epochs = eval_config.epochs if eval_config.epochs else 1
         total_samples = len(sample_ids) * epochs
 
-        # adaptive defaults for high-throughput runs
+        # high-throughput runs still get a larger flush buffer (fewer main
+        # eval-log flushes), but we no longer force `log_realtime` or
+        # `score_display` off. Realtime logging is now cheap: sample completion
+        # logs directly from resident memory instead of reading every event
+        # back out of the buffer DB (see `log_sample` in run.py), and the
+        # WAL/persistent-connection buffer DB removed the read/write contention
+        # that motivated disabling it (#3173). Score-display recompute is
+        # throttled and was measured to be negligible at high sample counts.
         high_throughput = _is_high_throughput(total_samples)
-        if high_throughput:
-            if eval_config.log_realtime is None:
-                eval_config.log_realtime = False
-            if eval_config.score_display is None:
-                eval_config.score_display = False
 
         # write defaults for unspecified config
         for name, value in eval_config_defaults().items():

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1460,12 +1460,26 @@ async def task_run_sample(
                         )
 
                     if logger:
+                        # When the full event history is still resident in
+                        # memory we can log the sample directly from memory
+                        # rather than reading every event back out of the
+                        # realtime buffer DB and re-validating it. This is the
+                        # case whenever realtime logging is off (no buffer DB)
+                        # OR the transcript was not bounded-evicted (events
+                        # never exceeded the resident tail — the common case for
+                        # high-throughput runs). Only fall back to the streaming
+                        # read-back when events were actually evicted.
+                        log_from_memory = (
+                            logger.buffer_db is None
+                            or not sample_transcript.history.resident_events_truncated
+                        )
                         eval_sample = await log_sample(
                             eval_sample=make_eval_sample(
-                                include_events=logger.buffer_db is None
+                                include_events=log_from_memory
                             ),
                             logger=logger,
                             log_images=log_images,
+                            from_memory=log_from_memory,
                         )
                     else:
                         eval_sample = make_eval_sample()
@@ -1619,13 +1633,24 @@ async def log_sample(
     eval_sample: EvalSample,
     logger: TaskLogger,
     log_images: bool,
+    *,
+    from_memory: bool,
 ) -> EvalSample:
-    if logger.buffer_db is None:
+    # No realtime buffer DB, or the full history is still resident in memory:
+    # log directly from the in-memory sample (which carries its events). This
+    # avoids the open_sample_history -> materialize_streaming_sample round-trip
+    # (read every event back out of SQLite + re-validate). `complete_sample`
+    # still finalizes the buffer DB via `_finalize_sample`, so when a realtime
+    # buffer exists it stays consistent for live viewing.
+    if logger.buffer_db is None or from_memory:
         await logger.complete_sample(
             condense_sample(eval_sample, log_images), flush=True
         )
         return eval_sample
 
+    # Events were bounded-evicted from memory: stream them back from the buffer
+    # DB (the only place the full history still lives) without re-materializing
+    # the whole sample in memory at once.
     logging_sample = condense_sample(
         eval_sample.model_copy(update={"events": [], "events_data": None}),
         log_images,

--- a/tests/log/test_streaming_completion.py
+++ b/tests/log/test_streaming_completion.py
@@ -81,7 +81,10 @@ async def test_log_sample_returns_materialized_streaming_sample(
     await recorder.log_start(spec, EvalPlan())
 
     materialized = await log_sample(
-        sample.model_copy(update={"events": []}), logger, log_images=True
+        sample.model_copy(update={"events": []}),
+        logger,
+        log_images=True,
+        from_memory=False,
     )
     await _finish_eval(recorder, spec)
 
@@ -126,7 +129,7 @@ async def test_log_sample_rebinds_timelines_to_materialized_events(tmp_path) -> 
     await recorder.log_init(spec, str(tmp_path / "streaming.eval"), clean=True)
     await recorder.log_start(spec, EvalPlan())
 
-    returned = await log_sample(sample, logger, log_images=True)
+    returned = await log_sample(sample, logger, log_images=True, from_memory=False)
     await _finish_eval(recorder, spec)
 
     assert returned.timelines is not None
@@ -290,7 +293,9 @@ async def _log_sample_with_buffer(
     logger.flush_pending = []
     logger._samples_completed = 0
 
-    returned = await log_sample(sample, logger, log_images=log_images)
+    returned = await log_sample(
+        sample, logger, log_images=log_images, from_memory=False
+    )
     await _finish_eval(recorder, spec)
 
     logged_samples = (
@@ -322,6 +327,37 @@ async def test_log_sample_writes_streamed_buffer_events_to_eval(tmp_path) -> Non
     logged_event = logged.events[0]
     assert isinstance(logged_event, ModelEvent)
     assert logged_event.input[0].content == "question"
+
+
+@pytest.mark.anyio
+async def test_log_sample_from_memory_writes_resident_events_without_buffer_readback(
+    tmp_path,
+) -> None:
+    # When the full history is still resident (from_memory=True), log_sample must
+    # write the in-memory events directly and NOT read them back from the buffer
+    # DB. The buffer here holds a DIFFERENT event ("buffer-1"); the resident
+    # event ("resident-1") is what must be logged.
+    sample = _sample().model_copy(
+        update={"events": [InfoEvent(uuid="resident-1", data={"k": "v"})]}
+    )
+    db = _buffer_db(tmp_path, [_model("buffer-1", "answer")])
+    recorder, spec = await _start_eval_recorder(tmp_path)
+    logger = _TaskLoggerShim(db)
+    logger.recorder = recorder
+    logger.eval = spec
+    logger.flush_buffer = 1
+    logger.flush_pending = []
+    logger._samples_completed = 0
+
+    returned = await log_sample(sample, logger, log_images=False, from_memory=True)
+    await _finish_eval(recorder, spec)
+
+    logged_samples = (
+        await read_eval_log_async(str(tmp_path / "streaming.eval"))
+    ).samples
+    assert logged_samples is not None
+    assert [event.uuid for event in returned.events] == ["resident-1"]
+    assert [event.uuid for event in logged_samples[0].events] == ["resident-1"]
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
### Background

  Issue #3173 reported a fast local model (vLLM) with ~1000 connections and a few
  thousand samples running pathologically slowly (~5 hours), dropping to <1 minute
  with `display="none", log_realtime=False`. PR #3232 responded by auto-disabling
  `log_realtime` and `score_display` for runs with ≥1000 samples.

  Since then the realtime buffer DB moved to WAL journal mode (#4148) and
  persistent per-thread connections (#4159), which removed the `database is locked`
  contention that caused the original blow-up. This PR investigates whether the
  auto-disable is still needed — and removes it.

  ### What changed

  - **`log.py`** — stop forcing `log_realtime`/`score_display` off at ≥1000
    samples (the larger `log_buffer` is kept).
  - **`run.py`** — complete samples by logging the resident in-memory events
    directly, instead of reading every event back out of the buffer DB and
    re-validating it (`open_sample_history` → `materialize_streaming_sample`). The
    streaming read-back is only used when the transcript was actually
    bounded-evicted (events exceeded the resident tail). This benefits *all*
    realtime runs, not just high-throughput ones.

  ### Why it's safe (measured)

  End-to-end via `eval()` with a zero-latency `mockllm` (worst case for overhead
  share), 5000 samples × ~62 events, `max_connections=500`:

  | condition | wall | Δ vs baseline |
  | --- | --- | --- |
  | realtime + score off (old default) | 42s | — |
  | realtime on, **before** this change | 92s | **+118%** |
  | realtime on, **after** this change | 54s | **+34%** |
  | score display on | 42s | **~0%** |

  - The +118% was dominated by the per-sample buffer read-back, not buffer writes;
    removing it brings realtime down to ~+34%, which is essentially just the
    per-event buffer writes (these overlap with real inference latency, so the
    real-world cost is far lower than this zero-latency worst case).
  - Score display is effectively free at high sample counts (throttled recompute).
  - The optimization also applies in bounded mode for samples that fit within the
    resident tail (the common high-throughput case).
  - Under an aggressive out-of-process `inspect view`–style reader hammering the
    live DB concurrently with writes: **0 writer and 0 reader lock errors** —
    confirming the WAL/persistent-connection work resolved the #3173 contention.
  - Logs are content-identical between the memory and read-back paths.

  ### Testing

  - `tests/log/test_streaming_completion.py`: existing streaming-path tests updated
    to `from_memory=False`; added a test for the new in-memory completion path.
  - `ruff` clean, full `mypy` clean, `tests/log` + `tests/_eval` pass (693).

  Closes #3173.

  🤖 Generated with [Claude Code](https://claude.com/claude-code)