### PR TITLE
fix(view): compare log identifiers in the namespace the listing produces

### DIFF
--- a/src/inspect_ai/_view/fastapi_server.py
+++ b/src/inspect_ai/_view/fastapi_server.py
@@ -666,9 +666,33 @@ class OnlyDirAccessPolicy(AccessPolicy):
     def __init__(self, dir: str) -> None:
         super().__init__()
         self.dir = dir
+        # Requests name a log with the identifier the listing produced, which
+        # is `fs.unstrip_protocol(...)` of the path (see
+        # `FileSystem._file_info`). On POSIX that happens to coincide with the
+        # configured path, so comparing raw strings worked; on Windows the
+        # configured dir is `C:\...\logs` while the identifier is
+        # `file://C:/.../logs/run.eval`, which differ in both the scheme and
+        # the separators, so every log in the configured directory was denied.
+        #
+        # Canonicalise into the identifier's namespace instead. The filesystem
+        # comes from the configured directory rather than from the requested
+        # path: normalising untrusted input with a filesystem derived from that
+        # same input would let a request choose its own comparison namespace.
+        self._fs = filesystem(dir).fs
+        self._canonical_dir = self._fs.unstrip_protocol(dir).rstrip("/")
 
     def _validate_log_dir(self, file: str) -> bool:
-        return file.startswith(self.dir) and ".." not in file
+        if ".." in file:
+            return False
+        # `unstrip_protocol` is idempotent, so this accepts a request naming
+        # the log either way round.
+        candidate = self._fs.unstrip_protocol(file)
+        # Match on a path boundary. A plain prefix test also admits a sibling
+        # directory whose name merely starts with the configured one, so a
+        # viewer scoped to `.../logs` would serve `.../logs-elsewhere/x.eval`.
+        return candidate == self._canonical_dir or candidate.startswith(
+            self._canonical_dir + "/"
+        )
 
     async def can_read(self, request: Request, file: str) -> bool:
         return self._validate_log_dir(file)

--- a/tests/_view/test_view_server.py
+++ b/tests/_view/test_view_server.py
@@ -28,6 +28,7 @@ import inspect_ai.log._recorders.buffer.filestore
 import inspect_ai.model
 from inspect_ai._util.asyncfiles import AsyncFilesystem
 from inspect_ai._util.event_loop_monitor import event_loop_monitor
+from inspect_ai._util.file import filesystem
 from inspect_ai._util.json import to_json_safe
 from inspect_ai._view import fastapi_server
 from inspect_ai._view.common import (
@@ -1601,6 +1602,39 @@ def test_fastapi_only_dir_access_policy() -> None:
     assert asyncio.run(policy.can_read(None, "/allowed/dir/file.eval"))  # type: ignore[arg-type]
     assert not asyncio.run(policy.can_read(None, "/other/dir/file.eval"))  # type: ignore[arg-type]
     assert not asyncio.run(policy.can_read(None, "/allowed/dir/../etc/passwd"))  # type: ignore[arg-type]
+
+
+def test_fastapi_only_dir_access_policy_canonical_identifiers(tmp_path: Path) -> None:
+    """The policy is handed the identifier the listing produced, not a raw path.
+
+    `FileSystem._file_info` names every log with `fs.unstrip_protocol(...)`, and
+    the frontend echoes that identifier back on the log-detail request. A raw
+    string prefix test does not recognise it: on Windows the configured dir is
+    `C:\...\logs` while the identifier is `file://C:/.../logs/run.eval`,
+    differing in both the scheme and the separators, so every log in the
+    configured directory was refused with 403.
+    """
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    fs = filesystem(str(log_dir)).fs
+    policy = fastapi_server.OnlyDirAccessPolicy(str(log_dir))
+
+    identifier = fs.unstrip_protocol(str(log_dir / "run.eval"))
+    assert asyncio.run(policy.can_read(None, identifier))  # type: ignore[arg-type]
+
+    # the native path form keeps working
+    assert asyncio.run(policy.can_read(None, str(log_dir / "run.eval")))  # type: ignore[arg-type]
+
+
+def test_fastapi_only_dir_access_policy_sibling_prefix(tmp_path: Path) -> None:
+    """A sibling directory sharing the configured name's prefix is not inside it."""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    sibling = tmp_path / "logs-elsewhere"
+    sibling.mkdir()
+    policy = fastapi_server.OnlyDirAccessPolicy(str(log_dir))
+
+    assert not asyncio.run(policy.can_read(None, str(sibling / "secret.eval")))  # type: ignore[arg-type]
 
 
 def test_fastapi_only_dir_policy_integration(mock_s3_eval_file: str) -> None:


### PR DESCRIPTION
Closes #4765.

`OnlyDirAccessPolicy._validate_log_dir` compares the requested log against the configured directory as raw strings. Requests never carry a raw path: every log is named by `fs.unstrip_protocol(...)` in `FileSystem._file_info`, and the frontend echoes that identifier back on the log-detail request.

## Reproduced on Windows

Feeding `list_eval_logs()`'s own output into the policy, rather than hand-writing the identifier:

```
configured log dir (what OnlyDirAccessPolicy stores):
  'C:\Users\...\logs'

identifier the listing produces (what the frontend echoes back):
  'file://C:/Users/.../logs/2026-08-09T00-00-00+00-00_task_abc.eval'

  identifier.startswith(configured) : False
  can_read(identifier)              : False
  -> HTTP 403 Forbidden
```

The two forms differ in the scheme *and* the separators. @josh-kosberg's diagnosis is exactly right.

## The fix

Canonicalise both sides with `unstrip_protocol` before comparing, so the check runs in the namespace the identifiers actually live in.

Two things worth review:

**The filesystem comes from the configured directory, never from the requested path.** Normalising untrusted input with a filesystem derived from that same input would let a request choose the namespace its own check runs in. With the configured fs, a request naming `s3://evil/x.eval` normalises to something that cannot match, and is denied.

**`to_uri()` is not usable here**, which surprised me. `urlparse` reads a Windows drive letter as a URI scheme, so `to_uri(r"C:\x")` sees `scheme='c'`, concludes it is already a URI, and returns the input unchanged. That is arguably its own latent bug; I have not touched it, since nothing in this path depends on it.

## A second defect in the same two lines

The prefix test also admits a sibling directory whose name merely begins with the configured one. On current `main`:

```
configured log dir : ...\logs
sibling file       : ...\logs-evil\secret.eval
can_read           : True
```

A viewer scoped to one directory serves files from another. It is the opposite direction to the reported bug — a false allow rather than a false deny — but it lives in the same expression, so the comparison is now anchored on a path boundary and this is fixed here rather than left behind. Say the word if you would rather have it split out.

## Verification

Seven cases, checked against the policy directly:

| case | before | after |
|---|---|---|
| log in dir, canonical identifier | deny | allow |
| log in dir, native path | deny | allow |
| the configured dir itself | deny | allow |
| prefix-adjacent sibling | **allow** | deny |
| other scheme (`s3://`) | deny | deny |
| unrelated path | deny | deny |
| traversal (`..`) | deny | deny |

Two tests added, both failing on current `main`. The existing `test_fastapi_only_dir_access_policy` (`/allowed/dir`) and `test_fastapi_only_dir_policy_integration` (relative `mocked_eval_set` with a `memory://` mapping) both still hold — I checked those two specifically, since the relative-path case is the one most likely to be disturbed by canonicalisation.

Run on Windows 10, Python 3.11. The repo `conftest.py` pulls in `boto3`/`moto` for AWS fixtures that would not install here, so I exercised the policy directly rather than through pytest; happy to re-run under CI's path if that matters for review.
