### PR TITLE
AzureAI: Honor explicit api_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- AzureAI: Honor an explicitly supplied `api_key` instead of replacing it with an environment credential.
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.
 - Control Channel: `inspect ctl tasks` now pins each eval's reported start to its first sample's start instead of letting it drift forward as early samples finish.

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -155,9 +155,10 @@ class AzureAIAPI(ModelAPI):
 
         # resolve api_key or managed identity (for Azure)
         self.token_provider = None
-        self.api_key = os.environ.get(
-            AZURE_API_KEY, os.environ.get(AZUREAI_API_KEY, None)
-        )
+        if not self.api_key:
+            self.api_key = os.environ.get(
+                AZURE_API_KEY, os.environ.get(AZUREAI_API_KEY, None)
+            )
         if not self.api_key:
             # try managed identity (Microsoft Entra ID)
             try:

--- a/tests/model/providers/test_azureai.py
+++ b/tests/model/providers/test_azureai.py
@@ -4,6 +4,27 @@ from test_helpers.utils import skip_if_no_azureai
 
 from inspect_ai import eval_async
 from inspect_ai.model import GenerateConfig, Model, get_model
+from inspect_ai.model._providers.azureai import (
+    AZURE_API_KEY,
+    AZUREAI_API_KEY,
+    AzureAIAPI,
+)
+
+
+def test_explicit_api_key_takes_precedence_over_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv(AZURE_API_KEY, "legacy-env-key")
+    monkeypatch.setenv(AZUREAI_API_KEY, "env-key")
+
+    api = AzureAIAPI(
+        model_name="test-model",
+        base_url="https://example.com/models",
+        api_key="explicit-key",
+    )
+
+    assert api.api_key == "explicit-key"
+    assert api.token_provider is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?
`AzureAIAPI` unconditionally replaces an explicitly supplied `api_key` with `AZURE_API_KEY` / `AZUREAI_API_KEY` from the environment. If neither variable is set, it falls through to managed identity instead of using the caller's key.

### What is the new behavior?
Environment credentials and managed identity are considered only when no explicit API key was supplied, restoring the intended precedence:

`api_key` argument → environment credential → managed identity

### Does this PR introduce a breaking change?
No.

### Other information
This was noticed while reviewing #4327. Includes a focused regression test.
