### PR TITLE
add `exclude_fields` to `read_eval_log()` and `samples_df()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Inspect View: Fix log-list grid columns snapping back to default widths while data loads
 - Inspect View: Fix transcript deep links across timelines, approvals, collapsed regions, and lanes; add event label pills.
 - Inspect View:  Improve tool input density
+- Log: `read_eval_log`, `read_eval_log_async`, and `samples_df` now accept `exclude_fields` for more memory-efficient loading of large samples.
 
 ## 0.3.240 (15 June 2026)
 

--- a/src/inspect_ai/analysis/_dataframe/samples/table.py
+++ b/src/inspect_ai/analysis/_dataframe/samples/table.py
@@ -64,6 +64,7 @@ def samples_df(
     strict: Literal[True] = True,
     parallel: bool | int = False,
     quiet: bool | None = None,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame": ...
 
 
@@ -75,6 +76,7 @@ def samples_df(
     strict: Literal[False] = False,
     parallel: bool | int = False,
     quiet: bool | None = None,
+    exclude_fields: set[str] | None = None,
 ) -> tuple["pd.DataFrame", list[ColumnError]]: ...
 
 
@@ -85,6 +87,7 @@ def samples_df(
     strict: bool = True,
     parallel: bool | int = False,
     quiet: bool | None = None,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame" | tuple["pd.DataFrame", list[ColumnError]]:
     """Read a dataframe containing samples from a set of evals.
 
@@ -105,6 +108,9 @@ def samples_df(
           do not read in parallel.
        quiet: If `True`, do not show any output or progress. Defaults to `False`
           for terminal environments, and `True` for notebooks.
+       exclude_fields: Set of EvalSample field names to skip when loading
+          samples (e.g. {"messages", "events", "store", "attachments"}).
+
 
     Returns:
        For `strict`, a Pandas `DataFrame` with information for the specified logs.
@@ -123,6 +129,7 @@ def samples_df(
         strict=strict,
         progress=not quiet,
         parallel=parallel,
+        exclude_fields=exclude_fields,
     )
 
 
@@ -149,6 +156,7 @@ def _read_samples_df(
     detail: MessagesDetail | EventsDetail | None = None,
     progress: bool = True,
     parallel: bool | int = False,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame" | tuple["pd.DataFrame", list[ColumnError]]:
     import pandas as pd
 
@@ -185,6 +193,7 @@ def _read_samples_df(
                         strict=strict,
                         detail=detail,
                         progress=False,
+                        exclude_fields=exclude_fields,
                     ): idx
                     for idx, log_path in enumerate(log_paths)
                 }
@@ -236,6 +245,7 @@ def _read_samples_df(
             strict=strict,
             detail=detail,
             progress=progress,
+            exclude_fields=exclude_fields,
         )
 
 
@@ -247,6 +257,7 @@ def _read_samples_df_serial(
     strict: bool = True,
     detail: MessagesDetail | EventsDetail | None = None,
     progress: bool = True,
+    exclude_fields: set[str] | None = None,
 ) -> "pd.DataFrame" | tuple["pd.DataFrame", list[ColumnError]]:
     # split columns by type
     columns_eval: list[Column] = []
@@ -318,7 +329,9 @@ def _read_samples_df_serial(
                 samples: Iterable[EvalSample | EvalSampleSummary] = eval_log.samples
             elif require_full_samples:
                 full_log = await read_eval_log_async(
-                    eval_log.location, resolve_attachments=True
+                    eval_log.location,
+                    resolve_attachments=True,
+                    exclude_fields=exclude_fields,
                 )
                 samples = full_log.samples or []
             else:

--- a/src/inspect_ai/analysis/_dataframe/samples/table.py
+++ b/src/inspect_ai/analysis/_dataframe/samples/table.py
@@ -111,7 +111,6 @@ def samples_df(
        exclude_fields: Set of EvalSample field names to skip when loading
           samples (e.g. {"messages", "events", "store", "attachments"}).
 
-
     Returns:
        For `strict`, a Pandas `DataFrame` with information for the specified logs.
        For `strict=False`, a tuple of Pandas `DataFrame` and a dictionary of errors

--- a/src/inspect_ai/analysis/_dataframe/samples/table.py
+++ b/src/inspect_ai/analysis/_dataframe/samples/table.py
@@ -110,6 +110,7 @@ def samples_df(
           for terminal environments, and `True` for notebooks.
        exclude_fields: Set of EvalSample field names to skip when loading
           samples (e.g. {"messages", "events", "store", "attachments"}).
+          Ignored for .json format logs (only applies to .eval logs).
 
     Returns:
        For `strict`, a Pandas `DataFrame` with information for the specified logs.

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -266,6 +266,7 @@ def read_eval_log(
     header_only: bool = False,
     resolve_attachments: bool | Literal["full", "core"] = False,
     format: Literal["eval", "json", "auto"] = "auto",
+    exclude_fields: set[str] | None = None,
 ) -> EvalLog:
     """Read an evaluation log.
 
@@ -279,6 +280,10 @@ def read_eval_log(
           to their full content.
        format (Literal["eval", "json", "auto"]): Read from format
           (defaults to 'auto' based on `log_file` extension).
+       exclude_fields: Set of EvalSample field names to skip when loading
+          samples (e.g. {"messages", "events", "store", "attachments"}).
+          Only applies to .eval format files. Has no effect when
+          header_only is True or when log_file is an IO[bytes] stream.
 
     Returns:
        EvalLog object read from file.
@@ -293,10 +298,7 @@ def read_eval_log(
     # flow, so force the use of asyncio
     return run_coroutine(
         read_eval_log_async(
-            log_file,
-            header_only,
-            resolve_attachments,
-            format,
+            log_file, header_only, resolve_attachments, format, exclude_fields
         )
     )
 
@@ -306,6 +308,7 @@ async def read_eval_log_async(
     header_only: bool = False,
     resolve_attachments: bool | Literal["full", "core"] = False,
     format: Literal["eval", "json", "auto"] = "auto",
+    exclude_fields: set[str] | None = None,
 ) -> EvalLog:
     """Read an evaluation log.
 
@@ -319,6 +322,10 @@ async def read_eval_log_async(
           to their full content.
        format (Literal["eval", "json", "auto"]): Read from format
           (defaults to 'auto' based on `log_file` extension).
+       exclude_fields: Set of EvalSample field names to skip when loading
+          samples (e.g. {"messages", "events", "store", "attachments"}).
+          Only applies to .eval format files. Has no effect when
+          header_only is True or when log_file is an IO[bytes] stream.
 
     Returns:
        EvalLog object read from file.
@@ -349,10 +356,15 @@ async def read_eval_log_async(
             recorder_type = recorder_type_for_location(log_file)
         else:
             recorder_type = recorder_type_for_format(format)
-        log = await recorder_type.read_log(log_file, header_only)
+
+        if exclude_fields and "events" in exclude_fields:
+            exclude_fields = exclude_fields | {"events_data"}
+
+        log = await recorder_type.read_log(log_file, header_only, exclude_fields)
 
     if log.samples:
         log.samples = [
+            # TODO: from merge conflict, need to pass exclude_fields to _resolve_sample_for_read
             _resolve_sample_for_read(sample, resolve_attachments)
             for sample in log.samples
         ]

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -357,14 +357,12 @@ async def read_eval_log_async(
         else:
             recorder_type = recorder_type_for_format(format)
 
-        if exclude_fields and "events" in exclude_fields:
-            exclude_fields = exclude_fields | {"events_data"}
+        exclude_fields = _normalize_excluded_fields(exclude_fields)
 
         log = await recorder_type.read_log(log_file, header_only, exclude_fields)
 
     if log.samples:
         log.samples = [
-            # TODO: from merge conflict, need to pass exclude_fields to _resolve_sample_for_read
             _resolve_sample_for_read(sample, resolve_attachments)
             for sample in log.samples
         ]
@@ -534,13 +532,7 @@ async def read_eval_log_sample_async(
         recorder_type = recorder_type_for_location(log_file)
     else:
         recorder_type = recorder_type_for_format(format)
-    if exclude_fields:
-        if "events" not in exclude_fields:
-            # events_data is needed to resolve refs in events
-            exclude_fields = exclude_fields - {"events_data"}
-        else:
-            # no events means events_data is useless
-            exclude_fields = exclude_fields | {"events_data"}
+    exclude_fields = _normalize_excluded_fields(exclude_fields)
 
     sample = await recorder_type.read_log_sample(
         log_file, id, epoch, uuid, exclude_fields, reader
@@ -921,6 +913,17 @@ def to_overview(header: EvalLog) -> LogOverview:
         completed_at=header.stats.completed_at,
         primary_metric=primary_metric,
     )
+
+
+def _normalize_excluded_fields(exclude_fields: set[str] | None) -> set[str] | None:
+    if exclude_fields:
+        if "events" not in exclude_fields:
+            # events_data is needed to resolve refs in events
+            exclude_fields = exclude_fields - {"events_data"}
+        else:
+            # no events means events_data is useless
+            exclude_fields = exclude_fields | {"events_data"}
+    return exclude_fields
 
 
 def _resolve_sample_for_read(

--- a/src/inspect_ai/log/_file.py
+++ b/src/inspect_ai/log/_file.py
@@ -282,8 +282,8 @@ def read_eval_log(
           (defaults to 'auto' based on `log_file` extension).
        exclude_fields: Set of EvalSample field names to skip when loading
           samples (e.g. {"messages", "events", "store", "attachments"}).
-          Only applies to .eval format files. Has no effect when
-          header_only is True or when log_file is an IO[bytes] stream.
+          Ignored for .json format logs (only applies to .eval logs). Has no
+          effect when header_only is True or when log_file is an IO[bytes] stream.
 
     Returns:
        EvalLog object read from file.
@@ -324,8 +324,8 @@ async def read_eval_log_async(
           (defaults to 'auto' based on `log_file` extension).
        exclude_fields: Set of EvalSample field names to skip when loading
           samples (e.g. {"messages", "events", "store", "attachments"}).
-          Only applies to .eval format files. Has no effect when
-          header_only is True or when log_file is an IO[bytes] stream.
+          Ignored for .json format logs (only applies to .eval logs). Has no
+          effect when header_only is True or when log_file is an IO[bytes] stream.
 
     Returns:
        EvalLog object read from file.
@@ -441,6 +441,7 @@ def read_eval_log_sample(
        exclude_fields (set[str] | None): Set of field names to exclude when reading
           the sample. Useful when reading large samples with fields like
           'store' or 'attachments' that aren't needed.
+          Ignored for .json format logs (only applies to .eval logs).
 
     Returns:
        EvalSample object read from file.
@@ -505,6 +506,7 @@ async def read_eval_log_sample_async(
        exclude_fields (set[str] | None): Set of field names to exclude when reading
           the sample. Useful when reading large samples with fields like
           'store' or 'attachments' that aren't needed.
+          Ignored for .json format logs (only applies to .eval logs).
        reader (AsyncZipReader | None): Optional async zip reader to use when reading the sample.
 
     Returns:
@@ -619,6 +621,7 @@ def read_eval_log_samples(
        exclude_fields (set[str] | None): Set of field names to exclude when reading
           the sample. Useful when reading large samples with fields like
           'store' or 'attachments' that aren't needed.
+          Ignored for .json format logs (only applies to .eval logs).
 
     Returns:
        Generator of EvalSample objects in the log file.

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -254,6 +254,7 @@ class EvalRecorder(FileRecorder):
         cls,
         location: str,
         header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog:
         async with AsyncFilesystem() as async_fs:
             # if the log is not stored in the local filesystem then download it
@@ -279,7 +280,9 @@ class EvalRecorder(FileRecorder):
                 read_location = temp_log or location
                 reader = AsyncZipReader(async_fs, read_location)
                 cd = await reader.entries()
-                log = await _read_log(reader, cd.entries, location, header_only)
+                log = await _read_log(
+                    reader, cd.entries, location, header_only, exclude_fields
+                )
 
                 if etag is not None:
                     log.etag = etag
@@ -955,6 +958,7 @@ async def _read_log(
     entries: list[ZipEntry],
     location: str,
     header_only: bool = False,
+    exclude_fields: set[str] | None = None,
 ) -> EvalLog:
     entry_names = {e.filename for e in entries}
 
@@ -977,7 +981,12 @@ async def _read_log(
             if entry.filename.startswith(f"{SAMPLES_DIR}/") and entry.filename.endswith(
                 ".json"
             ):
-                data = await _read_member_json(reader, entry.filename)
+                if exclude_fields:
+                    data = await _read_member_json_excluding(
+                        reader, entry.filename, exclude_fields
+                    )
+                else:
+                    data = await _read_member_json(reader, entry.filename)
                 samples.append(
                     EvalSample.model_validate(
                         data, context=get_deserializing_context()

--- a/src/inspect_ai/log/_recorders/eval.py
+++ b/src/inspect_ai/log/_recorders/eval.py
@@ -347,66 +347,11 @@ class EvalRecorder(FileRecorder):
                 epoch = sample.epoch
 
             if exclude_fields:
-                # Stream the sample JSON using low-level parse events.
-                # An ObjectBuilder accumulates events only for included fields;
-                # excluded fields are read as raw events and never allocated
-                # as Python objects, keeping peak memory proportional to the
-                # data we actually keep.
-                import ijson  # type: ignore
-                from ijson import IncompleteJSONError, ObjectBuilder
-                from ijson.backends.python import (  # type: ignore[import-untyped]
-                    UnexpectedSymbol,
+                data = await _read_member_json_excluding(
+                    reader,
+                    _sample_filename(id, epoch),
+                    exclude_fields,
                 )
-
-                try:
-                    data: dict[str, Any] = {}
-                    async with await reader.open_member(
-                        _sample_filename(id, epoch)
-                    ) as f:
-                        depth = 0
-                        current_key: str = ""
-                        builder: ObjectBuilder | None = None
-                        async for prefix, event, value in ijson.parse_async(
-                            adapt_to_reader(f), use_float=True
-                        ):
-                            # Depth must be updated before the completion check
-                            # so that a closing bracket that returns depth to 1
-                            # is recognised as completing the current value.
-                            if event in ("start_map", "start_array"):
-                                depth += 1
-                            elif event in ("end_map", "end_array"):
-                                depth -= 1
-
-                            if depth == 1 and event == "map_key":
-                                current_key = value
-                                builder = (
-                                    None
-                                    if current_key in exclude_fields
-                                    else ObjectBuilder()
-                                )
-                            elif builder is not None:
-                                builder.event(event, value)
-                                # Depth 1 means we have returned to the top-level
-                                # object, so the current field's value is complete.
-                                if depth == 1:
-                                    data[current_key] = builder.value
-                                    builder = None
-                except (
-                    ValueError,
-                    IncompleteJSONError,
-                    UnexpectedSymbol,
-                ) as ex:
-                    # ijson doesn't support NaN/Inf which are valid in
-                    # Python's JSON. Fall back to standard json.load
-                    # and manually remove excluded fields.
-                    if is_ijson_nan_inf_error(ex):
-                        data = json.loads(
-                            await reader.read_member_fully(_sample_filename(id, epoch))
-                        )
-                        for field in exclude_fields:
-                            data.pop(field, None)
-                    else:
-                        raise
             else:
                 data = json.loads(
                     await reader.read_member_fully(_sample_filename(id, epoch))
@@ -556,6 +501,62 @@ def _rewrite_eval_zip_via_filesystem(location: str, log: EvalLog) -> None:
     new_bytes = _rewrite_eval_zip_with_new_header(existing_bytes, log)
     with file(location, "wb") as f:
         f.write(new_bytes)
+
+
+async def _read_member_json_excluding(
+    reader: AsyncZipReader,
+    member: str,
+    exclude_fields: set[str],
+) -> dict[str, Any]:
+    """Parse a zip member's JSON, skipping excluded top-level fields via ijson streaming."""
+    import ijson  # type: ignore
+    from ijson import IncompleteJSONError, ObjectBuilder
+    from ijson.backends.python import (  # type: ignore[import-untyped]
+        UnexpectedSymbol,
+    )
+
+    try:
+        data: dict[str, Any] = {}
+        async with await reader.open_member(member) as f:
+            depth = 0
+            current_key: str = ""
+            builder: ObjectBuilder | None = None
+            async for prefix, event, value in ijson.parse_async(
+                adapt_to_reader(f), use_float=True
+            ):
+                # Depth must be updated before the completion check
+                # so that a closing bracket that returns depth to 1
+                # is recognised as completing the current value.
+                if event in ("start_map", "start_array"):
+                    depth += 1
+                elif event in ("end_map", "end_array"):
+                    depth -= 1
+
+                if depth == 1 and event == "map_key":
+                    current_key = value
+                    builder = None if current_key in exclude_fields else ObjectBuilder()
+                elif builder is not None:
+                    builder.event(event, value)
+                    # Depth 1 means we have returned to the top-level
+                    # object, so the current field's value is complete.
+                    if depth == 1:
+                        data[current_key] = builder.value
+                        builder = None
+    except (
+        ValueError,
+        IncompleteJSONError,
+        UnexpectedSymbol,
+    ) as ex:
+        # ijson doesn't support NaN/Inf which are valid in
+        # Python's JSON. Fall back to standard json.load
+        # and manually remove excluded fields.
+        if is_ijson_nan_inf_error(ex):
+            data = json.loads(await reader.read_member_fully(member))
+            for field in exclude_fields:
+                data.pop(field, None)
+        else:
+            raise
+    return data
 
 
 async def _write_eval_log_with_recorder(

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -184,6 +184,7 @@ class JSONRecorder(FileRecorder):
         cls,
         location: str,
         header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog:
         fs = filesystem(location)
 

--- a/src/inspect_ai/log/_recorders/recorder.py
+++ b/src/inspect_ai/log/_recorders/recorder.py
@@ -101,6 +101,7 @@ class Recorder(abc.ABC):
         cls,
         location: str,
         header_only: bool = False,
+        exclude_fields: set[str] | None = None,
     ) -> EvalLog: ...
 
     @classmethod

--- a/tests/analysis/test_samples_df_exclude_fields.py
+++ b/tests/analysis/test_samples_df_exclude_fields.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from inspect_ai.analysis import samples_df
+from inspect_ai.analysis._dataframe.samples.columns import SampleScores
+
+LOGS_DIR = Path(__file__).parent / "test_logs"
+POPULARITY_LOG = LOGS_DIR / "2025-05-12T20-28-13-04-00_popularity.json"
+
+
+def test_samples_df_exclude_fields_no_error():
+    """Smoke test: exclude_fields threads through without error.
+
+    Uses a .json fixture where exclude_fields is a no-op at the recorder
+    level — this verifies the parameter plumbing, not field exclusion.
+    """
+    df = samples_df(
+        POPULARITY_LOG,
+        columns=SampleScores,
+        exclude_fields={"messages", "events", "store", "attachments"},
+    )
+    assert len(df) > 0
+    score_cols = [c for c in df.columns if c.startswith("score_")]
+    assert len(score_cols) > 0

--- a/tests/analysis/test_samples_df_exclude_fields.py
+++ b/tests/analysis/test_samples_df_exclude_fields.py
@@ -1,23 +1,41 @@
 from pathlib import Path
 
-from inspect_ai.analysis import samples_df
+from inspect_ai.analysis import SampleColumn, samples_df
 from inspect_ai.analysis._dataframe.samples.columns import SampleScores
 
 LOGS_DIR = Path(__file__).parent / "test_logs"
-POPULARITY_LOG = LOGS_DIR / "2025-05-12T20-28-13-04-00_popularity.json"
+JSON_LOG = LOGS_DIR / "2025-05-12T20-28-13-04-00_popularity.json"
+EVAL_LOG = Path(__file__).parent / "test_logs_choices" / "mmlu-summary-choices.eval"
 
 
-def test_samples_df_exclude_fields_no_error():
+def test_samples_df_json_exclude_fields_no_error():
     """Smoke test: exclude_fields threads through without error.
 
     Uses a .json fixture where exclude_fields is a no-op at the recorder
     level — this verifies the parameter plumbing, not field exclusion.
     """
     df = samples_df(
-        POPULARITY_LOG,
+        JSON_LOG,
         columns=SampleScores,
         exclude_fields={"messages", "events", "store", "attachments"},
     )
     assert len(df) > 0
     score_cols = [c for c in df.columns if c.startswith("score_")]
     assert len(score_cols) > 0
+
+
+def test_samples_df_eval_exclude_fields():
+    columns = SampleScores + [
+        SampleColumn("num_messages", path=lambda s: len(s.messages), full=True)
+    ]
+    df = samples_df(
+        EVAL_LOG,
+        columns=columns,
+        exclude_fields={"messages", "events", "store", "attachments"},
+    )
+    assert len(df) == 1
+    score_cols = [c for c in df.columns if c.startswith("score_")]
+    assert len(score_cols) > 0
+    assert df["score_choice"].iloc[0] == "I"
+    # excluded: messages were skipped during the read, so none are extracted
+    assert df["num_messages"].iloc[0] == 0

--- a/tests/log/test_read_eval_log_exclude_fields.py
+++ b/tests/log/test_read_eval_log_exclude_fields.py
@@ -1,0 +1,22 @@
+import os
+
+from inspect_ai.log import read_eval_log
+
+EVAL_LOG_FILE = os.path.join("tests", "log", "test_eval_log", "log_read_sample.eval")
+
+
+def test_read_eval_log_exclude_fields_preserves_scores():
+    log = read_eval_log(
+        EVAL_LOG_FILE,
+        exclude_fields={"messages", "events", "store", "attachments"},
+    )
+    assert log.samples
+    sample = log.samples[0]
+    assert not sample.messages
+    assert not sample.events
+    assert not sample.store
+    assert not sample.attachments
+    assert sample.scores
+    score = sample.scores["match"]
+    assert score.value == "C"
+    assert score.answer == "Yes"

--- a/tests/log/test_read_eval_log_exclude_fields.py
+++ b/tests/log/test_read_eval_log_exclude_fields.py
@@ -1,6 +1,22 @@
+import math
 import os
+import tempfile
 
-from inspect_ai.log import read_eval_log
+from inspect_ai._util.constants import LOG_SCHEMA_VERSION
+from inspect_ai.log import (
+    EvalConfig,
+    EvalDataset,
+    EvalLog,
+    EvalPlan,
+    EvalResults,
+    EvalSpec,
+    EvalStats,
+    read_eval_log,
+    write_eval_log,
+)
+from inspect_ai.log._log import EvalSample
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_ai.scorer import Score
 
 EVAL_LOG_FILE = os.path.join("tests", "log", "test_eval_log", "log_read_sample.eval")
 
@@ -20,3 +36,57 @@ def test_read_eval_log_exclude_fields_preserves_scores():
     score = sample.scores["match"]
     assert score.value == "C"
     assert score.answer == "Yes"
+
+
+def _make_log_with_nan_score() -> EvalLog:
+    """Build a minimal log whose sample JSON contains a NaN literal."""
+    sample = EvalSample(
+        id="s1",
+        epoch=1,
+        input="hello",
+        target="world",
+        messages=[ChatMessageUser(content="hi")],
+        store={"k": "v"},
+        scores={"match": Score(value=float("nan"), answer="Yes")},
+    )
+    return EvalLog(
+        version=LOG_SCHEMA_VERSION,
+        status="success",
+        eval=EvalSpec(
+            task="t",
+            task_id="i",
+            model="m",
+            dataset=EvalDataset(name="d", samples=1),
+            config=EvalConfig(),
+            created="2025-01-01T00:00:00Z",
+        ),
+        plan=EvalPlan(),
+        results=EvalResults(total_samples=1, completed_samples=1),
+        stats=EvalStats(
+            started_at="2025-01-01T00:00:00Z",
+            completed_at="2025-01-01T00:01:00Z",
+        ),
+        samples=[sample],
+    )
+
+
+def test_read_eval_log_exclude_fields_nan_inf_fallback():
+    """When NaNs are present, ijson fails and we fall back to json.loads.
+
+    Make sure we still respect exclude_fields in that case.
+    """
+    log = _make_log_with_nan_score()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "nan.eval")
+        write_eval_log(log, path)
+
+        read_log = read_eval_log(path, exclude_fields={"messages", "store"})
+
+    assert read_log.samples
+    sample = read_log.samples[0]
+    # excluded fields are still dropped on the json.loads fallback path
+    assert not sample.messages
+    assert not sample.store
+    # the NaN value that forced the fallback is preserved
+    assert math.isnan(sample.scores["match"].value)
+    assert sample.scores["match"].answer == "Yes"


### PR DESCRIPTION
This PR supersedes @RoshDSIT's unmerged #3816:
- Rebases onto main (resolves merge conflicts)
- Normalises exclude_fields wrt `events` and `events_data` parity consistently (see `_normalize_excluded_fields()`)
- Enhances tests
- Document the fact that `exclude_fields` is ignored for .json format logs (this was already the case with `main`'s `read_eval_log_sample()` but was not documented). 

## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
See #3816 

### What is the new behavior?
See #3816 

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. see #3816

### Other information:
Note that as per existing behaviour in `read_eval_log_sample()` (and async equiv), `exclude_fields` has no effect when the log file is .json. This is documented int the parameter docstring.