### PR TITLE
Agent bridge: anchor descent on condensed attachment references (opencode answer capture)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@
 - Anthropic: Support enabling model-generated citations for provided `ContentDocument` inputs.
 - Agent Bridge: Support Anthropic clients that consume responses via `with_raw_response`, which previously failed with `'Message' object has no attribute 'parse'`.
 - Agent Bridge: Side model calls (e.g. opencode's session title generation) can no longer replace the agent's real conversation in the tracked agent state. (meridianlabs-ai/inspect_ai#140)
-- Agent Bridge: Task prompts that cross the bridge as condensed `attachment://` references still anchor the tracked conversation, so a side call can no longer displace the real answer. (meridianlabs-ai/inspect_ai#140)
 - Agent Bridge: Gemini tool results delivered as `functionResponse` parts in model-role turns are now converted to tool messages instead of dropped (fixes 400 "Requests ending with a model turn are not supported").
 - Agent Bridge: Google streaming requests targeting an inspect model now raise the intended streaming-unsupported error instead of being sent to the real Google API.
 - Sandbox: `Sandbox.exec` failure errors now include stdout as a fallback when stderr is empty, so commands that report diagnostics on stdout still produce a useful error message.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Anthropic: Support for Claude Opus 5 (released 2026-07-24), including model info, computer use, code execution, and disabling thinking via `reasoning_effort="none"`.
 - Agent Bridge: Support Anthropic clients that consume responses via `with_raw_response`, which previously failed with `'Message' object has no attribute 'parse'`.
 - Agent Bridge: Side model calls (e.g. opencode's session title generation) can no longer replace the agent's real conversation in the tracked agent state. (meridianlabs-ai/inspect_ai#140)
+- Agent Bridge: Task prompts that cross the bridge as condensed `attachment://` references still anchor the tracked conversation, so a side call can no longer displace the real answer. (meridianlabs-ai/inspect_ai#140)
 - Agent Bridge: Gemini tool results delivered as `functionResponse` parts in model-role turns are now converted to tool messages instead of dropped (fixes 400 "Requests ending with a model turn are not supported").
 - Agent Bridge: Google streaming requests targeting an inspect model now raise the intended streaming-unsupported error instead of being sent to the real Google API.
 - Sandbox: `Sandbox.exec` failure errors now include stdout as a fallback when stderr is empty, so commands that report diagnostics on stdout still produce a useful error message.

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -6,6 +6,7 @@ from shortuuid import uuid
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai.agent._agent import AgentState
+from inspect_ai.log._condense import ATTACHMENT_PROTOCOL
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
 from inspect_ai.model._compaction import (
     Compact,
@@ -91,6 +92,9 @@ class AgentBridge:
             _message_fingerprint(m)
             for m in self._compaction_prefix
             if m.role != "system"
+        ]
+        self._initial_fps_condensed = [
+            _condensed_fingerprint(fp) for fp in self._initial_fps
         ]
         self._tracked_fps: list[_MessageFingerprint] | None = None
         self._tracked_calls = 0
@@ -225,7 +229,9 @@ class AgentBridge:
           are a prefix of it, compared by role + text) always updates the state.
         - Otherwise the call starts a new thread and we consult *descent*: a
           thread descends from the initial input if its non-system messages
-          start with the initial input's non-system messages. A descending
+          start with the initial input's non-system messages (verbatim or as
+          their condensed ``attachment://<hash>`` references — see
+          `_descends_from_initial`). A descending
           thread displaces a tracked non-descending thread when that thread is
           a one-shot call (the opencode title case) or when the descending
           call is longer than the tracked thread (the main loop reclaiming
@@ -320,6 +326,14 @@ class AgentBridge:
     def _descends_from_initial(self, fps: list["_MessageFingerprint"]) -> bool | None:
         """Whether a thread's non-system messages start with the initial input.
 
+        Each initial message matches either verbatim or as its condensed
+        `attachment://<hash>` reference: a long prompt that rides into the
+        scaffold via inspect's transcript condensation crosses the bridge as
+        the placeholder rather than the original text (observed with opencode,
+        whose conversation store round-trips it), and the main loop must still
+        anchor. Only the exact reference to the initial content matches — an
+        attachment reference to other content is not a wildcard.
+
         Returns `None` when there is no initial input to anchor on (descent
         can't discriminate threads, so `_track_state` falls back to the legacy
         length heuristic).
@@ -327,7 +341,14 @@ class AgentBridge:
         if not self._initial_fps:
             return None
         non_system = [fp for fp in fps if fp.role != "system"]
-        return non_system[: len(self._initial_fps)] == self._initial_fps
+        if len(non_system) < len(self._initial_fps):
+            return False
+        return all(
+            fp == initial or fp == condensed
+            for fp, initial, condensed in zip(
+                non_system, self._initial_fps, self._initial_fps_condensed
+            )
+        )
 
 
 @lru_cache(maxsize=100)
@@ -349,6 +370,19 @@ class _MessageFingerprint(NamedTuple):
 
 def _message_fingerprint(message: ChatMessage) -> _MessageFingerprint:
     return _MessageFingerprint(role=message.role, text_hash=mm3_hash(message.text))
+
+
+def _condensed_fingerprint(fp: _MessageFingerprint) -> _MessageFingerprint:
+    """Fingerprint of the same message condensed to an attachment reference.
+
+    Transcript condensation replaces long text with
+    ``attachment://<mm3-hash-of-text>`` (see `inspect_ai.log._condense`);
+    since the attachment id is the same mm3 hash a fingerprint stores, the
+    condensed form is computable from the fingerprint alone.
+    """
+    return _MessageFingerprint(
+        role=fp.role, text_hash=mm3_hash(f"{ATTACHMENT_PROTOCOL}{fp.text_hash}")
+    )
 
 
 def _extends(prefix: list[_MessageFingerprint], fps: list[_MessageFingerprint]) -> bool:

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -7,15 +7,27 @@ as the agent state. See meridianlabs-ai/inspect_ai#140 for the failure
 mode where a longer side call permanently displaced the real conversation.
 """
 
+from typing import Any
+
+from test_helpers.checkpoint import RecordingCheckpointer
+
 from inspect_ai.agent._agent import AgentState
+from inspect_ai.agent._bridge.anthropic_api import inspect_anthropic_api_request
+from inspect_ai.agent._bridge.completions import inspect_completions_api_request
 from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.util import (
+    default_code_execution_providers,
+    internal_web_search_providers,
+)
 from inspect_ai.model._chat_message import (
     ChatMessage,
+    ChatMessageAssistant,
     ChatMessageSystem,
     ChatMessageTool,
     ChatMessageUser,
 )
-from inspect_ai.model._model_output import ModelOutput
+from inspect_ai.model._model import Model, get_model
+from inspect_ai.model._model_output import ModelOutput, ModelUsage
 
 TASK = "In the year 2022, what castle did the Doctor spend 4.5 billion years in?"
 
@@ -351,3 +363,477 @@ async def test_single_final_call_reclaims_main_thread_after_sub_agent_loop() -> 
 
     assert bridge.state.output.completion == "Castle"
     assert len(bridge.state.messages) == len(turn4) + 1
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint robustness
+# ---------------------------------------------------------------------------
+
+
+async def test_extension_recognized_despite_new_ids_and_metadata() -> None:
+    """Thread continuity must survive the scaffold's conversation store.
+
+    Messages round-trip through the scaffold's own store between calls, so
+    successive requests carry freshly-constructed message objects: new ids,
+    different metadata. Only role + text are stable, and extension detection
+    must key on exactly that.
+    """
+    bridge = task_bridge()
+
+    turn1: list[ChatMessage] = [
+        ChatMessageSystem(content="You are opencode, an agent that ...", id="sys-1"),
+        ChatMessageUser(content=TASK, id="user-1", metadata={"turn": 1}),
+    ]
+    out1 = await track(bridge, turn1, "working")
+
+    # the scaffold re-creates every message: different ids and metadata, and
+    # the assistant echo is rebuilt from text rather than reusing out1.message
+    turn2: list[ChatMessage] = [
+        ChatMessageSystem(content="You are opencode, an agent that ...", id="sys-2"),
+        ChatMessageUser(content=TASK, id="user-2", metadata={"turn": 2}),
+        ChatMessageAssistant(content=out1.message.text, metadata={"replayed": True}),
+        ChatMessageTool(content="tool result"),
+    ]
+    await track(bridge, turn2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn2) + 1
+
+
+# ---------------------------------------------------------------------------
+# Descent anchoring on the initial input
+# ---------------------------------------------------------------------------
+
+
+async def test_descent_anchor_ignores_system_prompt_replacement() -> None:
+    """Descent anchors on the initial input's non-system messages.
+
+    An agent state that starts with its own system prompt still anchors
+    descent on the user input: the scaffold substitutes its own system prompt,
+    and the task thread must still displace an earlier title call.
+    """
+    bridge = AgentBridge(
+        AgentState(
+            messages=[
+                ChatMessageSystem(content="You are a helpful assistant."),
+                ChatMessageUser(content=TASK),
+            ]
+        )
+    )
+
+    await track(bridge, title_generation_input(), "Doctor Who Series 9 setting")
+
+    # scaffold runs the task under its own (different) system prompt
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert [m.text for m in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        TASK,
+        "Castle",
+    ]
+
+
+async def test_multi_message_initial_input_anchors_descent() -> None:
+    """A multi-message input anchors descent on all of its non-system messages."""
+    part1 = "Here is a data file to analyze:"
+    part2 = "col_a,col_b\n1,2\n3,4"
+    bridge = AgentBridge(
+        AgentState(
+            messages=[ChatMessageUser(content=part1), ChatMessageUser(content=part2)]
+        )
+    )
+
+    # title call re-sends only the first input message (plus its preamble)
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a title generator ..."),
+            ChatMessageUser(content="Generate a title for this conversation:\n"),
+            ChatMessageUser(content=part1),
+        ],
+        "CSV analysis session",
+    )
+
+    # the real task call carries both input messages
+    await track(
+        bridge,
+        [
+            TASK_SYSTEM,
+            ChatMessageUser(content=part1),
+            ChatMessageUser(content=part2),
+        ],
+        "The columns sum to 4 and 6.",
+    )
+
+    assert bridge.state.output.completion == "The columns sum to 4 and 6."
+    assert len(bridge.state.messages) == 4
+
+
+async def test_system_only_initial_input_uses_legacy_fallback() -> None:
+    # an initial input with no non-system messages provides no descent anchor;
+    # accumulation and side-call rejection must still work via the legacy path
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageSystem(content="You are a helpful agent.")])
+    )
+
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    await track(bridge, turn2, "Castle")
+    assert bridge.state.output.completion == "Castle"
+
+    await track(bridge, [ChatMessageUser(content="side call")], "side answer")
+    assert bridge.state.output.completion == "Castle"
+
+
+# ---------------------------------------------------------------------------
+# Side-call interleaving
+# ---------------------------------------------------------------------------
+
+
+async def test_longer_side_call_between_main_loop_turns_is_ignored() -> None:
+    """A longer side call landing mid-loop must not derail the main thread.
+
+    Under the previous length heuristic the side call both displaced the
+    state *and* raised the bar above the main loop's next turn, so tracking
+    never recovered. The main loop's next turn extends the tracked thread and
+    must win regardless of the intervening call's length.
+    """
+    bridge = task_bridge()
+
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+
+    # longer side call lands between main-loop turns
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a title generator ..."),
+            ChatMessageUser(content="Generate a title for this conversation:\n"),
+            ChatMessageUser(content=TASK),
+            ChatMessageUser(content="Respond with the title only."),
+            ChatMessageUser(content="Do not use quotes."),
+        ],
+        "Doctor Who Series 9 setting",
+    )
+    assert bridge.state.output.completion == "working"
+
+    # main loop resumes (same length as the side call's total, still wins)
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    await track(bridge, turn2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn2) + 1
+
+
+async def test_repeated_title_calls_then_task_call_wins() -> None:
+    # a retried title-generation call must not establish itself as a
+    # multi-call thread that the task call can no longer displace
+    bridge = task_bridge()
+
+    await track(bridge, title_generation_input(), "Doctor Who Series 9 setting")
+    await track(bridge, title_generation_input(), "Doctor Who Series 9")
+
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == 3
+
+
+async def test_multiple_distinct_side_calls_then_task_call_wins() -> None:
+    bridge = task_bridge()
+
+    await track(bridge, title_generation_input(), "Doctor Who Series 9 setting")
+    await track(
+        bridge,
+        [ChatMessageUser(content="Detect the paths in this bash command: ls /tmp")],
+        "/tmp",
+    )
+
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == 3
+
+
+async def test_title_call_then_multi_turn_main_loop() -> None:
+    """After displacing the title call, the main loop keeps extending."""
+    bridge = task_bridge()
+
+    await track(bridge, title_generation_input(), "Doctor Who Series 9 setting")
+
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    assert bridge.state.output.completion == "working"
+
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    out2 = await track(bridge, turn2, "more work")
+    assert bridge.state.output.completion == "more work"
+
+    turn3 = turn2 + [out2.message, ChatMessageTool(content="tool result 2")]
+    await track(bridge, turn3, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn3) + 1
+
+
+# ---------------------------------------------------------------------------
+# Scaffolds that rewrite the input prompt (no fingerprint/descent continuity)
+# ---------------------------------------------------------------------------
+
+
+def rewritten_task(call: int | None = None) -> ChatMessageUser:
+    """The task message as rewritten by the scaffold.
+
+    Mirrors e.g. claude code's system-reminder injection; `call` varies the
+    text per call.
+    """
+    reminder = f"<system-reminder>call {call}</system-reminder>" if call else ""
+    return ChatMessageUser(content=f"{TASK}\n{reminder}")
+
+
+async def test_rewriting_scaffold_tracks_via_legacy_heuristic() -> None:
+    """A scaffold that rewrites the prompt *every call* still tracks its loop.
+
+    Per-call rewriting breaks both fingerprint continuity (no extension) and
+    descent (never anchored), so tracking runs entirely on the legacy
+    previous-call length comparison — which must keep working.
+    """
+    bridge = task_bridge()
+
+    call1: list[ChatMessage] = [TASK_SYSTEM, rewritten_task(1)]
+    out1 = await track(bridge, call1, "working")
+    assert bridge.state.output.completion == "working"
+
+    call2: list[ChatMessage] = [
+        TASK_SYSTEM,
+        rewritten_task(2),
+        ChatMessageAssistant(content=out1.message.text),
+        ChatMessageTool(content="tool result"),
+    ]
+    out2 = await track(bridge, call2, "more work")
+    assert bridge.state.output.completion == "more work"
+
+    # shorter side call ignored
+    await track(bridge, [ChatMessageUser(content="side call")], "side answer")
+    assert bridge.state.output.completion == "more work"
+
+    call3: list[ChatMessage] = [
+        TASK_SYSTEM,
+        rewritten_task(3),
+        ChatMessageAssistant(content=out1.message.text),
+        ChatMessageTool(content="tool result"),
+        ChatMessageAssistant(content=out2.message.text),
+        ChatMessageTool(content="tool result 2"),
+    ]
+    await track(bridge, call3, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(call3) + 1
+
+
+async def test_rewriting_scaffold_recovers_from_compaction() -> None:
+    """A stably-rewritten (non-descending) loop still recovers from compaction."""
+    bridge = task_bridge()
+
+    # loop with a stable rewritten prompt: extension works, descent never does
+    turn1: list[ChatMessage] = [TASK_SYSTEM, rewritten_task()]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    out2 = await track(bridge, turn2, "more work")
+    turn3 = turn2 + [out2.message, ChatMessageTool(content="tool result 2")]
+    await track(bridge, turn3, "even more work")
+
+    # compaction replaces the history with a summary; the new loop neither
+    # extends the tracked thread nor descends, so it recovers via candidate
+    # promotion when its next call extends it
+    compact1: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content="Summary of the conversation so far: ..."),
+    ]
+    cout1 = await track(bridge, compact1, "compacted work")
+    compact2 = compact1 + [cout1.message, ChatMessageTool(content="tool result 3")]
+    await track(bridge, compact2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(compact2) + 1
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint resume
+# ---------------------------------------------------------------------------
+
+
+async def test_resume_anchors_descent_on_original_input() -> None:
+    """On checkpoint resume, descent anchors on the *original* input.
+
+    A resumed agent state carries the full restored conversation, but the
+    checkpointer restores the compaction prefix to the original input, and the
+    descent anchor must come from that prefix. If it were (wrongly) derived
+    from the resumed state's messages, neither the replayed task call nor the
+    title call would descend and the longer title call would win.
+    """
+    original_input: list[ChatMessage] = [ChatMessageUser(content=TASK)]
+    restored_conversation: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content=TASK),
+        ChatMessageAssistant(content="working"),
+        ChatMessageTool(content="tool result"),
+        ChatMessageAssistant(content="prior answer"),
+    ]
+    cp = RecordingCheckpointer(
+        restored={"bridge_compaction_prefix": original_input.copy()}
+    )
+    bridge = AgentBridge(
+        AgentState(messages=restored_conversation.copy()), checkpointer=cp
+    )
+
+    # the scaffold restarts: title call fires first again
+    await track(bridge, title_generation_input(), "Doctor Who Series 9 setting")
+
+    # replayed one-shot task call must win
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == 3
+
+
+# ---------------------------------------------------------------------------
+# End-to-end through the real request handlers
+# ---------------------------------------------------------------------------
+
+BRIDGE_MODEL = "claude-opus-4"
+
+
+def scenario_model(completions: list[str]) -> Model:
+    def output(completion: str) -> ModelOutput:
+        out = ModelOutput.from_content("mockllm/model", completion)
+        # pre-set usage so mockllm skips its count_tokens estimate (which
+        # downloads a tiktoken encoding, requiring network access)
+        out.usage = ModelUsage(
+            input_tokens=1, output_tokens=len(completion), total_tokens=1
+        )
+        return out
+
+    return get_model(
+        "mockllm/model",
+        memoize=False,
+        custom_outputs=[output(completion) for completion in completions],
+    )
+
+
+async def test_completions_handler_tracks_main_thread_end_to_end() -> None:
+    """The opencode scenario through the real OpenAI completions handler.
+
+    Exercises message conversion, system-prompt handling and message-id
+    assignment together with `_track_state`: `apply_message_ids` gives every
+    request fresh ids, so thread continuity must survive the full request
+    path, not just hand-constructed messages.
+    """
+    model = scenario_model(
+        ["Doctor Who Series 9 setting", "let me look into that", "Castle"]
+    )
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: model},
+    )
+
+    async def request(messages: list[dict[str, str]]) -> str:
+        completion = await inspect_completions_api_request(
+            {"model": BRIDGE_MODEL, "messages": messages}, None, bridge
+        )
+        return completion.choices[0].message.content or ""
+
+    # opencode's title-generation call lands first
+    await request(
+        [
+            {"role": "system", "content": "You are a title generator ..."},
+            {"role": "user", "content": "Generate a title for this conversation:\n"},
+            {"role": "user", "content": TASK},
+        ]
+    )
+
+    # main loop: turn 1
+    main = [
+        {"role": "system", "content": "You are opencode, an agent that ..."},
+        {"role": "user", "content": TASK},
+    ]
+    reply = await request(main)
+    assert reply == "let me look into that"
+    assert bridge.state.output.completion == "let me look into that"
+
+    # main loop: turn 2 (scaffold round-trips through its own store)
+    main = main + [
+        {"role": "assistant", "content": reply},
+        {"role": "user", "content": "please continue"},
+    ]
+    await request(main)
+
+    assert bridge.state.output.completion == "Castle"
+    assert [m.text for m in bridge.state.messages] == [
+        "You are opencode, an agent that ...",
+        TASK,
+        "let me look into that",
+        "please continue",
+        "Castle",
+    ]
+
+
+async def test_anthropic_handler_tracks_main_thread_end_to_end() -> None:
+    """The opencode scenario through the real Anthropic messages handler."""
+    model = scenario_model(
+        ["Doctor Who Series 9 setting", "let me look into that", "Castle"]
+    )
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        model_aliases={BRIDGE_MODEL: model},
+    )
+
+    async def request(system: str, messages: list[dict[str, Any]]) -> str:
+        message = await inspect_anthropic_api_request(
+            {
+                "model": BRIDGE_MODEL,
+                "max_tokens": 1024,
+                "system": system,
+                "messages": messages,
+            },
+            None,
+            internal_web_search_providers(),
+            default_code_execution_providers(),
+            bridge,
+        )
+        block = message.content[0]
+        assert block.type == "text"
+        return block.text
+
+    # opencode's title-generation call lands first
+    await request(
+        "You are a title generator ...",
+        [
+            {"role": "user", "content": "Generate a title for this conversation:\n"},
+            {"role": "user", "content": TASK},
+        ],
+    )
+
+    # main loop: turn 1
+    main: list[dict[str, Any]] = [{"role": "user", "content": TASK}]
+    reply = await request("You are opencode, an agent that ...", main)
+    assert reply == "let me look into that"
+    assert bridge.state.output.completion == "let me look into that"
+
+    # main loop: turn 2
+    main = main + [
+        {"role": "assistant", "content": reply},
+        {"role": "user", "content": "please continue"},
+    ]
+    await request("You are opencode, an agent that ...", main)
+
+    assert bridge.state.output.completion == "Castle"
+    assert [m.text for m in bridge.state.messages] == [
+        "You are opencode, an agent that ...",
+        TASK,
+        "let me look into that",
+        "please continue",
+        "Castle",
+    ]

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from test_helpers.checkpoint import RecordingCheckpointer
 
