### PR TITLE
evalset: exclude runtime GenerateConfig knobs from model_roles in task_identifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - SageMaker: Fix streaming handler dropping reasoning tokens from thinking models.
 - Model API: Record model fallbacks as a typed `ModelOutput.fallback` and roll them up per-sample on `EvalSample.model_fallbacks` (and sample summaries); expose a `fallbacks` count column in `samples_df()`.
 - Agent Bridge: Preserve `NamespaceToolParam` grouping through to the OpenAI Responses API.
+- Eval Set: `task_identifier` now excludes runtime-only `GenerateConfig` fields from `model_roles` configs (matching the existing exclusion for the primary model), and adds `adaptive_connections`, `cache`, and `cache_prompt` to the excluded set — so tuning a role's concurrency or caching no longer breaks resume.
 - Adaptive Connections: Raise the default minimum from 4 to 10.
 - Control Channel: `inspect eval` / `inspect eval-set` now bind a per-process control server (AF_UNIX, default on) exposing a read surface for the live run. New `inspect ctl` commands let another process (CLI, scripts, agents) observe a running eval / eval-set.
 - Transcript: Reuse a persistent per-thread SQLite connection in the realtime sample buffer database.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Eval Set: `task_identifier` now excludes runtime-only `GenerateConfig` fields (`max_connections`, `max_retries`, etc.) from `model_roles` configs, matching the existing exclusion for the primary model — so tuning a role's concurrency no longer breaks resume.
+- Eval Set: `task_identifier` now excludes runtime-only `GenerateConfig` fields from `model_roles` configs (matching the existing exclusion for the primary model), adds `adaptive_connections`, `cache`, and `cache_prompt` to the excluded set, and excludes `base_url` from the `model_roles` hash — so tuning a role's concurrency, caching, or endpoint URL no longer breaks resume. `TASK_IDENTIFIER_VERSION` bumped to 2.
 — Inspect View: Fix log-list grid columns snapping back to default widths while data loads
 — Inspect View: Fix transcript deep links across timelines, approvals, collapsed regions, and lanes; add event label pills.
 — Inspect View:  Improve tool input density

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - SageMaker: Fix streaming handler dropping reasoning tokens from thinking models.
 - Model API: Record model fallbacks as a typed `ModelOutput.fallback` and roll them up per-sample on `EvalSample.model_fallbacks` (and sample summaries); expose a `fallbacks` count column in `samples_df()`.
 - Agent Bridge: Preserve `NamespaceToolParam` grouping through to the OpenAI Responses API.
