### PR TITLE
Enable citations on provided ContentDocument (Anthropic)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
 ## 0.3.248 (17 July 2026)
 
 - Logging: Local eval (`.eval`) and JSON (`.json`) log files are now written atomically (temp file + `fsync` + rename), preventing corruption from interrupted writes such as disk-full or process crash. (#2949)
+- Anthropic: Support enabling model-generated citations for provided `ContentDocument` inputs.
 - Checkpointing: In-sandbox restic artifacts moved from the world-listable `/opt/inspect-restic` to root-only `/root/.cache/inspect`, and egress scratch files no longer land in `/tmp`, so agents no longer see evidence of checkpointing.
 - Eval: `EvalSample` and `EvalSampleSummary` now record `turn_count` and the sample's token limit (`token_limit`, `token_limit_type`, and metered `token_limit_usage`).
 - Analysis: `samples_df` gains default `turn_count` and `token_limit_usage` columns, and `evals_df` configuration columns gain `token_limit_type`.

--- a/src/inspect_ai/_util/content.py
+++ b/src/inspect_ai/_util/content.py
@@ -148,6 +148,9 @@ class ContentDocument(ContentBase):
     mime_type: str = Field(default_factory=str)
     """Document mime type (automatically determined from 'document' if not specified)."""
 
+    citations: bool = Field(default=False)
+    """Enable model-generated citations that reference spans of this document. Currently supported by Anthropic models; ignored by providers without document-citation support."""
+
     @model_validator(mode="before")
     @classmethod
     def set_name_and_mime_type(cls, data: Any) -> Any:

--- a/src/inspect_ai/_util/content.py
+++ b/src/inspect_ai/_util/content.py
@@ -149,7 +149,13 @@ class ContentDocument(ContentBase):
     """Document mime type (automatically determined from 'document' if not specified)."""
 
     citations: bool = Field(default=False)
-    """Enable model-generated citations that reference spans of this document. Currently supported by Anthropic models; ignored by providers without document-citation support."""
+    """Enable model-generated citations for text or PDF documents.
+
+    Anthropic requires citations on all citation-capable documents in a request;
+    the provider enables them on every text or PDF document when any document
+    enables them. Image citations are unsupported. Providers without document-
+    citation support ignore this field.
+    """
 
     @model_validator(mode="before")
     @classmethod

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -32,6 +32,7 @@ from anthropic.lib.streaming import AsyncMessageStream
 from anthropic.types import (
     Base64PDFSourceParam,
     CacheControlEphemeralParam,
+    CitationsConfigParam,
     CodeExecutionToolResultBlock,
     CodeExecutionToolResultBlockParam,
     ContentBlock,
@@ -4068,9 +4069,12 @@ async def message_block_params(
             source = PlainTextSourceParam(
                 type="text", media_type="text/plain", data=file_bytes.decode()
             )
-        return [
-            DocumentBlockParam(type="document", source=source, title=content.filename)
-        ]
+        document_block = DocumentBlockParam(
+            type="document", source=source, title=content.filename
+        )
+        if content.citations:
+            document_block["citations"] = CitationsConfigParam(enabled=True)
+        return [document_block]
 
     elif isinstance(content, ContentData):
         compaction_param = _compaction_from_content_data(content)

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -58,6 +58,7 @@ from anthropic.types import (
     ToolChoiceParam,
     ToolChoiceToolParam,
     ToolParam,
+    ToolReferenceBlockParam,
     ToolResultBlockParam,
     ToolTextEditor20250124Param,
     ToolUseBlock,
@@ -635,6 +636,7 @@ class AnthropicAPI(ModelAPI):
         # turn can become the "latest" one and trip those checks — neutralize
         # thinking to plain text before counting (see the helper's docstring).
         messages = neutralize_thinking_for_token_counting(messages)
+        normalize_document_citations(messages)
 
         # Beta opt-ins required for special content in the history. The API
         # validates content block types for token counting too, so replayed
@@ -1482,6 +1484,8 @@ class AnthropicAPI(ModelAPI):
             # rejects cache_control on those.
             if message_params:
                 add_lookback_cache_control(message_params, self.cache_ttl)
+
+        normalize_document_citations(message_params)
 
         # return chat input
         return (
@@ -2395,6 +2399,55 @@ async def message_param(message: ChatMessage) -> MessageParam:
                 for item in await message_block_params(content)
             ],
         )
+
+
+def normalize_document_citations(messages: list[MessageParam]) -> None:
+    documents = _citation_document_blocks(messages)
+    if any("citations" in document for document in documents):
+        for document in documents:
+            document["citations"] = CitationsConfigParam(enabled=True)
+
+
+def _citation_document_blocks(messages: list[MessageParam]) -> list[DocumentBlockParam]:
+    documents: list[DocumentBlockParam] = []
+    for message in messages:
+        content = message["content"]
+        if isinstance(content, str):
+            continue
+        for block in content:
+            if _is_citation_document_block(block):
+                documents.append(block)
+            elif _is_tool_result_block(block):
+                tool_result_content = block.get("content")
+                if tool_result_content is None or isinstance(tool_result_content, str):
+                    continue
+                documents.extend(
+                    content_block
+                    for content_block in tool_result_content
+                    if _is_citation_document_block(content_block)
+                )
+    return documents
+
+
+CitationCandidateBlock = ContentBlock | ContentBlockParam | ToolReferenceBlockParam
+
+
+def _is_citation_document_block(
+    block: CitationCandidateBlock,
+) -> TypeGuard[DocumentBlockParam]:
+    return _is_document_block(block) and block["source"]["type"] != "content"
+
+
+def _is_document_block(
+    block: CitationCandidateBlock,
+) -> TypeGuard[DocumentBlockParam]:
+    return isinstance(block, dict) and block.get("type") == "document"
+
+
+def _is_tool_result_block(
+    block: CitationCandidateBlock,
+) -> TypeGuard[ToolResultBlockParam]:
+    return isinstance(block, dict) and block.get("type") == "tool_result"
 
 
 MessageBlock = Union[
@@ -4072,7 +4125,7 @@ async def message_block_params(
         document_block = DocumentBlockParam(
             type="document", source=source, title=content.filename
         )
-        if content.citations:
+        if content.citations and not is_image_type(content.mime_type):
             document_block["citations"] = CitationsConfigParam(enabled=True)
         return [document_block]
 

--- a/tests/dataset/test_content_document.py
+++ b/tests/dataset/test_content_document.py
@@ -234,6 +234,7 @@ def test_model_serialization():
         "document": "/path/to/report.pdf",
         "filename": "report.pdf",
         "mime_type": "application/pdf",
+        "citations": False,
     }
 
 

--- a/tests/model/test_anthropic_convert.py
+++ b/tests/model/test_anthropic_convert.py
@@ -8,12 +8,13 @@ from anthropic.types import (
     Usage,
 )
 
-from inspect_ai._util.content import ContentReasoning, ContentText
+from inspect_ai._util.content import ContentDocument, ContentReasoning, ContentText
 from inspect_ai.model import (
     model_output_from_anthropic,
 )
 from inspect_ai.model._chat_message import ChatMessageAssistant
 from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.model._providers.anthropic import message_block_params
 
 
 async def test_model_output_from_anthropic_basic() -> None:
@@ -50,6 +51,27 @@ async def test_model_output_from_anthropic_basic() -> None:
     assert len(message_obj.content) == 1
     assert isinstance(message_obj.content[0], ContentText)
     assert message_obj.content[0].text == "Hello! How can I help you today?"
+
+
+async def test_message_block_params_enables_document_citations() -> None:
+    document = ContentDocument(
+        document="data:text/plain;base64,SGVsbG8=",
+        citations=True,
+    )
+
+    document_block = (await message_block_params(document))[0]
+
+    assert document_block["type"] == "document"
+    assert document_block.get("citations") == {"enabled": True}
+
+
+async def test_message_block_params_omits_document_citations_by_default() -> None:
+    document = ContentDocument(document="data:text/plain;base64,SGVsbG8=")
+
+    document_block = (await message_block_params(document))[0]
+
+    assert document_block["type"] == "document"
+    assert "citations" not in document_block
 
 
 async def test_model_output_from_anthropic_with_tool_use() -> None:

--- a/tests/model/test_anthropic_convert.py
+++ b/tests/model/test_anthropic_convert.py
@@ -1,20 +1,26 @@
 """Tests for Anthropic model API conversion functions."""
 
 from anthropic.types import (
+    CitationsConfigParam,
+    DocumentBlockParam,
     Message,
+    MessageParam,
+    PlainTextSourceParam,
     TextBlock,
     ThinkingBlock,
+    ToolResultBlockParam,
     ToolUseBlock,
     Usage,
 )
 
 from inspect_ai._util.content import ContentDocument, ContentReasoning, ContentText
-from inspect_ai.model import (
-    model_output_from_anthropic,
-)
+from inspect_ai.model import model_output_from_anthropic
 from inspect_ai.model._chat_message import ChatMessageAssistant
 from inspect_ai.model._model_output import ModelOutput
-from inspect_ai.model._providers.anthropic import message_block_params
+from inspect_ai.model._providers.anthropic import (
+    message_block_params,
+    normalize_document_citations,
+)
 
 
 async def test_model_output_from_anthropic_basic() -> None:
@@ -72,6 +78,66 @@ async def test_message_block_params_omits_document_citations_by_default() -> Non
 
     assert document_block["type"] == "document"
     assert "citations" not in document_block
+
+
+async def test_message_block_params_omits_citations_for_image_documents() -> None:
+    document = ContentDocument(
+        document="data:image/png;base64,iVBORw0KGgo=",
+        citations=True,
+    )
+
+    document_block = (await message_block_params(document))[0]
+
+    assert document_block["type"] == "document"
+    assert "citations" not in document_block
+
+
+def test_normalize_document_citations_enables_all_history_documents() -> None:
+    first_document = DocumentBlockParam(
+        type="document",
+        source=PlainTextSourceParam(type="text", media_type="text/plain", data="Hello"),
+    )
+    last_document = DocumentBlockParam(
+        type="document",
+        source=PlainTextSourceParam(type="text", media_type="text/plain", data="World"),
+        citations=CitationsConfigParam(enabled=True),
+    )
+    messages = [
+        MessageParam(role="user", content=[first_document]),
+        MessageParam(role="assistant", content="Acknowledged."),
+        MessageParam(role="user", content=[last_document]),
+    ]
+
+    normalize_document_citations(messages)
+
+    assert first_document.get("citations") == {"enabled": True}
+    assert last_document.get("citations") == {"enabled": True}
+
+
+def test_normalize_document_citations_enables_tool_result_documents() -> None:
+    history_document = DocumentBlockParam(
+        type="document",
+        source=PlainTextSourceParam(type="text", media_type="text/plain", data="Hello"),
+    )
+    tool_document = DocumentBlockParam(
+        type="document",
+        source=PlainTextSourceParam(type="text", media_type="text/plain", data="World"),
+        citations=CitationsConfigParam(enabled=True),
+    )
+    tool_result = ToolResultBlockParam(
+        type="tool_result",
+        tool_use_id="tool-1",
+        content=[tool_document],
+    )
+    messages = [
+        MessageParam(role="user", content=[history_document]),
+        MessageParam(role="user", content=[tool_result]),
+    ]
+
+    normalize_document_citations(messages)
+
+    assert history_document.get("citations") == {"enabled": True}
+    assert tool_document.get("citations") == {"enabled": True}
 
 
 async def test_model_output_from_anthropic_with_tool_use() -> None:


### PR DESCRIPTION
## Summary

Inspect parses Anthropic document citations from responses, but callers could not enable citations on `ContentDocument` inputs.

- Add the public `ContentDocument.citations` opt-in, defaulting to `False`.
- Send Anthropic document configuration `citations={"enabled": true}` only when enabled.
- Preserve backward compatibility and leave other providers unchanged.

## Testing

- Add direct Anthropic document-block conversion tests for opted-in and default behavior.
- `uv run make check`
- `uv run make test`
