### PR TITLE
Support for Claude Opus 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - OpenAI Compatible: A length-truncated streaming response (e.g. `-M stream=true` hitting `max_tokens`) now degrades gracefully to a `max_tokens` stop reason instead of raising `LengthFinishReasonError` and aborting the eval. (#4552)
 - OpenRouter: Reasoning history replayed to Gemini models now contains only readable `<think>` text, rather than HTML-escaped signature JSON and encrypted payloads. (#4320)
 - Google: Added model info for Gemini 3.6 Flash and Gemini 3.5 Flash-Lite (released 2026-07-21).
+- Anthropic: Support for Claude Opus 5 (released 2026-07-24), including model info, computer use, code execution, and disabling thinking via `reasoning_effort="none"`.
 - Agent Bridge: Support Anthropic clients that consume responses via `with_raw_response`, which previously failed with `'Message' object has no attribute 'parse'`.
 - Sandbox: `Sandbox.exec` failure errors now include stdout as a fallback when stderr is empty, so commands that report diagnostics on stdout still produce a useful error message.
 - Memory tool: Canonicalize `/memories` paths so equivalent spellings map to one file rather than several, and add an `instance` parameter to `memory()` for independent per-instance memory stores.

--- a/docs/_reasoning-defaults.md
+++ b/docs/_reasoning-defaults.md
@@ -5,6 +5,7 @@
 | anthropic/claude-opus-4-6 | adaptive |
 | anthropic/claude-opus-4-7 | adaptive |
 | anthropic/claude-opus-4-8 | high |
+| anthropic/claude-opus-5 | high |
 | anthropic/claude-sonnet-4-6 | adaptive |
 | anthropic/claude-sonnet-5 | high |
 | deepseek/deepseek-reasoner | no effort scale |

--- a/src/inspect_ai/model/_model_data/anthropic.yml
+++ b/src/inspect_ai/model/_model_data/anthropic.yml
@@ -60,6 +60,23 @@ anthropic:
           snapshot: "20260528"
           aliases:
             - anthropic.claude-opus-4-8
+    claude-opus-5:
+      display_name: Claude Opus 5
+      release_date: 2026-07-24
+      knowledge_cutoff_date: 2026-05-01
+      context_length: 1000000
+      output_tokens: 128000
+      reasoning: True
+      # Adaptive thinking runs by default when no thinking config is sent
+      # (unlike Opus 4.8, which defaults to no thinking); server-side default
+      # effort is `high`. thinking can still be disabled at effort <= high.
+      # https://platform.claude.com/docs/en/build-with-claude/adaptive-thinking
+      reasoning_effort_default: high
+      versions:
+        claude-opus-5:
+          snapshot: "20260724"
+          aliases:
+            - anthropic.claude-opus-5
     claude-fable-5:
       display_name: Claude Fable 5
       release_date: 2026-06-09

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1089,17 +1089,20 @@ class AnthropicAPI(ModelAPI):
 
         Claude 4.7+ (Opus 4.7/4.8, Sonnet 5, Opus 5) run adaptive thinking by
         default and accept `disabled` to turn it off (on Opus 5 only at effort
-        `high` or below — see completion_config). Fable/Mythos 5 also always
-        think but reject `disabled` (400), so they're excluded — as are unknown
-        codename Claude 5 models, which are assumed to follow Fable rather than
-        the tier-named (opus/sonnet) models. Pre-4.7 models default to no
-        thinking, so `"none"` is honored by simply omitting the `thinking`
-        field.
+        `high` or below — see completion_config).
         """
-        return self.is_claude_4_7_or_later() and not (
-            self.is_claude_5()
-            and not (self.is_claude_sonnet_5() or self.is_claude_opus_5())
-        )
+        if not self.is_claude_4_7_or_later():
+            # pre-4.7 models default to no thinking, so `"none"` is honored by
+            # simply omitting the `thinking` field
+            return False
+        if not self.is_claude_5():
+            # Opus 4.7 / 4.8 (and future 4.x minors)
+            return True
+        # Claude 5: only tier-named models accept `disabled`. Fable/Mythos also
+        # always think but reject `disabled` (400) — as do unknown codename
+        # Claude 5 models, which are assumed to follow Fable rather than the
+        # tier-named (opus/sonnet) models.
+        return self.is_claude_sonnet_5() or self.is_claude_opus_5()
 
     def bridged_reasoning_tokens(self, config: GenerateConfig) -> int | None:
         """Effective `budget_tokens` for pre-4.6 Claude (uses extended thinking).

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -214,6 +214,10 @@ _REASONING_TOKENS_UNSUPPORTED_ERROR = (
     "thinking with an explicit token budget was removed in Claude 4.7). Use "
     "'reasoning_effort' to control reasoning depth instead."
 )
+_DISABLED_THINKING_EFFORT_WARNING = (
+    "anthropic model '{model}' rejects disabled thinking (reasoning_effort="
+    "'none') combined with effort above 'high'; clamping effort to 'high'."
+)
 _MID_CONV_SYSTEM_HOISTED_WARNING = (
     "anthropic: {count} mid-conversation system message(s) were repositioned "
     "to the top-level system field because their placement violated the API "
@@ -943,10 +947,26 @@ class AnthropicAPI(ModelAPI):
                 betas.append("output-128k-2025-02-19")
 
         elif config.reasoning_effort == "none" and self._supports_disabling_thinking():
-            # Claude 4.7+ (incl. Sonnet 5) run adaptive thinking by default, so
-            # `reasoning_effort="none"` must explicitly disable it. Pre-4.7 models
-            # default to no thinking, so omitting the field already suffices.
+            # Claude 4.7+ (incl. Sonnet 5 and Opus 5) run adaptive thinking by
+            # default, so `reasoning_effort="none"` must explicitly disable it.
+            # Pre-4.7 models default to no thinking, so omitting the field
+            # already suffices.
             params["thinking"] = {"type": "disabled"}
+            # Opus 5 returns a 400 for disabled thinking combined with effort
+            # above `high` (Opus 4.8 and Sonnet 5 accept the combination).
+            output_config = params.get("output_config")
+            if (
+                self.is_claude_opus_5()
+                and isinstance(output_config, dict)
+                and output_config.get("effort") in ("xhigh", "max")
+            ):
+                warn_once(
+                    logger,
+                    _DISABLED_THINKING_EFFORT_WARNING.format(
+                        model=self.service_model_name()
+                    ),
+                )
+                params["output_config"] = OutputConfigParam(effort="high")
 
         # config that applies to all models
         if config.stop_seqs is not None:
@@ -1067,14 +1087,18 @@ class AnthropicAPI(ModelAPI):
     def _supports_disabling_thinking(self) -> bool:
         """Whether `reasoning_effort="none"` should send `thinking:{type:"disabled"}`.
 
-        Claude 4.7+ (Opus 4.7/4.8, Sonnet 5) run adaptive thinking by default and
-        accept `disabled` to turn it off. Fable/Mythos 5 also always think but
-        reject `disabled` (400), so they're excluded — their thinking can't be
-        turned off. Pre-4.7 models default to no thinking, so `"none"` is honored
-        by simply omitting the `thinking` field.
+        Claude 4.7+ (Opus 4.7/4.8, Sonnet 5, Opus 5) run adaptive thinking by
+        default and accept `disabled` to turn it off (on Opus 5 only at effort
+        `high` or below — see completion_config). Fable/Mythos 5 also always
+        think but reject `disabled` (400), so they're excluded — as are unknown
+        codename Claude 5 models, which are assumed to follow Fable rather than
+        the tier-named (opus/sonnet) models. Pre-4.7 models default to no
+        thinking, so `"none"` is honored by simply omitting the `thinking`
+        field.
         """
         return self.is_claude_4_7_or_later() and not (
-            self.is_claude_5() and not self.is_claude_sonnet_5()
+            self.is_claude_5()
+            and not (self.is_claude_sonnet_5() or self.is_claude_opus_5())
         )
 
     def bridged_reasoning_tokens(self, config: GenerateConfig) -> int | None:
@@ -1147,6 +1171,9 @@ class AnthropicAPI(ModelAPI):
 
     def is_claude_sonnet_5(self) -> bool:
         return self.is_claude_5() and "sonnet" in self.model_family()
+
+    def is_claude_opus_5(self) -> bool:
+        return self.is_claude_5() and "opus" in self.model_family()
 
     def _is_claude_4_x(self, x: int) -> bool:
         return (
@@ -1262,16 +1289,17 @@ class AnthropicAPI(ModelAPI):
             return "anthropic/claude-opus-4-6"  # 1MM
         elif self.is_claude_latest():
             # Unknown future version: assume the current 1M frontier.
-            return "anthropic/claude-opus-4-8"  # 1MM
+            return "anthropic/claude-opus-5"  # 1MM
         elif (
             self.is_claude_5() and _get_model_info_direct(self.canonical_name()) is None
         ):
             # A Claude 5 variant not yet registered in the model-info database
             # (e.g. a tier-named claude-*-5 or a new codename): assume the 1M
             # Claude 5 frontier rather than missing the lookup. Registered
-            # Claude 5 models (Fable/Mythos and their point releases, which
-            # fuzzy-match their base entry) fall through to the database below.
-            return "anthropic/claude-opus-4-8"  # 1MM
+            # Claude 5 models (Opus/Sonnet/Fable/Mythos and their point
+            # releases, which fuzzy-match their base entry) fall through to the
+            # database below.
+            return "anthropic/claude-opus-5"  # 1MM
         else:
             return super().input_tokens_name()
 
@@ -1564,16 +1592,18 @@ class AnthropicAPI(ModelAPI):
                     "Use of Anthropic's native computer use support is not enabled in Claude 3.5. Please use 3.7 or later to leverage the native support.",
                 )
                 return None
-            # Among Claude 5 models only Sonnet 5 is documented to support native
-            # computer use (the computer-use-2025-11-24 tool). Fable/Mythos 5 are
-            # not listed in Anthropic's computer-use docs, so error for those
-            # rather than degrade to a non-native fallback tool.
-            if self.is_claude_5() and not self.is_claude_sonnet_5():
+            # Among Claude 5 models only Sonnet 5 and Opus 5 are documented to
+            # support native computer use (the computer-use-2025-11-24 tool).
+            # Fable/Mythos 5 are not listed in Anthropic's computer-use docs, so
+            # error for those rather than degrade to a non-native fallback tool.
+            if self.is_claude_5() and not (
+                self.is_claude_sonnet_5() or self.is_claude_opus_5()
+            ):
                 raise PrerequisiteError(
                     f"Computer use is not supported by the model '{self.service_model_name()}'. "
-                    "Anthropic's native computer use requires a Claude 4.x model or "
-                    "Claude Sonnet 5 (e.g. claude-opus-4-8, claude-sonnet-4-6, or "
-                    "claude-sonnet-5)."
+                    "Anthropic's native computer use requires a Claude 4.x model, "
+                    "Claude Sonnet 5, or Claude Opus 5 (e.g. claude-opus-4-8, "
+                    "claude-sonnet-5, or claude-opus-5)."
                 )
             # Note: The dimensions passed here for display_width_px and display_height_px
             # should match the dimensions of screenshots returned by the tool. Those
@@ -1585,8 +1615,8 @@ class AnthropicAPI(ModelAPI):
             #
             # TODO: enhance this code to calculate the dimensions based on the scaled screen
             # size used by the container.
-            # computer_20251124 is supported by Claude Sonnet 5, Opus 4.6/4.7/4.8,
-            # Sonnet 4.6, and Opus 4.5
+            # computer_20251124 is supported by Claude Opus 5, Sonnet 5,
+            # Opus 4.6/4.7/4.8, Sonnet 4.6, and Opus 4.5
             if self.is_claude_frontier() or (
                 self.is_claude_4_5() and self.is_claude_4_opus()
             ):
@@ -1802,16 +1832,17 @@ def _supports_web_search(model_name: str) -> bool:
 
 
 def _supports_code_interpreter(model_name: str) -> bool:
+    # https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool#model-compatibility
+    # (all Claude 5 models — Opus, Sonnet, Fable, Mythos — support it)
     return model_name.startswith(
         (
             "claude-opus-4",
             "claude-sonnet-4",
-            "claude-sonnet-5",
             "claude-haiku-4",
             "claude-3-7-sonnet",
             "claude-3-5-haiku-latest",
         )
-    )
+    ) or _is_claude_5(model_name)
 
 
 def _supports_memory(model_name: str) -> bool:

--- a/src/inspect_ai/model/_providers/bedrock.py
+++ b/src/inspect_ai/model/_providers/bedrock.py
@@ -478,6 +478,12 @@ class BedrockAPI(ModelAPI):
             return False
         if self._is_claude_4_x(7):
             return True
+        # claude 5 (e.g. anthropic.claude-opus-5, anthropic.claude-fable-5)
+        # shares the 4.7+ capability set (adaptive-thinking-only, no sampling
+        # params). names with a digit before the trailing -5 (claude-haiku-4-5)
+        # do not match.
+        if re.search(r"claude-[a-zA-Z]+-5", self.model_family()):
+            return True
         # future claude 4 minor not yet recognised
         if re.search(r"claude-[a-zA-Z]+-4-", self.model_family()):
             recognised = any(self._is_claude_4_x(x) for x in (0, 1, 5, 6))

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -1,5 +1,5 @@
 import types
-from typing import Any, cast
+from typing import Any, Literal, cast
 from unittest.mock import AsyncMock, create_autospec
 
 import pytest
@@ -167,6 +167,7 @@ def test_anthropic_thinking_keeps_display_without_full_thinking_beta() -> None:
     "model_name,disabled",
     [
         # 4.7+ run adaptive thinking by default and accept `disabled`
+        ("claude-opus-5", True),
         ("claude-sonnet-5", True),
         ("claude-opus-4-8", True),
         ("claude-opus-4-7", True),
@@ -203,6 +204,42 @@ def test_anthropic_reasoning_effort_high_still_adaptive_on_sonnet_5() -> None:
         GenerateConfig(max_tokens=64, reasoning_effort="high")
     )
     assert params["thinking"]["type"] == "adaptive"
+
+
+@pytest.mark.parametrize("effort", ["xhigh", "max"])
+def test_anthropic_opus_5_disabled_thinking_clamps_effort(
+    effort: Literal["xhigh", "max"],
+) -> None:
+    """Opus 5 rejects disabled thinking with effort above `high`; clamp to `high`."""
+    api = AnthropicAPI(model_name="claude-opus-5", api_key="test-key")
+    params, _e, _h, _b = api.completion_config(
+        GenerateConfig(max_tokens=64, reasoning_effort="none", effort=effort)
+    )
+    assert params["thinking"] == {"type": "disabled"}
+    assert params["output_config"]["effort"] == "high"
+
+
+@pytest.mark.parametrize("model_name", ["claude-opus-4-8", "claude-sonnet-5"])
+def test_anthropic_disabled_thinking_keeps_high_effort_elsewhere(
+    model_name: str,
+) -> None:
+    """Opus 4.8 / Sonnet 5 accept disabled thinking with effort above `high`."""
+    api = AnthropicAPI(model_name=model_name, api_key="test-key")
+    params, _e, _h, _b = api.completion_config(
+        GenerateConfig(max_tokens=64, reasoning_effort="none", effort="xhigh")
+    )
+    assert params["thinking"] == {"type": "disabled"}
+    assert params["output_config"]["effort"] == "xhigh"
+
+
+def test_anthropic_opus_5_disabled_thinking_keeps_high_effort() -> None:
+    """Effort at or below `high` passes through unclamped on Opus 5."""
+    api = AnthropicAPI(model_name="claude-opus-5", api_key="test-key")
+    params, _e, _h, _b = api.completion_config(
+        GenerateConfig(max_tokens=64, reasoning_effort="none", effort="high")
+    )
+    assert params["thinking"] == {"type": "disabled"}
+    assert params["output_config"]["effort"] == "high"
 
 
 @pytest.mark.parametrize(
@@ -1210,6 +1247,33 @@ async def test_anthropic_opus_4_7_accepts_temperature_with_reasoning_effort_none
     assert len(response.completion) >= 1
 
 
+@pytest.mark.anyio
+@skip_if_no_anthropic
+async def test_anthropic_opus_5_reasoning_effort_none_live() -> None:
+    """Opus 5 runs adaptive thinking by default; reasoning_effort='none' must disable it."""
+    model = get_model(
+        "anthropic/claude-opus-5",
+        config=GenerateConfig(reasoning_effort="none", max_tokens=64),
+    )
+    response = await model.generate(input="Say hello in one short sentence.")
+    assert len(response.completion) >= 1
+    content = response.choices[0].message.content
+    if isinstance(content, list):
+        assert not any(c.type == "reasoning" for c in content)
+
+
+@pytest.mark.anyio
+@skip_if_no_anthropic
+async def test_anthropic_opus_5_disabled_thinking_effort_clamp_live() -> None:
+    """reasoning_effort='none' + effort='xhigh' must not 400 on Opus 5 (clamped to high)."""
+    model = get_model(
+        "anthropic/claude-opus-5",
+        config=GenerateConfig(reasoning_effort="none", effort="xhigh", max_tokens=64),
+    )
+    response = await model.generate(input="Say hello in one short sentence.")
+    assert len(response.completion) >= 1
+
+
 # ---------------------------------------------------------------------------
 # max_tokens caps across model versions (incl. forward-compat routing)
 # ---------------------------------------------------------------------------
@@ -1223,7 +1287,8 @@ async def test_anthropic_opus_4_7_accepts_temperature_with_reasoning_effort_none
         ("claude-opus-4-7", 128000),
         # Hypothetical future minor opus version: 128k via frontier+opus
         ("claude-opus-4-8", 128000),
-        # Claude 5 (GA fable + hypothetical tier-named): 128k via "claude 5+" branch
+        # Claude 5 (GA opus/fable + hypothetical tier-named): 128k via "claude 5+" branch
+        ("claude-opus-5", 128000),
         ("claude-fable-5", 128000),
         ("claude-opus-5-0", 128000),
         ("claude-sonnet-5-0", 128000),
@@ -1252,6 +1317,7 @@ def test_anthropic_max_tokens_caps(model_name: str, expected_cap: int) -> None:
     "model_name",
     [
         # GA / limited-release names
+        "claude-opus-5",
         "claude-fable-5",
         "claude-mythos-5",
         # forward-compat variants: point release, tier-named, new codename
@@ -1262,7 +1328,10 @@ def test_anthropic_max_tokens_caps(model_name: str, expected_cap: int) -> None:
 )
 def test_anthropic_claude_5_is_known_frontier(model_name: str) -> None:
     """Any claude-*-5 is a known frontier version, not 'latest'/unknown."""
-    from inspect_ai.model._providers.anthropic import _supports_memory
+    from inspect_ai.model._providers.anthropic import (
+        _supports_code_interpreter,
+        _supports_memory,
+    )
 
     api = AnthropicAPI(model_name=model_name, api_key="test-key")
     assert api.is_claude_5() is True
@@ -1270,8 +1339,10 @@ def test_anthropic_claude_5_is_known_frontier(model_name: str) -> None:
     assert api.is_claude_frontier() is True
     assert api.is_claude_4_7_or_later() is True
     assert api.is_claude_4_8_or_later() is True
-    # native memory tool is enabled for all Claude 5 variants (per the launch docs)
+    # native memory and code-execution tools are enabled for all Claude 5
+    # variants (per the launch docs)
     assert _supports_memory(api.model_family()) is True
+    assert _supports_code_interpreter(api.model_family()) is True
 
 
 # ---------------------------------------------------------------------------
@@ -1294,13 +1365,13 @@ def _computer_tool_info() -> ToolInfo:
 
 
 @pytest.mark.parametrize(
-    "model_name", ["claude-fable-5", "claude-mythos-5", "claude-opus-5-0"]
+    "model_name", ["claude-fable-5", "claude-mythos-5", "claude-saga-5"]
 )
 def test_anthropic_claude_5_computer_use_errors(model_name: str) -> None:
     """Undocumented Claude 5 models error on computer use rather than degrade.
 
-    Covers Fable/Mythos and forward-compat non-Sonnet variants (e.g. Opus 5).
-    Sonnet 5 is supported and covered by test_anthropic_computer_use_tool_version.
+    Covers Fable/Mythos and forward-compat codename variants. Sonnet 5 and
+    Opus 5 are supported and covered by test_anthropic_computer_use_tool_version.
     """
     from inspect_ai._util.error import PrerequisiteError
 
@@ -1322,8 +1393,9 @@ def test_anthropic_claude_5_computer_use_errors(model_name: str) -> None:
         ("claude-opus-4-6", "computer_20251124"),
         ("claude-opus-4-5", "computer_20251124"),
         ("claude-sonnet-4-6", "computer_20251124"),
-        # Sonnet 5: the one Claude 5 model Anthropic documents for computer use
+        # Sonnet 5 / Opus 5: the Claude 5 models Anthropic documents for computer use
         ("claude-sonnet-5", "computer_20251124"),
+        ("claude-opus-5", "computer_20251124"),
         # Older 4.x → computer_20250124
         ("claude-sonnet-4-5", "computer_20250124"),
         ("claude-haiku-4-5", "computer_20250124"),

--- a/tests/model/providers/test_anthropic_model_names.py
+++ b/tests/model/providers/test_anthropic_model_names.py
@@ -550,10 +550,12 @@ def test_claude_4_6_opus(model_name: str) -> None:
 @pytest.mark.parametrize(
     "model_name",
     [
-        # GA + limited-release names (no tier word)
+        # GA + limited-release names
+        "claude-opus-5",
         "claude-fable-5",
         "claude-mythos-5",
         # Bedrock
+        "anthropic.claude-opus-5",
         "anthropic.claude-fable-5",
         # Point releases (hyphen + dot forms)
         "claude-fable-5-1",

--- a/tests/model/test_model_info.py
+++ b/tests/model/test_model_info.py
@@ -364,6 +364,12 @@ class TestGetModelInputTokens:
         tokens = get_model_input_tokens(model)
         assert tokens == 1_000_000
 
+    def test_claude_opus_5(self):
+        """Test that Claude Opus 5 reports 1MM input tokens."""
+        model = get_model("anthropic/claude-opus-5")
+        tokens = get_model_input_tokens(model)
+        assert tokens == 1_000_000
+
     def test_claude_fable_5(self):
         """Test that Claude Fable 5 reports 1MM input tokens."""
         model = get_model("anthropic/claude-fable-5")

--- a/tests/model/test_reasoning_claude.py
+++ b/tests/model/test_reasoning_claude.py
@@ -55,6 +55,26 @@ async def test_reasoning_claude_sonnet_5():
 
 @pytest.mark.anyio
 @skip_if_no_anthropic
+async def test_reasoning_claude_opus_5():
+    # Opus 5 (like Sonnet 5) rejects an explicit reasoning_tokens budget, so
+    # drive thinking via reasoning_effort only. It defaults thinking.display to
+    # 'omitted' while Inspect requests 'summarized', so a non-empty summarized
+    # reasoning block must come back — and reasoning must not leak into the
+    # visible response text.
+    model = get_model("anthropic/claude-opus-5")
+    output = await model.generate(
+        "Solve 3*x^3-5*x=1",
+        config=GenerateConfig(reasoning_effort="low", max_tokens=8192),
+    )
+    assert "<think>" not in output.completion
+    content = output.choices[0].message.content
+    assert isinstance(content, list)
+    assert isinstance(content[0], ContentReasoning)
+    assert content[0].reasoning.strip()
+
+
+@pytest.mark.anyio
+@skip_if_no_anthropic
 async def test_reasoning_claude_ignore_unsupported():
     @tool
     def addition():


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Claude Opus 5 (`claude-opus-5`, released 2026-07-24) is not registered in the model-info database, and several Claude 5 capability gates were written when "Claude 5" meant Fable/Mythos (plus Sonnet 5 exceptions), so Opus 5 gets the wrong behavior in a few places:

- `reasoning_effort="none"` silently omits the `thinking` field, so Opus 5 (which runs adaptive thinking by default) thinks anyway.
- Computer use raises `PrerequisiteError` even though Opus 5 supports `computer_20251124`.
- The native code-execution tool is not offered.
- On Bedrock, Claude 5 ids were not recognized as 4.7+, so sampling params were not stripped.

Model-name *detection* already handles it: `_is_claude_5()` matches any `claude-*-5`, so Opus 5 was already classified as a known Claude 5 frontier model (1M context, adaptive-thinking-only, effort `xhigh`/`max`, 128K max_tokens cap, sampling-param stripping, memory tool, web search).

### What is the new behavior?

Full support for Claude Opus 5:

- **Model info**: `claude-opus-5` entry in `anthropic.yml` (1M context, 128K output, reasoning with effort default `high`, May 2026 knowledge cutoff, `anthropic.claude-opus-5` Bedrock alias); `docs/_reasoning-defaults.md` regenerated.
- **Disabling thinking**: `_supports_disabling_thinking()` now includes Opus 5 (thinking on by default, `disabled` accepted), while continuing to exclude Fable/Mythos and unknown codename Claude 5 models (which reject `disabled` with a 400). Opus 5 additionally rejects `thinking: {disabled}` combined with effort above `high`, so that combination is clamped to `high` with a warning instead of failing the request ([migration guide](https://platform.claude.com/docs/en/about-claude/models/migration-guide)).
- **Computer use**: Opus 5 maps to `computer_20251124` per [Anthropic's computer-use docs](https://platform.claude.com/docs/en/agents-and-tools/computer-use); the Claude 5 rejection now applies only to Fable/Mythos/codename models.
- **Code execution**: gate switched from a prefix list to `_is_claude_5()` — all Claude 5 models (Opus, Sonnet, Fable, Mythos) support it per the [code-execution docs](https://platform.claude.com/docs/en/agents-and-tools/tool-use/code-execution-tool#model-compatibility).
- **Frontier alias**: `input_tokens_name()` unknown-Claude-5/latest fallback bumped from `claude-opus-4-8` to `claude-opus-5` (behavior neutral: both 1M).
- **Bedrock**: `is_claude_4_7_or_later()` now matches Claude 5 ids (e.g. `anthropic.claude-opus-5`), so sampling params are stripped there too.

Tests: detection-matrix rows, gating unit tests (disable/clamp/computer-use/code-exec/max-tokens caps), model-info lookup, plus live tests run against the real API (all passing): summarized reasoning via `reasoning_effort`, `reasoning_effort="none"` disabling thinking, the `disabled`+`xhigh` clamp not 400ing, and a default-config generate (adaptive thinking on by default, reasoning + text content handled).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

New Opus 5 API features that don't require Inspect changes for basic support (mid-conversation tool changes beta, `fallbacks: "default"` mode with the `server-side-fallback-2026-07-01` header, 512-token prompt-caching minimum, 300K batch output beta) were reviewed and deliberately left for follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
