### PR TITLE
Fix direct multi_scorer task usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 - MCP: Make sandbox MCP server shutdown best-effort during `sandbox_client` teardown so a slow or failing `mcp_kill_server` no longer escapes the task group as a masking "Attempted to exit a cancel scope" error.
 - MCP: Fix in-sandbox stdio MCP servers hanging on large tool responses.
 - Eval Set: `task_identifier` now excludes runtime-only `GenerateConfig` fields from `model_roles` configs
+- Eval Log: `read_eval_log`, `read_eval_log_async`, and `samples_df` now accept `exclude_fields` for more memory-efficient loading of large samples.
 - Sandbox: Preserve docker-compatible per-sample sandbox config (e.g. a per-sample `ComposeConfig`) when an eval-level sandbox override (`--sandbox <provider>`) is passed without its own config.
 - Limits: Added `turn_limit()` which tracks total generations.
 - Inspect View: Improve sample reading performance in viewer by serving `/log-bytes` range requests as plain responses instead of line-iterating a `BytesIO`.
 - Inspect View: Fix log-list grid columns snapping back to default widths while data loads
 - Inspect View: Fix transcript deep links across timelines, approvals, collapsed regions, and lanes; add event label pills.
 - Inspect View:  Improve tool input density
-- Log: `read_eval_log`, `read_eval_log_async`, and `samples_df` now accept `exclude_fields` for more memory-efficient loading of large samples.
+- Bugfix: Fix direct multi_scorer task usage.
 
 ## 0.3.240 (15 June 2026)
 

--- a/src/inspect_ai/scorer/_multi.py
+++ b/src/inspect_ai/scorer/_multi.py
@@ -1,12 +1,18 @@
 import functools
 
 from inspect_ai._util._async import tg_collect
+from inspect_ai._util.registry import (
+    RegistryInfo,
+    is_registry_object,
+    registry_name,
+    registry_tag,
+)
 from inspect_ai.scorer._reducer.registry import create_reducers
 from inspect_ai.solver._task_state import TaskState
 
-from ._metric import Score
+from ._metric import Metric, Score
 from ._reducer.types import ScoreReducer
-from ._scorer import Scorer
+from ._scorer import SCORER_METRICS, Scorer, scorer_metrics, scorer_register
 from ._target import Target
 
 
@@ -17,7 +23,9 @@ def multi_scorer(scorers: list[Scorer], reducer: str | ScoreReducer) -> Scorer:
         scorers: a list of Scorers.
         reducer: a function which takes in a list of Scores and returns a single Score.
     """
+    reducer_spec = reducer
     reducer = create_reducers(reducer)[0]
+    scorer_name = registry_name(multi_scorer, "multi_scorer")
 
     async def score(state: TaskState, target: Target) -> Score:
         scores = await tg_collect(
@@ -31,4 +39,31 @@ def multi_scorer(scorers: list[Scorer], reducer: str | ScoreReducer) -> Scorer:
             return Score.unscored()
         return reducer(resolved_scores)
 
+    registry_tag(
+        multi_scorer,
+        score,
+        RegistryInfo(
+            type="scorer",
+            name=scorer_name,
+            metadata={SCORER_METRICS: _multi_scorer_metrics(scorers)},
+        ),
+        scorers,
+        reducer_spec,
+    )
     return score
+
+
+def _multi_scorer_metrics(
+    scorers: list[Scorer],
+) -> list[Metric | dict[str, list[Metric]]] | dict[str, list[Metric]]:
+    for scorer in scorers:
+        if is_registry_object(scorer, type="scorer"):
+            return scorer_metrics(scorer)
+    return []
+
+
+scorer_register(
+    multi_scorer,
+    name=registry_name(multi_scorer, "multi_scorer"),
+    metadata={SCORER_METRICS: []},
+)

--- a/tests/scorer/test_multi_scorer_aggregation.py
+++ b/tests/scorer/test_multi_scorer_aggregation.py
@@ -2,9 +2,14 @@ import math
 
 import anyio
 
+from inspect_ai import Task, eval
 from inspect_ai._eval.task.results import eval_results
+from inspect_ai._util.content import ContentText
+from inspect_ai.dataset import Sample
+from inspect_ai.model import get_model
 from inspect_ai.model._model import ModelName
-from inspect_ai.scorer import Score, Target, mean, scorer
+from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.scorer import Score, Target, mean, model_graded_qa, scorer
 from inspect_ai.scorer._metric import SampleScore
 from inspect_ai.scorer._multi import multi_scorer
 from inspect_ai.scorer._scorer import unique_scorer_name
@@ -108,6 +113,60 @@ def test_reducer_consistent_across_scorers() -> None:
     for score_result in results.scores:
         assert "mean" in score_result.metrics
         assert score_result.metrics["mean"].value is not None
+
+
+def test_multi_scorer_can_be_used_as_task_scorer() -> None:
+    task = Task(
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+        scorer=multi_scorer(
+            [_make_fixed_scorer(1.0), _make_fixed_scorer(0.0)],
+            reducer="mean",
+        ),
+    )
+
+    log = eval(task, model="mockllm/model", display="none")[0]
+
+    assert log.results
+    assert log.results.scores is not None
+    assert len(log.results.scores) == 1
+    assert log.results.scores[0].name == "multi_scorer"
+    assert log.results.scores[0].metrics["mean"].value == 0.5
+
+
+def test_multi_scorer_can_wrap_model_graded_scorers() -> None:
+    grader_models = [
+        get_model(
+            "mockllm/grader1",
+            custom_outputs=[
+                ModelOutput.from_content(
+                    "mockllm/grader1", [ContentText(text="GRADE: C")]
+                )
+            ],
+        ),
+        get_model(
+            "mockllm/grader2",
+            custom_outputs=[
+                ModelOutput.from_content(
+                    "mockllm/grader2", [ContentText(text="GRADE: C")]
+                )
+            ],
+        ),
+    ]
+    task = Task(
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+        scorer=multi_scorer(
+            scorers=[model_graded_qa(model=model) for model in grader_models],
+            reducer="mode",
+        ),
+    )
+
+    log = eval(task, model="mockllm/model", display="none")[0]
+
+    assert log.results
+    assert log.results.scores is not None
+    assert len(log.results.scores) == 1
+    assert log.results.scores[0].name == "multi_scorer"
+    assert log.results.scores[0].metrics["accuracy"].value == 1.0
 
 
 def test_multi_scorer_all_none_returns_unscored() -> None:


### PR DESCRIPTION
## Summary
- tag `multi_scorer(...)` closures with scorer registry info so they can be used directly as `Task(scorer=...)`
- register the `multi_scorer` factory with the same package-qualified naming pattern used by built-in scorers
- preserve the existing reducer execution path and `Score.unscored()` behavior

This subsumes #4115 with a narrower change focused on registry tagging and regression coverage.

## Testing
- `uv run pytest tests/scorer/test_multi_scorer_aggregation.py tests/scorer/test_multiscorer.py -q`
- `uv run ruff check src/inspect_ai/scorer/_multi.py tests/scorer/test_multi_scorer_aggregation.py`