### PR TITLE
sandbox agent bridge: restrict web content access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+- Sandboxed bridged agents can no longer reach the web via provider web search, code execution, or remote MCP unless the eval grants it.
+- Sandboxed bridged agents can no longer make Inspect fetch a URL or read a host file by putting it in image or document content.
+
 ## 0.3.254 (08 August 2026)
 
 - Approval policies now apply to tool calls made by bridged agents; a rejected call is never run and the model is told to try something else.

--- a/docs/agent-bridge.qmd
+++ b/docs/agent-bridge.qmd
@@ -118,6 +118,23 @@ def my_agent() -> Agent:
 
 The [Claude Code](https://meridianlabs-ai.github.io/inspect_swe/claude_code.html) and [Codex CLI](https://meridianlabs-ai.github.io/inspect_swe/codex_cli.html) agents in the Inspect SWE package provide more in-depth demonstrations of running custom agents in sandboxes.
 
+### Granted Capabilities
+
+Some tools a bridged agent can request are executed *outside* the sandbox — `web_search`, `web_fetch`, `code_execution`, and remote MCP servers all run at the model provider. An agent that names one of these in a request therefore reaches the network regardless of the sandbox's own egress policy, so `sandbox_agent_bridge()` withholds them unless the evaluation grants them:
+
+``` python
+async with sandbox_agent_bridge(state, web_search=True) as bridge:
+    ...
+```
+
+Pass `True` to use the target model's internal provider, a `WebSearchProviders` configuration to select providers explicitly, or leave the default to withhold. `code_execution` works the same way, and `client_mcp_servers=True` honors MCP servers named by the agent (prefer [Bridged Tools](#bridged-tools) for servers you choose yourself). Whenever a declared tool is withheld a warning is logged, since an absent tool is otherwise indistinguishable from the model declining to call it.
+
+Ordinary function tools are never withheld — those are executed by the bridged agent inside the sandbox and grant it nothing it does not already have.
+
+For the same reason, image and document content in a request to a sandbox bridge must be an inline `data:` URI. A remote URL or host path would otherwise be dereferenced outside the sandbox, on the agent's behalf.
+
+None of this applies to the in-process `agent_bridge()`, where the scaffold already runs with the host's network and filesystem and there is no boundary to defend.
+
 ## Bridged Tools
 
 Host-side Inspect tools can be exposed as MCP tools to sandboxed agents using the `bridged_tools` parameter. This is useful when you have Inspect tools that need to run on the host (e.g. tools that access host resources, databases, or APIs) but want them available to agents running in a sandbox.

--- a/src/inspect_ai/agent/_bridge/_errors.py
+++ b/src/inspect_ai/agent/_bridge/_errors.py
@@ -22,6 +22,17 @@ Mirrored as a literal in the sandbox proxy; keep both in sync.
 """
 
 
+class BridgePolicyError(Exception):
+    """A bridged request asked for something the bridge is configured to withhold.
+
+    Carries `status_code` so `provider_error_payload()` reports a 400 rather than
+    an unrecoverable status — a policy denial is a deterministic client error, not
+    a bug in our request translation, and should not be logged with a traceback.
+    """
+
+    status_code = 400
+
+
 class ProviderErrorPayload(TypedDict):
     """Forwardable provider-error detail carried under `PROVIDER_ERROR_KEY`."""
 

--- a/src/inspect_ai/agent/_bridge/anthropic_api.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api.py
@@ -15,8 +15,8 @@ if TYPE_CHECKING:
 async def inspect_anthropic_api_request(
     json_data: dict[str, Any],
     headers: dict[str, str] | None,
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: AgentBridge,
     *,
     beta: bool = False,

--- a/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/anthropic_api_impl.py
@@ -80,8 +80,11 @@ from .util import (
     apply_message_ids,
     bridge_generate,
     clear_generation_params,
+    relax_tool_choice_for_withheld,
     resolve_generate_config,
     resolve_inspect_model,
+    validate_bridge_media,
+    withheld_bridge_tool,
 )
 
 logger = getLogger(__name__)
@@ -90,8 +93,8 @@ logger = getLogger(__name__)
 async def inspect_anthropic_api_request_impl(
     json_data: dict[str, Any],
     headers: dict[str, str] | None,
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: AgentBridge,
     *,
     beta: bool = False,
@@ -114,18 +117,25 @@ async def inspect_anthropic_api_request_impl(
         )
 
     tools = tools_from_anthropic_tools(
-        anthropic_tools, anthropic_mcp_servers, web_search, code_execution
+        anthropic_tools,
+        anthropic_mcp_servers,
+        web_search,
+        code_execution,
+        bridge.allow_remote_mcp,
     )
 
     # tool choice
     anthropic_tool_choice: ToolChoiceParam | None = json_data.get("tool_choice", None)
-    tool_choice = tool_choice_from_anthropic_tool_choice(anthropic_tool_choice)
+    tool_choice = relax_tool_choice_for_withheld(
+        tool_choice_from_anthropic_tool_choice(anthropic_tool_choice), tools
+    )
 
     # convert to inspect messages
     input: list[MessageParam] = json_data["messages"]
     debug_log("SCAFFOLD INPUT", input)
 
     messages = await messages_from_anthropic_input(input, tools)
+    validate_bridge_media(bridge, messages)
     debug_log("INSPECT MESSAGES", messages)
 
     # extract generate config (hoist instructions into system_message)
@@ -233,8 +243,9 @@ def generate_config_from_anthropic(json_data: dict[str, Any]) -> GenerateConfig:
 def tools_from_anthropic_tools(
     anthropic_tools: list[ToolParamDef] | None,
     anthropic_mcp_servers: list[BetaRequestMCPServerURLDefinitionParam] | None,
-    web_search_providers: WebSearchProviders,
-    code_execution_providers: CodeExecutionProviders,
+    web_search_providers: WebSearchProviders | None,
+    code_execution_providers: CodeExecutionProviders | None,
+    allow_remote_mcp: bool,
 ) -> list[ToolInfo | Tool]:
     tools: list[ToolInfo | Tool] = []
 
@@ -254,22 +265,40 @@ def tools_from_anthropic_tools(
         elif is_computer_tool(anthropic_tool):
             tools.append(computer())
         elif is_web_search_tool(anthropic_tool):
-            tools.append(
-                web_search(
-                    resolve_web_search_providers(anthropic_tool, web_search_providers)
+            if web_search_providers is None:
+                withheld_bridge_tool("web_search")
+            else:
+                tools.append(
+                    web_search(
+                        resolve_web_search_providers(
+                            anthropic_tool, web_search_providers
+                        )
+                    )
                 )
-            )
         elif is_web_fetch_tool(anthropic_tool):
-            # web fetch tool is collapsed into web_search for inspect
-            pass
+            # Inspect has no standalone fetch tool: on Anthropic, fetch rides
+            # along with a granted web_search (the provider emits both), so a
+            # declaration of it maps to nothing of its own. A client that
+            # declares fetch *without* search therefore gets no web tool even
+            # when search is granted — mapping it to web_search would hand it
+            # the search capability it didn't ask for.
+            if web_search_providers is None:
+                withheld_bridge_tool("web_fetch")
         elif is_code_execution_tool(anthropic_tool):
-            tools.append(code_execution(providers=code_execution_providers))
+            if code_execution_providers is None:
+                withheld_bridge_tool("code_execution")
+            else:
+                tools.append(code_execution(providers=code_execution_providers))
         elif is_bash_tool(anthropic_tool):
             tools.append(bash())
         else:
             raise RuntimeError(
                 f"ToolParam of type {anthropic_tool['type']} not supported by agent bridge."
             )
+
+    if anthropic_mcp_servers and not allow_remote_mcp:
+        withheld_bridge_tool("mcp_servers")
+        anthropic_mcp_servers = None
 
     for mcp_server in anthropic_mcp_servers or []:
         # allowed tools (default is 'all')

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -45,7 +45,8 @@ from .responses import inspect_responses_api_request
 from .util import (
     default_code_execution_providers,
     internal_web_search_providers,
-    resolve_web_search_providers,
+    resolve_bridge_code_execution,
+    resolve_bridge_web_search,
 )
 
 if TYPE_CHECKING:
@@ -103,8 +104,9 @@ async def agent_bridge(
     filter: GenerateFilter | None = None,
     retry_refusals: int | None = None,
     compaction: CompactionStrategy | None = None,
-    web_search: WebSearchProviders | None = None,
-    code_execution: CodeExecutionProviders | None = None,
+    web_search: WebSearchProviders | bool | None = None,
+    code_execution: CodeExecutionProviders | bool | None = None,
+    client_mcp_servers: bool | None = None,
     model_event_sink: ModelEventSink | None = None,
     forward_generation_config: bool = False,
     approval: list["ApprovalPolicy"] | None = None,
@@ -128,17 +130,22 @@ async def agent_bridge(
        compaction: Compact the conversation when it it is close to overflowing
           the model's context window. See [Compaction](https://inspect.aisi.org.uk/compaction.html) for details on compaction strategies.
        web_search: Configuration for mapping model internal
-          web_search tools to Inspect. By default, will map to the
-          internal provider of the target model (supported for OpenAI,
+          web_search tools to Inspect. By default (in-process bridges), will map
+          to the internal provider of the target model (supported for OpenAI,
           Anthropic, Gemini, Grok, and Perplexity). Pass an alternate
           configuration to use to use an external provider like
-          Tavili or Exa for models that don't support internal search.
+          Tavili or Exa for models that don't support internal search, or
+          `False` to withhold web search from the bridged agent entirely.
        code_execution: Configuration for mapping model internal
           code_execution tools to Inspect. By default, will map to the
           internal provider of the target model (supported for OpenAI,
           Anthropic, Google, and Grok). If the provider does not support
           native code execution then the bash() tool will be provided
           (note that this requires a sandbox by declared for the task).
+          Pass `False` to withhold code execution from the bridged agent.
+       client_mcp_servers: Honor MCP servers declared by the bridged client
+          (defaults to `True` for in-process bridges). When enabled, a client
+          may name any server URL and the model provider will connect to it.
        model_event_sink: Optional sink that takes ownership of `ModelEvent`
           emission for calls routed through the bridge. When set, the bridge
           installs it around `model.generate()` so the sink decides when and
@@ -159,9 +166,13 @@ async def agent_bridge(
     # ensure one time init
     init_bridge_request_patch()
 
-    # resolve web search config
-    web_search = resolve_web_search_providers(web_search)
-    code_execution = code_execution or default_code_execution_providers()
+    # resolve granted capabilities (in-process bridges grant by default: the
+    # scaffold already shares the host's network, so withholding buys nothing)
+    web_search_grant = resolve_bridge_web_search(web_search, default_grant=True)
+    code_execution_grant = resolve_bridge_code_execution(
+        code_execution, default_grant=True
+    )
+    allow_remote_mcp = True if client_mcp_servers is None else client_mcp_servers
 
     # create a state value that will be used to track mesages going over the bridge
     state = state or AgentState(messages=[])
@@ -175,14 +186,15 @@ async def agent_bridge(
         model_event_sink=model_event_sink,
         forward_generation_config=forward_generation_config,
         approval=approval,
+        allow_remote_mcp=allow_remote_mcp,
     )
 
     # set the patch config for this context and child coroutines
     token = _patch_config.set(
         PatchConfig(
             enabled=True,
-            web_search=web_search,
-            code_execution=code_execution,
+            web_search=web_search_grant,
+            code_execution=code_execution_grant,
             bridge=bridge,
         )
     )
@@ -198,10 +210,10 @@ _patch_initialised: bool = False
 @dataclass
 class PatchConfig:
     enabled: bool = field(default=False)
-    web_search: WebSearchProviders = field(
+    web_search: WebSearchProviders | None = field(
         default_factory=internal_web_search_providers
     )
-    code_execution: CodeExecutionProviders = field(
+    code_execution: CodeExecutionProviders | None = field(
         default_factory=default_code_execution_providers
     )
     bridge: AgentBridge = field(

--- a/src/inspect_ai/agent/_bridge/completions.py
+++ b/src/inspect_ai/agent/_bridge/completions.py
@@ -25,6 +25,7 @@ from .util import (
     clear_generation_params,
     resolve_generate_config,
     resolve_inspect_model,
+    validate_bridge_media,
 )
 
 if TYPE_CHECKING:
@@ -62,6 +63,7 @@ async def inspect_completions_api_request(
     # convert openai messages to inspect messages
     openai_messages: list[ChatCompletionMessageParam] = json_data["messages"]
     messages = await messages_from_openai(openai_messages, model_name)
+    validate_bridge_media(bridge, messages)
 
     # extract generate config (hoist instructions into system_message)
     config = generate_config_from_openai_completions(json_data)

--- a/src/inspect_ai/agent/_bridge/google_api.py
+++ b/src/inspect_ai/agent/_bridge/google_api.py
@@ -9,8 +9,8 @@ from inspect_ai.tool._tools._web_search._web_search import WebSearchProviders
 
 async def inspect_google_api_request(
     json_data: dict[str, Any],
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: AgentBridge,
 ) -> dict[str, Any]:
     from .google_api_impl import inspect_google_api_request_impl

--- a/src/inspect_ai/agent/_bridge/google_api_impl.py
+++ b/src/inspect_ai/agent/_bridge/google_api_impl.py
@@ -52,8 +52,11 @@ from .util import (
     apply_message_ids,
     bridge_generate,
     clear_generation_params,
+    relax_tool_choice_for_withheld,
     resolve_generate_config,
     resolve_inspect_model,
+    validate_bridge_media,
+    withheld_bridge_tool,
 )
 
 logger = getLogger(__name__)
@@ -61,8 +64,8 @@ logger = getLogger(__name__)
 
 async def inspect_google_api_request_impl(
     json_data: dict[str, Any],
-    web_search_providers: WebSearchProviders,
-    code_execution_providers: CodeExecutionProviders,
+    web_search_providers: WebSearchProviders | None,
+    code_execution_providers: CodeExecutionProviders | None,
     bridge: AgentBridge,
 ) -> dict[str, Any]:
     # resolve model
@@ -100,10 +103,13 @@ async def inspect_google_api_request_impl(
     )
 
     # translate tool choice
-    tool_choice = tool_choice_from_google_tool_config(tool_config)
+    tool_choice = relax_tool_choice_for_withheld(
+        tool_choice_from_google_tool_config(tool_config), tools
+    )
 
     # translate messages
     messages = messages_from_google_contents(contents, system_instruction)
+    validate_bridge_media(bridge, messages)
     debug_log("INSPECT MESSAGES", messages)
 
     # extract generate config
@@ -177,8 +183,8 @@ def generate_config_from_google(generation_config: dict[str, Any]) -> GenerateCo
 
 def tools_from_google_tools(
     google_tools: list[dict[str, Any]] | None,
-    web_search_providers: WebSearchProviders,
-    code_execution_providers: CodeExecutionProviders,
+    web_search_providers: WebSearchProviders | None,
+    code_execution_providers: CodeExecutionProviders | None,
 ) -> list[ToolInfo | Tool]:
     tools: list[ToolInfo | Tool] = []
 
@@ -200,13 +206,17 @@ def tools_from_google_tools(
                         else ToolParams(),
                     )
                 )
-        elif "googleSearch" in google_tool:
-            tools.append(web_search(web_search_providers))
+        elif "googleSearch" in google_tool or "googleSearchRetrieval" in google_tool:
+            # googleSearchRetrieval is the grounding variant; both map to search
+            if web_search_providers is None:
+                withheld_bridge_tool("googleSearch")
+            else:
+                tools.append(web_search(web_search_providers))
         elif "codeExecution" in google_tool:
-            tools.append(code_execution(providers=code_execution_providers))
-        elif "googleSearchRetrieval" in google_tool:
-            # Google Search Retrieval (grounding)
-            tools.append(web_search(web_search_providers))
+            if code_execution_providers is None:
+                withheld_bridge_tool("codeExecution")
+            else:
+                tools.append(code_execution(providers=code_execution_providers))
         elif "computerUse" in google_tool:
             tools.append(computer())
 

--- a/src/inspect_ai/agent/_bridge/responses.py
+++ b/src/inspect_ai/agent/_bridge/responses.py
@@ -14,8 +14,8 @@ if TYPE_CHECKING:
 async def inspect_responses_api_request(
     json_data: dict[str, Any],
     headers: dict[str, str] | None,
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: AgentBridge,
 ) -> "Response":
     validate_openai_client("agent bridge")

--- a/src/inspect_ai/agent/_bridge/responses_impl.py
+++ b/src/inspect_ai/agent/_bridge/responses_impl.py
@@ -176,8 +176,11 @@ from .util import (
     apply_message_ids,
     bridge_generate,
     clear_generation_params,
+    relax_tool_choice_for_withheld,
     resolve_generate_config,
     resolve_inspect_model,
+    validate_bridge_media,
+    withheld_bridge_tool,
 )
 
 logger = getLogger(__name__)
@@ -203,8 +206,8 @@ def _is_openai_responses_provider(model: Model) -> bool:
 async def inspect_responses_api_request_impl(
     json_data: dict[str, Any],
     headers: dict[str, str] | None,
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: AgentBridge,
 ) -> Response:
     # resolve model
@@ -259,12 +262,18 @@ async def inspect_responses_api_request_impl(
             continue
         if is_namespace_tool_param(tool):
             _harvest_tool_namespaces(tool, tool_namespaces)
-        tools.extend(tools_from_responses_tool(tool, web_search, code_execution))
+        tools.extend(
+            tools_from_responses_tool(
+                tool, web_search, code_execution, bridge.allow_remote_mcp
+            )
+        )
     tools = [tool for tool in tools if tool]
     responses_tool_choice: ResponsesToolChoiceParam | None = json_data.get(
         "tool_choice", None
     )
-    tool_choice = tool_choice_from_responses_tool_choice(responses_tool_choice)
+    tool_choice = relax_tool_choice_for_withheld(
+        tool_choice_from_responses_tool_choice(responses_tool_choice), tools
+    )
 
     # convert inspect messages (input was read above, before tool merging)
 
@@ -282,6 +291,7 @@ async def inspect_responses_api_request_impl(
     debug_log("SCAFFOLD INPUT", input)
 
     messages = messages_from_responses_input(input, tools, model_name)
+    validate_bridge_media(bridge, messages)
     debug_log("INSPECT MESSAGES", messages)
 
     # extract generate config (hoist instructions into system_message)
@@ -445,8 +455,9 @@ def responses_tool_choice_param_to_tool_choice(
 
 def tool_from_responses_tool(
     tool_param: ToolParam,
-    web_search_providers: WebSearchProviders,
-    code_execution_providers: CodeExecutionProviders,
+    web_search_providers: WebSearchProviders | None,
+    code_execution_providers: CodeExecutionProviders | None,
+    allow_remote_mcp: bool,
 ) -> ToolInfo | Tool | None:
     if is_function_tool_param(tool_param):
         # stash the original param so the OpenAI Responses provider can re-emit
@@ -473,10 +484,16 @@ def tool_from_responses_tool(
             },
         )
     elif is_web_search_tool_param(tool_param):
+        if web_search_providers is None:
+            withheld_bridge_tool("web_search")
+            return None
         return web_search(
             resolve_web_search_providers(tool_param, web_search_providers)
         )
     elif is_code_interpreter_tool_param(tool_param):
+        if code_execution_providers is None:
+            withheld_bridge_tool("code_interpreter")
+            return None
         return code_execution(
             providers=resolve_code_interpreter_providers(
                 tool_param, code_execution_providers
@@ -485,6 +502,9 @@ def tool_from_responses_tool(
     elif is_computer_tool_param(tool_param):
         return computer()
     elif is_mcp_tool_param(tool_param):
+        if not allow_remote_mcp:
+            withheld_bridge_tool("mcp")
+            return None
         allowed_tools = tool_param["allowed_tools"]
         if isinstance(allowed_tools, dict):
             raise RuntimeError(
@@ -529,8 +549,9 @@ def tool_from_responses_tool(
 
 def tools_from_responses_tool(
     tool_param: ToolParam,
-    web_search_providers: WebSearchProviders,
-    code_execution_providers: CodeExecutionProviders,
+    web_search_providers: WebSearchProviders | None,
+    code_execution_providers: CodeExecutionProviders | None,
+    allow_remote_mcp: bool,
 ) -> list[ToolInfo | Tool]:
     """Convert a responses ToolParam into zero or more inspect tools.
 
@@ -548,7 +569,10 @@ def tools_from_responses_tool(
         for inner in tool_param.get("tools", []):
             inner_param = cast(ToolParam, inner)
             inner_tool = tool_from_responses_tool(
-                inner_param, web_search_providers, code_execution_providers
+                inner_param,
+                web_search_providers,
+                code_execution_providers,
+                allow_remote_mcp,
             )
             if inner_tool is not None:
                 # Stash the namespace so openai_responses_tools can re-group
@@ -564,7 +588,7 @@ def tools_from_responses_tool(
                 flattened.append(inner_tool)
         return flattened
     tool = tool_from_responses_tool(
-        tool_param, web_search_providers, code_execution_providers
+        tool_param, web_search_providers, code_execution_providers, allow_remote_mcp
     )
     return [tool] if tool is not None else []
 

--- a/src/inspect_ai/agent/_bridge/sandbox/bridge.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/bridge.py
@@ -28,7 +28,7 @@ from inspect_ai.util._sandbox.exec_remote import (
 )
 
 from ..._agent import AgentState
-from ..util import default_code_execution_providers, internal_web_search_providers
+from ..util import resolve_bridge_code_execution, resolve_bridge_web_search
 from .service import MODEL_SERVICE, run_model_service
 from .types import SandboxAgentBridge
 
@@ -52,8 +52,9 @@ async def sandbox_agent_bridge(
     compaction: CompactionStrategy | None = None,
     sandbox: str | None = None,
     port: int = 13131,
-    web_search: WebSearchProviders | None = None,
-    code_execution: CodeExecutionProviders | None = None,
+    web_search: WebSearchProviders | bool | None = None,
+    code_execution: CodeExecutionProviders | bool | None = None,
+    client_mcp_servers: bool | None = None,
     bridged_tools: Sequence[BridgedToolsSpec] | None = None,
     model_event_sink: ModelEventSink | None = None,
     forward_generation_config: bool = False,
@@ -85,18 +86,24 @@ async def sandbox_agent_bridge(
             the model's context window. See [Compaction](https://inspect.aisi.org.uk/compaction.html) for details on compaction strategies.
         sandbox: Sandbox to run model proxy server within.
         port: Port to run proxy server on.
-        web_search: Configuration for mapping model internal
-            web_search tools to Inspect. By default, will map to the
-            internal provider of the target model (supported for OpenAI,
-            Anthropic, Gemini, Grok, and Perplexity). Pass an alternate
-            configuration to use to use an external provider like
-            Tavily or Exa for models that don't support internal search.
-        code_execution: Configuration for mapping model internal
-            code_execution tools to Inspect. By default, will map to the
-            internal provider of the target model (supported for OpenAI,
-            Anthropic, Google, and Grok). If the provider does not support
+        web_search: Configuration for mapping model internal web_search tools to
+            Inspect. Withheld by default: a sandboxed agent that names the native
+            tool in a request would otherwise reach the web through the model
+            provider, bypassing the sandbox's own network policy. Pass `True` to
+            map to the internal provider of the target model (supported for
+            OpenAI, Anthropic, Gemini, Grok, and Perplexity), or a configuration
+            to use an external provider like Tavily or Exa for models that don't
+            support internal search.
+        code_execution: Configuration for mapping model internal code_execution
+            tools to Inspect. Withheld by default (see `web_search`). Pass `True`
+            to map to the internal provider of the target model (supported for
+            OpenAI, Anthropic, Google, and Grok); if the provider does not support
             native code execution then the bash() tool will be provided
             (note that this requires a sandbox by declared for the task).
+        client_mcp_servers: Honor MCP servers declared by the sandboxed agent
+            (defaults to `False`). When enabled, the agent may name any server URL
+            and the model provider will connect to it. Prefer `bridged_tools` for
+            exposing tools you choose.
         bridged_tools: Host-side Inspect tools to expose to the sandboxed agent
             via MCP protocol. Each BridgedToolsSpec creates an MCP server that
             makes the specified tools available to the agent. The resolved
@@ -132,9 +139,15 @@ async def sandbox_agent_bridge(
     # resolve sandbox
     sandbox_env = await sandbox_with_injected_tools(sandbox_name=sandbox)
 
-    # resolve internal services
-    web_search = web_search or internal_web_search_providers()
-    code_execution = code_execution or default_code_execution_providers()
+    # resolve granted capabilities. These default to withheld: the sandboxed agent
+    # can otherwise obtain them just by naming the native tool in a request, which
+    # reaches the web through the model provider even when the sandbox has no
+    # network egress of its own.
+    web_search_grant = resolve_bridge_web_search(web_search, default_grant=False)
+    code_execution_grant = resolve_bridge_code_execution(
+        code_execution, default_grant=False
+    )
+    allow_remote_mcp = False if client_mcp_servers is None else client_mcp_servers
 
     # create a state value that will be used to track mesages going over the bridge
     state = state or AgentState(messages=[])
@@ -161,6 +174,7 @@ async def sandbox_agent_bridge(
                 forward_generation_config=forward_generation_config,
                 approval=approval,
                 checkpointer=checkpointer,
+                allow_remote_mcp=allow_remote_mcp,
             )
 
             # register bridged tools with the bridge
@@ -179,8 +193,8 @@ async def sandbox_agent_bridge(
             tg.start_soon(
                 run_model_service,
                 sandbox_env,
-                web_search,
-                code_execution,
+                web_search_grant,
+                code_execution_grant,
                 bridge,
                 instance,
                 started,

--- a/src/inspect_ai/agent/_bridge/sandbox/service.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/service.py
@@ -65,8 +65,8 @@ def _forward_provider_errors(generate: GenerateMethod) -> GenerateMethod:
 
 async def run_model_service(
     sandbox: SandboxEnvironment,
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: SandboxAgentBridge,
     instance: str,
     started: anyio.Event,
@@ -109,8 +109,8 @@ def generate_completions(
 
 
 def generate_responses(
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: SandboxAgentBridge,
 ) -> Callable[[dict[str, JsonValue]], Awaitable[dict[str, JsonValue]]]:
     async def generate(json_data: dict[str, JsonValue]) -> dict[str, JsonValue]:
@@ -123,8 +123,8 @@ def generate_responses(
 
 
 def generate_anthropic(
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: SandboxAgentBridge,
 ) -> Callable[[dict[str, JsonValue]], Awaitable[dict[str, JsonValue]]]:
     async def generate(json_data: dict[str, JsonValue]) -> dict[str, JsonValue]:
@@ -137,8 +137,8 @@ def generate_anthropic(
 
 
 def generate_google(
-    web_search: WebSearchProviders,
-    code_execution: CodeExecutionProviders,
+    web_search: WebSearchProviders | None,
+    code_execution: CodeExecutionProviders | None,
     bridge: SandboxAgentBridge,
 ) -> Callable[[dict[str, JsonValue]], Awaitable[dict[str, JsonValue]]]:
     async def generate(json_data: dict[str, JsonValue]) -> dict[str, JsonValue]:

--- a/src/inspect_ai/agent/_bridge/sandbox/types.py
+++ b/src/inspect_ai/agent/_bridge/sandbox/types.py
@@ -36,6 +36,8 @@ class SandboxAgentBridge(AgentBridge):
         forward_generation_config: bool = False,
         approval: list["ApprovalPolicy"] | None = None,
         checkpointer: Checkpointer | None = None,
+        allow_remote_mcp: bool = False,
+        allow_remote_media: bool = False,
     ) -> None:
         super().__init__(
             state,
@@ -48,6 +50,8 @@ class SandboxAgentBridge(AgentBridge):
             forward_generation_config=forward_generation_config,
             approval=approval,
             checkpointer=checkpointer,
+            allow_remote_mcp=allow_remote_mcp,
+            allow_remote_media=allow_remote_media,
         )
         self.port = port
         self.mcp_server_configs = mcp_server_configs or []

--- a/src/inspect_ai/agent/_bridge/types.py
+++ b/src/inspect_ai/agent/_bridge/types.py
@@ -46,7 +46,15 @@ class AgentBridge:
         forward_generation_config: bool = False,
         approval: list["ApprovalPolicy"] | None = None,
         checkpointer: Checkpointer | None = None,
+        allow_remote_mcp: bool = True,
+        allow_remote_media: bool = True,
     ) -> None:
+        # Capabilities a client-declared request may reach for. Both default to
+        # permissive because an in-process scaffold already shares the host's
+        # network and filesystem; `sandbox_agent_bridge()` tightens them, since
+        # there the sandbox boundary is the thing being defended.
+        self.allow_remote_mcp = allow_remote_mcp
+        self.allow_remote_media = allow_remote_media
         self._cp = checkpointer or _NoopCheckpointer()
         # AgentState is not a BaseModel so it can't be tracked directly;
         # track its messages and output separately (same approach as react()).

--- a/src/inspect_ai/agent/_bridge/util.py
+++ b/src/inspect_ai/agent/_bridge/util.py
@@ -2,16 +2,27 @@ import inspect
 import warnings
 from contextlib import contextmanager
 from contextvars import ContextVar
+from logging import getLogger
 from typing import Iterator, Sequence, cast
 
 from typing_extensions import TypeIs
 
+from inspect_ai._util.content import (
+    Content,
+    ContentAudio,
+    ContentDocument,
+    ContentImage,
+    ContentVideo,
+)
 from inspect_ai._util.json import to_json_str_safe
+from inspect_ai._util.logger import warn_once
+from inspect_ai._util.url import is_data_uri
 from inspect_ai.agent._bridge._approval import (
     MAX_CONSECUTIVE_REJECTIONS,
     apply_bridge_tool_approval,
     terminate_for_repeated_rejections,
 )
+from inspect_ai.agent._bridge._errors import BridgePolicyError
 from inspect_ai.agent._bridge.types import AgentBridge, message_json_hash
 from inspect_ai.model._chat_message import ChatMessage, ChatMessageUser
 from inspect_ai.model._generate_config import GenerateConfig, active_generate_config
@@ -27,7 +38,7 @@ from inspect_ai.model._model import (
 )
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.tool._tool import Tool
-from inspect_ai.tool._tool_choice import ToolChoice
+from inspect_ai.tool._tool_choice import ToolChoice, ToolFunction
 from inspect_ai.tool._tool_info import ToolInfo
 from inspect_ai.tool._tool_util import tool_to_tool_info
 from inspect_ai.tool._tools._code_execution import CodeExecutionProviders
@@ -391,6 +402,122 @@ def default_code_execution_providers() -> CodeExecutionProviders:
     return CodeExecutionProviders(
         openai={}, anthropic=True, google=True, grok=True, python={}
     )
+
+
+logger = getLogger(__name__)
+
+
+def withheld_bridge_tool(tool_type: str) -> None:
+    """Drop a client-declared tool this bridge does not grant.
+
+    Dropping rather than erroring keeps the rest of the request serviceable. The
+    warning is what makes the omission diagnosable: an absent tool is otherwise
+    indistinguishable from the model simply choosing not to call it.
+    """
+    warn_once(
+        logger,
+        f"The bridged agent declared a '{tool_type}' tool, which this bridge does "
+        "not grant; it has been withheld from the model. Grant it via the "
+        "corresponding agent_bridge() option if the evaluation intends it.",
+    )
+    return None
+
+
+def relax_tool_choice_for_withheld(
+    tool_choice: ToolChoice | None, tools: Sequence[ToolInfo | Tool]
+) -> ToolChoice | None:
+    """Fall back to "auto" when `tool_choice` names a tool this bridge withheld.
+
+    Forcing a tool that isn't in the list makes the model layer purge *every* tool
+    for the turn, so one withheld capability would take the agent's own function
+    tools down with it.
+    """
+    if not isinstance(tool_choice, ToolFunction):
+        return tool_choice
+    names = {
+        (tool.name if isinstance(tool, ToolInfo) else tool_to_tool_info(tool).name)
+        for tool in tools
+    }
+    return tool_choice if tool_choice.name in names else "auto"
+
+
+def resolve_bridge_web_search(
+    providers: WebSearchProviders | bool | None,
+    *,
+    default_grant: bool,
+) -> WebSearchProviders | None:
+    """Resolve a bridge `web_search` option, returning `None` to withhold it.
+
+    `None` defers to the bridge's own posture. A config that leaves no provider
+    enabled also withholds: otherwise "turn every provider off" would still serve
+    search through whichever provider the config neglected to name.
+
+    Note an *empty* config is the opposite of an all-`False` one — it enables the
+    default provider set, and callers rely on that to grant without pinning a list.
+    """
+    if providers is None:
+        providers = default_grant
+    if providers is False:
+        return None
+    if providers is True:
+        providers = internal_web_search_providers()
+    return cast(WebSearchProviders, _normalize_config(providers)) or None
+
+
+def resolve_bridge_code_execution(
+    providers: CodeExecutionProviders | bool | None,
+    *,
+    default_grant: bool,
+) -> CodeExecutionProviders | None:
+    """Resolve a bridge `code_execution` option, returning `None` to withhold it."""
+    if providers is None:
+        providers = default_grant
+    if providers is False:
+        return None
+    if providers is True:
+        return default_code_execution_providers()
+    return providers
+
+
+def _bridge_media_uri(content: Content) -> str | None:
+    match content:
+        case ContentImage():
+            return content.image
+        case ContentDocument():
+            return content.document
+        case ContentAudio():
+            return content.audio
+        case ContentVideo():
+            return content.video
+        case _:
+            return None
+
+
+def validate_bridge_media(bridge: AgentBridge, messages: Sequence[ChatMessage]) -> None:
+    """Reject inbound media the host would dereference on the agent's behalf.
+
+    Media content carries a URI that gets resolved outside the sandbox: an http(s)
+    URL is fetched by the Inspect process (or by the provider), and anything else
+    is read from the host filesystem via fsspec. For a sandboxed agent that is a
+    confused deputy — it turns an ordinary model request into an arbitrary read
+    performed by a process the sandbox is not supposed to reach. Only inline
+    `data:` URIs are accepted there.
+
+    In-process bridges are exempt: that scaffold already runs with the host's
+    filesystem and network, so there is no boundary here to defend.
+    """
+    if bridge.allow_remote_media:
+        return
+    for message in messages:
+        if isinstance(message.content, str):
+            continue
+        for content in message.content:
+            uri = _bridge_media_uri(content)
+            if uri is not None and not is_data_uri(uri):
+                raise BridgePolicyError(
+                    f"Bridged {content.type} content must be an inline 'data:' URI; "
+                    f"the agent bridge will not dereference {uri[:80]!r}."
+                )
 
 
 def apply_message_ids(bridge: AgentBridge, messages: list[ChatMessage]) -> None:

--- a/tests/agent/test_bridge_additional_tools.py
+++ b/tests/agent/test_bridge_additional_tools.py
@@ -136,7 +136,10 @@ def _emit(tool_info: ToolInfo) -> dict[str, Any]:
 def test_function_tool_round_trips_verbatim() -> None:
     original = _reserved_function_tool()
     tool_info = tool_from_responses_tool(
-        cast(Any, original), WEB_SEARCH_PROVIDERS, CODE_EXECUTION_PROVIDERS
+        cast(Any, original),
+        WEB_SEARCH_PROVIDERS,
+        CODE_EXECUTION_PROVIDERS,
+        allow_remote_mcp=True,
     )
     assert isinstance(tool_info, ToolInfo)
     assert RESPONSES_VERBATIM in (tool_info.options or {})
@@ -148,7 +151,10 @@ def test_function_tool_round_trips_verbatim() -> None:
 def test_custom_tool_round_trips_verbatim() -> None:
     original = _custom_tool()
     tool_info = tool_from_responses_tool(
-        cast(Any, original), WEB_SEARCH_PROVIDERS, CODE_EXECUTION_PROVIDERS
+        cast(Any, original),
+        WEB_SEARCH_PROVIDERS,
+        CODE_EXECUTION_PROVIDERS,
+        allow_remote_mcp=True,
     )
     assert isinstance(tool_info, ToolInfo)
     assert RESPONSES_VERBATIM in (tool_info.options or {})
@@ -162,7 +168,10 @@ def test_reconstruction_without_verbatim_drifts() -> None:
     # normalizes fields -> drift that reserved-schema models reject (HTTP 400).
     original = _reserved_function_tool()
     tool_info = tool_from_responses_tool(
-        cast(Any, original), WEB_SEARCH_PROVIDERS, CODE_EXECUTION_PROVIDERS
+        cast(Any, original),
+        WEB_SEARCH_PROVIDERS,
+        CODE_EXECUTION_PROVIDERS,
+        allow_remote_mcp=True,
     )
     assert isinstance(tool_info, ToolInfo)
 

--- a/tests/agent/test_bridge_namespace_tool.py
+++ b/tests/agent/test_bridge_namespace_tool.py
@@ -65,7 +65,7 @@ def test_tools_from_responses_tool_flattens_namespace():
         "description": "Submission tools",
         "tools": [_function_tool("submit_pov"), _function_tool("submit_patch")],
     }
-    tools = tools_from_responses_tool(ns, {}, {})
+    tools = tools_from_responses_tool(ns, {}, {}, allow_remote_mcp=True)
     assert [t.name for t in tools] == ["submit_pov", "submit_patch"]
     for t in tools:
         assert isinstance(t, ToolInfo)
@@ -78,7 +78,7 @@ def test_tools_from_responses_tool_stashes_namespace_on_options():
         "description": "Multi-agent orchestration tools",
         "tools": [_function_tool("spawn_agent"), _custom_tool("wait_agent")],
     }
-    tools = tools_from_responses_tool(ns, {}, {})
+    tools = tools_from_responses_tool(ns, {}, {}, allow_remote_mcp=True)
     for t in tools:
         assert isinstance(t, ToolInfo)
         assert t.options is not None
@@ -89,13 +89,17 @@ def test_tools_from_responses_tool_stashes_namespace_on_options():
 
 
 def test_tools_from_responses_tool_single_function():
-    tools = tools_from_responses_tool(_function_tool("calc"), {}, {})
+    tools = tools_from_responses_tool(
+        _function_tool("calc"), {}, {}, allow_remote_mcp=True
+    )
     assert len(tools) == 1
     assert tools[0].name == "calc"
 
 
 def test_tools_from_responses_tool_passes_through_custom():
-    tools = tools_from_responses_tool(_custom_tool("exec"), {}, {})
+    tools = tools_from_responses_tool(
+        _custom_tool("exec"), {}, {}, allow_remote_mcp=True
+    )
     assert len(tools) == 1
     assert tools[0].name == "exec"
 
@@ -107,17 +111,17 @@ def test_namespace_with_mixed_inner_tools():
         "description": "mixed",
         "tools": [_function_tool("fn"), _custom_tool("ct")],
     }
-    tools = tools_from_responses_tool(ns, {}, {})
+    tools = tools_from_responses_tool(ns, {}, {}, allow_remote_mcp=True)
     assert [t.name for t in tools] == ["fn", "ct"]
 
 
 def test_empty_namespace_returns_empty_list():
     ns = {"type": "namespace", "name": "empty", "description": "empty", "tools": []}
-    assert tools_from_responses_tool(ns, {}, {}) == []
+    assert tools_from_responses_tool(ns, {}, {}, allow_remote_mcp=True) == []
 
 
 def test_tool_from_responses_tool_unchanged_for_function():
-    t = tool_from_responses_tool(_function_tool("x"), {}, {})
+    t = tool_from_responses_tool(_function_tool("x"), {}, {}, allow_remote_mcp=True)
     assert isinstance(t, ToolInfo)
     assert t.name == "x"
 

--- a/tests/agent/test_bridge_tool_grants.py
+++ b/tests/agent/test_bridge_tool_grants.py
@@ -1,0 +1,303 @@
+"""Capabilities a bridged client may reach for are granted by the scaffold, not claimed.
+
+A sandboxed agent that names a native tool in a request would otherwise obtain web
+access through the model provider even when its sandbox has no network egress, so
+`sandbox_agent_bridge()` withholds those tools unless the evaluation grants them.
+In-process `agent_bridge()` stays permissive: that scaffold already runs with the
+host's network and filesystem, so there is no boundary to defend.
+"""
+
+from typing import Any, cast
+
+import pytest
+
+from inspect_ai._util.content import ContentAudio, ContentDocument, ContentImage
+from inspect_ai.agent._agent import AgentState
+from inspect_ai.agent._bridge._errors import BridgePolicyError
+from inspect_ai.agent._bridge.anthropic_api_impl import tools_from_anthropic_tools
+from inspect_ai.agent._bridge.responses_impl import tools_from_responses_tool
+from inspect_ai.agent._bridge.sandbox.types import SandboxAgentBridge
+from inspect_ai.agent._bridge.types import AgentBridge
+from inspect_ai.agent._bridge.util import (
+    relax_tool_choice_for_withheld,
+    resolve_bridge_code_execution,
+    resolve_bridge_web_search,
+    validate_bridge_media,
+)
+from inspect_ai.model._chat_message import ChatMessageUser
+from inspect_ai.tool import ToolFunction, ToolInfo, WebSearchProviders
+
+WEB_SEARCH_PARAM = cast(Any, {"type": "web_search"})
+MCP_PARAM = cast(
+    Any,
+    {
+        "type": "mcp",
+        "server_label": "elsewhere",
+        "server_url": "https://elsewhere.example/mcp",
+        "headers": None,
+        "allowed_tools": None,
+    },
+)
+ANTHROPIC_WEB_SEARCH = cast(Any, {"type": "web_search_20250305", "name": "web_search"})
+ANTHROPIC_MCP_SERVER = cast(
+    Any, {"type": "url", "name": "elsewhere", "url": "https://elsewhere.example/mcp"}
+)
+
+
+def sandbox_bridge(**kwargs: Any) -> SandboxAgentBridge:
+    return SandboxAgentBridge(
+        state=AgentState(messages=[]),
+        filter=None,
+        retry_refusals=None,
+        compaction=None,
+        port=3000,
+        model=None,
+        **kwargs,
+    )
+
+
+# --- resolution -------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,granted",
+    [
+        (None, False),
+        (False, False),
+        (True, True),
+        # an *empty* config means "the usual providers", which is how a caller
+        # grants without pinning a provider list
+        (WebSearchProviders(), True),
+        ({"openai": True}, True),
+        # ...whereas a config that enables nothing is a withhold, so that turning
+        # every provider off cannot leave search reachable via one not named
+        (
+            WebSearchProviders(
+                openai=False,
+                anthropic=False,
+                grok=False,
+                gemini=False,
+                mistral=False,
+                perplexity=False,
+            ),
+            False,
+        ),
+    ],
+)
+def test_sandbox_web_search_resolution(value: Any, granted: bool) -> None:
+    resolved = resolve_bridge_web_search(value, default_grant=False)
+    assert (resolved is not None) is granted
+
+
+def test_in_process_web_search_defaults_to_granted() -> None:
+    assert resolve_bridge_web_search(None, default_grant=True) is not None
+
+
+def test_sandbox_and_in_process_grants_are_the_same_provider_set() -> None:
+    assert resolve_bridge_web_search(True, default_grant=False) == (
+        resolve_bridge_web_search(None, default_grant=True)
+    )
+
+
+@pytest.mark.parametrize(
+    "value,granted", [(None, False), (False, False), (True, True), ({}, True)]
+)
+def test_sandbox_code_execution_resolution(value: Any, granted: bool) -> None:
+    assert (resolve_bridge_code_execution(value, default_grant=False) is not None) is (
+        granted
+    )
+
+
+# --- tool mapping -----------------------------------------------------------
+
+
+def test_responses_native_tools_withheld_by_default() -> None:
+    web_search = resolve_bridge_web_search(None, default_grant=False)
+    code_execution = resolve_bridge_code_execution(None, default_grant=False)
+
+    assert (
+        tools_from_responses_tool(
+            WEB_SEARCH_PARAM, web_search, code_execution, allow_remote_mcp=False
+        )
+        == []
+    )
+    assert (
+        tools_from_responses_tool(
+            MCP_PARAM, web_search, code_execution, allow_remote_mcp=False
+        )
+        == []
+    )
+
+
+def test_responses_native_tools_honored_when_granted() -> None:
+    web_search = resolve_bridge_web_search(True, default_grant=False)
+    code_execution = resolve_bridge_code_execution(True, default_grant=False)
+
+    assert (
+        len(
+            tools_from_responses_tool(
+                WEB_SEARCH_PARAM, web_search, code_execution, allow_remote_mcp=True
+            )
+        )
+        == 1
+    )
+    mcp = tools_from_responses_tool(
+        MCP_PARAM, web_search, code_execution, allow_remote_mcp=True
+    )
+    assert [getattr(t, "name", None) for t in mcp] == ["mcp_server_elsewhere"]
+
+
+def test_responses_function_tools_are_never_withheld() -> None:
+    """Function tools run inside the sandbox, so they are always forwarded."""
+    tools = tools_from_responses_tool(
+        cast(
+            Any,
+            {
+                "type": "function",
+                "name": "grep",
+                "description": "search files",
+                "parameters": {"type": "object", "properties": {}},
+                "strict": False,
+            },
+        ),
+        None,
+        None,
+        allow_remote_mcp=False,
+    )
+    assert [getattr(t, "name", None) for t in tools] == ["grep"]
+
+
+def test_anthropic_native_tools_withheld_by_default() -> None:
+    assert (
+        tools_from_anthropic_tools(
+            [ANTHROPIC_WEB_SEARCH], [ANTHROPIC_MCP_SERVER], None, None, False
+        )
+        == []
+    )
+
+
+def test_anthropic_native_tools_honored_when_granted() -> None:
+    tools = tools_from_anthropic_tools(
+        [ANTHROPIC_WEB_SEARCH],
+        [ANTHROPIC_MCP_SERVER],
+        resolve_bridge_web_search(True, default_grant=False),
+        None,
+        True,
+    )
+    assert len(tools) == 2
+    assert "mcp_server_elsewhere" in [getattr(t, "name", None) for t in tools]
+
+
+@pytest.mark.parametrize("granted", [False, True])
+def test_anthropic_web_fetch_alone_grants_nothing(granted: bool) -> None:
+    """web_fetch rides a granted web_search; alone it maps to nothing either way.
+
+    Withheld, it must not re-enable search. Granted, mapping it to `web_search`
+    would hand the client the search capability it did not declare.
+    """
+    assert (
+        tools_from_anthropic_tools(
+            [cast(Any, {"type": "web_fetch_20250910", "name": "web_fetch"})],
+            None,
+            resolve_bridge_web_search(granted, default_grant=False),
+            None,
+            False,
+        )
+        == []
+    )
+
+
+# --- tool choice ------------------------------------------------------------
+
+
+def test_tool_choice_forcing_a_withheld_tool_relaxes_to_auto() -> None:
+    """A forced choice at a missing tool makes the model layer purge *all* tools."""
+    tools = tools_from_responses_tool(
+        cast(
+            Any,
+            {
+                "type": "function",
+                "name": "grep",
+                "description": "search files",
+                "parameters": {"type": "object", "properties": {}},
+                "strict": False,
+            },
+        ),
+        None,
+        None,
+        allow_remote_mcp=False,
+    )
+    assert (
+        relax_tool_choice_for_withheld(ToolFunction(name="web_search"), tools) == "auto"
+    )
+
+
+@pytest.mark.parametrize("choice", [None, "auto", "any", "none", ToolFunction("grep")])
+def test_tool_choice_otherwise_passes_through(choice: Any) -> None:
+    tools = [ToolInfo(name="grep", description="search files")]
+    assert relax_tool_choice_for_withheld(choice, tools) == choice
+
+
+# --- media ------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "http://elsewhere.example/x.png",
+        "https://elsewhere.example/x.png",
+        "/etc/hosts",
+        "s3://bucket/key.png",
+        "file:///etc/hosts",
+    ],
+)
+def test_sandbox_media_must_be_inline(uri: str) -> None:
+    bridge = sandbox_bridge()
+    messages = [ChatMessageUser(content=[ContentImage(image=uri)])]
+    with pytest.raises(BridgePolicyError) as info:
+        validate_bridge_media(bridge, messages)
+    assert info.value.status_code == 400
+
+
+def test_sandbox_media_covers_non_uri_locators() -> None:
+    """A bare document/audio value is a *locator*, not a payload.
+
+    `ContentDocument.document` and `ContentAudio.audio` reach the provider through
+    `file_as_data`, which opens anything that isn't a `data:` URI off the host
+    filesystem — so an Anthropic `source={"type": "text"}` document carrying
+    "/etc/hosts" inlines that file into the request. The guard has to cover these
+    even though the wire shape looks inline.
+    """
+    for content in (
+        ContentDocument(document="/etc/hosts", mime_type="text/plain"),
+        ContentAudio(audio="/etc/hosts", format="mp3"),
+    ):
+        with pytest.raises(BridgePolicyError):
+            validate_bridge_media(
+                sandbox_bridge(), [ChatMessageUser(content=[content])]
+            )
+
+
+def test_sandbox_media_allows_data_uri() -> None:
+    messages = [
+        ChatMessageUser(content=[ContentImage(image="data:image/png;base64,AAAA")])
+    ]
+    validate_bridge_media(sandbox_bridge(), messages)
+
+
+def test_sandbox_media_covers_documents() -> None:
+    messages = [
+        ChatMessageUser(content=[ContentDocument(document="https://elsewhere/x.pdf")])
+    ]
+    with pytest.raises(BridgePolicyError):
+        validate_bridge_media(sandbox_bridge(), messages)
+
+
+def test_in_process_media_is_unrestricted() -> None:
+    messages = [ChatMessageUser(content=[ContentImage(image="http://elsewhere/x.png")])]
+    validate_bridge_media(AgentBridge(AgentState(messages=[])), messages)
+
+
+def test_sandbox_media_can_be_re_enabled() -> None:
+    messages = [ChatMessageUser(content=[ContentImage(image="http://elsewhere/x.png")])]
+    validate_bridge_media(sandbox_bridge(allow_remote_media=True), messages)

--- a/tests/agent/test_bridge_tool_search.py
+++ b/tests/agent/test_bridge_tool_search.py
@@ -68,7 +68,10 @@ def _discoverable_function_tool() -> dict[str, Any]:
 
 def test_tool_from_responses_tool_tool_search() -> None:
     tool = tool_from_responses_tool(
-        _tool_search_tool_param(), WEB_SEARCH_PROVIDERS, CODE_EXECUTION_PROVIDERS
+        _tool_search_tool_param(),
+        WEB_SEARCH_PROVIDERS,
+        CODE_EXECUTION_PROVIDERS,
+        allow_remote_mcp=True,
     )
     assert isinstance(tool, ToolInfo)
     assert tool.name == TOOL_SEARCH_NAME
@@ -83,7 +86,10 @@ def test_tool_from_responses_tool_tool_search() -> None:
 
 def test_maybe_tool_search_tool_emits_native_param() -> None:
     tool = tool_from_responses_tool(
-        _tool_search_tool_param(), WEB_SEARCH_PROVIDERS, CODE_EXECUTION_PROVIDERS
+        _tool_search_tool_param(),
+        WEB_SEARCH_PROVIDERS,
+        CODE_EXECUTION_PROVIDERS,
+        allow_remote_mcp=True,
     )
     assert isinstance(tool, ToolInfo)
 


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? 

A bridged agent running in a sandbox with no network egress can still reach the web,
by asking the model proxy for it.

The bridge maps a client's *declared* tools into Inspect tools. For function tools that
is the whole point — they run inside the sandbox. But the same mapping accepts
**native** tools, which run at the provider:

- `{"type": "web_search"}` (Responses), `web_search_20250305` (Anthropic),
  `googleSearch` / `googleSearchRetrieval` (Google) → `web_search()`
- `code_interpreter` / `code_execution_*` / `codeExecution` → `code_execution()`
- Anthropic top-level `mcp_servers` and Responses `{"type": "mcp", "server_url": …,
  "headers": …}` → hosted MCP, where the *provider* dials an attacker-chosen URL with
  attacker-chosen headers

So the client's declaration granted the capability rather than narrowing it. Setting
`web_search=` on the bridge could not express "off" either: a `WebSearchProviders` with
every provider `False` still produced a web_search tool, because an empty normalized
config falls back to the default provider set.

Separately, media content was a confused-deputy read primitive. A URL or path in an
image/document/audio block reaches `file_as_data`, which the **Inspect host process**
resolves: `httpx.get()` for http(s), fsspec `open_file()` for everything else. A
sandboxed agent could make the host fetch an arbitrary URL (an exfil channel as much as
an ingest one) or read `/etc/hosts`, `s3://…` with host credentials, and inline the
result into its own prompt. The Anthropic `{"source": {"type": "text"}}` document shape
does this too — that value is a locator, not inline text.

Reproduced end to end from a `network_mode: none` sandbox: codex issued `web_search`
with `name: "open_page"` against arbitrary URLs and got page content back; Claude Code's
nested request carried `web_fetch_20250910`. This class of issue was reported to us
against a peer project's model proxy; we verified the same holes here.

### What is the new behavior?

The scaffold declares what a bridged agent may reach; the client's declaration can only
narrow it, never grant it.

`agent_bridge()` and `sandbox_agent_bridge()` take `web_search`, `code_execution` and
`client_mcp_servers`. `web_search` / `code_execution` accept `True` (grant, using the
default providers), a providers config (grant, with that routing), or `False` / `None`
(withhold). A withheld tool is dropped from the request and reported through
`warn_once`, since an absent tool is otherwise indistinguishable from the model choosing
not to call it.

**Defaults differ by bridge, deliberately.** `sandbox_agent_bridge()` withholds by
default; in-process `agent_bridge()` keeps today's permissive defaults. An in-process
scaffold already runs with the host's network and filesystem, so there is no boundary
there to defend — and scoping it this way means no in-process consumer changed
(all 11 live-API bridge tests and both web-research examples pass unmodified).

Media content on a sandboxed bridge must be inline. Anything that is not a `data:` URI
raises `BridgePolicyError`, which carries `status_code = 400` so the agent gets a clean
provider error rather than a host traceback. In-process bridges are unrestricted, same
rationale as above.

Two details worth calling out:

- **Forced tool choice.** If a client forces `tool_choice` at a tool we withhold, the
  model layer filters the tool list empty and then purges *every* tool for that turn —
  withholding search would have silently taken the agent's own function tools with it.
  `relax_tool_choice_for_withheld` falls back to `"auto"` instead.
- **Anthropic `web_fetch`.** Fetch has no standalone Inspect tool; it rides along with a
  granted `web_search` (the provider emits both). A lone `web_fetch` declaration
  therefore maps to nothing, and now warns when search is withheld. Mapping it to
  `web_search` would hand the client a capability it never declared.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes, for `sandbox_agent_bridge()` only. A sandboxed scaffold that relied on
client-declared native web search, code execution or remote MCP now has to be granted
it: `sandbox_agent_bridge(web_search=True)`. The failure mode is a degraded eval rather
than an error, which is why the drop warns.

The affected consumer is inspect_swe, whose claude_code / codex_cli / gemini_cli all
obtain search this way (via a nested native sub-request, not from the sandbox).
meridianlabs-ai/inspect_swe#116 wires each agent's existing setting into the grant and
requires this release.

In-process `agent_bridge()` is unchanged.

### Other information:

New tests in `tests/agent/test_bridge_tool_grants.py` (35) cover the resolution matrix
including the all-providers-`False` config, per-dialect withhold/grant for Responses,
Anthropic and Google, function tools never being withheld, tool-choice relaxation, and
the media guard — including the non-URI locator shapes that look inline but are opened
off the host filesystem.

Docs: new "Granted Capabilities" section in `docs/agent-bridge.qmd`.

Verified live on a `network_mode: none` docker sandbox: with the grant wired up, codex
gets `web_search`, claude_code gets `web_search_20250305` + `web_fetch_20250910`, and
gemini gets `googleSearch`, all answering correctly; codex with `web_search="disabled"`
reaches the model with no web tools at all.

### Agent review
- Reviewer: code-review subagent, fresh context, 1 pass
- Findings: 2 — 1 fixed (a withheld Anthropic `web_fetch` was dropped without the
  warning the rest of the change emits), 1 dismissed (reported that inline Anthropic
  text documents and inline OpenAI base64 audio were being wrongly rejected; both were
  reproduced through their real converters as host *path* reads — `"Hello inline world"`
  raises `FileNotFoundError` on that path, `"/etc/hosts"` succeeds and inlines the file —
  so rejecting them is the fix, not a regression).
