### PR TITLE
fix(hf): allow selecting the AutoModel loader class via auto_model_class (#4438)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Docker: Support the `devices` field on compose services (device mappings such as `/dev/kvm`), previously rejected as an unknown field.
 - OpenAI: Surface OpenAI Responses API response `metadata` as `ModelOutput.metadata`.
 - Google: Include thinking tokens in reported `output_tokens` (matching the OpenAI/Anthropic convention where reasoning is a subset of output), so output-metered token limits and cost computations count Gemini thinking tokens.
+- Hugging Face: Add an `auto_model_class` model arg to select the `transformers` auto-class used to load the model, so architectures not registered with `AutoModelForCausalLM` (e.g. the Mistral 3 series and other image-text-to-text models) can be loaded with e.g. `AutoModelForImageTextToText`. (#4438)
 - Inspect View: Validate Host and browser origins, prevent framing, and require authorization or explicit acknowledgement for non-loopback binds.
 - Limits: Token limits can now meter only output tokens via `token_limit(n, type="output")`, `Task`/`eval()` `token_limit=TokenLimit(...)` values, or string forms like `--token-limit output:1m` (with `k`/`m`/`b` magnitude suffixes).
 - Performance: make `stable_message_ids()` linear per turn.

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -917,6 +917,26 @@ eval("arc.py", model="hf/some-org/custom-arch-model", model_args=dict(trust_remo
 
 The flag is applied to both the model and tokenizer `from_pretrained()` calls.
 
+### Model Class
+
+By default the Hugging Face provider loads models with `AutoModelForCausalLM`. Some architectures are not registered with that auto-class and must be loaded with a different one — for example the Mistral 3 series and other image-text-to-text models require `AutoModelForImageTextToText`. Use the `auto_model_class` model arg to name the `transformers` auto-class to use:
+
+``` bash
+inspect eval arc.py --model hf/mistralai/Ministral-3-8B-Instruct-2512 -M auto_model_class=AutoModelForImageTextToText
+```
+
+Or from Python:
+
+``` python
+eval(
+    "arc.py",
+    model="hf/mistralai/Ministral-3-8B-Instruct-2512",
+    model_args=dict(auto_model_class="AutoModelForImageTextToText"),
+)
+```
+
+The value must be the name of a class exported by `transformers`.
+
 ### Local Models
 
 In addition to using models from the Hugging Face Hub, the Hugging Face provider can also use local model weights and tokenizers (e.g. for a locally fine tuned model). Use `hf/local` along with the `model_path`, and (optionally) `tokenizer_path` arguments to select a local model. For example, from the command line, use the `-M` flag to pass the model arguments:

--- a/src/inspect_ai/model/_providers/hf.py
+++ b/src/inspect_ai/model/_providers/hf.py
@@ -18,6 +18,7 @@ from typing import Any, Literal, Protocol, cast
 import anyio
 import numpy as np
 import torch  # type: ignore
+import transformers  # type: ignore
 from torch import Tensor  # type: ignore
 from transformers import (  # type: ignore
     AutoModelForCausalLM,
@@ -108,6 +109,23 @@ class HuggingFaceAPI(ModelAPI):
         if not isinstance(trust_remote_code, bool):
             raise ValueError("trust_remote_code must be a bool")
 
+        # select the transformers auto-class used to load the model. Some
+        # architectures (e.g. the Mistral 3 series and other image-text-to-text
+        # models) are not registered with AutoModelForCausalLM and must be
+        # loaded with a different class such as AutoModelForImageTextToText.
+        auto_model_class = collect_model_arg("auto_model_class")
+        if auto_model_class is not None:
+            if not isinstance(auto_model_class, str):
+                raise ValueError("auto_model_class must be a str")
+            model_loader = getattr(transformers, auto_model_class, None)
+            if model_loader is None:
+                raise ValueError(
+                    f"auto_model_class '{auto_model_class}' is not a valid "
+                    "transformers class"
+                )
+        else:
+            model_loader = AutoModelForCausalLM
+
         # device
         if device:
             self.device = device
@@ -120,7 +138,7 @@ class HuggingFaceAPI(ModelAPI):
 
         # model
         if model_path:
-            self.model: Any = AutoModelForCausalLM.from_pretrained(
+            self.model: Any = model_loader.from_pretrained(
                 model_path,
                 device_map=self.device,
                 token=self.api_key,
@@ -128,7 +146,7 @@ class HuggingFaceAPI(ModelAPI):
                 **model_args,
             )
         else:
-            self.model = AutoModelForCausalLM.from_pretrained(
+            self.model = model_loader.from_pretrained(
                 model_name,
                 device_map=self.device,
                 token=self.api_key,

--- a/tests/model/providers/test_hf.py
+++ b/tests/model/providers/test_hf.py
@@ -254,7 +254,7 @@ def test_hf_auto_model_class_selects_alternate_loader(monkeypatch) -> None:
     AutoModelForCausalLM and must be loaded with e.g.
     AutoModelForImageTextToText.
     """
-    import transformers
+    import transformers  # type: ignore
 
     from inspect_ai.model._providers.hf import HuggingFaceAPI
 

--- a/tests/model/providers/test_hf.py
+++ b/tests/model/providers/test_hf.py
@@ -243,3 +243,65 @@ def test_hf_disable_chat_template() -> None:
     message = ChatMessageUser(content="Lorem ipsum dolor")
     chat = model.api.hf_chat([message], [])  # type: ignore[attr-defined]
     assert chat == "user: Lorem ipsum dolor\n"
+
+
+@skip_if_no_transformers
+@skip_if_no_accelerate
+def test_hf_auto_model_class_selects_alternate_loader(monkeypatch) -> None:
+    """auto_model_class must load the model via the named transformers class.
+
+    Architectures such as the Mistral 3 series are not registered with
+    AutoModelForCausalLM and must be loaded with e.g.
+    AutoModelForImageTextToText.
+    """
+    import transformers
+
+    from inspect_ai.model._providers.hf import HuggingFaceAPI
+
+    causal_calls: list[dict] = []
+    alternate_calls: list[dict] = []
+
+    def fake_causal(*args, **kwargs):
+        causal_calls.append({"args": args, "kwargs": kwargs})
+        return MagicMock()
+
+    class FakeAltModel:
+        @staticmethod
+        def from_pretrained(*args, **kwargs):
+            alternate_calls.append({"args": args, "kwargs": kwargs})
+            return MagicMock()
+
+    monkeypatch.setattr(
+        "transformers.AutoModelForCausalLM.from_pretrained", fake_causal
+    )
+    monkeypatch.setattr(
+        "transformers.AutoTokenizer.from_pretrained", lambda *a, **k: MagicMock()
+    )
+    monkeypatch.setattr(transformers, "FakeAltModel", FakeAltModel, raising=False)
+
+    HuggingFaceAPI(model_name="EleutherAI/pythia-70m", auto_model_class="FakeAltModel")
+
+    # the alternate class loads the model; the default is not used
+    assert len(alternate_calls) == 1
+    assert len(causal_calls) == 0
+
+
+@skip_if_no_transformers
+@skip_if_no_accelerate
+def test_hf_auto_model_class_rejects_unknown(monkeypatch) -> None:
+    """An auto_model_class that is not a transformers attribute must be rejected."""
+    from inspect_ai.model._providers.hf import HuggingFaceAPI
+
+    monkeypatch.setattr(
+        "transformers.AutoModelForCausalLM.from_pretrained",
+        lambda *a, **k: MagicMock(),
+    )
+    monkeypatch.setattr(
+        "transformers.AutoTokenizer.from_pretrained", lambda *a, **k: MagicMock()
+    )
+
+    with pytest.raises(ValueError, match="not a valid"):
+        HuggingFaceAPI(
+            model_name="EleutherAI/pythia-70m",
+            auto_model_class="NoSuchAutoModelClass",
+        )


### PR DESCRIPTION
## Summary

Fixes #4438.

The Hugging Face provider always loads models with `AutoModelForCausalLM`. Architectures that aren't registered with that auto-class — such as the **Mistral 3 series** and other image-text-to-text models — fail to load:

```
ValueError: Unrecognized configuration class
<class 'transformers.models.mistral3.configuration_mistral3.Mistral3Config'>
for this kind of AutoModel: AutoModelForCausalLM.
```

These models load fine with `AutoModelForImageTextToText`, but the provider gives no way to choose the loader class.

## Change

Add an optional **`auto_model_class`** model arg naming the `transformers` auto-class to use (defaults to `AutoModelForCausalLM`):

```bash
inspect eval arc.py \
  --model hf/mistralai/Ministral-3-8B-Instruct-2512 \
  -M auto_model_class=AutoModelForImageTextToText
```

- Applied to **both** load paths — Hub models and local models (`hf/local` / `model_path`).
- Validated as a `str`; resolved via `getattr(transformers, ...)` with a clear `ValueError` for unknown names.
- General (not Mistral-specific), so it also covers any future architecture needing a different auto-class.

## Tests

- `test_hf_auto_model_class_selects_alternate_loader` — the named class loads the model and `AutoModelForCausalLM` is not used.
- `test_hf_auto_model_class_rejects_unknown` — an invalid class name raises `ValueError`.

Docs (`providers.qmd` → new *Model Class* section) and CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
