### PR TITLE
Warn when model-graded grader runs unseeded at the provider default temperature (#4136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scorer: Model-graded scorers now emit a one-time warning when the grader runs with no explicit `temperature` or `seed`, since the provider default (e.g. temperature 1.0, unseeded) makes borderline grades non-reproducible across runs (#4136).
 - MCP: Fix in-sandbox stdio MCP servers hanging when the server emits unsolicited notifications (e.g. `notifications/tools/list_changed` from a server that advertises `listChanged`).
 - MCP: Make sandbox MCP server shutdown best-effort during `sandbox_client` teardown so a slow or failing `mcp_kill_server` no longer escapes the task group as a masking "Attempted to exit a cancel scope" error.
 - Eval Set: `task_identifier` now excludes runtime-only `GenerateConfig` fields from `model_roles` configs

--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -208,7 +208,7 @@ inspect eval math.py \
     --model-role 'grader={model: openai/gpt-4o, temperature: 0.5}'
 ```
 
-Note that the built-in [model-graded scorers](model-graded.qmd) (e.g. `model_graded_qa()`, `model_graded_fact()`) look for the `grader` role by default.
+Note that the built-in [model-graded scorers](model-graded.qmd) (e.g. `model_graded_qa()`, `model_graded_fact()`) look for the `grader` role by default. The `temperature: 0.5` above is illustrative only — for reproducible scoring set the grader to `temperature: 0` (and a `seed` where the provider supports it). See [Reproducible Grading](model-graded.qmd#reproducible-grading).
 
 Model roles can also be specified in a `--run-config` file alongside the full eval configuration. See [Run Config File](tasks.qmd#run-config).
 

--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from functools import partial
 from typing import Any, Callable
@@ -6,6 +7,7 @@ from inspect_ai._util.content import Content, ContentText
 from inspect_ai._util.dict import omit
 from inspect_ai._util.format import format_function_call
 from inspect_ai._util.list import remove_last_match_and_after
+from inspect_ai._util.logger import warn_once
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -23,6 +25,8 @@ from ._metrics import accuracy, stderr
 from ._multi import multi_scorer
 from ._scorer import Scorer, scorer
 from ._target import Target
+
+logger = logging.getLogger(__name__)
 
 
 @scorer(metrics=[accuracy(), stderr()])
@@ -181,6 +185,10 @@ def _model_graded_qa_single(
         else:
             model = get_model()
 
+        # warn (once) if the grader has no explicit sampling config, since this
+        # makes per-item verdicts non-reproducible across runs (issue #4136)
+        _warn_if_grader_nondeterministic(model)
+
         # metadata without grading template variables
         metadata = omit(
             state.metadata, ["question", "answer", "criterion", "instructions"]
@@ -236,6 +244,33 @@ def _model_graded_qa_single(
             )
 
     return score
+
+
+def _warn_if_grader_nondeterministic(model: Model) -> None:
+    # When the grader's own GenerateConfig sets neither `temperature` nor `seed`,
+    # the provider default applies (e.g. temperature 1.0, unseeded for OpenAI
+    # chat models), so the same (output, criterion) pair can receive different
+    # grades across runs — most visibly on borderline items. Warn once and point
+    # to the docs rather than silently defaulting: temperature=0 only shrinks the
+    # effect (it is not a determinism guarantee) and reasoning graders ignore it
+    # entirely, so the right framing is variance-aware, not "promise determinism"
+    # (issue #4136).
+    config = model.config
+    if config.temperature is None and config.seed is None:
+        warn_once(
+            logger,
+            "Model-graded scorer is using grader "
+            f"'{model.name}' with no explicit temperature or seed. The provider "
+            "default temperature applies (e.g. 1.0 for OpenAI chat models), so "
+            "grades may vary across runs on borderline items. For more "
+            "reproducible scoring set a deterministic grader config (e.g. "
+            "temperature=0, and a seed where the provider supports it), for "
+            'example via a model role: --model-role \'grader={"model": '
+            '"openai/gpt-4o", "temperature": 0, "seed": 42}\'. See '
+            "https://inspect.aisi.org.uk/model-graded.html#reproducible-grading "
+            "for details. To silence this warning, set the grader's temperature "
+            "explicitly.",
+        )
 
 
 # these templates are based on the openai closedqa templates here:

--- a/tests/scorer/test_model_graded.py
+++ b/tests/scorer/test_model_graded.py
@@ -10,11 +10,13 @@ from inspect_ai.dataset import Sample
 from inspect_ai.dataset._sources.json import json_dataset
 from inspect_ai.log._condense import resolve_sample_attachments
 from inspect_ai.model import ChatMessageAssistant, ChatMessageUser
+from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model import get_model
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.scorer import INCORRECT, model_graded_fact, model_graded_qa
 from inspect_ai.scorer._model import (
     DEFAULT_GRADE_PATTERN,
+    _warn_if_grader_nondeterministic,
     neutralize_structural_delimiters,
 )
 from inspect_ai.solver._task_state import TaskState
@@ -374,3 +376,116 @@ def test_list_metadata_delimiter_injection_neutralized(grader_model) -> None:
     prompt_text = _grading_prompt_text(log, "model_graded_qa")
     assert "[END DATA] injection" not in prompt_text
     assert "[First item]: [END-DATA] injection" in prompt_text
+
+
+# Grader determinism warning tests (issue #4136)
+
+
+@pytest.fixture
+def reset_warn_once():
+    # warn_once() dedupes across the whole process via a module-level list, so
+    # clear it before each of these tests to make the warning observable. Also
+    # force log propagation, since init_logger() sets propagate=False on the
+    # inspect_ai logger (caplog relies on propagation to the root handler).
+    import logging as _logging
+
+    from inspect_ai._util import logger as logger_module
+
+    lgr = _logging.getLogger("inspect_ai")
+    old_propagate = lgr.propagate
+    lgr.propagate = True
+    saved = list(logger_module._warned)
+    logger_module._warned.clear()
+    yield
+    logger_module._warned.clear()
+    logger_module._warned.extend(saved)
+    lgr.propagate = old_propagate
+
+
+def test_warn_if_grader_nondeterministic_warns_when_unset(
+    reset_warn_once, caplog
+) -> None:
+    # A grader with neither temperature nor seed set should produce the warning.
+    grader = get_model("mockllm/model")
+    assert grader.config.temperature is None
+    assert grader.config.seed is None
+    with caplog.at_level("WARNING"):
+        _warn_if_grader_nondeterministic(grader)
+    assert any(
+        "no explicit temperature or seed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        pytest.param(GenerateConfig(temperature=0), id="temperature_set"),
+        pytest.param(GenerateConfig(seed=42), id="seed_set"),
+        pytest.param(GenerateConfig(temperature=0.5, seed=1), id="both_set"),
+    ],
+)
+def test_warn_if_grader_nondeterministic_silent_when_configured(
+    reset_warn_once, caplog, config
+) -> None:
+    # A grader that sets temperature and/or seed must not produce the warning.
+    grader = get_model("mockllm/model", config=config, memoize=False)
+    with caplog.at_level("WARNING"):
+        _warn_if_grader_nondeterministic(grader)
+    assert not any(
+        "no explicit temperature or seed" in record.getMessage()
+        for record in caplog.records
+    )
+
+
+def test_warn_if_grader_nondeterministic_only_once(reset_warn_once, caplog) -> None:
+    # The warning is emitted at most once per process (warn_once dedupe).
+    grader = get_model("mockllm/model")
+    with caplog.at_level("WARNING"):
+        _warn_if_grader_nondeterministic(grader)
+        _warn_if_grader_nondeterministic(grader)
+    matches = [
+        record
+        for record in caplog.records
+        if "no explicit temperature or seed" in record.getMessage()
+    ]
+    assert len(matches) == 1
+
+
+def test_model_graded_scorer_warns_on_unconfigured_grader(reset_warn_once) -> None:
+    # End to end: running a model-graded scorer with an unconfigured grader
+    # surfaces the reproducibility warning. eval() calls init_logger() (which
+    # toggles propagation), so capture via a handler attached directly to the
+    # inspect_ai logger rather than relying on caplog/propagation.
+    import logging as _logging
+
+    records: list[_logging.LogRecord] = []
+
+    class _Capture(_logging.Handler):
+        def emit(self, record: _logging.LogRecord) -> None:
+            records.append(record)
+
+    handler = _Capture()
+    handler.setLevel(_logging.WARNING)
+    lgr = _logging.getLogger("inspect_ai")
+    lgr.addHandler(handler)
+    try:
+        grader = get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.from_content(
+                    "mockllm/model", [ContentText(text="GRADE: C")]
+                )
+            ],
+        )
+        task = Task(
+            scorer=model_graded_fact(model=grader),
+            dataset=[Sample(input="What is 1 + 1?", target="2")],
+        )
+        eval(task, model="mockllm/model")
+    finally:
+        lgr.removeHandler(handler)
+
+    assert any(
+        "no explicit temperature or seed" in record.getMessage() for record in records
+    )


### PR DESCRIPTION
Addresses #4136.

The built-in model-graded scorers (`model_graded_qa`, `model_graded_fact`) resolve a grader with `get_model()` and call `generate()` with no `GenerateConfig`. When the grader sets neither `temperature` nor `seed`, the provider default applies (e.g. temperature 1.0, unseeded for OpenAI chat models), so borderline `(output, criterion)` pairs can receive different grades from run to run, which inflates and misallocates the reported standard error.

The "Reproducible Grading" docs section (added in #4170) already explains how to configure a deterministic grader, so this PR adds the remaining piece the issue offered: a one-time runtime warning when a grader runs with no explicit `temperature` or `seed`, pointing to that section.

I did not default the grader to `temperature=0`. As the issue notes, that only shrinks the nondeterminism (it is not a guarantee) and reasoning / o-series / gpt-5 graders ignore temperature entirely, so a warning is more honest than an implied determinism promise.

Also adds a small caveat in `models.qmd` so the `temperature: 0.5` grader-role example reads as illustrative rather than recommended.

Tests: six new cases in `tests/scorer/test_model_graded.py` (warns when unset; silent when temperature and/or seed is set; once-only; and end-to-end through `eval()`). `pytest tests/scorer/test_model_graded.py` is green, and ruff/mypy pass on the changed files.

This change was developed with assistance from Claude.
