### PR TITLE
Fix all OpenAI-compatible requests failing with APIConnectionError under openai 3.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Agent Bridge: The final agent state now surfaces the real conversation instead of a side call (e.g. opencode's session title) when the scaffold decorates the task prompt, such as opencode quote-wrapping it. (#4768)
 - Inspect View: Logs inside the configured directory now open on Windows when listings identify them with canonical file URIs. (#4765)
 - Bugfix: Dataset fields holding float `NaN` (as produced by Pandas, Hugging Face, CSV, and PyArrow sources for missing values) are now treated as missing for `input`, `choices`, `setup`, `sandbox`, `files`, and `metadata`, matching the existing `target` behavior. (#4626)
+- Bugfix: OpenAI and OpenAI-compatible providers no longer fail every request with `APIConnectionError: Connection error.` when openai 3.x is installed.
 - Reasoning: Unsupported extended `reasoning_effort` values are now mapped to valid provider/model tiers for Together, SambaNova, Perplexity, and Fireworks.
 
 ## 0.3.257 (11 August 2026)

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -11,8 +11,6 @@ if TYPE_CHECKING:
 
 import httpx
 from openai import (
-    DEFAULT_CONNECTION_LIMITS,
-    DEFAULT_TIMEOUT,
     APIConnectionError,
     APIStatusError,
     APITimeoutError,
@@ -1222,6 +1220,21 @@ def openai_media_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
         value = copy(value)
         value.update(data=BASE_64_DATA_REMOVED)
     return value
+
+
+# httpx-typed equivalents of openai's DEFAULT_TIMEOUT / DEFAULT_CONNECTION_LIMITS
+# (same values). Do NOT import those from `openai`: as of openai 3.0 the SDK is
+# built on httpx2, so they are `httpx2.Timeout` / `httpx2.Limits` instances.
+# `httpx.AsyncClient` doesn't recognise the foreign types — `httpx.Timeout(
+# <httpx2.Timeout>)` falls through to its scalar branch and stores the object
+# itself as connect/read/write/pool, so httpcore ends up calling
+# `anyio.fail_after(<Timeout object>)` and every request dies with
+# "TypeError: unsupported operand type(s) for +: 'float' and 'Timeout'", which
+# the OpenAI SDK re-raises as `APIConnectionError: Connection error.`
+DEFAULT_TIMEOUT = httpx.Timeout(timeout=600, connect=5.0)
+DEFAULT_CONNECTION_LIMITS = httpx.Limits(
+    max_connections=1000, max_keepalive_connections=100
+)
 
 
 class OpenAIAsyncHttpxClient(httpx.AsyncClient):

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -1222,15 +1222,10 @@ def openai_media_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
     return value
 
 
-# httpx-typed equivalents of openai's DEFAULT_TIMEOUT / DEFAULT_CONNECTION_LIMITS
-# (same values). Do NOT import those from `openai`: as of openai 3.0 the SDK is
-# built on httpx2, so they are `httpx2.Timeout` / `httpx2.Limits` instances.
-# `httpx.AsyncClient` doesn't recognise the foreign types — `httpx.Timeout(
-# <httpx2.Timeout>)` falls through to its scalar branch and stores the object
-# itself as connect/read/write/pool, so httpcore ends up calling
-# `anyio.fail_after(<Timeout object>)` and every request dies with
-# "TypeError: unsupported operand type(s) for +: 'float' and 'Timeout'", which
-# the OpenAI SDK re-raises as `APIConnectionError: Connection error.`
+# httpx-native equivalents of openai's DEFAULT_TIMEOUT / DEFAULT_CONNECTION_LIMITS
+# (same values). Do NOT import those from `openai`: openai >= 3.0 is built on
+# httpx2, and its httpx2-typed constants silently corrupt the timeout config of
+# our legacy `httpx.AsyncClient`, failing every request with APIConnectionError.
 DEFAULT_TIMEOUT = httpx.Timeout(timeout=600, connect=5.0)
 DEFAULT_CONNECTION_LIMITS = httpx.Limits(
     max_connections=1000, max_keepalive_connections=100


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#198

With `openai >= 3.0.0` installed, every request through the OpenAI provider and all OpenAI-compatible providers (moonshot, deepseek, etc.) fails with `APIConnectionError: Connection error.` — which reads like a provider outage but is entirely local. openai 3.0 moved to httpx2, so `openai.DEFAULT_TIMEOUT` / `openai.DEFAULT_CONNECTION_LIMITS` are now `httpx2.Timeout` / `httpx2.Limits`. `OpenAIAsyncHttpxClient` (a legacy `httpx.AsyncClient` subclass) passed them straight to `httpx.AsyncClient`, whose `httpx.Timeout(<foreign object>)` falls through to its scalar branch and stores the object itself as connect/read/write/pool. httpcore then calls `anyio.fail_after(<Timeout object>)` → `TypeError: unsupported operand type(s) for +: 'float' and 'Timeout'`, which the SDK re-raises as `APIConnectionError`. This has been failing the fork's `slow-tests` CI job (50 failures per run, 40 of them xdist worker kills at the 900s test timeout) for four consecutive scheduled runs.

### What is the new behavior?

`_openai.py` no longer imports `DEFAULT_TIMEOUT` / `DEFAULT_CONNECTION_LIMITS` from the openai SDK; it defines httpx-native equivalents locally with the same values (`httpx.Timeout(timeout=600, connect=5.0)`, `httpx.Limits(max_connections=1000, max_keepalive_connections=100)`). These values are byte-identical to openai's own defaults on both 2.x and 3.x, so the change is a no-op for openai 2.x users and un-breaks openai 3.x. Passing a legacy `httpx.AsyncClient` to openai 3.x is supported by design (its `openai/_httpx2.py` compatibility layer); the constants were the only httpx2-typed objects crossing into legacy httpx.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Verification (local, with `openai==3.0.0` / `httpx==0.28.1` installed):
- `tests/model/providers/test_openai_proxy.py` — the test that caught the regression — passes (1 passed, trio variant skipped by default). No new test added: this test instantiates `OpenAIAsyncHttpxClient` and performs a real request, so it fails with the exact `TypeError` on unpatched code under openai 3.x.
- Sanity-checked `OpenAIAsyncHttpxClient().timeout.as_dict()` → `{'connect': 5.0, 'read': 600, 'write': 600, 'pool': 600}` and that the constants match `openai.DEFAULT_TIMEOUT` / `openai.DEFAULT_CONNECTION_LIMITS` values on 3.0.0.
- `ruff check`, `ruff format --check`, and `mypy` pass on the changed file.
- Not run: full `make check` / `make test` (the runner could not resolve the full `[dev]` extra: `inspect-scout` requires `inspect-ai>=0.3.224` but the shallow checkout computes a `0.1.dev1` version; the package plus the test dependencies needed for the covering test were installed instead).

Grepped `src/` to confirm these constants were imported from `openai` in exactly one place and that no other httpx2-typed objects cross into legacy httpx clients.

### Agent review
- Reviewer: Claude Fable 5 subagent (fresh context, same model as author), 1 pass, with live verification against openai 3.0.0 (reproduced the bug, confirmed value parity with openai 2.x/3.x defaults, end-to-end `AsyncOpenAI` request through the patched client, grep for other affected imports).
- Findings: 2 nits — 1 fixed (rationale comment replayed the commit message; trimmed per AGENTS.md comment style), 1 dismissed (suggested a dedicated constants-shape test; `test_openai_proxy.py` already exercises the regression end-to-end).

Agent involvement: this PR was authored by Claude Code from the analysis in meridianlabs-ai/inspect_ai#198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
