### PR TITLE
Report sandbox exec output truncation to callers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## Unreleased
 
 - Anthropic: models returning omitted (empty) thinking summaries no longer misreport `usage.reasoning_tokens` and log a token-counting warning on every generate.
+- Sandbox: Exec results now report whether captured stdout or stderr was truncated when the provider can detect it.
+
 - Security: Computer Tool bundled examples now bind dynamically assigned VNC and noVNC ports to loopback instead of all host interfaces.
 - Sandbox: Local samples now isolate and stop sandbox-tools servers during cleanup, preventing stale working directories and orphaned tool processes across samples.
 - Control Channel: `inspect ctl` mutations with piped or captured output now print one outcome line each instead of repeating the full task header (`--terse/--no-terse` to override).

--- a/docs/_sandboxenv-exec.md
+++ b/docs/_sandboxenv-exec.md
@@ -26,6 +26,6 @@ async def exec(
     ...
 ```
 
-The `exec()` method should enforce an output limit of `SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE` (default 10MB, configurable via the `INSPECT_SANDBOX_MAX_EXEC_OUTPUT_SIZE` environment variable) and front-truncate its output to the limit when it is exceeded.
+The `exec()` method should enforce an output limit of `SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE` (default 10MB, configurable via the `INSPECT_SANDBOX_MAX_EXEC_OUTPUT_SIZE` environment variable) and front-truncate its output to the limit when it is exceeded. Providers that can detect this set `stdout_truncated` or `stderr_truncated` on `ExecResult`; `None` means the provider cannot report truncation.
 
 To deal with potential unreliability of container services, the `exec()` method includes a `timeout_retry` parameter that defaults to `True`. For sandbox implementations this parameter is _advisory_ (they should only use it if potential unreliability exists in their runtime). No more than 2 retries should be attempted and both with timeouts less than 60 seconds. If you are executing commands that are not idempotent (i.e. the side effects of a failed first attempt may affect the results of subsequent attempts) then you can specify `timeout_retry=False` to override this behavior.

--- a/src/inspect_ai/util/_sandbox/environment.py
+++ b/src/inspect_ai/util/_sandbox/environment.py
@@ -120,13 +120,12 @@ class SandboxEnvironment(abc.ABC):
 
         By default, each output stream (stdout and stderr) is limited to 10 MiB. You can override this by setting the `INSPECT_SANDBOX_MAX_EXEC_OUTPUT_SIZE` environment variable (specified in bytes).
 
-        Behaviour above this limit depends on the sandbox provider. A provider may
-        raise `OutputLimitExceededError`, or return only the trailing portion of
-        the output with the beginning discarded. Callers should therefore not
-        assume that returned output is complete or rely on an exception to detect
-        overflow. This is particularly important when parsing structured output
-        such as JSON. For large output, write to a file and use `read_file()`,
-        which always raises `OutputLimitExceededError` when the limit is exceeded.
+        Providers that support truncation reporting set `stdout_truncated` and
+        `stderr_truncated` on the result. `True` means the stream exceeded the
+        limit, `False` means the provider checked and retained the complete stream,
+        and `None` means the provider cannot report this state. For large output,
+        write to a file and use `read_file()`, which always raises
+        `OutputLimitExceededError` when the limit is exceeded.
 
         Args:
           cmd: Command or command and arguments to execute.

--- a/src/inspect_ai/util/_sandbox/events.py
+++ b/src/inspect_ai/util/_sandbox/events.py
@@ -126,12 +126,24 @@ class SandboxEnvironmentProxy(SandboxEnvironment):
             OutputLimitExceededError: If an output stream exceeds the limit.
         """
         limit = SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE
-        stdout_truncated = truncate_string_to_bytes(exec_result.stdout, limit)
-        stderr_truncated = truncate_string_to_bytes(exec_result.stderr, limit)
+        stdout_truncated = (
+            truncate_string_to_bytes(exec_result.stdout, limit)
+            if exec_result.stdout_truncated is None
+            else exec_result.stdout_truncated
+        )
+        stderr_truncated = (
+            truncate_string_to_bytes(exec_result.stderr, limit)
+            if exec_result.stderr_truncated is None
+            else exec_result.stderr_truncated
+        )
         if not stdout_truncated and not stderr_truncated:
             return
-        stdout = stdout_truncated.output if stdout_truncated else exec_result.stdout
-        stderr = stderr_truncated.output if stderr_truncated else exec_result.stderr
+        stdout = exec_result.stdout
+        stderr = exec_result.stderr
+        if not isinstance(stdout_truncated, bool) and stdout_truncated:
+            stdout = stdout_truncated.output
+        if not isinstance(stderr_truncated, bool) and stderr_truncated:
+            stderr = stderr_truncated.output
         raise OutputLimitExceededError(
             limit_str=SandboxEnvironmentLimits.MAX_EXEC_OUTPUT_SIZE_STR,
             truncated_output=f"{stdout}{stderr}",

--- a/src/inspect_ai/util/_subprocess.py
+++ b/src/inspect_ai/util/_subprocess.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 from logging import getLogger
 from pathlib import Path
 from subprocess import DEVNULL, PIPE
-from typing import Generic, Literal, TypeVar, Union, overload
+from typing import Generic, Literal, NamedTuple, TypeVar, Union, overload
 
 import anyio
 from anyio import ClosedResourceError, create_task_group, open_process
@@ -41,6 +41,17 @@ class ExecResult(Generic[T]):
 
     stderr: T
     """Contents of stderr."""
+
+    stdout_truncated: bool | None = None
+    """Whether stdout exceeded its configured capture limit, if known."""
+
+    stderr_truncated: bool | None = None
+    """Whether stderr exceeded its configured capture limit, if known."""
+
+
+class StreamOutput(NamedTuple):
+    data: bytes
+    truncated: bool | None
 
 
 @overload
@@ -160,15 +171,23 @@ async def subprocess(
                 return ExecResult[str](
                     success=success,
                     returncode=returncode,
-                    stdout=stdout.decode(errors="replace") if capture_output else "",
-                    stderr=stderr.decode(errors="replace") if capture_output else "",
+                    stdout=stdout.data.decode(errors="replace")
+                    if capture_output
+                    else "",
+                    stderr=stderr.data.decode(errors="replace")
+                    if capture_output
+                    else "",
+                    stdout_truncated=stdout.truncated if capture_output else None,
+                    stderr_truncated=stderr.truncated if capture_output else None,
                 )
             else:
                 return ExecResult[bytes](
                     success=success,
                     returncode=returncode,
-                    stdout=stdout if capture_output else bytes(),
-                    stderr=stderr if capture_output else bytes(),
+                    stdout=stdout.data if capture_output else bytes(),
+                    stderr=stderr.data if capture_output else bytes(),
+                    stdout_truncated=stdout.truncated if capture_output else None,
+                    stderr_truncated=stderr.truncated if capture_output else None,
                 )
         # Handle cancellation before aclose() is called to avoid deadlock.
         except anyio.get_cancelled_exc_class():
@@ -314,24 +333,24 @@ async def drain_stream(stream: ByteReceiveStream | None) -> None:
 
 async def _read_stream(
     stream: ByteReceiveStream | None, *, output_limit: int | None = None
-) -> bytes:
+) -> StreamOutput:
     if stream is None:
-        return bytes()
+        return StreamOutput(bytes(), None)
     if output_limit is None:
         bytesio = io.BytesIO()
         async for chunk in stream:
             bytesio.write(chunk)
-        return bytesio.getvalue()
+        return StreamOutput(bytesio.getvalue(), None)
     else:
         circular = CircularByteBuffer(output_limit)
         async for chunk in stream:
             circular.write(chunk)
-        return circular.getvalue()
+        return StreamOutput(circular.getvalue(), circular.truncated)
 
 
-async def _log_stream(stream: ByteReceiveStream | None) -> bytes:
+async def _log_stream(stream: ByteReceiveStream | None) -> StreamOutput:
     if stream is None:
-        return bytes()
+        return StreamOutput(bytes(), None)
     buffer = bytes()
     async for chunk in stream:
         parts = (buffer + chunk).split(b"\n")
@@ -340,7 +359,7 @@ async def _log_stream(stream: ByteReceiveStream | None) -> bytes:
             logger.info(line.decode(errors="replace").rstrip())
     if buffer:
         logger.info(buffer.decode(errors="replace").rstrip())
-    return bytes()
+    return StreamOutput(bytes(), None)
 
 
 max_subprocesses_context_var = ContextVar[int](
@@ -357,12 +376,15 @@ class CircularByteBuffer:
         self._max_bytes = max_bytes
         self._chunks: deque[bytes] = deque()
         self._total_bytes = 0
+        self._truncated = False
 
     def write(self, data: bytes) -> None:
         if not data:
             return
         self._chunks.append(data)
         self._total_bytes += len(data)
+        if self._total_bytes > self._max_bytes:
+            self._truncated = True
 
         # Discard oldest chunks until under limit
         while self._total_bytes > self._max_bytes and len(self._chunks) > 1:
@@ -377,3 +399,7 @@ class CircularByteBuffer:
 
     def getvalue(self) -> bytes:
         return b"".join(self._chunks)
+
+    @property
+    def truncated(self) -> bool:
+        return self._truncated

--- a/tests/util/sandbox/test_sandbox_limits.py
+++ b/tests/util/sandbox/test_sandbox_limits.py
@@ -1,5 +1,6 @@
 import pytest
 
+from inspect_ai.util._sandbox.events import SandboxEnvironmentProxy
 from inspect_ai.util._sandbox.limits import (
     OutputLimitExceededError,
     SandboxEnvironmentLimits,
@@ -11,6 +12,24 @@ from inspect_ai.util._sandbox.limits import (
     set_sandbox_limits,
     verify_read_file_size,
 )
+from inspect_ai.util._subprocess import ExecResult
+
+
+def test_verify_exec_result_size_uses_provider_truncation_metadata():
+    with override_max_exec_output_size(5):
+        with pytest.raises(OutputLimitExceededError):
+            SandboxEnvironmentProxy.verify_exec_result_size(
+                ExecResult(True, 0, "x", "", stdout_truncated=True)
+            )
+
+        SandboxEnvironmentProxy.verify_exec_result_size(
+            ExecResult(True, 0, "x" * 100, "", stdout_truncated=False)
+        )
+
+        with pytest.raises(OutputLimitExceededError):
+            SandboxEnvironmentProxy.verify_exec_result_size(
+                ExecResult(True, 0, "x" * 100, "")
+            )
 
 
 def test_default_limits():

--- a/tests/util/test_subprocess.py
+++ b/tests/util/test_subprocess.py
@@ -219,6 +219,8 @@ async def test_subprocess_output_limit_under_limit():
     )
     assert result.success is True
     assert result.stdout.strip() == "hello"
+    assert result.stdout_truncated is False
+    assert result.stderr_truncated is False
 
 
 @pytest.mark.anyio
@@ -237,6 +239,8 @@ for i in range(10):
         text=False,
     )
     assert result.success is True
+    assert result.stdout_truncated is True
+    assert result.stderr_truncated is False
     # Should contain trailing digits (7s, 8s, 9s), not leading (0s, 1s)
     assert result.stdout[-100:] == b"9" * 100
     assert b"0" * 50 not in result.stdout  # Leading 0s should be gone
@@ -272,6 +276,22 @@ async def test_subprocess_output_limit_binary():
     assert result.success is True
     assert len(result.stdout) == 50
     assert result.stdout == b"x" * 50
+    assert result.stdout_truncated is True
+    assert result.stderr_truncated is False
+
+
+@pytest.mark.anyio
+async def test_subprocess_output_limit_marks_stderr_truncated():
+    result = await subprocess(
+        [
+            "python3",
+            "-c",
+            "import sys; sys.stderr.write('e' * 100)",
+        ],
+        output_limit=50,
+    )
+    assert result.stderr_truncated is True
+    assert result.stdout_truncated is False
 
 
 @pytest.mark.anyio
@@ -284,6 +304,8 @@ async def test_subprocess_output_limit_no_limit():
     )
     assert result.success is True
     assert len(result.stdout.strip()) == 1000
+    assert result.stdout_truncated is None
+    assert result.stderr_truncated is None
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [x] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes #4778

`sandbox.exec()` applies the configured output limit, but Local and Docker execution returned a successful `ExecResult` with the trailing output after truncation. Callers parsing structured JSON or JSONL could not tell whether the result was complete.

### What is the new behavior?

`ExecResult` now carries optional `stdout_truncated` and `stderr_truncated` metadata. Local subprocess-backed execution reports `True` when a stream exceeded its limit and `False` when it completed without truncation; providers that cannot report the state continue to return `None`. The sandbox proxy raises `OutputLimitExceededError` from positive metadata while retaining the previous byte-length fallback for older providers.

The sandbox execution contract and changelog now document the three-state behavior and the existing recommendation to use `read_file()` when complete large output is required.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. The new dataclass fields default to `None`, and providers that do not populate them retain the previous compatibility fallback. Callers can optionally inspect the metadata to detect truncated structured output.

### Other information:

Verification:

- `uv run pytest tests/util/test_subprocess.py tests/util/sandbox/test_sandbox_limits.py tests/util/sandbox/test_local_sandbox.py tests/util/sandbox/test_exec_remote.py tests/util/sandbox/test_docker_read_file.py tests/util/sandbox/test_sandbox_service.py tests/util/sandbox/test_sandbox_timeout.py tests/util/sandbox/test_json_rpc_transport.py` — 166 passed, 159 skipped (Docker/Trio unavailable in this environment).
- Final focused regression run — 38 passed, 22 skipped.
- `uv run mypy --exclude tests/test_package src tests` — passed (1,356 source files).
- Ruff check and format checks — passed.
- A full `uv run pytest` run was started but stopped after unrelated agent/provider and checkpoint failures appeared outside the changed paths; the targeted suites above passed.

### Agent review

- No independent review pass was run. The author performed targeted verification and reviewed the final diff; no separate model/tool review findings are claimed.
