### PR TITLE
Cut ~60s median and up to ~4 min of fetch variance from PR-gate jobs; document slow-test policy; 2026-08-05 CI perf report

### DIFF
--- a/.claude/skills/ci-perf/SKILL.md
+++ b/.claude/skills/ci-perf/SKILL.md
@@ -49,6 +49,32 @@ test-job logs for pytest `--durations` blocks.
 - If a snapshot for today already exists, overwrite it (re-runs same day
   are fine); history keeps one file per day.
 
+## Repo slow-test policy (context for analysis and fixes)
+
+- **Definition:** any test that uses docker or hits a real (unmocked)
+  external service is by definition slow and must carry
+  `@pytest.mark.slow`. A fully-mocked test may also be marked slow when
+  its cost is inherent (e.g. crossing the S3 1000-key page boundary means
+  1001+ real HTTP PUTs to the in-process moto server) — say why in the
+  test's docstring.
+- **Where slow tests run:** they are skipped in the PR-gate `test` jobs
+  (no `--runslow`) and run every ~2 hours by the scheduled suite in
+  `meridianlabs-ai/actions` (`inspect-ai-scheduled-tests.yml`, runner
+  label `slow_test_runner`, `pytest --runslow --runapi`). Marking a test
+  slow moves its coverage there — it does not delete it. Prefer the PR
+  gate for regression guards on core logic when the test can be made
+  cheap; prefer slow for anything matching the definition above.
+- **The docker trap:** docker is preinstalled and running on GitHub
+  `ubuntu-latest`, so nothing technically stops a docker test running in
+  the PR gate — `skip_if_no_docker` does not skip in CI. The slow mark is
+  the only enforcement, by convention: `@skip_if_no_docker` and
+  `@pytest.mark.slow` belong together. When durations data shows a
+  multi-second test, check for this pairing violation first (two found so
+  far: the 38s sandbox-init test, fixed in #4760, and
+  `test_docker_read_file.py` at 42s of fixture setup). Aggregate `setup`
+  and `teardown` phases as well as `call` — fixture-heavy offenders hide
+  outside `call`.
+
 ## Phase 2 — Analyze
 
 Read the fresh snapshot plus the previous few in `design/ci-perf/history/`
@@ -75,6 +101,19 @@ only). Compute:
    before dying; jobs whose checkout/setup overhead exceeds their useful
    work; unconditional `fetch-depth: 0` where history/tags are unused;
    cache effectiveness.
+6. **Step-level breakdown of the heavy jobs — always at p90, not just
+   median.** The snapshot carries per-step timings; sum each step name's
+   median AND p90 across runs. A step can look fine in one sample and be
+   the wall-clock lottery across many: `fetch-depth: 0` checkouts fetch
+   every branch and tag at full history (a ~400MB pack here), taking 30s
+   or 4min depending on GitHub's server-side pack cache. Rule of thumb:
+   any always-run step whose p90 exceeds ~2x its median is a variance
+   problem, not a size problem — hunt for the erratic dependency
+   (pack cache, registry, external download). For checkouts specifically,
+   `filter: "blob:none"` keeps setuptools_scm working (refs + commit
+   graph) while skipping historical file contents; only jobs that read
+   old blob contents (e.g. `git diff main -- <paths>` over sources) need
+   care, and even those lazy-fetch on demand.
 
 ## Phase 3 — Report
 

--- a/.claude/skills/ci-perf/scripts/collect_ci_data.py
+++ b/.claude/skills/ci-perf/scripts/collect_ci_data.py
@@ -74,6 +74,17 @@ def job_record(run: dict[str, Any], job: dict[str, Any]) -> dict[str, Any]:
         "wait_from_run_start_seconds": seconds_between(
             run["run_started_at"], job["started_at"]
         ),
+        # Per-step timings: job-level numbers hide which step costs what
+        # (checkout vs install vs the actual work) and hide high-variance
+        # steps whose median looks fine (e.g. full-pack git fetches that
+        # take 30s or 4min depending on server pack-cache luck).
+        "steps": [
+            {
+                "name": step["name"],
+                "seconds": seconds_between(step["started_at"], step["completed_at"]),
+            }
+            for step in job.get("steps", [])
+        ],
         "id": job["id"],
     }
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          # blob:none: all refs/commits for setuptools_scm, no historical
+          # file contents (the full pack is ~400MB and fetch time is erratic)
+          filter: "blob:none"
       - name: Lint with Ruff
         uses: astral-sh/ruff-action@v4.1.0
         with:
@@ -50,6 +53,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          filter: "blob:none"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
@@ -78,6 +82,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          filter: "blob:none"
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -142,6 +147,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          filter: "blob:none"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v9.0.0
@@ -199,6 +205,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          filter: "blob:none"
           submodules: true
 
       - uses: dorny/paths-filter@v4
@@ -219,6 +226,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          filter: "blob:none"
           submodules: true
 
       - name: Install uv
@@ -230,9 +238,13 @@ jobs:
 
       - name: Install dependencies
         if: env.RUN_TESTS == 'true'
+        # tests/test_package is pre-installed so ensure_test_package_installed()
+        # short-circuits instead of pip-installing it mid-run (~9s on the
+        # xdist critical path, paid by whichever test calls it first).
         run: |-
           uv venv
           uv pip install .[dev]
+          uv pip install --no-deps ./tests/test_package
 
       - name: Test with pytest
         if: env.RUN_TESTS == 'true'
@@ -559,5 +571,6 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          filter: "blob:none"
 
       - uses: hynek/build-and-inspect-python-package@v2

