### PR TITLE
fix: truncate oversized tool-call arguments to prevent unrecoverable 400s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
+## Unreleased
+
+- Bugfix: OpenAI: A tool call with an oversized arguments string no longer poisons the conversation, which previously failed every subsequent request with a 400 "string too long" error. (#4682)
+
 ## 0.3.251 (29 July 2026)
 
 - Hooks: `on_model_retry` now reports the retry cause via `exception_type` and `status_code` on `ModelRetry`, so hooks can distinguish e.g. timeouts from 429s and 5xxs.
 - Agent Bridge: Forward Codex `additional_tools` declarations (used by newer OpenAI models to declare tools via input items rather than the top-level `tools` array) through the bridge as real tools, preserving each tool's original schema verbatim. Previously these declarations were dropped, so the model received no tools; reconstructing them was also lossy and broke reserved-schema tools such as codex's `collaboration.*`. (#4556)
-- Bugfix: OpenAI: A tool call with an oversized arguments string no longer poisons the conversation, which previously failed every subsequent request with a 400 "string too long" error. (#4682)
 
 ## 0.3.250 (28 July 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Hooks: `on_model_retry` now reports the retry cause via `exception_type` and `status_code` on `ModelRetry`, so hooks can distinguish e.g. timeouts from 429s and 5xxs.
 - Agent Bridge: Forward Codex `additional_tools` declarations (used by newer OpenAI models to declare tools via input items rather than the top-level `tools` array) through the bridge as real tools, preserving each tool's original schema verbatim. Previously these declarations were dropped, so the model received no tools; reconstructing them was also lossy and broke reserved-schema tools such as codex's `collaboration.*`. (#4556)
+- Bugfix: OpenAI: A tool call with an oversized arguments string no longer poisons the conversation, which previously failed every subsequent request with a 400 "string too long" error. (#4682)
 
 ## 0.3.250 (28 July 2026)
 

--- a/src/inspect_ai/model/_call_tools.py
+++ b/src/inspect_ai/model/_call_tools.py
@@ -1159,7 +1159,15 @@ def truncate_tool_output(
 
 
 def tool_parse_error_message(arguments: str | None, ex: Exception) -> str:
-    return f"Error parsing the following tool call arguments:\n\n{arguments or ''}\n\nError details: {ex}"
+    # middle-truncate the raw arguments (they can be arbitrarily large when the
+    # model goes off the rails, and this message is echoed back to the model)
+    truncated = truncate_string_to_bytes(arguments or "", 16 * 1024)
+    shown = (
+        f"{truncated.output}\n\n(arguments middle-truncated from {truncated.original_bytes} bytes)"
+        if truncated
+        else (arguments or "")
+    )
+    return f"Error parsing the following tool call arguments:\n\n{shown}\n\nError details: {ex}"
 
 
 def parse_tool_call(

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -194,8 +194,22 @@ MESSAGE_PHASE = "message_phase"
 REASONING_ENCRYPTED_CONTENT = "reasoning_encrypted_content"
 
 # maximum length the OpenAI Responses API accepts for a function_call
-# `arguments` string on input (it imposes no such limit on output)
+# `arguments` string on input (it imposes no such limit on output). the API
+# limit is denominated in characters; we truncate by UTF-8 bytes, which is
+# never fewer than characters, so the result always satisfies the limit
 _MAX_FUNCTION_CALL_ARGUMENTS = 1_048_576
+
+
+def _limit_function_call_arguments(arguments: str) -> str:
+    """Middle-truncate `arguments` to fit the Responses API input limit.
+
+    OpenAI rejects input `arguments` strings longer than
+    _MAX_FUNCTION_CALL_ARGUMENTS, so sending an oversized string verbatim
+    would 400 every subsequent request. Strings within the limit are
+    returned unchanged.
+    """
+    truncated = truncate_string_to_bytes(arguments, _MAX_FUNCTION_CALL_ARGUMENTS)
+    return truncated.output if truncated is not None else arguments
 
 
 class ResponsesModelInfo(Protocol):
@@ -863,14 +877,9 @@ def _process_response_output_items(
                         ResponseFunctionToolCallParam,
                         output.model_dump(exclude_none=True),
                     )
-                    # OpenAI rejects input `arguments` strings longer than
-                    # _MAX_FUNCTION_CALL_ARGUMENTS, so replaying an oversized
-                    # string verbatim would 400 every subsequent request
-                    truncated_arguments = truncate_string_to_bytes(
-                        output.arguments, _MAX_FUNCTION_CALL_ARGUMENTS
+                    param["arguments"] = _limit_function_call_arguments(
+                        output.arguments
                     )
-                    if truncated_arguments is not None:
-                        param["arguments"] = truncated_arguments.output
                     assistant_internal().tool_calls[output.call_id] = param
 
                 call_name, call_arguments = _responses_call_to_inspect(
@@ -1605,7 +1614,7 @@ def _tool_call_items_from_assistant_message(
                 type="function_call",
                 call_id=call.id,
                 name=name,
-                arguments=arguments,
+                arguments=_limit_function_call_arguments(arguments),
             )
 
             # append the param

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -145,6 +145,7 @@ from inspect_ai._util.content import (
 )
 from inspect_ai._util.images import file_as_data_uri
 from inspect_ai._util.json import to_json_str_safe
+from inspect_ai._util.text import truncate_string_to_bytes
 from inspect_ai._util.url import is_http_url
 from inspect_ai.model._call_tools import parse_tool_call
 from inspect_ai.model._chat_message import (
@@ -191,6 +192,10 @@ logger = getLogger(__name__)
 MESSAGE_ID = "message_id"
 MESSAGE_PHASE = "message_phase"
 REASONING_ENCRYPTED_CONTENT = "reasoning_encrypted_content"
+
+# maximum length the OpenAI Responses API accepts for a function_call
+# `arguments` string on input (it imposes no such limit on output)
+_MAX_FUNCTION_CALL_ARGUMENTS = 1_048_576
 
 
 class ResponsesModelInfo(Protocol):
@@ -854,10 +859,19 @@ def _process_response_output_items(
             case ResponseFunctionToolCall():
                 has_tool_calls = True
                 if output.id is not None:
-                    assistant_internal().tool_calls[output.call_id] = cast(
+                    param = cast(
                         ResponseFunctionToolCallParam,
                         output.model_dump(exclude_none=True),
                     )
+                    # OpenAI rejects input `arguments` strings longer than
+                    # _MAX_FUNCTION_CALL_ARGUMENTS, so replaying an oversized
+                    # string verbatim would 400 every subsequent request
+                    truncated_arguments = truncate_string_to_bytes(
+                        output.arguments, _MAX_FUNCTION_CALL_ARGUMENTS
+                    )
+                    if truncated_arguments is not None:
+                        param["arguments"] = truncated_arguments.output
+                    assistant_internal().tool_calls[output.call_id] = param
 
                 call_name, call_arguments = _responses_call_to_inspect(
                     output.name, output.arguments, tools

--- a/tests/model/providers/test_openai_responses.py
+++ b/tests/model/providers/test_openai_responses.py
@@ -199,6 +199,38 @@ def test_tool_call_arguments_within_limit_cached_verbatim():
     assert assistant_internal().tool_calls["call_1"]["arguments"] == raw_arguments
 
 
+def test_oversized_tool_call_arguments_truncated_on_cache_miss():
+    """Valid-but-oversized arguments are truncated in the cache-miss fallback.
+
+    When a tool call isn't in the assistant_internal replay cache (e.g. a
+    message history constructed outside this sample), its arguments are
+    re-serialized from the parsed dict — which for valid oversized JSON
+    regenerates the oversized string.
+    """
+    from inspect_ai.model._assistant_internal import init_sample_assistant_internal
+    from inspect_ai.model._openai_responses import (
+        _MAX_FUNCTION_CALL_ARGUMENTS,
+        _tool_call_items_from_assistant_message,
+    )
+    from inspect_ai.tool._tool_call import ToolCall
+
+    init_sample_assistant_internal()
+
+    message = ChatMessageAssistant(
+        content="",
+        tool_calls=[
+            ToolCall(
+                id="call_1",
+                function="bash",
+                arguments={"command": "x" * 2_000_000},
+            )
+        ],
+    )
+    items = _tool_call_items_from_assistant_message(message)
+
+    assert len(items[0]["arguments"]) <= _MAX_FUNCTION_CALL_ARGUMENTS
+
+
 def test_non_consecutive_reasoning_blocks_filtering():
     """Test that non-consecutive ContentReasoning blocks are both kept."""
     message = ChatMessageAssistant(

--- a/tests/model/providers/test_openai_responses.py
+++ b/tests/model/providers/test_openai_responses.py
@@ -128,6 +128,77 @@ def test_image_generation_call_incomplete():
     assert len(content) == 0
 
 
+def test_oversized_tool_call_arguments_truncated_for_replay():
+    """Oversized arguments are truncated in the verbatim replay cache.
+
+    OpenAI rejects input `arguments` strings longer than 1,048,576 chars
+    (it imposes no such limit on output), so caching an oversized string
+    verbatim would 400 every subsequent request.
+    """
+    from openai.types.responses import ResponseFunctionToolCall
+
+    from inspect_ai.model._assistant_internal import init_sample_assistant_internal
+    from inspect_ai.model._openai_responses import (
+        _MAX_FUNCTION_CALL_ARGUMENTS,
+        _process_response_output_items,
+        _tool_call_items_from_assistant_message,
+        assistant_internal,
+    )
+
+    init_sample_assistant_internal()
+
+    raw_arguments = '{"command":"' + ("x" * 2_000_000) + '","}malformed'
+    outputs = [
+        ResponseFunctionToolCall(
+            type="function_call",
+            id="fc_1",
+            call_id="call_1",
+            name="bash",
+            arguments=raw_arguments,
+        )
+    ]
+    _content, tool_calls, _logprobs, has_tool_calls = _process_response_output_items(
+        outputs, []
+    )
+
+    assert has_tool_calls
+    assert tool_calls[0].parse_error is not None
+    assert tool_calls[0].arguments == {}
+    cached = assistant_internal().tool_calls["call_1"]
+    assert len(cached["arguments"]) <= _MAX_FUNCTION_CALL_ARGUMENTS
+
+    items = _tool_call_items_from_assistant_message(
+        ChatMessageAssistant(content="", tool_calls=tool_calls)
+    )
+    assert len(items[0]["arguments"]) <= _MAX_FUNCTION_CALL_ARGUMENTS
+
+
+def test_tool_call_arguments_within_limit_cached_verbatim():
+    from openai.types.responses import ResponseFunctionToolCall
+
+    from inspect_ai.model._assistant_internal import init_sample_assistant_internal
+    from inspect_ai.model._openai_responses import (
+        _process_response_output_items,
+        assistant_internal,
+    )
+
+    init_sample_assistant_internal()
+
+    raw_arguments = '{"command": "ls"}'
+    outputs = [
+        ResponseFunctionToolCall(
+            type="function_call",
+            id="fc_1",
+            call_id="call_1",
+            name="bash",
+            arguments=raw_arguments,
+        )
+    ]
+    _process_response_output_items(outputs, [])
+
+    assert assistant_internal().tool_calls["call_1"]["arguments"] == raw_arguments
+
+
 def test_non_consecutive_reasoning_blocks_filtering():
     """Test that non-consecutive ContentReasoning blocks are both kept."""
     message = ChatMessageAssistant(

--- a/tests/model/test_parse_tool_call.py
+++ b/tests/model/test_parse_tool_call.py
@@ -64,3 +64,27 @@ def test_parse_single_quotes_in_string_tool_call_without_a_dict():
 
     assert "param1" in tool_call.arguments
     assert tool_call.arguments["param1"] == "'"
+
+
+def test_parse_error_preserves_small_arguments():
+    malformed = '{"param1": "value",}invalid'
+    tool_call = parse_tool_call("id", "testing_tool", malformed, [testing_tool])
+
+    assert tool_call.arguments == {}
+    assert tool_call.parse_error is not None
+    assert malformed in tool_call.parse_error
+
+
+def test_parse_error_truncates_oversized_arguments():
+    # oversized malformed arguments are middle-truncated in the parse error
+    # (which is echoed back to the model as the tool result)
+    malformed = '{"param1": "' + ("x" * 2_000_000) + '",}invalid'
+    tool_call = parse_tool_call("id", "testing_tool", malformed, [testing_tool])
+
+    assert tool_call.arguments == {}
+    assert tool_call.parse_error is not None
+    assert len(tool_call.parse_error) < 20 * 1024
+    assert "middle-truncated" in tool_call.parse_error
+    # middle truncation preserves the head and tail
+    assert tool_call.parse_error.count('{"param1": "x') == 1
+    assert '",}invalid' in tool_call.parse_error


### PR DESCRIPTION
A model can emit a `function_call` whose raw `arguments` string exceeds OpenAI's 1,048,576-char *input* limit (no such limit applies to output). The raw item was cached verbatim in `assistant_internal()` and replayed byte-for-byte on every subsequent request, so both `generate` and `count_tokens` 400'd with "string too long" forever — killing the sample with no way to recover (compaction couldn't rescue it because its own `count_tokens` call was the first to fail). Fix: middle-truncate the cached `arguments` above OpenAI's input limit at cache-write time, and middle-truncate the raw arguments embedded in tool parse error messages to 16KB (the `max_tool_output` default), since those are echoed back to the model as the tool result.

Fixes #4682.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

See #4682: a malformed/oversized tool call poisons the conversation — every subsequent OpenAI Responses request (including compaction's token counting) fails with 400 "Invalid 'input[N].arguments': string too long", and the sample dies.

### What is the new behavior?

Cached tool-call `arguments` are middle-truncated (repo precedent: `truncate_string_to_bytes`, half front / half back) when above OpenAI's 1,048,576-byte input limit — anything under the limit still replays byte-faithfully. Tool parse error messages truncate the embedded raw arguments to 16KB with a note, matching the tool-output truncation default. The sample continues instead of crashing.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Slack report: https://inspectcommunity.slack.com/archives/C0805HJTK8U/p1785275074023209
