### PR TITLE
Fix mypy CI failure when httpx2 is installed alongside httpx

### DIFF
--- a/tests/_view/test_view_network.py
+++ b/tests/_view/test_view_network.py
@@ -1,9 +1,10 @@
 import importlib
 import inspect
+from collections.abc import Mapping
 from pathlib import Path
+from typing import Protocol
 
 import pytest
-from httpx import Response
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp
 
@@ -56,7 +57,19 @@ def _app(tmp_path: Path, policy: ViewerNetworkPolicy) -> tuple[ASGIApp, Path]:
     return app, log_dir
 
 
-def _assert_framing_headers(response: Response) -> None:
+class _ResponseLike(Protocol):
+    """The slice of a client response the framing assertions need.
+
+    Structural rather than `httpx.Response` because starlette's TestClient
+    returns httpx2 responses when the httpx2 package is installed (pulled in
+    by recent fastapi/mcp releases), and the two Response types don't unify.
+    """
+
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+
+def _assert_framing_headers(response: _ResponseLike) -> None:
     assert "frame-ancestors 'none'" in response.headers["content-security-policy"]
     assert response.headers["x-frame-options"] == "DENY"
 


### PR DESCRIPTION
## This PR contains:

- [x] Bug fixes (non-breaking change which fixes an issue)

### What is the current behavior? (You can also link to an open issue here)

The `mypy (3.10)` and `mypy (3.11)` CI jobs fail on every freshly resolved environment since ~13:00 UTC today, with 8 errors, all in `tests/_view/test_view_network.py`:

```
tests/_view/test_view_network.py:199: error: Argument 1 to "_assert_framing_headers" has incompatible type "httpx2._models.Response"; expected "httpx._models.Response"  [arg-type]
```

Cause: new `fastapi 0.140.10` / `mcp 2.0.0` releases pull in the new `httpx2` package, and starlette's `TestClient` returns `httpx2.Response` objects when `httpx2` is importable. The test helper `_assert_framing_headers` is annotated with `httpx.Response`, which no longer matches. (Main's last green run at 12:45 UTC resolved an environment without `httpx2`; runs after that get it. Verified by diffing the installed-package lists between the green and failing jobs.)

This blocks CI for all PRs (e.g. #4375) and will fail main's next build.

### What is the new behavior?

`_assert_framing_headers` takes a small structural `Protocol` exposing the one attribute it reads (`headers: Mapping[str, str]`), so it accepts both `httpx.Response` and `httpx2.Response`. Verified locally that mypy passes both with and without `httpx2` installed, and the 46 tests in the file still pass.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No — test-only change.

### Other information:

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
