### PR TITLE
Make sample finalization linear in conversation length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Log: Shared sample buffer files synced to S3 (via `--log-shared`) are now tagged `inspect-ephemeral=true` so they can be targeted by an S3 lifecycle rule.
 - Log: Reading sample summaries from an in-progress `.eval` on a remote filesystem (e.g. S3) now fetches the per-sample journal summary files concurrently, reducing load time for logs with many samples.
+- Log: Sample event condensing is now linear, not quadratic, in conversation length.
 - Eval: Warn when non-empty `task_args` are passed but cannot be applied to any task. (#4194)
 - Model API: Keep the connection-pool/adaptive-concurrency scope stable when a provider's `api_key` is a short-lived credential.
 - HuggingFace: Forward an explicitly supplied API key when loading tokenizers for private or gated models.

--- a/src/inspect_ai/event/_pool.py
+++ b/src/inspect_ai/event/_pool.py
@@ -8,23 +8,27 @@ through a serialize/parse round-trip, so rebuild-time hashes match),
 excluding the ``id`` field so that messages with identical content but
 different UUIDs are treated as duplicates.
 
-The batch functions here (``condense_model_event_inputs`` /
-``condense_model_event_calls``) hash every message and rely on a per-call
-``id(obj)`` cache; that is O(N) only when a single call spans all events
-(the final-log and recover paths). Per-event callers (the sample buffer
-and the transcript store) must NOT call these one event at a time — that
-is O(N²) in conversation length (each of the N model events carries the
-full ~N-message history). They use the incremental indices in
-``inspect_ai.event._pool_index`` instead, which resolve re-sent messages
-by object identity / id-bucket equality and hash only genuinely new
-content.
+``condense_model_event_inputs`` hashes every message and relies on a
+per-call ``id(obj)`` cache; that is O(N) only when a single call spans
+all events (the final-log and recover paths). ``condense_model_event_calls``
+additionally uses prefix-matching against the previous event's wire list
+to skip hashing the equal prefix, hashing only the divergent tail per
+event; the batch call is O(total unique call messages).
+
+Per-event callers (the sample buffer and the transcript store) must NOT
+call these one event at a time — that is O(N²) in conversation length
+(each of the N model events carries the full ~N-message history). They
+use the incremental indices in ``inspect_ai.event._pool_index`` instead,
+which resolve re-sent messages by object identity / id-bucket equality
+and hash only genuinely new content.
 """
 
+import dataclasses
 import json
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Final, TypeVar, cast
 
-from pydantic import JsonValue
+from pydantic import BaseModel, JsonValue
 from pydantic_core import to_jsonable_python
 
 from inspect_ai._util.hash import mm3_hash
@@ -43,6 +47,51 @@ def materialize_pooled_events(
     materialized = validate_events(list(events))
     materialized = resolve_model_event_inputs(materialized, message_pool)
     return resolve_model_event_calls(materialized, call_pool)
+
+
+def _strict_eq(a: object, b: object) -> bool:
+    """Equality that distinguishes values with different JSON serializations.
+
+    Python ``==`` conflates values the pool hashes distinguish: ``0 == 0.0``
+    and ``True == 1``, but ``json.dumps`` emits different bytes for each, so
+    ``_msg_hash``/``_call_hash`` differ. An ``==``-based merge of such values
+    would reuse a pool entry whose stored bytes round-trip to the *other*
+    value — silent data corruption. This comparison requires matching types
+    for scalars (recursing into models, dataclasses, dicts, and lists), so a
+    merge implies identical serialization.
+    """
+    if a is b:
+        return True
+    ta, tb = type(a), type(b)
+    if ta is not tb:
+        return False
+    if isinstance(a, BaseModel):
+        return _strict_eq(a.__dict__, b.__dict__)  # type: ignore[attr-defined]
+    if dataclasses.is_dataclass(a) and not isinstance(a, type):
+        return _strict_eq(vars(a), vars(b))
+    if ta is dict:
+        assert isinstance(a, dict) and isinstance(b, dict)
+        if len(a) != len(b):
+            return False
+        sentinel = object()
+        for k, v in a.items():
+            other = b.get(k, sentinel)
+            if other is sentinel or not _strict_eq(v, other):
+                return False
+            # dict lookup matches keys by ==, which conflates 0/0.0 and
+            # True/1 on the key axis just like values ({0: x} and {0.0: x}
+            # serialize to different JSON); str keys (the JSON-bound common
+            # case) cannot ==-collide across types, so only non-str keys
+            # need their counterpart's type checked
+            if type(k) is not str and not any(
+                bk == k and type(bk) is type(k) for bk in b
+            ):
+                return False
+        return True
+    if ta is list or ta is tuple:
+        assert isinstance(a, (list, tuple)) and isinstance(b, (list, tuple))
+        return len(a) == len(b) and all(_strict_eq(x, y) for x, y in zip(a, b))
+    return a == b
 
 
 def _msg_hash(msg: ChatMessage) -> str:
@@ -219,6 +268,12 @@ def condense_model_event_calls(
     ``call_refs``. Callers that need the pool list must rebuild it from
     ``new_entries``.
 
+    Wire requests are append-mostly, so the equal prefix of each event's
+    message list is resolved against the previous event's pool indices
+    without hashing; only the divergent tail is hashed. Output is identical
+    to hashing every message: a prefix element equal to the previous
+    element resolves to the index that hash-dedup of equal content would produce.
+
     Args:
         events: Events to condense.
         next_index: The pool position assigned to the first new unique
@@ -234,6 +289,8 @@ def condense_model_event_calls(
     index = dict(call_index)
     new_entries: list[tuple[str, JsonValue]] = []
     result: list[Event] = []
+    prev_msgs: list[JsonValue] = []
+    prev_indices: list[int] = []
     for event in events:
         if isinstance(event, ModelEvent) and event.call:
             if event.call.call_refs is not None:
@@ -244,13 +301,26 @@ def condense_model_event_calls(
             )
             msgs = event.call.request.get(msg_key) if msg_key else None
             if msgs and isinstance(msgs, list):
-                raw_indices: list[int] = []
-                for msg in msgs:
+                # Reuse the previous event's pool indices for the equal prefix;
+                # hash only the tail that diverges.
+                # _strict_eq, not ==: a prefix element drifting 0 -> 0.0 or
+                # True -> 1 is python-equal but serializes (and hashes)
+                # differently; reusing the pool index would round-trip the
+                # other value.
+                prefix_len = 0
+                for msg, prev_msg in zip(msgs, prev_msgs):
+                    if not _strict_eq(msg, prev_msg):
+                        break
+                    prefix_len += 1
+                raw_indices = list(prev_indices[:prefix_len])
+                for msg in msgs[prefix_len:]:
                     h = _call_hash(msg)
                     if h not in index:
                         index[h] = next_index + len(new_entries)
                         new_entries.append((h, msg))
                     raw_indices.append(index[h])
+                prev_msgs = list(msgs)
+                prev_indices = raw_indices
                 new_request = {
                     k: v for k, v in event.call.request.items() if k != msg_key
                 }

--- a/src/inspect_ai/event/_pool_index.py
+++ b/src/inspect_ai/event/_pool_index.py
@@ -64,7 +64,7 @@ from . import (
     _pool,  # accessed as module attributes so monkeypatching _pool._msg_hash is visible here
 )
 from ._model import ModelEvent
-from ._pool import _CALL_MESSAGE_KEYS, _compress_refs
+from ._pool import _CALL_MESSAGE_KEYS, _compress_refs, _strict_eq
 
 _BUCKET_CONTENT_LIMIT = 256 * 1024
 """Max single content-string length (bytes) for a message to be bucketed.