--- a/design/ci-perf/history/2026-08-05.json
+++ b/design/ci-perf/history/2026-08-05.json
@@ -1,0 +1,20750 @@
+{
+ "generated_at": "2026-08-05T13:53:25.063173+00:00",
+ "repo": "UKGovernmentBEIS/inspect_ai",
+ "run_count": 200,
+ "runs": [
+  {
+   "id": 31007211721,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "click-lock-final",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T12:47:51Z",
+   "updated_at": "2026-08-05T12:49:06Z",
+   "wall_seconds": 75.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:47:53Z",
+     "completed_at": "2026-08-05T12:47:59Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92309986480
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:47:53Z",
+     "completed_at": "2026-08-05T12:48:56Z",
+     "exec_seconds": 63.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92309986535
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:48:00Z",
+     "completed_at": "2026-08-05T12:48:33Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92309986594
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:47:53Z",
+     "completed_at": "2026-08-05T12:49:06Z",
+     "exec_seconds": 73.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92309986613
+    }
+   ]
+  },
+  {
+   "id": 31007211974,
+   "name": "Build",
+   "head_branch": "click-lock-final",
+   "conclusion": "failure",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T12:47:51Z",
+   "updated_at": "2026-08-05T12:55:58Z",
+   "wall_seconds": 487.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:48:00Z",
+     "completed_at": "2026-08-05T12:49:02Z",
+     "exec_seconds": 62.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92309987722
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:48:00Z",
+     "completed_at": "2026-08-05T12:48:54Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92309987757
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:47:58Z",
+     "completed_at": "2026-08-05T12:55:52Z",
+     "exec_seconds": 474.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92309987773
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:48:00Z",
+     "completed_at": "2026-08-05T12:48:47Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92309987777
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:47:54Z",
+     "completed_at": "2026-08-05T12:48:01Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92309987785
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:48:01Z",
+     "completed_at": "2026-08-05T12:55:57Z",
+     "exec_seconds": 476.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92309987798
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "failure",
+     "started_at": "2026-08-05T12:47:53Z",
+     "completed_at": "2026-08-05T12:49:23Z",
+     "exec_seconds": 90.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92309987818
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T12:47:59Z",
+     "completed_at": "2026-08-05T12:49:39Z",
+     "exec_seconds": 100.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92309987832
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:47:54Z",
+     "completed_at": "2026-08-05T12:48:01Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92309987914
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:48:02Z",
+     "completed_at": "2026-08-05T12:48:01Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92310028090
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:48:02Z",
+     "completed_at": "2026-08-05T12:48:01Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92310028621
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:48:02Z",
+     "completed_at": "2026-08-05T12:48:01Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92310028859
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:48:02Z",
+     "completed_at": "2026-08-05T12:48:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92310029361
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:48:02Z",
+     "completed_at": "2026-08-05T12:48:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92310029448
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:48:02Z",
+     "completed_at": "2026-08-05T12:48:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92310029701
+    }
+   ]
+  },
+  {
+   "id": 31006304495,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "docs/agent-review-disclosure",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T12:35:46Z",
+   "updated_at": "2026-08-05T12:37:09Z",
+   "wall_seconds": 83.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:56Z",
+     "completed_at": "2026-08-05T12:36:59Z",
+     "exec_seconds": 63.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92306927244
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:48Z",
+     "completed_at": "2026-08-05T12:36:13Z",
+     "exec_seconds": 25.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92306927288
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:50Z",
+     "completed_at": "2026-08-05T12:37:08Z",
+     "exec_seconds": 78.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92306927305
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:56Z",
+     "completed_at": "2026-08-05T12:36:05Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92306927330
+    }
+   ]
+  },
+  {
+   "id": 31006304429,
+   "name": "Build",
+   "head_branch": "docs/agent-review-disclosure",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T12:35:46Z",
+   "updated_at": "2026-08-05T12:37:43Z",
+   "wall_seconds": 117.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:55Z",
+     "completed_at": "2026-08-05T12:36:04Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92306927057
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:49Z",
+     "completed_at": "2026-08-05T12:35:56Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92306927102
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:50Z",
+     "completed_at": "2026-08-05T12:35:56Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92306927127
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:49Z",
+     "completed_at": "2026-08-05T12:37:43Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92306927141
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:49Z",
+     "completed_at": "2026-08-05T12:36:36Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92306927172
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:50Z",
+     "completed_at": "2026-08-05T12:37:41Z",
+     "exec_seconds": 111.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92306927196
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:48Z",
+     "completed_at": "2026-08-05T12:36:19Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92306927260
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:54Z",
+     "completed_at": "2026-08-05T12:35:59Z",
+     "exec_seconds": 5.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92306927264
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:35:49Z",
+     "completed_at": "2026-08-05T12:36:35Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92306927270
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:35:56Z",
+     "completed_at": "2026-08-05T12:35:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92306967974
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:35:56Z",
+     "completed_at": "2026-08-05T12:35:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92306968203
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:35:56Z",
+     "completed_at": "2026-08-05T12:35:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92306968304
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:35:56Z",
+     "completed_at": "2026-08-05T12:35:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92306968850
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:36:04Z",
+     "completed_at": "2026-08-05T12:36:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92306999776
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:36:04Z",
+     "completed_at": "2026-08-05T12:36:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92306999841
+    }
+   ]
+  },
+  {
+   "id": 31005531306,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix-required-checks",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T12:25:20Z",
+   "updated_at": "2026-08-05T12:26:37Z",
+   "wall_seconds": 77.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:27Z",
+     "completed_at": "2026-08-05T12:25:36Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92304385388
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:23Z",
+     "completed_at": "2026-08-05T12:26:37Z",
+     "exec_seconds": 74.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92304385405
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:22Z",
+     "completed_at": "2026-08-05T12:26:17Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92304385421
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:22Z",
+     "completed_at": "2026-08-05T12:25:51Z",
+     "exec_seconds": 29.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92304385477
+    }
+   ]
+  },
+  {
+   "id": 31005531725,
+   "name": "Build",
+   "head_branch": "fix-required-checks",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T12:25:20Z",
+   "updated_at": "2026-08-05T12:34:15Z",
+   "wall_seconds": 535.0,
+   "jobs": [
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:29Z",
+     "completed_at": "2026-08-05T12:33:54Z",
+     "exec_seconds": 505.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92304386469
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:23Z",
+     "completed_at": "2026-08-05T12:25:33Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92304386486
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:28Z",
+     "completed_at": "2026-08-05T12:34:15Z",
+     "exec_seconds": 527.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92304386492
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:29Z",
+     "completed_at": "2026-08-05T12:25:36Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92304386496
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:23Z",
+     "completed_at": "2026-08-05T12:26:19Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92304386520
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:22Z",
+     "completed_at": "2026-08-05T12:25:52Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92304386522
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:22Z",
+     "completed_at": "2026-08-05T12:27:27Z",
+     "exec_seconds": 125.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92304386552
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:23Z",
+     "completed_at": "2026-08-05T12:26:04Z",
+     "exec_seconds": 41.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92304386556
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T12:25:22Z",
+     "completed_at": "2026-08-05T12:27:10Z",
+     "exec_seconds": 108.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92304386575
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:25:33Z",
+     "completed_at": "2026-08-05T12:25:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92304434750
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:25:33Z",
+     "completed_at": "2026-08-05T12:25:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92304435100
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:25:33Z",
+     "completed_at": "2026-08-05T12:25:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92304435199
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:25:33Z",
+     "completed_at": "2026-08-05T12:25:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92304435844
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:25:37Z",
+     "completed_at": "2026-08-05T12:25:36Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92304449255
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T12:25:37Z",
+     "completed_at": "2026-08-05T12:25:36Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92304449392
+    }
+   ]
+  },
+  {
+   "id": 31003335866,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:54:12Z",
+   "updated_at": "2026-08-05T11:55:21Z",
+   "wall_seconds": 69.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:55:10Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217633
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:55:20Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217641
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:54:25Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217655
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:54:40Z",
+     "exec_seconds": 25.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217721
+    }
+   ]
+  },
+  {
+   "id": 31003335733,
+   "name": "Build",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:54:12Z",
+   "updated_at": "2026-08-05T12:03:20Z",
+   "wall_seconds": 548.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:54:20Z",
+     "exec_seconds": 5.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217122
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:22Z",
+     "completed_at": "2026-08-05T11:55:01Z",
+     "exec_seconds": 39.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92297217138
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:55:14Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217186
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:22Z",
+     "completed_at": "2026-08-05T12:02:19Z",
+     "exec_seconds": 477.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92297217225
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:20Z",
+     "completed_at": "2026-08-05T11:55:02Z",
+     "exec_seconds": 42.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92297217228
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:17Z",
+     "completed_at": "2026-08-05T11:54:26Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92297217252
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:23Z",
+     "completed_at": "2026-08-05T12:03:20Z",
+     "exec_seconds": 537.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92297217256
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:56:02Z",
+     "exec_seconds": 107.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217266
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:54:15Z",
+     "completed_at": "2026-08-05T11:56:10Z",
+     "exec_seconds": 115.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92297217309
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:54:21Z",
+     "completed_at": "2026-08-05T11:54:20Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92297245775
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:54:21Z",
+     "completed_at": "2026-08-05T11:54:20Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92297246150
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:54:27Z",
+     "completed_at": "2026-08-05T11:54:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92297268803
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:54:27Z",
+     "completed_at": "2026-08-05T11:54:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92297269467
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:54:27Z",
+     "completed_at": "2026-08-05T11:54:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92297269629
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:54:27Z",
+     "completed_at": "2026-08-05T11:54:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92297269754
+    }
+   ]
+  },
+  {
+   "id": 31002669399,
+   "name": "Build",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:44:27Z",
+   "updated_at": "2026-08-05T11:53:11Z",
+   "wall_seconds": 524.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:42Z",
+     "completed_at": "2026-08-05T11:45:37Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92295047436
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:29Z",
+     "completed_at": "2026-08-05T11:53:10Z",
+     "exec_seconds": 521.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92295047486
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:29Z",
+     "completed_at": "2026-08-05T11:45:03Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92295047489
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:36Z",
+     "completed_at": "2026-08-05T11:52:26Z",
+     "exec_seconds": 470.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92295047490
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:36Z",
+     "completed_at": "2026-08-05T11:44:45Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92295047523
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:35Z",
+     "completed_at": "2026-08-05T11:45:30Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92295047559
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:30Z",
+     "completed_at": "2026-08-05T11:44:38Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92295047577
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:35Z",
+     "completed_at": "2026-08-05T11:46:11Z",
+     "exec_seconds": 96.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92295047594
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:30Z",
+     "completed_at": "2026-08-05T11:46:03Z",
+     "exec_seconds": 93.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92295047610
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:44:39Z",
+     "completed_at": "2026-08-05T11:44:38Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92295088945
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:44:39Z",
+     "completed_at": "2026-08-05T11:44:38Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92295089066
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:44:46Z",
+     "completed_at": "2026-08-05T11:44:45Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92295113740
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:44:46Z",
+     "completed_at": "2026-08-05T11:44:45Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92295114058
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:44:46Z",
+     "completed_at": "2026-08-05T11:44:46Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92295114645
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:44:46Z",
+     "completed_at": "2026-08-05T11:44:45Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92295114689
+    }
+   ]
+  },
+  {
+   "id": 31002669539,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:44:27Z",
+   "updated_at": "2026-08-05T11:45:38Z",
+   "wall_seconds": 71.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:30Z",
+     "completed_at": "2026-08-05T11:45:01Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92295047457
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:30Z",
+     "completed_at": "2026-08-05T11:44:39Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92295047484
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:29Z",
+     "completed_at": "2026-08-05T11:45:24Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92295047515
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:44:29Z",
+     "completed_at": "2026-08-05T11:45:38Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92295047603
+    }
+   ]
+  },
+  {
+   "id": 31001908801,
+   "name": "Build",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:33:05Z",
+   "updated_at": "2026-08-05T11:42:05Z",
+   "wall_seconds": 540.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:14Z",
+     "completed_at": "2026-08-05T11:33:20Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92292538189
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:08Z",
+     "completed_at": "2026-08-05T11:42:04Z",
+     "exec_seconds": 536.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292538190
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:08Z",
+     "completed_at": "2026-08-05T11:33:39Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292538204
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:08Z",
+     "completed_at": "2026-08-05T11:35:01Z",
+     "exec_seconds": 113.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292538244
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:08Z",
+     "completed_at": "2026-08-05T11:41:05Z",
+     "exec_seconds": 477.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292538252
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:08Z",
+     "completed_at": "2026-08-05T11:34:40Z",
+     "exec_seconds": 92.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292538282
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:22Z",
+     "completed_at": "2026-08-05T11:34:22Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92292538323
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:21Z",
+     "completed_at": "2026-08-05T11:33:31Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92292538324
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:26Z",
+     "completed_at": "2026-08-05T11:34:16Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92292538417
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:33:20Z",
+     "completed_at": "2026-08-05T11:33:20Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92292593580
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:33:20Z",
+     "completed_at": "2026-08-05T11:33:20Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92292593743
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:33:31Z",
+     "completed_at": "2026-08-05T11:33:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92292631520
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:33:31Z",
+     "completed_at": "2026-08-05T11:33:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92292631629
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:33:31Z",
+     "completed_at": "2026-08-05T11:33:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92292631798
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:33:31Z",
+     "completed_at": "2026-08-05T11:33:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92292631929
+    }
+   ]
+  },
+  {
+   "id": 31001908720,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:33:05Z",
+   "updated_at": "2026-08-05T11:34:25Z",
+   "wall_seconds": 80.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:13Z",
+     "completed_at": "2026-08-05T11:33:20Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92292537994
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:08Z",
+     "completed_at": "2026-08-05T11:34:24Z",
+     "exec_seconds": 76.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292538002
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:09Z",
+     "completed_at": "2026-08-05T11:34:14Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92292538052
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:33:08Z",
+     "completed_at": "2026-08-05T11:33:31Z",
+     "exec_seconds": 23.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292538119
+    }
+   ]
+  },
+  {
+   "id": 31001865658,
+   "name": "Build",
+   "head_branch": "ci-perf/skill",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:32:27Z",
+   "updated_at": "2026-08-05T11:41:20Z",
+   "wall_seconds": 533.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:31Z",
+     "completed_at": "2026-08-05T11:32:38Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92292400101
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:30Z",
+     "completed_at": "2026-08-05T11:33:03Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92292400117
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:36Z",
+     "completed_at": "2026-08-05T11:41:19Z",
+     "exec_seconds": 523.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92292400128
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:29Z",
+     "completed_at": "2026-08-05T11:34:13Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92292400131
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:29Z",
+     "completed_at": "2026-08-05T11:40:26Z",
+     "exec_seconds": 477.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92292400141
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:29Z",
+     "completed_at": "2026-08-05T11:32:36Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92292400142
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:29Z",
+     "completed_at": "2026-08-05T11:33:20Z",
+     "exec_seconds": 51.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92292400145
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:35Z",
+     "completed_at": "2026-08-05T11:34:20Z",
+     "exec_seconds": 105.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92292400158
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:29Z",
+     "completed_at": "2026-08-05T11:33:17Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92292400255
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:32:36Z",
+     "completed_at": "2026-08-05T11:32:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92292432591
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:32:36Z",
+     "completed_at": "2026-08-05T11:32:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92292432670
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:32:36Z",
+     "completed_at": "2026-08-05T11:32:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92292433099
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:32:37Z",
+     "completed_at": "2026-08-05T11:32:36Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92292433743
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:32:39Z",
+     "completed_at": "2026-08-05T11:32:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92292441402
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:32:39Z",
+     "completed_at": "2026-08-05T11:32:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92292441682
+    }
+   ]
+  },
+  {
+   "id": 31001865815,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "ci-perf/skill",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:32:27Z",
+   "updated_at": "2026-08-05T11:33:54Z",
+   "wall_seconds": 87.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:29Z",
+     "completed_at": "2026-08-05T11:32:59Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92292400408
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:29Z",
+     "completed_at": "2026-08-05T11:33:24Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92292400455
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:31Z",
+     "completed_at": "2026-08-05T11:32:38Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92292400472
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:32:36Z",
+     "completed_at": "2026-08-05T11:33:54Z",
+     "exec_seconds": 78.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92292400492
+    }
+   ]
+  },
+  {
+   "id": 31001063712,
+   "name": "Build",
+   "head_branch": "ci-perf/pytest-durations",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:20:30Z",
+   "updated_at": "2026-08-05T11:29:16Z",
+   "wall_seconds": 526.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:33Z",
+     "completed_at": "2026-08-05T11:21:07Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289782064
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:37Z",
+     "completed_at": "2026-08-05T11:20:44Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92289782067
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:39Z",
+     "completed_at": "2026-08-05T11:22:28Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92289782081
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:33Z",
+     "completed_at": "2026-08-05T11:29:15Z",
+     "exec_seconds": 522.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289782084
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:34Z",
+     "completed_at": "2026-08-05T11:22:32Z",
+     "exec_seconds": 118.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92289782094
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:33Z",
+     "completed_at": "2026-08-05T11:21:21Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289782131
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:39Z",
+     "completed_at": "2026-08-05T11:21:33Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92289782136
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:33Z",
+     "completed_at": "2026-08-05T11:28:26Z",
+     "exec_seconds": 473.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289782154
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:41Z",
+     "completed_at": "2026-08-05T11:20:49Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92289782167
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:44Z",
+     "completed_at": "2026-08-05T11:20:44Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92289831141
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:44Z",
+     "completed_at": "2026-08-05T11:20:44Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92289831397
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:45Z",
+     "completed_at": "2026-08-05T11:20:44Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92289832185
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:45Z",
+     "completed_at": "2026-08-05T11:20:44Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92289832248
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:49Z",
+     "completed_at": "2026-08-05T11:20:49Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92289848063
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:49Z",
+     "completed_at": "2026-08-05T11:20:49Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92289848801
+    }
+   ]
+  },
+  {
+   "id": 31001063793,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "ci-perf/pytest-durations",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:20:30Z",
+   "updated_at": "2026-08-05T11:22:06Z",
+   "wall_seconds": 96.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:44Z",
+     "completed_at": "2026-08-05T11:20:51Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92289782301
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:46Z",
+     "completed_at": "2026-08-05T11:21:51Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92289782379
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:53Z",
+     "completed_at": "2026-08-05T11:22:05Z",
+     "exec_seconds": 72.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92289782451
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:51Z",
+     "completed_at": "2026-08-05T11:21:17Z",
+     "exec_seconds": 26.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92289782468
+    }
+   ]
+  },
+  {
+   "id": 31001035332,
+   "name": "Build",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:20:06Z",
+   "updated_at": "2026-08-05T11:28:54Z",
+   "wall_seconds": 528.0,
+   "jobs": [
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:08Z",
+     "completed_at": "2026-08-05T11:28:53Z",
+     "exec_seconds": 525.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92289688589
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:08Z",
+     "completed_at": "2026-08-05T11:21:55Z",
+     "exec_seconds": 107.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92289688637
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:08Z",
+     "completed_at": "2026-08-05T11:21:53Z",
+     "exec_seconds": 105.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92289688649
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:09Z",
+     "completed_at": "2026-08-05T11:21:05Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289688702
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:13Z",
+     "completed_at": "2026-08-05T11:21:05Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92289688707
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:17Z",
+     "completed_at": "2026-08-05T11:20:26Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92289688710
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:09Z",
+     "completed_at": "2026-08-05T11:20:42Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289688715
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:08Z",
+     "completed_at": "2026-08-05T11:27:48Z",
+     "exec_seconds": 460.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92289688719
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:08Z",
+     "completed_at": "2026-08-05T11:20:14Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92289688766
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:14Z",
+     "completed_at": "2026-08-05T11:20:14Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92289718408
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:14Z",
+     "completed_at": "2026-08-05T11:20:14Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92289718599
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:27Z",
+     "completed_at": "2026-08-05T11:20:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92289767157
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:27Z",
+     "completed_at": "2026-08-05T11:20:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92289767440
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:27Z",
+     "completed_at": "2026-08-05T11:20:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92289767654
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:20:27Z",
+     "completed_at": "2026-08-05T11:20:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92289767662
+    }
+   ]
+  },
+  {
+   "id": 31001035519,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:20:06Z",
+   "updated_at": "2026-08-05T11:21:17Z",
+   "wall_seconds": 71.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:08Z",
+     "completed_at": "2026-08-05T11:20:32Z",
+     "exec_seconds": 24.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92289688769
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:09Z",
+     "completed_at": "2026-08-05T11:20:19Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289688778
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:08Z",
+     "completed_at": "2026-08-05T11:21:16Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92289688792
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:20:09Z",
+     "completed_at": "2026-08-05T11:21:08Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92289688862
+    }
+   ]
+  },
+  {
+   "id": 31000149512,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "ci-perf/unserialize-test",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:06:53Z",
+   "updated_at": "2026-08-05T11:08:16Z",
+   "wall_seconds": 83.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:08:16Z",
+     "exec_seconds": 80.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286769325
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:07:26Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286769355
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:14Z",
+     "completed_at": "2026-08-05T11:08:09Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92286769395
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:28Z",
+     "completed_at": "2026-08-05T11:07:37Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 35.0,
+     "id": 92286769478
+    }
+   ]
+  },
+  {
+   "id": 31000149312,
+   "name": "Build",
+   "head_branch": "ci-perf/unserialize-test",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:06:53Z",
+   "updated_at": "2026-08-05T11:16:13Z",
+   "wall_seconds": 560.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:03Z",
+     "completed_at": "2026-08-05T11:08:00Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92286769166
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:58Z",
+     "completed_at": "2026-08-05T11:08:44Z",
+     "exec_seconds": 106.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92286769191
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:07:03Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286769210
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:16:12Z",
+     "exec_seconds": 556.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286769244
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:27Z",
+     "completed_at": "2026-08-05T11:07:35Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92286769275
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:07:47Z",
+     "exec_seconds": 51.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286769285
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:05Z",
+     "completed_at": "2026-08-05T11:07:43Z",
+     "exec_seconds": 38.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92286769289
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:33Z",
+     "completed_at": "2026-08-05T11:14:44Z",
+     "exec_seconds": 431.0,
+     "wait_from_run_start_seconds": 40.0,
+     "id": 92286769358
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:04Z",
+     "completed_at": "2026-08-05T11:08:59Z",
+     "exec_seconds": 115.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92286769360
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:07:04Z",
+     "completed_at": "2026-08-05T11:07:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92286804650
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:07:04Z",
+     "completed_at": "2026-08-05T11:07:03Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92286804694
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:07:04Z",
+     "completed_at": "2026-08-05T11:07:03Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92286804918
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:07:04Z",
+     "completed_at": "2026-08-05T11:07:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92286805231
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:07:36Z",
+     "completed_at": "2026-08-05T11:07:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92286925029
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:07:36Z",
+     "completed_at": "2026-08-05T11:07:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92286925487
+    }
+   ]
+  },
+  {
+   "id": 31000135243,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "ci-perf/skill",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:06:40Z",
+   "updated_at": "2026-08-05T11:07:49Z",
+   "wall_seconds": 69.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:07:06Z",
+     "exec_seconds": 23.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721650
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:06:49Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721652
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:07:48Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721717
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:07:49Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721787
+    }
+   ]
+  },
+  {
+   "id": 31000135268,
+   "name": "Build",
+   "head_branch": "ci-perf/skill",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:06:40Z",
+   "updated_at": "2026-08-05T11:16:31Z",
+   "wall_seconds": 591.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:49Z",
+     "completed_at": "2026-08-05T11:06:56Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92286721703
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:08:27Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721709
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:07:36Z",
+     "exec_seconds": 53.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721751
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:08:29Z",
+     "exec_seconds": 106.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721799
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:49Z",
+     "completed_at": "2026-08-05T11:06:55Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92286721815
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:07:18Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721840
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:06:43Z",
+     "completed_at": "2026-08-05T11:07:31Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286721957
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:06:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92286776507
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:06:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92286776730
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:06:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92286776836
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:06:56Z",
+     "completed_at": "2026-08-05T11:06:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92286777777
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:07Z",
+     "completed_at": "2026-08-05T11:16:30Z",
+     "exec_seconds": 563.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92286777885
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:07:08Z",
+     "completed_at": "2026-08-05T11:15:23Z",
+     "exec_seconds": 495.0,
+     "wait_from_run_start_seconds": 28.0,
+     "id": 92286777886
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:06:57Z",
+     "completed_at": "2026-08-05T11:06:56Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92286778841
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:06:57Z",
+     "completed_at": "2026-08-05T11:06:56Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92286778897
+    }
+   ]
+  },
+  {
+   "id": 31000037875,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:05:16Z",
+   "updated_at": "2026-08-05T11:06:39Z",
+   "wall_seconds": 83.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:19Z",
+     "completed_at": "2026-08-05T11:05:42Z",
+     "exec_seconds": 23.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286401222
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:25Z",
+     "completed_at": "2026-08-05T11:06:38Z",
+     "exec_seconds": 73.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92286401227
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:26Z",
+     "completed_at": "2026-08-05T11:05:33Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92286401263
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:19Z",
+     "completed_at": "2026-08-05T11:06:29Z",
+     "exec_seconds": 70.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286401377
+    }
+   ]
+  },
+  {
+   "id": 31000037797,
+   "name": "Build",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T11:05:16Z",
+   "updated_at": "2026-08-05T11:14:06Z",
+   "wall_seconds": 530.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:26Z",
+     "completed_at": "2026-08-05T11:06:00Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92286400877
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:19Z",
+     "completed_at": "2026-08-05T11:06:21Z",
+     "exec_seconds": 62.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286400896
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:25Z",
+     "completed_at": "2026-08-05T11:05:36Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92286400913
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:20Z",
+     "completed_at": "2026-08-05T11:07:12Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92286400919
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:19Z",
+     "completed_at": "2026-08-05T11:06:04Z",
+     "exec_seconds": 45.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286400958
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:19Z",
+     "completed_at": "2026-08-05T11:07:05Z",
+     "exec_seconds": 106.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286400972
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:19Z",
+     "completed_at": "2026-08-05T11:05:27Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92286401068
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:29Z",
+     "completed_at": "2026-08-05T11:13:11Z",
+     "exec_seconds": 462.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92286441718
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T11:05:29Z",
+     "completed_at": "2026-08-05T11:14:05Z",
+     "exec_seconds": 516.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92286441726
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:05:27Z",
+     "completed_at": "2026-08-05T11:05:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92286442339
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:05:27Z",
+     "completed_at": "2026-08-05T11:05:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92286442505
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:05:37Z",
+     "completed_at": "2026-08-05T11:05:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92286477991
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:05:37Z",
+     "completed_at": "2026-08-05T11:05:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92286478270
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:05:37Z",
+     "completed_at": "2026-08-05T11:05:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92286478493
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T11:05:37Z",
+     "completed_at": "2026-08-05T11:05:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92286479056
+    }
+   ]
+  },
+  {
+   "id": 30995458117,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "docs/inspect-skills-callouts",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T09:57:57Z",
+   "updated_at": "2026-08-05T09:59:17Z",
+   "wall_seconds": 80.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:01Z",
+     "completed_at": "2026-08-05T09:58:10Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92271353602
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:00Z",
+     "completed_at": "2026-08-05T09:58:31Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92271353710
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:05Z",
+     "completed_at": "2026-08-05T09:59:07Z",
+     "exec_seconds": 62.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92271353757
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:00Z",
+     "completed_at": "2026-08-05T09:59:16Z",
+     "exec_seconds": 76.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92271353899
+    }
+   ]
+  },
+  {
+   "id": 30995457914,
+   "name": "Build",
+   "head_branch": "docs/inspect-skills-callouts",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T09:57:57Z",
+   "updated_at": "2026-08-05T10:04:59Z",
+   "wall_seconds": 422.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:16Z",
+     "completed_at": "2026-08-05T09:58:23Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92271414398
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:16Z",
+     "completed_at": "2026-08-05T09:59:09Z",
+     "exec_seconds": 53.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92271414404
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:16Z",
+     "completed_at": "2026-08-05T09:59:03Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92271414422
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:16Z",
+     "completed_at": "2026-08-05T09:59:59Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92271414438
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:16Z",
+     "completed_at": "2026-08-05T10:00:05Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92271414461
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:16Z",
+     "completed_at": "2026-08-05T09:58:51Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92271414464
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:16Z",
+     "completed_at": "2026-08-05T09:58:22Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92271414482
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:58:24Z",
+     "completed_at": "2026-08-05T10:04:58Z",
+     "exec_seconds": 394.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92271446990
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:58:23Z",
+     "completed_at": "2026-08-05T09:58:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92271448073
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:58:23Z",
+     "completed_at": "2026-08-05T09:58:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92271448192
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:58:24Z",
+     "completed_at": "2026-08-05T09:58:23Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92271452046
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:58:24Z",
+     "completed_at": "2026-08-05T09:58:23Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92271452099
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:58:24Z",
+     "completed_at": "2026-08-05T09:58:23Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92271452171
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:58:24Z",
+     "completed_at": "2026-08-05T09:58:23Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92271452656
+    }
+   ]
+  },
+  {
+   "id": 30995097742,
+   "name": "Build",
+   "head_branch": "docs/inspect-skills-callouts",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T09:52:48Z",
+   "updated_at": "2026-08-05T09:58:14Z",
+   "wall_seconds": 326.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:51Z",
+     "completed_at": "2026-08-05T09:53:46Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92270167873
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:50Z",
+     "completed_at": "2026-08-05T09:54:06Z",
+     "exec_seconds": 76.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92270167977
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:55Z",
+     "completed_at": "2026-08-05T09:53:42Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92270167983
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:51Z",
+     "completed_at": "2026-08-05T09:53:01Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92270167987
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:50Z",
+     "completed_at": "2026-08-05T09:54:40Z",
+     "exec_seconds": 110.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92270168012
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:57Z",
+     "completed_at": "2026-08-05T09:53:31Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92270168022
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:51Z",
+     "completed_at": "2026-08-05T09:53:00Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92270168038
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T09:53:02Z",
+     "completed_at": "2026-08-05T09:58:13Z",
+     "exec_seconds": 311.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92270211357
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:53:00Z",
+     "completed_at": "2026-08-05T09:53:00Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92270212188
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:53:00Z",
+     "completed_at": "2026-08-05T09:53:00Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92270212411
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:53:01Z",
+     "completed_at": "2026-08-05T09:53:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92270215510
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:53:01Z",
+     "completed_at": "2026-08-05T09:53:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92270215517
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:53:01Z",
+     "completed_at": "2026-08-05T09:53:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92270216069
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T09:53:01Z",
+     "completed_at": "2026-08-05T09:53:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92270216234
+    }
+   ]
+  },
+  {
+   "id": 30995097741,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "docs/inspect-skills-callouts",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T09:52:48Z",
+   "updated_at": "2026-08-05T09:53:57Z",
+   "wall_seconds": 69.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:50Z",
+     "completed_at": "2026-08-05T09:52:58Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92270167659
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:50Z",
+     "completed_at": "2026-08-05T09:53:56Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92270167764
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:57Z",
+     "completed_at": "2026-08-05T09:53:29Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92270167795
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T09:52:50Z",
+     "completed_at": "2026-08-05T09:53:49Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92270167913
+    }
+   ]
+  },
+  {
+   "id": 30986513102,
+   "name": "Build",
+   "head_branch": "craig/sandbox-failures",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T07:49:35Z",
+   "updated_at": "2026-08-05T07:58:48Z",
+   "wall_seconds": 553.0,
+   "jobs": [
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:37Z",
+     "completed_at": "2026-08-05T07:50:27Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92242401499
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:38Z",
+     "completed_at": "2026-08-05T07:51:32Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92242401504
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:38Z",
+     "completed_at": "2026-08-05T07:49:45Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92242401523
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:38Z",
+     "completed_at": "2026-08-05T07:50:11Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92242401524
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:43Z",
+     "completed_at": "2026-08-05T07:49:52Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92242401526
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:39Z",
+     "completed_at": "2026-08-05T07:51:30Z",
+     "exec_seconds": 111.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92242401527
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:38Z",
+     "completed_at": "2026-08-05T07:50:43Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92242401532
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T07:49:46Z",
+     "completed_at": "2026-08-05T07:49:45Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92242438442
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T07:49:46Z",
+     "completed_at": "2026-08-05T07:49:45Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92242438454
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T07:49:46Z",
+     "completed_at": "2026-08-05T07:49:45Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92242438505
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T07:49:46Z",
+     "completed_at": "2026-08-05T07:49:46Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92242438936
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:50:01Z",
+     "completed_at": "2026-08-05T07:57:02Z",
+     "exec_seconds": 421.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92242463660
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:50:01Z",
+     "completed_at": "2026-08-05T07:58:47Z",
+     "exec_seconds": 526.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92242463697
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:55Z",
+     "completed_at": "2026-08-05T07:57:41Z",
+     "exec_seconds": 466.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92242463723
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T07:49:53Z",
+     "completed_at": "2026-08-05T07:49:52Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92242464578
+    }
+   ]
+  },
+  {
+   "id": 30986513077,
+   "name": "Changelog Lint",
+   "head_branch": "craig/sandbox-failures",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T07:49:35Z",
+   "updated_at": "2026-08-05T07:49:52Z",
+   "wall_seconds": 17.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:44Z",
+     "completed_at": "2026-08-05T07:49:51Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92242400619
+    }
+   ]
+  },
+  {
+   "id": 30986513076,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "craig/sandbox-failures",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T07:49:35Z",
+   "updated_at": "2026-08-05T07:51:01Z",
+   "wall_seconds": 86.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:45Z",
+     "completed_at": "2026-08-05T07:51:00Z",
+     "exec_seconds": 75.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92242400624
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:37Z",
+     "completed_at": "2026-08-05T07:50:30Z",
+     "exec_seconds": 53.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92242400650
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:37Z",
+     "completed_at": "2026-08-05T07:49:59Z",
+     "exec_seconds": 22.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92242400672
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T07:49:44Z",
+     "completed_at": "2026-08-05T07:49:52Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92242400673
+    }
+   ]
+  },
+  {
+   "id": 30980354734,
+   "name": "Build",
+   "head_branch": "fix/recover-usage-rollup-fields",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T06:08:30Z",
+   "updated_at": "2026-08-05T06:17:25Z",
+   "wall_seconds": 535.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:09:06Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260485
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:09:19Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260490
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:08:41Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260492
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:10:20Z",
+     "exec_seconds": 107.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260505
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:10:17Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260507
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:08:39Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260508
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:09:20Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260534
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T06:08:40Z",
+     "completed_at": "2026-08-05T06:08:39Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92223284099
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T06:08:40Z",
+     "completed_at": "2026-08-05T06:08:39Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92223284397
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T06:08:40Z",
+     "completed_at": "2026-08-05T06:08:40Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92223284601
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T06:08:40Z",
+     "completed_at": "2026-08-05T06:08:39Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92223284624
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:49Z",
+     "completed_at": "2026-08-05T06:17:24Z",
+     "exec_seconds": 515.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92223288120
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:48Z",
+     "completed_at": "2026-08-05T06:15:41Z",
+     "exec_seconds": 413.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92223288135
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T06:08:41Z",
+     "completed_at": "2026-08-05T06:08:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92223288660
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T06:08:41Z",
+     "completed_at": "2026-08-05T06:08:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92223288664
+    }
+   ]
+  },
+  {
+   "id": 30980354728,
+   "name": "Changelog Lint",
+   "head_branch": "fix/recover-usage-rollup-fields",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T06:08:30Z",
+   "updated_at": "2026-08-05T06:08:48Z",
+   "wall_seconds": 18.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:40Z",
+     "completed_at": "2026-08-05T06:08:48Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92223260028
+    }
+   ]
+  },
+  {
+   "id": 30980354726,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/recover-usage-rollup-fields",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T06:08:30Z",
+   "updated_at": "2026-08-05T06:10:01Z",
+   "wall_seconds": 91.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:10:00Z",
+     "exec_seconds": 87.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260422
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:39Z",
+     "completed_at": "2026-08-05T06:09:34Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92223260431
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:40Z",
+     "completed_at": "2026-08-05T06:09:10Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92223260444
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T06:08:33Z",
+     "completed_at": "2026-08-05T06:08:41Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92223260448
+    }
+   ]
+  },
+  {
+   "id": 30966166848,
+   "name": "Build",
+   "head_branch": "fix-required-checks",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:21:56Z",
+   "updated_at": "2026-08-05T01:30:56Z",
+   "wall_seconds": 540.0,
+   "jobs": [
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:23:44Z",
+     "exec_seconds": 105.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480281
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:29Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480297
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:06Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480313
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:45Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480317
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:58Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480323
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:22:00Z",
+     "completed_at": "2026-08-05T01:23:55Z",
+     "exec_seconds": 115.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92180480324
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:05Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480326
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:22:13Z",
+     "completed_at": "2026-08-05T01:30:09Z",
+     "exec_seconds": 476.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92180499351
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:22:14Z",
+     "completed_at": "2026-08-05T01:30:55Z",
+     "exec_seconds": 521.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92180499355
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:22:05Z",
+     "completed_at": "2026-08-05T01:22:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92180499658
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:22:05Z",
+     "completed_at": "2026-08-05T01:22:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92180500001
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:22:07Z",
+     "completed_at": "2026-08-05T01:22:06Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92180503801
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:22:07Z",
+     "completed_at": "2026-08-05T01:22:06Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92180503825
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:22:07Z",
+     "completed_at": "2026-08-05T01:22:06Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92180504364
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:22:07Z",
+     "completed_at": "2026-08-05T01:22:07Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92180504422
+    }
+   ]
+  },
+  {
+   "id": 30966166847,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix-required-checks",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:21:56Z",
+   "updated_at": "2026-08-05T01:23:17Z",
+   "wall_seconds": 81.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:54Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480355
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:09Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480371
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:21:59Z",
+     "completed_at": "2026-08-05T01:22:31Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92180480377
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:22:05Z",
+     "completed_at": "2026-08-05T01:23:16Z",
+     "exec_seconds": 71.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92180480382
+    }
+   ]
+  },
+  {
+   "id": 30965946583,
+   "name": "Build",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:17:17Z",
+   "updated_at": "2026-08-05T01:27:38Z",
+   "wall_seconds": 621.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:20Z",
+     "completed_at": "2026-08-05T01:17:53Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92179796472
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:22Z",
+     "completed_at": "2026-08-05T01:17:31Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92179796495
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:25Z",
+     "completed_at": "2026-08-05T01:18:24Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92179796523
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:26Z",
+     "completed_at": "2026-08-05T01:17:32Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179796528
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:20Z",
+     "completed_at": "2026-08-05T01:19:04Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92179796545
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:26Z",
+     "completed_at": "2026-08-05T01:19:18Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179796564
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:26Z",
+     "completed_at": "2026-08-05T01:18:12Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179796575
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:17:32Z",
+     "completed_at": "2026-08-05T01:17:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179829910
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:17:32Z",
+     "completed_at": "2026-08-05T01:17:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179830151
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:17:32Z",
+     "completed_at": "2026-08-05T01:17:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179830505
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:42Z",
+     "completed_at": "2026-08-05T01:27:37Z",
+     "exec_seconds": 595.0,
+     "wait_from_run_start_seconds": 25.0,
+     "id": 92179830565
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:37Z",
+     "completed_at": "2026-08-05T01:26:29Z",
+     "exec_seconds": 532.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92179830569
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:17:32Z",
+     "completed_at": "2026-08-05T01:17:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179830801
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:17:32Z",
+     "completed_at": "2026-08-05T01:17:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179830915
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:17:32Z",
+     "completed_at": "2026-08-05T01:17:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179831199
+    }
+   ]
+  },
+  {
+   "id": 30965946584,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:17:17Z",
+   "updated_at": "2026-08-05T01:18:37Z",
+   "wall_seconds": 80.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:20Z",
+     "completed_at": "2026-08-05T01:17:50Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92179796107
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:26Z",
+     "completed_at": "2026-08-05T01:18:23Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179796139
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:27Z",
+     "completed_at": "2026-08-05T01:18:36Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92179796141
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:17:27Z",
+     "completed_at": "2026-08-05T01:17:35Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92179796176
+    }
+   ]
+  },
+  {
+   "id": 30965795969,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "docs/agent-review-disclosure",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:14:16Z",
+   "updated_at": "2026-08-05T01:15:44Z",
+   "wall_seconds": 88.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:19Z",
+     "completed_at": "2026-08-05T01:15:26Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92179333264
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:25Z",
+     "completed_at": "2026-08-05T01:14:53Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179333296
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:26Z",
+     "completed_at": "2026-08-05T01:15:43Z",
+     "exec_seconds": 77.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92179333310
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:25Z",
+     "completed_at": "2026-08-05T01:14:32Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179333334
+    }
+   ]
+  },
+  {
+   "id": 30965795960,
+   "name": "Build",
+   "head_branch": "docs/agent-review-disclosure",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:14:16Z",
+   "updated_at": "2026-08-05T01:16:22Z",
+   "wall_seconds": 126.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:25Z",
+     "completed_at": "2026-08-05T01:14:31Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179333488
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:36Z",
+     "completed_at": "2026-08-05T01:15:07Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92179333501
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:25Z",
+     "completed_at": "2026-08-05T01:15:11Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179333503
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:25Z",
+     "completed_at": "2026-08-05T01:16:13Z",
+     "exec_seconds": 108.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92179333512
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:24Z",
+     "completed_at": "2026-08-05T01:14:34Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92179333521
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:19Z",
+     "completed_at": "2026-08-05T01:15:17Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92179333534
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:14:26Z",
+     "completed_at": "2026-08-05T01:16:22Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92179333540
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:14:31Z",
+     "completed_at": "2026-08-05T01:14:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179369332
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:14:31Z",
+     "completed_at": "2026-08-05T01:14:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179369361
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:14:31Z",
+     "completed_at": "2026-08-05T01:14:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92179369393
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:14:34Z",
+     "completed_at": "2026-08-05T01:14:34Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92179376086
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:14:34Z",
+     "completed_at": "2026-08-05T01:14:34Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92179376101
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:14:34Z",
+     "completed_at": "2026-08-05T01:14:34Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92179376554
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:14:34Z",
+     "completed_at": "2026-08-05T01:14:34Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92179376578
+    }
+   ]
+  },
+  {
+   "id": 30965474441,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:07:56Z",
+   "updated_at": "2026-08-05T01:09:28Z",
+   "wall_seconds": 92.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:03Z",
+     "completed_at": "2026-08-05T01:08:12Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92178384935
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:02Z",
+     "completed_at": "2026-08-05T01:09:00Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 6.0,
+     "id": 92178384966
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:03Z",
+     "completed_at": "2026-08-05T01:09:27Z",
+     "exec_seconds": 84.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92178384967
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:03Z",
+     "completed_at": "2026-08-05T01:08:34Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92178384973
+    }
+   ]
+  },
+  {
+   "id": 30965474421,
+   "name": "Build",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:07:56Z",
+   "updated_at": "2026-08-05T01:16:41Z",
+   "wall_seconds": 525.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:09Z",
+     "completed_at": "2026-08-05T01:08:16Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92178384145
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:02Z",
+     "completed_at": "2026-08-05T01:08:48Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 6.0,
+     "id": 92178384168
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:02Z",
+     "completed_at": "2026-08-05T01:09:46Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 6.0,
+     "id": 92178384176
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:08Z",
+     "completed_at": "2026-08-05T01:08:15Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92178384186
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:09Z",
+     "completed_at": "2026-08-05T01:08:59Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92178384196
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:03Z",
+     "completed_at": "2026-08-05T01:09:55Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92178384200
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:02Z",
+     "completed_at": "2026-08-05T01:08:37Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 6.0,
+     "id": 92178384239
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:21Z",
+     "completed_at": "2026-08-05T01:16:40Z",
+     "exec_seconds": 499.0,
+     "wait_from_run_start_seconds": 25.0,
+     "id": 92178421256
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:08:17Z",
+     "completed_at": "2026-08-05T01:15:57Z",
+     "exec_seconds": 460.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178421269
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:08:15Z",
+     "completed_at": "2026-08-05T01:08:15Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92178421877
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:08:16Z",
+     "completed_at": "2026-08-05T01:08:15Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178422186
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:08:16Z",
+     "completed_at": "2026-08-05T01:08:16Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178424226
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:08:17Z",
+     "completed_at": "2026-08-05T01:08:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178424426
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:08:17Z",
+     "completed_at": "2026-08-05T01:08:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178424738
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:08:17Z",
+     "completed_at": "2026-08-05T01:08:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178424922
+    }
+   ]
+  },
+  {
+   "id": 30965448398,
+   "name": "Build",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:07:24Z",
+   "updated_at": "2026-08-05T01:08:01Z",
+   "wall_seconds": 37.0,
+   "jobs": [
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:33Z",
+     "completed_at": "2026-08-05T01:08:00Z",
+     "exec_seconds": 27.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92178309370
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:32Z",
+     "completed_at": "2026-08-05T01:07:59Z",
+     "exec_seconds": 27.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92178309371
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:07:38Z",
+     "completed_at": "2026-08-05T01:07:44Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92178309384
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:32Z",
+     "completed_at": "2026-08-05T01:08:00Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92178309385
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:38Z",
+     "completed_at": "2026-08-05T01:07:58Z",
+     "exec_seconds": 20.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92178309388
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:07:36Z",
+     "completed_at": "2026-08-05T01:07:43Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92178309393
+    },
+    {
+     "name": "ruff",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:38Z",
+     "completed_at": "2026-08-05T01:07:59Z",
+     "exec_seconds": 21.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92178309394
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:53Z",
+     "completed_at": "2026-08-05T01:07:59Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92178340622
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:45Z",
+     "completed_at": "2026-08-05T01:07:59Z",
+     "exec_seconds": 14.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178340646
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:43Z",
+     "completed_at": "2026-08-05T01:07:43Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92178340928
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:43Z",
+     "completed_at": "2026-08-05T01:07:43Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92178341023
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:44Z",
+     "completed_at": "2026-08-05T01:07:44Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178343998
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:45Z",
+     "completed_at": "2026-08-05T01:07:44Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178344110
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:45Z",
+     "completed_at": "2026-08-05T01:07:44Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178344323
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:45Z",
+     "completed_at": "2026-08-05T01:07:44Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178344589
+    }
+   ]
+  },
+  {
+   "id": 30965448397,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:07:24Z",
+   "updated_at": "2026-08-05T01:08:01Z",
+   "wall_seconds": 37.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:52Z",
+     "completed_at": "2026-08-05T01:08:00Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 28.0,
+     "id": 92178338865
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:52Z",
+     "completed_at": "2026-08-05T01:07:59Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 28.0,
+     "id": 92178338890
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:45Z",
+     "completed_at": "2026-08-05T01:08:00Z",
+     "exec_seconds": 15.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178338913
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:07:45Z",
+     "completed_at": "2026-08-05T01:07:54Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92178338938
+    }
+   ]
+  },
+  {
+   "id": 30965420623,
+   "name": "Build",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:06:51Z",
+   "updated_at": "2026-08-05T01:07:30Z",
+   "wall_seconds": 39.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:11Z",
+     "completed_at": "2026-08-05T01:07:28Z",
+     "exec_seconds": 17.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178256222
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:11Z",
+     "completed_at": "2026-08-05T01:07:29Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178256240
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:11Z",
+     "completed_at": "2026-08-05T01:07:29Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178256250
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:07:11Z",
+     "completed_at": "2026-08-05T01:07:20Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178256252
+    },
+    {
+     "name": "ruff",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:11Z",
+     "completed_at": "2026-08-05T01:07:28Z",
+     "exec_seconds": 17.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178256254
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:07:16Z",
+     "completed_at": "2026-08-05T01:07:23Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 25.0,
+     "id": 92178256259
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:11Z",
+     "completed_at": "2026-08-05T01:07:27Z",
+     "exec_seconds": 16.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92178256272
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:23Z",
+     "completed_at": "2026-08-05T01:07:29Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92178284535
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:23Z",
+     "completed_at": "2026-08-05T01:07:29Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92178284551
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:20Z",
+     "completed_at": "2026-08-05T01:07:20Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92178285249
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:20Z",
+     "completed_at": "2026-08-05T01:07:20Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92178285251
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:24Z",
+     "completed_at": "2026-08-05T01:07:24Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92178294462
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:24Z",
+     "completed_at": "2026-08-05T01:07:24Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92178294579
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:24Z",
+     "completed_at": "2026-08-05T01:07:24Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92178294925
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:07:24Z",
+     "completed_at": "2026-08-05T01:07:24Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92178295006
+    }
+   ]
+  },
+  {
+   "id": 30965420719,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:06:51Z",
+   "updated_at": "2026-08-05T01:07:43Z",
+   "wall_seconds": 52.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:07:01Z",
+     "completed_at": "2026-08-05T01:07:09Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92178214150
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:06:53Z",
+     "completed_at": "2026-08-05T01:07:22Z",
+     "exec_seconds": 29.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92178214158
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:00Z",
+     "completed_at": "2026-08-05T01:07:42Z",
+     "exec_seconds": 42.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92178214191
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:07:00Z",
+     "completed_at": "2026-08-05T01:07:28Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92178214215
+    }
+   ]
+  },
+  {
+   "id": 30965310274,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:04:42Z",
+   "updated_at": "2026-08-05T01:05:59Z",
+   "wall_seconds": 77.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:05:58Z",
+     "exec_seconds": 73.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872526
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:04:51Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872576
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:05:43Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872608
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:05:08Z",
+     "exec_seconds": 23.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872640
+    }
+   ]
+  },
+  {
+   "id": 30965310260,
+   "name": "Build",
+   "head_branch": "chore/deferred-gate",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T01:04:42Z",
+   "updated_at": "2026-08-05T01:07:09Z",
+   "wall_seconds": 147.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:04:54Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872533
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:04:52Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872578
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:04:52Z",
+     "completed_at": "2026-08-05T01:06:53Z",
+     "exec_seconds": 121.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92177872594
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:05:31Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872621
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:51Z",
+     "completed_at": "2026-08-05T01:06:34Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92177872644
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:45Z",
+     "completed_at": "2026-08-05T01:05:16Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92177872661
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:04:52Z",
+     "completed_at": "2026-08-05T01:05:46Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92177872665
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:04:53Z",
+     "completed_at": "2026-08-05T01:04:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92177898321
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:04:53Z",
+     "completed_at": "2026-08-05T01:04:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92177898659
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:04:53Z",
+     "completed_at": "2026-08-05T01:04:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92177898753
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:04:53Z",
+     "completed_at": "2026-08-05T01:04:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92177899173
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:05:02Z",
+     "completed_at": "2026-08-05T01:07:07Z",
+     "exec_seconds": 125.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92177900889
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-05T01:04:56Z",
+     "completed_at": "2026-08-05T01:07:08Z",
+     "exec_seconds": 132.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92177900926
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:04:54Z",
+     "completed_at": "2026-08-05T01:04:54Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92177901713
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:04:54Z",
+     "completed_at": "2026-08-05T01:04:54Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92177901765
+    }
+   ]
+  },
+  {
+   "id": 30962733240,
+   "name": "Build",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T00:15:47Z",
+   "updated_at": "2026-08-05T00:24:46Z",
+   "wall_seconds": 539.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:50Z",
+     "completed_at": "2026-08-05T00:16:01Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92169947902
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:50Z",
+     "completed_at": "2026-08-05T00:16:42Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92169947907
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:56Z",
+     "completed_at": "2026-08-05T00:16:28Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92169947911
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:56Z",
+     "completed_at": "2026-08-05T00:17:45Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92169947927
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:56Z",
+     "completed_at": "2026-08-05T00:17:45Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92169947928
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:50Z",
+     "completed_at": "2026-08-05T00:15:57Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92169947942
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:51Z",
+     "completed_at": "2026-08-05T00:16:47Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92169948061
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:16:06Z",
+     "completed_at": "2026-08-05T00:23:53Z",
+     "exec_seconds": 467.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92169971543
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:16:06Z",
+     "completed_at": "2026-08-05T00:24:45Z",
+     "exec_seconds": 519.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92169971556
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T00:15:58Z",
+     "completed_at": "2026-08-05T00:15:57Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92169972002
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T00:15:58Z",
+     "completed_at": "2026-08-05T00:15:57Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92169972268
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T00:16:01Z",
+     "completed_at": "2026-08-05T00:16:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92169981149
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T00:16:01Z",
+     "completed_at": "2026-08-05T00:16:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92169981168
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T00:16:01Z",
+     "completed_at": "2026-08-05T00:16:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92169981535
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T00:16:02Z",
+     "completed_at": "2026-08-05T00:16:01Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92169982052
+    }
+   ]
+  },
+  {
+   "id": 30962733242,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "dependabot/github_actions/github-actions-84c3d95bcf",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-05T00:15:47Z",
+   "updated_at": "2026-08-05T00:17:09Z",
+   "wall_seconds": 82.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:50Z",
+     "completed_at": "2026-08-05T00:15:57Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92169947826
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:55Z",
+     "completed_at": "2026-08-05T00:16:47Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92169947845
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:55Z",
+     "completed_at": "2026-08-05T00:16:24Z",
+     "exec_seconds": 29.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92169947870
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T00:15:50Z",
+     "completed_at": "2026-08-05T00:17:08Z",
+     "exec_seconds": 78.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92169947871
+    }
+   ]
+  },
+  {
+   "id": 30950909003,
+   "name": "Changelog Lint",
+   "head_branch": "fix/hf-model-info-lookup-token",
+   "conclusion": "success",
+   "run_attempt": 2,
+   "run_started_at": "2026-08-05T01:03:08Z",
+   "updated_at": "2026-08-05T01:03:26Z",
+   "wall_seconds": 18.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:18Z",
+     "completed_at": "2026-08-05T01:03:26Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92177616948
+    }
+   ]
+  },
+  {
+   "id": 30950909060,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/hf-model-info-lookup-token",
+   "conclusion": "success",
+   "run_attempt": 2,
+   "run_started_at": "2026-08-05T01:03:08Z",
+   "updated_at": "2026-08-05T01:04:34Z",
+   "wall_seconds": 86.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:19Z",
+     "completed_at": "2026-08-05T01:04:23Z",
+     "exec_seconds": 64.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92177617944
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:12Z",
+     "completed_at": "2026-08-05T01:03:37Z",
+     "exec_seconds": 25.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92177617969
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:19Z",
+     "completed_at": "2026-08-05T01:03:25Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92177617983
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:12Z",
+     "completed_at": "2026-08-05T01:04:33Z",
+     "exec_seconds": 81.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92177617987
+    }
+   ]
+  },
+  {
+   "id": 30950909010,
+   "name": "Build",
+   "head_branch": "fix/hf-model-info-lookup-token",
+   "conclusion": "success",
+   "run_attempt": 2,
+   "run_started_at": "2026-08-05T01:03:08Z",
+   "updated_at": "2026-08-05T01:12:28Z",
+   "wall_seconds": 560.0,
+   "jobs": [
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:19Z",
+     "completed_at": "2026-08-05T01:04:26Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92177617890
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:13Z",
+     "completed_at": "2026-08-05T01:03:22Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92177617915
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:18Z",
+     "completed_at": "2026-08-05T01:05:12Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92177617921
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:18Z",
+     "completed_at": "2026-08-05T01:03:24Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92177617923
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:12Z",
+     "completed_at": "2026-08-05T01:03:46Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92177617931
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:18Z",
+     "completed_at": "2026-08-05T01:05:05Z",
+     "exec_seconds": 107.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92177617941
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:12Z",
+     "completed_at": "2026-08-05T01:04:09Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92177617942
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:03:23Z",
+     "completed_at": "2026-08-05T01:03:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92177653624
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:03:23Z",
+     "completed_at": "2026-08-05T01:03:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92177653923
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:03:23Z",
+     "completed_at": "2026-08-05T01:03:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92177654128
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:03:23Z",
+     "completed_at": "2026-08-05T01:03:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92177654573
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:32Z",
+     "completed_at": "2026-08-05T01:12:27Z",
+     "exec_seconds": 535.0,
+     "wait_from_run_start_seconds": 24.0,
+     "id": 92177658181
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-05T01:03:34Z",
+     "completed_at": "2026-08-05T01:11:20Z",
+     "exec_seconds": 466.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92177658189
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:03:25Z",
+     "completed_at": "2026-08-05T01:03:24Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92177658773
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-05T01:03:25Z",
+     "completed_at": "2026-08-05T01:03:24Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92177658825
+    }
+   ]
+  },
+  {
+   "id": 30950052811,
+   "name": "Build",
+   "head_branch": "sync-model-data",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:55:13Z",
+   "updated_at": "2026-08-04T21:04:44Z",
+   "wall_seconds": 571.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:16Z",
+     "completed_at": "2026-08-04T20:56:07Z",
+     "exec_seconds": 51.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92129582732
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:21Z",
+     "completed_at": "2026-08-04T20:55:54Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92129582766
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:22Z",
+     "completed_at": "2026-08-04T20:55:29Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92129582781
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:15Z",
+     "completed_at": "2026-08-04T20:55:24Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92129582782
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:33Z",
+     "completed_at": "2026-08-04T20:57:29Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92129582815
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:23Z",
+     "completed_at": "2026-08-04T20:56:17Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92129582849
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:34Z",
+     "completed_at": "2026-08-04T20:57:02Z",
+     "exec_seconds": 88.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92129582882
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:55:25Z",
+     "completed_at": "2026-08-04T20:55:24Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92129631846
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:55:25Z",
+     "completed_at": "2026-08-04T20:55:24Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92129631974
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:55:25Z",
+     "completed_at": "2026-08-04T20:55:24Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92129632249
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:55:25Z",
+     "completed_at": "2026-08-04T20:55:25Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92129632855
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:40Z",
+     "completed_at": "2026-08-04T21:04:43Z",
+     "exec_seconds": 543.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92129654517
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:36Z",
+     "completed_at": "2026-08-04T21:04:14Z",
+     "exec_seconds": 518.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92129654709
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:55:30Z",
+     "completed_at": "2026-08-04T20:55:30Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92129655420
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:55:30Z",
+     "completed_at": "2026-08-04T20:55:30Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92129655500
+    }
+   ]
+  },
+  {
+   "id": 30950052442,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "sync-model-data",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:55:12Z",
+   "updated_at": "2026-08-04T20:56:31Z",
+   "wall_seconds": 79.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:21Z",
+     "completed_at": "2026-08-04T20:55:32Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92129581449
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:16Z",
+     "completed_at": "2026-08-04T20:55:46Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92129581457
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:15Z",
+     "completed_at": "2026-08-04T20:56:13Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92129581551
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:55:16Z",
+     "completed_at": "2026-08-04T20:56:30Z",
+     "exec_seconds": 74.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92129581646
+    }
+   ]
+  },
+  {
+   "id": 30949883913,
+   "name": "Build",
+   "head_branch": "feat/openrouter-reported-cost",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:53:03Z",
+   "updated_at": "2026-08-04T21:02:50Z",
+   "wall_seconds": 587.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:06Z",
+     "completed_at": "2026-08-04T20:53:16Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92129032263
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:07Z",
+     "completed_at": "2026-08-04T20:53:45Z",
+     "exec_seconds": 38.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92129032277
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:12Z",
+     "completed_at": "2026-08-04T20:53:19Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92129032294
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:19Z",
+     "completed_at": "2026-08-04T20:55:06Z",
+     "exec_seconds": 107.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92129032323
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:12Z",
+     "completed_at": "2026-08-04T20:54:02Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92129032324
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:07Z",
+     "completed_at": "2026-08-04T20:56:26Z",
+     "exec_seconds": 199.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92129032333
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:06Z",
+     "completed_at": "2026-08-04T20:53:57Z",
+     "exec_seconds": 51.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92129032590
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:53:17Z",
+     "completed_at": "2026-08-04T20:53:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92129088893
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:53:17Z",
+     "completed_at": "2026-08-04T20:53:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92129089080
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:53:17Z",
+     "completed_at": "2026-08-04T20:53:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92129089839
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:53:17Z",
+     "completed_at": "2026-08-04T20:53:17Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92129090135
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:21Z",
+     "completed_at": "2026-08-04T21:01:11Z",
+     "exec_seconds": 470.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92129100543
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:21Z",
+     "completed_at": "2026-08-04T21:02:50Z",
+     "exec_seconds": 569.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92129100614
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:53:19Z",
+     "completed_at": "2026-08-04T20:53:19Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92129101453
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:53:19Z",
+     "completed_at": "2026-08-04T20:53:19Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92129101556
+    }
+   ]
+  },
+  {
+   "id": 30949883747,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "feat/openrouter-reported-cost",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:53:03Z",
+   "updated_at": "2026-08-04T20:55:10Z",
+   "wall_seconds": 127.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:10Z",
+     "completed_at": "2026-08-04T20:53:17Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92129031416
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:06Z",
+     "completed_at": "2026-08-04T20:53:43Z",
+     "exec_seconds": 37.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92129031445
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:08Z",
+     "completed_at": "2026-08-04T20:54:07Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92129031472
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:53:06Z",
+     "completed_at": "2026-08-04T20:55:09Z",
+     "exec_seconds": 123.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92129031505
+    }
+   ]
+  },
+  {
+   "id": 30949289285,
+   "name": "Build",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:45:10Z",
+   "updated_at": "2026-08-04T20:54:29Z",
+   "wall_seconds": 559.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:32Z",
+     "completed_at": "2026-08-04T20:46:48Z",
+     "exec_seconds": 76.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92127117230
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:31Z",
+     "completed_at": "2026-08-04T20:45:37Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92127117253
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:31Z",
+     "completed_at": "2026-08-04T20:46:03Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92127117265
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:33Z",
+     "completed_at": "2026-08-04T20:45:39Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92127117317
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:33Z",
+     "completed_at": "2026-08-04T20:47:28Z",
+     "exec_seconds": 115.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92127117329
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:47Z",
+     "completed_at": "2026-08-04T20:46:44Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 37.0,
+     "id": 92127117345
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:39Z",
+     "completed_at": "2026-08-04T20:47:59Z",
+     "exec_seconds": 140.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92127117360
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:40Z",
+     "completed_at": "2026-08-04T20:53:55Z",
+     "exec_seconds": 495.0,
+     "wait_from_run_start_seconds": 30.0,
+     "id": 92127155343
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:41Z",
+     "completed_at": "2026-08-04T20:54:29Z",
+     "exec_seconds": 528.0,
+     "wait_from_run_start_seconds": 31.0,
+     "id": 92127155391
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:45:38Z",
+     "completed_at": "2026-08-04T20:45:37Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 28.0,
+     "id": 92127156467
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:45:38Z",
+     "completed_at": "2026-08-04T20:45:37Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 28.0,
+     "id": 92127156821
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:45:40Z",
+     "completed_at": "2026-08-04T20:45:40Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 30.0,
+     "id": 92127166111
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:45:40Z",
+     "completed_at": "2026-08-04T20:45:40Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 30.0,
+     "id": 92127166194
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:45:40Z",
+     "completed_at": "2026-08-04T20:45:40Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 30.0,
+     "id": 92127166258
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:45:40Z",
+     "completed_at": "2026-08-04T20:45:40Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 30.0,
+     "id": 92127167073
+    }
+   ]
+  },
+  {
+   "id": 30949289699,
+   "name": "Changelog Lint",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:45:10Z",
+   "updated_at": "2026-08-04T20:45:26Z",
+   "wall_seconds": 16.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:19Z",
+     "completed_at": "2026-08-04T20:45:26Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92127038559
+    }
+   ]
+  },
+  {
+   "id": 30949289179,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:45:10Z",
+   "updated_at": "2026-08-04T20:46:34Z",
+   "wall_seconds": 84.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:18Z",
+     "completed_at": "2026-08-04T20:45:48Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92127037306
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:13Z",
+     "completed_at": "2026-08-04T20:46:14Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92127037353
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:27Z",
+     "completed_at": "2026-08-04T20:45:36Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92127037404
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:30Z",
+     "completed_at": "2026-08-04T20:46:33Z",
+     "exec_seconds": 63.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92127037450
+    }
+   ]
+  },
+  {
+   "id": 30949236980,
+   "name": "Build",
+   "head_branch": "sync-model-data",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:44:28Z",
+   "updated_at": "2026-08-04T20:53:53Z",
+   "wall_seconds": 565.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:31Z",
+     "completed_at": "2026-08-04T20:44:39Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126865149
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:36Z",
+     "completed_at": "2026-08-04T20:45:23Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92126865156
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:40Z",
+     "completed_at": "2026-08-04T20:44:49Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92126865167
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:32Z",
+     "completed_at": "2026-08-04T20:46:25Z",
+     "exec_seconds": 113.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92126865193
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:52Z",
+     "completed_at": "2026-08-04T20:46:41Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 24.0,
+     "id": 92126865214
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:31Z",
+     "completed_at": "2026-08-04T20:45:08Z",
+     "exec_seconds": 37.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126865222
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:46Z",
+     "completed_at": "2026-08-04T20:45:38Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92126865226
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:57Z",
+     "completed_at": "2026-08-04T20:52:48Z",
+     "exec_seconds": 471.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92126906312
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:45:17Z",
+     "completed_at": "2026-08-04T20:53:52Z",
+     "exec_seconds": 515.0,
+     "wait_from_run_start_seconds": 49.0,
+     "id": 92126906379
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:44:39Z",
+     "completed_at": "2026-08-04T20:44:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92126906904
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:44:39Z",
+     "completed_at": "2026-08-04T20:44:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92126907577
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:44:50Z",
+     "completed_at": "2026-08-04T20:44:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92126949281
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:44:50Z",
+     "completed_at": "2026-08-04T20:44:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92126949961
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:44:50Z",
+     "completed_at": "2026-08-04T20:44:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92126950001
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:44:50Z",
+     "completed_at": "2026-08-04T20:44:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92126950931
+    }
+   ]
+  },
+  {
+   "id": 30949237068,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "sync-model-data",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:44:28Z",
+   "updated_at": "2026-08-04T20:46:05Z",
+   "wall_seconds": 97.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:31Z",
+     "completed_at": "2026-08-04T20:45:31Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126864437
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:31Z",
+     "completed_at": "2026-08-04T20:44:37Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126864618
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:32Z",
+     "completed_at": "2026-08-04T20:46:04Z",
+     "exec_seconds": 92.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92126864632
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:44:47Z",
+     "completed_at": "2026-08-04T20:45:30Z",
+     "exec_seconds": 43.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92126864681
+    }
+   ]
+  },
+  {
+   "id": 30949080461,
+   "name": "Changelog Lint",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:42:26Z",
+   "updated_at": "2026-08-04T20:42:42Z",
+   "wall_seconds": 16.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:35Z",
+     "completed_at": "2026-08-04T20:42:42Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92126334025
+    }
+   ]
+  },
+  {
+   "id": 30949080453,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:42:26Z",
+   "updated_at": "2026-08-04T20:43:53Z",
+   "wall_seconds": 87.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:35Z",
+     "completed_at": "2026-08-04T20:42:58Z",
+     "exec_seconds": 23.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92126334189
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:29Z",
+     "completed_at": "2026-08-04T20:43:52Z",
+     "exec_seconds": 83.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126334208
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:35Z",
+     "completed_at": "2026-08-04T20:43:35Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92126334339
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:29Z",
+     "completed_at": "2026-08-04T20:42:37Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126334424
+    }
+   ]
+  },
+  {
+   "id": 30949080359,
+   "name": "Build",
+   "head_branch": "fix/model-event",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:42:26Z",
+   "updated_at": "2026-08-04T20:45:29Z",
+   "wall_seconds": 183.0,
+   "jobs": [
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:35Z",
+     "completed_at": "2026-08-04T20:43:22Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92126334190
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:29Z",
+     "completed_at": "2026-08-04T20:42:39Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126334191
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:29Z",
+     "completed_at": "2026-08-04T20:43:06Z",
+     "exec_seconds": 37.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126334203
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:31Z",
+     "completed_at": "2026-08-04T20:44:25Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92126334232
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:30Z",
+     "completed_at": "2026-08-04T20:43:22Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92126334289
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:31Z",
+     "completed_at": "2026-08-04T20:44:25Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92126334297
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:42:29Z",
+     "completed_at": "2026-08-04T20:42:36Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92126334501
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T20:42:40Z",
+     "completed_at": "2026-08-04T20:45:28Z",
+     "exec_seconds": 168.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92126379133
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T20:42:40Z",
+     "completed_at": "2026-08-04T20:45:27Z",
+     "exec_seconds": 167.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92126379146
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:42:37Z",
+     "completed_at": "2026-08-04T20:42:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92126379924
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:42:37Z",
+     "completed_at": "2026-08-04T20:42:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92126380051
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:42:39Z",
+     "completed_at": "2026-08-04T20:42:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92126390825
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:42:39Z",
+     "completed_at": "2026-08-04T20:42:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92126390860
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:42:40Z",
+     "completed_at": "2026-08-04T20:42:39Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92126392046
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:42:40Z",
+     "completed_at": "2026-08-04T20:42:39Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92126392647
+    }
+   ]
+  },
+  {
+   "id": 30948435644,
+   "name": "Changelog Lint",
+   "head_branch": "fix/preserve-nan-scores",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:33:53Z",
+   "updated_at": "2026-08-04T20:34:03Z",
+   "wall_seconds": 10.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:33:56Z",
+     "completed_at": "2026-08-04T20:34:02Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92124150210
+    }
+   ]
+  },
+  {
+   "id": 30948435406,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/preserve-nan-scores",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:33:53Z",
+   "updated_at": "2026-08-04T20:36:00Z",
+   "wall_seconds": 127.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:33:58Z",
+     "completed_at": "2026-08-04T20:34:08Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92124150036
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:34:02Z",
+     "completed_at": "2026-08-04T20:35:59Z",
+     "exec_seconds": 117.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92124150076
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:33:56Z",
+     "completed_at": "2026-08-04T20:34:18Z",
+     "exec_seconds": 22.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92124150106
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:34:04Z",
+     "completed_at": "2026-08-04T20:35:09Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92124150127
+    }
+   ]
+  },
+  {
+   "id": 30948435197,
+   "name": "Build",
+   "head_branch": "fix/preserve-nan-scores",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:33:53Z",
+   "updated_at": "2026-08-04T20:42:44Z",
+   "wall_seconds": 531.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:33:56Z",
+     "completed_at": "2026-08-04T20:34:06Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92124149112
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:34:03Z",
+     "completed_at": "2026-08-04T20:34:58Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92124149175
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:34:02Z",
+     "completed_at": "2026-08-04T20:35:52Z",
+     "exec_seconds": 110.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92124149192
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:33:56Z",
+     "completed_at": "2026-08-04T20:35:12Z",
+     "exec_seconds": 76.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92124149207
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:33:56Z",
+     "completed_at": "2026-08-04T20:34:51Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92124149228
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:33:56Z",
+     "completed_at": "2026-08-04T20:34:05Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92124149232
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:34:02Z",
+     "completed_at": "2026-08-04T20:36:05Z",
+     "exec_seconds": 123.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92124149246
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:34:06Z",
+     "completed_at": "2026-08-04T20:34:05Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92124203572
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:34:06Z",
+     "completed_at": "2026-08-04T20:34:05Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92124204114
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:34:08Z",
+     "completed_at": "2026-08-04T20:42:43Z",
+     "exec_seconds": 515.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92124204207
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:34:08Z",
+     "completed_at": "2026-08-04T20:41:53Z",
+     "exec_seconds": 465.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92124204240
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:34:06Z",
+     "completed_at": "2026-08-04T20:34:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92124204284
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:34:06Z",
+     "completed_at": "2026-08-04T20:34:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92124205167
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:34:06Z",
+     "completed_at": "2026-08-04T20:34:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92124205318
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:34:06Z",
+     "completed_at": "2026-08-04T20:34:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92124205782
+    }
+   ]
+  },
+  {
+   "id": 30947880300,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "ci-perf/skill",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:26:41Z",
+   "updated_at": "2026-08-04T20:28:38Z",
+   "wall_seconds": 117.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:55Z",
+     "completed_at": "2026-08-04T20:28:01Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92122270706
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:44Z",
+     "completed_at": "2026-08-04T20:27:11Z",
+     "exec_seconds": 27.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92122270720
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:44Z",
+     "completed_at": "2026-08-04T20:28:38Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92122270813
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:44Z",
+     "completed_at": "2026-08-04T20:26:57Z",
+     "exec_seconds": 13.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92122270867
+    }
+   ]
+  },
+  {
+   "id": 30947880318,
+   "name": "Build",
+   "head_branch": "ci-perf/skill",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:26:41Z",
+   "updated_at": "2026-08-04T20:35:52Z",
+   "wall_seconds": 551.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:50Z",
+     "completed_at": "2026-08-04T20:28:13Z",
+     "exec_seconds": 83.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92122271075
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:43Z",
+     "completed_at": "2026-08-04T20:26:53Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92122271086
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:44Z",
+     "completed_at": "2026-08-04T20:28:37Z",
+     "exec_seconds": 113.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92122271096
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:44Z",
+     "completed_at": "2026-08-04T20:28:26Z",
+     "exec_seconds": 102.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92122271113
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:45Z",
+     "completed_at": "2026-08-04T20:26:54Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92122271124
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:44Z",
+     "completed_at": "2026-08-04T20:27:42Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92122271160
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:57Z",
+     "completed_at": "2026-08-04T20:28:34Z",
+     "exec_seconds": 97.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92122271211
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:26:54Z",
+     "completed_at": "2026-08-04T20:26:54Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92122324174
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:26:54Z",
+     "completed_at": "2026-08-04T20:26:54Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92122324184
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:26:54Z",
+     "completed_at": "2026-08-04T20:26:54Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92122324729
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:26:54Z",
+     "completed_at": "2026-08-04T20:26:54Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92122325237
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:26:57Z",
+     "completed_at": "2026-08-04T20:34:32Z",
+     "exec_seconds": 455.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92122326592
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:27:05Z",
+     "completed_at": "2026-08-04T20:35:50Z",
+     "exec_seconds": 525.0,
+     "wait_from_run_start_seconds": 24.0,
+     "id": 92122326615
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:26:55Z",
+     "completed_at": "2026-08-04T20:26:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92122327383
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:26:55Z",
+     "completed_at": "2026-08-04T20:26:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92122327528
+    }
+   ]
+  },
+  {
+   "id": 30947642786,
+   "name": "Build",
+   "head_branch": "ci-perf/pytest-durations",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:23:35Z",
+   "updated_at": "2026-08-04T20:34:43Z",
+   "wall_seconds": 668.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:50Z",
+     "completed_at": "2026-08-04T20:24:21Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92121485869
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:44Z",
+     "completed_at": "2026-08-04T20:25:27Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92121485879
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:47Z",
+     "completed_at": "2026-08-04T20:24:52Z",
+     "exec_seconds": 5.0,
+     "wait_from_run_start_seconds": 72.0,
+     "id": 92121485930
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:52Z",
+     "completed_at": "2026-08-04T20:25:46Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 77.0,
+     "id": 92121485940
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:56Z",
+     "completed_at": "2026-08-04T20:24:46Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92121485956
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:54Z",
+     "completed_at": "2026-08-04T20:25:01Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 79.0,
+     "id": 92121485967
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:55Z",
+     "completed_at": "2026-08-04T20:26:58Z",
+     "exec_seconds": 123.0,
+     "wait_from_run_start_seconds": 80.0,
+     "id": 92121486024
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:24:53Z",
+     "completed_at": "2026-08-04T20:24:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 78.0,
+     "id": 92121809400
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:24:53Z",
+     "completed_at": "2026-08-04T20:24:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 78.0,
+     "id": 92121809423
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:24:53Z",
+     "completed_at": "2026-08-04T20:24:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 78.0,
+     "id": 92121810492
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:24:53Z",
+     "completed_at": "2026-08-04T20:24:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 78.0,
+     "id": 92121810792
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:25:04Z",
+     "completed_at": "2026-08-04T20:32:56Z",
+     "exec_seconds": 472.0,
+     "wait_from_run_start_seconds": 89.0,
+     "id": 92121843400
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:25:10Z",
+     "completed_at": "2026-08-04T20:34:42Z",
+     "exec_seconds": 572.0,
+     "wait_from_run_start_seconds": 95.0,
+     "id": 92121843429
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:25:01Z",
+     "completed_at": "2026-08-04T20:25:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92121844276
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:25:01Z",
+     "completed_at": "2026-08-04T20:25:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92121844649
+    }
+   ]
+  },
+  {
+   "id": 30947641166,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "ci-perf/unserialize-test",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:23:34Z",
+   "updated_at": "2026-08-04T20:24:46Z",
+   "wall_seconds": 72.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:37Z",
+     "completed_at": "2026-08-04T20:24:44Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121480291
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:37Z",
+     "completed_at": "2026-08-04T20:24:45Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121480304
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:37Z",
+     "completed_at": "2026-08-04T20:23:47Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121480354
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:43Z",
+     "completed_at": "2026-08-04T20:24:08Z",
+     "exec_seconds": 25.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92121480384
+    }
+   ]
+  },
+  {
+   "id": 30947642271,
+   "name": "Build",
+   "head_branch": "ci-perf/unserialize-test",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:23:34Z",
+   "updated_at": "2026-08-04T20:32:57Z",
+   "wall_seconds": 563.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:43Z",
+     "completed_at": "2026-08-04T20:24:41Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92121484348
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:11Z",
+     "completed_at": "2026-08-04T20:32:56Z",
+     "exec_seconds": 525.0,
+     "wait_from_run_start_seconds": 37.0,
+     "id": 92121484416
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:46Z",
+     "completed_at": "2026-08-04T20:23:55Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92121484460
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:54Z",
+     "completed_at": "2026-08-04T20:32:25Z",
+     "exec_seconds": 511.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92121484463
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:14Z",
+     "completed_at": "2026-08-04T20:25:01Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 40.0,
+     "id": 92121484470
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:03Z",
+     "completed_at": "2026-08-04T20:25:45Z",
+     "exec_seconds": 102.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92121484477
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:13Z",
+     "completed_at": "2026-08-04T20:26:18Z",
+     "exec_seconds": 125.0,
+     "wait_from_run_start_seconds": 39.0,
+     "id": 92121484489
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:23Z",
+     "completed_at": "2026-08-04T20:25:13Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 49.0,
+     "id": 92121484500
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:24:48Z",
+     "completed_at": "2026-08-04T20:24:57Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 74.0,
+     "id": 92121484644
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:56Z",
+     "completed_at": "2026-08-04T20:23:55Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92121571840
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:56Z",
+     "completed_at": "2026-08-04T20:23:55Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92121571972
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:56Z",
+     "completed_at": "2026-08-04T20:23:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92121572114
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:56Z",
+     "completed_at": "2026-08-04T20:23:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92121572862
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:24:57Z",
+     "completed_at": "2026-08-04T20:24:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 83.0,
+     "id": 92121827555
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:24:57Z",
+     "completed_at": "2026-08-04T20:24:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 83.0,
+     "id": 92121827676
+    }
+   ]
+  },
+  {
+   "id": 30947638708,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "ci-perf/pytest-durations",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:23:32Z",
+   "updated_at": "2026-08-04T20:25:01Z",
+   "wall_seconds": 89.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:34Z",
+     "completed_at": "2026-08-04T20:23:41Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92121471591
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:42Z",
+     "completed_at": "2026-08-04T20:24:11Z",
+     "exec_seconds": 29.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92121471599
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:36Z",
+     "completed_at": "2026-08-04T20:25:00Z",
+     "exec_seconds": 84.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92121471604
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:41Z",
+     "completed_at": "2026-08-04T20:24:52Z",
+     "exec_seconds": 71.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92121471678
+    }
+   ]
+  },
+  {
+   "id": 30947587006,
+   "name": "Changelog Lint",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:22:52Z",
+   "updated_at": "2026-08-04T20:23:04Z",
+   "wall_seconds": 12.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:55Z",
+     "completed_at": "2026-08-04T20:23:03Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121301065
+    }
+   ]
+  },
+  {
+   "id": 30947587117,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:22:52Z",
+   "updated_at": "2026-08-04T20:24:47Z",
+   "wall_seconds": 115.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:55Z",
+     "completed_at": "2026-08-04T20:24:47Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121301539
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:55Z",
+     "completed_at": "2026-08-04T20:23:19Z",
+     "exec_seconds": 24.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121301548
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:55Z",
+     "completed_at": "2026-08-04T20:23:49Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121301620
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:55Z",
+     "completed_at": "2026-08-04T20:23:03Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121301817
+    }
+   ]
+  },
+  {
+   "id": 30947583100,
+   "name": "Build",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:22:49Z",
+   "updated_at": "2026-08-04T20:31:08Z",
+   "wall_seconds": 499.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:59Z",
+     "completed_at": "2026-08-04T20:23:06Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92121289934
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:58Z",
+     "completed_at": "2026-08-04T20:23:54Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92121289970
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:53Z",
+     "completed_at": "2026-08-04T20:23:29Z",
+     "exec_seconds": 36.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92121289977
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:54Z",
+     "completed_at": "2026-08-04T20:24:51Z",
+     "exec_seconds": 117.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92121290054
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:52Z",
+     "completed_at": "2026-08-04T20:23:41Z",
+     "exec_seconds": 49.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92121290057
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:53Z",
+     "completed_at": "2026-08-04T20:25:03Z",
+     "exec_seconds": 130.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92121290067
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:22:53Z",
+     "completed_at": "2026-08-04T20:23:02Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92121290112
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:09Z",
+     "completed_at": "2026-08-04T20:30:54Z",
+     "exec_seconds": 465.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92121340064
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:23:04Z",
+     "completed_at": "2026-08-04T20:31:07Z",
+     "exec_seconds": 483.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92121340107
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:02Z",
+     "completed_at": "2026-08-04T20:23:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92121341328
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:02Z",
+     "completed_at": "2026-08-04T20:23:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92121341390
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:06Z",
+     "completed_at": "2026-08-04T20:23:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92121358551
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:06Z",
+     "completed_at": "2026-08-04T20:23:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92121358554
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:06Z",
+     "completed_at": "2026-08-04T20:23:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92121358637
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:23:06Z",
+     "completed_at": "2026-08-04T20:23:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 17.0,
+     "id": 92121359508
+    }
+   ]
+  },
+  {
+   "id": 30947234446,
+   "name": "Changelog Lint",
+   "head_branch": "fix/f1-exact-decimal-punctuation",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:18:17Z",
+   "updated_at": "2026-08-04T20:18:33Z",
+   "wall_seconds": 16.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:25Z",
+     "completed_at": "2026-08-04T20:18:33Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92120122228
+    }
+   ]
+  },
+  {
+   "id": 30947234492,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/f1-exact-decimal-punctuation",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:18:17Z",
+   "updated_at": "2026-08-04T20:19:34Z",
+   "wall_seconds": 77.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:20Z",
+     "completed_at": "2026-08-04T20:19:17Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92120122877
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:19Z",
+     "completed_at": "2026-08-04T20:19:33Z",
+     "exec_seconds": 74.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92120122892
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:19Z",
+     "completed_at": "2026-08-04T20:18:26Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92120122896
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:20Z",
+     "completed_at": "2026-08-04T20:18:52Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92120122938
+    }
+   ]
+  },
+  {
+   "id": 30947235030,
+   "name": "Build",
+   "head_branch": "fix/f1-exact-decimal-punctuation",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:18:17Z",
+   "updated_at": "2026-08-04T20:29:26Z",
+   "wall_seconds": 669.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:46Z",
+     "completed_at": "2026-08-04T20:19:21Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92120203535
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:38Z",
+     "completed_at": "2026-08-04T20:18:48Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92120203552
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:44Z",
+     "completed_at": "2026-08-04T20:18:50Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92120203565
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:40Z",
+     "completed_at": "2026-08-04T20:20:43Z",
+     "exec_seconds": 123.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92120203574
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:38Z",
+     "completed_at": "2026-08-04T20:21:05Z",
+     "exec_seconds": 147.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92120203625
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:42Z",
+     "completed_at": "2026-08-04T20:19:52Z",
+     "exec_seconds": 70.0,
+     "wait_from_run_start_seconds": 25.0,
+     "id": 92120203651
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:38Z",
+     "completed_at": "2026-08-04T20:19:52Z",
+     "exec_seconds": 74.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92120203870
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:19:00Z",
+     "completed_at": "2026-08-04T20:29:25Z",
+     "exec_seconds": 625.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92120255315
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:18:58Z",
+     "completed_at": "2026-08-04T20:28:10Z",
+     "exec_seconds": 552.0,
+     "wait_from_run_start_seconds": 41.0,
+     "id": 92120255530
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:18:49Z",
+     "completed_at": "2026-08-04T20:18:48Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92120256067
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:18:49Z",
+     "completed_at": "2026-08-04T20:18:48Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92120256388
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:18:51Z",
+     "completed_at": "2026-08-04T20:18:51Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92120264997
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:18:51Z",
+     "completed_at": "2026-08-04T20:18:51Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92120265421
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:18:51Z",
+     "completed_at": "2026-08-04T20:18:51Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92120265452
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:18:51Z",
+     "completed_at": "2026-08-04T20:18:51Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92120266076
+    }
+   ]
+  },
+  {
+   "id": 30946990027,
+   "name": "Changelog Lint",
+   "head_branch": "fix/f1-exact-decimal-punctuation",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:15:02Z",
+   "updated_at": "2026-08-04T20:15:11Z",
+   "wall_seconds": 9.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:04Z",
+     "completed_at": "2026-08-04T20:15:10Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92119311439
+    }
+   ]
+  },
+  {
+   "id": 30946990081,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/f1-exact-decimal-punctuation",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:15:02Z",
+   "updated_at": "2026-08-04T20:16:13Z",
+   "wall_seconds": 71.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:11Z",
+     "completed_at": "2026-08-04T20:15:19Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92119312113
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:05Z",
+     "completed_at": "2026-08-04T20:16:11Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92119312163
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:05Z",
+     "completed_at": "2026-08-04T20:15:39Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92119312225
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:11Z",
+     "completed_at": "2026-08-04T20:16:13Z",
+     "exec_seconds": 62.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92119312288
+    }
+   ]
+  },
+  {
+   "id": 30946990232,
+   "name": "Build",
+   "head_branch": "fix/f1-exact-decimal-punctuation",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:15:02Z",
+   "updated_at": "2026-08-04T20:18:36Z",
+   "wall_seconds": 214.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:05Z",
+     "completed_at": "2026-08-04T20:15:13Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92119312697
+    },
+    {
+     "name": "ruff",
+     "conclusion": "failure",
+     "started_at": "2026-08-04T20:15:05Z",
+     "completed_at": "2026-08-04T20:15:37Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92119312729
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:07Z",
+     "completed_at": "2026-08-04T20:17:09Z",
+     "exec_seconds": 122.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92119312740
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "failure",
+     "started_at": "2026-08-04T20:15:12Z",
+     "completed_at": "2026-08-04T20:16:10Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92119312756
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:06Z",
+     "completed_at": "2026-08-04T20:16:12Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92119312820
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:16Z",
+     "completed_at": "2026-08-04T20:17:12Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92119312840
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:15:11Z",
+     "completed_at": "2026-08-04T20:15:18Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92119312869
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:15:13Z",
+     "completed_at": "2026-08-04T20:15:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92119355738
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:15:13Z",
+     "completed_at": "2026-08-04T20:15:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92119356117
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:15:13Z",
+     "completed_at": "2026-08-04T20:15:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92119356210
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:15:13Z",
+     "completed_at": "2026-08-04T20:15:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92119356824
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T20:15:29Z",
+     "completed_at": "2026-08-04T20:18:35Z",
+     "exec_seconds": 186.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92119376102
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T20:15:34Z",
+     "completed_at": "2026-08-04T20:18:35Z",
+     "exec_seconds": 181.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92119376146
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:15:18Z",
+     "completed_at": "2026-08-04T20:15:18Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92119377048
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:15:18Z",
+     "completed_at": "2026-08-04T20:15:18Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92119377112
+    }
+   ]
+  },
+  {
+   "id": 30946035587,
+   "name": "Build",
+   "head_branch": "fix/sync-models-skip-curated",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:02:37Z",
+   "updated_at": "2026-08-04T20:12:12Z",
+   "wall_seconds": 575.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:47Z",
+     "completed_at": "2026-08-04T20:02:58Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92116132718
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:46Z",
+     "completed_at": "2026-08-04T20:02:54Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92116132761
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:46Z",
+     "completed_at": "2026-08-04T20:04:31Z",
+     "exec_seconds": 105.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92116132799
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:40Z",
+     "completed_at": "2026-08-04T20:03:32Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92116132811
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:40Z",
+     "completed_at": "2026-08-04T20:04:32Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92116132820
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:46Z",
+     "completed_at": "2026-08-04T20:03:58Z",
+     "exec_seconds": 72.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92116132825
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:40Z",
+     "completed_at": "2026-08-04T20:03:58Z",
+     "exec_seconds": 78.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92116132861
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:02:55Z",
+     "completed_at": "2026-08-04T20:02:54Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92116205975
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:02:55Z",
+     "completed_at": "2026-08-04T20:02:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92116206254
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:02:55Z",
+     "completed_at": "2026-08-04T20:02:54Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92116206400
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:02:55Z",
+     "completed_at": "2026-08-04T20:02:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92116206964
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:03:15Z",
+     "completed_at": "2026-08-04T20:12:11Z",
+     "exec_seconds": 536.0,
+     "wait_from_run_start_seconds": 38.0,
+     "id": 92116221157
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:03:13Z",
+     "completed_at": "2026-08-04T20:11:45Z",
+     "exec_seconds": 512.0,
+     "wait_from_run_start_seconds": 36.0,
+     "id": 92116221206
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:02:58Z",
+     "completed_at": "2026-08-04T20:02:58Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92116221844
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:02:59Z",
+     "completed_at": "2026-08-04T20:02:58Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92116222003
+    }
+   ]
+  },
+  {
+   "id": 30946035499,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/sync-models-skip-curated",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T20:02:37Z",
+   "updated_at": "2026-08-04T20:04:32Z",
+   "wall_seconds": 115.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:03:06Z",
+     "completed_at": "2026-08-04T20:04:31Z",
+     "exec_seconds": 85.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92116132905
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:03:00Z",
+     "completed_at": "2026-08-04T20:03:08Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92116132916
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:47Z",
+     "completed_at": "2026-08-04T20:03:46Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92116132931
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T20:02:56Z",
+     "completed_at": "2026-08-04T20:03:27Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92116133006
+    }
+   ]
+  },
+  {
+   "id": 30945266455,
+   "name": "Build",
+   "head_branch": "fix/model-event",
+   "conclusion": "failure",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:52:34Z",
+   "updated_at": "2026-08-04T20:03:07Z",
+   "wall_seconds": 633.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:37Z",
+     "completed_at": "2026-08-04T19:53:10Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92113557898
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:36Z",
+     "completed_at": "2026-08-04T19:53:28Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92113557953
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:38Z",
+     "completed_at": "2026-08-04T19:54:36Z",
+     "exec_seconds": 118.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92113557966
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:37Z",
+     "completed_at": "2026-08-04T19:55:05Z",
+     "exec_seconds": 148.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92113557974
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:42Z",
+     "completed_at": "2026-08-04T19:53:51Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92113557980
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:37Z",
+     "completed_at": "2026-08-04T19:52:46Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92113557991
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:37Z",
+     "completed_at": "2026-08-04T19:52:44Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92113558006
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:52Z",
+     "completed_at": "2026-08-04T20:00:48Z",
+     "exec_seconds": 476.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92113599550
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "failure",
+     "started_at": "2026-08-04T19:52:53Z",
+     "completed_at": "2026-08-04T20:03:06Z",
+     "exec_seconds": 613.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92113599568
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:52:44Z",
+     "completed_at": "2026-08-04T19:52:44Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92113600193
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:52:44Z",
+     "completed_at": "2026-08-04T19:52:44Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92113600298
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:52:47Z",
+     "completed_at": "2026-08-04T19:52:46Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92113608890
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:52:47Z",
+     "completed_at": "2026-08-04T19:52:46Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92113609274
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:52:47Z",
+     "completed_at": "2026-08-04T19:52:46Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92113609700
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:52:47Z",
+     "completed_at": "2026-08-04T19:52:46Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92113609786
+    }
+   ]
+  },
+  {
+   "id": 30945262603,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:52:31Z",
+   "updated_at": "2026-08-04T19:53:52Z",
+   "wall_seconds": 81.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:34Z",
+     "completed_at": "2026-08-04T19:52:43Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92113545054
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:39Z",
+     "completed_at": "2026-08-04T19:53:37Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92113545080
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:34Z",
+     "completed_at": "2026-08-04T19:53:51Z",
+     "exec_seconds": 77.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92113545081
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:40Z",
+     "completed_at": "2026-08-04T19:53:04Z",
+     "exec_seconds": 24.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92113545103
+    }
+   ]
+  },
+  {
+   "id": 30945262318,
+   "name": "Changelog Lint",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:52:30Z",
+   "updated_at": "2026-08-04T19:52:45Z",
+   "wall_seconds": 15.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:52:39Z",
+     "completed_at": "2026-08-04T19:52:44Z",
+     "exec_seconds": 5.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92113543852
+    }
+   ]
+  },
+  {
+   "id": 30944924063,
+   "name": "Build",
+   "head_branch": "feat/deepseekv4",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:48:02Z",
+   "updated_at": "2026-08-04T20:01:59Z",
+   "wall_seconds": 837.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:12Z",
+     "completed_at": "2026-08-04T19:48:23Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92112416996
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:11Z",
+     "completed_at": "2026-08-04T19:49:10Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92112417043
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:05Z",
+     "completed_at": "2026-08-04T19:48:13Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92112417060
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:05Z",
+     "completed_at": "2026-08-04T19:50:04Z",
+     "exec_seconds": 119.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92112417062
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:09Z",
+     "completed_at": "2026-08-04T19:49:37Z",
+     "exec_seconds": 88.0,
+     "wait_from_run_start_seconds": 7.0,
+     "id": 92112417079
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:06Z",
+     "completed_at": "2026-08-04T19:48:58Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 4.0,
+     "id": 92112417099
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:07Z",
+     "completed_at": "2026-08-04T19:48:41Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92112417173
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:15Z",
+     "completed_at": "2026-08-04T19:57:33Z",
+     "exec_seconds": 558.0,
+     "wait_from_run_start_seconds": 13.0,
+     "id": 92112460157
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:23Z",
+     "completed_at": "2026-08-04T19:54:54Z",
+     "exec_seconds": 391.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92112460177
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:20Z",
+     "completed_at": "2026-08-04T19:56:18Z",
+     "exec_seconds": 478.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92112460207
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:48:13Z",
+     "completed_at": "2026-08-04T19:48:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92112461085
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:25Z",
+     "completed_at": "2026-08-04T19:49:00Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92112503509
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:48:23Z",
+     "completed_at": "2026-08-04T19:48:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92112505042
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:49:04Z",
+     "completed_at": "2026-08-04T20:01:57Z",
+     "exec_seconds": 773.0,
+     "wait_from_run_start_seconds": 62.0,
+     "id": 92112663366
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T20:01:58Z",
+     "completed_at": "2026-08-04T20:01:57Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 836.0,
+     "id": 92115956940
+    }
+   ]
+  },
+  {
+   "id": 30944923611,
+   "name": "Changelog Lint",
+   "head_branch": "feat/deepseekv4",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:48:02Z",
+   "updated_at": "2026-08-04T19:48:19Z",
+   "wall_seconds": 17.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:11Z",
+     "completed_at": "2026-08-04T19:48:19Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 9.0,
+     "id": 92112414743
+    }
+   ]
+  },
+  {
+   "id": 30944923614,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "feat/deepseekv4",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:48:02Z",
+   "updated_at": "2026-08-04T19:49:35Z",
+   "wall_seconds": 93.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:10Z",
+     "completed_at": "2026-08-04T19:48:37Z",
+     "exec_seconds": 27.0,
+     "wait_from_run_start_seconds": 8.0,
+     "id": 92112415252
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:05Z",
+     "completed_at": "2026-08-04T19:49:35Z",
+     "exec_seconds": 90.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92112415267
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:04Z",
+     "completed_at": "2026-08-04T19:48:11Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92112415280
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:48:05Z",
+     "completed_at": "2026-08-04T19:49:10Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92112415281
+    }
+   ]
+  },
+  {
+   "id": 30943334604,
+   "name": "Build",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:27:08Z",
+   "updated_at": "2026-08-04T19:47:58Z",
+   "wall_seconds": 1250.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:20Z",
+     "completed_at": "2026-08-04T19:31:29Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 192.0,
+     "id": 92107000044
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:32Z",
+     "completed_at": "2026-08-04T19:28:41Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 84.0,
+     "id": 92107000099
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:01Z",
+     "completed_at": "2026-08-04T19:30:49Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 173.0,
+     "id": 92107000146
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:59Z",
+     "completed_at": "2026-08-04T19:29:53Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 111.0,
+     "id": 92107000149
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:29Z",
+     "completed_at": "2026-08-04T19:28:35Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 81.0,
+     "id": 92107000182
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:40Z",
+     "completed_at": "2026-08-04T19:33:16Z",
+     "exec_seconds": 156.0,
+     "wait_from_run_start_seconds": 212.0,
+     "id": 92107000203
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:03Z",
+     "completed_at": "2026-08-04T19:33:14Z",
+     "exec_seconds": 131.0,
+     "wait_from_run_start_seconds": 235.0,
+     "id": 92107000394
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:36Z",
+     "completed_at": "2026-08-04T19:28:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 88.0,
+     "id": 92107376428
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:36Z",
+     "completed_at": "2026-08-04T19:28:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 88.0,
+     "id": 92107376445
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:36Z",
+     "completed_at": "2026-08-04T19:28:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 88.0,
+     "id": 92107376671
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:36Z",
+     "completed_at": "2026-08-04T19:28:36Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 88.0,
+     "id": 92107377144
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:06Z",
+     "completed_at": "2026-08-04T19:39:18Z",
+     "exec_seconds": 492.0,
+     "wait_from_run_start_seconds": 238.0,
+     "id": 92107399848
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:39:34Z",
+     "completed_at": "2026-08-04T19:47:57Z",
+     "exec_seconds": 503.0,
+     "wait_from_run_start_seconds": 746.0,
+     "id": 92107399965
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:42Z",
+     "completed_at": "2026-08-04T19:28:41Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 94.0,
+     "id": 92107400954
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:42Z",
+     "completed_at": "2026-08-04T19:28:41Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 94.0,
+     "id": 92107401018
+    }
+   ]
+  },
+  {
+   "id": 30943334739,
+   "name": "Changelog Lint",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:27:08Z",
+   "updated_at": "2026-08-04T19:28:59Z",
+   "wall_seconds": 111.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:53Z",
+     "completed_at": "2026-08-04T19:28:58Z",
+     "exec_seconds": 5.0,
+     "wait_from_run_start_seconds": 105.0,
+     "id": 92106999572
+    }
+   ]
+  },
+  {
+   "id": 30943334912,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:27:08Z",
+   "updated_at": "2026-08-04T19:31:02Z",
+   "wall_seconds": 234.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:55Z",
+     "completed_at": "2026-08-04T19:28:51Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 47.0,
+     "id": 92107001326
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:38Z",
+     "completed_at": "2026-08-04T19:29:17Z",
+     "exec_seconds": 39.0,
+     "wait_from_run_start_seconds": 90.0,
+     "id": 92107001381
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:45Z",
+     "completed_at": "2026-08-04T19:29:53Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 97.0,
+     "id": 92107001438
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:53Z",
+     "completed_at": "2026-08-04T19:31:01Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 225.0,
+     "id": 92107001640
+    }
+   ]
+  },
+  {
+   "id": 30943242071,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2690-openrouter-app-attribution",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:54Z",
+   "updated_at": "2026-08-04T19:32:32Z",
+   "wall_seconds": 398.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:11Z",
+     "completed_at": "2026-08-04T19:29:16Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 137.0,
+     "id": 92106683958
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:26Z",
+     "completed_at": "2026-08-04T19:32:31Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 332.0,
+     "id": 92106683965
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:39Z",
+     "completed_at": "2026-08-04T19:27:10Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 45.0,
+     "id": 92106683968
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:48Z",
+     "completed_at": "2026-08-04T19:31:00Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 294.0,
+     "id": 92106683990
+    }
+   ]
+  },
+  {
+   "id": 30943240338,
+   "name": "Build",
+   "head_branch": "issue-2215-solver-score-metrics",
+   "conclusion": "failure",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:53Z",
+   "updated_at": "2026-08-04T19:50:57Z",
+   "wall_seconds": 1504.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:37Z",
+     "completed_at": "2026-08-04T19:29:08Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 164.0,
+     "id": 92106745891
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:41Z",
+     "completed_at": "2026-08-04T19:33:37Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 348.0,
+     "id": 92106745997
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:56Z",
+     "completed_at": "2026-08-04T19:35:05Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 543.0,
+     "id": 92106746025
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:32:33Z",
+     "completed_at": "2026-08-04T19:34:31Z",
+     "exec_seconds": 118.0,
+     "wait_from_run_start_seconds": 400.0,
+     "id": 92106746045
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:24Z",
+     "completed_at": "2026-08-04T19:36:33Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 631.0,
+     "id": 92106746050
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:00Z",
+     "completed_at": "2026-08-04T19:36:52Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 607.0,
+     "id": 92106746073
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:37:26Z",
+     "completed_at": "2026-08-04T19:39:42Z",
+     "exec_seconds": 136.0,
+     "wait_from_run_start_seconds": 693.0,
+     "id": 92106746102
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:42:30Z",
+     "completed_at": "2026-08-04T19:49:26Z",
+     "exec_seconds": 416.0,
+     "wait_from_run_start_seconds": 997.0,
+     "id": 92109089596
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:42:39Z",
+     "completed_at": "2026-08-04T19:50:43Z",
+     "exec_seconds": 484.0,
+     "wait_from_run_start_seconds": 1006.0,
+     "id": 92109089652
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "failure",
+     "started_at": "2026-08-04T19:42:47Z",
+     "completed_at": "2026-08-04T19:50:56Z",
+     "exec_seconds": 489.0,
+     "wait_from_run_start_seconds": 1014.0,
+     "id": 92109089693
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:35:05Z",
+     "completed_at": "2026-08-04T19:35:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 552.0,
+     "id": 92109090935
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:33Z",
+     "completed_at": "2026-08-04T19:36:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 640.0,
+     "id": 92109470380
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:33Z",
+     "completed_at": "2026-08-04T19:36:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 640.0,
+     "id": 92109470464
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:33Z",
+     "completed_at": "2026-08-04T19:36:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 640.0,
+     "id": 92109470603
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:33Z",
+     "completed_at": "2026-08-04T19:36:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 640.0,
+     "id": 92109471022
+    }
+   ]
+  },
+  {
+   "id": 30943237779,
+   "name": "Build",
+   "head_branch": "issue-3372-registry-sandbox-paths",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:51Z",
+   "updated_at": "2026-08-04T19:44:54Z",
+   "wall_seconds": 1143.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:51Z",
+     "completed_at": "2026-08-04T19:31:23Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 300.0,
+     "id": 92106745783
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:32:11Z",
+     "completed_at": "2026-08-04T19:32:22Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 380.0,
+     "id": 92106745843
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:02Z",
+     "completed_at": "2026-08-04T19:33:18Z",
+     "exec_seconds": 136.0,
+     "wait_from_run_start_seconds": 311.0,
+     "id": 92106745848
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:33:15Z",
+     "completed_at": "2026-08-04T19:34:02Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 444.0,
+     "id": 92106745872
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:30Z",
+     "completed_at": "2026-08-04T19:36:00Z",
+     "exec_seconds": 90.0,
+     "wait_from_run_start_seconds": 519.0,
+     "id": 92106745889
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:01Z",
+     "completed_at": "2026-08-04T19:35:58Z",
+     "exec_seconds": 117.0,
+     "wait_from_run_start_seconds": 490.0,
+     "id": 92106745928
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:35:03Z",
+     "completed_at": "2026-08-04T19:35:15Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 552.0,
+     "id": 92106745939
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:32:22Z",
+     "completed_at": "2026-08-04T19:32:22Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 391.0,
+     "id": 92108374964
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:32:23Z",
+     "completed_at": "2026-08-04T19:32:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 392.0,
+     "id": 92108375197
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:32:23Z",
+     "completed_at": "2026-08-04T19:32:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 392.0,
+     "id": 92108375975
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:32:23Z",
+     "completed_at": "2026-08-04T19:32:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 392.0,
+     "id": 92108376278
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:54Z",
+     "completed_at": "2026-08-04T19:44:46Z",
+     "exec_seconds": 472.0,
+     "wait_from_run_start_seconds": 663.0,
+     "id": 92109134699
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:59Z",
+     "completed_at": "2026-08-04T19:44:53Z",
+     "exec_seconds": 474.0,
+     "wait_from_run_start_seconds": 668.0,
+     "id": 92109134751
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:35:15Z",
+     "completed_at": "2026-08-04T19:35:15Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 564.0,
+     "id": 92109135610
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:35:15Z",
+     "completed_at": "2026-08-04T19:35:15Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 564.0,
+     "id": 92109135745
+    }
+   ]
+  },
+  {
+   "id": 30943238003,
+   "name": "Build",
+   "head_branch": "issue-2690-openrouter-app-attribution",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:51Z",
+   "updated_at": "2026-08-04T19:50:27Z",
+   "wall_seconds": 1476.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:54Z",
+     "completed_at": "2026-08-04T19:31:01Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 303.0,
+     "id": 92106746265
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:40Z",
+     "completed_at": "2026-08-04T19:32:36Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 349.0,
+     "id": 92106746285
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:26Z",
+     "completed_at": "2026-08-04T19:28:22Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 35.0,
+     "id": 92106746303
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:31Z",
+     "completed_at": "2026-08-04T19:36:41Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 640.0,
+     "id": 92106746332
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:37:13Z",
+     "completed_at": "2026-08-04T19:39:32Z",
+     "exec_seconds": 139.0,
+     "wait_from_run_start_seconds": 682.0,
+     "id": 92106746365
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:37:29Z",
+     "completed_at": "2026-08-04T19:38:26Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 698.0,
+     "id": 92106746388
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:38:04Z",
+     "completed_at": "2026-08-04T19:38:52Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 733.0,
+     "id": 92106746481
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:38:51Z",
+     "completed_at": "2026-08-04T19:45:21Z",
+     "exec_seconds": 390.0,
+     "wait_from_run_start_seconds": 780.0,
+     "id": 92108020086
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:42:31Z",
+     "completed_at": "2026-08-04T19:50:26Z",
+     "exec_seconds": 475.0,
+     "wait_from_run_start_seconds": 1000.0,
+     "id": 92108020106
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:41:26Z",
+     "completed_at": "2026-08-04T19:48:51Z",
+     "exec_seconds": 445.0,
+     "wait_from_run_start_seconds": 935.0,
+     "id": 92108020124
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:02Z",
+     "completed_at": "2026-08-04T19:31:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 311.0,
+     "id": 92108021013
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:41Z",
+     "completed_at": "2026-08-04T19:36:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 650.0,
+     "id": 92109506216
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:41Z",
+     "completed_at": "2026-08-04T19:36:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 650.0,
+     "id": 92109506527
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:42Z",
+     "completed_at": "2026-08-04T19:36:41Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 651.0,
+     "id": 92109507101
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:42Z",
+     "completed_at": "2026-08-04T19:36:41Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 651.0,
+     "id": 92109507151
+    }
+   ]
+  },
+  {
+   "id": 30943236504,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2215-solver-score-metrics",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:50Z",
+   "updated_at": "2026-08-04T19:29:02Z",
+   "wall_seconds": 192.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:21Z",
+     "completed_at": "2026-08-04T19:27:29Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 31.0,
+     "id": 92106663691
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:32Z",
+     "completed_at": "2026-08-04T19:27:03Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 42.0,
+     "id": 92106663697
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:18Z",
+     "completed_at": "2026-08-04T19:29:01Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 88.0,
+     "id": 92106663723
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:24Z",
+     "completed_at": "2026-08-04T19:27:31Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 94.0,
+     "id": 92106663734
+    }
+   ]
+  },
+  {
+   "id": 30943235036,
+   "name": "Build",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:49Z",
+   "updated_at": "2026-08-04T19:41:26Z",
+   "wall_seconds": 937.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:15Z",
+     "completed_at": "2026-08-04T19:26:26Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92106658722
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:36Z",
+     "completed_at": "2026-08-04T19:30:10Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 227.0,
+     "id": 92106658725
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:29Z",
+     "completed_at": "2026-08-04T19:30:33Z",
+     "exec_seconds": 64.0,
+     "wait_from_run_start_seconds": 220.0,
+     "id": 92106658737
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:12Z",
+     "completed_at": "2026-08-04T19:27:00Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92106658796
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:27Z",
+     "completed_at": "2026-08-04T19:32:53Z",
+     "exec_seconds": 146.0,
+     "wait_from_run_start_seconds": 278.0,
+     "id": 92106658821
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:25Z",
+     "completed_at": "2026-08-04T19:31:34Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 336.0,
+     "id": 92106658849
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:32:28Z",
+     "completed_at": "2026-08-04T19:33:51Z",
+     "exec_seconds": 83.0,
+     "wait_from_run_start_seconds": 399.0,
+     "id": 92106659101
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:26:26Z",
+     "completed_at": "2026-08-04T19:26:26Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 37.0,
+     "id": 92106818232
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:26:26Z",
+     "completed_at": "2026-08-04T19:26:26Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 37.0,
+     "id": 92106818306
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:26:26Z",
+     "completed_at": "2026-08-04T19:26:26Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 37.0,
+     "id": 92106818809
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:26:27Z",
+     "completed_at": "2026-08-04T19:26:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 38.0,
+     "id": 92106819366
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:10Z",
+     "completed_at": "2026-08-04T19:41:25Z",
+     "exec_seconds": 435.0,
+     "wait_from_run_start_seconds": 501.0,
+     "id": 92108161491
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:34Z",
+     "completed_at": "2026-08-04T19:31:34Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 345.0,
+     "id": 92108162277
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:34Z",
+     "completed_at": "2026-08-04T19:31:34Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 345.0,
+     "id": 92108162751
+    }
+   ]
+  },
+  {
+   "id": 30943235018,
+   "name": "Build",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:49Z",
+   "updated_at": "2026-08-04T19:46:35Z",
+   "wall_seconds": 1246.0,
+   "jobs": [
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:13Z",
+     "completed_at": "2026-08-04T19:28:21Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 84.0,
+     "id": 92106737380
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:31Z",
+     "completed_at": "2026-08-04T19:32:25Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 282.0,
+     "id": 92106737409
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:24Z",
+     "completed_at": "2026-08-04T19:28:31Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 155.0,
+     "id": 92106737470
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:35Z",
+     "completed_at": "2026-08-04T19:32:00Z",
+     "exec_seconds": 85.0,
+     "wait_from_run_start_seconds": 286.0,
+     "id": 92106737500
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:51Z",
+     "completed_at": "2026-08-04T19:38:34Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 662.0,
+     "id": 92106737502
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:35Z",
+     "completed_at": "2026-08-04T19:30:51Z",
+     "exec_seconds": 16.0,
+     "wait_from_run_start_seconds": 286.0,
+     "id": 92106737546
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:37:42Z",
+     "completed_at": "2026-08-04T19:38:43Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 713.0,
+     "id": 92106737790
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:32Z",
+     "completed_at": "2026-08-04T19:28:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 163.0,
+     "id": 92107359758
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:32Z",
+     "completed_at": "2026-08-04T19:28:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 163.0,
+     "id": 92107359938
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:32Z",
+     "completed_at": "2026-08-04T19:28:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 163.0,
+     "id": 92107360572
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:32Z",
+     "completed_at": "2026-08-04T19:28:32Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 163.0,
+     "id": 92107361340
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:38:35Z",
+     "completed_at": "2026-08-04T19:46:34Z",
+     "exec_seconds": 479.0,
+     "wait_from_run_start_seconds": 766.0,
+     "id": 92107974864
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:38:37Z",
+     "completed_at": "2026-08-04T19:46:12Z",
+     "exec_seconds": 455.0,
+     "wait_from_run_start_seconds": 768.0,
+     "id": 92107975001
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:30:52Z",
+     "completed_at": "2026-08-04T19:30:51Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 303.0,
+     "id": 92107976236
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:30:52Z",
+     "completed_at": "2026-08-04T19:30:51Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 303.0,
+     "id": 92107976598
+    }
+   ]
+  },
+  {
+   "id": 30943234823,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:49Z",
+   "updated_at": "2026-08-04T19:30:28Z",
+   "wall_seconds": 279.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:10Z",
+     "completed_at": "2026-08-04T19:26:24Z",
+     "exec_seconds": 14.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92106658842
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:15Z",
+     "completed_at": "2026-08-04T19:27:12Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 26.0,
+     "id": 92106658894
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:45Z",
+     "completed_at": "2026-08-04T19:29:34Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 116.0,
+     "id": 92106659008
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:59Z",
+     "completed_at": "2026-08-04T19:30:27Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 250.0,
+     "id": 92106659038
+    }
+   ]
+  },
+  {
+   "id": 30943234720,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:49Z",
+   "updated_at": "2026-08-04T19:31:25Z",
+   "wall_seconds": 336.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:55Z",
+     "completed_at": "2026-08-04T19:31:04Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 246.0,
+     "id": 92106658629
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:55Z",
+     "completed_at": "2026-08-04T19:30:19Z",
+     "exec_seconds": 24.0,
+     "wait_from_run_start_seconds": 246.0,
+     "id": 92106658661
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:54Z",
+     "completed_at": "2026-08-04T19:29:02Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 185.0,
+     "id": 92106658678
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:14Z",
+     "completed_at": "2026-08-04T19:31:24Z",
+     "exec_seconds": 70.0,
+     "wait_from_run_start_seconds": 265.0,
+     "id": 92106658743
+    }
+   ]
+  },
+  {
+   "id": 30943234701,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2747-unbounded-message-warning",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:49Z",
+   "updated_at": "2026-08-04T19:36:47Z",
+   "wall_seconds": 658.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:35Z",
+     "completed_at": "2026-08-04T19:29:43Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 166.0,
+     "id": 92106658844
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:33Z",
+     "completed_at": "2026-08-04T19:34:55Z",
+     "exec_seconds": 22.0,
+     "wait_from_run_start_seconds": 524.0,
+     "id": 92106658889
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:15Z",
+     "completed_at": "2026-08-04T19:36:21Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 626.0,
+     "id": 92106658939
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:35:13Z",
+     "completed_at": "2026-08-04T19:36:46Z",
+     "exec_seconds": 93.0,
+     "wait_from_run_start_seconds": 564.0,
+     "id": 92106658976
+    }
+   ]
+  },
+  {
+   "id": 30943234301,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:48Z",
+   "updated_at": "2026-08-04T19:27:30Z",
+   "wall_seconds": 102.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:17Z",
+     "completed_at": "2026-08-04T19:26:23Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92106656936
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:11Z",
+     "completed_at": "2026-08-04T19:26:43Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92106656956
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:15Z",
+     "completed_at": "2026-08-04T19:27:26Z",
+     "exec_seconds": 71.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92106656984
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:17Z",
+     "completed_at": "2026-08-04T19:27:29Z",
+     "exec_seconds": 72.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92106657011
+    }
+   ]
+  },
+  {
+   "id": 30943234139,
+   "name": "Build",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:48Z",
+   "updated_at": "2026-08-04T19:42:38Z",
+   "wall_seconds": 1010.0,
+   "jobs": [
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:09Z",
+     "completed_at": "2026-08-04T19:28:10Z",
+     "exec_seconds": 121.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92106729904
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:11Z",
+     "completed_at": "2026-08-04T19:29:48Z",
+     "exec_seconds": 37.0,
+     "wait_from_run_start_seconds": 203.0,
+     "id": 92106729920
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:44Z",
+     "completed_at": "2026-08-04T19:30:30Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 236.0,
+     "id": 92106729951
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:32:05Z",
+     "completed_at": "2026-08-04T19:34:46Z",
+     "exec_seconds": 161.0,
+     "wait_from_run_start_seconds": 377.0,
+     "id": 92106729958
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:16Z",
+     "completed_at": "2026-08-04T19:29:27Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 208.0,
+     "id": 92106729960
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:43Z",
+     "completed_at": "2026-08-04T19:31:50Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 355.0,
+     "id": 92106729985
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:26Z",
+     "completed_at": "2026-08-04T19:36:13Z",
+     "exec_seconds": 107.0,
+     "wait_from_run_start_seconds": 518.0,
+     "id": 92106730005
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:29:27Z",
+     "completed_at": "2026-08-04T19:29:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 219.0,
+     "id": 92107595375
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:29:27Z",
+     "completed_at": "2026-08-04T19:29:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 219.0,
+     "id": 92107595884
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:29:27Z",
+     "completed_at": "2026-08-04T19:29:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 219.0,
+     "id": 92107596051
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:29:27Z",
+     "completed_at": "2026-08-04T19:29:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 219.0,
+     "id": 92107596679
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:35:03Z",
+     "completed_at": "2026-08-04T19:42:37Z",
+     "exec_seconds": 454.0,
+     "wait_from_run_start_seconds": 555.0,
+     "id": 92108234138
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:35:06Z",
+     "completed_at": "2026-08-04T19:42:29Z",
+     "exec_seconds": 443.0,
+     "wait_from_run_start_seconds": 558.0,
+     "id": 92108234150
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:51Z",
+     "completed_at": "2026-08-04T19:31:50Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 363.0,
+     "id": 92108235096
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:51Z",
+     "completed_at": "2026-08-04T19:31:50Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 363.0,
+     "id": 92108235346
+    }
+   ]
+  },
+  {
+   "id": 30943234476,
+   "name": "Build",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "failure",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:48Z",
+   "updated_at": "2026-08-04T19:46:00Z",
+   "wall_seconds": 1212.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:14Z",
+     "completed_at": "2026-08-04T19:27:49Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92106739949
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:39Z",
+     "completed_at": "2026-08-04T19:28:34Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 111.0,
+     "id": 92106739978
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:00Z",
+     "completed_at": "2026-08-04T19:30:52Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 192.0,
+     "id": 92106739982
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:31Z",
+     "completed_at": "2026-08-04T19:31:41Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 343.0,
+     "id": 92106739997
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:18Z",
+     "completed_at": "2026-08-04T19:30:46Z",
+     "exec_seconds": 88.0,
+     "wait_from_run_start_seconds": 210.0,
+     "id": 92106740010
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:34Z",
+     "completed_at": "2026-08-04T19:34:16Z",
+     "exec_seconds": 402.0,
+     "wait_from_run_start_seconds": 106.0,
+     "id": 92106740017
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:58Z",
+     "completed_at": "2026-08-04T19:32:08Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 370.0,
+     "id": 92106740090
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:41Z",
+     "completed_at": "2026-08-04T19:31:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 353.0,
+     "id": 92108194658
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:41Z",
+     "completed_at": "2026-08-04T19:31:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 353.0,
+     "id": 92108194686
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:42Z",
+     "completed_at": "2026-08-04T19:31:41Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 354.0,
+     "id": 92108195657
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:31:42Z",
+     "completed_at": "2026-08-04T19:31:41Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 354.0,
+     "id": 92108195762
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:38:54Z",
+     "completed_at": "2026-08-04T19:46:00Z",
+     "exec_seconds": 426.0,
+     "wait_from_run_start_seconds": 786.0,
+     "id": 92108313504
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "failure",
+     "started_at": "2026-08-04T19:32:38Z",
+     "completed_at": "2026-08-04T19:42:27Z",
+     "exec_seconds": 589.0,
+     "wait_from_run_start_seconds": 410.0,
+     "id": 92108313560
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:39:20Z",
+     "completed_at": "2026-08-04T19:42:44Z",
+     "exec_seconds": 204.0,
+     "wait_from_run_start_seconds": 812.0,
+     "id": 92108313654
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:32:09Z",
+     "completed_at": "2026-08-04T19:32:08Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 381.0,
+     "id": 92108314197
+    }
+   ]
+  },
+  {
+   "id": 30943234557,
+   "name": "Build",
+   "head_branch": "issue-2747-unbounded-message-warning",
+   "conclusion": "failure",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:48Z",
+   "updated_at": "2026-08-04T19:46:16Z",
+   "wall_seconds": 1228.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:05Z",
+     "completed_at": "2026-08-04T19:30:47Z",
+     "exec_seconds": 102.0,
+     "wait_from_run_start_seconds": 197.0,
+     "id": 92106661969
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:15Z",
+     "completed_at": "2026-08-04T19:26:22Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92106662007
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:33:28Z",
+     "completed_at": "2026-08-04T19:34:42Z",
+     "exec_seconds": 74.0,
+     "wait_from_run_start_seconds": 460.0,
+     "id": 92106662092
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:33:45Z",
+     "completed_at": "2026-08-04T19:33:53Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 477.0,
+     "id": 92106662094
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:33:18Z",
+     "completed_at": "2026-08-04T19:34:55Z",
+     "exec_seconds": 97.0,
+     "wait_from_run_start_seconds": 450.0,
+     "id": 92106662098
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:51Z",
+     "completed_at": "2026-08-04T19:36:44Z",
+     "exec_seconds": 113.0,
+     "wait_from_run_start_seconds": 543.0,
+     "id": 92106662115
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:35:17Z",
+     "completed_at": "2026-08-04T19:37:11Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 569.0,
+     "id": 92106662120
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:37:05Z",
+     "completed_at": "2026-08-04T19:44:56Z",
+     "exec_seconds": 471.0,
+     "wait_from_run_start_seconds": 677.0,
+     "id": 92106801602
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:02Z",
+     "completed_at": "2026-08-04T19:43:22Z",
+     "exec_seconds": 440.0,
+     "wait_from_run_start_seconds": 614.0,
+     "id": 92106801611
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "failure",
+     "started_at": "2026-08-04T19:38:04Z",
+     "completed_at": "2026-08-04T19:46:15Z",
+     "exec_seconds": 491.0,
+     "wait_from_run_start_seconds": 736.0,
+     "id": 92106801647
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:26:23Z",
+     "completed_at": "2026-08-04T19:26:22Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 35.0,
+     "id": 92106802506
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:33:54Z",
+     "completed_at": "2026-08-04T19:33:53Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 486.0,
+     "id": 92108772215
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:33:54Z",
+     "completed_at": "2026-08-04T19:33:53Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 486.0,
+     "id": 92108772594
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:33:54Z",
+     "completed_at": "2026-08-04T19:33:53Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 486.0,
+     "id": 92108773079
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:33:54Z",
+     "completed_at": "2026-08-04T19:33:54Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 486.0,
+     "id": 92108773450
+    }
+   ]
+  },
+  {
+   "id": 30943234154,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:48Z",
+   "updated_at": "2026-08-04T19:30:29Z",
+   "wall_seconds": 281.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:17Z",
+     "completed_at": "2026-08-04T19:27:26Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 89.0,
+     "id": 92106656527
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:56Z",
+     "completed_at": "2026-08-04T19:30:12Z",
+     "exec_seconds": 76.0,
+     "wait_from_run_start_seconds": 188.0,
+     "id": 92106656616
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:19Z",
+     "completed_at": "2026-08-04T19:30:29Z",
+     "exec_seconds": 70.0,
+     "wait_from_run_start_seconds": 211.0,
+     "id": 92106656673
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:24Z",
+     "completed_at": "2026-08-04T19:29:57Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 216.0,
+     "id": 92106656741
+    }
+   ]
+  },
+  {
+   "id": 30943233855,
+   "name": "Build",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:48Z",
+   "updated_at": "2026-08-04T19:50:19Z",
+   "wall_seconds": 1471.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:34:01Z",
+     "completed_at": "2026-08-04T19:35:05Z",
+     "exec_seconds": 64.0,
+     "wait_from_run_start_seconds": 493.0,
+     "id": 92106735549
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:33:53Z",
+     "completed_at": "2026-08-04T19:34:28Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 485.0,
+     "id": 92106735569
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:02Z",
+     "completed_at": "2026-08-04T19:37:56Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 614.0,
+     "id": 92106735575
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:40Z",
+     "completed_at": "2026-08-04T19:36:50Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 652.0,
+     "id": 92106735576
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:49Z",
+     "completed_at": "2026-08-04T19:38:45Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 661.0,
+     "id": 92106735686
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:55Z",
+     "completed_at": "2026-08-04T19:37:04Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 667.0,
+     "id": 92106735733
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:36:53Z",
+     "completed_at": "2026-08-04T19:37:39Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 665.0,
+     "id": 92106735864
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:50Z",
+     "completed_at": "2026-08-04T19:36:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 662.0,
+     "id": 92109543727
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:50Z",
+     "completed_at": "2026-08-04T19:36:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 662.0,
+     "id": 92109544117
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:50Z",
+     "completed_at": "2026-08-04T19:36:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 662.0,
+     "id": 92109544488
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:36:50Z",
+     "completed_at": "2026-08-04T19:36:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 662.0,
+     "id": 92109544984
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:40:16Z",
+     "completed_at": "2026-08-04T19:47:15Z",
+     "exec_seconds": 419.0,
+     "wait_from_run_start_seconds": 868.0,
+     "id": 92109603845
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:39:44Z",
+     "completed_at": "2026-08-04T19:47:34Z",
+     "exec_seconds": 470.0,
+     "wait_from_run_start_seconds": 836.0,
+     "id": 92109603866
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:42:37Z",
+     "completed_at": "2026-08-04T19:50:18Z",
+     "exec_seconds": 461.0,
+     "wait_from_run_start_seconds": 1009.0,
+     "id": 92109603886
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:37:04Z",
+     "completed_at": "2026-08-04T19:37:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 676.0,
+     "id": 92109604975
+    }
+   ]
+  },
+  {
+   "id": 30943232378,
+   "name": "Build",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:47Z",
+   "updated_at": "2026-08-04T19:37:28Z",
+   "wall_seconds": 701.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:14Z",
+     "completed_at": "2026-08-04T19:27:08Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92106718634
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:18Z",
+     "completed_at": "2026-08-04T19:27:26Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 91.0,
+     "id": 92106718709
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:01Z",
+     "completed_at": "2026-08-04T19:28:56Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 134.0,
+     "id": 92106718716
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:32Z",
+     "completed_at": "2026-08-04T19:30:38Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 285.0,
+     "id": 92106718762
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:32:02Z",
+     "completed_at": "2026-08-04T19:33:59Z",
+     "exec_seconds": 117.0,
+     "wait_from_run_start_seconds": 375.0,
+     "id": 92106718813
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:56Z",
+     "completed_at": "2026-08-04T19:33:02Z",
+     "exec_seconds": 126.0,
+     "wait_from_run_start_seconds": 309.0,
+     "id": 92106718853
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:29:45Z",
+     "completed_at": "2026-08-04T19:32:03Z",
+     "exec_seconds": 138.0,
+     "wait_from_run_start_seconds": 238.0,
+     "id": 92106718884
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:36Z",
+     "completed_at": "2026-08-04T19:37:27Z",
+     "exec_seconds": 351.0,
+     "wait_from_run_start_seconds": 349.0,
+     "id": 92107079947
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:27:26Z",
+     "completed_at": "2026-08-04T19:27:26Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 99.0,
+     "id": 92107080682
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:27:26Z",
+     "completed_at": "2026-08-04T19:27:26Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 99.0,
+     "id": 92107081256
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:30:39Z",
+     "completed_at": "2026-08-04T19:30:38Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 292.0,
+     "id": 92107916745
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:30:39Z",
+     "completed_at": "2026-08-04T19:30:38Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 292.0,
+     "id": 92107916838
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:30:39Z",
+     "completed_at": "2026-08-04T19:30:38Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 292.0,
+     "id": 92107917746
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:30:39Z",
+     "completed_at": "2026-08-04T19:30:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 292.0,
+     "id": 92107917972
+    }
+   ]
+  },
+  {
+   "id": 30943233505,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:47Z",
+   "updated_at": "2026-08-04T19:28:54Z",
+   "wall_seconds": 187.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:14Z",
+     "completed_at": "2026-08-04T19:28:54Z",
+     "exec_seconds": 40.0,
+     "wait_from_run_start_seconds": 147.0,
+     "id": 92106656572
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:24Z",
+     "completed_at": "2026-08-04T19:27:52Z",
+     "exec_seconds": 88.0,
+     "wait_from_run_start_seconds": 37.0,
+     "id": 92106656631
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:02Z",
+     "completed_at": "2026-08-04T19:27:11Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 75.0,
+     "id": 92106656636
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:28Z",
+     "completed_at": "2026-08-04T19:28:37Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 101.0,
+     "id": 92106656676
+    }
+   ]
+  },
+  {
+   "id": 30943232746,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-3372-registry-sandbox-paths",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:47Z",
+   "updated_at": "2026-08-04T19:30:34Z",
+   "wall_seconds": 287.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:28Z",
+     "completed_at": "2026-08-04T19:27:37Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 101.0,
+     "id": 92106651444
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:45Z",
+     "completed_at": "2026-08-04T19:27:18Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 58.0,
+     "id": 92106651459
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:39Z",
+     "completed_at": "2026-08-04T19:28:41Z",
+     "exec_seconds": 62.0,
+     "wait_from_run_start_seconds": 112.0,
+     "id": 92106651514
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:58Z",
+     "completed_at": "2026-08-04T19:30:33Z",
+     "exec_seconds": 95.0,
+     "wait_from_run_start_seconds": 191.0,
+     "id": 92106651635
+    }
+   ]
+  },
+  {
+   "id": 30943231988,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:25:46Z",
+   "updated_at": "2026-08-04T19:29:43Z",
+   "wall_seconds": 237.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:07Z",
+     "completed_at": "2026-08-04T19:26:19Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 21.0,
+     "id": 92106648850
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:08Z",
+     "completed_at": "2026-08-04T19:27:15Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92106648875
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:31Z",
+     "completed_at": "2026-08-04T19:29:42Z",
+     "exec_seconds": 131.0,
+     "wait_from_run_start_seconds": 105.0,
+     "id": 92106648902
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:37Z",
+     "completed_at": "2026-08-04T19:28:08Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 111.0,
+     "id": 92106648977
+    }
+   ]
+  },
+  {
+   "id": 30942717170,
+   "name": "Build",
+   "head_branch": "feat/deepseekv4",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:19:03Z",
+   "updated_at": "2026-08-04T19:46:34Z",
+   "wall_seconds": 1651.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:14Z",
+     "completed_at": "2026-08-04T19:20:02Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92104900528
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:22:54Z",
+     "completed_at": "2026-08-04T19:25:13Z",
+     "exec_seconds": 139.0,
+     "wait_from_run_start_seconds": 231.0,
+     "id": 92104900531
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:21:17Z",
+     "completed_at": "2026-08-04T19:21:24Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 134.0,
+     "id": 92104900541
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:21:44Z",
+     "completed_at": "2026-08-04T19:22:14Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 161.0,
+     "id": 92104900548
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:34Z",
+     "completed_at": "2026-08-04T19:27:22Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 451.0,
+     "id": 92104900583
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:01Z",
+     "completed_at": "2026-08-04T19:28:46Z",
+     "exec_seconds": 165.0,
+     "wait_from_run_start_seconds": 418.0,
+     "id": 92104900621
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:58Z",
+     "completed_at": "2026-08-04T19:28:08Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 535.0,
+     "id": 92104900649
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:30:39Z",
+     "completed_at": "2026-08-04T19:31:34Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 696.0,
+     "id": 92105511170
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:21:25Z",
+     "completed_at": "2026-08-04T19:21:25Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 142.0,
+     "id": 92105512580
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:31:09Z",
+     "completed_at": "2026-08-04T19:36:25Z",
+     "exec_seconds": 316.0,
+     "wait_from_run_start_seconds": 726.0,
+     "id": 92107259337
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:32:27Z",
+     "completed_at": "2026-08-04T19:42:30Z",
+     "exec_seconds": 603.0,
+     "wait_from_run_start_seconds": 804.0,
+     "id": 92107259376
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:32:55Z",
+     "completed_at": "2026-08-04T19:41:24Z",
+     "exec_seconds": 509.0,
+     "wait_from_run_start_seconds": 832.0,
+     "id": 92107259388
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:28:08Z",
+     "completed_at": "2026-08-04T19:28:08Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 545.0,
+     "id": 92107260577
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:33:04Z",
+     "completed_at": "2026-08-04T19:46:33Z",
+     "exec_seconds": 809.0,
+     "wait_from_run_start_seconds": 841.0,
+     "id": 92108164879
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:46:33Z",
+     "completed_at": "2026-08-04T19:46:33Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 1650.0,
+     "id": 92112042866
+    }
+   ]
+  },
+  {
+   "id": 30942716955,
+   "name": "Changelog Lint",
+   "head_branch": "feat/deepseekv4",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:19:02Z",
+   "updated_at": "2026-08-04T19:22:05Z",
+   "wall_seconds": 183.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:21:55Z",
+     "completed_at": "2026-08-04T19:22:04Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 173.0,
+     "id": 92104898705
+    }
+   ]
+  },
+  {
+   "id": 30942717001,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "feat/deepseekv4",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:19:02Z",
+   "updated_at": "2026-08-04T19:27:12Z",
+   "wall_seconds": 490.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:25:25Z",
+     "completed_at": "2026-08-04T19:26:31Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 383.0,
+     "id": 92104899797
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:22:15Z",
+     "completed_at": "2026-08-04T19:22:57Z",
+     "exec_seconds": 42.0,
+     "wait_from_run_start_seconds": 193.0,
+     "id": 92104899799
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:22:44Z",
+     "completed_at": "2026-08-04T19:22:52Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 222.0,
+     "id": 92104899804
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:06Z",
+     "completed_at": "2026-08-04T19:27:11Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 424.0,
+     "id": 92104899852
+    }
+   ]
+  },
+  {
+   "id": 30942702665,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:18:51Z",
+   "updated_at": "2026-08-04T19:26:33Z",
+   "wall_seconds": 462.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:21:05Z",
+     "completed_at": "2026-08-04T19:21:31Z",
+     "exec_seconds": 26.0,
+     "wait_from_run_start_seconds": 134.0,
+     "id": 92104850793
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:22:16Z",
+     "completed_at": "2026-08-04T19:22:26Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 205.0,
+     "id": 92104850836
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:23:56Z",
+     "completed_at": "2026-08-04T19:25:03Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 305.0,
+     "id": 92104850847
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:25:15Z",
+     "completed_at": "2026-08-04T19:26:32Z",
+     "exec_seconds": 77.0,
+     "wait_from_run_start_seconds": 384.0,
+     "id": 92104850877
+    }
+   ]
+  },
+  {
+   "id": 30942702056,
+   "name": "Changelog Lint",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:18:50Z",
+   "updated_at": "2026-08-04T19:20:35Z",
+   "wall_seconds": 105.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:27Z",
+     "completed_at": "2026-08-04T19:20:34Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 97.0,
+     "id": 92104848848
+    }
+   ]
+  },
+  {
+   "id": 30942702120,
+   "name": "Build",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:18:50Z",
+   "updated_at": "2026-08-04T19:38:03Z",
+   "wall_seconds": 1153.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:21:22Z",
+     "completed_at": "2026-08-04T19:21:57Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 152.0,
+     "id": 92104848899
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:25:11Z",
+     "completed_at": "2026-08-04T19:25:22Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 381.0,
+     "id": 92104848976
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:22:51Z",
+     "completed_at": "2026-08-04T19:23:04Z",
+     "exec_seconds": 13.0,
+     "wait_from_run_start_seconds": 241.0,
+     "id": 92104848996
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:26:34Z",
+     "completed_at": "2026-08-04T19:28:24Z",
+     "exec_seconds": 110.0,
+     "wait_from_run_start_seconds": 464.0,
+     "id": 92104849009
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:25:18Z",
+     "completed_at": "2026-08-04T19:27:36Z",
+     "exec_seconds": 138.0,
+     "wait_from_run_start_seconds": 388.0,
+     "id": 92104849051
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:27:34Z",
+     "completed_at": "2026-08-04T19:29:22Z",
+     "exec_seconds": 108.0,
+     "wait_from_run_start_seconds": 524.0,
+     "id": 92104849052
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:09Z",
+     "completed_at": "2026-08-04T19:28:57Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 559.0,
+     "id": 92104849062
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:43Z",
+     "completed_at": "2026-08-04T19:37:24Z",
+     "exec_seconds": 521.0,
+     "wait_from_run_start_seconds": 593.0,
+     "id": 92105947711
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:28:43Z",
+     "completed_at": "2026-08-04T19:38:02Z",
+     "exec_seconds": 559.0,
+     "wait_from_run_start_seconds": 593.0,
+     "id": 92105947818
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:23:04Z",
+     "completed_at": "2026-08-04T19:23:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 254.0,
+     "id": 92105948517
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:23:04Z",
+     "completed_at": "2026-08-04T19:23:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 254.0,
+     "id": 92105948687
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:25:23Z",
+     "completed_at": "2026-08-04T19:25:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 393.0,
+     "id": 92106544429
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:25:23Z",
+     "completed_at": "2026-08-04T19:25:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 393.0,
+     "id": 92106544472
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:25:23Z",
+     "completed_at": "2026-08-04T19:25:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 393.0,
+     "id": 92106544617
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:25:23Z",
+     "completed_at": "2026-08-04T19:25:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 393.0,
+     "id": 92106545689
+    }
+   ]
+  },
+  {
+   "id": 30942058286,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:34Z",
+   "updated_at": "2026-08-04T19:21:48Z",
+   "wall_seconds": 674.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:32Z",
+     "completed_at": "2026-08-04T19:18:43Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 478.0,
+     "id": 92102707261
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:31Z",
+     "completed_at": "2026-08-04T19:17:44Z",
+     "exec_seconds": 73.0,
+     "wait_from_run_start_seconds": 357.0,
+     "id": 92102707268
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:54Z",
+     "completed_at": "2026-08-04T19:12:26Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 80.0,
+     "id": 92102707270
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:10Z",
+     "completed_at": "2026-08-04T19:21:47Z",
+     "exec_seconds": 97.0,
+     "wait_from_run_start_seconds": 576.0,
+     "id": 92102707356
+    }
+   ]
+  },
+  {
+   "id": 30942057514,
+   "name": "Build",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:34Z",
+   "updated_at": "2026-08-04T19:26:06Z",
+   "wall_seconds": 932.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:40Z",
+     "completed_at": "2026-08-04T19:13:07Z",
+     "exec_seconds": 27.0,
+     "wait_from_run_start_seconds": 126.0,
+     "id": 92102704627
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:20Z",
+     "completed_at": "2026-08-04T19:21:11Z",
+     "exec_seconds": 51.0,
+     "wait_from_run_start_seconds": 586.0,
+     "id": 92102704659
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:23:05Z",
+     "completed_at": "2026-08-04T19:24:57Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 751.0,
+     "id": 92102704684
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:49Z",
+     "completed_at": "2026-08-04T19:22:07Z",
+     "exec_seconds": 138.0,
+     "wait_from_run_start_seconds": 555.0,
+     "id": 92102704685
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:21:00Z",
+     "completed_at": "2026-08-04T19:21:09Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 626.0,
+     "id": 92102704712
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:22:59Z",
+     "completed_at": "2026-08-04T19:23:06Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 745.0,
+     "id": 92102704763
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:21:41Z",
+     "completed_at": "2026-08-04T19:22:42Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 667.0,
+     "id": 92102704817
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:21:09Z",
+     "completed_at": "2026-08-04T19:21:09Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 635.0,
+     "id": 92105444205
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:21:09Z",
+     "completed_at": "2026-08-04T19:21:09Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 635.0,
+     "id": 92105444230
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:21:10Z",
+     "completed_at": "2026-08-04T19:21:09Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 636.0,
+     "id": 92105444766
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:21:10Z",
+     "completed_at": "2026-08-04T19:21:09Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 636.0,
+     "id": 92105444789
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:25:04Z",
+     "completed_at": "2026-08-04T19:26:05Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 870.0,
+     "id": 92105956525
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:23:06Z",
+     "completed_at": "2026-08-04T19:25:49Z",
+     "exec_seconds": 163.0,
+     "wait_from_run_start_seconds": 752.0,
+     "id": 92105956602
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:23:06Z",
+     "completed_at": "2026-08-04T19:23:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 752.0,
+     "id": 92105957624
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:23:06Z",
+     "completed_at": "2026-08-04T19:23:06Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 752.0,
+     "id": 92105957759
+    }
+   ]
+  },
+  {
+   "id": 30942051661,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:29Z",
+   "updated_at": "2026-08-04T19:20:47Z",
+   "wall_seconds": 618.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:15Z",
+     "completed_at": "2026-08-04T19:18:24Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 466.0,
+     "id": 92102685062
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:07Z",
+     "completed_at": "2026-08-04T19:20:41Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 578.0,
+     "id": 92102685123
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:44Z",
+     "completed_at": "2026-08-04T19:20:46Z",
+     "exec_seconds": 62.0,
+     "wait_from_run_start_seconds": 555.0,
+     "id": 92102685173
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:34Z",
+     "completed_at": "2026-08-04T19:19:32Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 485.0,
+     "id": 92102685240
+    }
+   ]
+  },
+  {
+   "id": 30942050914,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2215-solver-score-metrics",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:29Z",
+   "updated_at": "2026-08-04T19:19:53Z",
+   "wall_seconds": 564.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:08Z",
+     "completed_at": "2026-08-04T19:11:16Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 39.0,
+     "id": 92102683150
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:04Z",
+     "completed_at": "2026-08-04T19:19:52Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 515.0,
+     "id": 92102683229
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:13:55Z",
+     "completed_at": "2026-08-04T19:15:39Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 206.0,
+     "id": 92102683234
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:41Z",
+     "completed_at": "2026-08-04T19:18:13Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 432.0,
+     "id": 92102683235
+    }
+   ]
+  },
+  {
+   "id": 30942051614,
+   "name": "Build",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:29Z",
+   "updated_at": "2026-08-04T19:26:04Z",
+   "wall_seconds": 935.0,
+   "jobs": [
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:48Z",
+     "completed_at": "2026-08-04T19:14:29Z",
+     "exec_seconds": 161.0,
+     "wait_from_run_start_seconds": 79.0,
+     "id": 92102684774
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:13:36Z",
+     "completed_at": "2026-08-04T19:14:23Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 187.0,
+     "id": 92102684810
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:25Z",
+     "completed_at": "2026-08-04T19:20:19Z",
+     "exec_seconds": 174.0,
+     "wait_from_run_start_seconds": 416.0,
+     "id": 92102684835
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:35Z",
+     "completed_at": "2026-08-04T19:21:39Z",
+     "exec_seconds": 244.0,
+     "wait_from_run_start_seconds": 426.0,
+     "id": 92102684859
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:43Z",
+     "completed_at": "2026-08-04T19:20:52Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 614.0,
+     "id": 92102684922
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:54Z",
+     "completed_at": "2026-08-04T19:20:04Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 565.0,
+     "id": 92102684931
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:21Z",
+     "completed_at": "2026-08-04T19:20:53Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 592.0,
+     "id": 92102684960
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:20:05Z",
+     "completed_at": "2026-08-04T19:20:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 576.0,
+     "id": 92105162446
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:20:05Z",
+     "completed_at": "2026-08-04T19:20:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 576.0,
+     "id": 92105162604
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:20:05Z",
+     "completed_at": "2026-08-04T19:20:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 576.0,
+     "id": 92105163365
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:20:05Z",
+     "completed_at": "2026-08-04T19:20:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 576.0,
+     "id": 92105163471
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:21:13Z",
+     "completed_at": "2026-08-04T19:26:02Z",
+     "exec_seconds": 289.0,
+     "wait_from_run_start_seconds": 644.0,
+     "id": 92105370656
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:20:53Z",
+     "completed_at": "2026-08-04T19:20:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 624.0,
+     "id": 92105371389
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:20:53Z",
+     "completed_at": "2026-08-04T19:20:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 624.0,
+     "id": 92105371875
+    }
+   ]
+  },
+  {
+   "id": 30942050834,
+   "name": "Build",
+   "head_branch": "issue-2215-solver-score-metrics",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:29Z",
+   "updated_at": "2026-08-04T19:26:10Z",
+   "wall_seconds": 941.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:44Z",
+     "completed_at": "2026-08-04T19:17:20Z",
+     "exec_seconds": 96.0,
+     "wait_from_run_start_seconds": 315.0,
+     "id": 92102682707
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:10:48Z",
+     "completed_at": "2026-08-04T19:11:00Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 19.0,
+     "id": 92102682718
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:34Z",
+     "completed_at": "2026-08-04T19:17:25Z",
+     "exec_seconds": 51.0,
+     "wait_from_run_start_seconds": 365.0,
+     "id": 92102682729
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:52Z",
+     "completed_at": "2026-08-04T19:17:39Z",
+     "exec_seconds": 107.0,
+     "wait_from_run_start_seconds": 323.0,
+     "id": 92102682778
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:54Z",
+     "completed_at": "2026-08-04T19:19:03Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 505.0,
+     "id": 92102682824
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:21Z",
+     "completed_at": "2026-08-04T19:19:55Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 532.0,
+     "id": 92102682905
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:02Z",
+     "completed_at": "2026-08-04T19:20:57Z",
+     "exec_seconds": 115.0,
+     "wait_from_run_start_seconds": 513.0,
+     "id": 92102683001
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:00Z",
+     "completed_at": "2026-08-04T19:11:00Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 31.0,
+     "id": 92102813694
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:00Z",
+     "completed_at": "2026-08-04T19:11:00Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 31.0,
+     "id": 92102813792
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:01Z",
+     "completed_at": "2026-08-04T19:11:00Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92102814787
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:01Z",
+     "completed_at": "2026-08-04T19:11:00Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92102814981
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:21:32Z",
+     "completed_at": "2026-08-04T19:26:09Z",
+     "exec_seconds": 277.0,
+     "wait_from_run_start_seconds": 663.0,
+     "id": 92104901614
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:21:58Z",
+     "completed_at": "2026-08-04T19:25:55Z",
+     "exec_seconds": 237.0,
+     "wait_from_run_start_seconds": 689.0,
+     "id": 92104901659
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:19:04Z",
+     "completed_at": "2026-08-04T19:25:53Z",
+     "exec_seconds": 409.0,
+     "wait_from_run_start_seconds": 515.0,
+     "id": 92104901664
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:19:04Z",
+     "completed_at": "2026-08-04T19:19:04Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 515.0,
+     "id": 92104902758
+    }
+   ]
+  },
+  {
+   "id": 30942049458,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:12:35Z",
+   "wall_seconds": 127.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:23Z",
+     "completed_at": "2026-08-04T19:12:02Z",
+     "exec_seconds": 39.0,
+     "wait_from_run_start_seconds": 55.0,
+     "id": 92102677975
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:21Z",
+     "completed_at": "2026-08-04T19:12:34Z",
+     "exec_seconds": 13.0,
+     "wait_from_run_start_seconds": 113.0,
+     "id": 92102677981
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:10Z",
+     "completed_at": "2026-08-04T19:12:19Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 42.0,
+     "id": 92102677984
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:07Z",
+     "completed_at": "2026-08-04T19:12:21Z",
+     "exec_seconds": 74.0,
+     "wait_from_run_start_seconds": 39.0,
+     "id": 92102677994
+    }
+   ]
+  },
+  {
+   "id": 30942050160,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-3372-registry-sandbox-paths",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:20:39Z",
+   "wall_seconds": 611.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:28Z",
+     "completed_at": "2026-08-04T19:13:51Z",
+     "exec_seconds": 83.0,
+     "wait_from_run_start_seconds": 120.0,
+     "id": 92102680365
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:32Z",
+     "completed_at": "2026-08-04T19:20:38Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 544.0,
+     "id": 92102680447
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:35Z",
+     "completed_at": "2026-08-04T19:19:13Z",
+     "exec_seconds": 38.0,
+     "wait_from_run_start_seconds": 487.0,
+     "id": 92102680471
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:18Z",
+     "completed_at": "2026-08-04T19:17:29Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 410.0,
+     "id": 92102680474
+    }
+   ]
+  },
+  {
+   "id": 30942050029,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2747-unbounded-message-warning",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:19:31Z",
+   "wall_seconds": 543.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:23Z",
+     "completed_at": "2026-08-04T19:12:35Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 115.0,
+     "id": 92102679948
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:47Z",
+     "completed_at": "2026-08-04T19:16:16Z",
+     "exec_seconds": 29.0,
+     "wait_from_run_start_seconds": 319.0,
+     "id": 92102680009
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:14:33Z",
+     "completed_at": "2026-08-04T19:15:42Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 245.0,
+     "id": 92102680033
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:39Z",
+     "completed_at": "2026-08-04T19:19:30Z",
+     "exec_seconds": 111.0,
+     "wait_from_run_start_seconds": 431.0,
+     "id": 92102680057
+    }
+   ]
+  },
+  {
+   "id": 30942049707,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2690-openrouter-app-attribution",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:20:25Z",
+   "wall_seconds": 597.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:53Z",
+     "completed_at": "2026-08-04T19:12:05Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 85.0,
+     "id": 92102679061
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:26Z",
+     "completed_at": "2026-08-04T19:20:24Z",
+     "exec_seconds": 118.0,
+     "wait_from_run_start_seconds": 478.0,
+     "id": 92102679132
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:10Z",
+     "completed_at": "2026-08-04T19:13:14Z",
+     "exec_seconds": 64.0,
+     "wait_from_run_start_seconds": 102.0,
+     "id": 92102679170
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:13:22Z",
+     "completed_at": "2026-08-04T19:14:02Z",
+     "exec_seconds": 40.0,
+     "wait_from_run_start_seconds": 174.0,
+     "id": 92102679221
+    }
+   ]
+  },
+  {
+   "id": 30942050067,
+   "name": "Build",
+   "head_branch": "issue-2747-unbounded-message-warning",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:25:50Z",
+   "wall_seconds": 922.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:06Z",
+     "completed_at": "2026-08-04T19:19:42Z",
+     "exec_seconds": 36.0,
+     "wait_from_run_start_seconds": 518.0,
+     "id": 92102755293
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:16Z",
+     "completed_at": "2026-08-04T19:18:14Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 408.0,
+     "id": 92102755303
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:55Z",
+     "completed_at": "2026-08-04T19:21:42Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 627.0,
+     "id": 92102755310
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:22:05Z",
+     "completed_at": "2026-08-04T19:22:13Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 697.0,
+     "id": 92102755351
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:20:43Z",
+     "completed_at": "2026-08-04T19:22:38Z",
+     "exec_seconds": 115.0,
+     "wait_from_run_start_seconds": 615.0,
+     "id": 92102755372
+    },
+    {
+     "name": "changes",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:10:46Z",
+     "completed_at": "2026-08-04T19:25:49Z",
+     "exec_seconds": 903.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92102755396
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:23:08Z",
+     "completed_at": "2026-08-04T19:24:58Z",
+     "exec_seconds": 110.0,
+     "wait_from_run_start_seconds": 760.0,
+     "id": 92102755440
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:22:13Z",
+     "completed_at": "2026-08-04T19:22:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 705.0,
+     "id": 92105727547
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:22:13Z",
+     "completed_at": "2026-08-04T19:22:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 705.0,
+     "id": 92105727572
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:22:13Z",
+     "completed_at": "2026-08-04T19:22:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 705.0,
+     "id": 92105727610
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:22:14Z",
+     "completed_at": "2026-08-04T19:22:13Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 706.0,
+     "id": 92105728627
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:25:50Z",
+     "completed_at": "2026-08-04T19:25:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 922.0,
+     "id": 92106660480
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:25:50Z",
+     "completed_at": "2026-08-04T19:25:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 922.0,
+     "id": 92106660522
+    },
+    {
+     "name": "test",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:25:50Z",
+     "completed_at": "2026-08-04T19:25:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 922.0,
+     "id": 92106660895
+    }
+   ]
+  },
+  {
+   "id": 30942049866,
+   "name": "Build",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:26:08Z",
+   "wall_seconds": 940.0,
+   "jobs": [
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:09Z",
+     "completed_at": "2026-08-04T19:16:58Z",
+     "exec_seconds": 49.0,
+     "wait_from_run_start_seconds": 341.0,
+     "id": 92102680058
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:38Z",
+     "completed_at": "2026-08-04T19:18:47Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 490.0,
+     "id": 92102680077
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:18Z",
+     "completed_at": "2026-08-04T19:11:25Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 50.0,
+     "id": 92102680106
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:48Z",
+     "completed_at": "2026-08-04T19:20:45Z",
+     "exec_seconds": 177.0,
+     "wait_from_run_start_seconds": 440.0,
+     "id": 92102680111
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:42Z",
+     "completed_at": "2026-08-04T19:20:35Z",
+     "exec_seconds": 53.0,
+     "wait_from_run_start_seconds": 554.0,
+     "id": 92102680119
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:13:18Z",
+     "completed_at": "2026-08-04T19:16:06Z",
+     "exec_seconds": 168.0,
+     "wait_from_run_start_seconds": 170.0,
+     "id": 92102680144
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:14Z",
+     "completed_at": "2026-08-04T19:17:23Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 346.0,
+     "id": 92102680150
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:25Z",
+     "completed_at": "2026-08-04T19:11:25Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 57.0,
+     "id": 92102919916
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:26Z",
+     "completed_at": "2026-08-04T19:11:25Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 58.0,
+     "id": 92102920383
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:26Z",
+     "completed_at": "2026-08-04T19:11:25Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 58.0,
+     "id": 92102920512
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:26Z",
+     "completed_at": "2026-08-04T19:11:25Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 58.0,
+     "id": 92102921498
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:19:58Z",
+     "completed_at": "2026-08-04T19:26:07Z",
+     "exec_seconds": 369.0,
+     "wait_from_run_start_seconds": 570.0,
+     "id": 92104832787
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:20:48Z",
+     "completed_at": "2026-08-04T19:26:07Z",
+     "exec_seconds": 319.0,
+     "wait_from_run_start_seconds": 620.0,
+     "id": 92104832806
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:21:01Z",
+     "completed_at": "2026-08-04T19:26:05Z",
+     "exec_seconds": 304.0,
+     "wait_from_run_start_seconds": 633.0,
+     "id": 92104832912
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:18:47Z",
+     "completed_at": "2026-08-04T19:18:47Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 499.0,
+     "id": 92104834432
+    }
+   ]
+  },
+  {
+   "id": 30942049840,
+   "name": "Build",
+   "head_branch": "issue-3372-registry-sandbox-paths",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:26:10Z",
+   "wall_seconds": 942.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:48Z",
+     "completed_at": "2026-08-04T19:18:38Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 440.0,
+     "id": 92102679562
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:25Z",
+     "completed_at": "2026-08-04T19:18:00Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 417.0,
+     "id": 92102679626
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:00Z",
+     "completed_at": "2026-08-04T19:17:09Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 392.0,
+     "id": 92102679637
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:22Z",
+     "completed_at": "2026-08-04T19:19:47Z",
+     "exec_seconds": 145.0,
+     "wait_from_run_start_seconds": 414.0,
+     "id": 92102679668
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:23Z",
+     "completed_at": "2026-08-04T19:18:29Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 475.0,
+     "id": 92102679672
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:24Z",
+     "completed_at": "2026-08-04T19:20:18Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 476.0,
+     "id": 92102679678
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:47Z",
+     "completed_at": "2026-08-04T19:18:36Z",
+     "exec_seconds": 49.0,
+     "wait_from_run_start_seconds": 439.0,
+     "id": 92102679704
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:17:09Z",
+     "completed_at": "2026-08-04T19:17:09Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 401.0,
+     "id": 92104405922
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:17:09Z",
+     "completed_at": "2026-08-04T19:17:09Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 401.0,
+     "id": 92104405948
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:17:09Z",
+     "completed_at": "2026-08-04T19:17:09Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 401.0,
+     "id": 92104406973
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:17:10Z",
+     "completed_at": "2026-08-04T19:17:09Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 402.0,
+     "id": 92104407969
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:18:45Z",
+     "completed_at": "2026-08-04T19:26:07Z",
+     "exec_seconds": 442.0,
+     "wait_from_run_start_seconds": 497.0,
+     "id": 92104758361
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:19:55Z",
+     "completed_at": "2026-08-04T19:26:09Z",
+     "exec_seconds": 374.0,
+     "wait_from_run_start_seconds": 567.0,
+     "id": 92104758401
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:18:30Z",
+     "completed_at": "2026-08-04T19:18:29Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 482.0,
+     "id": 92104758983
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:18:30Z",
+     "completed_at": "2026-08-04T19:18:29Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 482.0,
+     "id": 92104759207
+    }
+   ]
+  },
+  {
+   "id": 30942049619,
+   "name": "Build",
+   "head_branch": "issue-2690-openrouter-app-attribution",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:28Z",
+   "updated_at": "2026-08-04T19:26:10Z",
+   "wall_seconds": 942.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:19:12Z",
+     "completed_at": "2026-08-04T19:19:52Z",
+     "exec_seconds": 40.0,
+     "wait_from_run_start_seconds": 524.0,
+     "id": 92102678995
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:13:44Z",
+     "completed_at": "2026-08-04T19:14:36Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 196.0,
+     "id": 92102679056
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:14:32Z",
+     "completed_at": "2026-08-04T19:14:42Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 244.0,
+     "id": 92102679088
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:38Z",
+     "completed_at": "2026-08-04T19:18:33Z",
+     "exec_seconds": 175.0,
+     "wait_from_run_start_seconds": 310.0,
+     "id": 92102679136
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:28Z",
+     "completed_at": "2026-08-04T19:18:21Z",
+     "exec_seconds": 113.0,
+     "wait_from_run_start_seconds": 360.0,
+     "id": 92102679146
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:18Z",
+     "completed_at": "2026-08-04T19:17:23Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 350.0,
+     "id": 92102679148
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:17Z",
+     "completed_at": "2026-08-04T19:18:26Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 469.0,
+     "id": 92102679209
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:14:42Z",
+     "completed_at": "2026-08-04T19:14:42Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 254.0,
+     "id": 92103764842
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:14:42Z",
+     "completed_at": "2026-08-04T19:14:42Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 254.0,
+     "id": 92103765254
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:14:42Z",
+     "completed_at": "2026-08-04T19:14:42Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 254.0,
+     "id": 92103765677
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:14:42Z",
+     "completed_at": "2026-08-04T19:14:42Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 254.0,
+     "id": 92103766370
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:20:02Z",
+     "completed_at": "2026-08-04T19:26:08Z",
+     "exec_seconds": 366.0,
+     "wait_from_run_start_seconds": 574.0,
+     "id": 92104747927
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:20:53Z",
+     "completed_at": "2026-08-04T19:26:09Z",
+     "exec_seconds": 316.0,
+     "wait_from_run_start_seconds": 625.0,
+     "id": 92104747973
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:20:44Z",
+     "completed_at": "2026-08-04T19:26:09Z",
+     "exec_seconds": 325.0,
+     "wait_from_run_start_seconds": 616.0,
+     "id": 92104748013
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:18:27Z",
+     "completed_at": "2026-08-04T19:18:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 479.0,
+     "id": 92104748782
+    }
+   ]
+  },
+  {
+   "id": 30942049006,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:27Z",
+   "updated_at": "2026-08-04T19:16:26Z",
+   "wall_seconds": 359.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:29Z",
+     "completed_at": "2026-08-04T19:12:03Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 62.0,
+     "id": 92102676010
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:10:50Z",
+     "completed_at": "2026-08-04T19:11:51Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 23.0,
+     "id": 92102676083
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:13:16Z",
+     "completed_at": "2026-08-04T19:13:28Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 169.0,
+     "id": 92102676191
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:14:43Z",
+     "completed_at": "2026-08-04T19:16:26Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 256.0,
+     "id": 92102676212
+    }
+   ]
+  },
+  {
+   "id": 30942049031,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:27Z",
+   "updated_at": "2026-08-04T19:17:03Z",
+   "wall_seconds": 396.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:12Z",
+     "completed_at": "2026-08-04T19:15:43Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 285.0,
+     "id": 92102676173
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:14:37Z",
+     "completed_at": "2026-08-04T19:14:47Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 250.0,
+     "id": 92102676186
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:32Z",
+     "completed_at": "2026-08-04T19:16:28Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 305.0,
+     "id": 92102676239
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:41Z",
+     "completed_at": "2026-08-04T19:17:02Z",
+     "exec_seconds": 81.0,
+     "wait_from_run_start_seconds": 314.0,
+     "id": 92102676262
+    }
+   ]
+  },
+  {
+   "id": 30942049121,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:27Z",
+   "updated_at": "2026-08-04T19:19:54Z",
+   "wall_seconds": 567.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:12Z",
+     "completed_at": "2026-08-04T19:15:48Z",
+     "exec_seconds": 36.0,
+     "wait_from_run_start_seconds": 285.0,
+     "id": 92102676924
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:14Z",
+     "completed_at": "2026-08-04T19:19:53Z",
+     "exec_seconds": 99.0,
+     "wait_from_run_start_seconds": 467.0,
+     "id": 92102676997
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:05Z",
+     "completed_at": "2026-08-04T19:12:15Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 98.0,
+     "id": 92102677007
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:10:45Z",
+     "completed_at": "2026-08-04T19:11:41Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92102677032
+    }
+   ]
+  },
+  {
+   "id": 30942049055,
+   "name": "Build",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:27Z",
+   "updated_at": "2026-08-04T19:25:15Z",
+   "wall_seconds": 888.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:44Z",
+     "completed_at": "2026-08-04T19:13:42Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 137.0,
+     "id": 92102676994
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:07Z",
+     "completed_at": "2026-08-04T19:12:55Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 100.0,
+     "id": 92102677035
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:12:57Z",
+     "completed_at": "2026-08-04T19:13:04Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 150.0,
+     "id": 92102677098
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:06Z",
+     "completed_at": "2026-08-04T19:19:02Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 399.0,
+     "id": 92102677112
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:13:08Z",
+     "completed_at": "2026-08-04T19:13:17Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 161.0,
+     "id": 92102677120
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:40Z",
+     "completed_at": "2026-08-04T19:16:11Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 313.0,
+     "id": 92102677141
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:03Z",
+     "completed_at": "2026-08-04T19:19:57Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 456.0,
+     "id": 92102677255
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:29Z",
+     "completed_at": "2026-08-04T19:25:14Z",
+     "exec_seconds": 405.0,
+     "wait_from_run_start_seconds": 482.0,
+     "id": 92103347491
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:13:05Z",
+     "completed_at": "2026-08-04T19:13:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 158.0,
+     "id": 92103348234
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:13:05Z",
+     "completed_at": "2026-08-04T19:13:05Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 158.0,
+     "id": 92103348795
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:13:17Z",
+     "completed_at": "2026-08-04T19:13:17Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 170.0,
+     "id": 92103397992
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:13:17Z",
+     "completed_at": "2026-08-04T19:13:17Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 170.0,
+     "id": 92103398277
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:13:17Z",
+     "completed_at": "2026-08-04T19:13:17Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 170.0,
+     "id": 92103398483
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:13:17Z",
+     "completed_at": "2026-08-04T19:13:17Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 170.0,
+     "id": 92103399101
+    }
+   ]
+  },
+  {
+   "id": 30942048867,
+   "name": "Build",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:27Z",
+   "updated_at": "2026-08-04T19:26:08Z",
+   "wall_seconds": 941.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:10:30Z",
+     "completed_at": "2026-08-04T19:10:42Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92102675869
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:25Z",
+     "completed_at": "2026-08-04T19:19:18Z",
+     "exec_seconds": 113.0,
+     "wait_from_run_start_seconds": 418.0,
+     "id": 92102675901
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:14:50Z",
+     "completed_at": "2026-08-04T19:15:44Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 263.0,
+     "id": 92102675907
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:04Z",
+     "completed_at": "2026-08-04T19:16:12Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 337.0,
+     "id": 92102675927
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:10:32Z",
+     "completed_at": "2026-08-04T19:11:04Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 5.0,
+     "id": 92102675929
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:14:11Z",
+     "completed_at": "2026-08-04T19:15:38Z",
+     "exec_seconds": 87.0,
+     "wait_from_run_start_seconds": 224.0,
+     "id": 92102675935
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:15:50Z",
+     "completed_at": "2026-08-04T19:18:13Z",
+     "exec_seconds": 143.0,
+     "wait_from_run_start_seconds": 323.0,
+     "id": 92102676005
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:10:42Z",
+     "completed_at": "2026-08-04T19:10:42Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92102739282
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:10:42Z",
+     "completed_at": "2026-08-04T19:10:42Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 15.0,
+     "id": 92102739479
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:10:43Z",
+     "completed_at": "2026-08-04T19:10:42Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92102739652
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:10:43Z",
+     "completed_at": "2026-08-04T19:10:42Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 16.0,
+     "id": 92102740851
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:22:42Z",
+     "completed_at": "2026-08-04T19:26:07Z",
+     "exec_seconds": 205.0,
+     "wait_from_run_start_seconds": 735.0,
+     "id": 92104155081
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:20:54Z",
+     "completed_at": "2026-08-04T19:26:06Z",
+     "exec_seconds": 312.0,
+     "wait_from_run_start_seconds": 627.0,
+     "id": 92104155096
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:16:13Z",
+     "completed_at": "2026-08-04T19:16:12Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 346.0,
+     "id": 92104155868
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:16:13Z",
+     "completed_at": "2026-08-04T19:16:12Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 346.0,
+     "id": 92104156122
+    }
+   ]
+  },
+  {
+   "id": 30942048985,
+   "name": "Build",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:10:27Z",
+   "updated_at": "2026-08-04T19:26:07Z",
+   "wall_seconds": 940.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:14:38Z",
+     "completed_at": "2026-08-04T19:15:34Z",
+     "exec_seconds": 56.0,
+     "wait_from_run_start_seconds": 251.0,
+     "id": 92102676438
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:11:43Z",
+     "completed_at": "2026-08-04T19:11:52Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 76.0,
+     "id": 92102676440
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:44Z",
+     "completed_at": "2026-08-04T19:17:31Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 377.0,
+     "id": 92102676466
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:16:13Z",
+     "completed_at": "2026-08-04T19:17:37Z",
+     "exec_seconds": 84.0,
+     "wait_from_run_start_seconds": 346.0,
+     "id": 92102676484
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:17:26Z",
+     "completed_at": "2026-08-04T19:19:10Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 419.0,
+     "id": 92102676507
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:46Z",
+     "completed_at": "2026-08-04T19:18:52Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 499.0,
+     "id": 92102676548
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:18:55Z",
+     "completed_at": "2026-08-04T19:20:58Z",
+     "exec_seconds": 123.0,
+     "wait_from_run_start_seconds": 508.0,
+     "id": 92102676575
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:53Z",
+     "completed_at": "2026-08-04T19:11:52Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92103038307
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:53Z",
+     "completed_at": "2026-08-04T19:11:52Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92103038778
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:53Z",
+     "completed_at": "2026-08-04T19:11:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92103039676
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:11:53Z",
+     "completed_at": "2026-08-04T19:11:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92103039720
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:22:06Z",
+     "completed_at": "2026-08-04T19:26:06Z",
+     "exec_seconds": 240.0,
+     "wait_from_run_start_seconds": 699.0,
+     "id": 92104856479
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:23:41Z",
+     "completed_at": "2026-08-04T19:26:05Z",
+     "exec_seconds": 144.0,
+     "wait_from_run_start_seconds": 794.0,
+     "id": 92104856488
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:25:05Z",
+     "completed_at": "2026-08-04T19:26:05Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 878.0,
+     "id": 92104856523
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:18:53Z",
+     "completed_at": "2026-08-04T19:18:53Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 506.0,
+     "id": 92104857494
+    }
+   ]
+  },
+  {
+   "id": 30941826782,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:07:35Z",
+   "updated_at": "2026-08-04T19:10:27Z",
+   "wall_seconds": 172.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:18Z",
+     "completed_at": "2026-08-04T19:10:26Z",
+     "exec_seconds": 128.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92101897205
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:45Z",
+     "completed_at": "2026-08-04T19:07:56Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92101897241
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:08Z",
+     "completed_at": "2026-08-04T19:08:34Z",
+     "exec_seconds": 26.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92101897297
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:30Z",
+     "completed_at": "2026-08-04T19:09:35Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 55.0,
+     "id": 92101897338
+    }
+   ]
+  },
+  {
+   "id": 30941826137,
+   "name": "Changelog Lint",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:07:34Z",
+   "updated_at": "2026-08-04T19:08:07Z",
+   "wall_seconds": 33.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:58Z",
+     "completed_at": "2026-08-04T19:08:07Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 24.0,
+     "id": 92101894678
+    }
+   ]
+  },
+  {
+   "id": 30941824883,
+   "name": "Build",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:07:34Z",
+   "updated_at": "2026-08-04T19:18:53Z",
+   "wall_seconds": 679.0,
+   "jobs": [
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:24Z",
+     "completed_at": "2026-08-04T19:11:21Z",
+     "exec_seconds": 117.0,
+     "wait_from_run_start_seconds": 110.0,
+     "id": 92101962405
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:29Z",
+     "completed_at": "2026-08-04T19:09:21Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 55.0,
+     "id": 92101962470
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:31Z",
+     "completed_at": "2026-08-04T19:11:47Z",
+     "exec_seconds": 136.0,
+     "wait_from_run_start_seconds": 117.0,
+     "id": 92101962484
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:53Z",
+     "completed_at": "2026-08-04T19:09:27Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 79.0,
+     "id": 92101962500
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:12Z",
+     "completed_at": "2026-08-04T19:09:23Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 98.0,
+     "id": 92101962528
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:30Z",
+     "completed_at": "2026-08-04T19:10:22Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 116.0,
+     "id": 92101962637
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:43Z",
+     "completed_at": "2026-08-04T19:09:51Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 129.0,
+     "id": 92101962747
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:09:23Z",
+     "completed_at": "2026-08-04T19:09:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 109.0,
+     "id": 92102390574
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:09:23Z",
+     "completed_at": "2026-08-04T19:09:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 109.0,
+     "id": 92102390670
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:09:23Z",
+     "completed_at": "2026-08-04T19:09:23Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 109.0,
+     "id": 92102390970
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:09:24Z",
+     "completed_at": "2026-08-04T19:09:23Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 110.0,
+     "id": 92102391323
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:10:00Z",
+     "completed_at": "2026-08-04T19:18:52Z",
+     "exec_seconds": 532.0,
+     "wait_from_run_start_seconds": 146.0,
+     "id": 92102514411
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:56Z",
+     "completed_at": "2026-08-04T19:18:52Z",
+     "exec_seconds": 536.0,
+     "wait_from_run_start_seconds": 142.0,
+     "id": 92102514521
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:09:51Z",
+     "completed_at": "2026-08-04T19:09:51Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 137.0,
+     "id": 92102515287
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:09:52Z",
+     "completed_at": "2026-08-04T19:09:51Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 138.0,
+     "id": 92102515460
+    }
+   ]
+  },
+  {
+   "id": 30941711787,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:06:04Z",
+   "updated_at": "2026-08-04T19:09:05Z",
+   "wall_seconds": 181.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:49Z",
+     "completed_at": "2026-08-04T19:09:04Z",
+     "exec_seconds": 75.0,
+     "wait_from_run_start_seconds": 105.0,
+     "id": 92101467647
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:44Z",
+     "completed_at": "2026-08-04T19:08:49Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 100.0,
+     "id": 92101467679
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:39Z",
+     "completed_at": "2026-08-04T19:08:08Z",
+     "exec_seconds": 29.0,
+     "wait_from_run_start_seconds": 95.0,
+     "id": 92101467711
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:52Z",
+     "completed_at": "2026-08-04T19:08:06Z",
+     "exec_seconds": 14.0,
+     "wait_from_run_start_seconds": 108.0,
+     "id": 92101467918
+    }
+   ]
+  },
+  {
+   "id": 30941712107,
+   "name": "Build",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:06:04Z",
+   "updated_at": "2026-08-04T19:18:26Z",
+   "wall_seconds": 742.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:08Z",
+     "completed_at": "2026-08-04T19:08:16Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 124.0,
+     "id": 92101569597
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:49Z",
+     "completed_at": "2026-08-04T19:08:20Z",
+     "exec_seconds": 91.0,
+     "wait_from_run_start_seconds": 45.0,
+     "id": 92101569604
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:22Z",
+     "completed_at": "2026-08-04T19:08:28Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 138.0,
+     "id": 92101569609
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:16Z",
+     "completed_at": "2026-08-04T19:10:42Z",
+     "exec_seconds": 146.0,
+     "wait_from_run_start_seconds": 132.0,
+     "id": 92101569614
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:55Z",
+     "completed_at": "2026-08-04T19:08:31Z",
+     "exec_seconds": 36.0,
+     "wait_from_run_start_seconds": 111.0,
+     "id": 92101569637
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:38Z",
+     "completed_at": "2026-08-04T19:09:28Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 154.0,
+     "id": 92101569652
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:33Z",
+     "completed_at": "2026-08-04T19:11:06Z",
+     "exec_seconds": 153.0,
+     "wait_from_run_start_seconds": 149.0,
+     "id": 92101569743
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:08:16Z",
+     "completed_at": "2026-08-04T19:08:16Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 132.0,
+     "id": 92102079392
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:08:17Z",
+     "completed_at": "2026-08-04T19:08:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 133.0,
+     "id": 92102079761
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:08:17Z",
+     "completed_at": "2026-08-04T19:08:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 133.0,
+     "id": 92102080598
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:08:17Z",
+     "completed_at": "2026-08-04T19:08:16Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 133.0,
+     "id": 92102080779
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:00Z",
+     "completed_at": "2026-08-04T19:18:26Z",
+     "exec_seconds": 566.0,
+     "wait_from_run_start_seconds": 176.0,
+     "id": 92102133423
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:09:25Z",
+     "completed_at": "2026-08-04T19:17:47Z",
+     "exec_seconds": 502.0,
+     "wait_from_run_start_seconds": 201.0,
+     "id": 92102133446
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:08:29Z",
+     "completed_at": "2026-08-04T19:08:29Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 145.0,
+     "id": 92102133975
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:08:29Z",
+     "completed_at": "2026-08-04T19:08:29Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 145.0,
+     "id": 92102134283
+    }
+   ]
+  },
+  {
+   "id": 30941707633,
+   "name": "Changelog Lint",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:06:01Z",
+   "updated_at": "2026-08-04T19:06:43Z",
+   "wall_seconds": 42.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:35Z",
+     "completed_at": "2026-08-04T19:06:42Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92101451537
+    }
+   ]
+  },
+  {
+   "id": 30941479099,
+   "name": "Changelog Lint",
+   "head_branch": "fix/mistral-reasoning-effort",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:03:06Z",
+   "updated_at": "2026-08-04T19:06:14Z",
+   "wall_seconds": 188.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:08Z",
+     "completed_at": "2026-08-04T19:06:13Z",
+     "exec_seconds": 5.0,
+     "wait_from_run_start_seconds": 182.0,
+     "id": 92100650290
+    }
+   ]
+  },
+  {
+   "id": 30941479027,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/mistral-reasoning-effort",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:03:06Z",
+   "updated_at": "2026-08-04T19:08:27Z",
+   "wall_seconds": 321.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:27Z",
+     "completed_at": "2026-08-04T19:07:27Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 201.0,
+     "id": 92100650497
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:05Z",
+     "completed_at": "2026-08-04T19:06:31Z",
+     "exec_seconds": 26.0,
+     "wait_from_run_start_seconds": 179.0,
+     "id": 92100650523
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:14Z",
+     "completed_at": "2026-08-04T19:08:27Z",
+     "exec_seconds": 133.0,
+     "wait_from_run_start_seconds": 188.0,
+     "id": 92100650542
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:40Z",
+     "completed_at": "2026-08-04T19:06:47Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 214.0,
+     "id": 92100650567
+    }
+   ]
+  },
+  {
+   "id": 30941479121,
+   "name": "Build",
+   "head_branch": "fix/mistral-reasoning-effort",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:03:06Z",
+   "updated_at": "2026-08-04T19:16:43Z",
+   "wall_seconds": 817.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:05:11Z",
+     "completed_at": "2026-08-04T19:06:37Z",
+     "exec_seconds": 86.0,
+     "wait_from_run_start_seconds": 125.0,
+     "id": 92100652092
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:05:04Z",
+     "completed_at": "2026-08-04T19:05:51Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 118.0,
+     "id": 92100652097
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:35Z",
+     "completed_at": "2026-08-04T19:08:33Z",
+     "exec_seconds": 118.0,
+     "wait_from_run_start_seconds": 209.0,
+     "id": 92100652123
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:39Z",
+     "completed_at": "2026-08-04T19:07:12Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 213.0,
+     "id": 92100652135
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:44Z",
+     "completed_at": "2026-08-04T19:08:33Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 218.0,
+     "id": 92100652146
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:39Z",
+     "completed_at": "2026-08-04T19:06:49Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 213.0,
+     "id": 92100652156
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:33Z",
+     "completed_at": "2026-08-04T19:07:41Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 267.0,
+     "id": 92100652157
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:50Z",
+     "completed_at": "2026-08-04T19:06:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 224.0,
+     "id": 92101678631
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:50Z",
+     "completed_at": "2026-08-04T19:06:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 224.0,
+     "id": 92101678979
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:50Z",
+     "completed_at": "2026-08-04T19:06:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 224.0,
+     "id": 92101679602
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:50Z",
+     "completed_at": "2026-08-04T19:06:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 224.0,
+     "id": 92101680169
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:35Z",
+     "completed_at": "2026-08-04T19:16:32Z",
+     "exec_seconds": 477.0,
+     "wait_from_run_start_seconds": 329.0,
+     "id": 92101922773
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:42Z",
+     "completed_at": "2026-08-04T19:16:42Z",
+     "exec_seconds": 480.0,
+     "wait_from_run_start_seconds": 336.0,
+     "id": 92101922788
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:08:37Z",
+     "completed_at": "2026-08-04T19:15:30Z",
+     "exec_seconds": 413.0,
+     "wait_from_run_start_seconds": 331.0,
+     "id": 92101922917
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:07:42Z",
+     "completed_at": "2026-08-04T19:07:41Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 276.0,
+     "id": 92101923533
+    }
+   ]
+  },
+  {
+   "id": 30941337046,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/4743-bundle-hf-subdir-check",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:01:16Z",
+   "updated_at": "2026-08-04T19:07:20Z",
+   "wall_seconds": 364.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:01:55Z",
+     "completed_at": "2026-08-04T19:02:19Z",
+     "exec_seconds": 24.0,
+     "wait_from_run_start_seconds": 39.0,
+     "id": 92100160981
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:01Z",
+     "completed_at": "2026-08-04T19:07:19Z",
+     "exec_seconds": 78.0,
+     "wait_from_run_start_seconds": 285.0,
+     "id": 92100160990
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:10Z",
+     "completed_at": "2026-08-04T19:07:14Z",
+     "exec_seconds": 64.0,
+     "wait_from_run_start_seconds": 294.0,
+     "id": 92100160991
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:01Z",
+     "completed_at": "2026-08-04T19:06:12Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 285.0,
+     "id": 92100161260
+    }
+   ]
+  },
+  {
+   "id": 30941337028,
+   "name": "Build",
+   "head_branch": "fix/4743-bundle-hf-subdir-check",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:01:16Z",
+   "updated_at": "2026-08-04T19:18:15Z",
+   "wall_seconds": 1019.0,
+   "jobs": [
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:02:01Z",
+     "completed_at": "2026-08-04T19:03:30Z",
+     "exec_seconds": 89.0,
+     "wait_from_run_start_seconds": 45.0,
+     "id": 92100160476
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:02:55Z",
+     "completed_at": "2026-08-04T19:03:03Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 99.0,
+     "id": 92100160535
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:03:06Z",
+     "completed_at": "2026-08-04T19:04:52Z",
+     "exec_seconds": 106.0,
+     "wait_from_run_start_seconds": 110.0,
+     "id": 92100160557
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:03:05Z",
+     "completed_at": "2026-08-04T19:04:42Z",
+     "exec_seconds": 97.0,
+     "wait_from_run_start_seconds": 109.0,
+     "id": 92100160566
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:04:44Z",
+     "completed_at": "2026-08-04T19:07:36Z",
+     "exec_seconds": 172.0,
+     "wait_from_run_start_seconds": 208.0,
+     "id": 92100160577
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:05:47Z",
+     "completed_at": "2026-08-04T19:05:56Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 271.0,
+     "id": 92100160595
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:05:03Z",
+     "completed_at": "2026-08-04T19:05:34Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 227.0,
+     "id": 92100160597
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:03:03Z",
+     "completed_at": "2026-08-04T19:03:03Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 107.0,
+     "id": 92100636836
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:03:03Z",
+     "completed_at": "2026-08-04T19:03:03Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 107.0,
+     "id": 92100636940
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:03:03Z",
+     "completed_at": "2026-08-04T19:03:03Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 107.0,
+     "id": 92100637482
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:03:03Z",
+     "completed_at": "2026-08-04T19:03:03Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 107.0,
+     "id": 92100638173
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:16Z",
+     "completed_at": "2026-08-04T19:16:02Z",
+     "exec_seconds": 526.0,
+     "wait_from_run_start_seconds": 360.0,
+     "id": 92101425340
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:22Z",
+     "completed_at": "2026-08-04T19:18:14Z",
+     "exec_seconds": 652.0,
+     "wait_from_run_start_seconds": 366.0,
+     "id": 92101425350
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:05:56Z",
+     "completed_at": "2026-08-04T19:05:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 280.0,
+     "id": 92101426586
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:05:56Z",
+     "completed_at": "2026-08-04T19:05:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 280.0,
+     "id": 92101426824
+    }
+   ]
+  },
+  {
+   "id": 30941309587,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/4742-numeric-match-punctuation",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:00:56Z",
+   "updated_at": "2026-08-04T19:04:29Z",
+   "wall_seconds": 213.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:03:22Z",
+     "completed_at": "2026-08-04T19:04:25Z",
+     "exec_seconds": 63.0,
+     "wait_from_run_start_seconds": 146.0,
+     "id": 92100070137
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:01:50Z",
+     "completed_at": "2026-08-04T19:03:46Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 54.0,
+     "id": 92100070191
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:04:20Z",
+     "completed_at": "2026-08-04T19:04:28Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 204.0,
+     "id": 92100070254
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:02:45Z",
+     "completed_at": "2026-08-04T19:03:13Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 109.0,
+     "id": 92100070305
+    }
+   ]
+  },
+  {
+   "id": 30941309287,
+   "name": "Build",
+   "head_branch": "fix/4742-numeric-match-punctuation",
+   "conclusion": "failure",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:00:56Z",
+   "updated_at": "2026-08-04T19:17:18Z",
+   "wall_seconds": 982.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:03:55Z",
+     "completed_at": "2026-08-04T19:05:09Z",
+     "exec_seconds": 74.0,
+     "wait_from_run_start_seconds": 179.0,
+     "id": 92100073129
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "failure",
+     "started_at": "2026-08-04T19:04:10Z",
+     "completed_at": "2026-08-04T19:05:59Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 194.0,
+     "id": 92100073179
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:31Z",
+     "completed_at": "2026-08-04T19:07:20Z",
+     "exec_seconds": 49.0,
+     "wait_from_run_start_seconds": 335.0,
+     "id": 92100073196
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:58Z",
+     "completed_at": "2026-08-04T19:06:00Z",
+     "exec_seconds": 302.0,
+     "wait_from_run_start_seconds": 2.0,
+     "id": 92100073216
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:33Z",
+     "completed_at": "2026-08-04T19:06:44Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 337.0,
+     "id": 92100073221
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:05:36Z",
+     "completed_at": "2026-08-04T19:05:45Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 280.0,
+     "id": 92100073228
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:16Z",
+     "completed_at": "2026-08-04T19:07:45Z",
+     "exec_seconds": 89.0,
+     "wait_from_run_start_seconds": 320.0,
+     "id": 92100073234
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:06:54Z",
+     "completed_at": "2026-08-04T19:14:30Z",
+     "exec_seconds": 456.0,
+     "wait_from_run_start_seconds": 358.0,
+     "id": 92101374171
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:07:14Z",
+     "completed_at": "2026-08-04T19:17:18Z",
+     "exec_seconds": 604.0,
+     "wait_from_run_start_seconds": 378.0,
+     "id": 92101374308
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:05:46Z",
+     "completed_at": "2026-08-04T19:05:46Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 290.0,
+     "id": 92101375459
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:05:46Z",
+     "completed_at": "2026-08-04T19:05:46Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 290.0,
+     "id": 92101375823
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:45Z",
+     "completed_at": "2026-08-04T19:06:45Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 349.0,
+     "id": 92101656918
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:45Z",
+     "completed_at": "2026-08-04T19:06:45Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 349.0,
+     "id": 92101657092
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:45Z",
+     "completed_at": "2026-08-04T19:06:45Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 349.0,
+     "id": 92101657462
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:06:45Z",
+     "completed_at": "2026-08-04T19:06:45Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 349.0,
+     "id": 92101657795
+    }
+   ]
+  },
+  {
+   "id": 30941282327,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/4742-numeric-match-punctuation",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:00:37Z",
+   "updated_at": "2026-08-04T19:00:57Z",
+   "wall_seconds": 20.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099977743
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099977825
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099977851
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099977874
+    }
+   ]
+  },
+  {
+   "id": 30941282343,
+   "name": "Build",
+   "head_branch": "fix/4742-numeric-match-punctuation",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T19:00:37Z",
+   "updated_at": "2026-08-04T19:00:58Z",
+   "wall_seconds": 21.0,
+   "jobs": [
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099978882
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099978896
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099978910
+    },
+    {
+     "name": "ruff",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099978916
+    },
+    {
+     "name": "changes",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099978927
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099978975
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:00:56Z",
+     "exec_seconds": 18.0,
+     "wait_from_run_start_seconds": 1.0,
+     "id": 92099978983
+    },
+    {
+     "name": "test",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:57Z",
+     "completed_at": "2026-08-04T19:00:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92100069891
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:57Z",
+     "completed_at": "2026-08-04T19:00:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92100070064
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:57Z",
+     "completed_at": "2026-08-04T19:00:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92100070212
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:57Z",
+     "completed_at": "2026-08-04T19:00:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92100070426
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:57Z",
+     "completed_at": "2026-08-04T19:00:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92100070687
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:57Z",
+     "completed_at": "2026-08-04T19:00:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92100071117
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:57Z",
+     "completed_at": "2026-08-04T19:00:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 20.0,
+     "id": 92100071815
+    }
+   ]
+  },
+  {
+   "id": 30941144460,
+   "name": "Build",
+   "head_branch": "fix/model-event",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:58:54Z",
+   "updated_at": "2026-08-04T19:07:50Z",
+   "wall_seconds": 536.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:02:50Z",
+     "completed_at": "2026-08-04T19:02:56Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 236.0,
+     "id": 92099519836
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:03:10Z",
+     "completed_at": "2026-08-04T19:06:06Z",
+     "exec_seconds": 176.0,
+     "wait_from_run_start_seconds": 256.0,
+     "id": 92099519893
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:03:14Z",
+     "completed_at": "2026-08-04T19:04:03Z",
+     "exec_seconds": 49.0,
+     "wait_from_run_start_seconds": 260.0,
+     "id": 92099519915
+    },
+    {
+     "name": "ruff",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:03:59Z",
+     "completed_at": "2026-08-04T19:07:41Z",
+     "exec_seconds": 222.0,
+     "wait_from_run_start_seconds": 305.0,
+     "id": 92099519936
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:03:03Z",
+     "completed_at": "2026-08-04T19:04:42Z",
+     "exec_seconds": 99.0,
+     "wait_from_run_start_seconds": 249.0,
+     "id": 92099519959
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:04:34Z",
+     "completed_at": "2026-08-04T19:05:53Z",
+     "exec_seconds": 79.0,
+     "wait_from_run_start_seconds": 340.0,
+     "id": 92099519971
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:04:28Z",
+     "completed_at": "2026-08-04T19:04:37Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 334.0,
+     "id": 92099519998
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:05:50Z",
+     "completed_at": "2026-08-04T19:07:50Z",
+     "exec_seconds": 120.0,
+     "wait_from_run_start_seconds": 416.0,
+     "id": 92100606348
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:06:57Z",
+     "completed_at": "2026-08-04T19:07:36Z",
+     "exec_seconds": 39.0,
+     "wait_from_run_start_seconds": 483.0,
+     "id": 92100606503
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:02:56Z",
+     "completed_at": "2026-08-04T19:02:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 242.0,
+     "id": 92100607111
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:02:56Z",
+     "completed_at": "2026-08-04T19:02:56Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 242.0,
+     "id": 92100607419
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:04:37Z",
+     "completed_at": "2026-08-04T19:04:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 343.0,
+     "id": 92101064874
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:04:37Z",
+     "completed_at": "2026-08-04T19:04:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 343.0,
+     "id": 92101065052
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:04:37Z",
+     "completed_at": "2026-08-04T19:04:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 343.0,
+     "id": 92101065238
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T19:04:37Z",
+     "completed_at": "2026-08-04T19:04:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 343.0,
+     "id": 92101065811
+    }
+   ]
+  },
+  {
+   "id": 30941144788,
+   "name": "Changelog Lint",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:58:54Z",
+   "updated_at": "2026-08-04T19:01:55Z",
+   "wall_seconds": 181.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:01:44Z",
+     "completed_at": "2026-08-04T19:01:55Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 170.0,
+     "id": 92099519326
+    }
+   ]
+  },
+  {
+   "id": 30941144421,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/model-event",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:58:54Z",
+   "updated_at": "2026-08-04T19:03:04Z",
+   "wall_seconds": 250.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:01:45Z",
+     "completed_at": "2026-08-04T19:01:53Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 171.0,
+     "id": 92099518953
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:59:52Z",
+     "completed_at": "2026-08-04T19:00:26Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 58.0,
+     "id": 92099518964
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:01:57Z",
+     "completed_at": "2026-08-04T19:03:03Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 183.0,
+     "id": 92099519016
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:01:40Z",
+     "completed_at": "2026-08-04T19:03:03Z",
+     "exec_seconds": 83.0,
+     "wait_from_run_start_seconds": 166.0,
+     "id": 92099519044
+    }
+   ]
+  },
+  {
+   "id": 30940574001,
+   "name": "Build",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:51:27Z",
+   "updated_at": "2026-08-04T19:06:26Z",
+   "wall_seconds": 899.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:34Z",
+     "completed_at": "2026-08-04T18:52:46Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 67.0,
+     "id": 92097669949
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:27Z",
+     "completed_at": "2026-08-04T18:56:39Z",
+     "exec_seconds": 192.0,
+     "wait_from_run_start_seconds": 120.0,
+     "id": 92097670022
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:54:25Z",
+     "completed_at": "2026-08-04T18:56:08Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 178.0,
+     "id": 92097670023
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:58:59Z",
+     "completed_at": "2026-08-04T18:59:56Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 452.0,
+     "id": 92097670037
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:43Z",
+     "completed_at": "2026-08-04T18:56:49Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 316.0,
+     "id": 92097670050
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:58:14Z",
+     "completed_at": "2026-08-04T18:59:44Z",
+     "exec_seconds": 90.0,
+     "wait_from_run_start_seconds": 407.0,
+     "id": 92097670056
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:59:58Z",
+     "completed_at": "2026-08-04T19:01:37Z",
+     "exec_seconds": 99.0,
+     "wait_from_run_start_seconds": 511.0,
+     "id": 92097670117
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:46Z",
+     "completed_at": "2026-08-04T18:52:46Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 79.0,
+     "id": 92097929917
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:46Z",
+     "completed_at": "2026-08-04T18:52:46Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 79.0,
+     "id": 92097931371
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:46Z",
+     "completed_at": "2026-08-04T18:52:46Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 79.0,
+     "id": 92097931667
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:47Z",
+     "completed_at": "2026-08-04T18:52:46Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 80.0,
+     "id": 92097931717
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:33Z",
+     "completed_at": "2026-08-04T19:06:24Z",
+     "exec_seconds": 351.0,
+     "wait_from_run_start_seconds": 546.0,
+     "id": 92098975041
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:38Z",
+     "completed_at": "2026-08-04T19:06:25Z",
+     "exec_seconds": 347.0,
+     "wait_from_run_start_seconds": 551.0,
+     "id": 92098975062
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:56:50Z",
+     "completed_at": "2026-08-04T18:56:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 323.0,
+     "id": 92098975688
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:56:50Z",
+     "completed_at": "2026-08-04T18:56:49Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 323.0,
+     "id": 92098976125
+    }
+   ]
+  },
+  {
+   "id": 30940574090,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:51:27Z",
+   "updated_at": "2026-08-04T18:58:13Z",
+   "wall_seconds": 406.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:37Z",
+     "completed_at": "2026-08-04T18:53:09Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 70.0,
+     "id": 92097597593
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:41Z",
+     "completed_at": "2026-08-04T18:51:49Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 14.0,
+     "id": 92097597626
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:51Z",
+     "completed_at": "2026-08-04T18:58:12Z",
+     "exec_seconds": 81.0,
+     "wait_from_run_start_seconds": 324.0,
+     "id": 92097597643
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:06Z",
+     "completed_at": "2026-08-04T18:53:07Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 39.0,
+     "id": 92097597652
+    }
+   ]
+  },
+  {
+   "id": 30940570314,
+   "name": "Changelog Lint",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:51:24Z",
+   "updated_at": "2026-08-04T18:56:35Z",
+   "wall_seconds": 311.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:26Z",
+     "completed_at": "2026-08-04T18:56:35Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 302.0,
+     "id": 92097584672
+    }
+   ]
+  },
+  {
+   "id": 30940013394,
+   "name": "Build",
+   "head_branch": "issue-2690-openrouter-app-attribution",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:14Z",
+   "updated_at": "2026-08-04T19:03:07Z",
+   "wall_seconds": 1133.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:22Z",
+     "completed_at": "2026-08-04T18:47:42Z",
+     "exec_seconds": 80.0,
+     "wait_from_run_start_seconds": 128.0,
+     "id": 92095857283
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:46Z",
+     "completed_at": "2026-08-04T18:45:56Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 92.0,
+     "id": 92095857311
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:37Z",
+     "completed_at": "2026-08-04T18:53:21Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 443.0,
+     "id": 92095857344
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:49Z",
+     "completed_at": "2026-08-04T18:47:21Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 155.0,
+     "id": 92095857373
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:29Z",
+     "completed_at": "2026-08-04T18:51:23Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 315.0,
+     "id": 92095857412
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:58Z",
+     "completed_at": "2026-08-04T18:48:48Z",
+     "exec_seconds": 110.0,
+     "wait_from_run_start_seconds": 164.0,
+     "id": 92095857507
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:46Z",
+     "completed_at": "2026-08-04T18:51:58Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 452.0,
+     "id": 92095857581
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:02Z",
+     "completed_at": "2026-08-04T19:02:43Z",
+     "exec_seconds": 581.0,
+     "wait_from_run_start_seconds": 528.0,
+     "id": 92096165870
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:07Z",
+     "completed_at": "2026-08-04T19:01:43Z",
+     "exec_seconds": 336.0,
+     "wait_from_run_start_seconds": 713.0,
+     "id": 92096165876
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:54:11Z",
+     "completed_at": "2026-08-04T19:03:06Z",
+     "exec_seconds": 535.0,
+     "wait_from_run_start_seconds": 597.0,
+     "id": 92096165923
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:57Z",
+     "completed_at": "2026-08-04T18:45:56Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 103.0,
+     "id": 92096167665
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:59Z",
+     "completed_at": "2026-08-04T18:51:58Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 465.0,
+     "id": 92097729574
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:59Z",
+     "completed_at": "2026-08-04T18:51:58Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 465.0,
+     "id": 92097729876
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:59Z",
+     "completed_at": "2026-08-04T18:51:59Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 465.0,
+     "id": 92097730336
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:59Z",
+     "completed_at": "2026-08-04T18:51:59Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 465.0,
+     "id": 92097731008
+    }
+   ]
+  },
+  {
+   "id": 30940009515,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2690-openrouter-app-attribution",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:11Z",
+   "updated_at": "2026-08-04T18:47:57Z",
+   "wall_seconds": 226.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:20Z",
+     "completed_at": "2026-08-04T18:46:23Z",
+     "exec_seconds": 63.0,
+     "wait_from_run_start_seconds": 69.0,
+     "id": 92095715516
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:54Z",
+     "completed_at": "2026-08-04T18:45:03Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92095715656
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:10Z",
+     "completed_at": "2026-08-04T18:45:52Z",
+     "exec_seconds": 42.0,
+     "wait_from_run_start_seconds": 59.0,
+     "id": 92095715683
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:21Z",
+     "completed_at": "2026-08-04T18:47:56Z",
+     "exec_seconds": 95.0,
+     "wait_from_run_start_seconds": 130.0,
+     "id": 92095715751
+    }
+   ]
+  },
+  {
+   "id": 30940005666,
+   "name": "Build",
+   "head_branch": "issue-2215-solver-score-metrics",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:08Z",
+   "updated_at": "2026-08-04T19:09:53Z",
+   "wall_seconds": 1545.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:52Z",
+     "completed_at": "2026-08-04T18:52:01Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 464.0,
+     "id": 92095840517
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:43Z",
+     "completed_at": "2026-08-04T18:51:17Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 395.0,
+     "id": 92095840537
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:50Z",
+     "completed_at": "2026-08-04T18:48:37Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 222.0,
+     "id": 92095840544
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:12Z",
+     "completed_at": "2026-08-04T18:52:58Z",
+     "exec_seconds": 166.0,
+     "wait_from_run_start_seconds": 364.0,
+     "id": 92095840562
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:48Z",
+     "completed_at": "2026-08-04T18:56:05Z",
+     "exec_seconds": 197.0,
+     "wait_from_run_start_seconds": 520.0,
+     "id": 92095840577
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:18Z",
+     "completed_at": "2026-08-04T18:52:28Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 490.0,
+     "id": 92095840599
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:05Z",
+     "completed_at": "2026-08-04T18:56:57Z",
+     "exec_seconds": 52.0,
+     "wait_from_run_start_seconds": 717.0,
+     "id": 92095840608
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:01Z",
+     "completed_at": "2026-08-04T18:52:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 473.0,
+     "id": 92097740103
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:01Z",
+     "completed_at": "2026-08-04T18:52:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 473.0,
+     "id": 92097740224
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:01Z",
+     "completed_at": "2026-08-04T18:52:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 473.0,
+     "id": 92097740590
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:01Z",
+     "completed_at": "2026-08-04T18:52:01Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 473.0,
+     "id": 92097740964
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:58:44Z",
+     "completed_at": "2026-08-04T19:09:53Z",
+     "exec_seconds": 669.0,
+     "wait_from_run_start_seconds": 876.0,
+     "id": 92097855584
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:59:44Z",
+     "completed_at": "2026-08-04T19:06:38Z",
+     "exec_seconds": 414.0,
+     "wait_from_run_start_seconds": 936.0,
+     "id": 92097855632
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:59:41Z",
+     "completed_at": "2026-08-04T19:08:30Z",
+     "exec_seconds": 529.0,
+     "wait_from_run_start_seconds": 933.0,
+     "id": 92097855636
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:29Z",
+     "completed_at": "2026-08-04T18:52:29Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 501.0,
+     "id": 92097856477
+    }
+   ]
+  },
+  {
+   "id": 30940006177,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:08Z",
+   "updated_at": "2026-08-04T18:49:57Z",
+   "wall_seconds": 349.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:46Z",
+     "completed_at": "2026-08-04T18:49:56Z",
+     "exec_seconds": 190.0,
+     "wait_from_run_start_seconds": 158.0,
+     "id": 92095699506
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:47Z",
+     "completed_at": "2026-08-04T18:46:01Z",
+     "exec_seconds": 14.0,
+     "wait_from_run_start_seconds": 99.0,
+     "id": 92095699515
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:38Z",
+     "completed_at": "2026-08-04T18:45:06Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 30.0,
+     "id": 92095699546
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:38Z",
+     "completed_at": "2026-08-04T18:45:46Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 30.0,
+     "id": 92095699605
+    }
+   ]
+  },
+  {
+   "id": 30940006168,
+   "name": "Build",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:08Z",
+   "updated_at": "2026-08-04T19:02:48Z",
+   "wall_seconds": 1120.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:38Z",
+     "completed_at": "2026-08-04T18:51:58Z",
+     "exec_seconds": 80.0,
+     "wait_from_run_start_seconds": 390.0,
+     "id": 92095846079
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:01Z",
+     "completed_at": "2026-08-04T18:49:40Z",
+     "exec_seconds": 159.0,
+     "wait_from_run_start_seconds": 173.0,
+     "id": 92095846114
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:20Z",
+     "completed_at": "2026-08-04T18:49:50Z",
+     "exec_seconds": 150.0,
+     "wait_from_run_start_seconds": 192.0,
+     "id": 92095846119
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:51Z",
+     "completed_at": "2026-08-04T18:52:45Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 463.0,
+     "id": 92095846130
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:20Z",
+     "completed_at": "2026-08-04T18:49:30Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 312.0,
+     "id": 92095846132
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:41Z",
+     "completed_at": "2026-08-04T18:50:50Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 393.0,
+     "id": 92095846208
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:01Z",
+     "completed_at": "2026-08-04T18:52:56Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 473.0,
+     "id": 92095846249
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:49:30Z",
+     "completed_at": "2026-08-04T18:49:30Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 322.0,
+     "id": 92097088435
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:49:30Z",
+     "completed_at": "2026-08-04T18:49:30Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 322.0,
+     "id": 92097088466
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:49:30Z",
+     "completed_at": "2026-08-04T18:49:30Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 322.0,
+     "id": 92097088761
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:49:30Z",
+     "completed_at": "2026-08-04T18:49:30Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 322.0,
+     "id": 92097088782
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:59Z",
+     "completed_at": "2026-08-04T19:00:37Z",
+     "exec_seconds": 458.0,
+     "wait_from_run_start_seconds": 531.0,
+     "id": 92097437952
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:54:02Z",
+     "completed_at": "2026-08-04T19:02:47Z",
+     "exec_seconds": 525.0,
+     "wait_from_run_start_seconds": 594.0,
+     "id": 92097438179
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:50:50Z",
+     "completed_at": "2026-08-04T18:50:50Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 402.0,
+     "id": 92097439191
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:50:51Z",
+     "completed_at": "2026-08-04T18:50:50Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 403.0,
+     "id": 92097439680
+    }
+   ]
+  },
+  {
+   "id": 30940005534,
+   "name": "Build",
+   "head_branch": "issue-3372-registry-sandbox-paths",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:08Z",
+   "updated_at": "2026-08-04T19:05:29Z",
+   "wall_seconds": 1281.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:05Z",
+     "completed_at": "2026-08-04T18:46:02Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 57.0,
+     "id": 92095833741
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:58Z",
+     "completed_at": "2026-08-04T18:51:53Z",
+     "exec_seconds": 115.0,
+     "wait_from_run_start_seconds": 350.0,
+     "id": 92095833752
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:46Z",
+     "completed_at": "2026-08-04T18:47:02Z",
+     "exec_seconds": 76.0,
+     "wait_from_run_start_seconds": 98.0,
+     "id": 92095833798
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:06Z",
+     "completed_at": "2026-08-04T18:52:39Z",
+     "exec_seconds": 153.0,
+     "wait_from_run_start_seconds": 358.0,
+     "id": 92095833826
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:32Z",
+     "completed_at": "2026-08-04T18:52:25Z",
+     "exec_seconds": 113.0,
+     "wait_from_run_start_seconds": 384.0,
+     "id": 92095833847
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:25Z",
+     "completed_at": "2026-08-04T18:50:41Z",
+     "exec_seconds": 16.0,
+     "wait_from_run_start_seconds": 377.0,
+     "id": 92095833859
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:09Z",
+     "completed_at": "2026-08-04T18:52:17Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 481.0,
+     "id": 92095833908
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:14Z",
+     "completed_at": "2026-08-04T19:03:48Z",
+     "exec_seconds": 454.0,
+     "wait_from_run_start_seconds": 726.0,
+     "id": 92097398706
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:59Z",
+     "completed_at": "2026-08-04T19:05:29Z",
+     "exec_seconds": 510.0,
+     "wait_from_run_start_seconds": 771.0,
+     "id": 92097398829
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:50:41Z",
+     "completed_at": "2026-08-04T18:50:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 393.0,
+     "id": 92097399882
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:50:41Z",
+     "completed_at": "2026-08-04T18:50:41Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 393.0,
+     "id": 92097399921
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:18Z",
+     "completed_at": "2026-08-04T18:52:17Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 490.0,
+     "id": 92097808597
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:18Z",
+     "completed_at": "2026-08-04T18:52:17Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 490.0,
+     "id": 92097808889
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:18Z",
+     "completed_at": "2026-08-04T18:52:18Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 490.0,
+     "id": 92097809503
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:52:18Z",
+     "completed_at": "2026-08-04T18:52:18Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 490.0,
+     "id": 92097810387
+    }
+   ]
+  },
+  {
+   "id": 30940005595,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2215-solver-score-metrics",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:08Z",
+   "updated_at": "2026-08-04T18:46:32Z",
+   "wall_seconds": 144.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:41Z",
+     "completed_at": "2026-08-04T18:44:53Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92095697087
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:48Z",
+     "completed_at": "2026-08-04T18:45:31Z",
+     "exec_seconds": 43.0,
+     "wait_from_run_start_seconds": 40.0,
+     "id": 92095697175
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:37Z",
+     "completed_at": "2026-08-04T18:45:48Z",
+     "exec_seconds": 71.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92095697182
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:24Z",
+     "completed_at": "2026-08-04T18:46:31Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 76.0,
+     "id": 92095697186
+    }
+   ]
+  },
+  {
+   "id": 30940005562,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:08Z",
+   "updated_at": "2026-08-04T18:51:37Z",
+   "wall_seconds": 449.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:50Z",
+     "completed_at": "2026-08-04T18:48:50Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 222.0,
+     "id": 92095697563
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:48:48Z",
+     "completed_at": "2026-08-04T18:50:32Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 280.0,
+     "id": 92095697618
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:48:58Z",
+     "completed_at": "2026-08-04T18:49:30Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 290.0,
+     "id": 92095697660
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:25Z",
+     "completed_at": "2026-08-04T18:51:36Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 437.0,
+     "id": 92095697705
+    }
+   ]
+  },
+  {
+   "id": 30940005495,
+   "name": "Build",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:08Z",
+   "updated_at": "2026-08-04T18:56:04Z",
+   "wall_seconds": 716.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:04Z",
+     "completed_at": "2026-08-04T18:46:15Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 116.0,
+     "id": 92095822095
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:20Z",
+     "completed_at": "2026-08-04T18:49:22Z",
+     "exec_seconds": 122.0,
+     "wait_from_run_start_seconds": 192.0,
+     "id": 92095822139
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:19Z",
+     "completed_at": "2026-08-04T18:50:04Z",
+     "exec_seconds": 165.0,
+     "wait_from_run_start_seconds": 191.0,
+     "id": 92095822169
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:22Z",
+     "completed_at": "2026-08-04T18:48:10Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 194.0,
+     "id": 92095822170
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:44Z",
+     "completed_at": "2026-08-04T18:46:41Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 96.0,
+     "id": 92095822175
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:36Z",
+     "completed_at": "2026-08-04T18:50:20Z",
+     "exec_seconds": 44.0,
+     "wait_from_run_start_seconds": 328.0,
+     "id": 92095822194
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:42Z",
+     "completed_at": "2026-08-04T18:44:51Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92095822234
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:44:52Z",
+     "completed_at": "2026-08-04T18:44:51Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 44.0,
+     "id": 92095884435
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:44:52Z",
+     "completed_at": "2026-08-04T18:44:51Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 44.0,
+     "id": 92095885098
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:44:52Z",
+     "completed_at": "2026-08-04T18:44:51Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 44.0,
+     "id": 92095885315
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:44:52Z",
+     "completed_at": "2026-08-04T18:44:52Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 44.0,
+     "id": 92095885883
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:32Z",
+     "completed_at": "2026-08-04T18:56:03Z",
+     "exec_seconds": 391.0,
+     "wait_from_run_start_seconds": 324.0,
+     "id": 92096249118
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:16Z",
+     "completed_at": "2026-08-04T18:46:15Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 128.0,
+     "id": 92096250048
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:16Z",
+     "completed_at": "2026-08-04T18:46:15Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 128.0,
+     "id": 92096250640
+    }
+   ]
+  },
+  {
+   "id": 30940004286,
+   "name": "Build",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T19:01:54Z",
+   "wall_seconds": 1067.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:54Z",
+     "completed_at": "2026-08-04T18:47:20Z",
+     "exec_seconds": 86.0,
+     "wait_from_run_start_seconds": 107.0,
+     "id": 92095822846
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:17Z",
+     "completed_at": "2026-08-04T18:46:27Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 130.0,
+     "id": 92095822857
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:10Z",
+     "completed_at": "2026-08-04T18:45:44Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 63.0,
+     "id": 92095822885
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:28Z",
+     "completed_at": "2026-08-04T18:50:16Z",
+     "exec_seconds": 168.0,
+     "wait_from_run_start_seconds": 201.0,
+     "id": 92095822908
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:51Z",
+     "completed_at": "2026-08-04T18:48:37Z",
+     "exec_seconds": 46.0,
+     "wait_from_run_start_seconds": 224.0,
+     "id": 92095822942
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:48:18Z",
+     "completed_at": "2026-08-04T18:50:24Z",
+     "exec_seconds": 126.0,
+     "wait_from_run_start_seconds": 251.0,
+     "id": 92095822963
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:48:56Z",
+     "completed_at": "2026-08-04T18:49:15Z",
+     "exec_seconds": 19.0,
+     "wait_from_run_start_seconds": 289.0,
+     "id": 92095823738
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:28Z",
+     "completed_at": "2026-08-04T18:46:27Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 141.0,
+     "id": 92096305322
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:28Z",
+     "completed_at": "2026-08-04T18:46:27Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 141.0,
+     "id": 92096305463
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:28Z",
+     "completed_at": "2026-08-04T18:46:28Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 141.0,
+     "id": 92096306074
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:28Z",
+     "completed_at": "2026-08-04T18:46:28Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 141.0,
+     "id": 92096306871
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:12Z",
+     "completed_at": "2026-08-04T18:58:57Z",
+     "exec_seconds": 465.0,
+     "wait_from_run_start_seconds": 425.0,
+     "id": 92097025523
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:47Z",
+     "completed_at": "2026-08-04T19:01:53Z",
+     "exec_seconds": 546.0,
+     "wait_from_run_start_seconds": 520.0,
+     "id": 92097025555
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:58Z",
+     "completed_at": "2026-08-04T18:59:35Z",
+     "exec_seconds": 397.0,
+     "wait_from_run_start_seconds": 531.0,
+     "id": 92097025720
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:49:16Z",
+     "completed_at": "2026-08-04T18:49:15Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 309.0,
+     "id": 92097026629
+    }
+   ]
+  },
+  {
+   "id": 30940005409,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-3372-registry-sandbox-paths",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T18:47:19Z",
+   "wall_seconds": 192.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:25Z",
+     "completed_at": "2026-08-04T18:45:37Z",
+     "exec_seconds": 72.0,
+     "wait_from_run_start_seconds": 18.0,
+     "id": 92095696516
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:31Z",
+     "completed_at": "2026-08-04T18:45:01Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 24.0,
+     "id": 92095696564
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:08Z",
+     "completed_at": "2026-08-04T18:45:23Z",
+     "exec_seconds": 15.0,
+     "wait_from_run_start_seconds": 61.0,
+     "id": 92095696565
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:05Z",
+     "completed_at": "2026-08-04T18:47:18Z",
+     "exec_seconds": 133.0,
+     "wait_from_run_start_seconds": 58.0,
+     "id": 92095696598
+    }
+   ]
+  },
+  {
+   "id": 30940005338,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2747-unbounded-message-warning",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T18:47:39Z",
+   "wall_seconds": 212.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:01Z",
+     "completed_at": "2026-08-04T18:45:31Z",
+     "exec_seconds": 30.0,
+     "wait_from_run_start_seconds": 54.0,
+     "id": 92095696405
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:40Z",
+     "completed_at": "2026-08-04T18:45:41Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92095696419
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:36Z",
+     "completed_at": "2026-08-04T18:44:47Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 29.0,
+     "id": 92095696432
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:31Z",
+     "completed_at": "2026-08-04T18:47:38Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 144.0,
+     "id": 92095696452
+    }
+   ]
+  },
+  {
+   "id": 30940005028,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T18:50:11Z",
+   "wall_seconds": 364.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:58Z",
+     "completed_at": "2026-08-04T18:50:04Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 351.0,
+     "id": 92095695280
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:21Z",
+     "completed_at": "2026-08-04T18:47:26Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 134.0,
+     "id": 92095695291
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:03Z",
+     "completed_at": "2026-08-04T18:46:31Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 116.0,
+     "id": 92095695312
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:48:10Z",
+     "completed_at": "2026-08-04T18:50:10Z",
+     "exec_seconds": 120.0,
+     "wait_from_run_start_seconds": 243.0,
+     "id": 92095695366
+    }
+   ]
+  },
+  {
+   "id": 30940005020,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T18:50:33Z",
+   "wall_seconds": 386.0,
+   "jobs": [
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:46Z",
+     "completed_at": "2026-08-04T18:48:46Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 219.0,
+     "id": 92095695673
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:33Z",
+     "completed_at": "2026-08-04T18:45:44Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 86.0,
+     "id": 92095695683
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:23Z",
+     "completed_at": "2026-08-04T18:50:32Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 316.0,
+     "id": 92095695694
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:46Z",
+     "completed_at": "2026-08-04T18:46:12Z",
+     "exec_seconds": 26.0,
+     "wait_from_run_start_seconds": 99.0,
+     "id": 92095695746
+    }
+   ]
+  },
+  {
+   "id": 30940004919,
+   "name": "Build",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T19:02:49Z",
+   "wall_seconds": 1122.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:35Z",
+     "completed_at": "2026-08-04T18:51:07Z",
+     "exec_seconds": 32.0,
+     "wait_from_run_start_seconds": 388.0,
+     "id": 92095824180
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:20Z",
+     "completed_at": "2026-08-04T18:53:59Z",
+     "exec_seconds": 159.0,
+     "wait_from_run_start_seconds": 433.0,
+     "id": 92095824246
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:01Z",
+     "completed_at": "2026-08-04T18:53:00Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 474.0,
+     "id": 92095824262
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:49Z",
+     "completed_at": "2026-08-04T18:44:57Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 42.0,
+     "id": 92095824293
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:03Z",
+     "completed_at": "2026-08-04T18:51:11Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 416.0,
+     "id": 92095824299
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:00Z",
+     "completed_at": "2026-08-04T18:54:09Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 533.0,
+     "id": 92095824318
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:19Z",
+     "completed_at": "2026-08-04T18:54:09Z",
+     "exec_seconds": 110.0,
+     "wait_from_run_start_seconds": 492.0,
+     "id": 92095824333
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:09Z",
+     "completed_at": "2026-08-04T19:00:49Z",
+     "exec_seconds": 460.0,
+     "wait_from_run_start_seconds": 542.0,
+     "id": 92095908035
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:34Z",
+     "completed_at": "2026-08-04T19:02:48Z",
+     "exec_seconds": 554.0,
+     "wait_from_run_start_seconds": 567.0,
+     "id": 92095908058
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:44:57Z",
+     "completed_at": "2026-08-04T18:44:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 50.0,
+     "id": 92095908767
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:44:57Z",
+     "completed_at": "2026-08-04T18:44:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 50.0,
+     "id": 92095908813
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:11Z",
+     "completed_at": "2026-08-04T18:51:11Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 424.0,
+     "id": 92097528417
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:11Z",
+     "completed_at": "2026-08-04T18:51:11Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 424.0,
+     "id": 92097528571
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:12Z",
+     "completed_at": "2026-08-04T18:51:11Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 425.0,
+     "id": 92097528953
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:51:12Z",
+     "completed_at": "2026-08-04T18:51:11Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 425.0,
+     "id": 92097529795
+    }
+   ]
+  },
+  {
+   "id": 30940004897,
+   "name": "Build",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T19:04:27Z",
+   "wall_seconds": 1220.0,
+   "jobs": [
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:58Z",
+     "completed_at": "2026-08-04T18:49:56Z",
+     "exec_seconds": 118.0,
+     "wait_from_run_start_seconds": 231.0,
+     "id": 92095828549
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:52:48Z",
+     "completed_at": "2026-08-04T18:53:19Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 521.0,
+     "id": 92095828556
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:31Z",
+     "completed_at": "2026-08-04T18:45:37Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 84.0,
+     "id": 92095828560
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:15Z",
+     "completed_at": "2026-08-04T18:52:15Z",
+     "exec_seconds": 60.0,
+     "wait_from_run_start_seconds": 428.0,
+     "id": 92095828620
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:51:55Z",
+     "completed_at": "2026-08-04T18:54:17Z",
+     "exec_seconds": 142.0,
+     "wait_from_run_start_seconds": 468.0,
+     "id": 92095828630
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:58Z",
+     "completed_at": "2026-08-04T18:51:59Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 411.0,
+     "id": 92095828634
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:00Z",
+     "completed_at": "2026-08-04T18:53:10Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 533.0,
+     "id": 92095828695
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:11Z",
+     "completed_at": "2026-08-04T18:59:33Z",
+     "exec_seconds": 382.0,
+     "wait_from_run_start_seconds": 544.0,
+     "id": 92096086329
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:18Z",
+     "completed_at": "2026-08-04T19:01:48Z",
+     "exec_seconds": 510.0,
+     "wait_from_run_start_seconds": 551.0,
+     "id": 92096086437
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:55:26Z",
+     "completed_at": "2026-08-04T19:04:26Z",
+     "exec_seconds": 540.0,
+     "wait_from_run_start_seconds": 679.0,
+     "id": 92096086500
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:38Z",
+     "completed_at": "2026-08-04T18:45:38Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 91.0,
+     "id": 92096087516
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:53:11Z",
+     "completed_at": "2026-08-04T18:53:11Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 544.0,
+     "id": 92098037585
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:53:11Z",
+     "completed_at": "2026-08-04T18:53:11Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 544.0,
+     "id": 92098037828
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:53:11Z",
+     "completed_at": "2026-08-04T18:53:11Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 544.0,
+     "id": 92098037832
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:53:11Z",
+     "completed_at": "2026-08-04T18:53:11Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 544.0,
+     "id": 92098038866
+    }
+   ]
+  },
+  {
+   "id": 30940005335,
+   "name": "Build",
+   "head_branch": "issue-2747-unbounded-message-warning",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T19:10:46Z",
+   "wall_seconds": 1599.0,
+   "jobs": [
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:54:33Z",
+     "completed_at": "2026-08-04T18:54:40Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 626.0,
+     "id": 92095837320
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:58Z",
+     "completed_at": "2026-08-04T18:54:55Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 591.0,
+     "id": 92095837363
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:41Z",
+     "completed_at": "2026-08-04T18:48:08Z",
+     "exec_seconds": 147.0,
+     "wait_from_run_start_seconds": 94.0,
+     "id": 92095837373
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:55:29Z",
+     "completed_at": "2026-08-04T18:58:42Z",
+     "exec_seconds": 193.0,
+     "wait_from_run_start_seconds": 682.0,
+     "id": 92095837391
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:22Z",
+     "completed_at": "2026-08-04T18:53:56Z",
+     "exec_seconds": 34.0,
+     "wait_from_run_start_seconds": 555.0,
+     "id": 92095837398
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:54:10Z",
+     "completed_at": "2026-08-04T18:54:24Z",
+     "exec_seconds": 14.0,
+     "wait_from_run_start_seconds": 603.0,
+     "id": 92095837424
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:54:42Z",
+     "completed_at": "2026-08-04T18:55:27Z",
+     "exec_seconds": 45.0,
+     "wait_from_run_start_seconds": 635.0,
+     "id": 92095837428
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:54:24Z",
+     "completed_at": "2026-08-04T18:54:24Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 617.0,
+     "id": 92098343643
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:54:24Z",
+     "completed_at": "2026-08-04T18:54:24Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 617.0,
+     "id": 92098344448
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:54:24Z",
+     "completed_at": "2026-08-04T18:54:24Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 617.0,
+     "id": 92098344648
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:54:25Z",
+     "completed_at": "2026-08-04T18:54:24Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 618.0,
+     "id": 92098345473
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:56:41Z",
+     "completed_at": "2026-08-04T19:04:18Z",
+     "exec_seconds": 457.0,
+     "wait_from_run_start_seconds": 754.0,
+     "id": 92098411049
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T19:00:00Z",
+     "completed_at": "2026-08-04T19:08:53Z",
+     "exec_seconds": 533.0,
+     "wait_from_run_start_seconds": 953.0,
+     "id": 92098411085
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T19:00:58Z",
+     "completed_at": "2026-08-04T19:10:46Z",
+     "exec_seconds": 588.0,
+     "wait_from_run_start_seconds": 1011.0,
+     "id": 92098411383
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:54:40Z",
+     "completed_at": "2026-08-04T18:54:40Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 633.0,
+     "id": 92098412411
+    }
+   ]
+  },
+  {
+   "id": 30940004565,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T18:46:26Z",
+   "wall_seconds": 139.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:42Z",
+     "completed_at": "2026-08-04T18:44:54Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 35.0,
+     "id": 92095693964
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:42Z",
+     "completed_at": "2026-08-04T18:45:41Z",
+     "exec_seconds": 59.0,
+     "wait_from_run_start_seconds": 35.0,
+     "id": 92095693968
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:41Z",
+     "completed_at": "2026-08-04T18:46:25Z",
+     "exec_seconds": 104.0,
+     "wait_from_run_start_seconds": 34.0,
+     "id": 92095694032
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:44Z",
+     "completed_at": "2026-08-04T18:45:07Z",
+     "exec_seconds": 23.0,
+     "wait_from_run_start_seconds": 37.0,
+     "id": 92095694068
+    }
+   ]
+  },
+  {
+   "id": 30940004892,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T18:46:56Z",
+   "wall_seconds": 169.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:40Z",
+     "completed_at": "2026-08-04T18:45:16Z",
+     "exec_seconds": 36.0,
+     "wait_from_run_start_seconds": 33.0,
+     "id": 92095695074
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:46Z",
+     "completed_at": "2026-08-04T18:46:52Z",
+     "exec_seconds": 66.0,
+     "wait_from_run_start_seconds": 99.0,
+     "id": 92095695083
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:55Z",
+     "completed_at": "2026-08-04T18:45:01Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 48.0,
+     "id": 92095695105
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:57Z",
+     "completed_at": "2026-08-04T18:46:55Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 110.0,
+     "id": 92095695121
+    }
+   ]
+  },
+  {
+   "id": 30940005008,
+   "name": "Build",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:44:07Z",
+   "updated_at": "2026-08-04T18:55:25Z",
+   "wall_seconds": 678.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:53Z",
+     "completed_at": "2026-08-04T18:45:01Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 46.0,
+     "id": 92095808104
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:30Z",
+     "completed_at": "2026-08-04T18:49:10Z",
+     "exec_seconds": 100.0,
+     "wait_from_run_start_seconds": 203.0,
+     "id": 92095808110
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:30Z",
+     "completed_at": "2026-08-04T18:46:40Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 143.0,
+     "id": 92095808163
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:48:39Z",
+     "completed_at": "2026-08-04T18:50:28Z",
+     "exec_seconds": 109.0,
+     "wait_from_run_start_seconds": 272.0,
+     "id": 92095808197
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:12Z",
+     "completed_at": "2026-08-04T18:53:33Z",
+     "exec_seconds": 201.0,
+     "wait_from_run_start_seconds": 365.0,
+     "id": 92095808217
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:52Z",
+     "completed_at": "2026-08-04T18:51:38Z",
+     "exec_seconds": 106.0,
+     "wait_from_run_start_seconds": 345.0,
+     "id": 92095808230
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:48:39Z",
+     "completed_at": "2026-08-04T18:50:27Z",
+     "exec_seconds": 108.0,
+     "wait_from_run_start_seconds": 272.0,
+     "id": 92095808234
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:02Z",
+     "completed_at": "2026-08-04T18:45:01Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 55.0,
+     "id": 92095928636
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:02Z",
+     "completed_at": "2026-08-04T18:45:01Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 55.0,
+     "id": 92095929007
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:02Z",
+     "completed_at": "2026-08-04T18:45:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 55.0,
+     "id": 92095929189
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:02Z",
+     "completed_at": "2026-08-04T18:45:02Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 55.0,
+     "id": 92095930044
+    },
+    {
+     "name": "docs",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:34Z",
+     "completed_at": "2026-08-04T18:55:25Z",
+     "exec_seconds": 291.0,
+     "wait_from_run_start_seconds": 387.0,
+     "id": 92096359853
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:40Z",
+     "completed_at": "2026-08-04T18:46:40Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 153.0,
+     "id": 92096360610
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:41Z",
+     "completed_at": "2026-08-04T18:46:40Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 154.0,
+     "id": 92096361020
+    }
+   ]
+  },
+  {
+   "id": 30939525039,
+   "name": "Changelog Lint",
+   "head_branch": "fix/4618-exact-scorer-word-order",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:37:56Z",
+   "updated_at": "2026-08-04T18:38:32Z",
+   "wall_seconds": 36.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:23Z",
+     "completed_at": "2026-08-04T18:38:32Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 27.0,
+     "id": 92094062818
+    }
+   ]
+  },
+  {
+   "id": 30939523665,
+   "name": "Build",
+   "head_branch": "fix/4618-exact-scorer-word-order",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:37:55Z",
+   "updated_at": "2026-08-04T19:01:42Z",
+   "wall_seconds": 1427.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:42:23Z",
+     "completed_at": "2026-08-04T18:42:31Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 268.0,
+     "id": 92094057980
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:40:16Z",
+     "completed_at": "2026-08-04T18:44:00Z",
+     "exec_seconds": 224.0,
+     "wait_from_run_start_seconds": 141.0,
+     "id": 92094058018
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:54Z",
+     "completed_at": "2026-08-04T18:41:33Z",
+     "exec_seconds": 159.0,
+     "wait_from_run_start_seconds": 59.0,
+     "id": 92094058025
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:54:57Z",
+     "completed_at": "2026-08-04T18:56:18Z",
+     "exec_seconds": 81.0,
+     "wait_from_run_start_seconds": 1022.0,
+     "id": 92094058030
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:33Z",
+     "completed_at": "2026-08-04T18:46:43Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 518.0,
+     "id": 92094058031
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:47:04Z",
+     "completed_at": "2026-08-04T18:47:58Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 549.0,
+     "id": 92094058066
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:49:42Z",
+     "completed_at": "2026-08-04T18:50:57Z",
+     "exec_seconds": 75.0,
+     "wait_from_run_start_seconds": 707.0,
+     "id": 92094058078
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:42:31Z",
+     "completed_at": "2026-08-04T18:42:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 276.0,
+     "id": 92095274698
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:42:31Z",
+     "completed_at": "2026-08-04T18:42:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 276.0,
+     "id": 92095275224
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:42:31Z",
+     "completed_at": "2026-08-04T18:42:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 276.0,
+     "id": 92095275614
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:42:31Z",
+     "completed_at": "2026-08-04T18:42:31Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 276.0,
+     "id": 92095275744
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:50:29Z",
+     "completed_at": "2026-08-04T18:59:50Z",
+     "exec_seconds": 561.0,
+     "wait_from_run_start_seconds": 754.0,
+     "id": 92096373672
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:53:58Z",
+     "completed_at": "2026-08-04T19:01:42Z",
+     "exec_seconds": 464.0,
+     "wait_from_run_start_seconds": 963.0,
+     "id": 92096373703
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:44Z",
+     "completed_at": "2026-08-04T18:46:43Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 529.0,
+     "id": 92096374516
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:46:44Z",
+     "completed_at": "2026-08-04T18:46:43Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 529.0,
+     "id": 92096375047
+    }
+   ]
+  },
+  {
+   "id": 30939523407,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/4618-exact-scorer-word-order",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:37:54Z",
+   "updated_at": "2026-08-04T18:47:48Z",
+   "wall_seconds": 594.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:40:22Z",
+     "completed_at": "2026-08-04T18:40:37Z",
+     "exec_seconds": 15.0,
+     "wait_from_run_start_seconds": 148.0,
+     "id": 92094056790
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:43:34Z",
+     "completed_at": "2026-08-04T18:43:59Z",
+     "exec_seconds": 25.0,
+     "wait_from_run_start_seconds": 340.0,
+     "id": 92094056802
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:09Z",
+     "completed_at": "2026-08-04T18:46:12Z",
+     "exec_seconds": 63.0,
+     "wait_from_run_start_seconds": 435.0,
+     "id": 92094056850
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:53Z",
+     "completed_at": "2026-08-04T18:47:47Z",
+     "exec_seconds": 114.0,
+     "wait_from_run_start_seconds": 479.0,
+     "id": 92094056851
+    }
+   ]
+  },
+  {
+   "id": 30939436540,
+   "name": "Changelog Lint",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:36:48Z",
+   "updated_at": "2026-08-04T18:37:04Z",
+   "wall_seconds": 16.0,
+   "jobs": [
+    {
+     "name": "entries-under-unreleased",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:58Z",
+     "completed_at": "2026-08-04T18:37:04Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92093762238
+    }
+   ]
+  },
+  {
+   "id": 30939431603,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:36:44Z",
+   "updated_at": "2026-08-04T18:45:46Z",
+   "wall_seconds": 542.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:39:33Z",
+     "completed_at": "2026-08-04T18:39:40Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 169.0,
+     "id": 92093746421
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:13Z",
+     "completed_at": "2026-08-04T18:38:41Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 89.0,
+     "id": 92093746429
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:30Z",
+     "completed_at": "2026-08-04T18:45:45Z",
+     "exec_seconds": 75.0,
+     "wait_from_run_start_seconds": 466.0,
+     "id": 92093746456
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:39:54Z",
+     "completed_at": "2026-08-04T18:40:52Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 190.0,
+     "id": 92093746619
+    }
+   ]
+  },
+  {
+   "id": 30939431605,
+   "name": "Build",
+   "head_branch": "fix/issue-3765-bedrock-adaptive-thinking",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:36:44Z",
+   "updated_at": "2026-08-04T18:51:45Z",
+   "wall_seconds": 901.0,
+   "jobs": [
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:44:43Z",
+     "completed_at": "2026-08-04T18:45:21Z",
+     "exec_seconds": 38.0,
+     "wait_from_run_start_seconds": 479.0,
+     "id": 92093745881
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:40:03Z",
+     "completed_at": "2026-08-04T18:40:14Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 199.0,
+     "id": 92093745905
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:33Z",
+     "completed_at": "2026-08-04T18:38:20Z",
+     "exec_seconds": 47.0,
+     "wait_from_run_start_seconds": 49.0,
+     "id": 92093745913
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:03Z",
+     "completed_at": "2026-08-04T18:45:12Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 499.0,
+     "id": 92093745943
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:46:27Z",
+     "completed_at": "2026-08-04T18:47:17Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 583.0,
+     "id": 92093745944
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:25Z",
+     "completed_at": "2026-08-04T18:47:49Z",
+     "exec_seconds": 144.0,
+     "wait_from_run_start_seconds": 521.0,
+     "id": 92093746019
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:45:33Z",
+     "completed_at": "2026-08-04T18:47:16Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 529.0,
+     "id": 92093746055
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:46:40Z",
+     "completed_at": "2026-08-04T18:51:44Z",
+     "exec_seconds": 304.0,
+     "wait_from_run_start_seconds": 596.0,
+     "id": 92094668281
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:46:48Z",
+     "completed_at": "2026-08-04T18:51:44Z",
+     "exec_seconds": 296.0,
+     "wait_from_run_start_seconds": 604.0,
+     "id": 92094668358
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:40:14Z",
+     "completed_at": "2026-08-04T18:40:14Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 210.0,
+     "id": 92094669747
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:40:14Z",
+     "completed_at": "2026-08-04T18:40:14Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 210.0,
+     "id": 92094669785
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:12Z",
+     "completed_at": "2026-08-04T18:45:12Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 508.0,
+     "id": 92095976524
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:12Z",
+     "completed_at": "2026-08-04T18:45:12Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 508.0,
+     "id": 92095976698
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:13Z",
+     "completed_at": "2026-08-04T18:45:12Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 509.0,
+     "id": 92095977110
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:45:13Z",
+     "completed_at": "2026-08-04T18:45:12Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 509.0,
+     "id": 92095978045
+    }
+   ]
+  },
+  {
+   "id": 30939124624,
+   "name": "Build",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:52Z",
+   "updated_at": "2026-08-04T18:44:37Z",
+   "wall_seconds": 705.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:35Z",
+     "completed_at": "2026-08-04T18:39:42Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 343.0,
+     "id": 92092704159
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:05Z",
+     "completed_at": "2026-08-04T18:37:13Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 253.0,
+     "id": 92092704181
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:12Z",
+     "completed_at": "2026-08-04T18:37:24Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 260.0,
+     "id": 92092704185
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:43:30Z",
+     "completed_at": "2026-08-04T18:44:37Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 638.0,
+     "id": 92092704227
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:27Z",
+     "completed_at": "2026-08-04T18:38:22Z",
+     "exec_seconds": 55.0,
+     "wait_from_run_start_seconds": 275.0,
+     "id": 92092704245
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:44:02Z",
+     "completed_at": "2026-08-04T18:44:23Z",
+     "exec_seconds": 21.0,
+     "wait_from_run_start_seconds": 670.0,
+     "id": 92092704307
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:44:02Z",
+     "completed_at": "2026-08-04T18:44:22Z",
+     "exec_seconds": 20.0,
+     "wait_from_run_start_seconds": 670.0,
+     "id": 92092704344
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:13Z",
+     "completed_at": "2026-08-04T18:37:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 261.0,
+     "id": 92093872698
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:13Z",
+     "completed_at": "2026-08-04T18:37:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 261.0,
+     "id": 92093872970
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:13Z",
+     "completed_at": "2026-08-04T18:37:13Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 261.0,
+     "id": 92093873240
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:14Z",
+     "completed_at": "2026-08-04T18:37:13Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 262.0,
+     "id": 92093874600
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:37:25Z",
+     "completed_at": "2026-08-04T18:44:07Z",
+     "exec_seconds": 402.0,
+     "wait_from_run_start_seconds": 273.0,
+     "id": 92093924154
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:37:25Z",
+     "completed_at": "2026-08-04T18:44:07Z",
+     "exec_seconds": 402.0,
+     "wait_from_run_start_seconds": 273.0,
+     "id": 92093924175
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:37:25Z",
+     "completed_at": "2026-08-04T18:44:07Z",
+     "exec_seconds": 402.0,
+     "wait_from_run_start_seconds": 273.0,
+     "id": 92093924193
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:25Z",
+     "completed_at": "2026-08-04T18:37:25Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 273.0,
+     "id": 92093924982
+    }
+   ]
+  },
+  {
+   "id": 30939121574,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2293-azure-openai-token-auth",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:50Z",
+   "updated_at": "2026-08-04T18:37:00Z",
+   "wall_seconds": 250.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:12Z",
+     "completed_at": "2026-08-04T18:33:19Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 22.0,
+     "id": 92092697648
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:02Z",
+     "completed_at": "2026-08-04T18:36:12Z",
+     "exec_seconds": 70.0,
+     "wait_from_run_start_seconds": 132.0,
+     "id": 92092697727
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:43Z",
+     "completed_at": "2026-08-04T18:37:00Z",
+     "exec_seconds": 77.0,
+     "wait_from_run_start_seconds": 173.0,
+     "id": 92092697737
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:11Z",
+     "completed_at": "2026-08-04T18:36:35Z",
+     "exec_seconds": 24.0,
+     "wait_from_run_start_seconds": 201.0,
+     "id": 92092697814
+    }
+   ]
+  },
+  {
+   "id": 30939116460,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:46Z",
+   "updated_at": "2026-08-04T18:36:00Z",
+   "wall_seconds": 194.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:00Z",
+     "completed_at": "2026-08-04T18:34:27Z",
+     "exec_seconds": 27.0,
+     "wait_from_run_start_seconds": 74.0,
+     "id": 92092677445
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:52Z",
+     "completed_at": "2026-08-04T18:35:11Z",
+     "exec_seconds": 19.0,
+     "wait_from_run_start_seconds": 126.0,
+     "id": 92092677502
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:27Z",
+     "completed_at": "2026-08-04T18:35:21Z",
+     "exec_seconds": 54.0,
+     "wait_from_run_start_seconds": 101.0,
+     "id": 92092677530
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:50Z",
+     "completed_at": "2026-08-04T18:35:59Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 124.0,
+     "id": 92092677614
+    }
+   ]
+  },
+  {
+   "id": 30939116202,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:46Z",
+   "updated_at": "2026-08-04T18:40:37Z",
+   "wall_seconds": 471.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:22Z",
+     "completed_at": "2026-08-04T18:38:30Z",
+     "exec_seconds": 68.0,
+     "wait_from_run_start_seconds": 276.0,
+     "id": 92092676640
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:39:17Z",
+     "completed_at": "2026-08-04T18:40:19Z",
+     "exec_seconds": 62.0,
+     "wait_from_run_start_seconds": 391.0,
+     "id": 92092676712
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:29Z",
+     "completed_at": "2026-08-04T18:38:46Z",
+     "exec_seconds": 17.0,
+     "wait_from_run_start_seconds": 343.0,
+     "id": 92092676720
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:40:03Z",
+     "completed_at": "2026-08-04T18:40:36Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 437.0,
+     "id": 92092676869
+    }
+   ]
+  },
+  {
+   "id": 30939116051,
+   "name": "Build",
+   "head_branch": "issue-2716-react-loop-depth-docs",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:46Z",
+   "updated_at": "2026-08-04T18:44:34Z",
+   "wall_seconds": 708.0,
+   "jobs": [
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:13Z",
+     "completed_at": "2026-08-04T18:36:11Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 147.0,
+     "id": 92092676637
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:02Z",
+     "completed_at": "2026-08-04T18:37:18Z",
+     "exec_seconds": 136.0,
+     "wait_from_run_start_seconds": 136.0,
+     "id": 92092676653
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:00Z",
+     "completed_at": "2026-08-04T18:35:03Z",
+     "exec_seconds": 63.0,
+     "wait_from_run_start_seconds": 74.0,
+     "id": 92092676663
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:21Z",
+     "completed_at": "2026-08-04T18:34:54Z",
+     "exec_seconds": 33.0,
+     "wait_from_run_start_seconds": 95.0,
+     "id": 92092676707
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:15Z",
+     "completed_at": "2026-08-04T18:37:26Z",
+     "exec_seconds": 11.0,
+     "wait_from_run_start_seconds": 269.0,
+     "id": 92092676721
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:46Z",
+     "completed_at": "2026-08-04T18:38:32Z",
+     "exec_seconds": 106.0,
+     "wait_from_run_start_seconds": 240.0,
+     "id": 92092676726
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:30Z",
+     "completed_at": "2026-08-04T18:35:37Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 164.0,
+     "id": 92092676753
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:38:12Z",
+     "completed_at": "2026-08-04T18:44:33Z",
+     "exec_seconds": 381.0,
+     "wait_from_run_start_seconds": 326.0,
+     "id": 92093447861
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:35:37Z",
+     "completed_at": "2026-08-04T18:35:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 171.0,
+     "id": 92093448656
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:35:37Z",
+     "completed_at": "2026-08-04T18:35:37Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 171.0,
+     "id": 92093448804
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:27Z",
+     "completed_at": "2026-08-04T18:37:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 281.0,
+     "id": 92093932536
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:27Z",
+     "completed_at": "2026-08-04T18:37:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 281.0,
+     "id": 92093932999
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:27Z",
+     "completed_at": "2026-08-04T18:37:26Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 281.0,
+     "id": 92093933447
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:27Z",
+     "completed_at": "2026-08-04T18:37:27Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 281.0,
+     "id": 92093933850
+    }
+   ]
+  },
+  {
+   "id": 30939115662,
+   "name": "Build",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:46Z",
+   "updated_at": "2026-08-04T18:44:37Z",
+   "wall_seconds": 711.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:18Z",
+     "completed_at": "2026-08-04T18:33:28Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 32.0,
+     "id": 92092674806
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:38Z",
+     "completed_at": "2026-08-04T18:37:20Z",
+     "exec_seconds": 222.0,
+     "wait_from_run_start_seconds": 52.0,
+     "id": 92092674885
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:20Z",
+     "completed_at": "2026-08-04T18:36:48Z",
+     "exec_seconds": 88.0,
+     "wait_from_run_start_seconds": 154.0,
+     "id": 92092674888
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:17Z",
+     "completed_at": "2026-08-04T18:38:03Z",
+     "exec_seconds": 106.0,
+     "wait_from_run_start_seconds": 211.0,
+     "id": 92092674901
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:24Z",
+     "completed_at": "2026-08-04T18:34:12Z",
+     "exec_seconds": 48.0,
+     "wait_from_run_start_seconds": 38.0,
+     "id": 92092674908
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:44Z",
+     "completed_at": "2026-08-04T18:35:54Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 178.0,
+     "id": 92092674935
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:13Z",
+     "completed_at": "2026-08-04T18:37:03Z",
+     "exec_seconds": 50.0,
+     "wait_from_run_start_seconds": 207.0,
+     "id": 92092675138
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:29Z",
+     "completed_at": "2026-08-04T18:33:28Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92092864436
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:29Z",
+     "completed_at": "2026-08-04T18:33:28Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92092864535
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:29Z",
+     "completed_at": "2026-08-04T18:33:28Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92092865141
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:29Z",
+     "completed_at": "2026-08-04T18:33:29Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 43.0,
+     "id": 92092865340
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:41:00Z",
+     "completed_at": "2026-08-04T18:44:37Z",
+     "exec_seconds": 217.0,
+     "wait_from_run_start_seconds": 494.0,
+     "id": 92093527125
+    },
+    {
+     "name": "test",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:35:55Z",
+     "completed_at": "2026-08-04T18:35:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 189.0,
+     "id": 92093528005
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:35:55Z",
+     "completed_at": "2026-08-04T18:35:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 189.0,
+     "id": 92093528115
+    }
+   ]
+  },
+  {
+   "id": 30939116489,
+   "name": "Build",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:46Z",
+   "updated_at": "2026-08-04T18:44:38Z",
+   "wall_seconds": 712.0,
+   "jobs": [
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:38Z",
+     "completed_at": "2026-08-04T18:35:29Z",
+     "exec_seconds": 111.0,
+     "wait_from_run_start_seconds": 52.0,
+     "id": 92092677989
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:30Z",
+     "completed_at": "2026-08-04T18:33:39Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 44.0,
+     "id": 92092677999
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:21Z",
+     "completed_at": "2026-08-04T18:38:52Z",
+     "exec_seconds": 31.0,
+     "wait_from_run_start_seconds": 335.0,
+     "id": 92092678044
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:28Z",
+     "completed_at": "2026-08-04T18:39:52Z",
+     "exec_seconds": 144.0,
+     "wait_from_run_start_seconds": 282.0,
+     "id": 92092678045
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:17Z",
+     "completed_at": "2026-08-04T18:38:27Z",
+     "exec_seconds": 190.0,
+     "wait_from_run_start_seconds": 151.0,
+     "id": 92092678074
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:04Z",
+     "completed_at": "2026-08-04T18:35:12Z",
+     "exec_seconds": 8.0,
+     "wait_from_run_start_seconds": 138.0,
+     "id": 92092678075
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:21Z",
+     "completed_at": "2026-08-04T18:38:19Z",
+     "exec_seconds": 58.0,
+     "wait_from_run_start_seconds": 275.0,
+     "id": 92092678087
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:39Z",
+     "completed_at": "2026-08-04T18:33:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 53.0,
+     "id": 92092911564
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:39Z",
+     "completed_at": "2026-08-04T18:33:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 53.0,
+     "id": 92092911794
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:39Z",
+     "completed_at": "2026-08-04T18:33:39Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 53.0,
+     "id": 92092911949
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:33:40Z",
+     "completed_at": "2026-08-04T18:33:39Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 54.0,
+     "id": 92092912715
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:38:52Z",
+     "completed_at": "2026-08-04T18:44:37Z",
+     "exec_seconds": 345.0,
+     "wait_from_run_start_seconds": 366.0,
+     "id": 92093334408
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:39:38Z",
+     "completed_at": "2026-08-04T18:44:35Z",
+     "exec_seconds": 297.0,
+     "wait_from_run_start_seconds": 412.0,
+     "id": 92093334482
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:35:13Z",
+     "completed_at": "2026-08-04T18:35:12Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 147.0,
+     "id": 92093335177
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:35:13Z",
+     "completed_at": "2026-08-04T18:35:12Z",
+     "exec_seconds": -1.0,
+     "wait_from_run_start_seconds": 147.0,
+     "id": 92093335393
+    }
+   ]
+  },
+  {
+   "id": 30939115847,
+   "name": "Build",
+   "head_branch": "issue-2795-eval-set-bundle-retry",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:46Z",
+   "updated_at": "2026-08-04T18:44:43Z",
+   "wall_seconds": 717.0,
+   "jobs": [
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:39:43Z",
+     "completed_at": "2026-08-04T18:39:55Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 417.0,
+     "id": 92092675652
+    },
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:03Z",
+     "completed_at": "2026-08-04T18:39:36Z",
+     "exec_seconds": 93.0,
+     "wait_from_run_start_seconds": 317.0,
+     "id": 92092675714
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:26Z",
+     "completed_at": "2026-08-04T18:35:01Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 100.0,
+     "id": 92092675736
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:11Z",
+     "completed_at": "2026-08-04T18:37:21Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 265.0,
+     "id": 92092675751
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:24Z",
+     "completed_at": "2026-08-04T18:41:13Z",
+     "exec_seconds": 169.0,
+     "wait_from_run_start_seconds": 338.0,
+     "id": 92092675763
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:38:37Z",
+     "completed_at": "2026-08-04T18:40:53Z",
+     "exec_seconds": 136.0,
+     "wait_from_run_start_seconds": 351.0,
+     "id": 92092675770
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:40:52Z",
+     "completed_at": "2026-08-04T18:42:22Z",
+     "exec_seconds": 90.0,
+     "wait_from_run_start_seconds": 486.0,
+     "id": 92092675777
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:41:36Z",
+     "completed_at": "2026-08-04T18:44:42Z",
+     "exec_seconds": 186.0,
+     "wait_from_run_start_seconds": 530.0,
+     "id": 92093909026
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:42:50Z",
+     "completed_at": "2026-08-04T18:44:41Z",
+     "exec_seconds": 111.0,
+     "wait_from_run_start_seconds": 604.0,
+     "id": 92093909030
+    },
+    {
+     "name": "docs",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:21Z",
+     "completed_at": "2026-08-04T18:37:21Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 275.0,
+     "id": 92093909884
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:21Z",
+     "completed_at": "2026-08-04T18:37:21Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 275.0,
+     "id": 92093910551
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:39:55Z",
+     "completed_at": "2026-08-04T18:39:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 429.0,
+     "id": 92094581438
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:39:55Z",
+     "completed_at": "2026-08-04T18:39:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 429.0,
+     "id": 92094581530
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:39:55Z",
+     "completed_at": "2026-08-04T18:39:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 429.0,
+     "id": 92094582500
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:39:55Z",
+     "completed_at": "2026-08-04T18:39:55Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 429.0,
+     "id": 92094582931
+    }
+   ]
+  },
+  {
+   "id": 30939115649,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-679-score-sandbox-context",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:46Z",
+   "updated_at": "2026-08-04T18:37:10Z",
+   "wall_seconds": 264.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:59Z",
+     "completed_at": "2026-08-04T18:35:08Z",
+     "exec_seconds": 9.0,
+     "wait_from_run_start_seconds": 133.0,
+     "id": 92092675058
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:39Z",
+     "completed_at": "2026-08-04T18:37:09Z",
+     "exec_seconds": 90.0,
+     "wait_from_run_start_seconds": 173.0,
+     "id": 92092675060
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:29Z",
+     "completed_at": "2026-08-04T18:34:57Z",
+     "exec_seconds": 28.0,
+     "wait_from_run_start_seconds": 103.0,
+     "id": 92092675095
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:40Z",
+     "completed_at": "2026-08-04T18:35:41Z",
+     "exec_seconds": 61.0,
+     "wait_from_run_start_seconds": 114.0,
+     "id": 92092675119
+    }
+   ]
+  },
+  {
+   "id": 30939114261,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:45Z",
+   "updated_at": "2026-08-04T18:38:06Z",
+   "wall_seconds": 321.0,
+   "jobs": [
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:07Z",
+     "completed_at": "2026-08-04T18:37:33Z",
+     "exec_seconds": 86.0,
+     "wait_from_run_start_seconds": 202.0,
+     "id": 92092670168
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:21Z",
+     "completed_at": "2026-08-04T18:36:37Z",
+     "exec_seconds": 16.0,
+     "wait_from_run_start_seconds": 216.0,
+     "id": 92092670228
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:14Z",
+     "completed_at": "2026-08-04T18:34:41Z",
+     "exec_seconds": 27.0,
+     "wait_from_run_start_seconds": 89.0,
+     "id": 92092670256
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:58Z",
+     "completed_at": "2026-08-04T18:38:05Z",
+     "exec_seconds": 67.0,
+     "wait_from_run_start_seconds": 253.0,
+     "id": 92092670313
+    }
+   ]
+  },
+  {
+   "id": 30939115365,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2803-llm-conversation-docs",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:45Z",
+   "updated_at": "2026-08-04T18:37:55Z",
+   "wall_seconds": 310.0,
+   "jobs": [
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:29Z",
+     "completed_at": "2026-08-04T18:33:54Z",
+     "exec_seconds": 25.0,
+     "wait_from_run_start_seconds": 44.0,
+     "id": 92092673661
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:00Z",
+     "completed_at": "2026-08-04T18:35:43Z",
+     "exec_seconds": 103.0,
+     "wait_from_run_start_seconds": 75.0,
+     "id": 92092673755
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:50Z",
+     "completed_at": "2026-08-04T18:37:55Z",
+     "exec_seconds": 65.0,
+     "wait_from_run_start_seconds": 245.0,
+     "id": 92092673770
+    },
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:34:59Z",
+     "completed_at": "2026-08-04T18:35:11Z",
+     "exec_seconds": 12.0,
+     "wait_from_run_start_seconds": 134.0,
+     "id": 92092673772
+    }
+   ]
+  },
+  {
+   "id": 30939115131,
+   "name": "Build",
+   "head_branch": "issue-1883-vllm-log-level",
+   "conclusion": "cancelled",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:45Z",
+   "updated_at": "2026-08-04T18:44:39Z",
+   "wall_seconds": 714.0,
+   "jobs": [
+    {
+     "name": "Build & inspect the package.",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:12Z",
+     "completed_at": "2026-08-04T18:36:09Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 147.0,
+     "id": 92092673659
+    },
+    {
+     "name": "ruff",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:35:17Z",
+     "completed_at": "2026-08-04T18:36:57Z",
+     "exec_seconds": 100.0,
+     "wait_from_run_start_seconds": 152.0,
+     "id": 92092673671
+    },
+    {
+     "name": "mypy (3.10)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:32:57Z",
+     "completed_at": "2026-08-04T18:35:09Z",
+     "exec_seconds": 132.0,
+     "wait_from_run_start_seconds": 12.0,
+     "id": 92092673673
+    },
+    {
+     "name": "mypy (3.11)",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:33:48Z",
+     "completed_at": "2026-08-04T18:35:40Z",
+     "exec_seconds": 112.0,
+     "wait_from_run_start_seconds": 63.0,
+     "id": 92092673678
+    },
+    {
+     "name": "detect-slow",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:05Z",
+     "completed_at": "2026-08-04T18:37:15Z",
+     "exec_seconds": 10.0,
+     "wait_from_run_start_seconds": 260.0,
+     "id": 92092673732
+    },
+    {
+     "name": "changes",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:36:50Z",
+     "completed_at": "2026-08-04T18:36:57Z",
+     "exec_seconds": 7.0,
+     "wait_from_run_start_seconds": 245.0,
+     "id": 92092673743
+    },
+    {
+     "name": "pre-commit",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:37:06Z",
+     "completed_at": "2026-08-04T18:38:15Z",
+     "exec_seconds": 69.0,
+     "wait_from_run_start_seconds": 261.0,
+     "id": 92092673894
+    },
+    {
+     "name": "test (3.11)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:38:48Z",
+     "completed_at": "2026-08-04T18:44:38Z",
+     "exec_seconds": 350.0,
+     "wait_from_run_start_seconds": 363.0,
+     "id": 92093802447
+    },
+    {
+     "name": "docs",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:40:44Z",
+     "completed_at": "2026-08-04T18:44:35Z",
+     "exec_seconds": 231.0,
+     "wait_from_run_start_seconds": 479.0,
+     "id": 92093802455
+    },
+    {
+     "name": "test (3.10)",
+     "conclusion": "cancelled",
+     "started_at": "2026-08-04T18:41:54Z",
+     "completed_at": "2026-08-04T18:44:38Z",
+     "exec_seconds": 164.0,
+     "wait_from_run_start_seconds": 549.0,
+     "id": 92093802754
+    },
+    {
+     "name": "sandbox-tools-unit",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:36:57Z",
+     "completed_at": "2026-08-04T18:36:57Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 252.0,
+     "id": 92093803387
+    },
+    {
+     "name": "slow-tests",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:16Z",
+     "completed_at": "2026-08-04T18:37:16Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 271.0,
+     "id": 92093885594
+    },
+    {
+     "name": "check-version-bump",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:16Z",
+     "completed_at": "2026-08-04T18:37:16Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 271.0,
+     "id": 92093885936
+    },
+    {
+     "name": "slow-tool-tests-dev",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:16Z",
+     "completed_at": "2026-08-04T18:37:16Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 271.0,
+     "id": 92093886750
+    },
+    {
+     "name": "slow-tool-tests-release",
+     "conclusion": "skipped",
+     "started_at": "2026-08-04T18:37:16Z",
+     "completed_at": "2026-08-04T18:37:16Z",
+     "exec_seconds": 0.0,
+     "wait_from_run_start_seconds": 271.0,
+     "id": 92093887410
+    }
+   ]
+  },
+  {
+   "id": 30939113685,
+   "name": "Validate Embedded Viewer",
+   "head_branch": "issue-2747-unbounded-message-warning",
+   "conclusion": "success",
+   "run_attempt": 1,
+   "run_started_at": "2026-08-04T18:32:44Z",
+   "updated_at": "2026-08-04T18:34:50Z",
+   "wall_seconds": 126.0,
+   "jobs": [
+    {
+     "name": "submodule-on-main",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:32:47Z",
+     "completed_at": "2026-08-04T18:32:53Z",
+     "exec_seconds": 6.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92092668447
+    },
+    {
+     "name": "dist-validation",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:32:55Z",
+     "completed_at": "2026-08-04T18:33:30Z",
+     "exec_seconds": 35.0,
+     "wait_from_run_start_seconds": 11.0,
+     "id": 92092668530
+    },
+    {
+     "name": "check-schema-and-types",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:32:54Z",
+     "completed_at": "2026-08-04T18:34:50Z",
+     "exec_seconds": 116.0,
+     "wait_from_run_start_seconds": 10.0,
+     "id": 92092668568
+    },
+    {
+     "name": "viewer-tests",
+     "conclusion": "success",
+     "started_at": "2026-08-04T18:32:47Z",
+     "completed_at": "2026-08-04T18:33:44Z",
+     "exec_seconds": 57.0,
+     "wait_from_run_start_seconds": 3.0,
+     "id": 92092668602
+    }
+   ]
+  }
+ ],
+ "pytest_durations": {
+  "31005531725/test (3.11)": [
+   {
+    "seconds": 49.29,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 9.65,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 7.67,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 6.3,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.29,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 6.21,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 5.91,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.37,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 5.27,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 4.82,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 4.75,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.48,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.33,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 3.69,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.45,
+    "phase": "call",
+    "test": "tests/scorer/test_scorer.py::test_score_package_name"
+   },
+   {
+    "seconds": 3.41,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.3,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.14,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 3.11,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 3.03,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.99,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.92,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.76,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_identifiers"
+   },
+   {
+    "seconds": 2.74,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.63,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.6,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[log]"
+   },
+   {
+    "seconds": 2.41,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_limit_slices"
+   },
+   {
+    "seconds": 2.34,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.27,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.23,
+    "phase": "call",
+    "test": "tests/test_retry.py::test_eval_retry"
+   },
+   {
+    "seconds": 2.09,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.05,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.97,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[False]"
+   },
+   {
+    "seconds": 1.96,
+    "phase": "call",
+    "test": "tests/view/test_bundle.py::test_s3_embed"
+   },
+   {
+    "seconds": 1.9,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.89,
+    "phase": "call",
+    "test": "tests/analysis/test_large_string.py::test_convert_to_large_string_preserves_data"
+   },
+   {
+    "seconds": 1.85,
+    "phase": "call",
+    "test": "tests/test_sample_id.py::test_sample_id"
+   },
+   {
+    "seconds": 1.84,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 1.79,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[conversation]"
+   },
+   {
+    "seconds": 1.76,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_accumulates_across_attempts"
+   },
+   {
+    "seconds": 1.71,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_invalidation"
+   },
+   {
+    "seconds": 1.71,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_num_errors"
+   },
+   {
+    "seconds": 1.69,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 1.68,
+    "phase": "call",
+    "test": "tests/log/test_s3_conditional_writes.py::test_s3_concurrent_modification_scenario"
+   },
+   {
+    "seconds": 1.68,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[full]"
+   },
+   {
+    "seconds": 1.66,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scan_name_override_from_scan_job"
+   }
+  ],
+  "31005531725/test (3.10)": [
+   {
+    "seconds": 53.69,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 34.35,
+    "phase": "setup",
+    "test": "tests/util/sandbox/test_docker_read_file.py::test_docker_read_file_contains_untrusted_sources[asyncio]"
+   },
+   {
+    "seconds": 8.96,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 7.71,
+    "phase": "call",
+    "test": "tests/solver/test_solver_spec.py::test_solver_extension"
+   },
+   {
+    "seconds": 5.85,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.41,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 4.8,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 4.75,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 4.63,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 4.33,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 3.89,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 3.47,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.41,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 3.4,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 3.35,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.35,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 3.3,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.25,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.13,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 2.89,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 2.88,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.81,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.65,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.58,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 2.37,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.37,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.29,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit_scorer"
+   },
+   {
+    "seconds": 2.27,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_limit_slices"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.96,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 1.9,
+    "phase": "call",
+    "test": "tests/tools/test_tools.py::test_tool_calls"
+   },
+   {
+    "seconds": 1.9,
+    "phase": "call",
+    "test": "tests/test_sample_id.py::test_sample_id"
+   },
+   {
+    "seconds": 1.9,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[True]"
+   },
+   {
+    "seconds": 1.89,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 1.89,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_error_retry"
+   },
+   {
+    "seconds": 1.83,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 1.83,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.82,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[none]"
+   },
+   {
+    "seconds": 1.78,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_set_resume_scans_when_intermediate_run_crashed_after_clean_finalize"
+   },
+   {
+    "seconds": 1.7,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 1.61,
+    "phase": "call",
+    "test": "tests/test_cancellation_logging.py::test_fail_on_error_no_retry_for_cancelled[with_sandbox]"
+   },
+   {
+    "seconds": 1.56,
+    "phase": "call",
+    "test": "tests/agent/test_acp/test_approval.py::test_approval_e2e_attach_after_fire[asyncio]"
+   },
+   {
+    "seconds": 1.56,
+    "phase": "call",
+    "test": "tests/agent/test_acp/test_approval.py::test_approval_over_real_socket_round_trip[asyncio]"
+   },
+   {
+    "seconds": 1.54,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_without_scanner_leaves_scan_dir_alone"
+   },
+   {
+    "seconds": 1.52,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   },
+   {
+    "seconds": 1.52,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_scored"
+   },
+   {
+    "seconds": 1.49,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_failed_log_start_is_retried"
+   }
+  ],
+  "31003335733/test (3.11)": [
+   {
+    "seconds": 37.55,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 10.67,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 7.18,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 6.71,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 6.64,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.18,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 5.9,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.82,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 5.71,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 4.89,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 4.68,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.5,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 4.12,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 4.1,
+    "phase": "call",
+    "test": "tests/view/test_bundle.py::test_s3_embed"
+   },
+   {
+    "seconds": 3.98,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 3.75,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.62,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.25,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.03,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 2.96,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.9,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.84,
+    "phase": "call",
+    "test": "tests/scorer/test_scorer.py::test_score_package_name"
+   },
+   {
+    "seconds": 2.79,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[log]"
+   },
+   {
+    "seconds": 2.75,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.68,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.35,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.24,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.15,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 2.05,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_with_changed_scanner_set_fails_loudly"
+   },
+   {
+    "seconds": 2.04,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[False]"
+   },
+   {
+    "seconds": 2.04,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.0,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.92,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 1.87,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_pct_errors_continue_on_fail"
+   },
+   {
+    "seconds": 1.87,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 1.8,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 1.78,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_shuffle_seed_changed_not_reused_with_limit"
+   },
+   {
+    "seconds": 1.76,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.75,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_no_shuffle"
+   },
+   {
+    "seconds": 1.73,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_prints_scan_status_from_api"
+   },
+   {
+    "seconds": 1.68,
+    "phase": "call",
+    "test": "tests/log/test_s3_conditional_writes.py::test_s3_concurrent_modification_scenario"
+   },
+   {
+    "seconds": 1.68,
+    "phase": "call",
+    "test": "tests/test_retry.py::test_eval_retry_token_usage_multi_retry"
+   },
+   {
+    "seconds": 1.67,
+    "phase": "call",
+    "test": "tests/_control/test_eval_set_integration.py::test_task_retry_detaches_superseded_attempt_live"
+   },
+   {
+    "seconds": 1.66,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_failed_log_start_is_retried"
+   },
+   {
+    "seconds": 1.65,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   },
+   {
+    "seconds": 1.63,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[plain]"
+   },
+   {
+    "seconds": 1.63,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_invalidation"
+   }
+  ],
+  "31003335733/test (3.10)": [
+   {
+    "seconds": 40.49,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 26.14,
+    "phase": "setup",
+    "test": "tests/util/sandbox/test_docker_read_file.py::test_docker_read_file_contains_untrusted_sources[asyncio]"
+   },
+   {
+    "seconds": 9.89,
+    "phase": "call",
+    "test": "tests/solver/test_solver_spec.py::test_solver_extension"
+   },
+   {
+    "seconds": 8.97,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 6.31,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 6.26,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 6.23,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.03,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 5.79,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 4.84,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 4.67,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.56,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 4.11,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 3.79,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.77,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 3.41,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.35,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 3.28,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.27,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 2.97,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.92,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 2.9,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.66,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.55,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.18,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_identifiers"
+   },
+   {
+    "seconds": 2.12,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.06,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.78,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.73,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 1.68,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[False]"
+   },
+   {
+    "seconds": 1.65,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 1.65,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   },
+   {
+    "seconds": 1.61,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit_scorer"
+   },
+   {
+    "seconds": 1.6,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_no_shuffle"
+   },
+   {
+    "seconds": 1.6,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_retry_json_multi_file_emits_launch_per_file"
+   },
+   {
+    "seconds": 1.59,
+    "phase": "call",
+    "test": "tests/test_cancellation_logging.py::test_fail_on_error_no_retry_for_cancelled[no_sandbox]"
+   },
+   {
+    "seconds": 1.57,
+    "phase": "call",
+    "test": "tests/agent/test_acp/test_approval.py::test_approval_e2e_attach_after_fire[asyncio]"
+   },
+   {
+    "seconds": 1.56,
+    "phase": "call",
+    "test": "tests/agent/test_acp/test_approval.py::test_approval_over_real_socket_round_trip[asyncio]"
+   },
+   {
+    "seconds": 1.55,
+    "phase": "call",
+    "test": "tests/test_sample_id.py::test_sample_id"
+   },
+   {
+    "seconds": 1.54,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_limit_with_multiple_tasks"
+   },
+   {
+    "seconds": 1.53,
+    "phase": "call",
+    "test": "tests/test_retry.py::test_eval_retry_preserves_token_usage"
+   },
+   {
+    "seconds": 1.5,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_failed_log_start_is_retried"
+   },
+   {
+    "seconds": 1.49,
+    "phase": "call",
+    "test": "tests/log/test_s3_conditional_writes.py::test_s3_concurrent_modification_scenario"
+   }
+  ],
+  "31002669399/test (3.10)": [
+   {
+    "seconds": 38.06,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 24.01,
+    "phase": "setup",
+    "test": "tests/util/sandbox/test_docker_read_file.py::test_docker_read_file_contains_untrusted_sources[asyncio]"
+   },
+   {
+    "seconds": 9.99,
+    "phase": "call",
+    "test": "tests/solver/test_solver_spec.py::test_solver_extension"
+   },
+   {
+    "seconds": 9.56,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 6.39,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.23,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 6.18,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 5.97,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 5.77,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 4.74,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.54,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.28,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 4.23,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 4.14,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 3.79,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.78,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 3.41,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.17,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 2.98,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.89,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.84,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 2.66,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.54,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.38,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.19,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 2.16,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_error_retry"
+   },
+   {
+    "seconds": 2.12,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.11,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.1,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[True]"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.93,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 1.93,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_live_override[asyncio]"
+   },
+   {
+    "seconds": 1.81,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_without_scanner_leaves_scan_dir_alone"
+   },
+   {
+    "seconds": 1.79,
+    "phase": "call",
+    "test": "tests/agent/test_agent_react.py::test_react_agent_truncation[with_auto_truncation]"
+   },
+   {
+    "seconds": 1.75,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_anthropic_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 1.68,
+    "phase": "call",
+    "test": "tests/tools/test_mcp_tools.py::test_mcp_connection_refcount[asyncio]"
+   },
+   {
+    "seconds": 1.64,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   },
+   {
+    "seconds": 1.63,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_summary_complete_flips_to_false_when_resume_introduces_scan_errors"
+   },
+   {
+    "seconds": 1.61,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle_limit"
+   },
+   {
+    "seconds": 1.58,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit_scorer"
+   },
+   {
+    "seconds": 1.56,
+    "phase": "call",
+    "test": "tests/agent/test_acp/test_approval.py::test_approval_e2e_attach_after_fire[asyncio]"
+   },
+   {
+    "seconds": 1.56,
+    "phase": "call",
+    "test": "tests/agent/test_acp/test_approval.py::test_approval_over_real_socket_round_trip[asyncio]"
+   },
+   {
+    "seconds": 1.54,
+    "phase": "call",
+    "test": "tests/test_retry.py::test_eval_retry_preserves_token_usage"
+   }
+  ],
+  "31002669399/test (3.11)": [
+   {
+    "seconds": 38.26,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 10.79,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 7.89,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 6.84,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 6.73,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.3,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 5.9,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.88,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 5.41,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 5.29,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 4.84,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.8,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.38,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 4.32,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 4.13,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 3.97,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 3.73,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.68,
+    "phase": "call",
+    "test": "tests/scorer/test_scorer.py::test_score_package_name"
+   },
+   {
+    "seconds": 3.43,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 2.96,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 2.92,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.85,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.85,
+    "phase": "call",
+    "test": "tests/view/test_bundle.py::test_s3_embed"
+   },
+   {
+    "seconds": 2.83,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[log]"
+   },
+   {
+    "seconds": 2.8,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 2.76,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.68,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.24,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.21,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_anthropic_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 2.19,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   },
+   {
+    "seconds": 2.11,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 2.02,
+    "phase": "call",
+    "test": "tests/test_metadata.py::test_task_tags_in_task_profile"
+   },
+   {
+    "seconds": 2.02,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.0,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.93,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 1.93,
+    "phase": "call",
+    "test": "tests/agent/test_agent_react.py::test_react_agent_truncation[with_auto_truncation]"
+   },
+   {
+    "seconds": 1.86,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_pct_errors"
+   },
+   {
+    "seconds": 1.85,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_prints_scan_status_from_api"
+   },
+   {
+    "seconds": 1.84,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_uses_configured_scanner_model_for_all_tasks"
+   },
+   {
+    "seconds": 1.83,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 1.77,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/log/test_s3_conditional_writes.py::test_s3_concurrent_modification_scenario"
+   },
+   {
+    "seconds": 1.67,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_failed_log_start_is_retried"
+   },
+   {
+    "seconds": 1.66,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_shuffle_reused_without_limit"
+   },
+   {
+    "seconds": 1.65,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle_limit"
+   },
+   {
+    "seconds": 1.61,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_invalidation"
+   },
+   {
+    "seconds": 1.61,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[full]"
+   }
+  ],
+  "31001908801/test (3.10)": [
+   {
+    "seconds": 38.59,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 22.87,
+    "phase": "setup",
+    "test": "tests/util/sandbox/test_docker_read_file.py::test_docker_read_file_contains_untrusted_sources[asyncio]"
+   },
+   {
+    "seconds": 9.49,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 9.34,
+    "phase": "call",
+    "test": "tests/solver/test_solver_spec.py::test_solver_extension"
+   },
+   {
+    "seconds": 6.74,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 6.41,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 6.4,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 5.88,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 5.77,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 4.78,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.69,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.56,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 4.44,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 4.25,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 4.23,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 3.71,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.27,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.18,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 3.13,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 2.93,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.89,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.87,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 2.72,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 2.7,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.66,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.55,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.31,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[True]"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.2,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 2.09,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_live_override[asyncio]"
+   },
+   {
+    "seconds": 2.03,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.02,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 2.0,
+    "phase": "call",
+    "test": "tests/tools/test_tools.py::test_tool_calls"
+   },
+   {
+    "seconds": 2.0,
+    "phase": "call",
+    "test": "tests/test_retry.py::test_eval_retry_flushes_reused_samples_during_live_run"
+   },
+   {
+    "seconds": 1.83,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_anthropic_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 1.81,
+    "phase": "call",
+    "test": "tests/log/test_s3_conditional_writes.py::test_s3_concurrent_modification_scenario"
+   },
+   {
+    "seconds": 1.78,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_no_shuffle"
+   },
+   {
+    "seconds": 1.77,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_num_errors"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.71,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 1.7,
+    "phase": "call",
+    "test": "tests/util/test_notify.py::test_build_apprise_does_not_mutate_or_return_url"
+   },
+   {
+    "seconds": 1.67,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_limit_with_multiple_tasks"
+   },
+   {
+    "seconds": 1.65,
+    "phase": "call",
+    "test": "tests/log/test_log_formats.py::test_write_s3_eval_header_only_ignores_in_memory_sample_changes"
+   },
+   {
+    "seconds": 1.63,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   },
+   {
+    "seconds": 1.61,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scan_job_model_overrides_eval_model_for_scanner"
+   }
+  ],
+  "31001908801/test (3.11)": [
+   {
+    "seconds": 38.66,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 10.04,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 7.24,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 7.17,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.86,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 5.93,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.78,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 5.44,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 5.15,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 5.0,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 4.98,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.86,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.71,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 4.48,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_identifiers"
+   },
+   {
+    "seconds": 4.48,
+    "phase": "call",
+    "test": "tests/view/test_bundle.py::test_s3_embed"
+   },
+   {
+    "seconds": 4.02,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.45,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.44,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.29,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.23,
+    "phase": "call",
+    "test": "tests/scorer/test_scorer.py::test_score_package_name"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.18,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 3.03,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.92,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.89,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.8,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.66,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.64,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 2.58,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[log]"
+   },
+   {
+    "seconds": 2.41,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_without_scanner_leaves_scan_dir_alone"
+   },
+   {
+    "seconds": 2.31,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_error_retry"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.21,
+    "phase": "call",
+    "test": "tests/test_enqueue_task.py::test_enqueue_task_does_not_leak_active_model"
+   },
+   {
+    "seconds": 2.19,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_anthropic_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 2.16,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 2.09,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 2.06,
+    "phase": "call",
+    "test": "tests/test_metadata.py::test_task_and_eval_tags"
+   },
+   {
+    "seconds": 2.02,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.98,
+    "phase": "call",
+    "test": "tests/_control/test_eval_set_integration.py::test_ctl_ls_survives_fast_task_finishing_first"
+   },
+   {
+    "seconds": 1.89,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle_limit"
+   },
+   {
+    "seconds": 1.84,
+    "phase": "call",
+    "test": "tests/agent/test_agent_react.py::test_react_agent_truncation[with_auto_truncation]"
+   },
+   {
+    "seconds": 1.83,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_invalidation"
+   },
+   {
+    "seconds": 1.8,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.76,
+    "phase": "call",
+    "test": "tests/scorer/test_reducers.py::test_score_reducer"
+   },
+   {
+    "seconds": 1.75,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_retry_immediate_keeps_all_scans_when_retry_cleanup_disabled"
+   },
+   {
+    "seconds": 1.73,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_prints_scan_status_from_api"
+   }
+  ],
+  "31001865658/test (3.10)": [
+   {
+    "seconds": 37.88,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 23.41,
+    "phase": "setup",
+    "test": "tests/util/sandbox/test_docker_read_file.py::test_docker_read_file_contains_untrusted_sources[asyncio]"
+   },
+   {
+    "seconds": 10.14,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 9.52,
+    "phase": "call",
+    "test": "tests/solver/test_solver_spec.py::test_solver_extension"
+   },
+   {
+    "seconds": 6.48,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 6.26,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.05,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 5.89,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 5.77,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 4.9,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.56,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.4,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 4.29,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 4.24,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 4.02,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 3.74,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.42,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.27,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.27,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.1,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 3.06,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.93,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.92,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.78,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit_scorer"
+   },
+   {
+    "seconds": 2.72,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 2.67,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.56,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.47,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[True]"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.19,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_live_override[asyncio]"
+   },
+   {
+    "seconds": 2.18,
+    "phase": "call",
+    "test": "tests/agent/test_agent_react.py::test_react_agent_truncation[with_auto_truncation]"
+   },
+   {
+    "seconds": 2.17,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.12,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_without_scanner_leaves_scan_dir_alone"
+   },
+   {
+    "seconds": 2.09,
+    "phase": "call",
+    "test": "tests/tools/test_tools.py::test_tool_calls"
+   },
+   {
+    "seconds": 2.07,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.07,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_limit_changed"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.99,
+    "phase": "call",
+    "test": "tests/test_retry.py::test_invalidation"
+   },
+   {
+    "seconds": 1.92,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 1.84,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_set_resume_scans_when_scanner_added_on_resume"
+   },
+   {
+    "seconds": 1.78,
+    "phase": "call",
+    "test": "tests/log/test_s3_conditional_writes.py::test_s3_concurrent_modification_scenario"
+   },
+   {
+    "seconds": 1.77,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_anthropic_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.7,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 1.7,
+    "phase": "call",
+    "test": "tests/test_cancellation_logging.py::test_all_concurrent_samples_accounted_for[no_sandbox]"
+   },
+   {
+    "seconds": 1.64,
+    "phase": "call",
+    "test": "tests/log/test_log_formats.py::test_write_s3_eval_header_only_ignores_in_memory_sample_changes"
+   }
+  ],
+  "31001865658/test (3.11)": [
+   {
+    "seconds": 42.75,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 10.34,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 7.9,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 6.95,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.51,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 5.94,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.78,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 5.52,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 5.35,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 5.23,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[False]"
+   },
+   {
+    "seconds": 4.85,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.59,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.39,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 4.2,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 3.93,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.87,
+    "phase": "call",
+    "test": "tests/scorer/test_scorer.py::test_score_package_name"
+   },
+   {
+    "seconds": 3.43,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 3.02,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 2.97,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.94,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.92,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.76,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.75,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.73,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_set_resume_scans_when_finalize_did_not_run_cleanly"
+   },
+   {
+    "seconds": 2.67,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 2.59,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[log]"
+   },
+   {
+    "seconds": 2.34,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[True]"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_enqueue_task.py::test_enqueue_task_does_not_leak_active_model"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.22,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 2.19,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.18,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_without_scanner_leaves_scan_dir_alone"
+   },
+   {
+    "seconds": 2.14,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.07,
+    "phase": "call",
+    "test": "tests/view/test_bundle.py::test_s3_embed"
+   },
+   {
+    "seconds": 2.04,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.79,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 1.78,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_prints_scan_status_from_api"
+   },
+   {
+    "seconds": 1.75,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle_limit"
+   },
+   {
+    "seconds": 1.75,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/_control/test_eval_set_integration.py::test_ctl_samples_shows_task_level_retries"
+   },
+   {
+    "seconds": 1.7,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_no_shuffle"
+   },
+   {
+    "seconds": 1.66,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   },
+   {
+    "seconds": 1.66,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_failed_log_start_is_retried"
+   },
+   {
+    "seconds": 1.63,
+    "phase": "call",
+    "test": "tests/agent/test_agent_react.py::test_react_agent_custom_prompt"
+   },
+   {
+    "seconds": 1.63,
+    "phase": "call",
+    "test": "tests/scorer/test_reducers.py::test_score_reducer"
+   }
+  ],
+  "31001063712/test (3.10)": [
+   {
+    "seconds": 37.29,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 23.97,
+    "phase": "setup",
+    "test": "tests/util/sandbox/test_docker_read_file.py::test_docker_read_file_contains_untrusted_sources[asyncio]"
+   },
+   {
+    "seconds": 9.69,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 9.23,
+    "phase": "call",
+    "test": "tests/solver/test_solver_spec.py::test_solver_extension"
+   },
+   {
+    "seconds": 7.0,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 6.32,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.14,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 5.96,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 5.76,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.04,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 4.7,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.63,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.23,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 4.18,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 4.04,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 3.79,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.42,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.27,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.27,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.24,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 3.24,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 2.95,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.78,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 2.68,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.65,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.54,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.52,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_limit_slices"
+   },
+   {
+    "seconds": 2.31,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[True]"
+   },
+   {
+    "seconds": 2.26,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.13,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 2.11,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.1,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_live_override[asyncio]"
+   },
+   {
+    "seconds": 2.08,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_without_scanner_leaves_scan_dir_alone"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.89,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 1.86,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 1.83,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_no_shuffle"
+   },
+   {
+    "seconds": 1.81,
+    "phase": "call",
+    "test": "tests/log/test_s3_conditional_writes.py::test_s3_concurrent_modification_scenario"
+   },
+   {
+    "seconds": 1.79,
+    "phase": "call",
+    "test": "tests/tools/test_max_tool_output.py::test_max_tool_output"
+   },
+   {
+    "seconds": 1.76,
+    "phase": "call",
+    "test": "tests/util/test_notify.py::test_build_apprise_does_not_mutate_or_return_url"
+   },
+   {
+    "seconds": 1.75,
+    "phase": "call",
+    "test": "tests/test_retry.py::test_eval_retry_preserves_token_usage"
+   },
+   {
+    "seconds": 1.73,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.73,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_retry_json_multi_file_emits_launch_per_file"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_set_resume_short_circuits_when_prior_scan_clean"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/test_cancellation_logging.py::test_all_concurrent_samples_accounted_for[with_sandbox]"
+   },
+   {
+    "seconds": 1.72,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 1.66,
+    "phase": "call",
+    "test": "tests/tools/test_mcp_tools.py::test_mcp_connection_refcount[asyncio]"
+   },
+   {
+    "seconds": 1.63,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_set_json_batch_retry_done_reports_last_launch"
+   }
+  ],
+  "31001063712/test (3.11)": [
+   {
+    "seconds": 38.05,
+    "phase": "call",
+    "test": "tests/test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox"
+   },
+   {
+    "seconds": 8.87,
+    "phase": "call",
+    "test": "tests/util/test_asyncfiles.py::test_iter_files_s3_pagination"
+   },
+   {
+    "seconds": 7.14,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans"
+   },
+   {
+    "seconds": 7.05,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running"
+   },
+   {
+    "seconds": 6.64,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once"
+   },
+   {
+    "seconds": 6.15,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_scanner_resume_accumulates_summary_and_only_scans_rerun_samples[s3]"
+   },
+   {
+    "seconds": 5.95,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_previous_task_args"
+   },
+   {
+    "seconds": 5.73,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 5.07,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_google_bridge_streaming_not_supported"
+   },
+   {
+    "seconds": 4.98,
+    "phase": "call",
+    "test": "tests/log/test_eval_log_config.py::test_eval_log_run_config_round_trip"
+   },
+   {
+    "seconds": 4.84,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr"
+   },
+   {
+    "seconds": 4.2,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle"
+   },
+   {
+    "seconds": 4.2,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit"
+   },
+   {
+    "seconds": 3.94,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails"
+   },
+   {
+    "seconds": 3.84,
+    "phase": "call",
+    "test": "tests/scorer/test_scorer.py::test_score_package_name"
+   },
+   {
+    "seconds": 3.41,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_timeout_not_scored"
+   },
+   {
+    "seconds": 3.35,
+    "phase": "call",
+    "test": "tests/_control/test_launch_handoff.py::test_eval_detach_sigterm_terminates_child"
+   },
+   {
+    "seconds": 3.32,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_working_limit_reporting"
+   },
+   {
+    "seconds": 3.26,
+    "phase": "call",
+    "test": "tests/util/test_limit_working.py::test_working_limit_interrupts_local_sandbox_exec"
+   },
+   {
+    "seconds": 3.21,
+    "phase": "call",
+    "test": "tests/util/test_subprocess.py::test_subprocess_timeout_with_lost_child_watcher[asyncio]"
+   },
+   {
+    "seconds": 2.96,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_in_same_second_does_not_clobber_failed_log"
+   },
+   {
+    "seconds": 2.92,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout_exceeded"
+   },
+   {
+    "seconds": 2.79,
+    "phase": "call",
+    "test": "tests/test_task_retry_error_history.py::test_task_retry_does_not_count_cancelled_siblings"
+   },
+   {
+    "seconds": 2.77,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_s3_scan_dir_contains_expected_files"
+   },
+   {
+    "seconds": 2.74,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_identifiers"
+   },
+   {
+    "seconds": 2.7,
+    "phase": "call",
+    "test": "tests/test_task_cancel.py::test_abort_cancel_not_retried_without_task_retries"
+   },
+   {
+    "seconds": 2.57,
+    "phase": "call",
+    "test": "tests/util/test_display_counter.py::test_can_display_counter[log]"
+   },
+   {
+    "seconds": 2.43,
+    "phase": "call",
+    "test": "tests/view/test_bundle.py::test_s3_embed"
+   },
+   {
+    "seconds": 2.35,
+    "phase": "call",
+    "test": "tests/test_enqueue_task.py::test_enqueue_task_does_not_leak_active_model"
+   },
+   {
+    "seconds": 2.31,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_without_scanner_leaves_scan_dir_alone"
+   },
+   {
+    "seconds": 2.29,
+    "phase": "call",
+    "test": "tests/test_fail_on_error.py::test_fail_on_error_retry"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_time_limit"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_sample_limits.py::test_solver_scorer_combined_timeout"
+   },
+   {
+    "seconds": 2.25,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_set_resume_scans_when_finalize_did_not_run_cleanly"
+   },
+   {
+    "seconds": 2.23,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_limit_slices"
+   },
+   {
+    "seconds": 2.23,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestBackgroundExecution::test_background_subagent_actually_runs"
+   },
+   {
+    "seconds": 2.21,
+    "phase": "call",
+    "test": "tests/test_sample_shuffle.py::test_sample_shuffle_limit"
+   },
+   {
+    "seconds": 2.2,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_retry_started"
+   },
+   {
+    "seconds": 2.13,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_task_identifier_with_task_limits"
+   },
+   {
+    "seconds": 2.07,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set[False]"
+   },
+   {
+    "seconds": 2.05,
+    "phase": "call",
+    "test": "tests/agent/test_agent_bridge.py::test_anthropic_bridge_computer_use_incompatible_model"
+   },
+   {
+    "seconds": 2.02,
+    "phase": "call",
+    "test": "tests/util/test_zipfile_multiframe.py::test_large_entry_round_trip"
+   },
+   {
+    "seconds": 2.01,
+    "phase": "call",
+    "test": "tests/model/test_generate_attempt_timeout.py::test_generate_attempt_timeout_override_exempts_batched_calls[asyncio]"
+   },
+   {
+    "seconds": 1.85,
+    "phase": "call",
+    "test": "tests/scorer/test_categorical.py::test_frequency_strenum_recompute_round_trip"
+   },
+   {
+    "seconds": 1.82,
+    "phase": "call",
+    "test": "tests/agent/deepagent/test_deepagent_background.py::TestAgentCancelBoundedWait::test_cancel_reports_pending_when_child_slow_to_settle"
+   },
+   {
+    "seconds": 1.81,
+    "phase": "call",
+    "test": "tests/_control/test_eval_set_integration.py::test_ctl_ls_shows_reused_logs_as_completed"
+   },
+   {
+    "seconds": 1.78,
+    "phase": "call",
+    "test": "tests/test_eval_set_scanner.py::test_eval_retry_prints_scan_status_from_api"
+   },
+   {
+    "seconds": 1.77,
+    "phase": "call",
+    "test": "tests/_view/test_view_server.py::test_api_log_edit_s3_stale_if_match_returns_412"
+   },
+   {
+    "seconds": 1.77,
+    "phase": "call",
+    "test": "tests/test_eval_set.py::test_eval_set_epochs_changed"
+   },
+   {
+    "seconds": 1.75,
+    "phase": "call",
+    "test": "tests/test_sample_source.py::test_sample_source_task_retry_reuses_completed_followup"
+   }
+  ]
+ }
+}

--- a/design/ci-perf/report.md
+++ b/design/ci-perf/report.md
@@ -1,105 +1,127 @@
-# CI performance report — 2026-08-04
+# CI performance report — 2026-08-05
 
-Data: 200 PR runs, 2026-08-04 07:43..20:02 UTC (~12 hours — CI volume is
-high enough that 200 runs is half a day). Snapshot: `history/2026-08-04.json`.
+Data: 200 PR runs, 2026-08-04 18:32 .. 2026-08-05 12:47 UTC. Snapshot:
+`history/2026-08-05.json`. Previous: 2026-08-04.
 
 ## Summary
 
-Build (the slowest required workflow) has a median wall clock of **15.6 min,
-p90 23.8 min**; Validate Embedded Viewer 4.2/9.1 min; Changelog Lint is
-negligible. The dominant costs on Build's critical path are (1) the pytest
-job itself (median 8.0 min execution), (2) runner queue time (median ~2.5
-min per job, **p90 ~8 min** when PR batches saturate the pool), and (3) the
-`changes` → `test` serialization, which puts a full queue+run cycle
-(~2.5 min median, ~8 min p90) in front of the longest job. Setup overhead
-is not a problem: uv caching works (dependency install ~9 s) and checkout
-is ~30 s.
+Build median wall clock dropped **15.6 → 10.3 min** (p90 23.8 → 21.4).
+Two effects: last run's fixes merged mid-window (#4747 at 11:16 UTC), and
+this window has less batch-push queue contention than yesterday's. In the
+post-merge slice the effect is unambiguous: **test jobs now start ~9 s
+after run start (was 42 s median / 13 min p90 wait)**, and Build wall is
+8.9 min median (n=6 — small sample, confirm next run). With the
+serialization gone and queue quiet, the bottleneck is now **pytest
+execution itself: 8.5 min median**, of which one test contributes 38 s.
 
 ## Queue vs execution
 
