### PR TITLE
Linear storage for duplicate-content agent loops (occurrence-keyed pool positions)

### DIFF
--- a/src/inspect_ai/event/_pool.py
+++ b/src/inspect_ai/event/_pool.py
@@ -1,20 +1,33 @@
 """Message and call pool deduplication for eval samples.
 
-Design note — hash-based dedup
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Pool dedup keys on a murmur3 hash of the canonical JSON serialisation of
-each ChatMessage (pydantic field order; dict fields keep insertion order
+Design note — occurrence-keyed dedup
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Pool positions identify logical *occurrences* of a message in the
+conversation, not merely content. The batch functions here
+(``condense_model_event_inputs`` / ``condense_model_event_calls``)
+mirror the per-event helper in ``inspect_ai.event._pool_index``: the
+previous event's input list and assigned positions are carried across
+the event loop, and each event's longest shared prefix (object identity,
+then equality) reuses those positions directly. When an event purely
+appends to the previous one, the suffix messages are new occurrences and
+mint fresh per-occurrence rows without consulting the content-hash index
+— otherwise a loop emitting identical content each turn would map its
+history onto alternating positions, making the range-compressed refs
+quadratic in turns. Only prefix-*break* paths (first event, trim,
+compaction, fresh-id-rebuilt histories) fall back to content dedup,
+keyed on a murmur3 hash of the canonical JSON serialisation of each
+ChatMessage (pydantic field order; dict fields keep insertion order
 through a serialize/parse round-trip, so rebuild-time hashes match),
 excluding the ``id`` field so that messages with identical content but
 different UUIDs are treated as duplicates.
 
-The batch functions here (``condense_model_event_inputs`` /
-``condense_model_event_calls``) hash every message and rely on a per-call
-``id(obj)`` cache; that is O(N) only when a single call spans all events
-(the final-log and recover paths). Per-event callers (the sample buffer
-and the transcript store) must NOT call these one event at a time — that
-is O(N²) in conversation length (each of the N model events carries the
-full ~N-message history). They use the incremental indices in
+``condense_model_event_inputs`` additionally keeps a per-call ``id(obj)``
+→ position cache, so re-sent message objects skip hashing entirely; that
+is O(N) only when a single call spans all events (the final-log and
+recover paths). Per-event callers (the sample buffer and the transcript
+store) must NOT call these one event at a time — that is O(N²) in
+conversation length (each of the N model events carries the full
+~N-message history). They use the incremental indices in
 ``inspect_ai.event._pool_index`` instead, which resolve re-sent messages
 by object identity / id-bucket equality and hash only genuinely new
 content.
@@ -89,18 +102,18 @@ def _call_pool_json(call_msg: JsonValue) -> str:
 
 
 def _build_msg_index(pool: list[ChatMessage]) -> dict[str, int]:
-    """Build hash -> pool index mapping, matching condense_model_event_inputs logic."""
+    """Build hash -> first-occurrence pool index, matching condense_model_event_inputs logic."""
     index: dict[str, int] = {}
     for i, msg in enumerate(pool):
-        index[_msg_hash(msg)] = i
+        index.setdefault(_msg_hash(msg), i)
     return index
 
 
 def _build_call_index(pool: list[JsonValue]) -> dict[str, int]:
-    """Build hash -> pool index mapping, matching condense_model_event_calls logic."""
+    """Build hash -> first-occurrence pool index, matching condense_model_event_calls logic."""
     index: dict[str, int] = {}
     for i, call_msg in enumerate(pool):
-        index[_call_hash(call_msg)] = i
+        index.setdefault(_call_hash(call_msg), i)
     return index
 
 
@@ -111,12 +124,12 @@ def condense_model_event_inputs(
 ) -> tuple[list[Event], dict[str, int], list[tuple[str, ChatMessage]]]:
     """Replace ModelEvent.input with message_pool references.
 
-    Assigns each unique ChatMessage a position starting at ``next_index``
+    Assigns each message occurrence a position starting at ``next_index``
     and replaces ModelEvent inputs with range-encoded input_refs into a
     pool. Callers that need the pool list must rebuild it from
     ``new_entries`` (in order of appearance).
 
-    See module docstring for the hash-based dedup strategy.
+    See module docstring for the occurrence-keyed dedup strategy.
 
     Args:
         events: Events to condense.
@@ -132,8 +145,11 @@ def condense_model_event_inputs(
         order).
     """
     index = dict(msg_index)
-    obj_id_cache: dict[int, str] = {}
+    # object identity -> assigned position (re-sent objects skip hashing)
+    obj_pos_cache: dict[int, int] = {}
     new_entries: list[tuple[str, ChatMessage]] = []
+    prev_input: list[ChatMessage] = []
+    prev_indices: list[int] = []
     result: list[Event] = []
     for event in events:
         if isinstance(event, ModelEvent):
@@ -141,16 +157,33 @@ def condense_model_event_inputs(
                 result.append(event)
                 continue
             if event.input:
+                # longest prefix of the previous event's input (identity,
+                # then equality) — the same occurrence-identity mechanism
+                # as condense_model_event_with_indices
                 raw_indices: list[int] = []
-                for msg in event.input:
+                for msg, prev_msg, prev_index in zip(
+                    event.input, prev_input, prev_indices
+                ):
+                    if msg is prev_msg or msg == prev_msg:
+                        raw_indices.append(prev_index)
+                    else:
+                        break
+                pure_append = 0 < len(prev_input) == len(raw_indices)
+                for msg in event.input[len(raw_indices) :]:
                     obj_key = id(msg)
-                    h = obj_id_cache.get(obj_key) or obj_id_cache.setdefault(
-                        obj_key, _msg_hash(msg)
-                    )
-                    if h not in index:
-                        index[h] = next_index + len(new_entries)
-                        new_entries.append((h, msg))
-                    raw_indices.append(index[h])
+                    pos = obj_pos_cache.get(obj_key)
+                    if pos is None:
+                        h = _msg_hash(msg)
+                        pos = None if pure_append else index.get(h)
+                        if pos is None:
+                            pos = next_index + len(new_entries)
+                            if h not in index:
+                                index[h] = pos
+                            new_entries.append((h, msg))
+                        obj_pos_cache[obj_key] = pos
+                    raw_indices.append(pos)
+                prev_input = list(event.input)
+                prev_indices = list(raw_indices)
                 event = event.model_copy(
                     update={"input": [], "input_refs": _compress_refs(raw_indices)}
                 )
@@ -214,10 +247,12 @@ def condense_model_event_calls(
 ) -> tuple[list[Event], dict[str, int], list[tuple[str, JsonValue]]]:
     """Replace call.request messages with call_pool references.
 
-    Assigns each unique call message a position starting at ``next_index``
-    and replaces ``event.call.request[<messages_key>]`` with range-encoded
-    ``call_refs``. Callers that need the pool list must rebuild it from
-    ``new_entries``.
+    Assigns each call-message occurrence a position starting at
+    ``next_index`` and replaces ``event.call.request[<messages_key>]``
+    with range-encoded ``call_refs``. Callers that need the pool list
+    must rebuild it from ``new_entries``.
+
+    See module docstring for the occurrence-keyed dedup strategy.
 
     Args:
         events: Events to condense.
