### PR TITLE
tool: add INTERNAL_TOOL_TYPE options marker for server-side tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Tools: `internal_tool_type()` helper and `INTERNAL_TOOL_TYPE` options key marking server-side tools (`web_search`, `code_execution`, hosted MCP) so downstream filters can distinguish them from function tools.
 - Anthropic: Support for web search dynamic filtering on Claude 4.6 and later models.
 - Control Channel: `inspect eval` / `inspect eval-set` now bind a per-process control server (AF_UNIX, default on) exposing a read surface for the live run. New `inspect ctl` commands let another process (CLI, scripts, agents) observe a running eval / eval-set.
 - Transcript: Reuse a persistent per-thread SQLite connection in the realtime sample buffer database.

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -154,7 +154,7 @@ from inspect_ai.tool._mcp._config import MCPServerConfigHTTP
 from inspect_ai.tool._tool import Tool
 from inspect_ai.tool._tool_call import ToolCall
 from inspect_ai.tool._tool_choice import ToolChoice, ToolFunction
-from inspect_ai.tool._tool_info import ToolInfo
+from inspect_ai.tool._tool_info import INTERNAL_TOOL_TYPE, ToolInfo
 from inspect_ai.tool._tool_params import ToolParams
 from inspect_ai.tool._tool_util import tool_to_tool_info
 from inspect_ai.tool._tools._code_execution import (
@@ -470,7 +470,7 @@ def tool_from_responses_tool(
         return ToolInfo(
             name=f"mcp_server_{config.name}",
             description=f"mcp_server_{config.name}",
-            options=config.model_dump(),
+            options={INTERNAL_TOOL_TYPE: "mcp_call", **config.model_dump()},
         )
     elif is_tool_search_tool_param(tool_param):
         # client-resolved tool discovery (e.g. codex-cli). Preserve the native

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -23,7 +23,8 @@ from inspect_ai.model._model import (
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.tool._tool import Tool
 from inspect_ai.tool._tool_choice import ToolChoice
-from inspect_ai.tool._tool_info import ToolInfo, parse_tool_info
+from inspect_ai.tool._tool_info import ToolInfo
+from inspect_ai.tool._tool_util import tool_to_tool_info
 from inspect_ai.tool._tools._code_execution import CodeExecutionProviders
 from inspect_ai.tool._tools._web_search._web_search import (
     WebSearchProviders,
@@ -258,8 +259,12 @@ async def bridge_generate(
         # Apply filter if we have it (can either return output or alternate inputs)
         output: ModelOutput | None = None
         if bridge.filter:
+            # tool_to_tool_info (via ToolDef) preserves `options` — including
+            # the INTERNAL_TOOL_TYPE marker — so the filter sees the same
+            # ToolInfo the model provider would. parse_tool_info re-derives
+            # from the function signature and drops options.
             tool_info = [
-                parse_tool_info(tool) if not isinstance(tool, ToolInfo) else tool
+                tool_to_tool_info(tool) if not isinstance(tool, ToolInfo) else tool
                 for tool in tools
             ]
             if _is_model_filter(bridge.filter):

--- a/src/inspect_ai/tool/__init__.py
+++ b/src/inspect_ai/tool/__init__.py
@@ -41,7 +41,7 @@ from ._tool_call import (
 )
 from ._tool_choice import ToolChoice, ToolFunction
 from ._tool_def import ToolDef
-from ._tool_info import ToolInfo
+from ._tool_info import INTERNAL_TOOL_TYPE, ToolInfo, internal_tool_type
 from ._tool_params import ToolParam, ToolParams
 from ._tool_with import tool_with
 from ._tools._ask_user import ask_user
@@ -117,6 +117,8 @@ __all__ = [
     "ToolDef",
     "ToolFunction",
     "ToolInfo",
+    "INTERNAL_TOOL_TYPE",
+    "internal_tool_type",
     "ToolParam",
     "ToolParams",
     "Citation",

--- a/src/inspect_ai/tool/_tool_info.py
+++ b/src/inspect_ai/tool/_tool_info.py
@@ -58,6 +58,26 @@ class ToolInfo(BaseModel):
     """Optional property bag that can be used by the model provider to customize the implementation of the tool"""
 
 
+INTERNAL_TOOL_TYPE = "__internal_tool_type__"
+"""Well-known ``ToolInfo.options`` key carrying the
+:class:`~inspect_ai._util.content.ContentToolUse` ``tool_type`` literal
+(``"web_search"`` / ``"code_execution"`` / ``"mcp_call"``) for tools that a
+model provider may execute server-side within a single API call."""
+
+
+def internal_tool_type(tool: ToolInfo) -> str | None:
+    """Return the server-side tool type if ``tool`` is an internal tool.
+
+    Internal tools (:func:`~inspect_ai.tool.web_search`,
+    :func:`~inspect_ai.tool.code_execution`, hosted MCP) set
+    :data:`INTERNAL_TOOL_TYPE` in their ``options``; this returns that value
+    so callers (e.g. agent-bridge filters) can distinguish them from
+    ordinary function tools without name-matching. Returns ``None`` for
+    function tools.
+    """
+    return (tool.options or {}).get(INTERNAL_TOOL_TYPE)
+
+
 def parse_tool_info(func: Callable[..., Any]) -> ToolInfo:
     return _parse_tool_info_shared(func).model_copy(deep=True)
 

--- a/src/inspect_ai/tool/_tools/_code_execution.py
+++ b/src/inspect_ai/tool/_tools/_code_execution.py
@@ -4,6 +4,7 @@ from typing_extensions import TypedDict
 
 from inspect_ai.tool._tool import Tool, ToolResult, tool
 from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tool_info import INTERNAL_TOOL_TYPE
 from inspect_ai.tool._tools._execute import code_viewer, python
 
 CodeExecutionProvider: TypeAlias = Literal[
@@ -123,7 +124,10 @@ def code_execution(
     return ToolDef(
         execute,
         name="code_execution",
-        options=dict(providers=normalized_providers),
+        options={
+            INTERNAL_TOOL_TYPE: "code_execution",
+            "providers": normalized_providers,
+        },
     ).as_tool()
 
 

--- a/src/inspect_ai/tool/_tools/_web_search/_web_search.py
+++ b/src/inspect_ai/tool/_tools/_web_search/_web_search.py
@@ -9,6 +9,7 @@ from typing_extensions import TypedDict, Unpack
 
 from inspect_ai._util.deprecation import deprecation_warning
 from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tool_info import INTERNAL_TOOL_TYPE
 
 from ..._tool import Tool, ToolResult, tool
 from ._exa import ExaOptions, exa_search_provider
@@ -227,7 +228,9 @@ def web_search(
         )
 
     return ToolDef(
-        execute, name="web_search", options=dict(normalized_providers)
+        execute,
+        name="web_search",
+        options={INTERNAL_TOOL_TYPE: "web_search", **dict(normalized_providers)},
     ).as_tool()
 
 

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -4,6 +4,7 @@ import pytest
 from pydantic import ValidationError
 
 from inspect_ai.tool._tool_def import ToolDef
+from inspect_ai.tool._tool_info import INTERNAL_TOOL_TYPE
 from inspect_ai.tool._tools._web_search._web_search import (
     EXTERNAL_PROVIDERS,
     WebSearchProviders,
@@ -344,6 +345,11 @@ class TestCreateExternalProvider:
             _create_external_provider({"exa": {"text": "bogus"}})
 
 
+def _providers(tool):
+    """Provider config from a web_search tool's options (drops the marker key)."""
+    return {k: v for k, v in ToolDef(tool).options.items() if k != INTERNAL_TOOL_TYPE}
+
+
 class TestOldSignatureVariants:
     """Tests for the old signature variants of web_search function.
 
@@ -361,27 +367,27 @@ class TestOldSignatureVariants:
     @patch("inspect_ai.tool._tools._web_search._web_search.deprecation_warning")
     def test_bug_report_cse(self, mock_warning, mock_google_keys):
         """Test deprecated params without provider falls back to Google when env vars set."""
-        assert ToolDef(web_search(model="NA", num_results=1)).options == {
+        assert _providers(web_search(model="NA", num_results=1)) == {
             "google": {"model": "NA", "num_results": 1}
         }
 
     def test_no_parameters(self):
         """Test web_search() with no parameters returns all internal providers."""
-        assert ToolDef(web_search()).options == ALL_INTERNAL_PROVIDERS
+        assert _providers(web_search()) == ALL_INTERNAL_PROVIDERS
 
     @patch("inspect_ai.tool._tools._web_search._web_search.deprecation_warning")
     def test_only_provider_parameter(self, mock_warning):
         """Test deprecated provider parameter works."""
-        assert ToolDef(web_search(provider="google")).options == {"google": {}}
-        assert ToolDef(web_search(provider="tavily")).options == {"tavily": {}}
+        assert _providers(web_search(provider="google")) == {"google": {}}
+        assert _providers(web_search(provider="tavily")) == {"tavily": {}}
 
     @patch("inspect_ai.tool._tools._web_search._web_search.deprecation_warning")
     def test_provider_with_num_results(self, mock_warning):
         """Test deprecated provider + num_results parameters."""
-        assert ToolDef(web_search(provider="google", num_results=10)).options == {
+        assert _providers(web_search(provider="google", num_results=10)) == {
             "google": {"num_results": 10}
         }
-        assert ToolDef(web_search(provider="tavily", num_results=10)).options == {
+        assert _providers(web_search(provider="tavily", num_results=10)) == {
             "tavily": {"max_results": 10}
         }
 
@@ -392,7 +398,7 @@ class TestOldSignatureVariants:
     @patch("inspect_ai.tool._tools._web_search._web_search.deprecation_warning")
     def test_num_results_only(self, mock_warning, mock_google_keys):
         """Test deprecated num_results without provider falls back to Google when env vars set."""
-        assert ToolDef(web_search(num_results=10)).options == {
+        assert _providers(web_search(num_results=10)) == {
             "google": {"num_results": 10}
         }
 
@@ -409,12 +415,12 @@ class TestOldSignatureVariants:
             return_value=None,
         ):
             # num_results is ignored, returns all internal providers
-            assert ToolDef(web_search(num_results=10)).options == ALL_INTERNAL_PROVIDERS
+            assert _providers(web_search(num_results=10)) == ALL_INTERNAL_PROVIDERS
 
     @patch("inspect_ai.tool._tools._web_search._web_search.deprecation_warning")
     def test_provider_with_multiple_parameters(self, mock_warning):
         """Test deprecated provider with multiple deprecated parameters."""
-        assert ToolDef(
+        assert _providers(
             web_search(
                 provider="google",
                 num_results=10,
@@ -422,7 +428,7 @@ class TestOldSignatureVariants:
                 max_connections=15,
                 model="gpt-4o",
             )
-        ).options == {
+        ) == {
             "google": {
                 "num_results": 10,
                 "max_provider_calls": 5,
@@ -431,9 +437,9 @@ class TestOldSignatureVariants:
             }
         }
 
-        assert ToolDef(
+        assert _providers(
             web_search(provider="tavily", num_results=10, max_connections=15)
-        ).options == {"tavily": {"max_results": 10, "max_connections": 15}}
+        ) == {"tavily": {"max_results": 10, "max_connections": 15}}
 
     def test_conflict_between_old_and_new_signatures(self):
         """Test that using both provider and providers raises an error."""

--- a/tests/tools/test_web_search.py
+++ b/tests/tools/test_web_search.py
@@ -398,9 +398,7 @@ class TestOldSignatureVariants:
     @patch("inspect_ai.tool._tools._web_search._web_search.deprecation_warning")
     def test_num_results_only(self, mock_warning, mock_google_keys):
         """Test deprecated num_results without provider falls back to Google when env vars set."""
-        assert _providers(web_search(num_results=10)) == {
-            "google": {"num_results": 10}
-        }
+        assert _providers(web_search(num_results=10)) == {"google": {"num_results": 10}}
 
     def test_deprecated_params_without_google_env_vars(self):
         """Test deprecated params without provider and without Google env vars.


### PR DESCRIPTION
Each model provider currently re-derives whether a `ToolInfo` is a server-side built-in (`web_search`, `code_execution`, hosted MCP) by name-matching plus inspecting `options` for its own provider key. There is no shared discriminator that survives `Tool→ToolInfo` conversion, so downstream consumers (e.g. agent-bridge `GenerateFilter`s) have to hardcode the same name checks.

This adds:
- `INTERNAL_TOOL_TYPE = "__internal_tool_type__"` — well-known `options` key carrying the `ContentToolUse.tool_type` literal (`"web_search"` / `"code_execution"` / `"mcp_call"`)
- `internal_tool_type(tool: ToolInfo) -> str | None` helper
- Sets the key in `web_search()`, `code_execution()`, and the bridge's hosted-MCP `ToolInfo`

No `ToolInfo` schema change → no eval-log compat concerns. Existing provider checks (`"<me>" in tool.options`, `tool.options.get("providers")`) keep working since the new key sits alongside.

**Motivation:** `petri_dish` (and similar bridge filters) need to detect server-side tools to substitute them with interceptable function tools so the simulated environment can control results instead of leaking live web/code-execution. Currently this requires duplicating each provider's name+options heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)