### PR TITLE
Control Channel: report refusals and HTTP retries per eval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-- Control Channel: `inspect ctl task list` now reports per-eval `refusals` and `http_retries`. Previously these were tallied only in process-global counters that the TUI footer reads, so they were unavailable to a detached run (no display) and not attributable to a task (one process runs many evals). Both are running totals — finished samples plus the live counts of those still in flight — so they are readable mid-run; columns appear only when non-zero, and the `--json` row always carries both keys.
+- Control Channel: `inspect ctl task list` now reports per-eval `refusals` and `http_retries`.
 
 ## 0.3.254 (08 August 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Control Channel: `inspect ctl task list` now reports per-eval `refusals` and `http_retries`. Previously these were tallied only in process-global counters that the TUI footer reads, so they were unavailable to a detached run (no display) and not attributable to a task (one process runs many evals). Both are running totals — finished samples plus the live counts of those still in flight — so they are readable mid-run; columns appear only when non-zero, and the `--json` row always carries both keys.
+
 ## 0.3.254 (08 August 2026)
 
 - Approval policies now apply to tool calls made by bridged agents; a rejected call is never run and the model is told to try something else.

--- a/docs/control-channel.qmd
+++ b/docs/control-channel.qmd
@@ -136,6 +136,10 @@ fR8mWn2cQspD  inspect_evals/humaneval     anthropic/claude-sonnet-5  generate  1
 
 Each row is one task: retried tasks stay on a single row (with an `attempts` column showing how many attempts have run), and an `errors` column appears when any samples have errored. The `solver` column shows the plan's terminal solver (the agent name, e.g. `react`, for an agentic task). With `--json`, the response is an `{as_of, tasks}` envelope and each task row also carries `pid`, `socket_path`, and `log_location` (where results are being written — the handle for reading logs after the run).
 
+Two more columns appear only when they have something to report: `refusals` (model refusals) and `http_retries` (rate-limit and transient HTTP retries). Both are running totals over the task's own samples — the finished ones plus the live counts of those still in flight — so they are readable mid-run rather than only at the end. Both are always present in the `--json` row. They count every *attempt*, so a sample retried under `retry_on_error` contributes what each attempt saw; these are counts of things that happened, not properties of a final state. Note `http_retries` is unrelated to `attempts` (whole-task retries) and to a sample's own `retries` (failed attempts of that sample).
+
+These are the same events the TUI footer tallies, but attributed per eval rather than per process — which is what makes them usable from `inspect ctl` at all, since one process commonly runs several evals at once and a detached run has no display to print a footer. An event reported outside any sample is counted in the process-global total only, so it appears in the footer and in no task row.
+
 A task is finished exactly when `completed_at` is non-null; `status` (`running` / `completed`) is derived from it. Don't infer completion from sample counts — a cancelled or errored eval finishes with `completed < total`.
 
 ## Selecting a Task

--- a/src/inspect_ai/_cli/ctl.py
+++ b/src/inspect_ai/_cli/ctl.py
@@ -5481,6 +5481,12 @@ def _print_human_table(summaries: list[dict[str, Any]]) -> None:
     any_errors = any((s.get("samples") or {}).get("errored", 0) > 0 for s in summaries)
     any_retries = any(int(s.get("attempts", 1) or 1) > 1 for s in summaries)
     any_solver = any(s.get("solver") for s in summaries)
+    # Same "only when there is something to report" rule as errors/attempts. Zero
+    # is the overwhelmingly common value for both, and a permanent pair of 0
+    # columns would push the columns that always matter off a narrow terminal.
+    # `or 0` also covers an older server, which reports neither key.
+    any_refusals = any((s.get("refusals") or 0) > 0 for s in summaries)
+    any_http_retries = any((s.get("http_retries") or 0) > 0 for s in summaries)
     # shown only when some task is paused, so a paused run doesn't read as
     # stalled (the cell names the holding latch; `quiesced` = nothing left
     # in flight — the safe-to-kill signal)
@@ -5501,6 +5507,15 @@ def _print_human_table(summaries: list[dict[str, Any]]) -> None:
         cells.append(_format_samples(samples))
         if any_errors:
             cells.append(str(samples.get("errored", 0)))
+        # Blank, not 0, when the key is absent — the same rule the samples table
+        # uses for an unknown turn count. A row from an older server does not
+        # report these, and printing 0 there would assert "none happened" about a
+        # task that may well have had plenty. Only reachable in a mixed-version
+        # fleet, which is exactly when a false zero would mislead.
+        if any_refusals:
+            cells.append(_format_count(s.get("refusals")))
+        if any_http_retries:
+            cells.append(_format_count(s.get("http_retries")))
         if any_paused:
             cells.append(_format_paused(s))
         cells.append(_format_started(s.get("started_at", 0)))
