### PR TITLE
anthropic: route mythos-preview mid-conversation system via <system-reminder>

### DIFF
--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1124,6 +1124,12 @@ class AnthropicAPI(ModelAPI):
     def supports_mid_conversation_system(self) -> bool:
         if self.is_bedrock() or self.is_vertex():
             return False
+        # claude-mythos-preview falls through is_claude_latest() → True, but
+        # the endpoint rejects role:"system" in messages with
+        # "role 'system' is not supported on this model" (verified 2026-06-10
+        # vs. claude-opus-4-8 which accepts it). Route via <system-reminder>.
+        if "mythos-preview" in self.service_model_name():
+            return False
         return self.is_claude_4_8_or_later()
 
     # https://platform.claude.com/docs/en/build-with-claude/cache-diagnostics


### PR DESCRIPTION
## Problem

`claude-mythos-preview` falls through `is_claude_latest()` → True (no recognised version suffix), so `supports_mid_conversation_system()` returns True and inspect sends inline `role:"system"` in `messages`. The endpoint rejects this:

```
400 role 'system' is not supported on this model
```

Verified 2026-06-10 against `claude-opus-4-8` which accepts the same request (200), so this is a model-specific limitation, not the positional constraint (which both models enforce identically).

## Fix

Special-case `"mythos-preview" in service_model_name()` → False so it routes through `_split_system_as_reminders`. Matched on the full `mythos-preview` substring (not bare `mythos`) so a future released `claude-mythos-5` that does support the feature isn't affected.

## Note

PR #4203 added `is_claude_5()` matching `claude-<word>-5`, but `claude-mythos-preview` has no `-5` suffix so still falls through to `is_claude_latest()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)