### PR TITLE
fix(csv_dataset): skip ragged blank rows instead of crashing (#4546)

### DIFF
--- a/src/inspect_ai/dataset/_sources/csv.py
+++ b/src/inspect_ai/dataset/_sources/csv.py
@@ -76,7 +76,7 @@ def csv_dataset(
         valid_data = [
             data
             for data in csv_dataset_reader(f, dialect, fieldnames, delimiter)
-            if data and any(value.strip() for value in data.values())
+            if data and any(_value_has_content(value) for value in data.values())
         ]
         name = name if name else Path(csv_file).stem
         dataset = MemoryDataset(
@@ -99,6 +99,20 @@ def csv_dataset(
             return dataset[0:limit]
 
         return dataset
+
+
+def _value_has_content(value: Any) -> bool:
+    # csv.DictReader yields values that are not always strings for ragged rows:
+    # a short row (fewer fields than the header) fills missing columns with the
+    # restval (None by default), and a long row (extra fields) collects the
+    # surplus into a list under the restkey. Calling .strip() on either raises,
+    # which is exactly the crash the empty-row filter is meant to prevent. Treat
+    # a missing value as empty and recurse into the extras list.
+    if value is None:
+        return False
+    if isinstance(value, list):
+        return any(_value_has_content(item) for item in value)
+    return bool(value.strip())
 
 
 def csv_dataset_reader(

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -222,6 +222,30 @@ def test_dataset_nan_target_treated_as_missing() -> None:
     assert sample_num.target == "4"
 
 
+def test_csv_dataset_skips_blank_ragged_row(tmp_path: Path) -> None:
+    # A blank row with fewer fields than the header used to crash the empty-row
+    # filter with `AttributeError: 'NoneType' object has no attribute 'strip'`
+    # (csv.DictReader fills the missing column with None). The filter should skip
+    # the ragged blank row and load the two real rows. See issue #4546.
+    csv_file = tmp_path / "ragged.csv"
+    csv_file.write_text("input,target,id\n2+2,4,q1\n,\n3+3,6,q2\n", newline="")
+    dataset = csv_dataset(str(csv_file))
+    assert len(dataset) == 2
+    assert [str(sample.input) for sample in dataset] == ["2+2", "3+3"]
+
+
+def test_csv_value_has_content_handles_ragged_values() -> None:
+    # Guards both non-string branches produced by ragged rows: None (short row,
+    # missing column) and a list (long row, extras collected under the restkey).
+    from inspect_ai.dataset._sources.csv import _value_has_content
+
+    assert _value_has_content(None) is False
+    assert _value_has_content([""]) is False
+    assert _value_has_content(["x"]) is True
+    assert _value_has_content("") is False
+    assert _value_has_content(" a ") is True
+
+
 def test_dataset_zero_seed() -> None:
     dataset1 = json_dataset(dataset_path("dataset.jsonl"), shuffle=True, seed=0)
     dataset2 = json_dataset(dataset_path("dataset.jsonl"), shuffle=True, seed=0)


### PR DESCRIPTION
## Summary

`csv_dataset()` raised `AttributeError: 'NoneType' object has no attribute 'strip'` when a CSV contained a blank-looking row with fewer columns than the header — the exact rows the empty-row filter at `csv.py:79` is meant to skip. Fixes #4546.

## Root cause

`csv_dataset_reader` builds a `csv.DictReader` with the default `restval`/`restkey` (`None`). For a **short** row (fewer fields than the header) the missing columns are filled with `None`; for a **long** row (extra fields) the surplus is collected into a `list` under key `None`. The filter then called `.strip()` on every value:

```python
if data and any(value.strip() for value in data.values())
```

`None.strip()` and `list.strip()` both raise. The crash only surfaces on otherwise-empty ragged rows, because a non-blank field short-circuits `any()` before it reaches the `None`/list value — so it fires precisely on the empty ragged rows the filter exists to drop.

## Fix

Introduce `_value_has_content()`, which treats `None` as empty and recurses into the extras `list`, and use it in the filter predicate. Behavior is unchanged for well-formed rows; ragged blank rows are now skipped as intended instead of crashing.

## Tests

- `test_csv_dataset_skips_blank_ragged_row` mirrors the issue's reproduction (a `,` row under a 3-column header) and asserts the two real rows load.
- `test_csv_value_has_content_handles_ragged_values` unit-tests the helper's `None`/`list` handling.

Verified the reproduction and the fix locally against current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
