### PR TITLE
Enable citations on provided ContentDocument (Anthropic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Anthropic: Support enabling model-generated citations for provided `ContentDocument` inputs.
 - Eval: `EvalSample` and `EvalSampleSummary` now record `turn_count` and the sample's token limit (`token_limit`, `token_limit_type`, and metered `token_limit_usage`).
 - Analysis: `samples_df` gains default `turn_count` and `token_limit_usage` columns, and `evals_df` configuration columns gain `token_limit_type`.
 - Control Channel: `inspect ctl sample list` now shows per-sample turn count and, when a token limit is configured, its computed usage and configured ceiling.

--- a/src/inspect_ai/_util/content.py
+++ b/src/inspect_ai/_util/content.py
@@ -148,6 +148,9 @@ class ContentDocument(ContentBase):
     mime_type: str = Field(default_factory=str)
     """Document mime type (automatically determined from 'document' if not specified)."""
 
+    citations: bool = Field(default=False)
+    """Enable model-generated citations that reference spans of this document. Currently supported by Anthropic models; ignored by providers without document-citation support."""
+
     @model_validator(mode="before")
     @classmethod
     def set_name_and_mime_type(cls, data: Any) -> Any:

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -32,6 +32,7 @@ from anthropic.lib.streaming import AsyncMessageStream
 from anthropic.types import (
     Base64PDFSourceParam,
     CacheControlEphemeralParam,
+    CitationsConfigParam,
     CodeExecutionToolResultBlock,
     CodeExecutionToolResultBlockParam,
     ContentBlock,
@@ -4073,9 +4074,12 @@ async def message_block_params(
             source = PlainTextSourceParam(
                 type="text", media_type="text/plain", data=file_bytes.decode()
             )
-        return [
-            DocumentBlockParam(type="document", source=source, title=content.filename)
-        ]
+        document_block = DocumentBlockParam(
+            type="document", source=source, title=content.filename
+        )
+        if content.citations:
+            document_block["citations"] = CitationsConfigParam(enabled=True)
+        return [document_block]
 
     elif isinstance(content, ContentData):
         compaction_param = _compaction_from_content_data(content)

--- a/tests/dataset/test_content_document.py
+++ b/tests/dataset/test_content_document.py
@@ -234,6 +234,7 @@ def test_model_serialization():
         "document": "/path/to/report.pdf",
         "filename": "report.pdf",
         "mime_type": "application/pdf",
+        "citations": False,
     }
 
 

--- a/tests/model/test_anthropic_convert.py
+++ b/tests/model/test_anthropic_convert.py
@@ -8,12 +8,13 @@ from anthropic.types import (
     Usage,
 )
 
-from inspect_ai._util.content import ContentReasoning, ContentText
+from inspect_ai._util.content import ContentDocument, ContentReasoning, ContentText
 from inspect_ai.model import (
     model_output_from_anthropic,
 )
 from inspect_ai.model._chat_message import ChatMessageAssistant
 from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.model._providers.anthropic import message_block_params
 
 
 async def test_model_output_from_anthropic_basic() -> None:
@@ -50,6 +51,27 @@ async def test_model_output_from_anthropic_basic() -> None:
     assert len(message_obj.content) == 1
     assert isinstance(message_obj.content[0], ContentText)
     assert message_obj.content[0].text == "Hello! How can I help you today?"
+
+
+async def test_message_block_params_enables_document_citations() -> None:
+    document = ContentDocument(
+        document="data:text/plain;base64,SGVsbG8=",
+        citations=True,
+    )
+
+    document_block = (await message_block_params(document))[0]
+
+    assert document_block["type"] == "document"
+    assert document_block.get("citations") == {"enabled": True}
+
+
+async def test_message_block_params_omits_document_citations_by_default() -> None:
+    document = ContentDocument(document="data:text/plain;base64,SGVsbG8=")
+
+    document_block = (await message_block_params(document))[0]
+
+    assert document_block["type"] == "document"
+    assert "citations" not in document_block
 
 
 async def test_model_output_from_anthropic_with_tool_use() -> None:


### PR DESCRIPTION
## Summary

Inspect parses Anthropic document citations from responses, but callers could not enable citations on `ContentDocument` inputs.

- Add the public `ContentDocument.citations` opt-in, defaulting to `False`.
- Send Anthropic document configuration `citations={"enabled": true}` only when enabled.
- Preserve backward compatibility and leave other providers unchanged.

## Testing

- Add direct Anthropic document-block conversion tests for opted-in and default behavior.
- `uv run make check`
- `uv run make test`