### PR TITLE
Preserve every conversation when a sandboxed agent runs several

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Groq: An over-capacity, server, or rate-limit error delivered inside a streamed response is now retried instead of failing the sample, and a streamed context-length rejection yields `model_length` output.
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
+- Agent Bridge: `sandbox_agent_bridge()` can now preserve every conversation a sandbox runs, instead of returning only one when the sandbox ran several.
 
 ## 0.3.263 (03 September 2026)
 
@@ -31,7 +32,6 @@
 - Bugfix: Transcript markdown now reliably escapes HTML outside code blocks, so unusual code fences or line separators can no longer inject raw HTML into the rendered transcript.
 - Bugfix: Hugging Face and nnterp providers now record `hidden_states` (from `-M hidden_states`) as JSON-serializable nested lists instead of silently dropping them to `None` in the log; the batched Hugging Face path now records each sample's own activations rather than the whole batch's. Note: code reading `ModelOutput.metadata["hidden_states"]` live (in a solver or scorer) now receives nested lists rather than tensors — wrap with `torch.tensor(...)` if tensor operations are needed. (#2860)
 - Sandbox Tools: Injection now fails with a clear error when the tools directory already exists but is not a private directory owned by the tools user (an earlier rootless install is tightened to 0700 and reused).
-- Agent Bridge: `sandbox_agent_bridge()` can now preserve every conversation a sandbox runs, instead of returning only one when the sandbox ran several.
 
 ## 0.3.262 (02 September 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - Bugfix: Transcript markdown now reliably escapes HTML outside code blocks, so unusual code fences or line separators can no longer inject raw HTML into the rendered transcript.
 - Bugfix: Hugging Face and nnterp providers now record `hidden_states` (from `-M hidden_states`) as JSON-serializable nested lists instead of silently dropping them to `None` in the log; the batched Hugging Face path now records each sample's own activations rather than the whole batch's. Note: code reading `ModelOutput.metadata["hidden_states"]` live (in a solver or scorer) now receives nested lists rather than tensors — wrap with `torch.tensor(...)` if tensor operations are needed. (#2860)
 - Sandbox Tools: Injection now fails with a clear error when the tools directory already exists but is not a private directory owned by the tools user (an earlier rootless install is tightened to 0700 and reused).
+- Agent Bridge: `sandbox_agent_bridge()` can now preserve every conversation a sandbox runs, instead of returning only one when the sandbox ran several.
 
 ## 0.3.262 (02 September 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Bedrock, Groq, Mistral, Azure AI: Transient errors delivered mid-stream (throttling, capacity, dropped connections) are now retried instead of failing the sample or returning a truncated output.
 - Agent bridge: Bridged OpenAI and Google requests with a malformed `tool_choice`/`toolConfig` now return a 400 naming the bad field instead of a status-less error, and a non-string tool name no longer poisons the sample transcript.
 - Agent Bridge: `sandbox_agent_bridge()` can now preserve every conversation a sandbox runs, instead of returning only one when the sandbox ran several.
+- Agent Bridge: each preserved conversation now appears as its own transcript span, so multi-conversation sessions read as separate threads instead of one flat list.
 
 ## 0.3.263 (03 September 2026)
 

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -60,6 +60,7 @@ async def sandbox_agent_bridge(
     forward_generation_config: bool = False,
     approval: list["ApprovalPolicy"] | None = None,
     checkpointer: Checkpointer | None = None,
+    accumulate_conversations: bool = False,
 ) -> AsyncIterator[SandboxAgentBridge]:
     """Sandbox agent bridge.
 
@@ -132,6 +133,11 @@ async def sandbox_agent_bridge(
             state (messages, output, compaction prefix) for checkpoint backup
             and restore, so a checkpointed run survives resume. Defaults to
             `None` (no checkpointing).
+        accumulate_conversations: Keep every conversation observed over the bridge
+            rather than tracking a single main one. Defaults to `False`, which surfaces
+            the main agent loop and treats other traffic as side calls. Set `True` when
+            the sandbox may run several independent conversations: `state.messages`
+            then holds each in the order they started.
     """
     # instance id for this bridge
     instance = f"proxy_{uuid()}"
@@ -175,6 +181,7 @@ async def sandbox_agent_bridge(
                 approval=approval,
                 checkpointer=checkpointer,
                 allow_remote_mcp=allow_remote_mcp,
+                accumulate_conversations=accumulate_conversations,
             )
 
             # register bridged tools with the bridge

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -234,6 +234,7 @@ async def sandbox_agent_bridge(
                 yield bridge
                 agent_completed = True
             finally:
+                bridge.close_conversation_spans()
                 with anyio.CancelScope(shield=True):
                     # ensure the process terminates (no-op if already dead)
                     await proxy.kill()

--- a/src/inspect_ai/agent/_bridge/sandbox/types.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/types.py
@@ -48,6 +48,7 @@ class SandboxAgentBridge(AgentBridge):
         checkpointer: Checkpointer | None = None,
         allow_remote_mcp: bool = False,
         allow_remote_media: bool = False,
+        accumulate_conversations: bool = False,
     ) -> None:
         super().__init__(
             state,
@@ -62,6 +63,7 @@ class SandboxAgentBridge(AgentBridge):
             checkpointer=checkpointer,
             allow_remote_mcp=allow_remote_mcp,
             allow_remote_media=allow_remote_media,
+            accumulate_conversations=accumulate_conversations,
         )
         self.port = port
         self.mcp_server_configs = mcp_server_configs or []

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,4 +1,5 @@
 from enum import IntEnum
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, NamedTuple, NoReturn, Sequence, Set
 
@@ -47,6 +48,7 @@ class AgentBridge:
         model_event_sink: ModelEventSink | None = None,
         forward_generation_config: bool = False,
         approval: list["ApprovalPolicy"] | None = None,
+        accumulate_conversations: bool = False,
         checkpointer: Checkpointer | None = None,
         allow_remote_mcp: bool = True,
         allow_remote_media: bool = False,
@@ -118,6 +120,19 @@ class AgentBridge:
         self._tracked_descends: _Descent | None = None
         self._candidate_fps: list[_MessageFingerprint] | None = None
         self._pending_operator = 0
+        # accumulation state for _accumulate_conversation (see its docstring). Adopted on
+        # ANY resume, unlike bridge_messages above: the scaffold replays only the
+        # conversation it was in, so dropping the rest would lose every earlier one for
+        # good -- and they are the whole point of accumulating. Replays do not duplicate,
+        # because a call equal to or contained in a stored conversation is absorbed rather
+        # than appended.
+        self._accumulate_conversations = accumulate_conversations
+        self._conversations: list[_Conversation] = self._cp.track(
+            "bridge_conversations",
+            lambda: self._conversations,
+            [],
+            value_type=list[_Conversation],
+        )
         self._operator_keys: set[str] = set()
 
     state: AgentState
@@ -309,7 +324,15 @@ class AgentBridge:
           loop reclaims it on resumption, by extension when it makes several
           further calls (candidate promotion) or by the longer-descending-call
           displacement above when it makes only one.
+
+        When `accumulate_conversations` is set, none of the above applies: every
+        conversation observed over the bridge is kept and concatenated instead of
+        one being chosen. See `_accumulate_conversation`.
         """
+        if self._accumulate_conversations:
+            self._accumulate_conversation(input, output)
+            await self._cp.tick()
+            return
         messages = input + [output.message]
         fps = [_message_fingerprint(m) for m in messages]
 
@@ -358,6 +381,105 @@ class AgentBridge:
 
         # tick the checkpointer
         await self._cp.tick()
+
+    def _accumulate_conversation(
+        self, input: list[ChatMessage], output: ModelOutput
+    ) -> None:
+        """Keep EVERY conversation observed over the bridge, not just the main one.
+
+        `_track_state` chooses one "main" thread because a scaffold runs one agent
+        loop and its side calls are noise. A sandbox is not a scaffold: nothing
+        constrains it to one conversation, and a human-driven or multi-invocation
+        harness routinely runs several independent ones through the same bridge (for
+        example an operator running `claude -p` several times). Choosing one then
+        silently discards the rest, and the discarded ones exist nowhere in the
+        resulting sample.
+
+        A call is matched to the conversation it CONTINUES: the one whose messages are
+        a prefix of this call's, longest first. Matching is by `(role, text)` over
+        non-system messages, because a scaffold may rewrite its system prompt per
+        request (Claude Code stamps a per-request cache token into it) and matching on
+        it would make every call a new conversation.
+
+        "Prefix" is deliberately not-strict, and re-sends are absorbed rather than
+        appended, because a repeat is not a new conversation. A call identical to one
+        already stored REPLACES it, and a call already CONTAINED in a stored
+        conversation is dropped. Requiring a strict extension instead forks a whole
+        replica on any exact repeat -- two invocations making the same deterministic
+        aux call (Claude Code's bash-path probe) fingerprint identically -- and the
+        fork can never re-merge, so it strands a permanent stale duplicate whose tail
+        then sits at the end of `state.messages`.
+
+        Only genuinely new work starts a conversation. That still admits a one-shot
+        side call, because without a session identifier a real one-shot invocation is
+        indistinguishable from an aux call and dropping it loses real work; and two
+        calls sharing a history but answering DIFFERENTLY stay separate, since merging
+        them would invent a conversation in which one prompt drew two consecutive
+        replies.
+
+        `state.output` is this call, not the last conversation's: conversations keep
+        first-seen order, so a call resuming an earlier one leaves `state.messages`
+        ending on a later conversation. Order is the property this option exists to
+        provide, so it wins, and `state.messages[-1]` is not guaranteed to be
+        `state.output`'s message. Indexing output by conversation order instead lets a
+        single late side call poison it for the rest of the run.
+        """
+        messages = input + [output.message]
+        key = _non_system([_message_fingerprint(m) for m in messages])
+        continued: int | None = None
+        for index, conversation in enumerate(self._conversations):
+            if _is_prefix(conversation.key, key) and (
+                continued is None
+                or len(conversation.key) > len(self._conversations[continued].key)
+            ):
+                continued = index
+        if continued is None:
+            # Already covered by a stored conversation (a re-send of an earlier turn):
+            # it carries nothing the longer form does not.
+            if not any(_is_prefix(key, c.key) for c in self._conversations):
+                self._conversations.append(
+                    _Conversation(key=key, messages=messages, output=output)
+                )
+        else:
+            self._conversations[continued] = _Conversation(
+                key=key, messages=messages, output=output
+            )
+            # Absorb any other conversation this one now contains, so a fork that
+            # happened before the two met cannot persist as a stale duplicate.
+            self._conversations = [
+                conversation
+                for index, conversation in enumerate(self._conversations)
+                if index == continued or not _is_prefix(conversation.key, key)
+            ]
+        self.state.messages = self._flattened_conversations()
+        self.state.output = output
+
+    def _flattened_conversations(self) -> list[ChatMessage]:
+        """Every conversation concatenated in first-seen order, with unique message ids.
+
+        Ids are allocated from message CONTENT (`_id_for_message`), and each request only
+        ever sees its own conversation, so independent conversations that repeat a turn --
+        replicas of one script, a re-asked prompt -- arrive carrying the SAME id, while
+        `ChatMessage.id` is documented unique.
+
+        A repeat is re-identified on a copy that is written BACK into its conversation, so
+        the new id is allocated once and then held. Re-deriving it per call instead would
+        hand the same message a different id on every generation, which defeats the id
+        stability `apply_message_ids` exists to provide and breaks every consumer that
+        joins on the id (`log/_condense.py`'s walk cache, `solver/_run.py`'s prefix diff,
+        matching `sample.messages` back to `ModelEvent.input`).
+        """
+        flattened: list[ChatMessage] = []
+        seen: set[str] = set()
+        for conversation in self._conversations:
+            for position, message in enumerate(conversation.messages):
+                if message.id in seen:
+                    message = message.model_copy(update={"id": uuid()})
+                    conversation.messages[position] = message
+                if message.id is not None:
+                    seen.add(message.id)
+                flattened.append(message)
+        return flattened
 
     def _adopt_thread(
         self,
@@ -568,6 +690,38 @@ def _condensed_fingerprint(fp: _MessageFingerprint) -> _MessageFingerprint:
     return _MessageFingerprint(
         role=fp.role, text_hash=mm3_hash(f"{ATTACHMENT_PROTOCOL}{fp.text_hash}")
     )
+
+
+@dataclass
+class _Conversation:
+    """One conversation observed over the bridge (see `_accumulate_conversation`)."""
+
+    key: list[_MessageFingerprint]
+    messages: list[ChatMessage]
+    output: ModelOutput
+
+
+def _is_prefix(
+    prefix: list[_MessageFingerprint], fps: list[_MessageFingerprint]
+) -> bool:
+    """Whether `fps` continues `prefix`, or is exactly it."""
+    return len(fps) >= len(prefix) and fps[: len(prefix)] == prefix
+
+
+def _non_system(fps: list[_MessageFingerprint]) -> list[_MessageFingerprint]:
+    """Fingerprints of the non-system messages, for conversation-continuation matching.
+
+    A scaffold may rewrite its system prompt on every request -- Claude Code stamps a
+    per-request cache token into it -- so successive calls in one conversation need not
+    share a system-message fingerprint, and matching on it would make every call look
+    like a new conversation.
+
+    Used only by `_accumulate_conversation`. Main-thread tracking keeps comparing whole
+    message lists: a system prompt still carries meaning there (two sub-agents can share
+    a user prompt while differing only in role), and its `_extends` check is backed by the
+    length and descent heuristics rather than standing alone.
+    """
+    return [fp for fp in fps if fp.role != "system"]
 
 
 def _extends(prefix: list[_MessageFingerprint], fps: list[_MessageFingerprint]) -> bool:

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -572,26 +572,24 @@ class _ConversationMessageFingerprint(NamedTuple):
     """Stable identity for accumulating one conversation's non-system messages.
 
     Message IDs, source, metadata, and model name are transport details that may change
-    as a scaffold replays history. The full content retains non-text parts, while the
-    remaining model fields retain tool-call and tool-result identity.
+    as a scaffold replays history. Every remaining field participates, preserving
+    non-text content plus tool-call and tool-result identity.
     """
 
     role: str
-    content_hash: str
-    tool_identity_hash: str
+    identity_hash: str
 
 
 def _conversation_message_fingerprint(
     message: ChatMessage,
 ) -> _ConversationMessageFingerprint:
-    tool_identity = message.model_dump(
-        exclude={"id", "content", "metadata", "model", "source"},
+    message_identity = message.model_dump(
+        exclude={"id", "metadata", "model", "source"},
         exclude_none=True,
     )
     return _ConversationMessageFingerprint(
         role=message.role,
-        content_hash=mm3_hash(to_json_str_safe(message.content)),
-        tool_identity_hash=mm3_hash(to_json_str_safe(tool_identity)),
+        identity_hash=mm3_hash(to_json_str_safe(message_identity)),
     )
 
 

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,5 +1,5 @@
-from enum import IntEnum
 from dataclasses import dataclass
+from enum import IntEnum
 from functools import lru_cache
 from typing import TYPE_CHECKING, NamedTuple, NoReturn, Sequence, Set
 

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -396,10 +396,10 @@ class AgentBridge:
         resulting sample.
 
         A call is matched to the conversation it CONTINUES: the one whose messages are
-        a prefix of this call's, longest first. Matching is by `(role, text)` over
-        non-system messages, because a scaffold may rewrite its system prompt per
-        request (Claude Code stamps a per-request cache token into it) and matching on
-        it would make every call a new conversation.
+        a prefix of this call's, longest first. Matching ignores only system prompts,
+        which scaffolds may rewrite per request (Claude Code stamps a per-request cache
+        token into them). Non-system message identity includes full content plus tool
+        calls and tool results, so visually identical operations do not collapse.
 
         "Prefix" is deliberately not-strict, and re-sends are absorbed rather than
         appended, because a repeat is not a new conversation. A call identical to one
@@ -425,7 +425,7 @@ class AgentBridge:
         single late side call poison it for the rest of the run.
         """
         messages = input + [output.message]
-        key = _non_system([_message_fingerprint(m) for m in messages])
+        key = _non_system([_conversation_message_fingerprint(m) for m in messages])
         continued: int | None = None
         for index, conversation in enumerate(self._conversations):
             if _is_prefix(conversation.key, key) and (
@@ -568,6 +568,33 @@ def message_json_hash(message_json: str) -> str:
     return mm3_hash(message_json)
 
 
+class _ConversationMessageFingerprint(NamedTuple):
+    """Stable identity for accumulating one conversation's non-system messages.
+
+    Message IDs, source, metadata, and model name are transport details that may change
+    as a scaffold replays history. The full content retains non-text parts, while the
+    remaining model fields retain tool-call and tool-result identity.
+    """
+
+    role: str
+    content_hash: str
+    tool_identity_hash: str
+
+
+def _conversation_message_fingerprint(
+    message: ChatMessage,
+) -> _ConversationMessageFingerprint:
+    tool_identity = message.model_dump(
+        exclude={"id", "content", "metadata", "model", "source"},
+        exclude_none=True,
+    )
+    return _ConversationMessageFingerprint(
+        role=message.role,
+        content_hash=mm3_hash(to_json_str_safe(message.content)),
+        tool_identity_hash=mm3_hash(to_json_str_safe(tool_identity)),
+    )
+
+
 class _MessageFingerprint(NamedTuple):
     """(role, hash-of-text) identity used for thread prefix comparisons.
 
@@ -696,19 +723,22 @@ def _condensed_fingerprint(fp: _MessageFingerprint) -> _MessageFingerprint:
 class _Conversation:
     """One conversation observed over the bridge (see `_accumulate_conversation`)."""
 
-    key: list[_MessageFingerprint]
+    key: list[_ConversationMessageFingerprint]
     messages: list[ChatMessage]
     output: ModelOutput
 
 
 def _is_prefix(
-    prefix: list[_MessageFingerprint], fps: list[_MessageFingerprint]
+    prefix: list[_ConversationMessageFingerprint],
+    fps: list[_ConversationMessageFingerprint],
 ) -> bool:
     """Whether `fps` continues `prefix`, or is exactly it."""
     return len(fps) >= len(prefix) and fps[: len(prefix)] == prefix
 
 
-def _non_system(fps: list[_MessageFingerprint]) -> list[_MessageFingerprint]:
+def _non_system(
+    fps: list[_ConversationMessageFingerprint],
+) -> list[_ConversationMessageFingerprint]:
     """Fingerprints of the non-system messages, for conversation-continuation matching.
 
     A scaffold may rewrite its system prompt on every request -- Claude Code stamps a

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,3 +1,4 @@
+from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import IntEnum
 from functools import lru_cache
@@ -10,7 +11,11 @@ from inspect_ai._util.hash import mm3_hash
 from inspect_ai._util.json import to_json_str_safe
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.log._condense import ATTACHMENT_PROTOCOL
-from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
+from inspect_ai.model._chat_message import (
+    ChatMessage,
+    ChatMessageAssistant,
+    ChatMessageUser,
+)
 from inspect_ai.model._compaction import (
     Compact,
     CompactionStrategy,
@@ -32,6 +37,7 @@ if TYPE_CHECKING:
     # cycles back through partially-initialized modules). Same reason
     # `model/_call_tools.py` defers it.
     from inspect_ai.approval._policy import ApprovalPolicy
+    from inspect_ai.event import ModelEvent
 
 
 class AgentBridge:
@@ -119,6 +125,7 @@ class AgentBridge:
         self._tracked_calls = 0
         self._tracked_descends: _Descent | None = None
         self._candidate_fps: list[_MessageFingerprint] | None = None
+        self._candidate_messages: list[ChatMessage] | None = None
         self._pending_operator = 0
         # accumulation state for _accumulate_conversation (see its docstring). Adopted on
         # ANY resume, unlike bridge_messages above: the scaffold replays only the
@@ -134,6 +141,35 @@ class AgentBridge:
             value_type=list[_Conversation],
         )
         self._operator_keys: set[str] = set()
+        # Span emission for accumulated conversations. The emitter owns the
+        # `span_id`/`ordinal`/`first_seen_call`/`resume_adopted` fields on
+        # `_Conversation`; the accumulator owns `key`/`messages`/`output`. A
+        # caller-supplied sink takes precedence and disables span emission:
+        # existing callers that pair accumulation with their own sink (the
+        # external conversation-span sink this emitter replaces) keep exactly
+        # their current behavior until they migrate. The release that stops
+        # flattening `state.messages` upgrades this to a hard error.
+        self._span_emitter: _ConversationSpanEmitter | None = None
+        if accumulate_conversations and model_event_sink is None:
+            self._span_emitter = _ConversationSpanEmitter(self)
+            self.model_event_sink = self._span_emitter
+        # Conversations restored from a checkpoint predate this process: the spans
+        # that carried their events closed with the process that opened them, so the
+        # next call continuing one mints a fresh span, marked by `resume_adopted`.
+        # A legacy snapshot (written before span emission existed) restores every
+        # conversation with default span metadata; first-seen order survives as the
+        # list order, so ordinals are re-derived from it. `first_seen_call` is
+        # process-local and unknowable across the boundary: zeroed, with
+        # `resume_adopted` marking the discontinuity.
+        legacy_ordinals = len(self._conversations) > 1 and all(
+            conversation.ordinal == 0 for conversation in self._conversations
+        )
+        for index, conversation in enumerate(self._conversations):
+            conversation.span_id = None
+            conversation.resume_adopted = True
+            conversation.first_seen_call = 0
+            if legacy_ordinals:
+                conversation.ordinal = index
 
     state: AgentState
     """State updated from messages traveling over the bridge."""
@@ -189,6 +225,11 @@ class AgentBridge:
     agent body is invisible to them. Setting policies here is the only reliable way
     to scope approval from within the agent.
     """
+
+    def close_conversation_spans(self) -> None:
+        """End every accumulated conversation's span (no-op without accumulation)."""
+        if self._span_emitter is not None:
+            self._span_emitter.close()
 
     def request_terminate(self, reason: str) -> NoReturn:
         """Terminate the sample from a bridged generation.
@@ -341,10 +382,14 @@ class AgentBridge:
             # a side call the rules below displace it later)
             self._adopt_thread(messages, output, fps, calls=1)
         elif _extends(self._tracked_fps, fps):
+            messages = _preserve_producer_messages(self.state.messages, messages)
             self._adopt_thread(messages, output, fps, calls=self._tracked_calls + 1)
         elif self._candidate_fps is not None and _extends(self._candidate_fps, fps):
             # the candidate got continued so it is a live agent loop (e.g. the
             # post-compaction conversation): promote it over the tracked thread
+            messages = _preserve_producer_messages(
+                self._candidate_messages or [], messages
+            )
             self._adopt_thread(messages, output, fps, calls=2)
         else:
             descends = self._descends_from_initial(messages, fps)
@@ -376,6 +421,7 @@ class AgentBridge:
                 self._adopt_thread(messages, output, fps, calls=1)
             else:
                 self._candidate_fps = fps
+                self._candidate_messages = messages
 
         self._last_message_count = len(messages)
 
@@ -426,6 +472,11 @@ class AgentBridge:
         """
         messages = input + [output.message]
         key = _non_system([_conversation_message_fingerprint(m) for m in messages])
+        call_index = (
+            self._span_emitter.next_call_index()
+            if self._span_emitter is not None
+            else 0
+        )
         continued: int | None = None
         for index, conversation in enumerate(self._conversations):
             if _is_prefix(conversation.key, key) and (
@@ -434,23 +485,53 @@ class AgentBridge:
             ):
                 continued = index
         if continued is None:
-            # Already covered by a stored conversation (a re-send of an earlier turn):
-            # it carries nothing the longer form does not.
-            if not any(_is_prefix(key, c.key) for c in self._conversations):
-                self._conversations.append(
-                    _Conversation(key=key, messages=messages, output=output)
+            # A call already covered by a stored conversation (a re-send of an
+            # earlier turn) carries nothing the longer form does not: it joins
+            # that conversation rather than storing a replica.
+            current: _Conversation | None = None
+            for conversation in self._conversations:
+                if _is_prefix(key, conversation.key) and (
+                    current is None or len(conversation.key) > len(current.key)
+                ):
+                    current = conversation
+            if current is None:
+                current = _Conversation(
+                    key=key,
+                    messages=messages,
+                    output=output,
+                    ordinal=1
+                    + max((c.ordinal for c in self._conversations), default=-1),
+                    first_seen_call=call_index,
                 )
+                self._conversations.append(current)
         else:
-            self._conversations[continued] = _Conversation(
-                key=key, messages=messages, output=output
+            prior = self._conversations[continued]
+            messages = _preserve_producer_messages(prior.messages, messages)
+            current = _Conversation(
+                key=key,
+                messages=messages,
+                output=output,
+                span_id=prior.span_id,
+                ordinal=prior.ordinal,
+                first_seen_call=prior.first_seen_call,
+                resume_adopted=prior.resume_adopted,
             )
+            self._conversations[continued] = current
             # Absorb any other conversation this one now contains, so a fork that
-            # happened before the two met cannot persist as a stale duplicate.
-            self._conversations = [
-                conversation
-                for index, conversation in enumerate(self._conversations)
-                if index == continued or not _is_prefix(conversation.key, key)
-            ]
+            # happened before the two met cannot persist as a stale duplicate. An
+            # absorbed conversation's span (if any) ends now: its events stay inside
+            # it, and nothing will extend it again.
+            kept: list[_Conversation] = []
+            for index, conversation in enumerate(self._conversations):
+                if index == continued or not _is_prefix(conversation.key, key):
+                    kept.append(conversation)
+                elif (
+                    conversation.span_id is not None and self._span_emitter is not None
+                ):
+                    self._span_emitter.end_span(conversation.span_id)
+            self._conversations = kept
+        if self._span_emitter is not None:
+            self._span_emitter.attribute_call(current)
         self.state.messages = self._flattened_conversations()
         self.state.output = output
 
@@ -468,16 +549,33 @@ class AgentBridge:
         stability `apply_message_ids` exists to provide and breaks every consumer that
         joins on the id (`log/_condense.py`'s walk cache, `solver/_run.py`'s prefix diff,
         matching `sample.messages` back to `ModelEvent.input`).
+
+        When a synthetic carrier collides with a bridge-produced assistant message, retain
+        the producer id. The carrier is an independent input and may be re-identified; the
+        output id is the identity a later `ModelEvent` uses to establish authorship.
         """
         flattened: list[ChatMessage] = []
-        seen: set[str] = set()
-        for conversation in self._conversations:
+        seen: dict[str, tuple[int, int, int]] = {}
+        for conversation_index, conversation in enumerate(self._conversations):
             for position, message in enumerate(conversation.messages):
-                if message.id in seen:
-                    message = message.model_copy(update={"id": uuid()})
-                    conversation.messages[position] = message
+                if message.id is not None and (prior := seen.get(message.id)):
+                    prior_flattened, prior_conversation, prior_position = prior
+                    prior_message = flattened[prior_flattened]
+                    if _is_producer(message) and not _is_producer(prior_message):
+                        replacement_id = uuid()
+                        prior_message = prior_message.model_copy(
+                            update={"id": replacement_id}
+                        )
+                        self._conversations[prior_conversation].messages[
+                            prior_position
+                        ] = prior_message
+                        flattened[prior_flattened] = prior_message
+                        seen[replacement_id] = prior
+                    else:
+                        message = message.model_copy(update={"id": uuid()})
+                        conversation.messages[position] = message
                 if message.id is not None:
-                    seen.add(message.id)
+                    seen[message.id] = (len(flattened), conversation_index, position)
                 flattened.append(message)
         return flattened
 
@@ -500,6 +598,7 @@ class AgentBridge:
         self._tracked_calls = calls
         self._tracked_descends = self._descends_from_initial(messages, fps)
         self._candidate_fps = None
+        self._candidate_messages = None
 
     def _descends_from_initial(
         self, messages: list[ChatMessage], fps: list["_MessageFingerprint"]
@@ -591,6 +690,51 @@ def _conversation_message_fingerprint(
         role=message.role,
         identity_hash=mm3_hash(to_json_str_safe(message_identity)),
     )
+
+
+def _is_producer(message: ChatMessage) -> bool:
+    """Whether a message is a bridge model output with attribution authority."""
+    return isinstance(message, ChatMessageAssistant) and message.source == "generate"
+
+
+def _preserve_producer_messages(
+    previous: list[ChatMessage], messages: list[ChatMessage]
+) -> list[ChatMessage]:
+    """Reuse producer messages from an exactly continued non-system prefix.
+
+    Request conversion synthesizes inbound ids, source, and metadata. Those transport
+    fields cannot identify a continuation, so only semantic wire content participates.
+    Systems are also excluded because native CLIs may rewrite them per request. A mismatch
+    leaves the converted request untouched rather than inferring producer identity.
+    """
+    previous_non_system = [
+        (index, message)
+        for index, message in enumerate(previous)
+        if message.role != "system"
+    ]
+    message_non_system = [
+        (index, message)
+        for index, message in enumerate(messages)
+        if message.role != "system"
+    ]
+    if len(previous_non_system) > len(message_non_system):
+        return messages
+    if any(
+        _conversation_message_fingerprint(previous_message)
+        != _conversation_message_fingerprint(message)
+        for (_, previous_message), (_, message) in zip(
+            previous_non_system, message_non_system
+        )
+    ):
+        return messages
+
+    preserved = messages.copy()
+    for (_, previous_message), (message_index, _) in zip(
+        previous_non_system, message_non_system
+    ):
+        if _is_producer(previous_message):
+            preserved[message_index] = previous_message
+    return preserved
 
 
 class _MessageFingerprint(NamedTuple):
@@ -719,11 +863,211 @@ def _condensed_fingerprint(fp: _MessageFingerprint) -> _MessageFingerprint:
 
 @dataclass
 class _Conversation:
-    """One conversation observed over the bridge (see `_accumulate_conversation`)."""
+    """One conversation observed over the bridge (see `_accumulate_conversation`).
+
+    `key`/`messages`/`output` are accumulator-owned; `span_id`/`ordinal`/
+    `first_seen_call`/`resume_adopted` are owned by `_ConversationSpanEmitter`.
+    The span fields default for snapshots written before span emission existed,
+    and `span_id` is reset on every checkpoint restore (see
+    `AgentBridge.__init__`).
+    """
 
     key: list[_ConversationMessageFingerprint]
     messages: list[ChatMessage]
     output: ModelOutput
+    span_id: str | None = None
+    ordinal: int = 0
+    first_seen_call: int = 0
+    resume_adopted: bool = False
+
+
+BRIDGE_CONVERSATION_SPAN_TYPE = "conversation"
+"""Span type for accumulated bridge conversations.
+
+The type consumers of bridged conversation spans already read; timeline
+classification (`span_type == "agent"`) is intentionally not claimed here —
+flipping the type is a consumer-visible change reserved for the release that
+stops flattening conversations into `state.messages`.
+"""
+
+
+class _CallRecord(NamedTuple):
+    """One bridged call's emitted events and their emission-time parent span.
+
+    Lives in a task-local ContextVar: the sandbox service runs one handler task
+    per request, so the record's lifetime is exactly the call's — a handler
+    that fails before accumulating dies with its record, leaking nothing and
+    never mis-attributing to a reused task id.
+    """
+
+    parent_id: str | None
+    events: list["ModelEvent"]
+
+
+_call_record: ContextVar[_CallRecord | None] = ContextVar(
+    "_bridge_call_record", default=None
+)
+
+
+class _ConversationSpanEmitter:
+    """Emit one transcript span per accumulated conversation.
+
+    Installed as the bridge's `model_event_sink` when `accumulate_conversations`
+    is set, so `_record_model_interaction` routes each bridged `ModelEvent` here
+    instead of emitting it to the transcript directly. The emitter does no
+    conversation matching of its own: events are emitted immediately under their
+    ambient span and remembered per handler task, and `_accumulate_conversation`
+    — the only authoritative matcher — attributes them to the resolved
+    conversation's span after each call. Attribution by task rather than by
+    content is what keeps a compacted, filter-rewritten, or approval-retried
+    call's events in the conversation the accumulator chose: the request task
+    that generated the events is the request task that accumulates them, no
+    matter how the model input was transformed in between.
+
+    Span metadata (`conversation_ordinal`, `first_seen_call_index`,
+    `resume_adopted`) rides in an `InfoEvent` emitted inside the span with
+    `source="bridge_conversation"`. Producer message identity is carried by the
+    message ids themselves (see `_flattened_conversations`), not repeated here.
+    `first_seen_call_index` is process-local: it restarts after a resume, and
+    `resume_adopted` marks the discontinuity.
+    """
+
+    def __init__(self, bridge: "AgentBridge") -> None:
+        self._bridge = bridge
+        self._span_ids: list[str] = []
+        self._calls_seen = 0
+        self._closed = False
+
+    def on_pending(self, event: "ModelEvent") -> None:
+        from inspect_ai.log._transcript import transcript
+
+        transcript()._event(event)
+        if not self._closed:
+            record = _call_record.get()
+            if record is None:
+                record = _CallRecord(parent_id=event.span_id, events=[])
+                _call_record.set(record)
+            record.events.append(event)
+
+    def on_complete(self, event: "ModelEvent") -> None:
+        from inspect_ai.log._transcript import transcript
+
+        transcript()._event_updated(event)
+
+    def next_call_index(self) -> int:
+        """The zero-based index of the bridged call being accumulated."""
+        index = self._calls_seen
+        self._calls_seen += 1
+        return index
+
+    def attribute_call(self, conversation: _Conversation) -> None:
+        """Stamp the current call's events into the conversation's span.
+
+        Runs in the same handler task that emitted the events (the API shims
+        call `_track_state` after `bridge_generate` returns), so the task-local
+        record is exactly this call's events — including approval retries,
+        which generate more than once before the call accumulates. A filtered
+        call recorded no events; the conversation still gets its span so every
+        accumulated conversation is represented in the transcript.
+        """
+        from inspect_ai.log._transcript import transcript
+
+        record = _call_record.get()
+        _call_record.set(None)
+        if self._closed:
+            return
+        span_id = self._ensure_span(
+            conversation,
+            parent_id=record.parent_id if record is not None else None,
+            parent_known=record is not None,
+        )
+        for event in record.events if record is not None else []:
+            event.span_id = span_id
+            transcript()._event_updated(event)
+
+    def end_span(self, span_id: str) -> None:
+        """End one conversation's span (absorption: nothing extends it again)."""
+        from inspect_ai.event import SpanEndEvent
+        from inspect_ai.log._transcript import transcript
+
+        if span_id in self._span_ids:
+            self._span_ids.remove(span_id)
+            transcript()._event(SpanEndEvent(id=span_id))
+
+    def close(self) -> None:
+        """End every open conversation span. Idempotent."""
+        from inspect_ai.event import SpanEndEvent
+        from inspect_ai.log._transcript import transcript
+
+        if self._closed:
+            return
+        self._closed = True
+        for span_id in reversed(self._span_ids):
+            transcript()._event(SpanEndEvent(id=span_id))
+        self._span_ids.clear()
+        _call_record.set(None)
+
+    def _ensure_span(
+        self, conversation: _Conversation, *, parent_id: str | None, parent_known: bool
+    ) -> str:
+        """The conversation's span, minted on first attribution.
+
+        A conversation without a span was just created, was restored from a
+        checkpoint (its span closed with the process that opened it — the fresh
+        span is the adoption `resume_adopted` records), or was created by a
+        filtered call that never generated.
+        """
+        if conversation.span_id is None:
+            conversation.span_id = self._open_span(
+                conversation, parent_id=parent_id, parent_known=parent_known
+            )
+        return conversation.span_id
+
+    def _open_span(
+        self, conversation: _Conversation, *, parent_id: str | None, parent_known: bool
+    ) -> str:
+        """Open the conversation's span under its events' emission-time parent.
+
+        The parent is the span the call's events were emitted under, recorded at
+        emission: attribution runs later in the handler task, and a concurrent
+        handler may have rotated the ambient checkpoint span in between — reading
+        the ambient at attribution time would reparent events across checkpoints.
+        A filtered call emitted nothing, so the attribution-time ambient is the
+        only parent there is. `None` is legal — the span then becomes a tree
+        root, which is what an unspanned sample wants.
+        """
+        from inspect_ai.event import InfoEvent, SpanBeginEvent
+        from inspect_ai.log._transcript import transcript
+        from inspect_ai.util._span import current_span_id
+
+        if not parent_known:
+            parent_id = current_span_id()
+        span_id = uuid()
+        begin = SpanBeginEvent(
+            id=span_id,
+            parent_id=parent_id,
+            span_id=parent_id,
+            type=BRIDGE_CONVERSATION_SPAN_TYPE,
+            name=f"conversation {conversation.ordinal}",
+        )
+        # A captured None parent is authoritative (root span): construction fills
+        # a None span_id from the ambient span, which may be an unrelated later
+        # checkpoint by attribution time — restore the captured value.
+        begin.span_id = parent_id
+        transcript()._event(begin)
+        transcript()._event(
+            InfoEvent(
+                source="bridge_conversation",
+                span_id=span_id,
+                data={
+                    "conversation_ordinal": conversation.ordinal,
+                    "first_seen_call_index": conversation.first_seen_call,
+                    "resume_adopted": conversation.resume_adopted,
+                },
+            )
+        )
+        self._span_ids.append(span_id)
+        return span_id
 
 
 def _is_prefix(

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
     # cycles back through partially-initialized modules). Same reason
     # `model/_call_tools.py` defers it.
     from inspect_ai.approval._policy import ApprovalPolicy
-    from inspect_ai.event import Event, ModelEvent
+    from inspect_ai.event import Event, ModelEvent, SpanBeginEvent
 
 
 class AgentBridge:
@@ -1017,6 +1017,14 @@ class _ConversationSpanEmitter:
         # emission). Placed when the sink finally writes them, if it wrote them
         # back at the ambient rather than somewhere of its own choosing.
         self._deferred: dict[int, tuple[str, str | None]] = {}
+        # Composed only: for every arrival span some event has been moved out
+        # of, the conversation of the most recent moved event that ISSUED A TOOL
+        # CALL there. A sink that opens a sub-agent span under a parent call's
+        # arrival span -- possibly requests later, when the child's own first
+        # call comes in -- names a span whose events have since moved; the child
+        # follows the call that could have spawned it. A side call with no tool
+        # calls (a title generation) leaving the same span does not displace it.
+        self._rehomed: dict[str, str] = {}
         self._unsubscribe: Callable[[], None] | None = None
 
     def on_pending(self, event: "ModelEvent") -> None:
@@ -1056,7 +1064,7 @@ class _ConversationSpanEmitter:
         record.events.append(event)
 
     def _on_written(self, event: "Event") -> None:
-        """Place a formerly held event into its conversation once the sink writes it.
+        """React to the sink's writes: place released events, re-home late child spans.
 
         A sink that held an event past attribution and then wrote it back at the
         ambient span decided it was NOT a sub-agent's, so the conversation span
@@ -1064,8 +1072,13 @@ class _ConversationSpanEmitter:
         placement stands (see `attribute_call`). Runs inside the transcript's
         write, which guards re-entrancy, so the update here does not recurse.
         """
-        from inspect_ai.event import ModelEvent
+        from inspect_ai.event import ModelEvent, SpanBeginEvent
 
+        if isinstance(event, SpanBeginEvent):
+            target = self._rehomed.get(event.parent_id or "")
+            if target is not None:
+                self._rehome_child(event, event.parent_id or "", target)
+            return
         deferred = self._deferred.pop(id(event), None)
         if deferred is None or not isinstance(event, ModelEvent):
             return
@@ -1147,22 +1160,33 @@ class _ConversationSpanEmitter:
         former = event.span_id
         event.span_id = span_id
         transcript()._event_updated(event)
-        if former == span_id or self._writes_events:
+        if former == span_id or self._writes_events or former is None:
             return
+        # Only a call that ISSUED tool calls can have spawned a sub-agent, so only
+        # such a call claims its arrival span for later children. A tool-less call
+        # leaving the same span -- a version probe, a title generation -- claims
+        # nothing, whether it left first or last.
+        if any(choice.message.tool_calls for choice in event.output.choices):
+            self._rehomed[former] = span_id
+        if self._unsubscribe is None:
+            self._unsubscribe = transcript()._subscribe(self._on_written)
         events = transcript().events
         try:
             start = next(i for i, e in enumerate(events) if e is event)
         except StopIteration:
             return
         for child in events[start + 1 :]:
-            if (
-                isinstance(child, SpanBeginEvent)
-                and child.type == "agent"
-                and child.parent_id == former
-            ):
-                child.parent_id = span_id
-                child.span_id = span_id
-                transcript()._event_updated(child)
+            if isinstance(child, SpanBeginEvent):
+                self._rehome_child(child, former, span_id)
+
+    def _rehome_child(self, child: "SpanBeginEvent", former: str, span_id: str) -> None:
+        """Move a sink-opened sub-agent span from a vacated arrival span to the conversation."""
+        from inspect_ai.log._transcript import transcript
+
+        if child.type == "agent" and child.parent_id == former:
+            child.parent_id = span_id
+            child.span_id = span_id
+            transcript()._event_updated(child)
 
     def end_span(self, span_id: str) -> None:
         """End one conversation's span (absorption: nothing extends it again)."""
@@ -1185,6 +1209,7 @@ class _ConversationSpanEmitter:
             transcript()._event(SpanEndEvent(id=span_id))
         self._span_ids.clear()
         self._deferred.clear()
+        self._rehomed.clear()
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -143,16 +143,25 @@ class AgentBridge:
         self._operator_keys: set[str] = set()
         # Span emission for accumulated conversations. The emitter owns the
         # `span_id`/`ordinal`/`first_seen_call`/`resume_adopted` fields on
-        # `_Conversation`; the accumulator owns `key`/`messages`/`output`. A
-        # caller-supplied sink takes precedence and disables span emission:
-        # existing callers that pair accumulation with their own sink (the
-        # external conversation-span sink this emitter replaces) keep exactly
-        # their current behavior until they migrate. The release that stops
-        # flattening `state.messages` upgrades this to a hard error.
+        # `_Conversation`; the accumulator owns `key`/`messages`/`output`. It
+        # runs whenever conversations accumulate. A caller-supplied sink does
+        # not disable it -- the two compose: the sink keeps deciding when and
+        # under which span an event is written (sub-agent identity a native
+        # harness recovers from its own records), and the emitter attributes
+        # the events the sink wrote to their conversation's span. Disabling
+        # emission when a sink was present left every native-harness run
+        # (all four wrappers install one) span-less, carried by flattening
+        # alone.
         self._span_emitter: _ConversationSpanEmitter | None = None
-        if accumulate_conversations and model_event_sink is None:
-            self._span_emitter = _ConversationSpanEmitter(self)
-            self.model_event_sink = self._span_emitter
+        if accumulate_conversations:
+            self._span_emitter = _ConversationSpanEmitter(
+                self, writes_events=model_event_sink is None
+            )
+            self.model_event_sink = (
+                self._span_emitter
+                if model_event_sink is None
+                else _ComposedModelEventSink(self._span_emitter, model_event_sink)
+            )
         # Conversations restored from a checkpoint predate this process: the spans
         # that carried their events closed with the process that opened them, so the
         # next call continuing one mints a fresh span, marked by `resume_adopted`.
@@ -932,27 +941,43 @@ class _ConversationSpanEmitter:
     `resume_adopted` marks the discontinuity.
     """
 
-    def __init__(self, bridge: "AgentBridge") -> None:
+    def __init__(self, bridge: "AgentBridge", *, writes_events: bool = True) -> None:
         self._bridge = bridge
         self._span_ids: list[str] = []
         self._calls_seen = 0
         self._closed = False
+        # Standalone, the emitter is the transcript writer for bridged events.
+        # Composed with a caller sink (`_ComposedModelEventSink`), the sink
+        # writes and the emitter only records membership and re-parents.
+        self._writes_events = writes_events
 
     def on_pending(self, event: "ModelEvent") -> None:
         from inspect_ai.log._transcript import transcript
 
-        transcript()._event(event)
-        if not self._closed:
-            record = _call_record.get()
-            if record is None:
-                record = _CallRecord(parent_id=event.span_id, events=[])
-                _call_record.set(record)
-            record.events.append(event)
+        if self._writes_events:
+            transcript()._event(event)
+        self.record(event)
 
     def on_complete(self, event: "ModelEvent") -> None:
         from inspect_ai.log._transcript import transcript
 
-        transcript()._event_updated(event)
+        if self._writes_events:
+            transcript()._event_updated(event)
+
+    def record(self, event: "ModelEvent") -> None:
+        """Remember ``event`` as part of the handler task's bridged call.
+
+        The parent recorded here is the span the event was emitted under, read
+        before any sink has moved it: attribution runs later and a concurrent
+        handler may have rotated the ambient span in between.
+        """
+        if self._closed:
+            return
+        record = _call_record.get()
+        if record is None:
+            record = _CallRecord(parent_id=event.span_id, events=[])
+            _call_record.set(record)
+        record.events.append(event)
 
     def next_call_index(self) -> int:
         """The zero-based index of the bridged call being accumulated."""
@@ -969,6 +994,13 @@ class _ConversationSpanEmitter:
         which generate more than once before the call accumulates. A filtered
         call recorded no events; the conversation still gets its span so every
         accumulated conversation is represented in the transcript.
+
+        Composed with a caller sink, only events the sink has already written
+        are re-parented. An event the sink is still holding — a sub-agent call
+        awaiting the native identity that names its span — keeps the sink's
+        placement when the sink writes it: that identity is exact where the
+        prefix match is not, so it is adopted in place of the conversation
+        span, never alongside it as a second span for the same event.
         """
         from inspect_ai.log._transcript import transcript
 
@@ -982,6 +1014,8 @@ class _ConversationSpanEmitter:
             parent_known=record is not None,
         )
         for event in record.events if record is not None else []:
+            if not self._writes_events and not transcript()._is_resident(event):
+                continue
             event.span_id = span_id
             transcript()._event_updated(event)
 
@@ -1068,6 +1102,31 @@ class _ConversationSpanEmitter:
         )
         self._span_ids.append(span_id)
         return span_id
+
+
+class _ComposedModelEventSink:
+    """Route each bridged `ModelEvent` to both the span emitter and a caller sink.
+
+    The caller's sink is the writer: it decides when the event reaches the
+    transcript and under which span, exactly as it does without accumulation.
+    The emitter only records the event as part of the handler task's call, so
+    that `attribute_call` can move the events the sink wrote into their
+    conversation's span. Recording runs first so the emitter sees the span the
+    event was emitted under, before the sink has moved it.
+    """
+
+    def __init__(
+        self, emitter: _ConversationSpanEmitter, sink: "ModelEventSink"
+    ) -> None:
+        self._emitter = emitter
+        self._sink = sink
+
+    def on_pending(self, event: "ModelEvent") -> None:
+        self._emitter.record(event)
+        self._sink.on_pending(event)
+
+    def on_complete(self, event: "ModelEvent") -> None:
+        self._sink.on_complete(event)
 
 
 def _is_prefix(

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from contextvars import ContextVar
 from dataclasses import dataclass
 from enum import IntEnum
@@ -6,6 +7,7 @@ from typing import TYPE_CHECKING, NamedTuple, NoReturn, Sequence, Set
 
 from shortuuid import uuid
 
+from inspect_ai._util.content import ContentText
 from inspect_ai._util.exception import TerminateSampleError
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai._util.json import to_json_str_safe
@@ -37,7 +39,7 @@ if TYPE_CHECKING:
     # cycles back through partially-initialized modules). Same reason
     # `model/_call_tools.py` defers it.
     from inspect_ai.approval._policy import ApprovalPolicy
-    from inspect_ai.event import ModelEvent
+    from inspect_ai.event import Event, ModelEvent
 
 
 class AgentBridge:
@@ -691,14 +693,74 @@ class _ConversationMessageFingerprint(NamedTuple):
 def _conversation_message_fingerprint(
     message: ChatMessage,
 ) -> _ConversationMessageFingerprint:
+    """Identity of a message for conversation matching.
+
+    Content is compared by meaning, not by wire shape. The bridge's own output
+    message and the CLI's echo of it next request are the same turn, but they
+    differ in four transport-only ways, each of which made a producer message
+    never match its echo -- so every turn of one linear session started a new
+    conversation and the accumulator never extended anything:
+
+    - shape: the bridge emits `content` as a string, the CLI echoes a
+      one-element text list. A single plain text part fingerprints as its
+      string; several parts, an image or a reasoning block keep their structure,
+      which is what distinguishes them.
+    - condensation: the transcript replaces any string over 100 characters with
+      `attachment://<mm3-hash>` before the bridge sees the echo (a long sub-agent
+      prompt inside `tool_calls[].arguments`, for one). Every long string in the
+      identity is condensed the same way here, so both sides hash alike.
+    - empty content: an assistant turn that was only tool calls has `content ""`
+      on the way out and `"(no content)"` on the way back. Both fingerprint empty.
+    - `tool_calls[].view`: a render hint the bridge attaches on the way out and
+      the CLI never sends back. Presentation, not identity; dropped.
+    """
     message_identity = message.model_dump(
-        exclude={"id", "metadata", "model", "source"},
+        exclude={
+            "id": True,
+            "metadata": True,
+            "model": True,
+            "source": True,
+            "tool_calls": {"__all__": {"view"}},
+        },
         exclude_none=True,
     )
+    content = message.content
+    if (
+        isinstance(content, list)
+        and len(content) == 1
+        and isinstance(content[0], ContentText)
+        and content[0].refusal is None
+        and content[0].citations is None
+    ):
+        content = content[0].text
+    if isinstance(content, str):
+        message_identity["content"] = "" if content == _NO_CONTENT_ECHO else content
     return _ConversationMessageFingerprint(
         role=message.role,
-        identity_hash=mm3_hash(to_json_str_safe(message_identity)),
+        identity_hash=mm3_hash(to_json_str_safe(_condensed(message_identity))),
     )
+
+
+_NO_CONTENT_ECHO = "(no content)"
+"""How Claude Code renders an assistant turn that carried only tool calls."""
+
+_CONDENSE_OVER_CHARS = 100
+"""Transcript condensation threshold (`inspect_ai.log._condense`: text > 100)."""
+
+
+def _condensed(value: object) -> object:
+    """The value with every string the transcript would condense, condensed."""
+    if isinstance(value, str):
+        if len(value) > _CONDENSE_OVER_CHARS and not value.startswith(
+            ATTACHMENT_PROTOCOL
+        ):
+            return f"{ATTACHMENT_PROTOCOL}{mm3_hash(value)}"
+        return value
+    if isinstance(value, dict):
+        return {k: _condensed(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_condensed(v) for v in value]
+    return value
 
 
 def _is_producer(message: ChatMessage) -> bool:
@@ -950,6 +1012,12 @@ class _ConversationSpanEmitter:
         # Composed with a caller sink (`_ComposedModelEventSink`), the sink
         # writes and the emitter only records membership and re-parents.
         self._writes_events = writes_events
+        # Composed only: events the sink was still HOLDING when their call was
+        # attributed, keyed by id(event) -> (conversation span, ambient at
+        # emission). Placed when the sink finally writes them, if it wrote them
+        # back at the ambient rather than somewhere of its own choosing.
+        self._deferred: dict[int, tuple[str, str | None]] = {}
+        self._unsubscribe: Callable[[], None] | None = None
 
     def on_pending(self, event: "ModelEvent") -> None:
         from inspect_ai.log._transcript import transcript
@@ -967,17 +1035,43 @@ class _ConversationSpanEmitter:
     def record(self, event: "ModelEvent") -> None:
         """Remember ``event`` as part of the handler task's bridged call.
 
-        The parent recorded here is the span the event was emitted under, read
-        before any sink has moved it: attribution runs later and a concurrent
-        handler may have rotated the ambient span in between.
+        The parent recorded here is the AMBIENT span at emission time: the span
+        the bridge is running under when the call arrives. It is read now, not
+        at attribution, because a concurrent handler may rotate the ambient
+        span in between. It is deliberately not `event.span_id`: standalone the
+        two agree, but composed with a caller sink the event has not been
+        placed yet when it is recorded (recording runs first, so the sink's
+        placement is not mistaken for the emission context), and a sink that
+        holds the event may later place it under a sub-agent span -- a child
+        of the conversation, never the conversation's parent.
         """
+        from inspect_ai.util._span import current_span_id
+
         if self._closed:
             return
         record = _call_record.get()
         if record is None:
-            record = _CallRecord(parent_id=event.span_id, events=[])
+            record = _CallRecord(parent_id=current_span_id(), events=[])
             _call_record.set(record)
         record.events.append(event)
+
+    def _on_written(self, event: "Event") -> None:
+        """Place a formerly held event into its conversation once the sink writes it.
+
+        A sink that held an event past attribution and then wrote it back at the
+        ambient span decided it was NOT a sub-agent's, so the conversation span
+        its call was attributed to is its home. Written anywhere else, the sink's
+        placement stands (see `attribute_call`). Runs inside the transcript's
+        write, which guards re-entrancy, so the update here does not recurse.
+        """
+        from inspect_ai.event import ModelEvent
+
+        deferred = self._deferred.pop(id(event), None)
+        if deferred is None or not isinstance(event, ModelEvent):
+            return
+        span_id, ambient = deferred
+        if event.span_id == ambient and span_id in self._span_ids:
+            self._move_event(event, span_id)
 
     def next_call_index(self) -> int:
         """The zero-based index of the bridged call being accumulated."""
@@ -1013,11 +1107,62 @@ class _ConversationSpanEmitter:
             parent_id=record.parent_id if record is not None else None,
             parent_known=record is not None,
         )
-        for event in record.events if record is not None else []:
-            if not self._writes_events and not transcript()._is_resident(event):
-                continue
-            event.span_id = span_id
-            transcript()._event_updated(event)
+        if record is None:
+            return
+        for event in record.events:
+            if not self._writes_events:
+                if not transcript()._is_resident(event):
+                    # The sink is still holding it. Whichever of the sink's paths
+                    # finally writes it (a completion callback, a native-transcript
+                    # drain, a JSONL record) goes through the transcript, so the
+                    # transcript's write hook is the one place to catch the release.
+                    self._deferred[id(event)] = (span_id, record.parent_id)
+                    if self._unsubscribe is None:
+                        self._unsubscribe = transcript()._subscribe(self._on_written)
+                    continue
+                # The sink wrote it. If it also PLACED it -- anywhere but the
+                # ambient span the call arrived under -- that placement is an
+                # identity decision (a sub-agent span named by the CLI's own
+                # records), adopted in place of the conversation span, never
+                # beside it. An event still sitting at the ambient was written
+                # without a placement of its own, and the conversation is its home.
+                if event.span_id != record.parent_id:
+                    continue
+            self._move_event(event, span_id)
+
+    def _move_event(self, event: "ModelEvent", span_id: str) -> None:
+        """Move an event into its conversation span, carrying its child spans along.
+
+        A sink may open a sub-agent span under the event's span at completion
+        time -- which is BEFORE attribution, so it read the span the event
+        arrived under, not the conversation it turns out to belong to. Left
+        alone, the conversation and the sub-agent tree it spawned would sit as
+        siblings and nothing would record which conversation spawned it. Any
+        `agent` span begun under the event's former span after the event was
+        written, and not yet re-homed, moves with it.
+        """
+        from inspect_ai.event import SpanBeginEvent
+        from inspect_ai.log._transcript import transcript
+
+        former = event.span_id
+        event.span_id = span_id
+        transcript()._event_updated(event)
+        if former == span_id or self._writes_events:
+            return
+        events = transcript().events
+        try:
+            start = next(i for i, e in enumerate(events) if e is event)
+        except StopIteration:
+            return
+        for child in events[start + 1 :]:
+            if (
+                isinstance(child, SpanBeginEvent)
+                and child.type == "agent"
+                and child.parent_id == former
+            ):
+                child.parent_id = span_id
+                child.span_id = span_id
+                transcript()._event_updated(child)
 
     def end_span(self, span_id: str) -> None:
         """End one conversation's span (absorption: nothing extends it again)."""
@@ -1039,6 +1184,10 @@ class _ConversationSpanEmitter:
         for span_id in reversed(self._span_ids):
             transcript()._event(SpanEndEvent(id=span_id))
         self._span_ids.clear()
+        self._deferred.clear()
+        if self._unsubscribe is not None:
+            self._unsubscribe()
+            self._unsubscribe = None
         _call_record.set(None)
 
     def _ensure_span(

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, NamedTuple, NoReturn, Sequence, Set
 
 from shortuuid import uuid
 
-from inspect_ai._util.content import ContentText
+from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai._util.exception import TerminateSampleError
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai._util.json import to_json_str_safe
@@ -713,6 +713,20 @@ def _conversation_message_fingerprint(
       on the way out and `"(no content)"` on the way back. Both fingerprint empty.
     - `tool_calls[].view`: a render hint the bridge attaches on the way out and
       the CLI never sends back. Presentation, not identity; dropped.
+    - tool-call ids: a transport handle, not identity. Anthropic mints one the
+      CLI echoes verbatim, so ids happened to match; Gemini's wire format has
+      none, so the bridge drops the produced id on the way out and synthesizes
+      `call_<fn>_<hash(fn, args, position)>` on the way back -- which is to say
+      that on that transport an id already means nothing but function, arguments
+      and position. Comparing ids made every Gemini turn a new conversation.
+      Identity is the function and its arguments; the tool result's
+      `tool_call_id` goes the same way. Two byte-identical parallel sub-agents
+      therefore share a conversation until their content diverges (the fork
+      rule below splits them there); their EVENTS stay distinct through the
+      sink's placement, which is the sink's job, not a transport id's.
+    - reasoning parts: a provider's thought signature, which Gemini's CLI
+      re-attaches as a redacted reasoning part the producer never emitted.
+      Stripped from identity on both sides; what remains is what was said.
     """
     message_identity = message.model_dump(
         exclude={
@@ -720,11 +734,17 @@ def _conversation_message_fingerprint(
             "metadata": True,
             "model": True,
             "source": True,
-            "tool_calls": {"__all__": {"view"}},
+            "tool_call_id": True,
+            "tool_calls": {"__all__": {"id", "view"}},
         },
         exclude_none=True,
     )
     content = message.content
+    if isinstance(content, list):
+        content = [part for part in content if not isinstance(part, ContentReasoning)]
+        message_identity["content"] = [
+            part.model_dump(exclude_none=True) for part in content
+        ]
     if (
         isinstance(content, list)
         and len(content) == 1
@@ -1025,6 +1045,16 @@ class _ConversationSpanEmitter:
         # follows the call that could have spawned it. A side call with no tool
         # calls (a title generation) leaving the same span does not displace it.
         self._rehomed: dict[str, str] = {}
+        # Spans written after this emitter first subscribed to the transcript:
+        # a sink's own placement tree, never the harness's ambient spans, which
+        # were open before any bridged call (see `_adopt_placement`).
+        self._late_spans: dict[str, "SpanBeginEvent"] = {}
+        # A placing sink's ambient, claimed by the conversation of the last
+        # tool-calling event whose placement tree was rooted there: the trees a
+        # sink roots there afterwards -- a sub-agent's scheduling and calls --
+        # are that call's doing and nest under its conversation, as a sink-opened
+        # `agent` span does under the ambient a tool-calling call vacated.
+        self._claimed_roots: dict[str, str] = {}
         self._unsubscribe: Callable[[], None] | None = None
 
     def on_pending(self, event: "ModelEvent") -> None:
@@ -1075,6 +1105,7 @@ class _ConversationSpanEmitter:
         from inspect_ai.event import ModelEvent, SpanBeginEvent
 
         if isinstance(event, SpanBeginEvent):
+            self._late_spans[event.id] = event
             target = self._rehomed.get(event.parent_id or "")
             if target is not None:
                 self._rehome_child(event, event.parent_id or "", target)
@@ -1083,8 +1114,12 @@ class _ConversationSpanEmitter:
         if deferred is None or not isinstance(event, ModelEvent):
             return
         span_id, ambient = deferred
-        if event.span_id == ambient and span_id in self._span_ids:
+        if span_id not in self._span_ids:
+            return
+        if event.span_id == ambient:
             self._move_event(event, span_id)
+        else:
+            self._adopt_placement(event, span_id)
 
     def next_call_index(self) -> int:
         """The zero-based index of the bridged call being accumulated."""
@@ -1140,8 +1175,68 @@ class _ConversationSpanEmitter:
                 # beside it. An event still sitting at the ambient was written
                 # without a placement of its own, and the conversation is its home.
                 if event.span_id != record.parent_id:
+                    self._adopt_placement(event, span_id)
                     continue
             self._move_event(event, span_id)
+
+    def _adopt_placement(self, event: "ModelEvent", span_id: str) -> None:
+        """Hang a sink-placed event's span tree under its conversation.
+
+        A sink that places every event in a span tree of its own -- Gemini's
+        consumer rebuilds the CLI's native trace, `model` spans under `tool`
+        and `agent` spans -- roots that tree at ITS ambient, the span current
+        in the consumer's task, which is neither the bridge's ambient nor any
+        conversation. The placement is kept (it is the sink's identity
+        decision); its topmost span of the sink's own making is re-parented
+        onto the conversation the event was attributed to, so the contract
+        that every bridged event is owned by exactly one conversation holds
+        for a placing sink too. Only spans written since this emitter began
+        listening are the sink's; the harness's own spans -- open before any
+        bridged call -- are never moved. A tree already under a conversation
+        (this one or another sub-agent's) stays where it is.
+
+        Which conversation: the one that claimed the tree's root ambient, else
+        the event's own. A call that issued tool calls claims the ambient its
+        tree was rooted at, so a sub-agent's tree rooted there afterwards nests
+        under the PARENT call's conversation -- the shape a sink-opened `agent`
+        span already has (see `_move_event`), and the one the sub-agent's own
+        conversation span then sits beside, as its `bridge_conversation` record
+        says. Gemini's trace has no edge from a call to the tool scheduling it
+        caused; this is the one place that edge is known, so this is where it
+        is drawn.
+        """
+        from inspect_ai.event import SpanBeginEvent
+        from inspect_ai.log._transcript import transcript
+
+        if self._unsubscribe is None:
+            self._unsubscribe = transcript()._subscribe(self._on_written)
+        parents = {
+            begin.id: begin
+            for begin in transcript().events
+            if isinstance(begin, SpanBeginEvent)
+        }
+        node = event.span_id
+        root: SpanBeginEvent | None = None
+        seen: set[str] = set()
+        while node is not None and node not in seen:
+            seen.add(node)
+            if node in self._span_ids:
+                return
+            begin = parents.get(node)
+            if begin is None:
+                break
+            if node in self._late_spans:
+                root = begin
+            node = begin.parent_id
+        if root is None:
+            return
+        ambient = root.parent_id or ""
+        target = self._claimed_roots.get(ambient, span_id)
+        root.parent_id = target
+        root.span_id = target
+        transcript()._event_updated(root)
+        if any(choice.message.tool_calls for choice in event.output.choices):
+            self._claimed_roots[ambient] = target
 
     def _move_event(self, event: "ModelEvent", span_id: str) -> None:
         """Move an event into its conversation span, carrying its child spans along.
@@ -1210,6 +1305,8 @@ class _ConversationSpanEmitter:
         self._span_ids.clear()
         self._deferred.clear()
         self._rehomed.clear()
+        self._claimed_roots.clear()
+        self._late_spans.clear()
         if self._unsubscribe is not None:
             self._unsubscribe()
             self._unsubscribe = None

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -1532,3 +1532,228 @@ async def test_anthropic_handler_tracks_main_thread_end_to_end() -> None:
         "please continue",
         "Castle",
     ]
+
+
+# ---------------------------------------------------------------------------
+# accumulate_conversations: keep every conversation, not just the main one
+# ---------------------------------------------------------------------------
+
+
+def accumulating_bridge() -> AgentBridge:
+    return AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+    )
+
+
+def cc_system(nonce: int) -> ChatMessageSystem:
+    """Claude Code's system prompt, which carries a per-request cache token."""
+    return ChatMessageSystem(
+        content=f"x-anthropic-billing-header: cc_version=2.1.126; cch={nonce:05x};\n\nYou are a Claude agent."
+    )
+
+
+async def test_every_conversation_is_kept_not_just_the_main_one() -> None:
+    """Two independent conversations (e.g. two `claude -p` runs) both reach the state."""
+    bridge = accumulating_bridge()
+
+    first: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out = await track(bridge, first, "castle answer")
+    await track(
+        bridge, first + [out.message, ChatMessageTool(content="t")], "castle detail"
+    )
+
+    second: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content="Unrelated second question."),
+    ]
+    await track(bridge, second, "second answer")
+
+    texts = [m.text for m in bridge.state.messages]
+    assert "castle detail" in texts
+    assert "second answer" in texts
+    assert texts.index("castle detail") < texts.index("second answer")
+    # the first conversation is kept once, in its longest form -- not once per call
+    assert texts.count("castle answer") == 1
+    # output describes the final message
+    assert bridge.state.output.completion == "second answer"
+    assert texts[-1] == "second answer"
+
+
+async def test_accumulation_survives_a_per_request_system_prompt() -> None:
+    """A growing Claude Code conversation is ONE conversation, not one per call."""
+    bridge = accumulating_bridge()
+
+    turn: list[ChatMessage] = [cc_system(1), ChatMessageUser(content=TASK)]
+    out = await track(bridge, turn, "step 1")
+    for step in range(2, 5):
+        turn = [cc_system(step), *turn[1:], out.message, ChatMessageTool(content="t")]
+        out = await track(bridge, turn, f"step {step}")
+
+    texts = [m.text for m in bridge.state.messages]
+    assert texts.count("step 1") == 1
+    assert texts.count(TASK) == 1
+    assert texts[-1] == "step 4"
+
+
+async def test_accumulation_keeps_divergent_answers_to_one_history() -> None:
+    """Two answers to an identical history stay separate rather than being merged."""
+    bridge = accumulating_bridge()
+
+    history: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    await track(bridge, history, "answer A")
+    await track(bridge, history, "answer B")
+
+    texts = [m.text for m in bridge.state.messages]
+    assert "answer A" in texts
+    assert "answer B" in texts
+
+
+async def test_main_thread_tracking_is_the_default() -> None:
+    """Without the flag the bridge still surfaces one main conversation."""
+    bridge = task_bridge()
+
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "castle answer")
+    await track(
+        bridge, [TASK_SYSTEM, ChatMessageUser(content="Unrelated.")], "second answer"
+    )
+
+    assert "second answer" not in [m.text for m in bridge.state.messages]
+
+
+async def test_a_repeated_call_does_not_fork_a_replica() -> None:
+    """An exact repeat is the same conversation, not a new one.
+
+    Two invocations making the same deterministic aux call (claude code's bash-path probe)
+    fingerprint identically. Requiring a strict extension forks a whole replica on each.
+    """
+    bridge = accumulating_bridge()
+
+    call: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    await track(bridge, call, "Castle")
+    await track(bridge, call, "Castle")
+
+    assert [m.text for m in bridge.state.messages] == [TASK_SYSTEM.text, TASK, "Castle"]
+
+
+async def test_a_resend_after_growth_is_absorbed_not_stranded() -> None:
+    """A re-sent earlier turn carries nothing the grown conversation does not.
+
+    Appending it instead strands a fork that can never re-merge -- every later call
+    extends the longer copy -- leaving a stale duplicate at the end of state.messages.
+    """
+    bridge = accumulating_bridge()
+
+    first: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out = await track(bridge, first, "working")
+    grown = [*first, out.message, ChatMessageTool(content="tool result")]
+    await track(bridge, grown, "Castle")
+    await track(bridge, first, "working")
+
+    texts = [m.text for m in bridge.state.messages]
+    assert texts == [TASK_SYSTEM.text, TASK, "working", "tool result", "Castle"]
+
+
+async def test_a_late_side_call_does_not_poison_the_output() -> None:
+    """state.output is the newest call, not whichever conversation started last.
+
+    Indexing it by conversation order lets one aux call landing after the main loop's
+    first turn own the output for the rest of the run -- the meridianlabs-ai/inspect_ai#140
+    failure this tracker exists to prevent.
+    """
+    bridge = accumulating_bridge()
+
+    first: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out = await track(bridge, first, "working")
+    await track(bridge, [ChatMessageUser(content="Detect paths in: ls /tmp")], "/tmp")
+    await track(bridge, [*first, out.message, ChatMessageTool(content="t")], "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+
+
+async def test_accumulated_message_ids_are_unique_and_stable() -> None:
+    """Accumulated message ids must be unique AND stable.
+
+    Ids are content-derived and each request sees only its own conversation, so
+    independent conversations that repeat a turn arrive carrying the SAME id while
+    `ChatMessage.id` is documented unique.
+
+    The re-assigned id must be allocated ONCE and held: re-deriving it per call hands the
+    same message a new id every generation, defeating the stability `apply_message_ids`
+    provides and breaking every consumer that joins on the id.
+    """
+    bridge = accumulating_bridge()
+
+    await track(bridge, [ChatMessageUser(content="question one", id="collide")], "A")
+    await track(bridge, [ChatMessageUser(content="question two", id="collide")], "B")
+    first = [m.id for m in bridge.state.messages]
+
+    for index in range(3):
+        await track(bridge, [ChatMessageUser(content=f"other {index}")], f"o{index}")
+    later = [m.id for m in bridge.state.messages]
+
+    assert len(later) == len(set(later))
+    assert later[: len(first)] == first
+
+
+async def test_accumulated_conversations_keep_first_seen_order() -> None:
+    """A call resuming an earlier conversation does not move it to the end."""
+    bridge = accumulating_bridge()
+
+    first: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    out = await track(bridge, first, "first answer")
+
+    second: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content="Second question."),
+    ]
+    await track(bridge, second, "second answer")
+
+    resumed = [*first, out.message, ChatMessageTool(content="t")]
+    await track(bridge, resumed, "first conversation continues")
+
+    texts = [m.text for m in bridge.state.messages]
+    assert texts.index("first conversation continues") < texts.index("second answer")
+    # state.output is the newest work, which is the resumed conversation -- so with
+    # accumulation the last message and state.output need not be the same turn.
+    assert bridge.state.output.completion == "first conversation continues"
+    assert texts[-1] == "second answer"
+
+
+async def test_accumulated_conversations_survive_a_resume() -> None:
+    """A resumed run keeps the conversations it already saw, and a replay does not duplicate.
+
+    The scaffold replays only the conversation it was in, so dropping the rest on resume
+    would lose every earlier one -- and those are the whole point of accumulating. What
+    made dropping them look necessary was appending a replayed call as a new conversation;
+    an equal-or-contained call is now absorbed instead.
+    """
+    first = accumulating_bridge()
+    session_one: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    await track(first, session_one, "session one answer")
+    session_two: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content="Second question."),
+    ]
+    out_two = await track(first, session_two, "session two answer")
+
+    # resume with that state, then let the scaffold replay session two and continue it
+    checkpointer = RecordingCheckpointer(
+        restored={"bridge_conversations": first._conversations}
+    )
+    resumed = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        checkpointer=checkpointer,
+    )
+    await track(resumed, session_two, "session two answer")
+    await track(
+        resumed,
+        [*session_two, out_two.message, ChatMessageTool(content="t")],
+        "session two continues",
+    )
+
+    texts = [m.text for m in resumed.state.messages]
+    assert "session one answer" in texts
+    assert texts.count("session two answer") == 1
+    assert texts[-1] == "session two continues"

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -29,6 +29,7 @@ from inspect_ai.model._chat_message import (
 )
 from inspect_ai.model._model import Model, get_model
 from inspect_ai.model._model_output import ModelOutput, ModelUsage
