### PR TITLE
HuggingFace: Forward API key when loading tokenizers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- HuggingFace: Forward an explicitly supplied API key when loading tokenizers for private or gated models.
 - AzureAI: Honor an explicitly supplied `api_key` instead of replacing it with an environment credential.
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -139,20 +139,28 @@ class HuggingFaceAPI(ModelAPI):
         # tokenizer
         if tokenizer:
             self.tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
-                tokenizer, trust_remote_code=trust_remote_code
+                tokenizer,
+                token=self.api_key,
+                trust_remote_code=trust_remote_code,
             )
         elif model_path:
             if tokenizer_path:
                 self.tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
-                    tokenizer_path, trust_remote_code=trust_remote_code
+                    tokenizer_path,
+                    token=self.api_key,
+                    trust_remote_code=trust_remote_code,
                 )
             else:
                 self.tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
-                    model_path, trust_remote_code=trust_remote_code
+                    model_path,
+                    token=self.api_key,
+                    trust_remote_code=trust_remote_code,
                 )
         else:
             self.tokenizer = AutoTokenizer.from_pretrained(  # type: ignore[no-untyped-call]
-                model_name, trust_remote_code=trust_remote_code
+                model_name,
+                token=self.api_key,
+                trust_remote_code=trust_remote_code,
             )
         # LLMs generally don't have a pad token and we need one for batching
         self.tokenizer.pad_token = self.tokenizer.eos_token

--- a/tests/model/providers/test_hf.py
+++ b/tests/model/providers/test_hf.py
@@ -1,3 +1,6 @@
+import importlib
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -143,6 +146,67 @@ def test_hf_trust_remote_code_explicit_true(monkeypatch) -> None:
         kwargs = call["kwargs"]
         # only the explicit kwarg we passed; no duplicate via passthrough
         assert sum(1 for k in kwargs if k == "trust_remote_code") == 1
+
+
+@pytest.mark.parametrize(
+    "model_args",
+    [
+        {},
+        {"tokenizer": "custom-tokenizer"},
+        {"model_path": "local-model"},
+        {"model_path": "local-model", "tokenizer_path": "custom-tokenizer"},
+    ],
+)
+def test_hf_explicit_api_key_reaches_model_and_tokenizer(
+    monkeypatch: pytest.MonkeyPatch,
+    model_args: dict[str, str],
+) -> None:
+    model_calls: list[dict] = []
+    tokenizer_calls: list[dict] = []
+
+    class FakeAutoModelForCausalLM:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            model_calls.append({"args": args, "kwargs": kwargs})
+            return MagicMock()
+
+    class FakeAutoTokenizer:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            tokenizer_calls.append({"args": args, "kwargs": kwargs})
+            return MagicMock()
+
+    fake_transformers = ModuleType("transformers")
+    fake_transformers.AutoModelForCausalLM = FakeAutoModelForCausalLM  # type: ignore[attr-defined]
+    fake_transformers.AutoTokenizer = FakeAutoTokenizer  # type: ignore[attr-defined]
+    fake_transformers.PreTrainedTokenizerBase = object  # type: ignore[attr-defined]
+    fake_transformers.set_seed = lambda seed: None  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+
+    fake_torch = ModuleType("torch")
+    fake_torch.Tensor = object  # type: ignore[attr-defined]
+    fake_torch.backends = SimpleNamespace(  # type: ignore[attr-defined]
+        mps=SimpleNamespace(is_available=lambda: False)
+    )
+    fake_torch.cuda = SimpleNamespace(is_available=lambda: False)  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    module_name = "inspect_ai.model._providers.hf"
+    previous_module = sys.modules.pop(module_name, None)
+    try:
+        provider_module = importlib.import_module(module_name)
+        provider_module.HuggingFaceAPI(
+            model_name="private/model",
+            api_key="hf-test-token",
+            **model_args,
+        )
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_module is not None:
+            sys.modules[module_name] = previous_module
+
+    assert model_calls[0]["kwargs"]["token"] == "hf-test-token"
+    assert tokenizer_calls[0]["kwargs"]["token"] == "hf-test-token"
 
 
 @skip_if_no_transformers


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?
`HuggingFaceAPI` forwards an explicitly supplied `api_key` as the Hugging Face `token` when loading model weights, but not when loading the tokenizer. Tokenizer files in private or gated repositories therefore fail to load unless the same credential is also available globally through `HF_TOKEN` or a cached Hugging Face login.

### What is the new behavior?
The explicit key is forwarded to every tokenizer-loading path, matching model loading and allowing per-model credentials to work independently of global authentication.

### Does this PR introduce a breaking change?
No.

### Other information
Includes dependency-free regression coverage for the default, custom-tokenizer, model-path, and tokenizer-path branches.
