### PR TITLE
docs: Fix broken Python import in auto-generated eval pages

### DIFF
--- a/docs/evals/evals-filter.js
+++ b/docs/evals/evals-filter.js
@@ -131,14 +131,16 @@ export function getRunCmd(eval_, model = 'openai/gpt-5') {
 }
 
 export function getPythonSnippet(eval_, model = 'openai/gpt-5') {
-  const pkg  = eval_.source === 'harbor' ? 'inspect_harbor' : 'inspect_evals';
   // Use the task name from `code` (e.g. inspect_evals/mmlu_0_shot) rather
   // than `id` (the directory slug, e.g. mmlu) so the import/call work for
   // multi-task evals.
   const task = (eval_.code || '').split('/').pop() || eval_.id.replace(/^h_/, '');
+  // inspect_evals doesn't re-export tasks, so import from the `id` submodule;
+  // inspect_harbor does re-export, so `from inspect_harbor import <task>` works at the top level.
+  const module = eval_.source === 'harbor' ? 'inspect_harbor' : `inspect_evals.${eval_.id}`;
   return [
     `from inspect_ai import eval`,
-    `from ${pkg} import ${task}`,
+    `from ${module} import ${task}`,
     ``,
     `eval(${task}(), model="${model}")`,
   ].join('\n');


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The eval detail pages on the docs site (e.g. [`/evals/#/eval/browse_comp`](https://inspect.aisi.org.uk/evals/#/eval/browse_comp)) show a Python usage snippet generated by `getPythonSnippet()` in `docs/evals/evals-filter.js`. For `inspect_evals` sources it emits a top-level import:

```python

from inspect_ai import eval
from inspect_evals import browse_comp

eval(browse_comp(), model="openai/gpt-5")
```

This raises `ImportError` — `inspect_evals`'s top-level `__init__.py` is empty and does not re-export tasks. Each task lives in a submodule named after its directory slug (e.g. `inspect_evals/browse_comp/__init__.py` exports `browse_comp`), so the only working import is `from inspect_evals.browse_comp import browse_comp`.

### What is the new behavior?

The snippet now imports from the eval's submodule (`inspect_evals.<id>`, where `id` is the directory slug from `sync.py`):

```python
from inspect_ai import eval
from inspect_evals.browse_comp import browse_comp

eval(browse_comp(), model="openai/gpt-5")
```

This also fixes multi-task evals where the slug differs from the task name, e.g. `from inspect_evals.mmlu import mmlu_0_shot` and `from inspect_evals.gpqa import gpqa_diamond`.

`inspect_harbor` sources are unchanged: harbor *does* re-export its task functions at the top level (verified against its own docs page), so `from inspect_harbor import <task>` remains correct.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

- Verified all 129 `inspect_evals` tasks are importable from `inspect_evals.<id>` (zero exceptions) by cross-checking `evals.json` against each submodule's `__init__.py`.
- `evals-filter.js` is served as an unbundled ES module, so the fix takes effect on the next docs build with no regeneration of `evals.json` required.