-Median execution / median queue / p90 queue, successful runs. Queue for
-dependent jobs is measured from predecessor completion, not run start.
+Median execution / median queue / p90 queue, successful runs. (Queue for
+dependent jobs measured from predecessor completion.)
 
 | Workflow | Job | n | exec med | queue med | queue p90 |
 |---|---|---|---|---|---|
-| Build | test (per matrix leg) | 84 | 480s | 149s | 466s |
-| Build | docs (when docs change) | 27 | 390s | 196s | 470s |
-| Build | mypy (per matrix leg) | 98 | 114s | 194s | 456s |
-| Build | pre-commit | 49 | 57s | 128s | 533s |
-| Build | package | 49 | 52s | 154s | 473s |
-| Build | ruff | 49 | 34s | 152s | 485s |
-| Build | changes | 49 | 8s | 143s | 490s |
-| Build | detect-slow | 49 | 9s | 136s | 464s |
-| Viewer | check-schema-and-types | 85 | 79s | 116s | 424s |
-| Viewer | viewer-tests | 85 | 64s | 100s | 332s |
-| Viewer | dist-validation | 85 | 31s | 73s | 319s |
-| Viewer | submodule-on-main | 85 | 9s | 85s | 350s |
+| Build | test (per matrix leg) | 100 | 510s | 10s | 461s |
+| Build | docs (when docs change) | 16 | 392s | 210s | 470s |
+| Build | mypy (per matrix leg) | 114 | 114s | 21s | 433s |
+| Build | pre-commit | 57 | 57s | 18s | 519s |
+| Build | package | 57 | 51s | 21s | 451s |
+| Build | ruff | 57 | 34s | 20s | 395s |
+| Viewer | check-schema-and-types | 87 | 78s | 39s | 424s |
+| Viewer | viewer-tests | 87 | 62s | 26s | 305s |
+| Viewer | dist-validation | 87 | 30s | 33s | 285s |
 
