### PR TITLE
Add abliteration model provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Bugfix: Registry objects (`@solver`, `@agent`, `@tool`, …) that declare `**kwargs` no longer crash at registration when a keyword argument is named `type`, `o`, or `info`, and approval-policy params named `type`/`name` no longer collide on creation. (#4504)
 - Analysis: `frontier()` no longer errors when a model release date group has only missing (NA) headline scores; those rows are now skipped instead of crashing `idxmax()`.
 - Models: bounded `count_tokens()` concurrency (adaptive, like `generate()`) so large token-count fan-outs no longer overwhelm the provider connection pool.
+- Models: New `abliteration` provider for models hosted on [Abliteration](https://abliteration.ai/), using `abliteration/<model>` names and the `ABLIT_KEY` environment variable.
 - Model: `generate()` now retries the anyio transport-close race (`AttributeError: 'NoneType' object has no attribute 'call_soon'` during response cleanup) instead of failing the sample.
 - Inspect View: Improved log parsing performance; added real-payload benchmarks. (#384)
 - Inspect View: Fixed timeline discarding a solver span containing a single agent span child when it also contains other displayed events. (#443)

--- a/docs/_model-providers.md
+++ b/docs/_model-providers.md
@@ -3,7 +3,7 @@
 |------------------------------------|------------------------------------|
 | Lab APIs | [OpenAI](providers.qmd#openai), [Anthropic](providers.qmd#anthropic), [Google](providers.qmd#google), [Grok](providers.qmd#grok), [Mistral](providers.qmd#mistral), [DeepSeek](providers.qmd#deepseek), [Moonshot AI](providers.qmd#moonshot-ai), [Perplexity](providers.qmd#perplexity) |
 | Cloud APIs | [AWS Bedrock](providers.qmd#aws-bedrock), [AWS SageMaker](providers.qmd#aws-sagemaker), and [Azure AI](providers.qmd#azure-ai) |
-| Open (Hosted) | [Groq](providers.qmd#groq), [Together AI](providers.qmd#together-ai), [Fireworks AI](providers.qmd#fireworks-ai), [Cloudflare](providers.qmd#cloudflare), [HF Inference Providers](providers.qmd#hf-inference-providers), [SambaNova](providers.qmd#sambanova) |
+| Open (Hosted) | [Groq](providers.qmd#groq), [Together AI](providers.qmd#together-ai), [Fireworks AI](providers.qmd#fireworks-ai), [Cloudflare](providers.qmd#cloudflare), [HF Inference Providers](providers.qmd#hf-inference-providers), [SambaNova](providers.qmd#sambanova), [Abliteration](providers.qmd#abliteration) |
 | Open (Local) | [Hugging Face](providers.qmd#hugging-face), [vLLM](providers.qmd#vllm), [Ollama](providers.qmd#ollama), [Lllama-cpp-python](providers.qmd#llama-cpp-python), [SGLang](providers.qmd#sglang), [TransformerLens](providers.qmd#transformer-lens), [nnterp](providers.qmd#nnterp) |
 
 <br/>

--- a/docs/providers.qmd
+++ b/docs/providers.qmd
@@ -833,6 +833,25 @@ The following environment variables are supported by the SambaNova provider
 | `SAMBANOVA_API_KEY` | API key credentials (required). |
 | `SAMBANOVA_BASE_URL` | Base URL for requests (optional, defaults to `https://api.sambanova.ai/v1`) |
 
+## Abliteration {#abliteration}
+
+To use the [Abliteration](https://abliteration.ai/) provider (uncensored/abliterated open models hosted behind an OpenAI-compatible API), install the `openai` package, set your credentials, and specify a model using the `--model` option:
+
+``` bash
+pip install openai
+export ABLIT_KEY=your-abliteration-api-key
+inspect eval arc.py --model abliteration/huihui-ai/Llama-3.2-3B-Instruct-abliterated
+```
+
+For the `abliteration` provider, you can enable [Tool Emulation](#tool-emulation-openai) using the `emulate_tools` custom model arg (`-M`). Other custom model args are forwarded to the constructor of the `AsyncOpenAI` class.
+
+The following environment variables are supported by the Abliteration provider
+
+| Variable | Description |
+|----------------------------|--------------------------------------------|
+| `ABLIT_KEY` | API key credentials (required). |
+| `ABLITERATION_BASE_URL` | Base URL for requests (optional, defaults to `https://api.abliteration.ai/v1`) |
+
 ## Cloudflare {#cloudflare}
 
 To use the [Cloudflare](https://developers.cloudflare.com/workers-ai/) provider, set your account id and access token, and specify a model using the `--model` option:

--- a/src/inspect_ai/model/_providers/abliteration.py
+++ b/src/inspect_ai/model/_providers/abliteration.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from .._generate_config import GenerateConfig
+from .openai_compatible import OpenAICompatibleAPI
+
+ABLIT_KEY = "ABLIT_KEY"
+
+
+class AbliterationAPI(OpenAICompatibleAPI):
+    def __init__(
+        self,
+        model_name: str,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        config: GenerateConfig = GenerateConfig(),
+        emulate_tools: bool = False,
+        **model_args: Any,
+    ) -> None:
+        super().__init__(
+            model_name=model_name,
+            base_url=base_url,
+            api_key=api_key,
+            config=config,
+            service="Abliteration",
+            service_base_url="https://api.abliteration.ai/v1",
+            api_key_var=ABLIT_KEY,
+            emulate_tools=emulate_tools,
+            **model_args,
+        )

--- a/src/inspect_ai/model/_providers/providers.py
+++ b/src/inspect_ai/model/_providers/providers.py
@@ -203,6 +203,14 @@ def sambanova() -> type[ModelAPI]:
     return SambaNovaAPI
 
 
+@modelapi(name="abliteration")
+def abliteration() -> type[ModelAPI]:
+    validate_openai_client("Abliteration API")
+    from .abliteration import AbliterationAPI
+
+    return AbliterationAPI
+
+
 @modelapi(name="ollama")
 def ollama() -> type[ModelAPI]:
     # validate

--- a/tests/model/providers/test_abliteration.py
+++ b/tests/model/providers/test_abliteration.py
@@ -1,0 +1,51 @@
+import pytest
+from test_helpers.utils import skip_if_no_abliteration
+
+from inspect_ai.model import (
+    ChatMessageUser,
+    GenerateConfig,
+    get_model,
+)
+
+
+@pytest.fixture
+def mock_abliteration_env(monkeypatch):
+    """Mock required Abliteration environment variables."""
+    monkeypatch.setenv("ABLIT_KEY", "test-key")
+    monkeypatch.delenv("ABLITERATION_BASE_URL", raising=False)
+
+
+def test_abliteration_defaults(mock_abliteration_env):
+    from inspect_ai.model._providers.abliteration import AbliterationAPI
+
+    api = AbliterationAPI(model_name="huihui-ai/Llama-3.2-3B-Instruct-abliterated")
+    assert api.api_key == "test-key"
+    assert api.base_url == "https://api.abliteration.ai/v1"
+    assert api.service_model_name() == "huihui-ai/Llama-3.2-3B-Instruct-abliterated"
+
+
+def test_abliteration_base_url_env_override(mock_abliteration_env, monkeypatch):
+    from inspect_ai.model._providers.abliteration import AbliterationAPI
+
+    monkeypatch.setenv("ABLITERATION_BASE_URL", "https://example.com/v1")
+    api = AbliterationAPI(model_name="huihui-ai/Llama-3.2-3B-Instruct-abliterated")
+    assert api.base_url == "https://example.com/v1"
+
+
+def test_abliteration_missing_api_key(monkeypatch):
+    from inspect_ai.model._providers.abliteration import AbliterationAPI
+
+    monkeypatch.delenv("ABLIT_KEY", raising=False)
+    with pytest.raises(Exception, match="ABLIT_KEY"):
+        AbliterationAPI(model_name="huihui-ai/Llama-3.2-3B-Instruct-abliterated")
+
+
+@skip_if_no_abliteration
+async def test_abliteration_compatible() -> None:
+    model = get_model(
+        "abliteration/huihui-ai/Llama-3.2-3B-Instruct-abliterated",
+        config=GenerateConfig(max_tokens=50, temperature=0.0),
+    )
+    message = ChatMessageUser(content="What is an LLM")
+    res = await model.generate(input=[message])
+    assert len(res.completion) >= 1

--- a/tests/test_helpers/utils.py
+++ b/tests/test_helpers/utils.py
@@ -332,6 +332,11 @@ def skip_if_no_sambanova(func):
     return pytest.mark.api(skip_if_env_var("SAMBANOVA_API_KEY", exists=False)(func))
 
 
+def skip_if_no_abliteration(func):
+    func._needs_flaky_retry = True
+    return pytest.mark.api(skip_if_env_var("ABLIT_KEY", exists=False)(func))
+
+
 def skip_if_no_perplexity(func):
     func._needs_flaky_retry = True
     missing_requirements = []


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

[Abliteration](https://abliteration.ai/) hosts abliterated open models behind an OpenAI-compatible API (`https://api.abliteration.ai/v1`). It can only be used today via the generic `openai-api` provider with a manually configured base URL.

### What is the new behavior?

A dedicated `abliteration` provider, following the same pattern as the other hosted OpenAI-compatible providers (sambanova, fireworks, moonshot):

```bash
pip install openai
export ABLIT_KEY=your-abliteration-api-key
inspect eval arc.py --model abliteration/huihui-ai/Llama-3.2-3B-Instruct-abliterated
```

- Credentials are read from the `ABLIT_KEY` environment variable (the name the service documents).
- The base URL defaults to `https://api.abliteration.ai/v1` and can be overridden with `ABLITERATION_BASE_URL`.
- Supports the `emulate_tools` model arg; other custom model args are forwarded to the `AsyncOpenAI` constructor.

Docs (`providers.qmd`, `_model-providers.md`) and a CHANGELOG entry are included.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

`make check` (ruff + mypy) passes. `pytest tests/model` passes locally (1765 passed, 950 skipped). Unit tests for the provider (default config, `ABLITERATION_BASE_URL` override, missing-key error) run without credentials; the live API test is marked `api` and skips unless `ABLIT_KEY` is set.