+from inspect_ai.tool import ToolCall
 
 TASK = "In the year 2022, what castle did the Doctor spend 4.5 billion years in?"
 
@@ -1551,6 +1552,44 @@ def cc_system(nonce: int) -> ChatMessageSystem:
     return ChatMessageSystem(
         content=f"x-anthropic-billing-header: cc_version=2.1.126; cch={nonce:05x};\n\nYou are a Claude agent."
     )
+
+
+async def test_accumulation_keeps_distinct_tool_call_histories() -> None:
+    """Tool calls and results distinguish otherwise text-identical histories."""
+    bridge = accumulating_bridge()
+
+    def lookup_history(query: str) -> list[ChatMessage]:
+        call = ToolCall(
+            id=f"lookup-{query}",
+            function="lookup",
+            arguments={"query": query},
+        )
+        return [
+            TASK_SYSTEM,
+            ChatMessageUser(content="Find the castle."),
+            ChatMessageAssistant(content="", tool_calls=[call]),
+            ChatMessageTool(
+                content="lookup result",
+                tool_call_id=call.id,
+                function=call.function,
+            ),
+        ]
+
+    await track(bridge, lookup_history("A"), "done")
+    await track(bridge, lookup_history("B"), "done")
+
+    tool_calls = [
+        call
+        for message in bridge.state.messages
+        if isinstance(message, ChatMessageAssistant)
+        for call in message.tool_calls or []
+    ]
+    assert [call.arguments["query"] for call in tool_calls] == ["A", "B"]
+    assert [
+        message.tool_call_id
+        for message in bridge.state.messages
+        if isinstance(message, ChatMessageTool)
+    ] == ["lookup-A", "lookup-B"]
 
 
 async def test_every_conversation_is_kept_not_just_the_main_one() -> None:

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -2293,33 +2293,99 @@ async def test_a_root_conversations_begin_event_stays_at_root() -> None:
     assert event.span_id == begin.id
 
 