@@ -5514,6 +5529,12 @@ def _print_human_table(summaries: list[dict[str, Any]]) -> None:
     headers_list.append("samples")
     if any_errors:
         headers_list.append("errors")
+    if any_refusals:
+        headers_list.append("refusals")
+    if any_http_retries:
+        # Spelled out rather than "retries": the `attempts` column is also a
+        # retry count (of whole task attempts), and these are HTTP-level.
+        headers_list.append("http_retries")
     if any_paused:
         headers_list.append("paused")
     headers_list.append("started")
@@ -5521,6 +5542,15 @@ def _print_human_table(summaries: list[dict[str, Any]]) -> None:
         headers_list.append("attempts")
 
     _render_table(tuple(headers_list), rows)
+
+
+def _format_count(value: Any) -> str:
+    """A count cell: the number, or blank when the server didn't report it.
+
+    ``None`` (key absent) and ``0`` (reported, nothing happened) are different
+    claims and must not render the same way.
+    """
+    return "" if value is None else str(value)
 
 
 def _format_paused(summary: dict[str, Any]) -> str:

--- a/src/inspect_ai/_control/eval_state.py
+++ b/src/inspect_ai/_control/eval_state.py
@@ -324,6 +324,23 @@ class EvalState:
     total_messages: int = 0
     """Cumulative message count, accumulated like :attr:`total_tokens`."""
 
+    refusals: int = 0
+    """Cumulative model refusals reported by this eval's finished samples.
+
+    Accumulated by :func:`record_sample_event_counts` as each sample leaves
+    ``active_samples``; the control endpoint adds the in-flight samples' live
+    counts on top, exactly as it does for :attr:`total_tokens`.
+
+    UNLIKE the usage totals, this counts every *attempt*: a sample retried under
+    ``retry_on_error`` contributes the refusals of each attempt, because these are
+    counts of events that happened rather than a property of the final state. That
+    also keeps them consistent with the process-global counters the TUI footer
+    shows, which likewise count every occurrence."""
+
+    http_retries: int = 0
+    """Cumulative HTTP retries (rate-limit and transient), accumulated like
+    :attr:`refusals` — every attempt, not just the final one."""
+
     def observe_started(self, started: float | None) -> None:
         """Fold a sample's start time into :attr:`started_at` (running minimum).
 
@@ -654,6 +671,33 @@ def record_samples_added(
             state.total += total
             if sample_ids:
                 state.sample_ids.extend(sample_ids)
+
+
+def record_sample_event_counts(
+    eval_id: str, *, refusals: int = 0, http_retries: int = 0
+) -> None:
+    """Accumulate a finished sample's refusal / HTTP-retry counts onto the eval.
+
+    Separate from the ``record_sample_*`` family, and called from a different
+    place, because it answers a different question. Those fire once per sample at
+    its *final* outcome and carry that outcome's usage; this fires as each
+    *attempt* leaves ``active_samples``, since a retried attempt's refusals and
+    retries really did happen and are usually the very thing being watched (see
+    :attr:`EvalState.refusals`).
+
+    Called with the counts rather than the sample so this module keeps no
+    dependency on the log package (it is imported during eval bootstrap, before
+    the log package finishes initializing). Silently no-ops if the eval isn't
+    registered, and short-circuits when there is nothing to add — the common case,
+    since most samples neither refuse nor retry.
+    """
+    if not refusals and not http_retries:
+        return
+    with _lock:
+        state = _eval_states.get(eval_id)
+        if state is not None:
+            state.refusals += refusals
+            state.http_retries += http_retries
 
 
 def latest_eval_for_task(task_id: str) -> "EvalState | None":

--- a/src/inspect_ai/_control/state.py
+++ b/src/inspect_ai/_control/state.py
@@ -149,9 +149,10 @@ async def current_eval_summaries(started_at: float) -> list[dict[str, Any]]:
         One dict per task_id group, sorted by start time
         (oldest first). Each entry includes ``log_location`` (where this
         attempt's results are written), a nested ``samples`` block:
-        ``{total, completed, errored, in_flight, queued}``, and an
+        ``{total, completed, errored, in_flight, queued}``, an
         ``attempts`` count (1 for tasks without retries, >1 when
-        retries occurred).
+        retries occurred), and the running ``refusals`` / ``http_retries``
+        tallies for this eval's samples.
     """
     # Lazy imports to avoid pulling the full log/event/scorer chain at
     # module-import time (control server module is imported during
@@ -278,6 +279,10 @@ async def current_eval_summaries(started_at: float) -> list[dict[str, Any]]:
                 },
                 "total_tokens": sum(s.total_tokens for s in samples),
                 "total_messages": sum(s.total_messages for s in samples),
+                # No eval total to add: this path is the pre-registration window,
+                # where the only samples that exist are the live ones.
+                "refusals": sum(s.refusals for s in samples),
+                "http_retries": sum(s.http_retries for s in samples),
             }
         )
 
