### PR TITLE
Persist pre-overridden API key values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Limits: Added `turn_limit()` which tracks total generations.
 - Control Channel: `inspect ctl tasks` now reports keep-alive status (`on` / `off` / `mixed`) and a new `inspect ctl keep` command (backed by `POST /keep`) latches keep-alive on a running process so it parks after its eval.
 - Hooks: Add `on_model_retry` hook, fired before each model retry backoff with the model name, attempt number, and upcoming `wait_time` (useful for surfacing time spent in rate limiting and other retries).
+- Hooks: `override_api_key` hooks are now always passed the original API key value (from the env var or the explicit `api_key` argument) rather than a previously-overridden value, so hooks that resolve short-lived credentials can re-resolve on every (re)initialization.
 - Inspect View: Improve sample reading performance in viewer by serving `/log-bytes` range requests as plain responses instead of line-iterating a `BytesIO`.
 - Inspect View: Fix log-list grid columns snapping back to default widths while data loads
 - Inspect View: Fix transcript deep links across timelines, approvals, collapsed regions, and lanes; add event label pills.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -216,6 +216,9 @@ class ModelAPI(abc.ABC):
         self.model_name = model_name
         self.base_url = base_url
         self.api_key = api_key
+        # original explicit key, re-offered to hooks on re-init (since self.api_key gets
+        # overwritten with the resolved value). See _apply_api_key_overrides.
+        self._original_api_key = api_key
         self.api_key_vars = api_key_vars
         self._apply_api_key_overrides()
 
@@ -226,7 +229,10 @@ class ModelAPI(abc.ABC):
             # an explicitly set self.api_key (note this can also be set by subclasses)
             # takes precedence over the environment, so offer that value to the hook
             if self.api_key is not None:
-                override = override_api_key(key, self.api_key)
+                # re-resolve from the original explicit key when we have one, not from a
+                # value we previously overrode in place (which on re-init would be the
+                # hook's own prior output)
+                override = override_api_key(key, self._original_api_key or self.api_key)
                 if override is not None:
                     self.api_key = override
             # otherwise look it up in the environment and override it in

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -226,8 +226,9 @@ class ModelAPI(abc.ABC):
         from inspect_ai.hooks._hooks import has_api_key_override, override_api_key
 
         for key in self.api_key_vars:
-            # an explicitly set self.api_key (note this can also be set by subclasses)
-            # takes precedence over the environment, so offer that value to the hook
+            # an explicitly set self.api_key (which can be set by at initialisation, by
+            # subclasses and by hooks when no env var is matched) takes precedence over
+            # the environment, so offer that value to the hook.
             if self.api_key is not None:
                 # re-resolve from the original explicit key when we have one, not from a
                 # value we previously overrode in place (which on re-init would be the
@@ -235,8 +236,8 @@ class ModelAPI(abc.ABC):
                 override = override_api_key(key, self._original_api_key or self.api_key)
                 if override is not None:
                     self.api_key = override
-            # otherwise look it up in the environment and override it in
-            # place (so downstream provider SDKs read the resolved value)
+            # otherwise look it up in the environment and override it in place (so
+            # downstream provider SDKs read the resolved value)
             else:
                 value = _get_original_api_key_env_value(key)
                 if value is not None:

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -222,19 +222,17 @@ class ModelAPI(abc.ABC):
     def _apply_api_key_overrides(self) -> None:
         from inspect_ai.hooks._hooks import has_api_key_override, override_api_key
 
-        # apply api key override
-        api_key = self.api_key
         for key in self.api_key_vars:
-            # if there is an explicit api_key passed then it
-            # overrides anything in the environment so use it
-            if api_key is not None:
-                override = override_api_key(key, api_key)
+            # an explicitly set self.api_key (note this can also be set by subclasses)
+            # takes precedence over the environment, so offer that value to the hook
+            if self.api_key is not None:
+                override = override_api_key(key, self.api_key)
                 if override is not None:
