### PR TITLE
Test checkpoint resume after Ctrl-C, not just after a hard kill

### DIFF
--- a/tests/checkpoint/resume_kill_harness.py
+++ b/tests/checkpoint/resume_kill_harness.py
@@ -1,18 +1,19 @@
-"""Harness for the checkpoint resume-after-hard-kill e2e test.
+"""Harness for the checkpoint resume-after-interrupt e2e test.
 
 Lives alongside the e2e test in ``tests/checkpoint/`` and serves two roles:
 
 1. **Importable** by the test — registering the ``@task`` / ``@modelapi`` so
    the final in-process resume works, and exposing shared constants.
-2. **Runnable as a script** by the test for each killed attempt::
+2. **Runnable as a script** by the test for each interrupted attempt::
 
        python resume_kill_harness.py <log_dir> [<retry_from>]
 
-Running the killed attempts in child processes is what lets the test issue a
-*real* ``SIGKILL`` of the eval without taking down pytest. The ``crash`` tool
-``os.kill``s its own (child) process — abruptly, with no graceful unwind, no
-``finally``, no log finalize — exercising recovery from an unanticipated death
-(power loss / OOM / preemption), which is the whole point of checkpointing.
+Running the interrupted attempts in child processes is what lets the test
+issue a *real* signal to an eval without taking down pytest. The ``crash``
+tool ``os.kill``s its own (child) process with the signal named by
+``SIGNAL_ENV``: ``SIGKILL`` for an unanticipated death (power loss / OOM /
+preemption — no unwind, no log finalize), or ``SIGINT`` for what Ctrl-C
+delivers.
 
 Requires Docker (the sandbox backup path injects a Linux restic binary).
 """
@@ -67,6 +68,15 @@ RESUME_WRITE_CMD = 'printf resumed > "$HOME/workspace/resumed.txt"'
 # crash tool just before it kills the process.
 CANCEL_FILE_ENV = "INSPECT_TEST_RESUME_CANCEL_FILE"
 TARGET_ENV = "INSPECT_TEST_RESUME_TARGET_CANCELS"
+
+# Which signal the `crash` tool sends itself: SIGKILL (unanticipated death, no
+# unwind) or SIGINT (what Ctrl-C delivers — graceful cancel, log finalized,
+# sandboxes torn down). Resume must work from either.
+SIGNAL_ENV = "INSPECT_TEST_RESUME_SIGNAL"
+
+
+def crash_signal() -> signal.Signals:
+    return signal.Signals[os.environ.get(SIGNAL_ENV, "SIGKILL")]
 
 
 def cancels_done() -> int:
@@ -128,13 +138,14 @@ def remember() -> Tool:
 @tool
 def crash() -> Tool:
     async def execute() -> str:
-        """Kill the eval process immediately (uncatchable, no cleanup)."""
-        # Record the crash before dying (flushed to disk), then SIGKILL our own
-        # process. Running inside the child, this is the child's PID — an
-        # abrupt death with no unwind, mimicking a power loss / OOM / preempt.
+        """Signal the eval process to die (SIGKILL) or cancel (SIGINT)."""
+        # Record the crash before signalling (flushed to disk), then signal our
+        # own process. Running inside the child, this is the child's PID.
         bump_cancels()
-        os.kill(os.getpid(), signal.SIGKILL)
-        await anyio.sleep_forever()  # unreachable; SIGKILL is immediate
+        os.kill(os.getpid(), crash_signal())
+        # SIGKILL never gets here; under SIGINT this is where the eval's
+        # cancellation lands.
+        await anyio.sleep_forever()
         return "crashed"
 
     return execute

--- a/tests/checkpoint/test_checkpoint_e2e.py
+++ b/tests/checkpoint/test_checkpoint_e2e.py
@@ -1,12 +1,17 @@
-"""End-to-end checkpoint resume test: hard-kill an attempt, then retry — twice.
+"""End-to-end checkpoint resume test: interrupt an attempt, then retry — twice.
 
 Drives a ``react()`` agent through tool-calling turns with
 ``TurnInterval(every=1)``, so a checkpoint fires at the start of each turn
-after the first. Instead of cooperatively cancelling, the agent calls a
-``crash`` tool that ``SIGKILL``s its own process mid-run — an *unanticipated*
-death (power loss / OOM / preemption) with no graceful unwind, no log
-finalize, and an orphaned sandbox container. Recovering from exactly that is
-the point of checkpointing.
+after the first. The agent calls a ``crash`` tool that signals its own
+process mid-run, parametrized over both ways a run really ends:
+
+- ``SIGKILL`` — an *unanticipated* death (power loss / OOM / preemption)
+  with no graceful unwind, no log finalize, and an orphaned sandbox
+  container. Recovering from exactly that is the point of checkpointing.
+- ``SIGINT`` — what Ctrl-C delivers. The opposite hazard: a lot of cleanup
+  *does* run (sandbox teardown, log finalize, the sample logged with a
+  cancellation error), any of which could plausibly leave the run
+  unresumable.
 
 Because a real ``SIGKILL`` can't kill the pytest process and let it continue,
 each killed attempt runs in a **child process** (the harness in
@@ -43,6 +48,7 @@ from test_helpers.utils import flaky_retry, skip_if_no_anthropic, skip_if_no_doc
 from checkpoint.resume_kill_harness import (
     CANCEL_FILE_ENV,
     LAYER1_CONTENT,
+    SIGNAL_ENV,
     TARGET_ENV,
     generates,
     reset_generates,
@@ -94,21 +100,26 @@ def _latest_log(log_dir: str) -> str:
     return max(logs, key=lambda info: info.name).name
 
 
-def _run_killed_attempt(
+def _run_interrupted_attempt(
     log_dir: str,
     retry_from: str | None,
     tests_dir: Path,
+    interrupt: str = "SIGKILL",
     harness_name: str = "resume_kill_harness.py",
 ) -> None:
-    """Run an eval in a child process that ``SIGKILL``s itself mid-run.
+    """Run an eval in a child process that signals itself mid-run.
 
-    Asserts the child died by signal rather than exiting normally.
+    ``SIGKILL`` is an unanticipated death (no unwind, no log finalize);
+    ``SIGINT`` is what Ctrl-C delivers (graceful cancel, finalized log,
+    sandboxes torn down). Asserts the attempt ended the way the signal
+    implies, so a mode that silently stopped taking effect can't pass.
     """
     env = {
         **os.environ,
         "PYTHONPATH": os.pathsep.join(
             p for p in (str(tests_dir), os.environ.get("PYTHONPATH", "")) if p
         ),
+        SIGNAL_ENV: interrupt,
     }
     harness = str(tests_dir / "checkpoint" / harness_name)
     proc = subprocess.run(
@@ -116,10 +127,23 @@ def _run_killed_attempt(
         env=env,
         timeout=600,
     )
-    assert proc.returncode == -signal.SIGKILL, (
-        f"expected the child to die by SIGKILL (-{signal.SIGKILL}); "
-        f"got returncode {proc.returncode}"
-    )
+    if interrupt == "SIGKILL":
+        assert proc.returncode == -signal.SIGKILL, (
+            f"expected the child to die by SIGKILL (-{signal.SIGKILL}); "
+            f"got returncode {proc.returncode}"
+        )
+    else:
+        # The child's exit code is not a useful signal here: inspect absorbs
+        # the interrupt rather than re-raising KeyboardInterrupt, so a
+        # SIGINTed eval() exits 0 and a SIGINTed eval_retry() exits 1 on an
+        # IndexError. What matters is that the run wound down gracefully —
+        # a *finalized* log with status "cancelled" (a hard kill never
+        # finalizes one).
+        assert proc.returncode != -signal.SIGKILL, "child was hard-killed, not SIGINTed"
+        status = read_eval_log(_latest_log(log_dir), header_only=True).status
+        assert status == "cancelled", (
+            f"expected the SIGINTed attempt to finalize a cancelled log; got '{status}'"
+        )
 
 
 def _inspect_projects() -> set[str]:
@@ -253,7 +277,7 @@ def test_checkpoint_resume_restores_assistant_internal(
 
     projects_before = _inspect_projects()
     try:
-        _run_killed_attempt(
+        _run_interrupted_attempt(
             log_dir, None, tests_dir, harness_name="resume_kill_thinking_harness.py"
         )
         killed_log = _latest_log(log_dir)
@@ -284,9 +308,17 @@ def test_checkpoint_resume_restores_assistant_internal(
 
 @skip_if_no_docker
 @pytest.mark.slow
+@pytest.mark.parametrize("interrupt", ["SIGKILL", "SIGINT"])
 def test_checkpoint_resume_rehydrated_event_layout(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, interrupt: str
 ) -> None:
+    """Resume works whether the eval was hard-killed or Ctrl-C'd.
+
+    Ctrl-C (SIGINT) runs a lot of graceful cleanup a hard kill skips —
+    sandbox teardown, log finalize, a sample logged with a cancellation
+    error — so it reaches checkpoint resume down a different path than
+    the SIGKILL case, and gets the same result.
+    """
     # Crash count (host file) + target are inherited by the child processes.
     cancel_file = tmp_path / "cancels.txt"
     monkeypatch.setenv(CANCEL_FILE_ENV, str(cancel_file))
@@ -306,21 +338,24 @@ def test_checkpoint_resume_rehydrated_event_layout(
     # the ones this test leaks (the final resume cleans up its own).
     projects_before = _inspect_projects()
     try:
-        # --- attempt #0: fresh eval, hard-killed at turn 2 (after ck1/ck2) --
-        _run_killed_attempt(log_dir, None, tests_dir)
+        # --- attempt #0: fresh eval, interrupted at turn 2 (after ck1/ck2) --
+        _run_interrupted_attempt(log_dir, None, tests_dir, interrupt)
 
-        # The hard kill leaves the attempt's sandbox container running —
-        # probe it for the restic dir's location and permissions.
         leaked = [
             cid
             for name in _inspect_projects() - projects_before
             for cid in _project_container_ids(name)
         ]
-        assert leaked, "expected the killed attempt to leak its sandbox container"
-        _assert_restic_dir_hidden(leaked[0])
+        if interrupt == "SIGKILL":
+            # The hard kill leaves the attempt's sandbox container running —
+            # probe it for the restic dir's location and permissions.
+            assert leaked, "expected the killed attempt to leak its sandbox container"
+            _assert_restic_dir_hidden(leaked[0])
+        else:
+            assert not leaked, f"Ctrl-C should tear down the sandbox; leaked {leaked}"
 
-        # --- attempt #1: resume, work one turn (ck3), hard-kill at turn 3 ---
-        _run_killed_attempt(log_dir, _latest_log(log_dir), tests_dir)
+        # --- attempt #1: resume, work one turn (ck3), interrupt at turn 3 ---
+        _run_interrupted_attempt(log_dir, _latest_log(log_dir), tests_dir, interrupt)
 
         # --- final resume: runs in this process, to completion --------------
         reset_generates()


### PR DESCRIPTION
## This PR contains:
- [ ] New features
- [x] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

Test-only — no product code changes, so no CHANGELOG entry.

### What is the current behavior? (You can also link to an open issue here)

`test_checkpoint_resume_rehydrated_event_layout` only ever interrupted an attempt with `SIGKILL`. That covers the unanticipated-death case checkpointing exists for (power loss / OOM / preemption): no unwind, no log finalize, an orphaned sandbox container.

It does not cover Ctrl-C, which is how people actually stop a run. Ctrl-C is close to the opposite hazard: a lot of cleanup *does* run — sandbox teardown, log finalize, the sample logged with a cancellation error — and any of it could plausibly leave the run unresumable. The e2e test used to interrupt with Ctrl-C, but was switched to `SIGKILL` precisely because the graceful path does so much work, so that path has been untested for a while.

### What is the new behavior?

The test is parametrized over `SIGKILL` and `SIGINT`. The harness's `crash` tool takes its signal from `INSPECT_TEST_RESUME_SIGNAL`.

Assertions that differ by mode:

- `SIGKILL` asserts the child died by signal, and probes the leaked sandbox container for the restic dir's location and permissions (unchanged from before).
- `SIGINT` asserts the attempt finalized a log with status `cancelled` — a hard kill never finalizes one, so this fails if the mode silently stops taking effect — and that the sandbox was torn down rather than leaked.

Everything about resume itself is shared between the two: the `prior_run` restore spans and their numbering, span balance, which checkpoints are rehydrated vs. committed live, the sandbox file-listing deltas, that only the remaining turns run, and the final score.

The child's exit code is deliberately not asserted for `SIGINT`. Inspect absorbs the interrupt rather than re-raising `KeyboardInterrupt`, so a SIGINTed `eval()` exits 0 while a SIGINTed `eval_retry()` exits 1 on an `IndexError` — see #4859. The finalized `cancelled` log is the stable invariant, and it stays correct whichever way #4859 is resolved.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Tests only.

### Other information:

Adding this coverage turned up two real bugs, both filed separately and neither fixed here:

- #4859 — on Ctrl-C the cancelled log is written to disk correctly but dropped from what `eval()` returns. `eval_set` then reports `success=True` with zero logs and prints "Completed all tasks ... successfully"; the CLI exits 0 instead of 130; `eval_retry` raises `IndexError`.
- #4861 — interrupting a *resume* partway through hydration leaves the run permanently unresumable, because hydration copies the `ckpt-*.json` files ahead of the restic data behind them. More serious than #4859, and not Ctrl-C specific.

The `SIGINT` case passes today, so resume after a plain Ctrl-C does work; neither bug above blocks it.

Verification:

- `pytest tests/checkpoint/test_checkpoint_e2e.py -k rehydrated --runslow` — both params pass (76s, docker + restic).
- `pytest tests/checkpoint/ --runslow` (excluding the two other slow e2e tests) — 245 passed, 94 skipped.
- `make check` — ruff clean. mypy reports 8 errors, all pre-existing on `main` and none in the files touched here: `scorer/_math.py` and `tests/scorer/test_math.py` (missing optional `latex2sympy2_extended` in my local venv) and one `type-arg` error in `_cli/ctl.py`.

### Agent review
- Reviewer: none. No review pass was run on this diff.
- Author: written by Claude Code (Opus 5) under my direction, including the investigation that produced #4859 and #4861.
