### PR TITLE
Add CI drift detection for openai SDK default timeout/connection limits

### DIFF
--- a/tests/model/providers/test_openai.py
+++ b/tests/model/providers/test_openai.py
@@ -1,6 +1,7 @@
 import base64
 import json
 
+import openai
 import pytest
 from test_helpers.utils import skip_if_no_openai
 
@@ -13,7 +14,11 @@ from inspect_ai.model import (
 )
 from inspect_ai.model._chat_message import ChatMessageSystem
 from inspect_ai.model._internal import parse_content_with_internal
-from inspect_ai.model._openai import openai_completion_params
+from inspect_ai.model._openai import (
+    DEFAULT_CONNECTION_LIMITS,
+    DEFAULT_TIMEOUT,
+    openai_completion_params,
+)
 
 
 @pytest.mark.anyio
@@ -60,6 +65,34 @@ def test_openai_completion_params_extra_body_not_mutated() -> None:
             "metadata": {"source": "test"},
             "reasoning": {"effort": "low"},
         }
+
+
+@pytest.mark.parametrize("field", ["connect", "read", "write", "pool"])
+def test_openai_default_timeout_matches_sdk(field: str) -> None:
+    """Detect drift between our local DEFAULT_TIMEOUT and openai's.
+
+    `inspect_ai.model._openai` defines an httpx-native copy of openai's
+    DEFAULT_TIMEOUT rather than importing it (on openai >= 3.0 the SDK's
+    constant is httpx2-typed and would silently corrupt the config of our
+    legacy `httpx.AsyncClient`). Compare scalar fields — not objects — since
+    the SDK constant's type varies by openai version while the field names
+    are stable across httpx generations.
+    """
+    assert getattr(DEFAULT_TIMEOUT, field) == getattr(openai.DEFAULT_TIMEOUT, field)
+
+
+@pytest.mark.parametrize(
+    "field", ["max_connections", "max_keepalive_connections", "keepalive_expiry"]
+)
+def test_openai_default_connection_limits_match_sdk(field: str) -> None:
+    """Detect drift between our local DEFAULT_CONNECTION_LIMITS and openai's.
+
+    See test_openai_default_timeout_matches_sdk for why the constant is
+    duplicated and why comparison is per scalar field.
+    """
+    assert getattr(DEFAULT_CONNECTION_LIMITS, field) == getattr(
+        openai.DEFAULT_CONNECTION_LIMITS, field
+    )
 
 
 @skip_if_no_openai


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#204

UKGovernmentBEIS/inspect_ai#4837 stopped importing `DEFAULT_TIMEOUT` / `DEFAULT_CONNECTION_LIMITS` from the openai SDK (on openai >= 3.0 they are httpx2-typed and silently corrupt the timeout config of our legacy `httpx.AsyncClient`), defining httpx-native copies in `src/inspect_ai/model/_openai.py` instead. The values are now duplicated: if a future openai release changes its defaults, our copies drift silently and `OpenAIAsyncHttpxClient` quietly diverges from the SDK's recommended configuration — nothing fails, users just get different timeout/connection behavior than the SDK intends.

### What is the new behavior?

Two parametrized tests in `tests/model/providers/test_openai.py` assert field-level equality between our constants and `openai.DEFAULT_TIMEOUT` / `openai.DEFAULT_CONNECTION_LIMITS`:

- `Timeout`: `connect`, `read`, `write`, `pool`
- `Limits`: `max_connections`, `max_keepalive_connections`, `keepalive_expiry` (our local `Limits` omits it; httpx's default of 5.0 matches openai's, and the test pins that)

Scalar fields are compared rather than objects — on openai >= 3.0 the SDK constants are httpx2-typed, so object equality against httpx 1.x types is exactly the trap the original fix removed. Field names are stable across httpx generations. Any drift in a new openai release now surfaces as a CI failure naming the drifted field.

Test-only change, so no CHANGELOG entry.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No.

### Other information:

Verification (openai 3.0.0 / httpx 0.28.1): the 7 new test cases pass, and the full `tests/model/providers/test_openai.py` file passes (16 passed, 12 skipped for missing API keys). `ruff check`, `ruff format --check`, and `mypy` are clean on the changed file.

### Agent review
- Reviewer: Claude Fable 5 via a fresh-context subagent (same model as author), 1 pass
- Findings: 0 real issues. The pass verified module-level `import openai` matches existing suite conventions (many test files import openai at module level; `openai>=2.45.0` is pinned in requirements-dev.txt), that both SDK constants are exported top-level across the supported openai range, and that the parametrized fields cover the entire scalar state of `Timeout`/`Limits` (a removed field would raise `AttributeError` — failing safe rather than passing silently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)