@@ -91,51 +91,6 @@ tool code can populate with cyclic or pathologically nested structures.
 Capping out reports heavy — the safe direction (the message just isn't
 bucketed).
 """
-
-
-def _strict_eq(a: object, b: object) -> bool:
-    """Equality that distinguishes values with different JSON serializations.
-
-    Python ``==`` conflates values the pool hashes distinguish: ``0 == 0.0``
-    and ``True == 1``, but ``json.dumps`` emits different bytes for each, so
-    ``_msg_hash``/``_call_hash`` differ. An ``==``-based merge of such values
-    would reuse a pool entry whose stored bytes round-trip to the *other*
-    value — silent data corruption. This comparison requires matching types
-    for scalars (recursing into models, dataclasses, dicts, and lists), so a
-    merge implies identical serialization.
-    """
-    if a is b:
-        return True
-    ta, tb = type(a), type(b)
-    if ta is not tb:
-        return False
-    if isinstance(a, BaseModel):
-        return _strict_eq(a.__dict__, b.__dict__)  # type: ignore[attr-defined]
-    if dataclasses.is_dataclass(a) and not isinstance(a, type):
-        return _strict_eq(vars(a), vars(b))
-    if ta is dict:
-        assert isinstance(a, dict) and isinstance(b, dict)
-        if len(a) != len(b):
-            return False
-        sentinel = object()
-        for k, v in a.items():
-            other = b.get(k, sentinel)
-            if other is sentinel or not _strict_eq(v, other):
-                return False
-            # dict lookup matches keys by ==, which conflates 0/0.0 and
-            # True/1 on the key axis just like values ({0: x} and {0.0: x}
-            # serialize to different JSON); str keys (the JSON-bound common
-            # case) cannot ==-collide across types, so only non-str keys
-            # need their counterpart's type checked
-            if type(k) is not str and not any(
-                bk == k and type(bk) is type(k) for bk in b
-            ):
-                return False
-        return True
-    if ta is list or ta is tuple:
-        assert isinstance(a, (list, tuple)) and isinstance(b, (list, tuple))
-        return len(a) == len(b) and all(_strict_eq(x, y) for x, y in zip(a, b))
-    return a == b
 
 
 def _has_heavy_str(value: object, depth: int = 0) -> bool:

--- a/src/inspect_ai/log/_condense.py
+++ b/src/inspect_ai/log/_condense.py
@@ -60,7 +60,20 @@ ATTACHMENT_PROTOCOL = "attachment://"
 
 
 class WalkContext(TypedDict):
-    message_cache: dict[str, ChatMessage]
+    message_cache: dict[str, tuple[ChatMessage, ChatMessage]]
+    """Cache of walked messages keyed by message id.
+
+    Each value is ``(pre_walk_message, walked_result)``: lookups verify
+    against the *pre-walk* message (by identity first, then equality)
+    because the walked result has rewritten content and never compares
+    equal to an incoming un-walked message. A message mutated in place
+    after first being walked identity-hits and resolves to its
+    first-walked form (consistent with ``event/_pool_index.py``;
+    first-party code refreshes ``message.id`` on mutation). Entries are
+    only valid for one content function — never share a context across
+    walks with different content functions.
+    """
+
     only_core: bool
 
 
@@ -153,8 +166,14 @@ def condense_sample(sample: EvalSample, log_images: bool = True) -> EvalSample:
     attachments: dict[str, str] = dict(sample.attachments)
     events_fn = events_attachment_fn(attachments, log_images)
     messages_fn = messages_attachment_fn(attachments, log_images)
-    context = WalkContext(message_cache={}, only_core=False)
-    condensed_events = walk_events(sample.events, events_fn, context)
+    # The events and messages walks rewrite content differently (events_fn
+    # pools long text as attachments; messages_fn leaves it inline), so they
+    # must not share a message cache: sample.messages contains the same
+    # objects/ids as event inputs and a shared cache would return
+    # event-walked results during the messages walk.
+    events_context = WalkContext(message_cache={}, only_core=False)
+    messages_context = WalkContext(message_cache={}, only_core=False)
+    condensed_events = walk_events(sample.events, events_fn, events_context)
 
     # condense events
     existing = sample.events_data
@@ -182,8 +201,10 @@ def condense_sample(sample: EvalSample, log_images: bool = True) -> EvalSample:
 
     return sample.model_copy(
         update={
-            "input": walk_input(sample.input, messages_fn, context),
-            "messages": walk_chat_messages(sample.messages, messages_fn, context),
+            "input": walk_input(sample.input, messages_fn, messages_context),
+            "messages": walk_chat_messages(
+                sample.messages, messages_fn, messages_context
+            ),
             "events": condensed_events,
             "attachments": attachments,
             "events_data": events_data,
@@ -611,8 +632,10 @@ def walk_chat_message(
     cache = context.get("message_cache")
     if cache is not None and message.id is not None:
         hit = cache.get(message.id)
-        if hit is not None and hit == message:
-            return hit
+        if hit is not None:
+            pre_walk, walked = hit
+            if pre_walk is message or pre_walk == message:
+                return walked
     if isinstance(message.content, str):
         res = message.model_copy(update=dict(content=content_fn(message.content)))
     else:
@@ -631,7 +654,7 @@ def walk_chat_message(
             )
         )
     if cache is not None and message.id is not None:
-        cache[message.id] = res
+        cache[message.id] = (message, res)
     return res
 
 

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -1155,7 +1155,7 @@ class SampleBufferDatabase(SampleBuffer):
 
         cursor = conn.execute(query, params)
 
-        message_cache: dict[str, ChatMessage] = {}
+        message_cache: dict[str, tuple[ChatMessage, ChatMessage]] = {}
 
         for row in cursor:
             event = json.loads(row["data"])
@@ -1438,7 +1438,10 @@ class SampleBufferDatabase(SampleBuffer):
         return SampleEvent(id=event.id, epoch=event.epoch, event=condensed_event)
 
     def _resolve_event_attachments(
-        self, conn: Connection, event: JsonData, message_cache: dict[str, ChatMessage]
+        self,
+        conn: Connection,
+        event: JsonData,
+        message_cache: dict[str, tuple[ChatMessage, ChatMessage]],
     ) -> JsonData:
         return walk_json_dict(
             event,

--- a/src/inspect_ai/log/_recover/_stream.py
+++ b/src/inspect_ai/log/_recover/_stream.py
@@ -117,7 +117,12 @@ def _write_sample_streaming(
     call_pool: list[JsonValue] = []
     msg_index: dict[str, int] = {}
     call_index: dict[str, int] = {}
-    walk_context = WalkContext(message_cache={}, only_core=False)
+    events_context = WalkContext(message_cache={}, only_core=False)
+    # The events and messages walks rewrite content differently (condense_event
+    # pools long text as attachments; messages_fn leaves it inline), so they
+    # must not share a message cache: a hit crossing content functions would
+    # leak attachment refs into fields that keep long text inline.
+    messages_context = WalkContext(message_cache={}, only_core=False)
     accumulator = MessageAccumulator()
 
     # Per-sample reconstruction state captured from raw events
@@ -240,7 +245,7 @@ def _write_sample_streaming(
             stream.write(b',"events":[')
             if include_events and raw_events:
                 condensed = [
-                    condense_event(ev, attachments, context=walk_context)
+                    condense_event(ev, attachments, context=events_context)
                     for ev in raw_events
                 ]
 
@@ -290,8 +295,10 @@ def _write_sample_streaming(
 
             # Walk messages for attachment refs
             messages_fn = messages_attachment_fn(attachments)
-            walked_input = walk_input(summary.input, messages_fn, walk_context)
-            walked_messages = walk_chat_messages(messages, messages_fn, walk_context)
+            walked_input = walk_input(summary.input, messages_fn, messages_context)
+            walked_messages = walk_chat_messages(
+                messages, messages_fn, messages_context
+            )
 
             # Sample init-derived fields
             _write_json_field(stream, "sandbox", sandbox_value, comma=True)

--- a/tests/log/test_condense_linear.py
+++ b/tests/log/test_condense_linear.py
@@ -1,26 +1,46 @@
-"""Regression tests: per-event condensing must be O(new messages), not O(history).
+"""Regression tests for condensing correctness and complexity.
 
-Counts content-hash invocations while logging a growing conversation one
-event at a time (the live-eval pattern). Quadratic condensing computes
-~N²/2 hashes for N events; linear computes ~N. See
-inspect_ai/event/_pool_index.py for the strategy.
+Covers:
+
+Per-event condensing (live-eval pattern): counts content-hash invocations
+while logging a growing conversation one event at a time; quadratic behavior
+hashes ~N^2/2 messages, linear stays within a small multiple of N. See
+inspect_ai/event/_pool_index.py for the per-event strategy.
+
+Batch condensing (condense_sample): counts model_copy walks and pool hashes
+across a full condense_sample call; both must be O(unique messages), not
+O(history length). See inspect_ai/log/_condense.py walk-cache for the batch
+path.
+
+Cache isolation: asserts that the events walk and the messages walk use
+separate caches so that event-walked attachment refs never leak into
+sample.messages content (which must stay inline).
+
+Dedup correctness across paths: pool rows are reused on store reopen and
+buffer-to-transcript-store export (hash parity, insertion-order storage
+round-trips), and prefix matching never merges python-equal but
+JSON-distinct wire values (0 vs 0.0, True vs 1).
 """
 
 import json
 import tempfile
