### PR TITLE
fix: strip trailing separator in FileSystem.is_writeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Inspect view: Fix broken commit links for ssh-style GitHub origins
 - Inspect view: Cap oversized tool/text output to prevent resize layerization stalls
 - Inspect view: Fix event panel nav pills never expanding back from picker mode
+- Bug fix: Make the no-op trailing-separator strip in `FileSystem.is_writeable()` actually take effect, avoiding a double-separator write-test path for direct callers.
 
 ## 0.3.241 (22 June 2026)
 

--- a/src/inspect_ai/_util/file.py
+++ b/src/inspect_ai/_util/file.py
@@ -278,7 +278,7 @@ class FileSystem:
         # Data Writer). The marker file can just be gc'd later.
         _WRITE_TEST_FILENAME = ".inspect_write_test"
         touch_filename = _WRITE_TEST_FILENAME if is_azure_path(path) else uuid()
-        path.rstrip("/\\")
+        path = path.rstrip("/\\")
         touch_file = f"{path}{self.fs.sep}{touch_filename}"
         try:
             self.touch(touch_file)

--- a/tests/util/test_file.py
+++ b/tests/util/test_file.py
@@ -43,6 +43,18 @@ def test_filesystem_file_info():
     assert info.size == 0
 
 
+def test_is_writeable_strips_trailing_sep():
+    # is_writeable builds a "<path><sep><marker>" write-test file. A trailing
+    # slash on the path must be stripped first, otherwise the marker path gets a
+    # double separator (e.g. "s3://bucket/logs//.inspect_write_test"), which is a
+    # malformed key on S3/Azure.
+    fs = filesystem("memory://")
+    with patch.object(fs, "touch") as mock_touch, patch.object(fs, "rm"):
+        fs.is_writeable("mydir/")
+    touch_path = mock_touch.call_args[0][0]
+    assert f"{fs.fs.sep}{fs.fs.sep}" not in touch_path
+
+
 @pytest.mark.parametrize(
     "installed_version",
     [HF_FILESYSTEM_REQUIRED_VERSION, "1.6", "1.6.0.post1", "1.6.1", "2.0.0"],


### PR DESCRIPTION
## Summary

`FileSystem.is_writeable()` calls `path.rstrip("/\\")` but discards the result, so the trailing separator is never actually stripped:

```python
touch_filename = _WRITE_TEST_FILENAME if is_azure_path(path) else uuid()
path.rstrip("/\\")                                  # no-op: result discarded
touch_file = f"{path}{self.fs.sep}{touch_filename}"
```

`FileRecorder.is_writeable()` passes the user's `log_dir` straight through, and log dirs are commonly given with a trailing slash (`--log-dir ./logs/`, `s3://bucket/logs/`). With the trailing slash left in place, the write-test path becomes `s3://bucket/logs//.inspect_write_test` — a double separator, which is a malformed key on S3/Azure.

## Fix

Assign the stripped value back:

```python
path = path.rstrip("/\\")
```

(The module already has a `strip_trailing_sep()` helper; this just makes the existing inline strip actually take effect.)

## Test

Added `test_is_writeable_strips_trailing_sep` in `tests/util/test_file.py`: it calls `is_writeable("mydir/")` on an in-memory filesystem (with `touch`/`rm` patched) and asserts the write-test path contains no double separator. It fails on `main` (`assert '//' not in 'mydir//...'`) and passes with this change.

Verified locally with `pytest tests/util/test_file.py::test_is_writeable_strips_trailing_sep` and `ruff check` / `ruff format --check` (clean). A few unrelated path/URI tests in that file fail only on a Windows checkout due to POSIX-path assumptions; they're untouched by this change and pass on CI.
