### PR TITLE
Stable model connection pooling key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Model API: Keep the connection-pool/adaptive-concurrency scope stable when a provider's `api_key` is a short-lived credential.
 - AzureAI: Honor an explicitly supplied `api_key` instead of replacing it with an environment credential.
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -24,7 +24,6 @@ from typing import (
     Type,
     TypeAlias,
     cast,
-    final,
 )
 
 if TYPE_CHECKING:
@@ -419,9 +418,10 @@ class ModelAPI(abc.ABC):
         """Scope for enforcement of max_connections (and adaptive concurrency).
 
         Two instances of the *same provider* that return the same key share one
-        connection pool. Callers should use `connection_pool_key()`, which adds
-        the provider namespace so distinct providers never collide (see there);
-        this method only needs to distinguish accounts/models within a provider.
+        connection pool. This method only needs to distinguish accounts/models
+        within a provider; the model layer adds the provider namespace on top
+        (see `_connection_pool_key`), so distinct providers never collide even
+        when their `connection_key()` values coincide.
 
         Providers that scope by API key should use `self.initial_api_key` here,
         NOT the live `self.api_key`: the live key can rotate mid-eval (e.g. a
@@ -430,28 +430,6 @@ class ModelAPI(abc.ABC):
         ``initial_api_key`` is fixed at construction, so the scope stays stable.
         """
         return "default"
-
-    @final
-    def connection_pool_key(self) -> str:
-        """Provider-namespaced connection-pool key used by the model layer.
-
-        Final on purpose: providers customize pooling by overriding
-        `connection_key()` (their intra-provider scope); this wrapper owns the
-        provider namespacing and must stay consistent across all providers, so
-        it is not an override point.
-
-        Prefixes `connection_key()` with the provider class so two providers
-        serving the same model don't share a pool (e.g. `openai/gpt-5` and
-        `azureai/gpt-5`, whose `connection_key()` both reduce to `None:gpt-5`
-        when their api keys are elided). Namespacing here rather than in each
-        provider's `connection_key()` means a provider can't accidentally omit
-        it — `connection_key()` only owns its intra-provider scope.
-
-        This key is internal — an in-process semaphore scope, never displayed —
-        so it uses the class name (unique per provider, available without
-        registry plumbing) rather than the registry provider name.
-        """
-        return f"{type(self).__name__}:{self.connection_key()}"
 
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:
         """Whether compaction should add `redacted_reasoning_tokens` to its input estimate.
@@ -607,6 +585,17 @@ def _stamp_redacted_reasoning_tokens(output: ModelOutput) -> None:
         **(output.message.metadata or {}),
         REDACTED_REASONING_TOKENS_METADATA_KEY: output.usage.reasoning_tokens,
     }
+
+
+def _connection_pool_key(api: ModelAPI) -> str:
+    """Provider-namespaced connection-pool key for the model layer.
+
+    Prefixes the provider's `connection_key()` with the provider class so two
+    providers serving the same model don't share a pool (e.g. `openai/gpt-5`
+    and `azureai/gpt-5`, whose `connection_key()` both reduce to `None:gpt-5`
+    when their api keys are elided).
+    """
+    return f"{type(api).__name__}:{api.connection_key()}"
 
 
 class Model:
@@ -955,7 +944,7 @@ class Model:
                 config.max_tokens = self.api.max_tokens()
 
         model_name = ModelName(self)
-        key = f"ModelCompact({self.api.connection_pool_key()})"
+        key = f"ModelCompact({_connection_pool_key(self.api)})"
 
         async with concurrency(f"{model_name}_compact", 10, key, visible=False):
 
@@ -1409,7 +1398,7 @@ class Model:
         )
 
         model_name = ModelName(self)
-        key = f"Model{self.api.connection_pool_key()}"
+        key = f"Model{_connection_pool_key(self.api)}"
 
         # adaptive path: controller-managed CapacityLimiter. Two precedence
         # rules — both silent — keep deliberate overrides working under

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -217,6 +217,9 @@ class ModelAPI(abc.ABC):
         self.base_url = base_url
         self.api_key = api_key
         self.api_key_vars = api_key_vars
+        # Use initial api_key value as a stable identifier for connection
+        # pooling purposes.
+        self.initial_api_key = api_key
         self._apply_api_key_overrides()
 
     def _apply_api_key_overrides(self) -> None:

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -217,8 +217,10 @@ class ModelAPI(abc.ABC):
         self.base_url = base_url
         self.api_key = api_key
         self.api_key_vars = api_key_vars
-        # Use initial api_key value as a stable identifier for connection
-        # pooling purposes.
+        # Stable pooling identity for connection_key(). Captured from the
+        # constructor before _apply_api_key_overrides() runs and never mutated
+        # afterwards, so it survives api_key rotation (e.g. a credential hook
+        # refreshing self.api_key via initialize()). See connection_key().
         self.initial_api_key = api_key
         self._apply_api_key_overrides()
 
@@ -413,7 +415,15 @@ class ModelAPI(abc.ABC):
         return DEFAULT_MAX_CONNECTIONS
 
     def connection_key(self) -> str:
-        """Scope for enforcement of max_connections."""
+        """Scope for enforcement of max_connections (and adaptive concurrency).
+
+        Two model instances that return the same key share one connection pool.
+        Providers that scope by API key should use `self.initial_api_key` here,
+        NOT the live `self.api_key`: the live key can rotate mid-eval (e.g. a
+        credential hook refreshing it via `initialize()`), and keying on it
+        would discard all learned pool/adaptive state on every rotation.
+        ``initial_api_key`` is fixed at construction, so the scope stays stable.
+        """
         return "default"
 
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -24,6 +24,7 @@ from typing import (
     Type,
     TypeAlias,
     cast,
+    final,
 )
 
 if TYPE_CHECKING:
@@ -417,7 +418,11 @@ class ModelAPI(abc.ABC):
     def connection_key(self) -> str:
         """Scope for enforcement of max_connections (and adaptive concurrency).
 
