### PR TITLE
Fix re-score attachment resolution

### DIFF
--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -351,21 +351,29 @@ async def _run_score_task(
     scorers: list[Scorer],
     action: ScoreAction,
 ) -> Tuple[dict[str, SampleScore], list[str]]:
-    target = Target(sample.target)
+    # resolve attachment:// refs so scorers see real content rather than
+    # opaque hashes; rebind timelines to the resolved event objects. Done
+    # per-sample so peak memory is bounded by concurrency, not sample count.
+    resolved_sample = sample
+    if sample.attachments:
+        resolved_sample = resolve_sample_attachments(sample)
+        resolved_sample = rebind_sample_timelines(resolved_sample)
+
+    target = Target(resolved_sample.target)
     state = TaskState(
         model=ModelName(log_header.eval.model),
-        sample_id=sample.id,
-        epoch=sample.epoch,
-        input=sample.input,
+        sample_id=resolved_sample.id,
+        epoch=resolved_sample.epoch,
+        input=resolved_sample.input,
         target=target,
-        choices=sample.choices,
-        messages=sample.messages,
-        output=sample.output,
+        choices=resolved_sample.choices,
+        messages=resolved_sample.messages,
+        output=resolved_sample.output,
         completed=True,
-        metadata=sample.metadata,
-        store=sample.store,
-        scores=(sample.scores or {}).copy() if action == "append" else {},
-        sample_uuid=sample.uuid,
+        metadata=resolved_sample.metadata,
+        store=resolved_sample.store,
+        scores=(resolved_sample.scores or {}).copy() if action == "append" else {},
+        sample_uuid=resolved_sample.uuid,
     )
 
     # get the model then initialize the async context
@@ -382,18 +390,14 @@ async def _run_score_task(
     init_task_context(model, model_roles)
     init_subtask_store(state.store)
 
-    # resolve attachment:// refs so scorers see real content rather than
-    # opaque hashes; rebind timelines to the resolved event objects. Done
-    # per-sample so peak memory is bounded by concurrency, not sample count.
-    if sample.attachments:
-        sample = resolve_sample_attachments(sample)
-        sample = rebind_sample_timelines(sample)
-
     # load a copy of the current sample events into the transcript
-    init_transcript(Transcript([*sample.events], log_model_api=False, bounded=False))
+    init_transcript(
+        Transcript([*resolved_sample.events], log_model_api=False, bounded=False)
+    )
+
     # restore stored timelines so timeline-dependent scorers (e.g. scout
     # @scanner(timeline=True), petri's audit_judge) work on re-score
-    for tl in sample.timelines or []:
+    for tl in resolved_sample.timelines or []:
         transcript().add_timeline(tl)
 
     if state.scores is None:
@@ -438,7 +442,7 @@ async def _run_score_task(
                     )
 
     # slice off only the newly added events
-    new_events = transcript().events[len(sample.events) :]
+    new_events = transcript().events[len(resolved_sample.events) :]
 
     sample.scores = _get_updated_scores(sample, results, action=action)
     sample.events = _get_updated_events(sample, new_events, action=action)

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -429,8 +429,8 @@ async def _run_score_task(
                             scorer_args=registry_params(scorer)
                             if has_registry_params(scorer)
                             else None,
-                            model_usage=sample.model_usage or None,
-                            role_usage=sample.role_usage or None,
+                            model_usage=resolved_sample.model_usage or None,
+                            role_usage=resolved_sample.role_usage or None,
                         )
                     )
 

--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -626,9 +626,7 @@ async def test_score_resolves_attachments_for_scorer_state_and_transcript():
             seen["messages"] = state.messages[0].text
 
             model_events = [
-                event
-                for event in transcript().events
-                if isinstance(event, ModelEvent)
+                event for event in transcript().events if isinstance(event, ModelEvent)
             ]
             seen["transcript"] = model_events[0].input[0].text
             return Score(value=1.0)

