### PR TITLE
fix: OpenAI SDK 2.45.0 compatibility — populate required cache_write_tokens, bump min version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - OpenAI: Support for GPT-5.6 (Sol, Terra, and Luna) — model info database entries and codename frontier aliasing now target `gpt-5.6`.
 - OpenAI: `reasoning_effort="max"` is now passed through natively for GPT-5.6+ models rather than being clamped to `xhigh`.
+- OpenAI: Compatibility with openai >= 2.45.0, which is now the minimum required version (usage conversion now populates the new required `cache_write_tokens` field).
 - Model API: New `reasoning_mode` generation option (`--reasoning-mode`) for GPT-5.6 pro mode; requesting "pro" defaults to background processing like the gpt-5-pro model line.
 - Checkpointing: `Task(checkpoint=False)` now vetoes checkpointing for that task, overriding an eval-set/CLI enable (previously a no-op).
 - Control Channel: Reorganized the `inspect ctl` CLI into resource-noun groups (`ctl task`, `ctl sample`, `ctl config`, `ctl process`); the old flat spellings remain as hidden deprecated aliases, except `ctl sample` which is now the group (use `ctl sample show`).

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -17,7 +17,7 @@ mistralai>=2.4.5,
 moto[server]>=5.1.5
 mypy>=1.17.0
 nbformat
-openai>=2.40.0
+openai>=2.45.0
 pandas>=2.0.0
 pandas-stubs
 panflute

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -745,7 +745,8 @@ def responses_model_usage(usage: ModelUsage | None) -> ResponseUsage | None:
         return ResponseUsage(
             input_tokens=usage.input_tokens,
             input_tokens_details=InputTokensDetails(
-                cached_tokens=usage.input_tokens_cache_read or 0
+                cached_tokens=usage.input_tokens_cache_read or 0,
+                cache_write_tokens=usage.input_tokens_cache_write or 0,
             ),
             output_tokens=usage.output_tokens,
             output_tokens_details=OutputTokensDetails(

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -343,7 +343,7 @@ def hf_inference_providers() -> type[ModelAPI]:
 def validate_openai_client(feature: str) -> None:
     FEATURE = feature
     PACKAGE = "openai"
-    MIN_VERSION = "2.40.0"
+    MIN_VERSION = "2.45.0"
 
     # verify we have the package
     try:

--- a/tests/model/providers/test_openai_responses.py
+++ b/tests/model/providers/test_openai_responses.py
@@ -427,7 +427,9 @@ def test_chat_messages_from_compact_response():
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )
@@ -472,7 +474,9 @@ def test_chat_messages_from_compact_response_no_compaction_item():
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )
@@ -507,7 +511,9 @@ def test_model_usage_from_compact_response():
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )
@@ -610,7 +616,9 @@ def test_chat_messages_from_compact_response_mixed_items():
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )
@@ -704,7 +712,9 @@ def test_chat_messages_from_compact_response_developer_and_user_messages():
             input_tokens=100,
             output_tokens=50,
             total_tokens=150,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )
@@ -802,7 +812,9 @@ def test_chat_messages_from_compact_response_mixed_roles():
             input_tokens=200,
             output_tokens=100,
             total_tokens=300,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )

--- a/tests/model/test_openai_convert.py
+++ b/tests/model/test_openai_convert.py
@@ -211,7 +211,9 @@ async def test_model_output_from_openai_responses_basic() -> None:
             input_tokens=100,
             output_tokens=200,
             total_tokens=300,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
         incomplete_details=None,
@@ -265,7 +267,9 @@ async def test_model_output_from_openai_responses_with_reasoning() -> None:
             input_tokens=50,
             output_tokens=150,
             total_tokens=200,
-            input_tokens_details=InputTokensDetails(cached_tokens=10),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=10, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=50),
         ),
         incomplete_details=None,
@@ -320,7 +324,7 @@ async def test_model_output_from_openai_responses_dict_input() -> None:
             "input_tokens": 20,
             "output_tokens": 30,
             "total_tokens": 50,
