### PR TITLE
feat: warn when model-graded scorer runs without a grader model or role

### DIFF
--- a/src/inspect_ai/scorer/_model.py
+++ b/src/inspect_ai/scorer/_model.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from functools import partial
 from typing import Any, Callable
@@ -6,6 +7,7 @@ from inspect_ai._util.content import Content, ContentText
 from inspect_ai._util.dict import omit
 from inspect_ai._util.format import format_function_call
 from inspect_ai._util.list import remove_last_match_and_after
+from inspect_ai._util.logger import warn_once
 from inspect_ai.model._chat_message import (
     ChatMessage,
     ChatMessageAssistant,
@@ -13,7 +15,7 @@ from inspect_ai.model._chat_message import (
     ChatMessageTool,
     ChatMessageUser,
 )
-from inspect_ai.model._model import Model, get_model
+from inspect_ai.model._model import Model, get_model, model_roles
 from inspect_ai.model._model_output import ModelOutput
 from inspect_ai.solver._task_state import TaskState
 from inspect_ai.util import resource
@@ -23,6 +25,8 @@ from ._metrics import accuracy, stderr
 from ._multi import multi_scorer
 from ._scorer import Scorer, scorer
 from ._target import Target
+
+logger = logging.getLogger(__name__)
 
 
 @scorer(metrics=[accuracy(), stderr()])
@@ -173,6 +177,18 @@ def _model_graded_qa_single(
     async def score(state: TaskState, target: Target) -> Score:
         # resolve model
         nonlocal model
+
+        # no grader model or role bound -- the scorer grades with the model
+        # being evaluated (silent self-grading)
+        if model is None and (model_role is None or model_role not in model_roles()):
+            warn_once(
+                logger,
+                "model-graded scorer invoked without a grader model or model_role "
+                "bound; the model being evaluated will grade itself. Pass "
+                "model=<model> or bind model_role=<role> to use an independent "
+                "grader.",
+            )
+
         # Order of precedence: `model` > `model_role` > default model
         if model is not None:
             model = model if isinstance(model, Model) else get_model(model)

--- a/tests/scorer/test_model_graded.py
+++ b/tests/scorer/test_model_graded.py
@@ -177,6 +177,69 @@ def test_model_role_precedence_for_model_graded_scorer(
     assert grading_event.role == expected_role
 
 
+@pytest.fixture
+def _warn_once_messages() -> Any:
+    # warn_once dedupes via a module-level list; clear it and yield it so the
+    # test can assert on what was emitted.
+    from inspect_ai._util import logger as _inspect_logger
+
+    _inspect_logger._warned.clear()
+    yield _inspect_logger._warned
+    _inspect_logger._warned.clear()
+
+
+def _run_single_score(model_graded_fact_kwargs: dict[str, Any]) -> None:
+    task = Task(
+        scorer=model_graded_fact(**model_graded_fact_kwargs),
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+    )
+    eval(task, model="mockllm/model")[0]
+
+
+@pytest.mark.parametrize(
+    "model_graded_fact_kwargs",
+    [
+        pytest.param({}, id="no_model_no_role_binding"),
+        pytest.param({"model_role": None}, id="explicit_no_role"),
+        pytest.param(
+            {"model_role": "grader"}, id="role_requested_but_not_bound"
+        ),
+    ],
+)
+def test_model_graded_warns_when_no_grader_bound(
+    model_graded_fact_kwargs: dict[str, Any], _warn_once_messages: list[str]
+) -> None:
+    _run_single_score(model_graded_fact_kwargs)
+    assert any("will grade itself" in m for m in _warn_once_messages)
+
+
+@pytest.mark.parametrize(
+    "model_graded_fact_kwargs",
+    [
+        pytest.param({"model": "mockllm/model"}, id="explicit_model"),
+        pytest.param(
+            {"model_role": "grader"},
+            id="role_bound_uses_bound_grader",
+        ),
+    ],
+)
+def test_model_graded_no_warning_when_grader_bound(
+    model_graded_fact_kwargs: dict[str, Any], _warn_once_messages: list[str]
+) -> None:
+    grader_model = get_model(
+        "mockllm/model",
+        custom_outputs=[
+            ModelOutput.from_content("mockllm/model", [ContentText(text="GRADE: C")])
+        ],
+    )
+    task = Task(
+        scorer=model_graded_fact(**model_graded_fact_kwargs),
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+    )
+    eval(task, model="mockllm/model", model_roles={"grader": grader_model})[0]
+    assert not any("will grade itself" in m for m in _warn_once_messages)
+
+
 def test_model_graded_answer_set_on_grade_parse_failure():
     # #4025: parse failure is unscored, but answer must still carry the completion.
     subject_answer = "The capital of France is Paris."

--- a/tests/scorer/test_model_graded.py
+++ b/tests/scorer/test_model_graded.py
@@ -201,9 +201,7 @@ def _run_single_score(model_graded_fact_kwargs: dict[str, Any]) -> None:
     [
         pytest.param({}, id="no_model_no_role_binding"),
         pytest.param({"model_role": None}, id="explicit_no_role"),
-        pytest.param(
-            {"model_role": "grader"}, id="role_requested_but_not_bound"
-        ),
+        pytest.param({"model_role": "grader"}, id="role_requested_but_not_bound"),
     ],
 )
 def test_model_graded_warns_when_no_grader_bound(
@@ -238,6 +236,48 @@ def test_model_graded_no_warning_when_grader_bound(
     )
     eval(task, model="mockllm/model", model_roles={"grader": grader_model})[0]
     assert not any("will grade itself" in m for m in _warn_once_messages)
+
+
+def test_model_graded_no_warning_for_multi_scorer_model_list(
+    _warn_once_messages: list[str],
+) -> None:
+    # model_graded_qa with a list of models wraps each sub-scorer in a
+    # multi_scorer; every sub-scorer has an explicit grader model bound, so
+    # the self-grading warning must not fire.
+    graders = [
+        get_model(
+            "mockllm/model",
+            custom_outputs=[
+                ModelOutput.from_content(
+                    "mockllm/model", [ContentText(text="GRADE: C")]
+                )
+            ],
+        )
+        for _ in range(2)
+    ]
+    task = Task(
+        scorer=model_graded_qa(model=graders),
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+    )
+    log = eval(task, model="mockllm/model")[0]
+    assert log.results and log.results.scores
+    assert not any("will grade itself" in m for m in _warn_once_messages)
+
+
+def test_model_graded_nested_scorers_warn_once(
+    _warn_once_messages: list[str],
+) -> None:
+    # Multiple unbound model-graded scorers in a single task all hit the
+    # same self-grading fallback; warn_once must dedupe them to exactly one
+    # warning rather than spamming one per scorer.
+    task = Task(
+        scorer=[model_graded_qa(), model_graded_fact()],
+        dataset=[Sample(input="What is 1 + 1?", target="2")],
+    )
+    log = eval(task, model="mockllm/model")[0]
+    assert log.results and log.results.scores
+    assert len(log.results.scores) == 2
+    assert len([m for m in _warn_once_messages if "will grade itself" in m]) == 1
 
 
 def test_model_graded_answer_set_on_grade_parse_failure():


### PR DESCRIPTION
## Summary
Fixes #4695

Model-graded scorers (`model_graded_qa`, `model_graded_fact`) silently grade with the model being evaluated when no grader model or `model_role` is bound — producing self-graded scores with no signal.

This PR emits a runtime warning (via `warn_once`) when a model-graded scorer is invoked with no grader model and no bound model role. Behavior is unchanged; the fallback is now loud instead of silent.

## Changes
- `src/inspect_ai/scorer/_model.py`: warn when `model` is None and (`model_role` is None or the role is not bound in `model_roles()`) before model resolution
- `tests/scorer/test_model_graded.py`: 7 new tests — warning fires for unbound/no-role/unbound-role cases; silent when `model` is explicit or role is bound; multi-scorer model list silent; nested unbound scorers dedupe to one warning

## Test evidence
```
459 passed, 170 skipped in 110.11s  (tests/scorer)
```
ruff check: All checks passed
ruff format --check: clean

### Agent review
- Author: AI agent (FreakyAdy) — implementation authored in a prior session, edge-case tests added 2026-08-12
- Reviewer: Hermes agent, 1 pass in a fresh context (this session)
- Findings: 2 — 1 fixed (missing nested/multi-scorer config coverage, added as test), 1 dismissed (warning message omits the scorer name; dedupe-by-message keeps exactly one warning per eval, matching the brief's "one clear warning")