### PR TITLE
fix: checkpoint resume chain breaks with remote (S3) checkpoints destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Control Channel: `inspect ctl sample events` gains `--limit N` to cap the events returned per page (combinable with `--from-start`, `--tail`, or a cursor).
 - Model API: Fixed `max_retries` to permit N retries (N+1 total attempts); previously it counted total attempts, so e.g. `max_retries=1` never actually retried.
 - Bedrock: Assistant text and reasoning are now preserved alongside tool calls in the same turn instead of being dropped. (#4457)
+- Bugfix: With checkpoints stored on S3, a resumed sample can now itself be resumed — previously a crash after resume lost the checkpoint chain and the next retry restarted the sample from scratch.
 - Bugfix: Crash recovery now reconstructs `sample.messages` from the first model role's conversation when a solver runs multiple agents concurrently, instead of returning whichever agent's model call happened to fire last. (#4414)
 - Bugfix: Several raised errors (unexpected Anthropic input block, unsupported image data type, missing sample-buffer database) now interpolate the offending value into the message instead of showing the literal placeholder text.
 - Bugfix: React agent compaction now works after a checkpoint resume — the restored conversation is no longer treated as an always-preserved prefix, so compaction shrinks the context again.

--- a/src/inspect_ai/util/_checkpoint/_host_egress.py
+++ b/src/inspect_ai/util/_checkpoint/_host_egress.py
@@ -1,9 +1,11 @@
 """Host egress: ship sample staging dir → remote sample checkpoints dir.
 
-Runs at the end of each fire when the resolved sample checkpoints dir
-is remote. Mirrors the in-sandbox egress protocol: manifest of files already
-shipped, diff against the live staging dir, ship new files in a safe
-order, then atomically update the manifest.
+Runs when the resolved sample checkpoints dir is remote: at the end of
+each fire, and once at the end of resume hydration (shipping the resume
+payload to the new attempt's destination — with no manifest yet, every
+staged file is "new"). Mirrors the in-sandbox egress protocol: manifest
+of files already shipped, diff against the live staging dir, ship new
+files in a safe order, then atomically update the manifest.
 
 The ``context/`` subdir (restic source — host context files restic
 backs up) and the manifest file itself are excluded from shipping.
@@ -59,26 +61,6 @@ _EXCLUDED_TOP_LEVEL: frozenset[str] = frozenset({"context", MANIFEST_FILENAME})
 # well-formed restic content).
 _CHECKPOINT_FILE_RE = re.compile(r"^ckpt-\d+\.json$")
 _RESTIC_CONFIG = "restic/restic-config.json"
-
-
-def seed_manifest(staging_dir: str) -> int:
-    """Pre-populate ``.egress-manifest.txt`` after resume hydration.
-
-    Lists everything currently in ``staging_dir`` (minus the **context
-    subdir** and the manifest file itself). Use after a remote-resume
-    populates the staging dir from the destination — without seeding,
-    the first post-resume fire's host_egress would treat every
-    downloaded file as "new" and re-ship the whole resume payload to
-    the destination. Returns the entry count for diagnostics.
-    """
-    staging = Path(staging_dir)
-    files = [
-        rel
-        for rel in _scan_new_files(staging, shipped=set())
-        if _committed_checkpoint_or_other(staging, rel)
-    ]
-    _write_manifest(staging / MANIFEST_FILENAME, set(files))
-    return len(files)
 
 
 async def host_egress(*, staging_dir: str, destination_dir: str) -> None:

--- a/src/inspect_ai/util/_checkpoint/hydrate.py
+++ b/src/inspect_ai/util/_checkpoint/hydrate.py
@@ -18,8 +18,10 @@ Sample-root selection:
 - Local destination → sample root = sample checkpoints dir; no
   staging dir.
 - Remote destination → sample root = sample staging dir (host-local);
-  host egress (out of scope here) ships state to the remote sample
-  checkpoints dir at fire time.
+  host egress ships state to the remote sample checkpoints dir — once
+  at the end of hydration (the resume payload, so the new attempt's
+  destination is resumable before any agent work runs) and at each
+  fire (that fire's delta).
 
 Structure:
 
@@ -64,7 +66,7 @@ from inspect_ai.util._restic.ops import restic_env
 from inspect_ai.util._sandbox.context import sandbox
 from inspect_ai.util._span import current_span_id
 
-from ._host_egress import seed_manifest
+from ._host_egress import host_egress
 from ._layout import host_context
 from ._layout.eval_checkpoints_dir import eval_checkpoints_dir
 from ._layout.sample_checkpoints_dir import (
@@ -269,14 +271,22 @@ async def hydrate(
         )
     assert host_result is not None  # task group ran _run_host to completion
 
-    # Resume into a remote-destination staging dir: pre-populate the
-    # egress manifest with every file we just downloaded from the
-    # destination (everything in staging except the context subdir,
-    # which is local-only restic input). Without this, the first
-    # post-resume fire's host_egress diff would consider the whole
-    # resume payload "new" and re-ship it.
+    # Resume into a remote-destination staging dir: ship the resume
+    # payload (just downloaded from the *prior* attempt's sample dir)
+    # to this attempt's destination now, before any agent work runs.
+    # The destination is a fresh dir — each retry derives its own from
+    # its log location — so without this it would hold nothing until
+    # the first post-resume fire: a crash before that fire would leave
+    # the next retry (which looks only in this attempt's dir) finding
+    # no checkpoint and re-running the sample from scratch, and even
+    # after a fire the dir would hold only the post-resume delta —
+    # not a resumable repo. The egress also records the manifest, so
+    # subsequent fires ship only their deltas.
     if resume_checkpoint and sample_staging is not None:
-        await anyio.to_thread.run_sync(seed_manifest, sample_staging)
+        await host_egress(
+            staging_dir=sample_staging,
+            destination_dir=new_sample_checkpoints_dir,
+        )
 
     trace_message(
         logger, "Checkpoint", f"{verb} complete: sample={sample_id} epoch={epoch}"

--- a/tests/checkpoint/test_fs_copy_s3.py
+++ b/tests/checkpoint/test_fs_copy_s3.py
@@ -2,10 +2,11 @@
 
 Mostly against a moto-backed S3: ``_fs_copy_cross_cutting`` and
 ``_fs_copy_repo`` downloading a remote sample dir's contents into a
-local staging dir, plus the ``seed_manifest`` step that marks them as
-already-shipped so the next host_egress doesn't re-upload the resume
-payload. Also covers ``_fs_copy_repo`` against a local relative source
-(the path form eval-retry actually supplies).
+local staging dir, plus the hydrate-time ``host_egress`` that ships the
+resume payload to the new attempt's destination (and records it so the
+next fire's egress doesn't re-upload it). Also covers ``_fs_copy_repo``
+against a local relative source (the path form eval-retry actually
+supplies).
 """
 
 from __future__ import annotations
@@ -19,7 +20,6 @@ from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai.util._checkpoint._host_egress import (
     MANIFEST_FILENAME,
     host_egress,
-    seed_manifest,
 )
 from inspect_ai.util._checkpoint._layout.schemas import Checkpoint, SnapshotDetails
 from inspect_ai.util._checkpoint.hydrate import (
@@ -182,37 +182,52 @@ async def test_fs_copy_repo_raises_when_source_missing(
             raise AssertionError("expected RuntimeError when source missing")
 
 
-async def test_seed_manifest_after_remote_resume_blocks_reupload(
+async def test_remote_resume_ships_payload_to_new_destination(
     tmp_path: Path, mock_s3: None
 ) -> None:
-    """Seeding the manifest blocks the first post-resume host_egress.
+    """Hydrate-time host_egress makes the new attempt's dir resumable.
 
-    After resume populates staging from the destination and we
-    seed_manifest, a subsequent host_egress with no new files should be
-    a no-op — the destination is unchanged (no re-upload).
+    Each retry attempt writes to its own remote sample dir (derived from
+    its log location), so the payload downloaded from the *prior*
+    attempt's dir must ship to the *new* destination at hydrate time —
+    before any agent work runs. Otherwise a crash before the first
+    post-resume fire leaves the new dir empty and the next retry (which
+    looks only there) restarts the sample from scratch.
     """
-    src_root = f"{S3_BUCKET}/seed-manifest.checkpoints/s__0"
+    old_root = f"{S3_BUCKET}/old.checkpoints/s__0"
+    new_root = f"{S3_BUCKET}/new.checkpoints/s__0"
     staging = tmp_path / "staging"
     staging.mkdir()
     (staging / "context").mkdir()
 
     async with AsyncFilesystem() as fs:
-        # Set up the destination with a complete sample subtree.
+        # The prior attempt's sample dir holds a complete subtree.
         await _put(
-            fs, f"{src_root}/restic/restic-config.json", b'{"restic_password":"p"}'
+            fs, f"{old_root}/restic/restic-config.json", b'{"restic_password":"p"}'
         )
-        await _put(fs, f"{src_root}/restic/host/config", b"cfg")
-        await _put(fs, f"{src_root}/restic/host/data/ab/cd", b"pack")
-        await _put(fs, f"{src_root}/ckpt-00001.json", _checkpoint_bytes(1))
+        await _put(fs, f"{old_root}/restic/host/config", b"cfg")
+        await _put(fs, f"{old_root}/restic/host/data/ab/cd", b"pack")
+        await _put(fs, f"{old_root}/ckpt-00001.json", _checkpoint_bytes(1))
 
-        # Resume: download into a fresh local staging dir.
-        await _fs_copy_cross_cutting(src_root, str(staging))
+        # Resume: download into a fresh local staging dir, then ship the
+        # payload to the new attempt's destination (as hydrate does).
+        await _fs_copy_cross_cutting(old_root, str(staging))
         await _fs_copy_repo(
-            src_root, "restic/host", str(staging / "restic" / "host"), label="host"
+            old_root, "restic/host", str(staging / "restic" / "host"), label="host"
         )
-        seed_manifest(str(staging))
+        await host_egress(staging_dir=str(staging), destination_dir=new_root)
 
-        # Manifest should list everything we just downloaded.
+        # The new destination holds the full payload — resumable even if
+        # this attempt never fires another checkpoint.
+        assert await fs.read_file(f"{new_root}/ckpt-00001.json") == _checkpoint_bytes(1)
+        assert await fs.read_file(f"{new_root}/restic/host/config") == b"cfg"
+        assert await fs.read_file(f"{new_root}/restic/host/data/ab/cd") == b"pack"
+        assert (
+            await fs.read_file(f"{new_root}/restic/restic-config.json")
+            == b'{"restic_password":"p"}'
+        )
+
+        # Manifest records the shipment.
         manifest_lines = (staging / MANIFEST_FILENAME).read_text().splitlines()
         assert set(manifest_lines) == {
             "restic/restic-config.json",
@@ -222,10 +237,9 @@ async def test_seed_manifest_after_remote_resume_blocks_reupload(
         }
 
         # Tamper with the destination to prove the next host_egress doesn't
-        # touch already-manifested files.
-        await fs.write_file(f"{src_root}/restic/host/config", b"untouched")
+        # re-ship already-manifested files.
+        await fs.write_file(f"{new_root}/restic/host/config", b"untouched")
 
-        # Run host_egress with no new staging files — should be a no-op.
-        await host_egress(staging_dir=str(staging), destination_dir=src_root)
+        await host_egress(staging_dir=str(staging), destination_dir=new_root)
 
-        assert await fs.read_file(f"{src_root}/restic/host/config") == b"untouched"
+        assert await fs.read_file(f"{new_root}/restic/host/config") == b"untouched"

--- a/tests/checkpoint/test_host_egress.py
+++ b/tests/checkpoint/test_host_egress.py
@@ -17,7 +17,6 @@ from inspect_ai.util._checkpoint._host_egress import (
     MANIFEST_FILENAME,
     _safe_order,
     host_egress,
-    seed_manifest,
 )
 from inspect_ai.util._checkpoint._layout.schemas import Checkpoint, SnapshotDetails
 
@@ -145,17 +144,6 @@ async def test_sandbox_repos_shipped(staging: Path, dest: Path) -> None:
     assert (dest / "restic" / "sandboxes" / "default" / "data" / "ab" / "cd").is_file()
 
 
-def test_seed_manifest_skips_torn_checkpoint_files(staging: Path) -> None:
-    _write(staging / "restic" / "host" / "config", "host-config")
-    _write(staging / "ckpt-00001.json", _checkpoint_json(1))
-    _write(staging / "ckpt-00002.json", "{")
-
-    assert seed_manifest(str(staging)) == 2
-
-    manifest = (staging / MANIFEST_FILENAME).read_text().splitlines()
-    assert set(manifest) == {"restic/host/config", "ckpt-00001.json"}
-
-
 async def test_host_egress_does_not_manifest_torn_future_checkpoint(
     staging: Path, dest: Path
 ) -> None:
@@ -165,7 +153,12 @@ async def test_host_egress_does_not_manifest_torn_future_checkpoint(
     _write(staging / "ckpt-00003.json", "{")
     _write(staging / "ckpt-00004.json", "{")
 
-    seed_manifest(str(staging))
+    await host_egress(staging_dir=str(staging), destination_dir=str(dest))
+
+    manifest = (staging / MANIFEST_FILENAME).read_text().splitlines()
+    assert "ckpt-00002.json" in manifest
+    assert "ckpt-00003.json" not in manifest
+    assert not (dest / "ckpt-00003.json").exists()
 
     _write(staging / "ckpt-00003.json", _checkpoint_json(3))
     await host_egress(staging_dir=str(staging), destination_dir=str(dest))


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

In the remote (S3) case, a retry attempt's checkpoints dir isn't populated until its first checkpoint fires. Each retry gets a fresh dir, and the next retry looks only there — so if a resumed sample crashes before checkpointing again, no checkpoint is found and the sample restarts from scratch. (`seed_manifest` also permanently excluded the resume payload from egress, so even after a post-resume checkpoint the dir held only the delta — not a usable restic repo.) Local destinations were unaffected: hydration FS-copies directly into the new dir.

### What is the new behavior?

Hydration now populates the remote destination immediately: a `host_egress` of the resume payload at the end of hydrate (replacing `seed_manifest`), so the new dir is fully resumable before any agent work runs. The egress records the manifest, so subsequent fires still ship only deltas. Tests updated, plus a new test modeling the cross-attempt resume flow.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Resume into a remote destination now performs one upfront upload of the checkpoint payload per resumed attempt.

### Other information:
