### PR TITLE
Anthropic: fix failing token-count request on every generate with empty thinking summaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 
+- Anthropic: models returning omitted (empty) thinking summaries no longer misreport `usage.reasoning_tokens` and log a token-counting warning on every generate.
 - Security: Computer Tool bundled examples now bind dynamically assigned VNC and noVNC ports to loopback instead of all host interfaces.
 - Sandbox: Local samples now isolate and stop sandbox-tools servers during cleanup, preventing stale working directories and orphaned tool processes across samples.
 

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -3257,10 +3257,8 @@ async def model_output_from_message(
         span_recorder=span_recorder,
     )
 
-    # count reasoning tokens (skip empty thinking text -- models with
-    # thinking.display "omitted", e.g. adaptive-by-default models run without
-    # an explicit reasoning config, return thinking blocks whose text is ""
-    # and the count_tokens API rejects empty content with a 400)
+    # count reasoning tokens (skip empty thinking text -- omitted summaries
+    # come back as "" and count_tokens rejects empty content with a 400)
     reasoning_tokens = 0
     if client and model:
         for content_block in message.content:

--- a/src/inspect_ai/model/_providers/anthropic.py
+++ b/src/inspect_ai/model/_providers/anthropic.py
@@ -3257,11 +3257,14 @@ async def model_output_from_message(
         span_recorder=span_recorder,
     )
 
-    # count reasoning tokens
+    # count reasoning tokens (skip empty thinking text -- models with
+    # thinking.display "omitted", e.g. adaptive-by-default models run without
+    # an explicit reasoning config, return thinking blocks whose text is ""
+    # and the count_tokens API rejects empty content with a 400)
     reasoning_tokens = 0
     if client and model:
         for content_block in message.content:
-            if isinstance(content_block, ThinkingBlock):
+            if isinstance(content_block, ThinkingBlock) and content_block.thinking:
                 reasoning_tokens += await count_tokens(
                     client, model, content_block.thinking
                 )

--- a/tests/model/providers/test_anthropic.py
+++ b/tests/model/providers/test_anthropic.py
@@ -1875,3 +1875,107 @@ async def test_anthropic_container_continuation_live() -> None:
         break
     else:
         pytest.skip("model did not produce the mixed server/client tool turn")