-        Two model instances that return the same key share one connection pool.
+        Two instances of the *same provider* that return the same key share one
+        connection pool. Callers should use `connection_pool_key()`, which adds
+        the provider namespace so distinct providers never collide (see there);
+        this method only needs to distinguish accounts/models within a provider.
+
         Providers that scope by API key should use `self.initial_api_key` here,
         NOT the live `self.api_key`: the live key can rotate mid-eval (e.g. a
         credential hook refreshing it via `initialize()`), and keying on it
@@ -425,6 +430,28 @@ class ModelAPI(abc.ABC):
         ``initial_api_key`` is fixed at construction, so the scope stays stable.
         """
         return "default"
+
+    @final
+    def connection_pool_key(self) -> str:
+        """Provider-namespaced connection-pool key used by the model layer.
+
+        Final on purpose: providers customize pooling by overriding
+        `connection_key()` (their intra-provider scope); this wrapper owns the
+        provider namespacing and must stay consistent across all providers, so
+        it is not an override point.
+
+        Prefixes `connection_key()` with the provider class so two providers
+        serving the same model don't share a pool (e.g. `openai/gpt-5` and
+        `azureai/gpt-5`, whose `connection_key()` both reduce to `None:gpt-5`
+        when their api keys are elided). Namespacing here rather than in each
+        provider's `connection_key()` means a provider can't accidentally omit
+        it — `connection_key()` only owns its intra-provider scope.
+
+        This key is internal — an in-process semaphore scope, never displayed —
+        so it uses the class name (unique per provider, available without
+        registry plumbing) rather than the registry provider name.
+        """
+        return f"{type(self).__name__}:{self.connection_key()}"
 
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:
         """Whether compaction should add `redacted_reasoning_tokens` to its input estimate.
@@ -928,7 +955,7 @@ class Model:
                 config.max_tokens = self.api.max_tokens()
 
         model_name = ModelName(self)
-        key = f"ModelCompact({self.api.connection_key()})"
+        key = f"ModelCompact({self.api.connection_pool_key()})"
 
         async with concurrency(f"{model_name}_compact", 10, key, visible=False):
 
@@ -1364,8 +1391,8 @@ class Model:
     # (which would likely cause the rate limit to be exceeded). conversely if
     # you are using distinct models/endpoints/accounts within an eval you should
     # be able get the full max_connections for each of them. subclasses can
-    # override the _connection_key() argument to provide a scope within which
-    # to enforce max_connections (e.g. by account/api_key, by endpoint, etc.)
+    # override connection_key() to provide a scope within which to enforce
+    # max_connections (e.g. by account/api_key, by endpoint, etc.)
 
     @contextlib.asynccontextmanager
     async def _connection_concurrency(
@@ -1382,7 +1409,7 @@ class Model:
         )
 
         model_name = ModelName(self)
