### PR TITLE
Synthesize refusal trigger when validating Anthropic fallback blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Eval Log: `read_eval_log`, `read_eval_log_async`, and `samples_df` now accept `exclude_fields` for more memory-efficient loading of large samples.
 - Sandbox: Preserve docker-compatible per-sample sandbox config (e.g. a per-sample `ComposeConfig`) when an eval-level sandbox override (`--sandbox <provider>`) is passed without its own config.
 - Mistral: Forward `GenerateConfig.extra_headers` on the chat completions API path (previously only the conversation-api path honored it).
+- Anthropic: Synthesize a refusal `trigger` when validating fallback blocks from message history, fixing a `ValidationError` with `anthropic>=0.110.0` (which made `trigger` a required field on `BetaFallbackBlock`).
 - Limits: Added `turn_limit()` which tracks total generations.
 - Control Channel: `inspect ctl tasks` now reports keep-alive status (`on` / `off` / `mixed`) and a new `inspect ctl keep` command (backed by `POST /keep`) latches keep-alive on a running process so it parks after its eval.
 - Hooks: Add `on_model_retry` hook, fired before each model retry backoff with the model name, attempt number, and upcoming `wait_time` (useful for surfacing time spent in rate limiting and other retries).

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -2497,7 +2497,15 @@ async def assistant_message_blocks(
         elif block_param["type"] == "compaction":
             blocks.append(BetaCompactionBlock.model_validate(block_param))
         elif block_param["type"] == "fallback":
-            blocks.append(BetaFallbackBlock.model_validate(block_param))
+            # BetaFallbackBlock requires a server-side refusal `trigger` (added in
+            # anthropic 0.110.0); inspect only round-trips `from`/`to`, so
+            # synthesize one when the param doesn't carry it -- mirroring the
+            # server_tool_use "synthesize a default caller" pattern above.
+            blocks.append(
+                BetaFallbackBlock.model_validate(
+                    {"trigger": {"type": "refusal"}, **block_param}
+                )
+            )
         else:
             logger.warning(
                 f"Unexpecxted assistant message block type: {block_param['type']}"
@@ -3221,6 +3229,10 @@ def content_and_tool_calls_from_assistant_content_blocks(
                 fb = dict(block)
                 if "from_" in fb and "from" not in fb:
                     fb["from"] = fb.pop("from_")
+                # BetaFallbackBlock requires a server-side refusal `trigger`
+                # (added in anthropic 0.110.0); scaffold-echoed history doesn't
+                # carry it, so synthesize one. inspect never reads `trigger`.
+                fb.setdefault("trigger", {"type": "refusal"})
                 content_blocks.append(BetaFallbackBlock.model_validate(fb))
             else:
                 content_blocks.append(content_block_adapter.validate_python(block))


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The Anthropic SDK made `trigger` a **required** field on `BetaFallbackBlock` in `anthropic==0.110.0` (it was absent in `0.109.1`). inspect reconstructs fallback blocks from message history via `BetaFallbackBlock.model_validate(...)` supplying only `from`/`to`, so once the unpinned SDK installed `>=0.110.0`, validation raised:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for BetaFallbackBlock
trigger
  Field required [type=missing, ...]
```

This broke two tests under the newer SDK:
- `tests/model/providers/test_anthropic_fallback.py::test_fallback_bridge_round_trip`
- `tests/model/providers/test_anthropic_fallback.py::test_fallback_bridge_tolerates_from_alias`

Fixes meridianlabs-ai/actions#48.

### What is the new behavior?

inspect only round-trips the block's `from`/`to` (it never reads `trigger`), so a minimal refusal trigger (`{"type": "refusal"}`) is synthesized at both history-validation sites in `anthropic.py` — `assistant_message_blocks` and `content_and_tool_calls_from_assistant_content_blocks` — mirroring the existing `server_tool_use` "synthesize a default caller" pattern. A real `trigger` present in the input is preserved.

The synthesized field is tolerated by `0.109.1` (where `trigger` is not yet a model field, so the extra is ignored) and satisfies the requirement on `>=0.110.0`, making the fix backward- and forward-compatible. Verified by running the fallback test suite against both `anthropic==0.109.1` and `anthropic==0.111.0` (all pass; under `0.111.0` the suite fails without this change).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

The outbound param builder `_fallback_from_content_data` emits `BetaFallbackBlockParam` without `trigger`; that key is optional on the param TypedDict (`total=False`) on `0.111.0`, so it is not affected here and is left unchanged. No upper bound was added to the `anthropic` pin — this fix is forward-compatible, so the existing `anthropic>=0.109.1` is retained.
