### PR TITLE
fix(ctl): read control servers concurrently and allow a longer read timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - Grok: Unknown (predeployment) model names are now treated as the latest Grok model for context window (compaction) and capability detection.
 - Analysis: string values for `bool`-typed columns now coerce via YAML, so `"false"`/`"0"`/`"no"`/`"off"` parse to `False` instead of every non-empty string becoming `True`.
+- Control Channel: `inspect ctl` reads discovered processes concurrently, and `INSPECT_CTL_REQUEST_TIMEOUT` raises the per-attempt read timeout for busy evals.
 - Sandbox: Large sandbox-tool responses are transferred intact instead of corrupting JSON-RPC frames when they exceed the sandbox exec output limit.
 - Sandbox: Service method errors no longer include the host-side traceback in the response delivered into the sandbox; the traceback is logged host-side instead. (#4673)
 - Agent Bridge: Fix for `message_limit`/`token_limit`/`cost_limit` errors not being properly raised when running in a sandbox.

--- a/docs/control-channel.qmd
+++ b/docs/control-channel.qmd
@@ -338,6 +338,20 @@ $ inspect ctl process anomalies 12345
 
 Unlike the other reads, this one opens the process's trace file directly rather than asking the process — so it works even against a process too busy or wedged to answer (the escalation path when another command reports "busy"), and even post-mortem: passing the pid of an exited process reads its trace file (kept on disk for the last 10 runs) to show what was in flight when it died, with durations dated to the file's last write. With no `PID` it reads every running Inspect process, one section per pid.
 
+## Reads Against a Busy Eval
+
+The control server is embedded in the eval process and shares its event loop, so its response latency tracks how loaded the eval is. Under heavy load a perfectly healthy server can take tens of seconds to answer — probing a ten-process eval-set sweep driving ~2400 sandboxes, the same `GET /config` returned in 2.3s, 7.9s and 79.3s on consecutive attempts. Reads therefore retry a timeout several times before giving up, and report `busy` rather than claiming the eval is gone.
+
+When the default per-attempt timeout is too short for your workload, raise it for the invocation:
+
+```bash
+INSPECT_CTL_REQUEST_TIMEOUT=120 inspect ctl task
+```
+
+The value is in seconds and is read per command, so it applies to the invocation that sets it. An unusable value (non-numeric, zero, negative) is an error rather than a silent revert to the default, so a raised timeout that never took effect cannot be mistaken for a still-unresponsive eval. Mutations get the same budget, scaled by the retry count.
+
+A command that reads *every* discovered process contacts them concurrently (in bounded waves when many are running), so one loaded process no longer delays the rest — with several evals running, a serial fan-out would spend each process's full retry budget before contacting the next. Results are still ordered by discovery, so which process answers first does not change what a command reports. If a process stays busy through its retries, escalate to `inspect ctl process anomalies <pid>`, which reads the trace file directly and does not need the process to answer.
+
 ## Configuration
 
 `inspect ctl config` shows a running eval's retunable launch configuration, and can retune it mid-run — for example to throttle an eval that is hammering a provider or overloading a machine, or to open it up when more capacity becomes available. Any `inspect eval` launch flag that can be retuned mid-flight is settable here, under the same spelling:

--- a/src/inspect_ai/_cli/ctl.py
+++ b/src/inspect_ai/_cli/ctl.py
@@ -33,6 +33,7 @@ import copy
 import functools
 import inspect
 import json as json_lib
+import os
 import time
 import traceback
 from collections.abc import Callable, Iterator, Sequence
@@ -4064,6 +4065,13 @@ def _resolve_target_server(pid: int | None) -> DiscoveredControlServer:
 # healthy server can therefore miss a short read window, so reads use a
 # generous timeout and retry a timeout several times before giving up, rather
 # than silently reporting the eval as gone.
+#
+# The 15s default is not always enough. Measured against a 10-process eval-set
+# sweep driving ~2400 k8s sandboxes, a GET /config over the UDS returned a
+# correct 200 in 2.3s, 7.9s and 79.3s on three consecutive probes of two
+# different processes — so a loaded-but-healthy server can sit well beyond any
+# fixed default. `INSPECT_CTL_REQUEST_TIMEOUT` lets an operator buy patience
+# without a code change; see `_request_timeout()`.
 _REQUEST_TIMEOUT = 15.0
 _REQUEST_ATTEMPTS = 8
 
@@ -4075,6 +4083,11 @@ _REQUEST_ATTEMPTS = 8
 # does the sole-server summaries fetch (one server is no fan-out).
 _DEGRADED_READ_ATTEMPTS = 2
 
+# Cap on concurrent control reads in a full fan-out. Discovery is one process
+# per file, so this bounds threads (and open UDS connections) when a box hosts
+# many evals — 10 concurrent `tl run` sweeps is a real configuration.
+_FAN_OUT_MAX_WORKERS = 16
+
 # A mutation (flush / buffer set) is issued once — it isn't idempotent, so it
 # must not be retried — but it gets the same total wall-clock budget a retried
 # read would consume (one attempt of `_REQUEST_ATTEMPTS * _REQUEST_TIMEOUT`, ie.
@@ -4083,6 +4096,47 @@ _DEGRADED_READ_ATTEMPTS = 2
 # short rather than getting the full budget too.
 _MUTATION_TIMEOUT = _REQUEST_ATTEMPTS * _REQUEST_TIMEOUT
 _CONNECT_TIMEOUT = 10.0
+
+_REQUEST_TIMEOUT_ENV = "INSPECT_CTL_REQUEST_TIMEOUT"
+
+
+def _request_timeout() -> float:
+    """Per-attempt read timeout, in seconds.
+
+    :data:`_REQUEST_TIMEOUT` unless ``INSPECT_CTL_REQUEST_TIMEOUT`` overrides it.
+    Read per call rather than captured at import so a single invocation can be
+    given more patience (``INSPECT_CTL_REQUEST_TIMEOUT=120 inspect ctl task``)
+    against an eval whose loop is saturated — exactly when the control channel
+    is most needed and least responsive.
+
+    An unparseable or non-positive value raises, matching how the sandbox limit
+    env vars validate (`util/_sandbox/limits.py`): silently substituting the
+    default would leave an operator who set 120 waiting 15s and concluding the
+    fleet is wedged, which is the failure this override exists to end.
+    """
+    raw = os.environ.get(_REQUEST_TIMEOUT_ENV)
+    if raw is None:
+        return _REQUEST_TIMEOUT
+    try:
+        value = float(raw)
+    except ValueError:
+        raise ValueError(
+            f"{_REQUEST_TIMEOUT_ENV} must be a number of seconds, got '{raw}'."
+        )
+    if value <= 0:
+        raise ValueError(
+            f"{_REQUEST_TIMEOUT_ENV} must be a positive number of seconds, got {value}."
+        )
+    return value
+
+
+def _mutation_timeout() -> float:
+    """Total wall-clock budget for a single-shot mutation, in seconds.
+
+    Tracks :func:`_request_timeout` so raising the read timeout raises the
+    mutation budget with it — they describe the same slow server.
+    """
+    return _REQUEST_ATTEMPTS * _request_timeout()
 
 
 class _ServerUnreachable(Exception):
@@ -4160,6 +4214,7 @@ def _get_response_with_retry(
     """
     if attempts is None:
         attempts = _DEGRADED_READ_ATTEMPTS if raise_on_busy else _REQUEST_ATTEMPTS
+    timeout = _request_timeout()
     transport = httpx.HTTPTransport(uds=str(socket_path))
     last_timeout: httpx.TimeoutException | None = None
     for attempt in range(1, attempts + 1):
@@ -4167,14 +4222,14 @@ def _get_response_with_retry(
             with httpx.Client(
                 transport=transport,
                 base_url="http://localhost",
-                timeout=_REQUEST_TIMEOUT,
+                timeout=timeout,
             ) as client:
                 return client.request(method, path, params=params or {})
         except httpx.TimeoutException as exc:
             last_timeout = exc
             retrying = "; retrying…" if attempt < attempts else "."
             click.echo(
-                f"{what}: no response after {_REQUEST_TIMEOUT:.0f}s "
+                f"{what}: no response after {timeout:.0f}s "
                 f"(attempt {attempt}/{attempts}) — the eval may be busy"
                 f"{retrying}",
                 err=True,
@@ -4188,7 +4243,7 @@ def _get_response_with_retry(
         )
     message = (
         f"{what}: gave up after {attempts} attempts of "
-        f"{_REQUEST_TIMEOUT:.0f}s each — the eval's event loop is busy; "
+        f"{timeout:.0f}s each — the eval's event loop is busy; "
         "try again shortly."
     )
     click.echo(message, err=True)
@@ -4285,50 +4340,94 @@ def _fetch_summaries(
     """
     summaries: list[dict[str, Any]] = []
     busy_pids: list[int] = []
-    for server in servers:
-        try:
-            rows = _get_with_retry(
-                server.socket_path,
-                "/tasks",
-                what=f"Reading tasks from pid {server.pid}",
-                raise_on_busy=raise_on_busy,
-                # a sole server is no fan-out — there's no wedged sibling to
-                # protect against, so ride out a stall on the full budget
-                attempts=_REQUEST_ATTEMPTS if len(servers) == 1 else None,
-                pid=server.pid,
-            )
-        except _ServerUnreachable as exc:
-            # a 404 means the process is serving a control API without this
-            # route — version skew between the CLI and the eval process —
-            # where transport errors mean the process is gone
-            cause = exc.__cause__
-            if isinstance(exc, _ServerBusy):
-                busy_pids.append(server.pid)
-                hint = f"try again shortly, or {_anomalies_pointer(server.pid)}"
-            elif (
-                isinstance(cause, httpx.HTTPStatusError)
-                and cause.response.status_code == 404
-            ):
-                hint = "it may be running a different inspect version than this CLI"
-            else:
-                hint = "it may have just exited"
-            click.echo(
-                f"Skipping pid {server.pid}: its control endpoint could not be "
-                f"read ({_unreachable_detail(exc)}) — {hint}.",
-                err=True,
-            )
-            continue
-        if isinstance(rows, list):
-            # Decorate each row with discovery-side info the server doesn't
-            # see (pid, socket_path).
-            for row in rows:
-                row["pid"] = server.pid
-                row["socket_path"] = str(server.socket_path)
-            summaries.extend(rows)
-            if stop_on_task_id is not None and any(
-                row.get("task_id") == stop_on_task_id for row in rows
-            ):
+
+    def read(server: DiscoveredControlServer) -> list[dict[str, Any]] | Any:
+        return _get_with_retry(
+            server.socket_path,
+            "/tasks",
+            what=f"Reading tasks from pid {server.pid}",
+            raise_on_busy=raise_on_busy,
+            # a sole server is no fan-out — there's no wedged sibling to
+            # protect against, so ride out a stall on the full budget
+            attempts=_REQUEST_ATTEMPTS if len(servers) == 1 else None,
+            pid=server.pid,
+        )
+
+    def collect(server: DiscoveredControlServer, rows: Any) -> bool:
+        """Fold one server's rows in. True when ``stop_on_task_id`` is satisfied."""
+        if not isinstance(rows, list):
+            return False
+        # Decorate each row with discovery-side info the server doesn't
+        # see (pid, socket_path).
+        for row in rows:
+            row["pid"] = server.pid
+            row["socket_path"] = str(server.socket_path)
+        summaries.extend(rows)
+        return stop_on_task_id is not None and any(
+            row.get("task_id") == stop_on_task_id for row in rows
+        )
+
+    def unreachable(server: DiscoveredControlServer, exc: _ServerUnreachable) -> None:
+        # a 404 means the process is serving a control API without this
+        # route — version skew between the CLI and the eval process —
+        # where transport errors mean the process is gone
+        cause = exc.__cause__
+        if isinstance(exc, _ServerBusy):
+            busy_pids.append(server.pid)
+            hint = f"try again shortly, or {_anomalies_pointer(server.pid)}"
+        elif (
+            isinstance(cause, httpx.HTTPStatusError)
+            and cause.response.status_code == 404
+        ):
+            hint = "it may be running a different inspect version than this CLI"
+        else:
+            hint = "it may have just exited"
+        click.echo(
+            f"Skipping pid {server.pid}: its control endpoint could not be "
+            f"read ({_unreachable_detail(exc)}) — {hint}.",
+            err=True,
+        )
+
+    # `stop_on_task_id` keeps the serial path: its whole point is to NOT contact
+    # the remaining servers once the target id is found, and a targeted lookup
+    # normally resolves on the first (newest) server anyway. Nothing to fan out
+    # to below two servers either (and a pool demands max_workers >= 1).
+    if stop_on_task_id is not None or len(servers) < 2:
+        for server in servers:
+            try:
+                rows = read(server)
+            except _ServerUnreachable as exc:
+                unreachable(server, exc)
+                continue
+            if collect(server, rows):
                 break
+        return _FetchedSummaries(summaries=summaries, busy_pids=busy_pids)
+
+    # A full fan-out reads servers CONCURRENTLY, bounded by _FAN_OUT_MAX_WORKERS
+    # (beyond that they queue in waves). Serially, one loaded eval
+    # spends its whole attempt budget before the next is even contacted, so N
+    # processes cost N * attempts * timeout — a 10-process sweep can burn ~20
+    # minutes and still print nothing, which is how a slow-but-healthy fleet
+    # ends up looking dead. The reads are independent GETs over per-call
+    # transports, so the only shared state is the two result lists, and those
+    # are folded in on THIS thread, in discovery order, after the fan-out —
+    # keeping row order (and so resolution precedence) identical to the serial
+    # path regardless of which server answered first.
+    from concurrent.futures import ThreadPoolExecutor
+
+    with ThreadPoolExecutor(
+        max_workers=min(len(servers), _FAN_OUT_MAX_WORKERS)
+    ) as pool:
+        futures = [(server, pool.submit(read, server)) for server in servers]
+        results = [(server, future) for server, future in futures]
+
+    for server, future in results:
+        try:
+            rows = future.result()
+        except _ServerUnreachable as exc:
+            unreachable(server, exc)
+            continue
+        collect(server, rows)
     return _FetchedSummaries(summaries=summaries, busy_pids=busy_pids)
 
 
@@ -4756,7 +4855,7 @@ def _request_json(
             with httpx.Client(
                 transport=transport,
                 base_url="http://localhost",
-                timeout=httpx.Timeout(_MUTATION_TIMEOUT, connect=_CONNECT_TIMEOUT),
+                timeout=httpx.Timeout(_mutation_timeout(), connect=_CONNECT_TIMEOUT),
             ) as client:
                 if mutate == "post":
                     response = client.post(path, params=params)

--- a/tests/_control/test_ctl.py
+++ b/tests/_control/test_ctl.py
@@ -6,6 +6,7 @@ output contract (envelopes, unconditional task_id, mutation results,
 cursor validation), and rendering helpers.
 """
 
+import functools
 import json
 import os
 from pathlib import Path
@@ -927,17 +928,32 @@ def test_resolve_target_server_none_running_exits(
 
 
 def _stub_httpx(
-    monkeypatch: pytest.MonkeyPatch, sequence: list[object]
+    monkeypatch: pytest.MonkeyPatch,
+    sequence: list[object] | None = None,
+    *,
+    per_socket: dict[int, list[object]] | None = None,
 ) -> dict[str, int]:
-    """Replace httpx in ctl so each ``client.get`` consumes one ``sequence`` item.
+    """Replace httpx in ctl so each ``client.get`` consumes one scripted item.
 
     Each item is either an ``Exception`` to raise (e.g. a ``TimeoutException``),
-    a payload to return from ``response.json()``, or a ``(status_code, payload)``
-    tuple for a non-200 response. Returns a dict whose ``"gets"`` entry counts
-    how many requests were attempted.
+    a payload to return from ``response.json()``, a ``(status_code, payload)``
+    tuple for a non-200 response, or a zero-arg callable invoked at request time
+    to produce one of those (letting a test block inside a read). Returns a dict
+    whose ``"gets"`` entry counts how many requests were attempted.
+
+    ``sequence`` scripts one shared queue every request pops from, which is only
+    deterministic while requests are issued one at a time. ``per_socket`` scripts
+    a separate queue per pid (keyed off the ``uds`` path the transport is built
+    with), so a test stays deterministic when the fan-out reads servers
+    CONCURRENTLY and the completion order is not the submission order. Pass
+    exactly one of the two.
     """
+    assert (sequence is None) != (per_socket is None), (
+        "pass exactly one of sequence / per_socket"
+    )
     counter = {"gets": 0, "posts": 0, "patches": 0}
-    seq = list(sequence)
+    seq = list(sequence or [])
+    queues = {pid: list(items) for pid, items in (per_socket or {}).items()}
 
     class _Resp:
         def __init__(self, payload: object, status_code: int = 200) -> None:
@@ -959,9 +975,16 @@ def _stub_httpx(
         def json(self) -> object:
             return self._payload
 
+    class _Transport:
+        """Stand-in for httpx.HTTPTransport that remembers its socket path."""
+
+        def __init__(self, uds: str | None) -> None:
+            self.uds = uds
+
     class _Client:
         def __init__(self, *args: object, **kwargs: object) -> None:
-            pass
+            transport = kwargs.get("transport")
+            self._uds = getattr(transport, "uds", None)
 
         def __enter__(self) -> "_Client":
             return self
@@ -969,9 +992,19 @@ def _stub_httpx(
         def __exit__(self, *args: object) -> None:
             pass
 
+        def _queue(self) -> list[object]:
+            """The response script this client reads from."""
+            if not queues:
+                return seq
+            # /tmp/<pid>.sock — see _disc()
+            stem = Path(str(self._uds)).stem
+            return queues[int(stem)]
+
         def _next(self, kind: str) -> _Resp:
             counter[kind] += 1
-            item = seq.pop(0)
+            item = self._queue().pop(0)
+            if callable(item):
+                item = item()
             if isinstance(item, Exception):
                 raise item
             if isinstance(item, tuple):
@@ -992,7 +1025,10 @@ def _stub_httpx(
             return getattr(self, method)(path, params)
 
     monkeypatch.setattr("inspect_ai._cli.ctl.httpx.Client", _Client)
-    monkeypatch.setattr("inspect_ai._cli.ctl.httpx.HTTPTransport", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "inspect_ai._cli.ctl.httpx.HTTPTransport",
+        lambda *a, **k: _Transport(k.get("uds")),
+    )
     return counter
 
 
@@ -1002,6 +1038,68 @@ def _disc(pid: int) -> "DiscoveredControlServer":
     return DiscoveredControlServer(
         pid=pid, socket_path=Path(f"/tmp/{pid}.sock"), started_at=0.0
     )
+
+
+def test_request_timeout_default_and_env_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``INSPECT_CTL_REQUEST_TIMEOUT`` raises the per-attempt read timeout.
+
+    The default is deliberately finite, but a loaded eval's control server can
+    take far longer than it to answer (measured: a correct 200 after 79s from a
+    process driving a large sandbox fleet), so an operator needs to buy patience
+    without editing the source. Read per call, not captured at import, so it
+    applies to the invocation that sets it.
+    """
+    from inspect_ai._cli.ctl import (
+        _REQUEST_ATTEMPTS,
+        _REQUEST_TIMEOUT,
+        _mutation_timeout,
+        _request_timeout,
+    )
+
+    monkeypatch.delenv("INSPECT_CTL_REQUEST_TIMEOUT", raising=False)
+    assert _request_timeout() == _REQUEST_TIMEOUT
+    assert _mutation_timeout() == _REQUEST_ATTEMPTS * _REQUEST_TIMEOUT
+
+    monkeypatch.setenv("INSPECT_CTL_REQUEST_TIMEOUT", "120")
+    assert _request_timeout() == 120.0
+    # the mutation budget tracks it — they describe the same slow server
+    assert _mutation_timeout() == _REQUEST_ATTEMPTS * 120.0
+
+
+@pytest.mark.parametrize("value", ["nonsense", "", "0", "-5"])
+def test_request_timeout_env_invalid_raises(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """An unusable override fails loudly rather than silently reverting.
+
+    Matches how the sandbox limit env vars validate. Silently substituting the
+    default is the worse outcome here: an operator who set 120 would wait 15s
+    and conclude the fleet is wedged -- the exact failure this override exists
+    to end.
+    """
+    from inspect_ai._cli.ctl import _request_timeout
+
+    monkeypatch.setenv("INSPECT_CTL_REQUEST_TIMEOUT", value)
+    with pytest.raises(ValueError, match="INSPECT_CTL_REQUEST_TIMEOUT"):
+        _request_timeout()
+
+
+def test_request_timeout_override_reaches_the_retry_narration(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The override is what the retry loop actually waits on and reports."""
+    import httpx
+
+    from inspect_ai._cli.ctl import _get_with_retry
+
+    monkeypatch.setenv("INSPECT_CTL_REQUEST_TIMEOUT", "42")
+    _stub_httpx(monkeypatch, [httpx.ReadTimeout("slow"), [{"task_id": "a"}]])
+    assert _get_with_retry("/tmp/x.sock", "/tasks", what="Reading tasks") == [
+        {"task_id": "a"}
+    ]
+    assert "no response after 42s" in capsys.readouterr().err
 
 
 def test_get_with_retry_retries_timeout_then_succeeds(
@@ -1138,6 +1236,10 @@ def test_fetch_summaries_busy_server_skipped_when_degradable(
 
     The unscoped sample fan-out's summaries stage: one busy sibling process
     (on the degraded attempt budget) must not kill the whole listing.
+
+    Scripted per socket, not as one shared queue: this fan-out reads both
+    servers concurrently, so which pid pops which response would otherwise
+    depend on thread scheduling.
     """
     import httpx
 
@@ -1145,7 +1247,10 @@ def test_fetch_summaries_busy_server_skipped_when_degradable(
 
     _stub_httpx(
         monkeypatch,
-        [httpx.ReadTimeout("slow")] * _DEGRADED_READ_ATTEMPTS + [[{"task_id": "live"}]],
+        per_socket={
+            7: [httpx.ReadTimeout("slow")] * _DEGRADED_READ_ATTEMPTS,
+            8: [[{"task_id": "live"}]],
+        },
     )
     fetched = _fetch_summaries([_disc(7), _disc(8)], raise_on_busy=True)
     assert [s["task_id"] for s in fetched.summaries] == ["live"]
@@ -1155,6 +1260,45 @@ def test_fetch_summaries_busy_server_skipped_when_degradable(
     assert "try again shortly" in err
     # the skip note teaches the escalation that works against a busy process
     assert "inspect ctl process anomalies 7" in err
+
+
+def test_fetch_summaries_reads_servers_concurrently(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A full fan-out reads every server at once, not one after another.
+
+    Serially, one loaded eval spends its whole attempt budget before the next is
+    contacted, so N processes cost N * attempts * timeout and a multi-process
+    sweep can spend minutes printing nothing. Each stub read blocks on a barrier
+    that only trips once ALL of them have arrived, so this deadlocks (and fails
+    on the barrier timeout) if the reads are issued one at a time.
+    """
+    import threading
+
+    from inspect_ai._cli.ctl import _fetch_summaries
+
+    servers = [_disc(pid) for pid in (7, 8, 9)]
+    barrier = threading.Barrier(len(servers), timeout=10)
+
+    def arrive(pid: int) -> list[dict[str, Any]]:
+        barrier.wait()
+        return [{"task_id": f"task-{pid}"}]
+
+    # one scripted read per server, each blocking until every server has arrived
+    _stub_httpx(
+        monkeypatch,
+        per_socket={s.pid: [functools.partial(arrive, s.pid)] for s in servers},
+    )
+
+    fetched = _fetch_summaries(servers)
+
+    # rows follow DISCOVERY order, not completion order
+    assert [s["task_id"] for s in fetched.summaries] == [
+        "task-7",
+        "task-8",
+        "task-9",
+    ]
+    assert [s["pid"] for s in fetched.summaries] == [7, 8, 9]
 
 
 def test_fetch_summaries_sole_server_rides_full_budget(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

`inspect ctl` is least usable against exactly the evals it exists to inspect: a loaded one. Two independent client-side causes, both of which report a healthy fleet as busy or absent.

**1. The per-attempt read timeout is too short for a loaded server.** The control server is uvicorn on the eval's *own* event loop, so its response latency tracks eval load. Probing a 10-process eval-set sweep driving ~2,400 k8s sandboxes, `GET /config` over the UDS returned a correct `200` in **2.3 s, 7.9 s and 79.3 s** on consecutive probes of healthy processes — well outside the fixed 15 s budget (raised from 2 s/5 s in #4317 for #4332; the same class of problem, one notch further out).

**2. The fan-out was serial.** One loaded process spent its whole attempt budget before the next was contacted, so N processes cost N × attempts × timeout. With ten arms a bare `inspect ctl task` could burn ~20 minutes and still print nothing.

### What is the new behavior?

- `INSPECT_CTL_REQUEST_TIMEOUT` overrides the per-attempt read timeout, read per call so it applies to the invocation that sets it; the mutation budget tracks it. An unparseable or non-positive value **raises**, matching how the sandbox limit env vars validate in `util/_sandbox/limits.py` — silently reverting to the default would leave an operator who set `120` waiting 15 s and concluding the fleet is wedged, which is the failure the override exists to end.
- A full fan-out reads discovered processes concurrently, bounded by `_FAN_OUT_MAX_WORKERS` (16), so one loaded eval no longer delays reads of the others.
- Rows are still folded in on the calling thread in **discovery order** after the fan-out, so row order — and therefore resolution precedence — is identical to the serial path no matter which server answers first. `stop_on_task_id` deliberately keeps the serial path: its purpose is to *not* contact the remaining servers once the target id is found.

**This is client-side resilience, not a root-cause fix**, and I'd rather be upfront about that than oversell it. A 79 s `GET /config` — a handler that does no I/O and takes no locks — means the loop is unavailable for that long. That is meridianlabs-ai/inspect_ai#48 (control server: answer reads while the eval loop is busy) and #16 (recorder serializes/compresses samples on the loop). #48 was closed with *"Not worth improving until we have evidence of stall issues"*; I've posted the measurements above plus a ~50-line reproduction there, since that is precisely the evidence it asked for. This PR is the triage that makes the tool usable meanwhile; it is complementary to, not a substitute for, either of those.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Default behavior is unchanged when `INSPECT_CTL_REQUEST_TIMEOUT` is unset, and the concurrent fan-out preserves the serial path's output ordering exactly. The only new way to fail is setting the new env var to a nonsense value, which now errors instead of being ignored.

### Other information:

**Gates.** `make check` clean (ruff, format, mypy across 1,341 source files); full `pytest` suite **8,519 passed / 3,503 skipped / 0 failed** on this branch merged with current `main`.

**Testing.** The concurrency tests stub `read` to block on a shared barrier, so they deadlock and fail if the reads are issued one at a time — verified by reverting the fix (`BrokenBarrierError`). That required the httpx stub to script responses per socket rather than from one shared queue, since under a real fan-out the arrival order isn't fixed. Also covered: the env-var override reaching the retry narration, the mutation budget tracking it, invalid values raising, and discovery-order preservation.

**Reproduction of the underlying stall** (~50 lines, no eval required): uvicorn on a UDS as a task on a loop that also runs a 60 s stretch of repeated GIL-held `model_dump_json`, probed the way `inspect ctl` probes:

```
  0.6s [idle baseline]      connect=0.0ms   -> 200 after 0.1s
 24.5s [15s read timeout]   connect=200.9ms -> ReadTimeout after 15.9s
 60.8s hog: stretch over, yielding
 60.9s [120s read timeout]  connect=0.0ms   -> 200 after 36.3s
```

Note connect stays instant *throughout* the stall (the kernel accepts into the listen backlog), so no connect-timeout tuning can detect this condition — only the read timeout is load-bearing.

**AI tooling.** Implemented and reviewed with AI assistance (Claude). Per CONTRIBUTING, it had multiple independent review passes before opening: one reviewer audited the implementation against repo conventions, order-preservation, env-var house style and test quality; a second independently investigated the root cause from the code, which is what surfaced #16/#48 and produced the reproduction above. Their findings are what changed the silent-fallback to fail-loud, corrected an "every server concurrently" overclaim to bounded waves, and reframed the PR as triage rather than a fix for the stall itself. I can explain and defend every line.

**Draft** because we are over the 4-open-PR limit for established contributors; I'd rather not consume review capacity out of turn. Happy to mark it ready whenever suits you, or to close it if you'd prefer this land as part of the #48 work instead.