-        key = f"Model{self.api.connection_key()}"
+        key = f"Model{self.api.connection_pool_key()}"
 
         # adaptive path: controller-managed CapacityLimiter. Two precedence
         # rules — both silent — keep deliberate overrides working under

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1231,7 +1231,7 @@ class AnthropicAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.service_model_name()}"
+        return f"{self.initial_api_key}:{self.service_model_name()}"
 
     def service_model_name(self) -> str:
         """Model name without any service prefix."""

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -347,7 +347,7 @@ class AzureAIAPI(ModelAPI):
 
     @override
     def connection_key(self) -> str:
-        return f"{self.api_key}{self.model_name}"
+        return f"{self.initial_api_key}:{self.model_name}"
 
     def service_model_name(self) -> str:
         """Model name without any org prefix, for API calls."""

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -750,7 +750,7 @@ class GoogleGenAIAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.initial_api_key}:{self.model_name}"
 
     @override
     def tool_result_images(self) -> bool:

--- a/src/inspect_ai/model/_providers/grok.py
+++ b/src/inspect_ai/model/_providers/grok.py
@@ -328,7 +328,7 @@ class GrokAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.service_model_name()}"
+        return f"{self.initial_api_key}:{self.service_model_name()}"
 
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
         if isinstance(ex, grpc.RpcError):

