### PR TITLE
fix(_util): truncate fractional seconds in format_progress_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bugfix: Elapsed-time displays (e.g. the running-sample clock and timers) no longer render an impossible `:60` seconds when the elapsed time has a fractional second.
+
 ## 0.3.242 (29 June 2026)
 
 - Log: Shared sample buffer files synced to S3 (via `--log-shared`) are now tagged `inspect-ephemeral=true` so they can be targeted by an S3 lifecycle rule.

--- a/src/inspect_ai/_util/format.py
+++ b/src/inspect_ai/_util/format.py
@@ -30,10 +30,15 @@ def format_value(value: object, width: int) -> str:
 
 
 def format_progress_time(time: float, pad_hours: bool = True) -> str:
-    minutes, seconds = divmod(time, 60)
+    # Truncate sub-second elapsed time before splitting into H:MM:SS. The
+    # ".0f" format specs round, so a fractional component >= x.5 (e.g. 59.9s)
+    # would otherwise render an impossible ":60" in the seconds (or minutes)
+    # field of a live clock.
+    total_seconds = int(time)
+    minutes, seconds = divmod(total_seconds, 60)
     hours, minutes = divmod(minutes, 60)
-    hours_fmt = f"{hours:2.0f}" if pad_hours else f"{hours:.0f}"
-    return f"{hours_fmt}:{minutes:02.0f}:{seconds:02.0f}"
+    hours_fmt = f"{hours:2d}" if pad_hours else f"{hours:d}"
+    return f"{hours_fmt}:{minutes:02d}:{seconds:02d}"
 
 
 def format_template(

--- a/tests/util/test_format.py
+++ b/tests/util/test_format.py
@@ -1,0 +1,29 @@
+"""Tests for format_progress_time()."""
+
+from inspect_ai._util.format import format_progress_time
+
+
+def test_progress_time_whole_seconds() -> None:
+    assert format_progress_time(0.0) == " 0:00:00"
+    assert format_progress_time(5.0) == " 0:00:05"
+    assert format_progress_time(60.0) == " 0:01:00"
+    assert format_progress_time(3600.0) == " 1:00:00"
+    assert format_progress_time(3661.0) == " 1:01:01"
+
+
+def test_progress_time_truncates_fractional_seconds() -> None:
+    # A fractional component must be truncated, not rounded: the ".0f" spec used
+    # to round 59.9 up to ":60", which a clock can never legitimately show.
+    assert format_progress_time(59.9) == " 0:00:59"
+    assert format_progress_time(3599.9) == " 0:59:59"
+    assert format_progress_time(3659.9) == " 1:00:59"
+
+
+def test_progress_time_no_pad_hours() -> None:
+    assert format_progress_time(0.0, pad_hours=False) == "0:00:00"
+    assert format_progress_time(59.9, pad_hours=False) == "0:00:59"
+    assert format_progress_time(3661.0, pad_hours=False) == "1:01:01"
+
+
+def test_progress_time_hours_not_truncated_to_two_digits() -> None:
+    assert format_progress_time(36000.0) == "10:00:00"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Fixes #4395. `format_progress_time()` formats each H:MM:SS component with a `.0f` spec, which rounds. An elapsed time whose seconds part is `>= x.5` (e.g. `59.9`) renders an impossible `:60` in the seconds (or minutes) field, so live displays (running-sample clock, timers, human-agent panel, batch age) can show ` 0:00:60`, ` 0:59:60`, or ` 1:00:60`.

### What is the new behavior?
The elapsed time is truncated to whole seconds before being split into H:MM:SS, so no component can round up to 60. Output is otherwise byte-identical for every whole-second value; `59.9` now renders ` 0:00:59`. Adds `tests/util/test_format.py` covering the regression plus normal and `pad_hours=False` cases.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
CHANGELOG `## Unreleased` entry added. `make check` (ruff + mypy) and the `tests/util` subset pass locally.
