### PR TITLE
test: cover eval_set bundle retries

### DIFF
--- a/tests/test_eval_set.py
+++ b/tests/test_eval_set.py
@@ -1687,6 +1687,41 @@ def test_eval_set_bundle_when_all_complete(tmp_path: Path) -> None:
         )
 
 
+def test_eval_set_bundle_after_retries_once(tmp_path: Path) -> None:
+    @solver
+    def fail_first_attempt() -> Solver:
+        attempts = {"count": 0}
+
+        async def solve(state: TaskState, generate: Generate) -> TaskState:
+            attempts["count"] += 1
+            if attempts["count"] == 1:
+                raise ValueError("first attempt fails")
+            return state
+
+        return solve
+
+    bundle_dir = tmp_path / "bundle"
+    success, logs = eval_set(
+        tasks=Task(
+            dataset=[Sample(input="hello", target="hello")],
+            solver=[generate(), fail_first_attempt()],
+            scorer=exact(),
+        ),
+        log_dir=str(tmp_path / "logs"),
+        retry_attempts=2,
+        retry_wait=0.1,
+        retry_immediate=False,
+        model="mockllm/model",
+        bundle_dir=str(bundle_dir),
+    )
+
+    assert success
+    assert logs[0].status == "success"
+    assert (bundle_dir / "index.html").exists()
+    assert (bundle_dir / "logs" / "listing.json").exists()
+    assert len(list((bundle_dir / "logs").glob("*.eval"))) == 1
+
+
 def test_invalidation(tmp_path: Path):
     @task
     def task_for_invalidation():


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor
- [x] Tests

### What is the current behavior? (You can also link to an open issue here)

Issue #2795 reports that `eval_set(..., bundle_dir=...)` can attempt to create the output bundle on each retry. With the default `bundle_overwrite=False`, a duplicate bundle creation would fail once the first retry attempt has already created the output directory.

The current test coverage only verifies bundling when all logs are already complete; it does not exercise a retrying eval set with a real bundle output directory.

### What is the new behavior?

- Adds focused regression coverage for `eval_set()` batch retries with `bundle_dir`.
- The test makes the first eval-set attempt fail, retries successfully, and writes a real bundle with `bundle_overwrite=False`.
- The assertions verify the bundle exists after completion and contains only the successful eval log, so a duplicate bundle creation during retry would fail the test.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. This is test-only coverage for the existing eval-set bundling behavior.

### Other information:

Issue status:
- #2795 is labeled `accepted`.

Validation:
- Targeted:
  - `uv run pytest tests/test_eval_set.py::test_eval_set_bundle_after_retries_once -v`
    - Passed. Exercises the reported retry path directly: first batch attempt fails, retry succeeds, and the bundle is created once with overwrite disabled.
  - `uv run pytest tests/test_eval_set.py::test_eval_set_bundle_when_all_complete tests/test_eval_set.py::test_eval_set_bundle_after_retries_once -v`
    - Passed. Confirms the existing all-complete bundle behavior and the retry regression coverage both hold together.
- Regression:
  - `uv run make check`
    - Passed. Runs ruff, formatting checks, and mypy across source and tests.
  - `uv run make test`
    - Passed. Full pytest suite completed successfully with 12,195 collected tests.

CI/CD coverage expected:
- The standard Build workflow should run ruff, mypy, package inspection, and pytest on Python 3.10 and 3.11.
- The Build Log Viewer workflow should still run schema/type and dist validation; this PR does not touch viewer assets.
- No sandbox tool files or version gates are affected.

No changelog entry: test-only regression coverage.

Tooling disclosure: AI-assisted coding and review tools were used; the contributor reviewed the changes and ran the validation above.

Closes #2795.
