### PR TITLE
fix(checkpoint): reuse torn checkpoint ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.
 - Control Channel: `inspect ctl tasks` now pins each eval's reported start to its first sample's start instead of letting it drift forward as early samples finish.
-- Checkpointing: Keep torn checkpoint files out of remote egress uploads and manifests so resumed runs can repair and ship reused checkpoint ids.
 - Inspect view: Improve MathJax Sanitization
 - Inspect view: Fix stale running status on nav
 - Inspect view: Fix broken commit links for ssh-style GitHub origins
 - Inspect view: Cap oversized tool/text output to prevent resize layerization stalls
 - Inspect view: Fix event panel nav pills never expanding back from picker mode
+- Buf fix: Keep torn checkpoint files out of remote egress uploads and manifests so resumed runs can repair and ship reused checkpoint ids.
 
 ## 0.3.241 (22 June 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.
 - Control Channel: `inspect ctl tasks` now pins each eval's reported start to its first sample's start instead of letting it drift forward as early samples finish.
+- Checkpointing: Keep torn checkpoint files out of remote egress uploads and manifests so resumed runs can repair and ship reused checkpoint ids.
 - Inspect view: Improve MathJax Sanitization
 - Inspect view: Fix stale running status on nav
 - Inspect view: Fix broken commit links for ssh-style GitHub origins

--- a/src/inspect_ai/util/_checkpoint/_host_egress.py
+++ b/src/inspect_ai/util/_checkpoint/_host_egress.py
@@ -40,6 +40,7 @@ from inspect_ai._util.asyncfiles import get_async_filesystem
 from inspect_ai._util.trace import trace_action
 
 from ._async_fs import async_mkdir
+from ._layout.schemas import Checkpoint
 
 logger = getLogger(__name__)
 
@@ -71,7 +72,11 @@ def seed_manifest(staging_dir: str) -> int:
     the destination. Returns the entry count for diagnostics.
     """
     staging = Path(staging_dir)
-    files = _scan_new_files(staging, shipped=set())
+    files = [
+        rel
+        for rel in _scan_new_files(staging, shipped=set())
+        if _committed_checkpoint_or_other(staging, rel)
+    ]
     _write_manifest(staging / MANIFEST_FILENAME, set(files))
     return len(files)
 
@@ -132,6 +137,16 @@ def _scan_new_files(staging: Path, shipped: set[str]) -> list[str]:
             continue
         new.append(rel_s)
     return new
+
+
+def _committed_checkpoint_or_other(staging: Path, rel: str) -> bool:
+    if not _CHECKPOINT_FILE_RE.match(Path(rel).name):
+        return True
+    try:
+        Checkpoint.model_validate_json((staging / rel).read_bytes())
+    except Exception:
+        return False
+    return True
 
 
 def _safe_order(files: list[str]) -> list[str]:

--- a/src/inspect_ai/util/_checkpoint/_host_egress.py
+++ b/src/inspect_ai/util/_checkpoint/_host_egress.py
@@ -91,7 +91,11 @@ async def host_egress(*, staging_dir: str, destination_dir: str) -> None:
     staging = Path(staging_dir)
     manifest_path = staging / MANIFEST_FILENAME
     shipped = _read_manifest(manifest_path)
-    new_files = _scan_new_files(staging, shipped)
+    new_files = [
+        rel
+        for rel in _scan_new_files(staging, shipped)
+        if _committed_checkpoint_or_other(staging, rel)
+    ]
     if not new_files:
         return
     ordered = _safe_order(new_files)

--- a/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer_impl.py
@@ -61,7 +61,7 @@ from ._layout.host_context import (
     STORE,
 )
 from ._layout.sample_checkpoints_dir import (
-    _list_checkpoint_ids,
+    scan_latest_committed_id,
     write_checkpoint_file,
 )
 from ._layout.schemas import Checkpoint, SnapshotDetails
@@ -411,11 +411,9 @@ class _EnteredCheckpointer:
         # the per-checkpoint file.
         cycle_start = time.monotonic()
 
-        # Checkpoint file numbering continues from any checkpoint files
-        # already present in the dir (incl. those FS-copied from a prior
-        # eval on resume). Scanned per-fire rather than tracked in
-        # memory so the count naturally bridges resumed runs without an
-        # explicit handoff.
+        # Checkpoint file numbering continues from the latest committed
+        # checkpoint. Torn checkpoint files are intentionally ignored so
+        # the next successful fire can replace them.
         next_checkpoint_id = await _scan_next_checkpoint_id(self._sample_root)
 
         # Wrap the whole fire in a trace action so an in-progress fire is
@@ -672,14 +670,12 @@ class _EnteredCheckpointer:
 async def _scan_next_checkpoint_id(sample_root: str) -> int:
     """Return the next checkpoint file ordinal for this sample.
 
