### PR TITLE
openai_compatible: return partial completion on LengthFinishReasonError when streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- OpenAI Compatible: A length-truncated streaming response (e.g. `-M stream=true` hitting `max_tokens`) now degrades gracefully to a `max_tokens` stop reason instead of raising `LengthFinishReasonError` and aborting the eval (parity with the Together provider and the non-streaming path). (#4552)
+- OpenAI Compatible: A length-truncated streaming response (e.g. `-M stream=true` hitting `max_tokens`) now degrades gracefully to a `max_tokens` stop reason instead of raising `LengthFinishReasonError` and aborting the eval. (#4552)
 - Control Channel: `inspect ctl sample list` no longer recomputes sample summaries on every request, so polling an eval buffering many large samples (e.g. a retry's carried transcripts) can no longer stall the eval process.
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- OpenAI Compatible: A length-truncated streaming response (e.g. `-M stream=true` hitting `max_tokens`) now degrades gracefully to a `model_length` stop reason instead of raising `LengthFinishReasonError` and aborting the eval (parity with the Together provider and the non-streaming path). (#4552)
 - Control Channel: `inspect ctl sample list` no longer recomputes sample summaries on every request, so polling an eval buffering many large samples (e.g. a retry's carried transcripts) can no longer stall the eval process.
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- OpenAI Compatible: A length-truncated streaming response (e.g. `-M stream=true` hitting `max_tokens`) now degrades gracefully to a `model_length` stop reason instead of raising `LengthFinishReasonError` and aborting the eval (parity with the Together provider and the non-streaming path). (#4552)
+- OpenAI Compatible: A length-truncated streaming response (e.g. `-M stream=true` hitting `max_tokens`) now degrades gracefully to a `max_tokens` stop reason instead of raising `LengthFinishReasonError` and aborting the eval (parity with the Together provider and the non-streaming path). (#4552)
 - Control Channel: `inspect ctl sample list` no longer recomputes sample summaries on every request, so polling an eval buffering many large samples (e.g. a retry's carried transcripts) can no longer stall the eval process.
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -7,6 +7,7 @@ from openai import (
     APIStatusError,
     AsyncOpenAI,
     BadRequestError,
+    LengthFinishReasonError,
     PermissionDeniedError,
     UnprocessableEntityError,
 )
@@ -315,7 +316,10 @@ class OpenAICompatibleAPI(ModelAPI):
                     "probabilities.",
                 )
             async with self.client.chat.completions.stream(**request) as stream:
-                return await stream.get_final_completion()
+                try:
+                    return await stream.get_final_completion()
+                except LengthFinishReasonError as ex:
+                    return ex.completion
         else:
             return cast(
                 ChatCompletion, await self.client.chat.completions.create(**request)

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -18,6 +18,7 @@ from inspect_ai.model import (
     StopReason,
     get_model,
 )
+from inspect_ai.model._openai import chat_choices_from_openai
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
 from inspect_ai.model._providers.together import TogetherAIAPI
 from inspect_ai.tool import ToolInfo
@@ -346,7 +347,21 @@ async def test_openai_compatible_streaming_returns_partial_on_length(
         stream=True,
     )
 
-    partial = ChatCompletion.model_construct(id="partial")
+    partial = ChatCompletion.model_validate(
+        {
+            "id": "partial",
+            "object": "chat.completion",
+            "created": 0,
+            "model": "gpt-5",
+            "choices": [
+                {
+                    "index": 0,
+                    "finish_reason": "length",
+                    "message": {"role": "assistant", "content": "truncated"},
+                }
+            ],
+        }
+    )
 
     class _LengthTruncatedStream:
         async def __aenter__(self) -> "_LengthTruncatedStream":
@@ -367,5 +382,6 @@ async def test_openai_compatible_streaming_returns_partial_on_length(
     try:
         result = await api._generate_completion({}, GenerateConfig())
         assert result is partial
+        assert chat_choices_from_openai(result, [])[0].stop_reason == "max_tokens"
     finally:
         await api.aclose()

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -2,7 +2,8 @@ from typing import Any
 
 import httpx
 import pytest
-from openai import APIStatusError
+from openai import APIStatusError, LengthFinishReasonError
+from openai.types.chat import ChatCompletion
 from test_helpers.utils import (
     skip_if_no_openai,
     skip_if_no_together,
@@ -333,3 +334,38 @@ async def test_together_stream_end_to_end() -> None:
         input=[ChatMessageUser(content="This is a test string. What are you?")]
     )
     assert len(response.completion) >= 1
+
+
+async def test_openai_compatible_streaming_returns_partial_on_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    api = OpenAICompatibleAPI(
+        model_name="openai-api/openai/gpt-5",
+        api_key="test",
+        base_url="https://example.com",
+        stream=True,
+    )
+
+    partial = ChatCompletion.model_construct(id="partial")
+
+    class _LengthTruncatedStream:
+        async def __aenter__(self) -> "_LengthTruncatedStream":
+            return self
+
+        async def __aexit__(self, *exc: object) -> None:
+            return None
+
+        async def get_final_completion(self) -> ChatCompletion:
+            raise LengthFinishReasonError(completion=partial)
+
+    monkeypatch.setattr(
+        api.client.chat.completions,
+        "stream",
+        lambda **kwargs: _LengthTruncatedStream(),
+    )
+
+    try:
+        result = await api._generate_completion({}, GenerateConfig())
+        assert result is partial
+    finally:
+        await api.aclose()


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When the OpenAI-compatible provider (`openai-api/...`) generates with streaming (`-M stream=true`), a response that hits `max_tokens` (finish reason `length`) makes the OpenAI SDK's `stream.get_final_completion()` raise `LengthFinishReasonError`. `openai_compatible.py` does not catch it, and the error is not retryable, so a single length-truncated sample aborts the whole eval under the default fail-on-error (e.g. `Task interrupted (75 of 1,785 total samples logged before interruption)`).

The non-streaming path returns the truncated completion with a `model_length` stop reason, and the Together provider already handles this in its streaming path (#4111). Only the `openai_compatible` streaming path is missing it.

### What is the new behavior?

The streaming path catches `LengthFinishReasonError` and returns the partial completion (`ex.completion`), so a length-truncated streamed response is handled like the non-streaming path (stop reason `model_length`) and the run continues. This mirrors the Together provider fix in #4111.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Added a unit test that mocks `get_final_completion()` raising `LengthFinishReasonError` and asserts the partial completion is returned.