### PR TITLE
fix(log): keep async recovery off sync listing paths (Trio-safe; supersedes #4625 approach)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 - Bugfix: `is_data_uri()` now recognizes base64 data URIs that carry media-type parameters (e.g. `;charset=utf-8`) or an empty media type (`data:;base64,...`), which were previously misclassified as non-data URIs.
+- Bugfix: Async eval-log recovery (`recover_eval_log_async`, recoverable-log discovery) no longer uses sync listing/header reads that raise under a Trio async context.
 - Bugfix: `file_dataset()` now recognizes JSON and CSV URLs with query parameters while preserving the complete URL passed to the selected dataset reader.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).
 - Control Channel: `inspect ctl sample events --full` now pretty-prints the raw events instead of rendering a mostly-empty summary table.

--- a/src/inspect_ai/log/_recover/_api.py
+++ b/src/inspect_ai/log/_recover/_api.py
@@ -4,11 +4,19 @@ import logging
 import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
+from typing import Callable, Iterator
+
+import anyio
 
 from inspect_ai._util._async import run_coroutine
-from inspect_ai._util.file import dirname, filesystem
-from inspect_ai.log._file import EvalLogInfo, list_eval_logs, read_eval_log_async
+from inspect_ai._util.asyncfiles import AsyncFilesystem
+from inspect_ai._util.file import FileInfo, dirname, filesystem
+from inspect_ai.log._file import (
+    EvalLogInfo,
+    log_files_from_ls_async,
+    read_eval_log_async,
+    read_eval_log_headers_async,
+)
 from inspect_ai.log._log import EvalLog, EvalSample, EvalSampleSummary
 from inspect_ai.log._recorders.buffer.filestore import SampleBufferFilestore
 
@@ -22,6 +30,46 @@ from ._write import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+async def _list_eval_logs_filtered_async(
+    log_dir: str,
+    predicate: Callable[[EvalLog], bool],
+    *,
+    recursive: bool = True,
+) -> list[EvalLogInfo]:
+    """List eval logs in ``log_dir`` matching ``predicate`` without sync I/O.
+
+    Directory listing runs in a worker thread (sync fsspec ``exists``/``ls``).
+    Metadata and header reads use the async log readers so this is safe under
+    both asyncio and trio. Enters ``AsyncFilesystem`` itself so callers need
+    not wrap the await.
+
+    Args:
+        log_dir: Directory to list.
+        predicate: Keep logs whose header satisfies this callable.
+        recursive: Recurse into subdirectories (defaults to True).
+
+    Returns:
+        Matching ``EvalLogInfo`` entries in listing order.
+    """
+
+    def list_files() -> list[FileInfo]:
+        fs = filesystem(log_dir)
+        if not fs.exists(log_dir):
+            return []
+        return fs.ls(log_dir, recursive=recursive)
+
+    files = await anyio.to_thread.run_sync(list_files)
+    if not files:
+        return []
+
+    async with AsyncFilesystem():
+        logs = await log_files_from_ls_async(files)
+        if not logs:
+            return []
+        headers = await read_eval_log_headers_async(logs)
+        return [log for log, header in zip(logs, headers) if predicate(header)]
 
 
 class RecoveryNotAvailable(Exception):
@@ -125,9 +173,9 @@ async def recover_eval_log_async(
     # crashed logs before a successful retry exists.
     output_dir = dirname(write_output)
     task_id = crashed.eval.task_id
-    existing = list_eval_logs(
-        log_dir=output_dir,
-        filter=lambda log_header: (
+    existing = await _list_eval_logs_filtered_async(
+        output_dir,
+        lambda log_header: (
             log_header.status == "success" and log_header.eval.task_id == task_id
         ),
         recursive=False,
@@ -239,9 +287,9 @@ async def _recoverable_eval_logs_async(
 ) -> list[RecoverableEvalLog]:
     log_dir = log_dir or os.environ.get("INSPECT_LOG_DIR", "./logs") or "./logs"
 
-    crashed_logs = list_eval_logs(
-        log_dir=log_dir,
-        filter=lambda log: log.status == "started",
+    crashed_logs = await _list_eval_logs_filtered_async(
+        log_dir,
+        lambda log: log.status == "started",
     )
 
     result: list[RecoverableEvalLog] = []

--- a/src/inspect_ai/log/_recover/_api.py
+++ b/src/inspect_ai/log/_recover/_api.py
@@ -38,11 +38,13 @@ async def _list_eval_logs_filtered_async(
     *,
     recursive: bool = True,
 ) -> list[EvalLogInfo]:
-    """List eval logs in ``log_dir`` matching ``predicate`` without sync I/O.
+    """List eval logs in ``log_dir`` matching ``predicate`` (Trio-safe).
 
-    Directory listing runs in a worker thread (sync fsspec ``exists``/``ls``).
-    Metadata and header reads use the async log readers so this is safe under
-    both asyncio and trio. Enters ``AsyncFilesystem`` itself so callers need
+    Sync directory ``exists``/``ls`` run in an AnyIO worker thread so they do
+    not block the event loop. ``EvalLogInfo`` resolution and header reads use
+    only the async readers (``log_files_from_ls_async`` /
+    ``read_eval_log_headers_async``), never sync ``log_files_from_ls`` /
+    ``read_eval_log``. Enters ``AsyncFilesystem`` itself so public callers need
     not wrap the await.
 
     Args:
@@ -51,10 +53,17 @@ async def _list_eval_logs_filtered_async(
         recursive: Recurse into subdirectories (defaults to True).
 
     Returns:
-        Matching ``EvalLogInfo`` entries in listing order.
+        Matching ``EvalLogInfo`` entries in listing order (same descending
+        mtime order as ``list_eval_logs``).
+
+    Raises:
+        Exception: Unexpected filesystem or header-read failures propagate;
+            a missing directory yields ``[]``.
     """
 
     def list_files() -> list[FileInfo]:
+        # Construct the sync filesystem inside the worker so a stateful
+        # wrapper is not shared across threads.
         fs = filesystem(log_dir)
         if not fs.exists(log_dir):
             return []
@@ -69,7 +78,14 @@ async def _list_eval_logs_filtered_async(
         if not logs:
             return []
         headers = await read_eval_log_headers_async(logs)
-        return [log for log, header in zip(logs, headers) if predicate(header)]
+        if len(logs) != len(headers):
+            raise RuntimeError(
+                f"read_eval_log_headers_async returned {len(headers)} headers "
+                f"for {len(logs)} logs (order-preserving contract broken)"
+            )
+        return [
+            log for log, header in zip(logs, headers, strict=True) if predicate(header)
+        ]
 
 
 class RecoveryNotAvailable(Exception):

--- a/tests/log/test_recover_api.py
+++ b/tests/log/test_recover_api.py
@@ -5,8 +5,11 @@ import os
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Literal
+from unittest.mock import MagicMock
 from zipfile import ZipFile
 
+import anyio
 import pytest
 from pydantic_core import to_jsonable_python
 from test_helpers.buffer import simulate_crashed_buffer_db
@@ -14,7 +17,7 @@ from test_helpers.buffer import simulate_crashed_buffer_db
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.constants import LOG_SCHEMA_VERSION
 from inspect_ai.event._model import ModelEvent
-from inspect_ai.log._file import read_eval_log
+from inspect_ai.log._file import read_eval_log, read_eval_log_async
 from inspect_ai.log._log import (
     EvalConfig,
     EvalDataset,
@@ -32,6 +35,7 @@ from inspect_ai.log._recover import (
     recover_eval_log_async,
     recoverable_eval_logs,
 )
+from inspect_ai.log._recover._api import _recoverable_eval_logs_async
 from inspect_ai.model._chat_message import ChatMessageUser
 from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ModelOutput
@@ -326,3 +330,257 @@ def test_recoverable_eval_logs_excludes_already_recovered() -> None:
 
         result = recoverable_eval_logs(log_dir=temp_dir, _db_dir=db_dir)
         assert len(result) == 0
+
+
+def _write_header_eval(
+    path: str,
+    *,
+    task: str = "test_task",
+    status: Literal["started", "success", "cancelled", "error"] = "started",
+) -> None:
+    """Write a complete .eval with header.json (for listing/filter tests)."""
+    eval_spec = _make_eval_spec(task)
+    plan = EvalPlan()
+    log_start = LogStart(version=LOG_SCHEMA_VERSION, eval=eval_spec, plan=plan)
+    with ZipFile(path, "w") as zf:
+        zf.writestr("_journal/start.json", _to_json(log_start))
+        header = EvalLog(
+            version=LOG_SCHEMA_VERSION,
+            eval=eval_spec,
+            plan=plan,
+            status=status,
+        )
+        zf.writestr(HEADER_JSON, _to_json(header))
+
+
+def _run_recover_async_paths(backend: str) -> None:
+    """Exercise async recovery + discovery under the given anyio backend.
+
+    Uses the non-canonical ``test.eval`` name so metadata resolution must
+    fall through to the async header reader (not the sync filename parser
+    alone). Sample count is taken from an async re-read so LazyList
+    materialization cannot re-enter sync ``read_eval_log`` under trio.
+    """
+
+    async def main() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            eval_path = os.path.join(temp_dir, "test.eval")
+            db_dir = os.path.join(temp_dir, "bufferdb")
+            output_path = os.path.join(temp_dir, "test-recovered.eval")
+
+            flushed = [_make_sample(1), _make_sample(2)]
+            _write_crashed_eval(eval_path, samples=flushed)
+            _create_buffer_db(
+                eval_path, completed_ids=[3], in_progress_ids=[4], db_dir=db_dir
+            )
+
+            recoverable = await _recoverable_eval_logs_async(
+                log_dir=temp_dir, _db_dir=db_dir
+            )
+            assert len(recoverable) == 1
+            assert "test.eval" in recoverable[0].log.name
+
+            # No caller-provided AsyncFilesystem: recover must be self-contained.
+            log = await recover_eval_log_async(
+                eval_path, output=output_path, cleanup=False, _db_dir=db_dir
+            )
+            assert log.status == "error"
+            assert os.path.exists(output_path)
+            assert any(Path(db_dir).rglob("*.db"))
+
+            async with AsyncFilesystem():
+                reread = await read_eval_log_async(output_path)
+            assert reread.samples is not None
+            assert len(reread.samples) == 4
+
+    anyio.run(main, backend=backend)
+
+
+def test_recover_async_paths_under_trio_backend() -> None:
+    """Regression: async recovery paths must work under a trio backend.
+
+    Ordinary CI runs this sync harness via ``anyio.run(..., backend="trio")``
+    without needing ``--runtrio``. Sync ``recoverable_eval_logs()`` remains
+    out of scope here — it still raises under trio via ``run_coroutine()``.
+    """
+    _run_recover_async_paths("trio")
+
+
+def test_recover_async_paths_under_asyncio_backend() -> None:
+    """Asyncio parity for the same recovery/discovery body as the trio harness."""
+    _run_recover_async_paths("asyncio")
+
+
+def test_sync_recoverable_eval_logs_raises_under_trio() -> None:
+    """Document unchanged scope: sync discovery still Trio-prohibited."""
+    import warnings
+
+    async def main() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with warnings.catch_warnings():
+                # run_coroutine raises before awaiting the coroutine it was given.
+                warnings.simplefilter("ignore", RuntimeWarning)
+                with pytest.raises(RuntimeError, match="run_coroutine"):
+                    recoverable_eval_logs(log_dir=temp_dir)
+
+    anyio.run(main, backend="trio")
+
+
+async def test_list_eval_logs_filtered_missing_directory() -> None:
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+    missing = os.path.join(tempfile.gettempdir(), "inspect-missing-logs-dir-xyz")
+    assert not os.path.exists(missing)
+    result = await _list_eval_logs_filtered_async(missing, lambda _: True)
+    assert result == []
+
+
+async def test_list_eval_logs_filtered_canonical_filename() -> None:
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        name = "2024-01-15T10-30-00_mytask_abcd1234.eval"
+        path = os.path.join(temp_dir, name)
+        _write_crashed_eval(path)
+
+        logs = await _list_eval_logs_filtered_async(
+            temp_dir, lambda log: log.status == "started"
+        )
+        assert len(logs) == 1
+        assert name in logs[0].name
+        assert logs[0].task == "mytask"
+        assert logs[0].task_id == "abcd1234"
+
+
+async def test_list_eval_logs_filtered_noncanonical_header_fallback() -> None:
+    """Non-canonical ``test.eval`` forces async header metadata fallback."""
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        path = os.path.join(temp_dir, "test.eval")
+        _write_crashed_eval(path, task="fallback_task")
+
+        logs = await _list_eval_logs_filtered_async(
+            temp_dir, lambda log: log.status == "started"
+        )
+        assert len(logs) == 1
+        assert "test.eval" in logs[0].name
+        assert logs[0].task == "fallback_task"
+
+
+async def test_list_eval_logs_filtered_recursive_false() -> None:
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        nested = os.path.join(temp_dir, "nested")
+        os.makedirs(nested)
+        _write_crashed_eval(os.path.join(temp_dir, "top.eval"))
+        _write_crashed_eval(os.path.join(nested, "nested.eval"))
+
+        logs = await _list_eval_logs_filtered_async(
+            temp_dir, lambda log: log.status == "started", recursive=False
+        )
+        assert len(logs) == 1
+        assert "top.eval" in logs[0].name
+        assert "nested.eval" not in logs[0].name
+
+
+async def test_list_eval_logs_filtered_preserves_order() -> None:
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        older = os.path.join(temp_dir, "older.eval")
+        newer = os.path.join(temp_dir, "newer.eval")
+        _write_header_eval(older, task="older_task", status="started")
+        _write_header_eval(newer, task="newer_task", status="started")
+        os.utime(older, (1_700_000_000, 1_700_000_000))
+        os.utime(newer, (1_800_000_000, 1_800_000_000))
+
+        logs = await _list_eval_logs_filtered_async(
+            temp_dir, lambda log: log.status == "started"
+        )
+        assert [log.task for log in logs] == ["newer_task", "older_task"]
+
+
+async def test_list_eval_logs_filtered_predicate_subset() -> None:
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        _write_header_eval(
+            os.path.join(temp_dir, "ok.eval"), task="ok", status="success"
+        )
+        _write_header_eval(
+            os.path.join(temp_dir, "bad.eval"), task="bad", status="error"
+        )
+        _write_crashed_eval(os.path.join(temp_dir, "live.eval"), task="live")
+
+        success = await _list_eval_logs_filtered_async(
+            temp_dir, lambda log: log.status == "success"
+        )
+        assert len(success) == 1
+        assert "ok.eval" in success[0].name
+
+        none = await _list_eval_logs_filtered_async(
+            temp_dir, lambda log: log.status == "cancelled"
+        )
+        assert none == []
+
+
+async def test_list_eval_logs_filtered_listing_failure_propagates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import inspect_ai.log._recover._api as api
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+    boom_fs = MagicMock()
+    boom_fs.exists.return_value = True
+    boom_fs.ls.side_effect = OSError("listing failed")
+    monkeypatch.setattr(api, "filesystem", lambda _path: boom_fs)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with pytest.raises(OSError, match="listing failed"):
+            await _list_eval_logs_filtered_async(temp_dir, lambda _: True)
+
+
+def test_list_eval_logs_filtered_cancellation_propagates() -> None:
+    async def main() -> None:
+        import inspect_ai.log._recover._api as api
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+        real_run_sync = anyio.to_thread.run_sync
+
+        async def slow_run_sync(func, *args, **kwargs):  # type: ignore[no-untyped-def]
+            await anyio.sleep(60)
+            return await real_run_sync(func, *args, **kwargs)
+
+        original = api.anyio.to_thread.run_sync
+        api.anyio.to_thread.run_sync = slow_run_sync  # type: ignore[method-assign]
+        try:
+            with anyio.move_on_after(0.1) as scope:
+                await _list_eval_logs_filtered_async(
+                    tempfile.gettempdir(), lambda _: True
+                )
+            assert scope.cancel_called
+        finally:
+            api.anyio.to_thread.run_sync = original  # type: ignore[method-assign]
+
+    anyio.run(main)
+
+
+async def test_recover_eval_log_async_without_caller_async_filesystem() -> None:
+    """Public recover path must enter AsyncFilesystem itself when listing."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        eval_path = os.path.join(temp_dir, "test.eval")
+        db_dir = os.path.join(temp_dir, "bufferdb")
+        output_path = os.path.join(temp_dir, "test-recovered.eval")
+
+        _write_crashed_eval(eval_path, samples=[_make_sample(1)])
+        _create_buffer_db(
+            eval_path, completed_ids=[2], in_progress_ids=[], db_dir=db_dir
+        )
+
+        log = await recover_eval_log_async(
+            eval_path, output=output_path, cleanup=False, _db_dir=db_dir
+        )
+        assert log.status == "error"
+        assert os.path.exists(output_path)

--- a/tests/log/test_recover_api.py
+++ b/tests/log/test_recover_api.py
@@ -426,123 +426,184 @@ def test_sync_recoverable_eval_logs_raises_under_trio() -> None:
     anyio.run(main, backend="trio")
 
 
-async def test_list_eval_logs_filtered_missing_directory() -> None:
-    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
-
-    missing = os.path.join(tempfile.gettempdir(), "inspect-missing-logs-dir-xyz")
-    assert not os.path.exists(missing)
-    result = await _list_eval_logs_filtered_async(missing, lambda _: True)
-    assert result == []
+# ids must not contain "[trio" — conftest skips those unless --runtrio.
+_BACKENDS = [
+    pytest.param("asyncio", id="asyncio"),
+    pytest.param("trio", id="explicit_trio"),
+]
 
 
-async def test_list_eval_logs_filtered_canonical_filename() -> None:
-    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_missing_directory(backend: str) -> None:
+    async def main() -> None:
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        name = "2024-01-15T10-30-00_mytask_abcd1234.eval"
-        path = os.path.join(temp_dir, name)
-        _write_crashed_eval(path)
+        missing = os.path.join(tempfile.gettempdir(), "inspect-missing-logs-dir-xyz")
+        assert not os.path.exists(missing)
+        result = await _list_eval_logs_filtered_async(missing, lambda _: True)
+        assert result == []
 
-        logs = await _list_eval_logs_filtered_async(
-            temp_dir, lambda log: log.status == "started"
-        )
-        assert len(logs) == 1
-        assert name in logs[0].name
-        assert logs[0].task == "mytask"
-        assert logs[0].task_id == "abcd1234"
+    anyio.run(main, backend=backend)
 
 
-async def test_list_eval_logs_filtered_noncanonical_header_fallback() -> None:
-    """Non-canonical ``test.eval`` forces async header metadata fallback."""
-    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_canonical_filename(backend: str) -> None:
+    async def main() -> None:
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        path = os.path.join(temp_dir, "test.eval")
-        _write_crashed_eval(path, task="fallback_task")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            name = "2024-01-15T10-30-00_mytask_abcd1234.eval"
+            path = os.path.join(temp_dir, name)
+            _write_crashed_eval(path)
 
-        logs = await _list_eval_logs_filtered_async(
-            temp_dir, lambda log: log.status == "started"
-        )
-        assert len(logs) == 1
-        assert "test.eval" in logs[0].name
-        assert logs[0].task == "fallback_task"
+            logs = await _list_eval_logs_filtered_async(
+                temp_dir, lambda log: log.status == "started"
+            )
+            assert len(logs) == 1
+            assert name in logs[0].name
+            assert logs[0].task == "mytask"
+            assert logs[0].task_id == "abcd1234"
 
-
-async def test_list_eval_logs_filtered_recursive_false() -> None:
-    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
-
-    with tempfile.TemporaryDirectory() as temp_dir:
-        nested = os.path.join(temp_dir, "nested")
-        os.makedirs(nested)
-        _write_crashed_eval(os.path.join(temp_dir, "top.eval"))
-        _write_crashed_eval(os.path.join(nested, "nested.eval"))
-
-        logs = await _list_eval_logs_filtered_async(
-            temp_dir, lambda log: log.status == "started", recursive=False
-        )
-        assert len(logs) == 1
-        assert "top.eval" in logs[0].name
-        assert "nested.eval" not in logs[0].name
+    anyio.run(main, backend=backend)
 
 
-async def test_list_eval_logs_filtered_preserves_order() -> None:
-    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_noncanonical_header_fallback(backend: str) -> None:
+    """Non-canonical ``test.eval`` forces async header metadata fallback.
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        older = os.path.join(temp_dir, "older.eval")
-        newer = os.path.join(temp_dir, "newer.eval")
-        _write_header_eval(older, task="older_task", status="started")
-        _write_header_eval(newer, task="newer_task", status="started")
-        os.utime(older, (1_700_000_000, 1_700_000_000))
-        os.utime(newer, (1_800_000_000, 1_800_000_000))
+    Ordinary CI executes this under Trio via ``anyio.run`` (no ``--runtrio``).
+    Do not rename to a timestamped Inspect filename — that would skip the
+    header fallback this regression protects.
+    """
 
-        logs = await _list_eval_logs_filtered_async(
-            temp_dir, lambda log: log.status == "started"
-        )
-        assert [log.task for log in logs] == ["newer_task", "older_task"]
+    async def main() -> None:
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
 
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = os.path.join(temp_dir, "test.eval")
+            _write_crashed_eval(path, task="fallback_task")
 
-async def test_list_eval_logs_filtered_predicate_subset() -> None:
-    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+            logs = await _list_eval_logs_filtered_async(
+                temp_dir, lambda log: log.status == "started"
+            )
+            assert len(logs) == 1
+            assert "test.eval" in logs[0].name
+            assert logs[0].task == "fallback_task"
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        _write_header_eval(
-            os.path.join(temp_dir, "ok.eval"), task="ok", status="success"
-        )
-        _write_header_eval(
-            os.path.join(temp_dir, "bad.eval"), task="bad", status="error"
-        )
-        _write_crashed_eval(os.path.join(temp_dir, "live.eval"), task="live")
-
-        success = await _list_eval_logs_filtered_async(
-            temp_dir, lambda log: log.status == "success"
-        )
-        assert len(success) == 1
-        assert "ok.eval" in success[0].name
-
-        none = await _list_eval_logs_filtered_async(
-            temp_dir, lambda log: log.status == "cancelled"
-        )
-        assert none == []
+    anyio.run(main, backend=backend)
 
 
-async def test_list_eval_logs_filtered_listing_failure_propagates(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    import inspect_ai.log._recover._api as api
-    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_recursive_false(backend: str) -> None:
+    async def main() -> None:
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
 
-    boom_fs = MagicMock()
-    boom_fs.exists.return_value = True
-    boom_fs.ls.side_effect = OSError("listing failed")
-    monkeypatch.setattr(api, "filesystem", lambda _path: boom_fs)
+        with tempfile.TemporaryDirectory() as temp_dir:
+            nested = os.path.join(temp_dir, "nested")
+            os.makedirs(nested)
+            _write_crashed_eval(os.path.join(temp_dir, "top.eval"))
+            _write_crashed_eval(os.path.join(nested, "nested.eval"))
 
-    with tempfile.TemporaryDirectory() as temp_dir:
-        with pytest.raises(OSError, match="listing failed"):
-            await _list_eval_logs_filtered_async(temp_dir, lambda _: True)
+            logs = await _list_eval_logs_filtered_async(
+                temp_dir, lambda log: log.status == "started", recursive=False
+            )
+            assert len(logs) == 1
+            assert "top.eval" in logs[0].name
+            assert "nested.eval" not in logs[0].name
+
+    anyio.run(main, backend=backend)
 
 
-def test_list_eval_logs_filtered_cancellation_propagates() -> None:
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_preserves_order(backend: str) -> None:
+    async def main() -> None:
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            older = os.path.join(temp_dir, "older.eval")
+            newer = os.path.join(temp_dir, "newer.eval")
+            _write_header_eval(older, task="older_task", status="started")
+            _write_header_eval(newer, task="newer_task", status="started")
+            os.utime(older, (1_700_000_000, 1_700_000_000))
+            os.utime(newer, (1_800_000_000, 1_800_000_000))
+
+            logs = await _list_eval_logs_filtered_async(
+                temp_dir, lambda log: log.status == "started"
+            )
+            assert [log.task for log in logs] == ["newer_task", "older_task"]
+
+    anyio.run(main, backend=backend)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_predicate_subset(backend: str) -> None:
+    async def main() -> None:
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            _write_header_eval(
+                os.path.join(temp_dir, "ok.eval"), task="ok", status="success"
+            )
+            _write_header_eval(
+                os.path.join(temp_dir, "bad.eval"), task="bad", status="error"
+            )
+            _write_crashed_eval(os.path.join(temp_dir, "live.eval"), task="live")
+
+            success = await _list_eval_logs_filtered_async(
+                temp_dir, lambda log: log.status == "success"
+            )
+            assert len(success) == 1
+            assert "ok.eval" in success[0].name
+
+            none = await _list_eval_logs_filtered_async(
+                temp_dir, lambda log: log.status == "cancelled"
+            )
+            assert none == []
+
+    anyio.run(main, backend=backend)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_listing_failure_propagates(backend: str) -> None:
+    async def main() -> None:
+        import inspect_ai.log._recover._api as api
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+        boom_fs = MagicMock()
+        boom_fs.exists.return_value = True
+        boom_fs.ls.side_effect = OSError("listing failed")
+        original = api.filesystem
+        api.filesystem = lambda _path: boom_fs  # type: ignore[assignment]
+        try:
+            with tempfile.TemporaryDirectory() as temp_dir:
+                with pytest.raises(OSError, match="listing failed"):
+                    await _list_eval_logs_filtered_async(temp_dir, lambda _: True)
+        finally:
+            api.filesystem = original
+
+    anyio.run(main, backend=backend)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_malformed_header_propagates(backend: str) -> None:
+    """Corrupt ``.eval`` bytes must not be swallowed into an empty result."""
+
+    async def main() -> None:
+        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            bad = os.path.join(temp_dir, "corrupt.eval")
+            with open(bad, "wb") as f:
+                f.write(b"not-a-zip-or-eval-log")
+
+            with pytest.raises(Exception):
+                await _list_eval_logs_filtered_async(temp_dir, lambda _: True)
+
+    anyio.run(main, backend=backend)
+
+
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_list_eval_logs_filtered_cancellation_propagates(backend: str) -> None:
     async def main() -> None:
         import inspect_ai.log._recover._api as api
         from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
@@ -564,23 +625,28 @@ def test_list_eval_logs_filtered_cancellation_propagates() -> None:
         finally:
             api.anyio.to_thread.run_sync = original  # type: ignore[method-assign]
 
-    anyio.run(main)
+    anyio.run(main, backend=backend)
 
 
-async def test_recover_eval_log_async_without_caller_async_filesystem() -> None:
+@pytest.mark.parametrize("backend", _BACKENDS)
+def test_recover_eval_log_async_without_caller_async_filesystem(backend: str) -> None:
     """Public recover path must enter AsyncFilesystem itself when listing."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        eval_path = os.path.join(temp_dir, "test.eval")
-        db_dir = os.path.join(temp_dir, "bufferdb")
-        output_path = os.path.join(temp_dir, "test-recovered.eval")
 
-        _write_crashed_eval(eval_path, samples=[_make_sample(1)])
-        _create_buffer_db(
-            eval_path, completed_ids=[2], in_progress_ids=[], db_dir=db_dir
-        )
+    async def main() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            eval_path = os.path.join(temp_dir, "test.eval")
+            db_dir = os.path.join(temp_dir, "bufferdb")
+            output_path = os.path.join(temp_dir, "test-recovered.eval")
 
-        log = await recover_eval_log_async(
-            eval_path, output=output_path, cleanup=False, _db_dir=db_dir
-        )
-        assert log.status == "error"
-        assert os.path.exists(output_path)
+            _write_crashed_eval(eval_path, samples=[_make_sample(1)])
+            _create_buffer_db(
+                eval_path, completed_ids=[2], in_progress_ids=[], db_dir=db_dir
+            )
+
+            log = await recover_eval_log_async(
+                eval_path, output=output_path, cleanup=False, _db_dir=db_dir
+            )
+            assert log.status == "error"
+            assert os.path.exists(output_path)
+
+    anyio.run(main, backend=backend)

--- a/tests/log/test_recover_api.py
+++ b/tests/log/test_recover_api.py
@@ -434,13 +434,15 @@ _BACKENDS = [
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
-def test_list_eval_logs_filtered_missing_directory(backend: str) -> None:
+def test_list_eval_logs_filtered_missing_directory(
+    backend: str, tmp_path: Path
+) -> None:
     async def main() -> None:
         from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
 
-        missing = os.path.join(tempfile.gettempdir(), "inspect-missing-logs-dir-xyz")
-        assert not os.path.exists(missing)
-        result = await _list_eval_logs_filtered_async(missing, lambda _: True)
+        missing = tmp_path / "missing"
+        assert not missing.exists()
+        result = await _list_eval_logs_filtered_async(str(missing), lambda _: True)
         assert result == []
 
     anyio.run(main, backend=backend)
@@ -564,29 +566,32 @@ def test_list_eval_logs_filtered_predicate_subset(backend: str) -> None:
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
-def test_list_eval_logs_filtered_listing_failure_propagates(backend: str) -> None:
-    async def main() -> None:
-        import inspect_ai.log._recover._api as api
-        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
+def test_list_eval_logs_filtered_listing_failure_propagates(
+    backend: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import inspect_ai.log._recover._api as api
+    from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
 
-        boom_fs = MagicMock()
-        boom_fs.exists.return_value = True
-        boom_fs.ls.side_effect = OSError("listing failed")
-        original = api.filesystem
-        api.filesystem = lambda _path: boom_fs  # type: ignore[assignment]
-        try:
-            with tempfile.TemporaryDirectory() as temp_dir:
-                with pytest.raises(OSError, match="listing failed"):
-                    await _list_eval_logs_filtered_async(temp_dir, lambda _: True)
-        finally:
-            api.filesystem = original
+    boom_fs = MagicMock()
+    boom_fs.exists.return_value = True
+    boom_fs.ls.side_effect = OSError("listing failed")
+    monkeypatch.setattr(api, "filesystem", lambda _path: boom_fs)
+
+    async def main() -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with pytest.raises(OSError, match="listing failed"):
+                await _list_eval_logs_filtered_async(temp_dir, lambda _: True)
 
     anyio.run(main, backend=backend)
 
 
 @pytest.mark.parametrize("backend", _BACKENDS)
 def test_list_eval_logs_filtered_malformed_header_propagates(backend: str) -> None:
-    """Corrupt ``.eval`` bytes must not be swallowed into an empty result."""
+    """Corrupt ``.eval`` bytes must not be swallowed into an empty result.
+
+    Async zip reads raise ``ValueError('EOCD not found')`` for non-zip bytes
+    (not ``zipfile.BadZipFile``, which is the sync ``ZipFile`` path).
+    """
 
     async def main() -> None:
         from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
@@ -596,34 +601,8 @@ def test_list_eval_logs_filtered_malformed_header_propagates(backend: str) -> No
             with open(bad, "wb") as f:
                 f.write(b"not-a-zip-or-eval-log")
 
-            with pytest.raises(Exception):
+            with pytest.raises(ValueError, match="EOCD not found"):
                 await _list_eval_logs_filtered_async(temp_dir, lambda _: True)
-
-    anyio.run(main, backend=backend)
-
-
-@pytest.mark.parametrize("backend", _BACKENDS)
-def test_list_eval_logs_filtered_cancellation_propagates(backend: str) -> None:
-    async def main() -> None:
-        import inspect_ai.log._recover._api as api
-        from inspect_ai.log._recover._api import _list_eval_logs_filtered_async
-
-        real_run_sync = anyio.to_thread.run_sync
-
-        async def slow_run_sync(func, *args, **kwargs):  # type: ignore[no-untyped-def]
-            await anyio.sleep(60)
-            return await real_run_sync(func, *args, **kwargs)
-
-        original = api.anyio.to_thread.run_sync
-        api.anyio.to_thread.run_sync = slow_run_sync  # type: ignore[method-assign]
-        try:
-            with anyio.move_on_after(0.1) as scope:
-                await _list_eval_logs_filtered_async(
-                    tempfile.gettempdir(), lambda _: True
-                )
-            assert scope.cancel_called
-        finally:
-            api.anyio.to_thread.run_sync = original  # type: ignore[method-assign]
 
     anyio.run(main, backend=backend)
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Under a Trio async backend, 
ecover_eval_log_async() and _recoverable_eval_logs_async() list logs via sync list_eval_logs(..., filter=...). That path reaches sync 
ead_eval_log() (directly in the filter, and also via log_files_from_ls → _try_read_header for non-canonical names such as 	est.eval). Sync 
ead_eval_log() raises:


ead_eval_log cannot be called from a trio async context

Note: _try_read_header catches Exception and returns (None, None, None), so a Trio raise on the metadata fallback can be **swallowed**; the filter path still raises. Sync 
ecoverable_eval_logs() remains Trio-prohibited through 
un_coroutine() (unchanged scope).

Related to #4622. Supersedes the approach in #4625.

### What is the new behavior?

- **Fixed:** 
ecover_eval_log_async() and _recoverable_eval_logs_async() use a private recovery helper _list_eval_logs_filtered_async that:
  - offloads sync directory exists/ls via nyio.to_thread.run_sync
  - resolves metadata with log_files_from_ls_async (never sync log_files_from_ls / log_file_info)
  - filters with 
ead_eval_log_headers_async + ordered zip (length parity guarded)
  - enters AsyncFilesystem itself so the public recover path is self-contained
- **Unchanged:** sync 
ecoverable_eval_logs() still uses 
un_coroutine() and remains Trio-prohibited
- **No new public symbol:** does **not** add/export list_eval_logs_async from inspect_ai.log
- **Regression:** sync pytest harness 	est_recover_async_paths_under_trio_backend runs nyio.run(..., backend="trio") in ordinary CI (no --runtrio); keeps non-canonical 	est.eval to force header fallback. Helper coverage uses id="explicit_trio" so conftest does not skip Trio runs.

### Evidence (rebased final SHA 46251d02fb6f99c66edebe5746ad1e7ca8c1ebd)

Rebased onto origin/main tip 23df9d3e6246b977d3d6e8a4d030d26f79a89f2d. Evidence regenerated against this head only (not a historical merge base).

| Gate | SHA / setup | Exit |
|------|-------------|------|
| Base-red (origin/main sources + tests-only overlay via PYTHONPATH) | 23df9d3e6… + overlay 	ests/log/test_recover_api.py | **1** — RuntimeError: read_eval_log cannot be called from a trio async context at sync list_eval_logs → 
ead_eval_log |
| Head-green (Trio regression) | 46251d02… | **0** (1 passed) |
| Full 	ests/log/test_recover_api.py | 46251d02… | **0** (**28 passed**, 5 skipped [trio] variants without --runtrio) |
| 
uff check / 
uff format --check / focused mypy on _api.py | 46251d02… | **0** |

Local logs + SHA-256 digests: evidence/pr-4634/ (ase-red.log, head-green.log, suite-final.log, SHA256SUMS.txt) — untracked.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. No new public listing API; sync recovery wrappers unchanged.

### Other information:

**Residual risk:** sync wrappers stay Trio-prohibited; there is still no repo-wide Trio CI matrix; remote fsspec listing via 	o_thread was not redesigned (local listing only offloaded as specified); worker-thread cancellation under bandon_on_cancel=False is left to AnyIO defaults and is not asserted in this suite.

**CI note:** raware is pull-only on upstream workflows — first-time/fork runs typically need maintainer approval (ction_required). Do not treat absence of green checks as proof of failure or success until workflows are approved and complete.

Review against the final head SHA only.
