### PR TITLE
perf(model): make `stable_message_ids` linear per turn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Performane: make `stable_message_ids()` linear per turn.
+- Performance: make `stable_message_ids()` linear per turn.
 - Bugfix: `eval-retry --max-retries 0` now disables retries as documented instead of inheriting the original eval's retry policy.
 
 ## 0.3.244 (01 July 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Performane: make `stable_message_ids()` linear per turn.
 - Bugfix: `eval-retry --max-retries 0` now disables retries as documented instead of inheriting the original eval's retry policy.
 
 ## 0.3.244 (01 July 2026)

--- a/src/inspect_ai/model/_message_ids.py
+++ b/src/inspect_ai/model/_message_ids.py
@@ -41,11 +41,10 @@ def stable_message_ids() -> Callable[[Sequence[ChatMessage] | ModelEvent], None]
         hash_bytes = mmh3.hash_bytes(json_str.encode())
         return hash_bytes.hex()
 
-    def get_id(message: ChatMessage, conversation: list[ChatMessage]) -> str:
+    def get_id(message: ChatMessage, conversation_ids: set[str]) -> str:
         """Get stable ID for message, avoiding duplicates within conversation."""
         msg_hash = hash_message(message)
         existing_ids = hash_to_ids.get(msg_hash, [])
-        conversation_ids = {m.id for m in conversation if m.id}
 
         # Reuse existing ID if not already in this conversation
         for existing_id in existing_ids:
@@ -57,26 +56,30 @@ def stable_message_ids() -> Callable[[Sequence[ChatMessage] | ModelEvent], None]
         hash_to_ids.setdefault(msg_hash, []).append(new_id)
         return new_id
 
-    def apply_ids_to_messages(messages: Sequence[ChatMessage]) -> None:
-        """Apply stable IDs to a list of messages."""
-        processed: list[ChatMessage] = []
+    def apply_ids_to_messages(messages: Sequence[ChatMessage]) -> set[str]:
+        """Apply stable IDs to a list of messages, returning the assigned IDs."""
+        # Maintain the set of assigned IDs incrementally and pass it into
+        # get_id(). Avoids get_id() rebuilding it from the message list
+        # on every call (which would mean O(n^2) ID assignment).
+        conversation_ids: set[str] = set()
         for msg in messages:
-            msg.id = get_id(msg, processed)
-            processed.append(msg)
+            msg.id = get_id(msg, conversation_ids)
+            conversation_ids.add(msg.id)
+        return conversation_ids
 
     def apply_ids(target: Sequence[ChatMessage] | ModelEvent) -> None:
         """Apply stable IDs to messages or a ModelEvent."""
         # Use duck typing to check for ModelEvent (avoid circular import)
         if hasattr(target, "event") and getattr(target, "event") == "model":
             input_messages = list(target.input)  # type: ignore[union-attr]
-            apply_ids_to_messages(input_messages)
+            conversation_ids = apply_ids_to_messages(input_messages)
             output = target.output  # type: ignore[union-attr]
             if (
                 isinstance(output, ModelOutput)
                 and output.choices
                 and len(output.choices) > 0
             ):
-                output.message.id = get_id(output.message, input_messages)
+                output.message.id = get_id(output.message, conversation_ids)
         else:
             apply_ids_to_messages(target)  # type: ignore[arg-type]
 


### PR DESCRIPTION
## This PR contains:
- [x] Performance improvement 

### What is the current behaviour? (You can also link to an open issue here)
For importers that process a transcript as a sequence of growing `ModelEvent.input` lists, each call to `apply_ids()` was quadratic in that model call's input length. Summed over growing turns, that compounds to cubic work in the number of turns/messages.

As a result, trying to import an eval containing ~20k messages into a Scout transcript would take hours just on assigning message IDs. E.g.: if we assume a user then model response back and forth type eval which eventually grows to 20k total messages, we have 10k `ModelEvents` and we need to call `apply_ids()` on every one of these, and in the worst case, the last `ModelEvent` contains 20k messages.

`get_id()` rebuilt `conversation_ids = {m.id for m in conversation}` from scratch on every message, so assigning IDs to one N-message conversation was O(N^2).

### What is the new behaviour?
Each `apply_ids()` call is now linear in the conversation length for normal inputs.

For the growing-transcript importer pattern, scaling is quadratic overall instead of cubic.

Assigning message IDs takes ~7 minutes with this change.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No. The one behavioural difference: if the *same* message object instance appears more than once within a single conversation, the incremental set retains every ID assigned during the pass whereas the rebuild-from-objects approach retained only each object's current ID. Both remain valid, collision-free labelings; such aliased-object input does not arise from normal conversation construction.

### Other information:
`apply_ids_to_messages()` now maintains the conversation ID set incrementally and reuses it for the `ModelEvent` output message.

As we start to handle larger evals, we may wish to further improve the performance. I took a minimal approach here to get the Scout importer work unblocked and keep changes (hopefully) easy to understand.