### PR TITLE
fix: map POSIX 'no such file or directory' to FileNotFoundError in docker sandbox

### DIFF
--- a/src/inspect_ai/util/_sandbox/docker/docker.py
+++ b/src/inspect_ai/util/_sandbox/docker/docker.py
@@ -478,7 +478,10 @@ class DockerSandboxEnvironment(SandboxEnvironment):
                 message = str(ex).lower()
 
                 # FileNotFoundError
-                if "could not find the file" in message:
+                if (
+                    "could not find the file" in message
+                    or "no such file or directory" in message
+                ):
                     raise FileNotFoundError(
                         errno.ENOENT, "No such file or directory.", original_file
                     ) from ex

--- a/tests/util/sandbox/test_docker_read_file.py
+++ b/tests/util/sandbox/test_docker_read_file.py
@@ -174,6 +174,30 @@ async def test_read_file_preserves_missing_file_error(
     copy_mock.assert_awaited_once()
 
 
+@pytest.mark.parametrize(
+    "message",
+    [
+        # docker CLI daemon error (e.g. podman/docker variants)
+        "Error response from daemon: stat /sandbox/missing.txt: no such file or directory",
+        # docker compose v2 CLI error form, as wrapped by compose_cp
+        "Failed to copy file from 'default:/sandbox/missing.txt' to 'read-x': Error: no such file or directory",
+    ],
+)
+async def test_read_file_maps_no_such_file_or_directory_error(
+    message: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    environment = _environment()
+    copy_mock = AsyncMock(side_effect=RuntimeError(message))
+    monkeypatch.setattr(docker_module, "compose_cp", copy_mock)
+
+    with pytest.raises(FileNotFoundError) as ex:
+        await environment.read_file("missing")
+
+    assert ex.value.errno == errno.ENOENT
+    assert ex.value.filename == "missing"
+    copy_mock.assert_awaited_once()
+
+
 async def test_read_file_rejects_non_regular_copy_result(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
`DockerSandboxEnvironment.read_file` maps docker's missing-file error to `FileNotFoundError` by matching the Windows message `"could not find the file"`. On POSIX platforms docker returns `"no such file or directory"`, so missing-file reads surface as a raw `RuntimeError` instead.

This PR also matches the POSIX message so missing-file errors are consistently `FileNotFoundError` (with correct errno/filename) on all platforms.

## Changes
- `src/inspect_ai/util/_sandbox/docker/docker.py`: also match `"no such file or directory"`
- `tests/util/sandbox/test_docker_read_file.py`: parametrized test covering docker daemon + compose v2 error forms

### Agent review
- Author: AI agent (FreakyAdy) — authored in a prior session
- Reviewer: none in this session; verification via PR gate CI (green) and code re-read during PR status check on 2026-08-12