### PR TITLE
Inspect View: scope filesystem access to selected paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Inspect View: Canonically scope standalone file access to the configured log directory and add opt-in per-request file/directory capabilities for authorized VS Code sessions.
 - Log: Shared sample buffer files synced to S3 (via `--log-shared`) are now tagged `inspect-ephemeral=true` so they can be targeted by an S3 lifecycle rule.
 - Log: Reading sample summaries from an in-progress `.eval` on a remote filesystem (e.g. S3) now fetches the per-sample journal summary files concurrently, reducing load time for logs with many samples.
 - Log: Sample event condensing is now linear, not quadratic, in conversation length.

--- a/src/inspect_ai/_cli/view.py
+++ b/src/inspect_ai/_cli/view.py
@@ -26,6 +26,12 @@ def start_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
         help="Tcp/Ip host. Note: you can use `0.0.0.0` to expose the viewer and connect remotely (e.g. SSH).",
     )
     @click.option("--port", default=DEFAULT_VIEW_PORT, help="TCP/IP port")
+    @click.option(
+        "--scoped-authorization",
+        is_flag=True,
+        hidden=True,
+        help="Require extension-supplied path scopes on authorized requests.",
+    )
     @functools.wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> click.Context:
         return cast(click.Context, func(*args, **kwargs))
@@ -56,6 +62,7 @@ def start(
     recursive: bool,
     host: str,
     port: int,
+    scoped_authorization: bool,
     **common: Unpack[CommonOptions],
 ) -> None:
     """View evaluation logs."""
@@ -81,6 +88,7 @@ def start(
         port=port,
         authorization=authorization,
         log_level=common["log_level"],
+        scoped_authorization=scoped_authorization,
     )
 
 

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -3,11 +3,10 @@ import binascii
 import json
 import logging
 import os
-import urllib.parse
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Protocol, cast
+from typing import Any, Literal, Protocol, cast
 
 import anyio
 import uvicorn
@@ -59,6 +58,7 @@ from inspect_ai._view.path_scope import (
     VIEW_SCOPE_KIND_HEADER,
     PathScope,
     PathScopeKind,
+    canonical_path_location,
 )
 from inspect_ai._view.scout_routes import get_scout_search_router
 from inspect_ai._view.user_info import UserInfo, user_info
