### PR TITLE
Stop tests from destroying extension registrations, and make cross-test failures replayable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -255,7 +255,22 @@ jobs:
         # so it only fires on genuine hangs.
         # --durations feeds the recurring CI-performance analysis
         # (design/ci-perf/): per-test timings are mined from these logs.
-        run: uv run pytest -rA --doctest-modules --color=yes -n auto --timeout=900 --timeout-method=thread --durations=50 --durations-min=1
+        # --report-log records each test's worker and completion order, so a
+        # failure caused by an earlier test on the same worker can be replayed
+        # and bisected offline with scripts/pytest_bisect.py. Written
+        # uncompressed: reportlog flushes every line, and flushing a .gz forces
+        # a zlib flush per line (~4x the per-test cost). upload-artifact
+        # compresses on upload anyway.
+        run: uv run pytest -rA --doctest-modules --color=yes -n auto --timeout=900 --timeout-method=thread --durations=50 --durations-min=1 --report-log=test-report-log.jsonl --report-log-exclude-logs-on-passed-tests
+
+      - name: Upload test order log
+        if: ${{ !cancelled() && env.RUN_TESTS == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-report-log-${{ matrix.python-version }}
+          path: test-report-log.jsonl
+          if-no-files-found: ignore
+          retention-days: 14
 
       - name: Minimize uv cache
         if: ${{ !cancelled() && env.RUN_TESTS == 'true' }}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,6 +31,8 @@ pytest
 pytest-cov
 pytest-dotenv
 pytest-mock
+# --report-log records per-worker test order for scripts/pytest_bisect.py
+pytest-reportlog
 pytest-textual-snapshot
 pytest-timeout
 pytest-watcher

--- a/scripts/pytest_bisect.py
+++ b/scripts/pytest_bisect.py
@@ -1,0 +1,424 @@
+#!/usr/bin/env python3
+"""Replay a CI worker's test order and bisect it down to the polluting test.
+
+CI runs the suite under pytest-xdist, so a failure caused by one test
+corrupting process-global state for a later test on the same worker is
+invisible in the log: it names the worker that failed but not what that worker
+ran, or in what order. `--report-log` (pytest-reportlog) closes that gap — each
+report it writes carries the `worker_id` xdist stamped on it, so the artifact
+is a replayable per-worker execution order.
+
+Given that artifact and a failing nodeid, this script
+
+1. replays the failing worker's tests up to and including the victim, in order,
+   in a single process, and checks the failure reproduces;
+2. delta-debugs (Zeller's ddmin) the preceding tests down to a minimal set that
+   still makes the victim fail — usually the single polluting test.
+
+Both steps run plain `pytest` subprocesses, so any extra arguments the original
+run needed (`--runslow`, `-p some_plugin`, ...) can be forwarded verbatim after
+`--`.
+
+Bisection assumes the failure reproduces deterministically. If the victim is
+itself flaky, step 1 may pass by luck (reported as "did not reproduce"), or the
+reduction may wander and return a larger set than the true cause.
+
+Usage:
+
+    scripts/pytest_bisect.py REPORT_LOG --failing NODEID [-- PYTEST_ARGS...]
+
+Example:
+    scripts/pytest_bisect.py test-report-log.jsonl
+        --failing 'tests/test_extensions.py::test_hooks' -- --runslow --runapi
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Iterable, Iterator, NamedTuple, Sequence
+
+# ---------------------------------------------------------------------------
+# reading the recorded order
+# ---------------------------------------------------------------------------
+
+
+class Execution(NamedTuple):
+    """One test as executed by one worker."""
+
+    worker: str
+    nodeid: str
+    outcome: str
+
+
+def _open_report_log(path: Path) -> Iterator[str]:
+    opener = gzip.open if path.suffix == ".gz" else open
+    with opener(path, "rt", encoding="utf-8") as f:
+        yield from f
+
+
+def read_report_log(path: Path) -> list[Execution]:
+    """Per-worker execution order, in the order the reports were written.
+
+    A test produces up to three reports (setup/call/teardown). We key on first
+    appearance so a test that never reached its call phase (hang, crash,
+    setup error) still shows up in the order, and fold the phase outcomes into
+    a single per-test outcome ("failed" wins, then "skipped").
+    """
+    order: list[tuple[str, str]] = []
+    outcomes: dict[tuple[str, str], str] = {}
+    for line in _open_report_log(path):
+        line = line.strip()
+        if not line:
+            continue
+        report = json.loads(line)
+        if report.get("$report_type") != "TestReport":
+            continue
+        # Absent worker_id means the run was not distributed; treat the whole
+        # session as one worker so replay still works.
+        key = (report.get("worker_id") or "master", report["nodeid"])
+        if key not in outcomes:
+            order.append(key)
+            outcomes[key] = "passed"
+        outcome = report["outcome"]
+        if outcome == "failed" or (outcome == "skipped" and outcomes[key] == "passed"):
+            outcomes[key] = outcome
+    return [Execution(w, n, outcomes[(w, n)]) for w, n in order]
+
+
+class Worker(NamedTuple):
+    """The tests that led up to a victim on the worker that ran it."""
+
+    worker: str
+    prefix: list[str]
+    victim: str
+
+
+def locate_victim(
+    executions: Sequence[Execution], failing: str, worker: str | None
+) -> Worker:
+    by_worker: dict[str, list[str]] = defaultdict(list)
+    for e in executions:
+        by_worker[e.worker].append(e.nodeid)
+
+    candidates = [
+        w
+        for w, nodeids in by_worker.items()
+        if failing in nodeids and (worker is None or w == worker)
+    ]
+    if not candidates:
+        known = ", ".join(sorted(by_worker)) or "none"
+        raise SystemExit(
+            f"nodeid {failing!r} does not appear in the report log"
+            + (f" for worker {worker!r}" if worker else "")
+            + f" (workers recorded: {known})"
+        )
+    if len(candidates) > 1:
+        raise SystemExit(
+            f"nodeid {failing!r} ran on multiple workers ({', '.join(sorted(candidates))}); "
+            "pick one with --worker"
+        )
+
+    found = candidates[0]
+    nodeids = by_worker[found]
+    return Worker(found, nodeids[: nodeids.index(failing)], failing)
+
+
+# ---------------------------------------------------------------------------
+# running trials
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Runner:
+    """Runs `pytest <tests> <victim>` and reports whether the victim failed."""
+
+    victim: str
+    pytest_args: Sequence[str]
+    setup_command: str | None = None
+    verbose: bool = False
+    runs: int = 0
+    invocations: int = 0
+    seconds: float = 0.0
+    setup_seconds: float = 0.0
+    dropped: set[str] = field(default_factory=set)
+    _tmp: Path = field(default_factory=lambda: Path(tempfile.mkdtemp(prefix="bisect-")))
+
+    def victim_fails(self, prefix: Sequence[str]) -> bool:
+        log = self._tmp / f"trial-{self.runs}.jsonl"
+        started = time.monotonic()
+        proc = self._run(prefix, log)
+        elapsed = time.monotonic() - started
+        self.runs += 1
+        self.seconds += elapsed
+
+        outcome = self._victim_outcome(log)
+        if outcome is None:
+            print(
+                f"  ! trial {self.runs}: victim produced no report "
+                f"(pytest exit {proc.returncode}); treating as 'did not fail'",
+                file=sys.stderr,
+            )
+            if self.verbose:
+                print(proc.stdout[-4000:], file=sys.stderr)
+        if self.verbose:
+            print(
+                f"  trial {self.runs}: {len(prefix)} preceding test(s) "
+                f"-> victim {outcome or 'missing'} [{elapsed:.1f}s]"
+            )
+        return outcome == "failed"
+
+    def _run(
+        self, prefix: Sequence[str], log: Path
+    ) -> subprocess.CompletedProcess[str]:
+        """Run the trial, retrying once without nodeids this checkout lacks.
+
+        A recording can name tests that were since renamed, removed or
+        parametrized differently. pytest treats an unmatched nodeid argument as
+        a usage error and runs nothing at all, so drop the reported ones and
+        retry rather than mistaking it for "the victim passed".
+        """
+        selected = [t for t in prefix if t not in self.dropped]
+        while True:
+            if self.setup_command:
+                setup_started = time.monotonic()
+                setup = subprocess.run(self.setup_command, shell=True)
+                if setup.returncode != 0:
+                    raise SystemExit(
+                        f"--setup-command failed (exit {setup.returncode}): "
+                        f"{self.setup_command}"
+                    )
+                self.setup_seconds += time.monotonic() - setup_started
+            self.invocations += 1
+            proc = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "pytest",
+                    "-q",
+                    "--no-header",
+                    "-p",
+                    "no:cacheprovider",
+                    "--continue-on-collection-errors",
+                    *self.pytest_args,
+                    # after the forwarded args, so a --report-log among them
+                    # cannot redirect the log this trial reads back
+                    f"--report-log={log}",
+                    *selected,
+                    self.victim,
+                ],
+                capture_output=True,
+                text=True,
+            )
+            if self._missing_nodeids(proc.stderr, [self.victim]):
+                raise SystemExit(
+                    f"victim nodeid not found in this checkout: {self.victim}\n"
+                    "The recording is stale, or the test was renamed, removed "
+                    "or parametrized differently. Bisecting cannot proceed."
+                )
+            missing = self._missing_nodeids(proc.stderr, selected)
+            if not missing:
+                return proc
+            print(
+                f"  ! dropping {len(missing)} nodeid(s) not present in this "
+                f"checkout (e.g. {sorted(missing)[0]})",
+                file=sys.stderr,
+            )
+            self.dropped |= missing
+            selected = [t for t in selected if t not in missing]
+
+    @staticmethod
+    def _missing_nodeids(stderr: str, selected: Sequence[str]) -> set[str]:
+        """Nodeids pytest reported as `ERROR: not found:` (paths are absolute)."""
+        if "ERROR: not found:" not in stderr:
+            return set()
+        lines = [line.strip() for line in stderr.splitlines()]
+        return {t for t in selected if any(line.endswith(t) for line in lines)}
+
+    def _victim_outcome(self, log: Path) -> str | None:
+        if not log.exists():
+            return None
+        result: str | None = None
+        for line in _open_report_log(log):
+            line = line.strip()
+            if not line:
+                continue
+            report = json.loads(line)
+            if (
+                report.get("$report_type") == "TestReport"
+                and report["nodeid"] == self.victim
+            ):
+                if report["outcome"] == "failed":
+                    result = "failed"
+                elif result is None:
+                    result = report["outcome"]
+        return result
+
+
+# ---------------------------------------------------------------------------
+# delta debugging
+# ---------------------------------------------------------------------------
+
+
+def ddmin(candidates: Sequence[str], fails: "Runner") -> list[str]:
+    """Smallest subset of `candidates` that still makes the victim fail.
+
+    Zeller's ddmin. A plain binary search would be enough when exactly one test
+    pollutes, but ddmin also handles the case where the failure needs a
+    combination of earlier tests, and degenerates to binary search otherwise.
+    Subsets keep their original relative order, since pollution is frequently
+    order-sensitive.
+    """
+    current = list(candidates)
+    granularity = 2
+    while len(current) >= 2:
+        chunks = _chunks(current, granularity)
+        for chunk in chunks:
+            if fails.victim_fails(chunk):
+                current, granularity = chunk, 2
+                break
+        else:
+            for chunk in chunks:
+                complement = [t for t in current if t not in set(chunk)]
+                if complement and fails.victim_fails(complement):
+                    current = complement
+                    granularity = max(granularity - 1, 2)
+                    break
+            else:
+                if granularity >= len(current):
+                    break
+                granularity = min(granularity * 2, len(current))
+    return current
+
+
+def _chunks(items: Sequence[str], n: int) -> list[list[str]]:
+    size, extra = divmod(len(items), n)
+    out: list[list[str]] = []
+    start = 0
+    for i in range(n):
+        stop = start + size + (1 if i < extra else 0)
+        if stop > start:
+            out.append(list(items[start:stop]))
+        start = stop
+    return out
+
+
+# ---------------------------------------------------------------------------
+# cli
+# ---------------------------------------------------------------------------
+
+
+def _format(cmd: Iterable[str]) -> str:
+    return " ".join(shlex.quote(c) for c in cmd)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("report_log", type=Path, help="--report-log artifact from CI")
+    parser.add_argument("--failing", required=True, help="nodeid of the failing test")
+    parser.add_argument("--worker", help="worker id, if the nodeid ran on several")
+    parser.add_argument(
+        "--setup-command",
+        help="shell command run before every trial, to restore whatever the "
+        "previous run tore down (this suite's conftest, for instance, "
+        "uninstalls tests/test_package on session finish)",
+    )
+    parser.add_argument(
+        "--quiet", action="store_true", help="don't print a line per trial"
+    )
+    # Split on `--` ourselves: argparse re-parses options that follow it, so
+    # forwarded flags like `-p freshworker` would be swallowed.
+    argv = list(sys.argv[1:] if argv is None else argv)
+    pytest_args: list[str] = []
+    if "--" in argv:
+        split = argv.index("--")
+        argv, pytest_args = argv[:split], argv[split + 1 :]
+    args = parser.parse_args(argv)
+    args.pytest_args = pytest_args
+
+    executions = read_report_log(args.report_log)
+    if not executions:
+        raise SystemExit(f"no test reports found in {args.report_log}")
+    worker = locate_victim(executions, args.failing, args.worker)
+
+    workers = sorted({e.worker for e in executions})
+    print(
+        f"report log:  {args.report_log} ({len(executions)} test runs, {len(workers)} workers)"
+    )
+    print(f"victim:      {worker.victim}")
+    print(
+        f"worker:      {worker.worker} ({len(worker.prefix)} tests ran before the victim)"
+    )
+    print()
+
+    runner = Runner(
+        worker.victim,
+        args.pytest_args,
+        setup_command=args.setup_command,
+        verbose=not args.quiet,
+    )
+    started = time.monotonic()
+
+    print("[1/3] victim on its own (control) ...")
+    if runner.victim_fails([]):
+        print(
+            "\nThe victim fails with nothing before it, so this is not "
+            "cross-test pollution. Debug the test directly."
+        )
+        return _summary(runner, started, 1)
+
+    print("[2/3] replaying the worker's order ...")
+    if not runner.victim_fails(worker.prefix):
+        print(
+            "\nDID NOT REPRODUCE: the victim passes even after replaying every "
+            "test that ran before it on this worker.\n"
+            "The failure likely depends on something the recorded order does "
+            "not capture — a test on a different worker, the worker count, "
+            "timing/concurrency, or an environment difference from CI.\n"
+            "Try: rerun with the CI python and the CI extra pytest args, or "
+            "reproduce under `-n <same worker count>`."
+        )
+        return _summary(runner, started, 1)
+
+    print(f"[3/3] bisecting {len(worker.prefix)} preceding tests ...")
+    culprits = ddmin(worker.prefix, runner)
+
+    print(f"\nMinimal set that reproduces the failure ({len(culprits)} test(s)):")
+    for c in culprits:
+        print(f"  {c}")
+    print("\nReproduce with:")
+    print(f"  {_format(['pytest', *args.pytest_args, *culprits, worker.victim])}")
+    return _summary(runner, started, 0)
+
+
+def _summary(runner: Runner, started: float, status: int) -> int:
+    setup = (
+        f" ({runner.setup_seconds:.1f}s of it in --setup-command)"
+        if runner.setup_seconds
+        else ""
+    )
+    retries = (
+        f" ({runner.invocations - runner.runs} re-run after dropping stale nodeids)"
+        if runner.invocations != runner.runs
+        else ""
+    )
+    print(
+        f"\n{runner.runs} trials / {runner.invocations} pytest invocations{retries}, "
+        f"{time.monotonic() - started:.1f}s wall clock{setup}."
+    )
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 import warnings
+from collections.abc import Iterator
 from typing import TYPE_CHECKING
 
 import boto3
@@ -170,6 +171,77 @@ def fresh_concurrency_registry():
 
     init_concurrency()
     yield
+
+
+@pytest.fixture(scope="session")
+def registrations_at_session_start() -> dict[str, object]:
+    """Load extension entry points up front, then snapshot the registry.
+
+    Registration is an import side effect, so it happens at most once per
+    process: `ensure_entry_points()` re-runs `ep.load()`, but the `@hooks` /
+    `@modelapi` / ... decorators inside it do not re-run once the module is in
+    `sys.modules`. Nothing can re-create a registration that a test deletes.
+
+    Loading here — before any test body — is what stops a *first* load from
+    landing inside a test that has temporarily emptied the registry
+    (`registry_find` re-scans entry points whenever a find comes up empty).
+    That is how a registration once got created and then destroyed within a
+    single test, breaking unrelated tests later on the same worker. Note that
+    `ensure_test_package_installed()` calls `clear_entry_points_state()`, so a
+    later full re-scan can still happen; it is harmless, because by then the
+    modules are imported and re-loading them registers nothing new.
+
+    The snapshot is what `protect_registrations` puts back, and is the only
+    way back, for the same reason.
+
+    A regression is not unit-testable — it turns on *when* the load happens
+    during session startup — but it reproduces in about two seconds: restore
+    the pre-45de3f534 `_without_registered_hooks` in
+    tests/model/test_tool_info_lifecycle.py, then run that file's
+    `test_no_hook_model_event_tools_share_raw_tool_parameters` followed by
+    `tests/test_extensions.py::test_hooks`, collecting `tests/_control` first.
+    That last part matters: it registers a hook at import time, so
+    `init_hooks()`'s once-only first `get_all_hooks()` finds one and skips the
+    entry-point load, which defers the load into the fixture.
+    """
+    from inspect_ai._util.entrypoints import ensure_entry_points
+    from inspect_ai._util.registry import _registry
+
+    ensure_entry_points()
+    return dict(_registry)
+
+
+@pytest.fixture(autouse=True)
+def protect_registrations(
+    registrations_at_session_start: dict[str, object],
+) -> Iterator[None]:
+    """Restore any registration a test removed, and error its teardown.
+
+    Restoring stops the damage from spreading: without it a test that drops a
+    registration keeps passing while unrelated later tests on the same worker
+    fail, which is expensive to diagnose. Erroring names the test that did it
+    (it reports as a teardown ERROR, not as a failure of the test itself).
+    """
+    from inspect_ai._util.registry import (
+        _registry,
+        registry_add,
+        registry_info,
+    )
+
+    yield
+
+    missing = registrations_at_session_start.keys() - _registry.keys()
+    for key in missing:
+        registered = registrations_at_session_start[key]
+        registry_add(registered, registry_info(registered))
+    if missing:
+        pytest.fail(
+            f"test removed registration(s) that existed before it ran: "
+            f"{sorted(missing)}. Registration is an import side effect and "
+            f"cannot be redone, so this breaks unrelated later tests on the "
+            f"same worker. Restore exactly what you removed, and leave in "
+            f"place anything registered while you held the registry open."
+        )
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -2074,6 +2074,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "pytest-dotenv" },
     { name = "pytest-mock" },
+    { name = "pytest-reportlog" },
     { name = "pytest-textual-snapshot" },
     { name = "pytest-timeout" },
     { name = "pytest-watcher" },
@@ -2191,6 +2192,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'" },
     { name = "pytest-dotenv", marker = "extra == 'dev'" },
     { name = "pytest-mock", marker = "extra == 'dev'" },
+    { name = "pytest-reportlog", marker = "extra == 'dev'" },
     { name = "pytest-textual-snapshot", marker = "extra == 'dev'" },
     { name = "pytest-timeout", marker = "extra == 'dev'" },
     { name = "pytest-watcher", marker = "extra == 'dev'" },
@@ -5305,6 +5307,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
+name = "pytest-reportlog"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/93/d5/2f4a73822efaad1d6aea6660468d6290963e5f61d2f9d9ca707f7f0b1c13/pytest_reportlog-1.0.0.tar.gz", hash = "sha256:75aec3a92bb53456c3e028605a636579d26f31c6f1e035ad9f706c203cfcb74e", size = 5646, upload-time = "2025-11-11T16:05:15.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/70/807cbdac584629623c1c2f76b7a39a343e3989510cd52385f1f40581e963/pytest_reportlog-1.0.0-py3-none-any.whl", hash = "sha256:3fc837ef3be6e50f33b52aaf99f88bfbb2ec525febbc3990389d24bbfba28753", size = 6015, upload-time = "2025-11-11T16:05:14.585Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#217.

Extension registration is a module-import side effect, so it happens at most once per process. `ensure_entry_points()` re-runs `ep.load()`, but the `@hooks` / `@modelapi` decorators inside do not re-run once the module is in `sys.modules`. Two consequences:

1. **A deleted registration is gone for good.** When a test removes a key from `inspect_ai._util.registry._registry`, nothing restores it. Every later test on that xdist worker sees it missing. The test that caused the damage still passes; some unrelated test fails, usually in another file.
2. **The first load lands wherever it lands.** `registry_find()` loads entry points only when a lookup comes up empty, so the load can first fire *inside* a test that has temporarily emptied the registry — which is how a registration got created and then destroyed within one test.

That is the nightly failure `tests/test_extensions.py::test_hooks` → `assert [] == ['42']`, fixed for that one fixture in 45de3f534. Diagnosing it was slow for a separate reason: CI records which worker failed, but not what that worker ran or in what order, so the failure cannot be replayed.

### What is the new behavior?

**1. `tests/conftest.py` — load entry points at session start, then guard the registry.**

A session fixture calls `ensure_entry_points()` before any test body and snapshots `_registry`. An autouse fixture then restores any snapshotted key a test removed, and errors that test's teardown. Restoring stops the damage from spreading to unrelated tests; erroring names the test responsible.

The guard protects every key present at session start, not just entry-point ones — core registrations are equally unrecoverable import side effects.

**2. `--report-log` in CI, plus `scripts/pytest_bisect.py`.**

`--report-log` needs no new recording code: xdist already stamps `worker_id` and `item_index` onto every report, so the artifact is a replayable per-worker execution order. The script replays the failing worker's order in one process, then delta-debugs (ddmin) the preceding tests down to the polluting one.

### Does this PR introduce a breaking change?

No. Test and CI configuration only; nothing under `src/`, and no runtime behavior changes.

### Other information:

**Reproduction** (about 2 seconds, real test files, no simulation). With the pre-fix fixture restored:

```bash
git show 45de3f534^:tests/model/test_tool_info_lifecycle.py > tests/model/test_tool_info_lifecycle.py
pytest tests/_control tests/model/test_tool_info_lifecycle.py tests/test_extensions.py \
  -k "test_no_hook_model_event_tools_share_raw_tool_parameters or (test_hooks and extensions)"
```

`tests/_control` matters: it registers a hook at import time, so `init_hooks()`'s once-only first `get_all_hooks()` finds one and skips the entry-point load, deferring it into the fixture. Fails on `main`; passes with this PR.

**Measurements**

| check | result |
|---|---|
| False positives, full suite, single process | 0 violations / 12,674 tests |
| False positives, full suite, `-n logical` (12 workers) | 0 violations / 12,587 tests |
| Guard overhead | ~34 µs/test (~0.4 s across a 13-minute suite) |
| `--report-log` overhead | ~1 ms/test; ~27 MB artifact uncompressed, 2–3 MB zipped |
| Bisection demo | culprit found among 355 preceding tests in 15 pytest runs, 1–2 min |

Every registry-deletion site in the suite was checked against the guard's rule: each registers its key inside the test body, so none is protected and none trips it.

**Alternatives measured and rejected** (detail in the issue): per-test state diffing finds nothing (the key is created *and* deleted inside one test, so the diff is empty); random test order gave 0 reproductions in 35 full-suite runs; `--dist loadfile` still co-locates 26.8% of file pairs and did not neutralize it; `--forked` works but costs 7.3x on Linux and segfaulted 618 times on macOS; one process per file costs 2.3–3.8x CPU and misses same-file cases.

**Not included:** no test asserts the session-start load. The invariant is about *when* a load happens during startup, and the only extension package available is one the suite installs and uninstalls dynamically — every candidate test I wrote was itself order-dependent, which is the bug this PR exists to prevent. The reproduction above is recorded in the fixture docstring instead.

**Follow-ups** (separate issues, found while investigating, not addressed here): `tests/agent/test_acp/test_router_phase2.py` fails in 21–22 of 22 shuffled runs; `tests/model/test_assistant_internal.py`, `tests/test_eval_set_scanner.py` and `tests/analysis/test_df_parallel.py` pass in-suite but fail alone; `tests/test_log_dir/` shares one hardcoded directory across xdist workers. The nightly workflow in `meridianlabs-ai/actions` should also get `--report-log`, since that is where these failures actually surface.

**Local test results:** full suite `-n logical` and `--runtrio` both clean apart from 57 pre-existing `tests/scorer/test_math.py` failures (the optional `math` extra is not installed locally; they fail identically on `main`). `ruff format`, `ruff check` and `mypy` pass.

### Agent review
- Author: Claude Opus 5 (Claude Code). Reviewer: Claude Opus 5 via a fresh-context subagent, 1 pass, plus 4 independent investigation agents whose findings were cross-checked against each other and re-verified by hand.
- Findings: 2 confirmed bugs, both fixed. (1) The regression test I added was itself order-dependent — `ensure_test_package_installed()` calls `clear_entry_points_state()`, which resets the flag it asserted on; I reproduced the failure, then removed the test rather than ship a flaky one. (2) `pytest_bisect.py` reported a stale *victim* nodeid as "did not reproduce", sending the user chasing environment differences; it now fails fast. Also fixed: `--report-log` placement so a forwarded `--report-log` cannot redirect the log, an uncaught traceback on `--setup-command` failure, a docstring overstating an invariant, and missing type annotations.
- Dismissed: object aliased under two registry keys (verified 0 occurrences, not reachable today); the `Execution.outcome` dead field and a trial-number off-by-one in a temp filename (cosmetic, left as-is).
- One earlier claim of mine was wrong and is corrected here: I initially read 27–28 `no running event loop` lines per trio job as failures. They are a benign warning in passing tests' captured stdout; those jobs had one failure each.
