### PR TITLE
sample loading - more targeted perf improvement #2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Sandbox: Preserve docker-compatible per-sample sandbox config (e.g. a per-sample `ComposeConfig`) when an eval-level sandbox override (`--sandbox <provider>`) is passed without its own config.
 - Limits: Added `turn_limit()` which tracks total generations.
 - Inspect View: Improve sample reading performance in viewer by serving `/log-bytes` range requests as plain responses instead of line-iterating a `BytesIO`.
+- Inspect View: Parse task/task_id from filenames with a prefix before the ISO timestamp (e.g. copied logs like `[ext] 2025-...`) and cache header-derived info by (path, mtime, size), instead of re-reading headers on every listing (`/api/logs` on a 1418-file dir: 2.1s -> 0.04s).
 - Inspect View: Fix log-list grid columns snapping back to default widths while data loads
 - Inspect View: Fix transcript deep links across timelines, approvals, collapsed regions, and lanes; add event label pills.
 - Inspect View:  Improve tool input density

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -1,5 +1,6 @@
 import os
 import re
+from collections import OrderedDict
 from functools import partial
 from logging import getLogger
 from pathlib import Path
@@ -715,9 +716,15 @@ async def log_files_from_ls_async(
 
 
 log_file_pattern = r"^\d{4}-\d{2}-\d{2}T\d{2}[:-]\d{2}[:-]\d{2}.*$"
-# Native Inspect filenames always start with a full ISO timestamp
-# (date + T + HH[:-]MM[:-]SS); anything shorter must use the header fallback.
-_timestamp_prefix_re = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}[:-]\d{2}[:-]\d{2}")
+# Native Inspect filenames start with a full ISO timestamp (date + T +
+# HH[:-]MM[:-]SS). Tools that copy logs may prepend a bracketed tag (e.g.
+# "[ext] 2025-..."), so also accept a single leading "[...]" prefix. Anchored
+# at the start (matched with .match): a timestamp embedded later in a custom
+# name (e.g. "backup-2025-...") must NOT masquerade as native, or we would
+# silently parse the wrong task from the filename instead of the header.
+_timestamp_prefix_re = re.compile(
+    r"(?:\[[^\]]*\]\s*)?\d{4}-\d{2}-\d{2}T\d{2}[:-]\d{2}[:-]\d{2}"
+)
 
 
 def is_log_file(file: str, extensions: list[str]) -> bool:
