### PR TITLE
feat(anthropic): cache_prompt="prefix" suppresses the end-of-prompt auto-cache marker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Anthropic: New `cache_prompt: "prefix"` mode keeps the explicit cache breakpoints (system, tools, lookback) but suppresses the automatic end-of-prompt marker, so prompts with a varying final block (e.g. LLM-judge rubric + item) stop paying cache writes that never read back. Warns once if the mode leaves a request with no breakpoint at all. (#4505)
 - Sandbox: Large sandbox-tool responses are transferred intact instead of corrupting JSON-RPC frames when they exceed the sandbox exec output limit.
 - Agent Bridge: Fix for `message_limit`/`token_limit`/`cost_limit` errors not being properly raised when running in a sandbox.
 - Bugfix: Reading eval logs with field exclusion (e.g. header-only reads) no longer crashes under a trio event loop; the pure-Python ijson backend is now selected when the C backend's asyncio-only async parser is unavailable. (#4589)

--- a/src/inspect_ai/_cli/eval.py
+++ b/src/inspect_ai/_cli/eval.py
@@ -826,8 +826,8 @@ def eval_options(func: Callable[..., Any]) -> Callable[..., click.Context]:
     )
     @click.option(
         "--cache-prompt",
-        type=click.Choice(["auto", "true", "false"]),
-        help="Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic only.",
+        type=click.Choice(["auto", "prefix", "true", "false"]),
+        help="Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Set to 'prefix' to keep the explicit cache breakpoints but omit the automatic end-of-prompt marker. Anthropic only.",
         envvar="INSPECT_EVAL_CACHE_PROMPT",
     )
     @click.option(

--- a/src/inspect_ai/_view/inspect-openapi.json
+++ b/src/inspect_ai/_view/inspect-openapi.json
@@ -5185,7 +5185,10 @@
           "cache_prompt": {
             "anyOf": [
               {
-                "const": "auto",
+                "enum": [
+                  "auto",
+                  "prefix"
+                ],
                 "type": "string"
               },
               {

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -147,8 +147,8 @@ class GenerateConfigArgs(TypedDict, total=False):
     max_tool_output: int | None
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
-    cache_prompt: Literal["auto"] | bool | None
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic only."""
+    cache_prompt: Literal["auto", "prefix"] | bool | None
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Set to "prefix" to cache only up to the last shared block, leaving a varying tail uncached. Anthropic only."""
 
     fallback_models: list[str] | None
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""
@@ -274,8 +274,8 @@ class GenerateConfig(BaseModel):
     max_tool_output: int | None = Field(default=None)
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
-    cache_prompt: Literal["auto"] | bool | None = Field(default=None)
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Anthropic only."""
+    cache_prompt: Literal["auto", "prefix"] | bool | None = Field(default=None)
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Set to "prefix" to cache only up to the last shared block, leaving a varying tail uncached. Anthropic only."""
 
     fallback_models: list[str] | None = Field(default=None)
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""

--- a/src/inspect_ai/model/_generate_config.py
+++ b/src/inspect_ai/model/_generate_config.py
@@ -148,7 +148,7 @@ class GenerateConfigArgs(TypedDict, total=False):
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
     cache_prompt: Literal["auto", "prefix"] | bool | None
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Set to "prefix" to cache only up to the last shared block, leaving a varying tail uncached. Anthropic only."""
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Set to "prefix" to keep the explicit cache breakpoints but omit the automatic end-of-prompt marker, so a varying tail is not cache-written on every call. Anthropic only."""
 
     fallback_models: list[str] | None
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""
@@ -275,7 +275,7 @@ class GenerateConfig(BaseModel):
     """Maximum tool output (in bytes). Defaults to 16 * 1024."""
 
     cache_prompt: Literal["auto", "prefix"] | bool | None = Field(default=None)
-    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Set to "prefix" to cache only up to the last shared block, leaving a varying tail uncached. Anthropic only."""
+    """Whether to cache the prompt prefix. Enabled by default. Set to False to disable. Set to "prefix" to keep the explicit cache breakpoints but omit the automatic end-of-prompt marker, so a varying tail is not cache-written on every call. Anthropic only."""
 
     fallback_models: list[str] | None = Field(default=None)
     """Fallback models tried in order when the model's safety classifiers refuse the request. Anthropic Claude API only (not supported on Bedrock/Vertex/Azure or with batch mode)."""

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1547,13 +1547,20 @@ class AnthropicAPI(ModelAPI):
 
         normalize_document_citations(message_params)
 
+        # "prefix" keeps the explicit breakpoints placed above but drops the
+        # top-level auto-cache marker, which the API resolves onto the last
+        # block. When that block varies per call (the LLM-judge shape: a fixed
+        # rubric followed by the item under evaluation) that marker only ever
+        # cache-writes at the 1.25x premium and never reads back.
+        auto_cache = cache_prompt and config.cache_prompt != "prefix"
+
         # return chat input
         return (
             system_param,
             tools_params,
             mcp_server_params,
             message_params,
-            cache_prompt,
+            auto_cache,
         )
 
     def partition_tools(

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -1554,6 +1554,24 @@ class AnthropicAPI(ModelAPI):
         # cache-writes at the 1.25x premium and never reads back.
         auto_cache = cache_prompt and config.cache_prompt != "prefix"
 
+        # the lookback marker needs a second-to-last cacheable block, so a single
+        # block or bare-string content leaves nothing marked. Combined with the
+        # suppressed auto-cache that means no caching at all, which is worth
+        # saying out loud rather than degrading silently across a run.
+        if (
+            cache_prompt
+            and config.cache_prompt == "prefix"
+            and not has_cache_control(system_param, tools_params, message_params)
+        ):
+            warn_once(
+                logger,
+                'cache_prompt="prefix" produced a request with no cache breakpoint, '
+                "so this call is not cached at all. The mode suppresses the automatic "
+                "end-of-prompt marker and there was no earlier block to mark. Split "
+                "the prompt into a stable block followed by the varying one, or leave "
+                "cache_prompt at its default for single-block prompts.",
+            )
+
         # return chat input
         return (
             system_param,
@@ -2037,6 +2055,30 @@ def is_code_execution_tool(
 
 
 _NON_CACHEABLE_BLOCK_TYPES = frozenset({"thinking", "redacted_thinking"})
+
+
+def has_cache_control(
+    system_param: list[TextBlockParam] | None,
+    tools_params: list["ToolParamDef"],
+    message_params: list[MessageParam],
+) -> bool:
+    """Whether any explicit `cache_control` marker was placed on the request.
+
+    Distinct from the top-level auto-cache field, which is set on the request
+    body rather than on a block and so is invisible to this check.
+    """
+    if any(
+        "cache_control" in cast(dict[str, Any], param)
+        for param in [*(system_param or []), *tools_params]
+    ):
+        return True
+    for msg in message_params:
+        content = msg["content"]
+        if isinstance(content, list) and any(
+            isinstance(block, dict) and "cache_control" in block for block in content
+        ):
+            return True
+    return False
 
 
 def add_lookback_cache_control(

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -328,7 +328,10 @@ class OpenRouterAPI(OpenAICompatibleAPI):
         if not name.startswith("anthropic/"):
             return False
         # Matches direct anthropic provider: only explicit False disables;
-        # None, True, and "auto" all enable.
+        # None, True, "auto", and "prefix" all enable. "prefix" only suppresses
+        # the direct provider's top-level auto-cache marker; this provider has
+        # no equivalent of that marker (system, tools, and penultimate-block
+        # only), so its placement is already prefix-shaped.
         if config.cache_prompt is False:
             return False
         # Mirror the legacy-Claude gate from the direct anthropic provider.

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -1008,6 +1008,57 @@ async def test_anthropic_cache_prompt_prefix_keeps_breakpoints() -> None:
 
 
 @pytest.mark.anyio
+async def test_anthropic_cache_prompt_prefix_warns_without_breakpoint() -> None:
+    """Warn when "prefix" leaves a request with no breakpoint at all.
+
+    The lookback marker needs a second-to-last cacheable block, so single-block
+    and bare-string content have nothing to mark. With the auto-cache marker
+    suppressed that request is not cached at all, which would otherwise degrade
+    silently across a run.
+    """
+    from inspect_ai._util.logger import _warned
+
+    api = create_autospec(AnthropicAPI, instance=True)
+    api.service_model_name.return_value = "claude-sonnet-4-6"
+    api.partition_tools.return_value = ([], [])
+    # instance attribute set in __init__, not captured by create_autospec
+    api.cache_ttl = None
+    api.resolve_chat_input = types.MethodType(AnthropicAPI.resolve_chat_input, api)
+
+    async def resolve(content: Any) -> Any:
+        return await api.resolve_chat_input(
+            input=[ChatMessageUser(content=content)],
+            tools=[],
+            config=GenerateConfig(cache_prompt="prefix"),
+        )
+
+    def warned() -> bool:
+        return any("no cache breakpoint" in message for message in _warned)
+
+    # bare-string content cannot carry a marker
+    _warned.clear()
+    _, _, _, _, auto_cache = await resolve("one big prompt")
+    assert auto_cache is False
+    assert warned()
+
+    # a single block has no penultimate position to mark
+    _warned.clear()
+    _, _, _, msgs, auto_cache = await resolve([ContentText(text="only one")])
+    assert auto_cache is False
+    assert "cache_control" not in msgs[0]["content"][0]
+    assert warned()
+
+    # two blocks do get a breakpoint, so no warning
+    _warned.clear()
+    _, _, _, msgs, auto_cache = await resolve(
+        [ContentText(text="shared rubric"), ContentText(text="varying item")]
+    )
+    assert auto_cache is False
+    assert "cache_control" in msgs[0]["content"][0]
+    assert not warned()
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "model_name,expects_top_level_cache_control",
     [

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -956,6 +956,58 @@ async def test_anthropic_cache_marks_penultimate_block() -> None:
 
 
 @pytest.mark.anyio
+async def test_anthropic_cache_prompt_prefix_keeps_breakpoints() -> None:
+    """`cache_prompt="prefix"` keeps explicit breakpoints but drops auto-cache.
+
+    Auto-cache resolves onto the last block. When that block varies per call
+    (a fixed rubric followed by the item under evaluation) it cache-writes at
+    the 1.25x premium on every call and never reads back. "prefix" suppresses
+    that marker while leaving the shared-prefix breakpoint in place, which also
+    returns the auto-cache slot to Anthropic's four-breakpoint budget.
+    ref: https://docs.claude.com/en/docs/build-with-claude/prompt-caching#automatic-caching
+    """
+    api = create_autospec(AnthropicAPI, instance=True)
+    api.service_model_name.return_value = "claude-sonnet-4-6"
+    api.partition_tools.return_value = ([], [])
+    # instance attribute set in __init__, not captured by create_autospec
+    api.cache_ttl = None
+    api.resolve_chat_input = types.MethodType(AnthropicAPI.resolve_chat_input, api)
+
+    def marked(content: Any) -> list[int]:
+        assert isinstance(content, list)
+        return [i for i, b in enumerate(content) if "cache_control" in b]
+
+    blocks: list[Content] = [ContentText(text=f"block {i}") for i in range(4)]
+
+    async def resolve(cache_prompt: Any) -> Any:
+        return await api.resolve_chat_input(
+            input=[ChatMessageUser(content=blocks)],
+            tools=[],
+            config=GenerateConfig(cache_prompt=cache_prompt),
+        )
+
+    # default: explicit breakpoint placed, auto-cache requested
+    _, _, _, msgs, auto_cache = await resolve(True)
+    assert marked(msgs[0]["content"]) == [2]
+    assert auto_cache is True
+
+    # prefix: same explicit breakpoint, auto-cache suppressed
+    _, _, _, msgs, auto_cache = await resolve("prefix")
+    assert marked(msgs[0]["content"]) == [2]
+    assert auto_cache is False
+
+    # "auto" and None keep the documented default behaviour
+    for value in ("auto", None):
+        _, _, _, _, auto_cache = await resolve(value)
+        assert auto_cache is True
+
+    # disabled: no breakpoint, no auto-cache
+    _, _, _, msgs, auto_cache = await resolve(False)
+    assert marked(msgs[0]["content"]) == []
+    assert auto_cache is False
+
+
+@pytest.mark.anyio
 @pytest.mark.parametrize(
     "model_name,expects_top_level_cache_control",
     [

--- a/tests/model/providers/test_openrouter.py
+++ b/tests/model/providers/test_openrouter.py
@@ -206,6 +206,19 @@ def test_cache_prompt_enabled_when_config_auto() -> None:
     assert api._cache_prompt_enabled(GenerateConfig(cache_prompt="auto")) is True
 
 
+def test_cache_prompt_enabled_when_config_prefix() -> None:
+    """`cache_prompt="prefix"` enables caching here, deliberately.
+
+    The mode's only effect on the direct anthropic provider is suppressing the
+    top-level auto-cache marker, which the API resolves onto the last content
+    block. This provider's marker scheme has no equivalent of that marker (it
+    marks system, tools, and the penultimate block only), so its placement is
+    already prefix-shaped and "prefix" must not read as disabled.
+    """
+    api = _make_api("openrouter/anthropic/claude-sonnet-4-5")
+    assert api._cache_prompt_enabled(GenerateConfig(cache_prompt="prefix")) is True
+
+
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
Closes #4505.

Implements option 1 from the issue (`cache_prompt: "prefix"`), following the design discussion in [my first comment](https://github.com/UKGovernmentBEIS/inspect_ai/issues/4505#issuecomment-5080608720) and the breakpoint-slot accounting confirmed in [the follow-up](https://github.com/UKGovernmentBEIS/inspect_ai/issues/4505#issuecomment-5080749288). Opened as a draft while that design call is still open; happy to adjust or close if a maintainer prefers option 2 (per-block `cache_control`).

## What it does

`cache_prompt: "prefix"` keeps the explicit breakpoints exactly as today (system, tools, lookback) and suppresses only the top-level auto-cache marker, which the API resolves onto the last content block. When that block varies per call (the LLM-judge shape from the issue: fixed rubric + item under evaluation), the auto marker only ever cache-writes at the 1.25x premium and never reads back. Suppressing it also hands back one of the four breakpoint slots.

- `GenerateConfig.cache_prompt` widens `Literal["auto"] | bool | None` to include `"prefix"`; the CLI `--cache-prompt` choice accepts it.
- The Anthropic provider carries the mode through instead of coercing to bool, and gates the top-level `cache_control` request field on it. All other marker placement is untouched; `"auto"`, `True`, `False`, and `None` behave exactly as before.
- Degenerate case: with a bare-string or single-block prompt there is no penultimate block for the lookback marker, so `"prefix"` would silently disable caching entirely. The provider now detects that (new `has_cache_control()` helper) and emits a one-time `warn_once` naming the fix, rather than degrading silently.
- OpenRouter also reads `cache_prompt` and disables only on explicit `False`. That is correct for `"prefix"`: its marker scheme has no equivalent of the top-level auto marker (system, tools, penultimate block only), so its placement is already prefix-shaped. Pinned with a test and a comment stating the rationale.
- `inspect-openapi.json` regenerated; changelog entry under Unreleased.

## Testing

- New tests in `tests/model/providers/test_anthropic.py` assert which markers appear in each mode, the warn-once on the no-breakpoint case, and unchanged behavior for the existing values; one new pinning test in `test_openrouter.py`. 116 of the 181 inserted lines are tests.
- Locally green: provider test files pass (142 passed) including `--runtrio` variants, `mypy src` clean (723 files), ruff clean, schema drift check clean.

## Known CI caveat: generated.ts lives in the ts-mono submodule

The Literal widening changes one line of `packages/inspect-common/src/types/generated.ts`, which lives in the `meridianlabs-ai/ts-mono` submodule. The `check-schema-and-types` job will fail on this PR until a one-line companion PR merges there and the submodule pointer is bumped (the `submodule-on-main` job requires the pointer to be on ts-mono main, so I can't point at a fork commit). I can open that companion PR on request, or a maintainer may prefer to fold it into their next ts-mono sync. Diff:

```diff
-            cache_prompt?: "auto" | boolean | null;
+            cache_prompt?: ("auto" | "prefix") | boolean | null;
```

## Disclosure

Built with Claude Code (commits carry `Co-Authored-By`), matching the issue's own authorship note. The breakpoint-budget reasoning and design choices are mine; the line-number archaeology and test scaffolding were assisted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
