### PR TITLE
checkpointing: pre-ship polish from gap review

### DIFF
--- a/docs/checkpointing.qmd
+++ b/docs/checkpointing.qmd
@@ -210,7 +210,9 @@ When more than one of the sample / task / eval layers supplies a configuration, 
 
 ### Sandbox Paths
 
-`sandbox_paths` is a map of container name to paths that should be captured for that container. Sandboxes that use only a single container can use the `"default"` key to refer to that container. Note that `sandbox_paths` is treated as a single whole-dict value, not key-wise merged. To add a path to one sandbox while inheriting others, the higher-priority layer must redeclare the full map. Also, while sandbox home directories are included by default, if you specify `sandbox_paths` explicitly you must explicitly include the home directory if you want it checkpointed.
+`sandbox_paths` is a map of container name to paths that should be captured for that container. Sandboxes that use only a single container can use the `"default"` key to refer to that container. Note that `sandbox_paths` is treated as a single whole-dict value, not key-wise merged. To add a path to one sandbox while inheriting others, the higher-priority layer must redeclare the full map. Also, while sandbox home directories are included by default, if you specify `sandbox_paths` explicitly you must explicitly include the home directory if you want it checkpointed. An explicit empty list (e.g. `sandbox_paths={"tools": []}`) opts that sandbox out of checkpointing entirely.
+
+Cache directories are never backed up: any `.cache` directory at any depth (`**/.cache`, including the user's XDG cache dir) is always excluded from sandbox backups — even when you specify `sandbox_paths` explicitly. Agents should not keep state they need across a resume under a `.cache` directory.
 
 ## Checkpoint Flow
 
@@ -225,6 +227,8 @@ When checkpointing is enabled, each sample proceeds as follows:
 4.  **Emit**: A structured `CheckpointEvent` is emitted into the normal event stream (and into the `.eval` log) carrying the trigger, turn, duration, snapshot ids, and size.
 
 Crashed cycles that didn't reach step 3 leave orphan snapshots with no checkpoint file; resume discards them automatically.
+
+For debugging, you can set `INSPECT_CHECKPOINT_LIST_FILES=1` to additionally record each snapshot's added/changed file paths (capped at 100, with a count of any remainder) in the checkpoint file and the `CheckpointEvent`.
 
 ## Custom Agents {#custom-agents}
 

--- a/docs/checkpointing.qmd
+++ b/docs/checkpointing.qmd
@@ -228,8 +228,6 @@ When checkpointing is enabled, each sample proceeds as follows:
 
 Crashed cycles that didn't reach step 3 leave orphan snapshots with no checkpoint file; resume discards them automatically.
 
-Each snapshot's added/changed file paths (capped at 100, with a count of any remainder) are recorded in the checkpoint file and the `CheckpointEvent`.
-
 ## Custom Agents {#custom-agents}
 
 A custom agent participates in checkpointing by entering a `checkpointer()` context and calling `tick()` at each turn boundary.

--- a/docs/checkpointing.qmd
+++ b/docs/checkpointing.qmd
@@ -228,7 +228,7 @@ When checkpointing is enabled, each sample proceeds as follows:
 
 Crashed cycles that didn't reach step 3 leave orphan snapshots with no checkpoint file; resume discards them automatically.
 
-For debugging, you can set `INSPECT_CHECKPOINT_LIST_FILES=1` to additionally record each snapshot's added/changed file paths (capped at 100, with a count of any remainder) in the checkpoint file and the `CheckpointEvent`.
+Each snapshot's added/changed file paths (capped at 100, with a count of any remainder) are recorded in the checkpoint file and the `CheckpointEvent`.
 
 ## Custom Agents {#custom-agents}
 

--- a/src/inspect_ai/_cli/download.py
+++ b/src/inspect_ai/_cli/download.py
@@ -1,14 +1,11 @@
-"""Hidden CLI commands for inspect-managed binary downloads.
+"""CLI commands for inspect-managed binary downloads.
 
 Currently exposes a single subcommand, ``restic``, which pre-warms the
 restic binary cache (every supported platform) so that a checkpointed
 eval starts without waiting for downloads.
 
-The command group is hidden (``hidden=True``) for now: checkpointing
-itself is not yet user-visible, so exposing the command surface to
-customers would advertise functionality that has nothing to do. Shape
-is ``inspect download <kind>`` so other downloadable artifacts can slot
-in without restructuring the namespace.
+Shape is ``inspect download <kind>`` so other downloadable artifacts
+can slot in without restructuring the namespace.
 """
 
 import anyio
@@ -26,12 +23,12 @@ from inspect_ai.util._restic import (
 )
 
 
-@click.group("download", hidden=True)
+@click.group("download")
 def download_command() -> None:
-    """Inspect-managed binary downloads (hidden; internal use)."""
+    """Inspect-managed binary downloads."""
 
 
-@download_command.command("restic", hidden=True)
+@download_command.command("restic")
 def restic_command() -> None:
     """Pre-warm the restic binary cache for every supported platform."""
     anyio.run(_download_all_restic, backend=configured_async_backend())

--- a/src/inspect_ai/dataset/_dataset.py
+++ b/src/inspect_ai/dataset/_dataset.py
@@ -114,7 +114,7 @@ class Sample(BaseModel):
     checkpoint: CheckpointSampleConfig | None = Field(default=None)
     """Checkpoint configuration for this sample. Per-sample configs are
     restricted to the :class:`CheckpointSampleConfig` base class — the
-    eval-wide fields (``checkpoints_dir``, ``retention``) live only on
+    eval-wide fields (``checkpoints_location``, ``retention``) live only on
     :class:`CheckpointConfig` at the task / eval layers. Customize-only:
     a sample config never enables checkpointing (that happens at the task
     or eval layer) and is ignored when nothing enabled it."""

--- a/src/inspect_ai/util/_checkpoint/__init__.py
+++ b/src/inspect_ai/util/_checkpoint/__init__.py
@@ -3,9 +3,7 @@
 Public surface re-exported via :mod:`inspect_ai.util`. Other modules
 in the package (``layout``, ``parse_cli``, ``hydrate``,
 ``_sandbox_restic``, …) are import-from-leaf-module only when external
-callers genuinely need them. See
-``design/plans/checkpointing-working.md`` §2 for the full semantic
-model.
+callers genuinely need them.
 """
 
 from ._triggers import (

--- a/src/inspect_ai/util/_checkpoint/_host_egress.py
+++ b/src/inspect_ai/util/_checkpoint/_host_egress.py
@@ -1,8 +1,7 @@
 """Host egress: ship sample staging dir → remote sample checkpoints dir.
 
 Runs at the end of each fire when the resolved sample checkpoints dir
-is remote. Mirrors the in-sandbox egress protocol (Appendix B of
-``design/plans/checkpointing-working.md``): manifest of files already
+is remote. Mirrors the in-sandbox egress protocol: manifest of files already
 shipped, diff against the live staging dir, ship new files in a safe
 order, then atomically update the manifest.
 

--- a/src/inspect_ai/util/_checkpoint/_layout/host_context.py
+++ b/src/inspect_ai/util/_checkpoint/_layout/host_context.py
@@ -1,7 +1,7 @@
 """On-disk schema for the host context written at each checkpoint fire.
 
 A sample working dir holds five JSON files that restic snapshots each
-cycle (see ``design/plans/checkpointing-working.md`` §5):
+cycle:
 
 - ``events.json`` — condensed transcript events.
 - ``events_data.json`` — ``EventsData`` (messages, calls dedup pools).

--- a/src/inspect_ai/util/_checkpoint/_layout/sample_checkpoints_dir.py
+++ b/src/inspect_ai/util/_checkpoint/_layout/sample_checkpoints_dir.py
@@ -11,9 +11,6 @@ checkpoints dir under the eval checkpoints dir. The dir holds:
   ``sandboxes/<name>/`` (per-sandbox restic repos).
 - ``context/`` — restic backup source (host context JSON files).
 
-See ``design/plans/checkpointing-working.md`` §1 and
-``design/plans/checkpointing-hydration.md``.
-
 The optional ``_<retry>`` suffix on the dir name is omitted until
 ``ActiveSample`` exposes the attempt index — see the TODO at the
 ``Checkpointer.__aenter__`` identity capture.

--- a/src/inspect_ai/util/_checkpoint/_layout/schemas.py
+++ b/src/inspect_ai/util/_checkpoint/_layout/schemas.py
@@ -36,12 +36,11 @@ class SnapshotDetails(BaseModel):
     files: list[str] | None = None
     """Absolute paths of files added or changed in this snapshot (relative
     to its parent; the full file set for the first snapshot), capped at
-    ``MAX_LISTED_FILES``. Opt-in via the ``INSPECT_CHECKPOINT_LIST_FILES``
-    env var; ``None`` when listing is disabled."""
+    ``MAX_LISTED_FILES``."""
 
     additional_files: int | None = None
     """Count of files beyond ``MAX_LISTED_FILES`` not included in
-    ``files``. ``None`` when listing is disabled or nothing was truncated."""
+    ``files``. ``None`` when nothing was truncated."""
 
 
 class Checkpoint(BaseModel):

--- a/src/inspect_ai/util/_checkpoint/_layout/schemas.py
+++ b/src/inspect_ai/util/_checkpoint/_layout/schemas.py
@@ -1,10 +1,8 @@
 """Pydantic models for the on-disk checkpoint layout.
 
 Defines the shape of the per-sample ``restic/restic-config.json`` and
-the per-checkpoint ``ckpt-NNNNN.json`` checkpoint files. See
-``design/plans/checkpointing-working.md`` §1 for the full layout
-description. These are pure data types — read/write helpers live with
-the Phase 3 write code.
+the per-checkpoint ``ckpt-NNNNN.json`` checkpoint files. These are pure
+data types — read/write helpers live with the write code.
 """
 
 from __future__ import annotations
@@ -96,5 +94,5 @@ class ResticConfig(BaseModel):
 
     restic_password: str
     """Password used by every repo (host + each sandbox) under this
-    sample. See ``design/plans/checkpointing-hydration.md`` for how it
-    reaches sandbox-side restic without being persisted in the sandbox."""
+    sample. Reaches sandbox-side restic via the per-exec environment;
+    never persisted in the sandbox."""

--- a/src/inspect_ai/util/_checkpoint/checkpointer_factory.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_factory.py
@@ -27,13 +27,11 @@ def create_checkpointer(
     development — the function returns a no-op setup unless the
     ``INSPECT_CHECKPOINTING`` env var is set to ``"1"``.
     """
-    # TODO(checkpointing-phase-3): capture the sample-level retry /
-    # attempt index. `ActiveSample` does not currently carry it; the
-    # value is published via the `on_sample_attempt_start` hook with
-    # `attempt: int` (1-based).  Resolution options are listed in
-    # `design/plans/checkpointing-working.md` §1 (re: sample-level
-    # retries) — likely we add an `attempt` field to `ActiveSample`
-    # so it's symmetric with `epoch`.
+    # TODO(checkpointing): capture the sample-level retry / attempt
+    # index. `ActiveSample` does not currently carry it; the value is
+    # published via the `on_sample_attempt_start` hook with
+    # `attempt: int` (1-based). Likely we add an `attempt` field to
+    # `ActiveSample` so it's symmetric with `epoch`.
     if config is None:
         return _NoopCheckpointer()
 

--- a/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
@@ -12,7 +12,6 @@ initial inspect_ai package load — only at sample-run time, via the
 from __future__ import annotations
 
 import contextlib
-import os
 import time
 from collections.abc import (
     AsyncIterator,
@@ -77,24 +76,6 @@ logger = getLogger(__name__)
 T = TypeVar("T")
 
 CHECKPOINT_TRANSCRIPT_STORE = "checkpoint_transcript.sqlite"
-
-_LIST_FILES_ENV_VAR = "INSPECT_CHECKPOINT_LIST_FILES"
-_LIST_FILES_DEFAULT = False
-"""Whether to record each sandbox snapshot's added/changed file list (capped
-at :data:`MAX_LISTED_FILES`) in the checkpoint file. Opt-in via
-``INSPECT_CHECKPOINT_LIST_FILES=1``. No config/CLI surface yet."""
-
-
-def _list_files_enabled() -> bool:
-    """Resolve file-listing from the env var, else ``_LIST_FILES_DEFAULT``.
-
-    ``0``/``false``/``no`` (or empty) disable; any other value enables.
-    """
-    val = os.environ.get(_LIST_FILES_ENV_VAR)
-    if val is None:
-        return _LIST_FILES_DEFAULT
-    return val.strip().lower() not in ("", "0", "false", "no")
-
 
 # JSON-primitive Python types; these round-trip identically through
 # `json.dumps`/`json.loads`, so `track()` can return them on resume
@@ -476,27 +457,23 @@ class _EnteredCheckpointer:
                     for (name, _), summary in zip(sandbox_items, summaries[1:])
                 ]
 
-                # List each sandbox snapshot's added/changed files (default on
-                # in dev; see `_list_files_enabled`). Diffs host-side against
-                # the already-egressed repos in parallel, so the in-sandbox
+                # List each sandbox snapshot's added/changed files (capped at
+                # MAX_LISTED_FILES). Diffs host-side against the
+                # already-egressed repos in parallel, so the in-sandbox
                 # exec-output limit is never hit.
-                file_lists: list[tuple[list[str] | None, int]]
-                if _list_files_enabled():
-                    file_lists = await tg_collect(
-                        [
-                            partial(
-                                list_changed_files,
-                                self._host_restic,
-                                sandbox_repo_dir(self._sample_root, name),
-                                self._restic_password,
-                                summary.snapshot_id,
-                                MAX_LISTED_FILES,
-                            )
-                            for name, summary in sandbox_summaries
-                        ]
-                    )
-                else:
-                    file_lists = [(None, 0)] * len(sandbox_summaries)
+                file_lists: list[tuple[list[str] | None, int]] = await tg_collect(
+                    [
+                        partial(
+                            list_changed_files,
+                            self._host_restic,
+                            sandbox_repo_dir(self._sample_root, name),
+                            self._restic_password,
+                            summary.snapshot_id,
+                            MAX_LISTED_FILES,
+                        )
+                        for name, summary in sandbox_summaries
+                    ]
+                )
 
                 sandbox_infos = {
                     name: _snapshot_info(

--- a/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
@@ -79,11 +79,10 @@ T = TypeVar("T")
 CHECKPOINT_TRANSCRIPT_STORE = "checkpoint_transcript.sqlite"
 
 _LIST_FILES_ENV_VAR = "INSPECT_CHECKPOINT_LIST_FILES"
-_LIST_FILES_DEFAULT = True
+_LIST_FILES_DEFAULT = False
 """Whether to record each sandbox snapshot's added/changed file list (capped
-at :data:`MAX_LISTED_FILES`) in the checkpoint file. Defaulted **on** during
-development (opt-out via ``INSPECT_CHECKPOINT_LIST_FILES=0``); flip to
-``False`` (opt-in) before going public. No config/CLI surface yet."""
+at :data:`MAX_LISTED_FILES`) in the checkpoint file. Opt-in via
+``INSPECT_CHECKPOINT_LIST_FILES=1``. No config/CLI surface yet."""
 
 
 def _list_files_enabled() -> bool:

--- a/src/inspect_ai/util/_checkpoint/config.py
+++ b/src/inspect_ai/util/_checkpoint/config.py
@@ -3,9 +3,7 @@
 These dataclasses are the public surface that users construct when
 configuring checkpointing on a :class:`Sample`, :class:`Task`, or
 ``eval(...)``. Configs at different levels are combined via per-field
-merging — see :func:`merge_checkpoint_configs` in this module. The
-full semantic model is described in
-``design/plans/checkpointing-working.md`` §2.
+merging — see :func:`merge_checkpoint_configs` in this module.
 
 Every field on :class:`CheckpointConfig` defaults to ``None`` so that
 "not set at this level" is distinguishable from "explicitly set to a
@@ -39,12 +37,10 @@ class CheckpointSampleConfig:
     also accepted at the task and eval layers (where they participate in
     the per-field merge — precedence: eval > sample > task).
 
-    The fields excluded from this base class — ``checkpoints_dir`` and
-    ``retention`` — are eval-wide concerns that the sample layer must
+    The fields excluded from this base class — ``checkpoints_location``
+    and ``retention`` — are eval-wide concerns that the sample layer must
     not influence. They live only on the derived :class:`CheckpointConfig`,
     which is the type used at the task and eval layers.
-
-    See ``design/plans/checkpointing-working.md`` §2.
     """
 
     trigger: CheckpointTrigger | None = None
@@ -74,12 +70,10 @@ class CheckpointConfig(CheckpointSampleConfig):
     config; the layers are combined per-field at sample-run time
     (precedence: eval > sample > task).
 
-    Adds the eval-wide fields (``checkpoints_dir``, ``retention``) to
-    the sample-permitted base class. Sample-layer configs use the base
+    Adds the eval-wide fields (``checkpoints_location``, ``retention``)
+    to the sample-permitted base class. Sample-layer configs use the base
     :class:`CheckpointSampleConfig` directly — these fields cannot be
     set per-sample.
-
-    See ``design/plans/checkpointing-working.md`` §2.
     """
 
     checkpoints_location: str | None = None
@@ -131,7 +125,7 @@ def merge_checkpoint_configs(
     The sample layer is typed :class:`CheckpointSampleConfig`, so it can
     only contribute to fields shared with that base class
     (``trigger``, ``sandbox_paths``, ``max_consecutive_failures``). The
-    eval-wide fields (``checkpoints_dir``, ``retention``) come only
+    eval-wide fields (``checkpoints_location``, ``retention``) come only
     from the task or eval layers.
 
     For every field, the highest-priority layer with a non-None value

--- a/src/inspect_ai/util/_checkpoint/config.py
+++ b/src/inspect_ai/util/_checkpoint/config.py
@@ -24,9 +24,8 @@ DEFAULT_CHECKPOINT_TRIGGER = TokenInterval(every=500_000)
 """Trigger used when checkpointing is enabled but no layer set a trigger."""
 
 MAX_LISTED_FILES = 100
-"""Max files recorded per snapshot in a checkpoint file when file listing
-is enabled (``INSPECT_CHECKPOINT_LIST_FILES``); the count beyond this is
-recorded in ``additional_files``."""
+"""Max files recorded per snapshot in a checkpoint file; the count beyond
+this is recorded in ``additional_files``."""
 
 
 @dataclass

--- a/src/inspect_ai/util/_checkpoint/hydrate.py
+++ b/src/inspect_ai/util/_checkpoint/hydrate.py
@@ -21,10 +21,10 @@ Sample-root selection:
   host egress (out of scope here) ships state to the remote sample
   checkpoints dir at fire time.
 
-Structure (see ``design/plans/checkpointing-hydration.md`` §3):
+Structure:
 
 - ``_hydrate`` (orchestrator): Phase 1 prologue (paths / dirs /
-  ``sample.json`` / restic binary), then Phase 2 with ``_hydrate_host``
+  ``restic/restic-config.json`` / restic binary), then Phase 2 with ``_hydrate_host``
   and ``_hydrate_sandboxes`` in parallel.
 - ``_hydrate_host``: host repo init or restore.
 - ``_hydrate_sandboxes``: dispatches ``_hydrate_sandbox`` per sandbox in
@@ -177,7 +177,7 @@ async def hydrate(
     )
 
     # Phase 1: synchronous prologue. After this completes, every Phase 2
-    # function can read the password from <sample_root>/sample.json
+    # function can read the password from <sample_root>/restic/restic-config.json
     # and reach restic on the host.
     new_eval_checkpoints_dir = eval_checkpoints_dir(
         log_location, config.checkpoints_location

--- a/src/inspect_ai/util/_restic/ops.py
+++ b/src/inspect_ai/util/_restic/ops.py
@@ -24,7 +24,7 @@ async def init_repo(restic: Path, repo: str, password: str) -> None:
     Skips if the repo is already initialized — important for callers
     that may re-enter the same repo across retries. ``repo`` is always
     a local filesystem path; restic is never invoked against a remote
-    backend (see ``design/plans/checkpointing-remote-dest.md``).
+    backend (remote destinations are reached via host egress instead).
     """
     Path(repo).mkdir(parents=True, exist_ok=True)
     if (Path(repo) / "config").exists():

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -143,10 +143,6 @@ def test_checkpoint_resume_rehydrated_event_layout(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.setenv("INSPECT_CHECKPOINTING", "1")
-    # Opt into per-snapshot file listing so the ckpt JSON records the
-    # sandbox file paths (exercises host-side `restic ls` on the egressed
-    # sandbox repo).
-    monkeypatch.setenv("INSPECT_CHECKPOINT_LIST_FILES", "1")
     # Crash count (host file) + target are inherited by the child processes.
     cancel_file = tmp_path / "cancels.txt"
     monkeypatch.setenv(CANCEL_FILE_ENV, str(cancel_file))


### PR DESCRIPTION
Cleanups from a docs/plans/code gap review of the checkpointing feature.

- Unhide the `inspect download` command group and `restic` subcommand (the checkpointing docs reference it).
- Make per-snapshot file listing unconditional: remove the `INSPECT_CHECKPOINT_LIST_FILES` env var entirely; each snapshot's added/changed files (capped at 100, with a remainder count) are always recorded in the checkpoint file and `CheckpointEvent`.
- Docs (`checkpointing.qmd`): document the always-on `**/.cache` exclusion, the empty-list sandbox opt-out, and the per-snapshot file listing.
- Strip dangling `design/plans/checkpointing-*.md` references from code comments (docs never landed in the repo), preserving the substantive content.
- Fix stale docstring identifiers: `checkpoints_dir` → `checkpoints_location`, `sample.json` → `restic/restic-config.json`.

No behavior changes other than the CLI visibility and the file-listing env var removal.