### PR TITLE
Fix env-backed API key provenance across model instances

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -216,41 +216,111 @@ class ModelAPI(abc.ABC):
         self.model_name = model_name
         self.base_url = base_url
         self.api_key = api_key
-        # original explicit key, re-offered to hooks on re-init (since self.api_key gets
-        # overwritten with the resolved value). See _apply_api_key_overrides.
-        self._original_api_key = api_key
+        # Stable non-environment source, initially an explicit constructor key. A
+        # subclass may also populate self.api_key from its own source after super init;
+        # _apply_api_key_overrides captures that value on its first re-initialization.
+        self._api_key_source = api_key
+        self._api_key_source_is_set = api_key is not None
+        self._api_key_env_values: dict[str, str] = {}
+        self._api_key_without_env_value: str | None = None
         self.api_key_vars = api_key_vars
         self._apply_api_key_overrides()
 
     def _apply_api_key_overrides(self) -> None:
         from inspect_ai.hooks._hooks import has_api_key_override, override_api_key
 
+        api_key_uses_env = self.api_key is not None and self.api_key in (
+            self._api_key_env_values.values()
+        )
+        api_key_uses_no_env_override = (
+            self._api_key_without_env_value is not None
+            and self.api_key == self._api_key_without_env_value
+        )
+
+        # Preserve the existing extension-provider behavior where a subclass assigns
+        # self.api_key from its own source after super().__init__(). Capture that source
+        # once, while excluding values that Inspect itself supplied from an environment
+        # variable or from the no-environment hook path.
+        if (
+            not self._api_key_source_is_set
+            and self.api_key is not None
+            and not api_key_uses_env
+            and not api_key_uses_no_env_override
+        ):
+            self._api_key_source = self.api_key
+            self._api_key_source_is_set = True
+
+        # A stable non-environment key always resolves from its original source,
+        # including an empty string.
+        if self._api_key_source_is_set:
+            assert self._api_key_source is not None
+            api_key = self._api_key_source
+            for key in self.api_key_vars:
+                override = override_api_key(key, self._api_key_source)
+                if override is not None:
+                    api_key = override
+            self.api_key = api_key
+            return
+
         for key in self.api_key_vars:
-            # an explicitly set self.api_key (which can be set by at initialisation, by
-            # subclasses and by hooks when no env var is matched) takes precedence over
-            # the environment, so offer that value to the hook.
-            if self.api_key is not None:
-                # re-resolve from the original explicit key when we have one, not from a
-                # value we previously overrode in place (which on re-init would be the
-                # hook's own prior output)
-                override = override_api_key(key, self._original_api_key or self.api_key)
+            # Providers may copy an environment credential into self.api_key. Remember
+            # whether this model's current value came from this particular env var so it
+            # can be updated even if another model has since refreshed the process-wide
+            # environment value.
+            previous_model_value = self._api_key_env_values.get(key)
+            api_key_uses_env_value = (
+                previous_model_value is not None
+                and self.api_key == previous_model_value
+            ) or (
+                self._api_key_without_env_value is not None
+                and self.api_key == self._api_key_without_env_value
+            )
+
+            live_value = os.environ.get(key)
+            state = _api_key_env_overrides.get(key)
+            source: str | None
+
+            if state is not None and live_value == state.current:
+                # The live value is the credential Inspect most recently wrote, so
+                # resolve again from the source it replaced.
+                source = state.source
+            else:
+                # The variable is absent or was changed outside this state manager.
+                # Treat the live value as a new source and discard the stale association.
+                source = live_value
+                _api_key_env_overrides.pop(key, None)
+
+            if source is not None:
+                override = override_api_key(key, source)
+                current: str | None
+                if override is not None:
+                    current = override
+                    os.environ[key] = current
+                    _api_key_env_overrides[key] = _ApiKeyEnvOverride(
+                        source=source, current=current
+                    )
+                else:
+                    # If the hook declines to override a value previously written by
+                    # Inspect, continue using that live credential. Otherwise the live
+                    # value itself is the current credential.
+                    current = live_value
+
+                assert current is not None
+                self._api_key_env_values[key] = current
+                if api_key_uses_env_value:
+                    self.api_key = current
+                    self._api_key_without_env_value = None
+
+            # When a hook is registered but no API key exists anywhere, still call the
+            # hook so it can provide credentials from its own source (e.g. OAuth tokens,
+            # vault, etc.). Preserve the existing behavior of keeping this value only on
+            # the model rather than creating an environment variable.
+            elif has_api_key_override():
+                self._api_key_env_values.pop(key, None)
+                override = override_api_key(key, "")
                 if override is not None:
                     self.api_key = override
