### PR TITLE
Fix memory leak: synchronous API calls made from a context with no running event loop permanently leaked their result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Logging: Fixed a memory leak where every sync log read (e.g. each sample yielded by `read_eval_log_samples()`) stayed permanently in memory after the caller released it.
+- Fixed a memory leak where the result of any synchronous API call (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
 - Control Channel: `inspect ctl sample list` no longer recomputes sample summaries on every request, so polling an eval buffering many large samples (e.g. a retry's carried transcripts) can no longer stall the eval process.
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Logging: Fixed a memory leak where every sync log read (e.g. each sample yielded by `read_eval_log_samples()`) stayed permanently in memory after the caller released it.
 - Control Channel: `inspect ctl sample list` no longer recomputes sample summaries on every request, so polling an eval buffering many large samples (e.g. a retry's carried transcripts) can no longer stall the eval process.
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.
 - Agent Bridge: Support OpenAI clients that consume responses via `with_raw_response` (e.g. langchain-openai), which previously failed with `'ChatCompletion' object has no attribute 'parse'`. (#4341)
-- Bugfix: Fixed a memory leak where the result of any synchronous API call (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
+- Bugfix: Fixed a memory leak where the result of any synchronous API call made from a context with no running event loop (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
 
 ## 0.3.248 (17 July 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## Unreleased
 
-- Fixed a memory leak where the result of any synchronous API call (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
 - Control Channel: `inspect ctl sample list` no longer recomputes sample summaries on every request, so polling an eval buffering many large samples (e.g. a retry's carried transcripts) can no longer stall the eval process.
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.
 - Agent Bridge: Support OpenAI clients that consume responses via `with_raw_response` (e.g. langchain-openai), which previously failed with `'ChatCompletion' object has no attribute 'parse'`. (#4341)
-
+- Bugfix: Fixed a memory leak where the result of any synchronous API call (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
+- 
 ## 0.3.248 (17 July 2026)
 
 - Logging: Local eval (`.eval`) and JSON (`.json`) log files are now written atomically (temp file + `fsync` + rename), preventing corruption from interrupted writes such as disk-full or process crash. (#2949)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.
 - Agent Bridge: Support OpenAI clients that consume responses via `with_raw_response` (e.g. langchain-openai), which previously failed with `'ChatCompletion' object has no attribute 'parse'`. (#4341)
 - Bugfix: Fixed a memory leak where the result of any synchronous API call (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
-- 
+
 ## 0.3.248 (17 July 2026)
 
 - Logging: Local eval (`.eval`) and JSON (`.json`) log files are now written atomically (temp file + `fsync` + rename), preventing corruption from interrupted writes such as disk-full or process crash. (#2949)

--- a/src/inspect_ai/_util/_async.py
+++ b/src/inspect_ai/_util/_async.py
@@ -166,12 +166,42 @@ def run_coroutine(coroutine: Coroutine[None, None, T]) -> T:
             asyncio.get_running_loop()
         except RuntimeError:
             # No running event loop, so start one on the configured backend.
-            return anyio.run(
-                _run_with_async_filesystem, backend=configured_async_backend()
-            )
+            return _anyio_run_released(_run_with_async_filesystem)
     # Running asyncio loop -- re-enter it via nest_asyncio.
     init_nest_asyncio()
     return asyncio.run(_run_with_async_filesystem())
+
+
+def _anyio_run_released(func: Callable[[], Awaitable[T]]) -> T:
+    """Run `func` on a fresh event loop, then release anyio's per-loop state.
+
+    Without the release step, every call leaks its entire return value.
+    Here's why: anyio keeps per-event-loop state in a global
+    WeakKeyDictionary, `anyio.lowlevel._run_vars`, where the key is the loop
+    itself. Weak keys normally guarantee cleanup — once nothing else
+    references the loop, its entry disappears. But when `func` uses anyio's
+    threadpool, anyio stores the run's root task in that entry, and a task
+    always references the loop it ran on. So the entry's value points back at
+    its own key: the dictionary keeps the task alive, the task keeps the loop
+    alive, and the "weak" entry becomes immortal — along with the task's
+    result, which is our coroutine's return value. Popping the dead loop's
+    entry after the run breaks the cycle so everything can be collected.
+    """
+    from anyio.lowlevel import _run_vars
+
+    loop: asyncio.AbstractEventLoop | None = None
+
+    async def capture_loop_and_run() -> T:
+        nonlocal loop
+        if current_async_backend() == "asyncio":
+            loop = asyncio.get_running_loop()
+        return await func()
+
+    try:
+        return anyio.run(capture_loop_and_run, backend=configured_async_backend())
+    finally:
+        if loop is not None:
+            _run_vars.pop(loop, None)
 
 
 def current_async_backend() -> Literal["asyncio", "trio"] | None:

--- a/tests/util/test_async.py
+++ b/tests/util/test_async.py
@@ -1,0 +1,31 @@
+import gc
+import weakref
+
+import anyio.to_thread
+
+from inspect_ai._util._async import run_coroutine
+
+
+def test_run_coroutine_releases_result() -> None:
+    """run_coroutine() must not retain a reference to the coroutine's result.
+
+    When the coroutine uses anyio's threadpool (as the local-file read path
+    does), anyio caches the run's root task in a loop-keyed WeakKeyDictionary
+    (anyio.lowlevel._run_vars); the task references the loop (the weak key),
+    so the entry — and the task's result — is never evicted. Every such
+    run_coroutine() call would otherwise pin its entire return value forever
+    (e.g. each EvalSample yielded by read_eval_log_samples).
+    """
+
+    class Payload:
+        pass
+
+    async def make_payload() -> Payload:
+        await anyio.to_thread.run_sync(lambda: None)
+        return Payload()
+
+    result = run_coroutine(make_payload())
+    ref = weakref.ref(result)
+    del result
+    gc.collect()
+    assert ref() is None, "result still referenced after release"


### PR DESCRIPTION
Every sync API routed through `run_coroutine()` (e.g. `read_eval_log`, `read_eval_log_sample`, each sample yielded by `read_eval_log_samples`) permanently retained its entire return value: anyio caches each run's root task in `anyio.lowlevel._run_vars`, a global WeakKeyDictionary keyed by the event loop, and since the task references the loop (its own weak key) the entry is never evicted — pinning the task and its result forever. The fix pops the dead loop's entry after each fresh-loop `anyio.run()`, letting the loop, task, and result be collected.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Any synchronous API call made from a context with no running event loop permanently retains its result, even after the caller releases it. It's most visible where results are large and calls repeated — streaming a large `.eval` log with `read_eval_log_samples()` grows memory by one full sample per iteration, breaking the documented "only one sample at a time will be read into memory" promise. A user report measured ~650MB retained per sample on long agentic logs. Repro:

```python
for i, s in enumerate(read_eval_log_samples("big.eval"), 1):
    del s
    gc.collect()
    # EvalSample instances alive == i (one per iteration, forever)
```

Each retained result is held by a finished asyncio task from `run_coroutine`, which is itself held by anyio's `_run_vars` entry for the (closed) per-call event loop.

### What is the new behavior?

Sync API calls release their results. For the streaming case above, at most the generator's current sample is alive during iteration, and none after. Added `_anyio_run_released()` (used by `run_coroutine`'s fresh-loop path) which evicts the dead loop's `_run_vars` entry after the run, plus a regression test (`tests/util/test_async.py`) that fails on `main`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

The root cause is arguably an anyio bug (WeakKeyDictionary value referencing its own key); the fix reaches into `anyio.lowlevel._run_vars` (private) — if a future anyio removes it, the failure mode is a loud `ImportError` rather than a silent re-leak. The leak only triggers when the coroutine uses anyio's threadpool (`to_thread.run_sync`), which all local-file log I/O does.
