### PR TITLE
Fix checkpoint failures on long-running sandbox backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Bugfix: Elapsed-time displays (e.g. the running-sample clock and timers) no longer render an impossible `:60` seconds when the elapsed time has a fractional second.
+- Checkpointing: Run `restic backup` with `--quiet` so its progress output can't overflow the sandbox output cap on long backups.
 
 ## 0.3.242 (29 June 2026)
 

--- a/src/inspect_ai/util/_checkpoint/_sandbox_restic/repo.py
+++ b/src/inspect_ai/util/_checkpoint/_sandbox_restic/repo.py
@@ -90,6 +90,15 @@ async def run_sandbox_backup(
     relative to the network/IO savings on the egress path. ``exclude``
     paths become ``--exclude`` patterns (used to drop the XDG cache dir
     in auto-home mode); a pattern matching nothing is a harmless no-op.
+
+    ``--quiet`` suppresses restic's periodic ``status`` JSON lines (one
+    per progress tick, ~60/s). ``from_stdout`` reads only the trailing
+    ``summary`` line, so the status stream is pure waste. Worse, ``env.exec``
+    buffers it in full against a capped output size
+    (``MAX_EXEC_OUTPUT_SIZE``), so a long backup would overflow that cap and
+    fail the checkpoint. ``RESTIC_PROGRESS_FPS=""`` is belt-and-suspenders:
+    a non-empty value inherited from the container env re-enables the
+    status stream even under ``--quiet`` (empty parses as "unset").
     """
     cmd = [
         _SANDBOX_RESTIC_PATH,
@@ -103,8 +112,13 @@ async def run_sandbox_backup(
         "--tag",
         tag,
         "--json",
+        "--quiet",
     ]
-    result = await env.exec(cmd, env={"RESTIC_PASSWORD": password}, user="root")
+    result = await env.exec(
+        cmd,
+        env={"RESTIC_PASSWORD": password, "RESTIC_PROGRESS_FPS": ""},
+        user="root",
+    )
     if not result.success:
         raise RuntimeError(f"sandbox restic backup failed: {result.stderr}")
     return ResticBackupSummary.from_stdout(result.stdout)

--- a/src/inspect_ai/util/_restic/ops.py
+++ b/src/inspect_ai/util/_restic/ops.py
@@ -49,7 +49,11 @@ async def run_backup(
     ``restic backup PATH1 [PATH2 ...]``. The resulting snapshot is tagged
     with ``tag``. ``--compression max`` exploits high text-compressibility
     (zstd-max ≈ 5–10× vs the default `auto` ≈ 2–3×) for JSON-heavy sources;
-    ``--no-scan`` skips the up-front size-estimate walk.
+    ``--no-scan`` skips the up-front size-estimate walk. ``--quiet`` drops
+    restic's periodic ``status`` JSON lines (one per progress tick): only
+    the trailing ``summary`` line is read by ``from_stdout``, so the status
+    stream is buffered to no purpose (here in ``anyio.run_process``'s
+    in-memory pipe rather than against the sandbox output cap).
     """
     sources = [source] if isinstance(source, str) else list(source)
     proc = await anyio.run_process(
@@ -65,6 +69,7 @@ async def run_backup(
             "--tag",
             tag,
             "--json",
+            "--quiet",
         ],
         env=restic_env(password),
         check=True,

--- a/tests/checkpoint/test_sandbox_restic_repo.py
+++ b/tests/checkpoint/test_sandbox_restic_repo.py
@@ -1,0 +1,88 @@
+"""Regression tests for ``run_sandbox_backup`` command construction.
+
+The in-sandbox ``restic backup`` runs under ``SandboxEnvironment.exec``,
+whose captured stdout is capped (``MAX_EXEC_OUTPUT_SIZE``). restic's
+``--json`` status stream (one line per progress tick) is thrown away by
+``from_stdout`` yet still counts against that cap, so a long backup
+overflows it and ``OutputLimitExceededError`` surfaces as a failed
+checkpoint. The backup must therefore run ``--quiet`` (which drops the
+status stream) and pin ``RESTIC_PROGRESS_FPS`` empty so an inherited
+container value can't re-enable the stream despite ``--quiet``.
+"""
+
+from __future__ import annotations
+
+from typing import Literal, Union, overload
+
+from test_helpers.restic import SUMMARY_SNAPSHOT_ID, restic_summary_json
+
+from inspect_ai.util._checkpoint._sandbox_restic.repo import run_sandbox_backup
+from inspect_ai.util._sandbox.environment import (
+    SandboxEnvironment,
+    SandboxEnvironmentConfigType,
+)
+from inspect_ai.util._subprocess import ExecResult
+
+
+class _RecordingSandbox(SandboxEnvironment):
+    """Sandbox whose ``exec`` records each ``(cmd, env)`` and returns a summary."""
+
+    def __init__(self, stdout: str) -> None:
+        super().__init__()
+        self._stdout = stdout
+        self.calls: list[tuple[list[str], dict[str, str] | None]] = []
+
+    async def exec(
+        self,
+        cmd: list[str],
+        input: str | bytes | None = None,
+        cwd: str | None = None,
+        env: dict[str, str] | None = None,
+        user: str | None = None,
+        timeout: int | None = None,
+        timeout_retry: bool = True,
+        concurrency: bool = True,
+    ) -> ExecResult[str]:
+        self.calls.append((cmd, env))
+        return ExecResult(success=True, returncode=0, stdout=self._stdout, stderr="")
+
+    async def write_file(self, file: str, contents: str | bytes) -> None:
+        raise NotImplementedError
+
+    @overload
+    async def read_file(self, file: str, text: Literal[True] = True) -> str: ...
+
+    @overload
+    async def read_file(self, file: str, text: Literal[False]) -> bytes: ...
+
+    async def read_file(self, file: str, text: bool = True) -> Union[str, bytes]:
+        raise NotImplementedError
+
+    @classmethod
+    async def sample_cleanup(
+        cls,
+        task_name: str,
+        config: SandboxEnvironmentConfigType | None,
+        environments: dict[str, SandboxEnvironment],
+        interrupted: bool,
+    ) -> None:
+        raise NotImplementedError
+
+
+async def test_run_sandbox_backup_passes_quiet() -> None:
+    sandbox = _RecordingSandbox(restic_summary_json())
+
+    summary = await run_sandbox_backup(sandbox, "pw", ["/root"], "tag")
+
+    cmd, _env = sandbox.calls[-1]
+    assert "--quiet" in cmd
+    assert summary.snapshot_id == SUMMARY_SNAPSHOT_ID  # quiet summary still parses
+
+
+async def test_run_sandbox_backup_pins_progress_fps_empty() -> None:
+    sandbox = _RecordingSandbox(restic_summary_json())
+
+    await run_sandbox_backup(sandbox, "pw", ["/root"], "tag")
+
+    _cmd, env = sandbox.calls[-1]
+    assert env is not None and env.get("RESTIC_PROGRESS_FPS") == ""

--- a/tests/test_helpers/restic.py
+++ b/tests/test_helpers/restic.py
@@ -1,0 +1,39 @@
+"""Shared restic fixtures for tests."""
+
+from __future__ import annotations
+
+import json
+
+# A restic-shaped snapshot id (64 hex chars), recognizable in assertions.
+SUMMARY_SNAPSHOT_ID = "3a173af4" + "0" * 56
+
+
+def restic_summary_json(**overrides: object) -> str:
+    """A single-line ``restic backup --json`` ``summary`` message.
+
+    Carries every field ``ResticBackupSummary`` requires (so ``from_stdout``
+    parses it); keyword ``overrides`` replace individual fields. Returns the
+    JSON text restic emits on its final stdout line, with or without
+    ``--quiet`` (``--quiet`` drops only the preceding ``status`` lines, not
+    the summary).
+    """
+    fields: dict[str, object] = {
+        "message_type": "summary",
+        "files_new": 8,
+        "files_changed": 0,
+        "files_unmodified": 0,
+        "dirs_new": 2,
+        "dirs_changed": 0,
+        "dirs_unmodified": 0,
+        "data_blobs": 40,
+        "tree_blobs": 3,
+        "data_added": 83893579,
+        "data_added_packed": 83812345,
+        "total_files_processed": 8,
+        "total_bytes_processed": 83886080,
+        "backup_start": "2026-06-30T12:00:00+00:00",
+        "backup_end": "2026-06-30T12:00:03+00:00",
+        "total_duration": 3.0,
+        "snapshot_id": SUMMARY_SNAPSHOT_ID,
+    }
+    return json.dumps({**fields, **overrides})

--- a/tests/util/test_restic_ops.py
+++ b/tests/util/test_restic_ops.py
@@ -10,11 +10,18 @@ Both keep files only, cap the list, and count the overflow.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import anyio
+import pytest
+from test_helpers.restic import SUMMARY_SNAPSHOT_ID, restic_summary_json
 
 from inspect_ai.util._restic.ops import (
     _parse_changed_files,
     _parse_listed_files,
     _previous_id,
+    run_backup,
 )
 
 # --- restic ls (full snapshot) -------------------------------------------
@@ -134,3 +141,29 @@ def test_previous_id_matches_short_prefix() -> None:
 
 def test_previous_id_absent_snapshot() -> None:
     assert _previous_id(_SNAPS, "zzzz") is None
+
+
+# --- run_backup invocation (host-side) -----------------------------------
+
+
+async def test_run_backup_passes_quiet(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Host ``restic backup`` runs with ``--quiet``.
+
+    Without it restic emits one JSON ``status`` line per progress tick
+    (~60/s), every one of which ``from_stdout`` discards — but
+    ``anyio.run_process`` first buffers the whole stream in memory,
+    unbounded in backup duration. ``--quiet`` drops the status stream
+    while the trailing ``summary`` line (the only line we read) survives.
+    """
+    captured: dict[str, list[str]] = {}
+
+    async def fake_run_process(command: list[str], **kwargs: object) -> SimpleNamespace:
+        captured["command"] = command
+        return SimpleNamespace(stdout=restic_summary_json().encode())
+
+    monkeypatch.setattr(anyio, "run_process", fake_run_process)
+
+    summary = await run_backup(Path("/usr/bin/restic"), "/repo", "pw", "/src", "tag")
+
+    assert "--quiet" in captured["command"]
+    assert summary.snapshot_id == SUMMARY_SNAPSHOT_ID  # quiet summary still parses

--- a/tests/util/test_restic_summary.py
+++ b/tests/util/test_restic_summary.py
@@ -1,0 +1,34 @@
+"""Tests for ``ResticBackupSummary.from_stdout`` (last-line summary parsing).
+
+``restic backup --json`` emits one JSON object per line: periodic ``status``
+messages then a final ``summary``. ``from_stdout`` parses only the last line,
+so it must select the summary regardless of any preceding lines (the
+non-quiet case) and fail loudly on empty output.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from test_helpers.restic import SUMMARY_SNAPSHOT_ID, restic_summary_json
+
+from inspect_ai.util._restic import ResticBackupSummary
+
+
+def test_from_stdout_parses_summary_line() -> None:
+    summary = ResticBackupSummary.from_stdout(restic_summary_json())
+    assert summary.snapshot_id == SUMMARY_SNAPSHOT_ID
+    assert summary.files_new == 8
+
+
+def test_from_stdout_ignores_leading_status_lines() -> None:
+    """Non-quiet output: ``status`` lines precede the summary; only the last counts."""
+    status = json.dumps({"message_type": "status", "percent_done": 0.5})
+    stdout = "\n".join([status, status, restic_summary_json()])
+    assert ResticBackupSummary.from_stdout(stdout).snapshot_id == SUMMARY_SNAPSHOT_ID
+
+
+def test_from_stdout_empty_raises() -> None:
+    with pytest.raises(RuntimeError, match="no output"):
+        ResticBackupSummary.from_stdout("   \n  ")


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Checkpoint backups invoke `restic backup --json` without `--quiet`. Over a non-TTY pipe (exactly the `SandboxEnvironment.exec` mode) restic does *not* auto-suppress progress: it emits a `status` JSON line on every progress tick (~60/s), each carrying the in-flight file paths. `ResticBackupSummary.from_stdout` reads only the final `summary` line and throws the status lines away, but `env.exec` first buffers the entire stream and caps it at `MAX_EXEC_OUTPUT_SIZE`. On a long backup of a large sandbox the discarded status stream eventually exceeds the cap, raising `OutputLimitExceededError`, which is recorded as a failed checkpoint.

### What is the new behavior?

The sandbox and host backups now run with `--quiet`, which drops the status stream while preserving the trailing `summary` line that the parser actually reads. The sandbox exec additionally pins `RESTIC_PROGRESS_FPS=""`, because a non-empty value inherited from the container environment re-enables the status stream even under `--quiet`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `--quiet` only suppresses printed progress; it does not change exit codes, and warnings/errors still go to stderr (which we read on failure).

### Other information:

Verified against restic 0.18.1 (the pinned version) in non-TTY pipe mode:

| invocation | status lines | summary |
| --- | --- | --- |
| `--json` (current) | grows with duration | 1 |
| `--json --quiet` (this PR) | 0 | 1 (parses, all fields present) |
| `--json --quiet` + `RESTIC_PROGRESS_FPS=60` | grows with duration | 1 |

The host backup runs as a host subprocess and isn't under the sandbox output cap, but it buffers the same discarded stream in memory, so `--quiet` is applied there too for parity.