### PR TITLE
Replace retired openai/gpt-5.1-codex with gpt-5.3-codex in live tests

### DIFF
--- a/tests/model/test_compaction_auto.py
+++ b/tests/model/test_compaction_auto.py
@@ -176,7 +176,7 @@ async def test_auto_warns_on_native_error(
 async def test_auto_uses_native_when_supported() -> None:
     """CompactionAuto uses native compaction when the provider supports it."""
     strategy = CompactionAuto()
-    model = get_model("openai/gpt-5.1-codex")
+    model = get_model("openai/gpt-5.3-codex")
     messages = _sample_messages()
 
     result, summary = await strategy.compact(model, messages, [])

--- a/tests/model/test_compaction_native.py
+++ b/tests/model/test_compaction_native.py
@@ -130,7 +130,7 @@ async def test_native_not_implemented_error_survives_count_tokens_failure(
 async def test_native_compaction_with_supported_model() -> None:
     """CompactionNative succeeds with a provider that supports native compaction."""
     strategy = CompactionNative()
-    model = get_model("openai/gpt-5.1-codex")
+    model = get_model("openai/gpt-5.3-codex")
     messages = _sample_messages()
 
     result, summary = await strategy.compact(model, messages, [])

--- a/tests/tools/test_skill.py
+++ b/tests/tools/test_skill.py
@@ -523,7 +523,7 @@ def test_skill_end_to_end() -> None:
 
     result = eval(
         task,
-        model="openai/gpt-5.1-codex",
+        model="openai/gpt-5.3-codex",
     )[0]
 
     assert result.status == "success", f"Eval failed with status: {result.status}"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/actions#71

OpenAI retired `gpt-5.1-codex` — every request against it returns 404 `model_not_found` ("has been deprecated"). Three live tests hardcode `openai/gpt-5.1-codex` and fail:

- `tests/model/test_compaction_native.py::test_native_compaction_with_supported_model`
- `tests/model/test_compaction_auto.py::test_auto_uses_native_when_supported`
- `tests/tools/test_skill.py::test_skill_end_to_end`

### What is the new behavior?

The three call sites now use `openai/gpt-5.3-codex`. The triage issue originally proposed `gpt-5.2-codex`, but that model has since been retired too (same 404 `model_not_found` on a live request), so this bumps to `gpt-5.3-codex`, verified live with the same API key.

All three tests pass locally:
- both compaction tests with `--runapi`
- `test_skill_end_to_end` with `--runslow --runapi` (Docker; accuracy 1.000)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Test-only change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
