### PR TITLE
docs: fix broken Eval Options link in options.qmd

### DIFF
--- a/docs/options.qmd
+++ b/docs/options.qmd
@@ -12,7 +12,7 @@ Inspect evaluations have a large number of options available for logging, tuning
 
 2.  Options that you want to tweak per-eval to accommodate particular scenarios.
 
-For the former, we recommend you specify these options in a `.env` file within your project directory, which is covered in the section below. See the [Eval Options](#eval-options) for details on all available options.
+For the former, we recommend you specify these options in a `.env` file within your project directory, which is covered in the section below. See [Specifying Options](#specifying-options) for details on all available options.
 
 ## .env Files
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

In `docs/options.qmd`, the Overview section links to "Eval Options" via the anchor `#eval-options`. No heading with that anchor has ever existed in the file (the link was introduced broken in #1215), so it resolves to nothing.

### What is the new behavior?

The link now points at the existing **Specifying Options** section (`#specifying-options`), which is the section that actually documents all available options — matching the surrounding text ("details on all available options"). Link text updated to "Specifying Options" to match the target.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Docs-only change; one-line edit to `docs/options.qmd`.
