### PR TITLE
docs: align dataframe column table with EvalConfiguration rename

### DIFF
--- a/docs/dataframe.qmd
+++ b/docs/dataframe.qmd
@@ -412,7 +412,7 @@ if len(errors) > 0:
 | `EvalTask` | Task configuration (name, file, args, solver, etc.) |
 | `EvalModel` | Model name, args, generation config, etc. |
 | `EvalDataset` | Dataset name, location, sample ids, etc. |
-| `EvalConfig` | Epochs, approval, sample limits, etc. |
+| `EvalConfiguration` | Epochs, approval, sample limits, etc. |
 | `EvalResults` | Status, errors, samples completed, headline metric. |
 | `EvalScores` | All scores and metrics broken into separate columns. |
 


### PR DESCRIPTION
The Analysis column class was renamed from `EvalConfig` to `EvalConfiguration`, per the existing CHANGELOG entry:

> Analysis: Renamed \`EvalConfig\` column defs to \`EvalConfiguration\`.

But \`docs/dataframe.qmd\` still lists the old name in the "Eval column groups" table, so users following the docs hit:

\`\`\`
ImportError: cannot import name 'EvalConfig' from 'inspect_ai.analysis'
\`\`\`

and have to discover the new name by trial and error. One-line fix.

(The other \`EvalConfig\` references in the codebase refer to the unrelated \`inspect_ai.log.EvalConfig\` runtime config class, which is unaffected.)