-Read: most jobs finish in under 2 min of execution but wait 2–8 min for a
-runner. ~13 jobs fan out per PR push across 3 workflows; queue time is
-runner-pool contention, not job dependencies.
+Queue medians collapsed vs yesterday (10–40s vs 130–200s) — partly less
+contention in this window, partly 2 fewer serialized job-starts per Build.
+p90s remain 5–8 min: batch pushes still saturate the pool.
 
-Build critical path (median): queue `changes` 143s → exec 8s → queue
-`test` 149s → exec 480s ≈ 13 min, matching the 15.6 min median wall.
+## Impact verification (previous run's PRs)
+
+- **#4747 (un-serialize `changes` → `test`): confirmed.** Post-merge, test
+  jobs wait a median of **8 s** from run start (pre-merge in the same
+  window: 42 s median, 804 s p90; the mechanism — a queue+run cycle of
+  `changes` in front of `test` — is gone). Build wall median post-merge
+  8.9 min vs 11.3 pre (n=6, contention-confounded; predicted −2.5 min
+  median holds directionally).
+- **#4746 (`--durations`): confirmed working** — per-test data captured
+  from all 12 mined test jobs; table below exists because of it.
 
 ## Slowest tests
 
-(no data — `--durations` not in CI; proposal 1 adds it)
+Median `call` seconds across 12 CI test jobs (2026-08-05). Sum of all 108
+captured slow-test medians: 308 s of the ~510 s job execution (xdist
+spreads these across workers; the longest single test bounds the tail).
 