+from collections.abc import Mapping
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import Generator, Iterator
+from typing import Any, Generator, Iterator
 
 import pytest
 from pydantic import JsonValue
 
+from inspect_ai.event._event import Event
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.event._validate import validate_chat_messages
-from inspect_ai.log._log import EvalSampleSummary
+from inspect_ai.log._condense import condense_events, condense_sample, expand_events
+from inspect_ai.log._log import EvalSample, EvalSampleSummary
 from inspect_ai.log._recorders.buffer import SampleBufferDatabase
 from inspect_ai.log._recorders.types import SampleEvent
 from inspect_ai.log._transcript_store import TranscriptEventStore
-from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
+from inspect_ai.model._chat_message import ChatMessage, ChatMessageBase, ChatMessageUser
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
@@ -333,3 +353,271 @@ def test_transcript_store_reseed_dedups_dict_field_messages(tmp_path: Path) -> N
         f"(got {store2.counts().message_pool} rows)"
     )
     store2.close()
+
+
+class CopyCounter:
+    copies: int = 0
+
+
+@pytest.fixture
+def message_copy_counter(monkeypatch: pytest.MonkeyPatch) -> Iterator[CopyCounter]:
+    """Count ChatMessage.model_copy calls (== full message walks in condense)."""
+    counter = CopyCounter()
+    original = ChatMessageBase.model_copy
+
+    def counting_copy(
+        self: ChatMessageBase,
+        *,
+        update: Mapping[str, Any] | None = None,
+        deep: bool = False,
+    ) -> ChatMessageBase:
+        counter.copies += 1
+        return original(self, update=update, deep=deep)
+
+    monkeypatch.setattr(ChatMessageBase, "model_copy", counting_copy)
+    yield counter
+
+
+def _sample_with_growing_history(n_turns: int) -> EvalSample:
+    """A sample whose ModelEvent inputs re-send the same growing history objects.
+
+    Message content is ~250 chars (above the 100-char attachment threshold), so
+    the walk rewrites every message — the case where the old cache never hit.
+    Each event also carries a ModelCall with a growing wire list (fresh dicts
+    each turn, like providers produce) to exercise call-pool prefix matching.
+    """
+    history: list[ChatMessage] = []
+    wire: list[dict[str, JsonValue]] = []
+    events: list[Event] = []
+    for i in range(n_turns):
+        content = f"user message {i:06d} " * 12
+        history.append(ChatMessageUser(content=content))
+        wire.append({"role": "user", "content": content})
+        call_msgs: list[JsonValue] = [dict(m) for m in wire]
+        event = ModelEvent(
+            model="test",
+            input=list(history),
+            tools=[],
+            tool_choice="auto",
+            config=GenerateConfig(),
+            output=ModelOutput.from_content("test", f"assistant reply {i:06d} " * 12),
+            call=ModelCall(
+                request={"model": "test", "messages": call_msgs},
+                response={"id": "r1"},
+            ),
+            timestamp=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        events.append(event)
+        history.append(event.output.message)
+    return EvalSample(
+        id="s1",
+        epoch=1,
+        input="start",
+        target="done",
+        messages=list(history),
+        events=events,
+    )
+
+
+@pytest.mark.parametrize("n_turns", [100, 200])
+def test_condense_sample_walk_is_linear(
+    n_turns: int, hash_counter: HashCounter, message_copy_counter: CopyCounter
+) -> None:
+    """condense_sample full walks and pool hashes must be O(unique messages).
+
+    Quadratic behavior walks/hashes ~n_turns^2/2 messages (>= 5000 at
+    n_turns=100); linear behavior stays within a small multiple of the
+    2*n_turns unique messages. Running at two sizes pins the scaling.
+    """
+    sample = _sample_with_growing_history(n_turns)
+    condensed = condense_sample(sample)
+
+    # full walks: each unique message is walked at most once per walk context
+    # (events context + messages context), plus small constant overhead
+    assert message_copy_counter.copies <= 8 * n_turns, (
+        f"message walking is superlinear: {message_copy_counter.copies} "
+        f"model_copy calls for {2 * n_turns} unique messages"
+    )
+    # pool dedup: each unique walked object hashed once via the id(obj) cache
+    assert hash_counter.msg_hashes <= 6 * n_turns, (
+        f"message hashing is superlinear: {hash_counter.msg_hashes} hashes "
+        f"for {2 * n_turns} unique messages"
+    )
+    # call pool dedup: prefix-matching reuses the previous event's indices,
+    # so only the divergent tail is hashed
+    assert hash_counter.call_hashes <= 6 * n_turns, (
+        f"call hashing is superlinear: {hash_counter.call_hashes} hashes "
+        f"for {n_turns} events"
+    )
+
+    # the condensed result is still correct: all unique event-input messages
+    # pooled (the last assistant message never appears in any input)
+    assert condensed.events_data is not None
+    assert len(condensed.events_data["messages"]) == 2 * n_turns - 1
+    last_event = condensed.events[-1]
+    assert isinstance(last_event, ModelEvent)
+    assert last_event.input == []
+    assert last_event.input_refs == [(0, 2 * n_turns - 1)]
+
+    # call pool: one unique wire message per turn, all pooled
+    assert len(condensed.events_data["calls"]) == n_turns
+    assert last_event.call is not None
+    assert last_event.call.call_refs == [(0, n_turns)]
+    assert last_event.call.call_key == "messages"
+    assert "messages" not in last_event.call.request
+
+
+def test_condense_sample_rewritten_history_condenses_correctly() -> None:
+    """Event inputs that are NOT prefix-extensions must still condense correctly.
+
+    The walk cache and pool dedup are tuned for the common scaffold shape
+    where each event's input extends the previous one with the same objects.
+    A history rewritten mid-conversation (messages dropped/reordered, fresh
+    objects with equal content) must still dedup equal content into the same
+    pool entry and round-trip every event's input.
+    """
+    # content < 100 chars so the events walk leaves it inline and the
+    # round-tripped inputs compare equal to the originals
+    m0 = ChatMessageUser(content="message zero")
+    m1 = ChatMessageUser(content="message one")
+    # fresh object, equal content to m0 (new id): pool dedup must merge them
+    m2 = ChatMessageUser(content="message zero")
+    m3 = ChatMessageUser(content="message three")
+    m4 = ChatMessageUser(content="message four")
+
+    inputs: list[list[ChatMessage]] = [
+        [m0],  # growing
+        [m0, m1],  # growing (identical prefix)
+        [m1, m2, m3],  # rewritten: reordered, m0 replaced by equal-content m2
+        [m1, m2, m3, m4],  # growing again from the rewritten history
+    ]
+    events: list[Event] = [_model_event(list(msgs), []) for msgs in inputs]
+    sample = EvalSample(
+        id="s1",
+        epoch=1,
+        input="start",
+        target="done",
+        messages=[],
+        events=events,
+    )
+
+    condensed = condense_sample(sample)
+
+    # pool: m0, m1, m3, m4 (m2 deduped into m0's entry)
+    assert condensed.events_data is not None
+    pool = condensed.events_data["messages"]
+    assert [m.content for m in pool] == [
+        "message zero",
+        "message one",
+        "message three",
+        "message four",
+    ]
+
+    # refs: event 3's input [m1, m2, m3] -> indices [1, 0, 2]
+    ev3 = condensed.events[2]
+    assert isinstance(ev3, ModelEvent)
+    assert ev3.input == []
+    assert ev3.input_refs == [(1, 2), (0, 1), (2, 3)]
+    ev4 = condensed.events[3]
+    assert isinstance(ev4, ModelEvent)
+    assert ev4.input_refs == [(1, 2), (0, 1), (2, 4)]
+
+    # every event's input round-trips to the original (role, content) sequence
+    restored = expand_events(condensed.events, condensed.events_data)
+    for original_input, restored_event in zip(inputs, restored):
+        assert isinstance(restored_event, ModelEvent)
+        assert [(m.role, m.content) for m in restored_event.input] == [
+            (m.role, m.content) for m in original_input
+        ]
+
+
+def test_condense_sample_messages_stay_inline() -> None:
+    """sample.messages long content must stay inline after condense_sample.
+
+    sample.messages share objects/ids with event inputs but use different
+    attachment rules (events pool long text; messages keep it inline). The
+    walk's message cache must not leak event-walked results (attachment refs)
+    into the sample.messages walk — they must not share a cache.
+    """
+    long_text = "long message content " * 10  # > 100-char attachment threshold
+    msg = ChatMessageUser(content=long_text)
+    event = ModelEvent(
+        model="test",
+        input=[msg],
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("test", "ok"),
+    )
+    sample = EvalSample(
+        id="s1",
+        epoch=1,
+        input="start",
+        target="done",
+        messages=[msg],
+        events=[event],
+    )
+
+    condensed = condense_sample(sample)
+
+    # events side: the pooled message's long content became an attachment ref
+    assert condensed.events_data is not None
+    pooled = condensed.events_data["messages"]
+    assert len(pooled) == 1
+    pooled_content = pooled[0].content
+    assert isinstance(pooled_content, str)
+    assert pooled_content.startswith("attachment://")
+    # messages side: the same message object keeps its content inline
+    messages_content = condensed.messages[0].content
+    assert messages_content == long_text
+
+
+def test_batch_call_prefix_breaks_on_json_distinct_values() -> None:
+    """Batch prefix match must not reuse a pool index for a JSON-distinct element.
+
+    Python == conflates 0 == 0.0 and True == 1; if the batch loop in
+    condense_model_event_calls used == to decide the prefix length, a wire
+    message that drifts from 0.0 to 0 between events would reuse the previous
+    event's pool index (which stores the 0.0-serialized bytes) and round-trip
+    the wrong value.
+
+    Repro shape:
+      event 1 wire: [{"role": "user", "n": 0.0}]
+      event 2 wire: [{"role": "user", "n": 0}, {"role": "user", "content": "next"}]
+
+    The first element is python-equal (0 == 0.0) but JSON-distinct, so the
+    call pool must contain THREE entries (0.0-variant, 0-variant, "next"),
+    and round-tripping event 2 must restore n=0 as an int, not 0.0.
+    """
+    ev1 = _model_event(
+        input_msgs=[ChatMessageUser(content="a")],
+        call_msgs=[{"role": "user", "n": 0.0}],
+    )
+    ev2 = _model_event(
+        input_msgs=[ChatMessageUser(content="b")],
+        call_msgs=[{"role": "user", "n": 0}, {"role": "user", "content": "next"}],
+    )
+
+    condensed_events, events_data = condense_events([ev1, ev2])
+
+    # Three distinct call-pool entries: 0.0-variant, 0-variant, "next"
+    call_pool = events_data["calls"]
+    assert len(call_pool) == 3, (
+        f"expected 3 call-pool entries (0.0-variant, 0-variant, next) but got "
+        f"{len(call_pool)}: {call_pool}"
+    )
+
+    # Round-trip event 2: first wire message must have n=0 (int), not 0.0
+    restored = expand_events(condensed_events, events_data)
+    ev2_restored = restored[1]
+    assert isinstance(ev2_restored, ModelEvent)
+    assert ev2_restored.call is not None
+    wire_msgs = ev2_restored.call.request.get("messages")
+    assert isinstance(wire_msgs, list) and len(wire_msgs) == 2
+    first_msg = wire_msgs[0]
+    assert isinstance(first_msg, dict)
+    n_val = first_msg["n"]
+    assert n_val == 0, f"expected n=0 but got {n_val!r}"
+    assert isinstance(n_val, int) and not isinstance(n_val, bool), (
+        f"expected int 0 but got {type(n_val).__name__} {n_val!r}"
+    )

--- a/tests/log/test_recover_e2e.py
+++ b/tests/log/test_recover_e2e.py
@@ -1087,3 +1087,147 @@ async def test_recovery_preserves_uuid_from_in_progress_buffer_row() -> None:
             assert recovered.samples is not None
             target = next(s for s in recovered.samples if s.id == 7 and s.epoch == 1)
             assert target.uuid == expected_uuid
+
+
+async def test_streaming_recovery_output_message_stays_inline_in_messages() -> None:
+    """Long output message content must stay inline in recovered sample.messages.
+
+    _write_sample_streaming walks ModelEvent.output through condense_event
+    (events_context) and separately walks accumulated messages through
+    walk_chat_messages (messages_context). The output choice message ends up
+    in both walks because MessageAccumulator.result() appends it to messages.
+
+    If the two walks shared a WalkContext cache, the events walk (which uses
+    events_fn -- pooling text >100 chars as attachment refs) would cache the
+    rewritten message, and the subsequent messages walk would hit that cache
+    entry and return the attachment ref instead of the original inline content.
+    The split into events_context/messages_context prevents this; this test
+    would FAIL if the split were reverted to a single shared context.
+    """
+    import json
+    from zipfile import ZipFile
+
+    from pydantic_core import to_jsonable_python
+
+    from inspect_ai._util.constants import LOG_SCHEMA_VERSION
+    from inspect_ai.log._condense import ATTACHMENT_PROTOCOL
+    from inspect_ai.log._recorders.buffer.filestore import (
+        Manifest,
+        SampleManifest,
+        Segment,
+        segment_file_name,
+        segment_name,
+    )
+    from inspect_ai.log._recorders.buffer.types import EventData, SampleData
+    from inspect_ai.log._recorders.eval import LogStart
+
+    async with AsyncFilesystem():
+        with tempfile.TemporaryDirectory() as temp_dir:
+            eval_path = os.path.join(temp_dir, "ctx_split.eval")
+            output_path = os.path.join(temp_dir, "ctx_split-recovered.eval")
+
+            eval_spec = _make_eval_spec(task="ctx_split_test", num_samples=1)
+            plan = EvalPlan()
+            log_start = LogStart(version=LOG_SCHEMA_VERSION, eval=eval_spec, plan=plan)
+
+            with ZipFile(eval_path, "w") as zf:
+                zf.writestr(
+                    "_journal/start.json",
+                    json.dumps(to_jsonable_python(log_start, exclude_none=True)),
+                )
+
+            eval_name = os.path.splitext(os.path.basename(eval_path))[0]
+            buffer_dir = os.path.join(temp_dir, ".buffer", eval_name)
+            os.makedirs(buffer_dir, exist_ok=True)
+
+            # Long assistant reply: >100 chars so events_fn pools it as attachment.
+            # The same message (by object identity -- ModelOutput.message is a
+            # ChatMessageAssistant created once at construction time) will also
+            # appear in MessageAccumulator.result() messages.
+            long_reply = "assistant long reply " * 10  # 210 chars > 100-char threshold
+            model_event = ModelEvent(
+                model="mockllm/model",
+                input=[ChatMessageUser(content="hi")],
+                tools=[],
+                tool_choice="auto",
+                config=GenerateConfig(),
+                output=ModelOutput.from_content(
+                    model="mockllm/model", content=long_reply
+                ),
+            )
+            event_dict = to_jsonable_python(model_event, exclude_none=True)
+
+            summary = EvalSampleSummary(
+                id=99,
+                epoch=1,
+                input="hi",
+                target="reply",
+                started_at=datetime.now(timezone.utc).isoformat(),
+                completed_at=datetime.now(timezone.utc).isoformat(),
+            )
+
+            sample_data = SampleData(
+                events=[
+                    EventData(
+                        id=1,
+                        event_id="evt-1-0",
+                        sample_id=str(summary.id),
+                        epoch=summary.epoch,
+                        event=event_dict,
+                    )
+                ],
+                attachments=[],
+            )
+            seg_zip_path = os.path.join(buffer_dir, segment_name(1))
+            with ZipFile(seg_zip_path, "w") as zf:
+                zf.writestr(
+                    segment_file_name(summary.id, summary.epoch),
+                    json.dumps(to_jsonable_python(sample_data, exclude_none=True)),
+                )
+
+            manifest = Manifest(
+                samples=[SampleManifest(summary=summary, segments=[1])],
+                segments=[Segment(id=1, last_event_id=1, last_attachment_id=0)],
+            )
+            with open(os.path.join(buffer_dir, "manifest.json"), "w") as f:
+                f.write(manifest.model_dump_json())
+            with open(os.path.join(buffer_dir, ".keep"), "w") as f:
+                pass
+
+            empty_db_dir = os.path.join(temp_dir, "empty_db_dir")
+            await recover_eval_log_async(
+                eval_path, output=output_path, cleanup=False, _db_dir=empty_db_dir
+            )
+
+            # Read without resolving attachments so we can inspect the raw content.
+            recovered = read_eval_log(output_path, resolve_attachments=False)
+            assert recovered.samples is not None
+            sample = next(s for s in recovered.samples if s.id == 99 and s.epoch == 1)
+
+            # messages side: the assistant reply must be the original long text,
+            # NOT an attachment:// reference (proves messages_context is separate).
+            assistant_msgs = [
+                m for m in sample.messages if isinstance(m, ChatMessageAssistant)
+            ]
+            assert len(assistant_msgs) >= 1
+            assistant_content = assistant_msgs[-1].content
+            assert isinstance(assistant_content, str), (
+                f"Expected str content in messages, got {type(assistant_content)}"
+            )
+            assert not assistant_content.startswith(ATTACHMENT_PROTOCOL), (
+                "messages walk leaked attachment ref from events walk: "
+                f"content={assistant_content!r}"
+            )
+            assert assistant_content == long_reply
+
+            # events side: the same long content must have become an attachment ref,
+            # proving the events walk DID run with the attachment-creating fn.
+            # The condensed event's output choice message content is the ref.
+            model_events = [e for e in sample.events if isinstance(e, ModelEvent)]
+            assert len(model_events) >= 1
+            output_content = model_events[-1].output.choices[0].message.content
+            assert isinstance(output_content, str)
+            assert output_content.startswith(ATTACHMENT_PROTOCOL), (
+                "events walk did not pool long output content as attachment: "
+                f"content={output_content!r}"
+            )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

**Stacked on #4222**: review only the last commit (or the diff vs `METR:linear-event-condensing`).

Writing a completed sample to the `.eval` file is O(N²) in conversation length: `condense_sample` re-walks every message of every event's input. This is the "known residual" noted in #4222, which linearized the live per-event paths but not this final-write path.

The cause is a cache in `walk_chat_message` that structurally cannot hit: it stores the walked result but verifies it against the pre-walk message, and any message the walk rewrites (long text becomes `attachment://` refs) never compares equal to its walked form. Measured: 0 hits in 4M lookups on a 2,000-turn synthetic. At realistic worst-case scale (~600 model events with ~50KB messages), the redundant walks and pool hashes cost tens of seconds to a minute of synchronous CPU per sample at finalization. Also, more severely, N²-proportional throwaway allocations that can pin a runner at its memory limit and livelock finalization entirely (see below). On synthetic stress shapes it grows quadratically from there (33 s at 2,000 turns).

### What is the new behavior?

The cache stores `(pre_walk, walked)` pairs verified against the pre-walk message, identity first. Two follow-on issues are fixed in the same commit:

- `condense_sample` (and the recover-stream writer) shared one walk context between two content functions with different attachment rules; a hit crossing them would leak attachment refs into `sample.messages`, which keeps long text inline. Each content function now gets its own context.
- The call pool hashed every wire message of every event (n(n+1)/2 hashes). Wire requests are append-mostly, so it now reuses the previous event's pool indices for the equal prefix, compared with `_strict_eq` so JSON-distinct values (`0` vs `0.0`) never merge.

Condensed output is byte-identical to the previous implementation (verified by `cmp` on a 250-turn sample, with and without `ModelCall`s, and on a rewritten-history shape where event inputs are not prefix-extensions).

Validated against a real production incident: the pre-fix O(N²) walks pinned a runner at ~63 GiB (its container memory limit) in continuous direct reclaim at finalization, so the sample never finalized and the runner had to be killed manually. Recovering that same sample (~127k events, ~73k messages) via `inspect log recover` on this branch completed in ~14 min at <1 GB peak RSS.

| turns | `condense_sample` before | after |
|------:|-------------------------:|------:|
| 1,000 | 8.0 s | 0.21 s |
| 2,000 | 33.4 s | 0.79 s |

End-to-end (condense_stress synthetic agent loop): 191 s → 89 s at 4,000 steps; the remaining superlinearity profiles to per-generate model-layer preprocessing, a different pre-existing subsystem.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Known residual: each event still pays one O(1) cache lookup per input message (N²/2 lookups at ~0.25 µs). At realistic per-sample scale (≤ ~600 model events) this is milliseconds; on unbounded synthetic stress shapes it stays ~4×/doubling with a small constant (65 s at 16K turns). Accepted: an input-list prefix-matching fix was prototyped and dropped as not worth its complexity at real workload scale.

