### PR TITLE
Agent bridge: preserve Google structured-output schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Agent Bridge: Forward the Google `generationConfig` structured-output schema (`responseSchema`/`responseJsonSchema`) instead of dropping it.
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.
 - Control Channel: `inspect ctl tasks` now pins each eval's reported start to its first sample's start instead of letting it drift forward as early samples finish.

--- a/src/inspect_ai/agent/_bridge/google_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/google_api_impl.py
@@ -21,7 +21,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageTool,
     ChatMessageUser,
 )
-from inspect_ai.model._generate_config import GenerateConfig
+from inspect_ai.model._generate_config import GenerateConfig, ResponseSchema
 from inspect_ai.model._model import ModelName
 from inspect_ai.model._model_output import ModelOutput, ModelUsage, StopReason
 from inspect_ai.model._providers._google_computer_use import (
@@ -45,6 +45,7 @@ from inspect_ai.tool._tools._web_search._web_search import (
     WebSearchProviders,
     web_search,
 )
+from inspect_ai.util._json import JSONSchema
 
 from .types import AgentBridge
 from .util import (
@@ -152,6 +153,19 @@ def generate_config_from_google(generation_config: dict[str, Any]) -> GenerateCo
     config.stop_seqs = generation_config.get(
         "stopSequences", generation_config.get("stop_sequences")
     )
+
+    # structured output: responseJsonSchema is standard JSON Schema; responseSchema
+    # is Gemini's OpenAPI-style Schema (uppercase types) which we normalize.
+    schema = generation_config.get("responseJsonSchema") or generation_config.get(
+        "responseSchema"
+    )
+    if schema:
+        config.response_schema = ResponseSchema(
+            name="response",
+            json_schema=JSONSchema.model_validate(
+                _google_schema_to_json_schema(schema)
+            ),
+        )
 
     # NOTE: We deliberately do NOT set config.system_message from system_instruction here.
     # The system_instruction is already converted to ChatMessageSystem messages in
@@ -621,3 +635,25 @@ def _convert_google_enums(obj: Any) -> Any:
     elif hasattr(obj, "value"):  # Enum-like object
         return str(obj.value).lower()
     return obj
+
+
+def _google_schema_to_json_schema(schema: Any) -> Any:
+    """Normalize a Gemini OpenAPI-style Schema into a standard JSON Schema dict."""
+    return _lowercase_schema_types(_convert_google_enums(schema))
+
+
+def _lowercase_schema_types(value: Any) -> Any:
+    # Gemini emits uppercase JSON Schema `type` names like "OBJECT" / "STRING".
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            if k == "type" and isinstance(v, str):
+                out[k] = v.lower()
+            elif k == "type" and isinstance(v, list):
+                out[k] = [t.lower() if isinstance(t, str) else t for t in v]
+            else:
+                out[k] = _lowercase_schema_types(v)
+        return out
+    if isinstance(value, list):
+        return [_lowercase_schema_types(v) for v in value]
+    return value

--- a/tests/agent/test_bridge_generation_config.py
+++ b/tests/agent/test_bridge_generation_config.py
@@ -175,6 +175,16 @@ def test_google_forward_then_clear():
         "topK": 2,
         # structural
         "stopSequences": ["foo"],
+        # structured output (Gemini OpenAPI-style schema, uppercase type names)
+        "responseMimeType": "application/json",
+        "responseSchema": {
+            "type": "OBJECT",
+            "properties": {
+                "reasoning": {"type": "STRING"},
+                "confidence": {"type": "NUMBER"},
+            },
+            "required": ["reasoning", "confidence"],
+        },
     }
 
     config = generate_config_from_google(generation_config)
@@ -183,6 +193,38 @@ def test_google_forward_then_clear():
     assert config.top_p == 0.9
     assert config.top_k == 2
 
+    # responseSchema is mapped, with types normalized to lowercase JSON Schema
+    assert config.response_schema is not None
+    json_schema = config.response_schema.json_schema
+    assert json_schema.type == "object"
+    assert json_schema.properties is not None
+    assert json_schema.properties["confidence"].type == "number"
+    assert json_schema.required == ["reasoning", "confidence"]
+
     clear_generation_params(config)
     _assert_cleared(config)
     assert config.stop_seqs == ["foo"]
+    # structured output survives clearing (it's functional, not a tuning knob)
+    assert config.response_schema is not None
+
+
+def test_google_response_json_schema_used_directly():
+    # `responseJsonSchema` is already standard JSON Schema (lowercase types)
+    generation_config = {
+        "responseMimeType": "application/json",
+        "responseJsonSchema": {
+            "type": "object",
+            "properties": {"answer": {"type": "string"}},
+            "required": ["answer"],
+        },
+    }
+
+    config = generate_config_from_google(generation_config)
+    assert config.response_schema is not None
+    assert config.response_schema.json_schema.type == "object"
+    assert config.response_schema.json_schema.properties is not None
+
+
+def test_google_no_schema_leaves_response_schema_unset():
+    config = generate_config_from_google({"temperature": 0.5})
+    assert config.response_schema is None


### PR DESCRIPTION
The Google-format agent bridge converted an incoming Gemini `generationConfig` into an inspect `GenerateConfig` but silently dropped the structured-output fields (`responseMimeType`, `responseSchema` / `responseJsonSchema`). This breaks Gemini CLI features that request `application/json` with a schema -- notably loop detection and history compression -- which can cause samples to loop indefinitely.

Fixes #4328

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

https://github.com/UKGovernmentBEIS/inspect_ai/issues/4328

### What is the new behavior?

`generate_config_from_google()` now maps these onto `GenerateConfig.response_schema`, normalizing Gemini's OpenAPI-style uppercase type names to lowercase JSON Schema types. `responseJsonSchema` (already standard JSON Schema) is preferred when present.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:
