### PR TITLE
score: accept a dict of scorers for name aliasing (#4197)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scoring: `score()` / `score_async()` now accept a dict of scorers (`{name: scorer}`, or `(name, scorer)` tuples within a list) to alias scores to custom names — e.g. to run the same scorer with different parameters under distinct names.
 - Anthropic: Support for server-side refusal fallback via the `fallback_models` generate config (Claude 5+ on the first-party Anthropic API).
 - Anthropic: Support for web search dynamic filtering on Claude 4.6 and later models.
 - Anthropic: Raise a clear error when `reasoning_tokens` is set on Claude 4.7+ or Claude 5 (which removed the `budget_tokens` control); use `reasoning_effort` instead.

--- a/docs/scoring-workflow.qmd
+++ b/docs/scoring-workflow.qmd
@@ -128,6 +128,23 @@ for model, scored_log in zip(grader_models, scoring_logs):
     write_eval_log(scored_log, output_file)
 ```
 
+### Naming Scorers
+
+By default, score names are derived from the scorer's registry name (with a numeric suffix to disambiguate duplicates, e.g. `model_graded_qa1`). Pass a dict of `{name: scorer}` to give scores meaningful custom names — for example, scoring with several grader models in a single log:
+
+``` python
+scored_log = score(log, {
+    f"graded_{model.split('/')[1]}": model_graded_qa(model=model)
+    for model in grader_models
+})
+```
+
+The provided names are used everywhere the score appears (sample scores, score events, and results). You can also use `(name, scorer)` tuples within a list to mix named and unnamed scorers:
+
+``` python
+scored_log = score(log, [("strict", match()), includes()])
+```
+
 ## Editing Scores
 
 You may need to modify the results, for example correcting scoring errors or adjusting sample scores based on manual review. Inspect provides functions for modifying logs while maintaining data integrity and audit trails. Learn more about modifying scores in [Editing Logs](eval-logs.qmd#sec-eval-log-modification).

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -23,7 +23,10 @@ import anyio
 from inspect_ai._display import display as display_manager
 from inspect_ai._eval.context import init_task_context
 from inspect_ai._eval.loader import load_file_tasks, scorer_from_spec
-from inspect_ai._eval.task.task import resolve_scorer, resolve_scorer_metrics
+from inspect_ai._eval.task.task import (
+    resolve_scorer_metrics,
+    resolve_scorers_and_names,
+)
 from inspect_ai._util._async import configured_async_backend, run_coroutine, tg_collect
 from inspect_ai._util.platform import platform_init, running_in_notebook
 from inspect_ai._util.registry import (
@@ -88,7 +91,11 @@ def score(
 
     Args:
        log (EvalLog): Evaluation log.
-       scorers (Scorer): List of Scorers to apply to log
+       scorers (Scorers): Scorers to apply to log. Pass a dict of
+           `{name: scorer}` (or `(name, scorer)` tuples within a list)
+           to assign custom names to the resulting scores — e.g. to
+           run the same scorer with different parameters under
+           distinct names.
        metrics (list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]] | None):
            Alternative metrics (overrides the metrics provided by the
            specified scorer and log).
@@ -203,7 +210,11 @@ async def score_async(
        log (EvalLog):
          Evaluation log. Only the headers are needed if `samples`
          is passed as well.
-       scorers (list[Scorer]): Scorers to apply to log
+       scorers (Scorers): Scorers to apply to log. Pass a dict of
+         `{name: scorer}` (or `(name, scorer)` tuples within a list)
+         to assign custom names to the resulting scores — e.g. to
+         run the same scorer with different parameters under
+         distinct names.
        metrics (list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]] | None):
          Alternative metrics (overrides the metrics provided by the
          specified scorer and log).
@@ -224,8 +235,8 @@ async def score_async(
     if samples is None and log.samples is None:
         raise ValueError("There are no samples to score in the log.")
 
-    # resolve scorers
-    resolved_scorers = resolve_scorer(scorers)
+    # resolve scorers (along with any name aliases, e.g. from a dict of scorers)
+    resolved_scorers, scorer_aliases = resolve_scorers_and_names(scorers)
 
     if copy:
         # deepcopy so we don't mutate the passed log
@@ -272,7 +283,7 @@ async def score_async(
                 # since the sample score carries the scorer name that generated
                 # it (so using sample.scores directly isn't enough)
                 sample_score, names = await _run_score_task(
-                    log, sample, resolved_scorers, action
+                    log, sample, resolved_scorers, action, scorer_aliases
                 )
 
             assert sample.scores is not None
@@ -338,6 +349,7 @@ async def _run_score_task(
     sample: EvalSample,
     scorers: list[Scorer],
     action: ScoreAction,
+    scorer_aliases: list[str | None] | None = None,
 ) -> Tuple[dict[str, SampleScore], list[str]]:
     target = Target(sample.target)
     state = TaskState(
@@ -380,9 +392,11 @@ async def _run_score_task(
     results: dict[str, SampleScore] = {}
     scorer_names: list[str] = []
     async with span(name=SCORERS_SPAN_NAME):
-        for scorer in scorers:
+        for idx_scorer, scorer in enumerate(scorers):
+            alias = scorer_aliases[idx_scorer] if scorer_aliases else None
             scorer_name = unique_scorer_name(
-                scorer, list({*existing_score_names, *results})
+                alias if alias is not None else scorer,
+                list({*existing_score_names, *results}),
             )
             scorer_names.append(scorer_name)
             async with span(name=scorer_name, type=SCORER_SPAN_TYPE):

--- a/src/inspect_ai/_eval/task/task.py
+++ b/src/inspect_ai/_eval/task/task.py
@@ -491,6 +491,26 @@ def resolve_scorer(
     return [to_scorer(s) for s in scorers]
 
 
+def resolve_scorers_and_names(
+    scorer: "Scorers",
+) -> tuple[list[Scorer], list[str | None]]:
+    """Resolve scorers along with optional name aliases.
+
+    Accepts the same shapes as `resolve_scorer` plus named forms: a dict of
+    `{name: scorer}` or `(name, scorer)` tuples within a sequence. Returns
+    the resolved scorers and a parallel list of names (`None` for scorers
+    without an explicit name).
+    """
+    named: list[tuple[str | None, Any]]
+    if isinstance(scorer, dict):
+        named = list(scorer.items())
+    elif isinstance(scorer, Sequence):
+        named = [(s[0], s[1]) if isinstance(s, tuple) else (None, s) for s in scorer]
+    else:
+        named = [(None, scorer)]
+    return [to_scorer(s) for _, s in named], [name for name, _ in named]
+
+
 def to_scorer(s: Any) -> Scorer:
     if is_registry_object(s, type="scanner"):
         from inspect_scout import as_scorer

--- a/src/inspect_ai/scorer/_scorers.py
+++ b/src/inspect_ai/scorer/_scorers.py
@@ -9,6 +9,17 @@ if TYPE_CHECKING:
 
 
 Scorers: TypeAlias = (
-    "Scorer" | "Scanner[Transcript]" | Sequence["Scorer" | "Scanner[Transcript]"]
+    "Scorer"
+    | "Scanner[Transcript]"
+    | Sequence[
+        "Scorer" | "Scanner[Transcript]" | tuple[str, "Scorer" | "Scanner[Transcript]"]
+    ]
+    | dict[str, "Scorer" | "Scanner[Transcript]"]
 )
-"""Set of scorers."""
+"""Set of scorers.
+
+Scorers may optionally be named — either with a `dict` of `{name: scorer}`
+or with `(name, scorer)` tuples within a sequence. Named forms are
+supported by `score()` / `score_async()` (where the name becomes the
+score name); `Task(scorer=...)` accepts only unnamed forms.
+"""

--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -32,7 +32,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageAssistant,
     ChatMessageUser,
 )
-from inspect_ai.scorer import accuracy
+from inspect_ai.scorer import accuracy, includes, match
 from inspect_ai.scorer._metric import SampleScore, Score
 from inspect_ai.scorer._scorer import Scorer, scorer
 from inspect_ai.scorer._target import Target
@@ -548,3 +548,137 @@ async def test_score_preserves_model_usage_in_score_event():
     assert score_events[0].model_usage == sample_model_usage
     assert score_events[0].scorer == "simple_scorer"
     assert score_events[0].scorer_args == {"threshold": 0.75}
+
+
+def _scorer_aliasing_log():
+    """Minimal mockllm-based log for scorer name aliasing tests."""
+    from inspect_ai.log import EvalLog
+    from inspect_ai.log._log import (
+        EvalConfig,
+        EvalDataset,
+        EvalPlan,
+        EvalPlanStep,
+        EvalSpec,
+    )
+
+    samples = [
+        EvalSample(
+            id=f"sample-{i}",
+            epoch=1,
+            input="What is 2+2?",
+            target="4",
+            messages=[ChatMessageUser(role="user", content="What is 2+2?")],
+            output=ModelOutput(
+                choices=[
+                    ChatCompletionChoice(
+                        message=ChatMessageAssistant(role="assistant", content="4")
+                    )
+                ]
+            ),
+        )
+        for i in range(2)
+    ]
+    return EvalLog(
+        version=2,
+        status="success",
+        eval=EvalSpec(
+            created="2025-01-01T00:00:00Z",
+            task="test_task",
+            task_id="test",
+            run_id="test-run",
+            dataset=EvalDataset(),
+            model="mockllm/model",
+            config=EvalConfig(),
+        ),
+        plan=EvalPlan(
+            name="test",
+            steps=[EvalPlanStep(solver="generate")],
+            config=GenerateConfig(),
+        ),
+        samples=samples,
+    )
+
+
+async def test_score_scorers_dict_aliases():
+    """A dict of scorers aliases scores to the dict keys (#4197)."""
+    log = _scorer_aliasing_log()
+
+    scored = await score_async(
+        log,
+        {"match_exact": match("exact"), "match_any": match("any")},
+        display="none",
+    )
+
+    # sample scores are keyed by the aliases
+    assert scored.samples is not None
+    for sample in scored.samples:
+        assert sample.scores is not None
+        assert [*sample.scores] == ["match_exact", "match_any"]
+
+    # results are named by the aliases (with per-alias params preserved)
+    assert scored.results is not None
+    results = {score.name: score for score in scored.results.scores}
+    assert [*results] == ["match_exact", "match_any"]
+    assert results["match_exact"].params == {"location": "exact"}
+    assert results["match_any"].params == {"location": "any"}
+
+    # score events record the alias as the scorer name
+    score_events = [e for e in scored.samples[0].events if isinstance(e, ScoreEvent)]
+    assert {e.scorer for e in score_events} == {"match_exact", "match_any"}
+
+
+async def test_score_scorers_tuple_aliases():
+    """(name, scorer) tuples mix with unnamed scorers in a sequence."""
+    log = _scorer_aliasing_log()
+
+    scored = await score_async(
+        log, [("match_strict", match()), includes()], display="none"
+    )
+
+    assert scored.samples is not None
+    assert [*(scored.samples[0].scores or {})] == ["match_strict", "includes"]
+    assert scored.results is not None
+    assert [score.name for score in scored.results.scores] == [
+        "match_strict",
+        "includes",
+    ]
+
+
+async def test_score_scorers_duplicate_aliases():
+    """Duplicate aliases are deduped like duplicate registry names."""
+    log = _scorer_aliasing_log()
+
+    scored = await score_async(
+        log, [("dup", match()), ("dup", includes())], display="none"
+    )
+
+    assert scored.samples is not None
+    assert [*(scored.samples[0].scores or {})] == ["dup", "dup1"]
+
+
+async def test_score_scorers_alias_append_collision():
+    """On append, an alias colliding with an existing score is deduped."""
+    log = _scorer_aliasing_log()
+
+    scored = await score_async(log, {"verdict": match()}, display="none")
+    rescored = await score_async(
+        scored, {"verdict": includes()}, action="append", display="none"
+    )
+
+    assert rescored.samples is not None
+    assert [*(rescored.samples[0].scores or {})] == ["verdict", "verdict1"]
+    assert rescored.results is not None
+    assert {score.name for score in rescored.results.scores} == {
+        "verdict",
+        "verdict1",
+    }
+
+
+async def test_score_scorers_unnamed_unchanged():
+    """Unnamed scorer lists keep their auto-derived, deduped names."""
+    log = _scorer_aliasing_log()
+
+    scored = await score_async(log, [match(), match()], display="none")
+
+    assert scored.samples is not None
+    assert [*(scored.samples[0].scores or {})] == ["match", "match1"]


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #4197.

Score names in `score()` / `score_async()` are auto-derived from the scorer's registry name, with a numeric suffix on collision (`match`, `match1`, ...). There is no way to give a scorer a meaningful custom name, or to run the same scorer multiple times with different params under distinct, readable names.

### What is the new behavior?

`score()` / `score_async()` accept named scorers, mirroring Scout's `Scanners` shape:

```python
score(log, {"accuracy_strict": match("exact"), "accuracy_loose": match("any")})
score(log, [("strict", match()), includes()])   # tuples mix with unnamed scorers
```

- The `Scorers` type alias also allows `dict[str, Scorer | Scanner[Transcript]]` and `(name, scorer)` tuples within a sequence.
- A new `resolve_scorers_and_names()` (next to `resolve_scorer()` in `_eval/task/task.py`) resolves scorers plus a parallel list of optional names; `score_async()` threads the names into `_run_score_task()`, where the name is used as the base name for `unique_scorer_name()`.
- The provided name becomes the score name everywhere it appears: per-sample scores, `ScoreEvent.scorer`, and `results.scores` (with per-name scorer `params` preserved, so the same scorer under two names records its differing params). Per-sample `SampleScore.scorer` keeps the registry name for provenance.
- Name collisions keep today's semantics: names are deduped via `unique_scorer_name` against existing sample scores (relevant for `action="append"`) and within the run, exactly like auto-derived names. Unnamed forms are byte-for-byte unchanged.
- `Task(scorer=...)` is out of scope per the issue and continues to reject named forms (`to_scorer()` raises `TypeError`); the `Scorers` docstring notes this.

Tests cover: dict aliasing end-to-end (sample scores / events / results / per-name params), tuple + unnamed mixing, duplicate-name dedup, append-mode collision with an existing score name, and a regression test that unnamed lists keep their current naming. Docs: new "Naming Scorers" subsection in `scoring-workflow.qmd` + updated docstrings + CHANGELOG entry.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. All existing call shapes behave identically; named forms are purely additive.

### Other information:

`make check` (ruff + mypy) and `make test` pass locally. Happy to adjust naming or collision semantics if you'd prefer something different.