### PR TITLE
fix(analysis): handle empty DataFrames and missing model column in model_info (#4723)

### DIFF
--- a/src/inspect_ai/analysis/_prepare/model_info.py
+++ b/src/inspect_ai/analysis/_prepare/model_info.py
@@ -35,6 +35,12 @@ def model_info(
     import pandas as pd
 
     def transform(df: pd.DataFrame) -> pd.DataFrame:
+        if df.empty:
+            return df
+
+        if "model" not in df.columns:
+            raise ValueError("Required column 'model' not found in DataFrame")
+
         # Column mapping from DataFrame to ModelInfo field to read
         fields = {
             "model_organization_name": "organization",

--- a/tests/analysis/test_prepare.py
+++ b/tests/analysis/test_prepare.py
@@ -1,7 +1,14 @@
 from pathlib import Path
 from typing import Any
 
-from inspect_ai.analysis import evals_df, frontier, log_viewer, prepare, task_info
+from inspect_ai.analysis import (
+    evals_df,
+    frontier,
+    log_viewer,
+    model_info,
+    prepare,
+    task_info,
+)
 from inspect_ai.analysis._dataframe.samples.table import samples_df
 from inspect_ai.analysis._prepare.score_to_float import score_to_float
 
@@ -92,6 +99,27 @@ def test_frontier_all_na_scores_in_date_group():
     # the all-NA-score date group (2024-01-01) is skipped; the later scored
     # models are each an improvement, so both are on the frontier
     assert list(out["frontier"]) == [False, False, True, True]
+
+
+def test_model_info():
+    import pandas as pd
+    import pytest
+
+    # empty DataFrame should return empty DataFrame without error
+    df_empty = pd.DataFrame()
+    out_empty = prepare(df_empty, model_info())
+    assert out_empty.empty
+
+    # missing 'model' column should raise ValueError
+    df_no_model = pd.DataFrame({"task_name": ["t1"]})
+    with pytest.raises(ValueError, match="Required column 'model' not found"):
+        prepare(df_no_model, model_info())
+
+    # normal operation with valid model column (built-in model vs custom model)
+    df = pd.DataFrame({"model": ["openai/gpt-4o", "unknown_model"]})
+    out = prepare(df, model_info())
+    assert "model_display_name" in out.columns
+    assert out["model_display_name"].to_list() == ["GPT-4o", "unknown_model"]
 
 
 def check_log_viewer(


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Closes #4723

Currently, `model_info()` in `inspect_ai.analysis` (`src/inspect_ai/analysis/_prepare/model_info.py`) attempts to index `df["model"]` immediately without checking if `df` is empty or if `"model"` exists in `df.columns`. This results in an unhandled `KeyError: 'model'` exception when passed an empty DataFrame or a DataFrame missing the `"model"` column.

### What is the new behavior?
1. If passed an empty DataFrame (`df.empty`), `model_info()` returns `df` directly, matching the behavior of `score_to_float()` and `frontier()`.
2. If a non-empty DataFrame is missing the `"model"` column, `model_info()` raises a clear `ValueError("Required column 'model' not found in DataFrame")`, matching `score_to_float()`, `frontier()`, and `task_info()`.

### Root Cause
In `src/inspect_ai/analysis/_prepare/model_info.py`, `transform()` accessed `df["model"].astype(str)` immediately before checking `if df.empty` or validating `if "model" not in df.columns`.

### Why the approach is minimal
The fix adds a 4-line guard at the start of `transform()` in `src/inspect_ai/analysis/_prepare/model_info.py` without modifying any public API signatures or downstream transformation logic.

### Regression Tests Added
- `test_model_info()` in `tests/analysis/test_prepare.py` covering:
  - Empty DataFrames returning empty DataFrames without error.
  - DataFrames missing the `"model"` column raising `ValueError("Required column 'model' not found in DataFrame")`.
  - Normal operation mapping built-in and unregistered model display names.

### Validation Commands & Results
- `uv run pytest tests/analysis/test_prepare.py`: PASSED (6 passed in 1.55s)
- `uv run pytest tests/analysis/`: PASSED (99 passed in 13.22s)
- `uv run make check`: PASSED (`ruff check`, `ruff format`, `mypy` - success: no issues found in 1341 source files)
- `git diff --check`: PASSED (no whitespace/formatting issues)

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
N/A