+
+
+# ---------------------------------------------------------------------------
+# reasoning token counting (model_output_from_message)
+# ---------------------------------------------------------------------------
+
+
+class _CountTokensStub:
+    """Duck-typed stand-in for AsyncAnthropic that records count_tokens calls.
+
+    Mirrors the live API's validation: a user message with empty content is
+    rejected (400 "user messages must have non-empty content").
+    """
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.messages = types.SimpleNamespace(count_tokens=self._count_tokens)
+
+    async def _count_tokens(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        content = kwargs["messages"][0]["content"]
+        if not content:
+            raise RuntimeError(
+                "Error code: 400 - messages.0: user messages must have "
+                "non-empty content"
+            )
+        return types.SimpleNamespace(input_tokens=42)
+
+
+def _thinking_response_message(thinking: str) -> Any:
+    from anthropic.types.message import Message
+
+    return Message.model_validate(
+        {
+            "id": "msg_01",
+            "type": "message",
+            "role": "assistant",
+            "model": "claude-sonnet-5",
+            "content": [
+                {"type": "thinking", "thinking": thinking, "signature": "sig"},
+                {"type": "text", "text": "The answer is 4."},
+            ],
+            "stop_reason": "end_turn",
+            "usage": {"input_tokens": 10, "output_tokens": 20},
+        }
+    )
+
+
+@pytest.mark.anyio
+async def test_anthropic_empty_thinking_skips_reasoning_token_count() -> None:
+    """Empty thinking text must not be sent to the count_tokens API.
+
+    On models where adaptive thinking runs by default (Sonnet 5, Fable 5) and
+    no reasoning_effort is configured, the API's default display="omitted"
+    returns thinking blocks whose text is "". Sending "" to count_tokens gets
+    a 400 ("user messages must have non-empty content") on every generate —
+    swallowed by the estimate fallback, which then reports reasoning_tokens=1.
+    An empty block should be counted as 0 without touching the API.
+    """
+    from inspect_ai.model._providers.anthropic import (
+        init_sample_anthropic_assistant_internal,
+        model_output_from_message,
+    )
+
+    init_sample_anthropic_assistant_internal()
+    client = _CountTokensStub()
+
+    output, _ = await model_output_from_message(
+        client,  # type: ignore[arg-type]
+        "claude-sonnet-5",
+        _thinking_response_message(thinking=""),
+        [],
+    )
+
+    assert client.calls == [], (
+        "count_tokens API must not be called for empty thinking text "
+        f"(got {len(client.calls)} call(s): {client.calls})"
+    )
+    assert output.usage is not None
+    # follows the existing "reasoning_tokens if > 0 else None" convention
+    assert output.usage.reasoning_tokens is None
+
+
+@pytest.mark.anyio
+async def test_anthropic_nonempty_thinking_counts_reasoning_tokens() -> None:
+    """Non-empty thinking text is still counted via the count_tokens API."""
+    from inspect_ai.model._providers.anthropic import (
+        init_sample_anthropic_assistant_internal,
+        model_output_from_message,
+    )
+
+    init_sample_anthropic_assistant_internal()
+    client = _CountTokensStub()
+
+    output, _ = await model_output_from_message(
+        client,  # type: ignore[arg-type]
+        "claude-sonnet-5",
+        _thinking_response_message(thinking="Let me reason this through."),
+        [],
+    )
+
+    assert len(client.calls) == 1
+    assert output.usage is not None
+    assert output.usage.reasoning_tokens == 42


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior?

`model_output_from_message` counts reasoning tokens by calling the Anthropic `count_tokens` API for every `ThinkingBlock` in a response, with no guard for empty text. On models where adaptive thinking runs by default (Sonnet 5, Fable 5/Mythos) and the eval sets no reasoning config, Inspect sends no `thinking` param, so the API's default `thinking.display: "omitted"` returns thinking blocks whose text is `""`. Counting `""` POSTs `{"role": "user", "content": ""}`, which the API rejects with 400 `user messages must have non-empty content` — on **every** generate that produced a thinking block. The helper swallows the error (warn_once + character estimate), so the only symptoms are junk 400 traffic and `usage.reasoning_tokens` misreported as 1 per block.

User-facing trigger: during a monitoring drill we observed 11,492/11,492 `count_tokens` calls failing through a proxy (~19 junk requests/min) while the eval itself succeeded — token accounting was silently running on estimate fallbacks the whole time.

The unguarded call has existed since #1483 (March 2025) but was latent until adaptive-by-default models landed (#4203 June 2026, #4404 July 2026) — any Sonnet 5 / Fable eval run without explicit `reasoning_effort` since then has been affected.

### What is the new behavior?

Empty thinking text is counted as zero without touching the `count_tokens` API. Non-empty thinking text is counted via the API exactly as before. `usage.reasoning_tokens` keeps the existing "value if > 0 else None" convention.

### Does this PR introduce a breaking change?

No.

### Other information:

Reproduced deterministically before the fix with a single plain `generate()` against `anthropic/claude-sonnet-5` (no reasoning config): response contains a `reasoning` block with empty summary, one `count_tokens` POST returns 400, generate succeeds. After the fix, the same call issues no `count_tokens` request. Both `content: ""` and `content: []` were verified against the live API to produce the exact reported error string.

### Agent review
- Reviewer: fresh-context code-review subagent (separate context from author), 1 pass over the diff plus surrounding code
- Findings: 3 — 1 fixed (CHANGELOG entry reworded from mechanism to user-visible symptom), 2 dismissed: whitespace-only thinking text not guarded (no evidence the API returns whitespace-padded empty thinking; the real failure mode is `""`), test stub raises generic `RuntimeError` instead of the SDK's `BadRequestError` (the production helper catches broad `Exception`, so the test remains valid)
- Reviewer confirmed both new test assertions fail without the guard (the stub records the call before raising, and the estimate fallback yields `reasoning_tokens == 1`), and that the single `model_output_from_message` call site covers both streaming and non-streaming paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)