-            # otherwise look it up in the environment and override it in place (so
-            # downstream provider SDKs read the resolved value)
-            else:
-                value = _get_original_api_key_env_value(key)
-                if value is not None:
-                    override = override_api_key(key, value)
-                    if override is not None:
-                        os.environ[key] = override
-                # When a hook is registered but no API key exists anywhere,
-                # still call the hook so it can provide credentials from its
-                # own source (e.g. OAuth tokens, vault, etc.)
-                elif has_api_key_override():
-                    override = override_api_key(key, "")
-                    if override is not None:
-                        self.api_key = override
+                    self._api_key_without_env_value = override
 
     def initialize(self) -> None:
         """Reinitialize the model API client.
@@ -2490,26 +2560,15 @@ def sample_total_cost() -> float:
     )
 
 
-# Original (pre-override) values of api-key environment variables. Captured the
-# first time we override each var (e.g. "OPENAI_API_KEY": "arn:aws:..."). Overrides are
-# always resolved from these originals rather than from the live environment. os.environ
-# is overwritten with the *resolved* key so downstream provider SDKs (which read keys
-# straight from the environment) pick it up. That write would otherwise destroy the
-# original value — e.g. a secret-manager ARN that the override hook needs in order to
-# re-resolve credentials when the model is re-initialized (on a 401) or when a later
-# model is constructed.
-_original_api_key_env: dict[str, str | None] = {}
+@dataclasses.dataclass(frozen=True)
+class _ApiKeyEnvOverride:
+    """Source and current credential for an overridden API-key environment var."""
+
+    source: str
+    current: str
 
 
-def _get_original_api_key_env_value(env_var: str) -> str | None:
-    """Return the original, pre-override value of an api-key env var.
-
-    Sets the value if it hasn't been set yet.
-
-    Captured on first access: at that moment os.environ still holds the user's
-    original value, because a var is only ever overwritten *after* it has been
-    snapshotted here.
-    """
-    if env_var not in _original_api_key_env:
-        _original_api_key_env[env_var] = os.environ.get(env_var)
-    return _original_api_key_env[env_var]
+# Environment credentials are process-global, so retain one source/current association
+# per variable that Inspect has actually overwritten. The current value is replaced on
+# refresh; previously emitted credentials are not retained.
+_api_key_env_overrides: dict[str, _ApiKeyEnvOverride] = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,15 +205,14 @@ def mock_s3():
 
 
 @pytest.fixture(autouse=True)
-def _reset_model_api_key_env_snapshot():
-    # inspect_ai.model._model's _original_api_key_env is process-global and
-    # first-touch-wins, so clear it around every test to prevent a value captured in one
-    # test from leaking into another.
-    from inspect_ai.model._model import _original_api_key_env
+def _reset_model_api_key_env_overrides():
+    # API-key environment override state is process-global, so clear it around every
+    # test to prevent one test's source/current association from leaking into another.
+    from inspect_ai.model._model import _api_key_env_overrides
 
-    _original_api_key_env.clear()
+    _api_key_env_overrides.clear()
     yield
-    _original_api_key_env.clear()
+    _api_key_env_overrides.clear()
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Generator
 
 import pytest
@@ -78,12 +79,14 @@ class MockRefreshTokenHook(Hooks):
     def __init__(self) -> None:
         self.call_count = 0
         self.provided_tokens: list[str] = []
+        self.seen_values: list[str] = []
 
     def override_api_key(self, data: ApiKeyOverride) -> str | None:
         """Provide incrementing token values."""
         if data.env_var_name != "TEST_API_KEY":
             return None
 
+        self.seen_values.append(data.value)
         self.call_count += 1
         token = f"token-{self.call_count}"
         self.provided_tokens.append(token)
@@ -140,6 +143,33 @@ def test_reactive_token_refresh_on_401(mock_refresh_token_hook: MockRefreshToken
         del _registry["modelapi:mock401"]
 
 
+def test_explicit_empty_key_is_reoffered_on_refresh(
+    monkeypatch: pytest.MonkeyPatch, mock_refresh_token_hook: MockRefreshTokenHook
+):
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mockemptyexplicit")
+    def mockemptyexplicit() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        model = get_model(
+            "mockemptyexplicit/test",
+            api_key="",
+            memoize=False,
+        )
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key == "token-1"
+
+        provider.initialize()
+
+        assert provider.api_key == "token-2"
+        assert mock_refresh_token_hook.seen_values == ["", ""]
+    finally:
+        del _registry["modelapi:mockemptyexplicit"]
+
+
 class MockArnResolverHook(Hooks):
     """Resolves a secret-manager ARN to an incrementing real key.
 
@@ -149,6 +179,7 @@ class MockArnResolverHook(Hooks):
     """
 
     ARN = "arn:aws:secretsmanager:us-east-1:secret:openai"
+    SECOND_ARN = "arn:aws:secretsmanager:us-east-1:secret:openai-staging"
 
     def __init__(self) -> None:
         self.call_count = 0
@@ -158,10 +189,55 @@ class MockArnResolverHook(Hooks):
         if data.env_var_name != "TEST_API_KEY":
             return None
         self.seen_values.append(data.value)
-        if data.value != self.ARN:
+        if data.value not in (self.ARN, self.SECOND_ARN):
             return None
         self.call_count += 1
         return f"resolved-key-{self.call_count}"
+
+
+class MockEnvCopyAPI(Mock401API):
+    """Provider that copies its resolved environment key into self.api_key."""
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args,
+    ):
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            **model_args,
+        )
+        if self.api_key is None:
+            self.api_key = os.environ["TEST_API_KEY"]
+        self.initialize()
+
+
+class MockSubclassKeyAPI(Mock401API):
+    """Extension-provider shape that assigns an API key after super init."""
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args,
+    ):
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            **model_args,
+        )
+        self.api_key = MockArnResolverHook.ARN
+        self.initialize()
 
 
 @pytest.fixture
@@ -187,8 +263,6 @@ def test_env_override_reresolves_from_original_arn(
     They must not re-resolve from the previously-resolved key written back
     into os.environ.
     """
-    import os
-
     monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
 
     @modelapi(name="mockarn")
@@ -220,6 +294,134 @@ def test_env_override_reresolves_from_original_arn(
     finally:
         # Remove the model provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mockarn"]
+
+
+def test_env_override_updates_provider_copy_across_instances(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """An older provider copy refreshes after a newer model rotates the env key."""
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockenvcopy")
+    def mockenvcopy() -> type[ModelAPI]:
+        return MockEnvCopyAPI
+
+    try:
+        model_a = get_model("mockenvcopy/test", memoize=False)
+        provider_a = model_a.api
+        assert isinstance(provider_a, MockEnvCopyAPI)
+        assert provider_a.api_key == "resolved-key-2"
+
+        model_b = get_model("mockenvcopy/test", memoize=False)
+        provider_b = model_b.api
+        assert isinstance(provider_b, MockEnvCopyAPI)
+        assert provider_b.api_key == "resolved-key-4"
+
+        # model_a still holds resolved-key-2 while the process environment and model_b
+        # have advanced to resolved-key-4. It must still recover the ARN and update its
+        # copied key on refresh.
+        provider_a.initialize()
+
+        assert provider_a.api_key == "resolved-key-5"
+        assert os.environ["TEST_API_KEY"] == "resolved-key-5"
+        assert mock_arn_resolver_hook.seen_values == [MockArnResolverHook.ARN] * 5
+    finally:
+        del _registry["modelapi:mockenvcopy"]
+
+
+def test_subclass_assigned_api_key_retains_its_source(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """A provider-assigned non-environment key re-resolves from its first value."""
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mocksubclasskey")
+    def mocksubclasskey() -> type[ModelAPI]:
+        return MockSubclassKeyAPI
+
+    try:
+        model = get_model("mocksubclasskey/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, MockSubclassKeyAPI)
+        assert provider.api_key == "resolved-key-1"
+
+        provider.initialize()
+
+        assert provider.api_key == "resolved-key-2"
+        assert mock_arn_resolver_hook.seen_values == [
+            "",
+            MockArnResolverHook.ARN,
+            MockArnResolverHook.ARN,
+        ]
+    finally:
+        del _registry["modelapi:mocksubclasskey"]
+
+
+def test_env_override_adopts_external_environment_change(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """A live value not written by Inspect becomes the new environment source."""
+    from inspect_ai.model._model import _api_key_env_overrides
+
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockenvchange")
+    def mockenvchange() -> type[ModelAPI]:
+        return MockEnvCopyAPI
+
+    try:
+        model = get_model("mockenvchange/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, MockEnvCopyAPI)
+        assert provider.api_key == "resolved-key-2"
+
+        monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.SECOND_ARN)
+        provider.initialize()
+
+        assert mock_arn_resolver_hook.seen_values[-1] == MockArnResolverHook.SECOND_ARN
+        assert provider.api_key == "resolved-key-3"
+        assert _api_key_env_overrides["TEST_API_KEY"].source == (
+            MockArnResolverHook.SECOND_ARN
+        )
+
+        # If the replacement is already a usable credential and the hook declines it,
+        # use that live value directly and leave no stale source/current association.
+        monkeypatch.setenv("TEST_API_KEY", "direct-api-key")
+        provider.initialize()
+
+        assert mock_arn_resolver_hook.seen_values[-1] == "direct-api-key"
+        assert provider.api_key == "direct-api-key"
+        assert "TEST_API_KEY" not in _api_key_env_overrides
+    finally:
+        del _registry["modelapi:mockenvchange"]
+
+
+def test_env_override_state_is_bounded_by_environment_variables(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """Repeated refreshes replace one env-var state entry rather than accumulating."""
+    from inspect_ai.model._model import _api_key_env_overrides
+
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockbounded")
+    def mockbounded() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        model = get_model("mockbounded/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+
+        for _ in range(50):
+            provider.initialize()
+
+        assert list(_api_key_env_overrides) == ["TEST_API_KEY"]
+        state = _api_key_env_overrides["TEST_API_KEY"]
+        assert state.source == MockArnResolverHook.ARN
+        assert state.current == "resolved-key-51"
+    finally:
+        del _registry["modelapi:mockbounded"]
 
 
 def test_explicit_key_override_reresolves_from_original_arn(
@@ -313,8 +515,6 @@ def test_override_supplies_credentials_when_no_env_key(
     The hook is invoked even when no api key exists in the environment, and its
     credential is refreshed on re-initialization.
     """
-    import os
-
     # ensure there is no api key anywhere in the environment
     monkeypatch.delenv("TEST_API_KEY", raising=False)
 
@@ -336,6 +536,7 @@ def test_override_supplies_credentials_when_no_env_key(
         # re-initialization (as happens on a 401) refreshes the credential
         provider.initialize()
         assert provider.api_key == "own-source-token-2"
+        assert mock_own_source_hook.seen_values == ["", ""]
     finally:
         # Remove the model provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mockownsource"]


### PR DESCRIPTION
> [!NOTE]
> This PR is stacked on #4290 and is intended to merge into
> `craig/api-key-override-persistence`.

## This PR contains:

- [ ] New features
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

#4290 preserves the first value observed for each API-key environment
variable. However, `_apply_api_key_overrides()` still uses the current
`self.api_key` to decide whether a key was explicitly supplied.

Several providers, including `OpenAIAPI`, copy the overridden environment
value into `self.api_key` and subsequently call `initialize()`. The next hook
invocation therefore receives the previously emitted credential rather than
the original source:

```text
expected: ARN, ARN
actual:   ARN, token-1
```

The first-value snapshot also cannot distinguish an environment value written
by Inspect from a later deliberate environment change.

### What is the new behavior?

Environment-backed overrides track bounded state per environment variable:

```text
source:  original value used as hook input
current: most recent credential written by Inspect
```

When applying an override:

- If the live environment value equals `current`, the hook receives `source`.
- If it differs, the live value is treated as a new externally supplied source.
- Successful overrides replace `current`; previous credentials are not retained.
- A `ModelAPI` remembers the effective env value it observed, allowing
  `self.api_key` to be updated even if another model has since refreshed the
  process-global environment.
- Missing environment variables are not added to the process-global state.
- Explicit `api_key=` values are always refreshed from the exact constructor
  value, including an empty string.
- Providers that assign `self.api_key` from their own non-environment source
  after `super().__init__()` retain that source across refreshes.
- Hooks that supply credentials with no environment value continue receiving
  `""`; this path does not create or modify an environment variable.

The existing hook API, environment mutation behavior, and external provider
initialization contract remain unchanged.

### Does this PR introduce a breaking change?

This PR does not change the hook signature or provider API.

As intended by #4290, hooks are consistently offered the original source
rather than their previous output. Hooks relying on receiving a previously
emitted credential may therefore need updating.

A deliberate external change to an API-key environment variable is now adopted
on the next initialization or refresh rather than being ignored indefinitely.

### Tests

Regression coverage includes:

- A provider that copies an overridden env value into `self.api_key` before
  calling `initialize()`.
- Multiple `memoize=False` models constructed from the same source.
- Refreshing an older model after a newer model has updated the environment.
- Replacing an environment source between initializations.
- A provider assigning a non-environment key after `super().__init__()`.
- Explicit API keys, including `api_key=""`.
- Hooks that supply credentials when no environment variable exists.
- Repeated refreshes retaining one state entry per overridden env variable.

### Other information

This PR intentionally does not change connection-pool scoping or the
`override_api_key` return type. Those concerns remain separate from the
credential-source persistence bug addressed by #4290.
