### PR TITLE
fix(bridge): forward Anthropic adaptive thinking effort to reasoning_effort

### DIFF
--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -202,8 +202,17 @@ def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
 
     thinking = json_data.get("thinking", None)
     if thinking:
-        if thinking.get("type", None) == "enabled":
+        thinking_type = thinking.get("type", None)
+        if thinking_type == "enabled":
             config.reasoning_tokens = thinking.get("budget_tokens", None)
+        elif thinking_type == "adaptive":
+            # Claude 4.6+ adaptive thinking carries reasoning depth in
+            # output_config.effort rather than a token budget. Map it to
+            # reasoning_effort (cleared by clear_generation_params when not
+            # forwarding); `effort` is not in that list and would leak.
+            output_config = json_data.get("output_config") or {}
+            if (effort := output_config.get("effort", None)) is not None:
+                config.reasoning_effort = effort
 
     tool_choice = json_data.get("tool_choice", {})
     if tool_choice.get("disable_parallel_tool_use", None) is True:

--- a/tests/agent/test_bridge_generation_config.py
+++ b/tests/agent/test_bridge_generation_config.py
@@ -167,6 +167,39 @@ def test_anthropic_forward_then_clear():
     assert config.parallel_tool_calls is False
 
 
+def test_anthropic_adaptive_effort_forward_then_clear():
+    # Claude 4.6+ uses adaptive thinking and carries the reasoning depth in
+    # output_config.effort rather than thinking.budget_tokens.
+    json_data = {
+        "model": "inspect",
+        "max_tokens": 32000,
+        "thinking": {"type": "adaptive", "display": "summarized"},
+        "output_config": {"effort": "high"},
+    }
+
+    config = generate_config_from_anthropic(json_data)
+    # adaptive effort maps to reasoning_effort (a cleared generation param), not
+    # the bridge-leaking `effort` field
+    assert config.reasoning_effort == "high"
+
+    clear_generation_params(config)
+    _assert_cleared(config)
+    assert config.reasoning_effort is None
+
+
+def test_anthropic_adaptive_without_effort_is_noop():
+    # adaptive thinking with no explicit effort should leave reasoning depth to
+    # the model's default; nothing to forward
+    json_data = {
+        "model": "inspect",
+        "max_tokens": 32000,
+        "thinking": {"type": "adaptive"},
+    }
+    config = generate_config_from_anthropic(json_data)
+    assert config.reasoning_effort is None
+    assert config.reasoning_tokens is None
+
+
 def test_google_forward_then_clear():
     generation_config = {
         "temperature": 0.8,


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

When an agent bridge translates an incoming Anthropic Messages request into a `GenerateConfig`, `generate_config_from_anthropic` only handles `thinking.type == "enabled"` (the pre-4.6 extended-thinking path with `budget_tokens`). Claude 4.6+ uses adaptive thinking, where the reasoning depth is carried in `output_config.effort` and `thinking` looks like `{"type": "adaptive", ...}`. That branch is never matched, so the effort is silently dropped: a scaffold asking for `high` effort gets the model default instead. Our own Anthropic provider already emits requests in exactly this shape (`thinking = {"type": "adaptive", ...}` plus `output_config={"effort": ...}`), so a bridged scaffold round-tripping through it loses the setting.

### What is the new behavior?

Added an `adaptive` branch alongside `enabled`: it reads `output_config.effort` and sets `config.reasoning_effort`. I target `reasoning_effort` (not `effort`) on purpose: `reasoning_effort` is in `_GENERATION_PARAM_FIELDS`, so it is correctly cleared by `clear_generation_params` when the bridge is configured not to forward client generation params, whereas `effort` is not in that list and would leak through. The `output_config.effort` values (low/medium/high/xhigh/max) are all valid `reasoning_effort` literals. Adaptive thinking without an explicit effort stays a no-op, leaving the model's default behavior.

### Does this PR introduce a breaking change?

No.

### Other information:

Verified against the bug:

- `pytest tests/agent/test_bridge_generation_config.py -q` (7 passed). The new `test_anthropic_adaptive_effort_forward_then_clear` fails on current main (`reasoning_effort` is `None`) and passes with the fix; the existing `enabled` -> `reasoning_tokens` test stays green.
- `ruff check` / `ruff format --check` on the two changed files
- `mypy src/inspect_ai/agent/_bridge/anthropic_api_impl.py`
