### PR TITLE
fix(sandbox): include stdout fallback in Sandbox.exec failure error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.
 - Agent Bridge: Support OpenAI clients that consume responses via `with_raw_response` (e.g. langchain-openai), which previously failed with `'ChatCompletion' object has no attribute 'parse'`. (#4341)
+- Sandbox: `Sandbox.exec` failure errors now include stdout as a fallback when stderr is empty, so commands that report diagnostics on stdout still produce a useful error message.
 
 ## 0.3.248 (17 July 2026)
 

--- a/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
+++ b/src/inspect_ai/util/_sandbox/_json_rpc_transport.py
@@ -67,7 +67,15 @@ class SandboxJSONRPCTransport(JSONRPCTransport):
         )
 
         if not exec_result.success:
+            # Prefer stderr, but fall back to stdout — some failures
+            # (e.g. MCP server crash, entrypoint error) only surface in
+            # stdout because the sandbox CLI wrote its diagnostic there.
+            error_detail = (
+                exec_result.stderr
+                or exec_result.stdout
+                or "(no output captured — check container startup.log)"
+            )
             raise RuntimeError(
-                f"Sandbox.exec failure executing {rpc_call_description(method, params)}: {exec_result.stderr}"
+                f"Sandbox.exec failure executing {rpc_call_description(method, params)}: {error_detail}"
             )
         return exec_result.stdout


### PR DESCRIPTION
## What
When `Sandbox.exec` fails with empty stderr, include stdout in the raised error message as a fallback.

## Why
Some failing commands write their diagnostics to stdout; the current error message is empty and unhelpful in those cases.

## Notes
One-line diagnostic improvement. Relates to #4108.
