### PR TITLE
docs(multi-agent): document run() state propagation in solvers; fix workflow example (#4172)

### DIFF
--- a/docs/multi-agent.qmd
+++ b/docs/multi-agent.qmd
@@ -51,14 +51,14 @@ def researcher() -> Agent:
 
     async def execute(state: AgentState) -> AgentState:
         """Research assistant."""
-        
+
         state.messages.append(
-            ChatMessageSystem("You are an expert researcher.")
+            ChatMessageSystem(content="You are an expert researcher.")
         )
-        
-        state = run(research_planner(), state)
-        state = run(research_searcher(), state)
-        state = run(research_writer(), state)
+
+        state = await run(research_planner(), state)
+        state = await run(research_searcher(), state)
+        state = await run(research_writer(), state)
 
         return state
 ```
@@ -75,6 +75,27 @@ plans = await gather(
 ```
 
 Note that the `run()` method makes a copy of the input so is suitable for running in parallel as shown above (the two parallel runs will not make shared/conflicting edits to the `state`).
+
+### Running Agents in Solvers
+
+The copying behavior described above also means that `run()` never propagates the agent's conversation back to its input — it returns a new `AgentState`, and the caller decides what to do with it. This matters in particular when calling `run()` from a [solver](solvers.qmd): if you discard the returned state, the agent's conversation and output will not appear in the sample's messages (though they remain visible in the sample transcript), and scorers that read `state.output` or `state.messages` will not see the agent's work. Copy the fields you need back into the `TaskState`:
+
+``` python
+@solver
+def research_solver() -> Solver:
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        # per-sample setup
+        ...
+        # run the agent, then reflect its conversation and
+        # output back into the task state
+        agent_state = await run(researcher(), state.messages)
+        state.messages = agent_state.messages
+        state.output = agent_state.output
+        return state
+    return solve
+```
+
+Alternatively, if you don't need custom per-sample logic around the agent, use `as_solver()` to convert the agent into a solver that updates the `TaskState` automatically.
 
 
 ## Tools

--- a/src/inspect_ai/agent/_run.py
+++ b/src/inspect_ai/agent/_run.py
@@ -46,6 +46,14 @@ async def run(
     The input messages(s) will be copied prior to running so are
     not modified in place.
 
+    The agent's conversation is available only via the returned
+    `AgentState` — it is not propagated back to the input. When calling
+    `run()` from a solver, copy the returned state back into the
+    `TaskState` (e.g. `state.messages = agent_state.messages` and
+    `state.output = agent_state.output`) if the agent's conversation and
+    output should be reflected in the sample (`as_solver()` does this
+    automatically).
+
     Args:
         agent: Agent to run.
         input: Agent input (string, list of messages, or an `AgentState`).


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Addresses #4172 (per the comment there welcoming doc improvements).

1. Calling `run()` from a custom solver and discarding the returned `AgentState` silently leaves the agent's conversation out of the sample's messages/output (it only appears in the transcript). Neither `run()`'s docstring nor the multi-agent docs mention that the caller must propagate the returned state.
2. The Workflows example in `multi-agent.qmd` doesn't run as written: `run()` is called without `await` (cf. the awaited call in `agents.qmd`), and `ChatMessageSystem("...")` passes content positionally, which raises `TypeError: BaseModel.__init__() takes 1 positional argument but 2 were given`.

### What is the new behavior?

- New "Running Agents in Solvers" subsection in `multi-agent.qmd` explaining that `run()` returns a new `AgentState` that is not propagated back, with the copy-back pattern (`state.messages` / `state.output`, same as `as_solver()` does internally) and a pointer to `as_solver()` for the no-custom-logic case.
- `run()` docstring states the same.
- Workflow example fixed: `await run(...)` and `ChatMessageSystem(content=...)`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, docs and docstring only.

### Other information: