### PR TITLE
Agent bridge: track state by thread identity so side calls can't displace the real conversation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - OpenRouter: Reasoning history replayed to Gemini models now contains only readable `<think>` text, rather than HTML-escaped signature JSON and encrypted payloads. (#4320)
 - Google: Added model info for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite (released 2026-07-21).
 - Agent Bridge: Support Anthropic clients that consume responses via `with_raw_response`, which previously failed with `'Message' object has no attribute 'parse'`.
+- Agent Bridge: Side model calls (e.g. opencode's session title generation) can no longer replace the agent's real conversation in the tracked agent state. (meridianlabs-ai/inspect_ai#140)
 - Sandbox: `Sandbox.exec` failure errors now include stdout as a fallback when stderr is empty, so commands that report diagnostics on stdout still produce a useful error message.
 - Memory tool: Canonicalize `/memories` paths so equivalent spellings map to one file rather than several, and add an `instance` parameter to `memory()` for independent per-instance memory stores.
 - Registry: Add a `validation_predicate` type for Scout extensions.

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -230,9 +230,8 @@ class AgentBridge:
           a one-shot call (the opencode title case) or when the descending
           call is longer than the tracked thread (the main loop reclaiming
           tracking from a promoted sub-agent loop, below). A non-descending
-          call never directly
-          displaces a tracked descending thread (side calls, sub-agent
-          loops).
+          call never directly displaces a tracked descending thread (side
+          calls, sub-agent loops).
         - When descent can't discriminate (equal verdicts, or no initial input
           to anchor on — e.g. a scaffold that rewrites the input prompt), fall
           back to the legacy length heuristic: adopt the new thread when it

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -84,6 +84,18 @@ class AgentBridge:
         self._compaction = compaction
         self._compact: Compact | None = None
         self._last_message_count = 0
+        # thread-tracking state for _track_state (see its docstring). the
+        # descent anchor is the initial input (via _compaction_prefix, which
+        # restores to the original input on checkpoint resume).
+        self._initial_fps = [
+            _message_fingerprint(m)
+            for m in self._compaction_prefix
+            if m.role != "system"
+        ]
+        self._tracked_fps: list[_MessageFingerprint] | None = None
+        self._tracked_calls = 0
+        self._tracked_descends: bool | None = None
+        self._candidate_fps: list[_MessageFingerprint] | None = None
         self._pending_operator = 0
         self._operator_keys: set[str] = set()
 
@@ -199,25 +211,122 @@ class AgentBridge:
     _message_ids: dict[str, list[str]]
 
     async def _track_state(self, input: list[ChatMessage], output: ModelOutput) -> None:
-        # automatically track agent state based on observing generations made through
-        # the bridge. we need to distinguish between the "main" thread of generation
-        # and various types of side / sub-agent calls to the model (e.g. claude code
-        # does bash path detection using a side call). our heuristic is to keep the
-        # number of messages that were in the _last_ generation, and to update the
-        # state whenever the total messages exceeds it. this should pick up normal
-        # agent loops that keep appending, while at the same time discarding side model
-        # calls that tend to be shorter. finally, this should handle recovering from
-        # history compaction, which will shorten the message history considerably
+        """Track agent state by observing generations made through the bridge.
+
+        We need to distinguish the "main" thread of generation from side /
+        sub-agent model calls (e.g. claude code does bash path detection with a
+        side call; opencode names the session with a title-generation call).
+        Message counts alone can't do this: a side call that is longer than the
+        main conversation (opencode's title call fires before the main loop's
+        first call and carries an extra preamble message) would permanently
+        displace the real conversation. Instead we track thread identity:
+
+        - A call whose messages extend the tracked thread (the tracked messages
+          are a prefix of it, compared by role + text) always updates the state.
+        - Otherwise the call starts a new thread and we consult *descent*: a
+          thread descends from the initial input if its non-system messages
+          start with the initial input's non-system messages. A descending
+          thread displaces a tracked one-shot non-descending call (the opencode
+          title case), while a non-descending call never displaces a tracked
+          descending thread (side calls, sub-agent loops).
+        - When descent can't discriminate (equal verdicts, or no initial input
+          to anchor on — e.g. a scaffold that rewrites the input prompt), fall
+          back to the legacy length heuristic: adopt the new thread when it has
+          more messages than the previous generation.
+        - A new thread that isn't adopted is remembered as a candidate; if the
+          next call extends it, it's a live agent loop and is promoted. This is
+          what recovers tracking after history compaction (scaffold-side
+          compaction replaces the conversation with a summary, so the
+          post-compaction loop neither extends the tracked thread nor descends
+          from the initial input).
+        """
         messages = input + [output.message]
-        if len(messages) > self._last_message_count:
-            self.state.messages = messages
-            self.state.output = output
+        fps = [_message_fingerprint(m) for m in messages]
+
+        if self._tracked_fps is None:
+            # first observed call: best information available so far (if it is
+            # a side call the rules below displace it later)
+            self._adopt_thread(messages, output, fps, calls=1)
+        elif _extends(self._tracked_fps, fps):
+            self._adopt_thread(messages, output, fps, calls=self._tracked_calls + 1)
+        elif self._candidate_fps is not None and _extends(self._candidate_fps, fps):
+            # the candidate got continued so it is a live agent loop (e.g. the
+            # post-compaction conversation): promote it over the tracked thread
+            self._adopt_thread(messages, output, fps, calls=2)
+        else:
+            descends = self._descends_from_initial(fps)
+            if (
+                descends is True
+                and self._tracked_descends is False
+                and self._tracked_calls == 1
+            ):
+                # the real conversation displacing a one-shot side call that
+                # landed first (an established multi-call thread is instead
+                # reclaimed via candidate promotion to avoid flapping)
+                self._adopt_thread(messages, output, fps, calls=1)
+            elif descends != self._tracked_descends:
+                self._candidate_fps = fps
+            elif len(messages) > self._last_message_count:
+                # legacy length heuristic
+                self._adopt_thread(messages, output, fps, calls=1)
+            else:
+                self._candidate_fps = fps
+
         self._last_message_count = len(messages)
 
         # tick the checkpointer
         await self._cp.tick()
 
+    def _adopt_thread(
+        self,
+        messages: list[ChatMessage],
+        output: ModelOutput,
+        fps: list["_MessageFingerprint"],
+        calls: int,
+    ) -> None:
+        """Make `messages` the tracked main thread (see `_track_state`).
+
+        `calls` is the number of bridge calls attributed to the thread; it
+        gates displacement of one-shot calls by descending threads.
+        """
+        self.state.messages = messages
+        self.state.output = output
+        self._tracked_fps = fps
+        self._tracked_calls = calls
+        self._tracked_descends = self._descends_from_initial(fps)
+        self._candidate_fps = None
+
+    def _descends_from_initial(self, fps: list["_MessageFingerprint"]) -> bool | None:
+        """Whether a thread's non-system messages start with the initial input.
+
+        Returns `None` when there is no initial input to anchor on (descent
+        can't discriminate threads, so `_track_state` falls back to the legacy
+        length heuristic).
+        """
+        if not self._initial_fps:
+            return None
+        non_system = [fp for fp in fps if fp[0] != "system"]
+        return non_system[: len(self._initial_fps)] == self._initial_fps
+
 
 @lru_cache(maxsize=100)
 def message_json_hash(message_json: str) -> str:
     return mm3_hash(message_json)
+
+
+_MessageFingerprint = tuple[str, str]
+"""(role, hash-of-text) identity used for thread prefix comparisons.
+
+Deliberately excludes message ids and metadata: messages round-trip through
+the scaffold's own conversation store between calls, so only role and text
+content are stable across the main loop's successive requests.
+"""
+
+
+def _message_fingerprint(message: ChatMessage) -> _MessageFingerprint:
+    return (message.role, mm3_hash(message.text))
+
+
+def _extends(prefix: list[_MessageFingerprint], fps: list[_MessageFingerprint]) -> bool:
+    """Whether `fps` is a proper extension (continuation) of `prefix`."""
+    return len(fps) > len(prefix) and fps[: len(prefix)] == prefix

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -235,8 +235,10 @@ class AgentBridge:
           loops).
         - When descent can't discriminate (equal verdicts, or no initial input
           to anchor on — e.g. a scaffold that rewrites the input prompt), fall
