### PR TITLE
Trim accidental content from wheel and sdist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Smaller downloads: the wheel no longer includes the accidentally-bundled log viewer TypeScript source, and the sdist no longer includes tests, docs, or lockfiles.
+
 ## 0.3.250 (28 July 2026)
 
 - Sample Sources: Generate a task's samples dynamically while it runs by passing a `SampleSource` as the task's `dataset` (with `enqueue_sample()` for imperative additions) — the sample-level mirror of `TaskSource`, for RL loops and adaptive evals.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,6 +5,7 @@ recursive-exclude src/inspect_ai/tool/_tools/_web_browser/_resources *
 # Trim the sdist: none of these are needed to build or install from it
 # (the JS viewer ships prebuilt as src/inspect_ai/_view/dist). See #4588.
 prune tests
+prune src/inspect_sandbox_tools/tests
 prune docs
 prune src/inspect_ai/_view/ts-mono
 exclude uv.lock

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,11 @@
 # Exclude specific subdirectories
 recursive-exclude src/inspect_ai/tool/_tools/_computer/_resources *
 recursive-exclude src/inspect_ai/tool/_tools/_web_browser/_resources *
+
+# Trim the sdist: none of these are needed to build or install from it
+# (the JS viewer ships prebuilt as src/inspect_ai/_view/dist). See #4588.
+prune tests
+prune docs
+prune src/inspect_ai/_view/ts-mono
+exclude uv.lock
+exclude yarn.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,14 @@ git_describe_command = [
 where = ["src"]
 include = ["inspect_ai*"]
 
+# Keep the ts-mono TS source out of the wheel: the git-tracked files are
+# pruned in MANIFEST.in (include-package-data pulls the manifest into the
+# wheel), while this exclude stops the package-data globs below (e.g.
+# **/*.yml) from picking up untracked files inside ts-mono such as
+# node_modules. The viewer ships prebuilt as _view/dist.
+[tool.setuptools.exclude-package-data]
+inspect_ai = ["_view/ts-mono*"]
+
 [tool.setuptools.package-data]
 inspect_ai = [
     "binaries/*",


### PR DESCRIPTION
Closes #4664 (sub-issue of #4588).

The wheel accidentally ships the `_view/ts-mono` TypeScript source (1,591 files in the released 0.3.250 wheel) because `include-package-data` defaults to true under pyproject-based config, pulling every git-tracked file inside the package (submodules included) into the wheel on top of the explicit `package-data` globs. The sdist ships tests, docs, ts-mono, and lockfiles for the same reason. This PR prunes them: `MANIFEST.in` prunes trim the sdist (which also removes the tracked ts-mono files from the wheel, since the wheel's extra files come from the same manifest), and a `[tool.setuptools.exclude-package-data]` entry stops the `package-data` globs (e.g. `**/*.yml`) from picking up untracked files inside ts-mono — the released 0.3.250 wheel contains two `pipeline.yml` files from the release machine's local `node_modules`.

Scoped to changes with zero impact on sdist consumers: the sandbox-tools binaries stay in the sdist so a wheel built from it remains functionally identical to the released wheel (moving them out belongs to the `inspect-sandbox-tools` package work in #4588).

## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

#4588: each release uploads ~86 MB to PyPI (36.9 MB wheel + 49.4 MB sdist), and the project is at 9.17 GB of PyPI's 10 GB cap. The wheel includes 2 MB (compressed) of ts-mono TS source plus stray `node_modules` files; the sdist includes tests (9.4 MB), docs (11.8 MB), ts-mono (7.1 MB), and lockfiles, none of which are needed to build or install from it.

### What is the new behavior?

Wheel drops exactly the ts-mono files (verified by before/after listing diff: nothing else removed, nothing added). sdist drops tests, docs, ts-mono, `uv.lock`, `yarn.lock`. Per-release upload shrinks ~86 → ~65 MB; the larger reduction comes from the separate binaries package (#4588).

Verified: wheel built from the trimmed sdist is identical to one built from the source tree (modulo a pre-existing gap — a source-tree build picks up 9 `_computer/_resources` `.py` files that released wheels have never contained, since `MANIFEST.in` already excluded them from the sdist releases build from); `check-wheel-contents` passes; fresh-venv install of the trimmed wheel runs `inspect --version` and resolves `_view/dist` viewer assets.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Installs from the wheel are unchanged. sdist-based installs still produce a functionally identical wheel (binaries included); the sdist just no longer carries tests/docs — anyone running the test suite from the sdist should use a git checkout instead.

### Other information:
