### PR TITLE
Models: scope connection pools by original API key source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Control Channel: `inspect ctl tasks` now reports keep-alive status (`on` / `off` / `mixed`) and a new `inspect ctl keep` command (backed by `POST /keep`) latches keep-alive on a running process so it parks after its eval.
 - Hooks: Add `on_model_retry` hook, fired before each model retry backoff with the model name, attempt number, and upcoming `wait_time` (useful for surfacing time spent in rate limiting and other retries).
 - Hooks: `override_api_key` hooks are now always passed the original API key value (from the env var or the explicit `api_key` argument) rather than a previously-overridden value, so hooks that resolve short-lived credentials can re-resolve on every (re)initialization.
+- Models: Connection pooling for overridden API keys now uses the stable original key source when available rather than a rotating credential.
 - Inspect View: Improve sample reading performance in viewer by serving `/log-bytes` range requests as plain responses instead of line-iterating a `BytesIO`.
 - Inspect View: Fix log-list grid columns snapping back to default widths while data loads
 - Inspect View: Fix transcript deep links across timelines, approvals, collapsed regions, and lanes; add event label pills.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Limits: Added `turn_limit()` which tracks total generations.
 - Control Channel: `inspect ctl tasks` now reports keep-alive status (`on` / `off` / `mixed`) and a new `inspect ctl keep` command (backed by `POST /keep`) latches keep-alive on a running process so it parks after its eval.
 - Hooks: Add `on_model_retry` hook, fired before each model retry backoff with the model name, attempt number, and upcoming `wait_time` (useful for surfacing time spent in rate limiting and other retries).
+- Hooks: `override_api_key` hooks are now always passed the original API key value (from the env var or the explicit `api_key` argument) rather than a previously-overridden value, so hooks that resolve short-lived credentials can re-resolve on every (re)initialization.
 - Inspect View: Improve sample reading performance in viewer by serving `/log-bytes` range requests as plain responses instead of line-iterating a `BytesIO`.
 - Inspect View: Fix log-list grid columns snapping back to default widths while data loads
 - Inspect View: Fix transcript deep links across timelines, approvals, collapsed regions, and lanes; add event label pills.

--- a/docs/extensions-hooks.qmd
+++ b/docs/extensions-hooks.qmd
@@ -188,3 +188,11 @@ class ApiKeyFetcher(Hooks):
 def fetch_aws_secret(aws_arn: str) -> str:
     ...
 ```
+
+When a non-empty source such as a secret ARN is overridden, Inspect uses that
+source rather than the rotating credential to scope the model's connection
+pool. This keeps adaptive concurrency state stable across credential refreshes
+and model instances.
+
+When no non-empty source is available, Inspect continues to scope connection
+pooling by the current credential.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -216,6 +216,9 @@ class ModelAPI(abc.ABC):
         self.model_name = model_name
         self.base_url = base_url
         self.api_key = api_key
+        # original explicit key, re-offered to hooks on re-init (since self.api_key gets
+        # overwritten with the resolved value). See _apply_api_key_overrides.
+        self._original_api_key = api_key
         self.api_key_vars = api_key_vars
         self._apply_api_key_overrides()
 
@@ -226,7 +229,10 @@ class ModelAPI(abc.ABC):
             # an explicitly set self.api_key (note this can also be set by subclasses)
             # takes precedence over the environment, so offer that value to the hook
             if self.api_key is not None:
-                override = override_api_key(key, self.api_key)
+                # re-resolve from the original explicit key when we have one, not from a
+                # value we previously overrode in place (which on re-init would be the
+                # hook's own prior output)
+                override = override_api_key(key, self._original_api_key or self.api_key)
                 if override is not None:
                     self.api_key = override
             # otherwise look it up in the environment and override it in

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -216,41 +216,111 @@ class ModelAPI(abc.ABC):
         self.model_name = model_name
         self.base_url = base_url
         self.api_key = api_key
-        # original explicit key, re-offered to hooks on re-init (since self.api_key gets
-        # overwritten with the resolved value). See _apply_api_key_overrides.
-        self._original_api_key = api_key
+        # Stable non-environment source, initially an explicit constructor key. A
+        # subclass may also populate self.api_key from its own source after super init;
+        # _apply_api_key_overrides captures that value on its first re-initialization.
+        self._api_key_source = api_key
+        self._api_key_source_is_set = api_key is not None
+        self._api_key_env_values: dict[str, str] = {}
+        self._api_key_without_env_value: str | None = None
         self.api_key_vars = api_key_vars
         self._apply_api_key_overrides()
 
     def _apply_api_key_overrides(self) -> None:
         from inspect_ai.hooks._hooks import has_api_key_override, override_api_key
 
+        api_key_uses_env = self.api_key is not None and self.api_key in (
+            self._api_key_env_values.values()
+        )
+        api_key_uses_no_env_override = (
+            self._api_key_without_env_value is not None
+            and self.api_key == self._api_key_without_env_value
+        )
+
+        # Preserve the existing extension-provider behavior where a subclass assigns
+        # self.api_key from its own source after super().__init__(). Capture that source
+        # once, while excluding values that Inspect itself supplied from an environment
+        # variable or from the no-environment hook path.
+        if (
+            not self._api_key_source_is_set
+            and self.api_key is not None
+            and not api_key_uses_env
+            and not api_key_uses_no_env_override
+        ):
+            self._api_key_source = self.api_key
+            self._api_key_source_is_set = True
+
+        # A stable non-environment key always resolves from its original source,
+        # including an empty string.
+        if self._api_key_source_is_set:
+            assert self._api_key_source is not None
+            api_key = self._api_key_source
+            for key in self.api_key_vars:
+                override = override_api_key(key, self._api_key_source)
+                if override is not None:
+                    api_key = override
+            self.api_key = api_key
+            return
+
         for key in self.api_key_vars:
-            # an explicitly set self.api_key (which can be set by at initialisation, by
-            # subclasses and by hooks when no env var is matched) takes precedence over
-            # the environment, so offer that value to the hook.
-            if self.api_key is not None:
-                # re-resolve from the original explicit key when we have one, not from a
-                # value we previously overrode in place (which on re-init would be the
-                # hook's own prior output)
-                override = override_api_key(key, self._original_api_key or self.api_key)
+            # Providers may copy an environment credential into self.api_key. Remember
+            # whether this model's current value came from this particular env var so it
+            # can be updated even if another model has since refreshed the process-wide
+            # environment value.
+            previous_model_value = self._api_key_env_values.get(key)
+            api_key_uses_env_value = (
+                previous_model_value is not None
+                and self.api_key == previous_model_value
+            ) or (
+                self._api_key_without_env_value is not None
+                and self.api_key == self._api_key_without_env_value
+            )
+
+            live_value = os.environ.get(key)
+            state = _api_key_env_overrides.get(key)
+            source: str | None
+
+            if state is not None and live_value == state.current:
+                # The live value is the credential Inspect most recently wrote, so
+                # resolve again from the source it replaced.
+                source = state.source
+            else:
+                # The variable is absent or was changed outside this state manager.
+                # Treat the live value as a new source and discard the stale association.
+                source = live_value
+                _api_key_env_overrides.pop(key, None)
+
+            if source is not None:
+                override = override_api_key(key, source)
+                current: str | None
+                if override is not None:
+                    current = override
+                    os.environ[key] = current
+                    _api_key_env_overrides[key] = _ApiKeyEnvOverride(
+                        source=source, current=current
+                    )
+                else:
+                    # If the hook declines to override a value previously written by
+                    # Inspect, continue using that live credential. Otherwise the live
+                    # value itself is the current credential.
+                    current = live_value
+
+                assert current is not None
+                self._api_key_env_values[key] = current
+                if api_key_uses_env_value:
+                    self.api_key = current
+                    self._api_key_without_env_value = None
+
+            # When a hook is registered but no API key exists anywhere, still call the
+            # hook so it can provide credentials from its own source (e.g. OAuth tokens,
+            # vault, etc.). Preserve the existing behavior of keeping this value only on
+            # the model rather than creating an environment variable.
+            elif has_api_key_override():
+                self._api_key_env_values.pop(key, None)
+                override = override_api_key(key, "")
                 if override is not None:
                     self.api_key = override
-            # otherwise look it up in the environment and override it in place (so
-            # downstream provider SDKs read the resolved value)
-            else:
-                value = _get_original_api_key_env_value(key)
-                if value is not None:
-                    override = override_api_key(key, value)
-                    if override is not None:
-                        os.environ[key] = override
-                # When a hook is registered but no API key exists anywhere,
-                # still call the hook so it can provide credentials from its
-                # own source (e.g. OAuth tokens, vault, etc.)
-                elif has_api_key_override():
-                    override = override_api_key(key, "")
-                    if override is not None:
-                        self.api_key = override
+                    self._api_key_without_env_value = override
 
     def initialize(self) -> None:
         """Reinitialize the model API client.
@@ -2490,26 +2560,15 @@ def sample_total_cost() -> float:
     )
 
 
-# Original (pre-override) values of api-key environment variables. Captured the
-# first time we override each var (e.g. "OPENAI_API_KEY": "arn:aws:..."). Overrides are
-# always resolved from these originals rather than from the live environment. os.environ
-# is overwritten with the *resolved* key so downstream provider SDKs (which read keys
-# straight from the environment) pick it up. That write would otherwise destroy the
-# original value — e.g. a secret-manager ARN that the override hook needs in order to
-# re-resolve credentials when the model is re-initialized (on a 401) or when a later
-# model is constructed.
-_original_api_key_env: dict[str, str | None] = {}
+@dataclasses.dataclass(frozen=True)
+class _ApiKeyEnvOverride:
+    """Source and current credential for an overridden API-key environment var."""
+
+    source: str
+    current: str
 
 
-def _get_original_api_key_env_value(env_var: str) -> str | None:
-    """Return the original, pre-override value of an api-key env var.
-
-    Sets the value if it hasn't been set yet.
-
-    Captured on first access: at that moment os.environ still holds the user's
-    original value, because a var is only ever overwritten *after* it has been
-    snapshotted here.
-    """
-    if env_var not in _original_api_key_env:
-        _original_api_key_env[env_var] = os.environ.get(env_var)
-    return _original_api_key_env[env_var]
+# Environment credentials are process-global, so retain one source/current association
+# per variable that Inspect has actually overwritten. The current value is replaced on
+# refresh; previously emitted credentials are not retained.
+_api_key_env_overrides: dict[str, _ApiKeyEnvOverride] = {}

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -222,6 +222,7 @@ class ModelAPI(abc.ABC):
         self._api_key_source = api_key
         self._api_key_source_is_set = api_key is not None
         self._api_key_env_values: dict[str, str] = {}
+        self._api_key_env_sources: dict[str, str] = {}
         self._api_key_without_env_value: str | None = None
         self.api_key_vars = api_key_vars
         self._apply_api_key_overrides()
@@ -297,7 +298,8 @@ class ModelAPI(abc.ABC):
                     current = override
                     os.environ[key] = current
                     _api_key_env_overrides[key] = _ApiKeyEnvOverride(
-                        source=source, current=current
+                        source=source,
+                        current=current,
                     )
                 else:
                     # If the hook declines to override a value previously written by
@@ -307,6 +309,7 @@ class ModelAPI(abc.ABC):
 
                 assert current is not None
                 self._api_key_env_values[key] = current
+                self._api_key_env_sources[key] = source
                 if api_key_uses_env_value:
                     self.api_key = current
                     self._api_key_without_env_value = None
@@ -317,6 +320,7 @@ class ModelAPI(abc.ABC):
             # the model rather than creating an environment variable.
             elif has_api_key_override():
                 self._api_key_env_values.pop(key, None)
+                self._api_key_env_sources.pop(key, None)
                 override = override_api_key(key, "")
                 if override is not None:
                     self.api_key = override
@@ -484,6 +488,23 @@ class ModelAPI(abc.ABC):
     def connection_key(self) -> str:
         """Scope for enforcement of max_connections."""
         return "default"
+
+    def api_key_connection_scope(self) -> str | None:
+        """Stable API-key-derived scope for connection pooling."""
+        source_is_set = cast(bool, getattr(self, "_api_key_source_is_set", False))
+        if source_is_set:
+            source = cast(str | None, getattr(self, "_api_key_source", None))
+            api_key = cast(str | None, getattr(self, "api_key", None))
+            return source or api_key
+
+        api_key = cast(str | None, getattr(self, "api_key", None))
+        env_values = cast(dict[str, str], getattr(self, "_api_key_env_values", {}))
+        env_sources = cast(dict[str, str], getattr(self, "_api_key_env_sources", {}))
+        for key, value in env_values.items():
+            if api_key == value:
+                return env_sources.get(key) or value
+
+        return api_key
 
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:
         """Whether compaction should add `redacted_reasoning_tokens` to its input estimate.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -226,8 +226,9 @@ class ModelAPI(abc.ABC):
         from inspect_ai.hooks._hooks import has_api_key_override, override_api_key
 
         for key in self.api_key_vars:
-            # an explicitly set self.api_key (note this can also be set by subclasses)
-            # takes precedence over the environment, so offer that value to the hook
+            # an explicitly set self.api_key (which can be set by at initialisation, by
+            # subclasses and by hooks when no env var is matched) takes precedence over
+            # the environment, so offer that value to the hook.
             if self.api_key is not None:
                 # re-resolve from the original explicit key when we have one, not from a
                 # value we previously overrode in place (which on re-init would be the
@@ -235,8 +236,8 @@ class ModelAPI(abc.ABC):
                 override = override_api_key(key, self._original_api_key or self.api_key)
                 if override is not None:
                     self.api_key = override
-            # otherwise look it up in the environment and override it in
-            # place (so downstream provider SDKs read the resolved value)
+            # otherwise look it up in the environment and override it in place (so
+            # downstream provider SDKs read the resolved value)
             else:
                 value = _get_original_api_key_env_value(key)
                 if value is not None:

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -222,19 +222,17 @@ class ModelAPI(abc.ABC):
     def _apply_api_key_overrides(self) -> None:
         from inspect_ai.hooks._hooks import has_api_key_override, override_api_key
 
-        # apply api key override
-        api_key = self.api_key
         for key in self.api_key_vars:
-            # if there is an explicit api_key passed then it
-            # overrides anything in the environment so use it
-            if api_key is not None:
-                override = override_api_key(key, api_key)
+            # an explicitly set self.api_key (note this can also be set by subclasses)
+            # takes precedence over the environment, so offer that value to the hook
+            if self.api_key is not None:
+                override = override_api_key(key, self.api_key)
                 if override is not None:
-                    api_key = override
-            # otherwise look it up in the environment and
-            # override it if it has a value
+                    self.api_key = override
+            # otherwise look it up in the environment and override it in
+            # place (so downstream provider SDKs read the resolved value)
             else:
-                value = os.environ.get(key, None)
+                value = _get_original_api_key_env_value(key)
                 if value is not None:
                     override = override_api_key(key, value)
                     if override is not None:
@@ -245,10 +243,7 @@ class ModelAPI(abc.ABC):
                 elif has_api_key_override():
                     override = override_api_key(key, "")
                     if override is not None:
-                        api_key = override
-
-        # set any explicitly specified api key
-        self.api_key = api_key
+                        self.api_key = override
 
     def initialize(self) -> None:
         """Reinitialize the model API client.
@@ -2486,3 +2481,28 @@ def sample_total_cost() -> float:
         for usage in sample_model_usage().values()
         if usage.total_cost is not None
     )
+
+
+# Original (pre-override) values of api-key environment variables. Captured the
+# first time we override each var (e.g. "OPENAI_API_KEY": "arn:aws:..."). Overrides are
+# always resolved from these originals rather than from the live environment. os.environ
+# is overwritten with the *resolved* key so downstream provider SDKs (which read keys
+# straight from the environment) pick it up. That write would otherwise destroy the
+# original value — e.g. a secret-manager ARN that the override hook needs in order to
+# re-resolve credentials when the model is re-initialized (on a 401) or when a later
+# model is constructed.
+_original_api_key_env: dict[str, str | None] = {}
+
+
+def _get_original_api_key_env_value(env_var: str) -> str | None:
+    """Return the original, pre-override value of an api-key env var.
+
+    Sets the value if it hasn't been set yet.
+
+    Captured on first access: at that moment os.environ still holds the user's
+    original value, because a var is only ever overwritten *after* it has been
+    snapshotted here.
+    """
+    if env_var not in _original_api_key_env:
+        _original_api_key_env[env_var] = os.environ.get(env_var)
+    return _original_api_key_env[env_var]

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1231,7 +1231,7 @@ class AnthropicAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.service_model_name()}"
+        return f"{self.api_key_connection_scope()}:{self.service_model_name()}"
 
     def service_model_name(self) -> str:
         """Model name without any service prefix."""

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -346,7 +346,7 @@ class AzureAIAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        return f"{self.api_key}{self.model_name}"
+        return f"{self.api_key_connection_scope()}{self.model_name}"
 
     def service_model_name(self) -> str:
         """Model name without any org prefix, for API calls."""

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -740,7 +740,7 @@ class GoogleGenAIAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.api_key_connection_scope()}:{self.model_name}"
 
     @override
     def tool_result_images(self) -> bool:

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -328,7 +328,7 @@ class GrokAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.service_model_name()}"
+        return f"{self.api_key_connection_scope()}:{self.service_model_name()}"
 
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, grpc.RpcError):

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -280,7 +280,7 @@ class GroqAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.api_key_connection_scope()}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -291,7 +291,7 @@ class MistralAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.api_key_connection_scope()}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -605,7 +605,7 @@ class OpenAIAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.api_key_connection_scope()}:{self.model_name}"
 
     @override
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -333,7 +333,7 @@ class OpenAICompatibleAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.api_key_connection_scope()}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -327,7 +327,7 @@ class TogetherRESTAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.api_key_connection_scope()}:{self.model_name}"
 
     # Together uses a default of 512 so we bump it up
     @override

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -204,6 +204,18 @@ def mock_s3():
             os.environ[key] = value
 
 
+@pytest.fixture(autouse=True)
+def _reset_model_api_key_env_snapshot():
+    # inspect_ai.model._model's _original_api_key_env is process-global and
+    # first-touch-wins, so clear it around every test to prevent a value captured in one
+    # test from leaking into another.
+    from inspect_ai.model._model import _original_api_key_env
+
+    _original_api_key_env.clear()
+    yield
+    _original_api_key_env.clear()
+
+
 def pytest_sessionfinish(session, exitstatus):
     # When running under pytest-xdist, this hook fires once per worker as well
     # as on the controller. Letting every worker race to uninstall the test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -205,15 +205,14 @@ def mock_s3():
 
 
 @pytest.fixture(autouse=True)
-def _reset_model_api_key_env_snapshot():
-    # inspect_ai.model._model's _original_api_key_env is process-global and
-    # first-touch-wins, so clear it around every test to prevent a value captured in one
-    # test from leaking into another.
-    from inspect_ai.model._model import _original_api_key_env
+def _reset_model_api_key_env_overrides():
+    # API-key environment override state is process-global, so clear it around every
+    # test to prevent one test's source/current association from leaking into another.
+    from inspect_ai.model._model import _api_key_env_overrides
 
-    _original_api_key_env.clear()
+    _api_key_env_overrides.clear()
     yield
-    _original_api_key_env.clear()
+    _api_key_env_overrides.clear()
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -220,3 +220,73 @@ def test_env_override_reresolves_from_original_arn(
     finally:
         # Remove the model provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mockarn"]
+
+
+class MockOwnSourceHook(Hooks):
+    """Supplies credentials from its own source (e.g. OAuth/vault).
+
+    Returns an incrementing token regardless of input, so it can provide a key
+    even when none exists in the environment at all.
+    """
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.seen_values: list[str] = []
+
+    def override_api_key(self, data: ApiKeyOverride) -> str | None:
+        if data.env_var_name != "TEST_API_KEY":
+            return None
+        self.seen_values.append(data.value)
+        self.call_count += 1
+        return f"own-source-token-{self.call_count}"
+
+
+@pytest.fixture
+def mock_own_source_hook() -> Generator[MockOwnSourceHook, None, None]:
+    @hooks("test_own_source", description="Test own-source credential hook")
+    def get_hook() -> type[MockOwnSourceHook]:
+        return MockOwnSourceHook
+
+    hook = registry_lookup("hooks", "test_own_source")
+    assert isinstance(hook, MockOwnSourceHook)
+    try:
+        yield hook
+    finally:
+        # Remove the hook from the registry to avoid conflicts in other tests.
+        del _registry["hooks:test_own_source"]
+
+
+def test_override_supplies_credentials_when_no_env_key(
+    monkeypatch: pytest.MonkeyPatch, mock_own_source_hook: MockOwnSourceHook
+):
+    """A registered hook supplies credentials with no env key.
+
+    The hook is invoked even when no api key exists in the environment, and its
+    credential is refreshed on re-initialization.
+    """
+    import os
+
+    # ensure there is no api key anywhere in the environment
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mockownsource")
+    def mockownsource() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        # there is no env value to resolve, so the hook is invoked with an empty
+        # string and supplies the credential from its own source
+        model = get_model("mockownsource/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key == "own-source-token-1"
+        assert mock_own_source_hook.seen_values == [""]
+        # nothing is written back to the environment in this branch
+        assert "TEST_API_KEY" not in os.environ
+
+        # re-initialization (as happens on a 401) refreshes the credential
+        provider.initialize()
+        assert provider.api_key == "own-source-token-2"
+    finally:
+        # Remove the model provider from the registry to avoid conflicts in other tests.
+        del _registry["modelapi:mockownsource"]

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -138,3 +138,85 @@ def test_reactive_token_refresh_on_401(mock_refresh_token_hook: MockRefreshToken
     finally:
         # Remove the provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mock401"]
+
+
+class MockArnResolverHook(Hooks):
+    """Resolves a secret-manager ARN to an incrementing real key.
+
+    Unlike MockRefreshTokenHook, this hook's output *depends on its input* — it
+    only resolves when handed the original ARN. It therefore breaks if the
+    original value is clobbered by a previous resolution.
+    """
+
+    ARN = "arn:aws:secretsmanager:us-east-1:secret:openai"
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.seen_values: list[str] = []
+
+    def override_api_key(self, data: ApiKeyOverride) -> str | None:
+        if data.env_var_name != "TEST_API_KEY":
+            return None
+        self.seen_values.append(data.value)
+        if data.value != self.ARN:
+            return None
+        self.call_count += 1
+        return f"resolved-key-{self.call_count}"
+
+
+@pytest.fixture
+def mock_arn_resolver_hook() -> Generator[MockArnResolverHook, None, None]:
+    @hooks("test_arn_resolver", description="Test ARN resolver hook")
+    def get_hook() -> type[MockArnResolverHook]:
+        return MockArnResolverHook
+
+    hook = registry_lookup("hooks", "test_arn_resolver")
+    assert isinstance(hook, MockArnResolverHook)
+    try:
+        yield hook
+    finally:
+        # Remove the hook from the registry to avoid conflicts in other tests.
+        del _registry["hooks:test_arn_resolver"]
+
+
+def test_env_override_reresolves_from_original_arn(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """Env-var overrides re-resolve from the original value.
+
+    They must not re-resolve from the previously-resolved key written back
+    into os.environ.
+    """
+    import os
+
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockarn")
+    def mockarn() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        # initial construction resolves the ARN and writes the resolved key
+        # back to os.environ for downstream SDKs
+        model = get_model("mockarn/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key is None  # env-var path leaves api_key unset
+        assert os.environ["TEST_API_KEY"] == "resolved-key-1"
+
+        # re-initialization (as happens on a 401) must hand the hook the ARN
+        # again — not the already-resolved key now sitting in os.environ
+        provider.initialize()
+        assert os.environ["TEST_API_KEY"] == "resolved-key-2"
+
+        # a later, separately-constructed model must also re-resolve the ARN
+        model2 = get_model("mockarn/test", memoize=False)
+        assert os.environ["TEST_API_KEY"] == "resolved-key-3"
+        assert model2.api is not provider
+
+        # the hook only ever saw the original ARN, never a resolved key
+        assert set(mock_arn_resolver_hook.seen_values) == {MockArnResolverHook.ARN}
+        assert mock_arn_resolver_hook.call_count == 3
+    finally:
+        # Remove the model provider from the registry to avoid conflicts in other tests.
+        del _registry["modelapi:mockarn"]

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Generator
 
 import pytest
@@ -78,12 +79,14 @@ class MockRefreshTokenHook(Hooks):
     def __init__(self) -> None:
         self.call_count = 0
         self.provided_tokens: list[str] = []
+        self.seen_values: list[str] = []
 
     def override_api_key(self, data: ApiKeyOverride) -> str | None:
         """Provide incrementing token values."""
         if data.env_var_name != "TEST_API_KEY":
             return None
 
+        self.seen_values.append(data.value)
         self.call_count += 1
         token = f"token-{self.call_count}"
         self.provided_tokens.append(token)
@@ -140,6 +143,33 @@ def test_reactive_token_refresh_on_401(mock_refresh_token_hook: MockRefreshToken
         del _registry["modelapi:mock401"]
 
 
+def test_explicit_empty_key_is_reoffered_on_refresh(
+    monkeypatch: pytest.MonkeyPatch, mock_refresh_token_hook: MockRefreshTokenHook
+):
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mockemptyexplicit")
+    def mockemptyexplicit() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        model = get_model(
+            "mockemptyexplicit/test",
+            api_key="",
+            memoize=False,
+        )
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key == "token-1"
+
+        provider.initialize()
+
+        assert provider.api_key == "token-2"
+        assert mock_refresh_token_hook.seen_values == ["", ""]
+    finally:
+        del _registry["modelapi:mockemptyexplicit"]
+
+
 class MockArnResolverHook(Hooks):
     """Resolves a secret-manager ARN to an incrementing real key.
 
@@ -149,6 +179,7 @@ class MockArnResolverHook(Hooks):
     """
 
     ARN = "arn:aws:secretsmanager:us-east-1:secret:openai"
+    SECOND_ARN = "arn:aws:secretsmanager:us-east-1:secret:openai-staging"
 
     def __init__(self) -> None:
         self.call_count = 0
@@ -158,10 +189,55 @@ class MockArnResolverHook(Hooks):
         if data.env_var_name != "TEST_API_KEY":
             return None
         self.seen_values.append(data.value)
-        if data.value != self.ARN:
+        if data.value not in (self.ARN, self.SECOND_ARN):
             return None
         self.call_count += 1
         return f"resolved-key-{self.call_count}"
+
+
+class MockEnvCopyAPI(Mock401API):
+    """Provider that copies its resolved environment key into self.api_key."""
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args,
+    ):
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            **model_args,
+        )
+        if self.api_key is None:
+            self.api_key = os.environ["TEST_API_KEY"]
+        self.initialize()
+
+
+class MockSubclassKeyAPI(Mock401API):
+    """Extension-provider shape that assigns an API key after super init."""
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args,
+    ):
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            **model_args,
+        )
+        self.api_key = MockArnResolverHook.ARN
+        self.initialize()
 
 
 @pytest.fixture
@@ -187,8 +263,6 @@ def test_env_override_reresolves_from_original_arn(
     They must not re-resolve from the previously-resolved key written back
     into os.environ.
     """
-    import os
-
     monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
 
     @modelapi(name="mockarn")
@@ -220,6 +294,134 @@ def test_env_override_reresolves_from_original_arn(
     finally:
         # Remove the model provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mockarn"]
+
+
+def test_env_override_updates_provider_copy_across_instances(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """An older provider copy refreshes after a newer model rotates the env key."""
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockenvcopy")
+    def mockenvcopy() -> type[ModelAPI]:
+        return MockEnvCopyAPI
+
+    try:
+        model_a = get_model("mockenvcopy/test", memoize=False)
+        provider_a = model_a.api
+        assert isinstance(provider_a, MockEnvCopyAPI)
+        assert provider_a.api_key == "resolved-key-2"
+
+        model_b = get_model("mockenvcopy/test", memoize=False)
+        provider_b = model_b.api
+        assert isinstance(provider_b, MockEnvCopyAPI)
+        assert provider_b.api_key == "resolved-key-4"
+
+        # model_a still holds resolved-key-2 while the process environment and model_b
+        # have advanced to resolved-key-4. It must still recover the ARN and update its
+        # copied key on refresh.
+        provider_a.initialize()
+
+        assert provider_a.api_key == "resolved-key-5"
+        assert os.environ["TEST_API_KEY"] == "resolved-key-5"
+        assert mock_arn_resolver_hook.seen_values == [MockArnResolverHook.ARN] * 5
+    finally:
+        del _registry["modelapi:mockenvcopy"]
+
+
+def test_subclass_assigned_api_key_retains_its_source(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """A provider-assigned non-environment key re-resolves from its first value."""
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mocksubclasskey")
+    def mocksubclasskey() -> type[ModelAPI]:
+        return MockSubclassKeyAPI
+
+    try:
+        model = get_model("mocksubclasskey/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, MockSubclassKeyAPI)
+        assert provider.api_key == "resolved-key-1"
+
+        provider.initialize()
+
+        assert provider.api_key == "resolved-key-2"
+        assert mock_arn_resolver_hook.seen_values == [
+            "",
+            MockArnResolverHook.ARN,
+            MockArnResolverHook.ARN,
+        ]
+    finally:
+        del _registry["modelapi:mocksubclasskey"]
+
+
+def test_env_override_adopts_external_environment_change(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """A live value not written by Inspect becomes the new environment source."""
+    from inspect_ai.model._model import _api_key_env_overrides
+
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockenvchange")
+    def mockenvchange() -> type[ModelAPI]:
+        return MockEnvCopyAPI
+
+    try:
+        model = get_model("mockenvchange/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, MockEnvCopyAPI)
+        assert provider.api_key == "resolved-key-2"
+
+        monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.SECOND_ARN)
+        provider.initialize()
+
+        assert mock_arn_resolver_hook.seen_values[-1] == MockArnResolverHook.SECOND_ARN
+        assert provider.api_key == "resolved-key-3"
+        assert _api_key_env_overrides["TEST_API_KEY"].source == (
+            MockArnResolverHook.SECOND_ARN
+        )
+
+        # If the replacement is already a usable credential and the hook declines it,
+        # use that live value directly and leave no stale source/current association.
+        monkeypatch.setenv("TEST_API_KEY", "direct-api-key")
+        provider.initialize()
+
+        assert mock_arn_resolver_hook.seen_values[-1] == "direct-api-key"
+        assert provider.api_key == "direct-api-key"
+        assert "TEST_API_KEY" not in _api_key_env_overrides
+    finally:
+        del _registry["modelapi:mockenvchange"]
+
+
+def test_env_override_state_is_bounded_by_environment_variables(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """Repeated refreshes replace one env-var state entry rather than accumulating."""
+    from inspect_ai.model._model import _api_key_env_overrides
+
+    monkeypatch.setenv("TEST_API_KEY", MockArnResolverHook.ARN)
+
+    @modelapi(name="mockbounded")
+    def mockbounded() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        model = get_model("mockbounded/test", memoize=False)
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+
+        for _ in range(50):
+            provider.initialize()
+
+        assert list(_api_key_env_overrides) == ["TEST_API_KEY"]
+        state = _api_key_env_overrides["TEST_API_KEY"]
+        assert state.source == MockArnResolverHook.ARN
+        assert state.current == "resolved-key-51"
+    finally:
+        del _registry["modelapi:mockbounded"]
 
 
 def test_explicit_key_override_reresolves_from_original_arn(
@@ -313,8 +515,6 @@ def test_override_supplies_credentials_when_no_env_key(
     The hook is invoked even when no api key exists in the environment, and its
     credential is refreshed on re-initialization.
     """
-    import os
-
     # ensure there is no api key anywhere in the environment
     monkeypatch.delenv("TEST_API_KEY", raising=False)
 
@@ -336,6 +536,7 @@ def test_override_supplies_credentials_when_no_env_key(
         # re-initialization (as happens on a 401) refreshes the credential
         provider.initialize()
         assert provider.api_key == "own-source-token-2"
+        assert mock_own_source_hook.seen_values == ["", ""]
     finally:
         # Remove the model provider from the registry to avoid conflicts in other tests.
         del _registry["modelapi:mockownsource"]

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -74,6 +74,9 @@ class Mock401API(ModelAPI):
         """Retry on our mock 401 exception."""
         return isinstance(ex, Mock401Exception)
 
+    def connection_key(self) -> str:
+        return f"{self.api_key_connection_scope()}:{self.model_name}"
+
 
 class MockRefreshTokenHook(Hooks):
     def __init__(self) -> None:
@@ -170,6 +173,41 @@ def test_explicit_empty_key_is_reoffered_on_refresh(
         del _registry["modelapi:mockemptyexplicit"]
 
 
+def test_original_source_scopes_connection_key(
+    monkeypatch: pytest.MonkeyPatch, mock_refresh_token_hook: MockRefreshTokenHook
+):
+    """Plain-string hooks pool by their stable non-empty source."""
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mocksourcepool")
+    def mocksourcepool() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        model_a = get_model(
+            "mocksourcepool/test",
+            api_key="stable-source",
+            memoize=False,
+        )
+        model_b = get_model(
+            "mocksourcepool/test",
+            api_key="stable-source",
+            memoize=False,
+        )
+
+        assert model_a.api.api_key == "token-1"
+        assert model_b.api.api_key == "token-2"
+        assert model_a.api.connection_key() == "stable-source:test"
+        assert model_b.api.connection_key() == "stable-source:test"
+
+        model_a.api.initialize()
+
+        assert model_a.api.api_key == "token-3"
+        assert model_a.api.connection_key() == "stable-source:test"
+    finally:
+        del _registry["modelapi:mocksourcepool"]
+
+
 class MockArnResolverHook(Hooks):
     """Resolves a secret-manager ARN to an incrementing real key.
 
@@ -240,6 +278,38 @@ class MockSubclassKeyAPI(Mock401API):
         self.initialize()
 
 
+class MockMultiEnvAPI(Mock401API):
+    """Provider that canonically selects one of multiple overridden env vars."""
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        **model_args,
+    ):
+        ModelAPI.__init__(
+            self,
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            api_key_vars=["PRIMARY_API_KEY", "SECONDARY_API_KEY"],
+            config=config,
+        )
+        self.api_key = os.environ["PRIMARY_API_KEY"]
+        self.fail_count = model_args.get("fail_count", 0)
+        self.call_count = 0
+        self.initialize_count = 0
+
+
+class MockMultiEnvHook(Hooks):
+    def override_api_key(self, data: ApiKeyOverride) -> str | None:
+        if data.env_var_name not in ("PRIMARY_API_KEY", "SECONDARY_API_KEY"):
+            return None
+        return f"token-for-{data.env_var_name}"
+
+
 @pytest.fixture
 def mock_arn_resolver_hook() -> Generator[MockArnResolverHook, None, None]:
     @hooks("test_arn_resolver", description="Test ARN resolver hook")
@@ -253,6 +323,20 @@ def mock_arn_resolver_hook() -> Generator[MockArnResolverHook, None, None]:
     finally:
         # Remove the hook from the registry to avoid conflicts in other tests.
         del _registry["hooks:test_arn_resolver"]
+
+
+@pytest.fixture
+def mock_multi_env_hook() -> Generator[MockMultiEnvHook, None, None]:
+    @hooks("test_multi_env", description="Test multi-env override hook")
+    def get_hook() -> type[MockMultiEnvHook]:
+        return MockMultiEnvHook
+
+    hook = registry_lookup("hooks", "test_multi_env")
+    assert isinstance(hook, MockMultiEnvHook)
+    try:
+        yield hook
+    finally:
+        del _registry["hooks:test_multi_env"]
 
 
 def test_env_override_reresolves_from_original_arn(
@@ -316,6 +400,8 @@ def test_env_override_updates_provider_copy_across_instances(
         provider_b = model_b.api
         assert isinstance(provider_b, MockEnvCopyAPI)
         assert provider_b.api_key == "resolved-key-4"
+        assert provider_a.connection_key() == (f"{MockArnResolverHook.ARN}:test")
+        assert provider_b.connection_key() == (f"{MockArnResolverHook.ARN}:test")
 
         # model_a still holds resolved-key-2 while the process environment and model_b
         # have advanced to resolved-key-4. It must still recover the ARN and update its
@@ -324,6 +410,7 @@ def test_env_override_updates_provider_copy_across_instances(
 
         assert provider_a.api_key == "resolved-key-5"
         assert os.environ["TEST_API_KEY"] == "resolved-key-5"
+        assert provider_a.connection_key() == (f"{MockArnResolverHook.ARN}:test")
         assert mock_arn_resolver_hook.seen_values == [MockArnResolverHook.ARN] * 5
     finally:
         del _registry["modelapi:mockenvcopy"]
@@ -355,6 +442,26 @@ def test_subclass_assigned_api_key_retains_its_source(
         ]
     finally:
         del _registry["modelapi:mocksubclasskey"]
+
+
+def test_pooling_scope_follows_provider_selected_environment_key(
+    monkeypatch: pytest.MonkeyPatch, mock_multi_env_hook: MockMultiEnvHook
+):
+    """An irrelevant candidate override cannot replace the active pooling scope."""
+    monkeypatch.setenv("PRIMARY_API_KEY", "primary-source")
+    monkeypatch.setenv("SECONDARY_API_KEY", "secondary-source")
+
+    @modelapi(name="mockmultienv")
+    def mockmultienv() -> type[ModelAPI]:
+        return MockMultiEnvAPI
+
+    try:
+        model = get_model("mockmultienv/test", memoize=False)
+
+        assert model.api.api_key == "token-for-PRIMARY_API_KEY"
+        assert model.api.connection_key() == "primary-source:test"
+    finally:
+        del _registry["modelapi:mockmultienv"]
 
 
 def test_env_override_adopts_external_environment_change(
@@ -529,6 +636,7 @@ def test_override_supplies_credentials_when_no_env_key(
         provider = model.api
         assert isinstance(provider, Mock401API)
         assert provider.api_key == "own-source-token-1"
+        assert provider.connection_key() == "own-source-token-1:test"
         assert mock_own_source_hook.seen_values == [""]
         # nothing is written back to the environment in this branch
         assert "TEST_API_KEY" not in os.environ
@@ -536,6 +644,7 @@ def test_override_supplies_credentials_when_no_env_key(
         # re-initialization (as happens on a 401) refreshes the credential
         provider.initialize()
         assert provider.api_key == "own-source-token-2"
+        assert provider.connection_key() == "own-source-token-2:test"
         assert mock_own_source_hook.seen_values == ["", ""]
     finally:
         # Remove the model provider from the registry to avoid conflicts in other tests.

--- a/tests/model/test_token_refresh.py
+++ b/tests/model/test_token_refresh.py
@@ -222,6 +222,55 @@ def test_env_override_reresolves_from_original_arn(
         del _registry["modelapi:mockarn"]
 
 
+def test_explicit_key_override_reresolves_from_original_arn(
+    monkeypatch: pytest.MonkeyPatch, mock_arn_resolver_hook: MockArnResolverHook
+):
+    """An explicitly-supplied api key re-resolves from the original value.
+
+    The same re-resolution guarantee as the env-var path, but for the
+    `api_key=` argument: re-initialization must re-offer the original ARN to the
+    hook, not the resolved key we previously wrote into self.api_key.
+    """
+    # ensure the explicit key is the only source (nothing in the environment)
+    monkeypatch.delenv("TEST_API_KEY", raising=False)
+
+    @modelapi(name="mockarnexplicit")
+    def mockarnexplicit() -> type[ModelAPI]:
+        return Mock401API
+
+    try:
+        # initial construction resolves the explicitly-supplied ARN
+        model = get_model(
+            "mockarnexplicit/test",
+            api_key=MockArnResolverHook.ARN,
+            memoize=False,
+        )
+        provider = model.api
+        assert isinstance(provider, Mock401API)
+        assert provider.api_key == "resolved-key-1"
+
+        # re-initialization (as happens on a 401) must hand the hook the ARN
+        # again — not the resolved key now sitting in self.api_key
+        provider.initialize()
+        assert provider.api_key == "resolved-key-2"
+
+        # a later, separately-constructed model also re-resolves the ARN
+        model2 = get_model(
+            "mockarnexplicit/test",
+            api_key=MockArnResolverHook.ARN,
+            memoize=False,
+        )
+        assert model2.api.api_key == "resolved-key-3"
+        assert model2.api is not provider
+
+        # the hook only ever saw the original ARN, never a resolved key
+        assert set(mock_arn_resolver_hook.seen_values) == {MockArnResolverHook.ARN}
+        assert mock_arn_resolver_hook.call_count == 3
+    finally:
+        # Remove the model provider from the registry to avoid conflicts in other tests.
+        del _registry["modelapi:mockarnexplicit"]
+
+
 class MockOwnSourceHook(Hooks):
     """Supplies credentials from its own source (e.g. OAuth/vault).
 


### PR DESCRIPTION
> [!IMPORTANT]
> Depends on #4290 and #4293. This branch is stacked on those changes, so the
> diff is cumulative until they merge into `main`. Do not merge this PR first;
> after its dependencies land, this branch will be rebased so only the
> source-based pooling commit remains.

## This PR contains:

- [x] New features
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Providers generally scope connection concurrency by:

```python
f"{self.api_key}:{self.model_name}"
```

When an `override_api_key` hook returns short-lived or rotating credentials,
`self.api_key` changes on refresh and across model instances. Each credential
therefore receives a new connection pool, discarding adaptive concurrency state
and fragmenting limits for models that draw from the same account.

### What is the new behavior?

When #4293 preserves a non-empty original key source, such as a secret-manager
ARN, this PR uses that source as the API-key component of the provider's
connection key.

`ModelAPI.api_key_connection_scope()` returns:

- The stable explicit or provider-assigned source, when available.
- The source associated with the environment credential currently held by the
  model.
- The current API key when no non-empty source exists.

Built-in providers that currently scope by `self.api_key` use this helper
instead. Hooks continue returning `str | None`; no hook API or result type is
added.

Pooling metadata remains associated with each candidate environment variable,
so an overridden but unused candidate cannot replace the scope for the key the
provider actually selected.

### Does this PR introduce a breaking change?

No hook or provider constructor API changes.

Connection pools that were previously fragmented by rotating credentials will
now be shared when those credentials resolve from the same non-empty source.
Source-less hooks continue to pool by the current credential, preserving
existing behavior.

### Tests

Coverage includes:

- Explicit sources producing different rotating credentials with one stable
  connection key.
- Environment-backed credentials sharing a connection key across
  `memoize=False` model instances and refreshes.
- An older model retaining the correct scope after a newer model rotates the
  process-wide credential.
- Providers with multiple candidate environment variables using the source
  associated with the credential they selected.
- Source-less hooks continuing to use their current credential as the scope.
- Provider instances constructed via `__new__` continuing to fall back to
  `self.api_key`.

### Other information

This supersedes the `account_id` result-field approach in #4255. Source
preservation makes the common ARN/reference case automatic without changing the
hook API. A separate explicit pooling-key escape hatch can be considered later
if a concrete source-less or non-one-to-one account mapping requires it.
