### PR TITLE
Don't re-nest **kwargs in registry params on round-trip

### DIFF
--- a/src/inspect_ai/_util/registry.py
+++ b/src/inspect_ai/_util/registry.py
@@ -134,14 +134,24 @@ def extract_named_params(
     # bind arguments to params
     named_params: dict[str, Any] = {}
 
+    signature = inspect.signature(type)
     if apply_defaults:
-        bound_params = inspect.signature(type).bind_partial(*args, **kwargs)
+        bound_params = signature.bind_partial(*args, **kwargs)
         bound_params.apply_defaults()
     else:
-        bound_params = inspect.signature(type).bind(*args, **kwargs)
+        bound_params = signature.bind(*args, **kwargs)
 
     for param, value in bound_params.arguments.items():
-        named_params[param] = registry_value(value)
+        kind = signature.parameters[param].kind
+        # Flatten **kwargs into the top level rather than nesting it under the
+        # variadic parameter's name. Otherwise a registry round-trip replays the
+        # captured dict as a keyword arg literally named after the variadic
+        # parameter, re-nesting it on every round-trip (#4374).
+        if kind == inspect.Parameter.VAR_KEYWORD and isinstance(value, dict):
+            for kwarg, kwarg_value in value.items():
+                named_params[kwarg] = registry_value(kwarg_value)
+        else:
+            named_params[param] = registry_value(value)
 
     # callables are not serializable so use their names
     for param in named_params.keys():

--- a/tests/util/test_registry.py
+++ b/tests/util/test_registry.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from inspect_ai import Task, eval, task
 from inspect_ai._util.constants import PKG_NAME
 from inspect_ai._util.registry import (
@@ -123,6 +125,16 @@ def test_registry_kwargs() -> None:
 def _extract(fn, *args, **kwargs):
     """Helper to call extract_named_params with apply_defaults=True."""
     return extract_named_params(fn, True, *args, **kwargs)
+
+
+def test_extract_named_params_flattens_kwargs() -> None:
+    # Regression test for #4374: **kwargs are captured at the top level so a
+    # registry round-trip replays them as keyword arguments, rather than
+    # re-nesting them under the variadic parameter's name on each round-trip.
+    def factory(template: str, **kwargs: Any) -> None: ...
+
+    params = extract_named_params(factory, False, "t", value="correct", n=3)
+    assert params == {"template": "t", "value": "correct", "n": 3}
 
 
 def test_repr_params_serialization() -> None:


### PR DESCRIPTION
Addresses problem 1 of #4374.

`extract_named_params` stored a factory's `**kwargs` under the variadic parameter's *name* as a nested dict. Replaying that captured dict passed it back as a keyword argument literally named after the variadic parameter, so the params gained an extra level of nesting on **every** registry round-trip:

```python
generate(max_tokens=123)
# captured (before): {'kwargs': {'max_tokens': 123}}
# replayed (before): {'kwargs': {'kwargs': {'max_tokens': 123}}}   # and again each round-trip
```

### Fix
Flatten `**kwargs` into the top-level params at capture time, so they replay as ordinary keyword arguments. After the change, `**kwargs` are no longer re-nested under the variadic parameter's name on round-trip (verified by the new unit test and by the issue's reproduction - `generate`'s params replay as `{'max_tokens': 123}`, `prompt_template`'s as `{'value': 'correct'}`).

### Scope / a question for you
- I fixed this on the **capture** side (`extract_named_params`). If you'd rather preserve the stored shape and fix it on the **replay** side instead, I'm happy to switch - let me know your preference.
- **Old logs still load:** this only changes how new params are captured; an existing log with the old nested `{'kwargs': {...}}` shape still loads via `solver_from_spec` unchanged (no migration needed). The existing log-migration tests pass.
- **Out of scope:** problem 2 from the issue (ordinary dicts shaped like `{type, name, params}` being treated as encoded registry objects) is a separate design question - it needs a discriminator or escape mechanism - so I left it for a follow-up.

### Tests
- New `test_extract_named_params_flattens_kwargs` - passes with the fix, fails without it.
- Existing registry / solver-args / eval-retry / log-migration suites pass (47 passed locally).
- `ruff check`, `ruff format`, and `mypy` clean on the changed files.