@@ -1141,6 +1146,13 @@ def _build_summary(
     total_messages = latest.total_messages + sum(
         s.total_messages for s in in_flight_samples
     )
+    # Same two-term shape, and for the same reason: the eval total covers samples
+    # that have left `active_samples`, the live sum covers the ones still in it.
+    # Reading these live matters more than it does for usage — a refusal or a
+    # retry storm is worth knowing about while the run can still be steered, and
+    # on a long-episode benchmark no sample may finish for hours.
+    refusals = latest.refusals + sum(s.refusals for s in in_flight_samples)
+    http_retries = latest.http_retries + sum(s.http_retries for s in in_flight_samples)
 
     return {
         "run_id": run_id,
@@ -1175,4 +1187,6 @@ def _build_summary(
         },
         "total_tokens": total_tokens,
         "total_messages": total_messages,
+        "refusals": refusals,
+        "http_retries": http_retries,
     }

--- a/src/inspect_ai/_control/state.py
+++ b/src/inspect_ai/_control/state.py
@@ -232,6 +232,8 @@ async def current_eval_summaries(started_at: float) -> list[dict[str, Any]]:
         summaries.append(
             _build_summary(
                 latest=latest,
+                # every attempt, for the event counters only (see _build_summary)
+                states=group_states,
                 samples=group_samples,
                 attempts=attempts,
                 started_at_fallback=started_at,
@@ -1071,6 +1073,7 @@ def _iso_to_timestamp(value: str | None) -> float | None:
 def _build_summary(
     *,
     latest: "EvalState",
+    states: list["EvalState"],
     samples: list["ActiveSample"],
     attempts: int,
     started_at_fallback: float,
@@ -1083,6 +1086,15 @@ def _build_summary(
     would double-count. ``errored`` likewise reflects the latest
     attempt only (a sample that errored on attempt 1 and succeeded on
     attempt 2 shouldn't read as "errored" in the surface).
+
+    ``refusals`` / ``http_retries`` are the exception and are summed over
+    ``states`` (every attempt of this task). They count things that HAPPENED
+    rather than describing current state, so a retry must not discard the prior
+    attempt's tally — and it is the failed attempt whose retries you most want to
+    see, since a provider problem bad enough to fail a task is what triggered the
+    retry. Summing is safe where it isn't for ``completed`` because the attempts
+    are disjoint: a reused sample is never re-run, so it emits no new events, and
+    nothing seeds these from a reused log (they are not recorded in one).
     """
     first_sample = samples[0] if samples else None
     task_name = first_sample.task if first_sample else latest.task
@@ -1146,13 +1158,18 @@ def _build_summary(
     total_messages = latest.total_messages + sum(
         s.total_messages for s in in_flight_samples
     )
-    # Same two-term shape, and for the same reason: the eval total covers samples
+    # Same two-term shape, and for the same reason: the eval totals cover samples
     # that have left `active_samples`, the live sum covers the ones still in it.
     # Reading these live matters more than it does for usage — a refusal or a
     # retry storm is worth knowing about while the run can still be steered, and
-    # on a long-episode benchmark no sample may finish for hours.
-    refusals = latest.refusals + sum(s.refusals for s in in_flight_samples)
-    http_retries = latest.http_retries + sum(s.http_retries for s in in_flight_samples)
+    # on a long-episode benchmark no sample may finish for hours. Note the totals
+    # are summed over EVERY attempt, not read off `latest` (see the docstring).
+    refusals = sum(s.refusals for s in states) + sum(
+        s.refusals for s in in_flight_samples
+    )
+    http_retries = sum(s.http_retries for s in states) + sum(
+        s.http_retries for s in in_flight_samples
+    )
 
     return {
         "run_id": run_id,

--- a/src/inspect_ai/log/_refusal.py
+++ b/src/inspect_ai/log/_refusal.py
@@ -7,11 +7,16 @@ _log_refusals: bool = False
 
 
 def report_refusal(refusal: str) -> None:
-    from inspect_ai.log._samples import sample_active
+    from inspect_ai.log._samples import report_active_sample_refusal, sample_active
 
     # update counter
     global _refusal_count
     _refusal_count = _refusal_count + 1
+
+    # attribute to the active sample (and thereby to its eval) as well as to the
+    # process; the process-global total can't be reported per eval, since one
+    # process runs many evals concurrently
+    report_active_sample_refusal()
 
     # log warning
     global _log_refusals

--- a/src/inspect_ai/log/_samples.py
+++ b/src/inspect_ai/log/_samples.py
@@ -151,6 +151,14 @@ class ActiveSample:
         self.total_messages = 0
         self.total_tokens = 0
         self.total_turns = 0
+        # Counts of events reported from deep inside the model layer, where the
+        # only handle on "which sample is this?" is `sample_active()`. Both are
+        # also tallied in process-global counters that the TUI footer reads
+        # (`log._refusal`, `_util.retry`); these attribute them to a sample so
+        # the control channel can report them per eval, which a process-global
+        # cannot do — one process runs many evals concurrently.
+        self.refusals = 0
+        self.http_retries = 0
         # The sample's live `TaskState` — the handle observers read the
         # current conversation from (see the module docstring). Refreshed via
         # `set_sample_state` (sample start, `Chain`/`Plan` step boundaries,
@@ -432,6 +440,21 @@ async def active_sample(
                     )
         active.checkpointer.close()
         active.complete()
+        # Roll this attempt's refusal / HTTP-retry counts onto the eval as the
+        # sample leaves the live list, so the control channel's "so far" total
+        # survives it. Adjacent to the `remove` and with no await between them:
+        # the endpoint reports `eval total + sum(in-flight)`, so a suspension
+        # point here would let a poll see the sample in neither term (or, the
+        # other way round, in both). Local import because `_control.eval_state`
+        # is loaded during eval bootstrap, before this package finishes
+        # initializing.
+        from inspect_ai._control.eval_state import record_sample_event_counts
+
+        record_sample_event_counts(
+            active.eval_id,
+            refusals=active.refusals,
+            http_retries=active.http_retries,
+        )
         _active_samples.remove(active)
         _sample_active.set(None)
 
@@ -593,6 +616,25 @@ def report_active_sample_retry() -> None:
         if model_event.retries is None:
             model_event.retries = 0
         model_event.retries = model_event.retries + 1
+
+    # Also tally on the sample itself. The model event's count is per-generation
+    # and lands in the transcript; this one is what the control channel can read
+    # while the sample is still running, and what rolls up to the eval.
+    active = sample_active()
+    if active is not None:
+        active.http_retries += 1
+
+
+def report_active_sample_refusal() -> None:
+    """Count a model refusal against the active sample, if there is one.
+
+    Called alongside the process-global tally in :mod:`inspect_ai.log._refusal`.
+    A refusal reported outside a sample (nothing in ``sample_active()``) is
+    counted globally only — it belongs to no eval.
+    """
+    active = sample_active()
+    if active is not None:
+        active.refusals += 1
 
 
 # The retry-wait record stamped by *this* coroutine's model retry loop.

--- a/tests/_control/test_ctl.py
+++ b/tests/_control/test_ctl.py
@@ -126,6 +126,74 @@ def test_tasks_table_hides_solver_column_when_absent(
     assert "solver" not in header
 
 
+def test_tasks_table_shows_refusal_and_retry_columns_only_when_nonzero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Zero is the usual value for both, so a standing pair of 0 columns is clutter.
+
+    Same rule as `errors` / `attempts`: the column earns its width by having
+    something to report. The `--json` row always carries both keys.
+    """
+    _print_human_table([_task_row("aaa111", "t1", refusals=0, http_retries=0)])
+    header = capsys.readouterr().out.splitlines()[0]
+    assert "refusals" not in header and "http_retries" not in header
+
+    _print_human_table(
+        [
+            _task_row("aaa111", "t1", refusals=2, http_retries=0),
+            _task_row("bbb222", "t2", refusals=0, http_retries=9),
+        ]
+    )
+    lines = capsys.readouterr().out.splitlines()
+    assert "refusals" in lines[0] and "http_retries" in lines[0]
+    assert "2" in next(ln for ln in lines if ln.startswith("aaa111"))
+    assert "9" in next(ln for ln in lines if ln.startswith("bbb222"))
+
+
+def test_tasks_table_survives_a_server_that_omits_the_counters(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An older server reports neither key; that must read as "nothing to show"."""
+    _print_human_table([_task_row("aaa111", "t1", model="openai/gpt-5")])
+    header = capsys.readouterr().out.splitlines()[0]
+    assert "refusals" not in header and "http_retries" not in header
+
+
+def test_tasks_table_leaves_an_unreported_count_blank_not_zero(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """In a mixed-version fleet, `0` would assert "none happened" about an unknown.
+
+    Observed live: rows from an older server sat at `0` beside a task that had in
+    fact retried many times. Blank is the honest cell, matching how the samples
+    table renders an unknown turn count.
+    """
+    _print_human_table(
+        [
+            _task_row("aaa111", "t1", http_retries=7),  # this server reports
+            _task_row("bbb222", "t2"),  # this one does not
+            _task_row("ccc333", "t3", http_retries=0),  # reports, and it is zero
+        ]
+    )
+    lines = capsys.readouterr().out.splitlines()
+    header = lines[0]
+    assert "http_retries" in header
+    # Slice by the header's own column offset. Splitting on whitespace cannot work
+    # here: the cell under test is EMPTY on one row, so a split would silently
+    # return a neighbouring column's token and the assertion would pass for the
+    # wrong reason (the `samples` cell contains spaces too).
+    start = header.index("http_retries")
+    width = len("http_retries")
+
+    def cell(prefix: str) -> str:
+        row = next(ln for ln in lines if ln.startswith(prefix))
+        return row[start : start + width].strip()
+
+    assert cell("aaa111") == "7"
+    assert cell("bbb222") == "", "an unreported count must not read as zero"
+    assert cell("ccc333") == "0"
+
+
 def _sample(
     sample_id: int, status: str, scores: dict[str, object]
 ) -> dict[str, object]:

--- a/tests/_control/test_eval_set_integration.py
+++ b/tests/_control/test_eval_set_integration.py
@@ -1814,6 +1814,120 @@ def test_ctl_eval_usage_persists_after_samples_complete(short_data_dir: Path) ->
     assert entry["total_tokens"] > 0, entry
 
 
+def test_ctl_eval_reports_refusals_after_samples_complete(
+    short_data_dir: Path,
+) -> None:
+    """A refusal is attributed to its eval and survives the sample finishing.
+
+    The end-to-end proof of the whole chain, because every link is invisible from
+    the outside: the model layer reports a `content_filter` stop to a
+    process-global counter, `sample_active()` attributes it, and the count rolls
+    onto the eval as the sample leaves ``active_samples``. Observed at run end,
+    when no sample is left in flight — so a summary that only summed live samples
+    would read 0 here.
+    """
+    from inspect_ai.model import ModelOutput, get_model
+
+    @task
+    def refuses() -> Task:
+        return Task(
+            dataset=[Sample(id=i, input="hi", target="ok") for i in (1, 2)],
+            solver=[generate()],
+            name="refuses",
+        )
+
+    log_dir = str(short_data_dir / "logs")
+    Path(log_dir).mkdir()
+
+    with capturing() as cap:
+        eval_set(
+            tasks=[refuses()],
+            log_dir=log_dir,
+            model=get_model(
+                "mockllm/model",
+                custom_outputs=[
+                    ModelOutput.from_content(
+                        model="mockllm/model",
+                        content="I cannot help with that.",
+                        stop_reason="content_filter",
+                    )
+                    for _ in range(2)
+                ],
+            ),
+            retry_attempts=0,
+            max_samples=2,
+        )
+
+    entry = cap.eval("refuses")
+    assert entry is not None
+    assert entry["samples"]["in_flight"] == 0, entry
+    assert entry["refusals"] == 2, entry
+    # nothing produced an HTTP retry, so the other counter stays honest at 0
+    assert entry["http_retries"] == 0, entry
+
+
+def test_ctl_eval_reports_http_retries_per_eval(short_data_dir: Path) -> None:
+    """HTTP retries are attributed to the eval that incurred them, not the process.
+
+    Reported directly rather than by provoking a provider failure: the providers'
+    21 call sites all funnel through ``report_http_retry``, and what needs covering
+    is the attribution below it. TWO tasks in one ``eval_set`` — that is the whole
+    point of the change, since the process-global counter the TUI footer reads
+    cannot tell these two rows apart.
+    """
+    from inspect_ai._util.retry import http_retries_count, report_http_retry
+
+    def _retrying(n: int) -> Solver:
+        @solver
+        def s() -> Solver:
+            async def solve(state: TaskState, generate: Generate) -> TaskState:
+                for _ in range(n):
+                    report_http_retry()
+                return await generate(state)
+
+            return solve
+
+        return s()
+
+    @task
+    def noisy() -> Task:
+        return Task(
+            dataset=[Sample(id=1, input="hi", target="ok")],
+            solver=[_retrying(3)],
+            name="noisy",
+        )
+
+    @task
+    def quiet() -> Task:
+        return Task(
+            dataset=[Sample(id=1, input="hi", target="ok")],
+            solver=[_retrying(0)],
+            name="quiet",
+        )
+
+    log_dir = str(short_data_dir / "logs")
+    Path(log_dir).mkdir()
+
+    before = http_retries_count()
+    with capturing() as cap:
+        eval_set(
+            tasks=[noisy(), quiet()],
+            log_dir=log_dir,
+            model="mockllm/model",
+            retry_attempts=0,
+            max_samples=2,
+        )
+
+    noisy_entry = cap.eval("noisy")
+    quiet_entry = cap.eval("quiet")
+    assert noisy_entry is not None and quiet_entry is not None
+    assert noisy_entry["http_retries"] == 3, noisy_entry
+    # the discrimination the process-global counter cannot make
+    assert quiet_entry["http_retries"] == 0, quiet_entry
+    # and the global still counts every one, so the footer is unchanged
+    assert http_retries_count() - before == 3
+
+
 def test_ctl_eval_finishes_when_final_attempt_cancels_sibling(
     short_data_dir: Path,
 ) -> None:

--- a/tests/_control/test_eval_set_integration.py
+++ b/tests/_control/test_eval_set_integration.py
@@ -1928,6 +1928,57 @@ def test_ctl_eval_reports_http_retries_per_eval(short_data_dir: Path) -> None:
     assert http_retries_count() - before == 3
 
 
+def test_ctl_eval_event_counts_survive_a_task_retry(short_data_dir: Path) -> None:
+    """The folded row keeps both attempts' event counts, not just the retry's.
+
+    Retries fold onto one row reporting the LATEST attempt's state counters; event
+    counts must not follow that rule, or the attempt whose failure caused the retry
+    contributes nothing. Emits on both sides of a real task-level retry: attempt 1
+    reports 4 then fails, attempt 2 reports 3 and succeeds, so the row must read 7.
+    """
+    from inspect_ai._util.retry import report_http_retry
+
+    calls = {"n": 0}
+
+    @solver
+    def report_then_maybe_fail() -> Solver:
+        async def solve(state: TaskState, generate: Generate) -> TaskState:
+            calls["n"] += 1
+            first = calls["n"] == 1
+            for _ in range(4 if first else 3):
+                report_http_retry()
+            if first:
+                raise RuntimeError("synthetic first-attempt failure")
+            return state
+
+        return solve
+
+    @task
+    def flaky() -> Task:
+        return Task(
+            dataset=[Sample(id=1, input="x", target="y")],
+            solver=[report_then_maybe_fail()],
+            name="flaky",
+        )
+
+    log_dir = str(short_data_dir / "logs")
+    Path(log_dir).mkdir()
+
+    with capturing() as cap:
+        eval_set(
+            tasks=[flaky()],
+            log_dir=log_dir,
+            model="mockllm/model",
+            retry_attempts=2,
+            retry_immediate=True,
+        )
+
+    entry = cap.eval("flaky")
+    assert entry is not None
+    assert entry["attempts"] == 2, entry
+    assert entry["http_retries"] == 7, entry
+
+
 def test_ctl_eval_finishes_when_final_attempt_cancels_sibling(
     short_data_dir: Path,
 ) -> None:

--- a/tests/_control/test_eval_state.py
+++ b/tests/_control/test_eval_state.py
@@ -422,6 +422,8 @@ async def test_started_at_pinned_as_samples_complete(
             completed=None,
             total_tokens=0,
             total_messages=0,
+            refusals=0,
+            http_retries=0,
         )
 
     # First poll: all three samples in flight (starts 100, 200, 300).
@@ -468,6 +470,8 @@ async def test_started_at_pinned_from_terminal_record_before_first_poll(
             completed=None,
             total_tokens=0,
             total_messages=0,
+            refusals=0,
+            http_retries=0,
         )
 
     # The earliest sample (start 100) finished and left active_samples before
@@ -479,3 +483,39 @@ async def test_started_at_pinned_from_terminal_record_before_first_poll(
     monkeypatch.setattr(samples_mod, "active_samples", lambda: [_sample(300.0)])
     [entry] = await current_eval_summaries(0.0)
     assert entry["started_at"] == 100.0
+
+
+def test_event_counts_accumulate_across_attempts() -> None:
+    """Refusals and HTTP retries are counted per ATTEMPT, unlike the usage totals.
+
+    ``record_sample_completed`` fires once per sample with its final attempt's
+    usage; these fire as each attempt leaves ``active_samples``, because a retried
+    attempt's refusals and retries really did happen. That is also what keeps them
+    consistent with the process-global counters the TUI footer shows.
+    """
+    from inspect_ai._control.eval_state import record_sample_event_counts
+
+    register_eval("e1", 2)
+    record_sample_event_counts("e1", refusals=1, http_retries=3)  # attempt 1
+    record_sample_event_counts("e1", refusals=2, http_retries=0)  # its retry
+    record_sample_event_counts("e1", refusals=0, http_retries=5)  # a second sample
+
+    state = get_eval_state("e1")
+    assert state is not None
+    assert state.refusals == 3
+    assert state.http_retries == 8
+    # the terminal counters are untouched — this records neither an outcome nor usage
+    assert (state.completed, state.errored, state.total_tokens) == (0, 0, 0)
+
+
+def test_event_counts_no_op_when_empty_or_unregistered() -> None:
+    """The common case is a sample with neither, so it must not take the lock."""
+    from inspect_ai._control.eval_state import record_sample_event_counts
+
+    register_eval("e1", 1)
+    record_sample_event_counts("e1")  # nothing to add
+    record_sample_event_counts("nope", refusals=4)  # no such eval
+
+    state = get_eval_state("e1")
+    assert state is not None
+    assert (state.refusals, state.http_retries) == (0, 0)

--- a/tests/_control/test_pause.py
+++ b/tests/_control/test_pause.py
@@ -75,6 +75,8 @@ class _FakeActiveSample:
         self.run_id = "r1"
         self.total_tokens = 0
         self.total_messages = 0
+        self.refusals = 0
+        self.http_retries = 0
 
 
 def _patch_active_samples(

--- a/tests/_control/test_state.py
+++ b/tests/_control/test_state.py
@@ -499,3 +499,56 @@ async def test_batch_admin_retry_does_not_stamp_retry_wait() -> None:
         assert active.retry_wait is None
     finally:
         _sample_active.reset(token)
+
+
+def test_task_summary_adds_live_counts_to_the_eval_total(monkeypatch) -> None:
+    """Refusals / HTTP retries are reported as ``eval total + sum(in flight)``.
+
+    Both terms are needed and neither is sufficient. The eval total alone misses
+    everything the running samples have seen so far — which on a long-episode
+    benchmark is everything, since no sample may finish for hours, and a retry
+    storm is worth knowing about while the run can still be steered. The live sum
+    alone falls back toward zero as samples finish and leave ``active_samples``,
+    the bug already fixed for ``total_tokens``.
+    """
+    from types import SimpleNamespace
+
+    from inspect_ai._control.eval_state import (
+        clear_all_eval_states,
+        get_eval_state,
+        record_sample_event_counts,
+        register_eval,
+    )
+    from inspect_ai._control.state import _build_summary
+
+    clear_all_eval_states()
+    try:
+        register_eval("e1", 3, task="t", task_id="tid")
+        # two samples already finished and left active_samples
+        record_sample_event_counts("e1", refusals=2, http_retries=7)
+        latest = get_eval_state("e1")
+        assert latest is not None
+
+        in_flight = SimpleNamespace(
+            eval_id="e1",
+            run_id="r",
+            task="t",
+            model="m",
+            log_location="logs/a.eval",
+            started=100.0,
+            completed=None,
+            total_tokens=0,
+            total_messages=0,
+            refusals=1,
+            http_retries=4,
+        )
+        summary = _build_summary(
+            latest=latest,
+            samples=[cast("Any", in_flight)],
+            attempts=1,
+            started_at_fallback=0.0,
+        )
+        assert summary["refusals"] == 3
+        assert summary["http_retries"] == 11
+    finally:
+        clear_all_eval_states()

--- a/tests/_control/test_state.py
+++ b/tests/_control/test_state.py
@@ -544,11 +544,53 @@ def test_task_summary_adds_live_counts_to_the_eval_total(monkeypatch) -> None:
         )
         summary = _build_summary(
             latest=latest,
+            states=[latest],
             samples=[cast("Any", in_flight)],
             attempts=1,
             started_at_fallback=0.0,
         )
         assert summary["refusals"] == 3
         assert summary["http_retries"] == 11
+    finally:
+        clear_all_eval_states()
+
+
+def test_task_summary_sums_event_counts_across_retry_attempts() -> None:
+    """A task-level retry must not discard the prior attempt's tallies.
+
+    ``current_eval_summaries`` folds every attempt of a task onto ONE row, and the
+    state counters deliberately come from the latest attempt only (a retry's
+    ``completed`` already includes reused successes, so summing double-counts).
+    Event counts are the exception: they record what happened, and the attempt that
+    FAILED is the one whose retries matter most — a provider problem bad enough to
+    fail a task is what triggered the retry. With ``retry_attempts`` defaulting to
+    10, reading these off ``latest`` reset them on the default path.
+    """
+    from inspect_ai._control.eval_state import (
+        clear_all_eval_states,
+        get_eval_states,
+        record_sample_event_counts,
+        register_eval,
+    )
+    from inspect_ai._control.state import _build_summary
+
+    clear_all_eval_states()
+    try:
+        register_eval("e1", 2, task="t", task_id="tid")  # attempt 1
+        record_sample_event_counts("e1", refusals=2, http_retries=5)
+        register_eval("e2", 2, task="t", task_id="tid")  # its retry
+        record_sample_event_counts("e2", refusals=1, http_retries=3)
+        states = list(get_eval_states())
+        assert len(states) == 2
+
+        summary = _build_summary(
+            latest=states[-1],
+            states=states,
+            samples=[],
+            attempts=len(states),
+            started_at_fallback=0.0,
+        )
+        assert summary["refusals"] == 3
+        assert summary["http_retries"] == 8
     finally:
         clear_all_eval_states()


### PR DESCRIPTION
# Control Channel: report refusals and HTTP retries per eval

## Summary

Model refusals and HTTP retries are counted today in two process-global counters
(`log/_refusal.py::refusal_count`, `_util/retry.py::http_retries_count`). The only
consumer is the TUI footer, which makes them unavailable in the two situations
where they matter most:

- **A detached run has no display.** `inspect eval-set --detach` implies
  `--display none`, so nothing ever prints the footer and the numbers are simply
  unobservable for the whole run.
- **A process-global cannot be attributed to a task.** One process routinely runs
  several evals concurrently (`max_tasks` defaults to 10), so even with a display
  the footer's single number cannot say *which* eval is refusing or retrying.

This adds `refusals` and `http_retries` to the `inspect ctl task list` row, so an
agent or operator monitoring a detached run can see both per eval, while it is
still running.

## Approach

The change follows the shape already established for `total_tokens` /
`total_messages`, which solve the identical problem:

1. **Attribute at the increment site.** `report_refusal` and `report_http_retry`
   both already reach for `sample_active()` (the first for its warning text, the
   second via `report_active_sample_retry`), so each now also bumps a counter on
   the `ActiveSample`. An event reported outside any sample is counted globally
   only — it belongs to no eval.
2. **Accumulate as the sample leaves.** `active_sample()`'s teardown rolls the
   attempt's counts onto the `EvalState` via a new `record_sample_event_counts`,
   adjacent to the `active_samples` removal and with no `await` between them, so a
   concurrent poll can never see the sample in neither term or in both.
3. **Report both terms.** `_build_summary` returns
   `eval total + sum(in-flight samples)`. Both are needed: the total alone misses
   what running samples have seen so far (on a long-episode benchmark, that is
   everything — no sample may finish for hours), and the live sum alone decays
   toward zero as samples finish, which is the bug already fixed for
   `total_tokens`.

The process globals are left exactly as they are, so the footer is unchanged.

## Two deliberate choices

**Counted per attempt, not per sample.** `record_sample_completed` fires once per
sample carrying its final attempt's usage; these fire per attempt, because a
retried attempt's refusals and retries genuinely happened and are usually the very
thing being watched. It also keeps the new counters consistent with the
process-globals, which likewise count every occurrence. Documented on
`EvalState.refusals` and pinned by a test.

**Columns appear only when non-zero, and an unreported count renders blank.** Zero
is the overwhelmingly common value for both, so a standing pair of `0` columns
would push more important ones off a narrow terminal — the same rule `errors` and
`attempts` already use. The `--json` row always carries both keys.

Blank-not-zero matters in a mixed-version fleet and was caught by running this
against a real host: rows served by an older process (which reports neither key)
sat at `0` beside a task that had in fact retried many times. `None` ("not
reported") and `0` ("reported, none happened") are different claims, so they now
render differently — matching how the samples table already handles an unknown
turn count.

```
task_id       task                   samples               errors  http_retries  started
------------  ---------------------  --------------------  ------  ------------  --------
4aZQgPvhL7Tf  noisy                  2/2 (complete)        0       6             14:55:20
XdWif8756Pmg  holding                0/1 (1 running)       0       5             14:55:20
QmExvf2Lwv7N  quiet                  0/1 (1 running)       0       0             14:55:20
LBdxedXv7Uyz  veevals/sec_bench_pro  178/183 (5 running)   0                     10:57:30
```

Three tasks in **one process** reporting three different values is the point of the
change; the last row is an older server, left blank rather than falsely zeroed.

## Testing

- `tests/_control/test_eval_state.py` — accumulation across attempts; no-op when
  empty or unregistered (the common path must not take the lock).
- `tests/_control/test_state.py` — `_build_summary` returns
  `eval total + live sum`, with each term contributing.
- `tests/_control/test_eval_set_integration.py` — two real `eval_set` runs: a
  `content_filter` refusal observed at run end, after every sample has left
  `active_samples` (a live-only sum would read 0); and two tasks in one process
  reporting different `http_retries`, with the process-global still counting both.
- `tests/_control/test_ctl.py` — columns hidden when zero or absent, shown when
  non-zero, and an unreported count rendered blank rather than `0`.

Also verified manually against a live detached run, including mid-run reads of an
in-flight sample and the mixed-version rendering above.

`ruff`, `ruff format` and `mypy` clean on the changed files. `tests/_control`,
`tests/log` and `tests/agent/test_acp` pass. One pre-existing failure in
`tests/_control/test_launch_handoff.py::test_eval_json_redirects_stray_stdout_to_stderr`
reproduces unchanged on a pristine `origin/main` worktree and is unrelated.

## Notes for reviewers

- Two test fakes of `ActiveSample` (`test_eval_state.py`, `test_pause.py`) gained
  the new fields. They construct `SimpleNamespace`/stub objects that reach
  `_build_summary`; `getattr(..., 0)` defensiveness was deliberately *not* used in
  production code for attributes that always exist on the real class.
- `record_sample_event_counts` takes plain ints rather than the sample, so
  `_control/eval_state.py` keeps its documented "no runtime dependency on the log
  package" property (it is imported during eval bootstrap).
- The `log/_samples.py` → `_control.eval_state` import is local to the teardown
  block, matching the `acp_session` import a few lines above it and for the same
  reason.
