### PR TITLE
Fix relative dataset file resolution across filesystems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Bugfix: Several raised errors (unexpected Anthropic input block, unsupported image data type, missing sample-buffer database) now interpolate the offending value into the message instead of showing the literal placeholder text.
 - Bugfix: React agent compaction now works after a checkpoint resume — the restored conversation is no longer treated as an always-preserved prefix, so compaction shrinks the context again.
 - Viewer: log listing responses include the log dir's canonical URI (`log_dir_uri`) so the viewer can reliably scope its local cache to the directory.
+- Datasets: Relative sample files now resolve correctly on Windows and when CSV/JSON datasets are read from filesystem URIs. (#4502)
 
 ## 0.3.246 (10 July 2026)
 

--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -1,11 +1,10 @@
 import csv
-import os
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Any
 
 from inspect_ai._util.asyncfiles import is_s3_filename
-from inspect_ai._util.file import file
+from inspect_ai._util.file import absolute_file_path, file
 from inspect_ai.dataset._sources.util import resolve_sample_files
 
 from .._dataset import (
@@ -83,7 +82,7 @@ def csv_dataset(
         dataset = MemoryDataset(
             samples=data_to_samples(valid_data, data_to_sample, auto_id),
             name=name,
-            location=os.path.abspath(csv_file),
+            location=absolute_file_path(csv_file),
         )
 
         # resolve relative file paths

--- a/src/inspect_ai/dataset/_sources/json.py
+++ b/src/inspect_ai/dataset/_sources/json.py
@@ -1,5 +1,4 @@
 import json
-import os
 from io import TextIOWrapper
 from pathlib import Path
 from typing import Any
@@ -7,7 +6,7 @@ from typing import Any
 import jsonlines
 
 from inspect_ai._util.asyncfiles import is_s3_filename
-from inspect_ai._util.file import file
+from inspect_ai._util.file import absolute_file_path, file
 
 from .._dataset import (
     Dataset,
@@ -87,7 +86,7 @@ def json_dataset(
                 dataset_reader(f, **reader_kwargs), data_to_sample, auto_id
             ),
             name=name,
-            location=os.path.abspath(json_file),
+            location=absolute_file_path(json_file),
         )
 
         # resolve relative file paths

--- a/src/inspect_ai/dataset/_sources/util.py
+++ b/src/inspect_ai/dataset/_sources/util.py
@@ -7,7 +7,7 @@ from inspect_ai._util.content import (
     ContentImage,
     ContentVideo,
 )
-from inspect_ai._util.file import filesystem
+from inspect_ai._util.file import dirname, filesystem
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
 from inspect_ai.util._sandbox.environment import SandboxEnvironmentSpec
 
@@ -22,7 +22,7 @@ def resolve_sample_files(dataset: Dataset) -> None:
 
     # filesystem and parent for resolving paths
     fs = filesystem(dataset.location)
-    parent_dir = fs.sep.join(dataset.location.split(fs.sep)[:-1])
+    parent_dir = dirname(dataset.location)
 
     # resolve file locations
     def resolve_file(file: str) -> str:

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -1,3 +1,4 @@
+import csv as csv_module
 import json as json_module
 import os
 from pathlib import Path
@@ -8,6 +9,7 @@ from pydantic import BaseModel
 from test_helpers.utils import skip_if_github_action
 
 from inspect_ai._util.content import ContentImage
+from inspect_ai._util.file import file as open_file
 from inspect_ai.dataset import (
     Dataset,
     FieldSpec,
@@ -172,6 +174,48 @@ def test_dataset_image_paths() -> None:
     assert isinstance(sample.input[0].content[1], ContentImage)
     image = Path(sample.input[0].content[1].image)
     assert image.exists()
+
+
+def test_csv_dataset_relative_files_with_file_uri(tmp_path: Path) -> None:
+    asset = tmp_path / "asset.txt"
+    asset.write_text("asset", encoding="utf-8")
+    source = tmp_path / "dataset.csv"
+    with source.open("w", encoding="utf-8", newline="") as f:
+        writer = csv_module.DictWriter(f, fieldnames=["input", "target", "files"])
+        writer.writeheader()
+        writer.writerow(
+            {
+                "input": "question",
+                "target": "answer",
+                "files": json_module.dumps({"asset": "asset.txt"}),
+            }
+        )
+
+    dataset = csv_dataset(source.as_uri())
+
+    assert dataset.location == source.as_uri()
+    assert dataset[0].files == {"asset": asset.as_uri()}
+
+
+def test_json_dataset_relative_files_with_remote_uri(tmp_path: Path) -> None:
+    source = f"memory://{tmp_path.name}/dataset.json"
+    asset = f"memory://{tmp_path.name}/asset.txt"
+    with open_file(source, "w") as f:
+        json_module.dump(
+            {
+                "input": "question",
+                "target": "answer",
+                "files": {"asset": "asset.txt"},
+            },
+            f,
+        )
+    with open_file(asset, "w") as f:
+        f.write("asset")
+
+    dataset = json_dataset(source)
+
+    assert dataset.location == source
+    assert dataset[0].files == {"asset": asset}
 
 
 def test_dataset_auto_id() -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Closes #4502.

`json_dataset()` and `csv_dataset()` store locations with `os.path.abspath()` and derive the parent directory by splitting on the fsspec separator. On Windows, the separator mismatch leaves relative sample files unresolved. For filesystem URIs such as `file://` and `s3://`, `os.path.abspath()` also corrupts the scheme by treating the URI as a local path.

### What is the new behavior?

Dataset locations are normalized with the existing filesystem-aware `absolute_file_path()` helper, and relative sample files use the shared `dirname()` helper to find the dataset parent. Local paths keep their existing absolute-path behavior, while filesystem URIs retain their schemes.

Regression coverage verifies the existing Windows image-path case, CSV datasets loaded through `file://`, and JSON datasets on a remote-style `memory://` filesystem.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Checks performed:

- `uv run pytest tests/dataset/test_dataset.py -q` — 33 passed
- `uv run pytest tests/util/test_images.py tests/util/test_media.py tests/util/test_document.py tests/util/test_json.py -q` — 15 passed, 14 skipped (credential-gated provider tests)
- `uv run ruff check src tests`
- `uv run ruff format --check` on the four touched Python files
- `uv run mypy` on the three touched production files