-Static scan for real sleeps in tests (candidates to size once durations
-data exists): `tests/test_task_cancel.py` (9 sleep calls),
-`tests/agent/test_acp/test_react_integration.py` (7),
-`tests/util/test_limit_time.py`, `tests/test_cancellation_logging.py`,
-`tests/model/test_parallel_tools.py`, `tests/agent/test_agent_human.py`,
-`tests/agent/deepagent/test_deepagent_background.py` (4 each).
+| Median | Test | Classification |
+|---|---|---|
+| 38.4s | `test_eval.py::test_eval_sandbox_init_when_first_task_has_no_sandbox` | docker container lifecycle for a sandbox-type-agnostic gating check → **fix prepared: spy on `SandboxManager.start` + local sandbox, 38s → ~2s** |
+| 9.7s | `test_asyncfiles.py::test_iter_files_s3_pagination` | 1001+ keys are inherent (S3 default page size), each a real HTTP PUT to the moto server → **fix: writes parallelized and test marked `slow` — leaves the PR gate, runs in the 2-hourly slow suite** |
+| 9.4s | `test_solver_spec.py::test_solver_extension` | not the test: `ensure_test_package_installed()` pip-installs `tests/test_package` mid-run; first caller pays (hence n=6) → **fix: pre-install in the CI install step (#4760)** |
+| 6.6s | `test_eval_set_scanner.py::test_scout_scan_resume_reruns_failed_scans` | not yet examined |
+| 6.4s | `test_launch_handoff.py::test_eval_detach_hands_off_and_leaves_eval_running` | real subprocess + control-server handshake; file totals ~21s over 4 tests — next candidate |
+| 6.3s | `test_launch_handoff.py::test_eval_detach_via_dotenv_detaches_exactly_once` | (as above) |
+| 6.2s | `test_eval_set_scanner.py::test_scanner_resume_...[s3]` | not yet examined |
+| 5.9s | `test_eval_set.py::test_eval_set_previous_task_args` | not yet examined |
+| 5.1s | `test_agent_bridge.py::test_google_bridge_computer_use_incompatible_model` | not yet examined |
+| 4.8s | `test_launch_handoff.py::test_eval_json_redirects_subprocess_stdout_to_stderr` | (launch_handoff) |
+| 4.7s | `test_agent_bridge.py::test_google_bridge_streaming_not_supported` | not yet examined |
+| 4.7s | `test_eval_log_config.py::test_eval_log_run_config_round_trip` | not yet examined |
+| 4.3s | `test_sample_limits.py::test_working_limit` | likely real waits (limit tests) |
+| 4.2s | `test_sample_shuffle.py::test_sample_shuffle` | not yet examined |
+| 3.8s | `test_launch_handoff.py::test_eval_detach_fails_when_control_bind_fails` | (launch_handoff) |
 
 ## Regressions since last report
 
-First run — no baseline.
+None — first run with per-test data establishes the baseline.
 
 ## Waste
 
-- **Cancelled superseded runs:** 29/200 runs (14.5%) cancelled, burning
-  **526 runner-minutes in ~12 h**. Cancellation itself is prompt (~30 s
-  after the superseding push); the waste is work already done before the
-  next push in a rapid push sequence.
-- **Compute:** Build consumed 1,986 runner-min in the window (~4,000/day);
-  Viewer 271; Changelog Lint 4.
-- **Job-count pressure:** 4 Viewer jobs each execute ≤ 79 s median but each
-  occupies a runner slot and pays its own queue+checkout; they contribute
-  to the very contention that delays Build's `test`.
-- `docs` job executes 6.5 min (Quarto render, no caching of the render).
-- `fetch-depth: 0` is justified on jobs that install the package
-  (setuptools_scm needs tags); only `ruff` fetches full history without
-  needing it (~seconds — not worth a PR alone).
+- Cancelled superseded runs: 29/200, 417 runner-min burned (yesterday:
+  526). Steady-state cost of rapid push sequences.
+- Compute: Build 1,947 runner-min in the window; Viewer 277.
+- `docs` job: 6.5 min Quarto render, no render caching (proposal 5).
 
 ## Proposals (ranked)
 
-1. **Add `--durations=50 --durations-min=1` to the Build pytest invocation**
-   — impact: none directly; unlocks all per-test analysis for future runs.
-   Safe fix. Status: **PR opened #4746**.
-2. **Remove the `changes` → `test` serialization** by running the
-   docs-only paths-filter as a step inside the `test` job (steps
-   short-circuit when only docs changed; job names/required checks
-   unchanged; `changes` job stays for `docs`/`sandbox-tools-unit`) —
-   impact: ~2.5 min median, ~8 min p90 off Build wall clock. Safe fix.
-   Status: **PR opened #4747**.
-3. **Merge the 4 Viewer jobs into 1–2** — impact: frees 2–3 runner slots
-   per PR push, reducing pool contention for everything (queue med 2–3
-   min, p90 5–8 min across all jobs); renames required checks →
-   maintainer decision. Structural. Status: new.
-4. **Increase runner pool / larger runners for `test`** — queue p90 ~8 min
-   is contention; also `-n auto` on a bigger runner would cut the 8 min
-   pytest exec roughly linearly. Cost/policy decision. Structural.
-   Status: new.
-5. **Cache the Quarto render (freeze) for the `docs` job** — impact:
-   most of 6.5 min on docs-touching PRs; needs care that freeze data
-   stays fresh. Structural (build-behavior change). Status: new.
-6. **Speed up slow tests (sleeps → mock clocks/events, dedupe)** —
-   blocked on durations data from proposal 1. Trivial fixes are safe-fix
-   eligible. Status: blocked on 1.
+1. ~~Add `--durations` to Build pytest~~ — **done, #4746 merged, verified.**
+2. ~~Remove `changes` → `test` serialization~~ — **done, #4747 merged,
+   verified (test-job start wait 42s+ → 8s median).**
+3. **Replace docker with spied local sandbox in the 38s
+   `test_eval_sandbox_init_...` test** — impact: −38s from the longest
+   test (bounds the xdist tail); coverage verified preserved (test fails
+   when the original `next()` bug is reintroduced; a plain local-sandbox
+   swap without the spy does NOT fail and was rejected). Safe fix (trivial
+   test fix). Status: **PR opened #4760**.
+4. **`test_iter_files_s3_pagination`: parallelize writes and mark `slow`** —
+   impact: ~−10s median off the PR-gate suite (moved to the 2-hourly slow
+   run; also ~2x faster there). Safe fix. Status: **PR opened #4760**.
+5. **Merge the 4 Viewer jobs into 1–2** — structural (required-check
+   rename); still the biggest queue-pressure lever for batch pushes
+   (p90 queue 5–8 min). Status: carried, awaiting maintainer decision.
+6. **Runner pool size / larger runners for `test`** — structural/cost.
+   Status: carried.
+7. **Cache the Quarto render for `docs`** — structural. Status: carried.
+8. **Pre-install `tests/test_package` in the CI install step** — impact:
+   ~−9s off the xdist critical path per test job plus a ~3.5s lock echo;
+   also removes install noise from the durations data. Safe fix. Status:
+   **PR opened #4760** (same change proposed to the meridian scheduled
+   workflow separately).
+9. **`filter: blob:none` on the always-run jobs' checkouts** (ruff,
+   mypy, pre-commit, docs, test, package) — impact: caps the erratic
+   30s–4min full-pack fetch at tens of MB; slow-tool jobs keep full
+   blobs (they `git diff main` over sources). Not applied to the
+   meridian scheduled workflow: its self-hosted runner reuses the
+   workspace (checkouts measured 16–50s incremental). Safe fix. Status:
+   **PR opened #4760**.
+10. **Remaining slow tests** (`test_launch_handoff.py` cluster ~21s,
+   `test_solver_extension` 9.4s, eval-set scanner tests) — examine next
+   run with a second day of durations data. Status: new.
 
 ## PRs opened by this skill
 
