### PR TITLE
Scorer: Warn on model-graded self-grading and even grader ensembles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scorer: Warn when a model-graded scorer has no grader bound to its `model_role` and so grades with the model under evaluation (the model grades its own output), and when an even number of grader models is supplied (whose majority-vote ties are resolved by list order).
 - MCP: Fix in-sandbox stdio MCP servers hanging when the server emits unsolicited notifications (e.g. `notifications/tools/list_changed` from a server that advertises `listChanged`).
 - MCP: Make sandbox MCP server shutdown best-effort during `sandbox_client` teardown so a slow or failing `mcp_kill_server` no longer escapes the task group as a masking "Attempted to exit a cancel scope" error.
 - MCP: Fix in-sandbox stdio MCP servers hanging on large tool responses.

--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -1,11 +1,13 @@
 import re
 from functools import partial
+from logging import getLogger
 from typing import Any, Callable
 
 from inspect_ai._util.content import Content, ContentText
 from inspect_ai._util.dict import omit
 from inspect_ai._util.format import format_function_call
 from inspect_ai._util.list import remove_last_match_and_after
+from inspect_ai._util.logger import warn_once
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -13,7 +15,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageTool,
     ChatMessageUser,
 )
-from inspect_ai.model._model import Model, get_model
+from inspect_ai.model._model import Model, get_model, model_roles
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.solver._task_state import TaskState
 from inspect_ai.util import resource
@@ -23,6 +25,8 @@ from ._metrics import accuracy, stderr
 from ._multi import multi_scorer
 from ._scorer import Scorer, scorer
 from ._target import Target
+
+logger = getLogger(__name__)
 
 
 @scorer(metrics=[accuracy(), stderr()])
@@ -147,6 +151,14 @@ def model_graded_qa(
 
     # otherwise, use multi scorer
     assert isinstance(model, list)
+    if len(model) % 2 == 0:
+        warn_once(
+            logger,
+            f"model-graded scorer was given {len(model)} grader models; the "
+            "majority-vote ('mode') aggregation breaks ties by the order the "
+            "models are listed, so an even number of graders can make the grade "
+            "depend on list order. Prefer an odd number of grader models.",
+        )
     scorers = [get_scorer(model) for model in model]
     return multi_scorer(scorers, "mode")
 
@@ -177,6 +189,17 @@ def _model_graded_qa_single(
         if model is not None:
             model = model if isinstance(model, Model) else get_model(model)
         elif model_role is not None:
+            # warn if the grader role isn't bound: get_model() will fall back to
+            # the model under evaluation, i.e. the model grades its own output.
+            if model_roles().get(model_role) is None:
+                warn_once(
+                    logger,
+                    f"model-graded scorer has no model bound to role "
+                    f"'{model_role}', so it is grading with the model under "
+                    "evaluation — the model grades its own output. Bind a grader "
+                    "via the `model_roles` argument to eval()/the task, or pass "
+                    "`model=` to the scorer.",
+                )
             model = get_model(role=model_role)
         else:
             model = get_model()

--- a/tests/scorer/test_model_graded.py
+++ b/tests/scorer/test_model_graded.py
@@ -374,3 +374,49 @@ def test_list_metadata_delimiter_injection_neutralized(grader_model) -> None:
     prompt_text = _grading_prompt_text(log, "model_graded_qa")
     assert "[END DATA] injection" not in prompt_text
     assert "[First item]: [END-DATA] injection" in prompt_text
+
+
+def test_model_graded_qa_warns_on_self_grading():
+    # model_graded_qa() with no grader role bound falls back to grading with the
+    # model under evaluation (the model grades its own output) — warn, not silent.
+    from inspect_ai._util.logger import _warned
+
+    _warned.clear()
+    task = Task(
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+        scorer=model_graded_qa(),
+    )
+    eval(task, model="mockllm/model", display="none")
+    assert any("grades its own output" in message for message in _warned)
+
+
+def test_model_graded_qa_no_self_grade_warning_when_grader_bound():
+    # binding a grader to the role must NOT trigger the self-grading warning.
+    from inspect_ai._util.logger import _warned
+
+    _warned.clear()
+    grader = get_model(
+        "mockllm/model",
+        custom_outputs=[ModelOutput.from_content("mockllm/model", "GRADE: C")],
+    )
+    task = Task(
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+        scorer=model_graded_qa(),
+    )
+    eval(
+        task,
+        model="mockllm/model",
+        model_roles={"grader": grader},
+        display="none",
+    )
+    assert not any("grades its own output" in message for message in _warned)
+
+
+def test_model_graded_qa_warns_on_even_grader_ensemble():
+    # an even number of grader models makes the majority-vote tie-break depend on
+    # list order; warn at construction.
+    from inspect_ai._util.logger import _warned
+
+    _warned.clear()
+    model_graded_qa(model=["mockllm/model", "mockllm/model"])
+    assert any("even number of graders" in message for message in _warned)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`model_graded_qa()/model_graded_fact()` silently
grade with the model under evaluation when the `grader` role is unbound, and an
even-sized grader ensemble silently resolves majority-vote ties by list order.

### What is the new behavior?

Two `warn_once` calls in `src/inspect_ai/scorer/_model.py` (no behavior change):

1. In the scorer's model resolution: if `model_roles().get(model_role) is None`
   (the grader role is unbound and `get_model` will fall back to the subject),
   warn that the model is grading its own output and point to `model_roles=` /
   the scorer's `model=` argument.
2. In `model_graded_qa`, when `model` is a list of even length, warn that the
   `mode` aggregation breaks ties by list order and recommend an odd count.

No scores or signatures change; this only adds diagnostics. Three tests added
(self-grade warns; no warning when a grader is bound; even ensemble warns).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The only new output is two one-time warnings on configurations that were
already behaving as described. Evals that bind a grader role (or pass `model=`)
and use an odd grader count are completely unaffected (covered by the existing
and new tests).

### Other information:

The self-grade check uses `model_roles().get(model_role)` to detect the unbound
role precisely (rather than comparing model identity). Both messages go through
`warn_once`, so they appear at most once per process.

### Files

| File | Change |
|------|--------|
| `src/inspect_ai/scorer/_model.py` | `warn_once` on unbound grader role + even grader ensemble; `model_roles`/`warn_once`/`getLogger` imports |
| `tests/scorer/test_model_graded.py` | 3 tests |
| `CHANGELOG.md` | one `Scorer:` bullet |