### PR TITLE
fix(_util): support standalone signed Unicode fractions in str_to_float

### DIFF
--- a/src/inspect_ai/_util/text.py
+++ b/src/inspect_ai/_util/text.py
@@ -207,7 +207,11 @@ def str_to_float(s: str) -> float:
     # Calculate the base value (whole number + fraction if present)
     base_value = 0.0
 
-    if base_part:
+    if base_part in ("-", "+"):
+        if not fraction_char and not exponent_part:
+            raise ValueError(f"Value could not be parsed as a float: {s}")
+        base_value = 0.0 if fraction_char else (-1.0 if base_part == "-" else 1.0)
+    elif base_part:
         # find the first valid float (LLMs may include additional spurious output)
         match = re.match(r"^([+-]?\d+(?:\.\d+)?)", base_part)
         if match is None:
@@ -221,8 +225,8 @@ def str_to_float(s: str) -> float:
 
     if fraction_char:
         fraction_value = fraction_map[fraction_char]
-        if base_value < 0:
-            # For negative values, subtract the fraction (e.g., -2½ = -2.5)
+        if base_value < 0 or base_part == "-":
+            # For negative values, subtract the fraction (e.g., -2½ = -2.5, -½ = -0.5)
             base_value -= fraction_value
         else:
             # For zero or positive values, add the fraction

--- a/tests/util/test_str_to_float.py
+++ b/tests/util/test_str_to_float.py
@@ -88,6 +88,12 @@ def test_str_to_float_mixed_fractions():
     assert str_to_float("-2½") == -2.5
     assert str_to_float("-1¼") == -1.25
 
+    # Standalone signed fraction
+    assert str_to_float("-½") == -0.5
+    assert str_to_float("+½") == 0.5
+    assert str_to_float("-⅓") == -1 / 3
+    assert str_to_float("-½²") == 0.25
+
 
 def test_str_to_float_mixed_fractions_with_exponents():
     # Fraction with exponent


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
`str_to_float()` in `src/inspect_ai/_util/text.py` raises `ValueError: Value could not be parsed as a float: -½` when converting standalone signed Unicode fractions such as `"-½"` or `"+½"`.

Closes #4717

### What is the new behavior?
`str_to_float()` correctly parses standalone signed Unicode fractions (e.g., `"-½"` -> `-0.5`, `"+½"` -> `0.5`, `"-⅓"` -> `-1/3`, `"-½²"` -> `0.25`).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
- **Root Cause**: `base_part` accumulated sign characters (`"-"` or `"+"`). When `re.match(r"^([+-]?\d+(?:\.\d+)?)", base_part)` was evaluated on sign-only `base_part`, it returned `None` due to the required `\d+` digit match, raising a `ValueError`.
- **Validation**:
  - Added unit tests in `tests/util/test_str_to_float.py`.
  - `uv run pytest tests/util/test_str_to_float.py` (31/31 passed).
  - `uv run make check` passed with zero errors (ruff, mypy).
  - `git diff --check` passed.
