### PR TITLE
fix: catch LookupError in create_scorer file-load fallbacks

### DIFF
--- a/src/inspect_ai/_eval/loader.py
+++ b/src/inspect_ai/_eval/loader.py
@@ -796,7 +796,7 @@ def scorer_from_spec(spec: ScorerSpec, task_path: Path | None, **kwargs: Any) ->
 
             try:
                 return scorer_create(scorer_name, **kwargs)
-            except ValueError:
+            except (ValueError, LookupError):
                 # We need a valid path to a scorer file to try to load the scorer from there
                 if not task_path:
                     raise PrerequisiteError(
@@ -815,7 +815,7 @@ def scorer_from_spec(spec: ScorerSpec, task_path: Path | None, **kwargs: Any) ->
                     scorer_fn = create_scorer(scorer_name, **kwargs)
                     validate_scorer(scorer_fn, scorer_name, task_pretty_path)
                     return scorer_fn
-                except ValueError:
+                except (ValueError, LookupError):
                     # we still couldn't load this, request the user provide a path
                     raise PrerequisiteError(
                         f"The scorer '{scorer_name}' in the file '{task_pretty_path}' couldn't be loaded. Please provide a path to the file containing the scorer using the '--scorer' parameter."


### PR DESCRIPTION
Fixes #4541.

A registry miss propagates from `_util/registry.py` as `LookupError("<name> was not found in the registry")`, but both file-load fallbacks in `create_scorer` catch only `ValueError` — so the fallback path never fires and `inspect score` fails with a bare `LookupError` for any scorer not already in the registry (e.g. scorers living in a package loaded by file path).

This widens the two `except` clauses in `create_scorer` to `(ValueError, LookupError)`. The `except ValueError` in `resolve_task_args` is deliberately left untouched — it guards a different call path.

Reproduced on 0.3.241; the affected code is unchanged through 0.3.248 and current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)