### PR TITLE
fix(bridge): compare non-system messages when testing thread extension

### DIFF
--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -418,5 +418,18 @@ def _condensed_fingerprint(fp: _MessageFingerprint) -> _MessageFingerprint:
 
 
 def _extends(prefix: list[_MessageFingerprint], fps: list[_MessageFingerprint]) -> bool:
-    """Whether `fps` is a proper extension (continuation) of `prefix`."""
-    return len(fps) > len(prefix) and fps[: len(prefix)] == prefix
+    """Whether `fps` is a proper extension (continuation) of `prefix`.
+
+    Compared over non-system messages, for the same reason
+    `_descends_from_initial` drops them: a scaffold substitutes its own system
+    prompt, and some rewrite it on every request. Claude Code stamps a
+    per-request cache token into it, so no two calls in one conversation share
+    a system-message fingerprint and extension could never match at all —
+    every call fell through to the length and descent heuristics instead.
+    """
+    prefix_non_system = [fp for fp in prefix if fp.role != "system"]
+    fps_non_system = [fp for fp in fps if fp.role != "system"]
+    return (
+        len(fps_non_system) > len(prefix_non_system)
+        and fps_non_system[: len(prefix_non_system)] == prefix_non_system
+    )

--- a/tests/agent/test_bridge_track_state.py
+++ b/tests/agent/test_bridge_track_state.py
@@ -406,6 +406,49 @@ async def test_extension_recognized_despite_new_ids_and_metadata() -> None:
 # ---------------------------------------------------------------------------
 
 
+async def test_compaction_recovery_survives_a_per_request_system_prompt() -> None:
+    """Candidate promotion compares non-system messages.
+
+    Some scaffolds rewrite the system prompt on every request rather than once
+    per conversation: Claude Code stamps a per-request cache token into it, so
+    no two calls in one conversation share a system-message fingerprint.
+
+    Post-compaction recovery is where that bites hardest. The compacted thread
+    is shorter than the tracked one and no longer descends from the initial
+    input, so it is only parked as a candidate; extension is the sole route by
+    which it is promoted. If the prefix comparison includes the system message
+    the promotion can never fire, and the bridge keeps reporting the
+    pre-compaction thread while the agent is working on the compacted one.
+    """
+    bridge = task_bridge()
+
+    def system(token: str) -> ChatMessageSystem:
+        # cf. `x-anthropic-billing-header: ... cch=<token>`
+        return ChatMessageSystem(content=f"You are Claude Code. cch={token}")
+
+    turn1: list[ChatMessage] = [system("e7c7a"), ChatMessageUser(content=TASK)]
+    out1 = await track(bridge, turn1, "working")
+    turn2 = [system("f8278"), *turn1[1:], out1.message, ChatMessageTool(content="r1")]
+    out2 = await track(bridge, turn2, "more work")
+    turn3 = [system("a91b3"), *turn2[1:], out2.message, ChatMessageTool(content="r2")]
+    await track(bridge, turn3, "even more work")
+
+    # compaction: history replaced by a summary, so the new thread neither
+    # extends the tracked one nor descends from the initial input
+    compact1: list[ChatMessage] = [
+        system("b40cd"),
+        ChatMessageUser(content="Summary of the conversation so far: ..."),
+    ]
+    cout1 = await track(bridge, compact1, "compacted work")
+
+    # the loop continues; only extension can promote it
+    compact2 = [system("c51de"), *compact1[1:], cout1.message, ChatMessageTool(content="r3")]
+    await track(bridge, compact2, "Castle")
+
+    assert bridge.state.output.completion == "Castle"
+    assert len(bridge.state.messages) == len(compact2) + 1
+
+
 async def test_descent_anchor_ignores_system_prompt_replacement() -> None:
     """Descent anchors on the initial input's non-system messages.
 


### PR DESCRIPTION
Closes #4758.

`_extends` compared whole fingerprint lists, system message included. Its sibling `_descends_from_initial` already drops system messages, with a comment explaining why — a scaffold substitutes its own system prompt. Some go further and rewrite it on every request; Claude Code stamps a cache token into it, so no two calls in one conversation share a system-message fingerprint and `_extends` could never return `True`.

@sjawhar's measurement over a captured 80-call run, which is the part that makes this more than a style inconsistency:

```
_extends() returns True, today                 :  0
_extends() returns True, comparing non-system  : 48
```

Extension tracking did not degrade for this scaffold. It never engaged at all.

## Why the added test is the compaction case

This is the part worth reviewing, because my first attempt at a test was wrong.

I wrote the obvious one first — main-loop accumulation under a rotating system prompt — and **it passed without the fix**. The length and descent fallbacks reach the same verdict there, which is precisely why the defect stayed invisible: for most call shapes, losing extension costs nothing observable.

Post-compaction recovery is where it does cost something. The compacted thread is shorter than the tracked one and no longer descends from the initial input, so it is only parked as a candidate, and extension is the **sole** route by which it is promoted (`_track_state`'s `_extends(self._candidate_fps, fps)` branch). With a per-request system prompt that promotion can never fire, and the bridge keeps reporting the pre-compaction thread while the agent works on the compacted one.

So `test_compaction_recovery_survives_a_per_request_system_prompt` is `test_scaffold_compaction_recovery` with the system prompt rotating per call, which is the smallest change that makes the fallbacks unable to cover.

## Verification

Both directions, since a test that passes either way is worse than no test:

```
with the fix       29/29 pass
fix reverted,
test kept          28/29 — the new test fails
```

All 28 pre-existing tests in `test_bridge_track_state.py` pass unchanged, so the filtering does not disturb the cases extension already handled.

Run locally against a fresh editable install. The repo `conftest.py` imports `boto3`/`moto` for AWS fixtures that are unrelated to this module and would not install on this machine, so I drove the module's async tests directly rather than through pytest; happy to re-run under CI's path if the numbers matter for review.

## Note on scope

Only `_extends` changed. `_descends_from_initial` already did the right thing, and its `test_descent_anchor_ignores_system_prompt_replacement` continues to pass. The two functions now agree about what a system message means for thread identity, which is what the issue argues for.
