### PR TITLE
Fix crash when react sub-agents nest with checkpointing enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Bugfix: Elapsed-time displays (e.g. the running-sample clock and timers) no longer render an impossible `:60` seconds when the elapsed time has a fractional second.
+- Bugfix: A `react` sub-agent nested inside another `react` (as a tool, handoff, or deepagent task) no longer crashes under checkpointing.
 
 ## 0.3.242 (29 June 2026)
 

--- a/src/inspect_ai/util/_checkpoint/checkpointer.py
+++ b/src/inspect_ai/util/_checkpoint/checkpointer.py
@@ -188,6 +188,16 @@ async def checkpointer() -> AsyncIterator[Checkpointer]:
     active = sample_active()
     if active is None:
         raise RuntimeError("checkpointer() must be called inside an active sample")
+    # The checkpoint session is one-per-sample. A nested re-entry — a react
+    # sub-agent run as a tool / handoff / deepagent task — must not re-open the
+    # owner's session (re-opening its span scope trips "SpanRotationScope
+    # already open"); hand the nested loop an inert session instead.
+    if active.checkpointer.current() is not None:
+        from inspect_ai.util._checkpoint.checkpointer_noop import _NoopCheckpointer
+
+        async with _NoopCheckpointer() as nested:
+            yield nested
+        return
     async with active.checkpointer as cp:
         async with cp.span_session():
             yield cp
@@ -206,7 +216,8 @@ def current_checkpointer() -> Checkpointer | None:
     The session is shared and singular, so:
 
     - Do **not** re-enter :func:`checkpointer` from a sub-component — that
-      opens a duplicate ``span_session``.
+      yields an inert no-op session, so its ``track`` calls are silently
+      dropped. Borrow via this accessor instead.
     - ``track`` keys share one namespace and collide (raising
       ``ValueError``) across components; prefix yours uniquely (the agent
       bridge uses ``"bridge_*"`` keys, for example).

