### PR TITLE
Don't retry pytest.skip()/xfail() in flaky_retry

### DIFF
--- a/tests/test_flaky_retry.py
+++ b/tests/test_flaky_retry.py
@@ -59,6 +59,51 @@ class TestFlakyRetry:
 
         assert call_count == 1
 
+    def test_skip_not_retried(self):
+        """Test that pytest.skip() is honored immediately, not retried."""
+        call_count = 0
+
+        @flaky_retry(max_retries=3)
+        def skip_immediately():
+            nonlocal call_count
+            call_count += 1
+            pytest.skip("deliberate skip")
+
+        with pytest.raises(pytest.skip.Exception):
+            skip_immediately()
+
+        assert call_count == 1
+
+    def test_xfail_not_retried(self):
+        """Test that pytest.xfail() is honored immediately, not retried."""
+        call_count = 0
+
+        @flaky_retry(max_retries=3)
+        def xfail_immediately():
+            nonlocal call_count
+            call_count += 1
+            pytest.xfail("deliberate xfail")
+
+        with pytest.raises(pytest.xfail.Exception):
+            xfail_immediately()
+
+        assert call_count == 1
+
+    async def test_async_skip_not_retried(self):
+        """Test that pytest.skip() in an async test is honored immediately."""
+        call_count = 0
+
+        @flaky_retry(max_retries=3)
+        async def skip_immediately():
+            nonlocal call_count
+            call_count += 1
+            pytest.skip("deliberate skip")
+
+        with pytest.raises(pytest.skip.Exception):
+            await skip_immediately()
+
+        assert call_count == 1
+
     def test_preserves_function_metadata(self):
         """Test that decorator preserves original function metadata."""
 

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -14,7 +14,7 @@ from typing import Awaitable, Callable, Generator, ParamSpec, Sequence, TypeVar
 
 import anyio
 import pytest
-from _pytest.outcomes import OutcomeException
+from _pytest.outcomes import OutcomeException, Skipped, XFailed
 
 from inspect_ai import Task, eval, task
 from inspect_ai._util.entrypoints import clear_entry_points_state, ensure_entry_points
@@ -73,6 +73,9 @@ def flaky_retry(max_retries: int) -> Callable[[F], F]:
     """
     Decorator to retry flaky tests up to max_retries times.
 
+    Deliberate test outcomes -- ``pytest.skip()`` and ``pytest.xfail()`` --
+    are re-raised immediately rather than retried.
+
     **Use with discretion and as a last resort.** This decorator should only be used
     for tests that require specific model behavior to trigger the code under test,
     where the flakiness is due to inherent non-determinism in model responses
@@ -99,6 +102,10 @@ def flaky_retry(max_retries: int) -> Callable[[F], F]:
                 for attempt in range(max_retries + 1):
                     try:
                         return await func(*args, **kwargs)
+                    except (Skipped, XFailed):
+                        # pytest.skip()/xfail() are deliberate outcomes, not
+                        # flakiness -- honor them without retrying
+                        raise
                     except (Exception, OutcomeException) as e:
                         last_exception = e
                         if attempt < max_retries:
@@ -115,6 +122,10 @@ def flaky_retry(max_retries: int) -> Callable[[F], F]:
             for attempt in range(max_retries + 1):
                 try:
                     return func(*args, **kwargs)
+                except (Skipped, XFailed):
+                    # pytest.skip()/xfail() are deliberate outcomes, not
+                    # flakiness -- honor them without retrying
+                    raise
                 except (Exception, OutcomeException) as e:
                     last_exception = e
                     if attempt < max_retries:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#183

The `flaky_retry` test decorator catches `OutcomeException`, and `pytest.skip()` raises `Skipped`, which is a subclass. So a deliberate in-test skip — e.g. a live-model test's designed "model didn't cooperate → skip" give-up outcome — is retried up to 3 extra times as if it were a flaky failure. This multiplies the cost of expensive live tests (in the linked issue, up to ~15 Opus generates per attempt) and makes CI logs ambiguous about whether the retried attempts timed out or skipped. `pytest.xfail()` (`XFailed`) has the same problem.

### What is the new behavior?

`flaky_retry` re-raises `Skipped` and `XFailed` immediately (both sync and async paths) instead of retrying them. Genuine failures — including explicit `pytest.fail()` — are still retried. Tests added for the sync skip, sync xfail, and async skip cases.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No — test-infrastructure-only change; no product code touched, so no CHANGELOG entry.

### Other information:

Verified locally: `pytest tests/test_flaky_retry.py` (including the `--runtrio` variant), `ruff format --check`, `ruff check`, and `mypy` on the changed files all pass. Full CI is green on the fork's review PR (meridianlabs-ai/inspect_ai#184).

Agent involvement: implemented by Claude Code, reviewed by @ransomr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