-- Eval Set: `task_identifier` now excludes runtime-only `GenerateConfig` fields from `model_roles` configs (matching the existing exclusion for the primary model), and adds `adaptive_connections`, `cache`, and `cache_prompt` to the excluded set — so tuning a role's concurrency or caching no longer breaks resume.
+- Eval Set: `task_identifier` now excludes runtime-only `GenerateConfig` fields (`max_connections`, `max_retries`, etc.) from `model_roles` configs, matching the existing exclusion for the primary model — so tuning a role's concurrency no longer breaks resume.
 - Adaptive Connections: Raise the default minimum from 4 to 10.
 - Control Channel: `inspect eval` / `inspect eval-set` now bind a per-process control server (AF_UNIX, default on) exposing a read surface for the live run. New `inspect ctl` commands let another process (CLI, scripts, agents) observe a running eval / eval-set.
 - Transcript: Reuse a persistent per-thread SQLite connection in the realtime sample buffer database.

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -1242,7 +1242,7 @@ def resolve_solver(
 # Version of the task_identifier computation. Bump this when the task_identifier
 # logic changes, so that persisted identifiers (e.g. in inspect_flow) can be
 # recomputed.
-TASK_IDENTIFIER_VERSION = 1
+TASK_IDENTIFIER_VERSION = 2
 
 
 # yield a unique identifier for a task (used to pair resolved tasks to log files)

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -1221,10 +1221,7 @@ _GENERATE_CONFIG_FIELDS_TO_EXCLUDE = {
     "timeout",
     "attempt_timeout",
     "max_connections",
-    "adaptive_connections",
     "batch",
-    "cache",
-    "cache_prompt",
 }
 
 

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -1215,13 +1215,18 @@ def validate_eval_set_prerequisites(
         return all_logs
 
 
-# these generate config fields should not affect task identity
+# Runtime/transport GenerateConfig knobs that don't affect model outputs and so
+# must not affect task identity. Adding a field to GenerateConfig? See
+# test_generate_config_fields_classified — it will fail until you classify it.
 _GENERATE_CONFIG_FIELDS_TO_EXCLUDE = {
     "max_retries",
     "timeout",
     "attempt_timeout",
     "max_connections",
+    "adaptive_connections",
     "batch",
+    "cache",
+    "cache_prompt",
 }
 
 
@@ -1345,10 +1350,17 @@ def task_identifier(
 
     # hash for model roles
     if len(model_roles):
+        # base_url is excluded for symmetry with the primary model (whose
+        # base_url is not hashed) and because several providers populate it
+        # from env vars during init, which would make the identifier
+        # environment-dependent.
         additional_hash_input += to_json_safe(
             model_roles,
             exclude={
-                role: {"config": _GENERATE_CONFIG_FIELDS_TO_EXCLUDE}
+                role: {
+                    "base_url": True,
+                    "config": _GENERATE_CONFIG_FIELDS_TO_EXCLUDE,
+                }
                 for role in model_roles
             },
         )

--- a/src/inspect_ai/_eval/evalset.py
+++ b/src/inspect_ai/_eval/evalset.py
@@ -1221,7 +1221,10 @@ _GENERATE_CONFIG_FIELDS_TO_EXCLUDE = {
     "timeout",
     "attempt_timeout",
     "max_connections",
+    "adaptive_connections",
     "batch",
+    "cache",
+    "cache_prompt",
 }
 
 
@@ -1345,7 +1348,13 @@ def task_identifier(
 
     # hash for model roles
     if len(model_roles):
-        additional_hash_input += to_json_safe(model_roles)
+        additional_hash_input += to_json_safe(
+            model_roles,
+            exclude={
+                role: {"config": _GENERATE_CONFIG_FIELDS_TO_EXCLUDE}
+                for role in model_roles
+            },
+        )
 
     additional_hash_input += to_json_safe(additional_hash_fields)
 

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -46,7 +46,7 @@ from inspect_ai.log._file import (
 )
 from inspect_ai.log._log import EvalConfig, EvalLog
 from inspect_ai.log._recorders.eval import ZipLogFile
-from inspect_ai.model import CachePolicy, Model, get_model
+from inspect_ai.model import Model, get_model
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.scorer import exact
 from inspect_ai.scorer._match import includes
@@ -719,13 +719,10 @@ def test_task_identifier_with_model_roles_model_configs():
     "field,value",
     [
         ("max_connections", 48),
-        ("adaptive_connections", False),
         ("max_retries", 20),
         ("timeout", 600),
         ("attempt_timeout", 60),
         ("batch", True),
-        ("cache_prompt", True),
-        ("cache", CachePolicy(expiry="1M")),
     ],
 )
 def test_task_identifier_ignores_runtime_config(field: str, value: object):

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -22,6 +22,7 @@ from test_helpers.utils import (
 
 from inspect_ai import Task, task
 from inspect_ai._eval.evalset import (
+    _GENERATE_CONFIG_FIELDS_TO_EXCLUDE,
     EvalSetArgsInTaskIdentifier,
     _embed_viewer,
     epochs_changed,
@@ -46,7 +47,7 @@ from inspect_ai.log._file import (
 )
 from inspect_ai.log._log import EvalConfig, EvalLog
 from inspect_ai.log._recorders.eval import ZipLogFile
-from inspect_ai.model import Model, get_model
+from inspect_ai.model import CachePolicy, Model, get_model
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.scorer import exact
 from inspect_ai.scorer._match import includes
@@ -719,32 +720,143 @@ def test_task_identifier_with_model_roles_model_configs():
     "field,value",
     [
         ("max_connections", 48),
+        ("adaptive_connections", False),
         ("max_retries", 20),
         ("timeout", 600),
         ("attempt_timeout", 60),
         ("batch", True),
+        ("cache", CachePolicy(expiry="1M")),
+        ("cache_prompt", True),
     ],
 )
 def test_task_identifier_ignores_runtime_config(field: str, value: object):
     # runtime concurrency / caching knobs don't affect outputs and shouldn't
-    # break eval_set resume — for either the primary model's config or any
-    # role's config.
+    # break eval_set resume — for any of the three GenerateConfig sites that
+    # feed task_identifier: the primary model's config, the eval_set-level
+    # config (which becomes eval_plan.config), and each role model's config.
     tuned = GenerateConfig.model_validate({field: value})
-    primary_default = get_model("mockllm/model")
-    primary_tuned = get_model("mockllm/model", config=tuned)
-    role_default = get_model("mockllm/scorer")
-    role_tuned = get_model("mockllm/scorer", config=tuned)
-    args = EvalSetArgsInTaskIdentifier(config=GenerateConfig())
 
-    def ident(primary: Model, role: Model) -> str:
+    def ident(
+        primary_cfg: GenerateConfig = GenerateConfig(),
+        plan_cfg: GenerateConfig = GenerateConfig(),
+        role_cfg: GenerateConfig = GenerateConfig(),
+    ) -> str:
+        p = get_model("mockllm/model", config=primary_cfg)
+        r = get_model("mockllm/scorer", config=role_cfg)
+        t = hello_world()
+        task_with(t, model=p, model_roles={"scorer": r})
+        (resolved,) = resolve_tasks([t], {}, p, None, None, None)
+        return task_identifier(resolved, EvalSetArgsInTaskIdentifier(config=plan_cfg))
+
+    baseline = ident()
+    assert ident(primary_cfg=tuned) == baseline, f"primary model config: {field}"
+    assert ident(plan_cfg=tuned) == baseline, f"eval_plan.config: {field}"
+    assert ident(role_cfg=tuned) == baseline, f"role model config: {field}"
+
+    # sanity: a field that DOES affect identity still changes the hash on
+    # every path, so the test isn't trivially passing.
+    semantic = GenerateConfig(temperature=0.123)
+    assert ident(primary_cfg=semantic) != baseline
+    assert ident(plan_cfg=semantic) != baseline
+    assert ident(role_cfg=semantic) != baseline
+
+
+def test_task_identifier_ignores_role_base_url():
+    # base_url is not part of the primary model's identifier, and several
+    # providers populate it from env vars during init — so it must not be
+    # part of a role model's identifier either.
+    primary = get_model("mockllm/model")
+
+    def ident(role: Model) -> str:
         t = hello_world()
         task_with(t, model=primary, model_roles={"scorer": role})
         (resolved,) = resolve_tasks([t], {}, primary, None, None, None)
-        return task_identifier(resolved, args)
+        return task_identifier(
+            resolved, EvalSetArgsInTaskIdentifier(config=GenerateConfig())
+        )
 
-    baseline = ident(primary_default, role_default)
-    assert ident(primary_tuned, role_default) == baseline
-    assert ident(primary_default, role_tuned) == baseline
+    assert ident(get_model("mockllm/scorer")) == ident(
+        get_model("mockllm/scorer", base_url="http://localhost:8000")
+    )
+
+
+# GenerateConfig fields whose value can change model/tool outputs, and which
+# therefore form part of task identity (i.e. are hashed into task_identifier).
+# Every GenerateConfig field MUST appear either here or in
+# _GENERATE_CONFIG_FIELDS_TO_EXCLUDE — see test_generate_config_fields_classified.
+_GENERATE_CONFIG_IDENTITY_FIELDS = {
+    "system_message",
+    "max_tokens",
+    "top_p",
+    "temperature",
+    "stop_seqs",
+    "best_of",
+    "frequency_penalty",
+    "presence_penalty",
+    "logit_bias",
+    "seed",
+    "top_k",
+    "num_choices",
+    "logprobs",
+    "top_logprobs",
+    "prompt_logprobs",
+    "parallel_tool_calls",
+    "internal_tools",
+    "max_tool_output",
+    "fallback_models",
+    "verbosity",
+    "effort",
+    "reasoning_effort",
+    "reasoning_tokens",
+    "reasoning_summary",
+    "reasoning_history",
+    "response_schema",
+    "extra_headers",
+    "extra_body",
+    "modalities",
+}
+
+
+def test_generate_config_fields_classified():
+    """Force every GenerateConfig field to be explicitly classified.
+
+    eval_set resume matches live tasks to existing logs by hashing
+    GenerateConfig minus _GENERATE_CONFIG_FIELDS_TO_EXCLUDE. A new field that
+    isn't classified is hashed by default, so tuning it between runs silently
+    breaks resume — which is exactly how `adaptive_connections` slipped
+    through after it was added.
+    """
+    fields = set(GenerateConfig.model_fields)
+    excluded = _GENERATE_CONFIG_FIELDS_TO_EXCLUDE
+    identity = _GENERATE_CONFIG_IDENTITY_FIELDS
+
+    unclassified = fields - excluded - identity
+    assert not unclassified, (
+        f"GenerateConfig field(s) {sorted(unclassified)} are not classified "
+        f"for task_identifier hashing.\n"
+        f"  → If the field is a runtime/transport knob (concurrency, retries, "
+        f"timeouts, caching, batching) that does NOT change model outputs: "
+        f"add it to _GENERATE_CONFIG_FIELDS_TO_EXCLUDE in "
+        f"src/inspect_ai/_eval/evalset.py and bump TASK_IDENTIFIER_VERSION.\n"
+        f"  → If the field CAN change model outputs (sampling params, "
+        f"reasoning config, tool behaviour, etc.): add it to "
+        f"_GENERATE_CONFIG_IDENTITY_FIELDS in this test file. No version bump "
+        f"needed."
+    )
+
+    overlap = excluded & identity
+    assert not overlap, (
+        f"GenerateConfig field(s) {sorted(overlap)} appear in both "
+        f"_GENERATE_CONFIG_FIELDS_TO_EXCLUDE and "
+        f"_GENERATE_CONFIG_IDENTITY_FIELDS — pick one."
+    )
+
+    stale = (excluded | identity) - fields
+    assert not stale, (
+        f"GenerateConfig field(s) {sorted(stale)} no longer exist on "
+        f"GenerateConfig — remove from _GENERATE_CONFIG_FIELDS_TO_EXCLUDE "
+        f"(evalset.py) or _GENERATE_CONFIG_IDENTITY_FIELDS (this file)."
+    )
 
 
 def test_task_identifier_with_task_generate_configs():

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -46,7 +46,7 @@ from inspect_ai.log._file import (
 )
 from inspect_ai.log._log import EvalConfig, EvalLog
 from inspect_ai.log._recorders.eval import ZipLogFile
-from inspect_ai.model import get_model
+from inspect_ai.model import CachePolicy, Model, get_model
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.scorer import exact
 from inspect_ai.scorer._match import includes
@@ -713,6 +713,40 @@ def test_task_identifier_with_model_roles_model_configs():
         resolved_tasks[1], EvalSetArgsInTaskIdentifier(config=GenerateConfig())
     )
     run_eval_set(create_resolved_tasks)
+
+
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("max_connections", 48),
+        ("adaptive_connections", False),
+        ("max_retries", 20),
+        ("timeout", 600),
+        ("attempt_timeout", 60),
+        ("batch", True),
+        ("cache_prompt", True),
+        ("cache", CachePolicy(expiry="1M")),
+    ],
+)
+def test_task_identifier_ignores_runtime_config(field: str, value: object):
+    # runtime concurrency / caching knobs don't affect outputs and shouldn't
+    # break eval_set resume — for either the primary model's config or any
+    # role's config.
+    primary_default = get_model("mockllm/model")
+    primary_tuned = get_model("mockllm/model", config=GenerateConfig(**{field: value}))
+    role_default = get_model("mockllm/scorer")
+    role_tuned = get_model("mockllm/scorer", config=GenerateConfig(**{field: value}))
+    args = EvalSetArgsInTaskIdentifier(config=GenerateConfig())
+
+    def ident(primary: Model, role: Model) -> str:
+        t = hello_world()
+        task_with(t, model=primary, model_roles={"scorer": role})
+        (resolved,) = resolve_tasks([t], {}, primary, None, None, None)
+        return task_identifier(resolved, args)
+
+    baseline = ident(primary_default, role_default)
+    assert ident(primary_tuned, role_default) == baseline
+    assert ident(primary_default, role_tuned) == baseline
 
 
 def test_task_identifier_with_task_generate_configs():

--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -732,10 +732,11 @@ def test_task_identifier_ignores_runtime_config(field: str, value: object):
     # runtime concurrency / caching knobs don't affect outputs and shouldn't
     # break eval_set resume — for either the primary model's config or any
     # role's config.
+    tuned = GenerateConfig.model_validate({field: value})
     primary_default = get_model("mockllm/model")
-    primary_tuned = get_model("mockllm/model", config=GenerateConfig(**{field: value}))
+    primary_tuned = get_model("mockllm/model", config=tuned)
     role_default = get_model("mockllm/scorer")
-    role_tuned = get_model("mockllm/scorer", config=GenerateConfig(**{field: value}))
+    role_tuned = get_model("mockllm/scorer", config=tuned)
     args = EvalSetArgsInTaskIdentifier(config=GenerateConfig())
 
     def ident(primary: Model, role: Model) -> str:

--- a/tests/test_task_identifier_version.py
+++ b/tests/test_task_identifier_version.py
@@ -43,16 +43,20 @@ def _create_resolved_task_with_all_fields():
           - working_limit
           - cost_limit
     """
+    # Each GenerateConfig site (primary model, role model, and the
+    # EvalSetArgsInTaskIdentifier.config that becomes eval_plan.config) sets
+    # both a task-identity-relevant field (temperature) and a runtime knob
+    # that task_identifier excludes (max_connections / max_retries). The role
+    # also sets base_url, which is excluded for the same reason. The excluded
+    # values must be present so that future changes to what task_identifier
+    # excludes are detectable here.
     model = get_model(
         "mockllm/model",
-        config=GenerateConfig(temperature=0.5),
+        config=GenerateConfig(temperature=0.5, max_connections=10),
     )
-    # The scorer model role sets both a task-identity-relevant field
-    # (temperature) and a runtime knob that task_identifier excludes
-    # (max_connections). The excluded knob must be present so that changes
-    # to which model_roles config fields are excluded are detectable here.
     scorer_model = get_model(
         "mockllm/scorer",
+        base_url="http://test:8000",
         config=GenerateConfig(temperature=0.3, max_connections=5),
     )
 
@@ -91,7 +95,7 @@ def test_task_identifier_version_stability():
 
     resolved_task = _create_resolved_task_with_all_fields()
     eval_set_args = EvalSetArgsInTaskIdentifier(
-        config=GenerateConfig(temperature=0.7),
+        config=GenerateConfig(temperature=0.7, max_retries=3),
         message_limit=100,
         token_limit=5000,
         time_limit=300,

--- a/tests/test_task_identifier_version.py
+++ b/tests/test_task_identifier_version.py
@@ -16,6 +16,7 @@ from inspect_ai.solver import generate
 # new expected value and bump TASK_IDENTIFIER_VERSION.
 _EXPECTED_TASK_IDENTIFIERS: dict[int, str] = {
     1: "tests/test_task_identifier_version.py@version_test_task#44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a/mockllm/model/29797164a2ed3858f2e5b9a08f6594cfe398a975e2094dadb17a15f84e53613c",
+    2: "tests/test_task_identifier_version.py@version_test_task#44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a/mockllm/model/83650e91c9e6d632029a66c6c00022eadbc3ba23687c82c324f9f41cfc193104",
 }
 
 
@@ -46,7 +47,14 @@ def _create_resolved_task_with_all_fields():
         "mockllm/model",
         config=GenerateConfig(temperature=0.5),
     )
-    scorer_model = get_model("mockllm/scorer")
+    # The scorer model role sets both a task-identity-relevant field
+    # (temperature) and a runtime knob that task_identifier excludes
+    # (max_connections). The excluded knob must be present so that changes
+    # to which model_roles config fields are excluded are detectable here.
+    scorer_model = get_model(
+        "mockllm/scorer",
+        config=GenerateConfig(temperature=0.3, max_connections=5),
+    )
 
     @task
     def version_test_task(task_arg: str = "test_value"):

--- a/uv.lock
+++ b/uv.lock
@@ -17,16 +17,6 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
-[options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
-exclude-newer-span = "P1W"
-
-[options.exclude-newer-package]
-inspect-petri = false
-inspect-ai = false
-inspect-scout = false
-inspect-swe = false
-
 [[package]]
 name = "adlfs"
 version = "2026.5.0"

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,16 @@ resolution-markers = [
     "python_full_version < '3.11'",
 ]
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
+[options.exclude-newer-package]
+inspect-petri = false
+inspect-ai = false
+inspect-scout = false
+inspect-swe = false
+
 [[package]]
 name = "adlfs"
 version = "2026.5.0"


### PR DESCRIPTION
`task_identifier()` excludes `max_connections`/`max_retries`/`timeout`/`attempt_timeout`/`batch` from the primary model's `GenerateConfig` and from `eval_plan.config`, but **not** from `model_roles` configs — so setting `max_connections=48` on a role model breaks `eval_set` resume, while setting it on the primary doesn't.

This applies the same exclusion to each role's config and adds three more runtime-only fields to `_GENERATE_CONFIG_FIELDS_TO_EXCLUDE`:
- `adaptive_connections` — added after the exclude set was introduced; never updated
- `cache` — local response caching, performance-only
- `cache_prompt` — provider-side prompt caching, performance-only

**Backward-compatible:** `to_json_safe(exclude_none=True)` already drops these fields when they're at their `None` default, so existing logs and persisted identifiers are unchanged. `test_task_identifier_version_stability` passes without a `TASK_IDENTIFIER_VERSION` bump.

**Not addressed (possible follow-up):** `ModelConfig.base_url` is also hashed for roles but not for the primary, and several providers (`openai_compatible`, `google`, `grok`, `mistral`) reassign `self.base_url` from env vars — so role identifiers can be environment-dependent. Separate concern; happy to fold in if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)