@@ -756,6 +763,43 @@ def _try_parse_filename(
     task_id = part3[0]
     suffix = part3[1] if len(part3) > 1 else None
     return task, task_id, suffix
+
+
+# Cache header-derived (task, task_id, suffix) so repeated directory
+# listings don't re-read headers for files whose names lack a timestamp.
+# Keyed by (name, mtime, size, etag): a rewritten file changes mtime/size,
+# and on remote stores with coarse mtime (S3 LastModified is 1s) the etag is
+# a content validator that catches a same-second, same-size overwrite the
+# mtime alone would miss. Local files have no etag but nanosecond mtime.
+_HeaderCacheKey = tuple[str, float | None, int, str | None]
+_HeaderInfo = tuple[str | None, str | None, str | None]
+_header_info_cache: "OrderedDict[_HeaderCacheKey, _HeaderInfo]" = OrderedDict()
+_HEADER_INFO_CACHE_MAX = 25000
+
+
+def _header_cache_key(info: FileInfo) -> _HeaderCacheKey | None:
+    # without an mtime there is no way to detect a rewritten file
+    if info.mtime is None:
+        return None
+    return (info.name, info.mtime, info.size, info.etag)
+
+
+def _header_cache_get(info: FileInfo) -> _HeaderInfo | None:
+    key = _header_cache_key(info)
+    if key is None:
+        return None
+    return _header_info_cache.get(key)
+
+
+def _header_cache_put(info: FileInfo, value: _HeaderInfo) -> None:
+    key = _header_cache_key(info)
+    if key is None:
+        return
+    _header_info_cache[key] = value
+    # evict oldest entries rather than wiping the whole cache, so a directory
+    # with more files than the cap doesn't thrash (full re-read) every listing
+    while len(_header_info_cache) > _HEADER_INFO_CACHE_MAX:
+        _header_info_cache.popitem(last=False)
 
 
 def _try_read_header(
@@ -808,7 +852,15 @@ def log_file_info(info: FileInfo) -> "EvalLogInfo":
     parts = _filename_parts(info)
     task, task_id, suffix = _try_parse_filename(parts)
     if task is None:
-        task, task_id, suffix = _try_read_header(info.name)
+        cached = _header_cache_get(info)
+        if cached is not None:
+            task, task_id, suffix = cached
+        else:
+            task, task_id, suffix = _try_read_header(info.name)
+            # cache successes only: a transient read failure must not
+            # stick until the file's mtime happens to change
+            if task is not None:
+                _header_cache_put(info, (task, task_id, suffix))
     return _build_log_info(info, task, task_id, suffix)
 
 
@@ -816,7 +868,15 @@ async def log_file_info_async(info: FileInfo) -> "EvalLogInfo":
     parts = _filename_parts(info)
     task, task_id, suffix = _try_parse_filename(parts)
     if task is None:
-        task, task_id, suffix = await _try_read_header_async(info.name)
+        cached = _header_cache_get(info)
+        if cached is not None:
+            task, task_id, suffix = cached
+        else:
+            task, task_id, suffix = await _try_read_header_async(info.name)
+            # cache successes only: a transient read failure must not
+            # stick until the file's mtime happens to change
+            if task is not None:
+                _header_cache_put(info, (task, task_id, suffix))
     return _build_log_info(info, task, task_id, suffix)
 
 

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -551,6 +551,35 @@ def test_api_log_bytes(view_client: ViewTestClient) -> None:
     assert len(resp.content) == 100
 
 
+def test_api_log_bytes_large_range_fast(view_client: ViewTestClient) -> None:
+    # Regression test: a BytesIO body handed to StreamingResponse is iterated
+    # line by line (random binary has a newline every ~256 bytes), sending
+    # each fragment through a threadpool hop — measured ~3.3s for this 4MB
+    # range; served as a plain Response it takes ~40ms. The 1s bound leaves
+    # >3x margin on the failing side and >20x on the passing side.
+    import random
+    import time
+
+    fname = "2025-01-01T00-00-00+00-00_task_taskid.eval"
+    data = random.Random(0).randbytes(4 * 1024 * 1024)
+    (view_client.log_dir / fname).write_bytes(data)
+
+    start = time.monotonic()
+    resp = view_client.request(
+        "GET",
+        view_client.log_url("log-bytes", fname) + f"?start=0&end={len(data) - 1}",
+    )
+    elapsed = time.monotonic() - start
+
+    resp.raise_for_status()
+    assert resp.content == data
+    assert resp.headers.get("content-length") == str(len(data))
+    assert elapsed < 1.0, (
+        f"4MB range read took {elapsed:.2f}s (~40ms expected, ~3.3s if the "
+        f"line-iteration regression returns; 1s bound leaves >3x margin)"
+    )
+
+
 def test_api_log_download(view_client: ViewTestClient) -> None:
     fname = "2025-01-01T00-00-00+00-00_task_taskid.eval"
     full_path = write_eval_log(view_client.log_dir, fname)

--- a/tests/log/test_log_file_info_fallback.py
+++ b/tests/log/test_log_file_info_fallback.py
@@ -116,6 +116,25 @@ class TestLogFileInfoNativeParse:
         assert result.task == "mytask"
         assert result.task_id == "abc123"
 
+    def test_prefixed_timestamp_filename(self, monkeypatch):
+        """Bracket-prefixed timestamps (e.g. copied logs) skip the header read."""
+        import inspect_ai.log._file as file_mod
+
+        called = {"n": 0}
+
+        def boom(name):
+            called["n"] += 1
+            return None, None, None
+
+        monkeypatch.setattr(file_mod, "_try_read_header", boom)
+        info = _make_fileinfo(
+            "/logs/[ext] 2026-03-15T11-51-45+00-00_mytask_abc123.eval"
+        )
+        result = log_file_info(info)
+        assert called["n"] == 0  # parsed from name, no header read
+        assert result.task == "mytask"
+        assert result.task_id == "abc123"
+
 
 class TestLogFileInfoHeaderFallback:
     """Custom filenames (no ISO timestamp prefix) trigger header reading."""
@@ -145,6 +164,22 @@ class TestLogFileInfoHeaderFallback:
         result = log_file_info(info)
         assert result.task == "numeric_test"
         assert result.task_id == "num_id"
+
+    def test_embedded_timestamp_in_custom_name_uses_header(self, tmp_path):
+        """A timestamp embedded mid-name must NOT be parsed as a native name.
+
+        `backup-2025-...T..._results_x.eval` has an ISO timestamp after a "-"
+        boundary inside the first segment. It must fall back to the header
+        (task from the file), not silently take `results` from the filename.
+        """
+        header = _make_full_header(task="real_task", task_id="real_id")
+        eval_path = tmp_path / "backup-2025-01-01T00-00-00_results_x.eval"
+        _make_eval_zip(str(eval_path), header)
+
+        info = _make_fileinfo(str(eval_path), size=os.path.getsize(eval_path))
+        result = log_file_info(info)
+        assert result.task == "real_task"
+        assert result.task_id == "real_id"
 
     def test_hour_only_timestamp_not_native(self, tmp_path):
         """Truncated ISO prefix (YYYY-MM-DDTHH only) must not take the fast path."""
@@ -180,6 +215,120 @@ class TestLogFileInfoHeaderFallback:
         assert result.task == "onlytask"
         # EvalSpec.task_id has Field(default_factory=str) -> defaults to ""
         assert result.task_id == ""
+
+    def test_header_info_cached_across_calls(self, tmp_path, monkeypatch):
+        """Repeated listings reuse the cached header info for unchanged files."""
+        import inspect_ai.log._file as file_mod
+
+        file_mod._header_info_cache.clear()
+
+        header = _make_full_header(task="cached_task", task_id="cached_id")
+        eval_path = tmp_path / "cache_test.eval"
+        _make_eval_zip(str(eval_path), header)
+
+        calls = {"n": 0}
+        orig = file_mod._try_read_header
+
+        def counting(name):
+            calls["n"] += 1
+            return orig(name)
+
+        monkeypatch.setattr(file_mod, "_try_read_header", counting)
+
+        info = _make_fileinfo(str(eval_path), size=os.path.getsize(eval_path))
+        r1 = log_file_info(info)
+        r2 = log_file_info(info)
+        assert calls["n"] == 1
+        assert r1.task == r2.task == "cached_task"
+
+        # changed mtime invalidates the cache entry
+        info2 = FileInfo(
+            name=info.name, type="file", size=info.size, mtime=info.mtime + 1
+        )
+        log_file_info(info2)
+        assert calls["n"] == 2
+
+    def test_etag_distinguishes_same_mtime_size_overwrite(self, monkeypatch):
+        """A same-mtime, same-size overwrite with a new etag must re-read.
+
+        On S3 (LastModified is 1s-resolution), a fixed path like `latest.eval`
+        can be overwritten within one second by a different eval of the same
+        byte size. Without the etag in the key the stale task would be served
+        for the process lifetime; the etag is a content validator.
+        """
+        import inspect_ai.log._file as file_mod
+
+        file_mod._header_info_cache.clear()
+
+        calls = {"n": 0}
+
+        def fake_read(name):
+            calls["n"] += 1
+            return f"task{calls['n']}", f"id{calls['n']}", None
+
+        monkeypatch.setattr(file_mod, "_try_read_header", fake_read)
+
+        base = dict(
+            name="s3://bucket/latest.eval",
+            type="file",
+            size=1000,
+            mtime=1710000000.0,
+        )
+        r1 = log_file_info(FileInfo(**base, etag="etag-aaa"))
+        assert r1.task == "task1"
+
+        # new content (new etag), identical name/mtime/size -> must re-read
+        r2 = log_file_info(FileInfo(**base, etag="etag-bbb"))
+        assert calls["n"] == 2
+        assert r2.task == "task2"
+
+        # unchanged etag -> cache hit, no further read
+        r3 = log_file_info(FileInfo(**base, etag="etag-bbb"))
+        assert calls["n"] == 2
+        assert r3.task == "task2"
+
+    def test_cache_evicts_oldest_instead_of_full_wipe(self, monkeypatch):
+        """Exceeding the cap evicts only the oldest entry, not the whole cache.
+
+        A full wipe at the cap makes a directory larger than the cap re-read
+        every header on every listing (thundering herd); FIFO eviction keeps
+        the most-recent entries warm and still serving hits.
+        """
+        import inspect_ai.log._file as file_mod
+
+        file_mod._header_info_cache.clear()
+        monkeypatch.setattr(file_mod, "_HEADER_INFO_CACHE_MAX", 3)
+
+        reads = {"n": 0}
+
+        def counting(name):
+            reads["n"] += 1
+            return "t", "i", None
+
+        monkeypatch.setattr(file_mod, "_try_read_header", counting)
+
+        def info(i):
+            return FileInfo(name=f"/x/f{i}.eval", type="file", size=1, mtime=float(i))
+
+        for i in range(3):
+            log_file_info(info(i))
+        assert len(file_mod._header_info_cache) == 3
+        assert reads["n"] == 3
+
+        # one more past the cap: oldest (f0) evicted, cache stays bounded
+        log_file_info(info(3))
+        assert len(file_mod._header_info_cache) == 3
+        assert reads["n"] == 4
+        names = [key[0] for key in file_mod._header_info_cache]
+        assert "/x/f0.eval" not in names
+        assert "/x/f3.eval" in names
+
+        # the surviving recent entry still serves a hit (no re-read) ...
+        log_file_info(info(3))
+        assert reads["n"] == 4
+        # ... while the evicted entry must be re-read
+        log_file_info(info(0))
+        assert reads["n"] == 5
 
     def test_determinism(self, tmp_path):
         """Calling log_file_info twice on same file returns identical results."""


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
* sample loading feels slow => follow-up of #4211

### What is the new behavior?
* subjectively faster loading of lists of samples and sample details (measurements done by Fable 5 in commit messages)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
* no, I hope 🤞

### Other information:
* [x] merge main of this repo if #4211 is merged, exclude it if rejected
* [x] rebase to main of ts-mono after merging https://github.com/meridianlabs-ai/ts-mono/pull/318
