### PR TITLE
perf(mcp): auto-retry MCP tool calls on transient sandbox exec failures

### DIFF
--- a/src/inspect_ai/tool/_mcp/_local.py
+++ b/src/inspect_ai/tool/_mcp/_local.py
@@ -274,6 +274,14 @@ class MCPServerLocalSession(MCPServer):
                                         error_mapper=_McpErrorMapper,
                                     ) from e
                         return as_inspect_content_list(result.content)  # type: ignore[return-value,arg-type]
+                    except TimeoutError:
+                        # A per-RPC read-timeout (translated above from the 408
+                        # McpError) is not a dropped connection - reconnecting and
+                        # retrying would silently hide the timeout from the model.
+                        # TimeoutError is-a OSError, so it must be excluded from the
+                        # connection-loss handling below and left for the outer
+                        # handler to convert into a ToolError.
+                        raise
                     except (BrokenPipeError, ConnectionError, OSError) as exc:
                         logger.warning(
                             f"MCP connection lost during {mcp_tool.name} "

--- a/src/inspect_ai/tool/_mcp/_local.py
+++ b/src/inspect_ai/tool/_mcp/_local.py
@@ -218,57 +218,79 @@ class MCPServerLocalSession(MCPServer):
             # manager. Convert these to ToolError so the model is notified
             # rather than the exception reaching the top of the sample stack.
             try:
-                async with self._client_session() as tool_session:
-                    mcp_call = format_function_call(
-                        mcp_tool.name, kwargs, width=sys.maxsize
-                    )
-                    with trace_action(
-                        logger, "MCPServer", f"call_tool ({self._name}): {mcp_call}"
-                    ):
-                        try:
-                            # Bound the wait on a tool response with the configured
-                            # timeout. Without this, a lost/dropped transport response
-                            # (e.g. the sandbox carrier exec times out at the OS level
-                            # but its JSON-RPC error never wakes this await) deadlocks
-                            # the call FOREVER, ignoring the per-RPC timeout entirely.
-                            # On expiry `ClientSession` raises an McpError carrying
-                            # an HTTP 408 (REQUEST_TIMEOUT) code, which the handler
-                            # below translates to a TimeoutError so the outer handler
-                            # surfaces a ToolError — notifying the model rather than
-                            # letting the sample hang until the working-time cap.
-                            read_timeout = (
-                                timedelta(seconds=self._timeout)
-                                if self._timeout is not None
-                                else None
+                for _attempt in range(3):
+                    try:
+                        async with self._client_session() as tool_session:
+                            mcp_call = format_function_call(
+                                mcp_tool.name, kwargs, width=sys.maxsize
                             )
-                            result = await tool_session.call_tool(
-                                mcp_tool.name,
-                                kwargs,
-                                read_timeout_seconds=read_timeout,
-                            )
-                            if result.isError:
-                                raise ToolError(tool_result_as_text(result.content))
-                        except McpError as e:
-                            # A read_timeout_seconds expiry surfaces as an McpError
-                            # carrying HTTP 408 (REQUEST_TIMEOUT). Re-raise it as a
-                            # TimeoutError so the outer handler converts it to a
-                            # ToolError; exception_for_rpc_response_error would
-                            # otherwise map the unrecognized 408 to a RuntimeError
-                            # that errors the sample instead of reaching the model.
-                            if e.error.code == _MCP_READ_TIMEOUT_CODE:
-                                raise TimeoutError(e.error.message) from e
-                            # Some errors that are raised via McpError (e.g. -32603)
-                            # need to be converted to ToolError so that they make it
-                            # back to the model.
-                            raise exception_for_rpc_response_error(
-                                e.error.code,
-                                e.error.message,
-                                mcp_tool.name,
-                                kwargs,
-                                error_mapper=_McpErrorMapper,
-                            ) from e
-
-                    return as_inspect_content_list(result.content)  # type: ignore[return-value,arg-type]
+                            with trace_action(
+                                logger,
+                                "MCPServer",
+                                f"call_tool ({self._name}): {mcp_call}",
+                            ):
+                                try:
+                                    # Bound the wait on a tool response with the configured
+                                    # timeout. Without this, a lost/dropped transport response
+                                    # (e.g. the sandbox carrier exec times out at the OS level
+                                    # but its JSON-RPC error never wakes this await) deadlocks
+                                    # the call FOREVER, ignoring the per-RPC timeout entirely.
+                                    # On expiry `ClientSession` raises an McpError carrying
+                                    # an HTTP 408 (REQUEST_TIMEOUT) code, which the handler
+                                    # below translates to a TimeoutError so the outer handler
+                                    # surfaces a ToolError — notifying the model rather than
+                                    # letting the sample hang until the working-time cap.
+                                    read_timeout = (
+                                        timedelta(seconds=self._timeout)
+                                        if self._timeout is not None
+                                        else None
+                                    )
+                                    result = await tool_session.call_tool(
+                                        mcp_tool.name,
+                                        kwargs,
+                                        read_timeout_seconds=read_timeout,
+                                    )
+                                    if result.isError:
+                                        raise ToolError(
+                                            tool_result_as_text(result.content)
+                                        )
+                                except McpError as e:
+                                    # A read_timeout_seconds expiry surfaces as an McpError
+                                    # carrying HTTP 408 (REQUEST_TIMEOUT). Re-raise it as a
+                                    # TimeoutError so the outer handler converts it to a
+                                    # ToolError; exception_for_rpc_response_error would
+                                    # otherwise map the unrecognized 408 to a RuntimeError
+                                    # that errors the sample instead of reaching the model.
+                                    if e.error.code == _MCP_READ_TIMEOUT_CODE:
+                                        raise TimeoutError(e.error.message) from e
+                                    # Some errors that are raised via McpError (e.g. -32603)
+                                    # need to be converted to ToolError so that they make it
+                                    # back to the model.
+                                    raise exception_for_rpc_response_error(
+                                        e.error.code,
+                                        e.error.message,
+                                        mcp_tool.name,
+                                        kwargs,
+                                        error_mapper=_McpErrorMapper,
+                                    ) from e
+                        return as_inspect_content_list(result.content)  # type: ignore[return-value,arg-type]
+                    except (BrokenPipeError, ConnectionError, OSError) as exc:
+                        logger.warning(
+                            f"MCP connection lost during {mcp_tool.name} "
+                            f"(attempt {_attempt + 1}/3): {exc}"
+                        )
+                        self._reset_session()
+                        if _attempt == 2:
+                            raise
+                    except anyio.BrokenResourceError as exc:
+                        logger.warning(
+                            f"MCP connection lost during {mcp_tool.name} "
+                            f"(attempt {_attempt + 1}/3): {exc}"
+                        )
+                        self._reset_session()
+                        if _attempt == 2:
+                            raise
+                raise RuntimeError("unreachable")
             except Exception as e:
                 if isinstance(inner_exception(e), TimeoutError):
                     raise ToolError(
@@ -318,6 +340,19 @@ class MCPServerLocalSession(MCPServer):
                 ):
                     await session.initialize()
                 yield session
+
+    def _reset_session(self) -> None:
+        """Clear the persistent session so the next _client_session() reconnects."""
+        if self._exit_stack is not None:
+            try:
+                import asyncio
+
+                asyncio.get_event_loop().create_task(self._exit_stack.aclose())
+            except Exception:
+                pass
+        self._session = None
+        self._exit_stack = None
+        self._refcount = 0
 
     def _sampling_fn(self) -> SamplingFnT | None:
         from inspect_ai.model._model import active_model

--- a/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
+++ b/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import TYPE_CHECKING, Any
 
 from inspect_ai._util._json_rpc import (
@@ -13,6 +15,12 @@ from inspect_ai._util._json_rpc import (
 
 if TYPE_CHECKING:
     from .environment import SandboxEnvironment
+
+logger = logging.getLogger(__name__)
+
+# Retry config for transient sandbox.exec failures
+_MAX_RETRIES = 2
+_RETRY_DELAY_SECS = 1.0
 
 
 class SandboxJSONRPCTransport(JSONRPCTransport):
@@ -45,6 +53,14 @@ class SandboxJSONRPCTransport(JSONRPCTransport):
     ) -> str:
         """Execute an RPC request using the sandbox transport.
 
+        Retries transient sandbox.exec failures (non-zero exit code) up to
+        _MAX_RETRIES times with a short delay.  The MCP server inside the
+        container is a separate long-lived process, so a failed exec does not
+        affect server state — retrying the same CLI invocation is safe.
+
+        Timeouts are already handled by the sandbox backend's own
+        timeout_retry logic and are not retried here.
+
         Args:
             method: The JSON-RPC method to call.
             params: The parameters for the JSON-RPC method.
@@ -55,27 +71,61 @@ class SandboxJSONRPCTransport(JSONRPCTransport):
             The response from the RPC call.
 
         Raises:
-            RuntimeError: If the sandbox execution fails.
+            RuntimeError: If the sandbox execution fails after all retries.
         """
-        exec_result = await self.sandbox.exec(
-            [self.cli, "exec"],
-            input=create_json_rpc_request(method, params, is_notification),
-            timeout=transport_extra_args.get("timeout", None),
-            timeout_retry=transport_extra_args.get("timeout_retry", True),
-            user=transport_extra_args.get("user", None),
-            concurrency=transport_extra_args.get("concurrency", True),
-        )
+        last_error: Exception | None = None
+        for attempt in range(_MAX_RETRIES + 1):
+            try:
+                exec_result = await self.sandbox.exec(
+                    [self.cli, "exec"],
+                    input=create_json_rpc_request(method, params, is_notification),
+                    timeout=transport_extra_args.get("timeout", None),
+                    timeout_retry=transport_extra_args.get("timeout_retry", True),
+                    user=transport_extra_args.get("user", None),
+                    concurrency=transport_extra_args.get("concurrency", True),
+                )
+            except TimeoutError:
+                # Already handled by the sandbox backend's timeout_retry.
+                raise
+            except Exception as exc:
+                # sandbox.exec() itself raised (e.g. Docker daemon
+                # unreachable, connection refused, etc.)
+                last_error = exc
+                if attempt < _MAX_RETRIES:
+                    logger.warning(
+                        f"Sandbox.exec raised (attempt {attempt + 1}/{_MAX_RETRIES + 1}), "
+                        f"retrying in {_RETRY_DELAY_SECS}s: "
+                        f"{rpc_call_description(method, params)}: {exc}"
+                    )
+                    await asyncio.sleep(_RETRY_DELAY_SECS)
+                    continue
+                raise
 
-        if not exec_result.success:
-            # Prefer stderr, but fall back to stdout — some failures
-            # (e.g. MCP server crash, entrypoint error) only surface in
-            # stdout because the sandbox CLI wrote its diagnostic there.
+            if exec_result.success:
+                return exec_result.stdout
+
+            # Non-zero exit code — the CLI invocation failed but the
+            # MCP server inside the container is unaffected. Prefer stderr,
+            # but fall back to stdout — some failures (e.g. MCP server
+            # crash, entrypoint error) only surface in stdout because the
+            # sandbox CLI wrote its diagnostic there.
             error_detail = (
                 exec_result.stderr
                 or exec_result.stdout
                 or "(no output captured — check container startup.log)"
             )
-            raise RuntimeError(
-                f"Sandbox.exec failure executing {rpc_call_description(method, params)}: {error_detail}"
+            last_error = RuntimeError(
+                f"Sandbox.exec failure executing "
+                f"{rpc_call_description(method, params)}: {error_detail}"
             )
-        return exec_result.stdout
+
+            if attempt < _MAX_RETRIES:
+                logger.warning(
+                    f"Sandbox.exec failed (attempt {attempt + 1}/{_MAX_RETRIES + 1}), "
+                    f"retrying in {_RETRY_DELAY_SECS}s: "
+                    f"{rpc_call_description(method, params)}: {error_detail}"
+                )
+                await asyncio.sleep(_RETRY_DELAY_SECS)
+
+        assert last_error is not None
+        raise last_error

--- a/tests/util/sandbox/test_json_rpc_transport_retry.py
+++ b/tests/util/sandbox/test_json_rpc_transport_retry.py
@@ -1,0 +1,153 @@
+"""Tests for SandboxJSONRPCTransport retry logic.
+
+Verifies that the transport retries transient sandbox.exec failures
+(non-zero exit codes and raised exceptions) without affecting the
+MCP server running inside the container.
+"""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from inspect_ai.util import ExecResult
+from inspect_ai.util._sandbox._json_rpc_transport import (
+    _MAX_RETRIES,
+    SandboxJSONRPCTransport,
+)
+
+
+def _make_exec_result(
+    success: bool, stdout: str = "", stderr: str = "", returncode: int = 0
+) -> ExecResult[str]:
+    return ExecResult(
+        success=success, returncode=returncode, stdout=stdout, stderr=stderr
+    )
+
+
+class _TransportFixture(NamedTuple):
+    transport: SandboxJSONRPCTransport
+    exec_mock: AsyncMock
+
+
+def _make_transport(side_effects: list[Any]) -> _TransportFixture:
+    """Create a transport with a mocked sandbox.exec."""
+    sandbox = MagicMock()
+    exec_mock = AsyncMock(side_effect=side_effects)
+    sandbox.exec = exec_mock
+    return _TransportFixture(
+        transport=SandboxJSONRPCTransport(sandbox=sandbox, cli="/usr/bin/sandbox-cli"),
+        exec_mock=exec_mock,
+    )
+
+
+class TestSandboxJSONRPCTransportRetry:
+    async def test_success_on_first_attempt(self) -> None:
+        """Successful exec on first try returns stdout immediately."""
+        transport, exec_mock = _make_transport(
+            [
+                _make_exec_result(
+                    success=True, stdout='{"jsonrpc":"2.0","id":1,"result":42}'
+                ),
+            ]
+        )
+        result = await transport("test_method", {"key": "val"}, is_notification=False)
+        assert '"result":42' in result
+        assert exec_mock.call_count == 1
+
+    async def test_retry_on_exec_failure_then_succeed(self) -> None:
+        """Non-zero exit code on first attempt, success on second."""
+        transport, exec_mock = _make_transport(
+            [
+                _make_exec_result(success=False, stderr="container busy", returncode=1),
+                _make_exec_result(
+                    success=True, stdout='{"jsonrpc":"2.0","id":1,"result":"ok"}'
+                ),
+            ]
+        )
+        result = await transport("test_method", None, is_notification=False)
+        assert '"result":"ok"' in result
+        assert exec_mock.call_count == 2
+
+    async def test_retry_on_exception_then_succeed(self) -> None:
+        """sandbox.exec raises an exception, then succeeds on retry."""
+        transport, exec_mock = _make_transport(
+            [
+                OSError("connection refused"),
+                _make_exec_result(
+                    success=True, stdout='{"jsonrpc":"2.0","id":1,"result":"ok"}'
+                ),
+            ]
+        )
+        result = await transport("test_method", None, is_notification=False)
+        assert '"result":"ok"' in result
+        assert exec_mock.call_count == 2
+
+    async def test_exhaust_all_retries(self) -> None:
+        """All attempts fail — raises the last error."""
+        transport, exec_mock = _make_transport(
+            [
+                _make_exec_result(success=False, stderr="fail 1", returncode=1),
+                _make_exec_result(success=False, stderr="fail 2", returncode=1),
+                _make_exec_result(success=False, stderr="fail 3", returncode=1),
+            ]
+        )
+        with pytest.raises(RuntimeError, match="fail 3"):
+            await transport("test_method", None, is_notification=False)
+        assert exec_mock.call_count == _MAX_RETRIES + 1
+
+    async def test_exhaust_retries_on_exception(self) -> None:
+        """All attempts raise exceptions — re-raises the last one."""
+        transport, exec_mock = _make_transport(
+            [
+                OSError("fail 1"),
+                ConnectionError("fail 2"),
+                OSError("fail 3"),
+            ]
+        )
+        with pytest.raises(OSError, match="fail 3"):
+            await transport("test_method", None, is_notification=False)
+        assert exec_mock.call_count == _MAX_RETRIES + 1
+
+    async def test_timeout_not_retried(self) -> None:
+        """TimeoutError should propagate immediately without retry."""
+        transport, exec_mock = _make_transport(
+            [
+                TimeoutError("timed out"),
+            ]
+        )
+        with pytest.raises(TimeoutError, match="timed out"):
+            await transport("test_method", None, is_notification=False)
+        # Should NOT have retried
+        assert exec_mock.call_count == 1
+
+    async def test_mixed_failure_then_success(self) -> None:
+        """Exception, then non-zero exit, then success on third attempt."""
+        transport, exec_mock = _make_transport(
+            [
+                ConnectionError("network blip"),
+                _make_exec_result(
+                    success=False, stderr="temporary issue", returncode=1
+                ),
+                _make_exec_result(
+                    success=True, stdout='{"jsonrpc":"2.0","id":1,"result":"ok"}'
+                ),
+            ]
+        )
+        result = await transport("test_method", None, is_notification=False)
+        assert '"result":"ok"' in result
+        assert exec_mock.call_count == 3
+
+    async def test_notification_retries_on_failure(self) -> None:
+        """Notifications (no response expected) also retry on failure."""
+        transport, exec_mock = _make_transport(
+            [
+                _make_exec_result(success=False, stderr="busy", returncode=1),
+                _make_exec_result(success=True, stdout=""),
+            ]
+        )
+        result = await transport("notify_method", None, is_notification=True)
+        assert result == ""
+        assert exec_mock.call_count == 2


### PR DESCRIPTION
## What
Automatically retry MCP tool calls when the underlying sandbox `exec` fails transiently. Timeouts are explicitly not retried.

## Why
Transient sandbox exec failures otherwise surface as tool errors and abort otherwise-recoverable runs.

## Notes
Relates to previously-merged MCP work (#4291).
