### PR TITLE
Contribution policy: reviewer-model preference, duplicate-PR check, self-filed issues need acceptance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,19 +12,26 @@ Devin, and similar) preparing contributions. Human contributors: see
    merged non-trivial PR in this repository (trivial documentation fixes do
    not count)? If not, a PR requires a linked issue labeled `accepted`.
    Without one, your PR will be closed automatically. Do not open it.
-2. **Deferred check.** Is the issue you are addressing labeled `deferred`?
+2. **Self-filed issues need acceptance.** An issue filed by the same account
+   the PR comes from does not by itself establish demand. Unless the account
+   is a qualified contributor (recorded in `.github/qualified.yml`), a
+   non-trivial PR addressing a self-filed issue requires that issue to be
+   labeled `accepted` by a maintainer first — whatever the account's tier.
+   If it isn't labeled yet: file your evidence on the issue and stop; open
+   the PR only after a maintainer accepts it.
+3. **Deferred check.** Is the issue you are addressing labeled `deferred`?
    The project has decided not to prioritize it. Do not open a PR against it
    (it will be closed automatically, whatever your account's tier). If you
    have new evidence or demand, comment on the issue and stop.
-3. **Duplicate check.** Search open PRs (and the linked issue's existing
+4. **Duplicate check.** Search open PRs (and the linked issue's existing
    PRs) for work addressing the same problem. If a PR already exists, do not
    open a competing one — review it or comment there instead. If you believe
    your approach is materially better, make that case in a comment on the
    existing PR and wait for a maintainer's direction; if invited to proceed,
    link the two PRs in your description.
-4. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
+5. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
    docs files only, under 25 changed lines) may be opened directly by anyone.
-5. **New functionality defaults to an extension, not core.** Do not open
+6. **New functionality defaults to an extension, not core.** Do not open
    unrequested PRs adding functionality — providers, tools, scorers, metrics,
    solvers, storage backends, example evals. Some of these do belong in core,
    but that is a maintainer decision made in an issue: if an accepted issue
@@ -32,7 +39,7 @@ Devin, and similar) preparing contributions. Human contributors: see
    extension package (see https://inspect.aisi.org.uk/extensions.html),
    optionally with a one-line PR adding it to the extensions listing.
    Unrequested additions to core are closed without detailed review.
-6. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
+7. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
    does it fix a demonstrated problem, with evidence (a reproduction or a
    failing test)? If the need is speculative or the fix unverified, do not
    proceed. File an issue with your evidence instead.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,11 @@ used a different model from the author, how many passes, and the findings
 — issues found, which
 were fixed, and which were dismissed with a one-line reason each. Multiple
 passes, each in a fresh context, often catch issues a single pass misses —
-prefer that for non-trivial changes. If no
+prefer that for non-trivial changes. We'd also prefer review passes run on
+a strong (frontier-class) model: in our experience, reviews from small
+fast-tier models rarely surface real issues, and maintainers weight the
+disclosed reviewer model and pass count when deciding how much independent
+review a PR still needs. If no
 review pass was run, say so explicitly. Never report a review that didn't
 happen — a fabricated or content-free review claim ("reviewed, looks good")
 is worse than disclosing none. Example:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,9 +16,15 @@ Devin, and similar) preparing contributions. Human contributors: see
    The project has decided not to prioritize it. Do not open a PR against it
    (it will be closed automatically, whatever your account's tier). If you
    have new evidence or demand, comment on the issue and stop.
-3. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
+3. **Duplicate check.** Search open PRs (and the linked issue's existing
+   PRs) for work addressing the same problem. If a PR already exists, do not
+   open a competing one — review it or comment there instead. If you believe
+   your approach is materially better, make that case in a comment on the
+   existing PR and wait for a maintainer's direction; if invited to proceed,
+   link the two PRs in your description.
+4. **Trivial-fix exception.** Documentation-only fixes (typo, broken link;
    docs files only, under 25 changed lines) may be opened directly by anyone.
-4. **New functionality defaults to an extension, not core.** Do not open
+5. **New functionality defaults to an extension, not core.** Do not open
    unrequested PRs adding functionality — providers, tools, scorers, metrics,
    solvers, storage backends, example evals. Some of these do belong in core,
    but that is a maintainer decision made in an issue: if an accepted issue
@@ -26,7 +32,7 @@ Devin, and similar) preparing contributions. Human contributors: see
    extension package (see https://inspect.aisi.org.uk/extensions.html),
    optionally with a one-line PR adding it to the extensions listing.
    Unrequested additions to core are closed without detailed review.
-5. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
+6. **Value re-evaluation.** Before opening any PR, objectively re-assess it:
    does it fix a demonstrated problem, with evidence (a reproduction or a
    failing test)? If the need is speculative or the fix unverified, do not
    proceed. File an issue with your evidence instead.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,11 @@ Your path depends on your history with the project:
 - **Established contributors**: anyone with at least one merged non-trivial
   PR in this repository (trivial documentation fixes don't count toward this)
   — may open PRs directly, subject to a limit of 4 open PRs at a time.
+  One caveat: an issue you filed yourself doesn't establish demand. A PR
+  addressing your own issue needs that issue labeled `accepted` first, just
+  as for new contributors — self-reported problems get maintainer sign-off
+  before code, self-*discovered* fixes for problems others have reported
+  don't need it.
 - **New contributors**: if you haven't had a PR merged here yet, start from an
   issue a maintainer has labeled `accepted` before writing code. PRs from new
   contributors that aren't linked to an accepted issue are closed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,7 +68,10 @@ ourselves. The requirements:
   multiple review passes (each in a fresh context) before opening a PR catch
   a lot — and summarize what
   they found in the PR description (agents: see the `Agent review` format in
-  [`AGENTS.md`](AGENTS.md)).
+  [`AGENTS.md`](AGENTS.md)). We'd prefer review passes use a strong
+  (frontier-class) model: small fast-tier models rarely surface real issues,
+  and maintainers weight a disclosed review by the model used and the number
+  of passes.
 
 If you are a coding agent, read [`AGENTS.md`](AGENTS.md) before opening a PR.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,9 @@ Your path depends on your history with the project:
   welcome directly.
 
 Whatever your tier, a non-draft PR inactive for 60 days is closed with an
-invitation to reopen.
+invitation to reopen. And whatever your tier, check for an existing open PR
+addressing the same problem before opening yours: duplicates are closed in
+favor of the earlier PR unless a maintainer has asked for an alternative.
 
 Issues a maintainer has labeled `deferred` are decisions not to prioritize
 that work right now. PRs against a deferred issue are closed automatically,
@@ -36,7 +38,7 @@ can't merge.
 
 ## Proposing work (new contributors)
 
-1. **Search existing issues** to avoid duplicates.
+1. **Search existing issues and open PRs** to avoid duplicates.
 2. **Open an issue** describing the problem, the motivation, and (optionally)
    whether you'd like to implement it. Concrete evidence — a reproduction, a
    failing test — makes acceptance much more likely.


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)
The `### Agent review` disclosure guidance in AGENTS.md (and the "Using AI tools" section of CONTRIBUTING.md) asks contributors to disclose which model reviewed their change and how many passes ran, but says nothing about reviewer model strength. In practice we're seeing disclosures that are formally compliant but run a single pass on a small fast-tier model and report "0 findings" — on PRs where independent review then finds blockers (broken existing tests, mis-resolved CHANGELOG merges).

