### PR TITLE
autodetect reasoning parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Text Editor Tool: Cap undo history to 10 and no longer consider failures in undo history file operations fatal.
+- Reasoning: Auto-detect vLLM reasoning parsers for known open-weight model families.
 
 ## 0.3.226 (25 May 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Fixed sandbox agent bridge forwarding file inputs that are not inline `data:` URIs (e.g. host paths or URLs); such requests are now rejected.
 - Mistral: Provider-generated images remain available when replayed in subsequent conversation turns.
 - Docs: Clarify that the sandbox `exec()` output limit is enforced by front-truncating the output streams rather than by raising `OutputLimitExceededError` (which remains the behaviour for `read_file()`). (#4778)
+- Reasoning: Auto-detect vLLM reasoning parsers for known open-weight model families.
 
 ## 0.3.259 (16 August 2026)
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -162,11 +162,13 @@ The following reasoning options are available from the CLI and within `GenerateC
 
 vLLM and SGLang both support reasoning outputs, but the configuration is model-specific. See the [vLLM](https://docs.vllm.ai/en/stable/features/reasoning_outputs.html) and [SGLang](https://docs.sglang.ai/backend/separate_reasoning.html) docs for details.
 
-For vLLM, configure the model's reasoning parser using `-M` model arguments. For example, Qwen3:
+For vLLM, Inspect configures the reasoning parser automatically for known model families. You can also override it using `-M` model arguments. For example, Qwen3:
 
 ``` bash
 inspect eval math.py --model vllm/Qwen/Qwen3-8B -M reasoning_parser=qwen3
 ```
+
+For SGLang, Inspect starts the local server with `reasoning_parser=auto` unless you provide a parser explicitly.
 
 Thinking mode is model-specific and controlled separately from `--reasoning-effort`. For models where vLLM exposes template switches such as `enable_thinking` or `thinking`, pass them as chat-template kwargs:
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -168,7 +168,7 @@ For vLLM, Inspect configures the reasoning parser automatically for known model 
 inspect eval math.py --model vllm/Qwen/Qwen3-8B -M reasoning_parser=qwen3
 ```
 
-For SGLang, Inspect starts the local server with `reasoning_parser=auto` unless you provide a parser explicitly.
+For SGLang, Inspect starts the local server with `reasoning_parser=auto` unless you provide a parser explicitly. Pass `-M reasoning_parser=none` to omit the reasoning parser server argument.
 
 Thinking mode is model-specific and controlled separately from `--reasoning-effort`. For models where vLLM exposes template switches such as `enable_thinking` or `thinking`, pass them as chat-template kwargs:
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -254,7 +254,7 @@ For vLLM, Inspect configures the reasoning parser automatically for known model 
 inspect eval math.py --model vllm/Qwen/Qwen3-8B -M reasoning_parser=qwen3
 ```
 
-For SGLang, Inspect starts the local server with `reasoning_parser=auto` unless you provide a parser explicitly.
+For SGLang, Inspect starts the local server with `reasoning_parser=auto` unless you provide a parser explicitly. Pass `-M reasoning_parser=none` to omit the reasoning parser server argument.
 
 Thinking mode is model-specific and controlled separately from `--reasoning-effort`. For models where vLLM exposes template switches such as `enable_thinking` or `thinking`, pass them as chat-template kwargs:
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -248,11 +248,13 @@ The following reasoning options are available from the CLI and within `GenerateC
 
 vLLM and SGLang both support reasoning outputs, but the configuration is model-specific. See the [vLLM](https://docs.vllm.ai/en/stable/features/reasoning_outputs.html) and [SGLang](https://docs.sglang.ai/backend/separate_reasoning.html) docs for details.
 
-For vLLM, configure the model's reasoning parser using `-M` model arguments. For example, Qwen3:
+For vLLM, Inspect configures the reasoning parser automatically for known model families. You can also override it using `-M` model arguments. For example, Qwen3:
 
 ``` bash
 inspect eval math.py --model vllm/Qwen/Qwen3-8B -M reasoning_parser=qwen3
 ```
+
+For SGLang, Inspect starts the local server with `reasoning_parser=auto` unless you provide a parser explicitly.
 
 Thinking mode is model-specific and controlled separately from `--reasoning-effort`. For models where vLLM exposes template switches such as `enable_thinking` or `thinking`, pass them as chat-template kwargs:
 

--- a/src/inspect_ai/model/_providers/sglang.py
+++ b/src/inspect_ai/model/_providers/sglang.py
@@ -137,7 +137,11 @@ class SGLangAPI(OpenAICompatibleAPI):
         if not api_key:
             api_key = "inspectai"  # Create a default API key if not provided
 
-        if "reasoning_parser" not in self.server_args:
+        missing = object()
+        parser = self.server_args.get("reasoning_parser", missing)
+        if parser is None or str(parser).strip().lower() in ("", "none"):
+            self.server_args.pop("reasoning_parser", None)
+        elif parser is missing:
             self.server_args["reasoning_parser"] = "auto"
 
         # Handle device configuration

--- a/src/inspect_ai/model/_providers/sglang.py
+++ b/src/inspect_ai/model/_providers/sglang.py
@@ -137,6 +137,9 @@ class SGLangAPI(OpenAICompatibleAPI):
         if not api_key:
             api_key = "inspectai"  # Create a default API key if not provided
 
+        if "reasoning_parser" not in self.server_args:
+            self.server_args["reasoning_parser"] = "auto"
+
         # Handle device configuration
         self.server_args, env_vars = configure_devices(
             self.server_args, parallel_size_param="tp"

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -267,7 +267,11 @@ class VLLMAPI(OpenAICompatibleAPI):
         # Work on a copy — the pops below are destructive and the original
         # must survive intact for restarts after close().
         server_args = dict(self.server_args)
-        if "reasoning_parser" not in server_args:
+        missing = object()
+        parser = server_args.get("reasoning_parser", missing)
+        if parser is None or str(parser).strip().lower() in ("", "none"):
+            server_args.pop("reasoning_parser", None)
+        elif parser is missing:
             reasoning_parser = reasoning_parser_for_model(model_path)
             if reasoning_parser:
                 server_args["reasoning_parser"] = reasoning_parser

--- a/src/inspect_ai/model/_providers/vllm.py
+++ b/src/inspect_ai/model/_providers/vllm.py
@@ -34,6 +34,7 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model import RetryDecision
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.model._reasoning import reasoning_parser_for_model
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
 
@@ -266,6 +267,10 @@ class VLLMAPI(OpenAICompatibleAPI):
         # Work on a copy — the pops below are destructive and the original
         # must survive intact for restarts after close().
         server_args = dict(self.server_args)
+        if "reasoning_parser" not in server_args:
+            reasoning_parser = reasoning_parser_for_model(model_path)
+            if reasoning_parser:
+                server_args["reasoning_parser"] = reasoning_parser
 
         server = self._server
         if server.enable_lora:

--- a/src/inspect_ai/model/_reasoning.py
+++ b/src/inspect_ai/model/_reasoning.py
@@ -17,6 +17,59 @@ from inspect_ai.model._chat_message import ChatMessage, ChatMessageAssistant
 logger = getLogger(__name__)
 
 
+NO_REASONING_MODEL_PATTERNS: tuple[str, ...] = (
+    r"(^|/)[^/]*(?:Base|Embedding|Reranker|Guard)(?:[-._/]|$)[^/]*",
+    r"(^|/)[^/]*(?:Non[-._]?Thinking|No[-._]?Think)(?:[-._/]|$)[^/]*",
+    r"(^|/)Qwen3(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
+    r"(^|/)Qwen3-Coder-Next(?:[-._/]|$)[^/]*",
+    r"(^|/)Kimi-K2(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
+)
+
+REASONING_PARSER_BY_MODEL: tuple[tuple[str, str], ...] = (
+    (r"(^|/)DeepSeek-V4(?:[-_/]|$)[^/]*", "deepseek_v4"),
+    (r"(^|/)DeepSeek-V3(?:[-_/]|$)[^/]*", "deepseek_v3"),
+
+    (r"(^|/)(?:DeepSeek-R1|QwQ|Intern-S1)(?:[-._/]|$)[^/]*", "deepseek_r1"),
+    (r"(^|/)Trinity-[^/]*(?:Think|Reasoning)[^/]*", "deepseek_r1"),
+
+    (r"(^|/)Qwen3(?:[-._/]|$)[^/]*", "qwen3"),
+    (r"(^|/)Intern-S[2-9]\d*(?:[-._/]|$)[^/]*", "qwen3"),
+    (r"(^|/)Mellum\d*-[^/]*(?:Think|Reasoning)[^/]*", "qwen3"),
+
+    (r"(^|/)Kimi-K2(?:[-._/]|$)[^/]*", "kimi_k2"),
+
+    (r"(^|/)(?:Magistral(?:[-._/]|$)|Ministral[^/]*Reasoning)[^/]*", "mistral"),
+    (r"(^|/)Mistral-(?:Medium-3\.5|Small-4)(?:[-._/]|$)[^/]*", "mistral"),
+
+    (r"(^|/)(?:MiniMax|MM)-M2(?:[-._/]|$)[^/]*", "minimax_m2"),
+
+    (r"(^|/)GLM-(?:4\.(?:[5-9]|[1-9]\d+)|5(?:\.\d+)*)(?:V)?(?:[-._/]|$)[^/]*", "glm45"),
+    (r"(^|/)(?:GLM-GA|Glyph)(?:[-._/]|$)[^/]*", "glm45"),
+
+    (r"(^|/)gemma-4(?:[-._/]|$)[^/]*", "gemma4"),
+    (r"(^|/)ERNIE-4(?:\.\d+)*-[^/]*Thinking[^/]*", "ernie45"),
+    (r"(^|/)granite-3\.(?:[2-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "granite"),
+
+    (r"(^|/)Hunyuan-[^/]*A13B(?:[-._/]|$)[^/]*", "hunyuan_a13b"),
+    (r"(^|/)(?:Hy3|Hunyuan-?3)(?:[-._/]|$)[^/]*", "hy_v3"),
+    (r"(^|/)Holo2(?:[-._/]|$)[^/]*", "holo2"),
+
+    (r"(^|/)(?:Xiaomi)?MiMo-V2(?:[-._/]|$)[^/]*", "mimo"),
+    (r"(^|/)Olmo-3(?:\.\d+)*-[^/]*(?:Think|Reasoning)[^/]*", "olmo3"),
+    (r"(^|/)Seed[-._]?OSS(?:[-._/]|$)[^/]*", "seed_oss"),
+
+    (r"(^|/)(?:NVIDIA-)?Nemotron-3-(?:Super|Ultra)(?:[-._/]|$)[^/]*", "nemotron_v3"),
+    (r"(^|/)(?:NVIDIA-)?Nemotron-3-[^/]*(?:Omni|Reasoning)[^/]*", "nemotron_v3"),
+
+    (r"(^|/)Step-3\.(?:[5-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "step3p5"),
+    (r"(^|/)Step-3(?:[-._/]|$)[^/]*", "step3"),
+
+    (r"(^|/)command-a-[^/]*reasoning[^/]*", "cohere_command3"),
+    (r"(^|/)(?:command-a-plus(?:[-._/]|$)|North-)[^/]*", "cohere_command4"),
+
+    (r"(^|/)(?:Laguna(?:[-._/]|$)|Poolside-[^/]*Laguna)[^/]*", "poolside_v1"),
+)
+
 # Fixed effort -> token budget table used to bridge `reasoning_effort` onto
 # providers that only accept an explicit token budget (Anthropic Claude 3.7-4.5,
 # Google Gemini 2.5). Magnitudes mirror the existing Anthropic max_tokens-sizing
@@ -122,6 +175,21 @@ def parse_content_with_reasoning(content: str) -> tuple[str, ReasoningCapsule | 
         )
     else:
         return content, None
+
+
+def reasoning_parser_for_model(model: str | None) -> str | None:
+    if not model:
+        return None
+
+    for pattern in NO_REASONING_MODEL_PATTERNS:
+        if re.search(pattern, model, re.IGNORECASE):
+            return None
+
+    for pattern, parser in REASONING_PARSER_BY_MODEL:
+        if re.search(pattern, model, re.IGNORECASE):
+            return parser
+
+    return None
 
 
 def _parse_attr(attrs_str: str, name: str) -> str | None:

--- a/src/inspect_ai/model/_reasoning.py
+++ b/src/inspect_ai/model/_reasoning.py
@@ -1,4 +1,5 @@
 import base64
+import fnmatch
 import html
 import json
 import re
@@ -17,57 +18,152 @@ from inspect_ai.model._chat_message import ChatMessage, ChatMessageAssistant
 logger = getLogger(__name__)
 
 
+class ReasoningParserRule(NamedTuple):
+    families: tuple[str, ...]
+    parser: str
+    include: tuple[str, ...]
+
+
 NO_REASONING_MODEL_PATTERNS: tuple[str, ...] = (
-    r"(^|/)[^/]*(?:Base|Embedding|Reranker|Guard)(?:[-._/]|$)[^/]*",
-    r"(^|/)[^/]*(?:Non[-._]?Thinking|No[-._]?Think)(?:[-._/]|$)[^/]*",
-    r"(^|/)Qwen3(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
-    r"(^|/)Qwen3-Coder-Next(?:[-._/]|$)[^/]*",
-    r"(^|/)Kimi-K2(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
+    "*[-._/]base*",
+    "*[-._/]embedding*",
+    "*[-._/]reranker*",
+    "*[-._/]guard*",
+    "*no*think*",
+    "*qwen3*instruct*",
+    "*qwen3-coder-next*",
+    "*kimi-k2*instruct*",
 )
 
-REASONING_PARSER_BY_MODEL: tuple[tuple[str, str], ...] = (
-    (r"(^|/)DeepSeek-V4(?:[-_/]|$)[^/]*", "deepseek_v4"),
-    (r"(^|/)DeepSeek-V3(?:[-_/]|$)[^/]*", "deepseek_v3"),
-
-    (r"(^|/)(?:DeepSeek-R1|QwQ|Intern-S1)(?:[-._/]|$)[^/]*", "deepseek_r1"),
-    (r"(^|/)Trinity-[^/]*(?:Think|Reasoning)[^/]*", "deepseek_r1"),
-
-    (r"(^|/)Qwen3(?:[-._/]|$)[^/]*", "qwen3"),
-    (r"(^|/)Intern-S[2-9]\d*(?:[-._/]|$)[^/]*", "qwen3"),
-    (r"(^|/)Mellum\d*-[^/]*(?:Think|Reasoning)[^/]*", "qwen3"),
-
-    (r"(^|/)Kimi-K2(?:[-._/]|$)[^/]*", "kimi_k2"),
-
-    (r"(^|/)(?:Magistral(?:[-._/]|$)|Ministral[^/]*Reasoning)[^/]*", "mistral"),
-    (r"(^|/)Mistral-(?:Medium-3\.5|Small-4)(?:[-._/]|$)[^/]*", "mistral"),
-
-    (r"(^|/)(?:MiniMax|MM)-M2(?:[-._/]|$)[^/]*", "minimax_m2"),
-
-    (r"(^|/)GLM-(?:4\.(?:[5-9]|[1-9]\d+)|5(?:\.\d+)*)(?:V)?(?:[-._/]|$)[^/]*", "glm45"),
-    (r"(^|/)(?:GLM-GA|Glyph)(?:[-._/]|$)[^/]*", "glm45"),
-
-    (r"(^|/)gemma-4(?:[-._/]|$)[^/]*", "gemma4"),
-    (r"(^|/)ERNIE-4(?:\.\d+)*-[^/]*Thinking[^/]*", "ernie45"),
-    (r"(^|/)granite-3\.(?:[2-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "granite"),
-
-    (r"(^|/)Hunyuan-[^/]*A13B(?:[-._/]|$)[^/]*", "hunyuan_a13b"),
-    (r"(^|/)(?:Hy3|Hunyuan-?3)(?:[-._/]|$)[^/]*", "hy_v3"),
-    (r"(^|/)Holo2(?:[-._/]|$)[^/]*", "holo2"),
-
-    (r"(^|/)(?:Xiaomi)?MiMo-V2(?:[-._/]|$)[^/]*", "mimo"),
-    (r"(^|/)Olmo-3(?:\.\d+)*-[^/]*(?:Think|Reasoning)[^/]*", "olmo3"),
-    (r"(^|/)Seed[-._]?OSS(?:[-._/]|$)[^/]*", "seed_oss"),
-
-    (r"(^|/)(?:NVIDIA-)?Nemotron-3-(?:Super|Ultra)(?:[-._/]|$)[^/]*", "nemotron_v3"),
-    (r"(^|/)(?:NVIDIA-)?Nemotron-3-[^/]*(?:Omni|Reasoning)[^/]*", "nemotron_v3"),
-
-    (r"(^|/)Step-3\.(?:[5-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "step3p5"),
-    (r"(^|/)Step-3(?:[-._/]|$)[^/]*", "step3"),
-
-    (r"(^|/)command-a-[^/]*reasoning[^/]*", "cohere_command3"),
-    (r"(^|/)(?:command-a-plus(?:[-._/]|$)|North-)[^/]*", "cohere_command4"),
-
-    (r"(^|/)(?:Laguna(?:[-._/]|$)|Poolside-[^/]*Laguna)[^/]*", "poolside_v1"),
+REASONING_PARSER_RULES: tuple[ReasoningParserRule, ...] = (
+    ReasoningParserRule(("DeepSeek V4",), "deepseek_v4", ("*deepseek-v4*",)),
+    ReasoningParserRule(("DeepSeek V3",), "deepseek_v3", ("*deepseek-v3*",)),
+    ReasoningParserRule(
+        ("DeepSeek R1", "QwQ", "Intern-S1", "Trinity"),
+        "deepseek_r1",
+        (
+            "*deepseek-r1*",
+            "*qwq*",
+            "*intern-s1*",
+            "*trinity-*think*",
+            "*trinity-*reasoning*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Qwen3", "Intern-S2+", "Mellum"),
+        "qwen3",
+        (
+            "*qwen3*",
+            "*intern-s[2-9]*",
+            "*mellum*-*think*",
+            "*mellum*-*reasoning*",
+        ),
+    ),
+    ReasoningParserRule(("Kimi K2",), "kimi_k2", ("*kimi-k2*",)),
+    ReasoningParserRule(
+        ("Mistral", "Magistral", "Ministral"),
+        "mistral",
+        (
+            "*magistral*",
+            "*ministral*reasoning*",
+            "*mistral-medium-3.5*",
+            "*mistral-small-4*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("MiniMax M2", "MM M2"),
+        "minimax_m2",
+        ("*minimax-m2*", "*mm-m2*"),
+    ),
+    ReasoningParserRule(
+        ("GLM", "Glyph"),
+        "glm45",
+        (
+            "*glm-4.[5-9]*",
+            "*glm-4.[1-9][0-9]*",
+            "*glm-5*",
+            "*glm-ga*",
+            "*glyph*",
+        ),
+    ),
+    ReasoningParserRule(("Gemma 4",), "gemma4", ("*gemma-4*",)),
+    ReasoningParserRule(("ERNIE 4.5",), "ernie45", ("*ernie-4*-*thinking*",)),
+    ReasoningParserRule(
+        ("Granite",),
+        "granite",
+        (
+            "*granite-3.[2-9]*",
+            "*granite-3.[1-9][0-9]*",
+        ),
+    ),
+    ReasoningParserRule(("Hunyuan A13B",), "hunyuan_a13b", ("*hunyuan-*a13b*",)),
+    ReasoningParserRule(
+        ("Hunyuan V3", "Hy3"),
+        "hy_v3",
+        (
+            "*hy3*",
+            "*hunyuan3*",
+            "*hunyuan-3*",
+        ),
+    ),
+    ReasoningParserRule(("Holo2",), "holo2", ("*holo2*",)),
+    ReasoningParserRule(
+        ("MiMo V2", "Xiaomi MiMo V2"),
+        "mimo",
+        (
+            "*mimo-v2*",
+            "*xiaomimimo-v2*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Olmo 3",),
+        "olmo3",
+        ("*olmo-3*-*think*", "*olmo-3*-*reasoning*"),
+    ),
+    ReasoningParserRule(
+        ("Seed OSS",),
+        "seed_oss",
+        (
+            "*seed-oss*",
+            "*seed_oss*",
+            "*seedoss*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Nemotron V3", "NVIDIA Nemotron V3"),
+        "nemotron_v3",
+        (
+            "*nemotron-3-super*",
+            "*nvidia-nemotron-3-super*",
+            "*nemotron-3-ultra*",
+            "*nvidia-nemotron-3-ultra*",
+            "*nemotron-3-*omni*",
+            "*nemotron-3-*reasoning*",
+            "*nvidia-nemotron-3-*omni*",
+            "*nvidia-nemotron-3-*reasoning*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Step 3.5+",),
+        "step3p5",
+        ("*step-3.[5-9]*", "*step-3.[1-9][0-9]*"),
+    ),
+    ReasoningParserRule(("Step 3",), "step3", ("*step-3*",)),
+    ReasoningParserRule(
+        ("Cohere Command A reasoning",),
+        "cohere_command3",
+        ("*command-a-*reasoning*",),
+    ),
+    ReasoningParserRule(
+        ("Cohere Command A Plus", "North"),
+        "cohere_command4",
+        ("*command-a-plus*", "*north-*"),
+    ),
+    ReasoningParserRule(
+        ("Poolside V1", "Laguna"),
+        "poolside_v1",
+        ("*laguna*", "*poolside-*laguna*"),
+    ),
 )
 
 # Fixed effort -> token budget table used to bridge `reasoning_effort` onto
@@ -181,15 +277,19 @@ def reasoning_parser_for_model(model: str | None) -> str | None:
     if not model:
         return None
 
-    for pattern in NO_REASONING_MODEL_PATTERNS:
-        if re.search(pattern, model, re.IGNORECASE):
-            return None
+    if _matches_model_patterns(model, NO_REASONING_MODEL_PATTERNS):
+        return None
 
-    for pattern, parser in REASONING_PARSER_BY_MODEL:
-        if re.search(pattern, model, re.IGNORECASE):
-            return parser
+    for rule in REASONING_PARSER_RULES:
+        if _matches_model_patterns(model, rule.include):
+            return rule.parser
 
     return None
+
+
+def _matches_model_patterns(model: str, patterns: tuple[str, ...]) -> bool:
+    model_path = f"/{model}".lower()
+    return any(fnmatch.fnmatchcase(model_path, pattern) for pattern in patterns)
 
 
 def _parse_attr(attrs_str: str, name: str) -> str | None:

--- a/src/inspect_ai/model/_reasoning.py
+++ b/src/inspect_ai/model/_reasoning.py
@@ -1,4 +1,5 @@
 import base64
+import fnmatch
 import html
 import json
 import re
@@ -17,57 +18,152 @@ from inspect_ai.model._chat_message import ChatMessage, ChatMessageAssistant
 logger = getLogger(__name__)
 
 
+class ReasoningParserRule(NamedTuple):
+    families: tuple[str, ...]
+    parser: str
+    include: tuple[str, ...]
+
+
 NO_REASONING_MODEL_PATTERNS: tuple[str, ...] = (
-    r"(^|/)[^/]*(?:Base|Embedding|Reranker|Guard)(?:[-._/]|$)[^/]*",
-    r"(^|/)[^/]*(?:Non[-._]?Thinking|No[-._]?Think)(?:[-._/]|$)[^/]*",
-    r"(^|/)Qwen3(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
-    r"(^|/)Qwen3-Coder-Next(?:[-._/]|$)[^/]*",
-    r"(^|/)Kimi-K2(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
+    "*[-._/]base*",
+    "*[-._/]embedding*",
+    "*[-._/]reranker*",
+    "*[-._/]guard*",
+    "*no*think*",
+    "*qwen3*instruct*",
+    "*qwen3-coder-next*",
+    "*kimi-k2*instruct*",
 )
 
-REASONING_PARSER_BY_MODEL: tuple[tuple[str, str], ...] = (
-    (r"(^|/)DeepSeek-V4(?:[-_/]|$)[^/]*", "deepseek_v4"),
-    (r"(^|/)DeepSeek-V3(?:[-_/]|$)[^/]*", "deepseek_v3"),
-
-    (r"(^|/)(?:DeepSeek-R1|QwQ|Intern-S1)(?:[-._/]|$)[^/]*", "deepseek_r1"),
-    (r"(^|/)Trinity-[^/]*(?:Think|Reasoning)[^/]*", "deepseek_r1"),
-
-    (r"(^|/)Qwen3(?:[-._/]|$)[^/]*", "qwen3"),
-    (r"(^|/)Intern-S[2-9]\d*(?:[-._/]|$)[^/]*", "qwen3"),
-    (r"(^|/)Mellum\d*-[^/]*(?:Think|Reasoning)[^/]*", "qwen3"),
-
-    (r"(^|/)Kimi-K2(?:[-._/]|$)[^/]*", "kimi_k2"),
-
-    (r"(^|/)(?:Magistral(?:[-._/]|$)|Ministral[^/]*Reasoning)[^/]*", "mistral"),
-    (r"(^|/)Mistral-(?:Medium-3\.5|Small-4)(?:[-._/]|$)[^/]*", "mistral"),
-
-    (r"(^|/)(?:MiniMax|MM)-M2(?:[-._/]|$)[^/]*", "minimax_m2"),
-
-    (r"(^|/)GLM-(?:4\.(?:[5-9]|[1-9]\d+)|5(?:\.\d+)*)(?:V)?(?:[-._/]|$)[^/]*", "glm45"),
-    (r"(^|/)(?:GLM-GA|Glyph)(?:[-._/]|$)[^/]*", "glm45"),
-
-    (r"(^|/)gemma-4(?:[-._/]|$)[^/]*", "gemma4"),
-    (r"(^|/)ERNIE-4(?:\.\d+)*-[^/]*Thinking[^/]*", "ernie45"),
-    (r"(^|/)granite-3\.(?:[2-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "granite"),
-
-    (r"(^|/)Hunyuan-[^/]*A13B(?:[-._/]|$)[^/]*", "hunyuan_a13b"),
-    (r"(^|/)(?:Hy3|Hunyuan-?3)(?:[-._/]|$)[^/]*", "hy_v3"),
-    (r"(^|/)Holo2(?:[-._/]|$)[^/]*", "holo2"),
-
-    (r"(^|/)(?:Xiaomi)?MiMo-V2(?:[-._/]|$)[^/]*", "mimo"),
-    (r"(^|/)Olmo-3(?:\.\d+)*-[^/]*(?:Think|Reasoning)[^/]*", "olmo3"),
-    (r"(^|/)Seed[-._]?OSS(?:[-._/]|$)[^/]*", "seed_oss"),
-
-    (r"(^|/)(?:NVIDIA-)?Nemotron-3-(?:Super|Ultra)(?:[-._/]|$)[^/]*", "nemotron_v3"),
-    (r"(^|/)(?:NVIDIA-)?Nemotron-3-[^/]*(?:Omni|Reasoning)[^/]*", "nemotron_v3"),
-
-    (r"(^|/)Step-3\.(?:[5-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "step3p5"),
-    (r"(^|/)Step-3(?:[-._/]|$)[^/]*", "step3"),
-
-    (r"(^|/)command-a-[^/]*reasoning[^/]*", "cohere_command3"),
-    (r"(^|/)(?:command-a-plus(?:[-._/]|$)|North-)[^/]*", "cohere_command4"),
-
-    (r"(^|/)(?:Laguna(?:[-._/]|$)|Poolside-[^/]*Laguna)[^/]*", "poolside_v1"),
+REASONING_PARSER_RULES: tuple[ReasoningParserRule, ...] = (
+    ReasoningParserRule(("DeepSeek V4",), "deepseek_v4", ("*deepseek-v4*",)),
+    ReasoningParserRule(("DeepSeek V3",), "deepseek_v3", ("*deepseek-v3*",)),
+    ReasoningParserRule(
+        ("DeepSeek R1", "QwQ", "Intern-S1", "Trinity"),
+        "deepseek_r1",
+        (
+            "*deepseek-r1*",
+            "*qwq*",
+            "*intern-s1*",
+            "*trinity-*think*",
+            "*trinity-*reasoning*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Qwen3", "Intern-S2+", "Mellum"),
+        "qwen3",
+        (
+            "*qwen3*",
+            "*intern-s[2-9]*",
+            "*mellum*-*think*",
+            "*mellum*-*reasoning*",
+        ),
+    ),
+    ReasoningParserRule(("Kimi K2",), "kimi_k2", ("*kimi-k2*",)),
+    ReasoningParserRule(
+        ("Mistral", "Magistral", "Ministral"),
+        "mistral",
+        (
+            "*magistral*",
+            "*ministral*reasoning*",
+            "*mistral-medium-3.5*",
+            "*mistral-small-4*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("MiniMax M2", "MM M2"),
+        "minimax_m2",
+        ("*minimax-m2*", "*mm-m2*"),
+    ),
+    ReasoningParserRule(
+        ("GLM", "Glyph"),
+        "glm45",
+        (
+            "*glm-4.[5-9]*",
+            "*glm-4.[1-9][0-9]*",
+            "*glm-5*",
+            "*glm-ga*",
+            "*glyph*",
+        ),
+    ),
+    ReasoningParserRule(("Gemma 4",), "gemma4", ("*gemma-4*",)),
+    ReasoningParserRule(("ERNIE 4.5",), "ernie45", ("*ernie-4*-*thinking*",)),
+    ReasoningParserRule(
+        ("Granite",),
+        "granite",
+        (
+            "*granite-3.[2-9]*",
+            "*granite-3.[1-9][0-9]*",
+        ),
+    ),
+    ReasoningParserRule(("Hunyuan A13B",), "hunyuan_a13b", ("*hunyuan-*a13b*",)),
+    ReasoningParserRule(
+        ("Hunyuan V3", "Hy3"),
+        "hy_v3",
+        (
+            "*hy3*",
+            "*hunyuan3*",
+            "*hunyuan-3*",
+        ),
+    ),
+    ReasoningParserRule(("Holo2",), "holo2", ("*holo2*",)),
+    ReasoningParserRule(
+        ("MiMo V2", "Xiaomi MiMo V2"),
+        "mimo",
+        (
+            "*mimo-v2*",
+            "*xiaomimimo-v2*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Olmo 3",),
+        "olmo3",
+        ("*olmo-3*-*think*", "*olmo-3*-*reasoning*"),
+    ),
+    ReasoningParserRule(
+        ("Seed OSS",),
+        "seed_oss",
+        (
+            "*seed-oss*",
+            "*seed_oss*",
+            "*seedoss*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Nemotron V3", "NVIDIA Nemotron V3"),
+        "nemotron_v3",
+        (
+            "*nemotron-3-super*",
+            "*nvidia-nemotron-3-super*",
+            "*nemotron-3-ultra*",
+            "*nvidia-nemotron-3-ultra*",
+            "*nemotron-3-*omni*",
+            "*nemotron-3-*reasoning*",
+            "*nvidia-nemotron-3-*omni*",
+            "*nvidia-nemotron-3-*reasoning*",
+        ),
+    ),
+    ReasoningParserRule(
+        ("Step 3.5+",),
+        "step3p5",
+        ("*step-3.[5-9]*", "*step-3.[1-9][0-9]*"),
+    ),
+    ReasoningParserRule(("Step 3",), "step3", ("*step-3*",)),
+    ReasoningParserRule(
+        ("Cohere Command A reasoning",),
+        "cohere_command3",
+        ("*command-a-*reasoning*",),
+    ),
+    ReasoningParserRule(
+        ("Cohere Command A Plus", "North"),
+        "cohere_command4",
+        ("*command-a-plus*", "*north-*"),
+    ),
+    ReasoningParserRule(
+        ("Poolside V1", "Laguna"),
+        "poolside_v1",
+        ("*laguna*", "*poolside-*laguna*"),
+    ),
 )
 
 # Fixed effort -> token budget table used to bridge `reasoning_effort` onto
@@ -227,15 +323,19 @@ def reasoning_parser_for_model(model: str | None) -> str | None:
     if not model:
         return None
 
-    for pattern in NO_REASONING_MODEL_PATTERNS:
-        if re.search(pattern, model, re.IGNORECASE):
-            return None
+    if _matches_model_patterns(model, NO_REASONING_MODEL_PATTERNS):
+        return None
 
-    for pattern, parser in REASONING_PARSER_BY_MODEL:
-        if re.search(pattern, model, re.IGNORECASE):
-            return parser
+    for rule in REASONING_PARSER_RULES:
+        if _matches_model_patterns(model, rule.include):
+            return rule.parser
 
     return None
+
+
+def _matches_model_patterns(model: str, patterns: tuple[str, ...]) -> bool:
+    model_path = f"/{model}".lower()
+    return any(fnmatch.fnmatchcase(model_path, pattern) for pattern in patterns)
 
 
 def _parse_attr(attrs_str: str, name: str) -> str | None:

--- a/src/inspect_ai/model/_reasoning.py
+++ b/src/inspect_ai/model/_reasoning.py
@@ -17,6 +17,59 @@ from inspect_ai.model._chat_message import ChatMessage, ChatMessageAssistant
 logger = getLogger(__name__)
 
 
+NO_REASONING_MODEL_PATTERNS: tuple[str, ...] = (
+    r"(^|/)[^/]*(?:Base|Embedding|Reranker|Guard)(?:[-._/]|$)[^/]*",
+    r"(^|/)[^/]*(?:Non[-._]?Thinking|No[-._]?Think)(?:[-._/]|$)[^/]*",
+    r"(^|/)Qwen3(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
+    r"(^|/)Qwen3-Coder-Next(?:[-._/]|$)[^/]*",
+    r"(^|/)Kimi-K2(?:\.\d+)*-[^/]*Instruct(?:[-._/]|$)[^/]*",
+)
+
+REASONING_PARSER_BY_MODEL: tuple[tuple[str, str], ...] = (
+    (r"(^|/)DeepSeek-V4(?:[-_/]|$)[^/]*", "deepseek_v4"),
+    (r"(^|/)DeepSeek-V3(?:[-_/]|$)[^/]*", "deepseek_v3"),
+
+    (r"(^|/)(?:DeepSeek-R1|QwQ|Intern-S1)(?:[-._/]|$)[^/]*", "deepseek_r1"),
+    (r"(^|/)Trinity-[^/]*(?:Think|Reasoning)[^/]*", "deepseek_r1"),
+
+    (r"(^|/)Qwen3(?:[-._/]|$)[^/]*", "qwen3"),
+    (r"(^|/)Intern-S[2-9]\d*(?:[-._/]|$)[^/]*", "qwen3"),
+    (r"(^|/)Mellum\d*-[^/]*(?:Think|Reasoning)[^/]*", "qwen3"),
+
+    (r"(^|/)Kimi-K2(?:[-._/]|$)[^/]*", "kimi_k2"),
+
+    (r"(^|/)(?:Magistral(?:[-._/]|$)|Ministral[^/]*Reasoning)[^/]*", "mistral"),
+    (r"(^|/)Mistral-(?:Medium-3\.5|Small-4)(?:[-._/]|$)[^/]*", "mistral"),
+
+    (r"(^|/)(?:MiniMax|MM)-M2(?:[-._/]|$)[^/]*", "minimax_m2"),
+
+    (r"(^|/)GLM-(?:4\.(?:[5-9]|[1-9]\d+)|5(?:\.\d+)*)(?:V)?(?:[-._/]|$)[^/]*", "glm45"),
+    (r"(^|/)(?:GLM-GA|Glyph)(?:[-._/]|$)[^/]*", "glm45"),
+
+    (r"(^|/)gemma-4(?:[-._/]|$)[^/]*", "gemma4"),
+    (r"(^|/)ERNIE-4(?:\.\d+)*-[^/]*Thinking[^/]*", "ernie45"),
+    (r"(^|/)granite-3\.(?:[2-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "granite"),
+
+    (r"(^|/)Hunyuan-[^/]*A13B(?:[-._/]|$)[^/]*", "hunyuan_a13b"),
+    (r"(^|/)(?:Hy3|Hunyuan-?3)(?:[-._/]|$)[^/]*", "hy_v3"),
+    (r"(^|/)Holo2(?:[-._/]|$)[^/]*", "holo2"),
+
+    (r"(^|/)(?:Xiaomi)?MiMo-V2(?:[-._/]|$)[^/]*", "mimo"),
+    (r"(^|/)Olmo-3(?:\.\d+)*-[^/]*(?:Think|Reasoning)[^/]*", "olmo3"),
+    (r"(^|/)Seed[-._]?OSS(?:[-._/]|$)[^/]*", "seed_oss"),
+
+    (r"(^|/)(?:NVIDIA-)?Nemotron-3-(?:Super|Ultra)(?:[-._/]|$)[^/]*", "nemotron_v3"),
+    (r"(^|/)(?:NVIDIA-)?Nemotron-3-[^/]*(?:Omni|Reasoning)[^/]*", "nemotron_v3"),
+
+    (r"(^|/)Step-3\.(?:[5-9]|[1-9]\d+)(?:[-._/]|$)[^/]*", "step3p5"),
+    (r"(^|/)Step-3(?:[-._/]|$)[^/]*", "step3"),
+
+    (r"(^|/)command-a-[^/]*reasoning[^/]*", "cohere_command3"),
+    (r"(^|/)(?:command-a-plus(?:[-._/]|$)|North-)[^/]*", "cohere_command4"),
+
+    (r"(^|/)(?:Laguna(?:[-._/]|$)|Poolside-[^/]*Laguna)[^/]*", "poolside_v1"),
+)
+
 # Fixed effort -> token budget table used to bridge `reasoning_effort` onto
 # providers that only accept an explicit token budget (Anthropic Claude 3.7-4.5,
 # Google Gemini 2.5). Magnitudes mirror the existing Anthropic max_tokens-sizing
@@ -166,6 +219,21 @@ def _find_nested_think_block(content: str) -> re.Match[str] | None:
             depth -= 1
             if depth == 0:
                 return pattern.search(content, start, match.end())
+
+    return None
+
+
+def reasoning_parser_for_model(model: str | None) -> str | None:
+    if not model:
+        return None
+
+    for pattern in NO_REASONING_MODEL_PATTERNS:
+        if re.search(pattern, model, re.IGNORECASE):
+            return None
+
+    for pattern, parser in REASONING_PARSER_BY_MODEL:
+        if re.search(pattern, model, re.IGNORECASE):
+            return parser
 
     return None
 

--- a/tests/model/test_reasoning_parse.py
+++ b/tests/model/test_reasoning_parse.py
@@ -1,4 +1,32 @@
-from inspect_ai.model._reasoning import parse_content_with_reasoning
+from inspect_ai.model._reasoning import (
+    parse_content_with_reasoning,
+    reasoning_parser_for_model,
+)
+
+
+def test_reasoning_parser_for_model_matches_hf_and_quantized_names():
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B") == "qwen3"
+    assert reasoning_parser_for_model("unsloth/Qwen3-8B-AWQ") == "qwen3"
+    assert reasoning_parser_for_model("zai-org/GLM-4.5-Air") == "glm45"
+    assert reasoning_parser_for_model("zai-org/GLM-5") == "glm45"
+
+
+def test_reasoning_parser_for_model_does_not_match_next_generation():
+    assert reasoning_parser_for_model("Qwen/Qwen4-8B") is None
+    assert reasoning_parser_for_model("deepseek-ai/DeepSeek-V5-Pro") is None
+    assert reasoning_parser_for_model("zai-org/GLM-6") is None
+
+
+def test_reasoning_parser_for_model_skips_no_reasoning_patterns():
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-Base") is None
+    assert reasoning_parser_for_model("jinaai/jina-embeddings-v4") is None
+    assert reasoning_parser_for_model("acme/reward-reranker-v1") is None
+    assert reasoning_parser_for_model("meta-llama/Llama-Guard-4") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-Non-Thinking") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-NoThink") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-Instruct") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-Coder-Next") is None
+    assert reasoning_parser_for_model("moonshotai/Kimi-K2-Instruct") is None
 
 
 def test_reasoning_parse_basic():
@@ -87,6 +115,17 @@ def test_reasoning_parse_no_think_tag():
 def test_reasoning_parse_unclosed_tag():
     content, reasoning = parse_content_with_reasoning("<think>Unclosed reasoning")
     assert reasoning is None
+
+
+def test_reasoning_parse_skips_unmapped_models():
+    assert reasoning_parser_for_model("custom-org/custom-model") is None
+
+
+def test_reasoning_parse_uses_tags_when_model_missing():
+    content, reasoning = parse_content_with_reasoning("<think>private</think>answer")
+    assert reasoning is not None
+    assert reasoning.reasoning == "private"
+    assert content == "answer"
 
 
 # New tests for signature attribute

--- a/tests/model/test_reasoning_parse.py
+++ b/tests/model/test_reasoning_parse.py
@@ -1,4 +1,32 @@
-from inspect_ai.model._reasoning import parse_content_with_reasoning
+from inspect_ai.model._reasoning import (
+    parse_content_with_reasoning,
+    reasoning_parser_for_model,
+)
+
+
+def test_reasoning_parser_for_model_matches_hf_and_quantized_names():
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B") == "qwen3"
+    assert reasoning_parser_for_model("unsloth/Qwen3-8B-AWQ") == "qwen3"
+    assert reasoning_parser_for_model("zai-org/GLM-4.5-Air") == "glm45"
+    assert reasoning_parser_for_model("zai-org/GLM-5") == "glm45"
+
+
+def test_reasoning_parser_for_model_does_not_match_next_generation():
+    assert reasoning_parser_for_model("Qwen/Qwen4-8B") is None
+    assert reasoning_parser_for_model("deepseek-ai/DeepSeek-V5-Pro") is None
+    assert reasoning_parser_for_model("zai-org/GLM-6") is None
+
+
+def test_reasoning_parser_for_model_skips_no_reasoning_patterns():
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-Base") is None
+    assert reasoning_parser_for_model("jinaai/jina-embeddings-v4") is None
+    assert reasoning_parser_for_model("acme/reward-reranker-v1") is None
+    assert reasoning_parser_for_model("meta-llama/Llama-Guard-4") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-Non-Thinking") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-NoThink") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-8B-Instruct") is None
+    assert reasoning_parser_for_model("Qwen/Qwen3-Coder-Next") is None
+    assert reasoning_parser_for_model("moonshotai/Kimi-K2-Instruct") is None
 
 
 def test_reasoning_parse_basic():
@@ -123,6 +151,17 @@ def test_reasoning_parse_unclosed_nested_block_falls_back():
     assert reasoning is not None
     assert reasoning.reasoning == "Outer <think>inner"
     assert content == "continues<think> inner </think>Visible text"
+
+
+def test_reasoning_parse_skips_unmapped_models():
+    assert reasoning_parser_for_model("custom-org/custom-model") is None
+
+
+def test_reasoning_parse_uses_tags_when_model_missing():
+    content, reasoning = parse_content_with_reasoning("<think>private</think>answer")
+    assert reasoning is not None
+    assert reasoning.reasoning == "private"
+    assert content == "answer"
 
 
 # New tests for signature attribute


### PR DESCRIPTION
## Summary

This PR adds automatic reasoning parser configuration for local vLLM and SGLang backends.

Currently, users need to manually pass `reasoning_parser` for vLLM models that emit structured reasoning output. This PR lets Inspect infer the appropriate parser for known reasoning model families from the model name, while still preserving explicit user overrides.

## Changes

* Add `reasoning_parser_for_model()` to map known model families to their vLLM reasoning parser names.
* Configure vLLM `reasoning_parser` automatically when:

  * the model name matches a known reasoning model family;
  * the user has not already provided `reasoning_parser` via model/server arguments.
* Configure local SGLang servers with `reasoning_parser=auto` by default, unless explicitly overridden.
* Add exclusion patterns for models that should not be treated as reasoning models, such as:

  * base models;
  * embedding/reranker/guard models;
  * non-thinking / no-think variants;
  * selected instruct variants that do not use the reasoning parser format.
* Add unit tests for:

  * known model-family detection;
  * quantized/Hugging Face-style model names;
  * avoiding accidental matches for future major model versions;
  * no-reasoning exclusions;
  * unmapped/custom models.
* Update reasoning documentation to describe the new default behaviour and override path.

## Motivation

This reduces configuration friction for common local reasoning-model setups. Users can run models such as Qwen3, GLM, DeepSeek-style reasoning models, Kimi-K2, Mistral reasoning variants, and other supported families without needing to remember the exact vLLM parser name.

Explicit configuration remains supported and takes precedence, so this should not break users who already pass `-M reasoning_parser=...`.

## Behaviour

For vLLM:

```bash
inspect eval math.py --model vllm/Qwen/Qwen3-8B
```

Inspect will infer:

```text
reasoning_parser=qwen3
```

Users can still override it explicitly:

```bash
inspect eval math.py --model vllm/Qwen/Qwen3-8B -M reasoning_parser=qwen3
```

For SGLang, Inspect starts the local server with:

```text
reasoning_parser=auto
```

unless the user provides a different parser explicitly.

## Validation

Added unit coverage in `tests/model/test_reasoning_parse.py` for parser detection, exclusions, unmapped models, and fallback reasoning-tag parsing.

I am working on this with @amatveiakin, @vladmesh, @bodraski, and @elenaars.
