### PR TITLE
fix(model): bill 1-hour prompt-cache writes at the 1-hour rate (#4703)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Model: `total_cost` now bills Anthropic 1-hour prompt-cache writes at 2x the base input price rather than the 5-minute rate, so runs using `-M cache_ttl=1h` are no longer understated. (#4703)
 - Grok: Unknown (predeployment) model names are now treated as the latest Grok model for context window (compaction) and capability detection.
 - Analysis: string values for `bool`-typed columns now coerce via YAML, so `"false"`/`"0"`/`"no"`/`"off"` parse to `False` instead of every non-empty string becoming `True`.
 - Sandbox: Large sandbox-tool responses are transferred intact instead of corrupting JSON-RPC frames when they exceed the sandbox exec output limit.

--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -2542,7 +2542,11 @@ def record_and_check_model_usage(
     total_cost: float | None = None
     # Note that we handle info=None here because None is currently a valid output of get_model_info (e.g. for mock models)
     if info is not None and info.cost is not None:
-        total_cost = compute_model_cost(info.cost, usage)
+        # providers with a configurable prompt-cache TTL (currently Anthropic)
+        # expose it on the ModelAPI; longer TTLs bill cache writes at a higher rate
+        total_cost = compute_model_cost(
+            info.cost, usage, getattr(model.api, "cache_ttl", None)
+        )
         usage.total_cost = total_cost
 
     # record usage
@@ -2657,12 +2661,24 @@ sample_role_usage_context_var: ContextVar[dict[str, ModelUsage]] = ContextVar(
 )
 
 
-def compute_model_cost(cost_data: ModelCost, usage: ModelUsage) -> float:
+# Anthropic bills 1-hour cache writes at 2x the base input price, against 1.25x
+# for the default 5-minute writes, so a 1-hour write costs 2 / 1.25 times what
+# `ModelCost.input_cache_write` (the 5-minute rate) records.
+# https://platform.claude.com/docs/en/build-with-claude/prompt-caching#pricing
+CACHE_WRITE_1H_MULTIPLIER = 2.0 / 1.25
+
+
+def compute_model_cost(
+    cost_data: ModelCost, usage: ModelUsage, cache_ttl: str | None = None
+) -> float:
     """Compute cost for a model call based on usage and cost data.
 
     Args:
         cost_data: Per-token pricing for the model.
         usage: Token counts for the call.
+        cache_ttl: Prompt cache TTL used for the call (e.g. `"1h"`), for
+            providers that bill longer-lived cache writes at a higher rate.
+            `None` (the default) bills cache writes at `input_cache_write`.
 
     Returns:
         Cost in dollars.
@@ -2671,7 +2687,10 @@ def compute_model_cost(cost_data: ModelCost, usage: ModelUsage) -> float:
     cost += usage.output_tokens * cost_data.output / 1_000_000
 
     if usage.input_tokens_cache_write is not None:
-        cost += usage.input_tokens_cache_write * cost_data.input_cache_write / 1_000_000
+        input_cache_write = cost_data.input_cache_write
+        if cache_ttl == "1h":
+            input_cache_write *= CACHE_WRITE_1H_MULTIPLIER
+        cost += usage.input_tokens_cache_write * input_cache_write / 1_000_000
     if usage.input_tokens_cache_read is not None:
         cost += usage.input_tokens_cache_read * cost_data.input_cache_read / 1_000_000
 

--- a/src/inspect_ai/model/_model_data/model_data.py
+++ b/src/inspect_ai/model/_model_data/model_data.py
@@ -17,7 +17,14 @@ class ModelCost(BaseModel):
     """Price per million output tokens."""
 
     input_cache_write: float
-    """Price per million input tokens written to cache."""
+    """Price per million input tokens written to cache.
+
+    Record the provider's default-TTL rate here (for Anthropic, the 5-minute
+    rate). Providers that bill longer cache TTLs at a higher rate (e.g.
+    Anthropic's 1-hour writes at 2x base input) are adjusted at cost
+    computation time based on the configured TTL — do not pre-bake a
+    longer-TTL rate into this field or it will be double-applied.
+    """
 
     input_cache_read: float
     """Price per million input tokens read from cache."""

--- a/tests/model/test_model_output.py
+++ b/tests/model/test_model_output.py
@@ -148,3 +148,44 @@ def test_compute_model_cost_no_double_billing_cached_tokens() -> None:
     # total: 0.0036
     expected = (400 * 3.0 + 100 * 15.0 + 600 * 1.5) / 1_000_000
     assert math.isclose(cost, expected)
+
+
+def test_compute_model_cost_1h_cache_write_billed_above_5m_rate() -> None:
+    """1-hour cache writes bill at 2x base input, vs 1.25x for 5-minute writes."""
+    base_input = 3.0
+    cost_data = ModelCost(
+        input=base_input,
+        output=15.0,
+        input_cache_write=base_input * 1.25,  # the 5-minute rate
+        input_cache_read=0.3,
+    )
+    usage = ModelUsage(
+        input_tokens=0,
+        output_tokens=0,
+        total_tokens=1_000_000,
+        input_tokens_cache_write=1_000_000,
+    )
+
+    # exactly 1M cache-write tokens, so each cost is the effective $/M rate
+    assert math.isclose(compute_model_cost(cost_data, usage, "5m"), base_input * 1.25)
+    assert math.isclose(compute_model_cost(cost_data, usage, "1h"), base_input * 2.0)
+
+    # an unspecified TTL keeps the previous (5-minute) behaviour
+    assert math.isclose(compute_model_cost(cost_data, usage), base_input * 1.25)
+
+
+def test_compute_model_cost_cache_ttl_does_not_affect_other_tokens() -> None:
+    cost_data = ModelCost(
+        input=1000.0, output=2000.0, input_cache_write=0.0, input_cache_read=100.0
+    )
+    usage = ModelUsage(
+        input_tokens=10,
+        output_tokens=5,
+        total_tokens=45,
+        input_tokens_cache_read=30,
+    )
+
+    assert math.isclose(
+        compute_model_cost(cost_data, usage, "1h"),
+        compute_model_cost(cost_data, usage),
+    )


### PR DESCRIPTION
Fixes #4703.

### Problem

`ModelCost.input_cache_write` carries a single cache-write rate — in practice Anthropic's 5-minute rate, 1.25x base input. `compute_model_cost` applied that rate regardless of the TTL actually used for the call, so a run with `-M cache_ttl=1h`, where writes bill at **2x** base input, reported an understated `total_cost`. The ratio is already documented on the [Model Providers](https://inspect.aisi.org.uk/providers.html#anthropic-cache-ttl) page, and the TTL is known at request time — the cost primitive just had nowhere to put it.

Reproduction from the issue, with 1M cache-write tokens against `input=3.00` / `input_cache_write=3.75`:

```
5m 3.75
1h 3.75      <- expected 6.00 (2x base)
```

### Fix

Per @dragonstyle's steer on the issue ("I'd rather not grow `ModelCost` for this — the TTL multiplier at computation time sounds like a good approach"), `ModelCost` is untouched:

- `compute_model_cost(cost_data, usage, cache_ttl=None)` takes an optional TTL and scales the cache-write rate by `2.0 / 1.25` when it is `"1h"`.
- `record_and_check_model_usage` reads the TTL off the provider's `ModelAPI` (`getattr(model.api, "cache_ttl", None)`) — only the Anthropic provider defines one today, so every other provider keeps its current behaviour.
- Omitting `cache_ttl` (the two-argument call, including the existing public one) bills at `input_cache_write` exactly as before.

After the change the same repro prints `5m 3.75` / `1h 6.0`.

### Tests

`tests/model/test_model_output.py` gains two cases: 1M cache-write tokens billed at `1.25x` for `"5m"` / unset and `2x` for `"1h"`, and a check that a `"1h"` TTL leaves input, output and cache-*read* costs untouched. The existing `compute_model_cost` tests call it with two arguments and are unaffected.

Verified with the repo-pinned `ruff@0.9.6` (`check` + `format --check`) on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