-    Walks the sample root for ``ckpt-NNNNN.json`` filenames and returns
-    ``max(N) + 1`` — or 1 if none exist yet. Used by ``_fire`` so the
-    count continues across resume without an explicit handoff through
-    ``_hydrate``.
+    Uses the latest parseable checkpoint file as the commit point. A
+    torn ``ckpt-NNNNN.json`` is not committed, so the next successful
+    fire reuses that id instead of skipping ahead.
     """
-    ids = await _list_checkpoint_ids(sample_root)
-    next_id = (max(ids) + 1) if ids else 1
-    return next_id
+    latest = await scan_latest_committed_id(sample_root)
+    return latest + 1 if latest is not None else 1
 
 
 def _restic_tag(checkpoint_id: int) -> str:

--- a/tests/checkpoint/test_checkpointer.py
+++ b/tests/checkpoint/test_checkpointer.py
@@ -55,6 +55,7 @@ from inspect_ai.util._checkpoint.checkpointer_impl import (
     CheckpointFailureLimitExceeded,
     _CheckpointerSetup,
     _EnteredCheckpointer,
+    _scan_next_checkpoint_id,
 )
 from inspect_ai.util._checkpoint.checkpointer_noop import _NoopCheckpointer
 from inspect_ai.util._checkpoint.config import ResolvedCheckpointConfig
@@ -462,6 +463,16 @@ def _write_checkpoint_files(sample_root: Path, count: int) -> None:
         (sample_root / f"ckpt-{checkpoint_id:05d}.json").write_text(
             checkpoint.model_dump_json()
         )
+
+
+async def test_scan_next_checkpoint_id_reuses_torn_checkpoint_id(
+    tmp_path: Path,
+) -> None:
+    sample_root = tmp_path / "sample"
+    _write_checkpoint_files(sample_root, 2)
+    (sample_root / "ckpt-00003.json").write_text("{")
+
+    assert await _scan_next_checkpoint_id(str(sample_root)) == 3
 
 
 def _checkpoint_resume_events(count: int) -> list[Event]:

--- a/tests/checkpoint/test_fs_copy_s3.py
+++ b/tests/checkpoint/test_fs_copy_s3.py
@@ -35,20 +35,24 @@ async def _put(fs: AsyncFilesystem, uri: str, content: bytes) -> None:
 
 
 def _checkpoint_bytes(checkpoint_id: int) -> bytes:
-    return Checkpoint(
-        checkpoint_id=checkpoint_id,
-        trigger="turn",
-        turn=checkpoint_id,
-        created_at=datetime(2026, 5, 17, 18, 0, tzinfo=timezone.utc),
-        duration_ms=10,
-        size_bytes=100 + checkpoint_id,
-        host=SnapshotDetails(
-            snapshot_id=f"snap-{checkpoint_id}",
-            size_bytes=100 + checkpoint_id,
+    return (
+        Checkpoint(
+            checkpoint_id=checkpoint_id,
+            trigger="turn",
+            turn=checkpoint_id,
+            created_at=datetime(2026, 5, 17, 18, 0, tzinfo=timezone.utc),
             duration_ms=10,
-        ),
-        sandboxes={},
-    ).model_dump_json().encode()
+            size_bytes=100 + checkpoint_id,
+            host=SnapshotDetails(
+                snapshot_id=f"snap-{checkpoint_id}",
+                size_bytes=100 + checkpoint_id,
+                duration_ms=10,
+            ),
+            sandboxes={},
+        )
+        .model_dump_json()
+        .encode()
+    )
 
 
 async def test_fs_copy_cross_cutting_downloads_from_s3(

--- a/tests/checkpoint/test_fs_copy_s3.py
+++ b/tests/checkpoint/test_fs_copy_s3.py
@@ -10,6 +10,7 @@ payload. Also covers ``_fs_copy_repo`` against a local relative source
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -20,6 +21,7 @@ from inspect_ai.util._checkpoint._host_egress import (
     host_egress,
     seed_manifest,
 )
+from inspect_ai.util._checkpoint._layout.schemas import Checkpoint, SnapshotDetails
 from inspect_ai.util._checkpoint.hydrate import (
     _fs_copy_cross_cutting,
     _fs_copy_repo,
@@ -30,6 +32,23 @@ S3_BUCKET = "s3://test-bucket"
 
 async def _put(fs: AsyncFilesystem, uri: str, content: bytes) -> None:
     await fs.write_file(uri, content)
+
+
+def _checkpoint_bytes(checkpoint_id: int) -> bytes:
+    return Checkpoint(
+        checkpoint_id=checkpoint_id,
+        trigger="turn",
+        turn=checkpoint_id,
+        created_at=datetime(2026, 5, 17, 18, 0, tzinfo=timezone.utc),
+        duration_ms=10,
+        size_bytes=100 + checkpoint_id,
+        host=SnapshotDetails(
+            snapshot_id=f"snap-{checkpoint_id}",
+            size_bytes=100 + checkpoint_id,
+            duration_ms=10,
+        ),
+        sandboxes={},
+    ).model_dump_json().encode()
 
 
 async def test_fs_copy_cross_cutting_downloads_from_s3(
@@ -180,7 +199,7 @@ async def test_seed_manifest_after_remote_resume_blocks_reupload(
         )
         await _put(fs, f"{src_root}/restic/host/config", b"cfg")
         await _put(fs, f"{src_root}/restic/host/data/ab/cd", b"pack")
-        await _put(fs, f"{src_root}/ckpt-00001.json", b"side1")
+        await _put(fs, f"{src_root}/ckpt-00001.json", _checkpoint_bytes(1))
 
         # Resume: download into a fresh local staging dir.
         await _fs_copy_cross_cutting(src_root, str(staging))

--- a/tests/checkpoint/test_host_egress.py
+++ b/tests/checkpoint/test_host_egress.py
@@ -75,7 +75,7 @@ async def test_ships_new_files_and_writes_manifest(staging: Path, dest: Path) ->
     _write(staging / "restic" / "host" / "keys" / "abc", "host-key")
     _write(staging / "restic" / "host" / "data" / "ab" / "cdef", "pack-data")
     _write(staging / "restic" / "restic-config.json", '{"restic_password":"pwd"}')
-    _write(staging / "ckpt-00001.json", '{"checkpoint_id":1}')
+    _write(staging / "ckpt-00001.json", _checkpoint_json(1))
 
     await host_egress(staging_dir=str(staging), destination_dir=str(dest))
 
@@ -88,7 +88,7 @@ async def test_ships_new_files_and_writes_manifest(staging: Path, dest: Path) ->
     assert (
         dest / "restic" / "restic-config.json"
     ).read_text() == '{"restic_password":"pwd"}'
-    assert (dest / "ckpt-00001.json").read_text() == '{"checkpoint_id":1}'
+    assert (dest / "ckpt-00001.json").read_text() == _checkpoint_json(1)
 
     # Manifest reflects shipment
     manifest = (staging / MANIFEST_FILENAME).read_text().splitlines()
@@ -116,7 +116,7 @@ async def test_excludes_context_subdir(staging: Path, dest: Path) -> None:
 
 async def test_second_cycle_only_ships_new_files(staging: Path, dest: Path) -> None:
     _write(staging / "restic" / "host" / "config", "host-config")
-    _write(staging / "ckpt-00001.json", "first")
+    _write(staging / "ckpt-00001.json", _checkpoint_json(1))
     await host_egress(staging_dir=str(staging), destination_dir=str(dest))
 
     # Tamper with what's already at the destination to prove the
@@ -124,12 +124,12 @@ async def test_second_cycle_only_ships_new_files(staging: Path, dest: Path) -> N
     (dest / "restic" / "host" / "config").write_text("untouched-after-egress")
 
     _write(staging / "restic" / "host" / "data" / "ab" / "cd", "pack")
-    _write(staging / "ckpt-00002.json", "second")
+    _write(staging / "ckpt-00002.json", _checkpoint_json(2))
     await host_egress(staging_dir=str(staging), destination_dir=str(dest))
 
     assert (dest / "restic" / "host" / "config").read_text() == "untouched-after-egress"
     assert (dest / "restic" / "host" / "data" / "ab" / "cd").read_text() == "pack"
-    assert (dest / "ckpt-00002.json").read_text() == "second"
+    assert (dest / "ckpt-00002.json").read_text() == _checkpoint_json(2)
 
 
 async def test_sandbox_repos_shipped(staging: Path, dest: Path) -> None:
@@ -154,6 +154,32 @@ def test_seed_manifest_skips_torn_checkpoint_files(staging: Path) -> None:
 
     manifest = (staging / MANIFEST_FILENAME).read_text().splitlines()
     assert set(manifest) == {"restic/host/config", "ckpt-00001.json"}
+
+
+async def test_host_egress_does_not_manifest_torn_future_checkpoint(
+    staging: Path, dest: Path
+) -> None:
+    _write(staging / "restic" / "host" / "config", "host-config")
+    _write(staging / "ckpt-00001.json", _checkpoint_json(1))
+    _write(staging / "ckpt-00002.json", _checkpoint_json(2))
+    _write(staging / "ckpt-00003.json", "{")
+    _write(staging / "ckpt-00004.json", "{")
+
+    seed_manifest(str(staging))
+
+    _write(staging / "ckpt-00003.json", _checkpoint_json(3))
+    await host_egress(staging_dir=str(staging), destination_dir=str(dest))
+
+    manifest = (staging / MANIFEST_FILENAME).read_text().splitlines()
+    assert "ckpt-00003.json" in manifest
+    assert "ckpt-00004.json" not in manifest
+    assert (dest / "ckpt-00003.json").read_text() == _checkpoint_json(3)
+    assert not (dest / "ckpt-00004.json").exists()
+
+    _write(staging / "ckpt-00004.json", _checkpoint_json(4))
+    await host_egress(staging_dir=str(staging), destination_dir=str(dest))
+
+    assert (dest / "ckpt-00004.json").read_text() == _checkpoint_json(4)
 
 
 def test_safe_order_ships_checkpoint_file_last() -> None:

--- a/tests/checkpoint/test_host_egress.py
+++ b/tests/checkpoint/test_host_egress.py
@@ -8,6 +8,7 @@ remote sample checkpoints dir minus the network.
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 import pytest
@@ -16,7 +17,9 @@ from inspect_ai.util._checkpoint._host_egress import (
     MANIFEST_FILENAME,
     _safe_order,
     host_egress,
+    seed_manifest,
 )
+from inspect_ai.util._checkpoint._layout.schemas import Checkpoint, SnapshotDetails
 
 
 @pytest.fixture
@@ -42,6 +45,23 @@ def dest(tmp_path: Path) -> Path:
 def _write(p: Path, content: str = "x") -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_text(content)
+
+
+def _checkpoint_json(checkpoint_id: int) -> str:
+    return Checkpoint(
+        checkpoint_id=checkpoint_id,
+        trigger="turn",
+        turn=checkpoint_id,
+        created_at=datetime(2026, 5, 17, 18, 0, tzinfo=timezone.utc),
+        duration_ms=10,
+        size_bytes=100 + checkpoint_id,
+        host=SnapshotDetails(
+            snapshot_id=f"snap-{checkpoint_id}",
+            size_bytes=100 + checkpoint_id,
+            duration_ms=10,
+        ),
+        sandboxes={},
+    ).model_dump_json()
 
 
 async def test_noop_when_no_files(staging: Path, dest: Path) -> None:
@@ -123,6 +143,17 @@ async def test_sandbox_repos_shipped(staging: Path, dest: Path) -> None:
 
     assert (dest / "restic" / "sandboxes" / "default" / "config").is_file()
     assert (dest / "restic" / "sandboxes" / "default" / "data" / "ab" / "cd").is_file()
+
+
+def test_seed_manifest_skips_torn_checkpoint_files(staging: Path) -> None:
+    _write(staging / "restic" / "host" / "config", "host-config")
+    _write(staging / "ckpt-00001.json", _checkpoint_json(1))
+    _write(staging / "ckpt-00002.json", "{")
+
+    assert seed_manifest(str(staging)) == 2
+
+    manifest = (staging / MANIFEST_FILENAME).read_text().splitlines()
+    assert set(manifest) == {"restic/host/config", "ckpt-00001.json"}
 
 
 def test_safe_order_ships_checkpoint_file_last() -> None:

--- a/tests/checkpoint/test_host_egress_s3.py
+++ b/tests/checkpoint/test_host_egress_s3.py
@@ -8,10 +8,12 @@ files written into a local staging dir, host egress ships them to
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai.util._checkpoint._host_egress import MANIFEST_FILENAME, host_egress
+from inspect_ai.util._checkpoint._layout.schemas import Checkpoint, SnapshotDetails
 
 S3_BUCKET = "s3://test-bucket"
 
@@ -19,6 +21,27 @@ S3_BUCKET = "s3://test-bucket"
 def _write(p: Path, content: bytes = b"x") -> None:
     p.parent.mkdir(parents=True, exist_ok=True)
     p.write_bytes(content)
+
+
+def _checkpoint_bytes(checkpoint_id: int) -> bytes:
+    return (
+        Checkpoint(
+            checkpoint_id=checkpoint_id,
+            trigger="turn",
+            turn=checkpoint_id,
+            created_at=datetime(2026, 5, 17, 18, 0, tzinfo=timezone.utc),
+            duration_ms=10,
+            size_bytes=100 + checkpoint_id,
+            host=SnapshotDetails(
+                snapshot_id=f"snap-{checkpoint_id}",
+                size_bytes=100 + checkpoint_id,
+                duration_ms=10,
+            ),
+            sandboxes={},
+        )
+        .model_dump_json()
+        .encode()
+    )
 
 
 async def test_host_egress_roundtrip_to_s3(tmp_path: Path, mock_s3: None) -> None:
@@ -37,7 +60,7 @@ async def test_host_egress_roundtrip_to_s3(tmp_path: Path, mock_s3: None) -> Non
         b"sb-pack",
     )
     _write(staging / "restic" / "restic-config.json", b'{"restic_password":"pwd"}')
-    _write(staging / "ckpt-00001.json", b'{"checkpoint_id":1}')
+    _write(staging / "ckpt-00001.json", _checkpoint_bytes(1))
     # Should be excluded:
     _write(staging / "context" / "events.json", b"events")
 
@@ -63,7 +86,7 @@ async def test_host_egress_roundtrip_to_s3(tmp_path: Path, mock_s3: None) -> Non
             await fs.read_file(f"{dest}/restic/restic-config.json")
             == b'{"restic_password":"pwd"}'
         )
-        assert await fs.read_file(f"{dest}/ckpt-00001.json") == b'{"checkpoint_id":1}'
+        assert await fs.read_file(f"{dest}/ckpt-00001.json") == _checkpoint_bytes(1)
 
         # Context subdir must not have been shipped.
         assert not await fs.exists(f"{dest}/context/events.json")
@@ -82,7 +105,7 @@ async def test_host_egress_second_cycle_only_ships_new(
     staging.mkdir()
     (staging / "context").mkdir()
     _write(staging / "restic" / "host" / "config", b"v1")
-    _write(staging / "ckpt-00001.json", b"side1")
+    _write(staging / "ckpt-00001.json", _checkpoint_bytes(1))
     dest = f"{S3_BUCKET}/egress-second/eval.checkpoints/s__0"
 
     async with AsyncFilesystem() as fs:
@@ -93,7 +116,7 @@ async def test_host_egress_second_cycle_only_ships_new(
         await fs.write_file(f"{dest}/restic/host/config", b"untouched-after-egress")
 
         _write(staging / "restic" / "host" / "data" / "ab" / "cd", b"pack")
-        _write(staging / "ckpt-00002.json", b"side2")
+        _write(staging / "ckpt-00002.json", _checkpoint_bytes(2))
         await host_egress(staging_dir=str(staging), destination_dir=dest)
 
         assert (
@@ -101,4 +124,4 @@ async def test_host_egress_second_cycle_only_ships_new(
             == b"untouched-after-egress"
         )
         assert await fs.read_file(f"{dest}/restic/host/data/ab/cd") == b"pack"
-        assert await fs.read_file(f"{dest}/ckpt-00002.json") == b"side2"
+        assert await fs.read_file(f"{dest}/ckpt-00002.json") == _checkpoint_bytes(2)


### PR DESCRIPTION
## Summary
- choose the next checkpoint id from the latest parseable checkpoint instead of every ckpt filename
- keep torn checkpoint files out of the seeded host-egress manifest after remote resume
- update the S3 resume seed fixture to use a real checkpoint payload

Fixes #4181.

## To verify
- `PYTHONPATH=src python -m py_compile src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/util/_checkpoint/_host_egress.py tests/checkpoint/test_checkpointer.py tests/checkpoint/test_host_egress.py tests/checkpoint/test_fs_copy_s3.py`
- `PYTHONPATH=src python -m pytest tests/checkpoint/test_checkpointer.py::test_scan_next_checkpoint_id_reuses_torn_checkpoint_id tests/checkpoint/test_host_egress.py -q`
- `python -m ruff check src/inspect_ai/util/_checkpoint/checkpointer_impl.py src/inspect_ai/util/_checkpoint/_host_egress.py tests/checkpoint/test_checkpointer.py tests/checkpoint/test_host_egress.py tests/checkpoint/test_fs_copy_s3.py`
- `git diff --check`

Note: `tests/checkpoint/test_fs_copy_s3.py::test_seed_manifest_after_remote_resume_blocks_reupload` fails in my local Windows environment before this patch's assertions due to an aiobotocore/botocore signature mismatch (`s3_disable_express_session_auth`).
