### PR TITLE
fix(bridge): forward output_config.effort for adaptive thinking (#4258)

### DIFF
--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -205,6 +205,16 @@ def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
         if thinking.get("type", None) == "enabled":
             config.reasoning_tokens = thinking.get("budget_tokens", None)
 
+    # `output_config.effort` carries the reasoning depth for adaptive thinking
+    # (Claude 4.6+ clients send `thinking: {"type": "adaptive"}` and convey the
+    # depth here rather than via `budget_tokens`). Forward it so the served model
+    # keeps the requested effort instead of silently dropping it.
+    output_config = json_data.get("output_config", None)
+    if output_config:
+        effort = output_config.get("effort", None)
+        if effort is not None:
+            config.effort = effort
+
     tool_choice = json_data.get("tool_choice", {})
     if tool_choice.get("disable_parallel_tool_use", None) is True:
         config.parallel_tool_calls = False

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -50,6 +50,7 @@ _GENERATION_PARAM_FIELDS: tuple[str, ...] = (
     "top_logprobs",
     "prompt_logprobs",
     "logit_bias",
+    "effort",
     "reasoning_effort",
     "reasoning_tokens",
     "reasoning_summary",

--- a/tests/agent/test_bridge_generation_config.py
+++ b/tests/agent/test_bridge_generation_config.py
@@ -34,6 +34,7 @@ GENERATION_FIELDS = {
     "top_logprobs",
     "prompt_logprobs",
     "logit_bias",
+    "effort",
     "reasoning_effort",
     "reasoning_tokens",
     "reasoning_summary",
@@ -145,6 +146,7 @@ def test_anthropic_forward_then_clear():
         "top_k": 2,
         "top_p": 0.9,
         "thinking": {"type": "enabled", "budget_tokens": 2048},
+        "output_config": {"effort": "high"},
         # structural
         "system": "You are a dope model.",
         "stop_sequences": ["foo"],
@@ -157,14 +159,35 @@ def test_anthropic_forward_then_clear():
     assert config.top_k == 2
     # anthropic thinking budget maps to reasoning_tokens
     assert config.reasoning_tokens == 2048
+    # output_config.effort (adaptive-thinking depth) maps to effort
+    assert config.effort == "high"
 
     clear_generation_params(config)
     _assert_cleared(config)
-    # reasoning_tokens specifically must be among the cleared fields
+    # reasoning_tokens and effort specifically must be among the cleared fields
     assert config.reasoning_tokens is None
+    assert config.effort is None
     assert config.system_message == "You are a dope model."
     assert config.stop_seqs == ["foo"]
     assert config.parallel_tool_calls is False
+
+
+def test_anthropic_adaptive_thinking_effort_forwarded():
+    # `thinking: {"type": "adaptive"}` carries no budget_tokens; the reasoning
+    # depth arrives via `output_config.effort`. It must be forwarded rather than
+    # silently dropped (regression test for the bridge ignoring adaptive mode).
+    json_data = {
+        "model": "inspect",
+        "max_tokens": 32000,
+        "thinking": {"type": "adaptive"},
+        "output_config": {"effort": "high"},
+    }
+
+    config = generate_config_from_anthropic(json_data)
+    # adaptive mode has no explicit token budget
+    assert config.reasoning_tokens is None
+    # but the effort knob is preserved
+    assert config.effort == "high"
 
 
 def test_google_forward_then_clear():


### PR DESCRIPTION
## Summary

Fixes #4258.

`generate_config_from_anthropic()` in the agent bridge only translated extended-thinking config when `thinking.type == "enabled"`, and never read `output_config.effort` at all. Claude 4.6+ clients (e.g. Claude Code) send `thinking: {"type": "adaptive"}` and convey the reasoning depth via `output_config.effort` rather than `budget_tokens`. As a result, when `forward_generation_config=True`, the served model ran with the requested effort silently dropped.

## Changes

- **`anthropic_api_impl.py`** — read `output_config.effort` and map it to `GenerateConfig.effort` (the outbound Anthropic provider already reads `config.effort` to emit `output_config`, so this round-trips correctly). The `enabled`/`budget_tokens` → `reasoning_tokens` path is unchanged.
- **`util.py`** — add `effort` to `_GENERATION_PARAM_FIELDS`. This field was missing from the cleared-on-no-forward list (only `reasoning_effort` was present), so without this the newly-forwarded `effort` would leak through even when the bridge is configured not to forward generation params (the default). `effort` is a generation-tuning knob just like `reasoning_effort`, so it belongs there.
- **tests** — extend `test_anthropic_forward_then_clear` to assert `effort` is forwarded and then cleared, update the hard-coded `GENERATION_FIELDS` guard set, and add `test_anthropic_adaptive_thinking_effort_forwarded` covering the pure-adaptive (no `budget_tokens`) case from the issue.

## Verification

The added unit tests require no provider SDK or API key. With the fix, the issue's repro yields `adaptive.effort == "high"` (was `None`) while `reasoning_tokens` correctly stays `None` for adaptive mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
