### PR TITLE
openai: support Azure next-gen v1 API (no dated api-version) (#4192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- OpenAI: Support the Azure OpenAI next-generation v1 API ("always latest") — set `api_version` to `v1` (or `AZUREAI_OPENAI_API_VERSION=v1`) to target `{endpoint}/openai/v1/` with no dated api-version; managed identity (Entra ID) is supported via automatic token refresh.
 - Anthropic: Support for server-side refusal fallback via the `fallback_models` generate config (Claude 5+ on the first-party Anthropic API).
 - Anthropic: Support for web search dynamic filtering on Claude 4.6 and later models.
 - Anthropic: Raise a clear error when `reasoning_tokens` is set on Claude 4.7+ or Claude 5 (which removed the `budget_tokens` control); use `reasoning_effort` instead.

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -147,6 +147,19 @@ inspect eval math.py --model openai/azure/gpt-4o-mini
 
 Note that if the `AZUREAI_OPENAI_API_VERSION` is not specified, Inspect will generally default to the latest deployed version, which as of this writing is `2025-03-01-preview`. When using managed identity for authentication, install the `azure-identity` package and leave `AZUREAI_OPENAI_API_KEY` undefined.
 
+#### Next-generation v1 API
+
+Azure OpenAI also offers a [next-generation v1 API](https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle) that provides ongoing access to the latest features with no need to specify a new dated `api-version` each month. To opt in, set the API version to `v1`:
+
+``` bash
+export AZUREAI_OPENAI_API_KEY=your-api-key
+export AZUREAI_OPENAI_BASE_URL=https://your-resource.openai.azure.com
+export AZUREAI_OPENAI_API_VERSION=v1
+inspect eval math.py --model openai/azure/gpt-4o-mini
+```
+
+In this mode requests target `{base-url}/openai/v1/` with no `api-version` parameter (`preview` and `latest` are also accepted as aliases for `v1`). Set `AZUREAI_OPENAI_BASE_URL` to the resource endpoint — the `/openai/v1` path is appended automatically (endpoints that already include it are also fine). Features that are still in preview are opted into with feature-specific preview headers per the Microsoft documentation. Managed identity works as before: install `azure-identity` and leave the API key undefined.
+
 ### OpenAI on AWS Bedrock {#openai-on-aws-bedrock}
 
 The `openai` provider supports OpenAI models served through [Amazon Bedrock](https://aws.amazon.com/bedrock/). Use the normal `openai` provider with the `bedrock` qualifier, and use a standard OpenAI model identifier (Inspect automatically adds prefixes and suffixes required by Bedrock). For example:

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -50,8 +50,11 @@ from .._openai_responses import (
 )
 from ._openai_batch import OpenAIBatcher
 from .util import (
+    azure_v1_base_url,
+    azure_v1_token_key,
     check_azure_deployment_mismatch,
     environment_prerequisite_error,
+    is_azure_v1_api_version,
     model_base_url,
     require_azure_base_url,
     resolve_api_key,
@@ -266,6 +269,25 @@ class OpenAIAPI(ModelAPI):
             base_url = require_azure_base_url(
                 self.base_url, AZURE_OPENAI_BASE_URL_VARS, "OpenAI"
             )
+
+            # next-generation v1 API ("always latest"): the plain OpenAI
+            # client against {endpoint}/openai/v1/ with no dated api-version.
+            # managed identity works by passing the token provider as an
+            # async api_key callable (refreshed automatically per request).
+            if is_azure_v1_api_version(self.api_version):
+                return AsyncOpenAI(
+                    api_key=self.api_key
+                    if self.api_key
+                    else azure_v1_token_key(self.token_provider)
+                    if self.token_provider
+                    else None,
+                    base_url=azure_v1_base_url(base_url),
+                    http_client=self.http_client,
+                    timeout=self.client_timeout
+                    if self.client_timeout is not None
+                    else NOT_GIVEN,
+                    **self.model_args,
+                )
 
             # use managed identity if available, otherwise API key
             return AsyncAzureOpenAI(

--- a/src/inspect_ai/model/_providers/util/__init__.py
+++ b/src/inspect_ai/model/_providers/util/__init__.py
@@ -1,7 +1,10 @@
 from ..._call_tools import parse_tool_call, tool_parse_error_message
 from ..._model_output import as_stop_reason
 from .azure_hosting import (
+    azure_v1_base_url,
+    azure_v1_token_key,
     check_azure_deployment_mismatch,
+    is_azure_v1_api_version,
     require_azure_base_url,
     resolve_azure_token_provider,
 )
@@ -25,10 +28,13 @@ from .util import environment_prerequisite_error, model_base_url, resolve_api_ke
 __all__ = [
     "environment_prerequisite_error",
     "as_stop_reason",
+    "azure_v1_base_url",
+    "azure_v1_token_key",
     "chat_api_request",
     "chat_api_input",
     "should_retry_chat_api_error",
     "classify_chat_api_error",
+    "is_azure_v1_api_version",
     "model_base_url",
     "parse_tool_call",
     "require_azure_base_url",

--- a/src/inspect_ai/model/_providers/util/azure_hosting.py
+++ b/src/inspect_ai/model/_providers/util/azure_hosting.py
@@ -3,7 +3,7 @@
 import os
 import re
 from logging import getLogger
-from typing import Callable
+from typing import Awaitable, Callable
 
 from inspect_ai._util.error import PrerequisiteError
 
@@ -14,6 +14,48 @@ logger = getLogger(__name__)
 # Default Azure audience for managed identity
 AZUREAI_AUDIENCE = "AZUREAI_AUDIENCE"
 DEFAULT_AZURE_AUDIENCE = "https://cognitiveservices.azure.com/.default"
+
+# Sentinel api_version values that select the Azure OpenAI next-generation
+# v1 API ("always latest"). The v1 surface takes no dated api-version:
+# requests target {endpoint}/openai/v1/ and preview features are opted into
+# via feature-specific preview headers rather than an api-version. "v1" is
+# the canonical value; "preview" and "latest" are accepted as aliases (they
+# were used by the transitional Microsoft guidance).
+# https://learn.microsoft.com/en-us/azure/foundry/openai/api-version-lifecycle
+AZURE_V1_API_VERSIONS = ("v1", "preview", "latest")
+
+
+def is_azure_v1_api_version(api_version: str | None) -> bool:
+    """Check whether an api_version selects the Azure next-gen v1 API."""
+    return api_version is not None and api_version.lower() in AZURE_V1_API_VERSIONS
+
+
+def azure_v1_base_url(base_url: str) -> str:
+    """Resolve the base URL for the Azure OpenAI next-gen v1 API.
+
+    Appends `/openai/v1/` to the resource endpoint (tolerating endpoints
+    that already include it).
+    """
+    base_url = base_url.rstrip("/")
+    if not base_url.endswith("/openai/v1"):
+        base_url = f"{base_url}/openai/v1"
+    return f"{base_url}/"
+
+
+def azure_v1_token_key(
+    token_provider: Callable[[], str],
+) -> Callable[[], Awaitable[str]]:
+    """Adapt a sync bearer-token provider for use as an OpenAI client api_key.
+
+    The Azure next-gen v1 API uses the plain OpenAI client, which supports
+    managed identity by accepting an async api_key callable (invoked per
+    request for automatic token refresh).
+    """
+
+    async def token_key() -> str:
+        return token_provider()
+
+    return token_key
 
 
 def check_azure_deployment_mismatch(

--- a/tests/model/providers/test_openai_azure_v1.py
+++ b/tests/model/providers/test_openai_azure_v1.py
@@ -1,0 +1,116 @@
+"""Tests for the Azure OpenAI next-generation v1 API (no dated api-version).
+
+These are offline client-construction tests (no Azure credentials or network
+access required).
+"""
+
+import pytest
+from openai import AsyncAzureOpenAI, AsyncOpenAI
+
+from inspect_ai.model._providers.openai import OpenAIAPI
+from inspect_ai.model._providers.util.azure_hosting import (
+    azure_v1_base_url,
+    azure_v1_token_key,
+    is_azure_v1_api_version,
+)
+
+AZURE_ENDPOINT = "https://example-resource.openai.azure.com"
+
+
+@pytest.fixture
+def azure_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AZUREAI_OPENAI_API_KEY", "test-api-key")
+    monkeypatch.setenv("AZUREAI_OPENAI_BASE_URL", AZURE_ENDPOINT)
+    monkeypatch.delenv("AZUREAI_OPENAI_API_VERSION", raising=False)
+    monkeypatch.delenv("OPENAI_API_VERSION", raising=False)
+
+
+def azure_api(**model_args) -> OpenAIAPI:
+    return OpenAIAPI(model_name="azure/gpt-4o-mini", **model_args)
+
+
+def test_azure_dated_api_version_unchanged(azure_env) -> None:
+    """Default behavior (dated api-version + AsyncAzureOpenAI) is preserved."""
+    api = azure_api()
+    assert isinstance(api.client, AsyncAzureOpenAI)
+    assert api.api_version == "2025-03-01-preview"
+
+
+def test_azure_explicit_dated_api_version_unchanged(azure_env) -> None:
+    api = azure_api(api_version="2024-10-21")
+    assert isinstance(api.client, AsyncAzureOpenAI)
+    assert api.api_version == "2024-10-21"
+
+
+@pytest.mark.parametrize("api_version", ["v1", "preview", "latest", "V1"])
+def test_azure_v1_api_version_uses_plain_client(azure_env, api_version) -> None:
+    """v1 sentinels select the plain OpenAI client against /openai/v1/."""
+    api = azure_api(api_version=api_version)
+    assert isinstance(api.client, AsyncOpenAI)
+    assert not isinstance(api.client, AsyncAzureOpenAI)
+    assert str(api.client.base_url) == f"{AZURE_ENDPOINT}/openai/v1/"
+    assert api.client.api_key == "test-api-key"
+
+
+def test_azure_v1_api_version_via_env(
+    azure_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AZUREAI_OPENAI_API_VERSION", "v1")
+    api = azure_api()
+    assert isinstance(api.client, AsyncOpenAI)
+    assert not isinstance(api.client, AsyncAzureOpenAI)
+    assert str(api.client.base_url) == f"{AZURE_ENDPOINT}/openai/v1/"
+
+
+def test_azure_v1_base_url_not_doubled(
+    azure_env, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An endpoint that already includes /openai/v1 is left intact."""
+    monkeypatch.setenv("AZUREAI_OPENAI_BASE_URL", f"{AZURE_ENDPOINT}/openai/v1/")
+    api = azure_api(api_version="v1")
+    assert str(api.client.base_url) == f"{AZURE_ENDPOINT}/openai/v1/"
+
+
+async def test_azure_v1_managed_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    """With no API key, the token provider becomes an async api_key callable."""
+    monkeypatch.delenv("AZUREAI_OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("AZURE_OPENAI_API_KEY", raising=False)
+    monkeypatch.setenv("AZUREAI_OPENAI_BASE_URL", AZURE_ENDPOINT)
+    monkeypatch.setattr(
+        "inspect_ai.model._providers.openai.resolve_azure_token_provider",
+        lambda provider_name: (lambda: "entra-token"),
+    )
+    api = azure_api(api_version="v1")
+    assert isinstance(api.client, AsyncOpenAI)
+    # a callable api_key is stored by the SDK as its api key provider
+    # (the api_key property remains "" until the first refresh)
+    api_key_provider = api.client._api_key_provider
+    assert callable(api_key_provider)
+    assert await api_key_provider() == "entra-token"
+
+
+def test_is_azure_v1_api_version() -> None:
+    assert is_azure_v1_api_version("v1")
+    assert is_azure_v1_api_version("preview")
+    assert is_azure_v1_api_version("latest")
+    assert is_azure_v1_api_version("V1")
+    assert not is_azure_v1_api_version("2025-03-01-preview")
+    assert not is_azure_v1_api_version(None)
+
+
+def test_azure_v1_base_url() -> None:
+    assert azure_v1_base_url(AZURE_ENDPOINT) == f"{AZURE_ENDPOINT}/openai/v1/"
+    assert azure_v1_base_url(f"{AZURE_ENDPOINT}/") == f"{AZURE_ENDPOINT}/openai/v1/"
+    assert (
+        azure_v1_base_url(f"{AZURE_ENDPOINT}/openai/v1")
+        == f"{AZURE_ENDPOINT}/openai/v1/"
+    )
+    assert (
+        azure_v1_base_url(f"{AZURE_ENDPOINT}/openai/v1/")
+        == f"{AZURE_ENDPOINT}/openai/v1/"
+    )
+
+
+async def test_azure_v1_token_key() -> None:
+    token_key = azure_v1_token_key(lambda: "tok")
+    assert await token_key() == "tok"


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #4192.

The Azure path always resolves a dated `api-version` and constructs `AsyncAzureOpenAI`, so there is no way to target the Azure OpenAI next-generation v1 API ("always latest").

As noted on the issue, the linked Microsoft lifecycle doc has evolved since filing: the v1 surface now takes **no api-version at all** (neither dated nor `preview`/`latest` sentinels) — preview features are opted into via feature-specific preview headers. The documented client is the plain `OpenAI()` client against `{endpoint}/openai/v1/`, and Entra ID works by passing the bearer-token provider callable as `api_key` (the SDK refreshes it automatically; our pinned `openai` 2.40.0 accepts `api_key: str | Callable[[], Awaitable[str]] | None`).

### What is the new behavior?

Setting the API version to `v1` opts into the next-gen API (`preview` and `latest` are accepted as aliases since the transitional guidance used them; matching is case-insensitive):

```bash
export AZUREAI_OPENAI_API_VERSION=v1   # or -M api_version=v1
```

- `_create_client()` then returns `AsyncOpenAI(base_url=f"{azure_base_url}/openai/v1/", ...)` — no `api-version` query parameter. Base URLs that already include `/openai/v1` are not doubled.
- **Managed identity:** `resolve_azure_token_provider()` (including the `AZUREAI_AUDIENCE` override) is kept; its sync provider is wrapped as an async `api_key` callable (`azure_v1_token_key`), mirroring how the SDK's own `azure_ad_token_provider` path behaves.
- **Back-compat:** the dated default (`2025-03-01-preview`) and `AsyncAzureOpenAI` construction are untouched; v1 is opt-in only. `require_azure_base_url` and the deployment-mismatch check are unchanged (v1 routes by the body `model` field, which we already populate with the deployment name).

Helpers live in `_providers/util/azure_hosting.py` (`AZURE_V1_API_VERSIONS`, `is_azure_v1_api_version`, `azure_v1_base_url`, `azure_v1_token_key`) so other Azure-hosted providers can reuse them.

Tests (offline client-construction, no credentials/network): dated default unchanged, explicit dated version unchanged, each sentinel + case-insensitivity selects the plain client with the right base URL, env-var opt-in, idempotent `/openai/v1` append, managed-identity token provider wired as the async api_key callable, plus unit tests for the helpers. Docs: new "Next-generation v1 API" subsection under OpenAI on Azure in `providers.qmd`, and a CHANGELOG entry.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Dated api-version behavior is byte-for-byte unchanged; v1 is opt-in via the sentinel.

### Other information:

`make check` and `make test` pass locally. I don't have an Azure resource to hand for a live smoke test, so verification is via construction tests against the documented client shape — happy to adjust if you have a live environment to validate against.