### PR TITLE
fix(util): honor str -> str overload for cwd_relative_path on empty input

### DIFF
--- a/src/inspect_ai/_util/path.py
+++ b/src/inspect_ai/_util/path.py
@@ -89,17 +89,18 @@ def cwd_relative_path(file: None, walk_up: bool = False) -> None: ...
 
 
 def cwd_relative_path(file: str | None, walk_up: bool = False) -> str | None:
-    if file:
-        cwd = PurePath(os.getcwd())
-        task_path = PurePath(file)
-        if task_path.is_relative_to(cwd):
-            return task_path.relative_to(cwd).as_posix()
-        elif walk_up:
-            return relative_walk(cwd, task_path)
-        else:
-            return file
-    else:
+    if file is None:
         return None
+    if file == "":
+        return ""
+    cwd = PurePath(os.getcwd())
+    task_path = PurePath(file)
+    if task_path.is_relative_to(cwd):
+        return task_path.relative_to(cwd).as_posix()
+    elif walk_up:
+        return relative_walk(cwd, task_path)
+    else:
+        return file
 
 
 def pretty_path(file: str) -> str:

--- a/tests/util/test_path.py
+++ b/tests/util/test_path.py
@@ -1,0 +1,49 @@
+"""Tests for inspect_ai._util.path.cwd_relative_path.
+
+Covers the str -> str and None -> None overload contracts, including
+the regression case for issue 4451 where empty-string input was
+incorrectly routed to the None branch.
+"""
+
+import os
+from pathlib import PurePath
+
+from inspect_ai._util.path import cwd_relative_path
+
+
+def test_cwd_relative_path_none_returns_none():
+    """None input returns None (per overload)."""
+    assert cwd_relative_path(None) is None
+
+
+def test_cwd_relative_path_empty_string_returns_empty_string_issue_4451():
+    """Empty string input returns empty string (per str overload).
+
+    Regression test for issue 4451: previously the `if file:` truthiness
+    check routed empty string to the None branch, returning None and
+    violating the `str -> str` overload contract.
+    """
+    assert cwd_relative_path("") == ""
+
+
+def test_cwd_relative_path_absolute_in_cwd_returns_relative_posix():
+    """Absolute path inside cwd returns POSIX-formatted relative path."""
+    cwd = os.getcwd()
+    abs_path = os.path.join(cwd, "foo", "bar")
+    expected = PurePath(abs_path).relative_to(PurePath(cwd)).as_posix()
+    assert cwd_relative_path(abs_path) == expected
+
+
+def test_cwd_relative_path_relative_input_returns_input():
+    """Already-relative path returns input unchanged."""
+    assert cwd_relative_path("foo/bar") == "foo/bar"
+
+
+def test_cwd_relative_path_none_with_walk_up_returns_none():
+    """None input still returns None when walk_up=True."""
+    assert cwd_relative_path(None, walk_up=True) is None
+
+
+def test_cwd_relative_path_empty_with_walk_up_returns_empty_issue_4451():
+    """Empty string still returns empty string when walk_up=True."""
+    assert cwd_relative_path("", walk_up=True) == ""


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`cwd_relative_path("")` returns `None`, violating the `str -> str` overload declared for non-`None` input. The implementation in `src/inspect_ai/_util/path.py` uses `if file:` (truthiness), which routes empty string into the same branch as `None`. See #4451.

```python
>>> from inspect_ai._util.path import cwd_relative_path
>>> cwd_relative_path("") is None
True
```

This also propagates to `pretty_path(file: str) -> str`, which delegates to `cwd_relative_path` after `LocalFileSystem._strip_protocol(file)`. A degenerate empty-string `file` would come back as `None` from `pretty_path`, again contradicting its declared `-> str` return.

### What is the new behavior?

`cwd_relative_path` now branches on identity (`if file is None:`) and on equality (`if file == ""`), so the `str -> str` overload is honored:

```python
>>> cwd_relative_path("") == ""
True
>>> cwd_relative_path(None) is None
True
```

For all non-empty inputs the behavior is unchanged (same relative-path computation, same `walk_up` handling, same outside-cwd "return input unchanged" fallback).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The change only narrows the return type for one previously-broken input (`""`). Code that depended on `cwd_relative_path("") is None` would have been depending on a contract violation rather than on documented behavior.

### Other information:

- Adds `tests/util/test_path.py` covering: `None` input, empty-string input (regression for #4451), absolute path inside cwd, already-relative path, and both `walk_up` variants for `None` / empty.
- Fixes #4451.
