### PR TITLE
fix(analysis): handle None and non-dict inputs in score_values and score_value (#4732)

### DIFF
--- a/src/inspect_ai/analysis/_dataframe/extract.py
+++ b/src/inspect_ai/analysis/_dataframe/extract.py
@@ -1,6 +1,6 @@
 import hashlib
 import uuid
-from typing import Any, cast
+from typing import cast
 
 import shortuuid
 from pydantic import BaseModel, JsonValue
@@ -33,13 +33,18 @@ def remove_namespace(x: JsonValue) -> JsonValue:
 
 
 def score_values(x: JsonValue) -> dict[str, JsonValue]:
-    scores = cast(dict[str, Any], x)
-    return {k: v["value"] for k, v in scores.items()}
+    if not isinstance(x, dict):
+        return {}
+    return {k: v.get("value") if isinstance(v, dict) else v for k, v in x.items()}
 
 
 def score_value(x: JsonValue) -> JsonValue:
-    scores = cast(dict[str, Any], x)
-    return next(iter(scores.values()), None)
+    if not isinstance(x, dict):
+        return None
+    val = next(iter(x.values()), None)
+    if isinstance(val, dict):
+        return val.get("value")
+    return val
 
 
 def score_details(x: JsonValue) -> dict[str, JsonValue]:

--- a/tests/analysis/test_df.py
+++ b/tests/analysis/test_df.py
@@ -476,3 +476,17 @@ def test_evals_df_reflects_edited_tags_and_metadata(tmp_path: Path):
     df = evals_df(log_dir)
     assert df["tags"].to_list() == ["added"]
     assert df["metadata"].to_list() == ['{"key": "edited"}']
+
+
+def test_score_values_and_score_value_null_handling():
+    from inspect_ai.analysis._dataframe.extract import score_value, score_values
+
+    assert score_values(None) == {}
+    assert score_values("invalid") == {}
+    assert score_values({"acc": None}) == {"acc": None}
+    assert score_values({"acc": {"value": 0.9}}) == {"acc": 0.9}
+
+    assert score_value(None) is None
+    assert score_value("invalid") is None
+    assert score_value({}) is None
+    assert score_value({"acc": {"value": 0.9}}) == 0.9


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4732

`score_values()` and `score_value()` in `inspect_ai.analysis._dataframe.extract` raise `AttributeError: 'NoneType' object has no attribute 'items'` / `'values'` when `x` is `None` or not a `dict` (for example when processing evaluation logs with unscored or errored samples).

In addition, `score_value()` returns the full `Score` dictionary (e.g. `{"value": 1.0}`) instead of extracting the score scalar value (e.g. `1.0`).

### What is the new behavior?

- `score_values()` returns `{}` when `x` is `None` or not a `dict` (matching the safe guard pattern used by `score_details()`).
- `score_values()` safely handles entries in `x` that are missing a `"value"` key or are non-dict values without raising `TypeError`.
- `score_value()` returns `None` when `x` is `None` or not a `dict` or empty.
- `score_value()` unwraps `.get("value")` when the first entry in `x` is a `Score` dictionary, returning the scalar value (e.g. `1.0`).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

**Root Cause:**
`score_values()` and `score_value()` cast `x` to `dict[str, Any]` without verifying `isinstance(x, dict)`. Unlike `score_details()` in the same module, which returns `{}` for non-dict inputs, `score_values()` and `score_value()` unconditionally called `.items()` / `.values()` and subscripted inner dict entries without `isinstance(v, dict)` guards.

**Regression Tests Added:**
- `test_score_values_and_score_value_null_handling` in `tests/analysis/test_df.py`

**Validation Commands & Results:**
- `uv run pytest tests/analysis/test_df.py -k test_score_values_and_score_value_null_handling`: PASSED
- `uv run pytest tests/analysis`: PASSED (99 passed in 14.06s)
- `uv run make check`: PASSED (`ruff check`, `ruff format`, `mypy` - no issues found in 1341 source files)
- `git diff --check`: PASSED

**Tooling:**
This PR was prepared with AI assistance (Google Antigravity).
