### PR TITLE
Confine sandbox checkpoint egress tar extraction to dest_repo with the "data" filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Sandbox: `self_check` now verifies that a large (~1 MiB) command argument round-trips correctly through `exec`.
 - Buf fix: Keep torn checkpoint files out of remote egress uploads and manifests so resumed runs can repair and ship reused checkpoint ids.
 - Bug fix: Make the no-op trailing-separator strip in `FileSystem.is_writeable()` actually take effect, avoiding a double-separator write-test path for direct callers.
+- Security: Apply the `data` tar filter when extracting sandbox checkpoint egress tarballs on the host, preventing a sandboxed agent from writing files outside the destination repo via crafted `..`/absolute-path/symlink entries.
 
 ## 0.3.241 (22 June 2026)
 

--- a/src/inspect_ai/util/_checkpoint/_sandbox_restic/egress.py
+++ b/src/inspect_ai/util/_checkpoint/_sandbox_restic/egress.py
@@ -193,8 +193,13 @@ cat /tmp/egress-new.txt
 
 
 def _extract_tar(tar_bytes: bytes, dest_repo: str) -> None:
+    # The tarball bytes originate inside the sandbox (read via `read_file`),
+    # so they are untrusted: a sandboxed agent can plant a malicious tar at
+    # the egress staging path. `filter="data"` rejects absolute paths, `..`
+    # traversal, and outside-pointing links, preventing host-side writes
+    # outside `dest_repo` (CVE-2007-4559 class). See PEP 706.
     with tarfile.open(fileobj=io.BytesIO(tar_bytes), mode="r:") as tar:
-        tar.extractall(dest_repo)
+        tar.extractall(dest_repo, filter="data")
 
 
 async def _verify_destination(

--- a/tests/checkpoint/test_sandbox_egress_extract.py
+++ b/tests/checkpoint/test_sandbox_egress_extract.py
@@ -1,0 +1,80 @@
+"""Regression tests for host-side extraction of sandbox egress tarballs.
+
+``_extract_tar`` unpacks a tarball whose bytes were produced *inside* the
+sandbox, onto the host filesystem. The archive is therefore untrusted: a
+sandboxed agent could plant members with ``..`` traversal, absolute paths,
+or outside-pointing symlinks to write files outside ``dest_repo`` on the
+host (CVE-2007-4559 class). Extraction must use the ``data`` filter so such
+members are rejected.
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from inspect_ai.util._checkpoint._sandbox_restic.egress import _extract_tar
+
+
+def _tar_with(*members: tarfile.TarInfo, data: bytes = b"pwned") -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for member in members:
+            if member.issym() or member.islnk():
+                tar.addfile(member)
+            else:
+                member.size = len(data)
+                tar.addfile(member, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def test_extracts_benign_tarball(tmp_path: Path) -> None:
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    member = tarfile.TarInfo(name="data/ab/cdef")
+
+    _extract_tar(_tar_with(member, data=b"pack"), str(dest))
+
+    assert (dest / "data" / "ab" / "cdef").read_text() == "pack"
+
+
+def test_rejects_parent_traversal(tmp_path: Path) -> None:
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    member = tarfile.TarInfo(name="../escape.txt")
+
+    with pytest.raises(tarfile.FilterError):
+        _extract_tar(_tar_with(member), str(dest))
+
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_neutralizes_absolute_path(tmp_path: Path) -> None:
+    # The "data" filter strips the leading slash from an absolute member
+    # name, so the entry lands inside dest rather than at its absolute
+    # location on the host. The security property is that nothing is
+    # written outside dest.
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    target = tmp_path / "abs_escape.txt"
+    member = tarfile.TarInfo(name=str(target))
+
+    _extract_tar(_tar_with(member), str(dest))
+
+    assert not target.exists()
+
+
+def test_rejects_symlink_escape(tmp_path: Path) -> None:
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    link = tarfile.TarInfo(name="link")
+    link.type = tarfile.SYMTYPE
+    link.linkname = "../outside"
+
+    with pytest.raises(tarfile.FilterError):
+        _extract_tar(_tar_with(link), str(dest))
+
+    assert not (tmp_path / "outside").exists()


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

The sandbox restic checkpoint egress path extracts a per-cycle tarball on the host with `tarfile.extractall(dest_repo)` and no `filter=` (`util/_checkpoint/_sandbox_restic/egress.py`, `_extract_tar`).

The tarball bytes are read from inside the sandbox (`env.read_file`), so they are untrusted. A sandboxed agent with write access to the egress staging path can plant a tar whose members use `..` traversal, absolute paths, or outside-pointing symlinks. Because the safe `data` filter is not yet the default on current Python versions, those members are honored, letting the agent write arbitrary files on the host filesystem outside `dest_repo` — a sandbox escape (CVE-2007-4559 class).

### What is the new behavior?

`_extract_tar` now passes `filter="data"` to `extractall`, so absolute paths, parent-directory traversal, and unsafe links are rejected at extraction time and all writes are confined to `dest_repo`. Well-formed archives extract exactly as before.

A regression test (`tests/checkpoint/test_sandbox_egress_extract.py`) covers benign extraction plus rejection of `..` traversal, absolute-path, and symlink-escape members.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

`filter="data"` is available on the project's supported Python versions (`requires-python = ">=3.10"`; the argument landed in 3.10.12).
