### PR TITLE
fix(score): append merges log.reductions instead of replacing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Security: Parse `math()` scorer answers with a non-evaluating grammar under a bounded worker thread, preventing model output from executing Python on the evaluator host.
 - Hooks: `on_task_start` now receives the resolved solver plan as `data.plan`, including any `Task.setup` solvers.
+- Scoring: `score(action="append")` now merges `log.reductions` with the reductions already in the log instead of replacing them, so reductions from previously-run scorers are no longer dropped.
 
 ## 0.3.255 (09 August 2026)
 

--- a/src/inspect_ai/_eval/score.py
+++ b/src/inspect_ai/_eval/score.py
@@ -44,7 +44,7 @@ from inspect_ai.log import (
     EvalLog,
 )
 from inspect_ai.log._condense import resolve_sample_attachments
-from inspect_ai.log._log import EvalMetricDefinition, EvalSample
+from inspect_ai.log._log import EvalMetricDefinition, EvalSample, EvalSampleReductions
 from inspect_ai.log._resolve import rebind_sample_timelines
 from inspect_ai.log._score import _find_scorers_span
 from inspect_ai.log._transcript import Transcript, init_transcript, transcript
@@ -168,6 +168,46 @@ def _get_updated_scores(
         updated_scores[new_key] = score.score
 
     return updated_scores
+
+
+def _get_updated_reductions(
+    existing: list[EvalSampleReductions] | None,
+    reductions: list[EvalSampleReductions] | None,
+    action: ScoreAction,
+) -> list[EvalSampleReductions] | None:
+    """Merge the reductions produced by this scoring pass into the log's.
+
+    A scoring pass only computes reductions for the scorers it ran, so for
+    "append" the pre-existing entries have to be carried over. Without this,
+    results.scores keeps an entry for every scorer while reductions keeps only
+    the last pass's, and the two disagree about which scorers the log contains.
+
+    A reduction is identified by (scorer, reducer): the same scorer reduced two
+    different ways is two entries, so both fields take part in the key. When a
+    pass recomputes a pair that is already present, the fresh entry replaces the
+    old one in place rather than being appended beside it, which keeps the list
+    usable as a lookup by scorer.
+    """
+    if action == "overwrite":
+        return reductions
+
+    if not existing:
+        return reductions
+    if not reductions:
+        return existing
+
+    merged = list(existing)
+    positions = {(r.scorer, r.reducer): i for i, r in enumerate(merged)}
+    for reduction in reductions:
+        key = (reduction.scorer, reduction.reducer)
+        index = positions.get(key)
+        if index is None:
+            positions[key] = len(merged)
+            merged.append(reduction)
+        else:
+            merged[index] = reduction
+
+    return merged
 
 
 def _get_updated_events(
@@ -379,7 +419,7 @@ async def score_async(
         # Since the metrics calculation above is only be done using the scorers
         # and scores that were generated during this scoring run, we need to process
         # the results carefully, depending upon whether the action was "append" or "overwrite"
-        log.reductions = reductions
+        log.reductions = _get_updated_reductions(log.reductions, reductions, action)
         if action == "overwrite" or log.results is None:
             # Completely replace the results with the new results
             log.results = results

--- a/tests/_eval/test_score.py
+++ b/tests/_eval/test_score.py
@@ -11,6 +11,7 @@ from inspect_ai import score
 from inspect_ai._eval.score import (
     ScoreAction,
     _get_updated_events,
+    _get_updated_reductions,
     _get_updated_scores,
     resolve_scorers,
     score_async,
@@ -23,6 +24,8 @@ from inspect_ai.event._sample_init import SampleInitEvent
 from inspect_ai.event._score import ScoreEvent
 from inspect_ai.log import (
     EvalSample,
+    EvalSampleReductions,
+    EvalSampleScore,
     Transcript,
 )
 from inspect_ai.log._file import read_eval_log, read_eval_log_async
@@ -99,6 +102,102 @@ def test_get_updated_scores(test_case: UpdatedScoresTestCase):
     )
 
     assert updated_scores == test_case.expected_scores
+
+
+def _reduction(scorer: str, reducer: str | None, value: float) -> EvalSampleReductions:
+    return EvalSampleReductions(
+        scorer=scorer,
+        reducer=reducer,
+        samples=[EvalSampleScore(value=value, sample_id="1")],
+    )
+
+
+class UpdatedReductionsTestCase(pydantic.BaseModel):
+    action: ScoreAction
+    existing: list[EvalSampleReductions] | None
+    new: list[EvalSampleReductions] | None
+    expected: list[EvalSampleReductions] | None
+
+
+@pytest.mark.parametrize(
+    "test_case",
+    [
+        pytest.param(
+            UpdatedReductionsTestCase(
+                action="append",
+                existing=[_reduction("scorer_a", "mean", 0.1)],
+                new=[_reduction("scorer_b", "mean", 0.5)],
+                expected=[
+                    _reduction("scorer_a", "mean", 0.1),
+                    _reduction("scorer_b", "mean", 0.5),
+                ],
+            ),
+            id="append-keeps-pre-existing-scorer",
+        ),
+        pytest.param(
+            UpdatedReductionsTestCase(
+                action="append",
+                existing=[
+                    _reduction("scorer_a", "mean", 0.1),
+                    _reduction("scorer_b", "mean", 0.2),
+                ],
+                new=[_reduction("scorer_a", "mean", 0.9)],
+                expected=[
+                    _reduction("scorer_a", "mean", 0.9),
+                    _reduction("scorer_b", "mean", 0.2),
+                ],
+            ),
+            id="append-replaces-recomputed-pair-in-place",
+        ),
+        pytest.param(
+            UpdatedReductionsTestCase(
+                action="append",
+                existing=[_reduction("scorer_a", "mean", 0.1)],
+                new=[_reduction("scorer_a", "max", 0.3)],
+                expected=[
+                    _reduction("scorer_a", "mean", 0.1),
+                    _reduction("scorer_a", "max", 0.3),
+                ],
+            ),
+            id="append-keys-on-scorer-and-reducer",
+        ),
+        pytest.param(
+            UpdatedReductionsTestCase(
+                action="append",
+                existing=[_reduction("scorer_a", "mean", 0.1)],
+                new=None,
+                expected=[_reduction("scorer_a", "mean", 0.1)],
+            ),
+            id="append-with-nothing-new-keeps-existing",
+        ),
+        pytest.param(
+            UpdatedReductionsTestCase(
+                action="append",
+                existing=None,
+                new=[_reduction("scorer_a", "mean", 0.1)],
+                expected=[_reduction("scorer_a", "mean", 0.1)],
+            ),
+            id="append-with-no-existing",
+        ),
+        pytest.param(
+            UpdatedReductionsTestCase(
+                action="overwrite",
+                existing=[_reduction("scorer_a", "mean", 0.1)],
+                new=[_reduction("scorer_b", "mean", 0.5)],
+                expected=[_reduction("scorer_b", "mean", 0.5)],
+            ),
+            id="overwrite-drops-pre-existing",
+        ),
+    ],
+)
+def test_get_updated_reductions(test_case: UpdatedReductionsTestCase):
+    updated = _get_updated_reductions(
+        test_case.existing,
+        test_case.new,
+        action=test_case.action,
+    )
+
+    assert updated == test_case.expected
 
 
 class UpdatedEventsTestCase(pydantic.BaseModel):


### PR DESCRIPTION
## This PR contains:
- [x] Bug fixes

### What is the current behavior?

`score_async` assigns `log.reductions = reductions` unconditionally, but that list
covers only the scorers run in the current pass. Under `action="append"` every
pre-existing scorer's reductions are dropped, while `results.scores` is extended a
few lines below and keeps all of them. The log then disagrees with itself about
which scorers it contains.

Repro from #4764, on `mockllm/model`:

    results.scores: ['scorer_a', 'scorer_b']
    reductions    : ['scorer_b']          # scorer_a dropped

### What is the new behavior?

`append` merges. Same repro:

    results.scores: ['scorer_a', 'scorer_b']
    reductions    : ['scorer_a', 'scorer_b']

`_get_updated_reductions` sits beside `_get_updated_scores` and
`_get_updated_events` and follows their shape: `overwrite` returns the new list,
`append` merges into the existing one.

A reduction is identified by `(scorer, reducer)`, so the same scorer reduced two
different ways stays two entries. When a pass recomputes a pair that is already
present, the fresh entry replaces the old one in place rather than being appended
beside it, which keeps the list usable as a lookup by scorer.

#4753 proposes a third `update` action. The merge now lives in one helper, so
whatever semantics `update` needs can go there instead of at the assignment site.

### Does this PR introduce a breaking change?

No. `overwrite` behaviour is unchanged. `append` previously discarded data, so no
caller could have depended on the old result.

### Other information:

Six parametrized cases added next to `test_get_updated_scores`: merge, in-place
replacement of a recomputed pair, the `(scorer, reducer)` key, both empty sides,
and `overwrite`.

Verified against the issue's repro both ways: the drop reproduces on `main` and is
gone with the change, rather than only checking that the new tests pass.

`make check` is clean (ruff, ruff format, mypy across 1348 source files).
`make test` gives 8668 passed, 3534 skipped. The single error is
`test_docker_read_file` failing its Docker prerequisite, which reproduces
identically on `main` without this change.

Fixes #4764
