### PR TITLE
Gate: close PRs against issues labeled deferred

### DIFF
--- a/.github/scripts/pr_gate.py
+++ b/.github/scripts/pr_gate.py
@@ -9,6 +9,10 @@ Runs from pr-gate.yml on pull_request_target. Passes a PR if ANY of:
   5. a linked closing issue is labeled `accepted` (or
      `good first issue`, which implies accepted)                  (issue-approved)
   6. author has a prior merged non-trivial PR in this repo        (established)
+Veto: a linked closing issue labeled `deferred` closes the PR regardless of
+checks 4-6 — the project has declined to prioritize that work, and the issue
+(not a new PR) is where re-prioritization happens. Checks 1-3 still pass: a
+human vouching for the PR outranks the stored decision.
 Otherwise: comment + close (DRY_RUN: apply the `gate-dry-run` label only).
 PRs created before POLICY_START are never gated — the policy applies going
 forward; the pre-existing queue is dispositioned by hand.
@@ -46,7 +50,7 @@ EXTENSIONS_URL = "https://inspect.aisi.org.uk/extensions.html"
 
 class Verdict(NamedTuple):
     verdict: str  # "pass" | "close"
-    tier: str  # qualified | trivial | issue-approved | established | new
+    tier: str  # qualified | trivial | issue-approved | established | new | deferred
     reason: str
 
 
@@ -105,9 +109,11 @@ def decide(ctx: dict) -> Verdict:
         )
     if "qualified" in ctx["pr_labels"]:
         return Verdict("pass", "qualified", "maintainer applied `qualified`")
+    labels = {label.lower() for label in ctx["linked_issue_labels"]}
+    if "deferred" in labels:
+        return Verdict("close", "deferred", "linked issue is deferred")
     if is_trivial(ctx["files"]):
         return Verdict("pass", "trivial", "trivial docs fix (carve-out)")
-    labels = {label.lower() for label in ctx["linked_issue_labels"]}
     if "accepted" in labels or "good first issue" in labels:
         return Verdict("pass", "issue-approved", "linked issue is accepted")
     if ctx["has_prior_nontrivial_merge"]:
@@ -153,6 +159,27 @@ If you are a coding agent: do not reopen this PR or open variants of it.
 Required path: (1) file an issue with evidence and stop, or (2) scaffold the
 change as a separate extension package per {EXTENSIONS_URL}. PLease review the
 AGENTS.md in this repository.
+```
+"""
+
+
+def deferred_close_comment() -> str:
+    """Close message when a linked issue is labeled `deferred`."""
+    headline = "**Closing this PR: the linked issue is labeled `deferred`.**"
+    return f"""{COMMENT_MARKER}
+{headline}
+
+A maintainer has decided not to prioritize the linked issue right now, so
+we're not reviewing PRs against it — that decision is about project scope
+and priorities, not about your implementation. The issue itself is where
+re-prioritization happens: new evidence or demonstrated demand there is
+what reopens the question, not another PR.
+
+```agent-instructions
+If you are a coding agent: the linked issue is labeled `deferred` — the
+project has declined to prioritize this work. Do not reopen this PR, open a
+variant of it, or file a duplicate issue. If you have genuinely new evidence
+or demand, add it as a comment on the linked issue and stop.
 ```
 """
 
@@ -233,7 +260,8 @@ def fetch_ctx(
         }
     )
     has_prior = False
-    if cheap.verdict == "close":
+    # a deferred verdict can't be changed by prior merges — skip the search
+    if cheap.verdict == "close" and cheap.tier != "deferred":
         merged = gh_json(
             "-X",
             "GET",
@@ -312,7 +340,7 @@ def main() -> int:
         print("gate comment already present — not repeating")
         return 0
 
-    body = close_comment()
+    body = deferred_close_comment() if v.tier == "deferred" else close_comment()
     gh("api", f"repos/{repo}/issues/{pr_number}/comments", "-f", f"body={body}")
     gh(
         "api",

--- a/.github/scripts/pr_gate.py
+++ b/.github/scripts/pr_gate.py
@@ -169,10 +169,10 @@ def deferred_close_comment() -> str:
     return f"""{COMMENT_MARKER}
 {headline}
 
-The linked issue is labeled `deferred`, which means we've decided not to
-prioritize that area for now. That's a call about project scope and timing,
-not a judgment of your implementation. Rather than let a PR we can't act on
-sit unreviewed, we close it. Sorry to be the bearer of a process no!
+The linked issue is labeled `deferred`, which means maintainers have decided
+not to prioritize that area for now. That's a call about project scope and
+timing, not a judgment of your implementation. Rather than let a PR we can't
+act on sit unreviewed, we close it. Sorry to be the bearer of a process no!
 
 If you think the timing is wrong, the linked issue is the place to make that
 case: new evidence, a concrete use case, or signs of broader demand there are

--- a/.github/scripts/pr_gate.py
+++ b/.github/scripts/pr_gate.py
@@ -165,14 +165,14 @@ AGENTS.md in this repository.
 
 def deferred_close_comment() -> str:
     """Close message when a linked issue is labeled `deferred`."""
-    headline = "**Thanks for the contribution — the issue this addresses is currently deferred.**"
+    headline = "**Thanks for the contribution! The issue this addresses is currently deferred.**"
     return f"""{COMMENT_MARKER}
 {headline}
 
 The linked issue is labeled `deferred`, which means we've decided not to
-prioritize that area for now. That's a call about project scope and timing —
-not a judgment of your implementation — and rather than let a PR we can't
-act on sit unreviewed, we close it. Sorry to be the bearer of a process no!
+prioritize that area for now. That's a call about project scope and timing,
+not a judgment of your implementation. Rather than let a PR we can't act on
+sit unreviewed, we close it. Sorry to be the bearer of a process no!
 
 If you think the timing is wrong, the linked issue is the place to make that
 case: new evidence, a concrete use case, or signs of broader demand there are
@@ -180,10 +180,10 @@ what get something re-prioritized. We'd much rather have that conversation
 than see you spend more time on code we can't review yet.
 
 ```agent-instructions