@@ -132,25 +132,42 @@ def view_server_app(
             return await mapping_policy.unmap(request, file)
         return file
 
-    async def _validate_read(request: Request, file: str) -> None:
-        if access_policy is not None:
-            if not await access_policy.can_read(request, file):
-                raise HTTPException(status_code=HTTP_403_FORBIDDEN)
+    async def _resolve_access(
+        request: Request,
+        file: str,
+        operation: Literal["read", "delete", "write", "list"],
+    ) -> str:
+        normalized = normalize_uri(file)
+        canonical = canonical_path_location(file) or normalized
+        if access_policy is None:
+            return normalized if mapping_policy is not None else canonical
 
-    async def _validate_delete(request: Request, file: str) -> None:
-        if access_policy is not None:
-            if not await access_policy.can_delete(request, file):
+        # Resolving policies return the canonical location that was authorized.
+        # Explicit mapping policies translate from the caller-facing namespace
+        # and therefore receive the normalized external location.
+        resolver = getattr(access_policy, f"resolve_{operation}", None)
+        if resolver is not None:
+            resolved: str | None = await resolver(request, file)
+            if resolved is None:
                 raise HTTPException(status_code=HTTP_403_FORBIDDEN)
+            return normalized if mapping_policy is not None else resolved
 
-    async def _validate_write(request: Request, file: str) -> None:
-        if access_policy is not None:
-            if not await access_policy.can_write(request, file):
-                raise HTTPException(status_code=HTTP_403_FORBIDDEN)
+        validator = getattr(access_policy, f"can_{operation}")
+        if not await validator(request, normalized):
+            raise HTTPException(status_code=HTTP_403_FORBIDDEN)
+        return normalized if mapping_policy is not None else canonical
 
-    async def _validate_list(request: Request, file: str) -> None:
-        if access_policy is not None:
-            if not await access_policy.can_list(request, file):
-                raise HTTPException(status_code=HTTP_403_FORBIDDEN)
+    async def _validate_read(request: Request, file: str) -> str:
+        return await _resolve_access(request, file, "read")
+
+    async def _validate_delete(request: Request, file: str) -> str:
+        return await _resolve_access(request, file, "delete")
+
+    async def _validate_write(request: Request, file: str) -> str:
+        return await _resolve_access(request, file, "write")
+
+    async def _validate_list(request: Request, file: str) -> str:
+        return await _resolve_access(request, file, "list")
 
     def _validate_mutating_request(request: Request) -> None:
         if request.headers.get(VIEW_REQUEST_HEADER) != VIEW_REQUEST_HEADER_VALUE:
@@ -166,22 +183,19 @@ def view_server_app(
         log: str,
         header_only: str | None = Query(None, alias="header-only"),
     ) -> Response:
-        file = normalize_uri(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
         body, etag = await get_log_file(await _map_file(request, file), header_only)
         headers = {"ETag": etag} if etag is not None else {}
         return Response(content=body, media_type="application/json", headers=headers)
 
     @app.get("/log-size/{log:path}")
     async def api_log_size(request: Request, log: str) -> int:
-        file = normalize_uri(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
         return await get_log_size(await _map_file(request, file))
 
     @app.get("/log-info/{log:path}", response_model_exclude_none=True)
     async def api_log_info(request: Request, log: str) -> LogInfo:
-        file = normalize_uri(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
         return await get_log_info(
             await _map_file(request, file),
             generate_direct_url=generate_direct_urls,
@@ -190,16 +204,14 @@ def view_server_app(
     @app.delete("/log-delete/{log:path}")
     async def api_log_delete(request: Request, log: str) -> bool:
         _validate_mutating_request(request)
-        file = normalize_uri(log)
-        await _validate_delete(request, file)
+        file = await _validate_delete(request, log)
         await delete_log(await _map_file(request, file))
         return True
 
     @app.post("/log-edit/{log:path}", response_model=EvalLog)
     async def api_log_edit(request: Request, log: str, update: LogUpdate) -> Response:
         _validate_mutating_request(request)
-        file = normalize_uri(log)
-        await _validate_write(request, file)
+        file = await _validate_write(request, log)
         if_match = request.headers.get("If-Match")
         try:
             contents, new_etag = await apply_log_edits(
@@ -225,8 +237,7 @@ def view_server_app(
         start: int = Query(...),
         end: int = Query(...),
     ) -> Response:
-        file = normalize_uri(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
         mapped_file = await _map_file(request, file)
 
         # Get actual file size to clamp the requested range
@@ -267,8 +278,7 @@ def view_server_app(
         request: Request,
         log: str,
     ) -> Response:
-        file = normalize_uri(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
 
         mapped_file = await _map_file(request, file)
 
@@ -303,7 +313,7 @@ def view_server_app(
     ) -> LogDirResponse:
         if log_dir is None:
             log_dir = default_dir
-        await _validate_list(request, log_dir)
+        log_dir = await _validate_list(request, log_dir)
         return get_log_dir(log_dir)
 
     @app.get("/log-files", response_class=InspectJsonResponse)
@@ -313,7 +323,7 @@ def view_server_app(
     ) -> LogFilesResponse:
         if log_dir is None:
             log_dir = default_dir
-        await _validate_list(request, log_dir)
+        log_dir = await _validate_list(request, log_dir)
 
         client_etag = request.headers.get("If-None-Match")
         mtime = 0.0
@@ -340,7 +350,7 @@ def view_server_app(
     ) -> LogListingResponse | Response:
         if log_dir is None:
             log_dir = default_dir
-        await _validate_list(request, log_dir)
+        log_dir = await _validate_list(request, log_dir)
         listing = await get_logs(
             await _map_file(request, log_dir),
             recursive=recursive,
@@ -373,7 +383,7 @@ def view_server_app(
             eval_set_dir = base_dir
 
         # validate that the directory can be listed
-        await _validate_list(request, eval_set_dir)
+        eval_set_dir = await _validate_list(request, eval_set_dir)
 
         # return the eval set info for this directory
         return read_eval_set_info(
@@ -396,7 +406,7 @@ def view_server_app(
             flow_dir = base_dir
 
         # validate that the directory can be listed
-        await _validate_list(request, flow_dir)
+        flow_dir = await _validate_list(request, flow_dir)
 
         mapped_dir = await _map_file(request, flow_dir)
         fs = filesystem(mapped_dir)
@@ -418,12 +428,12 @@ def view_server_app(
     async def api_log_headers(
         request: Request, file: list[str] = Query([])
     ) -> list[EvalLog]:
-        files = [normalize_uri(f) for f in file]
+        files = list(file)
         mapped_files: list[str] = [""] * len(files)
 
         async def _validate_and_map(idx: int, f: str) -> None:
-            await _validate_read(request, f)
-            mapped_files[idx] = await _map_file(request, f)
+            resolved = await _validate_read(request, f)
+            mapped_files[idx] = await _map_file(request, resolved)
 
         async with anyio.create_task_group() as tg:
             for i, f in enumerate(files):
@@ -451,8 +461,7 @@ def view_server_app(
     async def api_pending_samples(
         request: Request, response: Response, log: str = Query(...)
     ) -> Samples | Response:
-        file = urllib.parse.unquote(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
 
         client_etag = request.headers.get("If-None-Match")
 
@@ -471,8 +480,7 @@ def view_server_app(
         request: Request, log_file: str, message: str
     ) -> Response:
         _validate_mutating_request(request)
-        file = urllib.parse.unquote(log_file)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log_file)
 
         logger = logging.getLogger(__name__)
         logger.warning(f"[CLIENT MESSAGE] ({file}): {message}")
@@ -494,8 +502,7 @@ def view_server_app(
         after_message_pool_id: int | None = Query(None, alias="after-message-pool-id"),
         after_call_pool_id: int | None = Query(None, alias="after-call-pool-id"),
     ) -> SampleData | Response:
-        file = urllib.parse.unquote(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
 
         buffer = sample_buffer(await _map_file(request, file))
         sample_data = buffer.get_sample_data(
@@ -530,8 +537,7 @@ def view_server_app(
         max_segments: int | None = Query(None, alias="max-segments"),
         tail: bool = Query(False),
     ) -> PendingSampleUrls | Response:
-        file = urllib.parse.unquote(log)
-        await _validate_read(request, file)
+        file = await _validate_read(request, log)
 
         mapped = await _map_file(request, file)
         body = await build_pending_sample_urls(
@@ -567,7 +573,10 @@ def view_server_app(
                 ).decode()
             except (binascii.Error, UnicodeDecodeError, ValueError):
                 raise HTTPException(status_code=400, detail="Invalid transcript path")
-            await _validate_read(request, transcript_dir)
+            transcript_dir = await _validate_read(request, transcript_dir)
+            request.path_params["dir"] = (
+                base64.urlsafe_b64encode(transcript_dir.encode()).decode().rstrip("=")
+            )
 
         app.include_router(
             scout_router,
@@ -634,6 +643,21 @@ class OnlyDirAccessPolicy(AccessPolicy):
     def _validate_log_dir(self, file: str) -> bool:
         return self._scope.allows(file)
 
+    def _resolve_log_dir(self, file: str) -> str | None:
+        return self._scope.resolve(file)
+
+    async def resolve_read(self, request: Request, file: str) -> str | None:
+        return self._resolve_log_dir(file)
+
+    async def resolve_delete(self, request: Request, file: str) -> str | None:
+        return self._resolve_log_dir(file)
+
+    async def resolve_list(self, request: Request, dir: str) -> str | None:
+        return self._resolve_log_dir(dir)
+
+    async def resolve_write(self, request: Request, file: str) -> str | None:
+        return self._resolve_log_dir(file)
+
     async def can_read(self, request: Request, file: str) -> bool:
         return self._validate_log_dir(file)
 
@@ -665,20 +689,36 @@ class ScopedAuthorizationAccessPolicy(AccessPolicy):
             return None
 
     async def can_read(self, request: Request, file: str) -> bool:
+        return await self.resolve_read(request, file) is not None
+
+    async def resolve_read(self, request: Request, file: str) -> str | None:
         scope = self._request_scope(request)
-        return scope is not None and scope.allows(file)
+        return scope.resolve(file) if scope is not None else None
 
     async def can_delete(self, request: Request, file: str) -> bool:
+        return await self.resolve_delete(request, file) is not None
+
+    async def resolve_delete(self, request: Request, file: str) -> str | None:
         scope = self._request_scope(request)
-        return scope is not None and scope.allows(file)
+        return scope.resolve(file) if scope is not None else None
 
     async def can_list(self, request: Request, dir: str) -> bool:
+        return await self.resolve_list(request, dir) is not None
+
+    async def resolve_list(self, request: Request, dir: str) -> str | None:
         scope = self._request_scope(request)
-        return scope is not None and scope.kind == "directory" and scope.allows(dir)
+        return (
+            scope.resolve(dir)
+            if scope is not None and scope.kind == "directory"
+            else None
+        )
 
     async def can_write(self, request: Request, file: str) -> bool:
+        return await self.resolve_write(request, file) is not None
+
+    async def resolve_write(self, request: Request, file: str) -> str | None:
         scope = self._request_scope(request)
-        return scope is not None and scope.allows(file)
+        return scope.resolve(file) if scope is not None else None
 
 
 def view_server(

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import json
 import logging
 import os
@@ -5,11 +7,11 @@ import urllib.parse
 from io import BytesIO
 from logging import getLogger
 from pathlib import Path
-from typing import Any, Protocol
+from typing import Any, Protocol, cast
 
 import anyio
 import uvicorn
-from fastapi import FastAPI, HTTPException, Query, Request, Response
+from fastapi import Depends, FastAPI, HTTPException, Query, Request, Response
 from fastapi.responses import StreamingResponse
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
 from starlette.responses import JSONResponse
@@ -51,6 +53,12 @@ from inspect_ai._view.common import (
     normalize_uri,
     parse_log_token,
     stream_log_bytes,
+)
+from inspect_ai._view.path_scope import (
+    VIEW_SCOPE_HEADER,
+    VIEW_SCOPE_KIND_HEADER,
+    PathScope,
+    PathScopeKind,
 )
 from inspect_ai._view.scout_routes import get_scout_search_router
 from inspect_ai._view.user_info import UserInfo, user_info
@@ -547,7 +555,25 @@ def view_server_app(
 
     scout_router = get_scout_search_router()
     if scout_router is not None:
-        app.include_router(scout_router, prefix="/scout")
+
+        async def _validate_scout_route_scope(request: Request) -> None:
+            encoded_dir = request.path_params.get("dir")
+            if encoded_dir is None:
+                return
+            try:
+                padding = "=" * (-len(encoded_dir) % 4)
+                transcript_dir = base64.urlsafe_b64decode(
+                    encoded_dir + padding
+                ).decode()
+            except (binascii.Error, UnicodeDecodeError, ValueError):
+                raise HTTPException(status_code=400, detail="Invalid transcript path")
+            await _validate_read(request, transcript_dir)
+
+        app.include_router(
+            scout_router,
+            prefix="/scout",
+            dependencies=[Depends(_validate_scout_route_scope)],
+        )
 
     return app
 
@@ -603,10 +629,10 @@ class _InspectStaticFiles(StaticFiles):
 class OnlyDirAccessPolicy(AccessPolicy):
     def __init__(self, dir: str) -> None:
         super().__init__()
-        self.dir = dir
+        self._scope = PathScope.parse("directory", dir)
 
     def _validate_log_dir(self, file: str) -> bool:
-        return file.startswith(self.dir) and ".." not in file
+        return self._scope.allows(file)
 
     async def can_read(self, request: Request, file: str) -> bool:
         return self._validate_log_dir(file)
@@ -621,6 +647,40 @@ class OnlyDirAccessPolicy(AccessPolicy):
         return self._validate_log_dir(file)
 
 
+class ScopedAuthorizationAccessPolicy(AccessPolicy):
+    def _request_scope(self, request: Request) -> PathScope | None:
+        scope_values = request.headers.getlist(VIEW_SCOPE_HEADER)
+        kind_values = request.headers.getlist(VIEW_SCOPE_KIND_HEADER)
+        if len(scope_values) != 1 or len(kind_values) != 1:
+            return None
+        kind = kind_values[0]
+        if kind not in ("directory", "file"):
+            return None
+        try:
+            return PathScope.parse(
+                kind=cast(PathScopeKind, kind),
+                location=scope_values[0],
+            )
+        except ValueError:
+            return None
+
+    async def can_read(self, request: Request, file: str) -> bool:
+        scope = self._request_scope(request)
+        return scope is not None and scope.allows(file)
+
+    async def can_delete(self, request: Request, file: str) -> bool:
+        scope = self._request_scope(request)
+        return scope is not None and scope.allows(file)
+
+    async def can_list(self, request: Request, dir: str) -> bool:
+        scope = self._request_scope(request)
+        return scope is not None and scope.kind == "directory" and scope.allows(dir)
+
+    async def can_write(self, request: Request, file: str) -> bool:
+        scope = self._request_scope(request)
+        return scope is not None and scope.allows(file)
+
+
 def view_server(
     log_dir: str,
     recursive: bool = True,
@@ -629,7 +689,11 @@ def view_server(
     authorization: str | None = None,
     fs_options: dict[str, Any] = {},
     generate_direct_urls: bool = False,
+    scoped_authorization: bool = False,
 ) -> None:
+    if scoped_authorization and not authorization:
+        raise ValueError("Scoped authorization requires request authorization.")
+
     # get filesystem and resolve log_dir to full path
     fs = filesystem(log_dir)
     if not fs.exists(log_dir):
@@ -637,9 +701,16 @@ def view_server(
     log_dir = fs.info(log_dir).name
 
     # setup server
+    if scoped_authorization:
+        access_policy: AccessPolicy | None = ScopedAuthorizationAccessPolicy()
+    elif authorization:
+        access_policy = None
+    else:
+        access_policy = OnlyDirAccessPolicy(log_dir)
+
     api = view_server_app(
         mapping_policy=None,
-        access_policy=OnlyDirAccessPolicy(log_dir) if not authorization else None,
+        access_policy=access_policy,
         default_dir=log_dir,
         recursive=recursive,
         fs_options=fs_options,

--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -657,7 +657,7 @@ class ScopedAuthorizationAccessPolicy(AccessPolicy):
         if kind not in ("directory", "file"):
             return None
         try:
-            return PathScope.parse(
+            return PathScope.parse_canonical(
                 kind=cast(PathScopeKind, kind),
                 location=scope_values[0],
             )

--- a/src/inspect_ai/_view/path_scope.py
+++ b/src/inspect_ai/_view/path_scope.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import os
+import posixpath
+import re
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+from fsspec.core import split_protocol  # type: ignore
+
+VIEW_SCOPE_HEADER = "X-Inspect-View-Scope"
+VIEW_SCOPE_KIND_HEADER = "X-Inspect-View-Scope-Kind"
+
+PathScopeKind = Literal["directory", "file"]
+
+_WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
+
+
+@dataclass(frozen=True)
+class _RemotePath:
+    scheme: str
+    authority: str
+    path: PurePosixPath
+
+
+@dataclass(frozen=True)
+class PathScope:
+    """Canonical filesystem or remote-object capability."""
+
+    kind: PathScopeKind
+    _local: Path | None
+    _remote: _RemotePath | None
+
+    @classmethod
+    def parse(cls, kind: PathScopeKind, location: str) -> "PathScope":
+        local = _canonical_local_path(location)
+        remote = None if local is not None else _canonical_remote_path(location)
+        if local is None and remote is None:
+            raise ValueError(f"Invalid viewer path scope: {location}")
+        if kind == "directory" and remote and remote.scheme in ("http", "https"):
+            raise ValueError(f"Unsupported viewer directory scheme: {remote.scheme}")
+        return cls(kind=kind, _local=local, _remote=remote)
+
+    def allows(self, location: str) -> bool:
+        if self._local is not None:
+            candidate = _canonical_local_path(location)
+            if candidate is None:
+                return False
+            if self.kind == "file":
+                return candidate == self._local
+            return candidate.is_relative_to(self._local)
+
+        remote_candidate = _canonical_remote_path(location)
+        if remote_candidate is None or self._remote is None:
+            return False
+        if (
+            remote_candidate.scheme != self._remote.scheme
+            or remote_candidate.authority != self._remote.authority
+        ):
+            return False
+        if self.kind == "file":
+            return remote_candidate.path == self._remote.path
+        return remote_candidate.path.is_relative_to(self._remote.path)
+
+
+def _canonical_local_path(location: str) -> Path | None:
+    if not location:
+        return None
+    if os.name == "nt" and _WINDOWS_DRIVE_PATH.match(location):
+        protocol = None
+    else:
+        protocol, _ = split_protocol(location)
+
+    if protocol is None:
+        path = location
+    elif protocol.lower() == "file":
+        try:
+            parsed = urllib.parse.urlsplit(location)
+        except ValueError:
+            return None
+        if (
+            parsed.query
+            or parsed.fragment
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.netloc.lower() not in ("", "localhost")
+        ):
+            return None
+        path = urllib.parse.unquote(parsed.path)
+        if (
+            os.name == "nt"
+            and path.startswith("/")
+            and len(path) > 3
+            and path[2] == ":"
+        ):
+            path = path[1:]
+    else:
+        return None
+
+    try:
+        return Path(path).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def _canonical_remote_path(location: str) -> _RemotePath | None:
+    protocol, _ = split_protocol(location)
+    if protocol is None or protocol.lower() == "file":
+        return None
+
+    try:
+        parsed = urllib.parse.urlsplit(location)
+    except ValueError:
+        return None
+    if (
+        not parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or "\\" in parsed.path
+    ):
+        return None
+
+    decoded_path = urllib.parse.unquote(parsed.path)
+    if "\\" in decoded_path or ".." in PurePosixPath(decoded_path).parts:
+        return None
+    path = posixpath.normpath("/" + decoded_path.lstrip("/"))
+    return _RemotePath(
+        scheme=protocol.lower(),
+        authority=parsed.netloc.lower(),
+        path=PurePosixPath(path),
+    )

--- a/src/inspect_ai/_view/path_scope.py
+++ b/src/inspect_ai/_view/path_scope.py
@@ -20,6 +20,9 @@ _WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
 
 def canonical_path_location(location: str) -> str | None:
     """Resolve a local or remote location to the value used for filesystem I/O."""
+    opaque_http = _parse_opaque_http_file(location)
+    if opaque_http is not None:
+        return opaque_http.location
     local = _canonical_local_path(location)
     if local is not None:
         return str(local)
@@ -41,12 +44,20 @@ class _RemotePath:
 
 
 @dataclass(frozen=True)
+class _OpaqueHttpFile:
+    scheme: str
+    authority: str
+    location: str
+
+
+@dataclass(frozen=True)
 class PathScope:
     """Canonical filesystem or remote-object capability."""
 
     kind: PathScopeKind
     _local: Path | None
     _remote: _RemotePath | None
+    _opaque_http: _OpaqueHttpFile | None
 
     @classmethod
     def parse(cls, kind: PathScopeKind, location: str) -> "PathScope":
@@ -65,9 +76,14 @@ class PathScope:
         *,
         canonical_local: bool,
     ) -> "PathScope":
+        opaque_http = _parse_opaque_http_file(location) if kind == "file" else None
         local = _canonical_local_path(location, canonical=canonical_local)
-        remote = None if local is not None else _canonical_remote_path(location)
-        if local is None and remote is None:
+        remote = (
+            None
+            if local is not None or opaque_http is not None
+            else _canonical_remote_path(location)
+        )
+        if local is None and remote is None and opaque_http is None:
             raise ValueError(f"Invalid viewer path scope: {location}")
         if kind == "directory" and remote:
             if remote.scheme in ("http", "https"):
@@ -76,17 +92,35 @@ class PathScope:
                 )
             if remote.query:
                 raise ValueError("Viewer directory scopes cannot contain a query")
-        return cls(kind=kind, _local=local, _remote=remote)
+        return cls(
+            kind=kind,
+            _local=local,
+            _remote=remote,
+            _opaque_http=opaque_http,
+        )
 
     def resolve(self, location: str) -> str | None:
         """Resolve an allowed location to the exact URI used for I/O."""
+        if self._opaque_http is not None:
+            opaque_candidate = _parse_opaque_http_file(location)
+            return (
+                self._opaque_http.location
+                if opaque_candidate is not None
+                and opaque_candidate.location == self._opaque_http.location
+                else None
+            )
+
         if self._local is not None:
-            candidate = _canonical_local_path(location)
-            if candidate is None:
+            local_candidate = _canonical_local_path(location)
+            if local_candidate is None:
                 return None
             if self.kind == "file":
-                return str(candidate) if candidate == self._local else None
-            return str(candidate) if candidate.is_relative_to(self._local) else None
+                return str(local_candidate) if local_candidate == self._local else None
+            return (
+                str(local_candidate)
+                if local_candidate.is_relative_to(self._local)
+                else None
+            )
 
         remote_candidate = _canonical_remote_path(location)
         if remote_candidate is None or self._remote is None:
@@ -211,7 +245,12 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
         return None
 
     decoded_path = urllib.parse.unquote(parsed.path)
-    if "\\" in decoded_path or ".." in PurePosixPath(decoded_path).parts:
+    if (
+        "\\" in decoded_path
+        or "?" in decoded_path
+        or "#" in decoded_path
+        or ".." in PurePosixPath(decoded_path).parts
+    ):
         return None
     path = posixpath.normpath("/" + decoded_path.lstrip("/"))
     return _RemotePath(
@@ -237,3 +276,25 @@ def _canonical_query(query: str) -> str:
         else:
             fields.append(encode(field))
     return "&".join(fields)
+
+
+def _parse_opaque_http_file(location: str) -> _OpaqueHttpFile | None:
+    try:
+        parsed = urllib.parse.urlsplit(location)
+        _ = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.scheme.lower() not in ("http", "https")
+        or not parsed.netloc
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or "\\" in parsed.path
+    ):
+        return None
+    return _OpaqueHttpFile(
+        scheme=parsed.scheme.lower(),
+        authority=parsed.netloc.lower(),
+        location=location,
+    )

--- a/src/inspect_ai/_view/path_scope.py
+++ b/src/inspect_ai/_view/path_scope.py
@@ -5,7 +5,7 @@ import posixpath
 import re
 import urllib.parse
 from dataclasses import dataclass
-from pathlib import Path, PurePosixPath
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Literal
 
 from fsspec.core import split_protocol  # type: ignore
@@ -23,6 +23,7 @@ class _RemotePath:
     scheme: str
     authority: str
     path: PurePosixPath
+    query: str
 
 
 @dataclass(frozen=True)
@@ -35,12 +36,32 @@ class PathScope:
 
     @classmethod
     def parse(cls, kind: PathScopeKind, location: str) -> "PathScope":
-        local = _canonical_local_path(location)
+        return cls._parse(kind, location, canonical_local=False)
+
+    @classmethod
+    def parse_canonical(cls, kind: PathScopeKind, location: str) -> "PathScope":
+        """Parse a scope already canonicalized by a trusted host."""
+        return cls._parse(kind, location, canonical_local=True)
+
+    @classmethod
+    def _parse(
+        cls,
+        kind: PathScopeKind,
+        location: str,
+        *,
+        canonical_local: bool,
+    ) -> "PathScope":
+        local = _canonical_local_path(location, canonical=canonical_local)
         remote = None if local is not None else _canonical_remote_path(location)
         if local is None and remote is None:
             raise ValueError(f"Invalid viewer path scope: {location}")
-        if kind == "directory" and remote and remote.scheme in ("http", "https"):
-            raise ValueError(f"Unsupported viewer directory scheme: {remote.scheme}")
+        if kind == "directory" and remote:
+            if remote.scheme in ("http", "https"):
+                raise ValueError(
+                    f"Unsupported viewer directory scheme: {remote.scheme}"
+                )
+            if remote.query:
+                raise ValueError("Viewer directory scopes cannot contain a query")
         return cls(kind=kind, _local=local, _remote=remote)
 
     def allows(self, location: str) -> bool:
@@ -61,11 +82,20 @@ class PathScope:
         ):
             return False
         if self.kind == "file":
-            return remote_candidate.path == self._remote.path
+            return (
+                remote_candidate.path == self._remote.path
+                and remote_candidate.query == self._remote.query
+            )
+        if remote_candidate.query:
+            return False
         return remote_candidate.path.is_relative_to(self._remote.path)
 
 
-def _canonical_local_path(location: str) -> Path | None:
+def _canonical_local_path(
+    location: str,
+    *,
+    canonical: bool = False,
+) -> Path | None:
     if not location:
         return None
     if os.name == "nt" and _WINDOWS_DRIVE_PATH.match(location):
@@ -76,33 +106,67 @@ def _canonical_local_path(location: str) -> Path | None:
     if protocol is None:
         path = location
     elif protocol.lower() == "file":
-        try:
-            parsed = urllib.parse.urlsplit(location)
-        except ValueError:
+        file_path = _local_path_from_file_uri(location)
+        if file_path is None:
             return None
-        if (
-            parsed.query
-            or parsed.fragment
-            or parsed.username is not None
-            or parsed.password is not None
-            or parsed.netloc.lower() not in ("", "localhost")
-        ):
-            return None
-        path = urllib.parse.unquote(parsed.path)
-        if (
-            os.name == "nt"
-            and path.startswith("/")
-            and len(path) > 3
-            and path[2] == ":"
-        ):
-            path = path[1:]
+        path = file_path
     else:
         return None
 
     try:
-        return Path(path).resolve()
+        local = Path(path)
+        if not canonical:
+            return local.resolve()
+        if not local.is_absolute() or ".." in local.parts:
+            return None
+        normalized = Path(os.path.normpath(path))
+        if normalized != local or local.resolve() != local:
+            return None
+        return local
     except (OSError, RuntimeError, ValueError):
         return None
+
+
+def _local_path_from_file_uri(
+    location: str,
+    *,
+    windows: bool | None = None,
+) -> str | None:
+    windows = os.name == "nt" if windows is None else windows
+    try:
+        parsed = urllib.parse.urlsplit(location)
+        port = parsed.port
+    except ValueError:
+        return None
+    if (
+        parsed.query
+        or parsed.fragment
+        or parsed.username is not None
+        or parsed.password is not None
+        or port is not None
+    ):
+        return None
+
+    decoded_path = urllib.parse.unquote(parsed.path)
+    if "\\" in decoded_path:
+        return None
+
+    authority = parsed.hostname or ""
+    if authority and authority.lower() != "localhost":
+        if not windows or not decoded_path.startswith("/"):
+            return None
+        if len(PurePosixPath(decoded_path).parts) < 2:
+            return None
+        return str(PureWindowsPath(f"//{authority}{decoded_path}"))
+
+    if (
+        windows
+        and decoded_path.startswith("/")
+        and len(decoded_path) > 3
+        and decoded_path[2] == ":"
+    ):
+        return decoded_path[1:]
+    return decoded_path
 
 
 def _canonical_remote_path(location: str) -> _RemotePath | None:
@@ -116,7 +180,6 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
         return None
     if (
         not parsed.netloc
-        or parsed.query
         or parsed.fragment
         or parsed.username is not None
         or parsed.password is not None
@@ -132,4 +195,5 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
         scheme=protocol.lower(),
         authority=parsed.netloc.lower(),
         path=PurePosixPath(path),
+        query=parsed.query,
     )

--- a/src/inspect_ai/_view/path_scope.py
+++ b/src/inspect_ai/_view/path_scope.py
@@ -18,12 +18,26 @@ PathScopeKind = Literal["directory", "file"]
 _WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:[\\/]")
 
 
+def canonical_path_location(location: str) -> str | None:
+    """Resolve a local or remote location to the value used for filesystem I/O."""
+    local = _canonical_local_path(location)
+    if local is not None:
+        return str(local)
+    remote = _canonical_remote_path(location)
+    return remote.location() if remote is not None else None
+
+
 @dataclass(frozen=True)
 class _RemotePath:
     scheme: str
     authority: str
     path: PurePosixPath
     query: str
+
+    def location(self) -> str:
+        return urllib.parse.urlunsplit(
+            (self.scheme, self.authority, self.path.as_posix(), self.query, "")
+        )
 
 
 @dataclass(frozen=True)
@@ -64,31 +78,40 @@ class PathScope:
                 raise ValueError("Viewer directory scopes cannot contain a query")
         return cls(kind=kind, _local=local, _remote=remote)
 
-    def allows(self, location: str) -> bool:
+    def resolve(self, location: str) -> str | None:
+        """Resolve an allowed location to the exact URI used for I/O."""
         if self._local is not None:
             candidate = _canonical_local_path(location)
             if candidate is None:
-                return False
+                return None
             if self.kind == "file":
-                return candidate == self._local
-            return candidate.is_relative_to(self._local)
+                return str(candidate) if candidate == self._local else None
+            return str(candidate) if candidate.is_relative_to(self._local) else None
 
         remote_candidate = _canonical_remote_path(location)
         if remote_candidate is None or self._remote is None:
-            return False
+            return None
         if (
             remote_candidate.scheme != self._remote.scheme
             or remote_candidate.authority != self._remote.authority
         ):
-            return False
+            return None
         if self.kind == "file":
-            return (
+            allowed = (
                 remote_candidate.path == self._remote.path
                 and remote_candidate.query == self._remote.query
             )
+            return remote_candidate.location() if allowed else None
         if remote_candidate.query:
-            return False
-        return remote_candidate.path.is_relative_to(self._remote.path)
+            return None
+        return (
+            remote_candidate.location()
+            if remote_candidate.path.is_relative_to(self._remote.path)
+            else None
+        )
+
+    def allows(self, location: str) -> bool:
+        return self.resolve(location) is not None
 
 
 def _canonical_local_path(
@@ -195,5 +218,22 @@ def _canonical_remote_path(location: str) -> _RemotePath | None:
         scheme=protocol.lower(),
         authority=parsed.netloc.lower(),
         path=PurePosixPath(path),
-        query=parsed.query,
+        query=_canonical_query(parsed.query),
     )
+
+
+def _canonical_query(query: str) -> str:
+    if not query:
+        return ""
+
+    def encode(value: str) -> str:
+        return urllib.parse.quote(urllib.parse.unquote(value), safe="-._~")
+
+    fields: list[str] = []
+    for field in query.split("&"):
+        if "=" in field:
+            name, value = field.split("=", 1)
+            fields.append(f"{encode(name)}={encode(value)}")
+        else:
+            fields.append(encode(field))
+    return "&".join(fields)

--- a/src/inspect_ai/_view/view.py
+++ b/src/inspect_ai/_view/view.py
@@ -28,6 +28,7 @@ def view(
     authorization: str | None = None,
     log_level: str | None = None,
     fs_options: dict[str, Any] = {},
+    scoped_authorization: bool = False,
 ) -> None:
     """Run the Inspect View server.
 
@@ -42,6 +43,8 @@ def view(
         fs_options: Additional arguments to pass through to the filesystem provider
             (e.g. `S3FileSystem`). Use `{"anon": True }` if you are accessing a
             public S3 bucket with no credentials.
+        scoped_authorization: Require a per-request file or directory scope on
+            authorization-protected path operations.
     """
     init_dotenv()
     init_logger(log_level)
@@ -49,6 +52,9 @@ def view(
     # initialize the log_dir
     if not log_dir:
         log_dir = os.getenv("INSPECT_LOG_DIR", "./logs")
+
+    if scoped_authorization and not authorization:
+        raise ValueError("Scoped authorization requires request authorization.")
 
     # acquire the requested port
     view_acquire_port(view_data_dir(), port)
@@ -62,6 +68,7 @@ def view(
         port=port,
         authorization=authorization,
         fs_options=fs_options,
+        scoped_authorization=scoped_authorization,
     )
 
 

--- a/tests/_cli/test_view_scope.py
+++ b/tests/_cli/test_view_scope.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from typing import Any
+
+from click.testing import CliRunner
+
+import inspect_ai._cli.view as view_cli
+
+
+def test_scoped_authorization_option_is_forwarded(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_view(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(view_cli, "view", fake_view)
+    monkeypatch.setattr(view_cli, "process_common_options", lambda _options: None)
+
+    result = CliRunner().invoke(
+        view_cli.view_command,
+        ["--scoped-authorization"],
+        env={"INSPECT_VIEW_AUTHORIZATION_TOKEN": "secret"},
+        standalone_mode=False,
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["authorization"] == "secret"
+    assert captured["scoped_authorization"] is True

--- a/tests/_view/test_path_scope.py
+++ b/tests/_view/test_path_scope.py
@@ -151,15 +151,13 @@ def test_signed_http_file_scopes_require_the_exact_query(scheme: str) -> None:
 
 def test_signed_query_values_use_canonical_rfc3986_encoding() -> None:
     selected = (
-        "https://example.test/run.eval?"
-        "credential=team%2Fmember&label=hello%20world"
+        "https://example.test/run.eval?credential=team%2Fmember&label=hello%20world"
     )
     scope = PathScope.parse("file", selected)
 
     assert (
         scope.resolve(
-            "https://example.test/run.eval?"
-            "credential=team/member&label=hello world"
+            "https://example.test/run.eval?credential=team/member&label=hello world"
         )
         == selected
     )
@@ -167,8 +165,7 @@ def test_signed_query_values_use_canonical_rfc3986_encoding() -> None:
 
 def test_scoped_authorization_canonicalizes_signed_query_values() -> None:
     selected = (
-        "https://example.test/run.eval?"
-        "credential=team%2Fmember&label=hello%20world"
+        "https://example.test/run.eval?credential=team%2Fmember&label=hello%20world"
     )
     request = _request(
         (VIEW_SCOPE_KIND_HEADER, "file"),

--- a/tests/_view/test_path_scope.py
+++ b/tests/_view/test_path_scope.py
@@ -150,23 +150,17 @@ def test_signed_http_file_scopes_require_the_exact_query(scheme: str) -> None:
 
 
 def test_signed_query_values_use_canonical_rfc3986_encoding() -> None:
-    selected = (
-        "https://example.test/run.eval?credential=team%2Fmember&label=hello%20world"
-    )
+    selected = "s3://bucket/run.eval?credential=team%2Fmember&label=hello%20world"
     scope = PathScope.parse("file", selected)
 
     assert (
-        scope.resolve(
-            "https://example.test/run.eval?credential=team/member&label=hello world"
-        )
+        scope.resolve("s3://bucket/run.eval?credential=team/member&label=hello world")
         == selected
     )
 
 
-def test_scoped_authorization_canonicalizes_signed_query_values() -> None:
-    selected = (
-        "https://example.test/run.eval?credential=team%2Fmember&label=hello%20world"
-    )
+def test_scoped_authorization_preserves_opaque_signed_url() -> None:
+    selected = "https://example.test/run.eval?token=a%26b&credential=team%2Fmember"
     request = _request(
         (VIEW_SCOPE_KIND_HEADER, "file"),
         (VIEW_SCOPE_HEADER, selected),
@@ -177,12 +171,27 @@ def test_scoped_authorization_canonicalizes_signed_query_values() -> None:
         asyncio.run(
             policy.resolve_read(
                 request,
-                "https://example.test/run.eval?"
-                "credential=team/member&label=hello world",
+                selected,
             )
         )
         == selected
     )
+    assert (
+        asyncio.run(
+            policy.resolve_read(
+                request,
+                "https://example.test/run.eval?token=a&b&credential=team%2Fmember",
+            )
+        )
+        is None
+    )
+
+
+def test_http_file_scope_preserves_encoded_path_delimiters() -> None:
+    selected = "https://example.test/logs/a%3Fb%23c.eval"
+    scope = PathScope.parse("file", selected)
+
+    assert scope.resolve(selected) == selected
 
 
 def test_remote_directory_scopes_reject_queries() -> None:

--- a/tests/_view/test_path_scope.py
+++ b/tests/_view/test_path_scope.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import urllib.parse
 from pathlib import Path, PureWindowsPath
 from typing import Any
 
@@ -11,6 +12,7 @@ from fastapi import APIRouter
 from fastapi.testclient import TestClient
 from starlette.requests import Request
 
+from inspect_ai._util.file import filesystem
 from inspect_ai._view import fastapi_server
 from inspect_ai._view.path_scope import (
     VIEW_SCOPE_HEADER,
@@ -115,6 +117,13 @@ def test_remote_directory_scope_requires_same_authority_and_components() -> None
         assert not scope.allows(location)
 
 
+def test_remote_file_scope_resolves_alias_to_authorized_location() -> None:
+    selected = "memory://bucket/logs/secret.eval"
+    scope = PathScope.parse("file", selected)
+
+    assert scope.resolve("memory://bucket/logs//secret.eval") == selected
+
+
 @pytest.mark.parametrize("scheme", ["http", "https"])
 def test_http_scopes_are_exact_file_only(scheme: str) -> None:
     selected = f"{scheme}://example.test/logs/run.eval"
@@ -138,6 +147,45 @@ def test_signed_http_file_scopes_require_the_exact_query(scheme: str) -> None:
         f"{scheme}://example.test/logs/run.eval?expires=60&signature=other"
     )
     assert not scope.allows(f"{scheme}://example.test/logs/run.eval")
+
+
+def test_signed_query_values_use_canonical_rfc3986_encoding() -> None:
+    selected = (
+        "https://example.test/run.eval?"
+        "credential=team%2Fmember&label=hello%20world"
+    )
+    scope = PathScope.parse("file", selected)
+
+    assert (
+        scope.resolve(
+            "https://example.test/run.eval?"
+            "credential=team/member&label=hello world"
+        )
+        == selected
+    )
+
+
+def test_scoped_authorization_canonicalizes_signed_query_values() -> None:
+    selected = (
+        "https://example.test/run.eval?"
+        "credential=team%2Fmember&label=hello%20world"
+    )
+    request = _request(
+        (VIEW_SCOPE_KIND_HEADER, "file"),
+        (VIEW_SCOPE_HEADER, selected),
+    )
+    policy = fastapi_server.ScopedAuthorizationAccessPolicy()
+
+    assert (
+        asyncio.run(
+            policy.resolve_read(
+                request,
+                "https://example.test/run.eval?"
+                "credential=team/member&label=hello world",
+            )
+        )
+        == selected
+    )
 
 
 def test_remote_directory_scopes_reject_queries() -> None:
@@ -182,6 +230,61 @@ def test_scoped_authorization_file_policy() -> None:
     assert asyncio.run(policy.can_write(request, "https://example.test/run.eval"))
     assert not asyncio.run(policy.can_read(request, "https://example.test/other.eval"))
     assert not asyncio.run(policy.can_list(request, "https://example.test"))
+
+
+def test_scoped_authorization_uses_resolved_remote_location() -> None:
+    selected = "memory://bucket/logs/secret.eval"
+    alias = "memory://bucket/logs//secret.eval"
+    fs = filesystem(selected)
+    fs.fs.pipe_file(fs.fs._strip_protocol(selected), b"selected")
+    fs.fs.pipe_file(fs.fs._strip_protocol(alias), b"alias")
+
+    app = fastapi_server.view_server_app(
+        access_policy=fastapi_server.ScopedAuthorizationAccessPolicy()
+    )
+    headers = {
+        VIEW_SCOPE_KIND_HEADER: "file",
+        VIEW_SCOPE_HEADER: selected,
+    }
+    encoded_alias = urllib.parse.quote(alias, safe="")
+
+    with TestClient(app) as client:
+        response = client.get(
+            f"/log-bytes/{encoded_alias}?start=0&end=7",
+            headers=headers,
+        )
+
+    assert response.status_code == 200
+    assert response.content == b"selected"
+
+
+def test_boolean_access_policy_still_uses_canonical_location() -> None:
+    class AllowAccess(fastapi_server.AccessPolicy):
+        async def can_read(self, request: Request, file: str) -> bool:
+            return True
+
+        async def can_delete(self, request: Request, file: str) -> bool:
+            return True
+
+        async def can_list(self, request: Request, dir: str) -> bool:
+            return True
+
+        async def can_write(self, request: Request, file: str) -> bool:
+            return True
+
+    selected = "memory://bucket/boolean/secret.eval"
+    alias = "memory://bucket/boolean//secret.eval"
+    fs = filesystem(selected)
+    fs.fs.pipe_file(fs.fs._strip_protocol(selected), b"selected")
+    fs.fs.pipe_file(fs.fs._strip_protocol(alias), b"alias")
+    app = fastapi_server.view_server_app(access_policy=AllowAccess())
+    encoded_alias = urllib.parse.quote(alias, safe="")
+
+    with TestClient(app) as client:
+        response = client.get(f"/log-bytes/{encoded_alias}?start=0&end=7")
+
+    assert response.status_code == 200
+    assert response.content == b"selected"
 
 
 def test_scoped_authorization_uses_a_canonical_local_scope(tmp_path: Path) -> None:
@@ -319,10 +422,16 @@ def test_mounted_scout_routes_use_inspect_path_scope(
             f"/scout/transcripts/{encode('s3://bucket/logs')}/item",
             headers=headers,
         )
+        canonicalized = client.get(
+            f"/scout/transcripts/{encode('s3://bucket/logs//team')}/item",
+            headers=headers,
+        )
         rejected = client.get(
             f"/scout/transcripts/{encode('s3://other/logs')}/item",
             headers=headers,
         )
 
     assert allowed.status_code == 200
+    assert canonicalized.status_code == 200
+    assert canonicalized.json()["dir"] == encode("s3://bucket/logs/team")
     assert rejected.status_code == 403

--- a/tests/_view/test_path_scope.py
+++ b/tests/_view/test_path_scope.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+from pathlib import Path
+from typing import Any
+
+import anyio
+import pytest
+from fastapi import APIRouter
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+from inspect_ai._view import fastapi_server
+from inspect_ai._view.path_scope import (
+    VIEW_SCOPE_HEADER,
+    VIEW_SCOPE_KIND_HEADER,
+    PathScope,
+)
+
+
+def _request(*headers: tuple[str, str]) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": "/",
+            "headers": [
+                (name.lower().encode(), value.encode()) for name, value in headers
+            ],
+        }
+    )
+
+
+def test_local_directory_scope_uses_canonical_containment(tmp_path: Path) -> None:
+    root = tmp_path / "logs"
+    root.mkdir()
+    sibling = tmp_path / "logs-archive"
+    sibling.mkdir()
+
+    scope = PathScope.parse("directory", str(root))
+    assert scope.allows(str(root))
+    assert scope.allows(str(root / "nested" / "run.eval"))
+    assert scope.allows((root / "run.eval").as_uri())
+    assert not scope.allows(str(sibling / "run.eval"))
+    assert not scope.allows(str(root / ".." / "outside" / "run.eval"))
+    assert not scope.allows("s3://bucket/logs/run.eval")
+
+
+def test_local_directory_scope_resolves_symlinks(tmp_path: Path) -> None:
+    target = tmp_path / "target"
+    target.mkdir()
+    selected = tmp_path / "selected"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    nested_escape = target / "outside"
+    try:
+        selected.symlink_to(target, target_is_directory=True)
+        nested_escape.symlink_to(outside, target_is_directory=True)
+    except OSError:
+        pytest.skip("Creating directory symlinks is not supported")
+
+    scope = PathScope.parse("directory", str(selected))
+    assert scope.allows(str(selected / "run.eval"))
+    assert not scope.allows(str(nested_escape / "secret.eval"))
+
+
+def test_local_file_scope_is_exact(tmp_path: Path) -> None:
+    selected = tmp_path / "selected.eval"
+    sibling = tmp_path / "sibling.eval"
+    scope = PathScope.parse("file", selected.as_uri())
+
+    assert scope.allows(str(selected))
+    assert scope.allows(selected.as_uri())
+    assert not scope.allows(str(sibling))
+
+
+def test_remote_directory_scope_requires_same_authority_and_components() -> None:
+    scope = PathScope.parse("directory", "s3://bucket/logs")
+    assert scope.allows("s3://bucket/logs/run.eval")
+    assert scope.allows("s3://bucket/logs/nested/run.eval")
+
+    rejected = [
+        "s3://bucket/logs-archive/run.eval",
+        "s3://other/logs/run.eval",
+        "s3://bucket/logs/../private/run.eval",
+        "s3://bucket/logs/%2e%2e/private/run.eval",
+        "file:///tmp/run.eval",
+        "https://bucket/logs/run.eval",
+    ]
+    for location in rejected:
+        assert not scope.allows(location)
+
+
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_http_scopes_are_exact_file_only(scheme: str) -> None:
+    selected = f"{scheme}://example.test/logs/run.eval"
+    with pytest.raises(ValueError, match="directory scheme"):
+        PathScope.parse("directory", f"{scheme}://example.test/logs")
+
+    scope = PathScope.parse("file", selected)
+    assert scope.allows(selected)
+    assert not scope.allows(f"{scheme}://example.test/logs/other.eval")
+    assert not scope.allows(f"{scheme}://other.test/logs/run.eval")
+    assert not scope.allows(f"{selected}?token=value")
+
+
+def test_scoped_authorization_directory_policy() -> None:
+    policy = fastapi_server.ScopedAuthorizationAccessPolicy()
+    request = _request(
+        (VIEW_SCOPE_KIND_HEADER, "directory"),
+        (VIEW_SCOPE_HEADER, "s3://bucket/logs"),
+    )
+
+    assert asyncio.run(policy.can_list(request, "s3://bucket/logs"))
+    assert asyncio.run(policy.can_read(request, "s3://bucket/logs/run.eval"))
+    assert asyncio.run(policy.can_write(request, "s3://bucket/logs/run.eval"))
+    assert not asyncio.run(policy.can_read(request, "s3://other/logs/run.eval"))
+
+
+def test_scoped_authorization_file_policy() -> None:
+    policy = fastapi_server.ScopedAuthorizationAccessPolicy()
+    request = _request(
+        (VIEW_SCOPE_KIND_HEADER, "file"),
+        (VIEW_SCOPE_HEADER, "https://example.test/run.eval"),
+    )
+
+    assert asyncio.run(policy.can_read(request, "https://example.test/run.eval"))
+    assert asyncio.run(policy.can_write(request, "https://example.test/run.eval"))
+    assert not asyncio.run(policy.can_read(request, "https://example.test/other.eval"))
+    assert not asyncio.run(policy.can_list(request, "https://example.test"))
+
+
+@pytest.mark.parametrize(
+    "headers",
+    [
+        (),
+        ((VIEW_SCOPE_KIND_HEADER, "directory"),),
+        ((VIEW_SCOPE_HEADER, "/tmp/logs"),),
+        (
+            (VIEW_SCOPE_KIND_HEADER, "unknown"),
+            (VIEW_SCOPE_HEADER, "/tmp/logs"),
+        ),
+        (
+            (VIEW_SCOPE_KIND_HEADER, "directory"),
+            (VIEW_SCOPE_HEADER, "/tmp/logs"),
+            (VIEW_SCOPE_HEADER, "/tmp/other"),
+        ),
+    ],
+)
+def test_scoped_authorization_rejects_missing_or_conflicting_headers(
+    headers: tuple[tuple[str, str], ...],
+) -> None:
+    policy = fastapi_server.ScopedAuthorizationAccessPolicy()
+    assert not asyncio.run(policy.can_read(_request(*headers), "/tmp/logs/run.eval"))
+
+
+@pytest.mark.parametrize(
+    ("authorization", "scoped", "expected_type"),
+    [
+        (None, False, fastapi_server.OnlyDirAccessPolicy),
+        ("secret", False, type(None)),
+        ("secret", True, fastapi_server.ScopedAuthorizationAccessPolicy),
+    ],
+)
+def test_view_server_selects_access_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    authorization: str | None,
+    scoped: bool,
+    expected_type: type[Any],
+) -> None:
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    captured: list[fastapi_server.AccessPolicy | None] = []
+    original = fastapi_server.view_server_app
+
+    def capture(**kwargs: Any) -> Any:
+        captured.append(kwargs.get("access_policy"))
+        return original(**kwargs)
+
+    monkeypatch.setattr(fastapi_server, "view_server_app", capture)
+    monkeypatch.setattr(anyio, "run", lambda _func: None)
+
+    fastapi_server.view_server(
+        log_dir=str(log_dir),
+        authorization=authorization,
+        scoped_authorization=scoped,
+    )
+
+    assert len(captured) == 1
+    assert isinstance(captured[0], expected_type)
+
+
+def test_scoped_authorization_requires_authorization(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="requires request authorization"):
+        fastapi_server.view_server(
+            log_dir=str(tmp_path),
+            scoped_authorization=True,
+        )
+
+
+def test_mounted_scout_routes_use_inspect_path_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    router = APIRouter()
+
+    @router.get("/transcripts/{dir}/item")
+    async def transcript_item(dir: str) -> dict[str, str]:
+        return {"dir": dir}
+
+    monkeypatch.setattr(fastapi_server, "get_scout_search_router", lambda: router)
+    app = fastapi_server.view_server_app(
+        access_policy=fastapi_server.ScopedAuthorizationAccessPolicy()
+    )
+    headers = {
+        VIEW_SCOPE_KIND_HEADER: "directory",
+        VIEW_SCOPE_HEADER: "s3://bucket/logs",
+    }
+
+    def encode(value: str) -> str:
+        return base64.urlsafe_b64encode(value.encode()).decode().rstrip("=")
+
+    with TestClient(app) as client:
+        allowed = client.get(
+            f"/scout/transcripts/{encode('s3://bucket/logs')}/item",
+            headers=headers,
+        )
+        rejected = client.get(
+            f"/scout/transcripts/{encode('s3://other/logs')}/item",
+            headers=headers,
+        )
+
+    assert allowed.status_code == 200
+    assert rejected.status_code == 403

--- a/tests/_view/test_path_scope.py
+++ b/tests/_view/test_path_scope.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any
 
 import anyio
@@ -16,6 +16,7 @@ from inspect_ai._view.path_scope import (
     VIEW_SCOPE_HEADER,
     VIEW_SCOPE_KIND_HEADER,
     PathScope,
+    _local_path_from_file_uri,
 )
 
 
@@ -65,6 +66,28 @@ def test_local_directory_scope_resolves_symlinks(tmp_path: Path) -> None:
     assert not scope.allows(str(nested_escape / "secret.eval"))
 
 
+def test_local_directory_scope_retains_selected_symlink_target(
+    tmp_path: Path,
+) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    selected = tmp_path / "selected"
+    first.mkdir()
+    second.mkdir()
+    (first / "allowed.eval").write_text("allowed", encoding="utf-8")
+    (second / "secret.eval").write_text("secret", encoding="utf-8")
+    try:
+        selected.symlink_to(first, target_is_directory=True)
+    except OSError:
+        pytest.skip("Creating directory symlinks is not supported")
+
+    scope = PathScope.parse("directory", str(selected))
+    selected.unlink()
+    selected.symlink_to(second, target_is_directory=True)
+
+    assert not scope.allows(str(selected / "secret.eval"))
+
+
 def test_local_file_scope_is_exact(tmp_path: Path) -> None:
     selected = tmp_path / "selected.eval"
     sibling = tmp_path / "sibling.eval"
@@ -105,6 +128,36 @@ def test_http_scopes_are_exact_file_only(scheme: str) -> None:
     assert not scope.allows(f"{selected}?token=value")
 
 
+@pytest.mark.parametrize("scheme", ["http", "https"])
+def test_signed_http_file_scopes_require_the_exact_query(scheme: str) -> None:
+    selected = f"{scheme}://example.test/logs/run.eval?expires=60&signature=selected"
+    scope = PathScope.parse("file", selected)
+
+    assert scope.allows(selected)
+    assert not scope.allows(
+        f"{scheme}://example.test/logs/run.eval?expires=60&signature=other"
+    )
+    assert not scope.allows(f"{scheme}://example.test/logs/run.eval")
+
+
+def test_remote_directory_scopes_reject_queries() -> None:
+    with pytest.raises(ValueError, match="cannot contain a query"):
+        PathScope.parse("directory", "s3://bucket/logs?version=selected")
+
+    scope = PathScope.parse("directory", "s3://bucket/logs")
+    assert not scope.allows("s3://bucket/logs/run.eval?version=selected")
+
+
+def test_file_uri_parsing_supports_windows_unc_paths() -> None:
+    assert _local_path_from_file_uri(
+        "file://server/share/logs/run.eval", windows=True
+    ) == str(PureWindowsPath("//server/share/logs/run.eval"))
+    assert (
+        _local_path_from_file_uri("file://server/share/logs/run.eval", windows=False)
+        is None
+    )
+
+
 def test_scoped_authorization_directory_policy() -> None:
     policy = fastapi_server.ScopedAuthorizationAccessPolicy()
     request = _request(
@@ -129,6 +182,46 @@ def test_scoped_authorization_file_policy() -> None:
     assert asyncio.run(policy.can_write(request, "https://example.test/run.eval"))
     assert not asyncio.run(policy.can_read(request, "https://example.test/other.eval"))
     assert not asyncio.run(policy.can_list(request, "https://example.test"))
+
+
+def test_scoped_authorization_uses_a_canonical_local_scope(tmp_path: Path) -> None:
+    first = tmp_path / "first"
+    second = tmp_path / "second"
+    selected = tmp_path / "selected"
+    first.mkdir()
+    second.mkdir()
+    (second / "secret.eval").write_text("secret", encoding="utf-8")
+    try:
+        selected.symlink_to(first, target_is_directory=True)
+    except OSError:
+        pytest.skip("Creating directory symlinks is not supported")
+
+    request = _request(
+        (VIEW_SCOPE_KIND_HEADER, "directory"),
+        (VIEW_SCOPE_HEADER, first.resolve().as_uri()),
+    )
+    selected.unlink()
+    selected.symlink_to(second, target_is_directory=True)
+
+    policy = fastapi_server.ScopedAuthorizationAccessPolicy()
+    assert not asyncio.run(policy.can_read(request, str(selected / "secret.eval")))
+
+
+def test_canonical_local_scope_rejects_relative_and_symlink_paths(
+    tmp_path: Path,
+) -> None:
+    target = tmp_path / "target"
+    selected = tmp_path / "selected"
+    target.mkdir()
+    try:
+        selected.symlink_to(target, target_is_directory=True)
+    except OSError:
+        pytest.skip("Creating directory symlinks is not supported")
+
+    with pytest.raises(ValueError, match="Invalid viewer path scope"):
+        PathScope.parse_canonical("directory", "relative/logs")
+    with pytest.raises(ValueError, match="Invalid viewer path scope"):
+        PathScope.parse_canonical("directory", str(selected))
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Related viewer security PRs

- [UKGovernmentBEIS/inspect_ai#4368](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4368) - Inspect standalone Host, Origin, authorization, and framing trust.
- [UKGovernmentBEIS/inspect_ai#4370](https://github.com/UKGovernmentBEIS/inspect_ai/pull/4370) - Inspect canonical standalone and scoped-authorized path capabilities.
- [meridianlabs-ai/inspect_vscode#123](https://github.com/meridianlabs-ai/inspect_vscode/pull/123) - VS Code host-selected file and directory scopes.
- [meridianlabs-ai/inspect_scout#482](https://github.com/meridianlabs-ai/inspect_scout/pull/482) - Scout standalone Host, Origin, authorization, and framing trust.
- [meridianlabs-ai/inspect_scout#483](https://github.com/meridianlabs-ai/inspect_scout/pull/483) - Scout startup filesystem and execution capabilities.

## Current behavior

Standalone Inspect compares requested paths with `file.startswith(log_dir)` and rejects only literal `..`. Prefix siblings and nested symlink escapes can pass.

When authorization is configured for VS Code, Inspect disables the path policy entirely because one singleton server supports arbitrary files and directories selected after startup. The authorization token identifies the extension but does not limit a request to the file or directory selected for its panel.

Mounted Scout transcript-search routes also accept a caller-selected transcript location without passing through Inspect's access policy.

## New behavior

- Canonical local scopes resolve selected roots, candidates, existing symlinks, and missing suffixes before comparing path components.
- Standalone roots are resolved once and retained as immutable capabilities.
- Scoped authorization accepts the trusted extension's canonical scope and rejects it if that canonical path is later replaced by a symlink.
- Remote scopes require the same scheme, authority, normalized path components, and query policy.
- Directory scopes allow canonical descendants only and reject queries.
- File scopes allow one exact local or remote file.
- Explicitly selected HTTP(S) files are retained as opaque exact URL capabilities, preserving path and query encoding.
- Windows UNC file URIs are parsed as local paths on Windows; remote file authorities remain rejected elsewhere.
- Standalone requests remain restricted to the configured `log_dir`.
- Missing, duplicate, malformed, conflicting, or non-canonical local scope headers fail closed.
- Mounted Scout transcript-search routes validate their decoded transcript location through the same policy.

Legacy authorization remains available during the extension rollout. The new mode is enabled only by a compatible VS Code extension.

## Compatibility

Default standalone use is unchanged except that paths accepted only through a prefix collision, traversal, or symlink escape are now rejected.

A selected symlink root remains usable and its resolved target stays fixed for that capability. A nested or later-retargeted symlink cannot expand it.

Authorized clients that do not opt into scoped authorization retain the existing behavior during the compatibility window.

The Inspect and Scout Python implementations intentionally remain separate while using matching conformance cases. Consolidation will be evaluated after rollout in [inspect_scout#484](https://github.com/meridianlabs-ai/inspect_scout/issues/484).

## Testing

- 145 Inspect viewer, path-scope, and CLI tests passed.
- Ruff formatting and lint passed.
- mypy passed for all changed source modules.
- Added immutable-root, canonical-header, signed-query, directory-query, and platform-independent Windows UNC parsing coverage.
- This repository does not currently run Windows CI; native UNC filesystem resolution still requires a manual Windows smoke test.