-                    api_key = override
-            # otherwise look it up in the environment and
-            # override it if it has a value
+                    self.api_key = override
+            # otherwise look it up in the environment and override it in
+            # place (so downstream provider SDKs read the resolved value)
             else:
-                value = os.environ.get(key, None)
+                value = _get_original_api_key_env_value(key)
                 if value is not None:
                     override = override_api_key(key, value)
                     if override is not None:
@@ -245,10 +243,7 @@ class ModelAPI(abc.ABC):
                 elif has_api_key_override():
                     override = override_api_key(key, "")
                     if override is not None:
-                        api_key = override
-
-        # set any explicitly specified api key
-        self.api_key = api_key
+                        self.api_key = override
 
     def initialize(self) -> None:
         """Reinitialize the model API client.
@@ -2486,3 +2481,28 @@ def sample_total_cost() -> float:
         for usage in sample_model_usage().values()
         if usage.total_cost is not None
     )
+
+
+# Original (pre-override) values of api-key environment variables. Captured the
+# first time we override each var (e.g. "OPENAI_API_KEY": "arn:aws:..."). Overrides are
+# always resolved from these originals rather than from the live environment. os.environ
+# is overwritten with the *resolved* key so downstream provider SDKs (which read keys
+# straight from the environment) pick it up. That write would otherwise destroy the
+# original value — e.g. a secret-manager ARN that the override hook needs in order to
+# re-resolve credentials when the model is re-initialized (on a 401) or when a later
+# model is constructed.
+_original_api_key_env: dict[str, str | None] = {}
+
+
+def _get_original_api_key_env_value(env_var: str) -> str | None:
+    """Return the original, pre-override value of an api-key env var.
+
+    Sets the value if it hasn't been set yet.
+
+    Captured on first access: at that moment os.environ still holds the user's
+    original value, because a var is only ever overwritten *after* it has been
+    snapshotted here.
+    """
+    if env_var not in _original_api_key_env:
+        _original_api_key_env[env_var] = os.environ.get(env_var)
+    return _original_api_key_env[env_var]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,18 @@ def mock_s3():
             os.environ[key] = value
 
 
+@pytest.fixture(autouse=True)
+def _reset_model_api_key_env_snapshot():
+    # inspect_ai.model._model's _original_api_key_env is process-global and
+    # first-touch-wins, so clear it around every test to prevent a value captured in one
+    # test from leaking into another.
+    from inspect_ai.model._model import _original_api_key_env
+
+    _original_api_key_env.clear()
+    yield
+    _original_api_key_env.clear()
+
+
 def pytest_sessionfinish(session, exitstatus):
     # When running under pytest-xdist, this hook fires once per worker as well
     # as on the controller. Letting every worker race to uninstall the test

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -220,3 +220,73 @@ def test_env_override_reresolves_from_original_arn(
     finally:
         # Remove the model provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mockarn"]
+
+
+class MockOwnSourceHook(Hooks):
+    """Supplies credentials from its own source (e.g. OAuth/vault).
+
+    Returns an incrementing token regardless of input, so it can provide a key
+    even when none exists in the environment at all.
+    """
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.seen_values: list[str] = []
+
+    def override_api_key(self, data: ApiKeyOverride) -> str | None:
+        if data.env_var_name != "TEST_API_KEY":
+            return None
+        self.seen_values.append(data.value)
+        self.call_count += 1
+        return f"own-source-token-{self.call_count}"
+
+
+@pytest.fixture
+def mock_own_source_hook() -> Generator[MockOwnSourceHook, None, None]:
+    @hooks("test_own_source", description="Test own-source credential hook")
+    def get_hook() -> type[MockOwnSourceHook]:
+        return MockOwnSourceHook
+
+    hook = registry_lookup("hooks", "test_own_source")
+    assert isinstance(hook, MockOwnSourceHook)
+    try:
+        yield hook
+    finally:
+        # Remove the hook from the registry to avoid conflicts in other tests.
+        del _registry["hooks:test_own_source"]
+
+
+def test_override_supplies_credentials_when_no_env_key(
+    monkeypatch: pytest.MonkeyPatch, mock_own_source_hook: MockOwnSourceHook
+):
+    """A registered hook supplies credentials with no env key.
+
+    The hook is invoked even when no api key exists in the environment, and its
+    credential is refreshed on re-initialization.
+    """
+    import os
+
+    # ensure there is no api key anywhere in the environment
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mockownsource")
+    def mockownsource() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        # there is no env value to resolve, so the hook is invoked with an empty
+        # string and supplies the credential from its own source
+        model = get_model("mockownsource/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key == "own-source-token-1"
+        assert mock_own_source_hook.seen_values == [""]
+        # nothing is written back to the environment in this branch
+        assert "TEST_API_KEY" not in os.environ
+
+        # re-initialization (as happens on a 401) refreshes the credential
+        provider.initialize()
+        assert provider.api_key == "own-source-token-2"
+    finally:
+        # Remove the model provider from the registry to avoid conflicts in other tests.
+        del _registry["modelapi:mockownsource"]

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -138,3 +138,85 @@ def test_reactive_token_refresh_on_401(mock_refresh_token_hook: MockRefreshToken
     finally:
         # Remove the provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mock401"]
+
+
+class MockArnResolverHook(Hooks):
+    """Resolves a secret-manager ARN to an incrementing real key.
+
+    Unlike MockRefreshTokenHook, this hook's output *depends on its input* — it
+    only resolves when handed the original ARN. It therefore breaks if the
+    original value is clobbered by a previous resolution.
+    """
+
+    ARN = "arn:aws:secretsmanager:us-east-1:secret:openai"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.seen_values: list[str] = []
+
+    def override_api_key(self, data: ApiKeyOverride) -> str | None:
+        if data.env_var_name != "TEST_API_KEY":
+            return None
+        self.seen_values.append(data.value)
+        if data.value != self.ARN:
+            return None
+        self.call_count += 1
+        return f"resolved-key-{self.call_count}"
+
+
+@pytest.fixture
+def mock_arn_resolver_hook() -> Generator[MockArnResolverHook, None, None]:
+    @hooks("test_arn_resolver", description="Test ARN resolver hook")
+    def get_hook() -> type[MockArnResolverHook]:
+        return MockArnResolverHook
+
+    hook = registry_lookup("hooks", "test_arn_resolver")
+    assert isinstance(hook, MockArnResolverHook)
+    try:
+        yield hook
+    finally:
+        # Remove the hook from the registry to avoid conflicts in other tests.
+        del _registry["hooks:test_arn_resolver"]
+
+
+def test_env_override_reresolves_from_original_arn(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """Env-var overrides re-resolve from the original value.
+
+    They must not re-resolve from the previously-resolved key written back
+    into os.environ.
+    """
+    import os
+
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockarn")
+    def mockarn() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        # initial construction resolves the ARN and writes the resolved key
+        # back to os.environ for downstream SDKs
+        model = get_model("mockarn/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key is None  # env-var path leaves api_key unset
+        assert os.environ["TEST_API_KEY"] == "resolved-key-1"
+
+        # re-initialization (as happens on a 401) must hand the hook the ARN
+        # again — not the already-resolved key now sitting in os.environ
+        provider.initialize()
+        assert os.environ["TEST_API_KEY"] == "resolved-key-2"
+
+        # a later, separately-constructed model must also re-resolve the ARN
+        model2 = get_model("mockarn/test", memoize=False)
+        assert os.environ["TEST_API_KEY"] == "resolved-key-3"
+        assert model2.api is not provider
+
+        # the hook only ever saw the original ARN, never a resolved key
+        assert set(mock_arn_resolver_hook.seen_values) == {MockArnResolverHook.ARN}
+        assert mock_arn_resolver_hook.call_count == 3
+    finally:
+        # Remove the model provider from the registry to avoid conflicts in other tests.
+        del _registry["modelapi:mockarn"]

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -222,6 +222,55 @@ def test_env_override_reresolves_from_original_arn(
         del _registry["modelapi:mockarn"]
 
 
+def test_explicit_key_override_reresolves_from_original_arn(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """An explicitly-supplied api key re-resolves from the original value.
+
+    The same re-resolution guarantee as the env-var path, but for the
+    `api_key=` argument: re-initialization must re-offer the original ARN to the
+    hook, not the resolved key we previously wrote into self.api_key.
+    """
+    # ensure the explicit key is the only source (nothing in the environment)
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mockarnexplicit")
+    def mockarnexplicit() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        # initial construction resolves the explicitly-supplied ARN
+        model = get_model(
+            "mockarnexplicit/test",
+            api_key=MockArnResolverHook.ARN,
+            memoize=False,
+        )
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key == "resolved-key-1"
+
+        # re-initialization (as happens on a 401) must hand the hook the ARN
+        # again — not the resolved key now sitting in self.api_key
+        provider.initialize()
+        assert provider.api_key == "resolved-key-2"
+
+        # a later, separately-constructed model also re-resolves the ARN
+        model2 = get_model(
+            "mockarnexplicit/test",
+            api_key=MockArnResolverHook.ARN,
+            memoize=False,
+        )
+        assert model2.api.api_key == "resolved-key-3"
+        assert model2.api is not provider
+
+        # the hook only ever saw the original ARN, never a resolved key
+        assert set(mock_arn_resolver_hook.seen_values) == {MockArnResolverHook.ARN}
+        assert mock_arn_resolver_hook.call_count == 3
+    finally:
+        # Remove the model provider from the registry to avoid conflicts in other tests.
+        del _registry["modelapi:mockarnexplicit"]
+
+
 class MockOwnSourceHook(Hooks):
     """Supplies credentials from its own source (e.g. OAuth/vault).
 


