### PR TITLE
fix(openai): don't cache reasoning_summaries probe failures that are transient

### DIFF
--- a/src/inspect_ai/model/_providers/openai.py
+++ b/src/inspect_ai/model/_providers/openai.py
@@ -40,6 +40,7 @@ from .._openai import (
     is_latest_model,
     is_o_series_model,
     openai_classify_retry,
+    openai_should_retry,
 )
 from .._openai_responses import (
     chat_messages_from_compact_response,
@@ -633,7 +634,6 @@ class OpenAIAPI(ModelAPI):
             return self._reasoning_summaries
         async with self._reasoning_summaries_lock:
             if self._reasoning_summaries is None:
-                reasoning_summaries = False
                 if self.responses_api and self.has_reasoning_options():
                     try:
                         await self.client.responses.create(
@@ -641,10 +641,21 @@ class OpenAIAPI(ModelAPI):
                             input="Please say 'hello, world'",
                             reasoning={"effort": "low", "summary": "auto"},
                         )
-                        reasoning_summaries = True
-                    except Exception:
-                        pass
-                self._reasoning_summaries = reasoning_summaries
+                        self._reasoning_summaries = True
+                    except Exception as ex:
+                        # A transient failure (timeout, dropped connection,
+                        # rate limit, 5xx) tells us nothing about whether
+                        # summaries are supported. Don't cache it, otherwise a
+                        # blip at startup would disable summaries for the rest
+                        # of the run; leave the bit unset so a later sample
+                        # re-probes. A deterministic rejection (e.g. the account
+                        # isn't a verified organization) does mean they aren't
+                        # available, so cache that.
+                        if openai_should_retry(ex):
+                            return False
+                        self._reasoning_summaries = False
+                else:
+                    self._reasoning_summaries = False
 
             return self._reasoning_summaries
 

--- a/tests/model/providers/test_openai_reasoning_summaries.py
+++ b/tests/model/providers/test_openai_reasoning_summaries.py
@@ -1,0 +1,79 @@
+"""Unit tests for OpenAIAPI.reasoning_summaries() error handling.
+
+These run without network access: the provider is constructed with a dummy key
+and ``client.responses.create`` is monkeypatched to raise the exception shapes
+the OpenAI SDK would produce.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from openai import APITimeoutError, BadRequestError
+
+from inspect_ai.model._providers.openai import OpenAIAPI
+
+
+def _make_api() -> OpenAIAPI:
+    # gpt-5 has reasoning options, and force the responses API so
+    # reasoning_summaries() actually probes the account.
+    return OpenAIAPI(model_name="gpt-5", api_key="test-key", responses_api=True)
+
+
+def _request() -> httpx.Request:
+    return httpx.Request("POST", "https://api.openai.com/v1/responses")
+
+
+@pytest.mark.anyio
+async def test_reasoning_summaries_transient_error_not_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _make_api()
+    assert api.has_reasoning_options()
+    try:
+        calls = {"n": 0}
+
+        async def flaky(**kwargs: object) -> object:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise APITimeoutError(request=_request())
+            return object()
+
+        monkeypatch.setattr(api.client.responses, "create", flaky)
+
+        # The first probe hits a transient timeout: degrade gracefully for this
+        # call, but don't cache the failure...
+        assert await api.reasoning_summaries() is False
+        # ...so once the blip clears the next probe still discovers support.
+        assert await api.reasoning_summaries() is True
+        assert calls["n"] == 2
+    finally:
+        await api.aclose()
+
+
+@pytest.mark.anyio
+async def test_reasoning_summaries_unsupported_error_cached(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = _make_api()
+    try:
+        calls = {"n": 0}
+        response = httpx.Response(status_code=400, request=_request())
+
+        async def unsupported(**kwargs: object) -> object:
+            calls["n"] += 1
+            raise BadRequestError(
+                message="Your organization must be verified to generate reasoning summaries",
+                response=response,
+                body=None,
+            )
+
+        monkeypatch.setattr(api.client.responses, "create", unsupported)
+
+        # A deterministic 400 means summaries really aren't available: cache it
+        # and don't re-probe on every later sample.
+        assert await api.reasoning_summaries() is False
+        assert await api.reasoning_summaries() is False
+        assert calls["n"] == 1
+    finally:
+        await api.aclose()


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

`OpenAIAPI.reasoning_summaries()` probes the account once per provider instance to find out whether reasoning summaries are available (only verified organizations can request them), then caches the answer for the rest of the run:

```python
if self._reasoning_summaries is None:
    if self.responses_api and self.has_reasoning_options():
        try:
            await self.client.responses.create(... summary="auto" ...)
            self._reasoning_summaries = True
        except Exception:
            self._reasoning_summaries = False
```

The bare `except Exception` treats every failure as "not supported." So if that one probe happens to hit a transient error at startup (timeout, dropped connection, a rate limit, a 5xx), `_reasoning_summaries` gets pinned to `False` and reasoning summaries stay off for the whole run even though the account actually supports them. There's no retry, because the probe only fires while the cached value is `None`.

### What is the new behavior?

Only cache `False` when the rejection is deterministic (e.g. the account genuinely isn't a verified organization, which comes back as a 400). For a retryable error we leave the bit unset and return `False` just for this call, so a later sample re-probes once the blip clears:

```python
except Exception as ex:
    if openai_should_retry(ex):
        return False
    self._reasoning_summaries = False
```

I reused the existing `openai_should_retry()` classifier rather than enumerate exception types here, so this stays in sync with how the rest of the provider already decides what's transient. This follows the same direction as #4321 and #4317, which stopped letting transient stream / control-channel failures look terminal.

Added `tests/model/providers/test_openai_reasoning_summaries.py` (no network — `client.responses.create` is monkeypatched): one test that a transient `APITimeoutError` on the first probe doesn't get cached and the next probe still discovers support, and one that a 400 `BadRequestError` is cached and not re-probed. The first test fails on `main` (the old code caches the timeout) and passes with this change.

### Does this PR introduce a breaking change?

No.

### Other information:

`make check` clean (`ruff check` + `ruff format --check`) on the two touched files.
