### PR TITLE
Add model info for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Sample Sources: Generate a task's samples dynamically while it runs by passing a `SampleSource` as the task's `dataset` (with `enqueue_sample()` for imperative additions) — the sample-level mirror of `TaskSource`, for RL loops and adaptive evals.
 - OpenAI Compatible: A length-truncated streaming response (e.g. `-M stream=true` hitting `max_tokens`) now degrades gracefully to a `max_tokens` stop reason instead of raising `LengthFinishReasonError` and aborting the eval. (#4552)
 - OpenRouter: Reasoning history replayed to Gemini models now contains only readable `<think>` text, rather than HTML-escaped signature JSON and encrypted payloads. (#4320)
+- Google: Added model info for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite (released 2026-07-21).
 - Agent Bridge: Support Anthropic clients that consume responses via `with_raw_response`, which previously failed with `'Message' object has no attribute 'parse'`.
 - Sandbox: `Sandbox.exec` failure errors now include stdout as a fallback when stderr is empty, so commands that report diagnostics on stdout still produce a useful error message.
 - Memory tool: Canonicalize `/memories` paths so equivalent spellings map to one file rather than several, and add an `instance` parameter to `memory()` for independent per-instance memory stores.

--- a/docs/_reasoning-defaults.md
+++ b/docs/_reasoning-defaults.md
@@ -13,12 +13,15 @@
 | google/gemini-3.1-flash-lite-preview | medium |
 | google/gemini-3.1-pro | high |
 | google/gemini-3.5-flash | medium |
+| google/gemini-3.5-flash-lite | minimal |
+| google/gemini-3.6-flash | medium |
 | grok/grok-3-mini | low |
 | grok/grok-4 | no effort scale |
 | grok/grok-4.3 | low |
 | grok/grok-4.5 | high |
 | mistral/magistral-medium-2506 | no effort scale |
 | mistral/magistral-small-2506 | no effort scale |
+| moonshotai/kimi-k3 | max |
 | openai/gpt-5 | medium |
 | openai/gpt-5-mini | medium |
 | openai/gpt-5-nano | medium |

--- a/src/inspect_ai/model/_model_data/gdm.yml
+++ b/src/inspect_ai/model/_model_data/gdm.yml
@@ -1,6 +1,16 @@
 google:
   display_name: Google
   models:
+    gemini-3.6-flash:
+      display_name: "Gemini 3.6 Flash"
+      release_date: 2026-07-21
+      knowledge_cutoff_date: 2026-03-01
+      context_length: 1048576
+      output_tokens: 65536
+      reasoning: True
+      # Gemini 3.6 Flash defaults to thinking_level=MEDIUM if unspecified.
+      # https://ai.google.dev/gemini-api/docs/models
+      reasoning_effort_default: medium
     gemini-3.5-flash:
       display_name: "Gemini 3.5 Flash"
       release_date: 2026-05-19
@@ -11,6 +21,16 @@ google:
       # Gemini 3 Flash supports MINIMAL/LOW/MEDIUM/HIGH; default thinking_level
       # is MEDIUM. https://ai.google.dev/gemini-api/docs/gemini-3
       reasoning_effort_default: medium
+    gemini-3.5-flash-lite:
+      display_name: "Gemini 3.5 Flash-Lite"
+      release_date: 2026-07-21
+      knowledge_cutoff_date: 2025-01-01
+      context_length: 1048576
+      output_tokens: 65536
+      reasoning: True
+      # Gemini 3.5 Flash-Lite defaults to thinking_level=MINIMAL if unspecified.
+      # https://ai.google.dev/gemini-api/docs/models
+      reasoning_effort_default: minimal
     gemini-3.1-pro:
       display_name: "Gemini 3.1 Pro"
       release_date: 2026-02-19

--- a/src/inspect_ai/model/_providers/google.py
+++ b/src/inspect_ai/model/_providers/google.py
@@ -765,7 +765,7 @@ class GoogleGenAIAPI(ModelAPI):
         # context window / compaction match. Bump when a newer frontier ships.
         # Mirrors OpenAI's and Anthropic's input_tokens_name() aliasing.
         if self.is_gemini() and _get_model_info_direct(self.canonical_name()) is None:
-            return "google/gemini-3.5-flash"
+            return "google/gemini-3.6-flash"
         return super().input_tokens_name()
 
     def is_latest(self) -> bool:

--- a/tests/model/providers/test_google_model_names.py
+++ b/tests/model/providers/test_google_model_names.py
@@ -28,6 +28,8 @@ KNOWN_MODELS = [
     "gemini-2.5-pro",
     "gemini-3-pro",
     "gemini-3.5-flash",
+    "gemini-3.5-flash-lite",
+    "gemini-3.6-flash",
 ]
 
 NON_GENERATIVE_MODELS = [

--- a/tests/model/providers/test_google_model_names.py
+++ b/tests/model/providers/test_google_model_names.py
@@ -85,7 +85,7 @@ def test_flash_codename_supports_minimal_thinking() -> None:
 def test_codename_aliases_to_frontier_context_window(model_name: str) -> None:
     # input_tokens_name() aliases to the current frontier so the context window
     # resolves correctly instead of falling back to the 128K default.
-    assert _api(model_name).input_tokens_name() == "google/gemini-3.5-flash"
+    assert _api(model_name).input_tokens_name() == "google/gemini-3.6-flash"
 
 
 @pytest.mark.parametrize("model_name", KNOWN_MODELS)
@@ -100,7 +100,7 @@ def test_future_gemini_version_aliases_to_frontier() -> None:
     api = _api("gemini-4-pro")
     assert api.is_latest() is False
     assert api.is_gemini_3_plus() is True
-    assert api.input_tokens_name() == "google/gemini-3.5-flash"
+    assert api.input_tokens_name() == "google/gemini-3.6-flash"
 
 
 def test_latest_scoped_to_dev_endpoint() -> None:


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Google's Gemini 3.6 Flash and Gemini 3.5 Flash-Lite (released 2026-07-21) are not in the model info database, so `get_model_info()` returns no metadata for them and `gemini-3.5-flash-lite` silently fuzzy-matches the `gemini-3.5-flash` entry. Unknown/codename Gemini models alias to `gemini-3.5-flash` for context-window lookup.

### What is the new behavior?

- Adds `gemini-3.6-flash` (1M context, 64K output, reasoning, default `thinking_level` MEDIUM, March 2026 knowledge cutoff) and `gemini-3.5-flash-lite` (1M context, 64K output, reasoning, default `thinking_level` MINIMAL, January 2025 cutoff) to `gdm.yml`.
- Bumps the `input_tokens_name()` frontier alias for unknown/codename Gemini models to `gemini-3.6-flash` (behavior neutral: same 1M window).
- Regenerates the reasoning defaults docs table (also restores a stale missing `moonshotai/kimi-k3` row).

Gemini 3.5 Flash Cyber (released alongside) is deliberately not added: it has no public API model ID (government/partner pilot via CodeMender only). No provider code changes are needed for the new models — `is_gemini_3*()` substring detection already applies correct thinking-level mapping (including MINIMAL for flash) and Gemini 3 request shaping.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

🤖 Generated with [Claude Code](https://claude.com/claude-code)
