### PR TITLE
fix(docs): typo in provider cache diagnostic docs

### DIFF
--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -260,7 +260,7 @@ See the [Fallbacks](fallbacks.qmd) article for complete documentation, including
 
 #### Cache Diagnostics {#anthropic-cache-diagnostics}
 
-Include the `cache-diagnosis-2026-04-07` beta header to produce diagnostics for prompt cachijng. Diagnostics are automatically included in `ChatMessageAssistant.metadata["diagnostics"]` (which you can see in the viewer) and a warning message is printed for cache misses. For example:
+Include the `cache-diagnosis-2026-04-07` beta header to produce diagnostics for prompt caching. Diagnostics are automatically included in `ChatMessageAssistant.metadata["diagnostics"]` (which you can see in the viewer) and a warning message is printed for cache misses. For example:
 
 ``` bash
 inspect eval arc.py --model anthropic/claude-sonnet-4-6 -M betas=cache-diagnosis-2026-04-07


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
A simple typo in [the Model Provider docs](https://inspect.aisi.org.uk/providers.html#anthropic-cache-diagnostics) `cachijing` (instead of `caching`)

### What is the new behavior?
`cachijing` -> `caching`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No, just a typo fix

### Other information:
N/A