### PR TITLE
fix(scorer): preserve decimal point in token punctuation stripping

### DIFF
--- a/src/inspect_ai/scorer/_classification.py
+++ b/src/inspect_ai/scorer/_classification.py
@@ -1,8 +1,7 @@
 import re
-import string
 from typing import Callable, List
 
-from inspect_ai._util.text import is_finite_number
+from inspect_ai._util.text import is_finite_number, strip_punctuation
 from inspect_ai.solver._task_state import TaskState
 
 from ._metric import CORRECT, INCORRECT, Score
@@ -120,9 +119,8 @@ def _remove_articles(text: str) -> str:
 
 
 def _remove_punc(text: str) -> str:
-    exclude = set(string.punctuation)
     if not is_finite_number(text):
-        return "".join(ch for ch in text if ch not in exclude)
+        return strip_punctuation(text)
     else:
         return text
 

--- a/tests/scorer/test_classification.py
+++ b/tests/scorer/test_classification.py
@@ -99,3 +99,24 @@ def test_max_score_empty_target_no_index_error():
     assert max_f1_score("hello", [""]) == 0.0
     assert max_exact_score("hello", [""]) == 0.0
     assert max_f1_score("hello", ["", "hello"]) == 1.0
+
+
+@pytest.mark.anyio
+async def test_f1_decimal_number_with_punctuation():
+    scorer = f1()
+    state1 = simple_task_state(model_output="(3.14)")
+    result1 = await scorer(state1, Target(["3.14"]))
+    assert result1.text == "1.0"
+
+    state2 = simple_task_state(model_output="The answer is (3.14)")
+    result2 = await scorer(state2, Target(["3.14"]))
+    assert result2.text == "0.5"
+
+
+@pytest.mark.anyio
+async def test_exact_decimal_number_with_punctuation():
+    scorer = exact()
+    state = simple_task_state(model_output="(3.14)")
+    result = await scorer(state, Target(["3.14"]))
+
+    assert result.text == CORRECT


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Closes #4620

When normalizing tokens for `f1()` and `exact()` scoring in `inspect_ai.scorer._classification`, `_remove_punc()` stripped all punctuation characters defined in `string.punctuation` from any non-finite-number token. Because `string.punctuation` includes `.`, tokens containing decimal numbers surrounded by punctuation or parentheses (e.g., `"(3.14)"` or `"3.14."`) had their decimal points stripped alongside the boundary punctuation. This converted `"(3.14)"` into `"314"`, which was subsequently formatted by `_normalize_number()` into `"314.0"`. As a consequence, `f1()` and `exact()` scorers failed on decimal numbers enclosed in parentheses or sentence punctuation.

### What is the new behavior?
`_remove_punc()` now uses `strip_punctuation()` from `inspect_ai._util.text`, which strips surrounding whitespace and boundary punctuation without removing internal punctuation characters like decimal points. Decimal numbers like `"(3.14)"` and `"3.14."` are properly stripped to `"3.14"` and accurately match target `"3.14"`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
Validation ran:
- `uv run pytest tests/scorer/test_classification.py` (Passed)
- `uv run make check` (Passed ruff formatting/linting and mypy strict checks across 1328 source files)
- Added unit tests covering `f1()` and `exact()` scoring behavior on decimal numbers with surrounding punctuation.
