### PR TITLE
Fix self_check test_read_file_limit to report the enforced limit

### DIFF
--- a/src/inspect_ai/util/_sandbox/limits.py
+++ b/src/inspect_ai/util/_sandbox/limits.py
@@ -123,6 +123,24 @@ def override_max_exec_output_size(limit: int) -> Iterator[None]:
         _max_exec_output_size_var.reset(token)
 
 
+@contextmanager
+def override_max_read_file_size(limit: int) -> Iterator[None]:
+    """Temporarily override the max read file size for the current context.
+
+    Updates both MAX_READ_FILE_SIZE and MAX_READ_FILE_SIZE_STR (they share a
+    ContextVar), so the enforced limit and its reported string stay consistent.
+    The override is scoped to the current async context and restored on exit.
+
+    Args:
+        limit: Read file size limit (in bytes) to apply within the context.
+    """
+    token = _max_read_file_size_var.set(limit)
+    try:
+        yield
+    finally:
+        _max_read_file_size_var.reset(token)
+
+
 class OutputLimitExceededError(Exception):
     """Exception raised when a sandbox invocation results in excessive output."""
 

--- a/src/inspect_ai/util/_sandbox/self_check.py
+++ b/src/inspect_ai/util/_sandbox/self_check.py
@@ -1,7 +1,6 @@
 import random
 import string
 from typing import Any, Callable, Coroutine, Generic, Optional, Type, TypeVar
-from unittest import mock
 
 import anyio
 
@@ -10,6 +9,7 @@ from inspect_ai.util import (
     SandboxEnvironment,
     SandboxEnvironmentLimits,
 )
+from inspect_ai.util._sandbox.limits import override_max_read_file_size
 
 # If you're wondering these tests are not using pytest fixtures,
 # see the discussion https://github.com/UKGovernmentBEIS/inspect_ai/pull/347
@@ -234,12 +234,12 @@ async def test_read_file_nonsense_name(
 async def test_read_file_limit(sandbox_env: SandboxEnvironment) -> None:
     file_name = "large.file"
     await sandbox_env.write_file(file_name, "a" * 2048)  # 2 KiB
-    # Patch limit down to 1KiB for the test to save us from writing a 100 MiB file.
-    with mock.patch.object(SandboxEnvironmentLimits, "MAX_READ_FILE_SIZE", 1024):
+    with override_max_read_file_size(1024):
+        expected_limit = SandboxEnvironmentLimits.MAX_READ_FILE_SIZE_STR
         with Raises(OutputLimitExceededError) as e_info:
             await sandbox_env.read_file(file_name, text=True)
     assert e_info is not None, "OutputLimitExceededError should be raised"
-    assert "limit of 100 MiB was exceeded" in str(e_info.value), (
+    assert f"limit of {expected_limit} was exceeded" in str(e_info.value), (
         f"OutputLimitExceededError should mention the limit, got {e_info.value=}"
     )
     await _cleanup_file(sandbox_env, file_name)


### PR DESCRIPTION
Fixes `test_read_file_limit` in `self_check`, which patched `MAX_READ_FILE_SIZE` (int) down to 1 KiB but asserted the error said `100 MiB`.

`MAX_READ_FILE_SIZE` and `MAX_READ_FILE_SIZE_STR` are separate descriptors over the same `ContextVar`; `mock.patch.object` touched only the int, so the test asserted an incoherent state (enforced 1 KiB, reported 100 MiB).
