### PR TITLE
fix(util): handle empty id in as_html_id to avoid IndexError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Bugfix: `as_html_id()` no longer raises `IndexError` for input that reduces to an empty string, returning a prefixed id instead.
+
 ## 0.3.243 (30 June 2026)
 
 - Bugfix: Elapsed-time displays (e.g. the running-sample clock and timers) no longer render an impossible `:60` seconds when the elapsed time has a fractional second.
@@ -47,7 +51,6 @@
 - Bugfix: Keep torn checkpoint files out of remote egress uploads and manifests so resumed runs can repair and ship reused checkpoint ids.
 - Bugfix: Make the no-op trailing-separator strip in `FileSystem.is_writeable()` actually take effect, avoiding a double-separator write-test path for direct callers.
 - Bugfix: Header-only reads of `.json` eval logs no longer parse the entire `samples` array, making header reads of large logs dramatically faster (e.g. a 29MB S3 log: ~47s -> ~0.4s).
-
 
 ## 0.3.241 (22 June 2026)
 

--- a/src/inspect_ai/_util/html.py
+++ b/src/inspect_ai/_util/html.py
@@ -1,3 +1,3 @@
 def as_html_id(prefix: str, text: str) -> str:
     id = "".join(c if c.isalnum() else "-" for c in text.lower())
-    return f"{prefix}-{id}" if id[0].isdigit() else id
+    return f"{prefix}-{id}" if not id or id[0].isdigit() else id

--- a/tests/util/test_html.py
+++ b/tests/util/test_html.py
@@ -1,0 +1,26 @@
+"""Tests for as_html_id()."""
+
+from inspect_ai._util.html import as_html_id
+
+
+def test_empty_text_is_prefixed() -> None:
+    # empty ids are invalid HTML, so fall back to the prefix
+    assert as_html_id("id", "") == "id-"
+
+
+def test_symbol_only_text_passthrough() -> None:
+    # non-alnum chars become dashes; non-empty result is left as-is, not prefixed
+    assert as_html_id("id", "***") == "---"
+
+
+def test_digit_start_is_prefixed() -> None:
+    # ids may not start with a digit
+    assert as_html_id("id", "3options") == "id-3options"
+
+
+def test_normal_text_is_lowercased_and_dashed() -> None:
+    assert as_html_id("id", "Hello World") == "hello-world"
+
+
+def test_already_valid_passthrough() -> None:
+    assert as_html_id("id", "abc") == "abc"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`as_html_id(prefix, text)` builds an id and prefixes it only when it starts with a digit: `f"{prefix}-{id}" if id[0].isdigit() else id`. When `text` has no alphanumeric characters and is empty, `id == ""` and `id[0]` raises `IndexError: string index out of range`.

Closes #4405.

### What is the new behavior?
The guard also covers the empty case, so an empty id falls back to the prefix (`as_html_id("id", "") -> "id-"`) instead of crashing, mirroring the existing digit-leading behavior. All non-empty inputs are unchanged: `"3options" -> "id-3options"`, `"Hello World" -> "hello-world"`, `"abc" -> "abc"`, `"***" -> "---"`. Adds the first unit tests for the helper.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
One-line bugfix plus 5 tests in a new `tests/util/test_html.py`. CHANGELOG entry added. The current sole call site passes `panel_type.__name__` (never empty), so this is defensive hardening of an untested helper rather than a user-visible crash.
