### PR TITLE
fix(_util): reject sample limits with more than one dash

### DIFF
--- a/src/inspect_ai/_util/samples.py
+++ b/src/inspect_ai/_util/samples.py
@@ -4,6 +4,11 @@ def parse_samples_limit(limit: str | None) -> int | tuple[int, int] | None:
             return int(limit)
         else:
             limit_split = [int(r) for r in limit.split("-")]
+            if len(limit_split) != 2:
+                raise ValueError(
+                    f"Invalid sample limit '{limit}': expected a single number "
+                    "or a range like '10-20'."
+                )
             return (limit_split[0] - 1, limit_split[1])
     else:
         return None

--- a/tests/_util/test_samples.py
+++ b/tests/_util/test_samples.py
@@ -1,0 +1,21 @@
+import pytest
+
+from inspect_ai._util.samples import parse_samples_limit
+
+
+def test_parse_samples_limit_single():
+    assert parse_samples_limit("10") == 10
+
+
+def test_parse_samples_limit_range():
+    assert parse_samples_limit("5-10") == (4, 10)
+
+
+def test_parse_samples_limit_none():
+    assert parse_samples_limit(None) is None
+
+
+def test_parse_samples_limit_rejects_extra_dash():
+    # "5-10-15" used to silently drop the trailing "15" and return (4, 10).
+    with pytest.raises(ValueError, match="Invalid sample limit"):
+        parse_samples_limit("5-10-15")


### PR DESCRIPTION
### Summary

`parse_samples_limit` (which backs the CLI `--limit` option) splits an `N-M` range on every `-`:

```python
limit_split = [int(r) for r in limit.split("-")]
return (limit_split[0] - 1, limit_split[1])
```

So a malformed limit like `--limit 5-10-15` parses `[5, 10, 15]`, uses only the first two, and silently returns `(4, 10)` — quietly dropping `15` and evaluating a different sample range than the user asked for, with no error.

### Fix

Validate that a range has exactly two parts and raise a clear `ValueError` otherwise. `10` and `5-10` are unchanged.

### Tests

Added `tests/_util/test_samples.py` covering the single value, the normal range, `None`, and the new rejection of `5-10-15` (it fails before this change and passes after). `ruff check` and `ruff format --check` are clean.
