### PR TITLE
openai_compatible: populate token usage for streaming requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Sandbox: Large sandbox-tool responses are transferred intact instead of corrupting JSON-RPC frames when they exceed the sandbox exec output limit.
 - Agent Bridge: Fix for `message_limit`/`token_limit`/`cost_limit` errors not being properly raised when running in a sandbox.
 - Bugfix: Reading eval logs with field exclusion (e.g. header-only reads) no longer crashes under a trio event loop; the pure-Python ijson backend is now selected when the C backend's asyncio-only async parser is unavailable. (#4589)
-- OpenAI Compatible: Streaming requests now ask for a final usage chunk (`stream_options={"include_usage": True}`) so token counts are populated rather than zero; opt out with `-M stream_include_usage=false`.
+- OpenAI Compatible: Streaming requests now ask for a final usage chunk (`stream_options={"include_usage": True}`) so token counts are populated rather than zero; opt out with `-M stream_include_usage=false`. Providers that stream implicitly rather than on request (HF Inference Providers) keep their existing requests and can opt in with `-M stream_include_usage=true`.
 - Control Channel: `inspect ctl sample list`/`show` now report a running sample's in-flight activity (`generating 7:12`, `bash 0:41`, `retrying in 0:45`), and `sample events` renders pending events, so long model calls and retry backoffs no longer read as silent idle.
 - Retry: Samples reused from a prior attempt no longer stay resident in memory awaiting a flush, and are written to the new attempt's log (readable by `inspect ctl` and viewers) as soon as the reuse sweep completes.
 - Control Channel: Paginating or polling a finished sample's events or messages no longer re-parses the whole sample per request (resolved terminal sources are briefly cached).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Sandbox: Large sandbox-tool responses are transferred intact instead of corrupting JSON-RPC frames when they exceed the sandbox exec output limit.
 - Agent Bridge: Fix for `message_limit`/`token_limit`/`cost_limit` errors not being properly raised when running in a sandbox.
 - Bugfix: Reading eval logs with field exclusion (e.g. header-only reads) no longer crashes under a trio event loop; the pure-Python ijson backend is now selected when the C backend's asyncio-only async parser is unavailable. (#4589)
+- OpenAI Compatible: Streaming requests now ask for a final usage chunk (`stream_options={"include_usage": True}`) so token counts are populated rather than zero; opt out with `-M stream_include_usage=false`.
 - Control Channel: `inspect ctl sample list`/`show` now report a running sample's in-flight activity (`generating 7:12`, `bash 0:41`, `retrying in 0:45`), and `sample events` renders pending events, so long model calls and retry backoffs no longer read as silent idle.
 - Retry: Samples reused from a prior attempt no longer stay resident in memory awaiting a flush, and are written to the new attempt's log (readable by `inspect ctl` and viewers) as soon as the reuse sweep completes.
 - Control Channel: Paginating or polling a finished sample's events or messages no longer re-parses the whole sample per request (resolved terminal sources are briefly cached).

--- a/src/inspect_ai/model/_providers/hf_inference_providers.py
+++ b/src/inspect_ai/model/_providers/hf_inference_providers.py
@@ -31,6 +31,10 @@ class HFInferenceProvidersAPI(OpenAICompatibleAPI):
         )
 
     @override
+    def default_stream_include_usage(self) -> bool:
+        return False
+
+    @override
     def canonical_name(self) -> str:
         """Canonical model name for model info database lookup.
 

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -137,7 +137,9 @@ class OpenAICompatibleAPI(ModelAPI):
             )
         self.stream = False if stream is None else stream
         self.stream_include_usage = (
-            True if stream_include_usage is None else stream_include_usage
+            self.default_stream_include_usage()
+            if stream_include_usage is None
+            else stream_include_usage
         )
         self.strict_tools = strict_tools
 
@@ -307,6 +309,14 @@ class OpenAICompatibleAPI(ModelAPI):
     ) -> tuple[list[ToolInfo], ToolChoice, GenerateConfig]:
         """Provides an opportunity for concrete classes to customize tool resolution."""
         return tools, tool_choice, config
+
+    def default_stream_include_usage(self) -> bool:
+        """Whether streaming requests ask for a final usage chunk by default.
+
+        Providers that stream implicitly (rather than only when the user opts in)
+        can return False to leave their requests unchanged.
+        """
+        return True
 
     def apply_stream_usage_options(self, request: dict[str, Any]) -> dict[str, Any]:
         """Request a final usage chunk so streamed completions report token usage."""

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -73,6 +73,7 @@ class OpenAICompatibleAPI(ModelAPI):
         responses_api: bool | None = None,
         responses_store: bool | None = None,
         stream: bool | None = None,
+        stream_include_usage: bool | None = None,
         strict_tools: bool = True,
         client_timeout: float | None = None,
         **model_args: Any,
@@ -135,6 +136,9 @@ class OpenAICompatibleAPI(ModelAPI):
                 "emulate_tools is not compatible with using the responses_api"
             )
         self.stream = False if stream is None else stream
+        self.stream_include_usage = (
+            True if stream_include_usage is None else stream_include_usage
+        )
         self.strict_tools = strict_tools
 
         # store client_timeout for http client creation
@@ -304,6 +308,14 @@ class OpenAICompatibleAPI(ModelAPI):
         """Provides an opportunity for concrete classes to customize tool resolution."""
         return tools, tool_choice, config
 
+    def apply_stream_usage_options(self, request: dict[str, Any]) -> dict[str, Any]:
+        """Request a final usage chunk so streamed completions report token usage."""
+        if self.stream_include_usage:
+            stream_options = dict(request.get("stream_options") or {})
+            stream_options.setdefault("include_usage", True)
+            request["stream_options"] = stream_options
+        return request
+
     async def _generate_completion(
         self, request: dict[str, Any], config: GenerateConfig
     ) -> ChatCompletion:
@@ -315,7 +327,9 @@ class OpenAICompatibleAPI(ModelAPI):
                     "be ignored. Disable streaming to receive prompt log "
                     "probabilities.",
                 )
-            async with self.client.chat.completions.stream(**request) as stream:
+            async with self.client.chat.completions.stream(
+                **self.apply_stream_usage_options(request)
+            ) as stream:
                 try:
                     return await stream.get_final_completion()
                 except LengthFinishReasonError as ex:

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -70,6 +70,43 @@ def test_strict_tools_default_true() -> None:
     assert tools[0]["function"]["strict"] is True
 
 
+def _stream_usage_api(
+    stream_include_usage: bool | None = None,
+) -> OpenAICompatibleAPI:
+    return OpenAICompatibleAPI(
+        model_name="openai-api/openai/gpt-5",
+        api_key="test",
+        base_url="https://example.com",
+        stream_include_usage=stream_include_usage,
+    )
+
+
+def test_stream_include_usage_defaults_to_true() -> None:
+    assert _stream_usage_api().stream_include_usage is True
+
+
+def test_stream_options_request_usage_by_default() -> None:
+    request = _stream_usage_api().apply_stream_usage_options({})
+
+    assert request["stream_options"] == {"include_usage": True}
+
+
+def test_stream_options_omitted_when_disabled() -> None:
+    request = _stream_usage_api(stream_include_usage=False).apply_stream_usage_options(
+        {}
+    )
+
+    assert "stream_options" not in request
+
+
+def test_stream_options_preserve_caller_supplied_values() -> None:
+    request = _stream_usage_api().apply_stream_usage_options(
+        {"stream_options": {"include_usage": False}}
+    )
+
+    assert request["stream_options"]["include_usage"] is False
+
+
 async def test_responses_phase_model_arg(monkeypatch: pytest.MonkeyPatch) -> None:
     """Test responses_phase is an openai-api model arg, not an SDK arg."""
     captured: dict[str, Any] = {}

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -19,6 +19,7 @@ from inspect_ai.model import (
     get_model,
 )
 from inspect_ai.model._openai import chat_choices_from_openai
+from inspect_ai.model._providers.hf_inference_providers import HFInferenceProvidersAPI
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
 from inspect_ai.model._providers.together import TogetherAIAPI
 from inspect_ai.tool import ToolInfo
@@ -105,6 +106,35 @@ def test_stream_options_preserve_caller_supplied_values() -> None:
     )
 
     assert request["stream_options"]["include_usage"] is False
+
+
+def _hf_inference_providers_api(
+    stream_include_usage: bool | None = None,
+) -> HFInferenceProvidersAPI:
+    return HFInferenceProvidersAPI(
+        model_name="hf-inference-providers/meta-llama/Llama-3.1-8B-Instruct",
+        api_key="test",
+        stream_include_usage=stream_include_usage,
+    )
+
+
+def test_hf_inference_providers_streams_by_default() -> None:
+    assert _hf_inference_providers_api().stream is True
+
+
+def test_hf_inference_providers_omits_stream_usage_by_default() -> None:
+    api = _hf_inference_providers_api()
+
+    assert api.stream_include_usage is False
+    assert "stream_options" not in api.apply_stream_usage_options({})
+
+
+def test_hf_inference_providers_stream_usage_can_be_opted_in() -> None:
+    api = _hf_inference_providers_api(stream_include_usage=True)
+
+    assert api.apply_stream_usage_options({})["stream_options"] == {
+        "include_usage": True
+    }
 
 
 async def test_responses_phase_model_arg(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Problem

When an eval runs against an OpenAI-compatible provider with streaming enabled (`-M stream=true`), token usage is reported as zero for every sample: `ModelOutput.usage` is `None` and `model_usage` ends up empty. The results panel and any cost accounting derived from it are therefore blank for streaming runs.

## Cause

The Chat Completions streaming API only emits a usage chunk when the request asks for one via `stream_options={"include_usage": true}`. `openai_compatible.py` never sets it, so the final completion assembled by the SDK carries no usage.

## Precedent

`sagemaker.py` already does exactly this, with the same rationale:

```python
# Ask vLLM to emit a final usage chunk in the stream so token
# counts are populated (otherwise streaming usage is all zeros).
request_body["stream_options"] = {"include_usage": True}
```

This change brings the OpenAI-compatible provider in line with that behaviour, but more conservatively: `sagemaker.py` always sets the flag when streaming and replaces any caller-supplied `stream_options`, whereas this change merges with `setdefault` and can be turned off per model.

## Change

- Add `stream_include_usage` (default `True`) to `OpenAICompatibleAPI`; streaming requests merge `include_usage` into `stream_options` with `setdefault`, so an explicit caller value is preserved.
- Endpoints that do not accept `stream_options` can opt out with `-M stream_include_usage=false`.
- Non-streaming requests are unchanged.

## Not covered here

`TogetherAIAPI` overrides `_generate_completion` with its own streaming call, so it still reports zero usage. It is left out to keep this change small; the helper added here makes that a one-line follow-up, which I am happy to send separately if wanted. `SagemakerAPI` derives from `ModelAPI` rather than `OpenAICompatibleAPI`, so it keeps its current always-on behaviour and gains no opt-out from this change.

## Verification

Against a vLLM-backed OpenAI-compatible endpoint:

- before: `usage=None` (all token counts zero)
- after: `input_tokens=20 output_tokens=60 total_tokens=80`

Truncated (`stop_reason="max_tokens"`) streams also carry usage.

Added unit tests for the default, the opt-out, and the caller-supplied case; `ruff format --check`, `ruff check`, and `tests/model/providers/test_openai_compatible.py` pass locally.