-            "input_tokens_details": {"cached_tokens": 0},
+            "input_tokens_details": {"cached_tokens": 0, "cache_write_tokens": 0},
             "output_tokens_details": {"reasoning_tokens": 0},
         },
     }
@@ -358,7 +362,9 @@ async def test_model_output_from_openai_responses_with_refusal() -> None:
             input_tokens=10,
             output_tokens=10,
             total_tokens=20,
-            input_tokens_details=InputTokensDetails(cached_tokens=0),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=0, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
         incomplete_details=None,
@@ -543,7 +549,9 @@ async def test_model_output_from_openai_responses_cache_normalization() -> None:
             input_tokens=1000,
             output_tokens=50,
             total_tokens=1050,
-            input_tokens_details=InputTokensDetails(cached_tokens=600),
+            input_tokens_details=InputTokensDetails(
+                cached_tokens=600, cache_write_tokens=0
+            ),
             output_tokens_details=OutputTokensDetails(reasoning_tokens=0),
         ),
     )

--- a/uv.lock
+++ b/uv.lock
@@ -2164,7 +2164,7 @@ requires-dist = [
     { name = "nbformat", marker = "extra == 'dev'" },
     { name = "nest-asyncio2", specifier = ">=1.7.2" },
     { name = "numpy" },
-    { name = "openai", marker = "extra == 'dev'", specifier = ">=2.40.0" },
+    { name = "openai", marker = "extra == 'dev'", specifier = ">=2.45.0" },
     { name = "pandas", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'" },
     { name = "panflute", marker = "extra == 'dev'" },
@@ -4204,7 +4204,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.40.0"
+version = "2.45.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -4216,9 +4216,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/9f/136562ec6c3b1a50fe06eb0bb34ed21f0d7426ec0140e5cc43ac785b69a5/openai-2.40.0.tar.gz", hash = "sha256:9a756f91f274a24ad6026cbcb2042fd356c8d4a10e8f347b08d34465e585f7a2", size = 781177, upload-time = "2026-06-01T21:48:23.878Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/60/d4219875289b11d2c2f7da93c36283da224a2e55865ed865ab64e0ce9217/openai-2.45.0.tar.gz", hash = "sha256:10d34ca9c5643bce775852fddbfc172505cb1d4de1ccd101696c3ecff358765d", size = 1109653, upload-time = "2026-07-09T18:02:44.091Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/46/180e14be801a75bc13f234cb1b594b232adeb9c84e60a9ab1832e8333591/openai-2.40.0-py3-none-any.whl", hash = "sha256:2b205637ff214477f9ce9ab035e9f494db0e3fa8f1e599008953735fbf6ff1ff", size = 1350935, upload-time = "2026-06-01T21:48:21.462Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b0/2291689e3ec4723fbf5bbf3b54afcd7b160f9ddc98ca7aedfd0132af5677/openai-2.45.0-py3-none-any.whl", hash = "sha256:5df105f5f8c9b711fcb9d06d2d3888cebc82506db216484c14a4e53cdf651777", size = 1629470, upload-time = "2026-07-09T18:02:42.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

openai 2.45.0 added a required `cache_write_tokens` field to `InputTokensDetails`. `responses_model_usage()` constructs that model without it, so with openai >= 2.45.0 usage conversion raises a pydantic `ValidationError` ("Field required ... input_value={'cached_tokens': 0}"), failing 18 slow tests (11 conversion tests directly, 7 agent bridge tests downstream). Tracked in https://github.com/meridianlabs-ai/actions/issues/56.

### What is the new behavior?

`responses_model_usage()` populates `cache_write_tokens` from `ModelUsage.input_tokens_cache_write`, and the minimum supported openai version is bumped to 2.45.0 (`validate_openai_client` runtime check and `requirements-dev.txt`). Test fixtures updated to construct `InputTokensDetails` with the new field.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Users of OpenAI-based providers must upgrade to `openai>=2.45.0` (the provider now errors on older versions).

### Other information:

Verified `cache_write_tokens` first appears (as a required field) in openai 2.45.0 by inspecting `response_usage.py` at each SDK tag from 2.41.0 through 2.45.0.