--- a/src/inspect_ai/model/_providers/groq.py
+++ b/src/inspect_ai/model/_providers/groq.py
@@ -280,7 +280,7 @@ class GroqAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.initial_api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/mistral.py
+++ b/src/inspect_ai/model/_providers/mistral.py
@@ -291,7 +291,7 @@ class MistralAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.initial_api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -605,7 +605,7 @@ class OpenAIAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.initial_api_key}:{self.model_name}"
 
     @override
     def apply_redacted_reasoning_tokens_to_input(self) -> bool:

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -333,7 +333,7 @@ class OpenAICompatibleAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.initial_api_key}:{self.model_name}"
 
     @override
     def is_auth_failure(self, ex: Exception) -> bool:

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -327,7 +327,7 @@ class TogetherRESTAPI(ModelAPI):
         Per-model scoping avoids that, at the cost of slight over-fragmentation
         when models actually share an upstream rate-limit budget.
         """
-        return f"{self.api_key}:{self.model_name}"
+        return f"{self.initial_api_key}:{self.model_name}"
 
     # Together uses a default of 512 so we bump it up
     @override

--- a/tests/model/providers/test_model_family.py
+++ b/tests/model/providers/test_model_family.py
@@ -6,6 +6,7 @@ import pytest
 from inspect_ai.model import (
     ChatMessageUser,
     GenerateConfig,
+    ModelAPI,
     ModelInfo,
     ModelOutput,
     set_model_info,
@@ -70,8 +71,7 @@ def test_grok_service_model_name_controls_wire_identity() -> None:
             return "grok-4-1-fast-reasoning"
 
     api = _AliasedGrokAPI.__new__(_AliasedGrokAPI)
-    api.model_name = "custom-alias"
-    api.api_key = "test-key"
+    ModelAPI.__init__(api, model_name="custom-alias", api_key="test-key")
 
     assert api.canonical_name() == "grok/grok-4-1-fast-reasoning"
     assert api.connection_key() == "test-key:grok-4-1-fast-reasoning"

--- a/tests/model/test_connection_key_stability.py
+++ b/tests/model/test_connection_key_stability.py
@@ -14,6 +14,7 @@ import pytest
 
 from inspect_ai.model import ModelAPI, ModelOutput
 from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._model import _connection_pool_key
 from inspect_ai.tool import ToolChoice, ToolInfo
 
 STUB_API_KEY = "STUB_API_KEY"
@@ -133,10 +134,10 @@ def test_connection_pool_key_disambiguates_providers_with_elided_key() -> None:
     # Two providers serving the same model name (e.g. openai/gpt-5 and
     # azureai/gpt-5) must not share a pool just because their api keys are
     # elided to None. Their connection_key() collides ("None:gpt-5"); the
-    # provider-class prefix added by connection_pool_key() keeps them distinct.
+    # provider-class prefix added by _connection_pool_key() keeps them distinct.
     openai = _OpenAIStubAPI("gpt-5")
     azure = _AzureAIStubAPI("gpt-5")
 
     assert openai.connection_key() == azure.connection_key() == "None:gpt-5"
-    assert openai.connection_pool_key() == "_OpenAIStubAPI:None:gpt-5"
-    assert azure.connection_pool_key() == "_AzureAIStubAPI:None:gpt-5"
+    assert _connection_pool_key(openai) == "_OpenAIStubAPI:None:gpt-5"
+    assert _connection_pool_key(azure) == "_AzureAIStubAPI:None:gpt-5"

--- a/tests/model/test_connection_key_stability.py
+++ b/tests/model/test_connection_key_stability.py
@@ -1,0 +1,121 @@
+"""Tests for connection-pool key stability across api_key rotation.
+
+The connection semaphore / adaptive concurrency controller are keyed by
+`ModelAPI.connection_key()`. Providers scope that key by api_key so distinct
+accounts get distinct pools. For long-running evals an api_key can be rotated
+mid-run (e.g. a hook refreshing an OAuth token, triggered by `initialize()` on
+an auth failure). Scoping the pool by the *live* `self.api_key` would discard
+all learned pool/adaptive state on every rotation. Providers therefore scope by
+`self.initial_api_key` — the constructor-provided value, captured once and never
+mutated by `initialize()`.
+"""
+
+import pytest
+
+from inspect_ai.model import ModelAPI, ModelOutput
+from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.tool import ToolChoice, ToolInfo
+
+STUB_API_KEY = "STUB_API_KEY"
+
+
+class _StubAPI(ModelAPI):
+    """Minimal provider that scopes the pool by initial_api_key, as real ones do."""
+
+    def __init__(self, model_name: str, api_key: str | None = None) -> None:
+        super().__init__(
+            model_name=model_name,
+            api_key=api_key,
+            api_key_vars=[STUB_API_KEY],
+            config=GenerateConfig(),
+        )
+
+    async def generate(
+        self,
+        input: list,
+        tools: list[ToolInfo],
+        tool_choice: ToolChoice,
+        config: GenerateConfig,
+    ) -> ModelOutput:
+        return ModelOutput.from_content(self.model_name, "ok")
+
+    def connection_key(self) -> str:
+        return f"{self.initial_api_key}:{self.model_name}"
+
+
+def _install_rotating_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make every override_api_key() call return a fresh, distinct token.
+
+    Simulates a credential hook that hands out a new value each time it is
+    consulted (the worst case for pool-key stability).
+    """
+    counter = {"n": 0}
+
+    def rotate(var: str, value: str) -> str:
+        counter["n"] += 1
+        return f"rotated-token-{counter['n']}"
+
+    # `override_api_key()` falls back to this legacy global when no Hooks
+    # subclass implements override_api_key(), which is the case under test.
+    monkeypatch.setattr(
+        "inspect_ai.hooks._legacy._override_api_key", rotate, raising=False
+    )
+
+
+def test_initial_api_key_captured_from_constructor() -> None:
+    api = _StubAPI("m1", api_key="explicit-key")
+    assert api.initial_api_key == "explicit-key"
+
+
+def test_initial_api_key_unaffected_by_construction_time_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Even though the override fires during __init__ and mutates self.api_key,
+    # initial_api_key reflects the value the caller passed in.
+    _install_rotating_override(monkeypatch)
+    api = _StubAPI("m1", api_key="explicit-key")
+    assert api.initial_api_key == "explicit-key"
+    assert api.api_key != "explicit-key"  # override applied to the live key
+
+
+def test_connection_key_stable_across_rotation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_rotating_override(monkeypatch)
+    api = _StubAPI("m1", api_key="explicit-key")
+
+    key_before = api.connection_key()
+    live_before = api.api_key
+
+    # initialize() re-applies overrides — the live key rotates again...
+    api.initialize()
+
+    assert api.api_key != live_before, "precondition: the live key must rotate"
+    assert api.connection_key() == key_before, (
+        "connection_key must not move when the live api_key rotates"
+    )
+    assert key_before == "explicit-key:m1"
+
+
+def test_same_explicit_key_shares_pool_across_instances() -> None:
+    a = _StubAPI("m1", api_key="shared-key")
+    b = _StubAPI("m1", api_key="shared-key")
+    assert a.connection_key() == b.connection_key()
+
+
+def test_distinct_explicit_keys_get_distinct_pools() -> None:
+    a = _StubAPI("m1", api_key="key-a")
+    b = _StubAPI("m1", api_key="key-b")
+    assert a.connection_key() != b.connection_key()
+
+
+def test_env_var_keys_collapse_to_shared_pool_per_model() -> None:
+    # No explicit api_key => initial_api_key is None for everyone. Per the
+    # design decision, env-var-sourced keys are assumed shared process-wide, so
+    # all instances of a given model share one pool (scoped only by model name).
+    a = _StubAPI("m1")
+    b = _StubAPI("m1")
+    c = _StubAPI("m2")
+    assert a.initial_api_key is None
+    assert a.connection_key() == b.connection_key()
+    assert a.connection_key() != c.connection_key()

