### PR TITLE
Reject Google streaming requests in agent_bridge() instead of forwarding them to the real API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - OpenRouter: Reasoning history replayed to Gemini models now contains only readable `<think>` text, rather than HTML-escaped signature JSON and encrypted payloads. (#4320)
 - Google: Added model info for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite (released 2026-07-21).
 - Agent Bridge: Support Anthropic clients that consume responses via `with_raw_response`, which previously failed with `'Message' object has no attribute 'parse'`.
+- Agent Bridge: Google streaming requests targeting an inspect model now raise the intended streaming-unsupported error instead of being sent to the real Google API.
 - Sandbox: `Sandbox.exec` failure errors now include stdout as a fallback when stderr is empty, so commands that report diagnostics on stdout still produce a useful error message.
 - Memory tool: Canonicalize `/memories` paths so equivalent spellings map to one file rather than several, and add an `instance` parameter to `memory()` for independent per-instance memory stores.
 - Registry: Add a `validation_predicate` type for Scout extensions.

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -479,9 +479,6 @@ def init_google_request_patch() -> None:
         if config.enabled and ":generateContent" in path:
             model_name = _google_api_model_name(path)
             if model_name and targets_inspect_model({"model": model_name}):
-                if ":streamGenerateContent" in path:
-                    raise_stream_error()
-
                 response = await inspect_google_api_request(
                     cast(dict[str, Any], request_dict),
                     config.web_search,
@@ -499,6 +496,36 @@ def init_google_request_patch() -> None:
         return result
 
     setattr(BaseApiClient, "async_request", patched_async_request)
+
+    # streaming requests use a separate entry point (`async_request_streamed`),
+    # so patch it as well to reject streaming for inspect models (parity with
+    # the OpenAI/Anthropic patches, which see streaming on the same method as
+    # non-streaming via their `stream` argument)
+    original_async_request_streamed = getattr(BaseApiClient, "async_request_streamed")
+    if original_async_request_streamed is None:
+        raise RuntimeError(
+            "Couldn't find 'async_request_streamed' method on BaseApiClient"
+        )
+
+    @wraps(original_async_request_streamed)
+    async def patched_async_request_streamed(
+        self: BaseApiClient,
+        http_method: str,
+        path: str,
+        request_dict: dict[str, object],
+        http_options: Any = None,
+    ) -> Any:
+        config = _patch_config.get()
+        if config.enabled and ":streamGenerateContent" in path:
+            model_name = _google_api_model_name(path)
+            if model_name and targets_inspect_model({"model": model_name}):
+                raise_stream_error()
+
+        return await original_async_request_streamed(
+            self, http_method, path, request_dict, http_options
+        )
+
+    setattr(BaseApiClient, "async_request_streamed", patched_async_request_streamed)
 
 
 def _google_api_model_name(path: str) -> str | None:

--- a/tests/agent/test_agent_bridge.py
+++ b/tests/agent/test_agent_bridge.py
@@ -688,6 +688,29 @@ def google_computer_agent() -> Agent:
     return execute
 
 
+@agent
+def google_streaming_agent() -> Agent:
+    async def execute(state: AgentState) -> AgentState:
+        async with agent_bridge(state) as bridge:
+            client = genai.Client(api_key="inspect")
+
+            stream = await client.aio.models.generate_content_stream(
+                model="inspect",
+                contents=[  # type: ignore[arg-type]
+                    {
+                        "role": "user",
+                        "parts": [{"text": user_prompt(state.messages).text}],
+                    }
+                ],
+            )
+            async for _ in stream:
+                pass
+
+            return bridge.state
+
+    return execute
+
+
 @task
 def bridged_task(agent: Agent):
     return Task(
@@ -1081,6 +1104,16 @@ def test_google_bridge_computer_use_incompatible_model():
     assert log.status == "error"
     assert log.error
     assert "computer use with the Google agent bridge" in log.error.message
+
+
+def test_google_bridge_streaming_not_supported():
+    log = eval(
+        bridged_task(google_streaming_agent()),
+        model="mockllm/model",
+    )[0]
+    assert log.status == "error"
+    assert log.error
+    assert "Streaming not currently supported for agent_bridge()" in log.error.message
 
 
 @skip_if_no_anthropic


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

A streaming call from a bridged agent (`client.aio.models.generate_content_stream(model="inspect", ...)`) is sent to the real Google API with the literal model name `inspect`, surfacing a confusing Google API error instead of the intended streaming-unsupported error. Two layers:

1. The streaming guard in `init_google_request_patch()` is unreachable. The outer condition checks `":generateContent" in path`, but streaming paths are `models/<model>:streamGenerateContent`, where the colon is followed by `stream`, so the outer check is False for exactly the paths the inner `raise_stream_error()` was meant to catch.
2. google-genai routes streaming through the separate `BaseApiClient.async_request_streamed`, which was not patched, so streaming requests bypassed the bridge entirely.

The OpenAI and Anthropic patches both see streaming on the same patched request method via their `stream` argument, so those guards work; Google was the only affected provider. Found while working on #4571.

### What is the new behavior?

`async_request_streamed` is patched with the same inspect-model check and raises `RuntimeError("Streaming not currently supported for agent_bridge()")`. Non-inspect streaming requests delegate to the original method unchanged. The unreachable guard in `patched_async_request` is removed.

Test follows the existing mockllm incompatible-model pattern (`test_google_bridge_streaming_not_supported`), verified in both directions: without the fix it fails with a Google API error rather than the intended RuntimeError.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

cc @craig-meridian
