### PR TITLE
fix(_util): keep truncate() within length when smaller than the overflow indicator

### DIFF
--- a/src/inspect_ai/_util/text.py
+++ b/src/inspect_ai/_util/text.py
@@ -263,6 +263,11 @@ def truncate(text: str, length: int, overflow: str = "...", pad: bool = True) ->
         return text + (" " * (length - len(text))) if pad else text
 
     overflow_length = len(overflow)
+    if length < overflow_length:
+        # Not enough room for the overflow indicator; clip to length so the
+        # result never grows past it (a negative slice index would otherwise
+        # keep most of the text and still append the indicator).
+        return text[: max(0, length)]
     truncated = text[: length - overflow_length] + overflow
 
     return truncated

--- a/tests/util/test_truncate.py
+++ b/tests/util/test_truncate.py
@@ -21,6 +21,16 @@ def test_exact_length():
     assert truncate("1234", 4, pad=False) == "1234"
 
 
+def test_length_smaller_than_overflow():
+    # When length cannot fit the overflow indicator, the result must still stay
+    # within length rather than growing past it (negative slice index bug).
+    assert len(truncate("Hello World!", 2)) <= 2
+    assert len(truncate("Hello World!", 2, pad=False)) <= 2
+    assert len(truncate("Hello World!", 1)) <= 1
+    assert len(truncate("Hello World!", 0)) <= 0
+    assert len(truncate("Hello World!", 2, overflow=">>>>")) <= 2
+
+
 def test_truncate_lines_no_truncation():
     text = "line1\nline2\nline3"
     result, additional = truncate_lines(text, max_lines=10)


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

`truncate(text, length, overflow="...")` computes `text[: length - len(overflow)] + overflow`. When `length` is smaller than the overflow indicator, `length - len(overflow)` is negative, so the slice drops only the last few characters and the indicator is still appended. The result then grows far past `length`, contradicting the docstring ("Maximum length including overflow indicator"):

```python
truncate("Hello World!", 2)        # -> "Hello World..."  (14 chars, not <= 2)
truncate("Hello World!", 1)        # -> "Hello World..."
```

### What is the new behavior?

When there is no room for the overflow indicator (`length < len(overflow)`), the text is clipped to `length` instead, so the result never exceeds `length`:

```python
truncate("Hello World!", 2)        # -> "He"
truncate("Hello World!", 0)        # -> ""
```

Behavior is unchanged whenever `length >= len(overflow)` (the normal case), so existing callers like `truncate_lines` are unaffected.

### Does this PR introduce a breaking change?

No.

### Other information:

Added `test_length_smaller_than_overflow` to `tests/util/test_truncate.py`; it fails on the current code and passes with the fix. All existing `test_truncate.py` / `test_text.py` tests still pass and `ruff` is clean.
