### PR TITLE
fix(solver): resolve file paths and resources in chain_of_thought (#4631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Bugfix: Resolve file paths and resources passed to the `chain_of_thought` solver. (#4631)
+
 - Bugfix: `file_dataset()` now recognizes JSON and CSV URLs with query parameters while preserving the complete URL passed to the selected dataset reader.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).
 - Control Channel: `inspect ctl sample events --full` now pretty-prints the raw events instead of rendering a mostly-empty summary table.

--- a/src/inspect_ai/solver/_prompt.py
+++ b/src/inspect_ai/solver/_prompt.py
@@ -147,9 +147,11 @@ def chain_of_thought(template: str = DEFAULT_COT_TEMPLATE) -> Solver:
        template: String or path to file containing CoT template.
           The template uses a single variable: `prompt`.
     """
+    # read template
+    cot_template = resource(template)
 
     async def solve(state: TaskState, generate: Generate) -> TaskState:
-        state.user_prompt.text = template.format(prompt=state.user_prompt.text)
+        state.user_prompt.text = cot_template.format(prompt=state.user_prompt.text)
         return state
 
     return solve

--- a/tests/solver/test_prompt.py
+++ b/tests/solver/test_prompt.py
@@ -2,7 +2,14 @@ from test_helpers.utils import skip_if_no_openai
 
 from inspect_ai import Task, eval
 from inspect_ai.dataset import Sample
-from inspect_ai.solver import Solver, generate, prompt_template, solver, system_message
+from inspect_ai.solver import (
+    Solver,
+    chain_of_thought,
+    generate,
+    prompt_template,
+    solver,
+    system_message,
+)
 from inspect_ai.solver._prompt import assistant_message, user_message
 from inspect_ai.solver._solver import Generate
 from inspect_ai.solver._task_state import TaskState
@@ -87,3 +94,19 @@ def test_user_and_assistant_message():
     assert log.status == "success"
     assert log.samples
     assert log.samples[0].messages[1].text == ASSISTANT_MESSAGE
+
+
+def test_chain_of_thought_resource(tmp_path):
+    template_file = tmp_path / "cot.txt"
+    template_file.write_text("Reason carefully:\n{prompt}\nANSWER: 42")
+
+    task = Task(
+        dataset=[Sample(input="What is 20 + 22?", target="42")],
+        solver=[chain_of_thought(str(template_file)), generate()],
+    )
+    log = eval(task, model="mockllm/model")[0]
+    assert log.samples
+    assert (
+        "Reason carefully:\nWhat is 20 + 22?\nANSWER: 42"
+        in log.samples[0].messages[0].text
+    )


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Closes #4631

The `chain_of_thought` solver docstring states that `template` can be a "String or path to file containing CoT template". However, `chain_of_thought` formats the raw `template` string argument directly without calling `resource(template)`. As a result, passing a file path or URL to `chain_of_thought(path)` treats the path string itself as the prompt template (e.g. setting user prompt text to `"/path/to/cot.txt"`) rather than reading the file's contents.

### What is the new behavior?
`chain_of_thought` now resolves its `template` parameter via `resource(template)` before formatting `{prompt}`, allowing file paths and URLs to be loaded and formatted as documented, matching the behavior of `prompt_template`, `system_message`, `user_message`, and `assistant_message`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking changes.

### Other information:
- Added `test_chain_of_thought_resource` in `tests/solver/test_prompt.py` to verify file path resolution.
- Validation:
  - `uv run make check` passed (ruff check, ruff format, mypy).
  - `uv run pytest tests/solver/test_prompt.py` passed (4 passed, 1 skipped).
  - `git diff --check` passed.
