### PR TITLE
Viewer: multi-log-dir server/CLI handshake (AppConfig.log_dirs)

### DIFF
--- a/src/inspect_ai/_cli/common.py
+++ b/src/inspect_ai/_cli/common.py
@@ -17,9 +17,8 @@ from inspect_ai.util._display import init_display_type
 from .util import parse_cli_args
 
 
-class CommonOptions(TypedDict):
+class CommonOptionsNoLogDir(TypedDict):
     log_level: str
-    log_dir: str
     display: Literal["full", "conversation", "rich", "plain", "log", "none"]
     no_ansi: bool | None
     traceback_locals: bool
@@ -27,6 +26,10 @@ class CommonOptions(TypedDict):
     debug: bool
     debug_port: int
     debug_errors: bool
+
+
+class CommonOptions(CommonOptionsNoLogDir):
+    log_dir: str
 
 
 def log_level_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
@@ -47,16 +50,23 @@ def log_level_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
     return wrapper
 
 
-def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
-    @log_level_options
-    @click.option(
+def log_dir_option(multiple: bool = False) -> Callable[..., Any]:
+    return click.option(
         "--log-dir",
         type=str,
-        default="./logs",
-        callback=clean_log_dir,
-        envvar="INSPECT_LOG_DIR",
-        help="Directory for log files.",
+        multiple=multiple,
+        default=None if multiple else "./logs",
+        callback=None if multiple else clean_log_dir,
+        envvar=None if multiple else "INSPECT_LOG_DIR",
+        help="Directory for log files."
+        + (" (repeatable; for the viewer)" if multiple else ""),
     )
+
+
+def common_options_no_log_dir(
+    func: Callable[..., Any],
+) -> Callable[..., click.Context]:
+    @log_level_options
     @click.option(
         "--display",
         type=click.Choice(
@@ -112,7 +122,17 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
     return wrapper
 
 
-def process_common_options(options: CommonOptions) -> None:
+def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
+    @log_dir_option()
+    @common_options_no_log_dir
+    @functools.wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> click.Context:
+        return cast(click.Context, func(*args, **kwargs))
+
+    return cast(Callable[..., click.Context], wrapper)
+
+
+def process_common_options(options: CommonOptionsNoLogDir) -> None:
     # set environment variables
     env_args = parse_cli_args(options["env"])
     init_cli_env(env_args)

--- a/src/inspect_ai/_cli/common.py
+++ b/src/inspect_ai/_cli/common.py
@@ -51,6 +51,13 @@ def log_level_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 
 
 def log_dir_option(multiple: bool = False) -> Callable[..., Any]:
+    """`--log-dir` option decorator.
+
+    With `multiple=True` (the viewer) the option is repeatable and the caller
+    owns env/cleanup — `INSPECT_LOG_DIR` and trailing-slash stripping are NOT
+    applied here (see `resolve_view_log_dirs`). The single-value default wires
+    `INSPECT_LOG_DIR` and the `clean_log_dir` callback as before.
+    """
     return click.option(
         "--log-dir",
         type=str,
@@ -133,6 +140,8 @@ def common_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 
 
 def process_common_options(options: CommonOptionsNoLogDir) -> None:
+    # typed without log_dir: this never reads it, and the viewer passes a
+    # log-dir-less dict (it owns multi-dir resolution separately).
     # set environment variables
     env_args = parse_cli_args(options["env"])
     init_cli_env(env_args)

--- a/src/inspect_ai/_cli/view.py
+++ b/src/inspect_ai/_cli/view.py
@@ -9,7 +9,35 @@ from inspect_ai._util.constants import DEFAULT_SERVER_HOST, DEFAULT_VIEW_PORT
 from inspect_ai._view.view import view
 from inspect_ai.log._bundle import bundle_log_dir, embed_log_dir
 
-from .common import CommonOptions, common_options, process_common_options
+from .common import (
+    CommonOptions,
+    CommonOptionsNoLogDir,
+    common_options,
+    common_options_no_log_dir,
+    log_dir_option,
+    process_common_options,
+)
+
+
+def resolve_view_log_dirs(log_dir_flags: tuple[str, ...], env: str | None) -> list[str]:
+    """Resolve the viewer's log dirs from --log-dir flags and INSPECT_LOG_DIR.
+
+    Flags take precedence; the env var is comma-split (comma is used rather
+    than os.pathsep so `s3://` / `file://` URIs survive). Falls back to
+    `./logs` when neither is provided.
+
+    Args:
+        log_dir_flags: Values from repeated `--log-dir` options.
+        env: Raw `INSPECT_LOG_DIR` value, or None.
+
+    Returns:
+        Ordered list of directory paths/URIs (at least one element).
+    """
+    if log_dir_flags:
+        return [d.rstrip("/\\") for d in log_dir_flags]
+    if env:
+        return [d.strip().rstrip("/\\") for d in env.split(",") if d.strip()]
+    return ["./logs"]
 
 
 def start_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
@@ -36,9 +64,10 @@ def start_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
 # Define the base command group
 @click.group(name="view", invoke_without_command=True)
 @start_options
-@common_options
+@log_dir_option(multiple=True)
+@common_options_no_log_dir
 @click.pass_context
-def view_command(ctx: click.Context, **kwargs: Unpack[CommonOptions]) -> None:
+def view_command(ctx: click.Context, /, **kwargs: Any) -> None:
     """Inspect log viewer.
 
     Learn more about using the log viewer at https://inspect.aisi.org.uk/log-viewer.html.
@@ -51,16 +80,21 @@ def view_command(ctx: click.Context, **kwargs: Unpack[CommonOptions]) -> None:
 
 @view_command.command("start")
 @start_options
-@common_options
+@log_dir_option(multiple=True)
+@common_options_no_log_dir
 def start(
     recursive: bool,
     host: str,
     port: int,
-    **common: Unpack[CommonOptions],
+    log_dir: tuple[str, ...],
+    **common: Unpack[CommonOptionsNoLogDir],
 ) -> None:
     """View evaluation logs."""
     # read common options
     process_common_options(common)
+
+    # resolve log dirs (repeatable flag + comma-delimited env var)
+    log_dirs = resolve_view_log_dirs(log_dir, os.environ.get("INSPECT_LOG_DIR"))
 
     # resolve optional auth token
     INSPECT_VIEW_AUTHORIZATION_TOKEN = "INSPECT_VIEW_AUTHORIZATION_TOKEN"
@@ -75,7 +109,7 @@ def start(
 
     # run the viewer
     view(
-        log_dir=common["log_dir"],
+        log_dir=log_dirs,
         recursive=recursive,
         host=host,
         port=port,

--- a/src/inspect_ai/_cli/view.py
+++ b/src/inspect_ai/_cli/view.py
@@ -74,8 +74,6 @@ def view_command(ctx: click.Context, /, **kwargs: Any) -> None:
     """
     if ctx.invoked_subcommand is None:
         ctx.invoke(start, **kwargs)
-    else:
-        pass
 
 
 @view_command.command("start")

--- a/src/inspect_ai/_view/common.py
+++ b/src/inspect_ai/_view/common.py
@@ -67,18 +67,30 @@ def normalize_uri(uri: str) -> str:
         return f"file://{path}"
 
 
+class LogDirInfo(BaseModel):
+    """A configured log directory.
+
+    Attributes:
+        log_dir: Resolved path/URI the client sends back as `?log_dir=`.
+        aliased: Display string with the home directory replaced by `~`.
+    """
+
+    log_dir: str
+    aliased: str
+
+
 class AppConfig(BaseModel):
     """Application configuration returned by GET /app-config."""
 
     inspect_version: str
     scout_version: str | None = None
+    log_dirs: list[LogDirInfo] = []
 
 
-def get_app_config() -> AppConfig:
-    """Return app config, including installed inspect and scout versions.
+def get_app_config(log_dirs: list[str] = []) -> AppConfig:
+    """Return app config: installed versions plus configured log directories.
 
-    `inspect_scout` is an optional dependency, so `scout_version` is None when
-    it isn't installed.
+    `inspect_scout` is optional, so `scout_version` is None when absent.
     """
     try:
         scout_version: str | None = version("inspect_scout")
@@ -87,6 +99,7 @@ def get_app_config() -> AppConfig:
     return AppConfig(
         inspect_version=version(PKG_NAME),
         scout_version=scout_version,
+        log_dirs=[LogDirInfo(log_dir=d, aliased=aliased_path(d)) for d in log_dirs],
     )
 
 

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -590,12 +590,12 @@ class _InspectStaticFiles(StaticFiles):
 
 
 class OnlyDirAccessPolicy(AccessPolicy):
-    def __init__(self, dir: str) -> None:
+    def __init__(self, dirs: list[str]) -> None:
         super().__init__()
-        self.dir = dir
+        self.dirs = dirs
 
     def _validate_log_dir(self, file: str) -> bool:
-        return file.startswith(self.dir) and ".." not in file
+        return ".." not in file and any(file.startswith(d) for d in self.dirs)
 
     async def can_read(self, request: Request, file: str) -> bool:
         return self._validate_log_dir(file)
@@ -628,7 +628,7 @@ def view_server(
     # setup server
     api = view_server_app(
         mapping_policy=None,
-        access_policy=OnlyDirAccessPolicy(log_dir) if not authorization else None,
+        access_policy=OnlyDirAccessPolicy([log_dir]) if not authorization else None,
         default_dirs=[log_dir],
         recursive=recursive,
         fs_options=fs_options,

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -100,12 +100,15 @@ class InspectJsonResponse(JSONResponse):
 def view_server_app(
     mapping_policy: FileMappingPolicy | None = None,
     access_policy: AccessPolicy | None = None,
-    default_dir: str = "",
+    default_dirs: list[str] = [],
     recursive: bool = True,
     fs_options: dict[str, Any] = {},
     generate_direct_urls: bool = False,
 ) -> "FastAPI":
     app = FastAPI()
+
+    def _default_dir() -> str:
+        return default_dirs[0] if default_dirs else ""
 
     @app.exception_handler(FileNotFoundError)
     async def _file_not_found(_request: Request, _exc: FileNotFoundError) -> Response:
@@ -281,7 +284,7 @@ def view_server_app(
         log_dir: str | None = Query(None, alias="log_dir"),
     ) -> LogDirResponse:
         if log_dir is None:
-            log_dir = default_dir
+            log_dir = _default_dir()
         await _validate_list(request, log_dir)
         return get_log_dir(log_dir)
 
@@ -291,7 +294,7 @@ def view_server_app(
         log_dir: str | None = Query(None, alias="log_dir"),
     ) -> LogFilesResponse:
         if log_dir is None:
-            log_dir = default_dir
+            log_dir = _default_dir()
         await _validate_list(request, log_dir)
 
         client_etag = request.headers.get("If-None-Match")
@@ -318,7 +321,7 @@ def view_server_app(
         log_dir: str | None = Query(None, alias="log_dir"),
     ) -> LogListingResponse | Response:
         if log_dir is None:
-            log_dir = default_dir
+            log_dir = _default_dir()
         await _validate_list(request, log_dir)
         listing = await get_logs(
             await _map_file(request, log_dir),
@@ -343,7 +346,7 @@ def view_server_app(
         sub_dir: str = Query(None, alias="dir"),
     ) -> EvalSet | None:
         # resolve the eval-set directory (using the log_dir and dir params)
-        base_dir = log_dir if log_dir else default_dir
+        base_dir = log_dir if log_dir else _default_dir()
         if sub_dir and base_dir:
             eval_set_dir = base_dir + "/" + sub_dir.lstrip("/")
         elif sub_dir:
@@ -366,7 +369,7 @@ def view_server_app(
         sub_dir: str = Query(None, alias="dir"),
     ) -> Response:
         # resolve the eval-set directory (using the log_dir and dir params)
-        base_dir = log_dir if log_dir else default_dir
+        base_dir = log_dir if log_dir else _default_dir()
         if sub_dir and base_dir:
             flow_dir = base_dir + "/" + sub_dir.lstrip("/")
         elif sub_dir:
@@ -529,7 +532,7 @@ def view_server_app(
 
     @app.get("/app-config", response_model=AppConfig)
     async def api_app_config() -> AppConfig:
-        return get_app_config()
+        return get_app_config(log_dirs=default_dirs)
 
     scout_router = get_scout_search_router()
     if scout_router is not None:
@@ -626,7 +629,7 @@ def view_server(
     api = view_server_app(
         mapping_policy=None,
         access_policy=OnlyDirAccessPolicy(log_dir) if not authorization else None,
-        default_dir=log_dir,
+        default_dirs=[log_dir],
         recursive=recursive,
         fs_options=fs_options,
         generate_direct_urls=generate_direct_urls,

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -610,8 +610,18 @@ class OnlyDirAccessPolicy(AccessPolicy):
         return self._validate_log_dir(file)
 
 
+def resolve_log_dirs(log_dirs: list[str]) -> list[str]:
+    resolved: list[str] = []
+    for log_dir in log_dirs:
+        fs = filesystem(log_dir)
+        if not fs.exists(log_dir):
+            fs.mkdir(log_dir, True)
+        resolved.append(fs.info(log_dir).name)
+    return resolved
+
+
 def view_server(
-    log_dir: str,
+    log_dirs: list[str],
     recursive: bool = True,
     host: str = DEFAULT_SERVER_HOST,
     port: int = DEFAULT_VIEW_PORT,
@@ -619,17 +629,13 @@ def view_server(
     fs_options: dict[str, Any] = {},
     generate_direct_urls: bool = False,
 ) -> None:
-    # get filesystem and resolve log_dir to full path
-    fs = filesystem(log_dir)
-    if not fs.exists(log_dir):
-        fs.mkdir(log_dir, True)
-    log_dir = fs.info(log_dir).name
+    resolved_dirs = resolve_log_dirs(log_dirs)
 
     # setup server
     api = view_server_app(
         mapping_policy=None,
-        access_policy=OnlyDirAccessPolicy([log_dir]) if not authorization else None,
-        default_dirs=[log_dir],
+        access_policy=OnlyDirAccessPolicy(resolved_dirs) if not authorization else None,
+        default_dirs=resolved_dirs,
         recursive=recursive,
         fs_options=fs_options,
         generate_direct_urls=generate_direct_urls,
@@ -656,7 +662,7 @@ def view_server(
     filter_fastapi_log()
 
     # run app
-    display().print(f"Inspect View: {log_dir}")
+    display().print(f"Inspect View: {', '.join(resolved_dirs)}")
 
     async def run_server() -> None:
         config = uvicorn.Config(

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -611,6 +611,18 @@ class OnlyDirAccessPolicy(AccessPolicy):
 
 
 def resolve_log_dirs(log_dirs: list[str]) -> list[str]:
+    """Ensure each log directory exists and return its canonical name.
+
+    Creates the directory if absent and returns the name reported by the
+    underlying filesystem (which re-attaches the scheme for `s3://` paths).
+    An unreachable or inaccessible directory raises, so startup fails fast.
+
+    Args:
+        log_dirs: Raw directory paths/URIs (local, `s3://`, `file://`).
+
+    Returns:
+        Canonical directory names, in the same order.
+    """
     resolved: list[str] = []
     for log_dir in log_dirs:
         fs = filesystem(log_dir)

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -140,6 +140,14 @@
             "title": "Inspect Version",
             "type": "string"
           },
+          "log_dirs": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/LogDirInfo"
+            },
+            "title": "Log Dirs",
+            "type": "array"
+          },
           "scout_version": {
             "anyOf": [
               {
@@ -153,7 +161,8 @@
           }
         },
         "required": [
-          "inspect_version"
+          "inspect_version",
+          "log_dirs"
         ],
         "title": "AppConfig",
         "type": "object"
@@ -1264,7 +1273,7 @@
         "type": "object"
       },
       "CheckpointSampleConfig": {
-        "description": "Checkpoint configuration fields that may be set at the sample layer.\n\nThese fields can be specified on ``Sample(checkpoint=...)`` and are\nalso accepted at the task and eval layers (where they participate in\nthe per-field merge \u2014 precedence: eval > sample > task).\n\nThe fields excluded from this base class \u2014 ``checkpoints_dir`` and\n``retention`` \u2014 are eval-wide concerns that the sample layer must\nnot influence. They live only on the derived :class:`CheckpointConfig`,\nwhich is the type used at the task and eval layers.\n\nSee ``design/plans/checkpointing-working.md`` \u00a72.",
+        "description": "Checkpoint configuration fields that may be set at the sample layer.\n\nThese fields can be specified on ``Sample(checkpoint=...)`` and are\nalso accepted at the task and eval layers (where they participate in\nthe per-field merge \u2014 precedence: eval > sample > task).\n\nThe fields excluded from this base class \u2014 ``checkpoints_location``\nand ``retention`` \u2014 are eval-wide concerns that the sample layer must\nnot influence. They live only on the derived :class:`CheckpointConfig`,\nwhich is the type used at the task and eval layers.",
         "properties": {
           "max_consecutive_failures": {
             "anyOf": [
@@ -6220,6 +6229,25 @@
           "type"
         ],
         "title": "LlmSearchRequest",
+        "type": "object"
+      },
+      "LogDirInfo": {
+        "description": "A configured log directory.\n\nAttributes:\n    log_dir: Resolved path/URI the client sends back as `?log_dir=`.\n    aliased: Display string with the home directory replaced by `~`.",
+        "properties": {
+          "aliased": {
+            "title": "Aliased",
+            "type": "string"
+          },
+          "log_dir": {
+            "title": "Log Dir",
+            "type": "string"
+          }
+        },
+        "required": [
+          "log_dir",
+          "aliased"
+        ],
+        "title": "LogDirInfo",
         "type": "object"
       },
       "LogDirResponse": {

--- a/src/inspect_ai/_view/view.py
+++ b/src/inspect_ai/_view/view.py
@@ -47,8 +47,8 @@ def view(
     init_dotenv()
     init_logger(log_level)
 
-    # initialize the log_dirs
-    if log_dir is None:
+    # initialize the log_dirs (treat None/empty as "use the default")
+    if not log_dir:
         log_dirs = [os.getenv("INSPECT_LOG_DIR", "./logs")]
     elif isinstance(log_dir, str):
         log_dirs = [log_dir]

--- a/src/inspect_ai/_view/view.py
+++ b/src/inspect_ai/_view/view.py
@@ -1,6 +1,7 @@
 import atexit
 import logging
 import os
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Any
 
@@ -21,7 +22,7 @@ logger = logging.getLogger(__name__)
 
 
 def view(
-    log_dir: str | None = None,
+    log_dir: str | Sequence[str] | None = None,
     recursive: bool = True,
     host: str = DEFAULT_SERVER_HOST,
     port: int = DEFAULT_VIEW_PORT,
@@ -32,7 +33,7 @@ def view(
     """Run the Inspect View server.
 
     Args:
-        log_dir: Directory to view logs from.
+        log_dir: Directory (or list of directories) to view logs from.
         recursive: Recursively list files in `log_dir`.
         host: Tcp/ip host (defaults to "127.0.0.1").
         port: Tcp/ip port (defaults to 7575).
@@ -46,9 +47,13 @@ def view(
     init_dotenv()
     init_logger(log_level)
 
-    # initialize the log_dir
-    if not log_dir:
-        log_dir = os.getenv("INSPECT_LOG_DIR", "./logs")
+    # initialize the log_dirs
+    if log_dir is None:
+        log_dirs = [os.getenv("INSPECT_LOG_DIR", "./logs")]
+    elif isinstance(log_dir, str):
+        log_dirs = [log_dir]
+    else:
+        log_dirs = list(log_dir)
 
     # acquire the requested port
     view_acquire_port(view_data_dir(), port)
@@ -56,7 +61,7 @@ def view(
     from .fastapi_server import view_server
 
     view_server(
-        log_dir=log_dir,
+        log_dirs=log_dirs,
         recursive=recursive,
         host=host,
         port=port,

--- a/tests/_cli/test_view_log_dirs.py
+++ b/tests/_cli/test_view_log_dirs.py
@@ -1,0 +1,23 @@
+from inspect_ai._cli.view import resolve_view_log_dirs
+
+
+def test_resolve_view_log_dirs_repeated_flag() -> None:
+    assert resolve_view_log_dirs(("~/logs", "s3://b/logs"), env=None) == [
+        "~/logs",
+        "s3://b/logs",
+    ]
+
+
+def test_resolve_view_log_dirs_comma_env_when_no_flag() -> None:
+    assert resolve_view_log_dirs((), env="~/logs,s3://b/logs") == [
+        "~/logs",
+        "s3://b/logs",
+    ]
+
+
+def test_resolve_view_log_dirs_flag_overrides_env() -> None:
+    assert resolve_view_log_dirs(("~/only",), env="~/ignored") == ["~/only"]
+
+
+def test_resolve_view_log_dirs_default_when_empty() -> None:
+    assert resolve_view_log_dirs((), env=None) == ["./logs"]

--- a/tests/_view/test_common_app_config.py
+++ b/tests/_view/test_common_app_config.py
@@ -1,0 +1,17 @@
+import os
+
+from inspect_ai._view.common import LogDirInfo, get_app_config
+
+
+def test_get_app_config_includes_resolved_and_aliased_log_dirs() -> None:
+    home = os.path.expanduser("~")
+    config = get_app_config(log_dirs=[f"{home}/logs", "s3://bucket/logs"])
+    assert config.log_dirs == [
+        LogDirInfo(log_dir=f"{home}/logs", aliased="~/logs"),
+        LogDirInfo(log_dir="s3://bucket/logs", aliased="s3://bucket/logs"),
+    ]
+
+
+def test_get_app_config_defaults_to_empty_log_dirs() -> None:
+    config = get_app_config()
+    assert config.log_dirs == []

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -1197,10 +1197,28 @@ def test_fastapi_nan_metric(test_client: TestClient) -> None:
 
 
 def test_fastapi_only_dir_access_policy() -> None:
-    policy = fastapi_server.OnlyDirAccessPolicy("/allowed/dir")
+    policy = fastapi_server.OnlyDirAccessPolicy(["/allowed/dir"])
     assert asyncio.run(policy.can_read(None, "/allowed/dir/file.eval"))  # type: ignore[arg-type]
     assert not asyncio.run(policy.can_read(None, "/other/dir/file.eval"))  # type: ignore[arg-type]
     assert not asyncio.run(policy.can_read(None, "/allowed/dir/../etc/passwd"))  # type: ignore[arg-type]
+
+
+def test_only_dir_access_policy_allows_any_configured_dir() -> None:
+    import anyio
+
+    from inspect_ai._view.fastapi_server import OnlyDirAccessPolicy
+
+    policy = OnlyDirAccessPolicy(["/logs/a", "/logs/b"])
+    req = None
+
+    async def check() -> None:
+        assert await policy.can_read(req, "/logs/a/run.eval") is True
+        assert await policy.can_read(req, "/logs/b/run.eval") is True
+        assert await policy.can_read(req, "/logs/c/run.eval") is False
+        assert await policy.can_list(req, "/logs/b") is True
+        assert await policy.can_read(req, "/logs/a/../../etc/passwd") is False
+
+    anyio.run(check)
 
 
 def test_fastapi_only_dir_policy_integration(mock_s3_eval_file: str) -> None:
@@ -1214,7 +1232,7 @@ def test_fastapi_only_dir_policy_integration(mock_s3_eval_file: str) -> None:
     with fastapi.testclient.TestClient(
         fastapi_server.view_server_app(
             mapping_policy=mapping_policy(),
-            access_policy=fastapi_server.OnlyDirAccessPolicy("mocked_eval_set"),
+            access_policy=fastapi_server.OnlyDirAccessPolicy(["mocked_eval_set"]),
         )
     ) as client:
         assert client.request("GET", f"/logs/{mock_s3_eval_file}").status_code == 200

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -1197,10 +1197,16 @@ def test_fastapi_nan_metric(test_client: TestClient) -> None:
 
 
 def test_fastapi_only_dir_access_policy() -> None:
+    import anyio
+
     policy = fastapi_server.OnlyDirAccessPolicy(["/allowed/dir"])
-    assert asyncio.run(policy.can_read(None, "/allowed/dir/file.eval"))  # type: ignore[arg-type]
-    assert not asyncio.run(policy.can_read(None, "/other/dir/file.eval"))  # type: ignore[arg-type]
-    assert not asyncio.run(policy.can_read(None, "/allowed/dir/../etc/passwd"))  # type: ignore[arg-type]
+
+    async def check() -> None:
+        assert await policy.can_read(None, "/allowed/dir/file.eval")  # type: ignore[arg-type]
+        assert not await policy.can_read(None, "/other/dir/file.eval")  # type: ignore[arg-type]
+        assert not await policy.can_read(None, "/allowed/dir/../etc/passwd")  # type: ignore[arg-type]
+
+    anyio.run(check)
 
 
 def test_only_dir_access_policy_allows_any_configured_dir() -> None:

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -59,7 +59,7 @@ class SimpleResponse:
 class ViewTestClient:
     def __init__(self, log_dir: Path) -> None:
         self.log_dir = log_dir
-        app = fastapi_server.view_server_app(default_dir=str(log_dir))
+        app = fastapi_server.view_server_app(default_dirs=[str(log_dir)])
         self._tc = fastapi.testclient.TestClient(app)
         self._tc.__enter__()
 
@@ -328,10 +328,10 @@ def test_api_app_config(view_client: ViewTestClient) -> None:
     resp.raise_for_status()
     config = resp.json()
     assert config["inspect_version"] == inspect_ai.__version__
-    # scout is an optional dependency: present as a string when installed,
-    # otherwise null.
     assert "scout_version" in config
     assert config["scout_version"] is None or isinstance(config["scout_version"], str)
+    assert [d["log_dir"] for d in config["log_dirs"]] == [str(view_client.log_dir)]
+    assert config["log_dirs"][0]["aliased"]
 
 
 def test_api_log_info(view_client: ViewTestClient) -> None:

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -1221,6 +1221,16 @@ def test_only_dir_access_policy_allows_any_configured_dir() -> None:
     anyio.run(check)
 
 
+def test_resolve_log_dirs_creates_and_normalizes(tmp_path: Path) -> None:
+    from inspect_ai._view.fastapi_server import resolve_log_dirs
+
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    resolved = resolve_log_dirs([str(a), str(b)])
+    assert len(resolved) == 2
+    assert a.exists() and b.exists()
+
+
 def test_fastapi_only_dir_policy_integration(mock_s3_eval_file: str) -> None:
     class mapping_policy(FileMappingPolicy):
         async def map(self, request: Request, file: str) -> str:


### PR DESCRIPTION
## Summary

**PR 2a** of the multi-log-directory effort (server/CLI side; single-dir behavior unchanged). Teaches the view server to serve **multiple** log directories and advertise them to the client via `GET /app-config`.

- `AppConfig.log_dirs: list[LogDirInfo]` — each entry is the resolved path (for `?log_dir=`) plus a `~`-aliased display string; `get_app_config(log_dirs)` populates it.
- `view_server_app(default_dirs: list[str])` + a `_default_dir()` fallback; `/app-config` advertises the configured dirs. `/log-dir` and the single-dir `?log_dir=` fallbacks still resolve to the first dir (back-compat).
- `OnlyDirAccessPolicy(dirs: list[str])` — allows any configured dir; still rejects `..`.
- `view()` / `view_server()` accept `str | Sequence[str]` (`resolve_log_dirs` creates/normalizes each).
- CLI: `inspect view` accepts a **repeatable** `--log-dir` and a **comma-delimited** `INSPECT_LOG_DIR` (comma chosen over `os.pathsep` so `s3://`/`file://` survive). Other commands' single `--log-dir` is unchanged.
- Regenerated `inspect-openapi.json` for the new `AppConfig` shape.

**Companion PR (required, coordinate merge):** the regenerated TypeScript types live in `meridianlabs-ai/ts-mono#321`. This PR leaves the ts-mono submodule pointer unbumped; bump it when #321 lands.

### Not in scope
Frontend consumption of `log_dirs` (merged listing + Directory column) and the individual-log loading refactor are later PRs.

## Test Plan
- [x] `pytest tests/_view/test_view_server.py tests/_view/test_common_app_config.py tests/_cli/test_view_log_dirs.py` — 88 pass (new: `LogDirInfo`/`get_app_config`, multi-dir access policy, `resolve_log_dirs`, repeatable-flag/comma-env CLI parsing).
- [x] `ruff check src tests` clean; `mypy src/inspect_ai/_view src/inspect_ai/_cli` clean.
- [ ] Manual: `inspect view start --log-dir A --log-dir B` serves both; `/app-config` returns both with resolved+aliased values; single-dir launch unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)