### PR TITLE
fix(scorer): fall back to full match in pattern scorer when no capture groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Scorer: `pattern()` now falls back to the full regex match when the pattern contains no explicit capture groups (previously such patterns always scored INCORRECT). (#4828)
 - OpenAI: Chat Completions usage now preserves prompt-cache read and write tokens for accurate cache-aware costing.
 - Scoring: `model_graded_qa`/`model_graded_fact` no longer score a malformed multi-character verdict such as `GRADE: CI` as correct; such verdicts now leave the sample unscored with `grade_parse_failure` recorded.
 - OpenAI: Fixed background responses failing on transient connection and timeout errors.

--- a/docs/_builtin-scorers.md
+++ b/docs/_builtin-scorers.md
@@ -9,7 +9,7 @@ Inspect includes both text matching scorers as well as model graded scorers. Bel
 :   Check whether the `target` appears at a known position: `begin`, `end` (the default), or `any`. With `location="exact"` the whole output must equal the target. Ignores case and white-space by default. Pass `numeric=True` to compare numbers rather than text; currency symbols (`$`, `€`, `£`), thousands separators (`,`), and formatting markers (`*`, `_`) are stripped first.
 
 `pattern()`
-:   Extract the answer from model output using a regular expression, for cases where the answer is embedded in templated text. Requires at least one capture group; with multiple groups, set `match_all=True` to require every captured value to match the target (the default matches any one group). Returns an `INCORRECT` score with `reason="invalid_response_format"` when the pattern does not match.
+:   Extract the answer from model output using a regular expression, for cases where the answer is embedded in templated text. With multiple capture groups, set `match_all=True` to require every captured value to match the target (the default matches any one group); if the pattern contains no capture groups, the full match is compared against the target. Returns an `INCORRECT` score with `reason="invalid_response_format"` when the pattern does not match.
 
 `answer()`
 :   For prompts that instruct the model to end with `ANSWER: X`. Extracts the letter, word, or remainder of the line that follows.

--- a/src/inspect_ai/scorer/_pattern.py
+++ b/src/inspect_ai/scorer/_pattern.py
@@ -56,12 +56,11 @@ def match_all_groups(
 def pattern(pattern: str, ignore_case: bool = True, match_all: bool = False) -> Scorer:
     """Scorer which extracts the model answer using a regex.
 
-    Note that at least one regex group is required to match
-    against the target.
-
     The regex can have a single capture group or multiple groups.
     In the case of multiple groups, the scorer can be configured
-    to match either one or all of the extracted groups
+    to match either one or all of the extracted groups. If the
+    pattern contains no capture groups, the full match is compared
+    against the target.
 
     Args:
        pattern: Regular expression for extracting the

--- a/src/inspect_ai/scorer/_pattern.py
+++ b/src/inspect_ai/scorer/_pattern.py
@@ -79,7 +79,7 @@ def pattern(pattern: str, ignore_case: bool = True, match_all: bool = False) -> 
         )
 
         if match:
-            groups = match.groups()
+            groups = match.groups() or (match.group(0),)
             if match_all:
                 found_match = match_all_groups(
                     matches=groups, target=target, ignore_case=ignore_case

--- a/tests/scorer/test_pattern.py
+++ b/tests/scorer/test_pattern.py
@@ -162,3 +162,27 @@ async def test_pattern_no_capture_groups():
 
     assert result.text == CORRECT
     assert result.answer == "42"
+
+
+@pytest.mark.anyio
+async def test_pattern_no_capture_groups_non_matching_target():
+    # No-groups fallback with a non-matching target: INCORRECT, with the
+    # extracted full match reported as the answer.
+    scorer = pattern(r"\d+")
+    state = simple_task_state(model_output="The answer is 42")
+    result = await scorer(state, Target(["43"]))
+
+    assert result.text == INCORRECT
+    assert result.answer == "42"
+
+
+@pytest.mark.anyio
+async def test_pattern_no_capture_groups_match_all():
+    # match_all=True with a no-groups pattern reduces to the single
+    # full-match comparison.
+    scorer = pattern(r"\d+", match_all=True)
+    state = simple_task_state(model_output="The answer is 42")
+    result = await scorer(state, Target(["42"]))
+
+    assert result.text == CORRECT
+    assert result.answer == "42"

--- a/tests/scorer/test_pattern.py
+++ b/tests/scorer/test_pattern.py
@@ -150,3 +150,15 @@ async def test_match_all_unmatched_optional_group_is_not_correct():
 
     assert result.text == INCORRECT
     assert result.answer is None
+
+
+@pytest.mark.anyio
+async def test_pattern_no_capture_groups():
+    # A regex without explicit capture groups (e.g. `\d+`) should fall back
+    # to the full match `match.group(0)`.
+    scorer = pattern(r"\d+")
+    state = simple_task_state(model_output="The answer is 42")
+    result = await scorer(state, Target(["42"]))
+
+    assert result.text == CORRECT
+    assert result.answer == "42"


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

When `inspect_ai.scorer.pattern` is used with a regular expression pattern that contains no explicit `(...)` capture groups (e.g. `pattern(r"\d+")` or `pattern(r"YES|NO")`), `re.Match.groups()` returns an empty tuple `()`. As a result, `match_first` and `match_all_groups` receive no matching strings to evaluate against `target`, returning `None` and setting `answer = None`. The scorer then returns `Score(value="I", answer=None)` on all samples even when the pattern matches the completion and target text.

Closes #4828

### What is the new behavior?

When `match.groups()` is an empty tuple (indicating that the regex pattern contains no explicit capture groups), `pattern` falls back to `(match.group(0),)` (the full regex match). The matched text is extracted as the sample answer and compared against `target`, correctly returning `Score(value="C", answer=...)` on matches.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

### Validation
- `uv run pytest tests/scorer/test_pattern.py`: All 15 tests passed.
- `uv run make check`: Ruff check, ruff format, and mypy passed cleanly with 0 issues across 1,353 source files.
- `git diff --check`: Clean, no trailing whitespace issues.

### Agent review
- Reviewer: Antigravity (Gemini 3.6 Flash), 2 passes
- Findings: 1 - 1 fixed (added unit test for regex without capture groups in `tests/scorer/test_pattern.py`)