+from inspect_ai._util.hash import mm3_hash
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.agent._bridge.anthropic_api import inspect_anthropic_api_request
 from inspect_ai.agent._bridge.completions import inspect_completions_api_request
@@ -576,6 +577,132 @@ async def test_title_call_then_multi_turn_main_loop() -> None:
 
     assert bridge.state.output.completion == "Castle"
     assert len(bridge.state.messages) == len(turn3) + 1
+
+
+# ---------------------------------------------------------------------------
+# Task prompts condensed to attachment references
+# ---------------------------------------------------------------------------
+
+
+def condensed(text: str) -> str:
+    """The attachment reference a text condenses to (see log/_condense.py)."""
+    return f"attachment://{mm3_hash(text)}"
+
+
+async def test_condensed_user_turn_anchors_descent() -> None:
+    """A main loop whose user turn arrives condensed must still win.
+
+    A long task prompt that rides into the scaffold via inspect's transcript
+    condensation crosses the bridge as an `attachment://<hash>` placeholder
+    rather than the original text (observed with opencode on single-turn
+    GAIA). Descent must still anchor on the initial input: under the length
+    fallback the earlier 3-message title call outranks the 2-message answer
+    call and `state.output` ends up as the session title.
+    """
+    bridge = task_bridge()
+
+    # title call fires first; the scaffold's store holds the condensed turn
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a title generator ..."),
+            ChatMessageUser(content="Generate a title for this conversation:\n"),
+            ChatMessageUser(content=condensed(TASK)),
+        ],
+        "Doctor Who Series 9 setting",
+    )
+
+    # single-turn answer call: the user turn is the condensed placeholder
+    await track(
+        bridge, [TASK_SYSTEM, ChatMessageUser(content=condensed(TASK))], "Castle"
+    )
+
+    assert bridge.state.output.completion == "Castle"
+    assert [m.text for m in bridge.state.messages] == [
+        TASK_SYSTEM.text,
+        condensed(TASK),
+        "Castle",
+    ]
+
+
+async def test_condensed_main_loop_keeps_extending() -> None:
+    """After a condensed turn anchors descent the loop tracks normally."""
+    bridge = task_bridge()
+
+    await track(bridge, title_generation_input(), "Doctor Who Series 9 setting")
+
+    turn1: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=condensed(TASK))]
+    out1 = await track(bridge, turn1, "working")
+    assert bridge.state.output.completion == "working"
+
+    turn2 = turn1 + [out1.message, ChatMessageTool(content="tool result")]
+    await track(bridge, turn2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(turn2) + 1
+
+
+async def test_partially_condensed_multi_message_input_anchors_descent() -> None:
+    """Only long input messages condense; descent matches per message."""
+    part1 = "Analyze the attached data file."
+    part2 = "col_a,col_b\n" + "\n".join(f"{i},{i * 2}" for i in range(100))
+    bridge = AgentBridge(
+        AgentState(
+            messages=[ChatMessageUser(content=part1), ChatMessageUser(content=part2)]
+        )
+    )
+
+    await track(bridge, title_generation_input(), "CSV analysis session")
+
+    # short message crosses verbatim, long one as an attachment reference
+    await track(
+        bridge,
+        [
+            TASK_SYSTEM,
+            ChatMessageUser(content=part1),
+            ChatMessageUser(content=condensed(part2)),
+        ],
+        "The columns sum as expected.",
+    )
+
+    assert bridge.state.output.completion == "The columns sum as expected."
+    assert len(bridge.state.messages) == 4
+
+
+async def test_unrelated_attachment_reference_does_not_anchor_descent() -> None:
+    """Only the initial input's own condensed form matches.
+
+    A side call whose first user turn is an attachment reference to *other*
+    content must not descend: if it did (e.g. if any placeholder were treated
+    as a wildcard) it would take over as the descending thread and the real
+    answer call could no longer displace it.
+    """
+    bridge = task_bridge()
+
+    await track(
+        bridge,
+        [
+            ChatMessageSystem(content="You are a title generator ..."),
+            ChatMessageUser(content="Generate a title for this conversation:\n"),
+            ChatMessageUser(content=condensed(TASK)),
+        ],
+        "Doctor Who Series 9 setting",
+    )
+
+    # side call summarizing an attachment reference to different content
+    await track(
+        bridge,
+        [ChatMessageUser(content=condensed("some tool output blob"))],
+        "summary of the blob",
+    )
+
+    # the real answer call must still displace the (non-descending) title call
+    await track(
+        bridge, [TASK_SYSTEM, ChatMessageUser(content=condensed(TASK))], "Castle"
+    )
+
+    assert bridge.state.output.completion == "Castle"
+    assert bridge.state.messages[-1].text == "Castle"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Follow-up to #4605 (meridianlabs-ai/inspect_ai#140). Testing opencode + gpt-5.5 on the #4605 build showed the answer-capture race still reproduces on single-turn GAIA: `state.output` ends up as opencode's session title instead of the real answer (accuracy 0).

Cause: opencode's main-loop user turns cross the bridge as `attachment://<hash>` placeholders rather than the original prompt text (long content that rides into the scaffold via inspect's transcript condensation, which opencode's conversation store round-trips). `_descends_from_initial` therefore never matches the initial input, tracking falls back to the legacy length heuristic, and the 3-message title call (which fires first) permanently outranks the 2-message answer call.

### What is the new behavior?

Descent now matches each initial input message either **verbatim or as its exact condensed `attachment://` reference**. The attachment id is the same mm3 hash a message fingerprint already stores (`log/_condense.py` writes `attachment://{mm3_hash(text)}`), so each initial message's condensed form is computable from its fingerprint alone — an exact-match check, not a wildcard: an attachment reference to *other* content still does not descend (covered by a test that fails under any wildcard implementation).

This PR also expands the `_track_state` regression suite well beyond the #4605 tests (28 tests total in `tests/agent/test_bridge_track_state.py`):

- **Condensed prompts** (the fix): single-turn GAIA repro, multi-turn continuation after a condensed turn anchors, partially-condensed multi-message inputs, unrelated-reference precision.
- **Fingerprint robustness**: extension recognized when the scaffold's store round-trip reassigns ids/metadata.
- **Descent anchoring**: system prompts excluded from the anchor, multi-message initial inputs, system-only inputs (legacy fallback), checkpoint resume anchoring on the original (restored) input rather than the resumed conversation.
- **Side-call interleaving**: longer side call landing mid-loop, retried title calls, multiple distinct side calls, post-displacement multi-turn continuation.
- **Rewritten-prompt scaffolds** (no fingerprint/descent continuity, e.g. claude code system-reminder injection): legacy-heuristic loop tracking and compaction recovery.
- **End-to-end**: the opencode scenario through the real OpenAI completions and Anthropic messages request handlers with mockllm, exercising message conversion and `apply_message_ids` together with `_track_state`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

The four condensed-prompt tests fail on current `main` with exactly the reported symptom (`state.output` == the session title). Verification: `pytest tests/agent/test_bridge_track_state.py` passes under both asyncio and trio (`--runtrio`), wider bridge suites pass, `ruff` and `mypy` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
