### PR TITLE
fix(score): merge reductions on append instead of replacing them

### DIFF
--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -379,14 +379,29 @@ async def score_async(
         # Since the metrics calculation above is only be done using the scorers
         # and scores that were generated during this scoring run, we need to process
         # the results carefully, depending upon whether the action was "append" or "overwrite"
-        log.reductions = reductions
         if action == "overwrite" or log.results is None:
             # Completely replace the results with the new results
+            log.reductions = reductions
             log.results = results
             log.eval.scorers = applied_eval_scorers
         else:
             # Only update the results with the new scores, leaving the rest
-            # of the results as they were
+            # of the results as they were. `reductions` covers just this pass,
+            # so it extends the existing entries rather than replacing them —
+            # assigning it outright dropped every pre-existing scorer's
+            # reductions while results.scores below correctly kept them.
+            #
+            # Plain concatenation is right, and does not need to disambiguate
+            # names: _run_score_task derives each scorer name against the
+            # sample's existing scores, so a scorer appended over one of the
+            # same name is already reduced under its unique name (`match1`)
+            # before it reaches here, matching results.scores.
+            #
+            # Guarded rather than `or []` on both sides so that a log with no
+            # reductions and a pass that produces none stays None instead of
+            # acquiring an empty list.
+            if reductions is not None:
+                log.reductions = (log.reductions or []) + reductions
             log.results.scores.extend(results.scores)
             log.eval.scorers = (log.eval.scorers or []) + applied_eval_scorers
 

--- a/tests/scorer/test_categorical.py
+++ b/tests/scorer/test_categorical.py
@@ -484,6 +484,82 @@ def test_score_rebuilds_eval_scorers_append() -> None:
         assert _metrics_snapshot(reloaded) == before
 
 
+def test_score_append_merges_reductions() -> None:
+    """`append` extends reductions rather than replacing them.
+
+    `eval_results` returns reductions for the scorers run in the current pass
+    only. Assigning that outright dropped every pre-existing scorer's
+    reductions while results.scores kept them, so a log rescored with `append`
+    reported metrics for both scorers but carried reduced samples for only the
+    last one.
+    """
+    from inspect_ai import score
+    from inspect_ai.scorer import includes, match
+
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target="x") for i in range(8)],
+        scorer=match(),
+        epochs=2,
+    )
+    with tempfile.TemporaryDirectory() as log_dir:
+        log = eval(task, model="mockllm/model", log_dir=log_dir, display="none")[0]
+        assert [r.scorer for r in (log.reductions or [])] == ["match"]
+
+        rescored = score(log, includes(), action="append")
+        assert rescored.results is not None
+        assert [s.name for s in rescored.results.scores] == ["match", "includes"]
+        # reductions track results.scores rather than lagging a pass behind
+        assert [r.scorer for r in (rescored.reductions or [])] == ["match", "includes"]
+
+
+def test_score_append_reductions_use_disambiguated_names() -> None:
+    """Appending a scorer of an existing name does not collide in reductions.
+
+    `_run_score_task` derives each scorer name against the sample's existing
+    scores, so the second `match` is reduced as `match1` before it reaches the
+    merge. The merge therefore needs no renaming of its own, and reductions
+    stay aligned with results.scores.
+    """
+    from inspect_ai import score
+    from inspect_ai.scorer import match
+
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target="x") for i in range(8)],
+        scorer=match(),
+        epochs=2,
+    )
+    with tempfile.TemporaryDirectory() as log_dir:
+        log = eval(task, model="mockllm/model", log_dir=log_dir, display="none")[0]
+
+        rescored = score(log, match(), action="append")
+        assert rescored.results is not None
+        assert [s.name for s in rescored.results.scores] == ["match", "match1"]
+        assert [r.scorer for r in (rescored.reductions or [])] == ["match", "match1"]
+
+
+def test_score_overwrite_replaces_reductions() -> None:
+    """`overwrite` keeps replacing reductions outright.
+
+    A guard rather than a regression test: this passes on both sides of the
+    append fix, and exists so that making append merge cannot quietly make
+    overwrite merge too.
+    """
+    from inspect_ai import score
+    from inspect_ai.scorer import includes, match
+
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target="x") for i in range(8)],
+        scorer=match(),
+        epochs=2,
+    )
+    with tempfile.TemporaryDirectory() as log_dir:
+        log = eval(task, model="mockllm/model", log_dir=log_dir, display="none")[0]
+        assert [r.scorer for r in (log.reductions or [])] == ["match"]
+
+        rescored = score(log, includes(), action="overwrite")
+        assert [r.scorer for r in (rescored.reductions or [])] == ["includes"]
+
+
 def test_score_append_duplicate_scorer_recompute_round_trip() -> None:
     from inspect_ai import score
     from inspect_ai.scorer import match

