### PR TITLE
Document token preference checks for stochastic evals

### DIFF
--- a/docs/models.qmd
+++ b/docs/models.qmd
@@ -69,6 +69,31 @@ eval("arc.py", model="google/gemini-2.5-pro", max_connections=20)
 
 Use `inspect eval --help` to learn about all of the available generation config options.
 
+### Stochastic Protocols
+
+Higher temperature can make model outputs less focused, but it does not guarantee
+uniform sampling across semantically equivalent labels. If an evaluation protocol
+depends on the model itself making a random choice, for example selecting between
+balanced labels, estimate the model's response distribution before treating the
+protocol as stochastic.
+
+Prefer external randomisation when the eval design needs randomness. When the
+model must supply the random response, run a small diagnostic with repeated
+epochs and report the output distribution alongside the evaluation result. For
+example, the token preference probe in `examples/token_preference_probe.py`
+records how often a model answers `heads`, `tails`, or `other`:
+
+``` bash
+inspect eval examples/token_preference_probe.py \
+  --model openai/gpt-4o \
+  --temperature 1 \
+  --epochs 50
+```
+
+Large skews in this diagnostic indicate that results from stochastic-response
+items may be confounded by model token preference rather than the capability
+being measured.
+
 ## Model Args
 
 If there is an additional aspect of a model you want to tweak that isn't covered by the `GenerateConfig`, you can use model args to pass additional arguments to model clients. For example, here we specify the `location` option for a Google Gemini model:

--- a/examples/token_preference_probe.py
+++ b/examples/token_preference_probe.py
@@ -1,0 +1,42 @@
+"""Probe a model's response distribution on a balanced binary prompt.
+
+Run with:
+    inspect eval examples/token_preference_probe.py --model openai/gpt-4o --temperature 1 --epochs 50
+"""
+
+from inspect_ai import Task, task
+from inspect_ai.dataset import Sample
+from inspect_ai.scorer import Score, Scorer, Target, frequency, scorer
+from inspect_ai.solver import TaskState, generate
+
+COIN_FLIP_PROMPT = (
+    "Flip a fair coin and report the result. "
+    "Respond with only 'Heads' or 'Tails', nothing else."
+)
+
+
+def _coin_flip_category(completion: str) -> str:
+    answer = completion.strip().lower().strip(" .")
+    if answer == "heads":
+        return "heads"
+    if answer == "tails":
+        return "tails"
+    return "other"
+
+
+@scorer(metrics=[frequency(categories=["heads", "tails", "other"])])
+def coin_flip_distribution() -> Scorer:
+    async def score(state: TaskState, target: Target) -> Score:
+        answer = _coin_flip_category(state.output.completion)
+        return Score(value=answer, answer=answer)
+
+    return score
+
+
+@task
+def token_preference_probe() -> Task:
+    return Task(
+        dataset=[Sample(input=COIN_FLIP_PROMPT)],
+        solver=generate(),
+        scorer=coin_flip_distribution(),
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The generation config docs explain temperature and related options, but they do not warn that high temperature does not guarantee uniform sampling across semantically equivalent labels. Evaluation protocols that ask the subject model to make a random choice can therefore be confounded by token preference bias.

Refs #4304.

### What is the new behavior?

Adds a `Stochastic Protocols` section to the model docs that recommends external randomisation when possible, and a repeated-epoch diagnostic when the model must supply a random response.

Adds `examples/token_preference_probe.py`, a small Inspect task that asks a balanced coin-flip prompt and reports the response distribution as `heads`, `tails`, or `other` using the existing `frequency()` metric.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Validation run locally:
- `python3 -m py_compile examples/token_preference_probe.py`
- `ruff check` and `ruff format --check` pass
- `inspect eval examples/token_preference_probe.py --model mockllm/model --temperature 1 --epochs 2`

Full `make check` and `make test` were not run locally.
