### PR TITLE
Fix slow header-only reads of large .json eval logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ## Unreleased
 
-- Log: Header-only reads of `.json` eval logs no longer parse the entire `samples` array, making header reads of large logs dramatically faster (e.g. a 29MB log: ~47s -> ~0.4s).
 - Log: Shared sample buffer files synced to S3 (via `--log-shared`) are now tagged `inspect-ephemeral=true` so they can be targeted by an S3 lifecycle rule.
 - Log: Reading sample summaries from an in-progress `.eval` on a remote filesystem (e.g. S3) now fetches the per-sample journal summary files concurrently, reducing load time for logs with many samples.
 - Log: Sample event condensing is now linear, not quadratic, in conversation length.
@@ -34,6 +33,7 @@
 - Security: Apply the `data` tar filter when extracting sandbox checkpoint egress tarballs on the host, preventing a sandboxed agent from writing files outside the destination repo via crafted `..`/absolute-path/symlink entries.
 - Bugfix: Keep torn checkpoint files out of remote egress uploads and manifests so resumed runs can repair and ship reused checkpoint ids.
 - Bugfix: Make the no-op trailing-separator strip in `FileSystem.is_writeable()` actually take effect, avoiding a double-separator write-test path for direct callers.
+- Bugfix: Header-only reads of `.json` eval logs no longer parse the entire `samples` array, making header reads of large logs dramatically faster (e.g. a 29MB S3 log: ~47s -> ~0.4s).
 
 ## 0.3.241 (22 June 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Log: Header-only reads of `.json` eval logs no longer parse the entire `samples` array, making header reads of large logs dramatically faster (e.g. a 29MB log: ~47s -> ~0.4s).
 - Log: Shared sample buffer files synced to S3 (via `--log-shared`) are now tagged `inspect-ephemeral=true` so they can be targeted by an S3 lifecycle rule.
 - Log: Reading sample summaries from an in-progress `.eval` on a remote filesystem (e.g. S3) now fetches the per-sample journal summary files concurrently, reducing load time for logs with many samples.
 - Log: Sample event condensing is now linear, not quadratic, in conversation length.

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -364,21 +364,35 @@ async def _s3_read_with_etag(
         return content, etag
 
 
+def _scan_header_keys(f: IO[bytes]) -> tuple[int | None, str]:
+    """Stream a JSON eval log's top-level keys, stopping at ``samples``.
+
+    Reads only as far as the start of the (potentially huge) ``samples`` array
+    and returns ``(version, last_header_field)`` — the log version and the name
+    of the last header field seen. The second pass stops re-parsing once it has
+    consumed ``last_header_field``, so it never has to materialize ``samples``.
+    Consumes ``f``; callers re-parsing the same handle must ``seek(0)`` after.
+    """
+    version: int | None = None
+    last_header_field = "stats"
+
+    for prefix, event, value in ijson.parse(f):
+        if (prefix, event) == ("version", "number"):
+            version = value
+        elif prefix == "samples":
+            # Break as soon as we hit samples as that can be very large
+            break
+        elif event == "map_key" and prefix == "":
+            last_header_field = value
+
+    return version, last_header_field
+
+
 def _read_header_streaming(log_file: str) -> EvalLog:
     with file(log_file, "rb") as f:
         # Do low-level parsing to get the version number and also
         # detect the presence of results or error sections
-        version: int | None = None
-        last_header_field = "stats"
-
-        for prefix, event, value in ijson.parse(f):
-            if (prefix, event) == ("version", "number"):
-                version = value
-            elif prefix == "samples":
-                # Break as soon as we hit samples as that can be very large
-                break
-            elif event == "map_key" and prefix == "":
-                last_header_field = value
+        version, last_header_field = _scan_header_keys(f)
 
         if version is None:
             raise ValueError("Unable to read version of log format.")

--- a/src/inspect_ai/log/_recorders/json.py
+++ b/src/inspect_ai/log/_recorders/json.py
@@ -379,10 +379,13 @@ def _scan_header_keys(f: IO[bytes]) -> tuple[int | None, str]:
     for prefix, event, value in ijson.parse(f):
         if (prefix, event) == ("version", "number"):
             version = value
-        elif prefix == "samples":
-            # Break as soon as we hit samples as that can be very large
-            break
         elif event == "map_key" and prefix == "":
+            # Stop at the top-level `samples` key, which can be enormous. Break
+            # *before* recording it: `samples` must not become last_header_field
+            # or the second pass would have to materialize the whole array to
+            # reach it. last_header_field stays the last real header field.
+            if value == "samples":
+                break
             last_header_field = value
 
     return version, last_header_field

--- a/tests/log/test_read_header_streaming.py
+++ b/tests/log/test_read_header_streaming.py
@@ -1,0 +1,19 @@
+import io
+
+from inspect_ai.log._recorders.json import _scan_header_keys
+
+
+def test_scan_header_keys_stops_at_last_header_field_not_samples():
+    """Pass 1 must report the last *header* field, never `samples` itself.
+
+    ijson emits the top-level `samples` key as a `map_key` event *before* its
+    `start_array` event, so the scan loop records `last_header_field = "samples"`
+    before it breaks. Pass 2 then can't stop until it has materialized the entire
+    `samples` array. For this payload the last header field is `status`.
+    """
+    payload = b'{"version": 2, "status": "success", "samples": [{"id": 1}]}'
+
+    version, last_header_field = _scan_header_keys(io.BytesIO(payload))
+
+    assert version == 2
+    assert last_header_field == "status"


### PR DESCRIPTION
### What is the current behavior? (You can also link to an open issue here)

A header-only read of a `.json` eval log (`read_eval_log(..., header_only=True)`, and the `/log-headers` path that Inspect View uses to populate the log list) parses the **entire** `samples` array even though the header excludes samples. For large logs this is very slow — a 29 MB log on S3 takes ~47s for a single header read. Because the viewer fetches a header for every log in the directory, these serialize into multi-minute stalls when browsing a directory of large `.json` logs.

Root cause is in `_read_header_streaming`, which makes two `ijson` passes. Pass 1 records the name of the last top-level header field so pass 2 knows where to stop re-parsing (before `samples`). But `ijson` emits the top-level `samples` key as a `map_key` event *before* its `start_array` event, and the loop recorded that `map_key` — leaving `last_header_field == "samples"`. Pass 2 then could not stop until `ijson.kvitems` yielded the fully-materialized `samples` value, forcing it to parse the whole array just to throw it away.

### What is the new behavior?

Pass 1 (extracted into `_scan_header_keys` for testability) now breaks on the top-level `samples` key *before* recording it, so `last_header_field` stays the last real header field. A header-only read stops at the header and never materializes `samples`. The same 29 MB S3 log now reads its header in ~0.4s (a ~100x improvement), and the returned header is unchanged. A focused regression test asserts `_scan_header_keys` returns the last header field rather than `"samples"`.

Only the single-file `.json` format was affected; `.eval` (zip) logs already read their header as a discrete member and were not impacted.