--- a/tests/scorer/test_categorical.py
+++ b/tests/scorer/test_categorical.py
@@ -537,6 +537,39 @@ def test_score_append_reductions_use_disambiguated_names() -> None:
         assert [r.scorer for r in (rescored.reductions or [])] == ["match", "match1"]
 
 
+def test_score_append_merges_reductions_with_multiple_reducers() -> None:
+    """One scorer can hold several reduction entries; the merge must keep them all.
+
+    `eval_results` appends one entry per reduced view, so a scorer under two
+    epoch reducers occupies two entries that share `scorer` and differ only in
+    `reducer`. Concatenation preserves them; a merge keyed on the scorer name
+    would have silently dropped one, and this is the case that rules that
+    implementation out.
+    """
+    from inspect_ai import Epochs, score
+    from inspect_ai.scorer import includes, match, max_score, mean_score
+
+    task = Task(
+        dataset=[Sample(input=f"q{i}", target="x") for i in range(8)],
+        scorer=match(),
+        epochs=Epochs(2, [mean_score(), max_score()]),
+    )
+    with tempfile.TemporaryDirectory() as log_dir:
+        log = eval(task, model="mockllm/model", log_dir=log_dir, display="none")[0]
+        assert [(r.scorer, r.reducer) for r in (log.reductions or [])] == [
+            ("match", "mean"),
+            ("match", "max"),
+        ]
+
+        rescored = score(log, includes(), action="append")
+        assert [(r.scorer, r.reducer) for r in (rescored.reductions or [])] == [
+            ("match", "mean"),
+            ("match", "max"),
+            ("includes", "mean"),
+            ("includes", "max"),
+        ]
+
+
 def test_score_overwrite_replaces_reductions() -> None:
     """`overwrite` keeps replacing reductions outright.
 


### PR DESCRIPTION
Closes #4764.

`score_async` assigned `log.reductions = reductions` outside the action branch, where `reductions` covers only the scorers run in the current pass. For `overwrite` that is right. For `append` it dropped every pre-existing scorer's reductions, while `results.scores.extend(...)` two lines below correctly kept them.

```
before  results.scores ['scorer_a', 'scorer_b']   reductions ['scorer_b']
after   results.scores ['scorer_a', 'scorer_b']   reductions ['scorer_a', 'scorer_b']
        overwrite      reductions ['scorer_b']    (unchanged)
```

## The part worth reviewing: why plain concatenation is enough

My first concern was that a merge would need to dedupe or rename — `EvalSampleReductions` is identified by `(scorer, reducer)`, and `append` does not stop you adding a scorer whose name already exists.

It does not, and the reason is that **names are disambiguated at scoring time, not at merge time**. `_run_score_task` derives each scorer name against the sample's existing scores (`score.py:451`), so a second `match` is reduced as `match1` before it ever reaches this code. Verified rather than assumed:

```
initial      results.scores ['match']            reductions [('match',  None)]
append match results.scores ['match', 'match1']  reductions [('match1', None)]   <- new pass, already renamed
merged       reductions [('match', None), ('match1', None)]   aligned with results.scores
```

So concatenation reproduces exactly what `results.scores` does, which is what the issue asks for.

## Two smaller decisions

**`if reductions is not None` rather than `or []` on both sides.** A log with no reductions, rescored by a pass that also produces none, keeps `None` instead of silently acquiring an empty list. Worth the extra line since the field is `list[...] | None` and it is serialised.

**No consumer is disturbed by a longer list.** Every reader — `_convert.py:168`, `_recorders/eval.py:655` and `:1536`, `_recorders/json.py`, `_cli/score.py:255` — passes it straight to a recorder. None indexes by scorer, assumes uniqueness, or assumes a 1:1 correspondence with `results.scores`.

## Tests

Three added; two fail on current `main`:

| test | before | after |
|---|---|---|
| append merges reductions across scorers | fail | pass |
| append of a same-named scorer lands as `match1` | fail | pass |
| overwrite still replaces | pass | pass |

The third is a guard rather than a regression test, and its docstring says so: it passes on both sides, and exists so that making `append` merge cannot quietly make `overwrite` merge too.

Existing suite: 30/33 before, 32/33 after, the constant failure being `test_score_append_with_unavailable_metrics`, which wants an `OPENAI_API_KEY` this machine does not have. The pre-existing `test_score_append_duplicate_scorer_recompute_round_trip` and `test_score_repeated_append_same_scorer_recompute_round_trip` pass unchanged — those are what turned the disambiguation reasoning above from plausible into checked.

Run on Windows. The repo `conftest.py` pulls in `moto`, which will not import in this venv, so I drove the two affected test modules directly rather than through pytest; happy to re-run under CI's path if the numbers matter for review.

## Re #4753

The issue notes that whatever merge logic the proposed `update` action gets, `append` needs the same. This change deliberately does not anticipate it — it makes `append` behave the way `results.scores` already does and no more, so `update` remains free to define its own semantics without unpicking anything here.