--- a/tests/model/test_connection_key_stability.py
+++ b/tests/model/test_connection_key_stability.py
@@ -43,6 +43,14 @@ class _StubAPI(ModelAPI):
         return f"{self.initial_api_key}:{self.model_name}"
 
 
+class _OpenAIStubAPI(_StubAPI):
+    """Stub standing in for the openai provider."""
+
+
+class _AzureAIStubAPI(_StubAPI):
+    """Stub standing in for the azureai provider."""
+
+
 def _install_rotating_override(monkeypatch: pytest.MonkeyPatch) -> None:
     """Make every override_api_key() call return a fresh, distinct token.
 
@@ -119,3 +127,16 @@ def test_env_var_keys_collapse_to_shared_pool_per_model() -> None:
     assert a.initial_api_key is None
     assert a.connection_key() == b.connection_key()
     assert a.connection_key() != c.connection_key()
+
+
+def test_connection_pool_key_disambiguates_providers_with_elided_key() -> None:
+    # Two providers serving the same model name (e.g. openai/gpt-5 and
+    # azureai/gpt-5) must not share a pool just because their api keys are
+    # elided to None. Their connection_key() collides ("None:gpt-5"); the
+    # provider-class prefix added by connection_pool_key() keeps them distinct.
+    openai = _OpenAIStubAPI("gpt-5")
+    azure = _AzureAIStubAPI("gpt-5")
+
+    assert openai.connection_key() == azure.connection_key() == "None:gpt-5"
+    assert openai.connection_pool_key() == "_OpenAIStubAPI:None:gpt-5"
+    assert azure.connection_pool_key() == "_AzureAIStubAPI:None:gpt-5"


### PR DESCRIPTION
## This PR contains:
- [x] New features

### What is the current behavior? (You can also link to an open issue here)
Model connection pooling / adaptive concurrency uses the model API key (`api_key` field). This field is subject to change, typically when a hook overrides an API key with a short-lived credential. This is refreshed on 401 errors via `ModelAPI.initialize()`.

Because the connection pool is keyed on `connection_key()`, which embeds `api_key`, every rotation produces a new key. The adaptive controller's learned state is discarded and a fresh pool is created at the default size.

### What is the new behavior?
Pool scoping now keys on `initial_api_key` — the value passed to `ModelAPI.__init__()`, captured once at construction and never mutated by `initialize()`. The live `api_key` continues to rotate for authentication, but `connection_key()` stays stable across rotations, so the pool and its adaptive state survive.

**What if I'm using env vars which are overridden by a hook?** `initial_api_key` will be `None` (no key was passed to the constructor), and it stays stable. I argue this is the right behavior: if you're setting credentials via **environment** variables (e.g. `OPENAI_API_KEY=<pointer to secret>`), every OpenAI model in the process is reading from the same source, so they should share one connection pool anyway. The scope collapses to `None:<model>` — i.e. one pool per model, shared across all instances — which is exactly what you want. (The same applies to credentials provided purely by a hook with no explicit key.)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
Other approaches were considered: #4255, #4290, #4293, #4294 (thanks a lot for your contributions Eric). See discussion on these PRs. This PR is a pragmatic approach designed to solve the immediate problem at hand. A rethink around API key handling and contracts with hooks, subclasses and consumers of `Model` might be in order (see [comment](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4293#issuecomment-4778394834)).

The model provider class name is included in the key too, so if you had models `openai/gpt-5` and `azureai/gpt-5` they would not both resolve to the same connection pool.