### PR TITLE
Speed up CI test suite

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,28 @@ jobs:
         if: ${{ !cancelled() }}
         run: uv cache prune --ci
 
+  # Detect whether anything outside docs changed, so the (expensive) test
+  # matrix can be skipped on documentation-only changes. A skipped job-level
+  # `if` still reports a (non-blocking) check, unlike workflow-level
+  # `paths-ignore` which would strand a required check.
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**'
+              - '!docs/**'
+              - '!**/*.md'
+
   test:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
@@ -123,7 +144,7 @@ jobs:
         # even through anyio cancel shields, which the conftest async timeout
         # cannot. The 900s budget sits above the conftest 300s per-test timeout
         # so it only fires on genuine hangs.
-        run: uv run pytest -rA --doctest-modules --color=yes -n auto --cov=inspect_ai --timeout=900 --timeout-method=thread
+        run: uv run pytest -rA --doctest-modules --color=yes -n auto --timeout=900 --timeout-method=thread
 
       - name: Minimize uv cache
         if: ${{ !cancelled() }}

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -242,6 +242,11 @@ def default_max_subprocesses() -> int:
 # under heavy load while still bounding teardown.
 LOST_SUBPROCESS_WAIT_TIMEOUT = 60
 
+# Grace period after SIGTERM before escalating to SIGKILL for a timed-out
+# process. Named (rather than inline) so tests exercising the timeout/kill
+# path can shrink it without waiting the full production grace.
+SUBPROCESS_SIGTERM_GRACE_SECONDS = 2
+
 
 def _warn_lost_subprocess(process: Process, where: str) -> None:
     logger.warning(
@@ -260,7 +265,7 @@ async def gracefully_terminate_cancelled_subprocess(process: Process) -> None:
             # Terminate timed out process -- try for graceful termination then kill if
             # required.
             process.terminate()
-            await anyio.sleep(2)
+            await anyio.sleep(SUBPROCESS_SIGTERM_GRACE_SECONDS)
             if process.returncode is None:
                 process.kill()
             # With anyio's asyncio backend, process.aclose() calls process.wait() which

--- a/tests/agent/test_acp/test_elicitation_e2e.py
+++ b/tests/agent/test_acp/test_elicitation_e2e.py
@@ -40,6 +40,12 @@ from inspect_ai.agent._acp.transport_live import LiveAcpTransport
 from inspect_ai.util import InputRequest
 from inspect_ai.util._input.acp import acp_handler
 
+# Heavy socket-integration suite: real AF_UNIX round-trips + agent evals
+# (~1.3s+ per test). Marked slow to keep it off the per-PR CI critical path
+# (the slow suite runs in a separate environment); lighter ACP tests still run
+# on every PR.
+pytestmark = pytest.mark.slow
+
 # ---------------------------------------------------------------------------
 # Harness
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_acp/test_raw_events.py
+++ b/tests/agent/test_acp/test_raw_events.py
@@ -47,6 +47,12 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ChatCompletionChoice, ModelOutput
 
+# Heavy socket-integration suite: real AF_UNIX round-trips + agent evals
+# (~1.3s+ per test). Marked slow to keep it off the per-PR CI critical path
+# (the slow suite runs in a separate environment); lighter ACP tests still run
+# on every PR.
+pytestmark = pytest.mark.slow
+
 # ---------------------------------------------------------------------------
 # Fixtures (reused from forwarding tests but kept self-contained)
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_acp/test_router.py
+++ b/tests/agent/test_acp/test_router.py
@@ -12,6 +12,7 @@ Two test styles:
 from typing import Any, cast
 
 import anyio
+import pytest
 from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
@@ -60,6 +61,12 @@ from inspect_ai.model._model_output import (
 from inspect_ai.tool._tool import Tool, tool
 
 from ._capture import acp_test_active_sample
+
+# Heavy socket-integration suite: real AF_UNIX round-trips + agent evals
+# (~1.3s+ per test). Marked slow to keep it off the per-PR CI critical path
+# (the slow suite runs in a separate environment); lighter ACP tests still run
+# on every PR.
+pytestmark = pytest.mark.slow
 
 # ---------------------------------------------------------------------------
 # Test helpers

--- a/tests/agent/test_acp/test_server_forwarding.py
+++ b/tests/agent/test_acp/test_server_forwarding.py
@@ -48,6 +48,12 @@ from inspect_ai.model._chat_message import ChatMessageAssistant
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ChatCompletionChoice, ModelOutput
 
+# Heavy socket-integration suite: real AF_UNIX round-trips + agent evals
+# (~1.3s+ per test). Marked slow to keep it off the per-PR CI critical path
+# (the slow suite runs in a separate environment); lighter ACP tests still run
+# on every PR.
+pytestmark = pytest.mark.slow
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_acp/test_server_session_info.py
+++ b/tests/agent/test_acp/test_server_session_info.py
@@ -24,6 +24,12 @@ from inspect_ai.agent._acp.server import acp_server
 from inspect_ai.agent._acp.transport_live import LiveAcpTransport
 from inspect_ai.log._transcript import Transcript
 
+# Heavy socket-integration suite: real AF_UNIX round-trips + agent evals
+# (~1.3s+ per test). Marked slow to keep it off the per-PR CI critical path
+# (the slow suite runs in a separate environment); lighter ACP tests still run
+# on every PR.
+pytestmark = pytest.mark.slow
+
 
 @pytest.fixture
 def short_data_dir(monkeypatch):

--- a/tests/agent/test_acp/test_standard_acp_client.py
+++ b/tests/agent/test_acp/test_standard_acp_client.py
@@ -39,6 +39,12 @@ from inspect_ai.agent._acp.server import acp_server
 from inspect_ai.agent._acp.transport_live import LiveAcpTransport
 from inspect_ai.log._transcript import Transcript
 
+# Heavy socket-integration suite: real AF_UNIX round-trips + agent evals
+# (~1.3s+ per test). Marked slow to keep it off the per-PR CI critical path
+# (the slow suite runs in a separate environment); lighter ACP tests still run
+# on every PR.
+pytestmark = pytest.mark.slow
+
 # ---------------------------------------------------------------------------
 # Fixtures (mirror the patterns used in test_server_dispatch / forwarding)
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,10 +65,44 @@ def local_inspect_tools(request):
     return request.config.getoption("--local-inspect-tools")
 
 
+@pytest.fixture(autouse=True)
+def fast_retry_waits(request):
+    """Zero out model-generate and chat-API retry backoff during tests.
+
+    Both retry paths default to ``wait_exponential_jitter(initial=3, ...)`` /
+    ``wait_exponential_jitter()``, so any test that exercises a retry waits a
+    real 3s + 6s + ... per attempt. The backoff *duration* is never the thing
+    under test, so we replace the module-level ``wait_exponential_jitter`` with
+    a no-wait stand-in. Tests that genuinely assert on backoff timing can opt
+    out with ``@pytest.mark.real_retry_wait``.
+    """
+    if request.node.get_closest_marker("real_retry_wait"):
+        yield
+        return
+
+    from tenacity.wait import wait_none
+
+    import inspect_ai.model._providers.util.chatapi as chatapi
+    import inspect_ai.model._retry as model_retry
+
+    def no_wait(*args: object, **kwargs: object) -> wait_none:
+        return wait_none()
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(model_retry, "wait_exponential_jitter", no_wait)
+        mp.setattr(chatapi, "wait_exponential_jitter", no_wait)
+        yield
+
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow: mark test as slow to run")
     config.addinivalue_line("markers", "api: mark test as requiring API access")
     config.addinivalue_line("markers", "flaky: mark test as flaky/unreliable")
+    config.addinivalue_line(
+        "markers",
+        "real_retry_wait: opt out of the fast-retry fixture and use real "
+        "exponential backoff (for tests that assert on retry wait timing)",
+    )
     os.environ["INSPECT_EVAL_LOG_MODEL_API"] = "1"
     # Dummy provider keys so tests that only construct a client (not call the
     # API) work without real credentials. Real keys (when present) win via

--- a/tests/model/providers/util/test_batch.py
+++ b/tests/model/providers/util/test_batch.py
@@ -6,6 +6,7 @@ import time
 import anyio
 import pytest
 from tenacity import RetryError
+from tenacity.wait import wait_none
 from typing_extensions import TypedDict
 
 from inspect_ai._util._async import tg_collect
@@ -53,7 +54,13 @@ class FakeBatcher(Batcher[str, FakeCompletionInfo]):
         super().__init__(
             config or BatchConfig(size=3, send_delay=0.01, tick=0.001),
             model_retry_config(
-                "test", 3, None, lambda e: True, lambda ex: None, lambda m, s: None
+                "test",
+                3,
+                None,
+                lambda e: True,
+                lambda ex: None,
+                lambda m, s: None,
+                wait=wait_none(),
             ),
             max_batch_request_count=10,
             max_batch_size_mb=1,

--- a/tests/test_eval_config.py
+++ b/tests/test_eval_config.py
@@ -1,17 +1,33 @@
 import os
-import subprocess
 import tempfile
 from pathlib import Path
 
 import pytest
+from click.testing import CliRunner, Result
 from pydantic import ValidationError
 
 from inspect_ai import Task, eval, task
-from inspect_ai._cli.eval import RunConfigInput
+from inspect_ai._cli.eval import RunConfigInput, eval_command
+from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.log import EvalLog
 from inspect_ai.log._file import list_eval_logs, read_eval_log
 from inspect_ai.model import get_model
 from inspect_ai.solver import solver
+
+
+def run_eval_cli(args: list[str], env: dict[str, str] | None = None) -> Result:
+    """Invoke `inspect eval` in-process via CliRunner.
+
+    In-process invocation avoids the ~2s interpreter + package-import startup
+    that a fresh `inspect` subprocess pays on every call. `eval_command` is the
+    same click command `inspect eval` dispatches to, so CLI option parsing and
+    config resolution are exercised identically.
+    """
+    return CliRunner().invoke(eval_command, args, env=env)
+
+
+def assert_cli_success(result: Result) -> None:
+    assert result.exit_code == 0, f"{result.output}\n{result.exception}"
 
 
 def test_run_config_rejects_unknown_top_level_field():
@@ -43,10 +59,8 @@ def test_eval_config_task():
 
 def test_eval_config_task_cli():
     with tempfile.TemporaryDirectory() as log_dir:
-        subprocess.run(
+        result = run_eval_cli(
             [
-                "inspect",
-                "eval",
                 "tests/test_eval_config.py@eval_config_task",
                 "--task-config",
                 config_path("task.yaml"),
@@ -66,16 +80,15 @@ def test_eval_config_task_cli():
                 "grader={model: mockllm/model, temperature: 0.5, max_tokens: 1000}",
             ]
         )
+        assert_cli_success(result)
         log = read_eval_log(list_eval_logs(log_dir)[0])
         check_log(log, "green", check_model_roles=True)
 
 
 def test_eval_generate_config_cli():
     with tempfile.TemporaryDirectory() as log_dir:
-        subprocess.run(
+        result = run_eval_cli(
             [
-                "inspect",
-                "eval",
                 "tests/test_eval_config.py@eval_config_task",
                 "--generate-config",
                 config_path("generate_config.yaml"),
@@ -85,9 +98,9 @@ def test_eval_generate_config_cli():
                 log_dir,
                 "--model",
                 "mockllm/model",
-            ],
-            check=True,
+            ]
         )
+        assert_cli_success(result)
         log = read_eval_log(list_eval_logs(log_dir)[0])
         # temperature should be overridden by explicit CLI option
         assert log.plan.config.temperature == 0.9
@@ -131,10 +144,8 @@ eval_config:
 """.strip()
         )
 
-        subprocess.run(
+        result = run_eval_cli(
             [
-                "inspect",
-                "eval",
                 "--run-config",
                 run_config.as_posix(),
                 "-T",
@@ -143,9 +154,9 @@ eval_config:
                 "0.9",
                 "--log-dir",
                 log_dir.as_posix(),
-            ],
-            check=True,
+            ]
         )
+        assert_cli_success(result)
         log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
         assert log.eval.task == "eval_config_task"
         assert log.eval.task_args["epochs"] == 2
@@ -178,18 +189,16 @@ eval_config:
 """.strip()
         )
 
-        subprocess.run(
+        result = run_eval_cli(
             [
-                "inspect",
-                "eval",
                 "--run-config",
                 run_config.as_posix(),
                 "--log-dir",
                 log_dir.as_posix(),
             ],
-            env={**os.environ, "INSPECT_EVAL_MODEL": "anthropic/claude-sonnet-4-6"},
-            check=True,
+            env={"INSPECT_EVAL_MODEL": "anthropic/claude-sonnet-4-6"},
         )
+        assert_cli_success(result)
         log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
         assert log.eval.model == "mockllm/model"
 
@@ -209,10 +218,8 @@ eval_config:
 """.strip()
         )
 
-        subprocess.run(
+        result = run_eval_cli(
             [
-                "inspect",
-                "eval",
                 "--run-config",
                 run_config.as_posix(),
                 "--model",
@@ -220,9 +227,9 @@ eval_config:
                 "--log-dir",
                 log_dir.as_posix(),
             ],
-            env={**os.environ, "INSPECT_EVAL_MODEL": "mockllm/from_env"},
-            check=True,
+            env={"INSPECT_EVAL_MODEL": "mockllm/from_env"},
         )
+        assert_cli_success(result)
         log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
         assert log.eval.model == "mockllm/from_cli"
 
@@ -246,33 +253,20 @@ eval_config:
         # override=True when TERM_PROGRAM=vscode, which would overwrite
         # INSPECT_EVAL_MODEL from the repo .env and mask the env value
         # this test is checking).
-        test_env = {
-            k: v
-            for k, v in os.environ.items()
-            if k
-            not in (
-                "VSCODE_IPYTHON_KERNEL",
-                "VSCODE_CLI_REQUIRE_TOKEN",
-                "VSCODE_PID",
-                "VSCODE_CWD",
-            )
-        }
-        if test_env.get("TERM_PROGRAM") == "vscode":
-            test_env["TERM_PROGRAM"] = "xterm"
-        test_env["INSPECT_EVAL_MODEL"] = "mockllm/from_env"
+        env = {"INSPECT_EVAL_MODEL": "mockllm/from_env"}
+        if os.environ.get("TERM_PROGRAM") == "vscode":
+            env["TERM_PROGRAM"] = "xterm"
 
-        subprocess.run(
+        result = run_eval_cli(
             [
-                "inspect",
-                "eval",
                 "--run-config",
                 run_config.as_posix(),
                 "--log-dir",
                 log_dir.as_posix(),
             ],
-            env=test_env,
-            check=True,
+            env=env,
         )
+        assert_cli_success(result)
         log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
         assert log.eval.model == "mockllm/from_env"
 
@@ -298,10 +292,8 @@ eval_config:
 """.strip()
         )
 
-        subprocess.run(
+        result = run_eval_cli(
             [
-                "inspect",
-                "eval",
                 "tests/test_eval_config.py@eval_config_task",
                 "--model",
                 "mockllm/model",
@@ -309,9 +301,9 @@ eval_config:
                 run_config.as_posix(),
                 "--log-dir",
                 log_dir.as_posix(),
-            ],
-            check=True,
+            ]
         )
+        assert_cli_success(result)
         log = read_eval_log(list_eval_logs(log_dir.as_posix())[0])
         assert log.eval.task == "eval_config_task"
         assert log.eval.model == "mockllm/model"
@@ -345,19 +337,16 @@ model: mockllm/model
             ],
         ]
         for conflict in conflicts:
-            result = subprocess.run(
+            result = run_eval_cli(
                 [
-                    "inspect",
-                    "eval",
                     "--run-config",
                     run_config.as_posix(),
                     *conflict,
-                ],
-                capture_output=True,
-                text=True,
+                ]
             )
-            assert result.returncode != 0
-            assert "--run-config cannot be used with" in result.stdout
+            assert result.exit_code != 0
+            assert isinstance(result.exception, PrerequisiteError)
+            assert "--run-config cannot be used with" in str(result.exception.message)
 
 
 @solver

--- a/tests/test_task_cancel.py
+++ b/tests/test_task_cancel.py
@@ -40,8 +40,11 @@ def test_abort_cancel_produces_error_status() -> None:
                 await anyio.sleep(0.01)
             # Trigger an abort cancellation (simulates clicking Cancel > Abort)
             cancel_holder[0].cancel_task("abort")
-            # Sleep to let the cancellation propagate
-            await anyio.sleep(10)
+            # Sleep to let the cancellation propagate. The abort is expected to
+            # interrupt this; the duration is only an upper bound on the
+            # propagation window (kept short so the run_multiple path, where the
+            # abort does not interrupt the sleep, doesn't burn the full window).
+            await anyio.sleep(2)
             return state
 
         return solve
@@ -99,8 +102,11 @@ def test_abort_cancel_not_retried_in_run_multiple() -> None:
                 await anyio.sleep(0.01)
             # Trigger an abort cancellation
             cancel_holder[0].cancel_task("abort")
-            # Sleep to let the cancellation propagate
-            await anyio.sleep(10)
+            # Sleep to let the cancellation propagate. The abort is expected to
+            # interrupt this; the duration is only an upper bound on the
+            # propagation window (kept short so the run_multiple path, where the
+            # abort does not interrupt the sleep, doesn't burn the full window).
+            await anyio.sleep(2)
             return state
 
         return solve

--- a/tests/util/test_dotenv.py
+++ b/tests/util/test_dotenv.py
@@ -1,0 +1,51 @@
+"""Unit coverage for `init_dotenv()` .env precedence.
+
+The CLI config tests in `tests/test_eval_config.py` run in-process via
+`CliRunner`, which invokes `eval_command` directly and so never reaches
+`init_dotenv()` (it lives in `main()`, the console entry point). These tests
+exercise the `.env` precedence behavior directly so a regression in it is
+caught regardless of how the CLI is driven. The real entry-point wiring
+(`main()` -> `init_dotenv()` -> command) still has integration coverage via the
+subprocess-based CLI tests (e.g. tests/log/test_eval_log_config.py).
+"""
+
+import inspect_ai._util.dotenv as dotenv_mod
+from inspect_ai._util.dotenv import init_dotenv
+
+_VAR = "INSPECT_TEST_DOTENV_VAR"
+
+
+def test_dotenv_does_not_override_existing_env_outside_vscode(tmp_path, monkeypatch):
+    """Outside vscode, a value already in the environment beats the .env file."""
+    monkeypatch.setattr(dotenv_mod, "is_running_in_vscode", lambda: False)
+    (tmp_path / ".env").write_text(f"{_VAR}=from_dotenv\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(_VAR, "from_env")
+
+    init_dotenv()
+
+    assert dotenv_mod.os.environ[_VAR] == "from_env"
+
+
+def test_dotenv_overrides_existing_env_in_vscode(tmp_path, monkeypatch):
+    """In vscode, .env overrides the environment so session edits take effect."""
+    monkeypatch.setattr(dotenv_mod, "is_running_in_vscode", lambda: True)
+    (tmp_path / ".env").write_text(f"{_VAR}=from_dotenv\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv(_VAR, "from_env")
+
+    init_dotenv()
+
+    assert dotenv_mod.os.environ[_VAR] == "from_dotenv"
+
+
+def test_dotenv_loads_var_absent_from_environment(tmp_path, monkeypatch):
+    """A .env var not present in the environment is loaded regardless of mode."""
+    monkeypatch.setattr(dotenv_mod, "is_running_in_vscode", lambda: False)
+    (tmp_path / ".env").write_text(f"{_VAR}=from_dotenv\n")
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv(_VAR, raising=False)
+
+    init_dotenv()
+
+    assert dotenv_mod.os.environ[_VAR] == "from_dotenv"

--- a/tests/util/test_notify.py
+++ b/tests/util/test_notify.py
@@ -10,7 +10,6 @@ import pytest
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.util import notify
 from inspect_ai.util._notify import (
-    NOTIFY_TIMEOUT_SECONDS,
     active_apprise,
     apprise_scope,
     build_apprise,
@@ -266,16 +265,25 @@ async def test_notify_swallows_backend_exception() -> None:
     fake.notify.assert_called_once()
 
 
-async def test_notify_bounded_when_backend_hangs() -> None:
+async def test_notify_bounded_when_backend_hangs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A hanging Apprise backend returns within `NOTIFY_TIMEOUT_SECONDS`.
 
     Uses a real thread-blocking `time.sleep` (not anyio.sleep) so the cap
     must be enforced via `anyio.move_on_after` around `run_sync`, not via
     cooperative cancellation inside the worker.
     """
+    # Shrink the production cap so the test asserts the same bounding behavior
+    # without waiting the full 5s. `notify()` reads the module global at call
+    # time, so patching it here takes effect.
+    from inspect_ai.util import _notify
+
+    timeout = 0.5
+    monkeypatch.setattr(_notify, "NOTIFY_TIMEOUT_SECONDS", timeout)
 
     def hang(*args: Any, **kwargs: Any) -> bool:
-        time.sleep(NOTIFY_TIMEOUT_SECONDS * 4)
+        time.sleep(timeout * 4)
         return True
 
     fake = MagicMock()
@@ -283,12 +291,12 @@ async def test_notify_bounded_when_backend_hangs() -> None:
 
     start = time.monotonic()
     with apprise_scope(fake):
-        with anyio.fail_after(NOTIFY_TIMEOUT_SECONDS + 2.0):
+        with anyio.fail_after(timeout + 2.0):
             await notify("hello")
     elapsed = time.monotonic() - start
 
-    # We expect ~NOTIFY_TIMEOUT_SECONDS; allow generous slack for CI jitter.
-    assert elapsed < NOTIFY_TIMEOUT_SECONDS + 2.0
+    # We expect ~timeout; allow generous slack for CI jitter.
+    assert elapsed < timeout + 2.0
 
 
 # -- apprise_scope contextvar plumbing ------------------------------------

--- a/tests/util/test_subprocess.py
+++ b/tests/util/test_subprocess.py
@@ -70,7 +70,10 @@ async def test_subprocess_env():
 
 
 @pytest.mark.anyio
-async def test_subprocess_timeout():
+async def test_subprocess_timeout(monkeypatch):
+    # Shrink the post-SIGTERM grace so the test doesn't pay the full 2s
+    # production grace on top of the 1s timeout (behavior is unchanged).
+    monkeypatch.setattr(_subprocess_mod, "SUBPROCESS_SIGTERM_GRACE_SECONDS", 0.2)
     # The random() serves as adding a unique "signature" to the subprocess command
     timeout_duration = 10 + random()
     subprocess_cmds = ["sleep", str(timeout_duration)]
@@ -129,6 +132,7 @@ async def test_subprocess_timeout_with_lost_child_watcher(monkeypatch):
     """
     # Keep the test fast: the bound is a safety net, not a tuning knob.
     monkeypatch.setattr(_subprocess_mod, "LOST_SUBPROCESS_WAIT_TIMEOUT", 1)
+    monkeypatch.setattr(_subprocess_mod, "SUBPROCESS_SIGTERM_GRACE_SECONDS", 0.2)
 
     real_open_process = anyio.open_process
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [x] Code refactor

### What is the current behavior? (You can also link to an open issue here)

The per-PR `test` job had grown slow (~8.5–9 min per Python version; e.g. #4319). Profiling showed the `pytest` step itself runs ~513s on the 4-vCPU CI runner. The dominant cost was a long tail of individual tests that spend real wall-clock time **waiting** rather than computing, which monopolize one of the few CI workers:

- Model-generate and chat-API retries default to `wait_exponential_jitter(initial=3, …)`, so every test exercising a retry path waited a real 3s + 6s + … (e.g. `test_batch` 41.5s, `test_token_refresh` 13.6s, chatapi retry tests ~6s).
- `test_eval_config` spawned a fresh `inspect` subprocess per test (~2s interpreter + import startup × 10 = ~21s).
- Fixed real-time sleeps: `test_task_cancel` (10s), `test_notify` (5s), subprocess timeout tests (~8s).
- The ACP socket-integration suites (~75s) do real AF_UNIX round-trips + agent evals on every PR.
- CI ran with `--cov=inspect_ai`, but coverage was computed and discarded (no codecov upload, report, or threshold).
- The full `test` matrix ran even on documentation-only changes.

### What is the new behavior?

Total test **call time** (local profiling) drops **487s → 336s (−31%)**, and the 10–15s long-poles that dominated the 4-worker CI tail are eliminated. Changes:

**Test speedups (no production behavior change):**
- New autouse `fast_retry_waits` fixture in `tests/conftest.py` zeroes model/chat-API retry backoff suite-wide; opt out with the new `@pytest.mark.real_retry_wait` for tests that assert on backoff timing.
- `test_batch` passes `wait=wait_none()` into its test batcher's retry config (41.5s → 1.2s).
- `test_eval_config` invokes `inspect eval` in-process via `CliRunner` instead of a subprocess (21s → 4s).
- `test_task_cancel` cancellation-propagation sleep 10s → 2s; `test_notify` shrinks `NOTIFY_TIMEOUT_SECONDS` via monkeypatch (5s → 0.5s).
- `gracefully_terminate_cancelled_subprocess`'s post-SIGTERM grace is extracted to a named constant `SUBPROCESS_SIGTERM_GRACE_SECONDS` (value unchanged) so the subprocess timeout tests can shrink it and stay on regular CI rather than being marked slow.

**Slow-marked** the 6 heaviest ACP socket-integration files (server_forwarding, raw_events, router, elicitation_e2e, standard_acp_client, server_session_info). Lighter ACP tests — including the approval e2e suite, dispatch, session, discovery, picker, react/deepagent integration and the TUI tests — still run on every PR.

**CI:**
- Removed the unused `--cov=inspect_ai`.
- Added a `changes` paths-filter job; the `test` matrix is gated with a job-level `if` so it skips on docs-only changes. (Job-level `if` still reports the check, unlike workflow-level `paths-ignore`, which would strand a required status check.)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. All changes are to tests and CI config. The one source change (`SUBPROCESS_SIGTERM_GRACE_SECONDS`) is a no-op refactor of a magic number into a named constant with the same value.

### Other information:

The slow-marked ACP tests are not lost — `-m slow` suites are run in a separate environment. No `CHANGELOG` entry is included since there is no user-facing functionality change.
