### PR TITLE
feat(model): fold OpenRouter's reported per-call cost into total_cost

### DIFF
--- a/src/inspect_ai/model/_model.py
+++ b/src/inspect_ai/model/_model.py
@@ -2541,7 +2541,11 @@ def record_and_check_model_usage(
     info = _get_model_info_direct(model)
     total_cost: float | None = None
     # Note that we handle info=None here because None is currently a valid output of get_model_info (e.g. for mock models)
-    if info is not None and info.cost is not None:
+    # A provider-reported cost (e.g. OpenRouter bills per request and returns
+    # the exact amount) always wins over re-pricing from the rate card.
+    if usage.total_cost is not None:
+        total_cost = usage.total_cost
+    elif info is not None and info.cost is not None:
         # providers with a configurable prompt-cache TTL (currently Anthropic)
         # expose it on the ModelAPI; longer TTLs bill cache writes at a higher rate
         total_cost = compute_model_cost(

--- a/src/inspect_ai/model/_providers/openrouter.py
+++ b/src/inspect_ai/model/_providers/openrouter.py
@@ -307,6 +307,7 @@ class OpenRouterAPI(OpenAICompatibleAPI):
             output, call = result
             if isinstance(output, ModelOutput):
                 _apply_cache_creation_usage(output, call)
+                _apply_reported_cost(output, call)
         return result
 
     @override
@@ -474,6 +475,33 @@ def _mark_last_content_block(msg: dict[str, Any]) -> None:
         msg["content"] = [
             {"type": "text", "text": content, "cache_control": _ephemeral()}
         ]
+
+
+def _apply_reported_cost(output: ModelOutput, call: ModelCall | None) -> None:
+    """Fold OpenRouter's reported per-call cost into ModelUsage.total_cost.
+
+    OpenRouter bills each request server-side and reports the exact amount on
+    the response usage object, which is more truthful than re-pricing from the
+    static rate card (BYOK especially, where the upstream part sits under
+    cost_details). record_model_usage only computes from the rate card when
+    total_cost is unset, so a reported value always wins.
+    """
+    if call is None or output.usage is None:
+        return
+    raw = call.response if isinstance(call.response, dict) else None
+    usage = raw.get("usage") if raw else None
+    if not isinstance(usage, dict):
+        return
+    reported = usage.get("cost")
+    cost = float(reported) if isinstance(reported, int | float) else 0.0
+    if usage.get("is_byok"):
+        details = usage.get("cost_details")
+        if isinstance(details, dict):
+            upstream = details.get("upstream_inference_cost")
+            if isinstance(upstream, int | float):
+                cost += float(upstream)
+    if cost > 0:
+        output.usage.total_cost = cost
 
 
 def _apply_cache_creation_usage(output: ModelOutput, call: ModelCall | None) -> None:

--- a/tests/model/providers/test_openrouter.py
+++ b/tests/model/providers/test_openrouter.py
@@ -11,6 +11,7 @@ from inspect_ai.model._providers.openrouter import (
     OpenRouterAPI,
     _add_anthropic_cache_markers,
     _apply_cache_creation_usage,
+    _apply_reported_cost,
 )
 
 EPHEMERAL: dict[str, str] = {"type": "ephemeral"}
@@ -510,3 +511,43 @@ async def test_messages_to_openai_replays_reasoning_content_for_deepseek_v4() ->
     payload = converted[0]
     assert payload["reasoning_content"] == "considered options"  # type: ignore[typeddict-item]
     assert "reasoning_details" in payload
+
+
+def test_apply_reported_cost_folds_openrouter_cost() -> None:
+    output = _make_output()
+    call = ModelCall(request={}, response={"usage": {"cost": 0.0042}})
+
+    _apply_reported_cost(output, call)
+
+    assert output.usage is not None
+    assert output.usage.total_cost == 0.0042
+
+
+def test_apply_reported_cost_adds_upstream_for_byok() -> None:
+    output = _make_output()
+    call = ModelCall(
+        request={},
+        response={
+            "usage": {
+                "cost": 0.0042,
+                "is_byok": True,
+                "cost_details": {"upstream_inference_cost": 0.001},
+            }
+        },
+    )
+
+    _apply_reported_cost(output, call)
+
+    assert output.usage is not None
+    assert output.usage.total_cost == 0.0052
+
+
+def test_apply_reported_cost_ignores_missing_or_zero_cost() -> None:
+    output = _make_output()
+
+    _apply_reported_cost(output, ModelCall(request={}, response={"usage": {}}))
+    _apply_reported_cost(output, ModelCall(request={}, response={"usage": {"cost": 0}}))
+    _apply_reported_cost(output, None)
+
+    assert output.usage is not None
+    assert output.usage.total_cost is None

--- a/tests/model/test_model_info.py
+++ b/tests/model/test_model_info.py
@@ -665,3 +665,32 @@ class TestDoesNotReinstantiateProvider:
         record_and_check_model_usage(model, usage)
         # (3 * 1000 + 4 * 1000) / 1_000_000 = 0.007
         assert usage.total_cost == pytest.approx(0.007)
+
+    def test_record_usage_keeps_provider_reported_cost(self):
+        """A provider-reported total_cost wins over re-pricing from the rate card.
+
+        OpenRouter bills per request and reports the exact amount; the guard
+        added for #4739 must not overwrite it with the static-rate estimate.
+        """
+        from inspect_ai.model._model import record_and_check_model_usage
+        from inspect_ai.model._model_output import ModelUsage
+
+        set_model_info(
+            "mockllm/model",
+            ModelInfo(
+                cost=ModelCost(
+                    input=1000.0,
+                    output=1000.0,
+                    input_cache_write=0.0,
+                    input_cache_read=0.0,
+                )
+            ),
+        )
+        model = get_model("mockllm/model")
+        usage = ModelUsage(
+            input_tokens=1, output_tokens=1, total_tokens=2, total_cost=0.0042
+        )
+
+        record_and_check_model_usage(model, usage)
+
+        assert usage.total_cost == pytest.approx(0.0042)


### PR DESCRIPTION
Fixes #4739.

OpenRouter bills each request server-side and reports the exact amount on the response usage object (`usage.cost`, plus `cost_details.upstream_inference_cost` for BYOK), but eval cost accounting re-priced every call from the static rate card in `record_and_check_model_usage`. For OpenRouter-backed evals that made `total_cost` an estimate at best and absent at worst, so cost limits could not apply.

The OpenRouter provider now folds the reported amount into `ModelUsage.total_cost` (BYOK adds the upstream component), and the recording path only re-prices from the rate card when the provider reported nothing. Reported always wins over computed.

## Tests

- `_apply_reported_cost`: plain reported cost, BYOK with the upstream component, and the missing/zero/absent-call cases leaving `total_cost` unset.
- `record_and_check_model_usage` with a pre-set `total_cost` and a configured rate card: the reported value survives re-pricing.
- Full `tests/model/` suite: 1898 passed, no failures.
