### PR TITLE
Fix eval_set KeyError when a provider rewrites its model name mid-run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- eval_set: Fix `KeyError` at finalisation when a provider rewrites its own model name mid-run (e.g. vLLM resolving a `base:adapter` LoRA spec to `base`).
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.
 - Control Channel: `inspect ctl tasks` now pins each eval's reported start to its first sample's start instead of letting it drift forward as early samples finish.

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -33,7 +33,7 @@ from inspect_ai.log import EvalConfig, EvalLog
 from inspect_ai.log._file import EvalLogInfo
 from inspect_ai.log._recorders import Recorder
 from inspect_ai.model import GenerateConfigArgs
-from inspect_ai.model._model import ModelName
+from inspect_ai.model._model import Model, ModelName
 from inspect_ai.scorer._metric import to_metric_specs
 from inspect_ai.scorer._reducer import ScoreReducer, reducer_log_names
 from inspect_ai.scorer._reducer.registry import validate_reducer
@@ -502,9 +502,20 @@ async def run_multiple(
     # model-balancing state (grows as tasks are injected)
     model_counts: dict[str, int] = {}
 
+    # A provider may rewrite its model's name mid-run — e.g. the vLLM provider
+    # resolves a "base:adapter" LoRA spec down to just "base" on the first
+    # generate(). Re-deriving the balancing key from the live str(model) would
+    # then decrement a different key than was incremented and raise KeyError at
+    # finalisation. Capture each model's name the first time it is seen and reuse
+    # that stable key for the lifetime of the run.
+    model_keys: dict[int, str] = {}
+
+    def model_key(model: Model) -> str:
+        return model_keys.setdefault(id(model), str(model))
+
     def note_models(options: list[TaskRunOptions]) -> None:
         for t in options:
-            model_counts.setdefault(str(t.model), 0)
+            model_counts.setdefault(model_key(t.model), 0)
 
     # pending (index, task) pairs: initial tasks keep their original order and
     # injected tasks are appended in arrival order, so results sort stably
@@ -530,9 +541,9 @@ async def run_multiple(
     def pick_balanced() -> tuple[int, TaskRunOptions]:
         # among models that have pending tasks, pick the least-used one (keeps as
         # many different models running concurrently as possible)
-        models_with_pending = {str(opts.model) for _, opts in pending}
+        models_with_pending = {model_key(opts.model) for _, opts in pending}
         model = min(models_with_pending, key=lambda m: model_counts[m])
-        item = next(p for p in pending if str(p[1].model) == model)
+        item = next(p for p in pending if model_key(p[1].model) == model)
         pending.remove(item)
         return item
 
@@ -548,7 +559,7 @@ async def run_multiple(
                         result = (await _run_task(options)).log
                     finally:
                         in_flight -= 1
-                        model_counts[str(options.model)] -= 1
+                        model_counts[model_key(options.model)] -= 1
                         if result is not None:
                             results.append((idx, result))
                         if result is None or result.status == "cancelled":
@@ -564,7 +575,7 @@ async def run_multiple(
                     # dispatch up to the concurrency cap (model-balanced)
                     while not cancelled and in_flight < parallel and pending:
                         idx, options = pick_balanced()
-                        model_counts[str(options.model)] += 1
+                        model_counts[model_key(options.model)] += 1
                         in_flight += 1
                         tg.start_soon(run_one, idx, options)
 
@@ -634,9 +645,20 @@ async def run_task_retry_attempts(
     # model-balancing state (grows as tasks are injected)
     model_counts: dict[str, int] = {}
 
+    # A provider may rewrite its model's name mid-run — e.g. the vLLM provider
+    # resolves a "base:adapter" LoRA spec down to just "base" on the first
+    # generate(). Re-deriving the balancing key from the live str(model) would
+    # then decrement a different key than was incremented and raise KeyError at
+    # finalisation. Capture each model's name the first time it is seen and reuse
+    # that stable key for the lifetime of the run.
+    model_keys: dict[int, str] = {}
+
+    def model_key(model: Model) -> str:
+        return model_keys.setdefault(id(model), str(model))
+
     def note_models(options: list[TaskRunOptions]) -> None:
         for t in options:
-            model_counts.setdefault(str(t.model), 0)
+            model_counts.setdefault(model_key(t.model), 0)
 
     # pending tasks: initial tasks keep their original order and injected tasks
     # are appended in arrival order, so results sort stably. A retry re-queues
@@ -671,9 +693,9 @@ async def run_task_retry_attempts(
     def pick_balanced() -> PendingTask:
         # among models that have pending tasks, pick the least-used one (keeps as
         # many different models running concurrently as possible)
-        models_with_pending = {str(p.options.model) for p in pending}
+        models_with_pending = {model_key(p.options.model) for p in pending}
         model = min(models_with_pending, key=lambda m: model_counts[m])
-        item = next(p for p in pending if str(p.options.model) == model)
+        item = next(p for p in pending if model_key(p.options.model) == model)
         pending.remove(item)
         return item
 
@@ -756,7 +778,7 @@ async def run_task_retry_attempts(
                     # finalize atomically (no awaits below) so the dispatcher sees
                     # a consistent (in_flight, pending) snapshot
                     in_flight -= 1
-                    model_counts[str(options.model)] -= 1
+                    model_counts[model_key(options.model)] -= 1
                     if result is not None:
                         results[item.idx] = result
                     if retry_item is not None:
@@ -776,7 +798,7 @@ async def run_task_retry_attempts(
                     # dispatch up to the concurrency cap (model-balanced)
                     while not cancelled and in_flight < parallel and pending:
                         item = pick_balanced()
-                        model_counts[str(item.options.model)] += 1
+                        model_counts[model_key(item.options.model)] += 1
                         in_flight += 1
                         tg.start_soon(run_one, item)
 

--- a/src/inspect_ai/_eval/run.py
+++ b/src/inspect_ai/_eval/run.py
@@ -499,23 +499,20 @@ async def run_multiple(
     """
     feed = feed or _empty_feed()
 
-    # model-balancing state (grows as tasks are injected)
-    model_counts: dict[str, int] = {}
-
-    # A provider may rewrite its model's name mid-run — e.g. the vLLM provider
-    # resolves a "base:adapter" LoRA spec down to just "base" on the first
-    # generate(). Re-deriving the balancing key from the live str(model) would
-    # then decrement a different key than was incremented and raise KeyError at
-    # finalisation. Capture each model's name the first time it is seen and reuse
-    # that stable key for the lifetime of the run.
-    model_keys: dict[int, str] = {}
-
-    def model_key(model: Model) -> str:
-        return model_keys.setdefault(id(model), str(model))
+    # model-balancing state (grows as tasks are injected). Keyed by the Model
+    # object (identity), not str(model): a provider may rewrite its model name
+    # mid-run (e.g. vLLM resolving a "base:adapter" LoRA spec to "base" on the
+    # first generate()), which would make the decrement key differ from the
+    # increment key and raise KeyError at finalisation. The connection pool that
+    # balancing spreads load across belongs to the Model instance, not its name,
+    # so identity is the right key; eval_resolve_tasks shares one Model object
+    # across all of a model's tasks. (Relies on Model being identity-hashable —
+    # a plain class, not a frozen dataclass with __eq__.)
+    model_counts: dict[Model, int] = {}
 
     def note_models(options: list[TaskRunOptions]) -> None:
         for t in options:
-            model_counts.setdefault(model_key(t.model), 0)
+            model_counts.setdefault(t.model, 0)
 
     # pending (index, task) pairs: initial tasks keep their original order and
     # injected tasks are appended in arrival order, so results sort stably
@@ -541,9 +538,9 @@ async def run_multiple(
     def pick_balanced() -> tuple[int, TaskRunOptions]:
         # among models that have pending tasks, pick the least-used one (keeps as
         # many different models running concurrently as possible)
-        models_with_pending = {model_key(opts.model) for _, opts in pending}
+        models_with_pending = {opts.model for _, opts in pending}
         model = min(models_with_pending, key=lambda m: model_counts[m])
-        item = next(p for p in pending if model_key(p[1].model) == model)
+        item = next(p for p in pending if p[1].model is model)
         pending.remove(item)
         return item
 
@@ -559,7 +556,7 @@ async def run_multiple(
                         result = (await _run_task(options)).log
                     finally:
                         in_flight -= 1
-                        model_counts[model_key(options.model)] -= 1
+                        model_counts[options.model] -= 1
                         if result is not None:
                             results.append((idx, result))
                         if result is None or result.status == "cancelled":
@@ -575,7 +572,7 @@ async def run_multiple(
                     # dispatch up to the concurrency cap (model-balanced)
                     while not cancelled and in_flight < parallel and pending:
                         idx, options = pick_balanced()
-                        model_counts[model_key(options.model)] += 1
+                        model_counts[options.model] += 1
                         in_flight += 1
                         tg.start_soon(run_one, idx, options)
 
@@ -642,23 +639,20 @@ async def run_task_retry_attempts(
     """
     feed = feed or _empty_feed()
 
-    # model-balancing state (grows as tasks are injected)
-    model_counts: dict[str, int] = {}
-
-    # A provider may rewrite its model's name mid-run — e.g. the vLLM provider
-    # resolves a "base:adapter" LoRA spec down to just "base" on the first
-    # generate(). Re-deriving the balancing key from the live str(model) would
-    # then decrement a different key than was incremented and raise KeyError at
-    # finalisation. Capture each model's name the first time it is seen and reuse
-    # that stable key for the lifetime of the run.
-    model_keys: dict[int, str] = {}
-
-    def model_key(model: Model) -> str:
-        return model_keys.setdefault(id(model), str(model))
+    # model-balancing state (grows as tasks are injected). Keyed by the Model
+    # object (identity), not str(model): a provider may rewrite its model name
+    # mid-run (e.g. vLLM resolving a "base:adapter" LoRA spec to "base" on the
+    # first generate()), which would make the decrement key differ from the
+    # increment key and raise KeyError at finalisation. The connection pool that
+    # balancing spreads load across belongs to the Model instance, not its name,
+    # so identity is the right key; eval_resolve_tasks shares one Model object
+    # across all of a model's tasks. (Relies on Model being identity-hashable —
+    # a plain class, not a frozen dataclass with __eq__.)
+    model_counts: dict[Model, int] = {}
 
     def note_models(options: list[TaskRunOptions]) -> None:
         for t in options:
-            model_counts.setdefault(model_key(t.model), 0)
+            model_counts.setdefault(t.model, 0)
 
     # pending tasks: initial tasks keep their original order and injected tasks
     # are appended in arrival order, so results sort stably. A retry re-queues
@@ -693,9 +687,9 @@ async def run_task_retry_attempts(
     def pick_balanced() -> PendingTask:
         # among models that have pending tasks, pick the least-used one (keeps as
         # many different models running concurrently as possible)
-        models_with_pending = {model_key(p.options.model) for p in pending}
+        models_with_pending = {p.options.model for p in pending}
         model = min(models_with_pending, key=lambda m: model_counts[m])
-        item = next(p for p in pending if model_key(p.options.model) == model)
+        item = next(p for p in pending if p.options.model is model)
         pending.remove(item)
         return item
 
@@ -778,7 +772,7 @@ async def run_task_retry_attempts(
                     # finalize atomically (no awaits below) so the dispatcher sees
                     # a consistent (in_flight, pending) snapshot
                     in_flight -= 1
-                    model_counts[model_key(options.model)] -= 1
+                    model_counts[options.model] -= 1
                     if result is not None:
                         results[item.idx] = result
                     if retry_item is not None:
@@ -798,7 +792,7 @@ async def run_task_retry_attempts(
                     # dispatch up to the concurrency cap (model-balanced)
                     while not cancelled and in_flight < parallel and pending:
                         item = pick_balanced()
-                        model_counts[model_key(item.options.model)] += 1
+                        model_counts[item.options.model] += 1
                         in_flight += 1
                         tg.start_soon(run_one, item)
 

--- a/tests/test_task_model.py
+++ b/tests/test_task_model.py
@@ -107,7 +107,9 @@ def test_dispatch_survives_model_name_mutation(task_retry_attempts: int) -> None
                 solver=generate(),
                 name="name_mutation_task",
             ),
-            model="namemut/base:adapter",
+            # unique per case: get_model() memoizes, so a shared spec would let
+            # the first case's already-mutated model satisfy the second
+            model=f"namemut/base-{task_retry_attempts}:adapter",
             log_dir=log_dir,
             task_retry_attempts=task_retry_attempts,
         )

--- a/tests/test_task_model.py
+++ b/tests/test_task_model.py
@@ -1,5 +1,20 @@
+import tempfile
+
+import pytest
+
 from inspect_ai import Task, eval, eval_retry, task
-from inspect_ai.model import Model, get_model
+from inspect_ai.dataset import Sample
+from inspect_ai.model import (
+    ChatMessage,
+    GenerateConfig,
+    Model,
+    ModelAPI,
+    ModelOutput,
+    get_model,
+    modelapi,
+)
+from inspect_ai.solver import generate
+from inspect_ai.tool import ToolChoice, ToolInfo
 
 
 def check_task_model(task):
@@ -42,3 +57,59 @@ def test_task_model_object_arg_with_args():
     )
     assert log.eval.model_base_url == "https://example.com"
     assert log.eval.model_args["foo"] == "bar"
+
+
+class _NameMutatingAPI(ModelAPI):
+    """Mimics vLLM: rewrites a ``base:adapter`` name to ``base`` on generate()."""
+
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+    ) -> None:
+        super().__init__(model_name, base_url, api_key, [], config)
+
+    async def generate(
+        self,
+        input: list[ChatMessage],
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        # the rewrite that broke str(model)-keyed balancing
+        self.model_name = self.model_name.split(":")[0]
+        return ModelOutput.from_content(self.model_name, "ok")
+
+
+@modelapi(name="namemut")
+def namemut():
+    return _NameMutatingAPI
+
+
+@pytest.mark.parametrize("task_retry_attempts", [0, 1])
+def test_dispatch_survives_model_name_mutation(task_retry_attempts: int) -> None:
+    """Balancing dispatch must survive a provider rewriting its name mid-run.
+
+    The vLLM provider resolves a ``base:adapter`` LoRA spec down to ``base`` on
+    the first ``generate()``. The dispatchers in ``_eval/run.py`` track in-flight
+    tasks per model, incrementing at dispatch and decrementing at completion.
+    Keying that count by ``str(model)`` meant the decrement targeted a different
+    key than the increment once the name changed, raising ``KeyError`` at
+    finalisation (e.g. ``"namemut/base"``). ``task_retry_attempts==0`` routes
+    through ``run_multiple``, ``>0`` through ``run_task_retry_attempts``.
+    """
+    with tempfile.TemporaryDirectory() as log_dir:
+        logs = eval(
+            Task(
+                dataset=[Sample(input="x", target="y")],
+                solver=generate(),
+                name="name_mutation_task",
+            ),
+            model="namemut/base:adapter",
+            log_dir=log_dir,
+            task_retry_attempts=task_retry_attempts,
+        )
+
+    assert logs[0].status == "success"


### PR DESCRIPTION
The model-balancing dispatchers in `run.py` (`run_multiple` and `run_task_retry_attempts`) track in-flight tasks per model in `model_counts`. They increment a count when a task is dispatched and decrement it when the task completes. A provider may rewrite its model's name after dispatch — e.g. the vLLM provider resolves a `"base:adapter"` LoRA spec down to just `"base"` on the first `generate()` — so when the count was keyed by `str(model)` the decrement key no longer matched the increment key and raised `KeyError` at finalisation (e.g. `vllm-lens/<base>`).

Key `model_counts` by the `Model` object itself (identity) rather than by `str(model)`. The connection pool / rate limit that balancing spreads load across belongs to the `Model` instance, not its name, so identity is the correct key — and it is immune to any mid-run name rewrite. This removes the `str(model)` capture/lookup indirection entirely. Adapter routing and request identity are unaffected.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`eval_set` raises `KeyError` at finalisation when a provider mutates its own model name during a run. The dispatchers in `_eval/run.py` (`run_multiple` and `run_task_retry_attempts`) incremented `model_counts[str(model)]` at dispatch and decremented `model_counts[str(model)]` at completion. The vLLM provider is lazy: on the first `generate()` it resolves the server and rewrites `model_name` from `"base:adapter"` to just `"base"`. So the run incremented under `vllm/<base>:<adapter>` but decremented under `vllm/<base>`, raising e.g. `KeyError: 'vllm/<base>'`.

### What is the new behavior?

`model_counts` is now keyed by the `Model` object (identity-hashable), so the increment and decrement always target the same entry regardless of any mid-run name rewrite. The run finalises cleanly. `eval_resolve_tasks` shares a single `Model` instance across all of a model's tasks, so object identity is a faithful per-model key. This is purely load-balancing bookkeeping — adapter routing (`service_model_name()`), the wire `model` field, and the logged eval identity are unchanged.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No user-facing change. One behavioral nuance worth noting: when two *distinct* `Model` objects happen to share the same `str(model)`, the previous `str(model)`-keyed code merged them into a single balancing bucket, whereas identity keying treats them as separate buckets. This is the more correct behavior — distinct `Model` instances own distinct connection pools / rate limits — and `model_counts` is only a soft dispatch-diversity heuristic (it is never displayed or used to enforce limits), so balancing is unaffected in practice. Within a single run this case does not arise at all, since `eval_resolve_tasks` shares one `Model` object per logical model.

### Other information:

Makes the balancer robust to any name-mutating provider, not just vLLM. The fix relies on `Model` being identity-hashable (a plain class, not a frozen dataclass with `__eq__`); a comment notes this at the `model_counts` declaration. Adds a regression test (`tests/test_task_model.py::test_dispatch_survives_model_name_mutation`) that registers a provider rewriting its name on `generate()` and exercises both `run_multiple` and `run_task_retry_attempts`.