-async def test_a_caller_sink_takes_precedence_over_span_emission() -> None:
-    """Transitional precedence: a caller-supplied sink keeps its current behavior.
+async def test_a_caller_sink_composes_with_span_emission() -> None:
+    """A caller sink no longer disables span emission; the two compose.
 
-    Existing callers pair accumulation with their own sink today; the bridge
-    must not race them for emission ownership, so it emits no spans for such a
-    bridge. The flattening-removal release upgrades this to a hard error.
+    Every native harness installs a sink, so "sink disables emitter" left every
+    such run span-less. Composed: the sink writes the event where and when it
+    chooses, and the emitter re-parents what the sink wrote into the
+    conversation's span. One writer, so no duplicate event.
     """
     init_transcript(Transcript())
 
-    class _Sink:
-        def on_pending(self, event: ModelEvent) -> None: ...
+    class _WritingSink:
+        def __init__(self) -> None:
+            self.pending: list[ModelEvent] = []
+            self.completed: list[ModelEvent] = []
 
-        def on_complete(self, event: ModelEvent) -> None: ...
+        def on_pending(self, event: ModelEvent) -> None:
+            self.pending.append(event)
+            transcript()._event(event)
 
-    sink = _Sink()
+        def on_complete(self, event: ModelEvent) -> None:
+            self.completed.append(event)
+            transcript()._event_updated(event)
+
+    sink = _WritingSink()
     bridge = AgentBridge(
         AgentState(messages=[ChatMessageUser(content=TASK)]),
         accumulate_conversations=True,
         model_event_sink=sink,
     )
-    assert bridge.model_event_sink is sink
-    assert bridge._span_emitter is None
+    assert bridge._span_emitter is not None
+    assert bridge.model_event_sink is not sink
 
-    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "answer")
-    assert len(bridge._conversations) == 1
-    assert bridge._conversations[0].span_id is None
-    assert span_begins() == []
+    event, _ = await spanned_track(
+        bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "answer"
+    )
+
+    # the sink saw both callbacks and did the one write
+    assert sink.pending == [event]
+    assert sink.completed == [event]
+    assert [e for e in transcript().events if isinstance(e, ModelEvent)] == [event]
+    # and the emitter still opened the conversation's span and placed the event in it
+    begins = span_begins()
+    assert [b.type for b in begins] == [BRIDGE_CONVERSATION_SPAN_TYPE]
+    assert event.span_id == begins[0].id
+    assert bridge._conversations[0].span_id == begins[0].id
+
+
+async def test_an_event_a_caller_sink_is_holding_keeps_the_sinks_placement() -> None:
+    """Sink-derived identity is adopted in place of the prefix match, not beside it.
+
+    A native harness holds a sub-agent's event until its own records name the
+    span that owns it. The emitter must not write that event for it, and must
+    not move it: when the sink finally writes it under the span it identified,
+    that is the event's one placement.
+    """
+    init_transcript(Transcript())
+
+    class _HoldingSink:
+        def __init__(self) -> None:
+            self.held: list[ModelEvent] = []
+
+        def on_pending(self, event: ModelEvent) -> None:
+            self.held.append(event)
+
+        def on_complete(self, event: ModelEvent) -> None: ...
+
+        def release(self) -> None:
+            for event in self.held:
+                event.span_id = "agent-task-1"
+                transcript()._event(event)
+            self.held.clear()
+
+    sink = _HoldingSink()
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        model_event_sink=sink,
+    )
+
+    event, _ = await spanned_track(
+        bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "answer"
+    )
+
+    # the conversation still got its span, but the held event was not written
+    # or moved by the emitter
+    assert len(span_begins()) == 1
+    assert [e for e in transcript().events if isinstance(e, ModelEvent)] == []
+    assert event.span_id != span_begins()[0].id
+
+    sink.release()
+    written = [e for e in transcript().events if isinstance(e, ModelEvent)]
+    assert written == [event]
+    assert event.span_id == "agent-task-1"
 
 
 async def test_an_absorbed_conversations_span_ends_at_absorption() -> None:

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -7,19 +7,28 @@ as the agent state. See meridianlabs-ai/inspect_ai#140 for the failure
 mode where a longer side call permanently displaced the real conversation.
 """
 
+import dataclasses
 from typing import Any
 
+import anyio
+from pydantic import TypeAdapter
 from test_helpers.checkpoint import RecordingCheckpointer
 
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.agent._bridge.anthropic_api import inspect_anthropic_api_request
 from inspect_ai.agent._bridge.completions import inspect_completions_api_request
-from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.types import (
+    BRIDGE_CONVERSATION_SPAN_TYPE,
+    AgentBridge,
+    _ConversationSpanEmitter,
+)
 from inspect_ai.agent._bridge.util import (
     default_code_execution_providers,
     internal_web_search_providers,
 )
+from inspect_ai.event import InfoEvent, ModelEvent, SpanBeginEvent, SpanEndEvent
+from inspect_ai.log._transcript import Transcript, init_transcript, transcript
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -27,9 +36,11 @@ from inspect_ai.model._chat_message import (
     ChatMessageTool,
     ChatMessageUser,
 )
+from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model import Model, get_model
 from inspect_ai.model._model_output import ModelOutput, ModelUsage
 from inspect_ai.tool import ToolCall
+from inspect_ai.util._span import span
 
 TASK = "In the year 2022, what castle did the Doctor spend 4.5 billion years in?"
 
@@ -1419,13 +1430,14 @@ def scenario_model(completions: list[str]) -> Model:
     )
 
 
-async def test_completions_handler_tracks_main_thread_end_to_end() -> None:
+async def test_completions_handler_tracks_main_thread_and_preserves_producer_id() -> (
+    None
+):
     """The opencode scenario through the real OpenAI completions handler.
 
-    Exercises message conversion, system-prompt handling and message-id
-    assignment together with `_track_state`: `apply_message_ids` gives every
-    request fresh ids, so thread continuity must survive the full request
-    path, not just hand-constructed messages.
+    The mock model returns `ModelOutput` only, without a provider response id.
+    A second scaffold request therefore must retain the first bridge-produced
+    assistant object rather than its synthetic request-history copy.
     """
     model = scenario_model(
         ["Doctor Who Series 9 setting", "let me look into that", "Castle"]
@@ -1458,6 +1470,11 @@ async def test_completions_handler_tracks_main_thread_end_to_end() -> None:
     reply = await request(main)
     assert reply == "let me look into that"
     assert bridge.state.output.completion == "let me look into that"
+    producer = bridge.state.messages[-1]
+    assert isinstance(producer, ChatMessageAssistant)
+    assert producer.source == "generate"
+    producer_id = producer.id
+    assert producer_id is not None
 
     # main loop: turn 2 (scaffold round-trips through its own store)
     main = main + [
@@ -1474,6 +1491,79 @@ async def test_completions_handler_tracks_main_thread_end_to_end() -> None:
         "please continue",
         "Castle",
     ]
+    assert bridge.state.messages[2] is producer
+    assert bridge.state.messages[2].id == producer_id
+
+
+async def test_tracked_extension_preserves_producer_metadata_after_serialization() -> (
+    None
+):
+    """A continued request retains the known output, not its inbound carrier."""
+    bridge = task_bridge()
+    first: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    producer_output = ModelOutput.from_content("mockllm/model", "working")
+    producer_output.message.id = "native-output"
+    producer_output.message.metadata = {"native_event_id": "event-1"}
+    await bridge._track_state(first, producer_output)
+
+    carrier = ChatMessageAssistant(
+        content="working",
+        id="synthetic-history",
+        metadata={"request_id": "request-2"},
+    )
+    continued: list[ChatMessage] = [
+        *first,
+        carrier,
+        ChatMessageUser(content="please continue"),
+    ]
+    await track(bridge, continued, "Castle")
+
+    assert bridge.state.messages[2] is producer_output.message
+    serialized = TypeAdapter(list[ChatMessage]).dump_json(bridge.state.messages)
+    restored = TypeAdapter(list[ChatMessage]).validate_json(serialized)
+    assert restored[2].id == "native-output"
+    assert restored[2].metadata == {"native_event_id": "event-1"}
+
+
+async def test_tracked_extension_does_not_preserve_identity_when_tool_args_rewrite() -> (
+    None
+):
+    """Matching text is not enough to carry an output's producer identity."""
+    bridge = task_bridge()
+    first: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    producer_output = ModelOutput.for_tool_call(
+        "mockllm/model",
+        "read_file",
+        {"path": "/workspace/original.txt"},
+        tool_call_id="tool-1",
+    )
+    producer_output.message.id = "native-output"
+    producer_output.message.metadata = {"native_event_id": "event-1"}
+    await bridge._track_state(first, producer_output)
+
+    rewritten_call = ToolCall(
+        id="tool-1",
+        function="read_file",
+        arguments={"path": "/workspace/rewritten.txt"},
+    )
+    carrier = ChatMessageAssistant(
+        content=producer_output.message.text,
+        id="synthetic-history",
+        tool_calls=[rewritten_call],
+    )
+    continued: list[ChatMessage] = [
+        *first,
+        carrier,
+        ChatMessageTool(
+            content="rewritten contents",
+            tool_call_id=rewritten_call.id,
+            function=rewritten_call.function,
+        ),
+    ]
+    await track(bridge, continued, "Castle")
+
+    assert bridge.state.messages[2] is carrier
+    assert bridge.state.messages[2].id == "synthetic-history"
 
 
 async def test_anthropic_handler_tracks_main_thread_end_to_end() -> None:
@@ -1554,8 +1644,10 @@ def cc_system(nonce: int) -> ChatMessageSystem:
     )
 
 
-async def test_accumulation_keeps_distinct_tool_call_histories() -> None:
-    """Tool calls and results distinguish otherwise text-identical histories."""
+async def test_accumulation_keeps_same_model_children_with_distinct_tool_histories() -> (
+    None
+):
+    """Tool calls distinguish same-model children with otherwise identical text."""
     bridge = accumulating_bridge()
 
     def lookup_history(query: str) -> list[ChatMessage]:
@@ -1567,7 +1659,9 @@ async def test_accumulation_keeps_distinct_tool_call_histories() -> None:
         return [
             TASK_SYSTEM,
             ChatMessageUser(content="Find the castle."),
-            ChatMessageAssistant(content="", tool_calls=[call]),
+            ChatMessageAssistant(
+                content="", model="mockllm/native-child", tool_calls=[call]
+            ),
             ChatMessageTool(
                 content="lookup result",
                 tool_call_id=call.id,
@@ -1590,6 +1684,36 @@ async def test_accumulation_keeps_distinct_tool_call_histories() -> None:
         for message in bridge.state.messages
         if isinstance(message, ChatMessageTool)
     ] == ["lookup-A", "lookup-B"]
+
+
+async def test_accumulation_preserves_producer_identity_across_system_rewrite() -> None:
+    """A continued native CLI conversation keeps its first producer object."""
+    bridge = accumulating_bridge()
+    first: list[ChatMessage] = [cc_system(1), ChatMessageUser(content=TASK)]
+    producer_output = ModelOutput.from_content("mockllm/model", "working")
+    producer_output.message.id = "native-output"
+    producer_output.message.metadata = {"native_event_id": "event-1"}
+    await bridge._track_state(first, producer_output)
+
+    carrier = ChatMessageAssistant(
+        content="working",
+        id="synthetic-history",
+        metadata={"request_id": "request-2"},
+    )
+    continued: list[ChatMessage] = [
+        cc_system(2),
+        ChatMessageUser(content=TASK),
+        carrier,
+        ChatMessageTool(content="tool result"),
+    ]
+    await track(bridge, continued, "Castle")
+
+    producer = next(
+        message for message in bridge.state.messages if message.text == "working"
+    )
+    assert producer is producer_output.message
+    assert producer.id == "native-output"
+    assert producer.metadata == {"native_event_id": "event-1"}
 
 
 async def test_every_conversation_is_kept_not_just_the_main_one() -> None:
@@ -1735,6 +1859,28 @@ async def test_accumulated_message_ids_are_unique_and_stable() -> None:
     assert later[: len(first)] == first
 
 
+async def test_flattening_keeps_producer_identity_when_carrier_id_collides() -> None:
+    """Deduplicating independent conversations must re-id the carrier, not output."""
+    bridge = accumulating_bridge()
+    await track(
+        bridge,
+        [ChatMessageUser(content="unrelated carrier", id="native-output")],
+        "side result",
+    )
+
+    producer_output = ModelOutput.from_content("mockllm/model", "main result")
+    producer_output.message.id = "native-output"
+    await bridge._track_state(
+        [ChatMessageUser(content="main conversation")], producer_output
+    )
+
+    assert bridge.state.messages[-1] is producer_output.message
+    assert producer_output.message.id == "native-output"
+    assert len({message.id for message in bridge.state.messages}) == len(
+        bridge.state.messages
+    )
+
+
 async def test_accumulated_conversations_keep_first_seen_order() -> None:
     """A call resuming an earlier conversation does not move it to the end."""
     bridge = accumulating_bridge()
@@ -1796,3 +1942,434 @@ async def test_accumulated_conversations_survive_a_resume() -> None:
     assert "session one answer" in texts
     assert texts.count("session two answer") == 1
     assert texts[-1] == "session two continues"
+
+
+async def test_compaction_rewrite_does_not_adopt_prior_producer_identity() -> None:
+    """A rewritten history is not a continuation just because it repeats text."""
+    bridge = task_bridge()
+    first: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    original_output = ModelOutput.from_content("mockllm/model", "working")
+    original_output.message.id = "native-output"
+    await bridge._track_state(first, original_output)
+
+    compacted: list[ChatMessage] = [
+        TASK_SYSTEM,
+        ChatMessageUser(content="Conversation summary"),
+    ]
+    compacted_output = ModelOutput.from_content("mockllm/model", "working")
+    compacted_output.message.id = "compacted-output"
+    await bridge._track_state(compacted, compacted_output)
+    continued: list[ChatMessage] = [
+        *compacted,
+        compacted_output.message,
+        ChatMessageUser(content="please continue"),
+    ]
+    await track(bridge, continued, "Castle")
+
+    assert bridge.state.messages[2] is compacted_output.message
+    assert bridge.state.messages[2].id == "compacted-output"
+
+
+# ---------------------------------------------------------------------------
+# accumulate_conversations: one transcript span per conversation
+# ---------------------------------------------------------------------------
+
+
+def pending_event(input: list[ChatMessage]) -> ModelEvent:
+    return ModelEvent(
+        model="mockllm/model",
+        input=list(input),
+        tools=[],
+        tool_choice="none",
+        config=GenerateConfig(),
+        output=ModelOutput.from_content("mockllm/model", ""),
+        pending=True,
+    )
+
+
+async def spanned_track(
+    bridge: AgentBridge, input: list[ChatMessage], completion: str
+) -> tuple[ModelEvent, ModelOutput]:
+    """One bridged call through the span emitter: pending, complete, accumulate."""
+    emitter = bridge.model_event_sink
+    assert emitter is not None
+    event = pending_event(input)
+    emitter.on_pending(event)
+    emitter.on_complete(event)
+    output = await track(bridge, input, completion)
+    return event, output
+
+
+def span_begins() -> list[SpanBeginEvent]:
+    return [e for e in transcript().events if isinstance(e, SpanBeginEvent)]
+
+
+def span_ends() -> list[SpanEndEvent]:
+    return [e for e in transcript().events if isinstance(e, SpanEndEvent)]
+
+
+def span_infos() -> list[InfoEvent]:
+    return [
+        e
+        for e in transcript().events
+        if isinstance(e, InfoEvent) and e.source == "bridge_conversation"
+    ]
+
+
+async def test_each_accumulated_conversation_gets_its_own_span() -> None:
+    """Independent conversations land in distinct spans; a continuation rejoins its own."""
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+
+    one: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    event_one, out_one = await spanned_track(bridge, one, "first answer")
+    two: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content="Second question.")]
+    event_two, _ = await spanned_track(bridge, two, "second answer")
+    event_cont, _ = await spanned_track(
+        bridge,
+        [*one, out_one.message, ChatMessageUser(content="And the year?")],
+        "third answer",
+    )
+
+    begins = span_begins()
+    assert [b.type for b in begins] == [BRIDGE_CONVERSATION_SPAN_TYPE] * 2
+    assert [b.name for b in begins] == ["conversation 0", "conversation 1"]
+    assert event_one.span_id == begins[0].id
+    assert event_two.span_id == begins[1].id
+    assert event_cont.span_id == begins[0].id
+    # the store binds each conversation to the span its events landed in
+    assert [c.span_id for c in bridge._conversations] == [begins[0].id, begins[1].id]
+    assert [c.ordinal for c in bridge._conversations] == [0, 1]
+
+
+async def test_conversation_span_metadata_rides_in_an_info_event() -> None:
+    """Each span carries ordinal, first-seen call index, and the resume marker."""
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+
+    await spanned_track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "a")
+    await spanned_track(
+        bridge, [TASK_SYSTEM, ChatMessageUser(content="Another thread.")], "b"
+    )
+
+    infos = span_infos()
+    begins = span_begins()
+    assert [i.span_id for i in infos] == [b.id for b in begins]
+    assert [i.data for i in infos] == [
+        {
+            "conversation_ordinal": 0,
+            "first_seen_call_index": 0,
+            "resume_adopted": False,
+        },
+        {
+            "conversation_ordinal": 1,
+            "first_seen_call_index": 1,
+            "resume_adopted": False,
+        },
+    ]
+
+
+async def test_every_event_of_one_call_lands_in_its_conversations_span() -> None:
+    """An approval retry generates twice in one call; both events join one span."""
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+    sink = bridge.model_event_sink
+    assert sink is not None
+    history: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+
+    rejected = pending_event(history)
+    sink.on_pending(rejected)
+    retried = pending_event(
+        [*history, ChatMessageAssistant(content="rejected attempt")]
+    )
+    sink.on_pending(retried)
+
+    await track(bridge, history, "accepted answer")
+
+    assert rejected.span_id is not None
+    assert rejected.span_id == retried.span_id
+    assert len(span_begins()) == 1
+    assert bridge._conversations[0].span_id == rejected.span_id
+
+
+async def test_compacted_call_events_stay_in_their_conversations_span() -> None:
+    """Attribution is by call, not content: a transformed model input cannot orphan events."""
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+    sink = bridge.model_event_sink
+    assert sink is not None
+    history: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    _, out = await spanned_track(bridge, history, "first answer")
+
+    # compaction hands the model a rewritten history that shares no prefix with
+    # the request history the accumulator will see
+    compacted = pending_event(
+        [TASK_SYSTEM, ChatMessageUser(content="[summary of the conversation so far]")]
+    )
+    sink.on_pending(compacted)
+    await track(
+        bridge,
+        [*history, out.message, ChatMessageUser(content="Go on.")],
+        "post-compaction answer",
+    )
+
+    begins = span_begins()
+    assert len(begins) == 1
+    assert compacted.span_id == begins[0].id
+
+
+async def test_a_filtered_call_still_opens_its_conversations_span() -> None:
+    """A filter-supplied output generates no model event; the span exists anyway."""
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+
+    # no pending event: the filter answered without model.generate()
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "filtered answer")
+
+    begins = span_begins()
+    assert len(begins) == 1
+    assert bridge._conversations[0].span_id == begins[0].id
+    assert [i.span_id for i in span_infos()] == [begins[0].id]
+    assert not any(isinstance(e, ModelEvent) for e in transcript().events)
+
+
+async def test_system_only_conversations_keep_one_span() -> None:
+    """A system-only opening call and its continuation share a single span."""
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+
+    opening: list[ChatMessage] = [TASK_SYSTEM]
+    event_open, out = await spanned_track(bridge, opening, "system-only answer")
+    event_cont, _ = await spanned_track(
+        bridge,
+        [TASK_SYSTEM, out.message, ChatMessageUser(content="Now a question.")],
+        "continued answer",
+    )
+
+    assert len(span_begins()) == 1
+    assert event_open.span_id == span_begins()[0].id
+    assert event_cont.span_id == event_open.span_id
+
+
+async def test_conversation_spans_end_at_bridge_close() -> None:
+    """Close ends every open span in reverse order, once."""
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+
+    await spanned_track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "a")
+    await spanned_track(
+        bridge, [TASK_SYSTEM, ChatMessageUser(content="Another thread.")], "b"
+    )
+    begins = span_begins()
+
+    bridge.close_conversation_spans()
+    assert [e.id for e in span_ends()] == [begins[1].id, begins[0].id]
+
+    bridge.close_conversation_spans()
+    assert len(span_ends()) == 2
+
+    # a call after close keeps its ambient span and opens nothing new
+    late = pending_event([TASK_SYSTEM, ChatMessageUser(content="Too late.")])
+    sink = bridge.model_event_sink
+    assert sink is not None
+    sink.on_pending(late)
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content="Too late.")], "late")
+    assert late.span_id is None
+    assert len(span_begins()) == 2
+
+
+async def test_restored_conversations_mint_fresh_spans_marked_adopted() -> None:
+    """A checkpoint-restored conversation's span closed with its process: continuation re-spans."""
+    init_transcript(Transcript())
+    first = accumulating_bridge()
+    session: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    event, out = await spanned_track(first, session, "session answer")
+    original_span = event.span_id
+    assert original_span is not None
+
+    checkpointer = RecordingCheckpointer(
+        restored={"bridge_conversations": first._conversations}
+    )
+    resumed = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        checkpointer=checkpointer,
+    )
+    restored = resumed._conversations[0]
+    assert restored.span_id is None
+    assert restored.resume_adopted
+
+    event_cont, _ = await spanned_track(
+        resumed,
+        [*session, out.message, ChatMessageUser(content="Continue.")],
+        "continued answer",
+    )
+    assert event_cont.span_id is not None
+    assert event_cont.span_id != original_span
+    # the continuation REPLACED the stored conversation; the store carries the span
+    assert resumed._conversations[0].span_id == event_cont.span_id
+    # the adoption is visible in the fresh span's metadata
+    assert span_infos()[-1].data == {
+        "conversation_ordinal": 0,
+        "first_seen_call_index": 0,
+        "resume_adopted": True,
+    }
+
+
+async def test_concurrent_handler_tasks_keep_their_calls_apart() -> None:
+    """Interleaved handler tasks attribute their events to their own conversations.
+
+    The sandbox service dispatches each RPC request in its own task; the call
+    record is task-local, so one call's events cannot be claimed by another
+    call accumulating first. A process-global record would fail this test.
+    """
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+    sink = bridge.model_event_sink
+    assert sink is not None
+
+    one: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    two: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content="Second thread.")]
+    events: dict[str, ModelEvent] = {}
+
+    async def handler(
+        history: list[ChatMessage],
+        completion: str,
+        started: anyio.Event,
+        proceed: anyio.Event,
+    ) -> None:
+        event = pending_event(history)
+        sink.on_pending(event)
+        events[completion] = event
+        started.set()
+        await proceed.wait()
+        await track(bridge, history, completion)
+
+    async with anyio.create_task_group() as tg:
+        started_one, proceed_one = anyio.Event(), anyio.Event()
+        started_two, proceed_two = anyio.Event(), anyio.Event()
+        tg.start_soon(handler, one, "answer one", started_one, proceed_one)
+        await started_one.wait()
+        tg.start_soon(handler, two, "answer two", started_two, proceed_two)
+        await started_two.wait()
+        # both calls hold pending events; accumulate in reverse arrival order
+        proceed_two.set()
+        proceed_one.set()
+
+    def span_of(completion: str) -> str | None:
+        for conversation in bridge._conversations:
+            if any(m.text == completion for m in conversation.messages):
+                return conversation.span_id
+        return None
+
+    assert len(span_begins()) == 2
+    assert events["answer one"].span_id == span_of("answer one")
+    assert events["answer two"].span_id == span_of("answer two")
+    assert events["answer one"].span_id != events["answer two"].span_id
+
+
+async def test_a_root_conversations_begin_event_stays_at_root() -> None:
+    """A None parent captured at emission survives ambient stamping at attribution.
+
+    SpanBeginEvent construction fills a None span_id from the ambient span; if
+    attribution runs inside a later checkpoint span, the begin event must keep
+    the captured root placement rather than bucket under that checkpoint.
+    """
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+    sink = bridge.model_event_sink
+    assert sink is not None
+    history: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+
+    event = pending_event(history)
+    sink.on_pending(event)  # ambient parent: None (no span open)
+
+    async with span("checkpoint 1", type="checkpoint"):
+        await track(bridge, history, "answer")
+
+    begin = next(b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE)
+    assert begin.parent_id is None
+    assert begin.span_id is None
+    assert event.span_id == begin.id
+
+
+async def test_a_caller_sink_takes_precedence_over_span_emission() -> None:
+    """Transitional precedence: a caller-supplied sink keeps its current behavior.
+
+    Existing callers pair accumulation with their own sink today; the bridge
+    must not race them for emission ownership, so it emits no spans for such a
+    bridge. The flattening-removal release upgrades this to a hard error.
+    """
+    init_transcript(Transcript())
+
+    class _Sink:
+        def on_pending(self, event: ModelEvent) -> None: ...
+
+        def on_complete(self, event: ModelEvent) -> None: ...
+
+    sink = _Sink()
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        model_event_sink=sink,
+    )
+    assert bridge.model_event_sink is sink
+    assert bridge._span_emitter is None
+
+    await track(bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "answer")
+    assert len(bridge._conversations) == 1
+    assert bridge._conversations[0].span_id is None
+    assert span_begins() == []
+
+
+async def test_an_absorbed_conversations_span_ends_at_absorption() -> None:
+    """A stale fork's span ends when the grown conversation absorbs it.
+
+    Organically a fork with its own span cannot arise (a covered call joins the
+    conversation that contains it), but a crash between a fork and its merge
+    can restore one; the absorb loop must end such a span rather than leak it
+    past close. White-box: the stale span is seeded the way a crash leaves it.
+    """
+    init_transcript(Transcript())
+    seed = accumulating_bridge()
+    session: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    _, out_one = await spanned_track(seed, session, "first answer")
+    grown: list[ChatMessage] = [
+        *session,
+        out_one.message,
+        ChatMessageUser(content="Go on."),
+    ]
+    _, out_two = await spanned_track(seed, grown, "second answer")
+    # crash artifact: the pre-growth state and the grown conversation both stored
+    full = seed._conversations[0]
+    fork = [
+        dataclasses.replace(full, key=full.key[:2], messages=full.messages[:3]),
+        full,
+    ]
+
+    checkpointer = RecordingCheckpointer(restored={"bridge_conversations": fork})
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        checkpointer=checkpointer,
+    )
+    sink = bridge.model_event_sink
+    assert isinstance(sink, _ConversationSpanEmitter)
+    stale = bridge._conversations[0]
+    stale.span_id = "stale-span"
+    sink._span_ids.append("stale-span")
+
+    # continuing along the grown path absorbs the stale fork: its span must end
+    event_grown, _ = await spanned_track(
+        bridge,
+        [*grown, out_two.message, ChatMessageUser(content="Finish.")],
+        "third answer",
+    )
+    assert event_grown.span_id is not None
+    assert event_grown.span_id != "stale-span"
+    assert [e.id for e in span_ends()] == ["stale-span"]
+    assert len(bridge._conversations) == 1
+
+    # close ends only the surviving conversation's span, not the absorbed one again
+    bridge.close_conversation_spans()
+    assert [e.id for e in span_ends()] == ["stale-span", event_grown.span_id]

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -14,7 +14,7 @@ import anyio
 from pydantic import TypeAdapter
 from test_helpers.checkpoint import RecordingCheckpointer
 
-from inspect_ai._util.content import ContentText
+from inspect_ai._util.content import ContentReasoning, ContentText
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.agent._bridge.anthropic_api import inspect_anthropic_api_request
@@ -2711,3 +2711,286 @@ async def test_a_late_child_span_follows_the_tool_calling_parent_not_a_side_call
     child = next(b for b in span_begins() if b.id == "opencode-session-child")
     assert child.parent_id == parent_event.span_id
     assert bridge._conversations[0].span_id == parent_event.span_id
+
+
+async def test_a_producer_message_matches_its_gemini_echo() -> None:
+    """One Gemini session is one conversation, whatever the transport re-attaches.
+
+    Gemini's wire format carries no tool-call ids, so the bridge drops the
+    produced id on the way out and synthesizes `call_<fn>_<hash>` on the way
+    back; the CLI also re-attaches the thought signature as a redacted
+    reasoning part the producer never emitted. Comparing either made every
+    Gemini turn a new conversation -- five spans for a five-call session in the
+    first gemini centaur run, and every bridged call unowned.
+    """
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+
+    one: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    produced = ToolCall(
+        id="for_tool_call_706613ab-7c30-425c-9069-bab4a3bc90e6",
+        function="run_shell_command",
+        arguments={"command": "printf 'child complete' > /workspace/child.txt"},
+    )
+    await track_with_tool_call(bridge, one, produced)
+    echoed_call = ToolCall(
+        id="call_run_shell_command_74cd2417",
+        function=produced.function,
+        arguments=dict(produced.arguments),
+    )
+    echoed = ChatMessageAssistant(
+        content=[
+            ContentText(text="tool call for tool run_shell_command"),
+            ContentReasoning(
+                reasoning="skip_thought_signature_validator", redacted=True
+            ),
+        ],
+        tool_calls=[echoed_call],
+    )
+    result = ChatMessageTool(
+        content='{"output": ""}',
+        tool_call_id=echoed_call.id,
+        function=echoed_call.function,
+    )
+    await spanned_track(bridge, [*one, echoed, result], "child complete")
+
+    assert len(bridge._conversations) == 1
+    assert [b.name for b in span_begins()] == ["conversation 0"]
+
+
+async def track_with_tool_call(
+    bridge: AgentBridge, input: list[ChatMessage], call: ToolCall
+) -> ModelEvent:
+    """One bridged call whose output is a tool call with a provider-minted id."""
+    emitter = bridge.model_event_sink
+    assert emitter is not None
+    event = pending_event(input)
+    emitter.on_pending(event)
+    emitter.on_complete(event)
+    output = ModelOutput.for_tool_call(
+        "mockllm/model",
+        tool_name=call.function,
+        tool_arguments=call.arguments,
+        tool_call_id=call.id,
+        content=f"tool call for tool {call.function}",
+    )
+    event.output = output
+    await bridge._track_state(input, output)
+    return event
+
+
+async def test_identical_parallel_sub_agents_share_a_conversation_until_they_diverge() -> (
+    None
+):
+    """The tiebreaker for byte-identical parallel sub-agents is content, not ids.
+
+    Two sub-agents given the same prompt that issue the same first tool call
+    are one conversation by content -- ids never told them apart on Gemini,
+    and on Anthropic they only did by accident of the provider minting one.
+    The moment their content diverges the fork rule splits them; until then
+    the shared prefix is genuinely shared. Their EVENTS are the sink's to
+    distinguish through placement (see the placing-sink tests), not a
+    transport id's.
+    """
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+    main: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    await spanned_track(bridge, main, "delegating")
+
+    prompt = ChatMessageUser(content="Explore the repo and report its layout.")
+
+    def first_call(sub_agent: str) -> ToolCall:
+        # the same call, a provider-minted id apart
+        return ToolCall(
+            id=f"toolu_{sub_agent}1", function="glob", arguments={"pattern": "**/*.py"}
+        )
+
+    for sub_agent in ("a", "b"):
+        await track_with_tool_call(bridge, [TASK_SYSTEM, prompt], first_call(sub_agent))
+    assert len(bridge._conversations) == 2  # main + the shared sub-agent prefix
+
+    def turn_two(sub_agent: str, listing: str) -> list[ChatMessage]:
+        call = first_call(sub_agent)
+        return [
+            TASK_SYSTEM,
+            prompt,
+            ChatMessageAssistant(content="tool call for tool glob", tool_calls=[call]),
+            ChatMessageTool(content=listing, tool_call_id=call.id, function="glob"),
+        ]
+
+    await spanned_track(bridge, turn_two("a", "src/a.py"), "found one file")
+    await spanned_track(bridge, turn_two("b", "src/a.py"), "found one file")
+    assert len(bridge._conversations) == 2  # still byte-identical: still shared
+
+    # b now answers differently from what the shared conversation holds
+    await spanned_track(bridge, turn_two("b", "src/a.py"), "found one file, no tests")
+    assert len(bridge._conversations) == 3  # forked at the divergence, not before
+
+
+class _PlacingSink:
+    """A sink that rebuilds a native trace of its own, as Gemini's does.
+
+    Every event lands in a leaf span of a tree rooted at the CONSUMER's ambient,
+    written late.
+    """
+
+    def __init__(self, ambient_id: str) -> None:
+        self.ambient_id = ambient_id
+        self.held: list[ModelEvent] = []
+        self.roots: list[SpanBeginEvent] = []
+
+    def on_pending(self, event: ModelEvent) -> None:
+        self.held.append(event)
+
+    def on_complete(self, event: ModelEvent) -> None: ...
+
+    def place(self, *, root: SpanBeginEvent | None = None) -> SpanBeginEvent:
+        if root is None:
+            root = SpanBeginEvent(
+                id=f"native-root-{len(self.roots)}",
+                parent_id=self.ambient_id,
+                type="tool",
+                name="schedule_tool_call",
+            )
+            transcript()._event(root)
+            self.roots.append(root)
+        for index, event in enumerate(self.held):
+            leaf = SpanBeginEvent(
+                id=f"native-llm-{root.id}-{index}",
+                parent_id=root.id,
+                type="model",
+                name="gemini-2.5-pro",
+            )
+            transcript()._event(leaf)
+            event.span_id = leaf.id
+            transcript()._event(event)
+        self.held.clear()
+        return root
+
+
+def _parent_of(span_id: str) -> str | None:
+    return next(b for b in span_begins() if b.id == span_id).parent_id
+
+
+async def test_a_placing_sinks_span_tree_hangs_under_its_conversation() -> None:
+    """A sink-placed event's own span tree is re-rooted onto its conversation.
+
+    Gemini's consumer places every bridged event in a native `model` span under
+    `tool`/`agent` spans rooted at the consumer's ambient -- not the bridge's,
+    and not any conversation. Kept as an identity decision and otherwise left
+    alone, that tree made every Gemini event unowned by any conversation span
+    (`subagent_conversation_missing` on every gemini centaur run). The
+    placement stands; the tree's topmost span of the sink's making moves under
+    the conversation. The event's own span is untouched.
+    """
+    init_transcript(Transcript())
+    async with span("human_cli", type="agent"):
+        consumer_ambient = current_span_id()
+        assert consumer_ambient is not None
+        sink = _PlacingSink(consumer_ambient)
+        bridge = AgentBridge(
+            AgentState(messages=[ChatMessageUser(content=TASK)]),
+            accumulate_conversations=True,
+            model_event_sink=sink,
+        )
+        one: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+        async with span("Gemini CLI", type="agent"):
+            event, _ = await spanned_track(bridge, one, "first")
+        root = sink.place()
+
+    conversation = next(
+        b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE
+    )
+    assert event.span_id == f"native-llm-{root.id}-0"  # placement kept
+    assert _parent_of(root.id) == conversation.id  # tree re-rooted
+    assert _parent_of(event.span_id) == root.id
+
+
+async def test_a_placing_sink_keeps_the_consumers_own_spans_where_they_were() -> None:
+    """Only the sink's late-written tree moves; the consumer's ambient never does.
+
+    The consumer's `human_cli` span was open before any bridged call. Stealing
+    it onto a conversation would move the whole native session under one of its
+    own conversations. And a tree already under a conversation -- a second
+    event placed in the same tree -- stays put: no double re-rooting.
+    """
+    init_transcript(Transcript())
+    async with span("outer", type="agent"):
+        outer = current_span_id()
+        async with span("human_cli", type="agent"):
+            consumer_ambient = current_span_id()
+            assert consumer_ambient is not None
+            sink = _PlacingSink(consumer_ambient)
+            bridge = AgentBridge(
+                AgentState(messages=[ChatMessageUser(content=TASK)]),
+                accumulate_conversations=True,
+                model_event_sink=sink,
+            )
+            one: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+            first, out = await spanned_track(bridge, one, "first")
+            root = sink.place()
+            echoed = ChatMessageAssistant(content=[ContentText(text="first")])
+            second, _ = await spanned_track(
+                bridge, [*one, echoed, ChatMessageUser(content="and?")], "second"
+            )
+            sink.place(root=root)  # same tree, already under the conversation
+
+    conversation = next(
+        b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE
+    )
+    assert len(bridge._conversations) == 1
+    assert _parent_of(consumer_ambient) == outer  # never moved
+    assert _parent_of(root.id) == conversation.id
+    assert _parent_of(first.span_id or "") == root.id
+    assert _parent_of(second.span_id or "") == root.id
+
+
+async def test_a_placing_sinks_sub_agent_tree_nests_under_the_parent_calls_conversation() -> (
+    None
+):
+    """A sub-agent's placed tree follows the tool-calling call that caused it.
+
+    Gemini roots the parent call's generation and the tool scheduling that
+    runs the sub-agent as siblings at its ambient, with no edge between them.
+    Rooting each tree at its own events' conversation put the parent's turn
+    under conversation 0 and the sub-agent's scheduling under conversation 1
+    -- the sub-agent's own -- where a Claude sub-agent's `agent` span nests
+    under the PARENT's conversation. Same shape here: the parent call, having
+    issued tool calls, claims the ambient; the scheduling tree rooted there
+    afterwards nests under the parent's conversation, and the two native
+    roots stay siblings. A sub-agent whose parent issued no tool calls keeps
+    its own conversation.
+    """
+    init_transcript(Transcript())
+    async with span("human_cli", type="agent"):
+        consumer_ambient = current_span_id()
+        assert consumer_ambient is not None
+        sink = _PlacingSink(consumer_ambient)
+        bridge = AgentBridge(
+            AgentState(messages=[ChatMessageUser(content=TASK)]),
+            accumulate_conversations=True,
+            model_event_sink=sink,
+        )
+        main: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+        async with span("Gemini CLI", type="agent"):
+            parent = await track_with_tool_call(
+                bridge,
+                main,
+                ToolCall(id="for_tool_call_1", function="invoke_agent", arguments={}),
+            )
+            generation = sink.place()
+            child_prompt = ChatMessageUser(content="Create the child proof file.")
+            child, _ = await spanned_track(bridge, [TASK_SYSTEM, child_prompt], "done")
+            scheduling = sink.place()
+
+    conversations = [
+        b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE
+    ]
+    assert [b.name for b in conversations] == ["conversation 0", "conversation 1"]
+    parent_conversation = conversations[0].id
+    assert _parent_of(generation.id) == parent_conversation
+    assert (
+        _parent_of(scheduling.id) == parent_conversation
+    )  # siblings, under the parent
+    assert _parent_of(child.span_id or "") == scheduling.id  # placement kept
+    assert _parent_of(parent.span_id or "") == generation.id

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -14,6 +14,7 @@ import anyio
 from pydantic import TypeAdapter
 from test_helpers.checkpoint import RecordingCheckpointer
 
+from inspect_ai._util.content import ContentText
 from inspect_ai._util.hash import mm3_hash
 from inspect_ai.agent._agent import AgentState
 from inspect_ai.agent._bridge.anthropic_api import inspect_anthropic_api_request
@@ -40,7 +41,7 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._model import Model, get_model
 from inspect_ai.model._model_output import ModelOutput, ModelUsage
 from inspect_ai.tool import ToolCall
-from inspect_ai.util._span import span
+from inspect_ai.util._span import current_span_id, span
 
 TASK = "In the year 2022, what castle did the Doctor spend 4.5 billion years in?"
 
@@ -2439,3 +2440,156 @@ async def test_an_absorbed_conversations_span_ends_at_absorption() -> None:
     # close ends only the surviving conversation's span, not the absorbed one again
     bridge.close_conversation_spans()
     assert [e.id for e in span_ends()] == ["stale-span", event_grown.span_id]
+
+
+async def test_a_producer_message_matches_its_own_content_list_echo() -> None:
+    """One linear session is one conversation, whatever shape the CLI echoes.
+
+    The bridge's output message carries `content` as a string; the CLI sends
+    that turn back as a one-element text list. Fingerprinting the shape made
+    the producer never match its echo, so every turn opened a new conversation
+    -- six spans for one six-call session in the first composed centaur run.
+    """
+    init_transcript(Transcript())
+    bridge = accumulating_bridge()
+
+    one: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    _, out = await spanned_track(bridge, one, "first answer")
+    echoed = ChatMessageAssistant(content=[ContentText(text="first answer")])
+    await spanned_track(
+        bridge, [*one, echoed, ChatMessageUser(content="And then?")], "second answer"
+    )
+
+    assert len(bridge._conversations) == 1
+    assert [b.name for b in span_begins()] == ["conversation 0"]
+
+
+async def test_composed_conversation_span_opens_under_the_ambient_span() -> None:
+    """The conversation's parent is where the bridge runs, not where the event sat.
+
+    Composed with a sink, the event is recorded BEFORE the sink places it, and a
+    sink may then file it under a sub-agent span -- a child of the conversation,
+    never its parent. So the recorded parent must be the ambient span at record
+    time, not `event.span_id`. The two coincide for an event constructed inside
+    the span (construction stamps the ambient), which is why the fixture builds
+    the event OUTSIDE it: only then does reading `event.span_id` give the wrong
+    answer, and the test bites.
+    """
+    init_transcript(Transcript())
+
+    class _RelocatingSink:
+        def on_pending(self, event: ModelEvent) -> None:
+            event.span_id = "agent-child"
+            transcript()._event(event)
+
+        def on_complete(self, event: ModelEvent) -> None: ...
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        model_event_sink=_RelocatingSink(),
+    )
+    input: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    event = pending_event(input)  # stamped with the (absent) ambient: None
+    sink = bridge.model_event_sink
+    assert sink is not None
+    async with span("outer", type="agent"):
+        outer = current_span_id()
+        sink.on_pending(event)
+        sink.on_complete(event)
+        await track(bridge, input, "a")
+
+    begin = next(b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE)
+    assert begin.parent_id == outer
+    assert event.span_id == "agent-child"
+
+
+async def test_an_event_a_sink_releases_back_at_the_ambient_joins_its_conversation() -> (
+    None
+):
+    """A held event the sink later writes at the ambient belongs to its conversation.
+
+    A native sink holds every main-thread event while a sub-agent is open, then
+    releases it -- from a drain or a JSONL record, not necessarily a completion
+    callback -- back at the span it arrived under, having decided it was NOT the
+    sub-agent's. Attribution already ran; skipping it as "held" left the main
+    thread's later calls on the agent span while its first call sat in the
+    conversation: one conversation split across two spans, which is what the
+    harness's sub-agent-parentage assertions tripped over.
+    """
+    init_transcript(Transcript())
+
+    class _HoldingSink:
+        def __init__(self) -> None:
+            self.held: list[ModelEvent] = []
+
+        def on_pending(self, event: ModelEvent) -> None:
+            self.held.append(event)
+
+        def on_complete(self, event: ModelEvent) -> None: ...
+
+        def drain(self) -> None:
+            # released where it arrived, by a path that is not on_complete
+            for event in self.held:
+                transcript()._event(event)
+            self.held.clear()
+
+    sink = _HoldingSink()
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        model_event_sink=sink,
+    )
+    input: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+    async with span("outer", type="agent"):
+        event, _ = await spanned_track(bridge, input, "a")
+        assert [e for e in transcript().events if isinstance(e, ModelEvent)] == []
+        sink.drain()
+
+    begin = next(b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE)
+    assert event.span_id == begin.id
+
+
+async def test_a_sub_agent_span_opened_before_attribution_follows_its_parent_call() -> (
+    None
+):
+    """A child span the sink opened under the parent's arrival span moves with the parent.
+
+    The sink opens a sub-agent span at completion time, under the span the
+    spawning event then carried -- and completion runs BEFORE the emitter has
+    attributed the call to a conversation. Left alone, the conversation and the
+    sub-agent tree it spawned sit as siblings and nothing records which
+    conversation spawned it.
+    """
+    init_transcript(Transcript())
+
+    class _SpawningSink:
+        def on_pending(self, event: ModelEvent) -> None:
+            transcript()._event(event)
+
+        def on_complete(self, event: ModelEvent) -> None:
+            transcript()._event(
+                SpanBeginEvent(
+                    id="agent-child",
+                    parent_id=event.span_id,
+                    type="agent",
+                    name="child",
+                )
+            )
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        model_event_sink=_SpawningSink(),
+    )
+    async with span("outer", type="agent"):
+        event, _ = await spanned_track(
+            bridge, [TASK_SYSTEM, ChatMessageUser(content=TASK)], "a"
+        )
+
+    conversation = next(
+        b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE
+    )
+    child = next(b for b in span_begins() if b.id == "agent-child")
+    assert event.span_id == conversation.id
+    assert child.parent_id == conversation.id

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -2593,3 +2593,121 @@ async def test_a_sub_agent_span_opened_before_attribution_follows_its_parent_cal
     child = next(b for b in span_begins() if b.id == "agent-child")
     assert event.span_id == conversation.id
     assert child.parent_id == conversation.id
+
+
+async def test_a_sub_agent_span_opened_requests_later_still_follows_its_parent_call() -> (
+    None
+):
+    """A child span opened on a LATER request, under the parent's arrival span, follows it.
+
+    The Claude consumer opens the child at the parent's completion; the OpenCode
+    consumer opens it when the child's own first call arrives, requests later.
+    The one-shot walk at attribution time cannot see a span that does not exist
+    yet, so the emitter remembers every vacated arrival span and re-homes a
+    child begun under it whenever it is written.
+    """
+    init_transcript(Transcript())
+    arrival: list[str | None] = []
+
+    class _LateSpawningSink:
+        def on_pending(self, event: ModelEvent) -> None:
+            arrival.append(event.span_id)
+            transcript()._event(event)
+
+        def on_complete(self, event: ModelEvent) -> None: ...
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        model_event_sink=_LateSpawningSink(),
+    )
+    async with span("outer", type="agent"):
+        # the parent spawns the child through a tool call -- the only kind of
+        # call that can, and the only kind that claims its arrival span
+        parent_input: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+        parent_out = ModelOutput.for_tool_call(
+            "mockllm/model", "task", {"prompt": "do it"}, tool_call_id="task-1"
+        )
+        parent = pending_event(parent_input)
+        parent.output = parent_out
+        sink = bridge.model_event_sink
+        assert sink is not None
+        sink.on_pending(parent)
+        sink.on_complete(parent)
+        await bridge._track_state(parent_input, parent_out)
+        # a later request: the child's first call arrives and the sink opens its
+        # span under the span the PARENT call arrived on
+        transcript()._event(
+            SpanBeginEvent(
+                id="opencode-session-child",
+                parent_id=arrival[0],
+                type="agent",
+                name="opencode",
+            )
+        )
+
+    conversation = next(
+        b for b in span_begins() if b.type == BRIDGE_CONVERSATION_SPAN_TYPE
+    )
+    child = next(b for b in span_begins() if b.id == "opencode-session-child")
+    assert parent.span_id == conversation.id
+    assert child.parent_id == conversation.id
+
+
+async def test_a_late_child_span_follows_the_tool_calling_parent_not_a_side_call() -> (
+    None
+):
+    """A side call that left the same arrival span later must not capture the child.
+
+    OpenCode's title-generation call arrives on the same span as the parent,
+    after it, carries no tool calls, and accumulates as its own conversation.
+    With last-writer-wins, a child opened after it was parented on the title
+    call's conversation. The child follows the most recent departing event that
+    issued a tool call -- the only kind that can spawn one.
+    """
+    init_transcript(Transcript())
+    arrival: list[str | None] = []
+
+    class _Sink:
+        def on_pending(self, event: ModelEvent) -> None:
+            arrival.append(event.span_id)
+            transcript()._event(event)
+
+        def on_complete(self, event: ModelEvent) -> None: ...
+
+    bridge = AgentBridge(
+        AgentState(messages=[ChatMessageUser(content=TASK)]),
+        accumulate_conversations=True,
+        model_event_sink=_Sink(),
+    )
+    async with span("outer", type="agent"):
+        # the parent: a call that spawns a child via a tool call
+        parent_input: list[ChatMessage] = [TASK_SYSTEM, ChatMessageUser(content=TASK)]
+        parent_out = ModelOutput.for_tool_call(
+            "mockllm/model", "task", {"prompt": "do it"}, tool_call_id="task-1"
+        )
+        parent_event = pending_event(parent_input)
+        parent_event.output = parent_out
+        sink = bridge.model_event_sink
+        assert sink is not None
+        sink.on_pending(parent_event)
+        sink.on_complete(parent_event)
+        await bridge._track_state(parent_input, parent_out)
+        # a title side call, no tool calls, its own conversation, same arrival span
+        await spanned_track(
+            bridge, [ChatMessageUser(content="Title this session")], "A title"
+        )
+        # the child's first request arrives; the sink opens its span under the
+        # parent's ARRIVAL span
+        transcript()._event(
+            SpanBeginEvent(
+                id="opencode-session-child",
+                parent_id=arrival[0],
+                type="agent",
+                name="opencode",
+            )
+        )
+
+    child = next(b for b in span_begins() if b.id == "opencode-session-child")
+    assert child.parent_id == parent_event.span_id
+    assert bridge._conversations[0].span_id == parent_event.span_id


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4759.

`sandbox_agent_bridge()` tracks one conversation. `AgentBridge._track_state` picks the main agent loop and treats other calls as side calls. That is appropriate for a scaffold that runs one loop, but a sandbox can run several independent conversations. In that case, all but one conversation are absent from `bridge.state`.

### What is the new behavior?

This adds the opt-in `accumulate_conversations: bool = False` argument to `sandbox_agent_bridge()`. The default preserves current behavior. When enabled, `state.messages` contains every conversation concatenated in first-seen order.

Conversation matching ignores a rewritten system prompt but preserves non-system content, tool-call data, and tool-result data. Histories that look identical as text but invoke `lookup(query=A)` and `lookup(query=B)` therefore remain distinct.

Matching is prefix-of or equal, so an extending call continues its existing conversation, an identical repeat replaces it, a call contained in a stored conversation is dropped, and an absorbed conversation does not remain as a stale duplicate. Duplicate message IDs are reassigned only when needed and remain stable across calls. Accumulated conversations are adopted on resume.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This is one additive keyword argument defaulting to `False`, so existing paths do not change. The PR diff is 456 additions and 0 deletions.

### Other information:

Verification:
- `uv run --no-sync pytest tests/agent/test_bridge_track_state.py -q --runtrio -p no:cacheprovider`: 60 passed, 60 skipped
- `uv run --no-sync ruff check src/inspect_ai/agent/_bridge/types.py tests/agent/test_bridge_track_state.py`
- `uv run --no-sync ruff format --check src/inspect_ai/agent/_bridge/types.py tests/agent/test_bridge_track_state.py`
- `uv run --no-sync mypy src/inspect_ai/agent/_bridge/types.py`

The CHANGELOG entry is under `## Unreleased` after rebasing on the current base.

### Agent review
- Reviewers: Claude Opus 5 via read-only consultation, fresh context, 1 pass; Fable 5 via independent reviewer subagent, fresh context, 1 pass
- Findings: 7 total. Five were fixed. One was dismissed because first-seen conversation order preserves sandbox history and callers can reorder it. One was obsolete because the unproven `_extends` change was removed and filed separately as #4758.