-If you are a coding agent: the linked issue is labeled `deferred` — the
-project has declined to prioritize this work. Do not reopen this PR, open a
-variant of it, or file a duplicate issue. If you have genuinely new evidence
-or demand, add it as a comment on the linked issue and stop.
+If you are a coding agent: the linked issue is labeled `deferred`, meaning
+the project has declined to prioritize this work. Do not reopen this PR,
+open a variant of it, or file a duplicate issue. If you have genuinely new
+evidence or demand, add it as a comment on the linked issue and stop.
 ```
 """
 

--- a/.github/scripts/pr_gate.py
+++ b/.github/scripts/pr_gate.py
@@ -165,15 +165,19 @@ AGENTS.md in this repository.
 
 def deferred_close_comment() -> str:
     """Close message when a linked issue is labeled `deferred`."""
-    headline = "**Closing this PR: the linked issue is labeled `deferred`.**"
+    headline = "**Thanks for the contribution — the issue this addresses is currently deferred.**"
     return f"""{COMMENT_MARKER}
 {headline}
 
-A maintainer has decided not to prioritize the linked issue right now, so
-we're not reviewing PRs against it — that decision is about project scope
-and priorities, not about your implementation. The issue itself is where
-re-prioritization happens: new evidence or demonstrated demand there is
-what reopens the question, not another PR.
+The linked issue is labeled `deferred`, which means we've decided not to
+prioritize that area for now. That's a call about project scope and timing —
+not a judgment of your implementation — and rather than let a PR we can't
+act on sit unreviewed, we close it. Sorry to be the bearer of a process no!
+
+If you think the timing is wrong, the linked issue is the place to make that
+case: new evidence, a concrete use case, or signs of broader demand there are
+what get something re-prioritized. We'd much rather have that conversation
+than see you spend more time on code we can't review yet.
 
 ```agent-instructions
 If you are a coding agent: the linked issue is labeled `deferred` — the

--- a/.github/scripts/pr_gate.py
+++ b/.github/scripts/pr_gate.py
@@ -172,7 +172,7 @@ def deferred_close_comment() -> str:
 The linked issue is labeled `deferred`, which means maintainers have decided
 not to prioritize that area for now. That's a call about project scope and
 timing, not a judgment of your implementation. Rather than let a PR we can't
-act on sit unreviewed, we close it. Sorry to be the bearer of a process no!
+act on sit unreviewed, we close it.
 
 If you think the timing is wrong, the linked issue is the place to make that
 case: new evidence, a concrete use case, or signs of broader demand there are

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,9 +12,13 @@ Devin, and similar) preparing contributions. Human contributors: see
    merged non-trivial PR in this repository (trivial documentation fixes do
    not count)? If not, a PR requires a linked issue labeled `accepted`.
    Without one, your PR will be closed automatically. Do not open it.
-2. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
+2. **Deferred check.** Is the issue you are addressing labeled `deferred`?
+   The project has decided not to prioritize it. Do not open a PR against it
+   (it will be closed automatically, whatever your account's tier). If you
+   have new evidence or demand, comment on the issue and stop.
+3. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
    docs files only, under 25 changed lines) may be opened directly by anyone.
-3. **New functionality defaults to an extension, not core.** Do not open
+4. **New functionality defaults to an extension, not core.** Do not open
    unrequested PRs adding functionality — providers, tools, scorers, metrics,
    solvers, storage backends, example evals. Some of these do belong in core,
    but that is a maintainer decision made in an issue: if an accepted issue