--- a/tests/checkpoint/test_checkpointer.py
+++ b/tests/checkpoint/test_checkpointer.py
@@ -41,6 +41,7 @@ from inspect_ai.model._chat_message import (
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_call import ModelCall
 from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.util import current_checkpointer
 from inspect_ai.util._checkpoint import (
     Manual,
     TimeInterval,
@@ -1054,6 +1055,124 @@ async def test_fire_writes_restic_config_and_checkpoint_files(
     assert (context / "events_data.json").is_file()
     assert (context / "attachments.json").is_file()
     assert (context / "store.json").is_file()
+
+
+# === nested re-entry: sub-agent loops (agent-as-tool / handoff / deepagent) ==
+
+
+async def test_nested_checkpointer_entry_yields_inert_session(
+    active_sample: _FakeActiveSample,
+) -> None:
+    """A nested ``checkpointer()`` borrows an inert session, not the owner's.
+
+    A react sub-agent run inside another (agent-as-tool, handoff, deepagent
+    task) re-enters the per-sample session; it gets a no-op, so ``track`` can't
+    collide and ``tick`` can't drive the owner's trigger.
+    """
+    from inspect_ai.util._checkpoint.checkpointer_factory import create_checkpointer
+
+    active_sample.checkpoint = ResolvedCheckpointConfig(trigger=TurnInterval(every=1))
+    assert active_sample.sample.id is not None
+    active_sample.checkpointer = create_checkpointer(
+        config=active_sample.checkpoint,
+        log_location=active_sample.log_location,
+        sample_id=active_sample.sample.id,
+        epoch=active_sample.epoch,
+    )
+    log = Path(active_sample.log_location)
+    sample_dir = log.parent / f"{log.stem}.checkpoints" / "1__0"
+
+    async with checkpointer() as outer:
+        outer.track("messages", lambda: ["a"], ["a"], value_type=list[str])
+        async with checkpointer() as inner:
+            assert inner is not outer
+            assert isinstance(inner, _NoopCheckpointer)
+            # same key the owner tracks: a real session raises, the no-op returns initial
+            restored = inner.track(
+                "messages", lambda: ["b"], ["b"], value_type=list[str]
+            )
+            assert restored == ["b"]
+            await inner.tick()
+
+        # owner's session intact: it still owns "messages" (re-track collides),
+        # and the inert nested tick fired nothing despite every=1
+        with pytest.raises(ValueError, match="unique"):
+            outer.track("messages", lambda: ["a"], ["a"], value_type=list[str])
+        assert sample_dir.is_dir()
+        assert not list(sample_dir.glob("ckpt-*.json"))
+
+
+async def test_nested_checkpointer_preserves_owner_session_lifecycle(
+    active_sample: _FakeActiveSample,
+) -> None:
+    """A nested ``checkpointer()`` exit must not tear down the owner's session.
+
+    The owner stays reachable via ``current_checkpointer()`` and fires its one
+    ``agent_complete`` finalize on its *own* clean exit, not early on the nested
+    exit.
+    """
+    from inspect_ai.util._checkpoint.checkpointer_factory import create_checkpointer
+
+    active_sample.sample.id = "s_nested"
+    active_sample.checkpoint = ResolvedCheckpointConfig(trigger=Manual())
+    active_sample.checkpointer = create_checkpointer(
+        config=active_sample.checkpoint,
+        log_location=active_sample.log_location,
+        sample_id=active_sample.sample.id,
+        epoch=active_sample.epoch,
+    )
+    log = Path(active_sample.log_location)
+    sample_dir = log.parent / f"{log.stem}.checkpoints" / "s_nested__0"
+
+    async with checkpointer() as outer:
+        async with checkpointer():
+            pass
+        # the nested exit left the owner's session live and un-finalized
+        assert current_checkpointer() is outer
+        assert sample_dir.is_dir()
+        assert not list(sample_dir.glob("ckpt-*.json"))
+
+    # the owner's clean exit fires exactly one agent_complete checkpoint
+    assert sorted(p.name for p in sample_dir.glob("ckpt-*.json")) == ["ckpt-00001.json"]
+    final = Checkpoint.model_validate_json((sample_dir / "ckpt-00001.json").read_text())
+    assert final.trigger == "agent_complete"
+
+
+async def test_nested_checkpointer_body_exception_does_not_disturb_owner(
+    active_sample: _FakeActiveSample,
+) -> None:
+    """An exception from a nested scope unwinds without disturbing the owner.
+
+    A raising sub-agent unwinds through the inert no-op, so the owner's one-shot
+    finalize isn't spent early and its span scope isn't wedged.
+    """
+    from inspect_ai.util._checkpoint.checkpointer_factory import create_checkpointer
+
+    active_sample.sample.id = "s_nested_exc"
+    active_sample.checkpoint = ResolvedCheckpointConfig(trigger=Manual())
+    active_sample.checkpointer = create_checkpointer(
+        config=active_sample.checkpoint,
+        log_location=active_sample.log_location,
+        sample_id=active_sample.sample.id,
+        epoch=active_sample.epoch,
+    )
+    log = Path(active_sample.log_location)
+    sample_dir = log.parent / f"{log.stem}.checkpoints" / "s_nested_exc__0"
+
+    async with checkpointer() as outer:
+        with pytest.raises(ValueError, match="boom"):
+            async with checkpointer():
+                raise ValueError("boom")
+        # the caught nested exception left the owner live and un-finalized
+        assert current_checkpointer() is outer
+        assert sample_dir.is_dir()
+        assert not list(sample_dir.glob("ckpt-*.json"))
+        await outer.tick()  # span session not wedged; Manual() never fires
+
+    # the owner still fires exactly one agent_complete on its own clean exit
+    assert sorted(p.name for p in sample_dir.glob("ckpt-*.json")) == ["ckpt-00001.json"]
+    final = Checkpoint.model_validate_json((sample_dir / "ckpt-00001.json").read_text())
+    assert final.trigger == "agent_complete"
 
 
 # === _write_host_context: condensed events round-trip =======================


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

With checkpointing enabled, any eval where a `react` agent runs nested inside another `react` (a sub-agent invoked as a tool, a `handoff`, or a deepagent task) crashes the sample. `checkpointer()` hands back the cached, one-per-sample session on re-entry, so the inner agent re-opens the session's span scope and trips `AssertionError: SpanRotationScope already open`. (Even past that point the inner agent would collide on the shared `track` namespace and prematurely spend the one-shot `agent_complete` finalize.) A single, non-nested `react` is unaffected.

### What is the new behavior?

`checkpointer()` is now re-entrant. When it is entered while the sample's session is already open (detected via `current()`), it yields an inert no-op session for the nested loop instead of re-opening the real one. Sub-components that legitimately share the live session (a tool, a custom `model` agent) still borrow it via `current_checkpointer()`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Nested sub-agents aren't checkpointed on their own. The outer agent checkpoints the whole sample at its turn boundaries, so on resume a sub-agent that already finished is kept (its result is in the restored messages), while one interrupted mid-run just re-runs from the start.

