### PR TITLE
Respect google rate limits

### DIFF
--- a/src/inspect_ai/_util/http.py
+++ b/src/inspect_ai/_util/http.py
@@ -83,6 +83,8 @@ def parse_retry_details(details: dict | None) -> float | None:
 
     items = details.get("error", {}).get("details", [])
     for item in items:
+        if "retryDelay" not in item:
+            continue
         delay = item["retryDelay"]
         return float(delay.removesuffix("s"))
 

--- a/src/inspect_ai/_util/http.py
+++ b/src/inspect_ai/_util/http.py
@@ -2,6 +2,7 @@ import re
 from collections.abc import Mapping
 from datetime import datetime, timezone
 from email.utils import parsedate_to_datetime
+import contextlib
 
 
 # see https://cloud.google.com/storage/docs/retry-strategy
@@ -72,21 +73,41 @@ def parse_retry_after(headers: Mapping[str, str]) -> float | None:
 
     return None
 
+def parse_retry_details(details: dict | None) -> float | None:
+    """
+    Extracts the retry delay in seconds from a nested error details dictionary.
+    Expects a structure like: {'error': {'details': [{'retryDelay': '60s'}]}}
+    """
+    if not isinstance(details, dict):
+        return None
+
+    items = details.get("error", {}).get("details", [])
+    for item in items:
+        delay = item["retryDelay"]
+        return float(delay.removesuffix("s"))
+
+    return None
 
 def parse_retry_after_from_exception(ex: BaseException) -> float | None:
     """Best-effort Retry-After / x-ratelimit-reset-* extraction from an exception.
 
     Walks `ex.response.headers` if present and delegates to `parse_retry_after`.
+    Also inspects `ex.details` if present and delegates to `parse_retry_details`.
     Returns None on any failure (missing attributes, parse error). Used by
     every provider's `should_retry` → `RetryDecision.rate_limit` path.
     """
-    headers = getattr(getattr(ex, "response", None), "headers", None)
-    if headers is None:
-        return None
-    try:
-        return parse_retry_after(headers)
-    except Exception:
-        return None
+    with contextlib.suppress(Exception):
+        headers = getattr(getattr(ex, "response", None), "headers", None)
+        if headers is not None:
+            val = parse_retry_after(headers)
+            if val is not None:
+                return val
+
+    with contextlib.suppress(Exception):
+        details = getattr(ex, "details", None)
+        return parse_retry_details(details)
+
+    return None
 
 
 def _parse_retry_after_value(value: str) -> float | None:

--- a/src/inspect_ai/model/_retry.py
+++ b/src/inspect_ai/model/_retry.py
@@ -17,6 +17,31 @@ if TYPE_CHECKING:
     from inspect_ai.model._model import RetryDecision
 
 
+class wait_rate_limit_or_exponential(WaitBaseT):
+    def __init__(
+        self,
+        initial: float = 3,
+        max: float = 1800,
+        exp_base: float = 2,
+        jitter: float = 3,
+    ):
+        self.exponential_wait = wait_exponential_jitter(
+            initial=initial, max=max, exp_base=exp_base, jitter=jitter
+        )
+
+    def __call__(self, retry_state: RetryCallState) -> float:
+        outcome = retry_state.outcome
+        if outcome and outcome.failed:
+            ex = outcome.exception()
+            if ex is not None:
+                from inspect_ai._util.http import parse_retry_after_from_exception
+                retry_after = parse_retry_after_from_exception(ex)
+                if retry_after is not None:
+                    return retry_after
+
+        return self.exponential_wait(retry_state)
+
+
 class ModelRetryConfig(TypedDict):
     wait: WaitBaseT
     retry: RetryBaseT
@@ -62,7 +87,7 @@ def model_retry_config(
     wait = (
         wait
         if wait is not None
-        else wait_exponential_jitter(initial=3, max=(30 * 60), jitter=3)
+        else wait_rate_limit_or_exponential(initial=3, max=(30 * 60), jitter=3)
     )
 
     # tenacity's retry_if_exception expects a bool predicate; coerce

--- a/src/inspect_ai/model/_retry.py
+++ b/src/inspect_ai/model/_retry.py
@@ -10,14 +10,14 @@ from tenacity import (
 )
 from tenacity.retry import RetryBaseT
 from tenacity.stop import StopBaseT
-from tenacity.wait import WaitBaseT
+from tenacity.wait import WaitBaseT, wait_base
 from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
     from inspect_ai.model._model import RetryDecision
 
 
-class wait_rate_limit_or_exponential(WaitBaseT):
+class wait_rate_limit_or_exponential(wait_base):
     def __init__(
         self,
         initial: float = 3,


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The code extracts rate-limit backoff times HTTP headers like `Retry-After` attached to an exception's response. But the google API returns this information in the response body, so inspect currently ignores google rate limits

### What is the new behavior?
Reads the retryDelay field from google API errors

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No

### Other information:
Simplified error handling in parse_retry_after_from_exception