### PR TITLE
fix reasoning effort mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Agent Bridge: The final agent state now surfaces the real conversation instead of a side call (e.g. opencode's session title) when the scaffold decorates the task prompt, such as opencode quote-wrapping it. (#4768)
 - Inspect View: Logs inside the configured directory now open on Windows when listings identify them with canonical file URIs. (#4765)
 - Bugfix: Dataset fields holding float `NaN` (as produced by Pandas, Hugging Face, CSV, and PyArrow sources for missing values) are now treated as missing for `input`, `choices`, `setup`, `sandbox`, `files`, and `metadata`, matching the existing `target` behavior. (#4626)
+- Reasoning: Unsupported extended `reasoning_effort` values are now mapped to valid provider/model tiers for Together, SambaNova, Perplexity, and Fireworks.
 
 ## 0.3.257 (11 August 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@
 - Bugfix: Anthropic: `count_tokens()` now sends `extra_headers` from the generate config (including any `anthropic-beta` values), matching `generate()`. (#4606)
 - Bugfix: Compaction: Fix `CompactionEdit` clearing server-side tool uses at stale message indices when `keep_tool_inputs=False` removes client-side tool messages, which raised `IndexError` or wrote a tool use into an unrelated message. (#4528)
 - Bugfix: UTF-8 output truncation now preserves character boundaries and respects configured byte limits instead of inserting replacement characters that can exceed the limit. (#4656)
+- Reasoning: Clamp extended effort values (`minimal` / `xhigh` / `max`) to the `low` / `medium` / `high` tier accepted by upstream APIs for SambaNova and Together.
+- Reasoning: Perplexity — clamp `xhigh` / `max` effort to `high` before forwarding (Perplexity accepts `minimal`, so it is preserved).
+- Reasoning: Fireworks — clamp `minimal` effort to `low` on all models and `xhigh` / `max` to `high` on gpt-oss, preserving `xhigh` / `max` for models that accept them.
 
 ## 0.3.251 (29 July 2026)
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -145,48 +145,50 @@ Passes through to the underlying model; OpenRouter itself maps `effort` to `budg
 
 
 
-#### Groq / Ollama / SageMaker / Together / SambaNova
+#### Groq / Ollama / SageMaker / SambaNova
 
-Upstream APIs accept only `low` / `medium` / `high`. Inspect clamps the extended values:
+Upstream APIs accept only `low` / `medium` / `high`. Inspect clamps the extended values. `none` is not a supported value, so it is omitted and the provider/model default applies — this does not disable reasoning (always-on models keep reasoning):
 
-| Inspect input            | API value         |
-|--------------------------|-------------------|
-| `none`                   | reasoning omitted |
-| `minimal` / `low`        | `low`             |
-| `medium`                 | `medium`          |
-| `high` / `xhigh` / `max` | `high`            |
+| Inspect input            | API value                        |
+|--------------------------|----------------------------------|
+| `none`                   | omitted (provider/model default) |
+| `minimal` / `low`        | `low`                            |
+| `medium`                 | `medium`                         |
+| `high` / `xhigh` / `max` | `high`                           |
+
+#### Together
+
+Together accepts `low` / `medium` / `high` for all reasoning models, and additionally `xhigh` / `max` on some (e.g. DeepSeek V4 Pro); only gpt-oss rejects the top-end values. `minimal` is never accepted. `none` is not a supported effort value, so it is omitted and the provider/model default applies — to turn reasoning off on hybrid models, pass `reasoning={"enabled": false}` rather than an effort value.
+
+| Inspect input             | API value (gpt-oss)              | API value (other models)         |
+|---------------------------|----------------------------------|----------------------------------|
+| `none`                    | omitted (provider/model default) | omitted (provider/model default) |
+| `minimal`                 | `low`                            | `low`                            |
+| `low` / `medium` / `high` | identical                        | identical                        |
+| `xhigh` / `max`           | `high`                           | identical                        |
 
 #### Perplexity
 
-Accepts `minimal` in addition to `low` / `medium` / `high`, so Inspect keeps `minimal` and clamps only the top-end values:
+Accepts `minimal` in addition to `low` / `medium` / `high`, so Inspect keeps `minimal` and clamps only the top-end values. `none` is not a supported value, so it is omitted and the provider/model default applies (reasoning is not disabled):
 
-| Inspect input            | API value         |
-|--------------------------|-------------------|
-| `none`                   | reasoning omitted |
-| `minimal`                | `minimal`         |
-| `low`                    | `low`             |
-| `medium`                 | `medium`          |
-| `high` / `xhigh` / `max` | `high`            |
+| Inspect input            | API value                        |
+|--------------------------|----------------------------------|
+| `none`                   | omitted (provider/model default) |
+| `minimal`                | `minimal`                        |
+| `low`                    | `low`                            |
+| `medium`                 | `medium`                         |
+| `high` / `xhigh` / `max` | `high`                           |
 
 #### Fireworks
 
-Effort validity is model-dependent: no Fireworks model accepts `minimal`, and the gpt-oss family additionally rejects `xhigh` / `max` (other reasoning models — DeepSeek, GLM, Kimi, MiniMax — accept them). Inspect maps `reasoning_effort` as follows:
+Effort validity is model-dependent. No Fireworks model accepts `minimal` (→ `low`). The gpt-oss and MiniMax families accept only `low` / `medium` / `high`: they reject `none` (omitted, so the provider/model default applies) and `xhigh` / `max` (→ `high`). Other reasoning models (DeepSeek, GLM, Kimi) accept `none` and `xhigh` / `max`, so those pass through:
 
-| Inspect input             | API value (gpt-oss) | API value (other models) |
-|---------------------------|---------------------|--------------------------|
-| `none`                    | `none`              | `none`                   |
-| `minimal`                 | `low`               | `low`                    |
-| `low` / `medium` / `high` | identical           | identical                |
-| `xhigh` / `max`           | `high`              | identical                |
-
-#### Moonshot
-
-Kimi-K3's API accepts only `max` effort, so Inspect coerces every `reasoning_effort` value to `max`. Unlike the other providers, `none` does **not** disable reasoning here — Kimi-K3 reasons at `max` and cannot be turned off:
-
-| Inspect input                                           | API value            |
-|---------------------------------------------------------|----------------------|
-| `none`                                                  | `max` (not disabled) |
-| `minimal` / `low` / `medium` / `high` / `xhigh` / `max` | `max`                |
+| Inspect input             | API value (gpt-oss / MiniMax)    | API value (other models) |
+|---------------------------|----------------------------------|--------------------------|
+| `none`                    | omitted (provider/model default) | `none`                   |
+| `minimal`                 | `low`                            | `low`                    |
+| `low` / `medium` / `high` | identical                        | identical                |
+| `xhigh` / `max`           | `high`                           | identical                |
 
 #### Bedrock
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -121,7 +121,7 @@ Passes through to the underlying model; OpenRouter itself maps `effort` to `budg
 
 
 
-#### Groq / Ollama / SageMaker
+#### Groq / Ollama / SageMaker / Together / SambaNova
 
 Upstream APIs accept only `low` / `medium` / `high`. Inspect clamps the extended values:
 
@@ -131,6 +131,38 @@ Upstream APIs accept only `low` / `medium` / `high`. Inspect clamps the extended
 | `minimal` / `low`        | `low`             |
 | `medium`                 | `medium`          |
 | `high` / `xhigh` / `max` | `high`            |
+
+#### Perplexity
+
+Accepts `minimal` in addition to `low` / `medium` / `high`, so Inspect keeps `minimal` and clamps only the top-end values:
+
+| Inspect input            | API value         |
+|--------------------------|-------------------|
+| `none`                   | reasoning omitted |
+| `minimal`                | `minimal`         |
+| `low`                    | `low`             |
+| `medium`                 | `medium`          |
+| `high` / `xhigh` / `max` | `high`            |
+
+#### Fireworks
+
+Effort validity is model-dependent: no Fireworks model accepts `minimal`, and the gpt-oss family additionally rejects `xhigh` / `max` (other reasoning models — DeepSeek, GLM, Kimi, MiniMax — accept them). Inspect maps `reasoning_effort` as follows:
+
+| Inspect input             | API value (gpt-oss) | API value (other models) |
+|---------------------------|---------------------|--------------------------|
+| `none`                    | `none`              | `none`                   |
+| `minimal`                 | `low`               | `low`                    |
+| `low` / `medium` / `high` | identical           | identical                |
+| `xhigh` / `max`           | `high`              | identical                |
+
+#### Moonshot
+
+Kimi-K3's API accepts only `max` effort, so Inspect coerces every `reasoning_effort` value to `max`. Unlike the other providers, `none` does **not** disable reasoning here — Kimi-K3 reasons at `max` and cannot be turned off:
+
+| Inspect input                                           | API value            |
+|---------------------------------------------------------|----------------------|
+| `none`                                                  | `max` (not disabled) |
+| `minimal` / `low` / `medium` / `high` / `xhigh` / `max` | `max`                |
 
 #### Bedrock
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -145,7 +145,7 @@ Passes through to the underlying model; OpenRouter itself maps `effort` to `budg
 
 
 
-#### Groq / Ollama / SageMaker
+#### Groq / Ollama / SageMaker / Together / SambaNova
 
 Upstream APIs accept only `low` / `medium` / `high`. Inspect clamps the extended values:
 
@@ -155,6 +155,38 @@ Upstream APIs accept only `low` / `medium` / `high`. Inspect clamps the extended
 | `minimal` / `low`        | `low`             |
 | `medium`                 | `medium`          |
 | `high` / `xhigh` / `max` | `high`            |
+
+#### Perplexity
+
+Accepts `minimal` in addition to `low` / `medium` / `high`, so Inspect keeps `minimal` and clamps only the top-end values:
+
+| Inspect input            | API value         |
+|--------------------------|-------------------|
+| `none`                   | reasoning omitted |
+| `minimal`                | `minimal`         |
+| `low`                    | `low`             |
+| `medium`                 | `medium`          |
+| `high` / `xhigh` / `max` | `high`            |
+
+#### Fireworks
+
+Effort validity is model-dependent: no Fireworks model accepts `minimal`, and the gpt-oss family additionally rejects `xhigh` / `max` (other reasoning models — DeepSeek, GLM, Kimi, MiniMax — accept them). Inspect maps `reasoning_effort` as follows:
+
+| Inspect input             | API value (gpt-oss) | API value (other models) |
+|---------------------------|---------------------|--------------------------|
+| `none`                    | `none`              | `none`                   |
+| `minimal`                 | `low`               | `low`                    |
+| `low` / `medium` / `high` | identical           | identical                |
+| `xhigh` / `max`           | `high`              | identical                |
+
+#### Moonshot
+
+Kimi-K3's API accepts only `max` effort, so Inspect coerces every `reasoning_effort` value to `max`. Unlike the other providers, `none` does **not** disable reasoning here — Kimi-K3 reasons at `max` and cannot be turned off:
+
+| Inspect input                                           | API value            |
+|---------------------------------------------------------|----------------------|
+| `none`                                                  | `max` (not disabled) |
+| `minimal` / `low` / `medium` / `high` / `xhigh` / `max` | `max`                |
 
 #### Bedrock
 

--- a/docs/reasoning.qmd
+++ b/docs/reasoning.qmd
@@ -181,9 +181,9 @@ Accepts `minimal` in addition to `low` / `medium` / `high`, so Inspect keeps `mi
 
 #### Fireworks
 
-Effort validity is model-dependent. No Fireworks model accepts `minimal` (→ `low`). The gpt-oss and MiniMax families accept only `low` / `medium` / `high`: they reject `none` (omitted, so the provider/model default applies) and `xhigh` / `max` (→ `high`). Other reasoning models (DeepSeek, GLM, Kimi) accept `none` and `xhigh` / `max`, so those pass through:
+Effort validity is model-dependent. No Fireworks model accepts `minimal` (→ `low`). gpt-oss and MiniMax M2 accept only `low` / `medium` / `high`: they reject `none` (omitted, so the provider/model default applies) and `xhigh` / `max` (→ `high`). Other reasoning models — DeepSeek, GLM, Kimi, and MiniMax M3 — accept `none` and `xhigh` / `max`, so those pass through:
 
-| Inspect input             | API value (gpt-oss / MiniMax)    | API value (other models) |
+| Inspect input             | API value (gpt-oss / MiniMax M2) | API value (other models) |
 |---------------------------|----------------------------------|--------------------------|
 | `none`                    | omitted (provider/model default) | `none`                   |
 | `minimal`                 | `low`                            | `low`                    |

--- a/src/inspect_ai/model/_providers/fireworks.py
+++ b/src/inspect_ai/model/_providers/fireworks.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from typing_extensions import override
 
 from .._generate_config import GenerateConfig
@@ -57,6 +59,24 @@ class FireworksAIAPI(OpenAICompatibleAPI):
         if name.startswith(prefix):
             name = name[len(prefix) :]
         return name
+
+    def is_gpt_oss(self) -> bool:
+        return "gpt-oss" in self.model_family().lower()
+
+    @override
+    def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        params = super().completion_params(config, tools)
+
+        # Fireworks' effort schema is a superset and validity is model-dependent:
+        # `minimal` is invalid on every model (-> low); `xhigh`/`max` are rejected
+        # only by gpt-oss (-> high), and pass through for models that accept them.
+        effort = params.get("reasoning_effort")
+        if effort == "minimal":
+            params["reasoning_effort"] = "low"
+        elif effort in ("xhigh", "max") and self.is_gpt_oss():
+            params["reasoning_effort"] = "high"
+
+        return params
 
     @override
     def should_stream(self, config: GenerateConfig) -> bool:

--- a/src/inspect_ai/model/_providers/fireworks.py
+++ b/src/inspect_ai/model/_providers/fireworks.py
@@ -3,6 +3,7 @@ from typing import Any
 from typing_extensions import override
 
 from .._generate_config import GenerateConfig
+from .._reasoning import clamp_reasoning_effort_to_low_medium_high
 from .openai_compatible import OpenAICompatibleAPI
 
 
@@ -63,18 +64,30 @@ class FireworksAIAPI(OpenAICompatibleAPI):
     def is_gpt_oss(self) -> bool:
         return "gpt-oss" in self.model_family().lower()
 
+    def is_minimax(self) -> bool:
+        return "minimax" in self.model_family().lower()
+
     @override
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         params = super().completion_params(config, tools)
 
-        # Fireworks' effort schema is a superset and validity is model-dependent:
-        # `minimal` is invalid on every model (-> low); `xhigh`/`max` are rejected
-        # only by gpt-oss (-> high), and pass through for models that accept them.
-        effort = params.get("reasoning_effort")
-        if effort == "minimal":
-            params["reasoning_effort"] = "low"
-        elif effort in ("xhigh", "max") and self.is_gpt_oss():
-            params["reasoning_effort"] = "high"
+        # Fireworks' effort schema is a superset and validity is model-dependent.
+        # No model accepts `minimal` (-> `low`). gpt-oss and MiniMax accept only
+        # `low`/`medium`/`high` (same constraint as SambaNova): extended values clamp
+        # down and `none` is omitted (provider/model default applies -- reasoning is
+        # not disabled). Other families (DeepSeek, GLM, Kimi) accept `none` and
+        # `xhigh`/`max`, so those pass through unchanged.
+        if "reasoning_effort" in params:
+            if self.is_gpt_oss() or self.is_minimax():
+                clamped = clamp_reasoning_effort_to_low_medium_high(
+                    params["reasoning_effort"]
+                )
+                if clamped is not None:
+                    params["reasoning_effort"] = clamped
+                else:
+                    del params["reasoning_effort"]
+            elif params["reasoning_effort"] == "minimal":
+                params["reasoning_effort"] = "low"
 
         return params
 

--- a/src/inspect_ai/model/_providers/fireworks.py
+++ b/src/inspect_ai/model/_providers/fireworks.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from typing_extensions import override
 
 from .._generate_config import GenerateConfig
@@ -36,6 +38,24 @@ class FireworksAIAPI(OpenAICompatibleAPI):
         if name.startswith(prefix):
             name = name[len(prefix) :]
         return name
+
+    def is_gpt_oss(self) -> bool:
+        return "gpt-oss" in self.model_family().lower()
+
+    @override
+    def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        params = super().completion_params(config, tools)
+
+        # Fireworks' effort schema is a superset and validity is model-dependent:
+        # `minimal` is invalid on every model (-> low); `xhigh`/`max` are rejected
+        # only by gpt-oss (-> high), and pass through for models that accept them.
+        effort = params.get("reasoning_effort")
+        if effort == "minimal":
+            params["reasoning_effort"] = "low"
+        elif effort in ("xhigh", "max") and self.is_gpt_oss():
+            params["reasoning_effort"] = "high"
+
+        return params
 
     @override
     def should_stream(self, config: GenerateConfig) -> bool:

--- a/src/inspect_ai/model/_providers/fireworks.py
+++ b/src/inspect_ai/model/_providers/fireworks.py
@@ -64,21 +64,23 @@ class FireworksAIAPI(OpenAICompatibleAPI):
     def is_gpt_oss(self) -> bool:
         return "gpt-oss" in self.model_family().lower()
 
-    def is_minimax(self) -> bool:
-        return "minimax" in self.model_family().lower()
+    def is_minimax_m2(self) -> bool:
+        # Only the MiniMax M2 line (e.g. minimax-m2p7) is restrictive; MiniMax M3
+        # accepts `none`/`xhigh`/`max`, so match `minimax-m2*` and not `minimax-m3`.
+        return "minimax-m2" in self.model_family().lower()
 
     @override
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         params = super().completion_params(config, tools)
 
         # Fireworks' effort schema is a superset and validity is model-dependent.
-        # No model accepts `minimal` (-> `low`). gpt-oss and MiniMax accept only
+        # No model accepts `minimal` (-> `low`). gpt-oss and MiniMax M2 accept only
         # `low`/`medium`/`high` (same constraint as SambaNova): extended values clamp
         # down and `none` is omitted (provider/model default applies -- reasoning is
-        # not disabled). Other families (DeepSeek, GLM, Kimi) accept `none` and
-        # `xhigh`/`max`, so those pass through unchanged.
+        # not disabled). Other models -- DeepSeek, GLM, Kimi, and MiniMax M3 -- accept
+        # `none` and `xhigh`/`max`, so those pass through unchanged.
         if "reasoning_effort" in params:
-            if self.is_gpt_oss() or self.is_minimax():
+            if self.is_gpt_oss() or self.is_minimax_m2():
                 clamped = clamp_reasoning_effort_to_low_medium_high(
                     params["reasoning_effort"]
                 )

--- a/src/inspect_ai/model/_providers/perplexity.py
+++ b/src/inspect_ai/model/_providers/perplexity.py
@@ -1,6 +1,7 @@
 from typing import Any, cast
 
 from openai.types.chat import ChatCompletion
+from typing_extensions import override
 
 from inspect_ai._util.citation import UrlCitation
 from inspect_ai._util.content import ContentText
@@ -8,6 +9,9 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model_output import ModelOutput, ModelUsage
 from inspect_ai.model._openai import chat_choices_from_openai
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
+from inspect_ai.model._reasoning import (
+    clamp_reasoning_effort_to_minimal_low_medium_high,
+)
 from inspect_ai.tool import ToolChoice, ToolInfo
 
 from .._chat_message import ChatMessage
@@ -37,6 +41,23 @@ class PerplexityAPI(OpenAICompatibleAPI):
         )
 
         self._response: dict[str, Any] | None = None
+
+    @override
+    def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        params = super().completion_params(config, tools)
+
+        # Perplexity's API accepts minimal/low/medium/high; clamp the extended
+        # top-end values (xhigh/max) to high while preserving minimal.
+        if "reasoning_effort" in params:
+            clamped = clamp_reasoning_effort_to_minimal_low_medium_high(
+                params["reasoning_effort"]
+            )
+            if clamped is not None:
+                params["reasoning_effort"] = clamped
+            else:
+                del params["reasoning_effort"]
+
+        return params
 
     def on_response(self, response: dict[str, Any]) -> None:
         """Capture the raw response for post-processing."""

--- a/src/inspect_ai/model/_providers/perplexity.py
+++ b/src/inspect_ai/model/_providers/perplexity.py
@@ -46,8 +46,10 @@ class PerplexityAPI(OpenAICompatibleAPI):
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         params = super().completion_params(config, tools)
 
-        # Perplexity's API accepts minimal/low/medium/high; clamp the extended
-        # top-end values (xhigh/max) to high while preserving minimal.
+        # Perplexity's API accepts `minimal`/`low`/`medium`/`high`; clamp the
+        # extended top-end values (`xhigh`/`max`) to `high` while preserving
+        # `minimal`. `none` isn't supported and is omitted, so the provider/model
+        # default applies -- reasoning is not disabled.
         if "reasoning_effort" in params:
             clamped = clamp_reasoning_effort_to_minimal_low_medium_high(
                 params["reasoning_effort"]

--- a/src/inspect_ai/model/_providers/sambanova.py
+++ b/src/inspect_ai/model/_providers/sambanova.py
@@ -30,8 +30,10 @@ class SambaNovaAPI(OpenAICompatibleAPI):
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         params = super().completion_params(config, tools)
 
-        # SambaNova's API accepts low/medium/high; clamp the extended effort
-        # values (minimal/xhigh/max) so requests aren't rejected.
+        # SambaNova's API accepts only `low`/`medium`/`high`; clamp the extended
+        # effort values (`minimal`/`xhigh`/`max`) so requests aren't rejected.
+        # `none` isn't supported and is omitted, so the provider/model default
+        # applies -- reasoning is not disabled (always-on models keep reasoning).
         if "reasoning_effort" in params:
             clamped = clamp_reasoning_effort_to_low_medium_high(
                 params["reasoning_effort"]

--- a/src/inspect_ai/model/_providers/sambanova.py
+++ b/src/inspect_ai/model/_providers/sambanova.py
@@ -1,4 +1,9 @@
+from typing import Any
+
+from typing_extensions import override
+
 from .._generate_config import GenerateConfig
+from .._reasoning import clamp_reasoning_effort_to_low_medium_high
 from .openai_compatible import OpenAICompatibleAPI
 
 
@@ -20,3 +25,20 @@ class SambaNovaAPI(OpenAICompatibleAPI):
             service_base_url="https://api.sambanova.ai/v1",
             emulate_tools=emulate_tools,
         )
+
+    @override
+    def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
+        params = super().completion_params(config, tools)
+
+        # SambaNova's API accepts low/medium/high; clamp the extended effort
+        # values (minimal/xhigh/max) so requests aren't rejected.
+        if "reasoning_effort" in params:
+            clamped = clamp_reasoning_effort_to_low_medium_high(
+                params["reasoning_effort"]
+            )
+            if clamped is not None:
+                params["reasoning_effort"] = clamped
+            else:
+                del params["reasoning_effort"]
+
+        return params

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -12,6 +12,7 @@ from openai.types.chat import (
 from typing_extensions import override
 
 from inspect_ai._util.constants import DEFAULT_MAX_TOKENS
+from inspect_ai.model._reasoning import clamp_reasoning_effort_to_low_medium_high
 from inspect_ai.model._retry import batch_admin_retry_config
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
@@ -151,6 +152,17 @@ class TogetherAIAPI(OpenAICompatibleAPI):
             params["logprobs"] = 1
         if "top_logprobs" in params:
             del params["top_logprobs"]
+
+        # Together's API accepts low/medium/high; clamp the extended effort
+        # values (minimal/xhigh/max), which are otherwise intermittently rejected.
+        if "reasoning_effort" in params:
+            clamped = clamp_reasoning_effort_to_low_medium_high(
+                params["reasoning_effort"]
+            )
+            if clamped is not None:
+                params["reasoning_effort"] = clamped
+            else:
+                del params["reasoning_effort"]
 
         # together requires temperature with num_choices
         if config.num_choices is not None and config.temperature is None:

--- a/src/inspect_ai/model/_providers/together.py
+++ b/src/inspect_ai/model/_providers/together.py
@@ -12,7 +12,6 @@ from openai.types.chat import (
 from typing_extensions import override
 
 from inspect_ai._util.constants import DEFAULT_MAX_TOKENS
-from inspect_ai.model._reasoning import clamp_reasoning_effort_to_low_medium_high
 from inspect_ai.model._retry import batch_admin_retry_config
 from inspect_ai.tool._tool_choice import ToolChoice
 from inspect_ai.tool._tool_info import ToolInfo
@@ -145,6 +144,9 @@ class TogetherAIAPI(OpenAICompatibleAPI):
         else:
             return ex
 
+    def is_gpt_oss(self) -> bool:
+        return "gpt-oss" in self.model_family().lower()
+
     @override
     def completion_params(self, config: GenerateConfig, tools: bool) -> dict[str, Any]:
         params = super().completion_params(config, tools)
@@ -153,16 +155,20 @@ class TogetherAIAPI(OpenAICompatibleAPI):
         if "top_logprobs" in params:
             del params["top_logprobs"]
 
-        # Together's API accepts low/medium/high; clamp the extended effort
-        # values (minimal/xhigh/max), which are otherwise intermittently rejected.
+        # Together accepts `low`/`medium`/`high` for all reasoning models, plus
+        # `xhigh`/`max` on some (e.g. DeepSeek V4 Pro). `minimal` is never accepted
+        # (-> `low`). `none` isn't a supported effort value, so it's omitted and the
+        # provider/model default applies -- reasoning is not disabled (hybrid models
+        # are disabled via reasoning={"enabled": false}, not an effort value). Only
+        # gpt-oss rejects `xhigh`/`max` (-> `high`); other models pass them through.
         if "reasoning_effort" in params:
-            clamped = clamp_reasoning_effort_to_low_medium_high(
-                params["reasoning_effort"]
-            )
-            if clamped is not None:
-                params["reasoning_effort"] = clamped
-            else:
+            effort = params["reasoning_effort"]
+            if effort == "minimal":
+                params["reasoning_effort"] = "low"
+            elif effort == "none":
                 del params["reasoning_effort"]
+            elif effort in ("xhigh", "max") and self.is_gpt_oss():
+                params["reasoning_effort"] = "high"
 
         # together requires temperature with num_choices
         if config.num_choices is not None and config.temperature is None:

--- a/src/inspect_ai/model/_reasoning.py
+++ b/src/inspect_ai/model/_reasoning.py
@@ -70,6 +70,32 @@ def clamp_reasoning_effort_to_low_medium_high(
     return None
 
 
+def clamp_reasoning_effort_to_minimal_low_medium_high(
+    effort: Literal["none", "minimal", "low", "medium", "high", "xhigh", "max"]
+    | str
+    | None,
+) -> Literal["minimal", "low", "medium", "high"] | None:
+    """Clamp a `reasoning_effort` value to the `minimal`/`low`/`medium`/`high` tier.
+
+    Used by providers that pass effort through to upstream APIs which accept
+    `minimal` in addition to the three-level scale (Perplexity); only the
+    top-end values (`xhigh`/`max`) are clamped down to `high`. Returns None for
+    `None` and `"none"`.
+    """
+    if effort is None or effort == "none":
+        return None
+    match effort:
+        case "minimal":
+            return "minimal"
+        case "low":
+            return "low"
+        case "medium":
+            return "medium"
+        case "high" | "xhigh" | "max":
+            return "high"
+    return None
+
+
 class ReasoningCapsule(NamedTuple):
     reasoning: str
     signature: str | None = None

--- a/src/inspect_ai/model/_reasoning.py
+++ b/src/inspect_ai/model/_reasoning.py
@@ -55,8 +55,7 @@ def clamp_reasoning_effort_to_low_medium_high(
     """Clamp a `reasoning_effort` value to the `low`/`medium`/`high` tier.
 
     Used by providers that pass effort through to upstream APIs which only
-    accept the three-level scale (Groq, Ollama, SageMaker). Returns None for
-    `None` and `"none"`.
+    accept the three-level scale. Returns None for `None` and `"none"`.
     """
     if effort is None or effort == "none":
         return None

--- a/tests/model/test_reasoning_effort.py
+++ b/tests/model/test_reasoning_effort.py
@@ -347,6 +347,14 @@ def test_together_frontier_model_preserves_xhigh_max(effort, expected):
     assert params.get("reasoning_effort") == expected
 
 
+def test_together_frontier_model_effort_none_omitted():
+    from inspect_ai.model._providers.together import TogetherAIAPI
+
+    api = TogetherAIAPI(model_name="deepseek-ai/DeepSeek-V4-Pro", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort="none"), tools=False)
+    assert "reasoning_effort" not in params
+
+
 # -- Fireworks clamping (model-conditional: gpt-oss and MiniMax M2 accept only
 #    low/medium/high; other models -- incl. MiniMax M3 -- accept none/xhigh/max) --
 

--- a/tests/model/test_reasoning_effort.py
+++ b/tests/model/test_reasoning_effort.py
@@ -325,9 +325,38 @@ def test_together_effort_none_omitted():
     assert "reasoning_effort" not in params
 
 
-# -- Fireworks clamping (model-conditional: only gpt-oss clamps xhigh/max) --
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "xhigh"),
+        ("max", "max"),
+    ],
+)
+def test_together_frontier_model_preserves_xhigh_max(effort, expected):
+    from inspect_ai.model._providers.together import TogetherAIAPI
+
+    # Non-gpt-oss Together models (e.g. DeepSeek V4 Pro) accept xhigh/max, so only
+    # `minimal` is clamped and the top-end values pass through.
+    api = TogetherAIAPI(model_name="deepseek-ai/DeepSeek-V4-Pro", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
+    assert params.get("reasoning_effort") == expected
 
 
+# -- Fireworks clamping (model-conditional: gpt-oss and MiniMax accept only
+#    low/medium/high; other families accept none/xhigh/max) --
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "accounts/fireworks/models/gpt-oss-120b",
+        "accounts/fireworks/models/minimax-m2",
+    ],
+)
 @pytest.mark.parametrize(
     "effort,expected",
     [
@@ -337,17 +366,30 @@ def test_together_effort_none_omitted():
         ("high", "high"),
         ("xhigh", "high"),
         ("max", "high"),
-        ("none", "none"),
     ],
 )
-def test_fireworks_gpt_oss_clamps_extended_effort_values(effort, expected):
+def test_fireworks_low_medium_high_models_clamp_extended(model_name, effort, expected):
     from inspect_ai.model._providers.fireworks import FireworksAIAPI
 
-    api = FireworksAIAPI(
-        model_name="accounts/fireworks/models/gpt-oss-120b", api_key="test-key"
-    )
+    api = FireworksAIAPI(model_name=model_name, api_key="test-key")
     params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
     assert params.get("reasoning_effort") == expected
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "accounts/fireworks/models/gpt-oss-120b",
+        "accounts/fireworks/models/minimax-m2",
+    ],
+)
+def test_fireworks_low_medium_high_models_omit_none(model_name):
+    from inspect_ai.model._providers.fireworks import FireworksAIAPI
+
+    # gpt-oss and MiniMax reject `none`, so it is omitted (provider/model default).
+    api = FireworksAIAPI(model_name=model_name, api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort="none"), tools=False)
+    assert "reasoning_effort" not in params
 
 
 @pytest.mark.parametrize(

--- a/tests/model/test_reasoning_effort.py
+++ b/tests/model/test_reasoning_effort.py
@@ -1,12 +1,17 @@
 """Tests for shared reasoning_effort utilities and per-provider mapping/clamping.
 
 Covers:
-- Unit tests for `effort_to_reasoning_tokens` and
-  `clamp_reasoning_effort_to_low_medium_high` in `_reasoning.py`.
+- Unit tests for `effort_to_reasoning_tokens`,
+  `clamp_reasoning_effort_to_low_medium_high`, and
+  `clamp_reasoning_effort_to_minimal_low_medium_high` in `_reasoning.py`.
 - Bridge tests: passing `reasoning_effort` to pre-4.6 Claude / Gemini 2.5 should
   produce a `budget_tokens` / `thinking_budget` via the fixed-table translation.
-- Clamp tests: Groq/Ollama/SageMaker should map extended effort values
-  (`minimal`/`xhigh`/`max`) down to the `low`/`medium`/`high` tier.
+- Clamp tests: Groq/Ollama/SageMaker/SambaNova/Together should map extended
+  effort values (`minimal`/`xhigh`/`max`) down to the `low`/`medium`/`high` tier;
+  Perplexity keeps `minimal` and clamps only `xhigh`/`max` down to `high`.
+- Fireworks is model-conditional (superset schema): `minimal`->`low` on all
+  models, but `xhigh`/`max` are clamped to `high` only for gpt-oss (which rejects
+  them) and preserved for other reasoning models (deepseek/glm/kimi/minimax).
 - OpenRouter: `max` is remapped to `xhigh` (OpenRouter does not accept `max`).
 """
 
@@ -19,6 +24,7 @@ from inspect_ai.model._providers.google import GoogleGenAIAPI
 from inspect_ai.model._providers.openrouter import OpenRouterAPI
 from inspect_ai.model._reasoning import (
     clamp_reasoning_effort_to_low_medium_high,
+    clamp_reasoning_effort_to_minimal_low_medium_high,
     effort_to_reasoning_tokens,
 )
 
@@ -57,6 +63,23 @@ def test_effort_to_reasoning_tokens(effort, expected):
 )
 def test_clamp_reasoning_effort_to_low_medium_high(effort, expected):
     assert clamp_reasoning_effort_to_low_medium_high(effort) == expected
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        (None, None),
+        ("none", None),
+        ("minimal", "minimal"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),
+        ("max", "high"),
+    ],
+)
+def test_clamp_reasoning_effort_to_minimal_low_medium_high(effort, expected):
+    assert clamp_reasoning_effort_to_minimal_low_medium_high(effort) == expected
 
 
 # -- Anthropic bridge: pre-4.6 Claude with reasoning_effort only --
