### PR TITLE
Aggregate dict-valued scorerless scores per numeric subscore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Bugfix: `file_dataset()` now recognizes JSON and CSV URLs with query parameters while preserving the complete URL passed to the selected dataset reader.
+- Scoring: Dict-valued scores with no scorer or task metrics now aggregate per numeric subscore by default, instead of computing accuracy over the raw dict.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).
 - Control Channel: `inspect ctl sample events --full` now pretty-prints the raw events instead of rendering a mostly-empty summary table.
 - Control Channel: New `inspect ctl sample messages TASK SID [EPOCH]` reads a running (or buffered-but-unlogged) sample's current conversation as a snapshot, with `--tail`/`--all`/`--full`.

--- a/src/inspect_ai/_eval/task/results.py
+++ b/src/inspect_ai/_eval/task/results.py
@@ -66,7 +66,7 @@ class ScorerInfo:
         return ScorerInfo(name=name, metrics=metrics, params=params, metadata=metadata)
 
     @staticmethod
-    def from_name(name: str) -> "ScorerInfo":
+    def from_name(name: str, values: Sequence[Value] | None = None) -> "ScorerInfo":
         from inspect_ai._eval.loader import scorer_from_spec
 
         # load the scorer to gather that scorer's metrics
@@ -76,13 +76,35 @@ class ScorerInfo:
             scorer = None
 
         # use the metrics if we were able to load the scorer
-        # otherwise, use the default metrics
+        # otherwise, use default metrics based on the score values
         if scorer is not None:
             metrics = scorer_metrics(scorer)
         else:
-            metrics = [accuracy(), stderr()]
+            metrics = _default_metrics_for_values(values or [])
 
         return ScorerInfo(name=name, metrics=metrics)
