### PR TITLE
fix(openrouter): emit clean <think> tag for Gemini reasoning replay (#4320)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Control Channel: `inspect ctl sample list` no longer recomputes sample summaries on every request, so polling an eval buffering many large samples (e.g. a retry's carried transcripts) can no longer stall the eval process.
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.
+- OpenRouter: Reasoning history replayed to Gemini models now contains only readable `<think>` text, rather than HTML-escaped signature JSON and encrypted payloads. (#4320)
 
 ## 0.3.248 (17 July 2026)
 

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -238,7 +238,17 @@ class OpenRouterAPI(OpenAICompatibleAPI):
             content: ContentReasoning,
         ) -> dict[str, JsonValue] | str:
             if _strip_reasoning_details:
-                return reasoning_to_think_tag(content)
+                # Gemini can't use reasoning_details on replay — emit only the
+                # readable text so the model sees clean CoT without the
+                # HTML-escaped JSON signature or encrypted blob.
+                text = (
+                    content.summary if content.redacted else content.reasoning
+                ) or ""
+                if not text.strip():
+                    # no readable text (e.g. redacted reasoning with no
+                    # summary) — skip the tag rather than emit an empty one
+                    return {}
+                return f"<think>\n{text}\n</think>"
             details = reasoning_to_openrouter_reasoning_details(content)
             if _replay_reasoning_content:
                 reasoning_content: dict[str, JsonValue] = {

--- a/tests/model/providers/test_openrouter.py
+++ b/tests/model/providers/test_openrouter.py
@@ -294,6 +294,140 @@ def test_apply_cache_creation_usage_noop_when_no_call() -> None:
 
 
 @pytest.mark.anyio
+async def test_messages_to_openai_gemini_think_tag_clean_for_text_and_encrypted() -> (
+    None
+):
+    """Gemini text+encrypted reasoning must produce a clean <think> tag (issue #4320).
+
+    The bug: reasoning_to_think_tag() dumps the full HTML-escaped JSON
+    signature blob as an attribute and the encrypted payload as the body.
+    The fix: emit only the readable summary text, no signature/blob.
+    """
+    from inspect_ai._util.content import ContentReasoning
+    from inspect_ai.model._chat_message import ChatMessageAssistant
+    from inspect_ai.model._providers.openrouter import (
+        OPENROUTER_REASONING_DETAILS_SIGNATURE,
+    )
+
+    readable_text = (
+        "I've determined the most direct path forward involves the run_bash tool."
+    )
+    encrypted_blob = "CjcBjz1rXxKfW2fJuqbBlfGrk8wxR..."
+    signature = OPENROUTER_REASONING_DETAILS_SIGNATURE + (
+        '[{"type": "reasoning.text", "text": "...", "format": "google-gemini-v1", "index": 0},'
+        '{"type": "reasoning.encrypted", "data": "CjcBjz1rXxKfW2fJ...", "format": "google-gemini-v1", "id": "tool_X", "index": 1}]'
+    )
+    msg = ChatMessageAssistant(
+        content=[
+            ContentReasoning(
+                reasoning=encrypted_blob,
+                summary=readable_text,
+                redacted=True,
+                signature=signature,
+            )
+        ],
+    )
+
+    api = _make_api("google/gemini-2.5-flash")
+    converted = await api.messages_to_openai([msg])
+
+    payload = converted[0]
+    content = payload.get("content")
+    if isinstance(content, list):
+        text = "".join(b.get("text", "") for b in content if isinstance(b, dict))
+    else:
+        text = content if isinstance(content, str) else ""
+
+    # Readable text must appear
+    assert readable_text in text
+    # Encrypted blob must NOT appear
+    assert encrypted_blob not in text
+    # No HTML-escaped JSON blob
+    assert "&quot;" not in text
+    # No signature attribute in the think tag
+    assert 'signature="' not in text
+    # Clean think tag
+    assert "<think>\n" in text
+    assert "</think>" in text
+
+
+@pytest.mark.anyio
+async def test_messages_to_openai_gemini_think_tag_text_only() -> None:
+    """Gemini text-only reasoning (not encrypted) uses reasoning field directly."""
+    from inspect_ai._util.content import ContentReasoning
+    from inspect_ai.model._chat_message import ChatMessageAssistant
+    from inspect_ai.model._providers.openrouter import (
+        OPENROUTER_REASONING_DETAILS_SIGNATURE,
+    )
+
+    signature = OPENROUTER_REASONING_DETAILS_SIGNATURE + (
+        '[{"type": "reasoning.text", "text": "Step by step reasoning here.", "id": "r1"}]'
+    )
+    msg = ChatMessageAssistant(
+        content=[
+            ContentReasoning(
+                reasoning="Step by step reasoning here.",
+                redacted=False,
+                signature=signature,
+            )
+        ],
+    )
+
+    api = _make_api("google/gemini-2.5-pro")
+    converted = await api.messages_to_openai([msg])
+
+    payload = converted[0]
+    content = payload.get("content")
+    if isinstance(content, list):
+        text = "".join(b.get("text", "") for b in content if isinstance(b, dict))
+    else:
+        text = content if isinstance(content, str) else ""
+
+    assert "Step by step reasoning here." in text
+    assert "&quot;" not in text
+    assert 'signature="' not in text
+
+
+@pytest.mark.anyio
+async def test_messages_to_openai_gemini_think_tag_skipped_without_readable_text() -> (
+    None
+):
+    """Reasoning without readable text must not produce a <think> tag.
+
+    Redacted reasoning with no summary (e.g. an Anthropic redacted block
+    replayed to a Gemini model) has no readable text — skip the tag entirely
+    rather than emit an empty <think></think>.
+    """
+    from inspect_ai._util.content import ContentReasoning
+    from inspect_ai.model._chat_message import ChatMessageAssistant
+
+    encrypted_blob = "ENCRYPTED_BLOB_xyz"
+    msg = ChatMessageAssistant(
+        content=[
+            ContentReasoning(
+                reasoning=encrypted_blob,
+                redacted=True,
+                signature="rs_abc123",
+            )
+        ],
+    )
+
+    api = _make_api("google/gemini-2.5-flash")
+    converted = await api.messages_to_openai([msg])
+
+    payload = converted[0]
+    content = payload.get("content")
+    if isinstance(content, list):
+        text = "".join(b.get("text", "") for b in content if isinstance(b, dict))
+    else:
+        text = content if isinstance(content, str) else ""
+
+    assert "<think>" not in text
+    assert encrypted_blob not in text
+    assert "reasoning_details" not in payload
+
+
+@pytest.mark.anyio
 async def test_messages_to_openai_strips_reasoning_details_for_gemini() -> None:
     """Gemini-family models must not get reasoning_details replayed.
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4320. When assistant reasoning history is replayed to Gemini-family models via OpenRouter, `reasoning_details` are (correctly) stripped and reasoning falls back to a `<think>` tag — but the tag is built with `reasoning_to_think_tag()`, which serializes every `ContentReasoning` field for round-trip fidelity. For Gemini text+encrypted reasoning that means the model receives the HTML-escaped `reasoning_details` JSON as a `signature` attribute and the encrypted payload as the tag body on every multi-turn continuation:

```
<think signature="reasoning-details://[{&quot;type&quot;: &quot;reasoning.text&quot;, ...}]" redacted="true">
<summary>I've determined the most direct path forward involves the run_bash tool.</summary>
CjcBjz1rXw...encrypted blob...
</think>
```

### What is the new behavior?

The Gemini strip path emits only the readable text — the `summary` when the content is redacted (text+encrypted case), otherwise the `reasoning` field:

```
<think>
I've determined the most direct path forward involves the run_bash tool.
</think>
```

Round-trip fidelity isn't needed here: the tag goes straight into the outbound request payload, and Gemini can't use the signature/encrypted data on replay anyway (that's why `reasoning_details` are stripped for it in the first place).

When there is no readable text at all (e.g. a redacted reasoning block with no summary, such as an Anthropic redacted block replayed to a Gemini model after a mid-eval model switch), the tag is skipped entirely rather than emitting an empty `<think></think>`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Only affects the wire format of reasoning history replayed to Gemini-family models via OpenRouter; stored transcripts are unchanged.

### Other information:

Supersedes #4377 (same fix by @premsai-pendela, whose commit and authorship are preserved here). This PR distills it by dropping the unrelated `format_traceback` caching change (which belongs to #4376), and adds ruff formatting, a CHANGELOG entry, and the skip-empty-tag refinement with a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
