### PR TITLE
AzureAI: Offer AZUREAI_API_KEY to override hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- AzureAI: Offer `AZUREAI_API_KEY` values to API key override hooks.
 - AzureAI: Honor an explicitly supplied `api_key` instead of replacing it with an environment credential.
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.

--- a/src/inspect_ai/model/_providers/azureai.py
+++ b/src/inspect_ai/model/_providers/azureai.py
@@ -83,7 +83,6 @@ from .util.llama31 import Llama31Handler
 logger = getLogger(__name__)
 
 AZUREAI_API_KEY = "AZUREAI_API_KEY"
-AZUREAI_ENDPOINT_KEY = "AZUREAI_ENDPOINT_KEY"
 AZUREAI_BASE_URL = "AZUREAI_BASE_URL"
 AZUREAI_ENDPOINT_URL = "AZUREAI_ENDPOINT_URL"
 AZUREAI_AUDIENCE = "AZUREAI_AUDIENCE"
@@ -136,7 +135,7 @@ class AzureAIAPI(ModelAPI):
             model_name=model_name,
             base_url=base_url,
             api_key=api_key,
-            api_key_vars=[AZURE_API_KEY, AZUREAI_ENDPOINT_KEY],
+            api_key_vars=[AZURE_API_KEY, AZUREAI_API_KEY],
             config=config,
         )
 

--- a/tests/model/providers/test_azureai.py
+++ b/tests/model/providers/test_azureai.py
@@ -27,6 +27,31 @@ def test_explicit_api_key_takes_precedence_over_environment(
     assert api.token_provider is None
 
 
+def test_azureai_api_key_is_offered_to_override_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    seen: list[tuple[str, str]] = []
+
+    def override_api_key(env_var_name: str, value: str) -> str:
+        seen.append((env_var_name, value))
+        return "overridden-key"
+
+    monkeypatch.delenv(AZURE_API_KEY, raising=False)
+    monkeypatch.setenv(AZUREAI_API_KEY, "source-key")
+    monkeypatch.setattr(
+        "inspect_ai.hooks._hooks.override_api_key",
+        override_api_key,
+    )
+
+    api = AzureAIAPI(
+        model_name="test-model",
+        base_url="https://example.com/models",
+    )
+
+    assert seen == [(AZUREAI_API_KEY, "source-key")]
+    assert api.api_key == "overridden-key"
+
+
 @pytest.mark.anyio
 @skip_if_no_azureai
 async def test_azureai_api() -> None:


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?
`AzureAIAPI` reads credentials from `AZURE_API_KEY` or `AZUREAI_API_KEY`, but registers `AZURE_API_KEY` and the otherwise-unused `AZUREAI_ENDPOINT_KEY` with API key override hooks. A value stored in `AZUREAI_API_KEY` is therefore never offered to the hook.

### What is the new behavior?
AzureAI registers the same two environment variables it actually reads, so `AZUREAI_API_KEY` references can be overridden before client initialization.

### Does this PR introduce a breaking change?
No.

### Other information
Follow-up to #4330. Includes a focused regression test.
