### PR TITLE
Sanitize untrusted text before terminal rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Security: Remove terminal control sequences and hyperlinks from untrusted assistant, scorer, error, metadata, and filename text before rendering it in console and TUI displays.
 - Log: Shared sample buffer files synced to S3 (via `--log-shared`) are now tagged `inspect-ephemeral=true` so they can be targeted by an S3 lifecycle rule.
 - Log: Reading sample summaries from an in-progress `.eval` on a remote filesystem (e.g. S3) now fetches the per-sample journal summary files concurrently, reducing load time for logs with many samples.
 - Log: Sample event condensing is now linear, not quadratic, in conversation length.

--- a/src/inspect_ai/_display/core/config.py
+++ b/src/inspect_ai/_display/core/config.py
@@ -2,6 +2,7 @@ from rich.console import RenderableType
 from rich.text import Text
 
 from inspect_ai._util.registry import is_model_dict, is_registry_dict
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.text import truncate_text
 from inspect_ai.log._log import eval_config_defaults
 from inspect_ai.model._cache import CachePolicy
@@ -66,7 +67,7 @@ def task_config_str(profile: TaskProfile, generate_config: bool = True) -> str:
                 value = value.replace("[", "\\[")
             config_print.append(f"{name}: {value}")
     values = ", ".join(config_print)
