### PR TITLE
Fix flaky test_base_exception_finalizes_sync_worker_state deadlock

### DIFF
--- a/tests/log/test_buffer_sync_thread.py
+++ b/tests/log/test_buffer_sync_thread.py
@@ -496,6 +496,21 @@ def test_base_exception_finalizes_sync_worker_state(
 
     monkeypatch.setattr(database_module, "sync_to_filestore", sync_that_stops)
 
+    # The shared_db fixture's start_sample() spawns a live background sync
+    # worker. Shut it down before driving _sync_to_filestore() synchronously,
+    # otherwise that worker can win the race for the forced-due sync request,
+    # consume it, and exit — leaving this thread's direct call blocked forever
+    # in _sync_wakeup.wait(timeout=None).
+    with shared_db._sync_lock:
+        shared_db._sync_closed = True
+        shared_db._sync_wakeup.notify_all()
+        background_worker = shared_db._sync_thread
+    if background_worker is not None and (
+        background_worker is not threading.current_thread()
+    ):
+        background_worker.join(timeout=5)
+    shared_db._sync_closed = False
+
     shared_db._sync_thread = threading.current_thread()
     shared_db._sync_requested = True
     shared_db._sync_pending = True


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`tests/log/test_buffer_sync_thread.py::test_base_exception_finalizes_sync_worker_state` is flaky and can deadlock (>900s pytest-timeout). Reproduced deterministically on CI (10/10) on commit `6427c67`; see meridianlabs-ai/actions#49.

The `shared_db` fixture's `start_sample()` spawns a live background sync worker thread (`inspect-buffer-sync`) running `SampleBufferDatabase._sync_to_filestore`. The test then, without stopping that worker, monkeypatches `sync_to_filestore` to raise a `BaseException`, forces the sync due, and calls `_sync_to_filestore()` synchronously on the main thread.

Two threads then race for the single forced-due sync request. When the background worker wins, it consumes the request (`_sync_requested = False`), runs the patched sync, hits the `except BaseException` finalization path, and exits. The test's own direct call then acquires the lock, finds `_sync_requested == False` so `timeout = None`, and blocks forever in `self._sync_wakeup.wait(timeout=None)` — no further notify ever arrives.

The production code is correct: only one `_sync_to_filestore` worker ever runs in real use, and an idle worker parking on `wait(timeout=None)` until notified is the intended behavior. The defect is test-only.

### What is the new behavior?

Before manipulating the sync internals and driving `_sync_to_filestore()` synchronously, the test now quiesces the fixture-spawned background worker: under `_sync_lock` it sets `_sync_closed = True`, notifies, and joins the worker (which takes the `else` branch and exits cleanly, without running the patched sync). It then resets `_sync_closed = False` so the subsequent direct call exercises the normal loop and the `except BaseException` finalization path the test is asserting on.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Test-only change.

### Other information:

Verification: the deadlock is timing-dependent and did not reproduce on my local hardware (the test passed pre-fix here), so I could not flip a failing local baseline. I verified the fix against the production sync loop in `database.py` — quiescing and joining the worker removes the second racer the triage identified — and confirmed the test still passes locally (15/15). Reproduction of the original deadlock is documented on CI in meridianlabs-ai/actions#49; relying on CI here for the before/after.

No production code changes, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
