### PR TITLE
CI: generic per-area slow-test matrix; add checkpoint area

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,16 +152,20 @@ jobs:
 
   # See design/sandbox-tools-ci-gates.md for the full gate matrix.
 
-  check-tool-paths:
+  detect-slow:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
-      tools_changed: ${{ steps.filter.outputs.tools }}
-      injectable_src_changed: ${{ steps.filter.outputs.injectable_src }}
+      tools_changed: ${{ steps.tools.outputs.tools }}
+      injectable_src_changed: ${{ steps.tools.outputs.injectable_src }}
+      areas: ${{ steps.areas.outputs.changes }}
     steps:
       - uses: actions/checkout@v5
+      # Special case: tools carries injectable-build/version/S3 baggage, so its
+      # filters feed a dedicated chain (check-version-bump -> slow-tool-tests-*)
+      # rather than the generic slow-tests matrix below.
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: tools
         with:
           filters: |
             tools:
@@ -170,14 +174,27 @@ jobs:
               - "tests/tools/**"
             injectable_src:
               - "src/inspect_sandbox_tools/**"
+      # Generic, growable table of areas whose slow tests run with nothing but
+      # `uv pip install .[dev]` + Docker-on-the-runner. `changes` is a JSON list
+      # of the keys that matched; the slow-tests matrix fans out over it.
+      # Convention: each key is also the tests/<key>/ directory to run.
+      # Tests needing an API key self-skip via skip_if_no_* (no secrets here),
+      # so only add an area whose slow tests need no build artifact or secret.
+      - uses: dorny/paths-filter@v3
+        id: areas
+        with:
+          filters: |
+            checkpoint:
+              - "src/inspect_ai/util/_checkpoint/**"
+              - "tests/checkpoint/**"
 
   # Fast gate: confirm sandbox_tools_version.txt is bumped to exactly N+1
   # when the injectable source changed. Blocks downstream slow jobs on
   # failure so PR contributors don't wait on a Docker build to learn they
   # forgot the bump.
   check-version-bump:
-    needs: check-tool-paths
-    if: needs.check-tool-paths.outputs.tools_changed == 'true'
+    needs: detect-slow
+    if: needs.detect-slow.outputs.tools_changed == 'true'
     runs-on: ubuntu-latest
     outputs:
       version_correctly_bumped: ${{ steps.bump.outputs.correctly_bumped }}
@@ -190,7 +207,7 @@ jobs:
       - name: Check version bump
         id: bump
         env:
-          INJECTABLE_SRC_CHANGED: ${{ needs.check-tool-paths.outputs.injectable_src_changed }}
+          INJECTABLE_SRC_CHANGED: ${{ needs.detect-slow.outputs.injectable_src_changed }}
           BASE_REF: ${{ github.base_ref }}
         run: |
           VERSION_PATH="src/inspect_ai/tool/_sandbox_tools_utils/sandbox_tools_version.txt"
@@ -218,8 +235,8 @@ jobs:
   # source or version changed, build a -dev binary first; otherwise let
   # pytest resolve the published v{N} via the runtime's S3 download path.
   slow-tool-tests-dev:
-    needs: [check-tool-paths, check-version-bump]
-    if: needs.check-tool-paths.outputs.tools_changed == 'true'
+    needs: [detect-slow, check-version-bump]
+    if: needs.detect-slow.outputs.tools_changed == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -255,7 +272,7 @@ jobs:
           uv pip install .[dev]
 
       - name: Build sandbox-tools -dev binaries (glibc + musl)
-        if: needs.check-tool-paths.outputs.injectable_src_changed == 'true' || needs.check-version-bump.outputs.version_correctly_bumped == 'true'
+        if: needs.detect-slow.outputs.injectable_src_changed == 'true' || needs.check-version-bump.outputs.version_correctly_bumped == 'true'
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: plain
@@ -279,8 +296,8 @@ jobs:
   # hint if not), then re-runs the slow tests against it. Maintainer reruns
   # from the Actions UI after uploading.
   slow-tool-tests-release:
-    needs: [check-tool-paths, check-version-bump, slow-tool-tests-dev]
-    if: needs.check-tool-paths.outputs.tools_changed == 'true' && needs.check-version-bump.outputs.version_correctly_bumped == 'true'
+    needs: [detect-slow, check-version-bump, slow-tool-tests-dev]
+    if: needs.detect-slow.outputs.tools_changed == 'true' && needs.check-version-bump.outputs.version_correctly_bumped == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
@@ -338,6 +355,46 @@ jobs:
           # "edited" on this PR (version.txt differs from main).
           INSPECT_SANDBOX_TOOLS_INSTALL_STATE: clean
         run: uv run pytest --runslow -m slow tests/tools/ -x
+
+      - name: Minimize uv cache
+        if: ${{ !cancelled() }}
+        run: uv cache prune --ci
+
+  # Generic per-area slow tests: one runner per changed area from the
+  # detect-slow `areas` table. Add an area by adding a filter entry there;
+  # no new job is needed. Runs plain `pytest --runslow` (no build artifact,
+  # no secrets); API-key tests self-skip via skip_if_no_*.
+  slow-tests:
+    needs: detect-slow
+    # An empty matrix vector errors, so skip the whole job when nothing matched.
+    if: needs.detect-slow.outputs.areas != '[]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        area: ${{ fromJSON(needs.detect-slow.outputs.areas) }}
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: true
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          version: ${{ env.UV_VERSION }}
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |-
+          uv venv
+          uv pip install .[dev]
+
+      - name: Run slow tests
+        run: uv run pytest --runslow -m slow tests/${{ matrix.area }}/
 
       - name: Minimize uv cache
         if: ${{ !cancelled() }}


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

CI's path-conditional slow-test support is hard-wired to the tool suite: a single `check-tool-paths` filter job feeds the sandbox-tools chain (`check-version-bump` → `slow-tool-tests-dev` → `slow-tool-tests-release`). There's no way to run another subsystem's slow tests when only that subsystem changed — e.g. checkpoint changes don't trigger the checkpoint slow tests.

### What is the new behavior?

`check-tool-paths` is generalized into a `detect-slow` job with two `paths-filter` steps:

- `tools` / `injectable_src` — unchanged, still feed the special sandbox-tools chain (which keeps its injectable build, version-bump gate, and S3 release gate). Tools stays special-cased on purpose; that machinery doesn't generalize.
- `areas` — a growable table mapping a key to its globs. Its `changes` output (JSON list of matched keys) drives a new generic `slow-tests` matrix job that runs `pytest --runslow -m slow tests/<area>/`, one runner per changed area.

Seeded with the `checkpoint` area (`src/inspect_ai/util/_checkpoint/**` + `tests/checkpoint/**`). Adding a future area is a one-line filter entry — no new job.

Design constraints encoded:
- An area belongs in the matrix only if its slow tests run with just `uv pip install .[dev]` + Docker-on-the-runner. Anything needing a build artifact (tools) or a secret graduates to its own job.
- No secrets in the matrix job; tests needing an API key self-skip via `skip_if_no_*` (e.g. the one anthropic-gated checkpoint test).
- Convention: each `areas` key is also the `tests/<key>/` directory to run.
- `slow-tests` is guarded by `if: areas != '[]'` (an empty matrix vector errors) and uses `fail-fast: false` so areas don't cancel each other.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. CI-only; the tool slow-test chain behaves identically (job renamed `check-tool-paths` → `detect-slow`, references rewired).

### Other information:

The anthropic-gated checkpoint e2e test will skip in CI (no `ANTHROPIC_API_KEY` wired); the Docker-only checkpoint slow tests run.