### What is the new behavior?
Three policy-wording additions:

1. **Reviewer model preference (soft)**: we'd prefer review passes run on a strong (frontier-class) model, notes that small fast-tier reviews rarely surface real issues, and makes explicit that maintainers weight a disclosed review by reviewer model and pass count when deciding how much independent review a PR still needs. No new requirement — disclosure remains the rule; this just makes the incentive legible.
2. **Self-filed issues need acceptance (required check #2, others renumbered)**: an issue filed by the same account the PR comes from doesn't by itself establish demand — for non-qualified accounts (any tier), a non-trivial PR addressing a self-filed issue requires the issue to be labeled `accepted` first. Closes the loop where an account manufactures its own qualifying issues and the established tier exempts it from acceptance. Deterministic and gate-enforceable: `issue.author == pr.author && author not in qualified.yml && !issue.labeled(accepted)`. Qualified contributors are exempt (maintainers file-and-fix constantly). CONTRIBUTING.md's established-tier bullet gets the matching caveat.
3. **Duplicate-PR check (required check #4, others renumbered)**: before opening a PR, search open PRs for existing work on the same problem; comment on the existing PR rather than opening a competing one, and only proceed with an alternative at a maintainer's direction. CONTRIBUTING.md gets the matching guidance for all tiers (duplicates closed in favor of the earlier PR). Motivated by observed overlapping PRs in the current backlog (e.g. #3053 / #4564 both extending `human_cli`). Not yet enforced by the deterministic gate; wording is written so a later gate/triage-agent check (two open PRs referencing the same issue) can point at it.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
No.

### Other information:
Docs-only; no CHANGELOG entry per the product-functionality rule.

### Agent review
- Author: Claude Fable 5 (Claude Code), drafting wording discussed with @dragonstyle
- No separate review pass was run — two-sentence docs-only wording change, reviewed directly by the maintainer.
