### PR TITLE
fix: interpolate values in raised error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Control Channel: `inspect ctl sample list` now shows per-sample turn count and, when a token limit is configured, its computed usage and configured ceiling.
 - Bedrock: Assistant text and reasoning are now preserved alongside tool calls in the same turn instead of being dropped. (#4457)
 - Bugfix: Crash recovery now reconstructs `sample.messages` from the first model role's conversation when a solver runs multiple agents concurrently, instead of returning whichever agent's model call happened to fire last. (#4414)
+- Bugfix: Several raised errors (unexpected Anthropic input block, unsupported image data type, missing sample-buffer database) now interpolate the offending value into the message instead of showing the literal placeholder text.
 
 ## 0.3.246 (10 July 2026)
 

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -447,7 +447,7 @@ async def messages_from_anthropic_input(
                     ):
                         pending_user_content.append(c)
                     else:
-                        raise RuntimeError("Unexpected input parameter: {c}")
+                        raise RuntimeError(f"Unexpected input parameter: {c}")
 
                 flush_pending_user_content()
 
@@ -522,7 +522,7 @@ def base_64_data(data: str | IO[bytes] | PathLike[str]) -> str:
     if isinstance(data, str):
         return data
     else:
-        raise RuntimeError("Unsupported image content type: {data}")
+        raise RuntimeError(f"Unsupported image content type: {data}")
 
 
 def anthropic_stop_reason(stop_reason: StopReason) -> AnthropicStopReason:

--- a/src/inspect_ai/log/_recorders/buffer/database.py
+++ b/src/inspect_ai/log/_recorders/buffer/database.py
@@ -231,7 +231,7 @@ class SampleBufferDatabase(SampleBuffer):
             if len(logs) > 0:
                 self.db_path = logs[0]
             else:
-                raise FileNotFoundError("Log database for '{location}' not found.")
+                raise FileNotFoundError(f"Log database for '{location}' not found.")
 
         # Per-sample pool indices; full pool entries live in SQLite.
         self._msg_indices: dict[tuple[str, int], MessagePoolIndex] = {}

--- a/tests/agent/test_bridge_anthropic_messages.py
+++ b/tests/agent/test_bridge_anthropic_messages.py
@@ -1,7 +1,11 @@
+from pathlib import Path
+
 import pytest
+from anthropic.types import ThinkingBlockParam
 
 from inspect_ai.agent._bridge.anthropic_api_impl import (
     anthropic_system_to_text,
+    base_64_data,
     messages_from_anthropic_input,
 )
 from inspect_ai.model._chat_message import (
@@ -56,3 +60,28 @@ def test_anthropic_system_to_text() -> None:
         )
         == "a\n\nb"
     )
+
+
+@pytest.mark.anyio
+async def test_unexpected_input_parameter_error_includes_value() -> None:
+    """An unhandled user content block reports the offending block, not '{c}'."""
+    block: ThinkingBlockParam = {
+        "type": "thinking",
+        "thinking": "hmm",
+        "signature": "sig",
+    }
+    with pytest.raises(RuntimeError) as exc_info:
+        await messages_from_anthropic_input(
+            [{"role": "user", "content": [block]}],
+            tools=[],
+        )
+    assert "thinking" in str(exc_info.value)
+    assert "{c}" not in str(exc_info.value)
+
+
+def test_base_64_data_error_includes_value() -> None:
+    """A non-str, non-stream image source reports its value, not '{data}'."""
+    with pytest.raises(RuntimeError) as exc_info:
+        base_64_data(Path("/tmp/image.png"))
+    assert "/tmp/image.png" in str(exc_info.value)
+    assert "{data}" not in str(exc_info.value)

--- a/tests/log/test_sample_history.py
+++ b/tests/log/test_sample_history.py
@@ -538,6 +538,15 @@ def test_read_only_is_incompatible_with_create(tmp_path):
         SampleBufferDatabase(str(tmp_path / "test.eval"), read_only=True)
 
 
+def test_missing_database_error_includes_location(tmp_path):
+    """Opening a non-existent buffer (create=False) names the missing location."""
+    location = str(tmp_path / "missing.eval")
+    with pytest.raises(FileNotFoundError) as exc_info:
+        SampleBufferDatabase(location, create=False, db_dir=tmp_path)
+    assert "missing.eval" in str(exc_info.value)
+    assert "{location}" not in str(exc_info.value)
+
+
 def test_provider_translates_store_failures_to_domain_error(tmp_path):
     """BufferTranscriptHistoryProvider raises the protocol's domain error.
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #4486.

Three raised exceptions are built from plain (non f-string) literals whose
messages contain `{placeholders}`, so the runtime value is never interpolated
and the user sees the literal brace text instead:

- `agent/_bridge/anthropic_api_impl.py`, `messages_from_anthropic_input`: an
  unhandled user content block raises `RuntimeError("Unexpected input
  parameter: {c}")`, printing the literal `{c}`.
- `agent/_bridge/anthropic_api_impl.py`, `base_64_data`: a non-str, non-stream
  image source raises `RuntimeError("Unsupported image content type: {data}")`,
  printing the literal `{data}`.
- `log/_recorders/buffer/database.py`, `SampleBufferDatabase` (`create=False`):
  a missing buffer database raises `FileNotFoundError("Log database for
  '{location}' not found.")`, printing the literal `{location}` instead of the
  path, so it gives no clue which log was missing.

The sibling branches around each of these already use f-strings for the same
names (e.g. `f"Unexpected message content: {c}"`, `f"Unsupported content block
type: {type(block)}"`), so interpolation was intended.

### What is the new behavior?

Each literal gets the missing `f` prefix, so the message now interpolates the
offending value:

- `Unexpected input parameter: {'type': 'thinking', ...}`
- `Unsupported image content type: /path/to/image.png`
- `Log database for '/path/to/missing.eval' not found.`

Added regression tests that drive each branch and assert the message contains
the real value and not the literal `{c}` / `{data}` / `{location}`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This only changes the text of three error messages; the exception types
and control flow are unchanged.

### Other information:

Added a `## Unreleased` CHANGELOG bugfix entry.
