### PR TITLE
Move #4555 CHANGELOG entry under Unreleased

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Control Channel: `inspect ctl sample events --full` now pretty-prints the raw events instead of rendering a mostly-empty summary table.
 - Control Channel: New `inspect ctl sample messages TASK SID [EPOCH]` reads a running (or buffered-but-unlogged) sample's current conversation as a snapshot, with `--tail`/`--all`/`--full`.
 - Sample Sources: Generate a task's samples dynamically while it runs by passing a `SampleSource` as the task's `dataset` (with `enqueue_sample()` for imperative additions) — the sample-level mirror of `TaskSource`, for RL loops and adaptive evals.
+- Bugfix: Fixed a memory leak where the result of any synchronous API call made from a context with no running event loop (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
 
 ## 0.3.249 (20 July 2026)
 
@@ -14,7 +15,6 @@
 - Control Channel: paged event reads served from the realtime sample buffer now load only the message/call pool entries and attachments the page references, instead of the sample's full pools and every attachment body.
 - Logging: Building a sample summary no longer serializes large structured metadata values just to exclude them, avoiding stalls when sample metadata embeds large data.
 - Agent Bridge: Support OpenAI clients that consume responses via `with_raw_response` (e.g. langchain-openai), which previously failed with `'ChatCompletion' object has no attribute 'parse'`. (#4341)
-- Bugfix: Fixed a memory leak where the result of any synchronous API call made from a context with no running event loop (e.g. each sample yielded by `read_eval_log_samples()`) was retained in memory forever after the caller released it.
 
 ## 0.3.248 (17 July 2026)
 


### PR DESCRIPTION
This PR contains:

- [ ] New features
- [ ] Changes to dev-facing APIs
- [x] Documentation improvements
- [ ] Bug fixes

## What is the current behavior?

The CHANGELOG entry for #4555 landed under the released `## 0.3.249` heading (it was silently relocated when the PR branch merged in main after the 0.3.249 release).

## What is the new behavior?

The entry sits under `## Unreleased` where it belongs.

## Does this PR introduce a breaking change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
