### PR TITLE
Google: OAuth/ADC auth for the Gemini Developer API; treat unknown model names as latest Gemini

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Model API: Fixed `max_retries` to permit N retries (N+1 total attempts); previously it counted total attempts, so e.g. `max_retries=1` never actually retried.
 - Bedrock: Assistant text and reasoning are now preserved alongside tool calls in the same turn instead of being dropped. (#4457)
 - Google: The Gemini Developer API endpoint now supports OAuth/ADC authentication (`-M use_adc=true` or `GOOGLE_USE_ADC=true`) with automatic token refresh, for deployments reachable without an API key.
+- Google: Unknown (predeployment) model names are now treated as the latest Gemini model for context window (compaction) and capability detection.
 - Bugfix: With checkpoints stored on S3, a resumed sample can now itself be resumed — previously a crash after resume lost the checkpoint chain and the next retry restarted the sample from scratch.
 - Bugfix: Crash recovery now reconstructs `sample.messages` from the first model role's conversation when a solver runs multiple agents concurrently, instead of returning whichever agent's model call happened to fire last. (#4414)
 - Bugfix: Errored samples that were scored (e.g. via `score_on_error`) now contribute their scores to metrics and `scored_samples`, matching what the sample log shows. (#4412)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - Control Channel: Added `inspect ctl task cancel` and `inspect ctl sample cancel` to cancel a running task or one running sample (idempotent, with `--dry-run`).
 - Model API: Fixed `max_retries` to permit N retries (N+1 total attempts); previously it counted total attempts, so e.g. `max_retries=1` never actually retried.
 - Bedrock: Assistant text and reasoning are now preserved alongside tool calls in the same turn instead of being dropped. (#4457)
+- Google: The Gemini Developer API endpoint now supports OAuth/ADC authentication (`-M use_adc=true`) with automatic token refresh, for deployments reachable without an API key.
 - Bugfix: With checkpoints stored on S3, a resumed sample can now itself be resumed — previously a crash after resume lost the checkpoint chain and the next retry restarted the sample from scratch.
 - Bugfix: Crash recovery now reconstructs `sample.messages` from the first model role's conversation when a solver runs multiple agents concurrently, instead of returning whichever agent's model call happened to fire last. (#4414)
 - Bugfix: Errored samples that were scored (e.g. via `score_on_error`) now contribute their scores to metrics and `scored_samples`, matching what the sample log shows. (#4412)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 - Control Channel: Added `inspect ctl task cancel` and `inspect ctl sample cancel` to cancel a running task or one running sample (idempotent, with `--dry-run`).
 - Model API: Fixed `max_retries` to permit N retries (N+1 total attempts); previously it counted total attempts, so e.g. `max_retries=1` never actually retried.
 - Bedrock: Assistant text and reasoning are now preserved alongside tool calls in the same turn instead of being dropped. (#4457)
-- Google: The Gemini Developer API endpoint now supports OAuth/ADC authentication (`-M use_adc=true`) with automatic token refresh, for deployments reachable without an API key.
+- Google: The Gemini Developer API endpoint now supports OAuth/ADC authentication (`-M use_adc=true` or `GOOGLE_USE_ADC=true`) with automatic token refresh, for deployments reachable without an API key.
 - Bugfix: With checkpoints stored on S3, a resumed sample can now itself be resumed — previously a crash after resume lost the checkpoint chain and the next retry restarted the sample from scratch.
 - Bugfix: Crash recovery now reconstructs `sample.messages` from the first model role's conversation when a solver runs multiple agents concurrently, instead of returning whichever agent's model call happened to fire last. (#4414)
 - Bugfix: Errored samples that were scored (e.g. via `score_on_error`) now contribute their scores to metrics and `scored_samples`, matching what the sample log shows. (#4412)

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -348,6 +348,7 @@ The following environment variables are supported by the Google provider
 |-------------------|----------------------------------|
 | `GOOGLE_API_KEY`  | API key credentials (required unless using OAuth/ADC). |
 | `GOOGLE_BASE_URL` | Base URL for requests (optional) |
+| `GOOGLE_USE_ADC` | Set to `true` to authenticate Gemini Developer API models with OAuth/ADC by default (optional). |
 | `GOOGLE_CLOUD_QUOTA_PROJECT` | Quota/billing project sent as `x-goog-user-project` when using OAuth/ADC (optional). |
 
 ### Gemini Developer API with OAuth / ADC {#gemini-oauth}
@@ -363,6 +364,11 @@ inspect eval task.py --model google/your-model \
    -M use_adc=true -M quota_project_id=your-project
 ```
 
+Alternatively, set `GOOGLE_USE_ADC=true` in the environment (e.g. in `.env`) to
+make OAuth the default for all Gemini Developer API models, so commands don't
+need to differ between API-key and OAuth environments; `-M use_adc=false`
+overrides it per model, and Vertex models ignore it (Vertex uses ADC natively).
+
 ADC covers all the standard credential sources: user credentials from
 `gcloud auth application-default login` (optionally with
 `--impersonate-service-account`), a service-account key or workload identity
@@ -371,9 +377,9 @@ accounts on GCP compute.
 
 Supported custom model args (`-M`): `use_adc` (bool), `scopes` (list, defaults
 to `cloud-platform`), and `quota_project_id` (falls back to the
-`GOOGLE_CLOUD_QUOTA_PROJECT` environment variable). Auth precedence:
-`use_adc=true` selects OAuth; otherwise an explicit API key, then
-`GOOGLE_API_KEY`, is used. Inspect refreshes the token as needed before each
+`GOOGLE_CLOUD_QUOTA_PROJECT` environment variable). Auth precedence: `-M
+use_adc` (or, when unset, `GOOGLE_USE_ADC`) selects OAuth; otherwise an
+explicit API key, then `GOOGLE_API_KEY`, is used. Inspect refreshes the token as needed before each
 request, so long-running evals are supported. Batch inference is **not** supported
 in this mode (the batch client is long-lived and cannot refresh the token).
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -346,8 +346,41 @@ The following environment variables are supported by the Google provider
 
 | Variable          | Description                      |
 |-------------------|----------------------------------|
-| `GOOGLE_API_KEY`  | API key credentials (required).  |
+| `GOOGLE_API_KEY`  | API key credentials (required unless using OAuth/ADC). |
 | `GOOGLE_BASE_URL` | Base URL for requests (optional) |
+| `GOOGLE_CLOUD_QUOTA_PROJECT` | Quota/billing project sent as `x-goog-user-project` when using OAuth/ADC (optional). |
+
+### Gemini Developer API with OAuth / ADC {#gemini-oauth}
+
+Some Gemini Developer API deployments (for example, partner-served models) are
+reachable only via an OAuth bearer token — Application Default Credentials (ADC)
+— plus a quota-project header, with no API key. Enable this **per model** (so a
+run can mix OAuth and API-key Google models) with `-M use_adc=true`:
+
+``` bash
+gcloud auth application-default login   # or an impersonated service account
+inspect eval task.py --model google/your-model \
+   -M use_adc=true -M quota_project_id=your-project
+```
+
+Alternatively, pass credentials programmatically with `get_model()`:
+
+``` python
+import google.auth
+from inspect_ai.model import get_model
+
+creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
+model = get_model("google/your-model", credentials=creds, quota_project_id="your-project")
+```
+
+Supported custom model args (`-M`): `use_adc` (bool), `credentials` (a
+`google.auth.credentials.Credentials` object, programmatic only), `scopes` (list,
+defaults to `cloud-platform`), and `quota_project_id` (falls back to the
+`GOOGLE_CLOUD_QUOTA_PROJECT` environment variable). Auth precedence: an explicit
+`credentials` object or `use_adc=true` selects OAuth; otherwise an explicit API
+key, then `GOOGLE_API_KEY`, is used. Inspect refreshes the token before each
+request, so long-running evals are supported. Batch inference is **not** supported
+in this mode (the batch client is long-lived and cannot refresh the token).
 
 ### Gemini on Vertex AI {#gemini-on-vertex-ai}
 

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -363,22 +363,17 @@ inspect eval task.py --model google/your-model \
    -M use_adc=true -M quota_project_id=your-project
 ```
 
-Alternatively, pass credentials programmatically with `get_model()`:
+ADC covers all the standard credential sources: user credentials from
+`gcloud auth application-default login` (optionally with
+`--impersonate-service-account`), a service-account key or workload identity
+federation config via `GOOGLE_APPLICATION_CREDENTIALS`, and attached service
+accounts on GCP compute.
 
-``` python
-import google.auth
-from inspect_ai.model import get_model
-
-creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/cloud-platform"])
-model = get_model("google/your-model", credentials=creds, quota_project_id="your-project")
-```
-
-Supported custom model args (`-M`): `use_adc` (bool), `credentials` (a
-`google.auth.credentials.Credentials` object, programmatic only), `scopes` (list,
-defaults to `cloud-platform`), and `quota_project_id` (falls back to the
-`GOOGLE_CLOUD_QUOTA_PROJECT` environment variable). Auth precedence: an explicit
-`credentials` object or `use_adc=true` selects OAuth; otherwise an explicit API
-key, then `GOOGLE_API_KEY`, is used. Inspect refreshes the token before each
+Supported custom model args (`-M`): `use_adc` (bool), `scopes` (list, defaults
+to `cloud-platform`), and `quota_project_id` (falls back to the
+`GOOGLE_CLOUD_QUOTA_PROJECT` environment variable). Auth precedence:
+`use_adc=true` selects OAuth; otherwise an explicit API key, then
+`GOOGLE_API_KEY`, is used. Inspect refreshes the token as needed before each
 request, so long-running evals are supported. Batch inference is **not** supported
 in this mode (the batch client is long-lived and cannot refresh the token).
 

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -188,6 +188,10 @@ class CategorizedTools(NamedTuple):
 
 
 class GoogleGenAIAPI(ModelAPI):
+    # Class-level default so should_retry() is safe on bare instances that
+    # bypass __init__ (tests probe retry classification via __new__).
+    _oauth = False
+
     def __init__(
         self,
         model_name: str,
@@ -254,9 +258,9 @@ class GoogleGenAIAPI(ModelAPI):
             )
 
         # OAuth / ADC state — only used on the Gemini Developer API path (set in
-        # the standard-endpoint branch below). Initialized here so the vertex
-        # path also carries these attributes.
-        self._oauth = False
+        # the standard-endpoint branch below, along with the class-level _oauth
+        # default). Initialized here so the vertex path also carries these
+        # attributes.
         self._credentials: GoogleOAuthCredentials | None = None
         self._quota_project_id: str | None = None
 

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -129,6 +129,7 @@ from inspect_ai.util._json import json_schema_dump
 
 from .util import (
     OAUTH_PLACEHOLDER_API_KEY,
+    ensure_google_credentials_valid,
     google_oauth_headers,
     model_base_url,
     resolve_google_credentials,
@@ -258,10 +259,19 @@ class GoogleGenAIAPI(ModelAPI):
         # path also carries these attributes.
         self._oauth = False
         self._credentials: Any | None = None
+        self._credentials_refresh_lock = anyio.Lock()
         self._quota_project_id: str | None = None
 
         # handle auth (vertex or standard google api key)
         if self.is_vertex():
+            if str(model_args.pop("use_adc", False)).lower() == "true":
+                raise PrerequisiteError(
+                    "The `use_adc` model arg applies only to the Gemini Developer "
+                    "API endpoint. Vertex AI authenticates with Application Default "
+                    "Credentials natively (optionally pass `credentials` as a model "
+                    "arg to use an explicit credentials object)."
+                )
+
             # see if we are running in express mode (propagate api key if we are)
             # https://cloud.google.com/vertex-ai/generative-ai/docs/start/express-mode/overview
             vertex_api_key = os.environ.get(VERTEX_API_KEY, None)
@@ -296,19 +306,29 @@ class GoogleGenAIAPI(ModelAPI):
         # normal google endpoint (Gemini Developer API)
         else:
             # OAuth / ADC support for the dev endpoint. Opted into per-model via
-            # an explicit `credentials` object or `-M use_adc=true` (NOT a
-            # process-global toggle, so a run can mix OAuth and API-key models).
-            credentials = model_args.pop("credentials", None)
+            # `-M use_adc=true` (NOT a process-global toggle, so a run can mix
+            # OAuth and API-key models).
             use_adc = str(model_args.pop("use_adc", False)).lower() == "true"
             scopes = model_args.pop("scopes", None)
             quota_project_id = model_args.pop("quota_project_id", None)
 
-            if credentials is not None or use_adc:
-                # OAuth: resolve credentials (explicit object or ADC) and carry
-                # the bearer token + quota header ourselves (genai's dev client
-                # can't take credentials).
+            # Explicit credentials objects are deliberately unsupported:
+            # get_model() memoization serializes object-valued model args as
+            # None in its cache key, so two models with different credentials
+            # would silently share one cached instance (and principal).
+            if "credentials" in model_args:
+                raise PrerequisiteError(
+                    "Explicit `credentials` objects are not supported for the "
+                    "Gemini Developer API endpoint. Use `-M use_adc=true` with "
+                    "Application Default Credentials instead (e.g. `gcloud auth "
+                    "application-default login` or GOOGLE_APPLICATION_CREDENTIALS)."
+                )
+
+            if use_adc:
+                # OAuth: load ADC and carry the bearer token + quota header
+                # ourselves (genai's dev client can't take credentials).
                 self._oauth = True
-                self._credentials = resolve_google_credentials(credentials, scopes)
+                self._credentials = resolve_google_credentials(scopes)
                 self._quota_project_id = quota_project_id or os.environ.get(
                     GOOGLE_CLOUD_QUOTA_PROJECT
                 )
@@ -348,6 +368,8 @@ class GoogleGenAIAPI(ModelAPI):
         tool_choice: ToolChoice,
         config: GenerateConfig,
     ) -> ModelOutput | tuple[ModelOutput | Exception, ModelCall]:
+        await self._ensure_oauth_token()
+
         # http options
         http_options = self._http_options(config)
 
@@ -658,6 +680,7 @@ class GoogleGenAIAPI(ModelAPI):
         input: str | list[ChatMessage],
         config: GenerateConfig | None = None,
     ) -> int:
+        await self._ensure_oauth_token()
         client = self.model_client(self._http_options(config))
         async with client.aio:
             # normalize to messages
@@ -733,6 +756,13 @@ class GoogleGenAIAPI(ModelAPI):
 
     @override
     def should_retry(self, ex: BaseException) -> bool | RetryDecision:
+        # An OAuth bearer token can be invalidated mid-flight; retrying routes
+        # through before_retry() -> initialize(), which invalidates the local
+        # token so the next attempt mints a fresh one. API-key 401s stay
+        # non-retryable here — they are retried only when an api-key override
+        # hook can rotate the key (see Model.should_retry).
+        if self._oauth and isinstance(ex, Exception) and self.is_auth_failure(ex):
+            return RetryDecision.transient()
         # HTTP 429 is always a rate-limit signal regardless of SDK status text.
         # 503 needs a guard: Google sometimes returns 503 RESOURCE_EXHAUSTED
         # for sustained capacity pressure on Gemini (rate-limit), while plain
@@ -796,13 +826,17 @@ class GoogleGenAIAPI(ModelAPI):
     def initialize(self) -> None:
         super().initialize()
         # Reactive backstop for the 401 -> aclose() -> initialize() -> retry
-        # loop: force a token refresh so the next client construction mints a
-        # fresh bearer. Proactive per-request minting in model_client() handles
-        # ordinary expiry; this covers a token invalidated mid-flight.
+        # loop (should_retry classifies OAuth 401s as retryable): invalidate
+        # the local token — no network I/O here — so the retried request mints
+        # a fresh bearer via _ensure_oauth_token().
         if self._oauth and self._credentials is not None:
-            from google.auth.transport.requests import Request
+            self._credentials.token = None
 
-            self._credentials.refresh(Request())
+    async def _ensure_oauth_token(self) -> None:
+        if self._oauth and self._credentials is not None:
+            await ensure_google_credentials_valid(
+                self._credentials, self._credentials_refresh_lock
+            )
 
     def model_client(self, http_options: HttpOptions | None = None) -> Client:
         from inspect_ai._util._async import current_async_backend
@@ -821,9 +855,9 @@ class GoogleGenAIAPI(ModelAPI):
         if self._oauth:
             # The dev-endpoint client requires a non-empty api_key; pass a
             # placeholder and carry the OAuth bearer token in headers instead
-            # (Authorization overrides the placeholder x-goog-api-key). Building
-            # the headers here — per client construction, i.e. per generate —
-            # refreshes the token when it nears expiry, so long runs Just Work.
+            # (Authorization overrides the placeholder x-goog-api-key). Header
+            # building does no I/O — token freshness is ensured by the awaited
+            # _ensure_oauth_token() at the top of generate()/count_tokens().
             api_key = OAUTH_PLACEHOLDER_API_KEY
             http_options.headers = {
                 **(http_options.headers or {}),

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -144,6 +144,18 @@ VERTEX_API_KEY = "VERTEX_API_KEY"
 GOOGLE_CLOUD_QUOTA_PROJECT = "GOOGLE_CLOUD_QUOTA_PROJECT"
 GOOGLE_USE_ADC = "GOOGLE_USE_ADC"
 
+# Google model-name tokens for non-generative / non-frontier models that must
+# never be treated as a "latest" frontier chat model by is_latest().
+_NON_GENERATIVE_TOKENS = (
+    "embedding",
+    "imagen",
+    "veo",
+    "gemma",
+    "aqa",
+    "learnlm",
+    "tts",
+)
+
 SAFETY_SETTINGS = "safety_settings"
 DEFAULT_GOOGLE_HTTP_TIMEOUT = 60 * 60
 
@@ -736,8 +748,38 @@ class GoogleGenAIAPI(ModelAPI):
         """Canonical model name for model info database lookup."""
         return f"google/{self.service_model_name()}"
 
+    @override
+    def input_tokens_name(self) -> str:
+        """Model name used for looking up model input tokens (context window)."""
+        from inspect_ai.model._model_info import _get_model_info_direct
+
+        # Codename/predeployment models (is_latest() folds into is_gemini())
+        # and gemini-named models not yet in the model-info database (future
+        # versions, unknown snapshots) alias to the current frontier so the
+        # context window / compaction match. Bump when a newer frontier ships.
+        # Mirrors OpenAI's and Anthropic's input_tokens_name() aliasing.
+        if self.is_gemini() and _get_model_info_direct(self.canonical_name()) is None:
+            return "google/gemini-3.5-flash"
+        return super().input_tokens_name()
+
+    def is_latest(self) -> bool:
+        # predeployment/codename models are treated as the current frontier;
+        # restricted to the dev endpoint (vertex custom endpoints/deployments
+        # have arbitrary names that say nothing about the model behind them).
+        # Mirrors OpenAI's is_latest_model() / Anthropic's is_claude_latest().
+        if self.is_vertex():
+            return False
+        name = self.model_family().lower()
+        if any(token in name for token in _NON_GENERATIVE_TOKENS):
+            return False
+        # known family naming — future gemini versions are already covered by
+        # is_gemini_3_plus() and the DB-miss branch of input_tokens_name()
+        if "gemini" in name:
+            return False
+        return True
+
     def is_gemini(self) -> bool:
-        return "gemini-" in self.model_family()
+        return "gemini-" in self.model_family() or self.is_latest()
 
     def is_gemini_flash(self) -> bool:
         return "flash" in self.model_family()
@@ -755,7 +797,7 @@ class GoogleGenAIAPI(ModelAPI):
         return "gemini-3" in self.model_family()
 
     def is_gemini_3_flash(self) -> bool:
-        return self.is_gemini_3() and self.is_gemini_flash()
+        return (self.is_gemini_3() or self.is_latest()) and self.is_gemini_flash()
 
     def is_gemini_3_plus(self) -> bool:
         return (
@@ -770,7 +812,7 @@ class GoogleGenAIAPI(ModelAPI):
 
     def is_gemini_thinking_only(self) -> bool:
         return (
-            self.is_gemini_2_5() or self.is_gemini_3()
+            self.is_gemini_2_5() or self.is_gemini_3() or self.is_latest()
         ) and "-pro" in self.model_family()
 
     @override

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -129,8 +129,7 @@ from inspect_ai.util._json import json_schema_dump
 
 from .util import (
     OAUTH_PLACEHOLDER_API_KEY,
-    ensure_google_credentials_valid,
-    google_oauth_headers,
+    GoogleOAuthCredentials,
     model_base_url,
     resolve_google_credentials,
 )
@@ -258,8 +257,7 @@ class GoogleGenAIAPI(ModelAPI):
         # the standard-endpoint branch below). Initialized here so the vertex
         # path also carries these attributes.
         self._oauth = False
-        self._credentials: Any | None = None
-        self._credentials_refresh_lock = anyio.Lock()
+        self._credentials: GoogleOAuthCredentials | None = None
         self._quota_project_id: str | None = None
 
         # handle auth (vertex or standard google api key)
@@ -830,13 +828,11 @@ class GoogleGenAIAPI(ModelAPI):
         # the local token — no network I/O here — so the retried request mints
         # a fresh bearer via _ensure_oauth_token().
         if self._oauth and self._credentials is not None:
-            self._credentials.token = None
+            self._credentials.invalidate()
 
     async def _ensure_oauth_token(self) -> None:
         if self._oauth and self._credentials is not None:
-            await ensure_google_credentials_valid(
-                self._credentials, self._credentials_refresh_lock
-            )
+            await self._credentials.ensure_valid()
 
     def model_client(self, http_options: HttpOptions | None = None) -> Client:
         from inspect_ai._util._async import current_async_backend
@@ -852,7 +848,7 @@ class GoogleGenAIAPI(ModelAPI):
         ):
             http_options.httpx_async_client = httpx.AsyncClient()
         api_key = self.api_key
-        if self._oauth:
+        if self._oauth and self._credentials is not None:
             # The dev-endpoint client requires a non-empty api_key; pass a
             # placeholder and carry the OAuth bearer token in headers instead
             # (Authorization overrides the placeholder x-goog-api-key). Header
@@ -861,7 +857,7 @@ class GoogleGenAIAPI(ModelAPI):
             api_key = OAUTH_PLACEHOLDER_API_KEY
             http_options.headers = {
                 **(http_options.headers or {}),
-                **google_oauth_headers(self._credentials, self._quota_project_id),
+                **self._credentials.headers(self._quota_project_id),
             }
         return Client(
             vertexai=self.is_vertex(),

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -139,8 +139,10 @@ logger = getLogger(__name__)
 
 
 GOOGLE_API_KEY = "GOOGLE_API_KEY"
+GEMINI_API_KEY = "GEMINI_API_KEY"
 VERTEX_API_KEY = "VERTEX_API_KEY"
 GOOGLE_CLOUD_QUOTA_PROJECT = "GOOGLE_CLOUD_QUOTA_PROJECT"
+GOOGLE_USE_ADC = "GOOGLE_USE_ADC"
 
 SAFETY_SETTINGS = "safety_settings"
 DEFAULT_GOOGLE_HTTP_TIMEOUT = 60 * 60
@@ -307,10 +309,16 @@ class GoogleGenAIAPI(ModelAPI):
 
         # normal google endpoint (Gemini Developer API)
         else:
-            # OAuth / ADC support for the dev endpoint. Opted into per-model via
-            # `-M use_adc=true` (NOT a process-global toggle, so a run can mix
-            # OAuth and API-key models).
-            use_adc = str(model_args.pop("use_adc", False)).lower() == "true"
+            # OAuth / ADC support for the dev endpoint. Opted into per-model
+            # via `-M use_adc` (so a run can mix OAuth and API-key models),
+            # with the GOOGLE_USE_ADC environment variable providing the
+            # default (so an environment can switch to OAuth without editing
+            # commands).
+            use_adc_arg = model_args.pop("use_adc", None)
+            if use_adc_arg is not None:
+                use_adc = str(use_adc_arg).lower() == "true"
+            else:
+                use_adc = os.environ.get(GOOGLE_USE_ADC, "").lower() == "true"
             scopes = model_args.pop("scopes", None)
             quota_project_id = model_args.pop("quota_project_id", None)
 
@@ -337,6 +345,15 @@ class GoogleGenAIAPI(ModelAPI):
             elif not self.api_key:
                 # read api key from env
                 self.api_key = os.environ.get(GOOGLE_API_KEY, None)
+                # fail fast, with pointers to both auth paths, when there is no
+                # auth at all (GEMINI_API_KEY is honored by the genai SDK)
+                if not self.api_key and not os.environ.get(GEMINI_API_KEY, None):
+                    raise PrerequisiteError(
+                        "No authentication for the Google provider: set the "
+                        f"{GOOGLE_API_KEY} (or {GEMINI_API_KEY}) environment "
+                        "variable, or use OAuth / Application Default Credentials "
+                        f"via `-M use_adc=true` or {GOOGLE_USE_ADC}=true."
+                    )
 
             # custom base_url
             self.base_url = model_base_url(self.base_url, "GOOGLE_BASE_URL")

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -127,7 +127,12 @@ from inspect_ai.tool import (
 )
 from inspect_ai.util._json import json_schema_dump
 
-from .util import model_base_url
+from .util import (
+    OAUTH_PLACEHOLDER_API_KEY,
+    google_oauth_headers,
+    model_base_url,
+    resolve_google_credentials,
+)
 from .util.hooks import HttpHooks, HttpxHooks
 
 logger = getLogger(__name__)
@@ -135,6 +140,7 @@ logger = getLogger(__name__)
 
 GOOGLE_API_KEY = "GOOGLE_API_KEY"
 VERTEX_API_KEY = "VERTEX_API_KEY"
+GOOGLE_CLOUD_QUOTA_PROJECT = "GOOGLE_CLOUD_QUOTA_PROJECT"
 
 SAFETY_SETTINGS = "safety_settings"
 DEFAULT_GOOGLE_HTTP_TIMEOUT = 60 * 60
@@ -247,6 +253,13 @@ class GoogleGenAIAPI(ModelAPI):
                 + "Currently 'vertex' is the only supported service."
             )
 
+        # OAuth / ADC state — only used on the Gemini Developer API path (set in
+        # the standard-endpoint branch below). Initialized here so the vertex
+        # path also carries these attributes.
+        self._oauth = False
+        self._credentials: Any | None = None
+        self._quota_project_id: str | None = None
+
         # handle auth (vertex or standard google api key)
         if self.is_vertex():
             # see if we are running in express mode (propagate api key if we are)
@@ -280,10 +293,27 @@ class GoogleGenAIAPI(ModelAPI):
                 self.base_url, ["GOOGLE_VERTEX_BASE_URL", "VERTEX_BASE_URL"]
             )
 
-        # normal google endpoint
+        # normal google endpoint (Gemini Developer API)
         else:
-            # read api key from env
-            if not self.api_key:
+            # OAuth / ADC support for the dev endpoint. Opted into per-model via
+            # an explicit `credentials` object or `-M use_adc=true` (NOT a
+            # process-global toggle, so a run can mix OAuth and API-key models).
+            credentials = model_args.pop("credentials", None)
+            use_adc = str(model_args.pop("use_adc", False)).lower() == "true"
+            scopes = model_args.pop("scopes", None)
+            quota_project_id = model_args.pop("quota_project_id", None)
+
+            if credentials is not None or use_adc:
+                # OAuth: resolve credentials (explicit object or ADC) and carry
+                # the bearer token + quota header ourselves (genai's dev client
+                # can't take credentials).
+                self._oauth = True
+                self._credentials = resolve_google_credentials(credentials, scopes)
+                self._quota_project_id = quota_project_id or os.environ.get(
+                    GOOGLE_CLOUD_QUOTA_PROJECT
+                )
+            elif not self.api_key:
+                # read api key from env
                 self.api_key = os.environ.get(GOOGLE_API_KEY, None)
 
             # custom base_url
@@ -762,6 +792,18 @@ class GoogleGenAIAPI(ModelAPI):
             return ex.code == 401
         return False
 
+    @override
+    def initialize(self) -> None:
+        super().initialize()
+        # Reactive backstop for the 401 -> aclose() -> initialize() -> retry
+        # loop: force a token refresh so the next client construction mints a
+        # fresh bearer. Proactive per-request minting in model_client() handles
+        # ordinary expiry; this covers a token invalidated mid-flight.
+        if self._oauth and self._credentials is not None:
+            from google.auth.transport.requests import Request
+
+            self._credentials.refresh(Request())
+
     def model_client(self, http_options: HttpOptions | None = None) -> Client:
         from inspect_ai._util._async import current_async_backend
 
@@ -775,9 +817,21 @@ class GoogleGenAIAPI(ModelAPI):
             and http_options.httpx_async_client is None
         ):
             http_options.httpx_async_client = httpx.AsyncClient()
+        api_key = self.api_key
+        if self._oauth:
+            # The dev-endpoint client requires a non-empty api_key; pass a
+            # placeholder and carry the OAuth bearer token in headers instead
+            # (Authorization overrides the placeholder x-goog-api-key). Building
+            # the headers here — per client construction, i.e. per generate —
+            # refreshes the token when it nears expiry, so long runs Just Work.
+            api_key = OAUTH_PLACEHOLDER_API_KEY
+            http_options.headers = {
+                **(http_options.headers or {}),
+                **google_oauth_headers(self._credentials, self._quota_project_id),
+            }
         return Client(
             vertexai=self.is_vertex(),
-            api_key=self.api_key,
+            api_key=api_key,
             http_options=http_options,
             **self.model_args,
         )
@@ -998,6 +1052,16 @@ class GoogleGenAIAPI(ModelAPI):
         if self.is_vertex():
             raise NotImplementedError(
                 "Cannot use batch inference with Vertex AI (GCS-based batch jobs not supported)"
+            )
+
+        # OAuth/ADC is unsupported for batch: the batcher holds a single
+        # long-lived client across submit + poll, which cannot refresh the
+        # bearer token the way per-request client creation does.
+        if self._oauth:
+            raise NotImplementedError(
+                "Cannot use batch inference with OAuth/ADC credentials for the "
+                "Gemini Developer API (the long-lived batch client cannot refresh "
+                "the bearer token). Use an API key for batch inference."
             )
 
         # create a dedicated client instance for the batcher

--- a/src/inspect_ai/model/_providers/util/__init__.py
+++ b/src/inspect_ai/model/_providers/util/__init__.py
@@ -18,6 +18,12 @@ from .chatapi import (
     classify_chat_api_error,
     should_retry_chat_api_error,
 )
+from .google_auth import (
+    DEFAULT_OAUTH_SCOPES,
+    OAUTH_PLACEHOLDER_API_KEY,
+    google_oauth_headers,
+    resolve_google_credentials,
+)
 from .hf_handler import HFHandler
 from .llama31 import Llama31Handler
 from .util import environment_prerequisite_error, model_base_url, resolve_api_key
@@ -25,6 +31,10 @@ from .util import environment_prerequisite_error, model_base_url, resolve_api_ke
 __all__ = [
     "environment_prerequisite_error",
     "as_stop_reason",
+    "DEFAULT_OAUTH_SCOPES",
+    "OAUTH_PLACEHOLDER_API_KEY",
+    "google_oauth_headers",
+    "resolve_google_credentials",
     "chat_api_request",
     "chat_api_input",
     "should_retry_chat_api_error",

--- a/src/inspect_ai/model/_providers/util/__init__.py
+++ b/src/inspect_ai/model/_providers/util/__init__.py
@@ -21,6 +21,7 @@ from .chatapi import (
 from .google_auth import (
     DEFAULT_OAUTH_SCOPES,
     OAUTH_PLACEHOLDER_API_KEY,
+    ensure_google_credentials_valid,
     google_oauth_headers,
     resolve_google_credentials,
 )
@@ -33,6 +34,7 @@ __all__ = [
     "as_stop_reason",
     "DEFAULT_OAUTH_SCOPES",
     "OAUTH_PLACEHOLDER_API_KEY",
+    "ensure_google_credentials_valid",
     "google_oauth_headers",
     "resolve_google_credentials",
     "chat_api_request",

--- a/src/inspect_ai/model/_providers/util/__init__.py
+++ b/src/inspect_ai/model/_providers/util/__init__.py
@@ -21,8 +21,7 @@ from .chatapi import (
 from .google_auth import (
     DEFAULT_OAUTH_SCOPES,
     OAUTH_PLACEHOLDER_API_KEY,
-    ensure_google_credentials_valid,
-    google_oauth_headers,
+    GoogleOAuthCredentials,
     resolve_google_credentials,
 )
 from .hf_handler import HFHandler
@@ -34,8 +33,7 @@ __all__ = [
     "as_stop_reason",
     "DEFAULT_OAUTH_SCOPES",
     "OAUTH_PLACEHOLDER_API_KEY",
-    "ensure_google_credentials_valid",
-    "google_oauth_headers",
+    "GoogleOAuthCredentials",
     "resolve_google_credentials",
     "chat_api_request",
     "chat_api_input",

--- a/src/inspect_ai/model/_providers/util/google_auth.py
+++ b/src/inspect_ai/model/_providers/util/google_auth.py
@@ -1,0 +1,77 @@
+"""OAuth / ADC credential support for the Gemini Developer API.
+
+The Gemini Developer API endpoint (``generativelanguage.googleapis.com``) is
+authenticated by ``google-genai`` with an API key only — the SDK's
+``credentials=`` argument is consulted for Vertex AI exclusively. Some
+deployments (e.g. partner-served models) are reachable only via an OAuth bearer
+token (Application Default Credentials) plus an ``x-goog-user-project`` quota
+header, with no API key available.
+
+These helpers resolve google-auth credentials and build the request headers that
+carry the bearer token. The provider passes a placeholder API key to satisfy the
+``google-genai`` client constructor and injects the ``Authorization`` header
+(which overrides the placeholder ``x-goog-api-key`` on the server side).
+"""
+
+from typing import Any
+
+from inspect_ai._util.error import PrerequisiteError
+
+DEFAULT_OAUTH_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
+
+# google-genai's dev-endpoint client constructor rejects an empty api_key; this
+# placeholder satisfies it and is overridden by the injected Authorization header.
+OAUTH_PLACEHOLDER_API_KEY = "oauth-placeholder"
+
+
+def resolve_google_credentials(
+    credentials: Any | None, scopes: list[str] | None
+) -> Any:
+    """Resolve google-auth credentials for the Gemini Developer API.
+
+    Args:
+        credentials: An explicit ``google.auth.credentials.Credentials`` object,
+            or ``None`` to load Application Default Credentials.
+        scopes: OAuth scopes to request (defaults to cloud-platform).
+
+    Returns:
+        A google-auth credentials object.
+    """
+    try:
+        import google.auth
+    except ImportError:
+        raise PrerequisiteError(
+            "OAuth/ADC support for the Google provider requires the `google-auth` "
+            "package (installed automatically with `google-genai`)."
+        )
+    if credentials is not None:
+        return credentials
+    creds, _ = google.auth.default(scopes=scopes or DEFAULT_OAUTH_SCOPES)
+    return creds
+
+
+def google_oauth_headers(
+    credentials: Any, quota_project_id: str | None
+) -> dict[str, str]:
+    """Build request headers carrying a fresh OAuth bearer token.
+
+    Refreshes the credentials if they are not currently valid, so callers that
+    invoke this per-request get automatic token refresh.
+
+    Args:
+        credentials: A google-auth credentials object.
+        quota_project_id: Project to bill/quota against (``x-goog-user-project``),
+            or ``None`` to omit the header.
+
+    Returns:
+        Headers to merge into the request (``Authorization`` and, if provided,
+        ``x-goog-user-project``).
+    """
+    from google.auth.transport.requests import Request
+
+    if not credentials.valid:
+        credentials.refresh(Request())
+    headers = {"Authorization": f"Bearer {credentials.token}"}
+    if quota_project_id:
+        headers["x-goog-user-project"] = quota_project_id
+    return headers

--- a/src/inspect_ai/model/_providers/util/google_auth.py
+++ b/src/inspect_ai/model/_providers/util/google_auth.py
@@ -14,9 +14,11 @@ to satisfy the ``google-genai`` client constructor and injects the
 the server side).
 """
 
+import threading
 from typing import Any
 
 import anyio
+from anyio import to_thread
 
 from inspect_ai._util.error import PrerequisiteError
 
@@ -26,15 +28,93 @@ DEFAULT_OAUTH_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 # placeholder satisfies it and is overridden by the injected Authorization header.
 OAUTH_PLACEHOLDER_API_KEY = "oauth-placeholder"
 
+# Bound on the token-endpoint round-trip (google-auth's transport default is
+# 120s). Keeps an abandoned refresh thread from holding the refresh lock — and
+# so blocking the next refresh attempt — for long after its waiter was cancelled.
+REFRESH_TIMEOUT_SECONDS = 30
 
-def resolve_google_credentials(scopes: list[str] | None) -> Any:
+
+class GoogleOAuthCredentials:
+    """Cancellation-safe refresh wrapper around google-auth credentials.
+
+    The refresh is a blocking token-endpoint round-trip, so ``ensure_valid``
+    offloads it to a worker thread (keeping the event loop responsive) with
+    ``abandon_on_cancel=True`` so the awaiting task can be cancelled
+    immediately (e.g. by attempt timeouts) rather than being shielded until
+    the thread finishes.
+    """
+
+    def __init__(self, credentials: Any) -> None:
+        """Wrap a google-auth credentials object.
+
+        Args:
+            credentials: A google-auth credentials object.
+        """
+        self.credentials = credentials
+        # Single-flight for the common path: one task offloads the refresh
+        # while the rest wait (cancellably) here and re-check validity.
+        self._task_lock = anyio.Lock()
+        # Cross-thread backstop: a cancelled waiter abandons its worker thread
+        # mid-refresh (releasing _task_lock), so a subsequent attempt can start
+        # a new refresh thread while the abandoned one still runs. google-auth
+        # credentials are not thread-safe for concurrent refresh, so the actual
+        # refresh is additionally serialized across threads.
+        self._thread_lock = threading.Lock()
+
+    async def ensure_valid(self) -> None:
+        """Refresh the credentials in a worker thread if they are not valid."""
+        if self.credentials.valid:
+            return
+        async with self._task_lock:
+            if not self.credentials.valid:
+                await to_thread.run_sync(self._refresh, abandon_on_cancel=True)
+
+    def _refresh(self) -> None:
+        with self._thread_lock:
+            if self.credentials.valid:
+                return
+            from google.auth.transport.requests import Request
+
+            request = Request()
+
+            def bounded_request(*args: Any, **kwargs: Any) -> Any:
+                kwargs.setdefault("timeout", REFRESH_TIMEOUT_SECONDS)
+                return request(*args, **kwargs)
+
+            self.credentials.refresh(bounded_request)
+
+    def invalidate(self) -> None:
+        """Force the next ``ensure_valid`` to mint a fresh token (no I/O)."""
+        self.credentials.token = None
+
+    def headers(self, quota_project_id: str | None) -> dict[str, str]:
+        """Build request headers carrying the OAuth bearer token.
+
+        Performs no I/O — callers must first ensure the token is fresh via
+        ``ensure_valid``.
+
+        Args:
+            quota_project_id: Project to bill/quota against
+                (``x-goog-user-project``), or ``None`` to omit the header.
+
+        Returns:
+            Headers to merge into the request (``Authorization`` and, if
+            provided, ``x-goog-user-project``).
+        """
+        headers = {"Authorization": f"Bearer {self.credentials.token}"}
+        if quota_project_id:
+            headers["x-goog-user-project"] = quota_project_id
+        return headers
+
+
+def resolve_google_credentials(scopes: list[str] | None) -> GoogleOAuthCredentials:
     """Load Application Default Credentials for the Gemini Developer API.
 
     Args:
         scopes: OAuth scopes to request (defaults to cloud-platform).
 
     Returns:
-        A google-auth credentials object.
+        Refreshable wrapper around the ADC credentials.
     """
     try:
         import google.auth
@@ -44,53 +124,4 @@ def resolve_google_credentials(scopes: list[str] | None) -> Any:
             "package (installed automatically with `google-genai`)."
         )
     creds, _ = google.auth.default(scopes=scopes or DEFAULT_OAUTH_SCOPES)
-    return creds
-
-
-async def ensure_google_credentials_valid(
-    credentials: Any, refresh_lock: anyio.Lock
-) -> None:
-    """Refresh the credentials in a worker thread if they are not valid.
-
-    The refresh is a blocking token-endpoint round-trip, so it is offloaded to
-    a worker thread to keep the event loop responsive and the awaiting task
-    cancellable (e.g. by attempt timeouts). Offloading introduces real
-    concurrency, so ``refresh_lock`` is required: google-auth credential
-    objects are not thread-safe for concurrent refresh, and all in-flight
-    samples reach token expiry at once. Waiters re-check validity after
-    acquiring the lock so only one refresh runs per expiry.
-
-    Args:
-        credentials: A google-auth credentials object.
-        refresh_lock: Lock serializing refreshes of this credentials object.
-    """
-    if credentials.valid:
-        return
-    async with refresh_lock:
-        if not credentials.valid:
-            from google.auth.transport.requests import Request
-
-            await anyio.to_thread.run_sync(credentials.refresh, Request())
-
-
-def google_oauth_headers(
-    credentials: Any, quota_project_id: str | None
-) -> dict[str, str]:
-    """Build request headers carrying the OAuth bearer token.
-
-    Performs no I/O — callers must first ensure the token is fresh via
-    ``ensure_google_credentials_valid``.
-
-    Args:
-        credentials: A google-auth credentials object.
-        quota_project_id: Project to bill/quota against (``x-goog-user-project``),
-            or ``None`` to omit the header.
-
-    Returns:
-        Headers to merge into the request (``Authorization`` and, if provided,
-        ``x-goog-user-project``).
-    """
-    headers = {"Authorization": f"Bearer {credentials.token}"}
-    if quota_project_id:
-        headers["x-goog-user-project"] = quota_project_id
-    return headers
+    return GoogleOAuthCredentials(creds)

--- a/src/inspect_ai/model/_providers/util/google_auth.py
+++ b/src/inspect_ai/model/_providers/util/google_auth.py
@@ -7,13 +7,16 @@ deployments (e.g. partner-served models) are reachable only via an OAuth bearer
 token (Application Default Credentials) plus an ``x-goog-user-project`` quota
 header, with no API key available.
 
-These helpers resolve google-auth credentials and build the request headers that
-carry the bearer token. The provider passes a placeholder API key to satisfy the
-``google-genai`` client constructor and injects the ``Authorization`` header
-(which overrides the placeholder ``x-goog-api-key`` on the server side).
+These helpers load Application Default Credentials and build the request
+headers that carry the bearer token. The provider passes a placeholder API key
+to satisfy the ``google-genai`` client constructor and injects the
+``Authorization`` header (which overrides the placeholder ``x-goog-api-key`` on
+the server side).
 """
 
 from typing import Any
+
+import anyio
 
 from inspect_ai._util.error import PrerequisiteError
 
@@ -24,14 +27,10 @@ DEFAULT_OAUTH_SCOPES = ["https://www.googleapis.com/auth/cloud-platform"]
 OAUTH_PLACEHOLDER_API_KEY = "oauth-placeholder"
 
 
-def resolve_google_credentials(
-    credentials: Any | None, scopes: list[str] | None
-) -> Any:
-    """Resolve google-auth credentials for the Gemini Developer API.
+def resolve_google_credentials(scopes: list[str] | None) -> Any:
+    """Load Application Default Credentials for the Gemini Developer API.
 
     Args:
-        credentials: An explicit ``google.auth.credentials.Credentials`` object,
-            or ``None`` to load Application Default Credentials.
         scopes: OAuth scopes to request (defaults to cloud-platform).
 
     Returns:
@@ -44,19 +43,43 @@ def resolve_google_credentials(
             "OAuth/ADC support for the Google provider requires the `google-auth` "
             "package (installed automatically with `google-genai`)."
         )
-    if credentials is not None:
-        return credentials
     creds, _ = google.auth.default(scopes=scopes or DEFAULT_OAUTH_SCOPES)
     return creds
+
+
+async def ensure_google_credentials_valid(
+    credentials: Any, refresh_lock: anyio.Lock
+) -> None:
+    """Refresh the credentials in a worker thread if they are not valid.
+
+    The refresh is a blocking token-endpoint round-trip, so it is offloaded to
+    a worker thread to keep the event loop responsive and the awaiting task
+    cancellable (e.g. by attempt timeouts). Offloading introduces real
+    concurrency, so ``refresh_lock`` is required: google-auth credential
+    objects are not thread-safe for concurrent refresh, and all in-flight
+    samples reach token expiry at once. Waiters re-check validity after
+    acquiring the lock so only one refresh runs per expiry.
+
+    Args:
+        credentials: A google-auth credentials object.
+        refresh_lock: Lock serializing refreshes of this credentials object.
+    """
+    if credentials.valid:
+        return
+    async with refresh_lock:
+        if not credentials.valid:
+            from google.auth.transport.requests import Request
+
+            await anyio.to_thread.run_sync(credentials.refresh, Request())
 
 
 def google_oauth_headers(
     credentials: Any, quota_project_id: str | None
 ) -> dict[str, str]:
-    """Build request headers carrying a fresh OAuth bearer token.
+    """Build request headers carrying the OAuth bearer token.
 
-    Refreshes the credentials if they are not currently valid, so callers that
-    invoke this per-request get automatic token refresh.
+    Performs no I/O — callers must first ensure the token is fresh via
+    ``ensure_google_credentials_valid``.
 
     Args:
         credentials: A google-auth credentials object.
@@ -67,10 +90,6 @@ def google_oauth_headers(
         Headers to merge into the request (``Authorization`` and, if provided,
         ``x-goog-user-project``).
     """
-    from google.auth.transport.requests import Request
-
-    if not credentials.valid:
-        credentials.refresh(Request())
     headers = {"Authorization": f"Bearer {credentials.token}"}
     if quota_project_id:
         headers["x-goog-user-project"] = quota_project_id

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1,9 +1,11 @@
 import asyncio
 import base64
+import time
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
+import anyio
 import pytest
 from google.genai.errors import APIError
 from google.genai.types import (
@@ -1506,6 +1508,24 @@ async def test_google_oauth_concurrent_refresh_single_flight() -> None:
     await tg_collect([api._ensure_oauth_token for _ in range(5)])
     assert creds.refresh_calls == 1
     assert creds.valid
+
+
+@pytest.mark.anyio
+async def test_google_oauth_refresh_cancellable() -> None:
+    """A cancelled waiter must not be shielded until the refresh thread finishes."""
+
+    class _SlowCreds(_FakeCreds):
+        def refresh(self, request: Any) -> None:
+            time.sleep(2)
+            super().refresh(request)
+
+    creds = _SlowCreds(valid=False)
+    api = _adc_api(creds)
+    start = time.monotonic()
+    with pytest.raises(TimeoutError):
+        with anyio.fail_after(0.1):
+            await api._ensure_oauth_token()
+    assert time.monotonic() - start < 1.0
 
 
 @pytest.mark.anyio

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -43,6 +43,7 @@ from inspect_ai.model._providers.google import (
     completion_choice_from_candidate,
     content,
 )
+from inspect_ai.model._providers.util import OAUTH_PLACEHOLDER_API_KEY
 from inspect_ai.model._providers.util.hooks import HttpHooks
 from inspect_ai.scorer import includes
 from inspect_ai.solver import use_tools
@@ -1367,3 +1368,243 @@ def test_usage_metadata_without_thoughts():
     assert usage is not None
     assert usage.output_tokens == 5
     assert usage.reasoning_tokens == 0
+
+
+# ---- OAuth / ADC credentials for the Gemini Developer API ----
+
+
+class _FakeCreds:
+    """Minimal google-auth credentials stand-in for OAuth tests."""
+
+    def __init__(self, token: str = "tok-1", valid: bool = True) -> None:
+        self.token = token
+        self.valid = valid
+        self.refresh_calls = 0
+
+    def refresh(self, request: Any) -> None:
+        self.refresh_calls += 1
+        self.valid = True
+        self.token = f"tok-refreshed-{self.refresh_calls}"
+
+
+@pytest.mark.anyio
+async def test_google_oauth_headers_injected() -> None:
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    with patch(
+        "inspect_ai.model._providers.google.Client", return_value=mock_client
+    ) as client:
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            credentials=_FakeCreds(token="tok-1"),
+            quota_project_id="proj-x",
+        )
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+        )
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer tok-1"
+    assert headers["x-goog-user-project"] == "proj-x"
+    assert client.call_args.kwargs["api_key"] == OAUTH_PLACEHOLDER_API_KEY
+
+
+@pytest.mark.anyio
+async def test_google_oauth_via_use_adc_model_arg(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "proj-env")
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    fake = _FakeCreds(token="tok-adc")
+    with (
+        patch(
+            "inspect_ai.model._providers.google.Client", return_value=mock_client
+        ) as client,
+        patch("google.auth.default", return_value=(fake, "proj-env")),
+    ):
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            use_adc=True,
+        )
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+        )
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer tok-adc"
+    assert headers["x-goog-user-project"] == "proj-env"
+
+
+@pytest.mark.anyio
+async def test_google_oauth_quota_header_omitted_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GOOGLE_CLOUD_QUOTA_PROJECT", raising=False)
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    with patch(
+        "inspect_ai.model._providers.google.Client", return_value=mock_client
+    ) as client:
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            credentials=_FakeCreds(),
+        )
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+        )
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert "x-goog-user-project" not in headers
+
+
+@pytest.mark.anyio
+async def test_google_oauth_refreshes_when_invalid() -> None:
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    creds = _FakeCreds(valid=False)
+    with patch(
+        "inspect_ai.model._providers.google.Client", return_value=mock_client
+    ) as client:
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            credentials=creds,
+        )
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+        )
+    assert creds.refresh_calls >= 1
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert headers["Authorization"] == f"Bearer tok-refreshed-{creds.refresh_calls}"
+
+
+@pytest.mark.anyio
+async def test_google_use_adc_takes_precedence_over_api_key() -> None:
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    fake = _FakeCreds(token="tok-adc")
+    with (
+        patch(
+            "inspect_ai.model._providers.google.Client", return_value=mock_client
+        ) as client,
+        patch("google.auth.default", return_value=(fake, None)),
+    ):
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key="explicit-key",
+            use_adc=True,
+        )
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+        )
+    assert api._oauth is True
+    assert client.call_args.kwargs["api_key"] == OAUTH_PLACEHOLDER_API_KEY
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer tok-adc"
+
+
+@pytest.mark.anyio
+async def test_google_oauth_args_not_forwarded_to_client() -> None:
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    with patch(
+        "inspect_ai.model._providers.google.Client", return_value=mock_client
+    ) as client:
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            credentials=_FakeCreds(),
+            quota_project_id="p",
+            scopes=["https://www.googleapis.com/auth/cloud-platform"],
+        )
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+        )
+    for key in ("credentials", "use_adc", "scopes", "quota_project_id"):
+        assert key not in client.call_args.kwargs
+        assert key not in api.model_args
+
+
+@pytest.mark.anyio
+async def test_google_oauth_initialize_refreshes() -> None:
+    creds = _FakeCreds()
+    with patch(
+        "inspect_ai.model._providers.google.Client",
+        return_value=_create_mock_google_client(AsyncMock()),
+    ):
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            credentials=creds,
+        )
+    before = creds.refresh_calls
+    api.initialize()
+    assert creds.refresh_calls == before + 1
+
+
+@pytest.mark.anyio
+async def test_google_oauth_batch_raises() -> None:
+    mock_client = _create_mock_google_client(
+        AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    )
+    with patch("inspect_ai.model._providers.google.Client", return_value=mock_client):
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            credentials=_FakeCreds(),
+        )
+        config = GenerateConfig(batch=BatchConfig(size=1))
+        with pytest.raises(NotImplementedError, match="OAuth"):
+            api._resolve_batcher(config, api._http_options(config))
+
+
+@pytest.mark.anyio
+async def test_google_oauth_count_tokens_headers() -> None:
+    mock_client = _create_mock_google_count_tokens_client()
+    with patch(
+        "inspect_ai.model._providers.google.Client", return_value=mock_client
+    ) as client:
+        api = GoogleGenAIAPI(
+            model_name="cys-finding-lc",
+            base_url=None,
+            api_key=None,
+            credentials=_FakeCreds(token="tok-ct"),
+            quota_project_id="proj",
+        )
+        await api.count_tokens("Hello")
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer tok-ct"
+    assert headers["x-goog-user-project"] == "proj"

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -1559,6 +1559,59 @@ async def test_google_use_adc_takes_precedence_over_api_key() -> None:
 
 
 @pytest.mark.anyio
+async def test_google_use_adc_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_USE_ADC", "true")
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    fake = _FakeCreds(token="tok-env")
+    with (
+        patch(
+            "inspect_ai.model._providers.google.Client", return_value=mock_client
+        ) as client,
+        patch("google.auth.default", return_value=(fake, None)),
+    ):
+        api = GoogleGenAIAPI(
+            model_name="gemini-2.0-flash",
+            base_url=None,
+            api_key=None,
+        )
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
+        )
+    assert api._oauth is True
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer tok-env"
+    assert client.call_args.kwargs["api_key"] == OAUTH_PLACEHOLDER_API_KEY
+
+
+def test_google_use_adc_arg_overrides_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GOOGLE_USE_ADC", "true")
+    api = GoogleGenAIAPI(
+        model_name="gemini-2.0-flash",
+        base_url=None,
+        api_key="test-key",
+        use_adc=False,
+    )
+    assert api._oauth is False
+
+
+def test_google_no_auth_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_USE_ADC", raising=False)
+    with pytest.raises(PrerequisiteError, match="GOOGLE_API_KEY"):
+        GoogleGenAIAPI(
+            model_name="gemini-2.0-flash",
+            base_url=None,
+            api_key=None,
+        )
+
+
+@pytest.mark.anyio
 async def test_google_oauth_args_not_forwarded_to_client() -> None:
     mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
     mock_client = _create_mock_google_client(mock_generate)

--- a/tests/model/providers/test_google.py
+++ b/tests/model/providers/test_google.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import aiohttp
 import pytest
+from google.genai.errors import APIError
 from google.genai.types import (
     Blob,
     Candidate,
@@ -20,6 +21,7 @@ from google.genai.types import (
 from test_helpers.utils import skip_if_no_google
 
 from inspect_ai import Task, eval
+from inspect_ai._util._async import tg_collect
 from inspect_ai._util.citation import Citation, UrlCitation
 from inspect_ai._util.content import (
     Content as InspectContent,
@@ -29,10 +31,12 @@ from inspect_ai._util.content import (
     ContentReasoning,
     ContentText,
 )
+from inspect_ai._util.error import PrerequisiteError
 from inspect_ai.dataset import Sample
 from inspect_ai.model import ChatMessageAssistant, ChatMessageTool
 from inspect_ai.model._chat_message import ChatMessageUser
 from inspect_ai.model._generate_config import BatchConfig, GenerateConfig
+from inspect_ai.model._model import RetryDecision
 from inspect_ai.model._providers._google_citations import (
     distribute_citations_to_text_parts,
 )
@@ -1374,17 +1378,38 @@ def test_usage_metadata_without_thoughts():
 
 
 class _FakeCreds:
-    """Minimal google-auth credentials stand-in for OAuth tests."""
+    """Minimal google-auth credentials stand-in for OAuth tests.
+
+    Mirrors google-auth semantics: `valid` derives from the token and an
+    expired flag, so invalidating the token (as `initialize()` does) makes
+    the credentials refreshable.
+    """
 
     def __init__(self, token: str = "tok-1", valid: bool = True) -> None:
-        self.token = token
-        self.valid = valid
+        self.token: str | None = token
+        self.expired = not valid
         self.refresh_calls = 0
+
+    @property
+    def valid(self) -> bool:
+        return self.token is not None and not self.expired
 
     def refresh(self, request: Any) -> None:
         self.refresh_calls += 1
-        self.valid = True
+        self.expired = False
         self.token = f"tok-refreshed-{self.refresh_calls}"
+
+
+def _adc_api(fake: _FakeCreds, **model_args: Any) -> GoogleGenAIAPI:
+    """Construct a dev-endpoint OAuth model backed by `fake` ADC credentials."""
+    with patch("google.auth.default", return_value=(fake, None)):
+        return GoogleGenAIAPI(
+            model_name="gemini-2.0-flash",
+            base_url=None,
+            api_key=None,
+            use_adc=True,
+            **model_args,
+        )
 
 
 @pytest.mark.anyio
@@ -1394,13 +1419,7 @@ async def test_google_oauth_headers_injected() -> None:
     with patch(
         "inspect_ai.model._providers.google.Client", return_value=mock_client
     ) as client:
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            credentials=_FakeCreds(token="tok-1"),
-            quota_project_id="proj-x",
-        )
+        api = _adc_api(_FakeCreds(token="tok-1"), quota_project_id="proj-x")
         await api.generate(
             input=[ChatMessageUser(content="Hello")],
             tools=[],
@@ -1415,25 +1434,16 @@ async def test_google_oauth_headers_injected() -> None:
 
 
 @pytest.mark.anyio
-async def test_google_oauth_via_use_adc_model_arg(
+async def test_google_oauth_quota_project_from_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("GOOGLE_CLOUD_QUOTA_PROJECT", "proj-env")
     mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
     mock_client = _create_mock_google_client(mock_generate)
-    fake = _FakeCreds(token="tok-adc")
-    with (
-        patch(
-            "inspect_ai.model._providers.google.Client", return_value=mock_client
-        ) as client,
-        patch("google.auth.default", return_value=(fake, "proj-env")),
-    ):
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            use_adc=True,
-        )
+    with patch(
+        "inspect_ai.model._providers.google.Client", return_value=mock_client
+    ) as client:
+        api = _adc_api(_FakeCreds(token="tok-adc"))
         await api.generate(
             input=[ChatMessageUser(content="Hello")],
             tools=[],
@@ -1456,12 +1466,7 @@ async def test_google_oauth_quota_header_omitted_when_unset(
     with patch(
         "inspect_ai.model._providers.google.Client", return_value=mock_client
     ) as client:
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            credentials=_FakeCreds(),
-        )
+        api = _adc_api(_FakeCreds())
         await api.generate(
             input=[ChatMessageUser(content="Hello")],
             tools=[],
@@ -1481,12 +1486,7 @@ async def test_google_oauth_refreshes_when_invalid() -> None:
     with patch(
         "inspect_ai.model._providers.google.Client", return_value=mock_client
     ) as client:
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            credentials=creds,
-        )
+        api = _adc_api(creds)
         await api.generate(
             input=[ChatMessageUser(content="Hello")],
             tools=[],
@@ -1497,6 +1497,15 @@ async def test_google_oauth_refreshes_when_invalid() -> None:
     headers = _client_http_options(client).headers
     assert headers is not None
     assert headers["Authorization"] == f"Bearer tok-refreshed-{creds.refresh_calls}"
+
+
+@pytest.mark.anyio
+async def test_google_oauth_concurrent_refresh_single_flight() -> None:
+    creds = _FakeCreds(valid=False)
+    api = _adc_api(creds)
+    await tg_collect([api._ensure_oauth_token for _ in range(5)])
+    assert creds.refresh_calls == 1
+    assert creds.valid
 
 
 @pytest.mark.anyio
@@ -1511,7 +1520,7 @@ async def test_google_use_adc_takes_precedence_over_api_key() -> None:
         patch("google.auth.default", return_value=(fake, None)),
     ):
         api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
+            model_name="gemini-2.0-flash",
             base_url=None,
             api_key="explicit-key",
             use_adc=True,
@@ -1536,11 +1545,8 @@ async def test_google_oauth_args_not_forwarded_to_client() -> None:
     with patch(
         "inspect_ai.model._providers.google.Client", return_value=mock_client
     ) as client:
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            credentials=_FakeCreds(),
+        api = _adc_api(
+            _FakeCreds(),
             quota_project_id="p",
             scopes=["https://www.googleapis.com/auth/cloud-platform"],
         )
@@ -1550,44 +1556,65 @@ async def test_google_oauth_args_not_forwarded_to_client() -> None:
             tool_choice="none",
             config=GenerateConfig(),
         )
-    for key in ("credentials", "use_adc", "scopes", "quota_project_id"):
+    for key in ("use_adc", "scopes", "quota_project_id"):
         assert key not in client.call_args.kwargs
         assert key not in api.model_args
 
 
-@pytest.mark.anyio
-async def test_google_oauth_initialize_refreshes() -> None:
-    creds = _FakeCreds()
-    with patch(
-        "inspect_ai.model._providers.google.Client",
-        return_value=_create_mock_google_client(AsyncMock()),
-    ):
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            credentials=creds,
-        )
-    before = creds.refresh_calls
+def test_google_oauth_initialize_invalidates_token() -> None:
+    creds = _FakeCreds(token="tok-0")
+    api = _adc_api(creds)
     api.initialize()
-    assert creds.refresh_calls == before + 1
+    assert creds.token is None
+    assert not creds.valid
+    assert creds.refresh_calls == 0
 
 
 @pytest.mark.anyio
-async def test_google_oauth_batch_raises() -> None:
-    mock_client = _create_mock_google_client(
-        AsyncMock(return_value=GenerateContentResponse(candidates=[]))
-    )
-    with patch("inspect_ai.model._providers.google.Client", return_value=mock_client):
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            credentials=_FakeCreds(),
+async def test_google_oauth_refresh_after_initialize() -> None:
+    mock_generate = AsyncMock(return_value=GenerateContentResponse(candidates=[]))
+    mock_client = _create_mock_google_client(mock_generate)
+    creds = _FakeCreds(token="tok-0")
+    with patch(
+        "inspect_ai.model._providers.google.Client", return_value=mock_client
+    ) as client:
+        api = _adc_api(creds)
+        # simulate the 401 backstop: before_retry() invalidates via initialize()
+        api.initialize()
+        await api.generate(
+            input=[ChatMessageUser(content="Hello")],
+            tools=[],
+            tool_choice="none",
+            config=GenerateConfig(),
         )
-        config = GenerateConfig(batch=BatchConfig(size=1))
-        with pytest.raises(NotImplementedError, match="OAuth"):
-            api._resolve_batcher(config, api._http_options(config))
+    assert creds.refresh_calls == 1
+    headers = _client_http_options(client).headers
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer tok-refreshed-1"
+
+
+def test_google_oauth_401_retry_classification() -> None:
+    err = APIError(401, {"error": {"message": "unauthorized", "code": 401}})
+    oauth_api = _adc_api(_FakeCreds())
+    decision = oauth_api.should_retry(err)
+    assert isinstance(decision, RetryDecision)
+    assert decision.retry
+
+    api_key_api = GoogleGenAIAPI(
+        model_name="gemini-2.0-flash",
+        base_url=None,
+        api_key="explicit-key",
+    )
+    decision = api_key_api.should_retry(err)
+    assert isinstance(decision, RetryDecision)
+    assert not decision.retry
+
+
+def test_google_oauth_batch_raises() -> None:
+    api = _adc_api(_FakeCreds())
+    config = GenerateConfig(batch=BatchConfig(size=1))
+    with pytest.raises(NotImplementedError, match="OAuth"):
+        api._resolve_batcher(config, api._http_options(config))
 
 
 @pytest.mark.anyio
@@ -1596,15 +1623,47 @@ async def test_google_oauth_count_tokens_headers() -> None:
     with patch(
         "inspect_ai.model._providers.google.Client", return_value=mock_client
     ) as client:
-        api = GoogleGenAIAPI(
-            model_name="cys-finding-lc",
-            base_url=None,
-            api_key=None,
-            credentials=_FakeCreds(token="tok-ct"),
-            quota_project_id="proj",
-        )
+        api = _adc_api(_FakeCreds(token="tok-ct"), quota_project_id="proj")
         await api.count_tokens("Hello")
     headers = _client_http_options(client).headers
     assert headers is not None
     assert headers["Authorization"] == "Bearer tok-ct"
     assert headers["x-goog-user-project"] == "proj"
+
+
+def test_google_oauth_headers_survive_real_client() -> None:
+    """Contract test against the real google-genai client (no mocking).
+
+    The OAuth approach relies on undocumented SDK behavior: the dev-endpoint
+    client accepts a placeholder api_key, and `patch_http_options` merges
+    caller-supplied headers with caller precedence, so `Authorization` survives
+    alongside the SDK-set `x-goog-api-key`. Guards against a google-genai
+    release changing that merge.
+    """
+    api = _adc_api(_FakeCreds(token="tok-real"), quota_project_id="proj-real")
+    client = api.model_client(api._http_options())
+    headers = client._api_client._http_options.headers
+    assert headers is not None
+    assert headers["Authorization"] == "Bearer tok-real"
+    assert headers["x-goog-user-project"] == "proj-real"
+    assert headers["x-goog-api-key"] == OAUTH_PLACEHOLDER_API_KEY
+
+
+def test_google_use_adc_rejected_on_vertex() -> None:
+    with pytest.raises(PrerequisiteError, match="use_adc"):
+        GoogleGenAIAPI(
+            model_name="vertex/gemini-2.0-flash",
+            base_url=None,
+            api_key=None,
+            use_adc=True,
+        )
+
+
+def test_google_credentials_arg_rejected() -> None:
+    with pytest.raises(PrerequisiteError, match="credentials"):
+        GoogleGenAIAPI(
+            model_name="gemini-2.0-flash",
+            base_url=None,
+            api_key=None,
+            credentials=object(),
+        )

--- a/tests/model/providers/test_google_model_names.py
+++ b/tests/model/providers/test_google_model_names.py
@@ -1,0 +1,120 @@
+"""Tests for GoogleGenAIAPI model-name feature detection, focused on is_latest().
+
+is_latest() recognizes Google predeployment/codename models (names matching no
+known family) as the current frontier, mirroring the OpenAI provider's
+is_latest_model() and the Anthropic provider's is_claude_latest(). Folding it
+into is_gemini() means a codename gets full frontier behavior (thinking config,
+native tools), and input_tokens_name() aliases unknown names to the current
+frontier so the context window (compaction) resolves correctly.
+"""
+
+import pytest
+
+from inspect_ai.model import get_model
+from inspect_ai.model._model_info import get_model_input_tokens
+from inspect_ai.model._providers.google import GoogleGenAIAPI
+
+
+def _api(model_name: str) -> GoogleGenAIAPI:
+    return GoogleGenAIAPI(model_name=model_name, base_url=None, api_key="test-key")
+
+
+# Known families and non-generative models must NOT be treated as latest.
+KNOWN_MODELS = [
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "gemini-2.0-flash",
+    "gemini-2.5-flash",
+    "gemini-2.5-pro",
+    "gemini-3-pro",
+    "gemini-3.5-flash",
+]
+
+NON_GENERATIVE_MODELS = [
+    "text-embedding-004",
+    "imagen-3.0-generate-002",
+    "veo-2.0",
+    "gemma-3-27b-it",
+    "learnlm-2.0-flash",
+]
+
+# Codename / predeployment names matching no known family.
+CODENAME_MODELS = [
+    "foo-bar-22",
+    "jellyfish",
+    "bluejay-preview",
+    "summit-2026",
+]
+
+
+@pytest.mark.parametrize("model_name", KNOWN_MODELS + NON_GENERATIVE_MODELS)
+def test_known_models_not_latest(model_name: str) -> None:
+    assert _api(model_name).is_latest() is False
+
+
+@pytest.mark.parametrize("model_name", NON_GENERATIVE_MODELS)
+def test_non_generative_models_not_gemini(model_name: str) -> None:
+    assert _api(model_name).is_gemini() is False
+
+
+@pytest.mark.parametrize("model_name", CODENAME_MODELS)
+def test_codename_models_are_latest(model_name: str) -> None:
+    api = _api(model_name)
+    assert api.is_latest() is True
+    # folded into is_gemini(), so frontier behavior follows transitively
+    # (thinking config, native web search / code execution, mixed tools)
+    assert api.is_gemini() is True
+    assert api.is_gemini_3_plus() is True
+    assert api.is_gemini_thinking() is True
+    # codename has no "-pro"/"flash" substring
+    assert api.is_gemini_thinking_only() is False
+    assert api.is_gemini_3_flash() is False
+
+
+def test_pro_codename_is_thinking_only() -> None:
+    assert _api("orion-pro-preview").is_gemini_thinking_only() is True
+
+
+def test_flash_codename_supports_minimal_thinking() -> None:
+    assert _api("nimbus-flash-preview").is_gemini_3_flash() is True
+
+
+@pytest.mark.parametrize("model_name", CODENAME_MODELS)
+def test_codename_aliases_to_frontier_context_window(model_name: str) -> None:
+    # input_tokens_name() aliases to the current frontier so the context window
+    # resolves correctly instead of falling back to the 128K default.
+    assert _api(model_name).input_tokens_name() == "google/gemini-3.5-flash"
+
+
+@pytest.mark.parametrize("model_name", KNOWN_MODELS)
+def test_known_model_input_tokens_name_unchanged(model_name: str) -> None:
+    assert _api(model_name).input_tokens_name() == f"google/{model_name}"
+
+
+def test_future_gemini_version_aliases_to_frontier() -> None:
+    # a gemini-named model not yet in the model-info database gets frontier
+    # treatment via is_gemini_3_plus() and the DB-miss alias (but is not a
+    # "latest" codename)
+    api = _api("gemini-4-pro")
+    assert api.is_latest() is False
+    assert api.is_gemini_3_plus() is True
+    assert api.input_tokens_name() == "google/gemini-3.5-flash"
+
+
+def test_latest_scoped_to_dev_endpoint() -> None:
+    # vertex custom endpoints/deployments have arbitrary names that say
+    # nothing about the model behind them
+    api = GoogleGenAIAPI(
+        model_name="vertex/some-partner-endpoint",
+        base_url=None,
+        api_key="test-key",
+        project="test-project",
+        location="us-central1",
+    )
+    assert api.is_latest() is False
+    assert api.is_gemini() is False
+
+
+def test_codename_context_window_resolves() -> None:
+    model = get_model("google/foo-bar-22", api_key="test-key")
+    assert get_model_input_tokens(model) == 1048576

--- a/tests/model/providers/test_hf.py
+++ b/tests/model/providers/test_hf.py
@@ -254,7 +254,9 @@ def test_hf_auto_model_class_selects_alternate_loader(monkeypatch) -> None:
     AutoModelForCausalLM and must be loaded with e.g.
     AutoModelForImageTextToText.
     """
-    import transformers  # type: ignore
+    # unused-ignore is listed because the ignore is environment-dependent:
+    # it fires only when transformers is not installed.
+    import transformers  # type: ignore[import-not-found,import-untyped,unused-ignore]
 
     from inspect_ai.model._providers.hf import HuggingFaceAPI
 

--- a/tests/model/providers/test_openai_responses.py
+++ b/tests/model/providers/test_openai_responses.py
@@ -338,7 +338,7 @@ def _completed_mock_response():
     )
 
 
-async def test_responses_api_pro_mode_defaults_to_background():
+async def test_responses_api_pro_mode_defaults_to_background() -> None:
     request: dict = {}
     await _generate_responses_with_mock(
         _completed_mock_response(),
@@ -348,7 +348,7 @@ async def test_responses_api_pro_mode_defaults_to_background():
     assert request["background"] is True
 
 
-async def test_responses_api_pro_mode_respects_explicit_background():
+async def test_responses_api_pro_mode_respects_explicit_background() -> None:
     request: dict = {}
     await _generate_responses_with_mock(
         _completed_mock_response(),
@@ -359,7 +359,7 @@ async def test_responses_api_pro_mode_respects_explicit_background():
     assert request["background"] is False
 
 
-async def test_responses_api_no_background_by_default():
+async def test_responses_api_no_background_by_default() -> None:
     request: dict = {}
     await _generate_responses_with_mock(
         _completed_mock_response(), capture_request=request

--- a/tests/model/test_canonical_names.py
+++ b/tests/model/test_canonical_names.py
@@ -416,14 +416,18 @@ class TestGoogleCanonicalName:
         """Test Google model canonical name includes google/ prefix."""
         from inspect_ai.model._providers.google import GoogleGenAIAPI
 
-        api = GoogleGenAIAPI(model_name="gemini-1.5-pro", base_url=None, api_key=None)
+        api = GoogleGenAIAPI(
+            model_name="gemini-1.5-pro", base_url=None, api_key="test-key"
+        )
         assert api.canonical_name() == "google/gemini-1.5-pro"
 
     def test_gemini_flash(self):
         """Test Gemini Flash model."""
         from inspect_ai.model._providers.google import GoogleGenAIAPI
 
-        api = GoogleGenAIAPI(model_name="gemini-2.0-flash", base_url=None, api_key=None)
+        api = GoogleGenAIAPI(
+            model_name="gemini-2.0-flash", base_url=None, api_key="test-key"
+        )
         assert api.canonical_name() == "google/gemini-2.0-flash"
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -103,7 +103,7 @@ def test_eval_sample_token_limit_fields_none_without_limit():
     assert sample.token_limit_usage is None
 
 
-def test_dynamic_token_limit_updates_active_sample():
+def test_dynamic_token_limit_updates_active_sample() -> None:
     from typing import Generator
 
     from inspect_ai.log._samples import sample_active
@@ -153,7 +153,7 @@ def test_dynamic_token_limit_updates_active_sample():
     ]
 
 
-def test_eval_sample_limit_values_reflect_final_retry_attempt():
+def test_eval_sample_limit_values_reflect_final_retry_attempt() -> None:
     from typing import Generator
 
     from inspect_ai.model import get_model


### PR DESCRIPTION
## Summary

Support for evaluating **predeployment / partner-served Google models** on the
Gemini Developer API (`generativelanguage.googleapis.com`), in two parts:

1. **OAuth / ADC authentication.** Some deployments (for example, partner-served
   models) are reachable only via an OAuth bearer token (Application Default
   Credentials) plus an `x-goog-user-project` quota-project header, with no API
   key available. This PR adds per-model OAuth/ADC support with automatic,
   cancellation-safe token refresh so long-running evals work without manual
   intervention.
2. **Unknown model names are treated as the latest Gemini model.** Predeployment
   models use unrecognized names, which previously missed the model-info
   database — compaction fell back to a 128K context window (vs the real ~1M)
   and every capability predicate failed. Unknown names now get frontier
   capability detection and context window, mirroring the OpenAI
   (`is_latest_model()`) and Anthropic (`is_claude_latest()`) providers.

## OAuth / ADC

### Approach

`google-genai`'s Gemini Developer API client is API-key-only: its constructor
rejects an empty `api_key` and never consults `credentials=` (that argument is
Vertex-gated throughout the SDK). So this PR:

1. Passes a **placeholder** API key to satisfy the client constructor.
2. Injects `Authorization: Bearer <token>` (and, when set, `x-goog-user-project`)
   via `http_options.headers`. The SDK merges caller headers with precedence, so
   `Authorization` overrides the placeholder `x-goog-api-key` server-side. A
   contract test constructs a **real** (unmocked) `genai.Client` and asserts the
   merged headers, so a future SDK change to header-merge precedence is caught
   at unit-test time.
3. Refreshes the token **before each request** when it is no longer valid. The
   refresh runs in a worker thread (`abandon_on_cancel=True`) so it neither
   blocks the event loop nor shields the awaiting task from attempt timeouts,
   with an async-lock single-flight plus a thread-lock backstop so concurrent
   samples (or an abandoned refresh thread) can never race two refreshes
   through the non-thread-safe google-auth credentials. The token-endpoint
   round-trip is bounded at 30s.
4. Makes OAuth 401s **retryable**: the retry loop routes through
   `initialize()`, which invalidates the local token (no I/O) so the retried
   request mints a fresh bearer — covering tokens invalidated mid-flight.

### Usage (opt-in per model or per environment)

```bash
gcloud auth application-default login   # or an impersonated service account
inspect eval task.py --model google/your-model \
   -M use_adc=true -M quota_project_id=your-project
```

Or set `GOOGLE_USE_ADC=true` in the environment (e.g. `.env`) so the same
command works across API-key and OAuth environments; `-M use_adc=false`
overrides per model, and Vertex models ignore the env var (Vertex uses ADC
natively).

Supported custom model args (`-M`): `use_adc` (bool), `scopes` (list, defaults
to `cloud-platform`), and `quota_project_id` (falls back to the official
`GOOGLE_CLOUD_QUOTA_PROJECT` environment variable).

**Auth precedence:** `-M use_adc` (or, when unset, `GOOGLE_USE_ADC`) selects
OAuth; otherwise an explicit API key, then `GOOGLE_API_KEY` (the SDK also
honors `GEMINI_API_KEY`). When no auth is available at all, model creation now
fails fast with a `PrerequisiteError` naming both paths (previously the SDK
raised a bare "No API key was provided" at first generate).

**Deliberately unsupported:**

- Explicit `credentials` objects — `get_model()` memoization serializes
  object-valued model args as `None` in its cache key, so two models with
  different credentials would silently share one cached instance (and
  principal). Passing `credentials` on the dev endpoint raises with a pointer
  to ADC. (On Vertex, `credentials` remains a native `genai.Client` argument.)
- `-M use_adc=true` on a Vertex model raises (Vertex authenticates with ADC
  natively); previously this fell through to an opaque SDK `TypeError`.
- Batch inference in OAuth mode raises with a clear message — the batcher holds
  a single long-lived client across submit and poll, which cannot refresh the
  bearer token the way per-request client creation does.

## Unknown model names → latest Gemini

- New `is_latest()` predicate (exclusion filter over known Gemini families and
  non-generative names like imagen/veo/gemma/embedding), scoped to the dev
  endpoint — Vertex custom endpoints have arbitrary names that say nothing
  about the model behind them.
- Folded into `is_gemini()` (and the `is_gemini_3_flash()` /
  `is_gemini_thinking_only()` refinements), so codenames transitively get
  thinking config (`thinking_level`), native web search / code execution, and
  mixed native + function tools.
- `input_tokens_name()` aliases codenames **and** gemini-named models missing
  from the model-info database (future versions) to the current frontier entry
  (`google/gemini-3.5-flash`, ~1M context), so compaction no longer falls back
  to the 128K default. The `set_model_info(family=...)` escape hatch still
  overrides everything.
- The computer-use gate is deliberately unchanged (literal preview-model names).

## Security

The bearer token lives only on client-level `http_options.headers`; recorded
`ModelCall`s capture the per-request config (request-id + `extra_headers`
only), so tokens never land in eval logs or transcripts.

## Testing

- Unit tests cover: header injection on `generate` and `count_tokens`, `use_adc`
  arg/env-var opt-in and precedence (arg over env, ADC over API key), quota
  header from arg/env/omitted, refresh-when-invalid, concurrent single-flight
  refresh, refresh cancellability under `anyio.fail_after`, `initialize()`
  token invalidation and refresh-after-initialize, OAuth 401 retry
  classification (API-key 401s stay non-retryable), the real-client SDK
  header-merge contract, batch/vertex/credentials/no-auth error cases, and the
  OAuth args not being forwarded to `genai.Client`.
- `tests/model/providers/test_google_model_names.py` mirrors the OpenAI
  model-names tests: codenames are latest/gemini/3-plus with the frontier
  context-window alias; known and non-generative models are unaffected; future
  gemini versions alias; vertex is excluded; end-to-end
  `get_model_input_tokens()` resolves 1048576 for a codename.
- Async tests pass under both asyncio and trio backends.
- Verified end-to-end against a live OAuth-only Gemini Developer API model: a
  direct generate and a 2-sample `eval` (with scorer) both succeed via
  `-M use_adc=true -M quota_project_id=<project>`.

## Docs

`docs/providers.qmd` gains a "Gemini Developer API with OAuth / ADC" section and
documents `GOOGLE_USE_ADC` / `GOOGLE_CLOUD_QUOTA_PROJECT`; CHANGELOG entries
added for both features.
