### PR TITLE
fix: return empty string from cwd_relative_path("")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - Bugfix: `eval-retry --max-retries 0` now disables retries as documented instead of inheriting the original eval's retry policy.
 - Bugfix: Ordinary dicts shaped like `{type, name, params}` are no longer misidentified as encoded registry objects during `registry_kwargs()` round-trip. (#4374)
 - Bugfix: Link plain HTTP sandbox ports (e.g. 80, 8080) as `http://` instead of `https://` in the running-samples port-mappings panel.
+- Bugfix: `cwd_relative_path("")` now returns `""` instead of `None`, matching its `str -> str` typing overload.
 
 ## 0.3.244 (01 July 2026)
 

--- a/src/inspect_ai/_util/path.py
+++ b/src/inspect_ai/_util/path.py
@@ -99,7 +99,9 @@ def cwd_relative_path(file: str | None, walk_up: bool = False) -> str | None:
         else:
             return file
     else:
-        return None
+        # file is either None or the empty string; return it unchanged so the
+        # `str -> str` overload holds ("" -> "") while `None -> None`.
+        return file
 
 
 def pretty_path(file: str) -> str:

--- a/tests/util/test_cwd_relative_path.py
+++ b/tests/util/test_cwd_relative_path.py
@@ -1,0 +1,33 @@
+"""Tests for cwd_relative_path() and pretty_path()."""
+
+import os
+
+from inspect_ai._util.path import chdir, cwd_relative_path, pretty_path
+
+
+def test_none_returns_none() -> None:
+    assert cwd_relative_path(None) is None
+    assert cwd_relative_path(None, walk_up=True) is None
+
+
+def test_empty_string_returns_str_not_none() -> None:
+    # The `str -> str` overload promises a str for any str input, including "".
+    assert cwd_relative_path("") == ""
+    assert cwd_relative_path("", walk_up=True) == ""
+
+
+def test_path_under_cwd_is_made_relative(tmp_path) -> None:
+    with chdir(str(tmp_path)):
+        absolute = os.path.join(str(tmp_path), "sub", "task.py")
+        assert cwd_relative_path(absolute) == "sub/task.py"
+
+
+def test_path_outside_cwd_returned_unchanged_without_walk_up(tmp_path) -> None:
+    sibling = tmp_path.parent / "elsewhere" / "task.py"
+    with chdir(str(tmp_path)):
+        assert cwd_relative_path(str(sibling)) == str(sibling)
+
+
+def test_pretty_path_empty_string_returns_str() -> None:
+    result = pretty_path("")
+    assert isinstance(result, str)


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #4451.

`cwd_relative_path(file: str | None, walk_up: bool = False)` in
`src/inspect_ai/_util/path.py` has a `str -> str` typing overload, but its
implementation guards on truthiness (`if file:`) and returns a hard-coded `None`
in the else branch. An empty string is a valid `str` yet falls through to that
branch, so `cwd_relative_path("")` returns `None`, contradicting the overload:

```python
>>> from inspect_ai._util.path import cwd_relative_path
>>> cwd_relative_path("") is None
True
```

Since type checkers trust the overload, direct callers passing a `str` are
type-checked as receiving a `str` while the empty-string case returns `None` at
runtime.

### What is the new behavior?

The else branch now returns `file` unchanged instead of a hard-coded `None`, so
the empty string honors the `str -> str` overload (`"" -> ""`) while `None` still
maps to `None`:

```python
>>> cwd_relative_path("")
''
>>> cwd_relative_path(None) is None
True
```

Non-empty paths are unaffected (that logic lives in the truthy branch and is
byte-identical). Returning `file` was chosen over changing the guard to
`if file is not None:`, because routing `""` into the truthy block would make
`cwd_relative_path("", walk_up=True)` raise `ValueError` from `relative_walk`
(mismatched anchors); returning `file` introduces no new exception path.

A regression test file `tests/util/test_cwd_relative_path.py` is added covering
the empty-string and `None` cases, a path made relative to cwd, and a path
outside cwd returned unchanged.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. `None` input still returns `None`, and non-empty paths are unchanged. Only the
empty-string case changes, from `None` to `""`, which is what the public typing
already promised.

### Other information:

`make check` (ruff check + format), `mypy` (on `path.py`, the new test, and the
real callers `util.py` / `log.py` / `loader.py` / `panel.py`), and
`pytest tests/util/test_cwd_relative_path.py` all pass. A CHANGELOG Bugfix line is
added under `## Unreleased`.
