### PR TITLE
Expose the resolved plan on the TaskStart hook event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- Hooks: `on_task_start` now receives the resolved solver plan as `data.plan`, including any `Task.setup` solvers.
+
 ## 0.3.255 (09 August 2026)
 
 - Sandbox Agent Bridge: Agents can no longer reach the web via provider web search, code execution, or remote MCP unless the eval grants it.

--- a/docs/extensions-hooks.qmd
+++ b/docs/extensions-hooks.qmd
@@ -59,7 +59,7 @@ These events bracket the execution of evaluations. A single `eval()` (or `eval_r
 | `on_eval_set_end` | `EvalSetEnd` | When an eval set finishes. |
 | `on_run_start` | `RunStart` | At the start of a single `eval()` / `eval_retry()` invocation (`data.task_names` lists the tasks to run). |
 | `on_run_end` | `RunEnd` | At the end of a run — `data.exception` and `data.logs` carry the outcome. |
-| `on_task_start` | `TaskStart` | When a task begins executing (`data.spec` is the `EvalSpec`). |
+| `on_task_start` | `TaskStart` | When a task begins executing (`data.spec` is the `EvalSpec`; `data.plan` is the resolved `EvalPlan`, including any `Task.setup` steps). |
 | `on_task_end` | `TaskEnd` | When a task completes (`data.log` is the `EvalLog`). |
 
 ### Sample

--- a/docs/extensions-hooks.qmd
+++ b/docs/extensions-hooks.qmd
@@ -59,7 +59,7 @@ These events bracket the execution of evaluations. A single `eval()` (or `eval_r
 | `on_eval_set_end` | `EvalSetEnd` | When an eval set finishes. |
 | `on_run_start` | `RunStart` | At the start of a single `eval()` / `eval_retry()` invocation (`data.task_names` lists the tasks to run). |
 | `on_run_end` | `RunEnd` | At the end of a run — `data.exception` and `data.logs` carry the outcome. |
-| `on_task_start` | `TaskStart` | When a task begins executing (`data.spec` is the `EvalSpec`; `data.plan` is the resolved `EvalPlan`, including any `Task.setup` steps). |
+| `on_task_start` | `TaskStart` | When a task begins executing (`data.spec` is the `EvalSpec`; `data.plan` is the resolved `EvalPlan`). |
 | `on_task_end` | `TaskEnd` | When a task completes (`data.log` is the `EvalLog`). |
 
 ### Sample

--- a/docs/extensions-hooks.qmd
+++ b/docs/extensions-hooks.qmd
@@ -47,7 +47,7 @@ def wandb_hooks():
 
 ## Hook Events {#sec-hook-events}
 
-Each event method is `async`, returns `None`, and receives a single immutable data object carrying the details of the event. Implement only the methods you need. The events below are grouped by lifecycle level, from the outermost scope (an entire `eval_set()`) down to individual model calls. All of the data types are importable from `inspect_ai.hooks`; see the [`inspect_ai.hooks`](reference/inspect_ai.hooks.qmd) reference for their full field definitions.
+Each event method is `async`, returns `None`, and receives a single data object carrying the details of the event. Treat that data as read-only: the event class itself is frozen, but the models nested inside it are not, and some of them are the objects Inspect goes on to write to the log. Implement only the methods you need. The events below are grouped by lifecycle level, from the outermost scope (an entire `eval_set()`) down to individual model calls. All of the data types are importable from `inspect_ai.hooks`; see the [`inspect_ai.hooks`](reference/inspect_ai.hooks.qmd) reference for their full field definitions.
 
 ### Run and Task
 

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -940,9 +940,10 @@ async def log_start(
     logger: TaskLogger,
     plan: Plan,
     config: GenerateConfig,
-) -> None:
+) -> EvalPlan:
     eval_plan = plan_to_eval_plan(plan, config)
     await logger.log_start(eval_plan)
+    return eval_plan
 
 
 def collect_eval_data(stats: EvalStats) -> None:

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -938,12 +938,9 @@ def plan_to_eval_plan(plan: Plan, config: GenerateConfig) -> EvalPlan:
 
 async def log_start(
     logger: TaskLogger,
-    plan: Plan,
-    config: GenerateConfig,
-) -> EvalPlan:
-    eval_plan = plan_to_eval_plan(plan, config)
-    await logger.log_start(eval_plan)
-    return eval_plan
+    plan: EvalPlan,
+) -> None:
+    await logger.log_start(plan)
 
 
 def collect_eval_data(stats: EvalStats) -> None:

--- a/src/inspect_ai/_eval/task/log.py
+++ b/src/inspect_ai/_eval/task/log.py
@@ -936,13 +936,6 @@ def plan_to_eval_plan(plan: Plan, config: GenerateConfig) -> EvalPlan:
     return eval_plan
 
 
-async def log_start(
-    logger: TaskLogger,
-    plan: EvalPlan,
-) -> None:
-    await logger.log_start(plan)
-
-
 def collect_eval_data(stats: EvalStats) -> None:
     from inspect_ai.log._log import ConnectionLimitChange
     from inspect_ai.util._concurrency import adaptive_controllers

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -687,7 +687,7 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
     ) as td:
         # start the log (do this outside fo the try b/c the try/except assumes
         # that the log is initialized)
-        await log_start(logger, plan, generate_config)
+        eval_plan = await log_start(logger, plan, generate_config)
 
         try:
             # return immediately if we are not running samples
@@ -695,7 +695,7 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
                 return await logger.log_finish("started", stats)
 
             # call hook
-            await emit_task_start(logger)
+            await emit_task_start(logger, eval_plan)
 
             sample_semaphore = create_sample_semaphore(
                 config,

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -185,7 +185,7 @@ from .images import (
     state_without_base64_content,
     states_with_base64_content,
 )
-from .log import TaskLogger, collect_eval_data, log_start
+from .log import TaskLogger, collect_eval_data, log_start, plan_to_eval_plan
 from .results import eval_results
 from .sample_source import (
     SampleEnqueuer,
@@ -687,7 +687,8 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
     ) as td:
         # start the log (do this outside fo the try b/c the try/except assumes
         # that the log is initialized)
-        eval_plan = await log_start(logger, plan, generate_config)
+        eval_plan = plan_to_eval_plan(plan, generate_config)
+        await log_start(logger, eval_plan)
 
         try:
             # return immediately if we are not running samples

--- a/src/inspect_ai/_eval/task/run.py
+++ b/src/inspect_ai/_eval/task/run.py
@@ -185,7 +185,7 @@ from .images import (
     state_without_base64_content,
     states_with_base64_content,
 )
-from .log import TaskLogger, collect_eval_data, log_start, plan_to_eval_plan
+from .log import TaskLogger, collect_eval_data, plan_to_eval_plan
 from .results import eval_results
 from .sample_source import (
     SampleEnqueuer,
@@ -688,7 +688,7 @@ async def task_run(options: TaskRunOptions, task_cancel: TaskCancel | None) -> E
         # start the log (do this outside fo the try b/c the try/except assumes
         # that the log is initialized)
         eval_plan = plan_to_eval_plan(plan, generate_config)
-        await log_start(logger, eval_plan)
+        await logger.log_start(eval_plan)
 
         try:
             # return immediately if we are not running samples

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -99,12 +99,15 @@ class TaskStart:
     eval_id: str
     """The globally unique identifier for this task execution."""
     spec: EvalSpec
-    """Specification of the task."""
-    plan: EvalPlan
-    """All solvers that will be run, in order.
+    """Specification of the task.
 
-    A ``finish`` solver appears both in ``finish`` and as the last entry of
-    ``steps``, so iterating ``steps`` counts it twice.
+    Do not mutate: this is the object the recorder holds until the final log
+    write, so changing it here corrupts the written log header.
+    """
+    plan: EvalPlan
+    """All solvers that will be run, in order. Note that a ``finish`` solver is
+    reported both in ``finish`` and as the last entry of ``steps``, so read one
+    or the other, not both.
 
     Do not mutate: this is the object the recorder holds until the final log
     write, so changing it here corrupts the written log header.

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -1,5 +1,5 @@
 import math
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from logging import getLogger
 from typing import Awaitable, Callable, Literal, Type, TypeVar, cast
 
@@ -100,7 +100,7 @@ class TaskStart:
     """The globally unique identifier for this task execution."""
     spec: EvalSpec
     """Specification of the task."""
-    plan: EvalPlan = field(default_factory=EvalPlan)
+    plan: EvalPlan
     """Solvers that will be run, in order, including setup solvers."""
 
 

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -105,9 +105,10 @@ class TaskStart:
     write, so changing it here corrupts the written log header.
     """
     plan: EvalPlan
-    """All solvers that will be run, in order. Note that a ``finish`` solver is
-    reported both in ``finish`` and as the last entry of ``steps``, so read one
-    or the other, not both.
+    """All solvers that will be run, in order.
+
+    Note that a ``finish`` solver is reported both in ``finish`` and as the
+    last entry of ``steps``, so read one or the other, not both.
 
     Do not mutate: this is the object the recorder holds until the final log
     write, so changing it here corrupts the written log header.

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -101,7 +101,7 @@ class TaskStart:
     spec: EvalSpec
     """Specification of the task."""
     plan: EvalPlan
-    """Solvers that will be run, in order, including setup solvers.
+    """All solvers that will be run, in order.
 
     A ``finish`` solver appears both in ``finish`` and as the last entry of
     ``steps``, so iterating ``steps`` counts it twice.

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -1,5 +1,5 @@
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from logging import getLogger
 from typing import Awaitable, Callable, Literal, Type, TypeVar, cast
 
@@ -100,12 +100,8 @@ class TaskStart:
     """The globally unique identifier for this task execution."""
     spec: EvalSpec
     """Specification of the task."""
-    plan: EvalPlan
-    """Solvers that will run, in order.
-
-    `Task.setup` steps are unrolled into the front of the plan by `resolve_plan`,
-    so they appear here too and are not distinguishable from solver steps.
-    """
+    plan: EvalPlan = field(default_factory=EvalPlan)
+    """Solvers that will be run, in order, including setup solvers."""
 
 
 @dataclass(frozen=True)

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -101,7 +101,14 @@ class TaskStart:
     spec: EvalSpec
     """Specification of the task."""
     plan: EvalPlan
-    """Solvers that will be run, in order, including setup solvers."""
+    """Solvers that will be run, in order, including setup solvers.
+
+    A ``finish`` solver appears both in ``finish`` and as the last entry of
+    ``steps``, so iterating ``steps`` counts it twice.
+
+    Do not mutate: this is the object the recorder holds until the final log
+    write, so changing it here corrupts the written log header.
+    """
 
 
 @dataclass(frozen=True)

--- a/src/inspect_ai/hooks/_hooks.py
+++ b/src/inspect_ai/hooks/_hooks.py
@@ -18,7 +18,13 @@ from inspect_ai._util.registry import (
 )
 from inspect_ai.event import Event
 from inspect_ai.hooks._legacy import override_api_key_legacy
-from inspect_ai.log._log import EvalLog, EvalSample, EvalSampleSummary, EvalSpec
+from inspect_ai.log._log import (
+    EvalLog,
+    EvalPlan,
+    EvalSample,
+    EvalSampleSummary,
+    EvalSpec,
+)
 from inspect_ai.log._samples import sample_active
 from inspect_ai.model._chat_message import ChatMessage
 from inspect_ai.model._generate_config import GenerateConfig
@@ -94,6 +100,12 @@ class TaskStart:
     """The globally unique identifier for this task execution."""
     spec: EvalSpec
     """Specification of the task."""
+    plan: EvalPlan
+    """Solvers that will run, in order.
+
+    `Task.setup` steps are unrolled into the front of the plan by `resolve_plan`,
+    so they appear here too and are not distinguishable from solver steps.
+    """
 
 
 @dataclass(frozen=True)
@@ -646,12 +658,13 @@ async def emit_run_end(
     await _emit_to_all(lambda hook: hook.on_run_end(data))
 
 
-async def emit_task_start(logger: TaskLogger) -> None:
+async def emit_task_start(logger: TaskLogger, plan: EvalPlan) -> None:
     data = TaskStart(
         eval_set_id=logger.eval.eval_set_id,
         run_id=logger.eval.run_id,
         eval_id=logger.eval.eval_id,
         spec=logger.eval,
+        plan=plan,
     )
     await _emit_to_all(lambda hook: hook.on_task_start(data))
 

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -186,6 +186,21 @@ def test_can_subscribe_to_events(mock_hooks: MockHooks) -> None:
     assert before_gen.task_name is not None
 
 
+def test_task_start_carries_plan_including_setup_steps(
+    mock_hooks: MockHooks,
+) -> None:
+    eval(
+        Task(dataset=[Sample("sample_1")], setup=_setup_marker_solver()),
+        model="mockllm/model",
+    )
+
+    assert len(mock_hooks.task_start_events) == 1
+    steps = [step.solver for step in mock_hooks.task_start_events[0].plan.steps]
+    # resolve_plan unrolls setup onto the front, ahead of the solver
+    assert "_setup_marker_solver" in steps[0]
+    assert len(steps) > 1
+
+
 def test_can_subscribe_to_events_with_multiple_hooks(
     mock_hooks: MockHooks, hooks_2: MockHooks
 ) -> None:
@@ -680,6 +695,16 @@ def _create_mock_hooks(name: str, hooks_class: Type[T]) -> Generator[T, None, No
     finally:
         # Remove the hook from the registry to avoid conflicts in other tests.
         del _registry[f"hooks:{name}"]
+
+
+@solver
+def _setup_marker_solver() -> Solver:
+    """No-op setup step, so the plan has a setup entry to find."""
+
+    async def solve(state: TaskState, generate: Generate) -> TaskState:
+        return state
+
+    return solve
 
 
 @solver

--- a/tests/hooks/test_hooks.py
+++ b/tests/hooks/test_hooks.py
@@ -189,10 +189,9 @@ def test_can_subscribe_to_events(mock_hooks: MockHooks) -> None:
 def test_task_start_carries_plan_including_setup_steps(
     mock_hooks: MockHooks,
 ) -> None:
-    eval(
-        Task(dataset=[Sample("sample_1")], setup=_setup_marker_solver()),
-        model="mockllm/model",
-    )
+    task = Task(dataset=[Sample("sample_1")], setup=_setup_marker_solver())
+
+    eval(task, model="mockllm/model")
 
     assert len(mock_hooks.task_start_events) == 1
     steps = [step.solver for step in mock_hooks.task_start_events[0].plan.steps]

--- a/tests/hooks/test_mlflow_tracing.py
+++ b/tests/hooks/test_mlflow_tracing.py
@@ -23,6 +23,7 @@ from inspect_ai.log._log import (
     EvalDataset,
     EvalLog,
     EvalMetric,
+    EvalPlan,
     EvalResults,
     EvalSample,
     EvalScore,
@@ -210,7 +211,13 @@ async def test_task_span_nested_under_run(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         assert mock_mlflow.start_span_no_context.call_count == 2
@@ -234,7 +241,13 @@ async def test_task_end_logs_scores_and_closes_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         log = EvalLog(
@@ -287,7 +300,13 @@ async def test_sample_span_nested_under_task(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -324,7 +343,13 @@ async def test_sample_end_logs_scores_and_output(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -379,7 +404,13 @@ async def test_model_event_creates_llm_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -449,7 +480,13 @@ async def test_tool_event_creates_tool_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -516,7 +553,13 @@ async def test_tool_event_with_error(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -575,7 +618,13 @@ async def test_score_event_creates_evaluator_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -635,7 +684,13 @@ async def test_span_begin_end_events_create_hierarchy(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -707,7 +762,13 @@ async def test_nested_inspect_spans_preserve_hierarchy(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -819,7 +880,13 @@ async def test_model_event_with_error(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(
@@ -880,7 +947,13 @@ async def test_model_event_with_cache_hit(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
         await hook.on_sample_start(
             SampleStart(

--- a/tests/hooks/test_mlflow_tracing.py
+++ b/tests/hooks/test_mlflow_tracing.py
@@ -23,7 +23,6 @@ from inspect_ai.log._log import (
     EvalDataset,
     EvalLog,
     EvalMetric,
-    EvalPlan,
     EvalResults,
     EvalSample,
     EvalScore,
@@ -211,13 +210,7 @@ async def test_task_span_nested_under_run(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         assert mock_mlflow.start_span_no_context.call_count == 2
@@ -241,13 +234,7 @@ async def test_task_end_logs_scores_and_closes_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         log = EvalLog(
@@ -300,13 +287,7 @@ async def test_sample_span_nested_under_task(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -343,13 +324,7 @@ async def test_sample_end_logs_scores_and_output(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -404,13 +379,7 @@ async def test_model_event_creates_llm_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -480,13 +449,7 @@ async def test_tool_event_creates_tool_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -553,13 +516,7 @@ async def test_tool_event_with_error(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -618,13 +575,7 @@ async def test_score_event_creates_evaluator_span(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -684,13 +635,7 @@ async def test_span_begin_end_events_create_hierarchy(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -762,13 +707,7 @@ async def test_nested_inspect_spans_preserve_hierarchy(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -880,13 +819,7 @@ async def test_model_event_with_error(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(
@@ -947,13 +880,7 @@ async def test_model_event_with_cache_hit(tracing_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["t"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
         await hook.on_sample_start(
             SampleStart(

--- a/tests/hooks/test_mlflow_tracking.py
+++ b/tests/hooks/test_mlflow_tracking.py
@@ -23,6 +23,7 @@ from inspect_ai.log._log import (
     EvalDataset,
     EvalLog,
     EvalMetric,
+    EvalPlan,
     EvalResults,
     EvalSample,
     EvalScore,
@@ -197,6 +198,7 @@ async def test_task_lifecycle(mlflow_env):
                 run_id="run-001",
                 eval_id="eval-001",
                 spec=spec,
+                plan=EvalPlan(),
             )
         )
 
@@ -262,7 +264,13 @@ async def test_sample_scores_logged_as_step_metrics(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         sample_0 = _make_sample(
@@ -372,7 +380,13 @@ async def test_sample_event_model_call(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         model_event = ModelEvent(
@@ -419,7 +433,13 @@ async def test_sample_event_tool_call(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         tool_event = ToolEvent(
@@ -494,7 +514,13 @@ async def test_event_counts_logged_on_task_end(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         # Send 2 model events and 1 tool event
@@ -568,7 +594,13 @@ async def test_artifact_logging_sample_table(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         samples = [
@@ -639,7 +671,13 @@ async def test_artifact_logging_disabled(mlflow_env, monkeypatch: pytest.MonkeyP
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         log = EvalLog(
@@ -678,7 +716,13 @@ async def test_artifact_logging_no_samples(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
+            TaskStart(
+                eval_set_id=None,
+                run_id="run-001",
+                eval_id="eval-001",
+                spec=spec,
+                plan=EvalPlan(),
+            )
         )
 
         log = EvalLog(

--- a/tests/hooks/test_mlflow_tracking.py
+++ b/tests/hooks/test_mlflow_tracking.py
@@ -23,7 +23,6 @@ from inspect_ai.log._log import (
     EvalDataset,
     EvalLog,
     EvalMetric,
-    EvalPlan,
     EvalResults,
     EvalSample,
     EvalScore,
@@ -198,7 +197,6 @@ async def test_task_lifecycle(mlflow_env):
                 run_id="run-001",
                 eval_id="eval-001",
                 spec=spec,
-                plan=EvalPlan(),
             )
         )
 
@@ -264,13 +262,7 @@ async def test_sample_scores_logged_as_step_metrics(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         sample_0 = _make_sample(
@@ -380,13 +372,7 @@ async def test_sample_event_model_call(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         model_event = ModelEvent(
@@ -433,13 +419,7 @@ async def test_sample_event_tool_call(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         tool_event = ToolEvent(
@@ -514,13 +494,7 @@ async def test_event_counts_logged_on_task_end(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         # Send 2 model events and 1 tool event
@@ -594,13 +568,7 @@ async def test_artifact_logging_sample_table(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         samples = [
@@ -671,13 +639,7 @@ async def test_artifact_logging_disabled(mlflow_env, monkeypatch: pytest.MonkeyP
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         log = EvalLog(
@@ -716,13 +678,7 @@ async def test_artifact_logging_no_samples(mlflow_env):
             RunStart(eval_set_id=None, run_id="run-001", task_names=["test_task"])
         )
         await hook.on_task_start(
-            TaskStart(
-                eval_set_id=None,
-                run_id="run-001",
-                eval_id="eval-001",
-                spec=spec,
-                plan=EvalPlan(),
-            )
+            TaskStart(eval_set_id=None, run_id="run-001", eval_id="eval-001", spec=spec)
         )
 
         log = EvalLog(


### PR DESCRIPTION
## Description

I want to add an `on_task_start` hook to verify that a setup solver is added to the each task. However, `EvalSpec` doesn't include setup solvers. This PR attempts to add `EvalPlan` to `on_task_start` so that task start hooks can check setup solvers.

Note that I'm not familiar enough with Inspect internal so this might be the wrong approach. But since it's easy to ask Claude to open a draft PR so here we are. There are two things that I'm concerned about:
1. **Whether the plan is finalised before `on_task_start` hook fires** - Claude thinks yes. I only scanned through the reasoning quickly but it seems reasonable.
2. **This might be a breaking change** - some tests that construct `TaskStart` events might break if we don't set a `default` value. So I set a default value even though technically only Inspect should create `TaskStart` objects at run time. Happy to remove the default value if we think backward compatibility for tests aren't required, and that ensuring `EvalPlan` is supplied whenever `TaskStart` event is constructed is more valuable.]

Alternative considered:
* Updating `EvalSpec` to include `setup` key similar to `solver`. But `EvalSpec` is also a file storage format and changing it is quite a bit more involved and I'm not up for the task at the moment.
* I'm currently working around this by stamping the eval with some metadata whenever I add the solver in the `setup` task. So this PR isn't really blocking me. Happy to do what's right.