### PR TITLE
fix(util): recognize base64 data URIs with media-type params or empty type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bugfix: `is_data_uri()` now recognizes base64 data URIs that carry media-type parameters (e.g. `;charset=utf-8`) or an empty media type (`data:;base64,...`), which were previously misclassified as non-data URIs.
 - Bugfix: `file_dataset()` now recognizes JSON and CSV URLs with query parameters while preserving the complete URL passed to the selected dataset reader.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).
 - Control Channel: `inspect ctl sample events --full` now pretty-prints the raw events instead of rendering a mostly-empty summary table.

--- a/src/inspect_ai/_util/url.py
+++ b/src/inspect_ai/_util/url.py
@@ -6,7 +6,10 @@ def is_http_url(url: str) -> bool:
 
 
 def is_data_uri(url: str) -> bool:
-    pattern = r"^data:([^;]+);base64,.*"
+    # Match any data: URI with a base64 payload. Per RFC 2397 the media type is
+    # optional (e.g. "data:;base64,...") and may carry parameters such as
+    # ";charset=utf-8", so only require the ";base64," marker before the data.
+    pattern = r"^data:[^,]*;base64,"
     return re.match(pattern, url) is not None
 
 

--- a/tests/util/test_url.py
+++ b/tests/util/test_url.py
@@ -1,0 +1,23 @@
+from inspect_ai._util.url import is_data_uri
+
+
+def test_is_data_uri_simple_base64() -> None:
+    assert is_data_uri("data:image/png;base64,iVBORw0KAAAA")
+
+
+def test_is_data_uri_with_media_type_parameters() -> None:
+    # media-type parameters (e.g. charset, name) before ";base64," are valid
+    assert is_data_uri("data:text/html;charset=utf-8;base64,PGh0bWw+")
+    assert is_data_uri("data:image/svg+xml;charset=utf-8;base64,PHN2Zz4=")
+    assert is_data_uri("data:image/jpeg;name=a.jpg;base64,QQ==")
+
+
+def test_is_data_uri_empty_media_type() -> None:
+    # RFC 2397 permits an omitted media type (defaults to text/plain)
+    assert is_data_uri("data:;base64,SGVsbG8=")
+
+
+def test_is_data_uri_rejects_non_base64_and_urls() -> None:
+    assert not is_data_uri("data:text/plain,hello")
+    assert not is_data_uri("data:text/plain;charset=utf-8,hello")
+    assert not is_data_uri("https://example.com/x.png")


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior? (You can also link to an open issue here)

Fixes #4613.

`is_data_uri()` uses `^data:([^;]+);base64,.*`, which requires a non-empty media type
with no semicolons immediately before `;base64,`. Valid base64 data URIs are therefore
misclassified as non-data URIs when the media type carries parameters
(`data:text/html;charset=utf-8;base64,...`, `data:image/jpeg;name=a.jpg;base64,...`) or
is omitted (`data:;base64,...`, allowed by RFC 2397). The sibling `data_uri_mime_type()`
(same file) parses these exact URIs fine, so the two functions disagree on identical
input.

`is_data_uri` gates data-URI handling in `_util/images.py::file_as_data`,
`model/_tokens.py`, and `log/_condense.py`, so a false negative sends a valid data URI
down the file/URL path (e.g. trying to open it as a file) or skips inline-image
condensing.

### What is the new behavior?

The media type is optional and may include parameters; only the `;base64,` marker is
required (`^data:[^,]*;base64,`). Valid base64 data URIs (with or without parameters /
media type) are recognized; non-base64 URIs (`data:text/plain,hello`) and normal URLs
stay `False`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No — it only broadens recognition to conformant data URIs that were previously rejected.

### Other information:

Adds `tests/util/test_url.py` (media-type parameters, empty media type, and negative
cases). Verified against the real function: the five valid URIs returned `False` before
and `True` after, while the three negative cases are unchanged. `ruff check` and
`ruff format` pass on the changed files.