@@ -191,7 +214,7 @@ def test_google_gemini_3_uses_thinking_level_not_bridge():
     assert thinking_config.thinking_budget is None
 
 
-# -- Groq / Ollama / SageMaker clamping --
+# -- Groq / Ollama / SageMaker / SambaNova / Together clamping --
 
 
 @pytest.mark.parametrize(
@@ -246,6 +269,137 @@ def test_ollama_effort_none_omitted():
     api = OllamaAPI(model_name="qwen3:8b")
     params = api.completion_params(GenerateConfig(reasoning_effort="none"), tools=False)
     assert "extra_body" not in params or "reasoning" not in params.get("extra_body", {})
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),
+        ("max", "high"),
+    ],
+)
+def test_sambanova_clamps_extended_effort_values(effort, expected):
+    from inspect_ai.model._providers.sambanova import SambaNovaAPI
+
+    api = SambaNovaAPI(model_name="gpt-oss-120b", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
+    assert params.get("reasoning_effort") == expected
+
+
+def test_sambanova_effort_none_omitted():
+    from inspect_ai.model._providers.sambanova import SambaNovaAPI
+
+    api = SambaNovaAPI(model_name="gpt-oss-120b", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort="none"), tools=False)
+    assert "reasoning_effort" not in params
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),
+        ("max", "high"),
+    ],
+)
+def test_together_clamps_extended_effort_values(effort, expected):
+    from inspect_ai.model._providers.together import TogetherAIAPI
+
+    api = TogetherAIAPI(model_name="openai/gpt-oss-120b", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
+    assert params.get("reasoning_effort") == expected
+
+
+def test_together_effort_none_omitted():
+    from inspect_ai.model._providers.together import TogetherAIAPI
+
+    api = TogetherAIAPI(model_name="openai/gpt-oss-120b", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort="none"), tools=False)
+    assert "reasoning_effort" not in params
+
+
+# -- Fireworks clamping (model-conditional: only gpt-oss clamps xhigh/max) --
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),
+        ("max", "high"),
+        ("none", "none"),
+    ],
+)
+def test_fireworks_gpt_oss_clamps_extended_effort_values(effort, expected):
+    from inspect_ai.model._providers.fireworks import FireworksAIAPI
+
+    api = FireworksAIAPI(
+        model_name="accounts/fireworks/models/gpt-oss-120b", api_key="test-key"
+    )
+    params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
+    assert params.get("reasoning_effort") == expected
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "low"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "xhigh"),
+        ("max", "max"),
+        ("none", "none"),
+    ],
+)
+def test_fireworks_frontier_model_preserves_xhigh_max(effort, expected):
+    from inspect_ai.model._providers.fireworks import FireworksAIAPI
+
+    api = FireworksAIAPI(
+        model_name="accounts/fireworks/models/deepseek-v4-pro", api_key="test-key"
+    )
+    params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
+    assert params.get("reasoning_effort") == expected
+
+
+# -- Perplexity clamping (keeps minimal, clamps only xhigh/max) --
+
+
+@pytest.mark.parametrize(
+    "effort,expected",
+    [
+        ("minimal", "minimal"),
+        ("low", "low"),
+        ("medium", "medium"),
+        ("high", "high"),
+        ("xhigh", "high"),
+        ("max", "high"),
+    ],
+)
+def test_perplexity_clamps_only_extended_top_end(effort, expected):
+    from inspect_ai.model._providers.perplexity import PerplexityAPI
+
+    api = PerplexityAPI(model_name="sonar-reasoning-pro", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
+    assert params.get("reasoning_effort") == expected
+
+
+def test_perplexity_effort_none_omitted():
+    from inspect_ai.model._providers.perplexity import PerplexityAPI
+
+    api = PerplexityAPI(model_name="sonar-reasoning-pro", api_key="test-key")
+    params = api.completion_params(GenerateConfig(reasoning_effort="none"), tools=False)
+    assert "reasoning_effort" not in params
 
 
 # -- OpenAI Responses path max -> xhigh clamp --

--- a/tests/model/test_reasoning_effort.py
+++ b/tests/model/test_reasoning_effort.py
@@ -10,8 +10,9 @@ Covers:
   effort values (`minimal`/`xhigh`/`max`) down to the `low`/`medium`/`high` tier;
   Perplexity keeps `minimal` and clamps only `xhigh`/`max` down to `high`.
 - Fireworks is model-conditional (superset schema): `minimal`->`low` on all
-  models, but `xhigh`/`max` are clamped to `high` only for gpt-oss (which rejects
-  them) and preserved for other reasoning models (deepseek/glm/kimi/minimax).
+  models; `none` is dropped and `xhigh`/`max` clamped to `high` only for gpt-oss and
+  MiniMax M2 (which reject them), while other models (deepseek/glm/kimi and MiniMax
+  M3) accept and pass through `none`/`xhigh`/`max`.
 - OpenRouter: `max` is remapped to `xhigh` (OpenRouter does not accept `max`).
 """
 
@@ -346,15 +347,15 @@ def test_together_frontier_model_preserves_xhigh_max(effort, expected):
     assert params.get("reasoning_effort") == expected
 
 
-# -- Fireworks clamping (model-conditional: gpt-oss and MiniMax accept only
-#    low/medium/high; other families accept none/xhigh/max) --
+# -- Fireworks clamping (model-conditional: gpt-oss and MiniMax M2 accept only
+#    low/medium/high; other models -- incl. MiniMax M3 -- accept none/xhigh/max) --
 
 
 @pytest.mark.parametrize(
     "model_name",
     [
         "accounts/fireworks/models/gpt-oss-120b",
-        "accounts/fireworks/models/minimax-m2",
+        "accounts/fireworks/models/minimax-m2p7",
     ],
 )
 @pytest.mark.parametrize(
@@ -380,18 +381,25 @@ def test_fireworks_low_medium_high_models_clamp_extended(model_name, effort, exp
     "model_name",
     [
         "accounts/fireworks/models/gpt-oss-120b",
-        "accounts/fireworks/models/minimax-m2",
+        "accounts/fireworks/models/minimax-m2p7",
     ],
 )
 def test_fireworks_low_medium_high_models_omit_none(model_name):
     from inspect_ai.model._providers.fireworks import FireworksAIAPI
 
-    # gpt-oss and MiniMax reject `none`, so it is omitted (provider/model default).
+    # gpt-oss and MiniMax M2 reject `none`, so it is omitted (provider/model default).
     api = FireworksAIAPI(model_name=model_name, api_key="test-key")
     params = api.completion_params(GenerateConfig(reasoning_effort="none"), tools=False)
     assert "reasoning_effort" not in params
 
 
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "accounts/fireworks/models/deepseek-v4-pro",
+        "accounts/fireworks/models/minimax-m3",
+    ],
+)
 @pytest.mark.parametrize(
     "effort,expected",
     [
@@ -404,12 +412,13 @@ def test_fireworks_low_medium_high_models_omit_none(model_name):
         ("none", "none"),
     ],
 )
-def test_fireworks_frontier_model_preserves_xhigh_max(effort, expected):
+def test_fireworks_non_restrictive_models_preserve_extended(
+    model_name, effort, expected
+):
     from inspect_ai.model._providers.fireworks import FireworksAIAPI
 
-    api = FireworksAIAPI(
-        model_name="accounts/fireworks/models/deepseek-v4-pro", api_key="test-key"
-    )
+    # DeepSeek and MiniMax M3 accept none/xhigh/max, so only `minimal` is clamped.
+    api = FireworksAIAPI(model_name=model_name, api_key="test-key")
     params = api.completion_params(GenerateConfig(reasoning_effort=effort), tools=False)
     assert params.get("reasoning_effort") == expected
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

For Together, SambaNova, Perplexity, and Fireworks, users can set `GenerateConfig.reasoning_effort` to a value where they'll get errors about invalid requests/with a `400`.

### What is the new behavior?

The code maps these values to the ones the providers accept, and users don't get these errors.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

I ran
```
python mre_reasoning_effort.py --model sambanova/gpt-oss-120b --reasoning-effort minimal
python mre_reasoning_effort.py --model sambanova/gpt-oss-120b --reasoning-effort xhigh
python mre_reasoning_effort.py --model sambanova/gpt-oss-120b --reasoning-effort max
python mre_reasoning_effort.py --model together/openai/gpt-oss-120b --reasoning-effort minimal
python mre_reasoning_effort.py --model together/openai/gpt-oss-120b --reasoning-effort xhigh
python mre_reasoning_effort.py --model together/openai/gpt-oss-120b --reasoning-effort max
python mre_reasoning_effort.py --model fireworks/accounts/fireworks/models/gpt-oss-120b --reasoning-effort minimal
python mre_reasoning_effort.py --model fireworks/accounts/fireworks/models/gpt-oss-120b --reasoning-effort xhigh
python mre_reasoning_effort.py --model fireworks/accounts/fireworks/models/gpt-oss-120b --reasoning-effort max
python mre_reasoning_effort.py --model perplexity/sonar-reasoning-pro --reasoning-effort xhigh
python mre_reasoning_effort.py --model perplexity/sonar-reasoning-pro --reasoning-effort max
```
where `mre_reasoning_effort.py` is
```
import argparse
import asyncio

from inspect_ai._util.content import ContentReasoning
from inspect_ai.model import GenerateConfig, get_model

parser = argparse.ArgumentParser()
parser.add_argument("--model", required=True)
parser.add_argument("--reasoning-effort", default="medium")
args = parser.parse_args()

config = GenerateConfig(reasoning_effort=args.reasoning_effort)


async def main() -> None:
    try:
        output = await get_model(args.model).generate(
            "What is 17 * 23? Reason it through.", config=config
        )
    except Exception as ex:
        print("rejected:", " ".join(str(ex).split())[-120:])
        return
    reasoning = [
        c.reasoning for c in output.message.content if isinstance(c, ContentReasoning)
    ]
    print("reasoning:", reasoning[0][:100] if reasoning else None)
    print("answer:", output.completion[:80])


asyncio.run(main())
```
.

I also added Moonshot to `docs/reasoning.qmd`.