+
+
+def _default_metrics_for_values(values: Sequence[Value]) -> Metrics:
+    """Default metrics for scores that have no scorer or task metrics.
+
+    Dict-valued scores aggregate per numeric subscore: applying accuracy to
+    the dict itself only logs conversion warnings and yields 0. Only sub-keys
+    that are present and numeric on every sample are included, since metric
+    computation raises on missing keys.
+    """
+    if values and all(isinstance(value, Mapping) for value in values):
+        mappings = cast(Sequence[Mapping[str, Any]], values)
+        shared_keys = set(mappings[0].keys())
+        for mapping in mappings[1:]:
+            shared_keys &= set(mapping.keys())
+        return {
+            str(key): [accuracy(), stderr()]
+            for key in sorted(shared_keys)
+            if all(isinstance(mapping[key], (int, float)) for mapping in mappings)
+        }
+
+    return [accuracy(), stderr()]
 
 
 def eval_results(
@@ -122,8 +144,14 @@ def eval_results(
     for sample_scores in scores:
         for name, sample_score in sample_scores.items():
             if sample_score.scorer is None and name not in resolved_scorer_names:
-                # the scorer info for this score
-                scorer_info = ScorerInfo.from_name(name)
+                # the scorer info for this score (all of the score's values
+                # inform the default metrics when no scorer can be loaded)
+                values = [
+                    other_scores[name].score.value
+                    for other_scores in scores
+                    if name in other_scores
+                ]
+                scorer_info = ScorerInfo.from_name(name, values)
 
                 # resolve the task scores
                 if metrics is not None:

--- a/tests/scorer/test_score_editing.py
+++ b/tests/scorer/test_score_editing.py
@@ -527,6 +527,88 @@ async def test_add_new_score_with_recompute_metrics():
     assert log.results.scores[0].metrics["mean"].value == original_mean
 
 
+@pytest.mark.anyio
+async def test_add_new_score_aggregates_with_default_metrics():
+    """Test that a created scalar score aggregates via the default metrics."""
+    logs = await eval_async(single_metric_task())
+    log = logs[0]
+
+    edit_score(
+        log,
+        log.samples[0].id,
+        "new_custom_score",
+        ScoreEdit(value=0.5),
+        recompute_metrics=False,
+    )
+    edit_score(
+        log,
+        log.samples[1].id,
+        "new_custom_score",
+        ScoreEdit(value=1.0),
+        recompute_metrics=False,
+    )
+    recompute_metrics(log)
+
+    new_result = next(s for s in log.results.scores if s.name == "new_custom_score")
+    assert new_result.metrics["accuracy"].value == 0.75
+    assert "stderr" in new_result.metrics
+
+
+@pytest.mark.anyio
+async def test_add_new_dict_score_aggregates_numeric_subscores():
+    """Test that a created dict score aggregates its numeric subscores."""
+    logs = await eval_async(single_metric_task())
+    log = logs[0]
+
+    edit_score(
+        log,
+        log.samples[0].id,
+        "review",
+        ScoreEdit(value={"quality": 4, "note": "needs work"}),
+        recompute_metrics=False,
+    )
+    edit_score(
+        log,
+        log.samples[1].id,
+        "review",
+        ScoreEdit(value={"quality": 2, "note": "fine"}),
+        recompute_metrics=False,
+    )
+    recompute_metrics(log)
+
+    quality_result = next(s for s in log.results.scores if s.name == "quality")
+    assert quality_result.scorer == "review"
+    assert quality_result.metrics["accuracy"].value == 3.0
+    assert all(s.name != "note" for s in log.results.scores)
+
+
+@pytest.mark.anyio
+async def test_add_new_dict_score_mixed_shapes_aggregates_shared_keys():
+    """Test that dict scores with differing keys aggregate only shared keys."""
+    logs = await eval_async(single_metric_task())
+    log = logs[0]
+
+    edit_score(
+        log,
+        log.samples[0].id,
+        "review",
+        ScoreEdit(value={"quality": 4, "extra": 1}),
+        recompute_metrics=False,
+    )
+    edit_score(
+        log,
+        log.samples[1].id,
+        "review",
+        ScoreEdit(value={"quality": 2}),
+        recompute_metrics=False,
+    )
+    recompute_metrics(log)
+
+    quality_result = next(s for s in log.results.scores if s.name == "quality")
+    assert quality_result.metrics["accuracy"].value == 3.0
+    assert all(s.name != "extra" for s in log.results.scores)
+
+
 @solver
 def solver_writes_score() -> Solver:
     async def run(state: TaskState, generate: Generate) -> TaskState:

--- a/tests/scorer/test_score_from_solver.py
+++ b/tests/scorer/test_score_from_solver.py
@@ -31,6 +31,30 @@ def test_solver_dict_score():
 
 
 @solver
+def no_scorer_solver_dict_with_str() -> Solver:
+    async def run(state: TaskState, generate: Generate) -> TaskState:
+        state.scores = {} if state.scores is None else state.scores
+        state.scores["review"] = Score(value={"base_val": 1, "note": "some text"})
+        return state
+
+    return run
+
+
+def test_solver_dict_score_default_metrics():
+    """Without task metrics, dict scores aggregate per numeric subscore."""
+    task = Task(
+        dataset=MemoryDataset([Sample(input="")]),
+        solver=no_scorer_solver_dict_with_str(),
+    )
+    eval_log = eval(tasks=task, model="mockllm/model")[0]
+    assert len(eval_log.results.scores) == 1
+    assert eval_log.results.scores[0].name == "base_val"
+    assert eval_log.results.scores[0].scorer == "review"
+    assert eval_log.results.scores[0].metrics["accuracy"].value == 1
+    assert "stderr" in eval_log.results.scores[0].metrics
+
+
+@solver
 def no_scorer_solver_simple() -> Solver:
     async def run(state: TaskState, generate: Generate) -> TaskState:
         state.scores = {} if state.scores is None else state.scores


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

A score with no corresponding scorer and no task metrics falls back to default metrics of `[accuracy(), stderr()]`. For dict-valued scores (written by a solver into `state.scores`, or created via `edit_score()` and recomputed) the defaults are applied to the raw dict, which logs `Unable to convert value to float` warnings and always yields `accuracy: 0.0`:

```python
state.scores["review"] = Score(value={"quality": 4, "note": "some text"})
# results: review accuracy 0.0, stderr 0.0, plus conversion warnings
```

### What is the new behavior?

The fallback infers default metrics from the score's values: dict-valued scores aggregate per numeric subscore (`quality` above gets `accuracy`/`stderr`; string sub-keys are skipped). Only sub-keys present and numeric on every scored sample are included, since metric computation raises on keys missing from a sample's value. Scalar scores, scores with a real scorer, and scores covered by task metrics (including `{"*": [...]}`) behave exactly as before.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Results that previously contained a meaningless `accuracy 0.0` entry for a dict-valued score now contain per-subscore entries instead. A dict score with no numeric sub-keys shared across samples now produces no results entry rather than a zero entry.

### Other information:

Also reachable via `edit_score()`: creating a new dict-valued score and recomputing metrics previously produced the same degenerate aggregate.