@@ -233,6 +268,8 @@ def condense_model_event_calls(
     """
     index = dict(call_index)
     new_entries: list[tuple[str, JsonValue]] = []
+    prev_msgs: list[JsonValue] = []
+    prev_indices: list[int] = []
     result: list[Event] = []
     for event in events:
         if isinstance(event, ModelEvent) and event.call:
@@ -245,12 +282,23 @@ def condense_model_event_calls(
             msgs = event.call.request.get(msg_key) if msg_key else None
             if msgs and isinstance(msgs, list):
                 raw_indices: list[int] = []
-                for msg in msgs:
+                for msg, prev_msg, prev_index in zip(msgs, prev_msgs, prev_indices):
+                    if msg == prev_msg:
+                        raw_indices.append(prev_index)
+                    else:
+                        break
+                pure_append = 0 < len(prev_msgs) == len(raw_indices)
+                for msg in msgs[len(raw_indices) :]:
                     h = _call_hash(msg)
-                    if h not in index:
-                        index[h] = next_index + len(new_entries)
+                    pos = None if pure_append else index.get(h)
+                    if pos is None:
+                        pos = next_index + len(new_entries)
+                        if h not in index:
+                            index[h] = pos
                         new_entries.append((h, msg))
-                    raw_indices.append(index[h])
+                    raw_indices.append(pos)
+                prev_msgs = list(msgs)
+                prev_indices = list(raw_indices)
                 new_request = {
                     k: v for k, v in event.call.request.items() if k != msg_key
                 }

--- a/src/inspect_ai/event/_pool.py
+++ b/src/inspect_ai/event/_pool.py
@@ -33,11 +33,12 @@ by object identity / id-bucket equality and hash only genuinely new
 content.
 """
 
+import dataclasses
 import json
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Final, TypeVar, cast
 
-from pydantic import JsonValue
+from pydantic import BaseModel, JsonValue
 from pydantic_core import to_jsonable_python
 
 from inspect_ai._util.hash import mm3_hash
@@ -56,6 +57,55 @@ def materialize_pooled_events(
     materialized = validate_events(list(events))
     materialized = resolve_model_event_inputs(materialized, message_pool)
     return resolve_model_event_calls(materialized, call_pool)
+
+
+def _strict_eq(a: object, b: object) -> bool:
+    """Equality that distinguishes values with different JSON serializations.
+
+    Python ``==`` conflates values the pool hashes distinguish: ``0 == 0.0``
+    and ``True == 1``, but ``json.dumps`` emits different bytes for each, so
+    ``_msg_hash``/``_call_hash`` differ. An ``==``-based merge of such values
+    would reuse a pool entry whose stored bytes round-trip to the *other*
+    value — silent data corruption. This comparison requires matching types
+    for scalars (recursing into models, dataclasses, dicts, and lists), so a
+    merge implies identical serialization.
+
+    Lives here (not ``_pool_index``) because both the batch condense
+    functions below and the per-event indices need it, and ``_pool_index``
+    already imports from this module.
+    """
+    if a is b:
+        return True
+    ta, tb = type(a), type(b)
+    if ta is not tb:
+        return False
+    if isinstance(a, BaseModel):
+        return _strict_eq(a.__dict__, b.__dict__)  # type: ignore[attr-defined]
+    if dataclasses.is_dataclass(a) and not isinstance(a, type):
+        return _strict_eq(vars(a), vars(b))
+    if ta is dict:
+        assert isinstance(a, dict) and isinstance(b, dict)
+        if len(a) != len(b):
+            return False
+        sentinel = object()
+        for k, v in a.items():
+            other = b.get(k, sentinel)
+            if other is sentinel or not _strict_eq(v, other):
+                return False
+            # dict lookup matches keys by ==, which conflates 0/0.0 and
+            # True/1 on the key axis just like values ({0: x} and {0.0: x}
+            # serialize to different JSON); str keys (the JSON-bound common
+            # case) cannot ==-collide across types, so only non-str keys
+            # need their counterpart's type checked
+            if type(k) is not str and not any(
+                bk == k and type(bk) is type(k) for bk in b
+            ):
+                return False
+        return True
+    if ta is list or ta is tuple:
+        assert isinstance(a, (list, tuple)) and isinstance(b, (list, tuple))
+        return len(a) == len(b) and all(_strict_eq(x, y) for x, y in zip(a, b))
+    return a == b
 
 
 def _msg_hash(msg: ChatMessage) -> str:
@@ -158,13 +208,15 @@ def condense_model_event_inputs(
                 continue
             if event.input:
                 # longest prefix of the previous event's input (identity,
-                # then equality) — the same occurrence-identity mechanism
-                # as condense_model_event_with_indices
+                # then strict equality) — the same occurrence-identity
+                # mechanism as condense_model_event_with_indices
                 raw_indices: list[int] = []
                 for msg, prev_msg, prev_index in zip(
                     event.input, prev_input, prev_indices
                 ):
-                    if msg is prev_msg or msg == prev_msg:
+                    if msg is prev_msg or (
+                        msg == prev_msg and _strict_eq(msg, prev_msg)
+                    ):
                         raw_indices.append(prev_index)
                     else:
                         break
@@ -283,7 +335,10 @@ def condense_model_event_calls(
             if msgs and isinstance(msgs, list):
                 raw_indices: list[int] = []
                 for msg, prev_msg, prev_index in zip(msgs, prev_msgs, prev_indices):
-                    if msg == prev_msg:
+                    # _strict_eq, not ==: a prefix element drifting 0 -> 0.0
+                    # or True -> 1 is python-equal but hashes differently;
+                    # reusing the pool index would round-trip the other value
+                    if _strict_eq(msg, prev_msg):
                         raw_indices.append(prev_index)
                     else:
                         break

--- a/src/inspect_ai/event/_pool.py
+++ b/src/inspect_ai/event/_pool.py
@@ -2,23 +2,30 @@
 
 Design note — hash-based dedup
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Pool dedup keys on a murmur3 hash of the sorted-keys JSON serialisation
-of each ChatMessage, excluding the ``id`` field so that messages with
-identical content but different UUIDs are treated as duplicates.
+Pool dedup keys on a murmur3 hash of the canonical JSON serialisation of
+each ChatMessage (pydantic field order; dict fields keep insertion order
+through a serialize/parse round-trip, so rebuild-time hashes match),
+excluding the ``id`` field so that messages with identical content but
+different UUIDs are treated as duplicates.
 
-The theoretical cost is O(N²) serialisations per sample (each of the N
-model events carries the full conversation history of ~N messages).
-In practice an ``id(obj)`` → hash cache avoids re-serialising the same
-Python object, bringing the common case back to O(N) while remaining
-correct even when users mutate objects (same object identity = same
-content by definition).
+The batch functions here (``condense_model_event_inputs`` /
+``condense_model_event_calls``) hash every message and rely on a per-call
+``id(obj)`` cache; that is O(N) only when a single call spans all events
+(the final-log and recover paths). Per-event callers (the sample buffer
+and the transcript store) must NOT call these one event at a time — that
+is O(N²) in conversation length (each of the N model events carries the
+full ~N-message history). They use the incremental indices in
+``inspect_ai.event._pool_index`` instead, which resolve re-sent messages
+by object identity / id-bucket equality and hash only genuinely new
+content.
 """
 
 import json
-from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Final, TypeVar
+from collections.abc import Iterable, Mapping, Sequence
+from typing import Final, TypeVar, cast
 
 from pydantic import JsonValue
+from pydantic_core import to_jsonable_python
 
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai.event._validate import validate_events
@@ -39,12 +46,50 @@ def materialize_pooled_events(
 
 
 def _msg_hash(msg: ChatMessage) -> str:
-    data = json.loads(msg.model_dump_json(exclude={"id"}))
-    return mm3_hash(json.dumps(data, sort_keys=True))
+    # Hash pydantic's canonical serialization directly (field order is
+    # class-definition order; dict fields keep insertion order through a
+    # serialize/parse round-trip, so rebuild-time hashes match). A dict
+    # with different key insertion order hashes differently — that only
+    # costs a duplicate pool entry, never wrong dedup.
+    return mm3_hash(msg.model_dump_json(exclude={"id"}))
+
+
+def _msg_pool_jsonable(msg: ChatMessage) -> JsonValue:
+    """Jsonable form of a message-pool row (serialize with `_msg_pool_json`)."""
+    return cast(
+        JsonValue, to_jsonable_python(msg, exclude_none=True, fallback=lambda _: None)
+    )
+
+
+def _msg_pool_json(message_jsonable: JsonValue) -> str:
+    """Serialize a message-pool row for storage.
+
+    Owns the hash↔storage round-trip invariant: stored bytes must re-parse
+    to a message whose `_msg_hash` equals the hash stored beside them.
+    `_msg_hash` hashes insertion-order serialization, so storage must
+    preserve insertion order too — never ``sort_keys=True``, which would
+    reorder dict fields (tool-call arguments, metadata) and make re-seeded
+    rows miss their own hash, duplicating pool entries on every resume.
+    """
+    return json.dumps(message_jsonable)
+
+
+def _call_hash(call_msg: JsonValue) -> str:
+    return mm3_hash(json.dumps(call_msg, sort_keys=True))
+
+
+def _call_pool_json(call_msg: JsonValue) -> str:
+    """Serialize a call-pool row for storage.
+
+    Owns the hash↔storage round-trip invariant for the call pool: stored
+    bytes must re-hash (via `_call_hash` after re-parse) to the hash stored
+    beside them. `_call_hash` sorts keys, so storage sorts keys too.
+    """
+    return json.dumps(call_msg, sort_keys=True)
 
 
 def _build_msg_index(pool: list[ChatMessage]) -> dict[str, int]:
-    """Build msg_id -> pool index mapping, matching condense_model_event_inputs logic."""
+    """Build hash -> pool index mapping, matching condense_model_event_inputs logic."""
     index: dict[str, int] = {}
     for i, msg in enumerate(pool):
         index[_msg_hash(msg)] = i
@@ -55,26 +100,8 @@ def _build_call_index(pool: list[JsonValue]) -> dict[str, int]:
     """Build hash -> pool index mapping, matching condense_model_event_calls logic."""
     index: dict[str, int] = {}
     for i, call_msg in enumerate(pool):
-        index[mm3_hash(json.dumps(call_msg, sort_keys=True))] = i
+        index[_call_hash(call_msg)] = i
     return index
-
-
-def condense_model_event_inputs_with_lookup(
-    event: Event,
-    lookup_message: Callable[[ChatMessage], int],
-) -> Event:
-    """Replace a single ModelEvent.input with message_pool references."""
-    if not isinstance(event, ModelEvent):
-        return event
-    if event.input_refs is not None and not event.input:
-        return event
-    if not event.input:
-        return event
-
-    raw_indices = [lookup_message(message) for message in event.input]
-    return event.model_copy(
-        update={"input": [], "input_refs": _compress_refs(raw_indices)}
-    )
 
 
 def condense_model_event_inputs(
@@ -180,33 +207,6 @@ def _expand_refs(
     return result
 
 
-def condense_model_event_calls_with_lookup(
-    event: Event,
-    lookup_call: Callable[[JsonValue], int],
-) -> Event:
-    """Replace a single ModelEvent call request message list with call_refs."""
-    if not isinstance(event, ModelEvent) or event.call is None:
-        return event
-    if event.call.call_refs is not None:
-        return event
-
-    msg_key = next((k for k in _CALL_MESSAGE_KEYS if k in event.call.request), None)
-    msgs = event.call.request.get(msg_key) if msg_key else None
-    if not isinstance(msgs, list) or not msgs:
-        return event
-
-    raw_indices = [lookup_call(message) for message in msgs]
-    new_request = {k: v for k, v in event.call.request.items() if k != msg_key}
-    new_call = event.call.model_copy(
-        update={
-            "request": new_request,
-            "call_refs": _compress_refs(raw_indices),
-            "call_key": msg_key,
-        }
-    )
-    return event.model_copy(update={"call": new_call})
-
-
 def condense_model_event_calls(
     events: Sequence[Event],
     next_index: int,
@@ -246,7 +246,7 @@ def condense_model_event_calls(
             if msgs and isinstance(msgs, list):
                 raw_indices: list[int] = []
                 for msg in msgs:
-                    h = mm3_hash(json.dumps(msg, sort_keys=True))
+                    h = _call_hash(msg)
                     if h not in index:
                         index[h] = next_index + len(new_entries)
                         new_entries.append((h, msg))

--- a/src/inspect_ai/event/_pool_index.py
+++ b/src/inspect_ai/event/_pool_index.py
@@ -169,6 +169,16 @@ class MessagePoolIndex:
     entries reconstructed from storage (no object reuse) via
     ``get_by_hash``.
 
+    Like ``CallPoolIndex``, the previous event's input list and its pool
+    positions are retained (``set_prev``) so the next event's shared
+    prefix can be matched element-by-element (``match_prefix``) — this
+    keeps positions monotone for duplicate-content occurrences instead of
+    collapsing them to the first hash hit.
+
+    ``size`` counts pool *rows* recorded (occurrence rows may share a
+    hash), not distinct hashes, so buffer callers can derive the next
+    row position from it.
+
     Supports ``mark()``/``restore()`` to unwind state when a surrounding
     database transaction rolls back.
     """
@@ -176,15 +186,65 @@ class MessagePoolIndex:
     def __init__(self) -> None:
         # msg.id -> [(pre-walk message, pool index)]
         self._buckets: dict[str, list[tuple[ChatMessage, int]]] = {}
-        # walked-form content hash -> pool index
+        # walked-form content hash -> pool index (first occurrence wins)
         self._hash_index: dict[str, int] = {}
-        # undo log: (bucket key appended to or None, hash added or None)
-        self._log: list[tuple[str | None, str | None]] = []
+        # pool rows recorded (NOT distinct hashes: occurrence rows share hashes)
+        self._size: int = 0
+        # undo log: (bucket key appended to or None, hash added or None, row counted)
+        self._log: list[tuple[str | None, str | None, bool]] = []
+        # previous event's pre-walk input and its pool positions
+        self._prev_msgs: list[ChatMessage] = []
+        self._prev_indices: list[int] = []
 
     @property
     def size(self) -> int:
-        """Number of distinct pool entries indexed."""
-        return len(self._hash_index)
+        """Number of pool rows recorded via ``add(..., new_entry=True)``.
+
+        Meaningful as a position source only when every counted add
+        corresponds to exactly one persisted row (the buffer's contract).
+        """
+        return self._size
+
+    @property
+    def prev_len(self) -> int:
+        """Length of the previously recorded input (0 if none recorded)."""
+        return len(self._prev_msgs)
+
+    def match_prefix(self, msgs: Sequence[ChatMessage]) -> list[int]:
+        """Pool indices for the longest shared prefix with the previous input.
+
+        Elements match by object identity first, then pydantic equality
+        (which includes ``id``, so fresh-id re-sends deliberately miss).
+        Comparison stops at the first non-matching element.
+
+        Args:
+            msgs: New event's input messages (pre-walk).
+
+        Returns:
+            Pool indices for the matched prefix; empty if no previous input
+            was recorded or the first element differs.
+        """
+        indices: list[int] = []
+        for msg, prev_msg, prev_index in zip(msgs, self._prev_msgs, self._prev_indices):
+            if msg is prev_msg or msg == prev_msg:
+                indices.append(prev_index)
+            else:
+                break
+        return indices
+
+    def set_prev(self, msgs: Sequence[ChatMessage], indices: Sequence[int]) -> None:
+        """Record the input just condensed for prefix-matching the next event.
+
+        Copies both sequences shallowly (same aliasing contract as
+        ``CallPoolIndex.set_prev``: message values are shared, and in-place
+        mutation aliases every holder, which is already documented behavior).
+
+        Args:
+            msgs: Pre-walk input message list.
+            indices: Corresponding pool indices, parallel to ``msgs``.
+        """
+        self._prev_msgs = list(msgs)
+        self._prev_indices = list(indices)
 
     def get(self, msg: ChatMessage) -> int | None:
         """Fast-path lookup without serialization (identity, then equality).
@@ -219,8 +279,10 @@ class MessagePoolIndex:
         """
         return self._hash_index.get(hash_value)
 
-    def add(self, msg: ChatMessage, hash_value: str, index: int) -> None:
-        """Record a pool entry.
+    def add(
+        self, msg: ChatMessage, hash_value: str, index: int, *, new_entry: bool = True
+    ) -> None:
+        """Record a pool entry (or accelerator-only lookup state).
 
         Messages with a content string over ``_BUCKET_CONTENT_LIMIT`` are
         recorded in the hash index only (see module docstring): bucketing
@@ -230,6 +292,10 @@ class MessagePoolIndex:
             msg: Pre-walk message object.
             hash_value: Walked-form content hash.
             index: Pool index for this entry.
+            new_entry: ``True`` when this call corresponds to a newly
+                persisted pool row (counted in ``size``); ``False`` for
+                accelerator-only registration of an existing row
+                (resume/seeding paths).
         """
         bucket_key = msg.id if not _has_heavy_str(msg.__dict__) else None
         if bucket_key is not None:
@@ -238,8 +304,25 @@ class MessagePoolIndex:
         if hash_value not in self._hash_index:
             self._hash_index[hash_value] = index
             hash_added = hash_value
-        if bucket_key is not None or hash_added is not None:
-            self._log.append((bucket_key, hash_added))
+        if new_entry:
+            self._size += 1
+        if bucket_key is not None or hash_added is not None or new_entry:
+            self._log.append((bucket_key, hash_added, new_entry))
+
+    def add_hash_only(self, hash_value: str, index: int) -> None:
+        """Register an existing row's hash without an object to bucket.
+
+        Used when seeding from storage where only walked JSON is available.
+        Does not count toward ``size``.
+
+        Args:
+            hash_value: Walked-form content hash.
+            index: Pool index for this entry. Ignored if the hash is
+                already registered (first occurrence wins).
+        """
+        if hash_value not in self._hash_index:
+            self._hash_index[hash_value] = index
+            self._log.append((None, hash_value, False))
 
     def mark(self) -> int:
         """Return a mark for later ``restore()``.
@@ -250,13 +333,17 @@ class MessagePoolIndex:
         return len(self._log)
 
     def restore(self, mark: int) -> None:
-        """Undo all ``add()`` calls made since ``mark()`` was obtained.
+        """Undo all ``add()`` and ``add_hash_only()`` calls made since ``mark()``.
+
+        Correctness-bearing state (hashes, row count) is rewound precisely;
+        the prefix-match state is accelerator-only and dropped instead
+        (same rationale as ``CallPoolIndex.restore``).
 
         Args:
             mark: Value previously returned by ``mark()``.
         """
         while len(self._log) > mark:
-            bucket_key, hash_added = self._log.pop()
+            bucket_key, hash_added, row_added = self._log.pop()
             if bucket_key is not None:
                 bucket = self._buckets[bucket_key]
                 bucket.pop()
@@ -264,6 +351,10 @@ class MessagePoolIndex:
                     del self._buckets[bucket_key]
             if hash_added is not None:
                 del self._hash_index[hash_added]
+            if row_added:
+                self._size -= 1
+        self._prev_msgs = []
+        self._prev_indices = []
 
 
 class CallPoolIndex:

--- a/src/inspect_ai/event/_pool_index.py
+++ b/src/inspect_ai/event/_pool_index.py
@@ -72,7 +72,7 @@ from . import (
     _pool,  # accessed as module attributes so monkeypatching _pool._msg_hash is visible here
 )
 from ._model import ModelEvent
-from ._pool import _CALL_MESSAGE_KEYS, _compress_refs
+from ._pool import _CALL_MESSAGE_KEYS, _compress_refs, _strict_eq
 
 _BUCKET_CONTENT_LIMIT = 64 * 1024
 """Max single content-string length (bytes) for a message to be bucketed.
@@ -95,51 +95,6 @@ tool code can populate with cyclic or pathologically nested structures.
 Capping out reports heavy — the safe direction (the message just isn't
 bucketed).
 """
-
-
-def _strict_eq(a: object, b: object) -> bool:
-    """Equality that distinguishes values with different JSON serializations.
-
-    Python ``==`` conflates values the pool hashes distinguish: ``0 == 0.0``
-    and ``True == 1``, but ``json.dumps`` emits different bytes for each, so
-    ``_msg_hash``/``_call_hash`` differ. An ``==``-based merge of such values
-    would reuse a pool entry whose stored bytes round-trip to the *other*
-    value — silent data corruption. This comparison requires matching types
-    for scalars (recursing into models, dataclasses, dicts, and lists), so a
-    merge implies identical serialization.
-    """
-    if a is b:
-        return True
-    ta, tb = type(a), type(b)
-    if ta is not tb:
-        return False
-    if isinstance(a, BaseModel):
-        return _strict_eq(a.__dict__, b.__dict__)  # type: ignore[attr-defined]
-    if dataclasses.is_dataclass(a) and not isinstance(a, type):
-        return _strict_eq(vars(a), vars(b))
-    if ta is dict:
-        assert isinstance(a, dict) and isinstance(b, dict)
-        if len(a) != len(b):
-            return False
-        sentinel = object()
-        for k, v in a.items():
-            other = b.get(k, sentinel)
-            if other is sentinel or not _strict_eq(v, other):
-                return False
-            # dict lookup matches keys by ==, which conflates 0/0.0 and
-            # True/1 on the key axis just like values ({0: x} and {0.0: x}
-            # serialize to different JSON); str keys (the JSON-bound common
-            # case) cannot ==-collide across types, so only non-str keys
-            # need their counterpart's type checked
-            if type(k) is not str and not any(
-                bk == k and type(bk) is type(k) for bk in b
-            ):
-                return False
-        return True
-    if ta is list or ta is tuple:
-        assert isinstance(a, (list, tuple)) and isinstance(b, (list, tuple))
-        return len(a) == len(b) and all(_strict_eq(x, y) for x, y in zip(a, b))
-    return a == b
 
 
 def _has_heavy_str(value: object, depth: int = 0) -> bool:
@@ -227,7 +182,9 @@ class MessagePoolIndex:
         """Pool indices for the longest shared prefix with the previous input.
 
         Elements match by object identity first, then pydantic equality
-        (which includes ``id``, so fresh-id re-sends deliberately miss).
+        (which includes ``id``, so fresh-id re-sends deliberately miss)
+        confirmed by ``_strict_eq`` (a ``0``-vs-``0.0`` or ``True``-vs-``1``
+        drift is python-equal but serializes and hashes differently).
         Comparison stops at the first non-matching element.
 
         Args:
@@ -239,7 +196,7 @@ class MessagePoolIndex:
         """
         indices: list[int] = []
         for msg, prev_msg, prev_index in zip(msgs, self._prev_msgs, self._prev_indices):
-            if msg is prev_msg or msg == prev_msg:
+            if msg is prev_msg or (msg == prev_msg and _strict_eq(msg, prev_msg)):
                 indices.append(prev_index)
             else:
                 break

--- a/src/inspect_ai/event/_pool_index.py
+++ b/src/inspect_ai/event/_pool_index.py
@@ -368,23 +368,38 @@ class CallPoolIndex:
     A hash index covers the non-prefix tail so individual messages can still
     be deduplicated across events.
 
+    ``size`` counts pool *rows* recorded (occurrence rows may share a
+    hash), not distinct hashes, so buffer callers can derive the next
+    row position from it.
+
     Supports ``mark()``/``restore()`` to unwind state when a surrounding
     database transaction rolls back.
     """
 
     def __init__(self) -> None:
-        # walked-form content hash -> pool index
+        # walked-form content hash -> pool index (first occurrence wins)
         self._hash_index: dict[str, int] = {}
+        # pool rows recorded (NOT distinct hashes)
+        self._size: int = 0
         # previous event's pre-walk wire messages and their pool indices
         self._prev_msgs: list[JsonValue] = []
         self._prev_indices: list[int] = []
-        # undo log of hashes added (for mark/restore)
-        self._added_hashes: list[str] = []
+        # undo log: (hash added or None, row counted)
+        self._log: list[tuple[str | None, bool]] = []
 
     @property
     def size(self) -> int:
-        """Number of distinct pool entries indexed."""
-        return len(self._hash_index)
+        """Number of pool rows recorded via ``add_hash(..., new_entry=True)``.
+
+        Meaningful as a position source only when every counted add
+        corresponds to exactly one persisted row (the buffer's contract).
+        """
+        return self._size
+
+    @property
+    def prev_len(self) -> int:
+        """Length of the previously recorded request (0 if none recorded)."""
+        return len(self._prev_msgs)
 
     def match_prefix(self, msgs: Sequence[JsonValue]) -> list[int]:
         """Pool indices for the longest shared prefix with the previous request.
@@ -422,18 +437,27 @@ class CallPoolIndex:
         """
         return self._hash_index.get(hash_value)
 
-    def add_hash(self, hash_value: str, index: int) -> None:
+    def add_hash(self, hash_value: str, index: int, *, new_entry: bool = True) -> None:
         """Record a pool entry by its walked-form hash.
 
-        Duplicate adds (same ``hash_value``) are silently ignored.
+        The hash index keeps the first occurrence's position; later
+        occurrence rows still count toward ``size``.
 
         Args:
             hash_value: Walked-form content hash.
             index: Pool index for this entry.
+            new_entry: ``True`` when this call corresponds to a newly
+                persisted pool row; ``False`` for accelerator-only
+                registration of an existing row (resume/seeding paths).
         """
+        hash_added: str | None = None
         if hash_value not in self._hash_index:
             self._hash_index[hash_value] = index
-            self._added_hashes.append(hash_value)
+            hash_added = hash_value
+        if new_entry:
+            self._size += 1
+        if hash_added is not None or new_entry:
+            self._log.append((hash_added, new_entry))
 
     def set_prev(self, msgs: Sequence[JsonValue], indices: Sequence[int]) -> None:
         """Record the request just condensed for prefix-matching the next one.
@@ -458,25 +482,30 @@ class CallPoolIndex:
         Returns:
             Opaque integer mark representing the current index state.
         """
-        return len(self._added_hashes)
+        return len(self._log)
 
     def restore(self, mark: int) -> None:
         """Drop all pool references recorded since ``mark()`` was obtained.
 
-        Hash entries are undone precisely (a stale entry would make the
-        retry skip an insert and emit dangling refs). The prefix-match
-        state is accelerator-only, so it is dropped rather than rewound:
-        the next event's prefix scan misses and falls through to hash
-        dedup, which is always safe. Rewinding it would require holding a
-        snapshot of ``_prev_msgs`` across the marked window, reintroducing
-        aliasing to reason about for a path that only runs after a
-        database transaction failure.
+        Hash entries and the row count are undone precisely (a stale entry
+        would make the retry skip an insert and emit dangling refs; a stale
+        count misaligns buffer positions). The prefix-match state is
+        accelerator-only, so it is dropped rather than rewound: the next
+        event's prefix scan misses and falls through to hash dedup, which
+        is always safe. Rewinding it would require holding a snapshot of
+        ``_prev_msgs`` across the marked window, reintroducing aliasing to
+        reason about for a path that only runs after a database
+        transaction failure.
 
         Args:
             mark: Value previously returned by ``mark()``.
         """
-        while len(self._added_hashes) > mark:
-            del self._hash_index[self._added_hashes.pop()]
+        while len(self._log) > mark:
+            hash_added, row_added = self._log.pop()
+            if hash_added is not None:
+                del self._hash_index[hash_added]
+            if row_added:
+                self._size -= 1
         self._prev_msgs = []
         self._prev_indices = []
 

--- a/src/inspect_ai/event/_pool_index.py
+++ b/src/inspect_ai/event/_pool_index.py
@@ -6,7 +6,9 @@ in each event rather than the full conversation history:
 - ``MessagePoolIndex`` buckets on ``ChatMessage.id`` (a random UUID) and
   verifies candidates by object identity, then content equality. Agents
   reuse the same message objects across turns, so the identity fast path
-  hits for the entire shared history without any serialization.
+  hits for the entire shared history without any serialization. It also
+  retains the previous event's input list and pool positions so the next
+  event's shared prefix can be matched element-by-element.
 - ``CallPoolIndex`` exploits the append-mostly structure of provider wire
   requests: the previous event's message list is retained and the shared
   prefix matched by plain equality; only the divergent suffix is hashed.
@@ -14,6 +16,17 @@ in each event rather than the full conversation history:
   (no serialization or allocation); it is not O(new) like the message
   index, but in practice most events share a long stable prefix so the
   total work per event stays low.
+
+Pool positions are occurrence-keyed: a position identifies a logical
+occurrence of a message in the conversation, not merely its content.
+Re-sends of the same occurrence resolve via the prefix match or the
+identity buckets; only prefix-*break* paths (first event, trim,
+compaction, resume, fresh-id-rebuilt histories) consult content hashes.
+When an event purely appends to the previous one, suffix messages mint
+fresh per-occurrence rows even if their content duplicates an earlier
+row — otherwise a loop emitting identical content each turn would map
+its history onto alternating positions, making the range-compressed
+refs quadratic in turns.
 
 Correctness never depends on these assumptions: a merge happens only when
 serialization-equivalent equality (``_strict_eq``; plain ``==`` would
@@ -557,14 +570,20 @@ def condense_model_event_with_indices(
         ``messages.restore()``/``calls.restore()`` on rollback to keep the
         in-memory indices consistent with storage.
 
-        Identity-bucket entries are only registered for messages that are new
-        to the pool (hash miss). A message whose content duplicates an
-        already-pooled entry under a different id is re-walked and re-hashed
-        on each event that re-sends it. This is a bounded cost (duplicate-
-        content messages are rare), and avoids O(events × history) pinned
-        objects for fresh-id scaffolds (bridge-style agents) where a hash hit
-        would leave a useless bucket entry that could never produce a future
-        identity hit.
+        Occurrence identity: pool positions identify logical occurrences,
+        not just content. When an event's input is a pure append of the
+        previous event's input, the suffix messages are new occurrences and
+        mint per-occurrence pool rows without consulting the content-hash
+        index (which would map repeated content onto alternating positions,
+        making the range-compressed refs quadratic across a long loop).
+        Suffix rows are bucketed (the heavy-content gate still applies), so
+        re-sends of those objects resolve by identity. A prefix break
+        (first event, trim, compaction, resume, fresh-id-rebuilt histories)
+        keeps content dedup — and there the original decision not to bucket
+        hash-hit messages still applies: it avoids O(events × history)
+        pinned objects for fresh-id scaffolds (bridge-style agents) where a
+        hash hit would leave a useless bucket entry that could never
+        produce a future identity hit.
     """
     update: dict[str, Any] = {}
 
@@ -574,17 +593,23 @@ def condense_model_event_with_indices(
     if event.input_refs is not None and not event.input:
         pass
     elif event.input:
-        raw_indices: list[int] = []
-        for msg in event.input:
+        raw_indices = messages.match_prefix(event.input)
+        # 0 < prev_len guards the first-event/post-restore case (an empty
+        # previous input must not classify as append); == len(raw_indices)
+        # requires the FULL previous input to have matched. See the Note
+        # in this function's docstring for the append/break semantics.
+        pure_append = 0 < messages.prev_len == len(raw_indices)
+        for msg in event.input[len(raw_indices) :]:
             index = messages.get(msg)
             if index is None:
                 walked = walk_message(msg)
                 msg_hash = _pool._msg_hash(walked)
-                index = messages.get_by_hash(msg_hash)
+                index = None if pure_append else messages.get_by_hash(msg_hash)
                 if index is None:
                     index = add_message(msg_hash, walked)
                     messages.add(msg, msg_hash, index)
             raw_indices.append(index)
+        messages.set_prev(event.input, raw_indices)
         update["input"] = []
         update["input_refs"] = _compress_refs(raw_indices)
 
@@ -594,13 +619,14 @@ def condense_model_event_with_indices(
         msgs = call.request.get(msg_key) if msg_key else None
         if msgs and isinstance(msgs, list):
             call_indices = calls.match_prefix(msgs)
+            pure_append_calls = 0 < calls.prev_len == len(call_indices)
             for msg_value in msgs[len(call_indices) :]:
                 walked_value = walk_call_message(msg_value)
                 call_hash = _pool._call_hash(walked_value)
-                call_index = calls.get_by_hash(call_hash)
+                call_index = None if pure_append_calls else calls.get_by_hash(call_hash)
                 if call_index is None:
                     call_index = add_call(call_hash, walked_value)
-                calls.add_hash(call_hash, call_index)
+                    calls.add_hash(call_hash, call_index)
                 call_indices.append(call_index)
             calls.set_prev(msgs, call_indices)
             new_request = {k: v for k, v in call.request.items() if k != msg_key}

--- a/src/inspect_ai/event/_pool_index.py
+++ b/src/inspect_ai/event/_pool_index.py
@@ -1,0 +1,495 @@
+"""In-memory acceleration indices for message/call pool dedup.
+
+These make per-event condensing cost proportional to the *new* messages
+in each event rather than the full conversation history:
+
+- ``MessagePoolIndex`` buckets on ``ChatMessage.id`` (a random UUID) and
+  verifies candidates by object identity, then content equality. Agents
+  reuse the same message objects across turns, so the identity fast path
+  hits for the entire shared history without any serialization.
+- ``CallPoolIndex`` exploits the append-mostly structure of provider wire
+  requests: the previous event's message list is retained and the shared
+  prefix matched by plain equality; only the divergent suffix is hashed.
+  The prefix scan is O(shared-history) comparisons with a small constant
+  (no serialization or allocation); it is not O(new) like the message
+  index, but in practice most events share a long stable prefix so the
+  total work per event stays low.
+
+Correctness never depends on these assumptions: a merge happens only when
+serialization-equivalent equality (``_strict_eq``; plain ``==`` would
+conflate ``0``/``0.0`` and ``True``/``1``, which hash differently) or hash
+equality confirms it. The worst case is extra hashing, never wrong dedup. Indices hold pre-walk
+objects (what callers re-send across events); hashes are of the walked
+form (what resume/recover paths recompute from stored pool entries).
+Both indices support ``mark()``/``restore()`` so callers can unwind
+in-memory state when a database transaction rolls back. The restore
+contract: ``restore(mark)`` guarantees the index references no pool
+position added after ``mark``. Correctness-bearing hash entries are
+undone precisely (a stale entry yields dangling refs or, in the buffer,
+misaligned ``size``-derived positions); accelerator state may instead be
+conservatively dropped — a lookup miss is always safe, a stale entry
+never is. The message buckets get precise undo because the same log that
+the hash entries need carries them for free; the call prefix state is
+dropped.
+
+Messages containing a content string over ``_BUCKET_CONTENT_LIMIT``
+(base64 media payloads) are never bucketed: bucketed pre-walk objects are
+pinned for the sample's lifetime, which would re-accumulate exactly the
+memory that bounded transcripts (``INSPECT_TRANSCRIPT_BOUNDED``) evict.
+Such messages dedup via the hash path instead, costing one re-walk and
+re-hash per event that re-sends them — cheap, because their walked form
+replaces payloads with short attachment refs.
+
+Note on in-place mutation: a ``ChatMessage`` mutated after being pooled
+identity-hits on the index and resolves to its first-pooled form. This
+is consistent with the prior ``id(obj)``-cache behavior documented in
+``_pool.py`` — mutation aliases every holder of the object, so no
+distinct prior value exists.
+"""
+
+import dataclasses
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from pydantic import BaseModel, JsonValue
+
+from inspect_ai.model._chat_message import ChatMessage
+
+from . import (
+    _pool,  # accessed as module attributes so monkeypatching _pool._msg_hash is visible here
+)
+from ._model import ModelEvent
+from ._pool import _CALL_MESSAGE_KEYS, _compress_refs
+
+_BUCKET_CONTENT_LIMIT = 64 * 1024
+"""Max single content-string length (bytes) for a message to be bucketed.
+
+Separates the two observed content populations by orders of magnitude:
+text/tool content strings sit at p99 ≈ 8.5KB (worst observed outlier
+94KB, whose un-bucketed re-hash costs ~9µs/event), while base64 media
+payloads start around 100KB and are typically 1-5MB. Anything above the
+limit is media-scale and must not be pinned in memory; anything below is
+cheap to pin and benefits from the equality fast path.
+"""
+
+
+_MAX_SCAN_DEPTH = 20
+"""Recursion bound for the heavy-string scan.
+
+Real message structures are a handful of levels deep; the bound exists
+for arbitrary ``metadata``/``ContentData.data`` values, which agent and
+tool code can populate with cyclic or pathologically nested structures.
+Capping out reports heavy — the safe direction (the message just isn't
+bucketed).
+"""
+
+
+def _strict_eq(a: object, b: object) -> bool:
+    """Equality that distinguishes values with different JSON serializations.
+
+    Python ``==`` conflates values the pool hashes distinguish: ``0 == 0.0``
+    and ``True == 1``, but ``json.dumps`` emits different bytes for each, so
+    ``_msg_hash``/``_call_hash`` differ. An ``==``-based merge of such values
+    would reuse a pool entry whose stored bytes round-trip to the *other*
+    value — silent data corruption. This comparison requires matching types
+    for scalars (recursing into models, dataclasses, dicts, and lists), so a
+    merge implies identical serialization.
+    """
+    if a is b:
+        return True
+    ta, tb = type(a), type(b)
+    if ta is not tb:
+        return False
+    if isinstance(a, BaseModel):
+        return _strict_eq(a.__dict__, b.__dict__)  # type: ignore[attr-defined]
+    if dataclasses.is_dataclass(a) and not isinstance(a, type):
+        return _strict_eq(vars(a), vars(b))
+    if ta is dict:
+        assert isinstance(a, dict) and isinstance(b, dict)
+        if len(a) != len(b):
+            return False
+        sentinel = object()
+        for k, v in a.items():
+            other = b.get(k, sentinel)
+            if other is sentinel or not _strict_eq(v, other):
+                return False
+            # dict lookup matches keys by ==, which conflates 0/0.0 and
+            # True/1 on the key axis just like values ({0: x} and {0.0: x}
+            # serialize to different JSON); str keys (the JSON-bound common
+            # case) cannot ==-collide across types, so only non-str keys
+            # need their counterpart's type checked
+            if type(k) is not str and not any(
+                bk == k and type(bk) is type(k) for bk in b
+            ):
+                return False
+        return True
+    if ta is list or ta is tuple:
+        assert isinstance(a, (list, tuple)) and isinstance(b, (list, tuple))
+        return len(a) == len(b) and all(_strict_eq(x, y) for x, y in zip(a, b))
+    return a == b
+
+
+def _has_heavy_str(value: object, depth: int = 0) -> bool:
+    """Whether any string within a value exceeds ``_BUCKET_CONTENT_LIMIT``.
+
+    Recurses into models, dataclasses, dicts, and lists, so every
+    payload-bearing field is covered uniformly (content blocks,
+    ``ContentData.data``, tool-call arguments and views, metadata)
+    without enumerating fields that would have to be kept in sync.
+    Short-circuits on the first heavy string and stops descending at
+    ``_MAX_SCAN_DEPTH`` (reporting heavy), so the scan is cheap on the
+    hot path and safe on cyclic values.
+    """
+    if depth >= _MAX_SCAN_DEPTH:
+        return True
+    if isinstance(value, str):
+        return len(value) > _BUCKET_CONTENT_LIMIT
+    if isinstance(value, BaseModel):
+        return _has_heavy_str(value.__dict__, depth + 1)
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        # vars() not dataclasses.asdict(): asdict deep-copies, which would
+        # defeat the cheap scan on multi-MB payloads
+        return _has_heavy_str(vars(value), depth + 1)
+    if isinstance(value, dict):
+        return any(_has_heavy_str(v, depth + 1) for v in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_has_heavy_str(v, depth + 1) for v in value)
+    return False
+
+
+class MessagePoolIndex:
+    """Id-bucketed, identity-first lookup index for ChatMessage objects.
+
+    Buckets messages by their ``id`` field (a random UUID) and verifies
+    candidates first by object identity, then by content equality. This
+    allows O(1)-per-message lookup when agents reuse the same objects
+    across turns.
+
+    A walked-form content hash is also maintained so callers can locate
+    entries reconstructed from storage (no object reuse) via
+    ``get_by_hash``.
+
+    Supports ``mark()``/``restore()`` to unwind state when a surrounding
+    database transaction rolls back.
+    """
+
+    def __init__(self) -> None:
+        # msg.id -> [(pre-walk message, pool index)]
+        self._buckets: dict[str, list[tuple[ChatMessage, int]]] = {}
+        # walked-form content hash -> pool index
+        self._hash_index: dict[str, int] = {}
+        # undo log: (bucket key appended to or None, hash added or None)
+        self._log: list[tuple[str | None, str | None]] = []
+
+    @property
+    def size(self) -> int:
+        """Number of distinct pool entries indexed."""
+        return len(self._hash_index)
+
+    def get(self, msg: ChatMessage) -> int | None:
+        """Fast-path lookup without serialization (identity, then equality).
+
+        The equality arm runs pydantic ``==`` first (cheap C-level reject)
+        and confirms prospective merges with ``_strict_eq``, which a
+        ``0``-vs-``0.0`` or ``True``-vs-``1`` difference in metadata or
+        tool-call arguments fails even though ``==`` passes.
+
+        Args:
+            msg: The message to look up.
+
+        Returns:
+            Pool index if found, ``None`` otherwise. Returns ``None`` when
+            ``msg.id`` is ``None`` (no bucket can be checked).
+        """
+        if msg.id is None:
+            return None
+        for stored, index in self._buckets.get(msg.id, ()):
+            if stored is msg or (stored == msg and _strict_eq(stored, msg)):
+                return index
+        return None
+
+    def get_by_hash(self, hash_value: str) -> int | None:
+        """Look up a pool index by walked-form content hash.
+
+        Args:
+            hash_value: Walked-form hash string.
+
+        Returns:
+            Pool index if found, ``None`` otherwise.
+        """
+        return self._hash_index.get(hash_value)
+
+    def add(self, msg: ChatMessage, hash_value: str, index: int) -> None:
+        """Record a pool entry.
+
+        Messages with a content string over ``_BUCKET_CONTENT_LIMIT`` are
+        recorded in the hash index only (see module docstring): bucketing
+        would pin their payload in memory for the sample's lifetime.
+
+        Args:
+            msg: Pre-walk message object.
+            hash_value: Walked-form content hash.
+            index: Pool index for this entry.
+        """
+        bucket_key = msg.id if not _has_heavy_str(msg.__dict__) else None
+        if bucket_key is not None:
+            self._buckets.setdefault(bucket_key, []).append((msg, index))
+        hash_added: str | None = None
+        if hash_value not in self._hash_index:
+            self._hash_index[hash_value] = index
+            hash_added = hash_value
+        if bucket_key is not None or hash_added is not None:
+            self._log.append((bucket_key, hash_added))
+
+    def mark(self) -> int:
+        """Return a mark for later ``restore()``.
+
+        Returns:
+            Opaque integer mark representing the current index state.
+        """
+        return len(self._log)
+
+    def restore(self, mark: int) -> None:
+        """Undo all ``add()`` calls made since ``mark()`` was obtained.
+
+        Args:
+            mark: Value previously returned by ``mark()``.
+        """
+        while len(self._log) > mark:
+            bucket_key, hash_added = self._log.pop()
+            if bucket_key is not None:
+                bucket = self._buckets[bucket_key]
+                bucket.pop()
+                if not bucket:
+                    del self._buckets[bucket_key]
+            if hash_added is not None:
+                del self._hash_index[hash_added]
+
+
+class CallPoolIndex:
+    """Prefix-diff lookup index for provider wire-request message lists.
+
+    Wire-format call messages have no stable ids and no object reuse, so
+    instead this index exploits the append-only growth pattern: the
+    previous event's message list is retained and compared element-by-element
+    against new requests; the matching prefix is reused directly.
+
+    A hash index covers the non-prefix tail so individual messages can still
+    be deduplicated across events.
+
+    Supports ``mark()``/``restore()`` to unwind state when a surrounding
+    database transaction rolls back.
+    """
+
+    def __init__(self) -> None:
+        # walked-form content hash -> pool index
+        self._hash_index: dict[str, int] = {}
+        # previous event's pre-walk wire messages and their pool indices
+        self._prev_msgs: list[JsonValue] = []
+        self._prev_indices: list[int] = []
+        # undo log of hashes added (for mark/restore)
+        self._added_hashes: list[str] = []
+
+    @property
+    def size(self) -> int:
+        """Number of distinct pool entries indexed."""
+        return len(self._hash_index)
+
+    def match_prefix(self, msgs: Sequence[JsonValue]) -> list[int]:
+        """Pool indices for the longest shared prefix with the previous request.
+
+        Comparison stops at the first element that differs from the
+        corresponding element in the previous request; later elements
+        are ignored even if equal.
+
+        Args:
+            msgs: New request's message list (pre-walk wire format).
+
+        Returns:
+            List of pool indices for the matched prefix. Empty if no prefix
+            matches or no previous request has been recorded.
+        """
+        indices: list[int] = []
+        for msg, prev_msg, prev_index in zip(msgs, self._prev_msgs, self._prev_indices):
+            # _strict_eq, not ==: a prefix element drifting 0 -> 0.0 or
+            # True -> 1 is python-equal but serializes (and hashes)
+            # differently; reusing the pool index would round-trip the
+            # other value
+            if not _strict_eq(msg, prev_msg):
+                break
+            indices.append(prev_index)
+        return indices
+
+    def get_by_hash(self, hash_value: str) -> int | None:
+        """Look up a pool index by walked-form content hash.
+
+        Args:
+            hash_value: Walked-form hash string.
+
+        Returns:
+            Pool index if found, ``None`` otherwise.
+        """
+        return self._hash_index.get(hash_value)
+
+    def add_hash(self, hash_value: str, index: int) -> None:
+        """Record a pool entry by its walked-form hash.
+
+        Duplicate adds (same ``hash_value``) are silently ignored.
+
+        Args:
+            hash_value: Walked-form content hash.
+            index: Pool index for this entry.
+        """
+        if hash_value not in self._hash_index:
+            self._hash_index[hash_value] = index
+            self._added_hashes.append(hash_value)
+
+    def set_prev(self, msgs: Sequence[JsonValue], indices: Sequence[int]) -> None:
+        """Record the request just condensed for prefix-matching the next one.
+
+        Copies both sequences shallowly, so callers may freely mutate the
+        sequences themselves afterwards. The copy is shallow: message
+        *values* are shared with the caller, and the next event's
+        ``match_prefix`` compares against them — mutating one in place to
+        equal new content would match the prefix against content that was
+        never pooled at that position, returning a wrong pool index.
+
+        Args:
+            msgs: Pre-walk wire-format message list.
+            indices: Corresponding pool indices, parallel to ``msgs``.
+        """
+        self._prev_msgs = list(msgs)
+        self._prev_indices = list(indices)
+
+    def mark(self) -> int:
+        """Return a mark for later ``restore()``.
+
+        Returns:
+            Opaque integer mark representing the current index state.
+        """
+        return len(self._added_hashes)
+
+    def restore(self, mark: int) -> None:
+        """Drop all pool references recorded since ``mark()`` was obtained.
+
+        Hash entries are undone precisely (a stale entry would make the
+        retry skip an insert and emit dangling refs). The prefix-match
+        state is accelerator-only, so it is dropped rather than rewound:
+        the next event's prefix scan misses and falls through to hash
+        dedup, which is always safe. Rewinding it would require holding a
+        snapshot of ``_prev_msgs`` across the marked window, reintroducing
+        aliasing to reason about for a path that only runs after a
+        database transaction failure.
+
+        Args:
+            mark: Value previously returned by ``mark()``.
+        """
+        while len(self._added_hashes) > mark:
+            del self._hash_index[self._added_hashes.pop()]
+        self._prev_msgs = []
+        self._prev_indices = []
+
+
+def condense_model_event_with_indices(
+    event: ModelEvent,
+    *,
+    messages: MessagePoolIndex,
+    calls: CallPoolIndex,
+    walk_message: Callable[[ChatMessage], ChatMessage],
+    walk_call_message: Callable[[JsonValue], JsonValue],
+    add_message: Callable[[str, ChatMessage], int],
+    add_call: Callable[[str, JsonValue], int],
+) -> ModelEvent:
+    """Condense one ModelEvent against in-memory pool indices.
+
+    Only messages not already indexed are walked, hashed, and persisted via
+    ``add_message``/``add_call``; index-hit messages cost a bucket probe or a
+    prefix comparison with no serialization.
+
+    Args:
+        event: The ModelEvent to condense.
+        messages: In-memory index for ``ChatMessage`` objects.
+        calls: In-memory index for provider wire-request message lists.
+        walk_message: Applies the attachment-ref transform to a ChatMessage
+            before hashing; the result is what ``add_message`` receives.
+        walk_call_message: Applies the attachment-ref transform to a raw
+            wire-format message value before hashing; the result is what
+            ``add_call`` receives.
+        add_message: Must persist the walked ChatMessage and return its pool
+            position (an integer row index within the caller's storage).
+            Contract: each result is registered in ``messages`` before the
+            next ``add_message`` call, so callers may derive positions from
+            ``messages.size`` (the buffer does).
+        add_call: Must persist the walked wire-format message value and return
+            its pool position (an integer row index within the caller's
+            storage). Same ordering contract as ``add_message``, against
+            ``calls.size``.
+
+    Returns:
+        A new ModelEvent with ``input``/``input_refs`` and/or
+        ``call``/``call_refs`` updated to reference pool positions, or the
+        original ``event`` unchanged if there was nothing to condense.
+
+    Note:
+        Atomicity: on exception, indices may already reference pool positions
+        whose rows belong to the caller's open transaction. Callers must call
+        ``messages.mark()`` and ``calls.mark()`` before a batch and
+        ``messages.restore()``/``calls.restore()`` on rollback to keep the
+        in-memory indices consistent with storage.
+
+        Identity-bucket entries are only registered for messages that are new
+        to the pool (hash miss). A message whose content duplicates an
+        already-pooled entry under a different id is re-walked and re-hashed
+        on each event that re-sends it. This is a bounded cost (duplicate-
+        content messages are rare), and avoids O(events × history) pinned
+        objects for fresh-id scaffolds (bridge-style agents) where a hash hit
+        would leave a useless bucket entry that could never produce a future
+        identity hit.
+    """
+    update: dict[str, Any] = {}
+
+    # Mirror condense_model_event_inputs guard ordering exactly:
+    # passthrough if already condensed (refs set, input empty); skip if
+    # input is empty (nothing to condense).
+    if event.input_refs is not None and not event.input:
+        pass
+    elif event.input:
+        raw_indices: list[int] = []
+        for msg in event.input:
+            index = messages.get(msg)
+            if index is None:
+                walked = walk_message(msg)
+                msg_hash = _pool._msg_hash(walked)
+                index = messages.get_by_hash(msg_hash)
+                if index is None:
+                    index = add_message(msg_hash, walked)
+                    messages.add(msg, msg_hash, index)
+            raw_indices.append(index)
+        update["input"] = []
+        update["input_refs"] = _compress_refs(raw_indices)
+
+    call = event.call
+    if call is not None and call.call_refs is None:
+        msg_key = next((k for k in _CALL_MESSAGE_KEYS if k in call.request), None)
+        msgs = call.request.get(msg_key) if msg_key else None
+        if msgs and isinstance(msgs, list):
+            call_indices = calls.match_prefix(msgs)
+            for msg_value in msgs[len(call_indices) :]:
+                walked_value = walk_call_message(msg_value)
+                call_hash = _pool._call_hash(walked_value)
+                call_index = calls.get_by_hash(call_hash)
+                if call_index is None:
+                    call_index = add_call(call_hash, walked_value)
+                calls.add_hash(call_hash, call_index)
+                call_indices.append(call_index)
+            calls.set_prev(msgs, call_indices)
+            new_request = {k: v for k, v in call.request.items() if k != msg_key}
+            update["call"] = call.model_copy(
+                update={
+                    "request": new_request,
+                    "call_refs": _compress_refs(call_indices),
+                    "call_key": msg_key,
+                }
+            )
+
+    return event.model_copy(update=update) if update else event

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -120,23 +120,30 @@ class SampleBufferDatabase(SampleBuffer):
         UNIQUE(sample_id, sample_epoch, hash)
     );
 
+    -- Pool rows are per-occurrence: equal-content rows at distinct
+    -- positions are valid (positions derive from insertion order), so
+    -- there is deliberately no uniqueness on msg_id/hash.
     CREATE TABLE message_pool (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         sample_id TEXT,
         sample_epoch INTEGER,
         msg_id TEXT,
-        data TEXT,
-        UNIQUE(sample_id, sample_epoch, msg_id)
+        data TEXT
     );
+
+    CREATE INDEX IF NOT EXISTS idx_message_pool_sample
+        ON message_pool(sample_id, sample_epoch);
 
     CREATE TABLE call_pool (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         sample_id TEXT,
         sample_epoch INTEGER,
         hash TEXT,
-        data TEXT,
-        UNIQUE(sample_id, sample_epoch, hash)
+        data TEXT
     );
+
+    CREATE INDEX IF NOT EXISTS idx_call_pool_sample
+        ON call_pool(sample_id, sample_epoch);
 
     -- Indices for foreign keys and common queries
     CREATE INDEX IF NOT EXISTS idx_events_sample ON events(sample_id, sample_epoch);
@@ -1473,7 +1480,7 @@ class SampleBufferDatabase(SampleBuffer):
         msg: ChatMessage,
     ) -> None:
         conn.execute(
-            "INSERT OR IGNORE INTO message_pool (sample_id, sample_epoch, msg_id, data) VALUES (?, ?, ?, ?)",
+            "INSERT INTO message_pool (sample_id, sample_epoch, msg_id, data) VALUES (?, ?, ?, ?)",
             (str(sample_id), epoch, msg_id, _msg_pool_json(_msg_pool_jsonable(msg))),
         )
 
@@ -1486,7 +1493,7 @@ class SampleBufferDatabase(SampleBuffer):
         call_msg: JsonValue,
     ) -> None:
         conn.execute(
-            "INSERT OR IGNORE INTO call_pool (sample_id, sample_epoch, hash, data) VALUES (?, ?, ?, ?)",
+            "INSERT INTO call_pool (sample_id, sample_epoch, hash, data) VALUES (?, ?, ?, ?)",
             (str(sample_id), epoch, hash, _call_pool_json(call_msg)),
         )
 

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -29,9 +29,15 @@ from inspect_ai._util.json import to_json_str_safe
 from inspect_ai._util.trace import trace_action
 from inspect_ai.event._model import ModelEvent
 from inspect_ai.event._pool import (
+    _call_pool_json,
     _compress_refs,
-    condense_model_event_calls,
-    condense_model_event_inputs,
+    _msg_pool_json,
+    _msg_pool_jsonable,
+)
+from inspect_ai.event._pool_index import (
+    CallPoolIndex,
+    MessagePoolIndex,
+    condense_model_event_with_indices,
 )
 from inspect_ai.log._recorders.buffer.history import SampleHistory
 from inspect_ai.model import ChatMessage
@@ -40,9 +46,11 @@ from ..._condense import (
     ATTACHMENT_PROTOCOL,
     WalkContext,
     attachments_content_fn,
+    walk_chat_message,
     walk_events,
     walk_input,
     walk_json_dict,
+    walk_json_value,
 )
 from ..._log import EvalSampleSummary
 from ..types import SampleEvent
@@ -223,9 +231,9 @@ class SampleBufferDatabase(SampleBuffer):
             else:
                 raise FileNotFoundError("Log database for '{location}' not found.")
 
-        # Per-sample hash → pool index maps; full pool entries live in SQLite.
-        self._msg_indices: dict[tuple[str, int], dict[str, int]] = {}
-        self._call_indices: dict[tuple[str, int], dict[str, int]] = {}
+        # Per-sample pool indices; full pool entries live in SQLite.
+        self._msg_indices: dict[tuple[str, int], MessagePoolIndex] = {}
+        self._call_indices: dict[tuple[str, int], CallPoolIndex] = {}
 
         # Prevent late ModelEvents from restarting indices at 0 after completion.
         self._completed_samples: set[tuple[str, int]] = set()
@@ -261,21 +269,24 @@ class SampleBufferDatabase(SampleBuffer):
             )
 
     def log_events(self, events: list[SampleEvent]) -> None:
-        index_snapshots: dict[
-            tuple[str, int], tuple[dict[str, int] | None, dict[str, int] | None]
-        ] = {}
+        # `None` mark = the index didn't exist before this batch (pop on restore)
+        index_snapshots: dict[tuple[str, int], tuple[int | None, int | None]] = {}
 
         def restore_index_snapshots() -> None:
-            for key, (msg_index, call_index) in index_snapshots.items():
-                if msg_index is None:
+            for key, (msg_mark, call_mark) in index_snapshots.items():
+                if msg_mark is None:
                     self._msg_indices.pop(key, None)
                 else:
-                    self._msg_indices[key] = msg_index
+                    msg_index = self._msg_indices.get(key)
+                    if msg_index is not None:
+                        msg_index.restore(msg_mark)
 
-                if call_index is None:
+                if call_mark is None:
                     self._call_indices.pop(key, None)
                 else:
-                    self._call_indices[key] = call_index
+                    call_index = self._call_indices.get(key)
+                    if call_index is not None:
+                        call_index.restore(call_mark)
 
         with self._get_connection(
             write=True, on_rollback=restore_index_snapshots
@@ -289,8 +300,8 @@ class SampleBufferDatabase(SampleBuffer):
                         msg_index = self._msg_indices.get(key)
                         call_index = self._call_indices.get(key)
                         index_snapshots[key] = (
-                            None if msg_index is None else dict(msg_index),
-                            None if call_index is None else dict(call_index),
+                            None if msg_index is None else msg_index.mark(),
+                            None if call_index is None else call_index.mark(),
                         )
 
                 event = self._condense_event(conn, event)
@@ -1339,6 +1350,9 @@ class SampleBufferDatabase(SampleBuffer):
         )
 
     def _condense_event(self, conn: Connection, event: SampleEvent) -> SampleEvent:
+        if isinstance(event.event, ModelEvent):
+            return self._condense_model_event(conn, event, event.event)
+
         # alias attachments
         attachments: dict[str, str] = {}
         event.event = walk_events(
@@ -1349,38 +1363,62 @@ class SampleBufferDatabase(SampleBuffer):
 
         # insert attachments
         self._insert_attachments(conn, event.id, event.epoch, attachments)
-
-        # message/call pool dedup for ModelEvents
-        if isinstance(event.event, ModelEvent):
-            key = (str(event.id), event.epoch)
-            if key in self._completed_samples:
-                raise RuntimeError(
-                    f"ModelEvent for sample {key} arrived after "
-                    "complete_sample; this would corrupt buffer DB pool "
-                    "indices."
-                )
-
-            # message pool
-            msg_index = self._msg_indices.get(key, {})
-            [condensed_event], msg_index, new_msgs = condense_model_event_inputs(
-                [event.event], len(msg_index), msg_index
-            )
-            event = SampleEvent(id=event.id, epoch=event.epoch, event=condensed_event)
-            for h, msg in new_msgs:
-                self._insert_message_pool_entry(conn, event.id, event.epoch, h, msg)
-            self._msg_indices[key] = msg_index
-
-            # call pool
-            call_index = self._call_indices.get(key, {})
-            [condensed_event], call_index, new_calls = condense_model_event_calls(
-                [event.event], len(call_index), call_index
-            )
-            event = SampleEvent(id=event.id, epoch=event.epoch, event=condensed_event)
-            for h, call_msg in new_calls:
-                self._insert_call_pool_entry(conn, event.id, event.epoch, h, call_msg)
-            self._call_indices[key] = call_index
-
         return event
+
+    def _condense_model_event(
+        self, conn: Connection, event: SampleEvent, model_event: ModelEvent
+    ) -> SampleEvent:
+        key = (str(event.id), event.epoch)
+        if key in self._completed_samples:
+            raise RuntimeError(
+                f"ModelEvent for sample {key} arrived after "
+                "complete_sample; this would corrupt buffer DB pool "
+                "indices."
+            )
+
+        msg_index = self._msg_indices.get(key)
+        if msg_index is None:
+            msg_index = self._msg_indices[key] = MessagePoolIndex()
+        call_index = self._call_indices.get(key)
+        if call_index is None:
+            call_index = self._call_indices[key] = CallPoolIndex()
+
+        attachments: dict[str, str] = {}
+        content_fn = self._create_attachments_content_fn(attachments)
+        context = WalkContext(message_cache={}, only_core=False)
+
+        # positions derive from index size: valid only because the condense
+        # helper registers each add_message/add_call result in the index
+        # before the next call (see condense_model_event_with_indices), so
+        # size == rows already inserted for this sample
+        def add_message(hash_value: str, walked: ChatMessage) -> int:
+            index = msg_index.size
+            self._insert_message_pool_entry(
+                conn, event.id, event.epoch, hash_value, walked
+            )
+            return index
+
+        def add_call(hash_value: str, walked: JsonValue) -> int:
+            index = call_index.size
+            self._insert_call_pool_entry(
+                conn, event.id, event.epoch, hash_value, walked
+            )
+            return index
+
+        condensed = condense_model_event_with_indices(
+            model_event,
+            messages=msg_index,
+            calls=call_index,
+            walk_message=lambda m: walk_chat_message(m, content_fn, context),
+            walk_call_message=lambda v: walk_json_value(v, content_fn, context),
+            add_message=add_message,
+            add_call=add_call,
+        )
+
+        # walk the remainder (input now [], call request without messages)
+        condensed_event = walk_events([condensed], content_fn, context)[0]
+        self._insert_attachments(conn, event.id, event.epoch, attachments)
+        return SampleEvent(id=event.id, epoch=event.epoch, event=condensed_event)
 
     def _resolve_event_attachments(
         self, conn: Connection, event: JsonData, message_cache: dict[str, ChatMessage]
@@ -1436,7 +1474,7 @@ class SampleBufferDatabase(SampleBuffer):
     ) -> None:
         conn.execute(
             "INSERT OR IGNORE INTO message_pool (sample_id, sample_epoch, msg_id, data) VALUES (?, ?, ?, ?)",
-            (str(sample_id), epoch, msg_id, msg.model_dump_json()),
+            (str(sample_id), epoch, msg_id, _msg_pool_json(_msg_pool_jsonable(msg))),
         )
 
     def _insert_call_pool_entry(
@@ -1449,7 +1487,7 @@ class SampleBufferDatabase(SampleBuffer):
     ) -> None:
         conn.execute(
             "INSERT OR IGNORE INTO call_pool (sample_id, sample_epoch, hash, data) VALUES (?, ?, ?, ?)",
-            (str(sample_id), epoch, hash, json.dumps(call_msg)),
+            (str(sample_id), epoch, hash, _call_pool_json(call_msg)),
         )
 
     def _get_attachments_content(

--- a/src/inspect_ai/log/_transcript_store.py
+++ b/src/inspect_ai/log/_transcript_store.py
@@ -14,16 +14,23 @@ from pydantic_core import to_jsonable_python
 from shortuuid import uuid
 
 from inspect_ai._util.file import write_atomic_text
-from inspect_ai._util.hash import mm3_hash
+from inspect_ai.event import (
+    _pool,  # accessed as module attributes so monkeypatching _pool hashes is visible here
+)
 from inspect_ai.event._event import Event
-from inspect_ai.event._pool import (
-    _msg_hash,
-    condense_model_event_calls_with_lookup,
-    condense_model_event_inputs_with_lookup,
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._pool_index import (
+    CallPoolIndex,
+    MessagePoolIndex,
+    condense_model_event_with_indices,
 )
 from inspect_ai.log._condense import (
+    WalkContext,
     attachment_refs_from_value,
     condense_event,
+    events_attachment_fn,
+    walk_chat_message,
+    walk_json_value,
 )
 from inspect_ai.model._chat_message import ChatMessage
 
@@ -55,8 +62,11 @@ class TranscriptEventStore:
             self._reset_files()
         self._conn = connect(self._path, check_same_thread=False)
         self._lock = RLock()
-        self._pending_message_pos_by_event: dict[str, dict[int, int]] = {}
-        self._pending_call_pos_by_event: dict[str, dict[int, int]] = {}
+        # one store per sample transcript; full pool state lives in SQLite, so
+        # on a reopened store these start empty and _pool_pos transparently
+        # resolves existing rows by hash
+        self._msg_pool_index = MessagePoolIndex()
+        self._call_pool_index = CallPoolIndex()
         self._conn.row_factory = None
         self._closed = False
         self._init_schema(self._conn)
@@ -96,33 +106,38 @@ class TranscriptEventStore:
                 event.uuid = uuid()
             logical_id = event.uuid
 
-            with self._conn:
-                event_attachments: dict[str, str] = {}
-                event = condense_event(event, event_attachments)
-                pending_message_cache, pending_call_cache = (
-                    self._pending_caches_for_event(logical_id, event)
-                )
-                condensed_event = self._condense_event(
-                    event, pending_message_cache, pending_call_cache
-                )
-                event_json = json.dumps(
-                    to_jsonable_python(
-                        condensed_event, exclude_none=True, fallback=lambda _: None
-                    ),
-                    separators=(",", ":"),
-                )
-                self._upsert_event(logical_id, event_json)
-                self._insert_attachments(event_attachments)
-                self._merge_attachment_refs(
-                    self._attachment_refs(event),
-                    lambda ref: event_attachments.get(ref) or attachment_lookup(ref),
-                )
-                self._commit_pending_caches(
-                    logical_id,
-                    condensed_event,
-                    pending_message_cache,
-                    pending_call_cache,
-                )
+            msg_mark = self._msg_pool_index.mark()
+            call_mark = self._call_pool_index.mark()
+            try:
+                with self._conn:
+                    event_attachments: dict[str, str] = {}
+                    incoming_refs: set[str] = set()
+                    if isinstance(event, ModelEvent):
+                        condensed_event: Event = self._condense_model_event(
+                            event, event_attachments, incoming_refs
+                        )
+                    else:
+                        condensed_event = condense_event(event, event_attachments)
+                        incoming_refs.update(self._attachment_refs(condensed_event))
+                    event_json = json.dumps(
+                        to_jsonable_python(
+                            condensed_event, exclude_none=True, fallback=lambda _: None
+                        ),
+                        separators=(",", ":"),
+                    )
+                    self._upsert_event(logical_id, event_json)
+                    self._insert_attachments(event_attachments)
+                    self._merge_attachment_refs(
+                        incoming_refs,
+                        lambda ref: event_attachments.get(ref)
+                        or attachment_lookup(ref),
+                    )
+            except BaseException:
+                # the SQLite transaction rolled back; unwind the in-memory
+                # indices so they don't reference rolled-back pool rows
+                self._msg_pool_index.restore(msg_mark)
+                self._call_pool_index.restore(call_mark)
+                raise
 
     def merge_condensed_event(
         self,
@@ -150,9 +165,14 @@ class TranscriptEventStore:
     def merge_message_pool(self, messages: Iterable[ChatMessage]) -> None:
         with self._lock:
             self._ensure_open()
-            with self._conn:
-                for message in messages:
-                    self._message_pos(message)
+            mark = self._msg_pool_index.mark()
+            try:
+                with self._conn:
+                    for message in messages:
+                        self._message_pos(message)
+            except BaseException:
+                self._msg_pool_index.restore(mark)
+                raise
 
     def merge_call_pool_entry(self, hash_value: str, json_text: str) -> int:
         with self._lock:
@@ -163,9 +183,14 @@ class TranscriptEventStore:
     def merge_call_pool(self, calls: Iterable[JsonValue]) -> None:
         with self._lock:
             self._ensure_open()
-            with self._conn:
-                for call in calls:
-                    self._call_pos(call)
+            mark = self._call_pool_index.mark()
+            try:
+                with self._conn:
+                    for call in calls:
+                        self._call_pos(call)
+            except BaseException:
+                self._call_pool_index.restore(mark)
+                raise
 
     def _upsert_event(self, logical_id: str, event_json: str) -> None:
         row = self._conn.execute(
@@ -303,82 +328,96 @@ class TranscriptEventStore:
         assert row is not None
         return int(row[0])
 
-    def _pending_caches_for_event(
-        self, logical_id: str, event: Event
-    ) -> tuple[dict[int, int] | None, dict[int, int] | None]:
-        if not event.pending:
-            return (
-                self._pending_message_pos_by_event.get(logical_id),
-                self._pending_call_pos_by_event.get(logical_id),
-            )
-        return (
-            dict(self._pending_message_pos_by_event.get(logical_id, {})),
-            dict(self._pending_call_pos_by_event.get(logical_id, {})),
-        )
-
-    def _condense_event(
+    def _condense_model_event(
         self,
-        event: Event,
-        message_cache: dict[int, int] | None,
-        call_cache: dict[int, int] | None,
+        event: ModelEvent,
+        event_attachments: dict[str, str],
+        incoming_refs: set[str],
     ) -> Event:
-        event = condense_model_event_inputs_with_lookup(
-            event, lambda message: self._message_pos(message, message_cache)
-        )
-        return condense_model_event_calls_with_lookup(
-            event, lambda call_message: self._call_pos(call_message, call_cache)
+        """Condense a ModelEvent against the in-memory pool indices.
+
+        Pool dedup walks/serializes only messages new to the pool; attachment
+        refs are collected from new pool entries plus the walked remainder
+        (input emptied, call request without messages), so the per-event ref
+        scan is O(event-own-content) rather than O(history).
+
+        Args:
+            event: The model event to condense.
+            event_attachments: Out-parameter — attachment content produced by
+                walking is added here (mutated via the walk closures).
+            incoming_refs: Out-parameter — attachment refs from new pool
+                entries and the walked remainder are added here.
+
+        Returns:
+            The condensed event (input/call request replaced by pool refs).
+        """
+        content_fn = events_attachment_fn(event_attachments)
+        context = WalkContext(message_cache={}, only_core=False)
+
+        def add_message(hash_value: str, walked: ChatMessage) -> int:
+            message_jsonable = _pool._msg_pool_jsonable(walked)
+            incoming_refs.update(attachment_refs_from_value(message_jsonable))
+            return self._pool_pos(
+                "message_pool",
+                hash_value,
+                _pool._msg_pool_json(message_jsonable),
+            )
+
+        def add_call(hash_value: str, walked: JsonValue) -> int:
+            incoming_refs.update(attachment_refs_from_value(walked))
+            return self._pool_pos(
+                "call_pool", hash_value, _pool._call_pool_json(walked)
+            )
+
+        condensed = condense_model_event_with_indices(
+            event,
+            messages=self._msg_pool_index,
+            calls=self._call_pool_index,
+            walk_message=lambda m: walk_chat_message(m, content_fn, context),
+            walk_call_message=lambda v: walk_json_value(v, content_fn, context),
+            add_message=add_message,
+            add_call=add_call,
         )
 
-    def _commit_pending_caches(
-        self,
-        logical_id: str,
-        event: Event,
-        message_cache: dict[int, int] | None,
-        call_cache: dict[int, int] | None,
-    ) -> None:
-        if event.pending:
-            self._pending_message_pos_by_event[logical_id] = message_cache or {}
-            self._pending_call_pos_by_event[logical_id] = call_cache or {}
-        else:
-            self._pending_message_pos_by_event.pop(logical_id, None)
-            self._pending_call_pos_by_event.pop(logical_id, None)
-
-    def _message_pos(
-        self, message: ChatMessage, cache: dict[int, int] | None = None
-    ) -> int:
-        message_id = id(message)
-        if cache is not None:
-            cached_pos = cache.get(message_id)
-            if cached_pos is not None:
-                return cached_pos
-
-        message_jsonable = to_jsonable_python(
-            message,
-            exclude_none=True,
-            fallback=lambda _: None,
+        # walk the remainder (input now [], call request without messages)
+        condensed_remainder = condense_event(
+            condensed, event_attachments, context=context
         )
-        pos = self._pool_pos(
-            "message_pool",
-            _msg_hash(message),
-            json.dumps(message_jsonable, sort_keys=True),
-        )
-        if cache is not None:
-            cache[message_id] = pos
+        incoming_refs.update(self._attachment_refs(condensed_remainder))
+        return condensed_remainder
+
+    def _message_pos(self, message: ChatMessage) -> int:
+        """Pool position for a message already in walked/stored pool form.
+
+        Callers (`merge_message_pool`, seeding from hydrated pool entries)
+        pass walked-form messages, so hashing here matches the condense
+        path's walked-form hashes. Unlike the per-event condense path, the
+        index entry is registered even on a hash hit: resume-pool objects
+        recur across the seeding pass, so pinning them earns identity hits.
+        """
+        pos = self._msg_pool_index.get(message)
+        if pos is not None:
+            return pos
+        hash_value = _pool._msg_hash(message)
+        pos = self._msg_pool_index.get_by_hash(hash_value)
+        if pos is None:
+            pos = self._pool_pos(
+                "message_pool",
+                hash_value,
+                _pool._msg_pool_json(_pool._msg_pool_jsonable(message)),
+            )
+        self._msg_pool_index.add(message, hash_value, pos)
         return pos
 
-    def _call_pos(
-        self, call_message: JsonValue, cache: dict[int, int] | None = None
-    ) -> int:
-        call_message_id = id(call_message)
-        if cache is not None:
-            cached_pos = cache.get(call_message_id)
-            if cached_pos is not None:
-                return cached_pos
-
-        call_json = json.dumps(call_message, sort_keys=True)
-        pos = self._pool_pos("call_pool", mm3_hash(call_json), call_json)
-        if cache is not None:
-            cache[call_message_id] = pos
+    def _call_pos(self, call_message: JsonValue) -> int:
+        """Pool position for a call message already in walked/stored form."""
+        hash_value = _pool._call_hash(call_message)
+        pos = self._call_pool_index.get_by_hash(hash_value)
+        if pos is None:
+            pos = self._pool_pos(
+                "call_pool", hash_value, _pool._call_pool_json(call_message)
+            )
+        self._call_pool_index.add_hash(hash_value, pos)
         return pos
 
     def _pool_pos(self, table: str, hash_value: str, json_text: str) -> int:

--- a/src/inspect_ai/log/_transcript_store.py
+++ b/src/inspect_ai/log/_transcript_store.py
@@ -62,14 +62,29 @@ class TranscriptEventStore:
             self._reset_files()
         self._conn = connect(self._path, check_same_thread=False)
         self._lock = RLock()
-        # one store per sample transcript; full pool state lives in SQLite, so
-        # on a reopened store these start empty and _pool_pos transparently
-        # resolves existing rows by hash
+        # one store per sample transcript; full pool state lives in SQLite,
+        # and the in-memory indices are seeded from existing rows below so a
+        # reopened store dedups re-sent history against them
         self._msg_pool_index = MessagePoolIndex()
         self._call_pool_index = CallPoolIndex()
+        self._merge_cursors: dict[str, int] = {"message_pool": 0, "call_pool": 0}
         self._conn.row_factory = None
         self._closed = False
         self._init_schema(self._conn)
+        # Reopened stores have rows the empty in-memory indices don't know
+        # about; seed hash lookup state (first occurrence per hash) so the
+        # break path dedups re-sent history against existing rows. The
+        # condense callbacks insert unconditionally (the helper owns dedup),
+        # so without this seeding every reopen would duplicate re-sent
+        # history rows.
+        for pos, hash_value in self._conn.execute(
+            "SELECT pos, hash FROM message_pool ORDER BY pos"
+        ):
+            self._msg_pool_index.add_hash_only(str(hash_value), int(pos))
+        for pos, hash_value in self._conn.execute(
+            "SELECT pos, hash FROM call_pool ORDER BY pos"
+        ):
+            self._call_pool_index.add_hash(str(hash_value), int(pos), new_entry=False)
 
     @property
     def path(self) -> Path:
@@ -156,11 +171,61 @@ class TranscriptEventStore:
                     attachment_refs_from_value(event_jsonable), attachment_lookup
                 )
 
+    def _merge_pool_entry(
+        self, table: str, hash_value: str, json_text: str, *, dedup: bool = False
+    ) -> int:
+        """Merge one entry of a position-ordered pool list.
+
+        Positional-prefix semantics: sequential calls walk the existing
+        table from pos 0 via a per-table cursor. A hash match at the
+        cursor reuses that row (so re-seeding the same pool list is
+        idempotent and position-preserving); otherwise the entry is
+        appended — or, with ``dedup=True``, first looked up by hash
+        anywhere in the table.
+
+        ``dedup=False`` (hydration seeding): merged condensed events keep
+        their refs verbatim, so positions must round-trip exactly; a
+        hash-keyed merge would collapse occurrence rows (equal-content
+        rows at distinct positions), shifting every later position and
+        corrupting those refs.
+
+        ``dedup=True`` (buffer export): the caller remaps refs through the
+        returned positions, so cross-boundary hash dedup is safe — and
+        needed, because export runs after seeding and the buffer's
+        re-condensed history would otherwise duplicate every seeded row.
+
+        The cursor is not rewound on transaction rollback. That is safe:
+        a stale cursor pointing past the rolled-back row misses the
+        positional match and falls through to append / ``dedup`` lookup,
+        which never returns a wrong position — the cost is one skipped
+        cursor-match, not corruption. (``merge_message_pool`` /
+        ``merge_call_pool`` additionally reset the cursor to 0 on entry.)
+        """
+        cursor = self._merge_cursors[table]
+        row = self._conn.execute(
+            f"SELECT hash FROM {table} WHERE pos = ?", (cursor,)
+        ).fetchone()
+        if row is not None and str(row[0]) == hash_value:
+            pos = cursor
+        elif dedup:
+            pos = self._pool_pos(table, hash_value, json_text)
+        else:
+            pos = self._pool_append(table, hash_value, json_text)
+        self._merge_cursors[table] = pos + 1
+        return pos
+
     def merge_message_pool_entry(self, hash_value: str, json_text: str) -> int:
         with self._lock:
             self._ensure_open()
             with self._conn:
-                return self._pool_pos("message_pool", hash_value, json_text)
+                pos = self._merge_pool_entry(
+                    "message_pool", hash_value, json_text, dedup=True
+                )
+                # the live condense path dedups in memory only, so exported
+                # rows must be registered here or a later live merge of
+                # equal content would duplicate them
+                self._msg_pool_index.add_hash_only(hash_value, pos)
+                return pos
 
     def merge_message_pool(self, messages: Iterable[ChatMessage]) -> None:
         with self._lock:
@@ -168,8 +233,35 @@ class TranscriptEventStore:
             mark = self._msg_pool_index.mark()
             try:
                 with self._conn:
+                    # full position-ordered pool list: walk from pos 0 so
+                    # re-seeding the same list is idempotent
+                    self._merge_cursors["message_pool"] = 0
+                    positions: list[int] = []
+                    msgs: list[ChatMessage] = []
                     for message in messages:
-                        self._message_pos(message)
+                        hash_value = _pool._msg_hash(message)
+                        pos = self._merge_pool_entry(
+                            "message_pool",
+                            hash_value,
+                            _pool._msg_pool_json(_pool._msg_pool_jsonable(message)),
+                        )
+                        # registered even on a cursor hit: resume-pool objects
+                        # recur across the seeding pass, so pinning them earns
+                        # identity hits
+                        self._msg_pool_index.add(
+                            message, hash_value, pos, new_entry=False
+                        )
+                        positions.append(pos)
+                        msgs.append(message)
+                    # seed prefix state: the first post-resume event re-sends
+                    # this history; matching it as a prefix keeps positions
+                    # monotone instead of hash-mapping occurrence rows back
+                    # to first positions. Best-effort: hydrated pools are
+                    # walked-form while live inputs are pre-walk, so on any
+                    # mismatch the break path runs (correct, just not
+                    # single-range for that one event).
+                    if msgs:
+                        self._msg_pool_index.set_prev(msgs, positions)
             except BaseException:
                 self._msg_pool_index.restore(mark)
                 raise
@@ -178,7 +270,11 @@ class TranscriptEventStore:
         with self._lock:
             self._ensure_open()
             with self._conn:
-                return self._pool_pos("call_pool", hash_value, json_text)
+                pos = self._merge_pool_entry(
+                    "call_pool", hash_value, json_text, dedup=True
+                )
+                self._call_pool_index.add_hash(hash_value, pos, new_entry=False)
+                return pos
 
     def merge_call_pool(self, calls: Iterable[JsonValue]) -> None:
         with self._lock:
@@ -186,8 +282,21 @@ class TranscriptEventStore:
             mark = self._call_pool_index.mark()
             try:
                 with self._conn:
+                    self._merge_cursors["call_pool"] = 0
+                    positions: list[int] = []
+                    call_list: list[JsonValue] = []
                     for call in calls:
-                        self._call_pos(call)
+                        hash_value = _pool._call_hash(call)
+                        pos = self._merge_pool_entry(
+                            "call_pool",
+                            hash_value,
+                            _pool._call_pool_json(call),
+                        )
+                        self._call_pool_index.add_hash(hash_value, pos, new_entry=False)
+                        positions.append(pos)
+                        call_list.append(call)
+                    if call_list:
+                        self._call_pool_index.set_prev(call_list, positions)
             except BaseException:
                 self._call_pool_index.restore(mark)
                 raise
@@ -354,10 +463,16 @@ class TranscriptEventStore:
         content_fn = events_attachment_fn(event_attachments)
         context = WalkContext(message_cache={}, only_core=False)
 
+        # the callbacks append unconditionally: the helper has already made
+        # the dedup decision when it calls back (occurrence row on pure
+        # append, hash dedup on a break). A hash-keyed lookup here would
+        # collapse occurrence rows back onto their first positions and
+        # disagree with what set_prev records. Safe across reopen because
+        # __init__ seeds the in-memory hash indices from existing rows.
         def add_message(hash_value: str, walked: ChatMessage) -> int:
             message_jsonable = _pool._msg_pool_jsonable(walked)
             incoming_refs.update(attachment_refs_from_value(message_jsonable))
-            return self._pool_pos(
+            return self._pool_append(
                 "message_pool",
                 hash_value,
                 _pool._msg_pool_json(message_jsonable),
@@ -365,7 +480,7 @@ class TranscriptEventStore:
 
         def add_call(hash_value: str, walked: JsonValue) -> int:
             incoming_refs.update(attachment_refs_from_value(walked))
-            return self._pool_pos(
+            return self._pool_append(
                 "call_pool", hash_value, _pool._call_pool_json(walked)
             )
 
@@ -386,48 +501,13 @@ class TranscriptEventStore:
         incoming_refs.update(self._attachment_refs(condensed_remainder))
         return condensed_remainder
 
-    def _message_pos(self, message: ChatMessage) -> int:
-        """Pool position for a message already in walked/stored pool form.
+    def _pool_append(self, table: str, hash_value: str, json_text: str) -> int:
+        """Insert a new pool row at the next position, unconditionally.
 
-        Callers (`merge_message_pool`, seeding from hydrated pool entries)
-        pass walked-form messages, so hashing here matches the condense
-        path's walked-form hashes. Unlike the per-event condense path, the
-        index entry is registered even on a hash hit: resume-pool objects
-        recur across the seeding pass, so pinning them earns identity hits.
+        The condense helper owns dedup decisions (occurrence rows on pure
+        append, hash dedup on a break); this storage primitive never
+        second-guesses them.
         """
-        pos = self._msg_pool_index.get(message)
-        if pos is not None:
-            return pos
-        hash_value = _pool._msg_hash(message)
-        pos = self._msg_pool_index.get_by_hash(hash_value)
-        if pos is None:
-            pos = self._pool_pos(
-                "message_pool",
-                hash_value,
-                _pool._msg_pool_json(_pool._msg_pool_jsonable(message)),
-            )
-        self._msg_pool_index.add(message, hash_value, pos)
-        return pos
-
-    def _call_pos(self, call_message: JsonValue) -> int:
-        """Pool position for a call message already in walked/stored form."""
-        hash_value = _pool._call_hash(call_message)
-        pos = self._call_pool_index.get_by_hash(hash_value)
-        if pos is None:
-            pos = self._pool_pos(
-                "call_pool", hash_value, _pool._call_pool_json(call_message)
-            )
-        self._call_pool_index.add_hash(hash_value, pos)
-        return pos
-
-    def _pool_pos(self, table: str, hash_value: str, json_text: str) -> int:
-        row = self._conn.execute(
-            f"SELECT pos FROM {table} WHERE hash = ?",
-            (hash_value,),
-        ).fetchone()
-        if row is not None:
-            return int(row[0])
-
         pos_row = self._conn.execute(
             f"SELECT COALESCE(MAX(pos), -1) + 1 FROM {table}"
         ).fetchone()
@@ -438,6 +518,20 @@ class TranscriptEventStore:
             (pos, hash_value, json_text),
         )
         return pos
+
+    def _pool_pos(self, table: str, hash_value: str, json_text: str) -> int:
+        """Position of the first row with this hash, inserting if absent.
+
+        ``MIN(pos)`` makes the first occurrence the canonical dedup target,
+        deterministically, now that equal-content rows can coexist.
+        """
+        row = self._conn.execute(
+            f"SELECT MIN(pos) FROM {table} WHERE hash = ?",
+            (hash_value,),
+        ).fetchone()
+        if row is not None and row[0] is not None:
+            return int(row[0])
+        return self._pool_append(table, hash_value, json_text)
 
     @staticmethod
     def _attachment_refs(event: Event) -> set[str]:
@@ -517,15 +611,21 @@ class TranscriptEventStore:
 
             CREATE TABLE IF NOT EXISTS message_pool (
                 pos INTEGER PRIMARY KEY,
-                hash TEXT NOT NULL UNIQUE,
+                hash TEXT NOT NULL,
                 json TEXT NOT NULL
             );
 
+            CREATE INDEX IF NOT EXISTS idx_message_pool_hash
+                ON message_pool(hash);
+
             CREATE TABLE IF NOT EXISTS call_pool (
                 pos INTEGER PRIMARY KEY,
-                hash TEXT NOT NULL UNIQUE,
+                hash TEXT NOT NULL,
                 json TEXT NOT NULL
             );
+
+            CREATE INDEX IF NOT EXISTS idx_call_pool_hash
+                ON call_pool(hash);
 
             CREATE TABLE IF NOT EXISTS attachments (
                 hash TEXT PRIMARY KEY,
@@ -533,4 +633,42 @@ class TranscriptEventStore:
             );
             """
         )
+        for table in ("message_pool", "call_pool"):
+            TranscriptEventStore._migrate_unique_hash(conn, table)
         conn.commit()
+
+    @staticmethod
+    def _migrate_unique_hash(conn: Connection, table: str) -> None:
+        """Rebuild a pool table created by pre-occurrence-row code.
+
+        Old stores declared ``hash TEXT NOT NULL UNIQUE``; occurrence rows
+        require duplicate hashes. SQLite can't drop a column constraint in
+        place, so detect the inline UNIQUE in the table SQL and rebuild.
+        Positions (``pos``) are preserved exactly, so refs in stored events
+        remain valid.
+        """
+        row = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name=?",
+            (table,),
+        ).fetchone()
+        if row is None or "UNIQUE" not in str(row[0]).upper():
+            return
+        # explicit BEGIN/COMMIT: executescript runs in autocommit otherwise,
+        # and a crash between RENAME and DROP would strand a {table}_old
+        # orphan holding a duplicate of every pool row
+        conn.executescript(
+            f"""
+            BEGIN;
+            ALTER TABLE {table} RENAME TO {table}_old;
+            CREATE TABLE {table} (
+                pos INTEGER PRIMARY KEY,
+                hash TEXT NOT NULL,
+                json TEXT NOT NULL
+            );
+            INSERT INTO {table}(pos, hash, json)
+                SELECT pos, hash, json FROM {table}_old;
+            DROP TABLE {table}_old;
+            CREATE INDEX IF NOT EXISTS idx_{table}_hash ON {table}(hash);
+            COMMIT;
+            """
+        )

--- a/tests/agent/test_acp/test_span_boundary.py
+++ b/tests/agent/test_acp/test_span_boundary.py
@@ -244,6 +244,9 @@ def test_no_remaining_literal_agent_type_in_span_call_sites() -> None:
     pattern = re.compile(r'span\([^)]*type\s*=\s*"agent"', re.DOTALL)
     offenders: list[str] = []
     for path in src.rglob("*.py"):
+        # skip dangling symlinks (e.g. local build artifacts under binaries/)
+        if not path.is_file():
+            continue
         text = path.read_text()
         if pattern.search(text):
             offenders.append(str(path))

--- a/tests/checkpoint/test_checkpointer.py
+++ b/tests/checkpoint/test_checkpointer.py
@@ -197,6 +197,21 @@ def _counting(config: ResolvedCheckpointConfig, dirs: _Dirs) -> _CountingCheckpo
     return cp
 
 
+async def _close_trailing_span(cp: _EnteredCheckpointer) -> None:
+    """Close the `checkpoint N` span left open by the last fire.
+
+    These policy tests drive fires directly rather than through the
+    production ``span_session()`` wrapper, so the span that each fire
+    reopens (``_open_next_span`` in ``_fire_once``'s ``finally``) is
+    never exited. An abandoned span CM is finalized later by GC inside
+    whatever test happens to be running, emitting a stray
+    ``SpanEndEvent`` (plus an "Exiting span created in another context"
+    warning) into that test's transcript. Every test that triggers at
+    least one fire must call this before returning.
+    """
+    await cp._close_current_span()
+
+
 class _FlakyError(RuntimeError):
     """Sentinel raised by `_FlakyCheckpointer` to stand in for a fire failure."""
 
@@ -240,6 +255,7 @@ async def test_turn_interval_fires_at_each_threshold(dirs: _Dirs) -> None:
     for _ in range(10):
         await cp.tick()
     assert cp.fire_count == 3
+    await _close_trailing_span(cp)
 
 
 async def test_turn_interval_resets_counter_on_fire(dirs: _Dirs) -> None:
@@ -258,6 +274,7 @@ async def test_turn_interval_resets_counter_on_fire(dirs: _Dirs) -> None:
     assert cp.fire_count == 1
     await cp.tick()
     assert cp.fire_count == 2
+    await _close_trailing_span(cp)
 
 
 # --- time-based -----------------------------------------------------------
@@ -294,6 +311,7 @@ async def test_time_interval_fires_when_elapsed_exceeds_threshold(dirs: _Dirs) -
         fake_now[0] = 1025.0
         await cp.tick()
         assert cp.fire_count == 2
+        await _close_trailing_span(cp)
 
 
 # --- token-based ----------------------------------------------------------
@@ -336,6 +354,7 @@ async def test_token_interval_fires_when_usage_crosses_threshold(
         fake_tokens[0] = 2100
         await cp.tick()
         assert cp.fire_count == 2
+        await _close_trailing_span(cp)
 
 
 # --- manual ---------------------------------------------------------------
@@ -354,6 +373,7 @@ async def test_checkpoint_method_fires(dirs: _Dirs) -> None:
     await cp.checkpoint()
     await cp.checkpoint()
     assert cp.fire_count == 2
+    await _close_trailing_span(cp)
 
 
 # --- CheckpointEvent emission ---------------------------------------------
@@ -380,6 +400,7 @@ async def test_fire_emits_checkpoint_event(dirs: _Dirs) -> None:
     # restic the stub values from `_CountingCheckpointer._backup_host`
     # round-trip.
     assert first.host.snapshot_id.startswith("fake-snap-")
+    await _close_trailing_span(cp)
 
 
 async def test_fire_includes_events_emitted_before_checkpointer_construction(
@@ -398,6 +419,7 @@ async def test_fire_includes_events_emitted_before_checkpointer_construction(
     ):
         cp = _counting(ResolvedCheckpointConfig(trigger=Manual()), dirs)
         await cp.checkpoint()
+        await _close_trailing_span(cp)
 
     events = json.loads((Path(dirs.context) / "events.json").read_text())
     assert events[0]["uuid"] == preexisting.uuid
@@ -766,6 +788,7 @@ async def test_fire_emits_trace_action(dirs: _Dirs) -> None:
         cp = _counting(ResolvedCheckpointConfig(trigger=Manual()), dirs)
         await cp.tick()
         await cp.checkpoint()
+        await _close_trailing_span(cp)
     finally:
         target.removeHandler(handler)
         target.setLevel(prev_level)

--- a/tests/log/test_buffer_pool_dedup.py
+++ b/tests/log/test_buffer_pool_dedup.py
@@ -445,31 +445,59 @@ def test_rollback_restores_pool_indices(
     assert last["input_refs"] == [[0, 2]]
 
 
-def test_buffer_pool_dedup_uses_content_hash_not_msg_id(
+def test_buffer_pool_dedup_break_path_uses_content_hash(
     db: SampleBufferDatabase,
 ) -> None:
-    """Messages with same content but different .id fields dedup to one pool entry."""
+    """On a prefix break, equal-content/different-id messages still hash-dedup.
+
+    The second event rewrites history (drops msg_1), so it takes the break
+    path, where content dedup is what protects sliding-window and bridge
+    scaffolds from per-occurrence row growth.
+    """
     sample = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
     db.start_sample(sample)
 
-    # Two distinct ChatMessage objects with identical content but different .id
     msg_1 = ChatMessageUser(content="Hello").model_copy(update={"id": "uuid-aaa"})
     msg_2 = ChatMessageUser(content="Hello").model_copy(update={"id": "uuid-bbb"})
+    msg_3 = ChatMessageUser(content="Other").model_copy(update={"id": "uuid-ccc"})
+
+    db.log_events(
+        [SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_1, msg_3]))]
+    )
+    # history rewritten (msg_1 dropped) -> prefix break -> hash dedup applies
+    db.log_events(
+        [SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_3, msg_2]))]
+    )
+
+    data = db.get_sample_data("s1", 1)
+    assert data is not None
+    # msg_2 deduped against msg_1's row by content despite the different id
+    assert len(data.message_pool) == 2
+
+    last = data.events[-1].event
+    assert isinstance(last, dict)
+    assert last["input_refs"] == [[1, 2], [0, 1]]
+
+
+def test_buffer_pool_append_path_mints_occurrence_rows(
+    db: SampleBufferDatabase,
+) -> None:
+    """On pure append, equal-content suffix messages get their own rows."""
+    sample = EvalSampleSummary(id="s1", epoch=1, input="test", target="target")
+    db.start_sample(sample)
+
+    msg_1 = ChatMessageUser(content="Hello")
+    msg_2 = ChatMessageUser(content="Hello")  # fresh id, equal content
 
     db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_1]))])
+    # pure append: previous input [msg_1] is a full prefix
     db.log_events(
         [SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_1, msg_2]))]
     )
 
     data = db.get_sample_data("s1", 1)
     assert data is not None
-
-    # Same content -> should be 1 pool entry, not 2
-    assert len(data.message_pool) == 1, (
-        f"Expected 1 pool entry for identical content, got {len(data.message_pool)}"
-    )
-
-    # both occurrences in the second event resolve to pool position 0
+    assert len(data.message_pool) == 2  # one row per occurrence
     last = data.events[-1].event
     assert isinstance(last, dict)
-    assert last["input_refs"] == [[0, 1], [0, 1]]
+    assert last["input_refs"] == [[0, 2]]  # single monotone range

--- a/tests/log/test_buffer_pool_dedup.py
+++ b/tests/log/test_buffer_pool_dedup.py
@@ -337,6 +337,114 @@ def test_buffer_pool_refs_resolve_correctly(db: SampleBufferDatabase) -> None:
         )
 
 
+# ---------------------------------------------------------------------------
+# Pool-index dedup semantics
+# ---------------------------------------------------------------------------
+
+
+def _start_sample(db: SampleBufferDatabase) -> None:
+    db.start_sample(EvalSampleSummary(id="s1", epoch=1, input="test", target="target"))
+
+
+def _log_model_event(db: SampleBufferDatabase, input_msgs: list) -> None:
+    db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event(input_msgs))])
+
+
+def _pool_contents(db: SampleBufferDatabase) -> list[str]:
+    data = db.get_sample_data("s1", 1)
+    assert data is not None
+    return [json.loads(entry.data)["content"] for entry in data.message_pool]
+
+
+def test_clone_then_mutate_gets_own_pool_entry(db: SampleBufferDatabase) -> None:
+    """Same .id, different content (model_copy preserves id) must NOT merge."""
+    _start_sample(db)
+    msg = ChatMessageUser(content="original content")
+    mutated = msg.model_copy(update={"content": "mutated content"})
+    assert mutated.id == msg.id
+
+    _log_model_event(db, [msg])
+    _log_model_event(db, [msg, mutated])
+
+    assert sorted(_pool_contents(db)) == ["mutated content", "original content"]
+
+
+def test_in_place_mutation_reuses_first_pooled_version(
+    db: SampleBufferDatabase,
+) -> None:
+    """Mutating a pooled object in place aliases history.
+
+    The identity fast path resolves to the first-pooled version
+    (documented, accepted).
+    """
+    _start_sample(db)
+    msg = ChatMessageUser(content="version one")
+    _log_model_event(db, [msg])
+    msg.content = "version two"
+    _log_model_event(db, [msg])
+
+    assert _pool_contents(db) == ["version one"]
+
+
+def test_rollback_restores_pool_indices(
+    db: SampleBufferDatabase, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed log_events batch must unwind in-memory index state.
+
+    SQLite and the indices must stay consistent for subsequent batches.
+
+    Failure injection: monkeypatch to_json_str_safe (called in log_events to
+    serialize the event row, AFTER _condense_event has already inserted pool
+    entries and mutated the in-memory indices).  The first call during the
+    failing batch raises, which triggers the on_rollback callback that must
+    restore the indices to their pre-batch state.
+
+    Note: the condensed event row contains the model output ("response") but
+    NOT the message content (that lives only in pool rows).  We therefore
+    fail unconditionally on the first call inside the second log_events
+    invocation -- this is safe because the monkeypatch is installed only
+    around that specific call.
+    """
+    import inspect_ai.log._recorders.buffer.database as database_module
+
+    _start_sample(db)
+    msg_a = ChatMessageUser(content="message a")
+    _log_model_event(db, [msg_a])
+
+    # Install patch: fail on the first to_json_str_safe call in this batch.
+    # That call happens AFTER _condense_event mutated the indices (pool inserts
+    # for msg_b ran), but BEFORE conn.execute inserts the event row.
+    original = getattr(database_module, "to_json_str_safe")
+    call_count = 0
+
+    def fail_first_call(value: object) -> str:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("induced failure")
+        return original(value)
+
+    monkeypatch.setattr(database_module, "to_json_str_safe", fail_first_call)
+    msg_b = ChatMessageUser(content="message b")
+    with pytest.raises(RuntimeError, match="induced failure"):
+        _log_model_event(db, [msg_a, msg_b])
+    monkeypatch.undo()
+
+    # guard: the injected failure fired exactly at the event-row serialization
+    # (if a future to_json_str_safe call is added earlier in the batch, this
+    # test would silently stop exercising the post-condense rollback path)
+    assert call_count == 1
+
+    # retry the same batch: indices were restored, so positions must align
+    _log_model_event(db, [msg_a, msg_b])
+    data = db.get_sample_data("s1", 1)
+    assert data is not None
+    assert _pool_contents(db) == ["message a", "message b"]
+    last = data.events[-1].event
+    assert isinstance(last, dict)
+    assert last["input_refs"] == [[0, 2]]
+
+
 def test_buffer_pool_dedup_uses_content_hash_not_msg_id(
     db: SampleBufferDatabase,
 ) -> None:
@@ -349,7 +457,9 @@ def test_buffer_pool_dedup_uses_content_hash_not_msg_id(
     msg_2 = ChatMessageUser(content="Hello").model_copy(update={"id": "uuid-bbb"})
 
     db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_1]))])
-    db.log_events([SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_2]))])
+    db.log_events(
+        [SampleEvent(id="s1", epoch=1, event=_make_model_event([msg_1, msg_2]))]
+    )
 
     data = db.get_sample_data("s1", 1)
     assert data is not None