-          back to the legacy length heuristic: adopt the new thread when it has
-          more messages than the previous generation.
+          back to the legacy length heuristic: adopt the new thread when it
+          has more messages than the previous generation (or, when both
+          threads descend, than the tracked thread — so a parked side call
+          can't lower the bar for a stray descending one-shot).
         - A new thread that isn't adopted is remembered as a candidate; if the
           next call extends it, it's a live agent loop and is promoted. This is
           what recovers tracking after history compaction (scaffold-side
@@ -277,11 +279,16 @@ class AgentBridge:
                 # still can't displace an established non-descending thread
                 # (flapping guard).
                 self._adopt_thread(messages, output, fps, calls=1)
-            elif (
-                descends == self._tracked_descends
-                and len(messages) > self._last_message_count
+            elif descends == self._tracked_descends and len(messages) > (
+                len(self._tracked_fps) if descends is True else self._last_message_count
             ):
-                # legacy length heuristic
+                # legacy length heuristic. when both threads descend, compare
+                # against the tracked thread so a parked side call can't lower
+                # the bar for a stray descending one-shot; for False/None
+                # verdicts keep the previous-call comparison — a scaffold that
+                # rewrites message text every call (breaking fingerprint
+                # continuity and descent) recovers from compaction only
+                # through it.
                 self._adopt_thread(messages, output, fps, calls=1)
             else:
                 self._candidate_fps = fps

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -226,9 +226,12 @@ class AgentBridge:
         - Otherwise the call starts a new thread and we consult *descent*: a
           thread descends from the initial input if its non-system messages
           start with the initial input's non-system messages. A descending
-          thread displaces a tracked one-shot non-descending call (the opencode
-          title case), while a non-descending call never displaces a tracked
-          descending thread (side calls, sub-agent loops).
+          thread displaces a tracked non-descending thread when that thread is
+          a one-shot call (the opencode title case) or when the descending
+          call is longer (the main loop reclaiming tracking from a promoted
+          sub-agent loop, below). A non-descending call never directly
+          displaces a tracked descending thread (side calls, sub-agent
+          loops).
         - When descent can't discriminate (equal verdicts, or no initial input
           to anchor on — e.g. a scaffold that rewrites the input prompt), fall
           back to the legacy length heuristic: adopt the new thread when it has
@@ -238,7 +241,11 @@ class AgentBridge:
           what recovers tracking after history compaction (scaffold-side
           compaction replaces the conversation with a summary, so the
           post-compaction loop neither extends the tracked thread nor descends
-          from the initial input).
+          from the initial input). Promotion is unconditional, so a multi-call
+          sub-agent loop transiently takes over tracking this way — the main
+          loop reclaims it on resumption, by extension when it makes several
+          further calls (candidate promotion) or by the longer-descending-call
+          displacement above when it makes only one.
         """
         messages = input + [output.message]
         fps = [_message_fingerprint(m) for m in messages]
@@ -258,11 +265,17 @@ class AgentBridge:
             if (
                 descends is True
                 and self._tracked_descends is False
-                and self._tracked_calls == 1
+                and (
+                    self._tracked_calls == 1 or len(messages) > self._last_message_count
+                )
             ):
-                # the real conversation displacing a one-shot side call that
-                # landed first (an established multi-call thread is instead
-                # reclaimed via candidate promotion to avoid flapping)
+                # the real conversation displacing a non-descending thread:
+                # a one-shot side call that landed first (the opencode title
+                # case) or, when longer, a promoted multi-call sub-agent loop
+                # (a main loop resuming with a single final call would
+                # otherwise be parked as a candidate that nothing extends).
+                # a short stray descending one-shot still can't displace an
+                # established non-descending thread (flapping guard).
                 self._adopt_thread(messages, output, fps, calls=1)
             elif descends != self._tracked_descends:
                 self._candidate_fps = fps
@@ -286,8 +299,9 @@ class AgentBridge:
     ) -> None:
         """Make `messages` the tracked main thread (see `_track_state`).
 
-        `calls` is the number of bridge calls attributed to the thread; it
-        gates displacement of one-shot calls by descending threads.
+        `calls` is the number of bridge calls attributed to the thread; a
+        descending thread may displace a non-descending one-shot (`calls == 1`)
+        thread regardless of length.
         """
         self.state.messages = messages
         self.state.output = output

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,5 +1,5 @@
 from functools import lru_cache
-from typing import Sequence, Set
+from typing import NamedTuple, Sequence, Set
 
 from shortuuid import uuid
 
@@ -228,8 +228,9 @@ class AgentBridge:
           start with the initial input's non-system messages. A descending
           thread displaces a tracked non-descending thread when that thread is
           a one-shot call (the opencode title case) or when the descending
-          call is longer (the main loop reclaiming tracking from a promoted
-          sub-agent loop, below). A non-descending call never directly
+          call is longer than the tracked thread (the main loop reclaiming
+          tracking from a promoted sub-agent loop, below). A non-descending
+          call never directly
           displaces a tracked descending thread (side calls, sub-agent
           loops).
         - When descent can't discriminate (equal verdicts, or no initial input
@@ -265,21 +266,21 @@ class AgentBridge:
             if (
                 descends is True
                 and self._tracked_descends is False
-                and (
-                    self._tracked_calls == 1 or len(messages) > self._last_message_count
-                )
+                and (self._tracked_calls == 1 or len(messages) > len(self._tracked_fps))
             ):
                 # the real conversation displacing a non-descending thread:
                 # a one-shot side call that landed first (the opencode title
-                # case) or, when longer, a promoted multi-call sub-agent loop
-                # (a main loop resuming with a single final call would
-                # otherwise be parked as a candidate that nothing extends).
-                # a short stray descending one-shot still can't displace an
-                # established non-descending thread (flapping guard).
+                # case) or, when longer than the tracked thread, a promoted
+                # multi-call sub-agent loop (a main loop resuming with a
+                # single final call would otherwise be parked as a candidate
+                # that nothing extends). a short stray descending one-shot
+                # still can't displace an established non-descending thread
+                # (flapping guard).
                 self._adopt_thread(messages, output, fps, calls=1)
-            elif descends != self._tracked_descends:
-                self._candidate_fps = fps
-            elif len(messages) > self._last_message_count:
+            elif (
+                descends == self._tracked_descends
+                and len(messages) > self._last_message_count
+            ):
                 # legacy length heuristic
                 self._adopt_thread(messages, output, fps, calls=1)
             else:
@@ -319,7 +320,7 @@ class AgentBridge:
         """
         if not self._initial_fps:
             return None
-        non_system = [fp for fp in fps if fp[0] != "system"]
+        non_system = [fp for fp in fps if fp.role != "system"]
         return non_system[: len(self._initial_fps)] == self._initial_fps
 
 
@@ -328,17 +329,20 @@ def message_json_hash(message_json: str) -> str:
     return mm3_hash(message_json)
 
 
-_MessageFingerprint = tuple[str, str]
-"""(role, hash-of-text) identity used for thread prefix comparisons.
+class _MessageFingerprint(NamedTuple):
+    """(role, hash-of-text) identity used for thread prefix comparisons.
 
-Deliberately excludes message ids and metadata: messages round-trip through
-the scaffold's own conversation store between calls, so only role and text
-content are stable across the main loop's successive requests.
-"""
+    Deliberately excludes message ids and metadata: messages round-trip through
+    the scaffold's own conversation store between calls, so only role and text
+    content are stable across the main loop's successive requests.
+    """
+
+    role: str
+    text_hash: str
 
 
 def _message_fingerprint(message: ChatMessage) -> _MessageFingerprint:
-    return (message.role, mm3_hash(message.text))
+    return _MessageFingerprint(role=message.role, text_hash=mm3_hash(message.text))
 
 
 def _extends(prefix: list[_MessageFingerprint], fps: list[_MessageFingerprint]) -> bool:

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -233,6 +233,53 @@ async def test_sub_agent_loop_recovers_to_main_thread() -> None:
     assert len(bridge.state.messages) == len(turn4) + 1
 
 
+async def test_stray_descending_one_shot_does_not_displace_established_thread() -> None:
+    """A short stray descending one-shot can't displace an established thread.
+
+    The displacement gate's length arm compares against the tracked thread,
+    not the previous call: a short intervening side call must not re-open the
+    displacement window for a stray descending one-shot (e.g. a topic-detection
+    call that re-sends the original user message under its own system prompt).
+    """
+    bridge = task_bridge()
+
+    # main loop, then scaffold compaction: the compacted loop is promoted, so
+    # the tracked thread is non-descending with multiple calls
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    await track(bridge, turn2, "more work")
+
+    compact1: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content="Summary of the conversation so far: ..."),
+    ]
+    cout1 = await track(bridge, compact1, "compacted work")
+    compact2 = compact1 + [cout1.message, ChatMessageTool(content="tool result 2")]
+    await track(bridge, compact2, "Castle")
+
+    # short side call is parked (and lowers the previous-call message count)
+    await track(
+        bridge,
+        [ChatMessageUser(content="Detect the paths in this bash command: ls /tmp")],
+        "/tmp",
+    )
+
+    # stray descending one-shot: longer than the side call but shorter than
+    # the tracked thread, so it must not displace the real conversation
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a topic detector ..."),
+            ChatMessageUser(content=TASK),
+        ],
+        "Doctor Who",
+    )
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(compact2) + 1
+
+
 async def test_single_final_call_reclaims_main_thread_after_sub_agent_loop() -> None:
     """One final main-loop call reclaims tracking from a promoted sub-agent loop.
 

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -231,3 +231,38 @@ async def test_sub_agent_loop_recovers_to_main_thread() -> None:
 
     assert bridge.state.output.completion == "Castle"
     assert len(bridge.state.messages) == len(turn4) + 1
+
+
+async def test_single_final_call_reclaims_main_thread_after_sub_agent_loop() -> None:
+    """One final main-loop call reclaims tracking from a promoted sub-agent loop.
+
+    A multi-call sub-agent loop takes over tracking via candidate promotion;
+    when the main loop then resumes with exactly *one* further (longer) call,
+    nothing will ever extend it, so it must displace the sub-agent thread
+    directly rather than being parked as a candidate.
+    """
+    bridge = task_bridge()
+
+    # establish main loop
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "delegating")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    out2 = await track(bridge, turn2, "spawning subtask")
+    turn3 = turn2 + [out2.message, ChatMessageTool(content="tool result 2")]
+    out3 = await track(bridge, turn3, "waiting on subtask")
+
+    # sub-agent loop (its own conversation, multiple calls -> promoted)
+    sub1: list[ChatMessage] = [
+        ChatMessageSystem(content="You are a subtask agent ..."),
+        ChatMessageUser(content="Research Doctor Who series 9 filming locations."),
+    ]
+    sout1 = await track(bridge, sub1, "researching")
+    sub2 = sub1 + [sout1.message, ChatMessageTool(content="search results")]
+    await track(bridge, sub2, "Cardiff Castle")
+
+    # main loop resumes with exactly one final call and stops
+    turn4 = turn3 + [out3.message, ChatMessageTool(content="subtask: Cardiff Castle")]
+    await track(bridge, turn4, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn4) + 1

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -280,6 +280,44 @@ async def test_stray_descending_one_shot_does_not_displace_established_thread() 
     assert len(bridge.state.messages) == len(compact2) + 1
 
 
+async def test_stray_descending_one_shot_does_not_displace_descending_thread() -> None:
+    """Same lowered-bar guard for a *descending* tracked thread.
+
+    With an intact (descending) main loop, a stray descending one-shot lands
+    in the equal-verdict legacy arm; that arm must compare against the tracked
+    thread, not the previous call, so a short intervening side call can't
+    re-open the displacement window.
+    """
+    bridge = task_bridge()
+
+    # intact main loop runs to its final answer (tracked thread descending)
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    await track(bridge, turn2, "Castle")
+
+    # short side call is parked (and lowers the previous-call message count)
+    await track(
+        bridge,
+        [ChatMessageUser(content="Detect the paths in this bash command: ls /tmp")],
+        "/tmp",
+    )
+
+    # stray descending one-shot: longer than the side call but shorter than
+    # the tracked thread, so it must not displace the real conversation
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a topic detector ..."),
+            ChatMessageUser(content=TASK),
+        ],
+        "Doctor Who",
+    )
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn2) + 1
+
+
 async def test_single_final_call_reclaims_main_thread_after_sub_agent_loop() -> None:
     """One final main-loop call reclaims tracking from a promoted sub-agent loop.
 

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -1,0 +1,233 @@
+"""Tests for AgentBridge._track_state main-thread tracking.
+
+The bridge observes every generation a scaffold makes (main agent loop,
+side calls like opencode's session title generation, sub-agent loops,
+post-compaction continuations) and must surface the *main* conversation
+as the agent state. See meridianlabs-ai/inspect_ai#140 for the failure
+mode where a longer side call permanently displaced the real conversation.
+"""
+
+from inspect_ai.agent._agent import AgentState
+from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageSystem,
+    ChatMessageTool,
+    ChatMessageUser,
+)
+from inspect_ai.model._model_output import ModelOutput
+
+TASK = "In the year 2022, what castle did the Doctor spend 4.5 billion years in?"
+
+TASK_SYSTEM = ChatMessageSystem(content="You are opencode, an agent that ...")
+
+
+def task_bridge() -> AgentBridge:
+    return AgentBridge(AgentState(messages=[ChatMessageUser(content=TASK)]))
+
+
+async def track(
+    bridge: AgentBridge, input: list[ChatMessage], completion: str
+) -> ModelOutput:
+    output = ModelOutput.from_content(model="mockllm/model", content=completion)
+    await bridge._track_state(input, output)
+    return output
+
+
+def title_generation_input() -> list[ChatMessage]:
+    # mirrors opencode's session title generation request: its own system
+    # prompt, a "Generate a title" preamble, then the first user message
+    return [
+        ChatMessageSystem(content="You are a title generator ..."),
+        ChatMessageUser(content="Generate a title for this conversation:\n"),
+        ChatMessageUser(content=TASK),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Reproduction of meridianlabs-ai/inspect_ai#140
+# ---------------------------------------------------------------------------
+
+
+async def test_side_call_arriving_first_does_not_displace_task_thread() -> None:
+    """A longer side call that lands before the main loop must not win.
+
+    opencode fires a 4-message title-generation call before the (3-message,
+    single-turn) task call; the task thread descends from the agent's input
+    while the title thread does not, so the task thread must be tracked.
+    """
+    bridge = task_bridge()
+
+    await track(bridge, title_generation_input(), "Doctor Who Series 9 setting")
+
+    # the real task call (single turn agent loop)
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "Castle")
+
+    # a subsequent same-length one-shot task call must not displace the answer
+    await track(
+        bridge,
+        [TASK_SYSTEM, ChatMessageUser(content=TASK)],
+        "Castle TARDIS Console Room",
+    )
+
+    assert bridge.state.output.completion == "Castle"
+    assert [m.text for m in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "Castle",
+    ]
+
+
+async def test_side_call_after_main_loop_does_not_displace_task_thread() -> None:
+    """A longer side call must not displace an established main loop."""
+    bridge = task_bridge()
+
+    # two-turn main loop
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "let me look into that")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    await track(bridge, turn2, "Castle")
+
+    # longer unrelated side call (would win under a pure length heuristic)
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a title generator ..."),
+            ChatMessageUser(content="Generate a title for this conversation:\n"),
+            ChatMessageUser(content=TASK),
+            ChatMessageUser(content="Respond with the title only."),
+            ChatMessageUser(content="Do not use quotes."),
+        ],
+        "Doctor Who Series 9 setting",
+    )
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn2) + 1
+
+
+# ---------------------------------------------------------------------------
+# Regression: behaviors the previous heuristic already supported
+# ---------------------------------------------------------------------------
+
+
+async def test_main_loop_accumulation_is_tracked() -> None:
+    bridge = task_bridge()
+
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "checking")
+    assert bridge.state.output.completion == "checking"
+
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    out2 = await track(bridge, turn2, "still checking")
+    assert bridge.state.output.completion == "still checking"
+
+    turn3 = turn2 + [out2.message, ChatMessageTool(content="tool result 2")]
+    await track(bridge, turn3, "Castle")
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn3) + 1
+
+
+async def test_shorter_side_call_is_ignored() -> None:
+    # e.g. claude code's bash path detection side call
+    bridge = task_bridge()
+
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    out2 = await track(bridge, turn2, "more work")
+
+    await track(
+        bridge,
+        [ChatMessageUser(content="Detect the paths in this bash command: ls /tmp")],
+        "/tmp",
+    )
+    assert bridge.state.output.completion == "more work"
+
+    # main loop continues to be tracked afterwards
+    turn3 = turn2 + [out2.message, ChatMessageTool(content="tool result 2")]
+    await track(bridge, turn3, "Castle")
+    assert bridge.state.output.completion == "Castle"
+
+
+async def test_scaffold_compaction_recovery() -> None:
+    """After the scaffold compacts its history the new (shorter) loop wins."""
+    bridge = task_bridge()
+
+    # main loop accumulates
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    out2 = await track(bridge, turn2, "more work")
+    turn3 = turn2 + [out2.message, ChatMessageTool(content="tool result 2")]
+    await track(bridge, turn3, "even more work")
+
+    # compaction: history replaced by a summary (no longer shares the
+    # original input prefix), then the loop keeps appending
+    compact1: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content="Summary of the conversation so far: ..."),
+    ]
+    cout1 = await track(bridge, compact1, "compacted work")
+    compact2 = compact1 + [cout1.message, ChatMessageTool(content="tool result 3")]
+    await track(bridge, compact2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(compact2) + 1
+
+
+async def test_length_heuristic_fallback_without_initial_input() -> None:
+    # with no initial input to anchor descent, accumulation still tracks
+    bridge = AgentBridge(AgentState(messages=[]))
+
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    await track(bridge, turn2, "Castle")
+    assert bridge.state.output.completion == "Castle"
+
+    # shorter side call ignored
+    await track(bridge, [ChatMessageUser(content="side call")], "side answer")
+    assert bridge.state.output.completion == "Castle"
+
+
+# ---------------------------------------------------------------------------
+# Additional thread-tracking behaviors
+# ---------------------------------------------------------------------------
+
+
+async def test_repeated_same_length_call_keeps_first_answer() -> None:
+    # a second one-shot call with the same input does not displace the answer
+    bridge = task_bridge()
+    input: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    await track(bridge, input, "Castle")
+    await track(bridge, input, "Castle TARDIS Console Room")
+    assert bridge.state.output.completion == "Castle"
+
+
+async def test_sub_agent_loop_recovers_to_main_thread() -> None:
+    """The main loop reclaims tracking after a sub-agent loop runs."""
+    bridge = task_bridge()
+
+    # establish main loop
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "delegating")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    out2 = await track(bridge, turn2, "spawning subtask")
+
+    # sub-agent loop (its own conversation, multiple calls)
+    sub1: list[ChatMessage] = [
+        ChatMessageSystem(content="You are a subtask agent ..."),
+        ChatMessageUser(content="Research Doctor Who series 9 filming locations."),
+    ]
+    sout1 = await track(bridge, sub1, "researching")
+    sub2 = sub1 + [sout1.message, ChatMessageTool(content="search results")]
+    await track(bridge, sub2, "Cardiff Castle")
+
+    # main loop resumes and keeps appending
+    turn3 = turn2 + [out2.message, ChatMessageTool(content="subtask: Cardiff Castle")]
+    tout3 = await track(bridge, turn3, "almost there")
+    turn4 = turn3 + [tout3.message, ChatMessageTool(content="tool result 2")]
+    await track(bridge, turn4, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn4) + 1


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#140

