### PR TITLE
OpenAI-compatible: report source API key env var to override hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Eval: Warn when non-empty `task_args` are passed but cannot be applied to any task. (#4194)
 - HuggingFace: Forward an explicitly supplied API key when loading tokenizers for private or gated models.
 - NNterp: Forward an explicitly supplied API key when loading private or gated Hugging Face models and tokenizers.
+- OpenAI-compatible providers: Report the source environment variable (e.g. `CLOUDFLARE_API_TOKEN`, `HF_TOKEN`) to API key override hooks rather than the derived `*_API_KEY` name.
 - AzureAI: Offer `AZUREAI_API_KEY` values to API key override hooks.
 - AzureAI: Honor an explicitly supplied `api_key` instead of replacing it with an environment credential.
 - Google: Retry truncated response streams (`ClientPayloadError` wrapping a `PayloadEncodingError`, e.g. a connection reset mid-body) instead of crashing the sample.

--- a/src/inspect_ai/model/_providers/cloudflare.py
+++ b/src/inspect_ai/model/_providers/cloudflare.py
@@ -28,8 +28,12 @@ class CloudFlareAPI(OpenAICompatibleAPI):
         **model_args: Any,
     ):
         # migrate formerly used CLOUDFLARE_API_TOKEN if no other key is specified
+        # (report the variable the key actually came from to override hooks)
+        api_key_var = CLOUDFLARE_API_KEY
         if api_key is None and CLOUDFLARE_API_KEY not in os.environ:
             api_key = os.environ.get(CLOUDFLARE_API_TOKEN, None)
+            if api_key is not None:
+                api_key_var = CLOUDFLARE_API_TOKEN
 
         # account id used for limits and forming base url
         self.account_id = os.getenv("CLOUDFLARE_ACCOUNT_ID", None)
@@ -40,6 +44,7 @@ class CloudFlareAPI(OpenAICompatibleAPI):
             model_name=f"@cf/{model_name}",
             base_url=base_url,
             api_key=api_key,
+            api_key_var=api_key_var,
             config=config,
             service="CloudFlare",
             service_base_url=f"https://api.cloudflare.com/client/v4/accounts/{self.account_id}/ai/v1",

--- a/src/inspect_ai/model/_providers/cloudflare.py
+++ b/src/inspect_ai/model/_providers/cloudflare.py
@@ -27,9 +27,9 @@ class CloudFlareAPI(OpenAICompatibleAPI):
         config: GenerateConfig = GenerateConfig(),
         **model_args: Any,
     ):
-        # migrate formerly used CLOUDFLARE_API_TOKEN if no other key is specified
-        # (report the variable the key actually came from to override hooks)
+        # report the variable that the key actually came from to override hooks
         api_key_var = CLOUDFLARE_API_KEY
+        # migrate formerly used CLOUDFLARE_API_TOKEN if no other key is specified
         if api_key is None and CLOUDFLARE_API_KEY not in os.environ:
             api_key = os.environ.get(CLOUDFLARE_API_TOKEN, None)
             if api_key is not None:

--- a/src/inspect_ai/model/_providers/hf_inference_providers.py
+++ b/src/inspect_ai/model/_providers/hf_inference_providers.py
@@ -1,11 +1,9 @@
-import os
 from typing import Any
 
 from typing_extensions import override
 
 from .._generate_config import GenerateConfig
 from .openai_compatible import OpenAICompatibleAPI
-from .util import environment_prerequisite_error
 
 HF_TOKEN = "HF_TOKEN"
 
@@ -20,19 +18,13 @@ class HFInferenceProvidersAPI(OpenAICompatibleAPI):
         stream: bool | None = None,
         **model_args: Any,
     ) -> None:
-        # Handle API key before calling super() to avoid the automatic key generation
-        if not api_key:
-            api_key = os.environ.get(HF_TOKEN, None)
-            if not api_key:
-                raise environment_prerequisite_error(
-                    "HF Inference Providers",
-                    [HF_TOKEN],
-                )
-
         super().__init__(
             model_name=model_name,
             base_url=base_url or "https://router.huggingface.co/v1",
             api_key=api_key,
+            # HF credentials come from HF_TOKEN rather than the derived
+            # service env var, so override hooks see the right variable
+            api_key_var=HF_TOKEN,
             config=config,
             service="HF Inference Providers",
             service_base_url="https://router.huggingface.co/v1",

--- a/src/inspect_ai/model/_providers/hf_inference_providers.py
+++ b/src/inspect_ai/model/_providers/hf_inference_providers.py
@@ -22,8 +22,6 @@ class HFInferenceProvidersAPI(OpenAICompatibleAPI):
             model_name=model_name,
             base_url=base_url or "https://router.huggingface.co/v1",
             api_key=api_key,
-            # HF credentials come from HF_TOKEN rather than the derived
-            # service env var, so override hooks see the right variable
             api_key_var=HF_TOKEN,
             config=config,
             service="HF Inference Providers",

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -66,6 +66,7 @@ class OpenAICompatibleAPI(ModelAPI):
         config: GenerateConfig = GenerateConfig(),
         service: str | None = None,
         service_base_url: str | None = None,
+        api_key_var: str | None = None,
         emulate_tools: bool = False,
         responses_api: bool | None = None,
         responses_store: bool | None = None,
@@ -85,9 +86,11 @@ class OpenAICompatibleAPI(ModelAPI):
         else:
             self.service = service
 
-        # compute api key
+        # compute api key env var (providers may override the derived name when
+        # their credential comes from a differently-named variable, so that
+        # api_key override hooks see the variable the value actually came from)
         service_env_name = self.service.upper().replace("-", "_")
-        api_key_var = f"{service_env_name}_API_KEY"
+        api_key_var = api_key_var or f"{service_env_name}_API_KEY"
 
         super().__init__(
             model_name=model_name,

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -86,8 +86,8 @@ class OpenAICompatibleAPI(ModelAPI):
         else:
             self.service = service
 
-        # Compute API key env var name (e.g. HF_API_KEY). Callers may provide
-        # non-standard env vars (e.g. HF_TOKEN). Ensure the API key override
+        # Compute API key env var name (e.g. HF_API_KEY). Callers may provide a
+        # non-standard env var (e.g. HF_TOKEN). Ensure the API key override
         # hooks in ModelAPI receive the env var name the value actually came
         # from.
         service_env_name = self.service.upper().replace("-", "_")

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -86,9 +86,10 @@ class OpenAICompatibleAPI(ModelAPI):
         else:
             self.service = service
 
-        # compute api key env var (providers may override the derived name when
-        # their credential comes from a differently-named variable, so that
-        # api_key override hooks see the variable the value actually came from)
+        # Compute API key env var name (e.g. HF_API_KEY). Callers may provide
+        # non-standard env vars (e.g. HF_TOKEN). Ensure the API key override
+        # hooks in ModelAPI receive the env var name the value actually came
+        # from.
         service_env_name = self.service.upper().replace("-", "_")
         api_key_var = api_key_var or f"{service_env_name}_API_KEY"
 

--- a/tests/model/providers/test_cloudflare.py
+++ b/tests/model/providers/test_cloudflare.py
@@ -1,5 +1,5 @@
 import pytest
-from test_helpers.utils import skip_if_no_cloudflare
+from test_helpers.utils import skip_if_no_cloudflare, skip_if_no_openai_package
 
 from inspect_ai.model import get_model
 
@@ -11,3 +11,67 @@ async def test_cloudflare_api() -> None:
         message = "This is a test string. What are you?"
         response = await model.generate(input=message)
         assert len(response.completion) >= 1
+
+
+@skip_if_no_openai_package
+def test_cloudflare_token_reported_to_override_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_ai.model._providers.cloudflare import (
+        CLOUDFLARE_API_KEY,
+        CLOUDFLARE_API_TOKEN,
+        CloudFlareAPI,
+    )
+
+    seen: list[tuple[str, str]] = []
+
+    def override_api_key(env_var_name: str, value: str) -> str:
+        seen.append((env_var_name, value))
+        return "overridden-key"
+
+    monkeypatch.delenv(CLOUDFLARE_API_KEY, raising=False)
+    monkeypatch.setenv(CLOUDFLARE_API_TOKEN, "source-key")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account-id")
+    monkeypatch.setattr(
+        "inspect_ai.hooks._hooks.override_api_key",
+        override_api_key,
+    )
+
+    api = CloudFlareAPI(model_name="meta/llama-3.1-8b-instruct-awq")
+
+    # the key came from CLOUDFLARE_API_TOKEN, so that is the variable the hook
+    # must be told about (not the derived CLOUDFLARE_API_KEY)
+    assert seen[0] == (CLOUDFLARE_API_TOKEN, "source-key")
+    assert all(name == CLOUDFLARE_API_TOKEN for name, _ in seen)
+    assert api.api_key == "overridden-key"
+
+
+@skip_if_no_openai_package
+def test_cloudflare_api_key_reported_to_override_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from inspect_ai.model._providers.cloudflare import (
+        CLOUDFLARE_API_KEY,
+        CLOUDFLARE_API_TOKEN,
+        CloudFlareAPI,
+    )
+
+    seen: list[tuple[str, str]] = []
+
+    def override_api_key(env_var_name: str, value: str) -> str:
+        seen.append((env_var_name, value))
+        return "overridden-key"
+
+    monkeypatch.delenv(CLOUDFLARE_API_TOKEN, raising=False)
+    monkeypatch.setenv(CLOUDFLARE_API_KEY, "source-key")
+    monkeypatch.setenv("CLOUDFLARE_ACCOUNT_ID", "account-id")
+    monkeypatch.setattr(
+        "inspect_ai.hooks._hooks.override_api_key",
+        override_api_key,
+    )
+
+    api = CloudFlareAPI(model_name="meta/llama-3.1-8b-instruct-awq")
+
+    assert seen[0] == (CLOUDFLARE_API_KEY, "source-key")
+    assert all(name == CLOUDFLARE_API_KEY for name, _ in seen)
+    assert api.api_key == "overridden-key"

--- a/tests/model/test_hf_inference_providers.py
+++ b/tests/model/test_hf_inference_providers.py
@@ -74,3 +74,20 @@ def test_hf_token_reported_to_override_hook(
     assert seen[0] == (HF_TOKEN, "source-key")
     assert all(name == HF_TOKEN for name, _ in seen)
     assert api.api_key == "overridden-key"
+
+
+@skip_if_no_openai_package
+def test_hf_missing_token_raises_prerequisite_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A missing HF_TOKEN (and no override hook) still raises a prerequisite error."""
+    from inspect_ai._util.error import PrerequisiteError
+    from inspect_ai.model._providers.hf_inference_providers import (
+        HF_TOKEN,
+        HFInferenceProvidersAPI,
+    )
+
+    monkeypatch.delenv(HF_TOKEN, raising=False)
+
+    with pytest.raises(PrerequisiteError, match=HF_TOKEN):
+        HFInferenceProvidersAPI(model_name="openai/gpt-oss-20b")

--- a/tests/model/test_hf_inference_providers.py
+++ b/tests/model/test_hf_inference_providers.py
@@ -45,3 +45,32 @@ async def test_hf_inference_providers_caching():
 
     # Verify we got the same cached instance
     assert model1 is model2
+
+
+@skip_if_no_openai_package
+def test_hf_token_reported_to_override_hook(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The HF_TOKEN variable (not the derived service var) is offered to hooks."""
+    from inspect_ai.model._providers.hf_inference_providers import (
+        HF_TOKEN,
+        HFInferenceProvidersAPI,
+    )
+
+    seen: list[tuple[str, str]] = []
+
+    def override_api_key(env_var_name: str, value: str) -> str:
+        seen.append((env_var_name, value))
+        return "overridden-key"
+
+    monkeypatch.setenv(HF_TOKEN, "source-key")
+    monkeypatch.setattr(
+        "inspect_ai.hooks._hooks.override_api_key",
+        override_api_key,
+    )
+
+    api = HFInferenceProvidersAPI(model_name="openai/gpt-oss-20b")
+
+    assert seen[0] == (HF_TOKEN, "source-key")
+    assert all(name == HF_TOKEN for name, _ in seen)
+    assert api.api_key == "overridden-key"


### PR DESCRIPTION
Fixes #4334.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

See #4334.

Some `OpenAICompatibleAPI` subclasses (e.g. HF) obtain credentials from an environment variable (`HF_TOKEN`) whose name differs from the variable derived from their `service` name (`HF_API_KEY`). They preload the credential and pass it as an explicit `api_key`, after which `ModelAPI` offers it to `override_api_key` under the *derived* name (`HF_API_KEY`) rather than the variable (`HF_TOKEN`) it actually came from:

This applies to CloudFlare and HF. See #4334 for further details.

Authentication itself works; the problem is purely that hooks branching on `env_var_name` (to select provider-specific credential resolution) see the wrong name.

### What is the new behavior?

Implements **option 1** from the issue: `OpenAICompatibleAPI` accepts an optional `api_key_var` so a provider can name the variable its credential actually originates from. It defaults to the existing derived `f"{service_env_name}_API_KEY"`, so unaffected providers are unchanged.

### Does this PR introduce a breaking change?

No. Credential precedence, aliases, and the prerequisite-error message for HF are unchanged; the only observable difference is that override hooks now receive the correct source variable name.

### Other information:
