### PR TITLE
Agent bridge: preserve NamespaceToolParam through to the Responses API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Agent bridge: preserve `NamespaceToolParam` grouping through to the OpenAI Responses API. Namespaced tools (e.g. codex's `multi_agent_v1.spawn_agent`) were previously flattened to `functions.<name>`, which OpenAI rejects on models that reserve those names for encrypted tool use.
 - Anthropic: Support for server-side refusal fallback via the `fallback_models` generate config (Claude 5+ on the first-party Anthropic API).
 - Anthropic: `cache_ttl` model arg for specifying the prompt cache TTL ("5m" or "1h").
 - Anthropic: Support for web search dynamic filtering on Claude 4.6 and later models.

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -95,6 +95,7 @@ from inspect_ai.model._internal import (
 from inspect_ai.model._model import Model, ModelName
 from inspect_ai.model._model_output import StopReason
 from inspect_ai.model._openai_responses import (
+    RESPONSES_NAMESPACE,
     TOOL_SEARCH_NAME,
     TOOL_SEARCH_OPTIONS_MARKER,
     assistant_internal,
@@ -512,6 +513,8 @@ def tools_from_responses_tool(
     locate the tool on the return trip.
     """
     if is_namespace_tool_param(tool_param):
+        ns_name = tool_param.get("name")
+        ns_desc = tool_param.get("description") or ns_name
         flattened: list[ToolInfo | Tool] = []
         for inner in tool_param.get("tools", []):
             inner_param = cast(ToolParam, inner)
@@ -519,6 +522,16 @@ def tools_from_responses_tool(
                 inner_param, web_search_providers, code_execution_providers
             )
             if inner_tool is not None:
+                # Stash the namespace so openai_responses_tools can re-group
+                # into a NamespaceToolParam on the outgoing request. Without
+                # this the tool reaches the API flat as functions.<name>,
+                # which OpenAI rejects on models that reserve those names for
+                # encrypted tool use (e.g. codex's multi_agent_v1.spawn_agent).
+                if isinstance(inner_tool, ToolInfo) and ns_name:
+                    inner_tool.options = {
+                        **(inner_tool.options or {}),
+                        RESPONSES_NAMESPACE: (ns_name, ns_desc),
+                    }
                 flattened.append(inner_tool)
         return flattened
     tool = tool_from_responses_tool(

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -48,7 +48,12 @@ from openai.types.responses import (
     WebSearchToolParam,
 )
 from openai.types.responses import Response as OpenAIResponse
-from openai.types.responses.namespace_tool_param import NamespaceToolParam
+from openai.types.responses.namespace_tool_param import (
+    NamespaceToolParam,
+)
+from openai.types.responses.namespace_tool_param import (
+    Tool as NamespaceInnerTool,
+)
 from openai.types.responses.response import IncompleteDetails
 from openai.types.responses.response_code_interpreter_tool_call import (
     OutputImage,
@@ -495,15 +500,44 @@ def openai_responses_tool_choice(
             )
 
 
+RESPONSES_NAMESPACE = "__responses_namespace__"
+"""``ToolInfo.options`` key under which the agent bridge stashes the
+``(name, description)`` of the ``NamespaceToolParam`` a tool was flattened
+from, so that :func:`openai_responses_tools` can re-group it on the outgoing
+request. Without this, namespaced tools (e.g. codex's
+``multi_agent_v1.spawn_agent``) are sent flat as ``functions.spawn_agent``,
+which OpenAI's reserved-name validation rejects on models configured for
+encrypted tool use."""
+
+
 def openai_responses_tools(
     tools: list[ToolInfo],
     model_name: str,
     config: GenerateConfig,
     is_latest: bool = False,
 ) -> list[ToolParam]:
-    result = [
-        _tool_param_for_tool_info(tool, model_name, config, is_latest) for tool in tools
-    ]
+    result: list[ToolParam] = []
+    namespaces: dict[tuple[str, str], list[FunctionToolParam | CustomToolParam]] = {}
+    for tool in tools:
+        param = _tool_param_for_tool_info(tool, model_name, config, is_latest)
+        ns = (tool.options or {}).get(RESPONSES_NAMESPACE)
+        if isinstance(ns, tuple) and len(ns) == 2:
+            # Only function/custom tools may live inside a NamespaceToolParam;
+            # the bridge only stashes RESPONSES_NAMESPACE on those, so cast.
+            namespaces.setdefault(ns, []).append(
+                cast(FunctionToolParam | CustomToolParam, param)
+            )
+        else:
+            result.append(param)
+    for (ns_name, ns_desc), ns_tools in namespaces.items():
+        result.append(
+            NamespaceToolParam(
+                type="namespace",
+                name=ns_name,
+                description=ns_desc,
+                tools=cast(list[NamespaceInnerTool], ns_tools),
+            )
+        )
 
     # Add at most one image_generation tool if image output modality requested
     img_config = image_output_config(config.modalities)

--- a/tests/agent/test_bridge_namespace_tool.py
+++ b/tests/agent/test_bridge_namespace_tool.py
@@ -10,6 +10,7 @@ from inspect_ai.agent._bridge.responses_impl import (
 )
 from inspect_ai.model._chat_message import ChatMessageAssistant
 from inspect_ai.model._openai_responses import (
+    RESPONSES_NAMESPACE,
     is_custom_tool_param,
     is_function_tool_param,
     is_namespace_tool_param,
@@ -68,6 +69,23 @@ def test_tools_from_responses_tool_flattens_namespace():
     assert [t.name for t in tools] == ["submit_pov", "submit_patch"]
     for t in tools:
         assert isinstance(t, ToolInfo)
+
+
+def test_tools_from_responses_tool_stashes_namespace_on_options():
+    ns = {
+        "type": "namespace",
+        "name": "multi_agent_v1",
+        "description": "Multi-agent orchestration tools",
+        "tools": [_function_tool("spawn_agent"), _custom_tool("wait_agent")],
+    }
+    tools = tools_from_responses_tool(ns, {}, {})
+    for t in tools:
+        assert isinstance(t, ToolInfo)
+        assert t.options is not None
+        assert t.options[RESPONSES_NAMESPACE] == (
+            "multi_agent_v1",
+            "Multi-agent orchestration tools",
+        )
 
 
 def test_tools_from_responses_tool_single_function():

--- a/tests/model/providers/test_openai_responses.py
+++ b/tests/model/providers/test_openai_responses.py
@@ -1109,6 +1109,47 @@ def test_openai_responses_tools_image_modality():
     assert len(tools) == 0
 
 
+def test_openai_responses_tools_regroups_namespace():
+    """ToolInfos carrying RESPONSES_NAMESPACE are re-grouped into a NamespaceToolParam."""
+    from inspect_ai.model._generate_config import GenerateConfig
+    from inspect_ai.model._openai_responses import (
+        RESPONSES_NAMESPACE,
+        openai_responses_tools,
+    )
+    from inspect_ai.tool._tool_info import ToolInfo
+
+    ns = ("multi_agent_v1", "Multi-agent orchestration tools")
+    tools = openai_responses_tools(
+        [
+            ToolInfo(name="exec_command", description="exec"),
+            ToolInfo(
+                name="spawn_agent",
+                description="spawn",
+                options={RESPONSES_NAMESPACE: ns},
+            ),
+            ToolInfo(
+                name="wait_agent",
+                description="wait",
+                options={RESPONSES_NAMESPACE: ns},
+            ),
+        ],
+        "gpt-5",
+        GenerateConfig(),
+    )
+
+    flat = [t for t in tools if t["type"] == "function"]
+    assert len(flat) == 1
+    assert flat[0]["name"] == "exec_command"
+
+    namespaces = [t for t in tools if t["type"] == "namespace"]
+    assert len(namespaces) == 1
+    assert namespaces[0]["name"] == "multi_agent_v1"
+    assert namespaces[0]["description"] == "Multi-agent orchestration tools"
+    inner = list(namespaces[0]["tools"])
+    assert [t["name"] for t in inner] == ["spawn_agent", "wait_agent"]
+    assert all(t["type"] == "function" for t in inner)
+
+
 def test_reasoning_only_fallback_enabled():
     """When fallback is enabled and content is reasoning-only, NO_CONTENT text is appended."""
     model_info = ModelInfo()  # default: has_reasoning_only_fallback() == True


### PR DESCRIPTION
## Symptom

Running codex (or any scaffold that uses `NamespaceToolParam`) through the agent bridge against OpenAI models configured for "encrypted tool use" fails with:

```
400: "Function 'functions.spawn_agent' is reserved for encrypted tool use by this model and must match the configured declaration."
```

The namespaced form `multi_agent_v1.spawn_agent` is accepted with the plain v1 schema and returns plaintext args; only the flat `functions.spawn_agent` form trips the reserved-name check. (The inverse polarity — gpt-5.4 rejecting the *encrypted* declaration — is openai/codex#26753.)

## Root cause

`tools_from_responses_tool()` in the bridge flattens `NamespaceToolParam` into bare `ToolInfo`s, tracking the namespace in a separate `tool_namespaces` map only so it can restore `ResponseFunctionToolCall.namespace` on the *return* trip to the scaffold. On the *outgoing* request, `openai_responses_tools()` only ever emits flat `FunctionToolParam`s, so a tool the scaffold declared as `multi_agent_v1.spawn_agent` reaches the API as `functions.spawn_agent`.

## Fix

- When the bridge flattens a `NamespaceToolParam`, stash the originating `(name, description)` on each inner `ToolInfo.options[RESPONSES_NAMESPACE]`.
- `openai_responses_tools()` re-groups any `ToolInfo` carrying that key back into a single `NamespaceToolParam` per namespace; un-namespaced tools are emitted flat as before.

Verified end-to-end against a predeployment model that exhibits the reserved-name behaviour: with this change the bridge round-trips codex's `multi_agent_v1` namespace and the request is accepted.

## Tests

- `test_openai_responses_tools_regroups_namespace` — three `ToolInfo`s (one flat, two namespaced) produce one flat `FunctionToolParam` + one `NamespaceToolParam` containing both namespaced tools.
- `test_tools_from_responses_tool_stashes_namespace_on_options` — flattening a `NamespaceToolParam` writes `RESPONSES_NAMESPACE` onto each inner `ToolInfo.options`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