-    return values
+    return clean_control_characters(values)
 
 
 def task_config(

--- a/src/inspect_ai/_display/core/panel.py
+++ b/src/inspect_ai/_display/core/panel.py
@@ -9,6 +9,10 @@ from rich.text import Text
 
 from inspect_ai._util.constants import CONSOLE_DISPLAY_WIDTH
 from inspect_ai._util.path import cwd_relative_path
+from inspect_ai._util.rich import (
+    clean_control_characters,
+    clean_control_characters_renderable,
+)
 from inspect_ai._util.task import task_display_name
 from inspect_ai.util._display import display_type_plain
 
@@ -91,6 +95,7 @@ def task_panel(
     # enclose in outer table for log link footer
     root = table
     if log_location:
+        log_location = clean_control_characters(log_location)
         # if we are in jupyter then use a real hyperlink
         if jupyter:
             log_location = f"[link={log_location}]{log_location}[/link]"
@@ -118,14 +123,16 @@ def task_panel(
             height=3,
             expand=True,
         )
-        return Group(panel, root)
+        return clean_control_characters_renderable(Group(panel, root))
     else:
-        return Panel(
-            root,
-            title=task_panel_title(profile, show_model),
-            title_align="left",
-            width=width,
-            expand=True,
+        return clean_control_characters_renderable(
+            Panel(
+                root,
+                title=task_panel_title(profile, show_model),
+                title_align="left",
+                width=width,
+                expand=True,
+            )
         )
 
 
@@ -166,6 +173,7 @@ def task_panel_plain(
 
     # log location
     if log_location:
+        log_location = clean_control_characters(log_location)
         # Print a cwd relative path
         try:
             log_location_relative = cwd_relative_path(log_location, walk_up=True)
@@ -176,7 +184,7 @@ def task_panel_plain(
     table.add_row(delimeter)
     table.add_row("")
 
-    return table
+    return clean_control_characters_renderable(table)
 
 
 def task_panel_title(profile: TaskProfile, show_model: bool) -> str:
@@ -188,7 +196,7 @@ def task_panel_title(profile: TaskProfile, show_model: bool) -> str:
 
 def to_renderable(item: RenderableType | str, style: str = "") -> RenderableType:
     if isinstance(item, str):
-        return Text.from_markup(item, style=style)
+        return Text.from_markup(clean_control_characters(item), style=style)
     else:
         return item
 
@@ -197,7 +205,7 @@ def tasks_title(completed: int, total: int) -> str:
     title = f"{completed}/{total} tasks complete"
     if eval_set_id := get_eval_set_id_display():
         title = f"[{eval_set_id}] {title}"
-    return title
+    return clean_control_characters(title)
 
 
 def task_title(profile: TaskProfile, show_model: bool) -> str:
@@ -209,8 +217,8 @@ def task_title(profile: TaskProfile, show_model: bool) -> str:
         title = f"{title}: {profile.model}"
     if eval_set_id := get_eval_set_id_display():
         title = f"[{eval_set_id}] {title}"
-    return title
+    return clean_control_characters(title)
 
 
 def task_targets(profile: TaskProfile) -> str:
-    return f"dataset: {profile.dataset}"
+    return clean_control_characters(f"dataset: {profile.dataset}")

--- a/src/inspect_ai/_display/core/progress.py
+++ b/src/inspect_ai/_display/core/progress.py
@@ -11,6 +11,7 @@ from rich.progress import Progress as RProgress
 from rich.text import Text
 from typing_extensions import override
 
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.task import task_display_name
 from inspect_ai.model._model import ModelName
 
@@ -102,7 +103,7 @@ MAX_AGENT_NAME_WIDTH = 16
 def progress_model_name(
     model_name: ModelName, max_width: int = MAX_MODEL_NAME_WIDTH, pad: bool = False
 ) -> Text:
-    model = Text(model_name.name)
+    model = Text(clean_control_characters(model_name.name))
     model.truncate(max_width, overflow="ellipsis", pad=pad)
     return model
 
@@ -110,7 +111,7 @@ def progress_model_name(
 def progress_agent_name(
     agent: str | None, max_width: int = MAX_AGENT_NAME_WIDTH, pad: bool = False
 ) -> Text:
-    name = Text(agent or "")
+    name = Text(clean_control_characters(agent or ""))
     name.truncate(max_width, overflow="ellipsis", pad=pad)
     return name
 
@@ -118,7 +119,7 @@ def progress_agent_name(
 def progress_description(
     profile: TaskProfile, max_width: int = MAX_DESCRIPTION_WIDTH, pad: bool = False
 ) -> Text:
-    description = Text(task_display_name(profile.name))
+    description = Text(clean_control_characters(task_display_name(profile.name)))
     description.truncate(max_width, overflow="ellipsis", pad=pad)
     return description
 

--- a/src/inspect_ai/_display/core/results.py
+++ b/src/inspect_ai/_display/core/results.py
@@ -7,7 +7,7 @@ from rich.table import Table
 from rich.text import Text
 
 from inspect_ai._util.dateutil import datetime_from_iso_format_safe
-from inspect_ai._util.rich import rich_traceback
+from inspect_ai._util.rich import clean_control_characters, rich_traceback
 from inspect_ai.log import EvalStats
 from inspect_ai.log._log import EvalScore
 from inspect_ai.model._model_output import ModelUsage
@@ -153,9 +153,12 @@ def task_scores(scores: list[EvalScore], pad_edge: bool = False) -> list[Table]:
             table.add_column()
 
             # Add score name and metrics
-            table.add_row(f"[bold]{score.name}[/bold]")
+            table.add_row(f"[bold]{clean_control_characters(score.name)}[/bold]")
             for name, metric in score.metrics.items():
-                table.add_row(f"{name}", f"{metric.value:.3f}")
+                table.add_row(
+                    clean_control_characters(name),
+                    f"{metric.value:.3f}",
+                )
 
             score_tables.append(table)
 
@@ -259,7 +262,7 @@ def model_usage_summary(model: str, usage: ModelUsage) -> list[RenderableType]:
         reasoning_tokens = ""
 
     return [
-        Text(model, style="bold"),
+        Text(clean_control_characters(model), style="bold"),
         f"  {usage.total_tokens:,} tokens [{input_tokens}, [bold]O: [/bold]{usage.output_tokens:,}{reasoning_tokens}]",
     ]
 
@@ -269,7 +272,7 @@ def task_can_retry(profile: TaskProfile) -> bool:
 
 
 def task_interrupted(profile: TaskProfile, samples_completed: int) -> RenderableType:
-    log_location = profile.log_location
+    log_location = clean_control_characters(profile.log_location)
     theme = rich_theme()
     message = f"[bold][{theme.error}]Task interrupted ("
     if samples_completed > 0:
@@ -292,7 +295,7 @@ def task_interrupted(profile: TaskProfile, samples_completed: int) -> Renderable
             f"{message}no samples completed before interruption)[/{theme.error}][/bold]"
         )
 
-    return message
+    return clean_control_characters(message)
 
 
 def task_metric(metrics: list[TaskDisplayMetric], width: int | None = None) -> str:
@@ -316,7 +319,7 @@ def task_metric(metrics: list[TaskDisplayMetric], width: int | None = None) -> s
 
     if width is not None:
         metric_str = metric_str.rjust(width)
-    return metric_str
+    return clean_control_characters(metric_str)
 
 
 def task_metrics(scores: list[EvalScore]) -> str:
@@ -347,6 +350,8 @@ def task_metrics(scores: list[EvalScore]) -> str:
             output[key] = value
 
     if output:
-        return f"[{theme.metric}]{task_dict(output, True)}[/{theme.metric}]"
+        return clean_control_characters(
+            f"[{theme.metric}]{task_dict(output, True)}[/{theme.metric}]"
+        )
     else:
         return ""

--- a/src/inspect_ai/_display/plain/display.py
+++ b/src/inspect_ai/_display/plain/display.py
@@ -7,6 +7,7 @@ import rich
 from inspect_ai._display.core.rich import rich_initialise
 from inspect_ai._util._async import configured_async_backend, run_coroutine
 from inspect_ai._util.platform import running_in_notebook
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.text import truncate
 from inspect_ai.util._throttle import throttle
 
@@ -37,7 +38,7 @@ class PlainDisplay(Display):
         rich_initialise()
 
     def print(self, message: str) -> None:
-        print(message)
+        print(clean_control_characters(message))
 
     @contextlib.contextmanager
     def progress(self, total: int) -> Iterator[Progress]:

--- a/src/inspect_ai/_display/rich/display.py
+++ b/src/inspect_ai/_display/rich/display.py
@@ -14,6 +14,7 @@ from typing_extensions import override
 from inspect_ai._util._async import configured_async_backend, run_coroutine
 from inspect_ai._util.constants import CONSOLE_DISPLAY_WIDTH
 from inspect_ai._util.platform import running_in_notebook
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai.event._input import InputEvent
 from inspect_ai.log._transcript import transcript
 from inspect_ai.util._display import display_type
@@ -68,7 +69,11 @@ class RichDisplay(Display):
 
     @override
     def print(self, message: str) -> None:
-        rich.get_console().print(message, markup=False, highlight=False)
+        rich.get_console().print(
+            clean_control_characters(message),
+            markup=False,
+            highlight=False,
+        )
 
     @override
     @contextlib.contextmanager

--- a/src/inspect_ai/_display/textual/display.py
+++ b/src/inspect_ai/_display/textual/display.py
@@ -4,6 +4,8 @@ from typing import AsyncIterator, Callable, Coroutine, Iterator
 import rich
 from typing_extensions import override
 
+from inspect_ai._util.rich import clean_control_characters
+
 from ..core.display import (
     TR,
     Display,
@@ -21,7 +23,11 @@ from .app import TaskScreenApp
 class TextualDisplay(Display):
     @override
     def print(self, message: str) -> None:
-        rich.get_console().print(message, markup=False, highlight=False)
+        rich.get_console().print(
+            clean_control_characters(message),
+            markup=False,
+            highlight=False,
+        )
 
     @override
     @contextlib.contextmanager

--- a/src/inspect_ai/_display/textual/widgets/console.py
+++ b/src/inspect_ai/_display/textual/widgets/console.py
@@ -1,6 +1,7 @@
-from rich.text import Text
 from textual.reactive import reactive
 from textual.widgets import RichLog
+
+from inspect_ai._util.rich import untrusted_text_from_ansi
 
 # maximum number of lines to keep in the console
 MAX_CONSOLE_LINES = 100
@@ -53,4 +54,4 @@ class ConsoleView(RichLog):
                         break
             line = "".join(chars) + " "
 
-        self.write(Text.from_ansi(line))
+        self.write(untrusted_text_from_ansi(line))

--- a/src/inspect_ai/_display/textual/widgets/samples.py
+++ b/src/inspect_ai/_display/textual/widgets/samples.py
@@ -34,6 +34,7 @@ from inspect_ai._display.textual.widgets.vscode import conditional_vscode_link
 from inspect_ai._util.file import to_uri
 from inspect_ai._util.format import format_progress_time
 from inspect_ai._util.port_names import get_service_by_port
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.task import task_display_name
 from inspect_ai._util.vscode import EXTENSION_COMMAND_OPEN_SAMPLE, VSCodeCommand
 from inspect_ai.event._model import ModelEvent
@@ -187,11 +188,15 @@ class SamplesList(OptionList):
             table.add_column(width=20)
             table.add_column(width=11, justify="right")
             table.add_column(width=1)
-            task_name = Text.from_markup(f"{task_display_name(sample.task)}")
+            task_name = Text.from_markup(
+                clean_control_characters(task_display_name(sample.task))
+            )
             task_name.truncate(18, overflow="ellipsis", pad=True)
             task_time = Text.from_markup(f"{format_progress_time(sample.running_time)}")
             table.add_row(task_name, task_time, " ")
-            sample_id = Text.from_markup(f"id: {sample.sample.id}")
+            sample_id = Text.from_markup(
+                clean_control_characters(f"id: {sample.sample.id}")
+            )
             sample_id.truncate(18, overflow="ellipsis", pad=True)
             sample_epoch = Text.from_markup(f"epoch: {sample.epoch:.0f}")
             table.add_row(
@@ -405,7 +410,7 @@ class SampleInfo(Vertical):
             title = f"{task_display_name(sample.task)} (id: {sample.sample.id}, epoch {sample.epoch}): {sample.model}"
             if sample.fallback_models:
                 title = f"{title} [italic](fallback → {', '.join(sample.fallback_models)})[/italic]"
-            self.query_one(Collapsible).title = title
+            self.query_one(Collapsible).title = clean_control_characters(title)
             sandboxes = self.query_one(SandboxesView)
             await sandboxes.sync_sample(sample)
             await self.query_one(SampleVNC).sync_sample(sample)

--- a/src/inspect_ai/_display/textual/widgets/task_detail.py
+++ b/src/inspect_ai/_display/textual/widgets/task_detail.py
@@ -9,6 +9,7 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from inspect_ai._display.core.display import TaskDisplayMetric
+from inspect_ai._util.rich import clean_control_characters
 
 
 @dataclass
@@ -226,18 +227,26 @@ class TaskMetrics(Widget):
                     self._metric_value(metric.value), markup=False
                 )
             if grid.is_attached:
-                grid.mount(Static(metric.name, markup=False))
+                grid.mount(Static(clean_control_characters(metric.name), markup=False))
                 grid.mount(self.value_widgets[metric.name])
 
     def _title(self) -> Widget:
         if self.scorer is None:
             return Static("")
         elif self.reducer is None:
-            return Static(self.scorer, markup=False)
+            return Static(clean_control_characters(self.scorer), markup=False)
         else:
             return Horizontal(
-                Static(self.scorer, classes="scorer", markup=False),
-                Static(f"({self.reducer})", classes="reducer", markup=False),
+                Static(
+                    clean_control_characters(self.scorer),
+                    classes="scorer",
+                    markup=False,
+                ),
+                Static(
+                    clean_control_characters(f"({self.reducer})"),
+                    classes="reducer",
+                    markup=False,
+                ),
             )
 
     def _metric_value(self, val: float) -> str:

--- a/src/inspect_ai/_display/textual/widgets/transcript.py
+++ b/src/inspect_ai/_display/textual/widgets/transcript.py
@@ -10,7 +10,11 @@ from textual.widget import Widget
 from textual.widgets import Static
 
 from inspect_ai._util.content import ContentReasoning, ContentText
-from inspect_ai._util.rich import tool_result_display
+from inspect_ai._util.rich import (
+    clean_control_characters,
+    clean_control_characters_renderable,
+    tool_result_display,
+)
 from inspect_ai._util.transcript import (
     content_display,
     set_transcript_markdown_options,
@@ -118,7 +122,7 @@ class TranscriptView(ScrollableContainer):
         def append_content(c: RenderableType) -> None:
             if isinstance(c, Markdown):
                 set_transcript_markdown_options(c)
-            widgets.append(Static(c, markup=False))
+            widgets.append(Static(clean_control_characters_renderable(c), markup=False))
 
         # first set aside events we don't render
         filtered_events = [e for e in events if can_render_event(e)]
@@ -222,19 +226,22 @@ def render_sample_init_event(event: SampleInitEvent) -> EventDisplay:
         content.append(Text())
         content.append(Text("Target", style="bold"))
         content.append(Text())
-        content.append(str(sample.target).strip())
+        content.append(Text(clean_control_characters(str(sample.target).strip())))
 
     return EventDisplay("sample init", Group(*content))
 
 
 def render_sample_limit_event(event: SampleLimitEvent) -> EventDisplay:
-    return EventDisplay(f"limit: {event.type}", Text(event.message))
+    return EventDisplay(
+        f"limit: {event.type}",
+        Text(clean_control_characters(event.message)),
+    )
 
 
 def render_interrupt_event(event: InterruptEvent) -> EventDisplay:
     return EventDisplay(
         f"interrupt: {event.source}",
-        Text(f"interrupted during {event.interrupted}"),
+        Text(clean_control_characters(f"interrupted during {event.interrupted}")),
     )
 
 
@@ -334,10 +341,12 @@ def render_score_event(event: ScoreEvent) -> EventDisplay:
     table = Table(box=None, show_header=False)
     table.add_column("", min_width=10, justify="left")
     table.add_column("", justify="left")
-    table.add_row("Target", str(event.target).strip())
+    table.add_row("Target", Text(clean_control_characters(str(event.target).strip())))
     if event.score.answer:
         table.add_row("Answer", transcript_markdown(event.score.answer, escape=True))
-    table.add_row("Score", str(event.score.value).strip())
+    table.add_row(
+        "Score", Text(clean_control_characters(str(event.score.value).strip()))
+    )
     if event.score.explanation:
         table.add_row(
             "Explanation", transcript_markdown(event.score.explanation, escape=True)
@@ -353,7 +362,7 @@ def render_subtask_event(event: SubtaskEvent) -> list[EventDisplay]:
     if event.result:
         content.append(Text())
         if isinstance(event.result, str | int | float | bool | None):
-            content.append(Text(str(event.result)))
+            content.append(Text(clean_control_characters(str(event.result))))
         else:
             content.append(render_as_json(event.result))
 
@@ -366,7 +375,9 @@ def render_input_event(event: InputEvent) -> EventDisplay:
 
 def render_approval_event(event: ApprovalEvent) -> EventDisplay:
     content: list[RenderableType] = [
-        f"[bold]{event.approver}[/bold]: {event.decision} ({event.explanation})"
+        clean_control_characters(
+            f"[bold]{event.approver}[/bold]: {event.decision} ({event.explanation})"
+        )
     ]
 
     return EventDisplay("approval", Group(*content))
@@ -411,11 +422,14 @@ def render_logger_event(event: LoggerEvent) -> EventDisplay:
     if event.message.name:
         content = f"{content} (${event.message.name})"
     content = f"{content}: {event.message.message}"
-    return EventDisplay("logger", content)
+    return EventDisplay("logger", Text(clean_control_characters(content)))
 
 
 def render_error_event(event: ErrorEvent) -> EventDisplay:
-    return EventDisplay("error", event.error.traceback.strip())
+    return EventDisplay(
+        "error",
+        Text(clean_control_characters(event.error.traceback.strip())),
+    )
 
 
 def render_as_json(json: Any) -> RenderableType:

--- a/src/inspect_ai/_util/logger.py
+++ b/src/inspect_ai/_util/logger.py
@@ -21,7 +21,6 @@ from typing import IO, Literal, TypeAlias, cast
 import rich
 from rich.console import ConsoleRenderable
 from rich.logging import RichHandler
-from rich.text import Text
 from typing_extensions import TypedDict, override
 
 from .constants import (
@@ -37,6 +36,7 @@ from .constants import (
 )
 from .error import PrerequisiteError
 from .log_context import install_sample_context_filter
+from .rich import clean_control_characters, untrusted_text_from_ansi
 from .trace import (
     TraceFormatter,
     compress_trace_log,
@@ -128,7 +128,9 @@ class LogHandler(RichHandler):
         if self.logger_format == "rich":
             super().emit(record)
         elif self.logger_format == "plain":
-            formatted = self.plain_formatter.format(record).replace("\n", "\\n")
+            formatted = clean_control_characters(
+                self.plain_formatter.format(record).replace("\n", "\\n")
+            )
             self.display_stream.write(f"{formatted}\n")
             self.display_stream.flush()
         elif self.logger_format == "json":
@@ -137,7 +139,7 @@ class LogHandler(RichHandler):
 
     @override
     def render_message(self, record: LogRecord, message: str) -> ConsoleRenderable:
-        return Text.from_ansi(message)
+        return untrusted_text_from_ansi(message)
 
 
 class LogHandlerVar(TypedDict):

--- a/src/inspect_ai/_util/rich.py
+++ b/src/inspect_ai/_util/rich.py
@@ -1,16 +1,19 @@
 import asyncio
 import os
+import re
 import sys
 import traceback
 import unicodedata
+from dataclasses import dataclass
 from types import TracebackType
 from typing import Any, Tuple, Type
 
 import click
 import tenacity
-from rich.console import Console, RenderableType
-from rich.style import Style
-from rich.text import Text
+from rich.console import Console, ConsoleOptions, RenderableType, RenderResult
+from rich.segment import Segment
+from rich.style import Style, StyleType
+from rich.text import Span, Text
 from rich.traceback import Traceback
 
 from inspect_ai._util.constants import CONSOLE_DISPLAY_WIDTH, PKG_NAME
@@ -43,11 +46,78 @@ def lines_display(
     return content
 
 
-# clean control characters sent by untrusted sources (e.g. tool output)
-# which can trigger rich text measurement bugs
 def clean_control_characters(text: str) -> str:
+    """Remove terminal-directed controls while preserving useful whitespace."""
     return "".join(
         c for c in text if c in "\n\t" or unicodedata.category(c) not in ("Cc", "Cf")
+    )
+
+
+@dataclass
+class _ControlCharacterCleanRenderable:
+    renderable: RenderableType
+
+    def __rich_console__(
+        self, console: Console, options: ConsoleOptions
+    ) -> RenderResult:
+        for segment in console.render(self.renderable, options):
+            if segment.control:
+                yield segment
+            else:
+                yield Segment(
+                    clean_control_characters(segment.text),
+                    segment.style,
+                )
+
+
+def clean_control_characters_renderable(
+    renderable: RenderableType,
+) -> RenderableType:
+    """Clean text emitted by a nested Rich renderable without removing styles."""
+    return _ControlCharacterCleanRenderable(renderable)
+
+
+def untrusted_text_from_ansi(text: str) -> Text:
+    """Parse visual ANSI styles while discarding controls and hyperlinks."""
+    safe_ansi: list[str] = []
+    offset = 0
+    for match in re.finditer(r"\x1b\[[0-9;:]*m", text):
+        safe_ansi.append(clean_control_characters(text[offset : match.start()]))
+        safe_ansi.append(match.group())
+        offset = match.end()
+    safe_ansi.append(clean_control_characters(text[offset:]))
+
+    parsed = Text.from_ansi("".join(safe_ansi))
+    plain = parsed.plain
+
+    offsets = [0]
+    cleaned: list[str] = []
+    for char in plain:
+        if char in "\n\t" or unicodedata.category(char) not in ("Cc", "Cf"):
+            cleaned.append(char)
+        offsets.append(len(cleaned))
+
+    def safe_style(style: StyleType) -> StyleType:
+        return (
+            style.update_link(None)
+            if isinstance(style, Style) and style.link
+            else style
+        )
+
+    spans = [
+        Span(offsets[span.start], offsets[span.end], safe_style(span.style))
+        for span in parsed.spans
+        if offsets[span.start] < offsets[span.end]
+    ]
+    return Text(
+        "".join(cleaned),
+        style=safe_style(parsed.style),
+        justify=parsed.justify,
+        overflow=parsed.overflow,
+        no_wrap=parsed.no_wrap,
+        end=parsed.end,
+        tab_size=parsed.tab_size,
+        spans=spans,
     )
 
 
@@ -62,7 +132,7 @@ def rich_traceback(
         show_locals=os.environ.get("INSPECT_TRACEBACK_LOCALS", None) == "1",
         width=CONSOLE_DISPLAY_WIDTH,
     )
-    return rich_tb
+    return clean_control_characters_renderable(rich_tb)
 
 
 def truncate_traceback(

--- a/src/inspect_ai/_util/transcript.py
+++ b/src/inspect_ai/_util/transcript.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from rich.markdown import Markdown
 
 from inspect_ai._util.content import ContentReasoning
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.text import truncate_lines
 
 from .format import format_function_call
@@ -27,6 +28,7 @@ def transcript_code_theme() -> str:
 def transcript_markdown(content: str, *, escape: bool = False) -> Markdown:
     from rich.markdown import Markdown
 
+    content = clean_control_characters(content)
     code_theme = transcript_code_theme()
     return Markdown(
         html_escape_markdown(content) if escape else content,
@@ -81,6 +83,9 @@ def transcript_panel(
 ) -> Panel:
     from rich.markdown import Markdown
 
+    title = clean_control_characters(title)
+    subtitle = clean_control_characters(subtitle) if subtitle else subtitle
+
     # resolve content to list
     if content is None:
         content = []
@@ -127,6 +132,7 @@ def transcript_panel(
 
 def content_display(text: str, max_lines: int = 50) -> list[RenderableType]:
     """Truncate text content and render as markdown."""
+    text = clean_control_characters(text)
     truncated_text, additional = truncate_lines(text, max_lines)
     content: list[RenderableType] = [transcript_markdown(truncated_text, escape=True)]
     if additional is not None:
@@ -145,7 +151,8 @@ def transcript_reasoning(reasoning: ContentReasoning) -> list[RenderableType]:
         (reasoning.reasoning or reasoning.summary or "")
         if not reasoning.redacted
         else (reasoning.summary or "Reasoning encrypted by model provider.")
-    ).strip()
+    )
+    text = clean_control_characters(text).strip()
 
     if len(text) > 0:
         truncated_text, additional = truncate_lines(text, 50)
@@ -166,7 +173,7 @@ def transcript_separator(
     title: str, color: str, characters: str = "─"
 ) -> RenderableType:
     return Rule(
-        title=title,
+        title=clean_control_characters(title),
         characters=characters,
         style=f"{color} bold",
         align="center",

--- a/src/inspect_ai/agent/_acp/tui/app.py
+++ b/src/inspect_ai/agent/_acp/tui/app.py
@@ -16,6 +16,7 @@ from typing import Any
 from textual.app import App
 from textual.binding import Binding
 
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.sockets import parse_host_port
 from inspect_ai.agent._acp.discovery import (
     TargetAddress,
@@ -111,7 +112,7 @@ class InspectAcpApp(App[None]):
             # An explicit --server that fails to parse is a CLI-level
             # error; surface to stderr + exit (we're past click's
             # parse phase but still pre-render).
-            print(str(exc), file=sys.stderr, flush=True)
+            print(clean_control_characters(str(exc)), file=sys.stderr, flush=True)
             self.exit(return_code=2)
             return
 
@@ -174,7 +175,7 @@ class InspectAcpApp(App[None]):
             return rows
         except Exception as exc:
             print(
-                f"inspect acp: enumeration failed: {exc}",
+                clean_control_characters(f"inspect acp: enumeration failed: {exc}"),
                 file=sys.stderr,
                 flush=True,
             )

--- a/src/inspect_ai/agent/_acp/tui/client.py
+++ b/src/inspect_ai/agent/_acp/tui/client.py
@@ -38,6 +38,7 @@ from acp.schema import (
 )
 
 from inspect_ai._util._async import tg_collect
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai.agent._acp._config import ACP_STREAM_BUFFER_LIMIT
 from inspect_ai.agent._acp.discovery import TargetAddress
 from inspect_ai.agent._acp.inspect_ext import (
@@ -237,7 +238,9 @@ async def enumerate_sessions(
             return await _list_for_target(eval_id, target)
         except Exception as exc:
             print(
-                f"inspect acp: failed to enumerate {target.describe()}: {exc}",
+                clean_control_characters(
+                    f"inspect acp: failed to enumerate {target.describe()}: {exc}"
+                ),
                 file=sys.stderr,
                 flush=True,
             )

--- a/src/inspect_ai/agent/_acp/tui/picker_screen.py
+++ b/src/inspect_ai/agent/_acp/tui/picker_screen.py
@@ -27,6 +27,8 @@ from textual.screen import Screen
 from textual.widgets import DataTable, Input, Markdown, Static
 from textual.widgets._data_table import CellDoesNotExist
 
+from inspect_ai._util.rich import clean_control_characters
+
 from .client import SessionRow
 from .widgets import AppFooter
 from .widgets._formatting import format_running, format_tokens
@@ -86,8 +88,8 @@ def _display_task(task: str) -> str:
     """
     head, sep, tail = task.partition("/")
     if not sep:
-        return task
-    return tail or head
+        return clean_control_characters(task)
+    return clean_control_characters(tail or head)
 
 
 def _sort_rows(rows: list[SessionRow]) -> list[SessionRow]:
@@ -210,6 +212,7 @@ def _sample_cell(sample_id: str, *, is_cursor: bool, dim: bool = False) -> Text:
     (DataTable's ``cell_padding: 1`` applies to BOTH adjacent columns,
     so an extra column adds 2 cells, not 1).
     """
+    sample_id = clean_control_characters(sample_id)
     if is_cursor:
         # ``$warning`` (warm amber in the dark theme) matches the
         # plan-overlay running-row highlight, sharing one selection
@@ -664,7 +667,9 @@ class PickerScreen(Screen[None]):
             # ``dim=True`` to every cell helper so the whole row
             # reads as muted at a glance.
             agent_cell: Text = (
-                Text("—", style="dim") if not is_acp else Text(row.agent_name or "—")
+                Text("—", style="dim")
+                if not is_acp
+                else Text(clean_control_characters(row.agent_name or "—"))
             )
             task_text = _display_task(row.task)
             task_cell = Text(task_text, style="dim")

--- a/src/inspect_ai/agent/_acp/tui/widgets/_collapsible.py
+++ b/src/inspect_ai/agent/_acp/tui/widgets/_collapsible.py
@@ -17,6 +17,7 @@ from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Static
 
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.text import truncate_lines
 
 from ._scroll import schedule_scroll_to_end_if_at_bottom
@@ -54,7 +55,7 @@ class CollapsibleContent(Widget):
 
     def __init__(self, full_text: str, *, max_lines: int) -> None:
         super().__init__()
-        self._full_text = full_text
+        self._full_text = clean_control_characters(full_text)
         self._max_lines = max_lines
         self._expanded = False
 
@@ -98,7 +99,7 @@ class CollapsibleContent(Widget):
         the body text + truncation note avoids a full re-mount that
         would flash the surrounding card.
         """
-        self._full_text = text
+        self._full_text = clean_control_characters(text)
         try:
             body_static = self.query_one("#cc-body", Static)
         except NoMatches:

--- a/src/inspect_ai/agent/_acp/tui/widgets/event_chip.py
+++ b/src/inspect_ai/agent/_acp/tui/widgets/event_chip.py
@@ -36,6 +36,11 @@ from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Static
 
+from inspect_ai._util.rich import (
+    clean_control_characters,
+    untrusted_text_from_ansi,
+)
+
 from ..state import EventChip, EventChipKind
 from ._collapsible import CollapsibleContent
 from ._scroll import schedule_scroll_to_end_if_at_bottom
@@ -180,7 +185,11 @@ class EventChipWidget(Widget):
                     # a one-line chip). Error messages are typically
                     # short; if they grow long, the traceback block
                     # below carries the deep-dive content.
-                    yield Static(body, classes="event-body-plain", markup=False)
+                    yield Static(
+                        clean_control_characters(body),
+                        classes="event-body-plain",
+                        markup=False,
+                    )
                 else:
                     yield CollapsibleContent(body, max_lines=_EVENT_BODY_MAX_LINES)
             if has_traceback:
@@ -216,7 +225,7 @@ class EventChipWidget(Widget):
             _, _, rest = summary.partition(" · ")
             rest_segments = rest.split(" · ")
             tail = " ".join(
-                f"[dim]·[/] [dim]{escape_markup(seg)}[/]"
+                f"[dim]·[/] [dim]{escape_markup(clean_control_characters(seg))}[/]"
                 for seg in rest_segments
                 if seg
             )
@@ -391,7 +400,10 @@ class _TracebackBlock(Widget):
         # through cleanly. If the wire only had the plain traceback
         # (no escape codes), ``from_ansi`` still produces a readable
         # ``Text`` — just without colour.
-        yield Static(Text.from_ansi(self._traceback), classes="traceback-body")
+        yield Static(
+            untrusted_text_from_ansi(self._traceback),
+            classes="traceback-body",
+        )
 
     def on_click(self) -> None:
         # Toggle — click expands when collapsed, collapses when
@@ -421,4 +433,4 @@ class _TracebackBlock(Widget):
             body = self.query_one(".traceback-body", Static)
         except NoMatches:
             return
-        body.update(Text.from_ansi(self._traceback))
+        body.update(untrusted_text_from_ansi(self._traceback))

--- a/src/inspect_ai/agent/_acp/tui/widgets/markdown.py
+++ b/src/inspect_ai/agent/_acp/tui/widgets/markdown.py
@@ -23,11 +23,14 @@ terminal display.
 
 from __future__ import annotations
 
+from typing import Any
+
 from rich.console import Console, ConsoleOptions, RenderResult
 from rich.markdown import CodeBlock, Heading, Markdown
 from rich.syntax import Syntax
 from rich.text import Text
 
+from inspect_ai._util.rich import clean_control_characters
 from inspect_ai._util.transcript import transcript_code_theme
 
 _CODE_BG = "#282c34"
@@ -99,6 +102,9 @@ class PlainHeading(Heading):
 
 class StyledMarkdown(Markdown):
     """Markdown variant with custom code + heading renderers."""
+
+    def __init__(self, markup: str, *args: Any, **kwargs: Any) -> None:
+        super().__init__(clean_control_characters(markup), *args, **kwargs)
 
     elements = {
         **Markdown.elements,

--- a/src/inspect_ai/agent/_acp/tui/widgets/message.py
+++ b/src/inspect_ai/agent/_acp/tui/widgets/message.py
@@ -31,6 +31,8 @@ from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Static
 
+from inspect_ai._util.rich import clean_control_characters
+
 from ..state import MessageGroup, Segment
 from ._collapsible import CollapsibleContent
 from ._formatting import SPINNER_FRAMES, format_duration
@@ -240,16 +242,18 @@ class MessageWidget(Widget):
             if self._group.is_queued:
                 base = f"{base} [dim]· queued[/dim]"
             elif self._group.user_source:
-                base = f"{base} [dim]· {self._group.user_source}[/dim]"
+                source = clean_control_characters(self._group.user_source)
+                base = f"{base} [dim]· {source}[/dim]"
             return f"[{fg}]•[/] {base}"
         # Assistant: prefer the group's own model attribution; fall back
         # to the session's current model when the chunk had no
         # `_meta["inspect.model"]` (e.g. an old server).
-        model = self._group.model or self._current_model or "—"
+        model = clean_control_characters(
+            self._group.model or self._current_model or "—"
+        )
         if self._group.fallback_model:
-            model = (
-                f"{model} [italic](fallback → {self._group.fallback_model})[/italic]"
-            )
+            fallback_model = clean_control_characters(self._group.fallback_model)
+            model = f"{model} [italic](fallback → {fallback_model})[/italic]"
         base = f"[bold {fg}]assistant[/] [dim]· {model}[/dim]"
         # Glyph prefix on every assistant chip — animated braille
         # spinner while the model event is in flight, then a small

--- a/src/inspect_ai/agent/_acp/tui/widgets/score.py
+++ b/src/inspect_ai/agent/_acp/tui/widgets/score.py
@@ -37,6 +37,8 @@ from textual.css.query import NoMatches
 from textual.widget import Widget
 from textual.widgets import Static
 
+from inspect_ai._util.rich import clean_control_characters
+
 from ..state import ScoreChip
 from ._collapsible import CollapsibleContent
 from ._formatting import SPINNER_FRAMES, format_duration
@@ -211,11 +213,11 @@ class ScoreChipWidget(Widget):
             f"[{glyph_colour}]{_SCORE_GLYPH}[/] [bold {glyph_colour}]score[/]"
         ]
         if self._chip.scorer is not None:
-            parts.append(f"[dim]·[/] [dim]{escape_markup(self._chip.scorer)}[/]")
+            scorer = escape_markup(clean_control_characters(self._chip.scorer))
+            parts.append(f"[dim]·[/] [dim]{scorer}[/]")
         if self._chip.value:
-            parts.append(
-                f"[dim]·[/] [dim]value:[/] [dim]{escape_markup(self._chip.value)}[/]"
-            )
+            value = escape_markup(clean_control_characters(self._chip.value))
+            parts.append(f"[dim]·[/] [dim]value:[/] [dim]{value}[/]")
         return " ".join(parts)
 
     def _indicator_text(self) -> str:
@@ -238,7 +240,8 @@ class ScoreChipWidget(Widget):
         ]
         scorer_name = self._chip.scorer_name
         if scorer_name:
-            parts.append(f"[dim]·[/] [dim]{escape_markup(scorer_name)}[/]")
+            scorer_name = escape_markup(clean_control_characters(scorer_name))
+            parts.append(f"[dim]·[/] [dim]{scorer_name}[/]")
         elapsed = self._elapsed_str()
         if elapsed:
             parts.append(f"[dim]·[/] [dim]{elapsed}[/]")

--- a/src/inspect_ai/agent/_acp/tui/widgets/tool_call.py
+++ b/src/inspect_ai/agent/_acp/tui/widgets/tool_call.py
@@ -815,13 +815,15 @@ def compose_content_item(item: object, *, context_id: str = "") -> ComposeResult
 
 def compose_diff_item(item: object) -> ComposeResult:
     """Render a ``FileEditToolCallContent`` (ACP ``Diff`` variant)."""
-    path = getattr(item, "path", "?")
+    path = clean_control_characters(str(getattr(item, "path", "?")))
     old_text = getattr(item, "old_text", None)
     new_text = getattr(item, "new_text", "") or ""
     yield Static(f"--- {path}", classes="diff-header", markup=False)
     if old_text:
+        old_text = clean_control_characters(str(old_text))
         for line in old_text.splitlines() or [""]:
             yield Static(f"- {line}", classes="diff-old", markup=False)
+    new_text = clean_control_characters(str(new_text))
     for line in new_text.splitlines() or [""]:
         yield Static(f"+ {line}", classes="diff-new", markup=False)
 

--- a/tests/display/test_terminal_text.py
+++ b/tests/display/test_terminal_text.py
@@ -1,0 +1,180 @@
+import io
+import unicodedata
+
+from rich.console import Console
+from rich.style import Style
+from rich.text import Text
+
+from inspect_ai._display.core.config import task_config
+from inspect_ai._display.core.display import TaskProfile
+from inspect_ai._display.core.panel import task_panel
+from inspect_ai._display.textual.widgets.transcript import (
+    render_error_event,
+    render_score_event,
+)
+from inspect_ai._util.error import EvalError
+from inspect_ai._util.rich import (
+    clean_control_characters,
+    rich_traceback,
+    untrusted_text_from_ansi,
+)
+from inspect_ai._util.transcript import transcript_markdown
+from inspect_ai.agent._acp.tui.state import ScoreChip
+from inspect_ai.agent._acp.tui.widgets._collapsible import CollapsibleContent
+from inspect_ai.agent._acp.tui.widgets.markdown import StyledMarkdown
+from inspect_ai.agent._acp.tui.widgets.score import ScoreChipWidget
+from inspect_ai.event import ErrorEvent, ScoreEvent
+from inspect_ai.log import EvalConfig
+from inspect_ai.model import GenerateConfig, ModelName
+from inspect_ai.scorer import Score
+
+PAYLOAD = (
+    "VISIBLE-BEFORE"
+    "\x1b[2J"
+    "\x1b[H"
+    "FORGED-SCREEN"
+    "\x1b]52;c;UEFTVEVfSElKQUNL\x07"
+    "\x1b]8;;file:///etc/passwd\x1b\\"
+    "DISGUISED-LINK"
+    "\x1b]8;;\x1b\\"
+    "\x9b2J"
+    "\x9d52;c;UEFTVEVfSElKQUNL\x9c"
+    "\r\b\x00\x7f"
+    "VISIBLE-AFTER"
+    "\nNEXT\tCELL"
+)
+
+
+def _render(renderable: object) -> str:
+    stream = io.StringIO()
+    console = Console(
+        file=stream,
+        force_terminal=False,
+        color_system=None,
+        width=1000,
+    )
+    console.print(renderable)
+    return stream.getvalue()
+
+
+def _assert_safe(text: str) -> None:
+    assert all(
+        char in "\n\t" or unicodedata.category(char) not in ("Cc", "Cf")
+        for char in text
+    )
+    assert "VISIBLE-BEFORE" in text
+    assert "VISIBLE-AFTER" in text
+
+
+def test_clean_control_characters_preserves_visible_text_and_whitespace() -> None:
+    cleaned = clean_control_characters(PAYLOAD)
+
+    _assert_safe(cleaned)
+    assert "\nNEXT\tCELL" in cleaned
+
+
+def test_transcript_markdown_removes_terminal_controls() -> None:
+    output = _render(transcript_markdown(PAYLOAD, escape=True))
+
+    _assert_safe(output)
+
+
+def test_score_event_removes_controls_from_all_text_fields() -> None:
+    event = ScoreEvent(
+        score=Score(
+            value=PAYLOAD,
+            answer=PAYLOAD,
+            explanation=PAYLOAD,
+        ),
+        target=PAYLOAD,
+    )
+
+    output = _render(render_score_event(event).content)
+
+    _assert_safe(output)
+    assert output.count("VISIBLE-BEFORE") == 4
+
+
+def test_error_event_and_rich_traceback_remove_terminal_controls() -> None:
+    event = ErrorEvent(
+        error=EvalError(
+            message=PAYLOAD,
+            traceback=PAYLOAD,
+            traceback_ansi=PAYLOAD,
+        )
+    )
+    _assert_safe(_render(render_error_event(event).content))
+
+    try:
+        raise RuntimeError(PAYLOAD)
+    except RuntimeError as ex:
+        output = _render(rich_traceback(type(ex), ex, ex.__traceback__))
+
+    _assert_safe(output)
+
+
+def test_task_panel_cleans_metadata_and_filename_content() -> None:
+    profile = TaskProfile(
+        name=PAYLOAD,
+        file=None,
+        model=ModelName("mockllm/model"),
+        agent=None,
+        dataset=PAYLOAD,
+        scorer=PAYLOAD,
+        samples=1,
+        steps=1,
+        eval_config=EvalConfig(),
+        task_args={"metadata": PAYLOAD},
+        generate_config=GenerateConfig(),
+        tags=None,
+        log_location=f"/tmp/{PAYLOAD}.eval",
+        task_id="task",
+        task_cancel=None,
+    )
+    panel = task_panel(
+        profile=profile,
+        show_model=True,
+        body=Text(PAYLOAD),
+        subtitle=task_config(profile),
+        footer=None,
+        log_location=profile.log_location,
+    )
+
+    _assert_safe(_render(panel))
+
+
+def test_untrusted_ansi_keeps_visual_style_but_drops_links_and_controls() -> None:
+    text = untrusted_text_from_ansi(f"\x1b[31mred\x1b[0m {PAYLOAD}")
+
+    _assert_safe(text.plain)
+    assert any(
+        isinstance(span.style, Style) and span.style.color is not None
+        for span in text.spans
+    )
+    assert all(
+        not isinstance(span.style, Style) or span.style.link is None
+        for span in text.spans
+    )
+
+
+def test_acp_markdown_and_collapsible_content_clean_before_layout() -> None:
+    markdown = StyledMarkdown(PAYLOAD)
+    collapsible = CollapsibleContent(PAYLOAD, max_lines=5)
+
+    _assert_safe(markdown.markup)
+    _assert_safe(collapsible._full_text)
+
+
+def test_acp_score_header_removes_controls() -> None:
+    chip = ScoreChip(
+        scorer=PAYLOAD,
+        value=PAYLOAD,
+        passed=None,
+        answer=None,
+        reason=None,
+        chip_id="score",
+    )
+
+    output = ScoreChipWidget(chip)._chip_text()
+
+    _assert_safe(output)

--- a/tests/util/test_logger_format.py
+++ b/tests/util/test_logger_format.py
@@ -6,9 +6,19 @@ from types import TracebackType
 from typing import Any
 
 import pytest
+from rich.style import Style
+from rich.text import Text
 
 from inspect_ai._util.error import PrerequisiteError
 from inspect_ai._util.logger import LogHandler, logger_display_format
+
+CONTROL_PAYLOAD = (
+    "before"
+    "\x1b[2J"
+    "\x1b]52;c;UEFTVEVfSElKQUNL\x07"
+    "\x1b]8;;file:///etc/passwd\x1b\\link\x1b]8;;\x1b\\"
+    "after"
+)
 
 
 def log_record(
@@ -140,3 +150,49 @@ def test_plain_logger_format_escapes_newlines_in_exception(
     assert output.count("\n") == 1
     assert "\\n" in output
     assert "ValueError: boom" in output
+
+
+def test_plain_logger_format_removes_terminal_controls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("INSPECT_TRACE_LEVEL", "info")
+    stream = io.StringIO()
+    handler = LogHandler(
+        capture_levelno=INFO,
+        display_levelno=INFO,
+        transcript_levelno=0,
+        trace_dir=tmp_path,
+        logger_format="plain",
+        display_stream=stream,
+    )
+
+    handler.emit_display(log_record(CONTROL_PAYLOAD))
+
+    output = stream.getvalue()
+    assert "\x1b" not in output
+    assert "before" in output
+    assert "after" in output
+
+
+def test_rich_logger_format_removes_terminal_links_and_controls(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    monkeypatch.setenv("INSPECT_TRACE_LEVEL", "info")
+    handler = LogHandler(
+        capture_levelno=INFO,
+        display_levelno=INFO,
+        transcript_levelno=0,
+        trace_dir=tmp_path,
+        logger_format="rich",
+    )
+
+    rendered = handler.render_message(log_record(CONTROL_PAYLOAD), CONTROL_PAYLOAD)
+
+    assert isinstance(rendered, Text)
+    assert "\x1b" not in rendered.plain
+    assert "before" in rendered.plain
+    assert "after" in rendered.plain
+    assert all(
+        not isinstance(span.style, Style) or span.style.link is None
+        for span in rendered.spans
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Assistant output, scores, errors, metadata, filenames, and log messages can reach Rich/Textual containing raw terminal controls. Payloads containing CSI screen commands, OSC 8 hyperlinks, or OSC 52 clipboard writes can therefore survive terminal rendering.

Inspect already removes these characters from untrusted tool output. The wider pass-through appears accidental: terminal Markdown was intentionally retained, as were Inspect-generated ANSI tracebacks and locally recorded operator input, but there is no documented intent to execute terminal controls supplied by model or artifact content.

### What is the new behavior?

The existing `clean_control_characters()` boundary is applied before Markdown parsing, truncation, layout, or Rich markup across transcript, score, error, task-panel, logging, filename, and ACP TUI surfaces.

A narrow ANSI conversion path retains ordinary visual SGR styling for generated tracebacks while dropping terminal commands and OSC hyperlinks. Nested Rich renderables are also cleaned as defense in depth without removing framework-generated cursor or color controls.

Stored logs remain unchanged, and the trusted `InputEvent.input_ansi` replay path remains intact.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No API change. Raw controls embedded in untrusted terminal text no longer affect terminal state or create hyperlinks. Visible text, tabs, newlines, Markdown formatting, and generated traceback colors remain available.

### Other information:

Regression payloads cover CSI clear/home, OSC 8, OSC 52, C0/C1 controls, carriage return, backspace, NUL, and DEL.

Verification:
- `pytest -q tests/display tests/util/test_logger_format.py tests/util/test_rich_traceback.py`
- `pytest -q --runslow -n0 tests/agent/test_acp/test_tui/test_event_chip_widget.py tests/agent/test_acp/test_tui/test_widgets.py`
- focused `mypy` over all changed Python modules
- `ruff check` and `ruff format --check` over all changed Python files

### Related PR

- Scout scanner terminal rendering: meridianlabs-ai/inspect_scout#480