### PR TITLE
view: add --direct-urls flag for presigned S3 byte-range reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.
 - Sandbox Tools: Lower the glibc build floor from 2.31 to 2.17 (build against a conda-forge CPython) so injected tools run on older glibc sandboxes including Ubuntu 16.04 and 18.04.
 - Control Channel: `inspect ctl tasks` now pins each eval's reported start to its first sample's start instead of letting it drift forward as early samples finish.
+- Inspect view: Add `--direct-urls` flag so the browser fetches log bytes directly from S3 via presigned URLs instead of proxying through the view server.
 - Inspect view: Improve MathJax Sanitization
 - Inspect view: Fix stale running status on nav
 - Inspect view: Fix broken commit links for ssh-style GitHub origins

--- a/src/inspect_ai/_cli/view.py
+++ b/src/inspect_ai/_cli/view.py
@@ -26,6 +26,16 @@ def start_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         help="Tcp/Ip host. Note: you can use `0.0.0.0` to expose the viewer and connect remotely (e.g. SSH).",
     )
     @click.option("--port", default=DEFAULT_VIEW_PORT, help="TCP/IP port")
+    @click.option(
+        "--direct-urls/--no-direct-urls",
+        default=False,
+        help=(
+            "Return presigned S3 URLs from /log-info so the browser fetches "
+            "log bytes directly from S3 instead of proxying through this "
+            "server. Recommended when port-forwarding from a remote machine. "
+            "Requires the bucket to permit CORS Range requests."
+        ),
+    )
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> click.Context:
         return cast(click.Context, func(*args, **kwargs))
@@ -56,6 +66,7 @@ def start(
     recursive: bool,
     host: str,
     port: int,
+    direct_urls: bool,
     **common: Unpack[CommonOptions],
 ) -> None:
     """View evaluation logs."""
@@ -81,6 +92,7 @@ def start(
         port=port,
         authorization=authorization,
         log_level=common["log_level"],
+        generate_direct_urls=direct_urls,
     )
 
 

--- a/src/inspect_ai/_view/view.py
+++ b/src/inspect_ai/_view/view.py
@@ -28,6 +28,7 @@ def view(
     authorization: str | None = None,
     log_level: str | None = None,
     fs_options: dict[str, Any] = {},
+    generate_direct_urls: bool = False,
 ) -> None:
     """Run the Inspect View server.
 
@@ -42,6 +43,12 @@ def view(
         fs_options: Additional arguments to pass through to the filesystem provider
             (e.g. `S3FileSystem`). Use `{"anon": True }` if you are accessing a
             public S3 bucket with no credentials.
+        generate_direct_urls: For S3-backed log files, return a presigned URL
+            from `/log-info` so the browser fetches log bytes directly from S3
+            instead of proxying through this server. Useful when the server is
+            reached over a slow link (e.g. SSH port-forward) but the browser
+            has good bandwidth to S3. Requires the bucket to permit CORS
+            `Range` requests from the viewer's origin.
     """
     init_dotenv()
     init_logger(log_level)
@@ -62,6 +69,7 @@ def view(
         port=port,
         authorization=authorization,
         fs_options=fs_options,
+        generate_direct_urls=generate_direct_urls,
     )
 
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

`view_server()` / `view_server_app()` already accept `generate_direct_urls`, which makes `/api/log-info` return a presigned S3 URL so the viewer fetches `log-bytes` ranges directly from S3 instead of proxying through the server. The frontend already prefers `direct_url` when present (`remoteLogFile.ts`). But `inspect view` never exposes the option, so it's effectively unreachable from the CLI.

### What is the new behavior?

Adds `--direct-urls / --no-direct-urls` to `inspect view [start]` and threads it through `view()` → `view_server(generate_direct_urls=...)`.

Use case: running `inspect view` on a remote VM and reaching it over an SSH port-forward. All `log-bytes` traffic currently funnels through the single SSH TCP stream (measured ~700 KB/s in profiling). With `--direct-urls`, only the small control-plane calls go through the tunnel; the browser pulls sample bytes from S3 at its own bandwidth, and the companion ts-mono change (meridianlabs-ai/ts-mono#357) drops the parallel-fetch chunk size on the direct path so 1–8 MB sample entries split across the browser's connection pool.

Defaults off — the S3 bucket must permit CORS `Range` requests from the viewer's origin, which isn't universally configured.

### Does this PR introduce a breaking change?

No. New optional flag; default preserves existing behaviour.

### Other information:

Companion frontend PR: meridianlabs-ai/ts-mono#357 (promise-memoised zip-open, 128 KB tail-window cache, configurable parallel chunk size, un-gated sample fetch). The two are independent — this flag works with the current frontend, and the frontend changes help all deploy modes regardless of this flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
