### PR TITLE
fix(scorer): preserve score metadata only if equal across epochs (#4779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Scorers: Score reducers now preserve score metadata only if it is equal across all epochs. (#4779)
 - Sandbox: `ComposeService` now accepts the standard compose keys `restart`, `stdin_open`, and `tty` (previously rejected as unknown fields).
 - Bugfix: Model info lookup no longer sends its internal placeholder API key to the Hugging Face Hub when canonicalizing model names. (#4600)
 - Scorer: NaN score values (scalar, dict key, or list element) now survive eval logs and realtime views instead of becoming null, being miscounted as 0.0 on `eval_set` retry, or failing log validation.

--- a/src/inspect_ai/scorer/_reducer/reducer.py
+++ b/src/inspect_ai/scorer/_reducer/reducer.py
@@ -534,7 +534,9 @@ def _reduced_score(value: Value, scores: list[Score]) -> Score:
         explanation=scores[0].explanation
         if len(set(score.explanation for score in scores)) == 1
         else None,
-        metadata=scores[0].metadata,
+        metadata=scores[0].metadata
+        if all(score.metadata == scores[0].metadata for score in scores)
+        else None,
     )
 
 
@@ -559,7 +561,9 @@ def _nan_score(scores: list[Score]) -> Score:
         explanation=scores[0].explanation
         if len(set(score.explanation for score in scores)) == 1
         else None,
-        metadata=scores[0].metadata,
+        metadata=scores[0].metadata
+        if all(score.metadata == scores[0].metadata for score in scores)
+        else None,
     )
 
 

--- a/tests/scorer/test_reducers.py
+++ b/tests/scorer/test_reducers.py
@@ -394,7 +394,7 @@ def test_reducer_preserve_metadata() -> None:
         reduced = reducer(simple_scores)
         assert reduced.answer is None
         assert reduced.explanation is None
-        assert reduced.metadata == simple_scores[0].metadata
+        assert reduced.metadata is None
         # reduce all scores _except_ the last one
         reduced = reducer(simple_scores[:-1])
         assert reduced.answer == simple_scores[0].answer
@@ -424,6 +424,7 @@ Point = namedtuple("Point", ["x", "y"])  # noqa: F821
 
 
 def test_complex_metadata_reduce():
+    now = datetime.now(timezone.utc)
     list_scores = [
         Score(
             value=1,
@@ -435,7 +436,7 @@ def test_complex_metadata_reduce():
                 "probability": 0.75,
                 "tags": ["math", "algebra"],
                 "user": {"id": 123, "name": "John"},
-                "timestamp": datetime.now(timezone.utc),
+                "timestamp": now,
                 "difficulty": DifficultyLevel.MEDIUM,
                 "optional_data": None,
                 "stats": {"attempts": 3, "success_rate": 0.67},
@@ -453,7 +454,7 @@ def test_complex_metadata_reduce():
                 "probability": 0.75,
                 "tags": ["math", "algebra"],
                 "user": {"id": 123, "name": "John"},
-                "timestamp": datetime.now(timezone.utc),
+                "timestamp": now,
                 "difficulty": DifficultyLevel.MEDIUM,
                 "optional_data": None,
                 "stats": {"attempts": 3, "success_rate": 0.67},
@@ -471,7 +472,7 @@ def test_complex_metadata_reduce():
                 "probability": 0.75,
                 "tags": ["math", "algebra"],
                 "user": {"id": 123, "name": "John"},
-                "timestamp": datetime.now(timezone.utc),
+                "timestamp": now,
                 "difficulty": DifficultyLevel.MEDIUM,
                 "optional_data": None,
                 "stats": {"attempts": 3, "success_rate": 0.67},


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?
When reducing scores across multiple epochs, `_reduced_score` and `_nan_score` in `src/inspect_ai/scorer/_reducer/reducer.py` preserve `answer` and `explanation` only if equal across all scores (setting them to `None` if they differ), but unconditionally retain `scores[0].metadata` even when `metadata` differs across scores.

Closes #4779

### What is the new behavior?
`ScoreReducer` implementations now preserve `Score.metadata` only if `metadata` is equal across all scores being reduced (setting it to `None` when `metadata` differs between epochs). This matches the equality contract enforced for `answer` and `explanation` and aligns with the code comment `# retain remaining fields only if equal across all Scores`.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
- **Validation**:
  - `uv run pytest tests/scorer/test_reducers.py` (37 passed)
  - `uv run make check` (ruff linter/formatter and mypy pass cleanly across 1348 files)
  - `git diff --check` (0 issues)

### Agent review
- Reviewer: Antigravity agent (fresh context pass)
- Findings: 1 — fixed (`test_complex_metadata_reduce` recreated `datetime.now(timezone.utc)` inline per score creating microsecond differences; updated test to reuse a single `now` timestamp variable so metadata dictionaries are strictly equal across scores).
