### PR TITLE
Hooks: allow override_api_key to supply a stable account_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Hooks: `override_api_key` may now return an `ApiKeyOverrideResult` with a stable `account_id`, used to scope the connection pool when the credential itself is short-lived.
 - Anthropic: Support for server-side refusal fallback via the `fallback_models` generate config (Claude 5+ on the first-party Anthropic API).
 - Anthropic: `cache_ttl` model arg for specifying the prompt cache TTL ("5m" or "1h").
 - Anthropic: Support for web search dynamic filtering on Claude 4.6 and later models.

--- a/docs/extensions-hooks.qmd
+++ b/docs/extensions-hooks.qmd
@@ -188,3 +188,17 @@ class ApiKeyFetcher(Hooks):
 def fetch_aws_secret(aws_arn: str) -> str:
     ...
 ```
+
+If your hook returns short-lived or rotating credentials, return an `ApiKeyOverrideResult` with a stable `account_id` (e.g. the secret ARN) so the model's connection pool is scoped by account rather than by the rotating credential:
+
+``` python
+from inspect_ai.hooks import ApiKeyOverride, ApiKeyOverrideResult
+
+def override_api_key(self, data: ApiKeyOverride) -> ApiKeyOverrideResult | None:
+    if data.value.startswith("arn:aws:secretsmanager:"):
+        return ApiKeyOverrideResult(
+            value=fetch_short_lived_credential(data.value),
+            account_id=data.value,
+        )
+    return None
+```

--- a/docs/reference/inspect_ai.hooks.qmd
+++ b/docs/reference/inspect_ai.hooks.qmd
@@ -11,6 +11,7 @@ description: Hook into Inspect lifecycle events.
 ## Hook Data
 
 ### ApiKeyOverride
+### ApiKeyOverrideResult
 ### ModelUsageData
 ### EvalSetStart
 ### EvalSetEnd

--- a/src/inspect_ai/hooks/__init__.py
+++ b/src/inspect_ai/hooks/__init__.py
@@ -1,5 +1,6 @@
 from inspect_ai.hooks._hooks import (
     ApiKeyOverride,
+    ApiKeyOverrideResult,
     BeforeModelGenerate,
     EvalSetEnd,
     EvalSetStart,
@@ -22,6 +23,7 @@ from inspect_ai.hooks._hooks import (
 
 __all__ = [
     "ApiKeyOverride",
+    "ApiKeyOverrideResult",
     "BeforeModelGenerate",
     "ModelCacheUsageData",
     "Hooks",

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -312,6 +312,22 @@ class ApiKeyOverride:
     """The original value of the environment variable."""
 
 
+@dataclass(frozen=True)
+class ApiKeyOverrideResult:
+    """Result of an `override_api_key` hook."""
+
+    value: str
+    """The new API key value to use."""
+    account_id: str | None = None
+    """Stable identifier for the quota/account this credential draws on.
+
+    When set, this scopes the model's connection pool in place of the API key
+    itself. Hooks that return short-lived or rotating credentials should set
+    this so concurrency limits remain stable across refreshes and shared
+    across model instances on the same account.
+    """
+
+
 class Hooks:
     """Base class for hooks.
 
@@ -521,17 +537,25 @@ class Hooks:
         """
         pass
 
-    def override_api_key(self, data: ApiKeyOverride) -> str | None:
+    def override_api_key(
+        self, data: ApiKeyOverride
+    ) -> str | ApiKeyOverrideResult | None:
         """Optionally override an API key.
 
         When overridden, this method may return a new API key value which will be used
         in place of the original one during the eval.
 
+        Hooks that return short-lived or rotating credentials should return an
+        `ApiKeyOverrideResult` with `account_id` set to a stable identifier for
+        the underlying account, so the model's connection pool is scoped by
+        account rather than by the rotating credential.
+
         Args:
             data: Api key override data.
 
         Returns:
-            str | None: The new API key value to use, or None to use the original value.
+            The new API key value (as a string or `ApiKeyOverrideResult`), or
+            None to leave the original value in place.
         """
         return None
 
@@ -919,21 +943,24 @@ def has_api_key_override() -> bool:
     return False
 
 
-def override_api_key(env_var_name: str, value: str) -> str | None:
+def override_api_key(env_var_name: str, value: str) -> ApiKeyOverrideResult | None:
     data = ApiKeyOverride(env_var_name=env_var_name, value=value)
     for hook in get_all_hooks():
         if not hook.enabled():
             continue
         try:
             overridden = hook.override_api_key(data)
-            if overridden is not None:
+            if isinstance(overridden, str):
+                return ApiKeyOverrideResult(value=overridden)
+            elif overridden is not None:
                 return overridden
         except Exception as ex:
             logger.warning(
                 f"Exception calling override_api_key on hook '{hook.__class__.__name__}': {ex}"
             )
     # If none have been overridden, fall back to legacy behaviour.
-    return override_api_key_legacy(env_var_name, value)
+    legacy = override_api_key_legacy(env_var_name, value)
+    return ApiKeyOverrideResult(value=legacy) if legacy is not None else None
 
 
 _hooks_cache: list[Hooks] = []

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -216,6 +216,12 @@ class ModelAPI(abc.ABC):
         self.base_url = base_url
         self.api_key = api_key
         self.api_key_vars = api_key_vars
+        self.account_id: str | None = None
+        """Stable account identifier supplied by an `override_api_key` hook.
+
+        Used to scope the connection pool when the credential itself is
+        short-lived; remains `None` when no hook supplies one.
+        """
         self._apply_api_key_overrides()
 
     def _apply_api_key_overrides(self) -> None:
@@ -229,7 +235,8 @@ class ModelAPI(abc.ABC):
             if api_key is not None:
                 override = override_api_key(key, api_key)
                 if override is not None:
-                    api_key = override
+                    api_key = override.value
+                    self.account_id = override.account_id or self.account_id
             # otherwise look it up in the environment and
             # override it if it has a value
             else:
@@ -237,14 +244,16 @@ class ModelAPI(abc.ABC):
                 if value is not None:
                     override = override_api_key(key, value)
                     if override is not None:
-                        os.environ[key] = override
+                        os.environ[key] = override.value
+                        self.account_id = override.account_id or self.account_id
                 # When a hook is registered but no API key exists anywhere,
                 # still call the hook so it can provide credentials from its
                 # own source (e.g. OAuth tokens, vault, etc.)
                 elif has_api_key_override():
                     override = override_api_key(key, "")
                     if override is not None:
-                        api_key = override
+                        api_key = override.value
+                        self.account_id = override.account_id or self.account_id
 
         # set any explicitly specified api key
         self.api_key = api_key

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -194,6 +194,13 @@ class ModelAPI(abc.ABC):
     https://inspect.aisi.org.uk/models.html#model-args)
     """
 
+    account_id: str | None = None
+    """Stable account identifier supplied by an `override_api_key` hook.
+
+    Used to scope the connection pool when the credential itself is
+    short-lived; remains `None` when no hook supplies one.
+    """
+
     def __init__(
         self,
         model_name: str,
@@ -216,12 +223,6 @@ class ModelAPI(abc.ABC):
         self.base_url = base_url
         self.api_key = api_key
         self.api_key_vars = api_key_vars
-        self.account_id: str | None = None
-        """Stable account identifier supplied by an `override_api_key` hook.
-
-        Used to scope the connection pool when the credential itself is
-        short-lived; remains `None` when no hook supplies one.
-        """
         self._apply_api_key_overrides()
 
     def _apply_api_key_overrides(self) -> None:

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1231,7 +1231,7 @@ class AnthropicAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.service_model_name()}"
+        return f"{self.account_id or self.api_key}:{self.service_model_name()}"
 
     def service_model_name(self) -> str:
         """Model name without any service prefix."""

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -346,7 +346,7 @@ class AzureAIAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        return f"{self.api_key}{self.model_name}"
+        return f"{self.account_id or self.api_key}{self.model_name}"
 
     def service_model_name(self) -> str:
         """Model name without any org prefix, for API calls."""

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -740,7 +740,7 @@ class GoogleGenAIAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.account_id or self.api_key}:{self.model_name}"
 
     @override
     def tool_result_images(self) -> bool:

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -328,7 +328,7 @@ class GrokAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.service_model_name()}"
+        return f"{self.account_id or self.api_key}:{self.service_model_name()}"
 
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, grpc.RpcError):

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -280,7 +280,7 @@ class GroqAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.account_id or self.api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -290,7 +290,7 @@ class MistralAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.account_id or self.api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -605,7 +605,7 @@ class OpenAIAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.account_id or self.api_key}:{self.model_name}"
 
     @override
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -333,7 +333,7 @@ class OpenAICompatibleAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.account_id or self.api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -327,7 +327,7 @@ class TogetherRESTAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.account_id or self.api_key}:{self.model_name}"
 
     # Together uses a default of 512 so we bump it up
     @override

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -494,7 +494,9 @@ def test_has_api_key_override_multiple_hooks(
 def test_api_key_override(mock_hooks: MockHooks) -> None:
     overridden = override_api_key("TEST_VAR", "test_value")
 
-    assert overridden == "mocked-TEST_VAR-test_value"
+    assert overridden is not None
+    assert overridden.value == "mocked-TEST_VAR-test_value"
+    assert overridden.account_id is None
 
 
 def test_api_key_override_falls_back_to_legacy(mock_hooks: MockHooks) -> None:
@@ -509,7 +511,8 @@ def test_api_key_override_falls_back_to_legacy(mock_hooks: MockHooks) -> None:
         ):
             overridden = override_api_key("TEST_VAR", "test_value")
 
-    assert overridden == "legacy-TEST_VAR-test_value"
+    assert overridden is not None
+    assert overridden.value == "legacy-TEST_VAR-test_value"
 
 
 def test_init_hooks_can_be_called_multiple_times(mock_hooks: MockHooks) -> None:

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -5,7 +5,7 @@ import pytest
 from inspect_ai import Task, eval
 from inspect_ai._util.registry import _registry, registry_lookup
 from inspect_ai.dataset import Sample
-from inspect_ai.hooks import ApiKeyOverride, Hooks, hooks
+from inspect_ai.hooks import ApiKeyOverride, ApiKeyOverrideResult, Hooks, hooks
 from inspect_ai.model import (
     ChatMessage,
     GenerateConfig,
@@ -73,6 +73,9 @@ class Mock401API(ModelAPI):
         """Retry on our mock 401 exception."""
         return isinstance(ex, Mock401Exception)
 
+    def connection_key(self) -> str:
+        return f"{self.account_id or self.api_key}:{self.model_name}"
+
 
 class MockRefreshTokenHook(Hooks):
     def __init__(self) -> None:
@@ -138,3 +141,56 @@ def test_reactive_token_refresh_on_401(mock_refresh_token_hook: MockRefreshToken
     finally:
         # Remove the provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mock401"]
+
+
+class MockAccountIdHook(Hooks):
+    def __init__(self) -> None:
+        self.call_count = 0
+
+    def override_api_key(self, data: ApiKeyOverride) -> ApiKeyOverrideResult | None:
+        if data.env_var_name != "TEST_API_KEY":
+            return None
+        self.call_count += 1
+        return ApiKeyOverrideResult(
+            value=f"token-{self.call_count}", account_id="account-a"
+        )
+
+
+@pytest.fixture
+def mock_account_id_hook() -> Generator[MockAccountIdHook, None, None]:
+    @hooks("test_account_id", description="Account-id override hook")
+    def get_hook() -> type[MockAccountIdHook]:
+        return MockAccountIdHook
+
+    hook = registry_lookup("hooks", "test_account_id")
+    assert isinstance(hook, MockAccountIdHook)
+    try:
+        yield hook
+    finally:
+        del _registry["hooks:test_account_id"]
+
+
+def test_account_id_scopes_connection_key(
+    mock_account_id_hook: MockAccountIdHook,
+) -> None:
+    """connection_key is stable across instances and refreshes given an account_id."""
+
+    @modelapi(name="mock401_account")
+    def mock401() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        a = get_model("mock401_account/test", api_key="seed", fail_count=2)
+        a_key_before = a.api.connection_key()
+        b = get_model("mock401_account/test", api_key="seed", memoize=False)
+
+        assert a.api.api_key == "token-1"
+        assert b.api.api_key == "token-2"
+        assert a.api.connection_key() == b.api.connection_key() == "account-a:test"
+
+        log = eval(Task(dataset=[Sample(input="t", target="t")]), model=a)[0]
+        assert log.status == "success"
+        assert a.api.api_key == "token-4"
+        assert a.api.connection_key() == a_key_before
+    finally:
+        del _registry["modelapi:mock401_account"]


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [x] Docs

### What is the current behavior?
`override_api_key` hooks return a `str`. Providers scope their connection pool by `f"{self.api_key}:{self.model_name}"`. When a hook returns short-lived credentials and refreshes them on auth retry, `self.api_key` changes, so the pool key changes — the adaptive controller's learned state is discarded and a fresh pool is created at the default size. Separate `Model` instances on the same account also each get their own pool, since each construction calls the hook and may receive a distinct credential.

### What is the new behavior?
`override_api_key` may return an `ApiKeyOverrideResult(value, account_id)`. When `account_id` is set, providers use it (instead of the credential) in `connection_key()`, so the pool stays stable across refreshes and is shared across instances on the same account. Hooks that return a plain `str` are unchanged.

### Does this PR introduce a breaking change?
No. Existing hooks returning `str | None` continue to work; `account_id` defaults to `None` which preserves current behavior.

### Other information:
