### PR TITLE
fix(scorer): reduce dict scores over the union of keys

### DIFF
--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -218,12 +218,13 @@ def max_score(value_to_float: ValueToFloat = value_to_float()) -> ScoreReducer:
         if isinstance(representative.value, dict):
             dict_scores = _partition_dict_scores(scores)
             dict_result: dict[str, str | int | float | bool | None] = {}
-            keys = dict_scores[0].value.keys()  # type: ignore
+            keys = _union_dict_keys(dict_scores)
             for key in keys:
                 key_values = [
                     cast(str | int | float | bool, score.value[key])  # type: ignore
                     for score in dict_scores
-                    if _is_reducible(score.value[key])  # type: ignore
+                    if key in score.value  # type: ignore
+                    and _is_reducible(score.value[key])  # type: ignore
                 ]
                 if len(key_values) == 0:
                     dict_result[key] = float("nan")
@@ -300,10 +301,12 @@ def _count_dict(
         return _nan_score(scores)
 
     dict_result: dict[str, str | int | float | bool] = {}
-    keys = dict_scores[0].value.keys()  # type: ignore
+    keys = _union_dict_keys(dict_scores)
     for key in keys:
         key_values = []
         for score in dict_scores:
+            if key not in score.value:  # type: ignore
+                continue
             key_value = cast(str | int | float | bool, score.value[key])  # type: ignore
             if _is_reducible(key_value):
                 key_values.append(key_value)
@@ -368,9 +371,11 @@ def _compute_dict_stat(
         return _nan_score(scores)
 
     dict_result: dict[str, str | int | float | bool | None] = {}
-    for key in dict_scores[0].value.keys():  # type: ignore
+    for key in _union_dict_keys(dict_scores):
         values = []
         for score in dict_scores:
+            if key not in score.value:  # type: ignore
+                continue
             key_value = value_to_float(score.value[key])  # type: ignore
             if _is_reducible(key_value):
                 values.append(key_value)
@@ -470,6 +475,22 @@ def _partition_dict_scores(scores: list[Score]) -> list[Score]:
                 "Attempting to reduce a dictionary score for a non-dictionary value"
             )
     return result
+
+
+def _union_dict_keys(dict_scores: list[Score]) -> list[str]:
+    r"""Ordered union of keys across dict-valued scores.
+
+    Epoch scores for a sample can legitimately carry different keys (for
+    example a scorer that only emits an optional metric for some outputs), so
+    reducing over the first score's keys alone would both miss keys that only
+    appear later and raise a KeyError on keys absent from a later score. Reduce
+    over the union instead; scores lacking a given key are skipped for that key,
+    mirroring how non-reducible values are filtered out elsewhere.
+    """
+    keys: dict[str, None] = {}
+    for score in dict_scores:
+        keys.update(dict.fromkeys(score.value.keys()))  # type: ignore
+    return list(keys)
 
 
 def _partition_list_scores(scores: list[Score]) -> list[Score]:

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -246,6 +246,28 @@ def test_nan_root_first_score_dict_reducers() -> None:
     assert max_reducer(dict_scores).value == {"coolness": 4, "spiciness": 1}
 
 
+def test_heterogeneous_keys_dict_reducers() -> None:
+    # Epoch scores for a sample can legitimately carry different keys — e.g. a
+    # scorer that only emits an optional metric for some model outputs. Reducers
+    # should reduce over the union of keys (computing each key over the scores
+    # that actually have it) rather than raising KeyError off the first score's
+    # keys, or silently dropping keys that only appear in a later score.
+    dict_scores = [
+        Score(value={"coolness": 6, "spiciness": 2}),
+        Score(value={"coolness": 4}),  # "spiciness" absent this epoch
+        Score(value={"coolness": 2, "spiciness": 10, "zest": 8}),  # "zest" only here
+    ]
+
+    assert avg_reducer(dict_scores).value == {"coolness": 4, "spiciness": 6, "zest": 8}
+    assert median_reducer(dict_scores).value == {
+        "coolness": 4,
+        "spiciness": 6,
+        "zest": 8,
+    }
+    assert max_reducer(dict_scores).value == {"coolness": 6, "spiciness": 10, "zest": 8}
+    assert mode_reducer(dict_scores).value == {"coolness": 6, "spiciness": 2, "zest": 8}
+
+
 def test_dict_reducer_value_to_float_applied_once() -> None:
     # A custom value_to_float should be applied once per value, like the scalar
     # and list branches. Halving isn't idempotent, so applying it twice in the


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

The dict-valued epoch reducers (`mean`, `median`, `max`, `mode`, `at_least`, `pass_at`, `pass_k`) reduce key by key off the **first** score's keys and then index every score unconditionally:

```python
keys = dict_scores[0].value.keys()
for key in keys:
    ... score.value[key] ...   # KeyError if this score lacks `key`
```

If a scorer emits an optional metric for only some of a sample's epochs, the per-epoch dicts carry different keys. With `epochs > 1` the reducer then raises `KeyError` at the reduction step — after every model call for the sample has already run, so the whole eval fails. A key that appears only in a *later* score is also silently dropped from the result.

Repro on `main`:

```python
from inspect_ai.scorer import Score, mean_score

scores = [
    Score(value={"correct": 1.0, "partial": 0.5}),  # this epoch had partial credit
    Score(value={"correct": 0.0}),                   # this one didn't
]
mean_score()(scores)   # KeyError: 'partial'
```

### What is the new behavior?

Reduction runs over the **ordered union** of keys across the dict scores. Scores that lack a given key are skipped for that key, exactly mirroring how non-reducible values are already filtered out and how `_partition_dict_scores` already tolerates NaN-at-root sentinels. Each key is reduced over the scores that actually carry it; keys that appear only in a later score are now included rather than dropped.

The same `mean_score()(scores)` call above now returns `{"correct": 0.5, "partial": 0.5}`.

A small helper `_union_dict_keys()` centralizes the union, applied in the three dict code paths (`max_score`, `_count_dict`, `_compute_dict_stat`) that back all dict reducers.

### Does this PR introduce a breaking change?

No. For the existing uniform-key case the union equals the first score's keys, so behavior is unchanged; only the previously-crashing heterogeneous-key case changes (from `KeyError` to a computed reduction).

### Other information:

Added `test_heterogeneous_keys_dict_reducers` (it fails with `KeyError: 'spiciness'` on `main`, passes here). `pytest tests/scorer/test_reducers.py` and `ruff check` / `ruff format --check` pass locally.