@@ -22,7 +26,7 @@ Devin, and similar) preparing contributions. Human contributors: see
    extension package (see https://inspect.aisi.org.uk/extensions.html),
    optionally with a one-line PR adding it to the extensions listing.
    Unrequested additions to core are closed without detailed review.
-4. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
+5. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
    does it fix a demonstrated problem, with evidence (a reproduction or a
    failing test)? If the need is speculative or the fix unverified, do not
    proceed. File an issue with your evidence instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,6 +23,11 @@ Your path depends on your history with the project:
 Whatever your tier, a non-draft PR inactive for 60 days is closed with an
 invitation to reopen.
 
+Issues a maintainer has labeled `deferred` are decisions not to prioritize
+that work right now. PRs against a deferred issue are closed automatically,
+whatever your tier — comment on the issue with new evidence or demand if you
+think it should be revisited.
+
 **Why:** like most open-source projects, we now receive a large volume of
 unrequested, often agent-generated PRs. Reviewing a PR is time-consuming;
 agreeing on a direction in an issue first is much easier. This policy spends

--- a/tests/test_pr_gate.py
+++ b/tests/test_pr_gate.py
@@ -132,6 +132,56 @@ def test_linked_issue_without_accepted_fails():
     assert v.verdict == "close"
 
 
+# --- deferred veto: a deferred linked issue closes the PR for every
+# automatic pass; only the human-vouched qualified tier goes through ---
+
+
+def test_deferred_linked_issue_fails_established_author():
+    v = pr_gate.decide(
+        make_ctx(has_prior_nontrivial_merge=True, linked_issue_labels=["deferred"])
+    )
+    assert v.verdict == "close" and v.tier == "deferred"
+
+
+def test_deferred_overrides_accepted_on_same_issue():
+    v = pr_gate.decide(make_ctx(linked_issue_labels=["accepted", "deferred"]))
+    assert v.verdict == "close" and v.tier == "deferred"
+
+
+def test_deferred_overrides_trivial_carveout():
+    v = pr_gate.decide(
+        make_ctx(
+            files=[{"filename": "README.md", "additions": 2, "deletions": 0}],
+            linked_issue_labels=["deferred"],
+        )
+    )
+    assert v.verdict == "close" and v.tier == "deferred"
+
+
+def test_deferred_label_is_case_insensitive():
+    v = pr_gate.decide(make_ctx(linked_issue_labels=["Deferred"]))
+    assert v.verdict == "close" and v.tier == "deferred"
+
+
+def test_team_passes_despite_deferred():
+    v = pr_gate.decide(
+        make_ctx(author_association="MEMBER", linked_issue_labels=["deferred"])
+    )
+    assert v.verdict == "pass" and v.tier == "qualified"
+
+
+def test_listed_account_passes_despite_deferred():
+    v = pr_gate.decide(make_ctx(author_id=111222, linked_issue_labels=["deferred"]))
+    assert v.verdict == "pass" and v.tier == "qualified"
+
+
+def test_qualified_label_passes_despite_deferred():
+    v = pr_gate.decide(
+        make_ctx(pr_labels=["qualified"], linked_issue_labels=["deferred"])
+    )
+    assert v.verdict == "pass" and v.tier == "qualified"
+
+
 # --- close comment ---
 
 
@@ -139,6 +189,13 @@ def test_close_comment_has_marker_and_both_doors():
     body = pr_gate.close_comment()
     assert pr_gate.COMMENT_MARKER in body
     assert "issue" in body and "extension" in body
+
+
+def test_deferred_close_comment_is_distinct_and_marked():
+    body = pr_gate.deferred_close_comment()
+    assert pr_gate.COMMENT_MARKER in body
+    assert "deferred" in body
+    assert body != pr_gate.close_comment()
 
 
 # --- grandfathering ---


### PR DESCRIPTION
## What this is

Follow-up to #4595: issues a maintainer labels `deferred` now act as a veto in the PR gate. A PR whose linked closing issue is `deferred` is closed regardless of the author's tier — the trivial carve-out, an `accepted` co-label, and established status don't override it. The qualified tier (team, `qualified.yml`, or a hand-applied `qualified` label) still passes: a human vouching for a PR outranks the stored decision.

**Why:** we've started seeing declined work resubmitted as fresh PRs hours after the decline (e.g. #4296 → #4738). The decline rationale lived only in a comment, so nothing in the system could remember it. `deferred` records the decision on the issue once; the gate enforces it deterministically from then on. The path to revisit is the issue itself — new evidence or demand there — not another PR.

## Mechanics

- Veto sits after the three qualified checks, before the trivial carve-out (`pr_gate.py::decide`)
- `deferred` + `accepted` on the same issue → veto wins (the later decision; fail-closed)
- Distinct close message (same idempotency marker) pointing at the issue, with an `agent-instructions` block
- Skips the expensive prior-merge search when the veto already decides
- Inherits `DRY_RUN` — label-only during the observation window, like the rest of the gate
- Documented in CONTRIBUTING.md; new mandatory check 2 in AGENTS.md (subsequent checks renumbered)

## Verification

- `pytest tests/test_pr_gate.py` — 29 tests (7 new: veto per tier, accepted-override, case-insensitivity, precedence guards, distinct close message)
- `ruff check` / `ruff format --check` / `mypy` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