### PR DESCRIPTION
**Draft** - I want to validate this won't break anyone who might be relying on the existing behaviour, and re-review my changes before publishing.

**Might close** - see comment https://github.com/UKGovernmentBEIS/inspect_ai/pull/4293#issuecomment-4778394834

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?
When an `override_api_key` hook resolves a reference value into a real credential, that credential is fed back to the hook on subsequent resolutions instead of the original reference — so the hook can no longer re-resolve.

**Env-var path**: Suppose `OPENAI_API_KEY="arn:aws:..."` (a pointer to a secret) and a hook resolves it to `sk-...` We write the resolved `sk-...` back into `os.environ["OPENAI_API_KEY"]` (so downstream provider SDKs can read it). The next time a model is initialised, or re-initialised after a 401, the hook is handed `sk-...,` not the `arn:aws:...` it needs to do the resolution. It can't re-resolve and so the stale value will persist. This was harmless for long-lived credentials (the original override stays valid), but breaks short-lived credentials/tokens that must be refreshed.

**Explicit api_key path**: The same problem exists for a key supplied via the `api_key` constructor argument. We overwrite `self.api_key` with the resolved value, so every later call hands the hook its own previous output rather than the original key.

### What is the new behavior?
Hooks are always offered the original value, on every (re)initialisation:

**Env-var path:** the original env-var value is captured the first time we override it and re-offered thereafter. `os.environ` is still overwritten with the resolved value so downstream SDKs keep working.

**Explicit api_key path:** the original constructor-supplied api_key is remembered and re-offered, rather than the value we previously wrote back into `self.api_key`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
It is a change to existing behaviour. A hook that depends on receiving the value it previously returned (rather than the user's original value) will break. I'd argue the existing behaviour is wrong. It contradicts what `ApiKeyOverride` documents: value is "the original value of the environment variable", and a hook returns "the new API key value to use, or None to use the original value". A hook that needs to track a previously emitted value is free to do so via an instance field.

### Other information:
* This PR is born out of #4255.
* Updates to `os.environ` after the initial value has been captured will be ignored.