### PR TITLE
Agent bridge: attribute, replay verbatim, and never silently drop Codex Multi-Agent V2 agent messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Agent Bridge: Codex agents on Multi-Agent V2 models can now spawn subagents through the bridge instead of failing the sample. (#4762)
+- Agent Bridge: Codex agents on Multi-Agent V2 models can now spawn subagents through the bridge instead of failing the sample. Inter-agent `agent_message` items are rendered as author-attributed user messages and replayed verbatim to OpenAI Responses targets so encrypted payloads survive. (#4762)
 - Bugfix: Model info lookup no longer sends its internal placeholder API key to the Hugging Face Hub when canonicalizing model names. (#4600)
 - Scorer: NaN score values (scalar, dict key, or list element) now survive eval logs and realtime views instead of becoming null, being miscounted as 0.0 on `eval_set` retry, or failing log validation.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Agent Bridge: Codex agents on Multi-Agent V2 models can now spawn subagents through the bridge instead of failing the sample. Inter-agent `agent_message` items are rendered as author-attributed user messages and replayed verbatim to OpenAI Responses targets so encrypted payloads survive. (#4762)
+- Agent Bridge: Codex agents on Multi-Agent V2 models can now spawn subagents through the bridge instead of failing the sample. (#4762)
 - Bugfix: Model info lookup no longer sends its internal placeholder API key to the Hugging Face Hub when canonicalizing model names. (#4600)
 - Scorer: NaN score values (scalar, dict key, or list element) now survive eval logs and realtime views instead of becoming null, being miscounted as 0.0 on `eval_set` retry, or failing log validation.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Agent Bridge: Codex agents on Multi-Agent V2 models can now spawn subagents through the bridge instead of failing the sample. (#4762)
 - Bugfix: Model info lookup no longer sends its internal placeholder API key to the Hugging Face Hub when canonicalizing model names. (#4600)
 - Scorer: NaN score values (scalar, dict key, or list element) now survive eval logs and realtime views instead of becoming null, being miscounted as 0.0 on `eval_set` retry, or failing log validation.
 - Eval: Multi-task runs without `task_retry_attempts` now use the same task dispatcher as runs with retries (the separate no-retry dispatcher was removed).

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -103,6 +103,7 @@ from inspect_ai.model._openai_responses import (
     code_interpreter_to_tool_use,
     content_from_response_input_content_param,
     is_additional_tools,
+    is_agent_message,
     is_assistant_message_param,
     is_code_interpreter_tool_param,
     is_computer_call_output,
@@ -995,6 +996,20 @@ def messages_from_responses_input(
             # harmful: some model backends fail on tool-declaration text and
             # the model cannot call text-declared tools anyway.)
             pass
+        elif is_agent_message(item):
+            # Codex Multi-Agent V2 delivers inter-agent messages as input items.
+            # Forward plaintext input_text parts to the recipient and drop
+            # response-bound encrypted_content parts that cannot be replayed.
+            agent_message = cast(dict[str, Any], item)
+            text_parts = [
+                content["text"]
+                for content in agent_message.get("content", []) or []
+                if isinstance(content, dict)
+                and content.get("type") == "input_text"
+                and isinstance(content.get("text"), str)
+            ]
+            if text_parts:
+                messages.append(ChatMessageUser(content="\n".join(text_parts)))
         else:
             # ImageGenerationCall
             # ResponseCodeInterpreterToolCallParam

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -1014,17 +1014,25 @@ def messages_from_responses_input(
                 and part.get("type") == "input_text"
                 and isinstance(part.get("text"), str)
             ]
-            if not text_parts and any(
-                isinstance(part, dict) and part.get("type") == "encrypted_content"
-                for part in agent_message_parts
-            ):
-                warn_once(
-                    logger,
-                    "agent_message item carries only encrypted content: it "
-                    "replays natively to OpenAI Responses targets, but other "
-                    "targets see only a placeholder.",
-                )
-                text_parts = ["[encrypted content: readable only by OpenAI]"]
+            if not text_parts:
+                if any(
+                    isinstance(part, dict) and part.get("type") == "encrypted_content"
+                    for part in agent_message_parts
+                ):
+                    warn_once(
+                        logger,
+                        "agent_message item carries only encrypted content: it "
+                        "replays natively to OpenAI Responses targets, but other "
+                        "targets see only a placeholder.",
+                    )
+                    text_parts = ["[encrypted content: readable only by OpenAI]"]
+                else:
+                    warn_once(
+                        logger,
+                        "agent_message item carries no readable content: "
+                        "rendering a placeholder.",
+                    )
+                    text_parts = ["[no readable content]"]
             messages.append(
                 ChatMessageUser(
                     content=[

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -998,18 +998,44 @@ def messages_from_responses_input(
             pass
         elif is_agent_message(item):
             # Codex Multi-Agent V2 delivers inter-agent messages as input items.
-            # Forward plaintext input_text parts to the recipient and drop
-            # response-bound encrypted_content parts that cannot be replayed.
+            # Render an author-attributed user message (Codex's own downgrade
+            # convention, so the recipient never mistakes another agent's words
+            # for the user's) and stash the original item on ContentText.internal
+            # so the OpenAI Responses provider can replay it natively --
+            # encrypted_content parts are undecryptable here but decryptable
+            # by OpenAI server-side.
             agent_message = cast(dict[str, Any], item)
+            author = str(agent_message.get("author", "agent"))
+            agent_message_parts = agent_message.get("content", []) or []
             text_parts = [
-                content["text"]
-                for content in agent_message.get("content", []) or []
-                if isinstance(content, dict)
-                and content.get("type") == "input_text"
-                and isinstance(content.get("text"), str)
+                part["text"]
+                for part in agent_message_parts
+                if isinstance(part, dict)
+                and part.get("type") == "input_text"
+                and isinstance(part.get("text"), str)
             ]
-            if text_parts:
-                messages.append(ChatMessageUser(content="\n".join(text_parts)))
+            if not text_parts and any(
+                isinstance(part, dict) and part.get("type") == "encrypted_content"
+                for part in agent_message_parts
+            ):
+                warn_once(
+                    logger,
+                    "agent_message item carries only encrypted content: it "
+                    "replays natively to OpenAI Responses targets, but other "
+                    "targets see only a placeholder.",
+                )
+                text_parts = ["[encrypted content: readable only by OpenAI]"]
+            messages.append(
+                ChatMessageUser(
+                    content=[
+                        ContentText(
+                            text=f"Agent message from {author}:\n"
+                            + "\n".join(text_parts),
+                            internal={"agent_message": agent_message},
+                        )
+                    ]
+                )
+            )
         else:
             # ImageGenerationCall
             # ResponseCodeInterpreterToolCallParam

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -924,7 +924,58 @@ def messages_from_responses_input(
         # see if we need to collect a pending assistant message
         collect_pending_assistant_message()
 
-        if is_response_input_message(item):
+        if is_agent_message(item):
+            # Codex Multi-Agent V2 delivers inter-agent messages as input items.
+            # Render an author-attributed user message (Codex's own downgrade
+            # convention, so the recipient never mistakes another agent's words
+            # for the user's) and stash the original item on ContentText.internal
+            # so the OpenAI Responses provider can replay it natively --
+            # encrypted_content parts are undecryptable here but decryptable
+            # by OpenAI server-side. Checked before is_response_input_message
+            # (an exact type match vs. a loose keys-based one) so a future
+            # Codex adding a "role" key to agent_message items can't silently
+            # reroute them into the plain-message branch.
+            agent_message = cast(dict[str, Any], item)
+            author = str(agent_message.get("author") or "agent")
+            agent_message_parts = agent_message.get("content", []) or []
+            text_parts = [
+                part["text"]
+                for part in agent_message_parts
+                if isinstance(part, dict)
+                and part.get("type") == "input_text"
+                and isinstance(part.get("text"), str)
+            ]
+            if not text_parts:
+                if any(
+                    isinstance(part, dict) and part.get("type") == "encrypted_content"
+                    for part in agent_message_parts
+                ):
+                    warn_once(
+                        logger,
+                        "agent_message item carries only encrypted content: it "
+                        "replays natively to OpenAI Responses targets, but other "
+                        "targets see only a placeholder.",
+                    )
+                    text_parts = ["[encrypted content: readable only by OpenAI]"]
+                else:
+                    warn_once(
+                        logger,
+                        "agent_message item carries no readable content: "
+                        "rendering a placeholder.",
+                    )
+                    text_parts = ["[no readable content]"]
+            messages.append(
+                ChatMessageUser(
+                    content=[
+                        ContentText(
+                            text=f"Agent message from {author}:\n"
+                            + "\n".join(text_parts),
+                            internal={"agent_message": agent_message},
+                        )
+                    ]
+                )
+            )
+        elif is_response_input_message(item):
             # normalize item content
             item_content: list[ResponseInputContentParam] = (
                 [ResponseInputTextParam(type="input_text", text=item["content"])]
@@ -996,54 +1047,6 @@ def messages_from_responses_input(
             # harmful: some model backends fail on tool-declaration text and
             # the model cannot call text-declared tools anyway.)
             pass
-        elif is_agent_message(item):
-            # Codex Multi-Agent V2 delivers inter-agent messages as input items.
-            # Render an author-attributed user message (Codex's own downgrade
-            # convention, so the recipient never mistakes another agent's words
-            # for the user's) and stash the original item on ContentText.internal
-            # so the OpenAI Responses provider can replay it natively --
-            # encrypted_content parts are undecryptable here but decryptable
-            # by OpenAI server-side.
-            agent_message = cast(dict[str, Any], item)
-            author = str(agent_message.get("author", "agent"))
-            agent_message_parts = agent_message.get("content", []) or []
-            text_parts = [
-                part["text"]
-                for part in agent_message_parts
-                if isinstance(part, dict)
-                and part.get("type") == "input_text"
-                and isinstance(part.get("text"), str)
-            ]
-            if not text_parts:
-                if any(
-                    isinstance(part, dict) and part.get("type") == "encrypted_content"
-                    for part in agent_message_parts
-                ):
-                    warn_once(
-                        logger,
-                        "agent_message item carries only encrypted content: it "
-                        "replays natively to OpenAI Responses targets, but other "
-                        "targets see only a placeholder.",
-                    )
-                    text_parts = ["[encrypted content: readable only by OpenAI]"]
-                else:
-                    warn_once(
-                        logger,
-                        "agent_message item carries no readable content: "
-                        "rendering a placeholder.",
-                    )
-                    text_parts = ["[no readable content]"]
-            messages.append(
-                ChatMessageUser(
-                    content=[
-                        ContentText(
-                            text=f"Agent message from {author}:\n"
-                            + "\n".join(text_parts),
-                            internal={"agent_message": agent_message},
-                        )
-                    ]
-                )
-            )
         else:
             # ImageGenerationCall
             # ResponseCodeInterpreterToolCallParam

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -259,6 +259,29 @@ def _extract_compaction_from_content_data(
     return None
 
 
+def _extract_agent_message_from_internal(
+    content: str | list[Content],
+) -> ResponseInputItemParam | None:
+    """Recover a verbatim Codex `agent_message` item stashed by the agent bridge.
+
+    The bridge renders agent_message items as author-attributed user text (which
+    non-OpenAI targets consume) and stashes the original item on
+    ContentText.internal; OpenAI Responses targets replay the item natively so
+    `encrypted_content` parts (decryptable only by OpenAI server-side) survive.
+    """
+    if not isinstance(content, list):
+        return None
+    for item in content:
+        if isinstance(item, ContentText) and isinstance(item.internal, dict):
+            agent_message = item.internal.get("agent_message")
+            if (
+                isinstance(agent_message, dict)
+                and agent_message.get("type") == "agent_message"
+            ):
+                return cast(ResponseInputItemParam, agent_message)
+    return None
+
+
 async def openai_responses_inputs(
     messages: list[ChatMessage],
     model_info: ResponsesModelInfo | None = None,
@@ -289,6 +312,11 @@ async def _openai_input_item_from_chat_message(
         if compaction_param:
             # This is a compaction marker - return compaction item
             return [compaction_param]
+
+        # Check for a verbatim Codex agent_message stashed by the agent bridge
+        agent_message_param = _extract_agent_message_from_internal(message.content)
+        if agent_message_param is not None:
+            return [agent_message_param]
 
         # Regular user message handling
         return [
@@ -2132,8 +2160,9 @@ def is_additional_tools(
 def is_agent_message(param: ResponseInputItemParam) -> bool:
     # tolerate items without a "type" key (e.g. simple user messages) since this
     # is scanned over raw input items, some of which omit "type". The OpenAI SDK
-    # has not yet added agent_message to ResponseInputItemParam.
-    return dict(param).get("type") == "agent_message"
+    # has not yet added agent_message to ResponseInputItemParam, so the cast
+    # sidesteps a comparison-overlap error against the SDK's literal union.
+    return cast(dict[str, Any], param).get("type") == "agent_message"
 
 
 def is_function_tool_param(tool_param: ToolParam) -> TypeGuard[FunctionToolParam]:

--- a/src/inspect_ai/model/_openai_responses.py
+++ b/src/inspect_ai/model/_openai_responses.py
@@ -2129,6 +2129,13 @@ def is_additional_tools(
     return param.get("type") == "additional_tools"
 
 
+def is_agent_message(param: ResponseInputItemParam) -> bool:
+    # tolerate items without a "type" key (e.g. simple user messages) since this
+    # is scanned over raw input items, some of which omit "type". The OpenAI SDK
+    # has not yet added agent_message to ResponseInputItemParam.
+    return dict(param).get("type") == "agent_message"
+
+
 def is_function_tool_param(tool_param: ToolParam) -> TypeGuard[FunctionToolParam]:
     return tool_param.get("type") == "function"
 

--- a/tests/agent/test_bridge_additional_tools.py
+++ b/tests/agent/test_bridge_additional_tools.py
@@ -28,7 +28,6 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._openai_responses import (
     RESPONSES_VERBATIM,
     is_additional_tools,
-    is_agent_message,
     openai_responses_tools,
 )
 from inspect_ai.tool._tool_info import ToolInfo
@@ -74,15 +73,6 @@ def _additional_tools_item(*tools: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _agent_message_item(*content: dict[str, Any]) -> dict[str, Any]:
-    return {
-        "type": "agent_message",
-        "author": "subagent",
-        "recipient": "parent",
-        "content": list(content),
-    }
-
-
 # 1. is_additional_tools predicate
 
 
@@ -97,75 +87,6 @@ def test_is_additional_tools_predicate() -> None:
             {"type": "message", "role": "user", "content": "hi"},
         )
     )
-
-
-# 2. agent_message items are converted to user messages
-
-
-def test_is_agent_message_predicate() -> None:
-    assert is_agent_message(
-        cast(
-            ResponseInputItemParam,
-            _agent_message_item({"type": "input_text", "text": "delegate result"}),
-        )
-    )
-    assert not is_agent_message(
-        cast(
-            ResponseInputItemParam,
-            {"type": "message", "role": "user", "content": "hi"},
-        )
-    )
-    assert not is_agent_message(cast(ResponseInputItemParam, _additional_tools_item()))
-
-
-def test_messages_from_responses_input_converts_agent_message() -> None:
-    input_items = cast(
-        list[ResponseInputItemParam],
-        [
-            {
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": "delegate this"}],
-            },
-            _agent_message_item({"type": "input_text", "text": "delegate result"}),
-        ],
-    )
-
-    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
-
-    assert [message.text for message in messages] == [
-        "delegate this",
-        "delegate result",
-    ]
-    assert all(isinstance(message, ChatMessageUser) for message in messages)
-
-
-def test_messages_from_responses_input_drops_agent_message_encrypted_content() -> None:
-    input_items = cast(
-        list[ResponseInputItemParam],
-        [
-            _agent_message_item(
-                {"type": "input_text", "text": "Payload:"},
-                {"type": "encrypted_content", "encrypted_content": "ciphertext"},
-            )
-        ],
-    )
-
-    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
-
-    assert [message.text for message in messages] == ["Payload:"]
-    assert all(isinstance(message, ChatMessageUser) for message in messages)
-
-
-def test_messages_from_responses_input_agent_message_only() -> None:
-    input_items = cast(
-        list[ResponseInputItemParam],
-        [_agent_message_item({"type": "input_text", "text": "delegate result"})],
-    )
-
-    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
-
-    assert [message.text for message in messages] == ["delegate result"]
 
 
 # 2. converting input containing an additional_tools item does not raise and

--- a/tests/agent/test_bridge_additional_tools.py
+++ b/tests/agent/test_bridge_additional_tools.py
@@ -28,6 +28,7 @@ from inspect_ai.model._generate_config import GenerateConfig
 from inspect_ai.model._openai_responses import (
     RESPONSES_VERBATIM,
     is_additional_tools,
+    is_agent_message,
     openai_responses_tools,
 )
 from inspect_ai.tool._tool_info import ToolInfo
@@ -73,6 +74,15 @@ def _additional_tools_item(*tools: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _agent_message_item(*content: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "agent_message",
+        "author": "subagent",
+        "recipient": "parent",
+        "content": list(content),
+    }
+
+
 # 1. is_additional_tools predicate
 
 
@@ -87,6 +97,75 @@ def test_is_additional_tools_predicate() -> None:
             {"type": "message", "role": "user", "content": "hi"},
         )
     )
+
+
+# 2. agent_message items are converted to user messages
+
+
+def test_is_agent_message_predicate() -> None:
+    assert is_agent_message(
+        cast(
+            ResponseInputItemParam,
+            _agent_message_item({"type": "input_text", "text": "delegate result"}),
+        )
+    )
+    assert not is_agent_message(
+        cast(
+            ResponseInputItemParam,
+            {"type": "message", "role": "user", "content": "hi"},
+        )
+    )
+    assert not is_agent_message(cast(ResponseInputItemParam, _additional_tools_item()))
+
+
+def test_messages_from_responses_input_converts_agent_message() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "delegate this"}],
+            },
+            _agent_message_item({"type": "input_text", "text": "delegate result"}),
+        ],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert [message.text for message in messages] == [
+        "delegate this",
+        "delegate result",
+    ]
+    assert all(isinstance(message, ChatMessageUser) for message in messages)
+
+
+def test_messages_from_responses_input_drops_agent_message_encrypted_content() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [
+            _agent_message_item(
+                {"type": "input_text", "text": "Payload:"},
+                {"type": "encrypted_content", "encrypted_content": "ciphertext"},
+            )
+        ],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert [message.text for message in messages] == ["Payload:"]
+    assert all(isinstance(message, ChatMessageUser) for message in messages)
+
+
+def test_messages_from_responses_input_agent_message_only() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [_agent_message_item({"type": "input_text", "text": "delegate result"})],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert [message.text for message in messages] == ["delegate result"]
 
 
 # 2. converting input containing an additional_tools item does not raise and

--- a/tests/agent/test_bridge_agent_message.py
+++ b/tests/agent/test_bridge_agent_message.py
@@ -134,6 +134,39 @@ def test_agent_message_attribution_uses_author_field() -> None:
     assert messages[0].text == "Agent message from parent:\ndo the subtask"
 
 
+def test_agent_message_with_null_author_uses_default_attribution() -> None:
+    # an explicit null author must not render as "Agent message from None:"
+    item = _agent_message_item(_text("delegate result"))
+    item["author"] = None
+
+    messages = messages_from_responses_input(
+        cast(list[ResponseInputItemParam], [item]), [], MODEL_NAME
+    )
+
+    assert len(messages) == 1
+    assert messages[0].text == "Agent message from agent:\ndelegate result"
+
+
+def test_agent_message_with_role_key_is_still_attributed() -> None:
+    # dispatch-order guard: is_agent_message (exact type match) must win over
+    # is_response_input_message (loose keys-based match), so an agent_message
+    # that grows a "role" key in a future Codex version keeps its attribution
+    # and verbatim stash instead of being swallowed as a plain message
+    item = _agent_message_item(_text("delegate result"))
+    item["role"] = "user"
+
+    messages = messages_from_responses_input(
+        cast(list[ResponseInputItemParam], [item]), [], MODEL_NAME
+    )
+
+    assert len(messages) == 1
+    assert messages[0].text == "Agent message from subagent:\ndelegate result"
+    content = messages[0].content
+    assert isinstance(content, list)
+    assert isinstance(content[0], ContentText)
+    assert content[0].internal == {"agent_message": item}
+
+
 def test_agent_message_joins_multiple_text_parts() -> None:
     input_items = cast(
         list[ResponseInputItemParam],

--- a/tests/agent/test_bridge_agent_message.py
+++ b/tests/agent/test_bridge_agent_message.py
@@ -24,9 +24,9 @@ These tests cover the conversion helpers directly (no network).
 
 from __future__ import annotations
 
-import logging
 from typing import Any, cast
 
+import pytest
 from openai.types.responses import ResponseInputItemParam
 
 from inspect_ai._util.content import ContentText
@@ -40,6 +40,19 @@ from inspect_ai.model._openai_responses import (
 )
 
 MODEL_NAME = "openai/gpt-5.6"
+
+
+@pytest.fixture
+def _warn_once_messages() -> Any:
+    # warn_once dedupes via a module-level list; clear it and yield it so the
+    # test can assert on what was emitted. caplog isn't reliable here because
+    # init_logger sets propagate=False on the inspect_ai logger once any
+    # earlier test triggers it.
+    from inspect_ai._util import logger as _inspect_logger
+
+    _inspect_logger._warned.clear()
+    yield _inspect_logger._warned
+    _inspect_logger._warned.clear()
 
 
 def _agent_message_item(
@@ -180,14 +193,13 @@ async def test_plain_user_message_still_emits_message_item() -> None:
 
 
 async def test_encrypted_only_agent_message_is_not_silently_dropped(
-    caplog: Any,
+    _warn_once_messages: list[str],
 ) -> None:
     original = _agent_message_item(_encrypted(), author="parent")
 
-    with caplog.at_level(logging.WARNING):
-        messages = messages_from_responses_input(
-            cast(list[ResponseInputItemParam], [original]), [], MODEL_NAME
-        )
+    messages = messages_from_responses_input(
+        cast(list[ResponseInputItemParam], [original]), [], MODEL_NAME
+    )
 
     # a message survives, attributed, with a placeholder mentioning the
     # encrypted payload (non-OpenAI targets see this text)
@@ -198,14 +210,34 @@ async def test_encrypted_only_agent_message_is_not_silently_dropped(
 
     # the warning names the degradation
     assert any(
-        "agent_message" in record.message and "encrypted" in record.message
-        for record in caplog.records
+        "agent_message" in message and "encrypted" in message
+        for message in _warn_once_messages
     )
 
     # and the verbatim payload still replays natively to OpenAI targets
     items = await openai_responses_inputs(messages)
     assert len(items) == 1
     assert dict(items[0]) == original
+
+
+def test_empty_agent_message_is_not_silently_dropped(
+    _warn_once_messages: list[str],
+) -> None:
+    # content with neither input_text nor encrypted_content parts must still
+    # produce an attributed placeholder plus a warning
+    original = _agent_message_item(author="parent")
+
+    messages = messages_from_responses_input(
+        cast(list[ResponseInputItemParam], [original]), [], MODEL_NAME
+    )
+
+    assert len(messages) == 1
+    assert isinstance(messages[0], ChatMessageUser)
+    assert messages[0].text == "Agent message from parent:\n[no readable content]"
+    assert any(
+        "agent_message" in message and "no readable content" in message
+        for message in _warn_once_messages
+    )
 
 
 def test_agent_message_carries_verbatim_item_as_internal() -> None:

--- a/tests/agent/test_bridge_agent_message.py
+++ b/tests/agent/test_bridge_agent_message.py
@@ -1,0 +1,222 @@
+r"""Unit tests for Codex Multi-Agent V2 `agent_message` handling in the bridge.
+
+Codex >= 0.146 delivers inter-agent communication (spawn_agent / send_message /
+followup_task tasking and child FINAL_ANSWER returns) as Responses input items
+of type `agent_message` (openai/codex#26210). The bridge must:
+
+(a) not choke on the item when converting input to messages (regression:
+    it previously raised "Type agent_message is not supported by the agent
+    bridge", #4762);
+(b) attribute the message to its author in the rendered text, using Codex's
+    own downgrade convention ("Agent message from {author}:\n{text}") so the
+    receiving model never mistakes another agent's words for the user's or
+    its own;
+(c) preserve the original item verbatim (via ContentText.internal) so the
+    OpenAI Responses provider can replay it natively -- `encrypted_content`
+    parts are undecryptable to us but ARE decryptable by OpenAI server-side,
+    so dropping them would silently degrade delegation on OpenAI targets;
+(d) never drop content silently: an item with no plaintext still produces an
+    attributed placeholder (and the verbatim payload for replay), plus a
+    logged warning that non-OpenAI targets see only the placeholder.
+
+These tests cover the conversion helpers directly (no network).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+from openai.types.responses import ResponseInputItemParam
+
+from inspect_ai._util.content import ContentText
+from inspect_ai.agent._bridge.responses_impl import (
+    messages_from_responses_input,
+)
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_ai.model._openai_responses import (
+    is_agent_message,
+    openai_responses_inputs,
+)
+
+MODEL_NAME = "openai/gpt-5.6"
+
+
+def _agent_message_item(
+    *content: dict[str, Any],
+    author: str = "subagent",
+    recipient: str = "parent",
+) -> dict[str, Any]:
+    return {
+        "type": "agent_message",
+        "author": author,
+        "recipient": recipient,
+        "content": list(content),
+    }
+
+
+def _text(text: str) -> dict[str, Any]:
+    return {"type": "input_text", "text": text}
+
+
+def _encrypted(ciphertext: str = "gAAAAA-ciphertext") -> dict[str, Any]:
+    return {"type": "encrypted_content", "encrypted_content": ciphertext}
+
+
+# 1. predicate
+
+
+def test_is_agent_message_predicate() -> None:
+    assert is_agent_message(
+        cast(ResponseInputItemParam, _agent_message_item(_text("delegate result")))
+    )
+    assert not is_agent_message(
+        cast(
+            ResponseInputItemParam,
+            {"type": "message", "role": "user", "content": "hi"},
+        )
+    )
+    assert not is_agent_message(
+        cast(
+            ResponseInputItemParam,
+            {"type": "additional_tools", "role": "developer", "tools": []},
+        )
+    )
+
+
+# 2. conversion: agent_message becomes an author-attributed user message
+
+
+def test_agent_message_converts_to_attributed_user_message() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [_text("delegate this")],
+            },
+            _agent_message_item(_text("delegate result")),
+        ],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert [message.text for message in messages] == [
+        "delegate this",
+        "Agent message from subagent:\ndelegate result",
+    ]
+    assert all(isinstance(message, ChatMessageUser) for message in messages)
+
+
+def test_agent_message_attribution_uses_author_field() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [_agent_message_item(_text("do the subtask"), author="parent")],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert len(messages) == 1
+    assert messages[0].text == "Agent message from parent:\ndo the subtask"
+
+
+def test_agent_message_joins_multiple_text_parts() -> None:
+    input_items = cast(
+        list[ResponseInputItemParam],
+        [_agent_message_item(_text("part one"), _text("part two"))],
+    )
+
+    messages = messages_from_responses_input(input_items, [], MODEL_NAME)
+
+    assert len(messages) == 1
+    assert messages[0].text == "Agent message from subagent:\npart one\npart two"
+
+
+# 3. fidelity: the original item round-trips verbatim to an OpenAI Responses
+#    target (encrypted_content is undecryptable to us but decryptable by
+#    OpenAI server-side, so it must survive the bridge round-trip)
+
+
+async def test_agent_message_round_trips_verbatim_to_openai_responses() -> None:
+    original = _agent_message_item(_text("Payload:"), _encrypted())
+
+    messages = messages_from_responses_input(
+        cast(list[ResponseInputItemParam], [original]), [], MODEL_NAME
+    )
+    assert len(messages) == 1
+
+    items = await openai_responses_inputs(messages)
+
+    assert len(items) == 1
+    assert dict(items[0]) == original
+
+
+async def test_plain_user_message_still_emits_message_item() -> None:
+    # guard: the verbatim replay path must not hijack ordinary user messages
+    messages = messages_from_responses_input(
+        cast(
+            list[ResponseInputItemParam],
+            [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [_text("hello")],
+                }
+            ],
+        ),
+        [],
+        MODEL_NAME,
+    )
+
+    items = await openai_responses_inputs(messages)
+
+    assert len(items) == 1
+    assert dict(items[0]).get("type") == "message"
+
+
+# 4. no silent drops: encrypted-only items produce an attributed placeholder,
+#    preserve the verbatim payload for replay, and log a warning
+
+
+async def test_encrypted_only_agent_message_is_not_silently_dropped(
+    caplog: Any,
+) -> None:
+    original = _agent_message_item(_encrypted(), author="parent")
+
+    with caplog.at_level(logging.WARNING):
+        messages = messages_from_responses_input(
+            cast(list[ResponseInputItemParam], [original]), [], MODEL_NAME
+        )
+
+    # a message survives, attributed, with a placeholder mentioning the
+    # encrypted payload (non-OpenAI targets see this text)
+    assert len(messages) == 1
+    assert isinstance(messages[0], ChatMessageUser)
+    assert messages[0].text.startswith("Agent message from parent:")
+    assert "encrypted" in messages[0].text
+
+    # the warning names the degradation
+    assert any(
+        "agent_message" in record.message and "encrypted" in record.message
+        for record in caplog.records
+    )
+
+    # and the verbatim payload still replays natively to OpenAI targets
+    items = await openai_responses_inputs(messages)
+    assert len(items) == 1
+    assert dict(items[0]) == original
+
+
+def test_agent_message_carries_verbatim_item_as_internal() -> None:
+    original = _agent_message_item(_text("delegate result"))
+
+    messages = messages_from_responses_input(
+        cast(list[ResponseInputItemParam], [original]), [], MODEL_NAME
+    )
+
+    assert len(messages) == 1
+    content = messages[0].content
+    assert isinstance(content, list)
+    assert isinstance(content[0], ContentText)
+    assert content[0].internal == {"agent_message": original}


### PR DESCRIPTION
## This PR contains:

- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Codex Multi-Agent V2 (codex >= 0.146, forced for models like `gpt-5.6-terra`/`gpt-5.6-sol`) delivers inter-agent communication as `agent_message` Responses input items. The agent bridge does not recognize them, so any bridged Codex agent that delegates to a subagent fails with `Type agent_message is not supported by the agent bridge`.

Fixes #4762. Supersedes and builds directly on #4776 — this branch keeps @MajaCernja's commit intact and extends it. Many thanks to them for the excellent report and the original fix; the core `agent_message` handling here is their work.

### What is the new behavior?

Three layers on top of the crash fix:

1. **Author attribution.** `agent_message` items are rendered as user messages prefixed `"Agent message from {author}:"` — the same downgrade convention Codex itself uses internally (guardian prompts, web-search history, realtime context all format agent messages this way). Without this, the receiving model cannot distinguish another agent's words from the user's or its own, since the bridge has no way to know which agent is making a given request.

2. **Verbatim replay to OpenAI targets.** The original item is preserved on `ContentText.internal` and re-emitted byte-for-byte by the OpenAI Responses provider (mirroring the existing compaction-marker mechanism). `encrypted_content` parts are undecryptable to the bridge but *are* decryptable by OpenAI server-side — so on OpenAI targets, delegation payloads now survive with full fidelity instead of being dropped. Validated against the live Responses API: a plain (non-Multi-Agent-V2) `gpt-5` target accepts replayed `agent_message` items (HTTP 200), so the replay path does not depend on the target model being MAV2-enabled.

3. **No silent drops.** An item with no readable plaintext (encrypted-only or empty content) previously vanished without a trace. It now produces an attributed placeholder (so non-OpenAI targets at least see that a delegation occurred) plus a logged warning naming the degradation.

Tests moved to a dedicated `tests/agent/test_bridge_agent_message.py` (as suggested by the original author on #4776) and extended to cover attribution, the verbatim round-trip (encrypted payload intact), the plain-user-message guard, the placeholder/warning paths, dispatch ordering, and null-author fallback. The original suite was verified to fail against the pre-fix bridge.

### Known limitation

For non-OpenAI parents, Codex stores plaintext under the `encrypted_content` key (openai/codex#33551); until that upstream fix lands, non-OpenAI targets see the placeholder rather than the payload. The verbatim-replay layer here means OpenAI targets are unaffected.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information

### Agent review
- Reviewer: Claude Code (fresh context each pass), 2 passes — both recorded as reviews on this PR
- Pass 1 findings: 4 — warn_once test isolation (fixed, 277b1397), empty-content silent-drop edge (fixed, 277b1397), changelog entry length (fixed, 277b1397), missing Agent review section (fixed, this description)
- Pass 2 findings: 3 — dispatch-order robustness vs. the loose `is_response_input_message` predicate (fixed, 53bad444), `"Agent message from None:"` on explicit null author (fixed, 53bad444), question on live-API validation of verbatim replay (resolved by testing against the live API — see the inline thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
