### PR TITLE
Fix flaky responses-bridge web_search test by forcing tool_choice

### DIFF
--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -196,6 +196,11 @@ def responses_web_search_agent() -> Agent:
                             "search_context_size": "low",
                         }
                     ],
+                    # forced: the question is answerable from parametric
+                    # knowledge, and under auto choice models sometimes skip
+                    # the search (the test verifies bridge translation, not
+                    # whether the model elects to search)
+                    tool_choice="required",
                     input=user_prompt(state.messages).text,
                 )
 


### PR DESCRIPTION
Closes https://github.com/meridianlabs-ai/actions/issues/70

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`test_bridged_web_search_tool_openai_to_anthropic` flakes intermittently. The test question ("What movie won best picture in 2025?") is answerable from the model's parametric knowledge, and `responses_web_search_agent()` sets no `tool_choice`, so under auto tool choice the model sometimes answers directly without invoking the web_search server tool — `check_server_tool_use` then fails on `assert tool_use`.

### What is the new behavior?

`responses_web_search_agent()` now passes `tool_choice="required"`, which the responses bridge maps to inspect `"any"`, guaranteeing the search happens. The test now asserts what it's meant to cover — bridge translation of the web_search server tool (and, as a bonus, the `required` → `any` tool_choice mapping) — rather than whether the model elects to search.

Verified live with `--runapi`: `test_bridged_web_search_tool_openai` (gpt-5 accepts `required` with the hosted web_search tool, so the shared helper is safe), `test_bridged_web_search_tool_openai_to_anthropic` (3×), and `test_bridged_web_search_tool_anthropic_to_openai` all pass.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No — test-only change.

### Other information:
