### PR TITLE
Codex subagent delegation no longer crashes the agent bridge under Multi-Agent V2 (Issue #4762)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Agent Bridge: Codex agents on Multi-Agent V2 models can now spawn subagents through the bridge instead of failing the sample. (#4762)
 - Bugfix: Model info lookup no longer sends its internal placeholder API key to the Hugging Face Hub when canonicalizing model names. (#4600)
 - Scorer: NaN score values (scalar, dict key, or list element) now survive eval logs and realtime views instead of becoming null, being miscounted as 0.0 on `eval_set` retry, or failing log validation.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -103,6 +103,7 @@ from inspect_ai.model._openai_responses import (
     code_interpreter_to_tool_use,
     content_from_response_input_content_param,
     is_additional_tools,
+    is_agent_message,
     is_assistant_message_param,
     is_code_interpreter_tool_param,
     is_computer_call_output,
@@ -995,6 +996,20 @@ def messages_from_responses_input(
             # harmful: some model backends fail on tool-declaration text and
             # the model cannot call text-declared tools anyway.)
             pass
+        elif is_agent_message(item):
+            # Codex Multi-Agent V2 delivers inter-agent messages as input items.
+            # Forward plaintext input_text parts to the recipient and drop
+            # response-bound encrypted_content parts that cannot be replayed.
+            agent_message = cast(dict[str, Any], item)
+            text_parts = [
+                content["text"]
+                for content in agent_message.get("content", []) or []
+                if isinstance(content, dict)
+                and content.get("type") == "input_text"
+                and isinstance(content.get("text"), str)
+            ]
+            if text_parts:
+                messages.append(ChatMessageUser(content="\n".join(text_parts)))
         else:
             # ImageGenerationCall
             # ResponseCodeInterpreterToolCallParam

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -2129,6 +2129,13 @@ def is_additional_tools(
     return param.get("type") == "additional_tools"
 
 
+def is_agent_message(param: ResponseInputItemParam) -> bool:
+    # tolerate items without a "type" key (e.g. simple user messages) since this
+    # is scanned over raw input items, some of which omit "type". The OpenAI SDK
+    # has not yet added agent_message to ResponseInputItemParam.
+    return dict(param).get("type") == "agent_message"
+
+
 def is_function_tool_param(tool_param: ToolParam) -> TypeGuard[FunctionToolParam]:
     return tool_param.get("type") == "function"
 

--- a/tests/agent/test_bridge_additional_tools.py
+++ b/tests/agent/test_bridge_additional_tools.py
@@ -28,6 +28,7 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._openai_responses import (
     RESPONSES_VERBATIM,
     is_additional_tools,
+    is_agent_message,
     openai_responses_tools,
 )
 from inspect_ai.tool._tool_info import ToolInfo
@@ -73,6 +74,15 @@ def _additional_tools_item(*tools: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _agent_message_item(*content: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "agent_message",
+        "author": "subagent",
+        "recipient": "parent",
+        "content": list(content),
+    }
+
+
 # 1. is_additional_tools predicate
 
 
@@ -87,6 +97,75 @@ def test_is_additional_tools_predicate() -> None:
             {"type": "message", "role": "user", "content": "hi"},
         )
     )
+
+
+# 2. agent_message items are converted to user messages
+
+
+def test_is_agent_message_predicate() -> None:
+    assert is_agent_message(
+        cast(
+            ResponseInputItemParam,
+            _agent_message_item({"type": "input_text", "text": "delegate result"}),
+        )
+    )
+    assert not is_agent_message(
+        cast(
+            ResponseInputItemParam,
+            {"type": "message", "role": "user", "content": "hi"},
+        )
+    )
+    assert not is_agent_message(cast(ResponseInputItemParam, _additional_tools_item()))
+
+
+def test_messages_from_responses_input_converts_agent_message() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "delegate this"}],
+            },
+            _agent_message_item({"type": "input_text", "text": "delegate result"}),
+        ],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert [message.text for message in messages] == [
+        "delegate this",
+        "delegate result",
+    ]
+    assert all(isinstance(message, ChatMessageUser) for message in messages)
+
+
+def test_messages_from_responses_input_drops_agent_message_encrypted_content() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [
+            _agent_message_item(
+                {"type": "input_text", "text": "Payload:"},
+                {"type": "encrypted_content", "encrypted_content": "ciphertext"},
+            )
+        ],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert [message.text for message in messages] == ["Payload:"]
+    assert all(isinstance(message, ChatMessageUser) for message in messages)
+
+
+def test_messages_from_responses_input_agent_message_only() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [_agent_message_item({"type": "input_text", "text": "delegate result"})],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert [message.text for message in messages] == ["delegate result"]
 
 
 # 2. converting input containing an additional_tools item does not raise and


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Codex Multi-Agent V2 delivers inter-agent communication as `agent_message` Responses input items. The agent bridge does not recognize those items, so a delegated sample fails with `Type agent_message is not supported by the agent bridge`.

Fixes #4762.

### What is the new behavior?
The bridge converts an `agent_message` item's plaintext `input_text` parts into a
`ChatMessageUser` for the receiving agent. `encrypted_content` parts are dropped:
they are bound to the original OpenAI response and cannot be decrypted or replayed
in a fresh bridge request, so only the plaintext envelope Codex supplies alongside
them survives. This is separate from a parent's `spawn_agent` tool-call arguments,
which Inspect already forwards verbatim.

### Related upstream issue / known limitation
The root cause is upstream: Codex Multi-Agent V2 emits OpenAI-specific
`agent_message` items to every Responses consumer, including non-OpenAI routes and
the Inspect bridge (openai/codex#33551). Two cases:

- **OpenAI parent** — `encrypted_content` is real Fernet ciphertext (`gAAAAA…`),
  undecryptable outside OpenAI. Only the plaintext envelope is recoverable; this PR
  forwards that and drops the ciphertext.
- **Non-OpenAI parent** — Codex stores the task as plaintext under the
  `encrypted_content` key. This PR does not yet forward that payload, so such a
  child may see only the envelope. Full fidelity depends on the upstream fix in
  openai/codex#33551 (emit standard `message`/`user`/`input_text` on non-OpenAI
  routes); the bridge change here removes the crash and forwards everything it can
  legitimately treat as plaintext today.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
Validation:
- `uv run make check` — passed.
- `uv run pytest tests/agent/test_bridge_additional_tools.py -v` — passed (10 tests).
- Installed this branch into the repository where we run evals with Inspect AI and successfully ran the previously failing tasks with Codex – looking at the logs sub-agents were successfully spawned as part of completing the task 

<img width="1406" height="369" alt="Screenshot 2026-08-06 at 12 51 52" src="https://github.com/user-attachments/assets/027a82e5-a53c-4e5a-883f-3d2e191b20fe" />

 

### Agent review
- Reviewer: GPT-5.6 Terra via Cursor (fresh read-only context), 1 pass.
- Findings: None.

This change was implemented with AI assistance.