### PR TITLE
NNterp: Forward explicit Hugging Face token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- NNterp: Forward an explicitly supplied API key when loading private or gated Hugging Face models and tokenizers.
 - AzureAI: Honor an explicitly supplied `api_key` instead of replacing it with an environment credential.
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.

--- a/src/inspect_ai/model/_providers/nnterp.py
+++ b/src/inspect_ai/model/_providers/nnterp.py
@@ -57,6 +57,12 @@ class NNterpAPI(ModelAPI):
         dtype = collect_model_arg("dtype", torch.float16)
         self.hidden_states = collect_model_arg("hidden_states", False)
 
+        if self.api_key is not None:
+            model_args["token"] = self.api_key
+            tokenizer_kwargs = dict(model_args.get("tokenizer_kwargs") or {})
+            tokenizer_kwargs["token"] = self.api_key
+            model_args["tokenizer_kwargs"] = tokenizer_kwargs
+
         self.model = StandardizedTransformer(
             model_name,
             dispatch=dispatch,

--- a/tests/model/providers/test_nnterp.py
+++ b/tests/model/providers/test_nnterp.py
@@ -1,3 +1,8 @@
+import importlib
+import sys
+from types import ModuleType
+from unittest.mock import MagicMock
+
 import pytest
 from test_helpers.utils import skip_if_no_nnterp
 
@@ -7,6 +12,46 @@ from inspect_ai.model import (
     get_model,
 )
 from inspect_ai.model._chat_message import ChatMessage
+
+
+def test_nnterp_explicit_api_key_reaches_huggingface_loaders(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict = {}
+
+    class FakeStandardizedTransformer:
+        def __init__(self, *args, **kwargs) -> None:
+            captured.update(kwargs)
+            self.tokenizer = MagicMock()
+
+    fake_nnterp = ModuleType("nnterp")
+    fake_nnterp.StandardizedTransformer = FakeStandardizedTransformer  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "nnterp", fake_nnterp)
+
+    fake_torch = ModuleType("torch")
+    fake_torch.float16 = object()  # type: ignore[attr-defined]
+    fake_torch.Tensor = object  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+
+    module_name = "inspect_ai.model._providers.nnterp"
+    previous_module = sys.modules.pop(module_name, None)
+    try:
+        provider_module = importlib.import_module(module_name)
+        provider_module.NNterpAPI(
+            model_name="private/model",
+            api_key="hf-test-token",
+            tokenizer_kwargs={"padding_side": "right"},
+        )
+    finally:
+        sys.modules.pop(module_name, None)
+        if previous_module is not None:
+            sys.modules[module_name] = previous_module
+
+    assert captured["token"] == "hf-test-token"
+    assert captured["tokenizer_kwargs"] == {
+        "padding_side": "right",
+        "token": "hf-test-token",
+    }
 
 
 @pytest.fixture


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?
`NNterpAPI` accepts the standard model `api_key` argument and registers `HF_TOKEN` for override hooks, but an explicitly supplied or overridden key is only stored on `ModelAPI`. It is not passed to NNsight when loading the Hugging Face model or tokenizer. The normal `HF_TOKEN` environment path still works through Hugging Face's global credential discovery.

### What is the new behavior?
When an explicit key is present, NNterp forwards it as:

- `token` for Hugging Face model/config loading.
- `tokenizer_kwargs["token"]` for tokenizer loading.

This enables per-model credentials for private or gated repositories without requiring a global Hugging Face login.

### Does this PR introduce a breaking change?
No.

### Other information
Includes a dependency-free regression test using a minimal `StandardizedTransformer` stand-in, so the credential handoff is covered without adding NNterp or Torch to the default test environment.
