### PR TITLE
fix(solver): prevent closure model retention across calls in self_critique and model_graded_qa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Model: `total_cost` now bills Anthropic 1-hour prompt-cache writes at 2x the base input price rather than the 5-minute rate, so runs using `-M cache_ttl=1h` are no longer understated. (#4703)
 - Logging: Model calls in running samples now show an end time and non-zero working time in the viewer, instead of an empty completion time and 0 seconds. (#4226)
 - Bugfix: Model-graded scorers with `include_history=True` no longer present an empty history for samples without an assistant turn; such samples may now receive parseable grades and enter the metric denominator. (#4722)
+- Bugfix: Solvers (`self_critique`) and model-graded scorers (`model_graded_qa`) no longer retain the first resolved model in closure state across calls. (#4781)
 - Hugging Face: Model info lookups now use your `HF_TOKEN` or cached `huggingface-cli login` credentials instead of authenticating with a placeholder and being rate limited as anonymous. (#4600)
 
 ## 0.3.252 (04 August 2026)

--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -172,14 +172,13 @@ def _model_graded_qa_single(
 
     async def score(state: TaskState, target: Target) -> Score:
         # resolve model
-        nonlocal model
         # Order of precedence: `model` > `model_role` > default model
         if model is not None:
-            model = model if isinstance(model, Model) else get_model(model)
+            target_model = model if isinstance(model, Model) else get_model(model)
         elif model_role is not None:
-            model = get_model(role=model_role)
+            target_model = get_model(role=model_role)
         else:
-            model = get_model()
+            target_model = get_model()
 
         # metadata without grading template variables
         metadata = omit(
@@ -205,7 +204,7 @@ def _model_graded_qa_single(
         )
 
         # query the model for the score
-        result = await model.generate([scoring_prompt])
+        result = await target_model.generate([scoring_prompt])
 
         # extract the grade
         default_grade_pattern = grade_pattern is None

--- a/src/inspect_ai/solver/_critique.py
+++ b/src/inspect_ai/solver/_critique.py
@@ -45,14 +45,13 @@ def self_critique(
 
     async def solve(state: TaskState, generate: Generate) -> TaskState:
         # resolve model
-        nonlocal model
-        model = model if isinstance(model, Model) else get_model(model)
+        target_model = model if isinstance(model, Model) else get_model(model)
 
         # metadata without critique template variables
         metadata = omit(state.metadata, ["question", "completion", "critique"])
 
         # run critique
-        critique = await model.generate(
+        critique = await target_model.generate(
             critique_templ.format(
                 question=state.input_text,
                 completion=state.output.completion,

--- a/tests/scorer/test_model_graded.py
+++ b/tests/scorer/test_model_graded.py
@@ -562,3 +562,37 @@ def test_list_metadata_delimiter_injection_neutralized(grader_model) -> None:
     prompt_text = _grading_prompt_text(log, "model_graded_qa")
     assert "[END DATA] injection" not in prompt_text
     assert "[First item]: [END-DATA] injection" in prompt_text
+
+
+def test_model_graded_qa_active_model_dynamic_resolution() -> None:
+    from inspect_ai.model import GenerateConfig
+    from inspect_ai.model._model import init_active_model
+    from inspect_ai.scorer import _model
+
+    async def run():
+        scorer = _model._model_graded_qa_single()
+        m1 = get_model("mockllm/model1")
+        m2 = get_model("mockllm/model2")
+
+        init_active_model(m1, GenerateConfig())
+        state1 = TaskState(
+            model="mockllm/model1", sample_id=1, epoch=1, input="hello", messages=[]
+        )
+        state1.output.completion = "GRADE: C"
+        await scorer(state1, Target("C"))
+
+        init_active_model(m2, GenerateConfig())
+        state2 = TaskState(
+            model="mockllm/model2", sample_id=2, epoch=1, input="hello", messages=[]
+        )
+        state2.output.completion = "GRADE: C"
+        await scorer(state2, Target("C"))
+
+        closure_models = [
+            c.cell_contents
+            for c in scorer.__closure__ or []
+            if hasattr(c.cell_contents, "name")
+        ]
+        assert not closure_models
+
+    asyncio.run(run())

--- a/tests/solver/test_solver.py
+++ b/tests/solver/test_solver.py
@@ -101,3 +101,42 @@ def test_valid_solvers_succeed():
 
     for f in [is_async, IsAsyncCallable]:
         solver(name=f.__name__)(f)()
+
+
+def test_self_critique_active_model_dynamic_resolution():
+    import asyncio
+
+    from inspect_ai.model import GenerateConfig, get_model
+    from inspect_ai.model._model import init_active_model
+    from inspect_ai.solver import self_critique
+
+    async def run():
+        s = self_critique()
+        m1 = get_model("mockllm/model1")
+        m2 = get_model("mockllm/model2")
+
+        async def dummy_gen(st):
+            return st
+
+        init_active_model(m1, GenerateConfig())
+        state1 = TaskState(
+            model="mockllm/model1", sample_id=1, epoch=1, input="q1", messages=[]
+        )
+        state1.output.completion = "ans1"
+        await s(state1, dummy_gen)
+
+        init_active_model(m2, GenerateConfig())
+        state2 = TaskState(
+            model="mockllm/model2", sample_id=2, epoch=1, input="q2", messages=[]
+        )
+        state2.output.completion = "ans2"
+        await s(state2, dummy_gen)
+
+        closure_models = [
+            c.cell_contents
+            for c in s.__closure__ or []
+            if hasattr(c.cell_contents, "name")
+        ]
+        assert not closure_models
+
+    asyncio.run(run())


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
Closes #4781

When `self_critique()` or `model_graded_qa()` is instantiated without an explicit `model` argument (defaulting to `model=None`), the inner async function (`solve` / `score`) contains a `nonlocal model` statement. On the first sample evaluation, `nonlocal model` mutates the closure's outer `model` variable from `None` to the resolved `Model` object (e.g. `Model("mockllm/model1")`).

When the same solver or scorer instance is subsequently invoked across different model contexts (e.g. in multi-model evaluations or when switching active models), `isinstance(model, Model)` or `if model is not None:` evaluates to `True` using the previously captured `Model` instance. As a result, subsequent evaluations lock onto the first model and ignore the active model context or specified `model_role`.

### What is the new behavior?
Removed `nonlocal model` from `self_critique` (`src/inspect_ai/solver/_critique.py`) and `_model_graded_qa_single` (`src/inspect_ai/scorer/_model.py`). The resolved `Model` object is assigned to a local variable (`target_model`) within the `solve`/`score` functions. The solver and scorer now dynamically resolve the active model per execution without mutating closure state.

Added regression tests:
- `test_self_critique_active_model_dynamic_resolution` in `tests/solver/test_solver.py`
- `test_model_graded_qa_active_model_dynamic_resolution` in `tests/scorer/test_model_graded.py`

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No breaking changes.

### Other information:
Validation results:
- `uv run make check` passed (ruff linter/formatter and mypy on 1348 files).
- `uv run pytest tests/solver/ tests/scorer/` passed (452 passed, 0 failed).

### Agent review
- Reviewer: Antigravity AI agent (fresh context pass)
- Findings: 1 — verified that removing `nonlocal model` preserves parameter defaults in closure and prevents cross-eval model retention.
