### PR TITLE
fix: hf_dataset auto_id not shuffle-stable — assign ids before shuffle (#4459)

### DIFF
--- a/src/inspect_ai/dataset/_sources/hf.py
+++ b/src/inspect_ai/dataset/_sources/hf.py
@@ -17,7 +17,12 @@ from .._dataset import (
     MemoryDataset,
     RecordToSample,
 )
-from .._util import data_to_samples, record_to_sample_fn, shuffle_choices_if_requested
+from .._util import (
+    as_sample_list,
+    data_to_samples,
+    record_to_sample_fn,
+    shuffle_choices_if_requested,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -215,17 +220,42 @@ def hf_dataset(
         dataset = _call_with_hf_retry(_load) if retry else _load()
         dataset.save_to_disk(dataset_cache_dir)
 
-    # shuffle if requested
-    if shuffle:
-        dataset = dataset.shuffle(seed=seed)
+    if auto_id:
+        # Assign ids in the original dataset order (before any shuffle) so a
+        # record keeps the same id regardless of the shuffle seed, mirroring
+        # csv_dataset/json_dataset. Row order for a given seed is unchanged:
+        # the permutation comes from datasets.Dataset.shuffle, which depends
+        # only on the dataset length and seed.
+        sample_groups = [
+            as_sample_list(data_to_sample(record)) for record in dataset.to_list()
+        ]
+        next_id = 1
+        for group in sample_groups:
+            for sample in group:
+                sample.id = next_id
+                next_id += 1
+        if shuffle:
+            indices = datasets.Dataset.from_dict(
+                {"index": list(range(len(sample_groups)))}
+            ).shuffle(seed=seed)["index"]
+            sample_groups = [sample_groups[i] for i in indices]
+        if limit is not None:
+            sample_groups = sample_groups[:limit]
+        samples = [sample for group in sample_groups for sample in group]
+    else:
+        # shuffle if requested
+        if shuffle:
+            dataset = dataset.shuffle(seed=seed)
 
-    # limit if requested
-    if limit is not None:
-        dataset = dataset.select(range(limit))
+        # limit if requested
+        if limit is not None:
+            dataset = dataset.select(range(limit))
+
+        samples = data_to_samples(dataset.to_list(), data_to_sample, auto_id)
 
     # return the dataset
     memory_dataset = MemoryDataset(
-        samples=data_to_samples(dataset.to_list(), data_to_sample, auto_id),
+        samples=samples,
         name=Path(path).stem if Path(path).exists() else path,
         location=path,
         shuffled=shuffle,

--- a/tests/dataset/test_hf_dataset.py
+++ b/tests/dataset/test_hf_dataset.py
@@ -344,6 +344,108 @@ def test_hf_dataset_cache_key_includes_revision(tmp_path, monkeypatch) -> None:
     )
 
 
+def _install_real_datasets_from_dict(monkeypatch, tmp_path, records):
+    """Serve `records` through the real `datasets` library (Dataset.from_dict)."""
+    import datasets  # type: ignore
+
+    columns: dict = {k: [r[k] for r in records] for k in records[0]}
+
+    monkeypatch.setattr(
+        "inspect_ai.dataset._sources.hf.inspect_cache_dir",
+        lambda *_a, **_k: str(tmp_path),
+    )
+    return lambda *_a, **_k: datasets.Dataset.from_dict(columns)
+
+
+@skip_if_no_package("datasets")
+def test_hf_dataset_auto_id_stable_across_shuffle_seeds(tmp_path, monkeypatch):
+    # Regression for auto_id assigning ids to the already-shuffled order:
+    # a record must keep the same id regardless of shuffle seed, matching
+    # csv_dataset/json_dataset.
+    import sys
+
+    records = [{"input": f"Q{i}", "target": f"A{i}"} for i in range(6)]
+    load = _install_real_datasets_from_dict(monkeypatch, tmp_path, records)
+    import datasets as real_datasets  # type: ignore
+
+    monkeypatch.setattr(real_datasets, "load_dataset", load)
+    monkeypatch.setitem(sys.modules, "datasets", real_datasets)
+
+    from inspect_ai.dataset import hf_dataset
+
+    def ids(**kwargs):
+        ds = hf_dataset(
+            path="org/ds", split="test", auto_id=True, cached=False, **kwargs
+        )
+        return {s.input: s.id for s in ds}
+
+    unshuffled = ids()
+    seed1 = ids(shuffle=True, seed=1)
+    seed2 = ids(shuffle=True, seed=2)
+
+    assert seed1 == unshuffled
+    assert seed2 == unshuffled
+
+
+@skip_if_no_package("datasets")
+def test_hf_dataset_auto_id_preserves_shuffle_order(tmp_path, monkeypatch):
+    # auto_id must not change which order a given seed produces: the row
+    # order with auto_id=True has to match auto_id=False for the same seed.
+    import sys
+
+    records = [{"input": f"Q{i}", "target": f"A{i}"} for i in range(12)]
+    load = _install_real_datasets_from_dict(monkeypatch, tmp_path, records)
+    import datasets as real_datasets  # type: ignore
+
+    monkeypatch.setattr(real_datasets, "load_dataset", load)
+    monkeypatch.setitem(sys.modules, "datasets", real_datasets)
+
+    from inspect_ai.dataset import hf_dataset
+
+    def order(auto_id: bool):
+        ds = hf_dataset(
+            path="org/ds",
+            split="test",
+            auto_id=auto_id,
+            shuffle=True,
+            seed=42,
+            cached=False,
+        )
+        return [s.input for s in ds]
+
+    assert order(auto_id=True) == order(auto_id=False)
+
+
+@skip_if_no_package("datasets")
+def test_hf_dataset_auto_id_with_shuffle_and_limit(tmp_path, monkeypatch):
+    # limit still applies after the shuffle, and surviving samples keep
+    # their original-order ids.
+    import sys
+
+    records = [{"input": f"Q{i}", "target": f"A{i}"} for i in range(10)]
+    load = _install_real_datasets_from_dict(monkeypatch, tmp_path, records)
+    import datasets as real_datasets  # type: ignore
+
+    monkeypatch.setattr(real_datasets, "load_dataset", load)
+    monkeypatch.setitem(sys.modules, "datasets", real_datasets)
+
+    from inspect_ai.dataset import hf_dataset
+
+    ds = hf_dataset(
+        path="org/ds",
+        split="test",
+        auto_id=True,
+        shuffle=True,
+        seed=7,
+        limit=4,
+        cached=False,
+    )
+    assert len(ds) == 4
+    for sample in ds:
+        # id is the record's position in the original (unshuffled) order
+        assert sample.id == int(str(sample.input)[1:]) + 1
+
+
 def test_hf_dataset_cache_hit_does_not_invoke_retry(tmp_path, monkeypatch):
     # Regression guard: cache-hit must skip the retry wrapper, otherwise a
     # corrupted local cache would stall behind the 5-minute backoff window.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4459. `hf_dataset` assigns `auto_id` ids to the *already-shuffled* order, so the same record gets a different `sample.id` for different shuffle seeds. `csv_dataset`/`json_dataset` assign ids in file order before shuffling, which was the intent of #626 (fixing #618 — originally reported against an HF dataset, so the reported case was still broken).

### What is the new behavior?

When `auto_id=True`, samples are built and ids assigned in the original dataset order, then reordered by the same permutation `datasets.Dataset.shuffle` produces (it depends only on dataset length and seed), then `limit` applies as before.

- Ids are now stable across seeds and identical to what `json_dataset` assigns for the same data (verified in the repro from the issue: `hf stable: True | hf==json ids: True`).
- **Row order for any given seed is unchanged** — existing pinned-seed runs sample the same records in the same order; only the ids change (they become the stable ones). This is Option B from the issue discussion; Option A (unifying on `MemoryDataset.shuffle`) would have silently changed the sampling order of every existing pinned-seed HF run.
- `auto_id=False` path is untouched.

Multi-sample `RecordToSample` expansion keeps exact `data_to_samples` numbering semantics (ids assigned sequentially in original record order).

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Ids produced by `hf_dataset(auto_id=True, shuffle=True)` change from seed-dependent values to the stable original-order values (the documented intent). Row order per seed is preserved. One note: with `auto_id=True` and `limit`, records are now expanded to samples before the limit is applied (needed to number ids in original order), which does slightly more work for large datasets with small limits.

### Other information:

Tests: three regressions added in `tests/dataset/test_hf_dataset.py` using the real `datasets` library — id stability across seeds, shuffle-order preservation vs the `auto_id=False` path, and the shuffle+limit interaction. `pytest tests/dataset/test_hf_dataset.py` 29/29 pass; ruff + mypy clean.

Process note: #4459 hasn't been triaged/`accepted` yet — I filed the issue and had the fix analysis in-thread, so I've opened this to make review concrete. Happy to adjust if Option A is preferred, or to hold for triage.

(AI-assisted: implemented with Claude Code.)