--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -550,6 +550,116 @@ async def test_score_preserves_model_usage_in_score_event():
     assert score_events[0].scorer_args == {"threshold": 0.75}
 
 
+@pytest.mark.anyio
+async def test_score_resolves_attachments_for_scorer_state_and_transcript():
+    from inspect_ai._eval.score import _run_score_task
+    from inspect_ai.log import EvalLog
+    from inspect_ai.log._log import (
+        EvalConfig,
+        EvalDataset,
+        EvalPlan,
+        EvalPlanStep,
+        EvalSpec,
+    )
+    from inspect_ai.log._transcript import transcript
+
+    input_ref = "attachment://input-ref"
+    message_ref = "attachment://message-ref"
+    event_ref = "attachment://event-ref"
+
+    sample = EvalSample(
+        id="test-1",
+        epoch=1,
+        input=[ChatMessageUser(content=input_ref)],
+        target="target",
+        messages=[ChatMessageUser(content=message_ref)],
+        output=ModelOutput(
+            choices=[ChatCompletionChoice(message=ChatMessageAssistant(content="done"))]
+        ),
+        events=[
+            ModelEvent(
+                model="mockllm/model",
+                role="assistant",
+                input=[ChatMessageUser(content=event_ref)],
+                output=ModelOutput(
+                    choices=[
+                        ChatCompletionChoice(
+                            message=ChatMessageAssistant(content="done")
+                        )
+                    ]
+                ),
+                tools=[],
+                tool_choice="none",
+                config=GenerateConfig(),
+            )
+        ],
+        attachments={
+            "input-ref": "resolved input",
+            "message-ref": "resolved message",
+            "event-ref": "resolved event",
+        },
+    )
+    log_header = EvalLog(
+        version=2,
+        status="success",
+        eval=EvalSpec(
+            created="2025-01-01T00:00:00Z",
+            task="t",
+            task_id="t",
+            run_id="r",
+            dataset=EvalDataset(),
+            model="mockllm/model",
+            config=EvalConfig(),
+        ),
+        plan=EvalPlan(
+            name="t", steps=[EvalPlanStep(solver="generate")], config=GenerateConfig()
+        ),
+    )
+
+    seen: dict[str, str] = {}
+
+    @scorer(metrics=[accuracy()])
+    def attachment_scorer() -> Scorer:
+        async def score(state: TaskState, target: Target) -> Score:
+            assert isinstance(state.input, list)
+            seen["input"] = state.input[0].text
+            seen["messages"] = state.messages[0].text
+
+            model_events = [
+                event
+                for event in transcript().events
+                if isinstance(event, ModelEvent)
+            ]
+            seen["transcript"] = model_events[0].input[0].text
+            return Score(value=1.0)
+
+        return score
+
+    await _run_score_task(
+        log_header=log_header,
+        sample=sample,
+        scorers=[attachment_scorer()],
+        action="append",
+    )
+
+    assert seen == {
+        "input": "resolved input",
+        "messages": "resolved message",
+        "transcript": "resolved event",
+    }
+
+    assert isinstance(sample.input, list)
+    assert sample.input[0].content == input_ref
+    assert sample.messages[0].content == message_ref
+    assert isinstance(sample.events[0], ModelEvent)
+    assert sample.events[0].input[0].content == event_ref
+    assert sample.attachments == {
+        "input-ref": "resolved input",
+        "message-ref": "resolved message",
+        "event-ref": "resolved event",
+    }
+
+
 async def test_score_restores_sample_timelines():
     """Re-scoring should expose stored ``sample.timelines`` to scorers.
 


### PR DESCRIPTION
Resolve sample attachments before constructing TaskState so scorers see expanded input, messages, and transcript events during re-score.

Keep writes targeted at the original log sample so appended or overwritten sample scores and events persist without expanding attachment payloads back into the log.

Adds coverage for scorer-visible state/transcript attachment resolution and compact sample persistence.

Fixes https://github.com/meridianlabs-ai/actions/issues/47

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

### What is the new behavior?

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

### Other information:
