### PR TITLE
Fix sandbox read_file raising RuntimeError for missing files on some Docker setups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Bugfix: Docker `sandbox.read_file()` now raises `FileNotFoundError` for a missing file when Docker reports the POSIX "no such file or directory" message (previously only one phrasing was recognized, so callers got a `RuntimeError`). (#4686)
 - Sandbox: `ComposeService` now accepts the standard compose keys `restart`, `stdin_open`, and `tty` (previously rejected as unknown fields).
 - Bugfix: Model info lookup no longer sends its internal placeholder API key to the Hugging Face Hub when canonicalizing model names. (#4600)
 - Scorer: NaN score values (scalar, dict key, or list element) now survive eval logs and realtime views instead of becoming null, being miscounted as 0.0 on `eval_set` retry, or failing log validation.

--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -477,8 +477,13 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                 # extract the message and normalise case
                 message = str(ex).lower()
 
-                # FileNotFoundError
-                if "could not find the file" in message:
+                # FileNotFoundError. Docker/OS variants phrase the missing-file
+                # error differently ("could not find the file" vs. the POSIX
+                # "no such file or directory"), so match both.
+                if (
+                    "could not find the file" in message
+                    or "no such file or directory" in message
+                ):
                     raise FileNotFoundError(
                         errno.ENOENT, "No such file or directory.", original_file
                     ) from ex

--- a/tests/util/sandbox/test_docker_read_file.py
+++ b/tests/util/sandbox/test_docker_read_file.py
@@ -174,6 +174,29 @@ async def test_read_file_preserves_missing_file_error(
     copy_mock.assert_awaited_once()
 
 
+@pytest.mark.parametrize(
+    "copy_error",
+    [
+        "Could not find the file in the container",
+        "Error: No such file or directory",
+        "lstat /work/missing: no such file or directory",
+    ],
+)
+async def test_read_file_maps_missing_file_message_variants(
+    copy_error: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    environment = _environment()
+    copy_mock = AsyncMock(side_effect=RuntimeError(copy_error))
+    monkeypatch.setattr(docker_module, "compose_cp", copy_mock)
+
+    with pytest.raises(FileNotFoundError) as ex:
+        await environment.read_file("missing")
+
+    assert ex.value.errno == errno.ENOENT
+    assert ex.value.filename == "missing"
+    copy_mock.assert_awaited_once()
+
+
 async def test_read_file_rejects_non_regular_copy_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4686.

When reading a missing file from a Docker sandbox, `read_file()` maps the failed
`docker compose cp` error to a Python exception by matching the error text. It only
matched the phrasing `"could not find the file"`. On some Docker/OS setups the copy
fails with the POSIX phrasing `"no such file or directory"` instead, which fell through
to the `else: raise`, so callers received a bare `RuntimeError` rather than
`FileNotFoundError`. This breaks evals that catch `FileNotFoundError` — e.g.
`core_bench`'s scorer.

### What is the new behavior?

The missing-file branch now matches both phrasings (`"could not find the file"` **or**
`"no such file or directory"`), so a missing file consistently raises
`FileNotFoundError(errno.ENOENT, ...)` regardless of which message Docker emits. The
ordering is unchanged and safe: the `"cannot copy directory"` / `"is a directory"`
(→ `IsADirectoryError`) and `"permission denied"` (→ `PermissionError`) branches are
unaffected, and neither is a substring of `"no such file or directory"`.

A parametrized regression test (`test_read_file_maps_missing_file_message_variants`)
covers both phrasings and asserts `errno == ENOENT` and the original filename.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. It only reclassifies an error that was previously a `RuntimeError` into the more
specific `FileNotFoundError` that the docstring already documents for this method.

### Other information:

**Testing:** `make check` / `make test` were **not** run in the authoring environment
(no Python 3.10+ available there; Inspect requires >=3.10), so this change is
unverified by a local test run and relies on CI. The change is a one-line predicate
broadening plus a test that mirrors the existing `test_read_file_preserves_missing_file_error`
pattern; the branch logic was validated in isolation and both changed files pass
`py_compile`.

### Agent review
- Author: written by Claude Code (Claude Opus 4.8).
- Review: one self-review pass in the same context — verified branch ordering (no
  misclassification of directory/permission errors), confirmed the copy destination is
  a pre-created host temp file so `"no such file or directory"` can only refer to the
  source, and checked the test matches repo async/mocking conventions. No separate
  fresh-context or different-model review pass was run.
- Not run: `make check` / `make test` (environment lacked Python >=3.10) — CI is the
  first real execution of the test.