`AgentBridge._track_state` distinguished the scaffold's "main" conversation from side model calls purely by message count, comparing each generation against the *previous* call's count. A side call that is longer than the main conversation and lands first — opencode's session title-generation call (its own system prompt + a "Generate a title for this conversation:\n" preamble + the first user message = 4 messages) — sets the bar, and since the comparison is strictly greater, the real single-turn task calls (3 messages) never win. Both `state.messages` and `state.output` end up permanently replaced by the title-generation thread, poisoning the transcript and scoring (every single-turn sample on e.g. GAIA level 1).

### What is the new behavior?

`_track_state` now tracks thread identity rather than a raw count (verified against opencode 1.x's actual title-generation and compaction request shapes):

- A call whose messages **extend the tracked thread** (prefix continuity by role + text hash; ids/metadata excluded since messages round-trip through the scaffold's store) always updates state.
- A call starting a new thread is arbitrated by **descent**: whether its non-system messages begin with the initial input's non-system messages. A descending thread displaces a tracked one-shot non-descending call (the opencode title case); a non-descending call never displaces a tracked descending thread (side calls, sub-agent loops) — so a longer side call can no longer win at any point.
- When descent can't discriminate (equal verdicts, or no initial input to anchor on — e.g. scaffolds that rewrite the prompt, like claude code's system-reminder injection), the **legacy length heuristic** applies unchanged, so existing scaffolds see identical behavior.
- A new thread that isn't adopted is kept as a **candidate** and promoted if the next call extends it — this preserves (and slightly strengthens) recovery after history compaction, where the post-compaction loop neither extends the tracked thread nor descends from the initial input (opencode/claude code replace the history with a summary).

Tests (`tests/agent/test_bridge_track_state.py`): the two displacement tests reproduce the issue and fail on the previous implementation; the remaining tests (loop accumulation, shorter side calls ignored, scaffold-compaction recovery, no-initial-input fallback, repeated same-length call, sub-agent loop recovery) pass on both old and new code as regression guards.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Verification: `pytest tests/agent tests/tools/test_tools_bridge.py tests/model/test_compaction.py` (1300+ passed, API-key-gated tests skipped; new tests also run under `--runtrio`), `ruff check`, and `mypy` on changed files all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