-- #4746 — add `--durations=50` to Build pytest (2026-08-04, open)
-- #4747 — remove `changes` → `test` serialization (2026-08-04, open)
+- #4746 — add `--durations=50` to Build pytest (2026-08-04, **merged**,
+  impact verified)
+- #4747 — remove `changes` → `test` serialization (2026-08-04, **merged**,
+  impact verified)
+- #4748 — the ci-perf skill itself (2026-08-04, **merged**)
+- #4760 — combined: both slow-test fixes + this report/snapshot (2026-08-05, open)

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -4,11 +4,11 @@ import tempfile
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, cast
+from unittest import mock
 
 import anyio
 import pytest
 from botocore.exceptions import ClientError
-from test_helpers.utils import skip_if_no_docker
 
 from inspect_ai import (
     Epochs,
@@ -311,20 +311,33 @@ def test_eval_approval_override():
     assert log.eval.config.approval == eval_approval
 
 
-@skip_if_no_docker
 def test_eval_sandbox_init_when_first_task_has_no_sandbox():
-    """Check that Sandbox initialization runs when ANY task has a sandbox, not just the first."""
-    results = eval(
-        tasks=[
-            Task(dataset=[Sample(input="x")], name="no_sandbox"),
-            Task(dataset=[Sample(input="x")], sandbox="docker", name="docker_sandbox"),
-        ],
-        model="mockllm/model",
-        max_tasks=2,
-    )
+    """Check that Sandbox initialization runs when ANY task has a sandbox, not just the first.
+
+    Startup is asserted via a spy rather than a docker task whose init
+    crashes when skipped: a local sandbox keeps the regression coverage
+    (the gating logic is sandbox-type agnostic) without docker's ~40s of
+    container lifecycle in CI.
+    """
+    from inspect_ai._eval.run import SandboxManager
+
+    with mock.patch.object(
+        SandboxManager, "start", autospec=True, side_effect=SandboxManager.start
+    ) as start_spy:
+        results = eval(
+            tasks=[
+                Task(dataset=[Sample(input="x")], name="no_sandbox"),
+                Task(
+                    dataset=[Sample(input="x")], sandbox="local", name="local_sandbox"
+                ),
+            ],
+            model="mockllm/model",
+            max_tasks=2,
+        )
     assert len(results) == 2
     for r in results:
         assert r.status == "success", f"{r.eval.task}: {r.error}"
+    start_spy.assert_called_once()
 
 
 # -- unconsumed task_args warning (#4194) ------------------------------------

--- a/tests/util/test_asyncfiles.py
+++ b/tests/util/test_asyncfiles.py
@@ -1,4 +1,5 @@
 import asyncio
+import functools
 import io
 import tempfile
 import time
@@ -889,14 +890,23 @@ def test_iter_files_s3_missing_prefix(mock_s3: None) -> None:
     asyncio.run(run())
 
 
+@pytest.mark.slow
 def test_iter_files_s3_pagination(mock_s3: None) -> None:
-    """Pagination: >1000 keys must all be returned."""
+    """Pagination: >1000 keys must all be returned.
+
+    Marked slow: creating 1001+ keys (the S3 default page size) means ~1050
+    real HTTP PUTs against the moto server, several seconds even in-process.
+    """
     base = f"{S3_BUCKET}/iter_test_files_page"
 
     async def run() -> None:
         async with AsyncFilesystem() as fs:
-            for i in range(1050):
-                await fs.write_file(f"{base}/k{i:04d}.txt", b"x")
+            await tg_collect(
+                [
+                    functools.partial(fs.write_file, f"{base}/k{i:04d}.txt", b"x")
+                    for i in range(1050)
+                ]
+            )
             paths = await _collect(fs.iter_files(base, recursive=True))
             assert len(paths) == 1050
 


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior?

Three sources of avoidable overhead account for ~60s of the PR-gate pytest run's ~8.5 min:

- `test_eval_sandbox_init_when_first_task_has_no_sandbox` (38s median in CI) spins up a real docker container only so that *skipped* sandbox init would crash — the gating logic it guards (`any` vs `next` over tasks, f39605ccb) is sandbox-type agnostic.
- `test_iter_files_s3_pagination` (10s median) writes 1050 files to mock S3 sequentially to cross the 1000-key pagination boundary.
- `ensure_test_package_installed()` pip-installs `tests/test_package` mid-run (~9s on the xdist critical path, visible as `test_solver_extension` 9.4s, plus a ~3.5s lock-wait echo in `test_score_package_name`).

### What is the new behavior?

- The sandbox-init test uses a real `local` sandbox plus a spy asserting `SandboxManager.start` was called: 38s → ~2s, and the now-unneeded `@skip_if_no_docker` is removed. Coverage verified empirically: reintroducing the original `next()` bug makes the new test fail (a naive docker→local swap without the spy does NOT fail with the bug, and was rejected for that reason).
- The pagination test writes the 1050 keys concurrently via `tg_collect` (~2x faster) and is marked `@pytest.mark.slow`: 1001+ keys are inherent to crossing the S3 default page size and each is a real HTTP PUT to the moto server, so it moves out of the PR gate into the scheduled slow suite.

Also pre-installs `tests/test_package` in the CI install step: `ensure_test_package_installed()` was pip-installing it mid-run (~9s subprocess on the xdist critical path, paid by whichever of its three callers ran first, plus a lock-wait echo in a second caller — `test_solver_extension` 9.4s and `test_score_package_name` 3.6s in the durations data). Pre-installed via uv it costs ~100ms off the critical path, and the helper's `find_spec` check short-circuits; local/dev behavior is unchanged.

Also adds `filter: "blob:none"` to the always-run jobs' checkouts (ruff, mypy, pre-commit, docs, test, package): `fetch-depth: 0` + `fetch-tags` fetches all 344 branches and 254 tags at full history — a ~400MB pack that takes 30s on a warm GitHub pack cache and ~4 min on a cold one (observed on this PR's own run). blob:none keeps every ref and the full commit graph (setuptools_scm unaffected) while skipping historical file contents. The slow-tool jobs are deliberately untouched (they `git diff main` over sandbox-tools sources; lazy fetch should work but hasn't been exercised there). The ci-perf collector now also records per-step timings so step-level variance like this is visible in future runs.

Also documents the repo's slow-test policy in the ci-perf skill (docker or unmocked external service ⇒ `@pytest.mark.slow`; slow tests run in the 2-hourly scheduled suite, not the PR gate), and includes the 2026-08-05 CI-performance report and data snapshot (`design/ci-perf/`), which identified these tests and verifies the impact of #4746/#4747 (Build wall clock 15.6 → 10.3 min median; test jobs now start ~8s after run start vs 42s+). Combined into one PR to reduce per-PR landing overhead.

### Does this PR introduce a breaking change?

No.

### Other information:

Test-only + dev-tooling changes; no CHANGELOG entry per contribution guidelines.

### Agent review
- Author: Claude (Fable 5) via /ci-perf, maintainer-reviewed diffs before push
- Verification in lieu of a separate review pass: the sandbox-init test was run against a deliberately reintroduced regression (the original `next()` bug) to prove it still fails; the pagination test was verified skipped without `--runslow` and passing with it; full `tests/test_eval.py` + `tests/util/test_asyncfiles.py` pass locally (92 passed); mypy and ruff clean. No fresh-context review pass was run.

