### PR TITLE
Include errored-but-scored samples in metrics for score_on_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
 - Bugfix: `eval-retry --max-retries 0` now disables retries as documented instead of inheriting the original eval's retry policy.
 - Bugfix: Ordinary dicts shaped like `{type, name, params}` are no longer misidentified as encoded registry objects during `registry_kwargs()` round-trip. (#4374)
 - Bugfix: Link plain HTTP sandbox ports (e.g. 80, 8080) as `http://` instead of `https://` in the running-samples port-mappings panel.
+- Bugfix: `score_on_error` now includes errored-but-scored samples in metric computation and the `scored_samples` denominator (matching the documented behaviour); previously the score was written to the sample log but dropped from metrics.
 
 ## 0.3.244 (01 July 2026)
 

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1827,7 +1827,11 @@ async def task_run_sample(
         # scores so they contribute to metrics (as documented in handling-errors),
         # rather than only being written to the sample log. The sample is still
         # counted as an error via the SampleErrorHandler. See #4412.
-        if results:
+        #
+        # `results` is only populated on the errored path when score_on_error is
+        # on (see the scoring guard above), but gate the return on it explicitly
+        # so this can never change behaviour when score_on_error is off.
+        if score_on_error and results:
             await sample_complete(state.sample_id, state.epoch, results)
             return results
         return None

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -1823,6 +1823,13 @@ async def task_run_sample(
         record_sample_errored(
             task_id, started=_sample_started(), **_sample_usage(state)
         )
+        # With score_on_error the sample was scored despite erroring; return its
+        # scores so they contribute to metrics (as documented in handling-errors),
+        # rather than only being written to the sample log. The sample is still
+        # counted as an error via the SampleErrorHandler. See #4412.
+        if results:
+            await sample_complete(state.sample_id, state.epoch, results)
+            return results
         return None
 
 

--- a/tests/test_score_on_error.py
+++ b/tests/test_score_on_error.py
@@ -69,6 +69,19 @@ def test_score_on_error_basic():
     assert sample.scores is not None and len(sample.scores) > 0
 
 
+def test_score_on_error_errored_sample_included_in_metrics():
+    # Regression for #4412: an errored-but-scored sample's score must be included
+    # in metric computation and the scored_samples denominator, not only written
+    # to the sample log. Sample 1 errors, sample 2 succeeds -> both are scored.
+    log = eval(_make_task([True, False]), score_on_error=True, fail_on_error=False)[0]
+    assert log.results is not None
+    score = log.results.scores[0]
+    # both samples counted (was 1 before the fix, which dropped the errored score)
+    assert score.scored_samples == 2
+    errored = [s for s in log.samples if s.error is not None]
+    assert len(errored) == 1 and errored[0].scores
+
+
 def test_score_on_error_disabled_default_behavior():
     log = eval(_make_task([True]), fail_on_error=False)[0]
     assert log.samples is not None


### PR DESCRIPTION
## Summary

With `score_on_error=True`, an errored sample is scored on its partial `TaskState` and the score is written to the sample log, but `task_run_sample` returns `None` on the errored path (`error` set, `raise_error is None`). That `None` is filtered out of `completed_scores`, so the score is excluded from metric computation and the `scored_samples` denominator.

This contradicts the documented behaviour in `docs/handling-errors.qmd`: each errored sample is recorded "with both its `error` … **and** its `scores` (so the sample contributes to metrics)".

Fixes #4412.

## Fix

In the final "error and should not raise" branch of `task_run_sample`, return the populated `results` dict (and call `sample_complete`) when the sample was scored, instead of `None`. The sample is still counted as an error via the `SampleErrorHandler`, so `fail_on_error` accounting is unchanged; errored-but-scored samples now count as both an error and a scored sample, as documented.

## Verification

The reproduction from the issue now reports `accuracy=0.5`, `scored_samples=2` (previously `1.0` / `1`). Added regression test `test_score_on_error_errored_sample_included_in_metrics`; the full `tests/test_score_on_error.py` suite (15 tests) passes. `ruff check` / `ruff format` clean. CHANGELOG updated.