@@ -358,3 +468,8 @@ def test_buffer_pool_dedup_uses_content_hash_not_msg_id(
     assert len(data.message_pool) == 1, (
         f"Expected 1 pool entry for identical content, got {len(data.message_pool)}"
     )
+
+    # both occurrences in the second event resolve to pool position 0
+    last = data.events[-1].event
+    assert isinstance(last, dict)
+    assert last["input_refs"] == [[0, 1], [0, 1]]

--- a/tests/log/test_condense_linear.py
+++ b/tests/log/test_condense_linear.py
@@ -1,0 +1,335 @@
+"""Regression tests: per-event condensing must be O(new messages), not O(history).
+
+Counts content-hash invocations while logging a growing conversation one
+event at a time (the live-eval pattern). Quadratic condensing computes
+~N²/2 hashes for N events; linear computes ~N. See
+inspect_ai/event/_pool_index.py for the strategy.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from typing import Generator, Iterator
+
+import pytest
+from pydantic import JsonValue
+
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._validate import validate_chat_messages
+from inspect_ai.log._log import EvalSampleSummary
+from inspect_ai.log._recorders.buffer import SampleBufferDatabase
+from inspect_ai.log._recorders.types import SampleEvent
+from inspect_ai.log._transcript_store import TranscriptEventStore
+from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput
+
+N_EVENTS = 100
+
+
+class HashCounter:
+    msg_hashes: int = 0
+    call_hashes: int = 0
+
+
+@pytest.fixture
+def hash_counter(monkeypatch: pytest.MonkeyPatch) -> Iterator[HashCounter]:
+    """Count _msg_hash/_call_hash calls across all modules that bind them."""
+    import inspect_ai.event._pool as pool
+
+    counter = HashCounter()
+    original_msg_hash = pool._msg_hash
+    original_call_hash = pool._call_hash
+
+    def counting_msg_hash(msg: ChatMessage) -> str:
+        counter.msg_hashes += 1
+        return original_msg_hash(msg)
+
+    def counting_call_hash(call_msg: JsonValue) -> str:
+        counter.call_hashes += 1
+        return original_call_hash(call_msg)
+
+    monkeypatch.setattr(pool, "_msg_hash", counting_msg_hash)
+    monkeypatch.setattr(pool, "_call_hash", counting_call_hash)
+    # all condense paths (buffer, transcript store, pool-index helper) access
+    # these as _pool module attributes, so patching _pool intercepts them all
+    yield counter
+
+
+@pytest.fixture
+def db() -> Generator[SampleBufferDatabase, None, None]:
+    with tempfile.TemporaryDirectory() as db_dir:
+        test_db = SampleBufferDatabase(location="test_location", db_dir=Path(db_dir))
+        yield test_db
+        test_db.cleanup()
+
+
+def _model_event(
+    input_msgs: list[ChatMessage], call_msgs: list[JsonValue]
+) -> ModelEvent:
+    return ModelEvent(
+        model="test",
+        input=input_msgs,
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("test", "response"),
+        call=ModelCall(
+            request={"model": "test", "messages": call_msgs},
+            response={"id": "r1"},
+        ),
+    )
+
+
+def test_buffer_condense_is_linear(
+    db: SampleBufferDatabase, hash_counter: HashCounter
+) -> None:
+    db.start_sample(EvalSampleSummary(id="s1", epoch=1, input="in", target="t"))
+
+    history: list[ChatMessage] = []
+    wire: list[dict[str, JsonValue]] = []
+    for i in range(N_EVENTS):
+        # same objects re-sent each turn, like a real agent loop
+        history.append(ChatMessageUser(content=f"message {i}"))
+        wire.append({"role": "user", "content": f"message {i}"})
+        # fresh wire dicts each event, like providers produce
+        call_msgs: list[JsonValue] = [dict(m) for m in wire]
+        db.log_events(
+            [
+                SampleEvent(
+                    id="s1", epoch=1, event=_model_event(list(history), call_msgs)
+                )
+            ]
+        )
+
+    # linear: ~1 new message + ~1 new call message hashed per event.
+    # quadratic computes ~N_EVENTS^2/2 = 5050 of each.
+    budget = 3 * N_EVENTS
+    assert hash_counter.msg_hashes <= budget, (
+        f"message hashing is superlinear: {hash_counter.msg_hashes} hashes "
+        f"for {N_EVENTS} events"
+    )
+    assert hash_counter.call_hashes <= budget, (
+        f"call hashing is superlinear: {hash_counter.call_hashes} hashes "
+        f"for {N_EVENTS} events"
+    )
+
+    # and the result is still correct
+    data = db.get_sample_data("s1", 1)
+    assert data is not None
+    assert len(data.message_pool) == N_EVENTS
+    assert len(data.call_pool) == N_EVENTS
+
+    # the last event's refs must cover the full pools in order
+    last_event = data.events[-1].event
+    assert isinstance(last_event, dict)
+    assert last_event["input"] == []
+    assert last_event["input_refs"] == [[0, N_EVENTS]]
+    call = last_event["call"]
+    assert isinstance(call, dict)
+    assert call["call_refs"] == [[0, N_EVENTS]]
+    assert call["call_key"] == "messages"
+    request = call["request"]
+    assert isinstance(request, dict)
+    assert "messages" not in request
+
+    # pool entries resolve to the original contents in order
+    pool_msgs = [json.loads(entry.data) for entry in data.message_pool]
+    assert [m["content"] for m in pool_msgs] == [
+        f"message {i}" for i in range(N_EVENTS)
+    ]
+    pool_calls = [json.loads(entry.data) for entry in data.call_pool]
+    assert pool_calls == [
+        {"role": "user", "content": f"message {i}"} for i in range(N_EVENTS)
+    ]
+
+
+def _no_attachment(_: str) -> str | None:
+    return None
+
+
+def test_transcript_store_condense_is_linear(
+    tmp_path: Path, hash_counter: HashCounter
+) -> None:
+    store = TranscriptEventStore(tmp_path / "transcript_event_store.sqlite")
+
+    history: list[ChatMessage] = []
+    wire: list[dict[str, JsonValue]] = []
+    for i in range(N_EVENTS):
+        # same objects re-sent each turn, like a real agent loop
+        history.append(ChatMessageUser(content=f"message {i}"))
+        wire.append({"role": "user", "content": f"message {i}"})
+        # fresh wire dicts each event, like providers produce
+        call_msgs: list[JsonValue] = [dict(m) for m in wire]
+        store.merge_event(_model_event(list(history), call_msgs), _no_attachment)
+
+    # linear: ~1 new message + ~1 new call message hashed per event.
+    # quadratic computes ~N_EVENTS^2/2 = 5050 of each.
+    budget = 3 * N_EVENTS
+    assert hash_counter.msg_hashes <= budget, (
+        f"message hashing is superlinear: {hash_counter.msg_hashes} hashes "
+        f"for {N_EVENTS} events"
+    )
+    assert hash_counter.call_hashes <= budget, (
+        f"call hashing is superlinear: {hash_counter.call_hashes} hashes "
+        f"for {N_EVENTS} events"
+    )
+
+    counts = store.counts()
+    assert counts.message_pool == N_EVENTS
+    assert counts.call_pool == N_EVENTS
+    store.close()
+
+
+def test_transcript_store_reopen_reuses_pool_rows(tmp_path: Path) -> None:
+    """On resume the in-memory index is empty; SQLite hash lookup must dedup.
+
+    Simulates the common resume pattern: a store is written, closed, and
+    reopened in a fresh process (empty in-memory indices).  A re-parsed
+    equal-content message must hit the existing pool row via the SQLite
+    hash lookup rather than inserting a duplicate: pool counts stay at 2
+    (msg_a deduped, msg_b new), and the second event's refs span both
+    positions as a single contiguous range [[0, 2]].
+    """
+    db_path = tmp_path / "transcript_event_store.sqlite"
+    msg_a = ChatMessageUser(content="message a")
+
+    store = TranscriptEventStore(db_path)
+    store.merge_event(_model_event([msg_a], [{"content": "a"}]), _no_attachment)
+    store.close()
+
+    # Simulate a fresh process: new store object, empty in-memory indices.
+    # Re-parse msg_a from JSON so object identity differs but content matches.
+    reparsed_a = ChatMessageUser.model_validate_json(msg_a.model_dump_json())
+    msg_b = ChatMessageUser(content="message b")
+
+    store2 = TranscriptEventStore(db_path)  # reset=False (default) preserves rows
+    store2.merge_event(
+        _model_event([reparsed_a, msg_b], [{"content": "a"}, {"content": "b"}]),
+        _no_attachment,
+    )
+
+    counts = store2.counts()
+    assert counts.message_pool == 2, (
+        f"expected 2 pool rows (msg_a deduped, msg_b new) but got {counts.message_pool}"
+    )
+    assert counts.call_pool == 2, (
+        f"expected 2 call-pool rows but got {counts.call_pool}"
+    )
+
+    work_dir = tmp_path / "out"
+    work_dir.mkdir()
+    store2.write_transcript_files(
+        events_path=work_dir / "events.json",
+        events_data_path=work_dir / "events_data.json",
+        attachments_path=work_dir / "attachments.json",
+    )
+    store2.close()
+
+    events = json.loads((work_dir / "events.json").read_text())
+    # The second event (index 1) covers both pool entries [0, 2].
+    assert events[1]["input_refs"] == [[0, 2]], (
+        f"expected input_refs [[0, 2]] but got {events[1].get('input_refs')}"
+    )
+    assert events[1]["call"]["call_refs"] == [[0, 2]], (
+        f"expected call_refs [[0, 2]] but got {events[1]['call'].get('call_refs')}"
+    )
+
+
+def test_buffer_export_to_transcript_store_hash_parity(tmp_path: Path) -> None:
+    """Buffer-exported pool rows must dedup against the store's live merges.
+
+    Drives the real ``export_transcript_events`` into a real
+    ``TranscriptEventStore`` (the checkpointer seeding path).  The buffer
+    stores rows with its own hash and serialization; the store's live
+    condense path computes hashes from walked message objects.  If the two
+    sides ever disagree (serialization key order, walked form, hash
+    function), a live merge of content already exported duplicates pool
+    rows.  Unsorted dict metadata is the case that catches key-order drift.
+    """
+    msg_a = ChatMessageUser(content="message a", metadata={"b": 1, "a": 2})
+    msg_b = ChatMessageUser(content="message b")
+    wire: list[dict[str, JsonValue]] = [
+        {"role": "user", "content": "message a", "z": 1, "a": 2}
+    ]
+    wire_msgs: list[JsonValue] = list(wire)
+
+    db = SampleBufferDatabase(location="export_parity", db_dir=tmp_path)
+    try:
+        db.start_sample(EvalSampleSummary(id="s1", epoch=1, input="in", target="t"))
+        db.log_events(
+            [SampleEvent(id="s1", epoch=1, event=_model_event([msg_a], wire_msgs))]
+        )
+        db.log_events(
+            [
+                SampleEvent(
+                    id="s1", epoch=1, event=_model_event([msg_a, msg_b], wire_msgs)
+                )
+            ]
+        )
+
+        store = TranscriptEventStore(tmp_path / "transcript_event_store.sqlite")
+        exported = db.export_transcript_events("s1", 1, store)
+        assert exported == 2
+        counts = store.counts()
+        assert counts.message_pool == 2
+        assert counts.call_pool == 1
+    finally:
+        db.cleanup()
+
+    # live-merge equal content (fresh objects, fresh ids — only the hash can
+    # dedup): pool counts must not grow if buffer and store hashes agree
+    reparsed_a = ChatMessageUser.model_validate_json(msg_a.model_dump_json())
+    fresh_wire: list[JsonValue] = [dict(wire[0])]
+    store.merge_event(_model_event([reparsed_a], fresh_wire), _no_attachment)
+    counts = store.counts()
+    assert counts.message_pool == 2, (
+        f"buffer-exported and live-merged hashes diverged: {counts.message_pool} rows"
+    )
+    assert counts.call_pool == 1, (
+        f"buffer-exported and live-merged call hashes diverged: {counts.call_pool} rows"
+    )
+    assert counts.events == 3
+    store.close()
+
+
+def test_transcript_store_reseed_dedups_dict_field_messages(tmp_path: Path) -> None:
+    """Stored pool bytes must re-hash to the stored hash on re-seed.
+
+    ``_msg_hash`` hashes insertion-order serialization, so the stored pool
+    JSON must use insertion order too: ``json.dumps(..., sort_keys=True)``
+    would reorder dict fields (tool-call arguments, metadata), making the
+    re-parsed message hash differently from its own stored row and
+    inserting a duplicate on every checkpoint-resume re-seed
+    (``merge_message_pool`` over hydrated pool entries).
+    """
+    db_path = tmp_path / "transcript_event_store.sqlite"
+    # dict field whose insertion order differs from sorted order
+    msg = ChatMessageUser(content="hello", metadata={"b": 1, "a": 2})
+
+    store = TranscriptEventStore(db_path)
+    store.merge_message_pool([msg])
+    assert store.counts().message_pool == 1
+
+    # export the pool the way hydration reads it back on resume
+    work_dir = tmp_path / "out"
+    work_dir.mkdir()
+    store.write_transcript_files(
+        events_path=work_dir / "events.json",
+        events_data_path=work_dir / "events_data.json",
+        attachments_path=work_dir / "attachments.json",
+    )
+    store.close()
+
+    raw = json.loads((work_dir / "events_data.json").read_text())
+    reparsed = validate_chat_messages(raw["messages"])
+
+    # reopen (reset=False) and re-seed, like checkpointer resume does
+    store2 = TranscriptEventStore(db_path)
+    store2.merge_message_pool(reparsed)
+    assert store2.counts().message_pool == 1, (
+        "re-seeded message must dedup against its own stored row "
+        f"(got {store2.counts().message_pool} rows)"
+    )
+    store2.close()

--- a/tests/log/test_condense_linear.py
+++ b/tests/log/test_condense_linear.py
@@ -358,6 +358,147 @@ def test_buffer_export_to_transcript_store_hash_parity(tmp_path: Path) -> None:
     store.close()
 
 
+def test_transcript_store_duplicate_content_loop_is_linear(
+    tmp_path: Path, hash_counter: HashCounter
+) -> None:
+    """Done-loop through the store: occurrence rows, single-range refs."""
+    store = TranscriptEventStore(tmp_path / "transcript_event_store.sqlite")
+
+    n_turns = 50
+    history: list[ChatMessage] = []
+    wire: list[dict[str, JsonValue]] = []
+    for _ in range(n_turns):
+        history.append(ChatMessageUser(content="continue"))
+        history.append(ChatMessageAssistant(content="Done"))
+        wire.append({"role": "user", "content": "continue"})
+        wire.append({"role": "assistant", "content": "Done"})
+        call_msgs: list[JsonValue] = [dict(m) for m in wire]
+        store.merge_event(_model_event(list(history), call_msgs), _no_attachment)
+
+    budget = 5 * n_turns
+    assert hash_counter.msg_hashes <= budget
+    assert hash_counter.call_hashes <= budget
+
+    counts = store.counts()
+    assert counts.message_pool == 2 * n_turns
+    assert counts.call_pool == 2 * n_turns
+
+    work_dir = tmp_path / "out"
+    work_dir.mkdir()
+    store.write_transcript_files(
+        events_path=work_dir / "events.json",
+        events_data_path=work_dir / "events_data.json",
+        attachments_path=work_dir / "attachments.json",
+    )
+    store.close()
+
+    events = json.loads((work_dir / "events.json").read_text())
+    for i, ev in enumerate(events):
+        k = 2 * (i + 1)
+        assert ev["input_refs"] == [[0, k]], f"event {i}: {ev['input_refs']}"
+        assert ev["call"]["call_refs"] == [[0, k]]
+    # pool resolves to alternating contents in order
+    data = json.loads((work_dir / "events_data.json").read_text())
+    assert [m["content"] for m in data["messages"]] == ["continue", "Done"] * n_turns
+
+
+def test_transcript_store_positional_merge_preserves_occurrence_rows(
+    tmp_path: Path,
+) -> None:
+    """Seeding merges must align by position, not collapse by hash.
+
+    Simulates checkpoint-resume: a store with duplicate-content occurrence
+    rows is exported, then a new store is seeded from the hydrated pool
+    (merge_message_pool / merge_call_pool). Positions must round-trip so
+    refs in re-seeded condensed events stay valid.
+    """
+    db_path = tmp_path / "store.sqlite"
+    store = TranscriptEventStore(db_path)
+    # build occurrence rows via the append path
+    m1 = ChatMessageUser(content="same")
+    store.merge_event(_model_event([m1], [{"content": "same"}]), _no_attachment)
+    m2 = ChatMessageUser(content="same")  # fresh id, equal content
+    store.merge_event(
+        _model_event([m1, m2], [{"content": "same"}, {"content": "same"}]),
+        _no_attachment,
+    )
+    assert store.counts().message_pool == 2
+    assert store.counts().call_pool == 2
+
+    work_dir = tmp_path / "out"
+    work_dir.mkdir()
+    store.write_transcript_files(
+        events_path=work_dir / "events.json",
+        events_data_path=work_dir / "events_data.json",
+        attachments_path=work_dir / "attachments.json",
+    )
+    store.close()
+
+    raw = json.loads((work_dir / "events_data.json").read_text())
+    hydrated_msgs = validate_chat_messages(raw["messages"])
+    hydrated_calls: list[JsonValue] = raw["calls"]
+
+    # fresh store, seed from hydrated pools (checkpointer_impl pattern)
+    store2 = TranscriptEventStore(tmp_path / "store2.sqlite")
+    store2.merge_message_pool(hydrated_msgs)
+    store2.merge_call_pool(hydrated_calls)
+    assert store2.counts().message_pool == 2, "hash-collapse lost an occurrence row"
+    assert store2.counts().call_pool == 2
+
+    # re-seeding the same pools is idempotent (positional prefix match)
+    store2.merge_message_pool(hydrated_msgs)
+    store2.merge_call_pool(hydrated_calls)
+    assert store2.counts().message_pool == 2
+    assert store2.counts().call_pool == 2
+    store2.close()
+
+
+def test_transcript_store_migrates_old_unique_hash_schema(tmp_path: Path) -> None:
+    """A store created by old code (UNIQUE hash) must accept occurrence rows."""
+    import sqlite3
+
+    db_path = tmp_path / "old_store.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.executescript(
+        """
+        CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE TABLE events (
+            logical_id TEXT PRIMARY KEY,
+            first_seq INTEGER NOT NULL UNIQUE,
+            latest_json TEXT NOT NULL
+        );
+        CREATE TABLE message_pool (
+            pos INTEGER PRIMARY KEY,
+            hash TEXT NOT NULL UNIQUE,
+            json TEXT NOT NULL
+        );
+        CREATE TABLE call_pool (
+            pos INTEGER PRIMARY KEY,
+            hash TEXT NOT NULL UNIQUE,
+            json TEXT NOT NULL
+        );
+        CREATE TABLE attachments (hash TEXT PRIMARY KEY, content TEXT NOT NULL);
+        INSERT INTO message_pool(pos, hash, json)
+            VALUES (0, 'h-old', '{"role":"user","content":"old"}');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    store = TranscriptEventStore(db_path)
+    # the Done-loop append path must be able to insert two equal-content rows
+    m1 = ChatMessageUser(content="same")
+    store.merge_event(_model_event([m1], [{"content": "same"}]), _no_attachment)
+    m2 = ChatMessageUser(content="same")
+    store.merge_event(
+        _model_event([m1, m2], [{"content": "same"}, {"content": "same"}]),
+        _no_attachment,
+    )
+    counts = store.counts()
+    assert counts.message_pool == 3  # old row + 2 occurrence rows
+    store.close()
+
+
 def test_transcript_store_reseed_dedups_dict_field_messages(tmp_path: Path) -> None:
     """Stored pool bytes must re-hash to the stored hash on re-seed.
 

--- a/tests/log/test_condense_linear.py
+++ b/tests/log/test_condense_linear.py
@@ -20,7 +20,11 @@ from inspect_ai.log._log import EvalSampleSummary
 from inspect_ai.log._recorders.buffer import SampleBufferDatabase
 from inspect_ai.log._recorders.types import SampleEvent
 from inspect_ai.log._transcript_store import TranscriptEventStore
-from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageUser,
+)
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
@@ -143,6 +147,66 @@ def test_buffer_condense_is_linear(
     assert pool_calls == [
         {"role": "user", "content": f"message {i}"} for i in range(N_EVENTS)
     ]
+
+
+def test_buffer_duplicate_content_loop_is_linear(
+    db: SampleBufferDatabase, hash_counter: HashCounter
+) -> None:
+    """Done-loop: identical content every turn, fresh ids, history re-sent.
+
+    Occurrence-keyed positions make this linear in turns: one pool row per
+    occurrence, single-range refs per event, ~2 hashes per turn.
+    """
+    db.start_sample(EvalSampleSummary(id="s1", epoch=1, input="in", target="t"))
+
+    n_turns = 50
+    history: list[ChatMessage] = []
+    wire: list[dict[str, JsonValue]] = []
+    for _ in range(n_turns):
+        # fresh objects with fresh ids each turn, content always identical
+        history.append(ChatMessageUser(content="continue"))
+        history.append(ChatMessageAssistant(content="Done"))
+        wire.append({"role": "user", "content": "continue"})
+        wire.append({"role": "assistant", "content": "Done"})
+        call_msgs: list[JsonValue] = [dict(m) for m in wire]
+        db.log_events(
+            [
+                SampleEvent(
+                    id="s1", epoch=1, event=_model_event(list(history), call_msgs)
+                )
+            ]
+        )
+
+    # linear hashing: ~2 message + ~2 call hashes per turn
+    budget = 5 * n_turns
+    assert hash_counter.msg_hashes <= budget, (
+        f"message hashing is superlinear: {hash_counter.msg_hashes}"
+    )
+    assert hash_counter.call_hashes <= budget, (
+        f"call hashing is superlinear: {hash_counter.call_hashes}"
+    )
+
+    data = db.get_sample_data("s1", 1)
+    assert data is not None
+    # one pool row per occurrence
+    assert len(data.message_pool) == 2 * n_turns
+    assert len(data.call_pool) == 2 * n_turns
+
+    # every event's refs are a single monotone range (the storage fix)
+    for i, ev in enumerate(data.events):
+        event_dict = ev.event
+        assert isinstance(event_dict, dict)
+        k = 2 * (i + 1)
+        assert event_dict["input_refs"] == [[0, k]], (
+            f"event {i}: {event_dict['input_refs']}"
+        )
+        call = event_dict["call"]
+        assert isinstance(call, dict)
+        assert call["call_refs"] == [[0, k]], f"event {i}: {call['call_refs']}"
+
+    # pool rows resolve to the original alternating contents in order
+    pool_msgs = [json.loads(entry.data) for entry in data.message_pool]
+    assert [m["content"] for m in pool_msgs] == ["continue", "Done"] * n_turns
 
 
 def _no_attachment(_: str) -> str | None:

--- a/tests/log/test_message_pool.py
+++ b/tests/log/test_message_pool.py
@@ -20,6 +20,8 @@ from inspect_ai.event._pool import (
     _msg_hash,
     _msg_pool_json,
     _msg_pool_jsonable,
+    condense_model_event_calls,
+    condense_model_event_inputs,
 )
 from inspect_ai.event._validate import validate_chat_messages
 from inspect_ai.log._condense import (
@@ -784,6 +786,91 @@ def test_condense_produces_range_encoded_call_refs():
     assert model_events[0].call.call_refs == [(0, 1)]
     # Event 2: 3 messages [0,1,2] -> [(0,3)]
     assert model_events[1].call.call_refs == [(0, 3)]
+
+
+def _make_model_event(input: list[ChatMessage]) -> ModelEvent:
+    return ModelEvent(
+        model="test-model",
+        input=input,
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput(),
+    )
+
+
+def _make_call_event(messages: list[JsonValue]) -> ModelEvent:
+    return ModelEvent(
+        model="test-model",
+        input=[],
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput(),
+        call=ModelCall(
+            request={"model": "test", "messages": messages},
+            response={"choices": []},
+        ),
+    )
+
+
+def test_condense_duplicate_content_loop_single_range_refs():
+    """Batch condense: Done-loop histories produce single-range refs.
+
+    Same occurrence-keyed semantics as the per-event helper: each event
+    whose input extends the previous event's input mints fresh pool rows
+    for the suffix; refs stay monotone single ranges.
+    """
+    history: list[ChatMessage] = []
+    events: list[Event] = []
+    n = 10
+    for _ in range(n):
+        history.append(ChatMessageUser(content="continue"))
+        history.append(ChatMessageAssistant(content="Done"))
+        events.append(_make_model_event(list(history)))
+
+    condensed, _, new_entries = condense_model_event_inputs(events, 0, {})
+    # one pool row per occurrence
+    assert len(new_entries) == 2 * n
+    for i, ev in enumerate(condensed):
+        assert isinstance(ev, ModelEvent)
+        k = 2 * (i + 1)
+        assert ev.input_refs == [(0, k)], f"event {i}: {ev.input_refs}"
+
+
+def test_condense_calls_duplicate_content_loop_single_range_refs():
+    wire: list[dict[str, JsonValue]] = []
+    events: list[Event] = []
+    n = 10
+    for _ in range(n):
+        wire.append({"role": "user", "content": "continue"})
+        wire.append({"role": "assistant", "content": "Done"})
+        events.append(_make_call_event([dict(m) for m in wire]))
+
+    condensed, _, new_entries = condense_model_event_calls(events, 0, {})
+    assert len(new_entries) == 2 * n
+    for i, ev in enumerate(condensed):
+        assert isinstance(ev, ModelEvent)
+        assert ev.call is not None
+        k = 2 * (i + 1)
+        assert ev.call.call_refs == [(0, k)], f"event {i}: {ev.call.call_refs}"
+
+
+def test_condense_batch_prefix_break_still_dedups():
+    """A non-extending event falls back to content dedup in the batch path."""
+    a = ChatMessageUser(content="a")
+    b = ChatMessageAssistant(content="b")
+    c = ChatMessageUser(content="c")
+    fresh_c = ChatMessageUser(content="c")  # fresh id, equal content
+    events: list[Event] = [
+        _make_model_event([a, b, c]),
+        _make_model_event([a, c, fresh_c]),  # b dropped: break after a
+    ]
+    condensed, _, new_entries = condense_model_event_inputs(events, 0, {})
+    assert len(new_entries) == 3  # a, b, c — fresh_c hash-deduped on the break
+    ev1 = condensed[1]
+    assert isinstance(ev1, ModelEvent)
+    assert ev1.input_refs == [(0, 1), (2, 3), (2, 3)]
 
 
 def test_resolve_range_encoded_input_refs():

--- a/tests/log/test_message_pool.py
+++ b/tests/log/test_message_pool.py
@@ -12,7 +12,16 @@ from inspect_ai._util.constants import LOG_SCHEMA_VERSION
 from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai.event import Event, Timeline, TimelineEvent, TimelineSpan
 from inspect_ai.event._model import ModelEvent
-from inspect_ai.event._pool import _compress_refs, _expand_refs
+from inspect_ai.event._pool import (
+    _call_hash,
+    _call_pool_json,
+    _compress_refs,
+    _expand_refs,
+    _msg_hash,
+    _msg_pool_json,
+    _msg_pool_jsonable,
+)
+from inspect_ai.event._validate import validate_chat_messages
 from inspect_ai.log._condense import (
     condense_events,
     condense_sample,
@@ -32,6 +41,7 @@ from inspect_ai.log._log import (
 )
 from inspect_ai.log._resolve import resolve_sample_events_data
 from inspect_ai.model._chat_message import (
+    ChatMessage,
     ChatMessageAssistant,
     ChatMessageSystem,
     ChatMessageUser,
@@ -39,6 +49,7 @@ from inspect_ai.model._chat_message import (
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.tool._tool_call import ToolCall
 
 
 def _make_sample_with_repeated_inputs() -> EvalSample:
@@ -1041,3 +1052,45 @@ def test_resolve_call_empty_refs_preserves_request():
     # request must be unchanged — no spurious keys, 'input' preserved
     assert resolved_call.request == {"model": "test", "input": "What is 2+2?"}
     assert "messages" not in resolved_call.request
+
+
+def test_msg_hash_stable_across_serialization_roundtrip() -> None:
+    """Insert-time hash must equal rebuild-time hash (_build_msg_index re-parses pool JSON)."""
+    messages: list[ChatMessage] = [
+        ChatMessageUser(content="x" * 200, metadata={"b": 1, "a": [1, {"k": "v"}]}),
+        ChatMessageAssistant(
+            content=[
+                ContentText(text="t" * 150),
+                ContentReasoning(reasoning="r" * 150),
+            ],
+            tool_calls=[ToolCall(id="tc1", function="f", arguments={"x": 1})],
+        ),
+    ]
+    for msg in messages:
+        [reparsed] = validate_chat_messages([json.loads(msg.model_dump_json())])
+        assert _msg_hash(reparsed) == _msg_hash(msg)
+
+    # the hash excludes .id: same content under different ids hashes equal
+    a = ChatMessageUser(content="same content")
+    b = ChatMessageUser(content="same content")
+    assert a.id != b.id
+    assert _msg_hash(a) == _msg_hash(b)
+
+
+def test_pool_json_helpers_roundtrip_to_own_hash() -> None:
+    """Stored pool bytes must re-hash to the hash stored beside them.
+
+    This is the invariant `_msg_pool_json`/`_call_pool_json` own: a pool
+    row written by one process and re-parsed by another (resume/re-seed)
+    must land on its own hash, or every resume duplicates the pool. The
+    unsorted dict fields here are the case that breaks if storage and
+    hash disagree on key order.
+    """
+    msg = ChatMessageUser(content="hello", metadata={"b": 1, "a": 2})
+    stored = _msg_pool_json(_msg_pool_jsonable(msg))
+    [reparsed] = validate_chat_messages([json.loads(stored)])
+    assert _msg_hash(reparsed) == _msg_hash(msg)
+
+    call_msg: JsonValue = {"role": "user", "b": 1, "a": 2}
+    stored_call = _call_pool_json(call_msg)
+    assert _call_hash(json.loads(stored_call)) == _call_hash(call_msg)

--- a/tests/log/test_pool_index.py
+++ b/tests/log/test_pool_index.py
@@ -61,19 +61,6 @@ def test_message_pool_index_none_id_never_bucketed() -> None:
     assert index.get_by_hash("hash-a") == 0
 
 
-def test_message_pool_index_hash_dedup_across_ids() -> None:
-    """Same content, different id: second add maps to the same entry, size stays 1."""
-    index = MessagePoolIndex()
-    a = ChatMessageUser(content="same")
-    b = ChatMessageUser(content="same")
-    index.add(a, "hash-a", 0)
-    assert index.get(b) is None
-    assert index.get_by_hash("hash-a") == 0
-    index.add(b, "hash-a", 0)
-    assert index.get(b) == 0
-    assert index.size == 1
-
-
 def test_message_pool_index_mark_restore() -> None:
     index = MessagePoolIndex()
     a = ChatMessageUser(content="a")
@@ -84,7 +71,7 @@ def test_message_pool_index_mark_restore() -> None:
     d = ChatMessageUser(content="same")
     index.add(b, "hash-b", 1)
     index.add(c, "hash-c", 2)
-    index.add(d, "hash-c", 2)  # bucket-only add (hash already present)
+    index.add(d, "hash-c", 2, new_entry=False)  # accelerator-only registration
     assert index.size == 3
     index.restore(mark)
     assert index.size == 1
@@ -95,6 +82,100 @@ def test_message_pool_index_mark_restore() -> None:
     assert index.get_by_hash("hash-b") is None
     assert index.get_by_hash("hash-c") is None
     assert index.get_by_hash("hash-a") == 0
+
+
+def test_message_pool_index_match_prefix_identity_and_equality() -> None:
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="a")
+    b = ChatMessageUser(content="b")
+    assert index.match_prefix([a, b]) == []
+    assert index.prev_len == 0
+    index.set_prev([a, b], [0, 1])
+    assert index.prev_len == 2
+    assert index.match_prefix([a, b]) == [0, 1]
+    # a re-parsed clone (same id, same content) matches by equality
+    clone_a = ChatMessageUser.model_validate_json(a.model_dump_json())
+    assert index.match_prefix([clone_a, b]) == [0, 1]
+    # fresh id -> pydantic equality fails -> prefix breaks immediately
+    fresh = ChatMessageUser(content="a")
+    assert index.match_prefix([fresh, b]) == []
+    # divergence mid-list stops the match
+    c = ChatMessageUser(content="c")
+    assert index.match_prefix([a, c]) == [0]
+
+
+def test_message_pool_index_set_prev_copies_input() -> None:
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="a")
+    msgs: list[ChatMessage] = [a]
+    indices = [0]
+    index.set_prev(msgs, indices)
+    msgs.append(ChatMessageUser(content="b"))
+    indices.append(99)
+    b = ChatMessageUser(content="b")
+    assert index.match_prefix([a, b]) == [0]
+
+
+def test_message_pool_index_size_counts_rows_not_hashes() -> None:
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="same")
+    b = ChatMessageUser(content="same")  # fresh id, equal content
+    index.add(a, "hash-same", 0)
+    index.add(b, "hash-same", 1)  # second occurrence row sharing the hash
+    assert index.size == 2
+    assert index.get_by_hash("hash-same") == 0  # first occurrence wins
+    assert index.get(a) == 0
+    assert index.get(b) == 1  # own bucket entry
+
+
+def test_message_pool_index_accelerator_add_does_not_count() -> None:
+    """new_entry=False registers lookup state without claiming a pool row."""
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="a")
+    index.add(a, "hash-a", 0, new_entry=False)
+    assert index.size == 0
+    assert index.get(a) == 0
+    assert index.get_by_hash("hash-a") == 0
+
+
+def test_message_pool_index_restore_rewinds_size_and_drops_prefix() -> None:
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="a")
+    index.add(a, "hash-a", 0)
+    index.set_prev([a], [0])
+    mark = index.mark()
+
+    b = ChatMessageUser(content="same")
+    c = ChatMessageUser(content="same")
+    index.add(b, "hash-same", 1)
+    index.add(c, "hash-same", 2)
+    seed = ChatMessageUser(content="seed")
+    index.add(seed, "hash-seed", 0, new_entry=False)
+    index.set_prev([a, b, c], [0, 1, 2])
+    assert index.size == 3
+
+    index.restore(mark)
+    assert index.size == 1
+    assert index.get_by_hash("hash-same") is None
+    assert index.get(b) is None
+    assert index.get(seed) is None
+    # prefix state is dropped (a miss is safe, a stale hit is not)
+    assert index.match_prefix([a]) == []
+
+
+def test_message_pool_index_add_hash_only() -> None:
+    """Registers an existing row's hash with no object to bucket (seeding)."""
+    index = MessagePoolIndex()
+    index.add_hash_only("hash-x", 4)
+    assert index.size == 0
+    assert index.get_by_hash("hash-x") == 4
+    mark = index.mark()
+    index.add_hash_only("hash-y", 5)
+    index.add_hash_only("hash-y", 9)  # duplicate: first wins
+    assert index.get_by_hash("hash-y") == 5
+    index.restore(mark)
+    assert index.get_by_hash("hash-y") is None
+    assert index.get_by_hash("hash-x") == 4
 
 
 def test_call_pool_index_prefix_match() -> None:
@@ -497,6 +578,20 @@ def test_message_pool_index_heavy_add_mark_restore() -> None:
     assert index.size == 1
     assert index.get_by_hash("hash-heavy") is None
     assert index.get(light) == 0
+
+
+def test_message_pool_index_heavy_existing_hash_accelerator_add_not_logged() -> None:
+    """Heavy msg + existing hash + new_entry=False: nothing changes, nothing logged."""
+    index = MessagePoolIndex()
+    index.add_hash_only("hash-x", 7)
+    mark = index.mark()
+    heavy = _heavy_image_message()
+    index.add(heavy, "hash-x", 7, new_entry=False)
+    # nothing was logged: the log length must be unchanged
+    assert index.mark() == mark
+    assert index.size == 0
+    index.restore(mark)  # must be a no-op
+    assert index.get_by_hash("hash-x") == 7
 
 
 def test_condense_helper_heavy_message_dedups_via_hash_path() -> None:

--- a/tests/log/test_pool_index.py
+++ b/tests/log/test_pool_index.py
@@ -104,6 +104,23 @@ def test_message_pool_index_match_prefix_identity_and_equality() -> None:
     assert index.match_prefix([a, c]) == [0]
 
 
+def test_message_prefix_breaks_on_json_distinct_metadata() -> None:
+    """Python-equal, JSON-distinct prefix drift must break the message match.
+
+    Same corruption class as the call side: a metadata value drifting
+    0 -> 0.0 is python-equal but hashes differently, so reusing the prior
+    pool index would round-trip the old value.
+    """
+    index = MessagePoolIndex()
+    msg = ChatMessageUser(content="hi", metadata={"n": 0})
+    index.set_prev([msg], [0])
+    clone = msg.model_copy(update={"metadata": {"n": 0}})
+    assert index.match_prefix([clone]) == [0]  # equal-by-value still matches
+    drifted = msg.model_copy(update={"metadata": {"n": 0.0}})
+    assert msg == drifted  # python equality conflates them...
+    assert index.match_prefix([drifted]) == []  # ...the prefix must not
+
+
 def test_message_pool_index_set_prev_copies_input() -> None:
     index = MessagePoolIndex()
     a = ChatMessageUser(content="a")

--- a/tests/log/test_pool_index.py
+++ b/tests/log/test_pool_index.py
@@ -217,10 +217,11 @@ def test_call_pool_index_mark_restore() -> None:
     mark = index.mark()
 
     index.add_hash("h-b", 1)
-    index.add_hash("h-b", 1)  # duplicate add is a no-op
+    index.add_hash("h-b", 2)  # second occurrence row sharing the hash
     prev_two: list[JsonValue] = [{"content": "a"}, {"content": "b"}]
     index.set_prev(prev_two, [0, 1])
-    assert index.size == 2
+    assert index.size == 3
+    assert index.get_by_hash("h-b") == 1  # first occurrence wins
 
     index.restore(mark)
     assert index.size == 1
@@ -233,6 +234,29 @@ def test_call_pool_index_mark_restore() -> None:
     # and the next set_prev/match_prefix cycle works normally
     index.set_prev(after_restore, [0, 1])
     assert index.match_prefix(after_restore) == [0, 1]
+
+
+def test_call_pool_index_size_counts_rows_not_hashes() -> None:
+    index = CallPoolIndex()
+    index.add_hash("h-a", 0)
+    index.add_hash("h-a", 1)  # second occurrence row sharing the hash
+    assert index.size == 2
+    assert index.get_by_hash("h-a") == 0  # first occurrence wins
+
+
+def test_call_pool_index_accelerator_add_does_not_count() -> None:
+    index = CallPoolIndex()
+    index.add_hash("h-a", 0, new_entry=False)
+    assert index.size == 0
+    assert index.get_by_hash("h-a") == 0
+
+
+def test_call_pool_index_prev_len() -> None:
+    index = CallPoolIndex()
+    assert index.prev_len == 0
+    msgs: list[JsonValue] = [{"content": "a"}, {"content": "b"}]
+    index.set_prev(msgs, [0, 1])
+    assert index.prev_len == 2
 
 
 def test_message_pool_index_restore_idempotent_and_mark_reusable() -> None:

--- a/tests/log/test_pool_index.py
+++ b/tests/log/test_pool_index.py
@@ -455,12 +455,129 @@ def test_condense_helper_duplicate_message_in_one_event() -> None:
     assert event.input_refs == [(0, 1), (0, 1)]
     assert len(recorder.messages) == 1
 
+    # append path: the same object appearing twice in the suffix
+    # identity-hits its just-minted row rather than minting another
+    # (raw indices [0, 0, 1, 1]; the middle 0, 1 run compresses to (0, 2))
+    other = ChatMessageUser(content="other")
+    event = _condense(
+        _model_event([msg, msg, other, other]), msg_index, call_index, recorder
+    )
+    assert event.input_refs == [(0, 1), (0, 2), (1, 2)]
+    assert len(recorder.messages) == 2
 
-def test_condense_helper_fresh_ids_bounded_index() -> None:
-    """Fresh objects/ids each turn (bridge-style agents) must not grow the index.
 
-    The identity bucket must stay bounded at the number of unique pool entries,
-    not grow with the number of events.
+def test_condense_helper_duplicate_content_loop_single_range_refs() -> None:
+    """Done-loop: identical content each turn, fresh objects+ids, history re-sent.
+
+    Occurrence-keyed positions: every event's refs compress to one range,
+    pool rows grow linearly, and re-sent objects never re-hash.
+    """
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    history: list[ChatMessage] = []
+    wire: list[dict[str, JsonValue]] = []
+    n = 10
+    for i in range(n):
+        history.append(ChatMessageUser(content="continue"))
+        history.append(ChatMessageAssistant(content="Done"))
+        wire.append({"role": "user", "content": "continue"})
+        wire.append({"role": "assistant", "content": "Done"})
+        call_msgs: list[JsonValue] = [dict(m) for m in wire]
+        event = _condense(
+            _model_event(list(history), call_msgs=call_msgs),
+            msg_index,
+            call_index,
+            recorder,
+        )
+        k = 2 * (i + 1)
+        assert event.input_refs == [(0, k)], f"turn {i}: {event.input_refs}"
+        assert event.call is not None
+        assert event.call.call_refs == [(0, k)], f"turn {i}: {event.call.call_refs}"
+
+    # one pool row per occurrence (2 per turn), each walked exactly once
+    assert len(recorder.messages) == 2 * n
+    assert len(recorder.calls) == 2 * n
+    assert recorder.walked_messages == 2 * n
+    assert recorder.walked_calls == 2 * n
+    assert msg_index.size == 2 * n
+    assert call_index.size == 2 * n
+
+
+def test_condense_helper_prefix_break_falls_back_to_hash_dedup() -> None:
+    """A diverged history (trim/compaction) must not mint occurrence rows."""
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    a = ChatMessageUser(content="a")
+    b = ChatMessageAssistant(content="b")
+    c = ChatMessageUser(content="c")
+    _condense(_model_event([a, b, c]), msg_index, call_index, recorder)
+    assert len(recorder.messages) == 3
+
+    # history rewritten: b dropped (compaction) -> prefix breaks after a
+    event = _condense(_model_event([a, c]), msg_index, call_index, recorder)
+    # a matches prefix (position 0); c hash-hits its existing row (position 2)
+    assert event.input_refs == [(0, 1), (2, 3)]
+    assert len(recorder.messages) == 3  # no new rows
+
+    # equal-content fresh-id message on ANOTHER break dedups by hash
+    # ([c, ...] does not extend [a, c], so this is a break, not an append)
+    fresh_c = ChatMessageUser(content="c")
+    event = _condense(_model_event([c, fresh_c]), msg_index, call_index, recorder)
+    assert event.input_refs == [(2, 3), (2, 3)]
+    assert len(recorder.messages) == 3
+
+    # whereas the same fresh-id duplicate appended to an extending history
+    # is a new occurrence and mints its own row (the design's core trade)
+    # (raw indices [2, 2, 3]; the trailing 2, 3 run compresses to (2, 4))
+    fresh_c2 = ChatMessageUser(content="c")
+    event = _condense(
+        _model_event([c, fresh_c, fresh_c2]), msg_index, call_index, recorder
+    )
+    assert event.input_refs == [(2, 3), (2, 4)]
+    assert len(recorder.messages) == 4
+
+
+def test_condense_helper_first_event_uses_hash_dedup() -> None:
+    """No previous input recorded -> break path, duplicates collapse."""
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    dup_a = ChatMessageUser(content="dup")
+    dup_b = ChatMessageUser(content="dup")  # fresh id, equal content
+    event = _condense(_model_event([dup_a, dup_b]), msg_index, call_index, recorder)
+    assert event.input_refs == [(0, 1), (0, 1)]
+    assert len(recorder.messages) == 1
+    assert msg_index.size == 1
+
+
+def test_condense_helper_append_path_buckets_suffix_rows() -> None:
+    """Occurrence rows from the append path identity-hit on later breaks."""
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    a = ChatMessageUser(content="same")
+    _condense(_model_event([a]), msg_index, call_index, recorder)
+    b = ChatMessageUser(content="same")  # fresh id, equal content
+    _condense(
+        _model_event([a, b]), msg_index, call_index, recorder
+    )  # append: b -> row 1
+    assert len(recorder.messages) == 2
+    # b was bucketed by the append path: a rebuilt history containing the
+    # same b object resolves it by identity (position 1), without rehashing
+    assert msg_index.get(b) == 1
+
+
+def test_condense_helper_fresh_ids_keep_todays_semantics() -> None:
+    """Bridge-style scaffolds (fresh objects+ids each turn) are unchanged.
+
+    Prefix can't match (pydantic == includes id) -> every event is a break;
+    content dedup keeps the pool at n rows and the index bounded.
     """
     msg_index = MessagePoolIndex()
     call_index = CallPoolIndex()
@@ -468,15 +585,12 @@ def test_condense_helper_fresh_ids_bounded_index() -> None:
 
     n = 20
     for k in range(1, n + 1):
-        # Rebuild full history with fresh objects and fresh ids each event,
-        # simulating bridge-style scaffolds that never reuse message objects.
         history = [ChatMessageUser(content=f"msg {i}") for i in range(k)]
         _condense(_model_event(history), msg_index, call_index, recorder)
 
     assert len(recorder.messages) == n  # content-deduped in the pool
     assert msg_index.size == n
-    # White-box: identity buckets must not accumulate one entry per occurrence;
-    # each unique message should produce exactly one bucket entry.
+    # identity buckets must not accumulate one entry per occurrence
     assert sum(len(b) for b in msg_index._buckets.values()) == n
 
 
@@ -629,11 +743,15 @@ def test_condense_helper_heavy_message_dedups_via_hash_path() -> None:
 
     first = _condense(_model_event([heavy]), msg_index, call_index, recorder)
     assert first.input_refs == [(0, 1)]
+    # a pure-append re-send resolves via the prefix match without a re-walk
     second = _condense(_model_event([heavy, light]), msg_index, call_index, recorder)
     assert second.input_refs == [(0, 2)]
+    assert recorder.walked_messages == 2
 
-    # heavy message pooled once but re-walked on the second event
-    # (the deliberate cost of not pinning it)
+    # a prefix break re-walks the unbucketed heavy message and hash-hits
+    # its existing row (the deliberate cost of not pinning it)
+    third = _condense(_model_event([light, heavy]), msg_index, call_index, recorder)
+    assert third.input_refs == [(1, 2), (0, 1)]
     assert len(recorder.messages) == 2
     assert recorder.walked_messages == 3
 

--- a/tests/log/test_pool_index.py
+++ b/tests/log/test_pool_index.py
@@ -1,0 +1,593 @@
+import gc
+import weakref
+from collections.abc import Callable, Sequence
+
+import pytest
+from pydantic import JsonValue
+
+from inspect_ai._util.content import ContentImage, ContentText
+from inspect_ai.event._model import ModelEvent
+from inspect_ai.event._pool_index import (
+    _BUCKET_CONTENT_LIMIT,
+    CallPoolIndex,
+    MessagePoolIndex,
+    condense_model_event_with_indices,
+)
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageUser,
+)
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model_call import ModelCall
+from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.tool._tool_call import ToolCall, ToolCallContent
+
+
+def test_message_pool_index_identity_and_equality_hits() -> None:
+    """Same object hits by identity; a re-parsed equal copy hits by equality."""
+    index = MessagePoolIndex()
+    msg = ChatMessageUser(content="hello")
+    assert index.get(msg) is None
+    index.add(msg, "hash-a", 0)
+    assert index.get(msg) == 0
+    assert index.size == 1
+
+    clone = msg.model_copy()
+    assert clone is not msg
+    assert index.get(clone) == 0
+
+
+def test_message_pool_index_miss_for_mutated_clone() -> None:
+    """Clone-then-mutate (same id, different content) is a miss, then its own entry."""
+    index = MessagePoolIndex()
+    msg = ChatMessageUser(content="hello")
+    mutated = msg.model_copy(update={"content": "changed"})
+    assert mutated.id == msg.id
+    index.add(msg, "hash-a", 0)
+    assert index.get(mutated) is None
+    index.add(mutated, "hash-b", 1)
+    assert index.get(mutated) == 1
+    assert index.get(msg) == 0
+    assert index.size == 2
+
+
+def test_message_pool_index_none_id_never_bucketed() -> None:
+    index = MessagePoolIndex()
+    msg = ChatMessageUser(content="hello")
+    msg.id = None
+    index.add(msg, "hash-a", 0)
+    assert index.get(msg) is None  # falls to hash path
+    assert index.get_by_hash("hash-a") == 0
+
+
+def test_message_pool_index_hash_dedup_across_ids() -> None:
+    """Same content, different id: second add maps to the same entry, size stays 1."""
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="same")
+    b = ChatMessageUser(content="same")
+    index.add(a, "hash-a", 0)
+    assert index.get(b) is None
+    assert index.get_by_hash("hash-a") == 0
+    index.add(b, "hash-a", 0)
+    assert index.get(b) == 0
+    assert index.size == 1
+
+
+def test_message_pool_index_mark_restore() -> None:
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="a")
+    index.add(a, "hash-a", 0)
+    mark = index.mark()
+    b = ChatMessageUser(content="b")
+    c = ChatMessageUser(content="same")
+    d = ChatMessageUser(content="same")
+    index.add(b, "hash-b", 1)
+    index.add(c, "hash-c", 2)
+    index.add(d, "hash-c", 2)  # bucket-only add (hash already present)
+    assert index.size == 3
+    index.restore(mark)
+    assert index.size == 1
+    assert index.get(a) == 0
+    assert index.get(b) is None
+    assert index.get(c) is None
+    assert index.get(d) is None
+    assert index.get_by_hash("hash-b") is None
+    assert index.get_by_hash("hash-c") is None
+    assert index.get_by_hash("hash-a") == 0
+
+
+def test_call_pool_index_prefix_match() -> None:
+    index = CallPoolIndex()
+    first: list[JsonValue] = [{"role": "user", "content": "a"}]
+    assert index.match_prefix(first) == []  # nothing to match before set_prev
+    index.add_hash("h-a", 0)
+    index.set_prev(first, [0])
+
+    second: list[JsonValue] = [
+        {"role": "user", "content": "a"},
+        {"role": "assistant", "content": "b"},
+    ]
+    assert index.match_prefix(second) == [0]  # equal-by-value, not identity
+    index.add_hash("h-b", 1)
+    index.set_prev(second, [0, 1])
+    assert index.match_prefix(second) == [0, 1]
+
+
+def test_call_pool_index_prefix_breaks_on_mismatch() -> None:
+    index = CallPoolIndex()
+    index.set_prev(
+        [{"content": "a"}, {"content": "b"}, {"content": "c"}],
+        [0, 1, 2],
+    )
+    # element 1 differs -> only index 0 reused, regardless of later equality
+    result: list[JsonValue] = [{"content": "a"}, {"content": "X"}, {"content": "c"}]
+    assert index.match_prefix(result) == [0]
+    # new list shorter than prev: fine
+    short: list[JsonValue] = [{"content": "a"}]
+    assert index.match_prefix(short) == [0]
+
+
+def test_call_pool_index_mark_restore() -> None:
+    index = CallPoolIndex()
+    index.add_hash("h-a", 0)
+    prev_one: list[JsonValue] = [{"content": "a"}]
+    index.set_prev(prev_one, [0])
+    mark = index.mark()
+
+    index.add_hash("h-b", 1)
+    index.add_hash("h-b", 1)  # duplicate add is a no-op
+    prev_two: list[JsonValue] = [{"content": "a"}, {"content": "b"}]
+    index.set_prev(prev_two, [0, 1])
+    assert index.size == 2
+
+    index.restore(mark)
+    assert index.size == 1
+    assert index.get_by_hash("h-b") is None
+    assert index.get_by_hash("h-a") == 0
+    # prefix state is dropped on restore (accelerator-only; a miss is safe,
+    # a stale ref to a rolled-back row is not)
+    after_restore: list[JsonValue] = [{"content": "a"}, {"content": "b"}]
+    assert index.match_prefix(after_restore) == []
+    # and the next set_prev/match_prefix cycle works normally
+    index.set_prev(after_restore, [0, 1])
+    assert index.match_prefix(after_restore) == [0, 1]
+
+
+def test_message_pool_index_restore_idempotent_and_mark_reusable() -> None:
+    index = MessagePoolIndex()
+    a = ChatMessageUser(content="a")
+    index.add(a, "hash-a", 0)
+    mark = index.mark()
+
+    b = ChatMessageUser(content="b")
+    index.add(b, "hash-b", 1)
+    index.restore(mark)
+    index.restore(mark)  # second restore with same mark: no-op
+    assert index.size == 1
+
+    # mark reuse after restore (the SQLite-retry pattern)
+    c = ChatMessageUser(content="c")
+    index.add(c, "hash-c", 1)
+    index.restore(mark)
+    assert index.size == 1
+    assert index.get(c) is None
+    assert index.get(a) == 0
+
+
+def test_message_pool_index_restore_pops_only_post_mark_bucket_entry() -> None:
+    """A bucket holding a pre-mark entry and a post-mark clone keeps the former."""
+    index = MessagePoolIndex()
+    msg = ChatMessageUser(content="original")
+    index.add(msg, "hash-orig", 0)
+    mark = index.mark()
+
+    mutated = msg.model_copy(update={"content": "mutated"})
+    index.add(mutated, "hash-mut", 1)
+    assert index.get(mutated) == 1
+    index.restore(mark)
+    assert index.get(msg) == 0
+    assert index.get(mutated) is None
+    assert index.get_by_hash("hash-mut") is None
+
+
+def test_call_pool_index_set_prev_copies_input() -> None:
+    """Caller-side mutation after set_prev must not corrupt prefix matching."""
+    index = CallPoolIndex()
+    msgs: list[JsonValue] = [{"content": "a"}]
+    indices = [0]
+    index.set_prev(msgs, indices)
+    msgs.append({"content": "b"})
+    indices.append(99)
+    query: list[JsonValue] = [{"content": "a"}, {"content": "b"}]
+    assert index.match_prefix(query) == [0]
+
+
+# ---------------------------------------------------------------------------
+# condense_model_event_with_indices tests
+# ---------------------------------------------------------------------------
+
+
+def _model_event(
+    input_msgs: Sequence[ChatMessage], call_msgs: list[JsonValue] | None = None
+) -> ModelEvent:
+    event = ModelEvent(
+        model="test",
+        input=list(input_msgs),
+        tools=[],
+        tool_choice="auto",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("test", "response"),
+    )
+    if call_msgs is not None:
+        event = event.model_copy(
+            update={
+                "call": ModelCall(
+                    request={"model": "test", "messages": call_msgs},
+                    response={"id": "r1"},
+                )
+            }
+        )
+    return event
+
+
+class _Recorder:
+    """Persistence callbacks that count invocations and assign positions."""
+
+    def __init__(self) -> None:
+        self.messages: list[ChatMessage] = []
+        self.calls: list[JsonValue] = []
+        self.walked_messages = 0
+        self.walked_calls = 0
+
+    def walk_message(self, msg: ChatMessage) -> ChatMessage:
+        self.walked_messages += 1
+        return msg.model_copy()
+
+    def walk_call_message(self, msg: JsonValue) -> JsonValue:
+        self.walked_calls += 1
+        return msg
+
+    def add_message(self, hash_value: str, walked: ChatMessage) -> int:
+        self.messages.append(walked)
+        return len(self.messages) - 1
+
+    def add_call(self, hash_value: str, walked: JsonValue) -> int:
+        self.calls.append(walked)
+        return len(self.calls) - 1
+
+
+def _condense(
+    event: ModelEvent,
+    msg_index: MessagePoolIndex,
+    call_index: CallPoolIndex,
+    recorder: _Recorder,
+) -> ModelEvent:
+    return condense_model_event_with_indices(
+        event,
+        messages=msg_index,
+        calls=call_index,
+        walk_message=recorder.walk_message,
+        walk_call_message=recorder.walk_call_message,
+        add_message=recorder.add_message,
+        add_call=recorder.add_call,
+    )
+
+
+def test_condense_helper_walks_only_new_messages() -> None:
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    history = [ChatMessageUser(content=f"msg {i}") for i in range(10)]
+    for k in range(1, 11):
+        event = _condense(_model_event(history[:k]), msg_index, call_index, recorder)
+        assert event.input == []
+        assert event.input_refs == [(0, k)]
+
+    # 10 unique messages: walked and pooled exactly once each, despite
+    # 55 message occurrences across the 10 events
+    assert recorder.walked_messages == 10
+    assert len(recorder.messages) == 10
+
+
+def test_condense_helper_call_prefix_diff() -> None:
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    wire: list[dict[str, JsonValue]] = [
+        {"role": "user", "content": f"m{i}"} for i in range(10)
+    ]
+    for k in range(1, 11):
+        # fresh dict objects each event, like providers produce
+        msgs: list[JsonValue] = [dict(m) for m in wire[:k]]
+        event = _condense(
+            _model_event([], call_msgs=msgs), msg_index, call_index, recorder
+        )
+        assert event.call is not None
+        assert event.call.call_refs == [(0, k)]
+        assert event.call.call_key == "messages"
+        assert "messages" not in event.call.request
+
+    assert recorder.walked_calls == 10
+    assert len(recorder.calls) == 10
+
+
+def test_condense_helper_preserves_passthrough_cases() -> None:
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    # empty input, no call -> unchanged
+    event = _model_event([])
+    result = _condense(event, msg_index, call_index, recorder)
+    assert result.input == [] and result.input_refs is None
+    assert recorder.walked_messages == 0
+
+    # already-condensed input refs -> untouched
+    condensed = _model_event([]).model_copy(update={"input_refs": [(0, 3)]})
+    result = _condense(condensed, msg_index, call_index, recorder)
+    assert result.input_refs == [(0, 3)]
+
+    # call with call_refs already set -> untouched
+    event = _model_event([], call_msgs=[{"content": "x"}])
+    assert event.call is not None
+    pre = event.call.model_copy(update={"call_refs": [(0, 1)], "request": {}})
+    event = event.model_copy(update={"call": pre})
+    result = _condense(event, msg_index, call_index, recorder)
+    assert result.call is not None and result.call.call_refs == [(0, 1)]
+    assert recorder.walked_calls == 0
+
+
+def test_condense_helper_duplicate_message_in_one_event() -> None:
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    msg = ChatMessageUser(content="dup")
+    event = _condense(_model_event([msg, msg]), msg_index, call_index, recorder)
+    assert event.input_refs == [(0, 1), (0, 1)]
+    assert len(recorder.messages) == 1
+
+
+def test_condense_helper_fresh_ids_bounded_index() -> None:
+    """Fresh objects/ids each turn (bridge-style agents) must not grow the index.
+
+    The identity bucket must stay bounded at the number of unique pool entries,
+    not grow with the number of events.
+    """
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    n = 20
+    for k in range(1, n + 1):
+        # Rebuild full history with fresh objects and fresh ids each event,
+        # simulating bridge-style scaffolds that never reuse message objects.
+        history = [ChatMessageUser(content=f"msg {i}") for i in range(k)]
+        _condense(_model_event(history), msg_index, call_index, recorder)
+
+    assert len(recorder.messages) == n  # content-deduped in the pool
+    assert msg_index.size == n
+    # White-box: identity buckets must not accumulate one entry per occurrence;
+    # each unique message should produce exactly one bucket entry.
+    assert sum(len(b) for b in msg_index._buckets.values()) == n
+
+
+def _heavy_image_message() -> ChatMessageUser:
+    payload = "data:image/png;base64," + "A" * (_BUCKET_CONTENT_LIMIT + 1)
+    return ChatMessageUser(
+        content=[ContentText(text="look at this"), ContentImage(image=payload)]
+    )
+
+
+def _assert_not_pinned(make_msg: Callable[[], ChatMessage]) -> None:
+    """Add a heavy message to a fresh index and prove it isn't retained.
+
+    Takes a factory rather than the message itself: a message passed as an
+    argument stays referenced from the caller's frame (and from pytest's
+    assertion-rewriting temporaries) on some Python versions, which would
+    make the weakref check fail even when the index itself holds nothing.
+    The add/lookup asserts run in an inner frame that has exited before
+    the collection check.
+    """
+    index = MessagePoolIndex()
+
+    def add_and_check() -> "weakref.ref[ChatMessage]":
+        msg = make_msg()
+        ref = weakref.ref(msg)
+        index.add(msg, "hash-heavy", 0)
+        assert index.get(msg) is None, "heavy message was bucketed"
+        assert index.get_by_hash("hash-heavy") == 0
+        return ref
+
+    ref = add_and_check()
+    gc.collect()
+    assert ref() is None, "index retained a reference to the heavy message"
+
+
+def test_heavy_tool_call_arguments_not_pinned() -> None:
+    """String content must not short-circuit the gate past tool-call payloads.
+
+    Regression: an assistant message with short string content and a
+    multi-MB tool-call argument measured as len(content) and was bucketed,
+    pinning the payload.
+    """
+    _assert_not_pinned(
+        lambda: ChatMessageAssistant(
+            content="ok",
+            tool_calls=[
+                ToolCall(
+                    id="1",
+                    function="f",
+                    arguments={"data": "X" * (_BUCKET_CONTENT_LIMIT + 1)},
+                )
+            ],
+        )
+    )
+
+
+def test_heavy_tool_call_view_not_pinned() -> None:
+    """Heavy ToolCallContent views nested inside tool calls are measured.
+
+    Regression: the field-enumerating gate measured only
+    ``tool_call.arguments``, so a heavy ``view.content`` slipped past it.
+    """
+    _assert_not_pinned(
+        lambda: ChatMessageAssistant(
+            content="ok",
+            tool_calls=[
+                ToolCall(
+                    id="1",
+                    function="f",
+                    arguments={},
+                    view=ToolCallContent(
+                        format="markdown",
+                        content="Y" * (_BUCKET_CONTENT_LIMIT + 1),
+                    ),
+                )
+            ],
+        )
+    )
+
+
+def test_cyclic_metadata_does_not_crash_gate() -> None:
+    """Arbitrary metadata can be cyclic or deeply nested; the scan must cap.
+
+    Cap-out reports heavy (not bucketed) — the safe, conservative
+    direction. Hash dedup still works.
+    """
+    cyclic: dict = {"a": 1}
+    cyclic["self"] = cyclic
+    msg = ChatMessageUser(content="hi", metadata=cyclic)
+
+    index = MessagePoolIndex()
+    index.add(msg, "hash-cyc", 0)
+    assert index.get_by_hash("hash-cyc") == 0
+    # cap-out must report heavy: a payload nested below the scan depth
+    # would otherwise be bucketed and pinned
+    assert index.get(msg) is None
+
+
+def test_message_pool_index_does_not_pin_heavy_messages() -> None:
+    """Messages with media-scale content must not be retained by the index.
+
+    Bucketed pre-walk objects are pinned for the sample's lifetime; for
+    base64 payloads that re-accumulates the memory bounded transcripts
+    (INSPECT_TRANSCRIPT_BOUNDED) exist to evict. Heavy messages are
+    recorded in the hash index only.
+    """
+    _assert_not_pinned(_heavy_image_message)
+
+
+def test_message_pool_index_heavy_add_mark_restore() -> None:
+    """Hash-only (unbucketed) adds must unwind cleanly on restore."""
+    index = MessagePoolIndex()
+    light = ChatMessageUser(content="light")
+    index.add(light, "hash-light", 0)
+    mark = index.mark()
+
+    heavy = _heavy_image_message()
+    index.add(heavy, "hash-heavy", 1)
+    assert index.size == 2
+    assert index.get(heavy) is None  # hash-only: heavy is never bucketed
+
+    index.restore(mark)
+    assert index.size == 1
+    assert index.get_by_hash("hash-heavy") is None
+    assert index.get(light) == 0
+
+
+def test_condense_helper_heavy_message_dedups_via_hash_path() -> None:
+    """A heavy message re-sent across events pools once via hash dedup."""
+    msg_index = MessagePoolIndex()
+    call_index = CallPoolIndex()
+    recorder = _Recorder()
+
+    heavy = _heavy_image_message()
+    light = ChatMessageUser(content="hello")
+
+    first = _condense(_model_event([heavy]), msg_index, call_index, recorder)
+    assert first.input_refs == [(0, 1)]
+    second = _condense(_model_event([heavy, light]), msg_index, call_index, recorder)
+    assert second.input_refs == [(0, 2)]
+
+    # heavy message pooled once but re-walked on the second event
+    # (the deliberate cost of not pinning it)
+    assert len(recorder.messages) == 2
+    assert recorder.walked_messages == 3
+
+
+# ---------------------------------------------------------------------------
+# Serialization-equivalent equality (== conflates 0/0.0 and True/1)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [({"n": 0}, {"n": 0.0}), ({"flag": True}, {"flag": 1})],
+    ids=["int-vs-float", "bool-vs-int"],
+)
+def test_message_index_distinguishes_json_distinct_metadata(
+    first: dict[str, JsonValue], second: dict[str, JsonValue]
+) -> None:
+    """Python-equal but JSON-distinct metadata must not merge.
+
+    The values hash differently (json.dumps emits different bytes), so a
+    merge would reuse a pool entry whose stored bytes round-trip to the
+    other value — silent data corruption.
+    """
+    msg = ChatMessageUser(content="hi", metadata=dict(first))
+    variant = msg.model_copy(update={"metadata": dict(second)})
+    assert msg == variant  # python equality conflates them...
+
+    index = MessagePoolIndex()
+    index.add(msg, "hash-first", 0)
+    assert index.get(variant) is None  # ...the index must not
+    assert index.get(msg) == 0  # true re-send still hits
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        ({"role": "user", "tokens": 0}, {"role": "user", "tokens": 0.0}),
+        ({"role": "user", "ok": True}, {"role": "user", "ok": 1}),
+    ],
+    ids=["int-vs-float", "bool-vs-int"],
+)
+def test_call_prefix_breaks_on_json_distinct_values(
+    first: dict[str, JsonValue], second: dict[str, JsonValue]
+) -> None:
+    """Python-equal, JSON-distinct prefix drift must break the match.
+
+    Reusing the prior pool index would round-trip the old value.
+    """
+    index = CallPoolIndex()
+    index.add_hash("h-first", 0)
+    index.set_prev([first], [0])
+    assert index.match_prefix([dict(first)]) == [0]  # equal-by-value still matches
+    assert index.match_prefix([second]) == []  # json-distinct must not
+
+
+def test_strict_eq_distinguishes_json_distinct_dict_keys() -> None:
+    """Key-axis conflation: {0: x} and {0.0: x} serialize differently.
+
+    Dict lookup matches keys by ==, so the value-axis type gate alone
+    would merge messages whose metadata dicts differ only in numeric/bool
+    key type — the same corruption class as values, on keys.
+    """
+    base = ChatMessageUser(content="hi", metadata={"k": {0: "x"}})
+    variant = base.model_copy(update={"metadata": {"k": {0.0: "x"}}})
+    assert base == variant  # python equality conflates them...
+
+    index = MessagePoolIndex()
+    index.add(base, "hash-first", 0)
+    assert index.get(variant) is None  # ...the index must not
+    assert index.get(base) == 0
+    # bool/int key conflation too
+    b1 = ChatMessageUser(content="hi", metadata={"k": {True: "x"}})
+    b2 = b1.model_copy(update={"metadata": {"k": {1: "x"}}})
+    index2 = MessagePoolIndex()
+    index2.add(b1, "hash-b1", 0)
+    assert index2.get(b2) is None

--- a/tests/log/test_transcript_event_store.py
+++ b/tests/log/test_transcript_event_store.py
@@ -388,6 +388,12 @@ def test_transcript_event_store_reuses_pending_message_positions_on_update(
 def test_transcript_event_store_discards_pending_cache_on_rollback(
     tmp_path: Path,
 ) -> None:
+    """A rolled-back merge must not leave stale index state behind.
+
+    Failure mode under a broken rollback: the retry sees positions that were
+    rolled back from the DB but still registered in the in-memory index,
+    producing duplicate pool rows or refs dangling at nonexistent positions.
+    """
     transcript_store = TranscriptEventStore(tmp_path / TRANSCRIPT_EVENT_STORE)
     message = ChatMessageUser(content="question")
     event = make_model_event([message])
@@ -399,11 +405,20 @@ def test_transcript_event_store_discards_pending_cache_on_rollback(
         except RuntimeError:
             pass
 
+    # retry with same uuid so the event row is an upsert, not a duplicate insert
     retry = make_model_event([message], uuid=event.uuid)
-    retry.pending = True
+    retry.pending = False
     transcript_store.merge_event(retry, attachment_lookup=_no_attachment)
 
     assert transcript_store.counts().message_pool == 1
+
+    # the stored event must reference the retry's pool position, not a stale one
+    work_dir = tmp_path / "out"
+    work_dir.mkdir()
+    _write_transcript_files(transcript_store, work_dir)
+    events = _exported_events(work_dir)
+    assert len(events) == 1
+    assert events[0]["input_refs"] == [[0, 1]]
 
 
 def test_transcript_event_store_deduplicates_messages_using_pool_hash(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Builds on #4222 (first 7 commits are that PR; review the commits from "feat(pool): message-side prefix state…" onward).

When an agent gets stuck emitting identical content every turn (e.g. scaffold sends "continue", model replies "Done", for thousands of turns, with the full history re-sent per model event), event-pool dedup maps the alternating history onto alternating pool positions 0,1,0,1,…. Range compression can't compress that — one ref range per turn per event — so refs storage is O(turns²). Measured: refs JSON is 96–98% of the buffer DB (133 MB at 2,000 turns, 2.2 GB at 8,000, ~85 GB extrapolated at 50K); the disk fills before the eval's limits trip. Each duplicate-content message also re-hashes on every event (~N²/2 hashes). #4222's O(new-messages) claim assumes fresh content per turn; this workload breaks the assumption and degrades to main's behavior.

The root cause: the pool dedups on content hash as a proxy for *occurrence* identity. Dedup of the same logical occurrence re-sent across events is essential; dedup of distinct occurrences with coincidentally equal content is what creates the alternating positions.

### What is the new behavior?

Pool positions identify logical occurrences. The condense paths (per-event helper, batch functions) classify each model event's input against the previous event's input:

- **Pure append** (the previous input is a full prefix of the new one, matched by identity then strict equality): suffix messages are new occurrences and mint fresh pool rows without consulting the content-hash index. Positions stay monotone; every event's refs compress to a single range.
- **Any break** (first event, trim, compaction, resume, fresh-id-rebuilt histories): exactly today's path — identity bucket, then hash dedup. Bridge-style and sliding-window scaffolds keep current behavior and pool sizes.

Measured on the 1,000-turn loop workload: buffer DB 34 MB → 1.5 MB, refs collapse to `[[0, 2000]]`, hashing linear. A probe on a real react-style tool loop showed every event after the first taking the append path.

Storage changes are confined to the transient stores; the `.eval` format and all read paths are untouched (they resolve by position, never by hash):

- Buffer DB: pool tables drop their hash-uniqueness constraints (buffer DBs are per-process transient; no migration needed).
- Transcript event store (persists in checkpoint context dirs): drops `UNIQUE(hash)` with an automatic, atomic table-rebuild migration on open that preserves positions exactly; checkpoint seeding merges become positional so occurrence rows round-trip through checkpoint/resume.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Old transcript stores are migrated automatically on open; the `.eval` format is unchanged. Behavior delta: re-sent-history loops with repeated content now store one small pool row per occurrence instead of merging them (linear, a few hundred KB where it previously saved bytes by aliasing positions).

### Other information:

Out of scope (documented in the module docstring): a scaffold that rebuilds the entire history with fresh objects *and* emits duplicate content still takes the break path (pydantic equality includes `id`), so its refs still alternate — fixing that would require id-excluding comparison, which reintroduces the O(N²) serialization this PR removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)