### PR TITLE
ctl: document --json payload shapes in --help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Security: Computer Tool bundled examples now bind dynamically assigned VNC and noVNC ports to loopback instead of all host interfaces.
 - Sandbox: Local samples now isolate and stop sandbox-tools servers during cleanup, preventing stale working directories and orphaned tool processes across samples.
+- Control Channel: Every `inspect ctl` command's `--help` now sketches its `--json` payload's top-level keys, so scripted consumers can parse output without a discovery run.
 
 ## 0.3.258 (11 August 2026)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Security: Computer Tool bundled examples now bind dynamically assigned VNC and noVNC ports to loopback instead of all host interfaces.
 - Sandbox: Local samples now isolate and stop sandbox-tools servers during cleanup, preventing stale working directories and orphaned tool processes across samples.
-- Control Channel: Every `inspect ctl` command's `--help` now sketches its `--json` payload's top-level keys, so scripted consumers can parse output without a discovery run.
+- Control Channel: Every `inspect ctl` command's `--help` now sketches its `--json` payload's top-level keys.
 
 ## 0.3.258 (11 August 2026)
 

--- a/src/inspect_ai/_cli/ctl.py
+++ b/src/inspect_ai/_cli/ctl.py
@@ -309,7 +309,11 @@ def _mirror_list_options(group: click.Group, list_command: click.Command) -> Non
     for param in list_command.params:
         if isinstance(param, click.Option):
             mirrored = copy.copy(param)
-            mirrored.help = "Mirrored from `list` for the bare-noun default."
+            # keep the verb's own help (the payload sketch especially — the
+            # bare noun is the spelling scripted consumers reach for first)
+            mirrored.help = (
+                f"{param.help or ''} Mirrored from `list` for the bare-noun default."
+            ).strip()
             group.params.append(mirrored)
 
 
@@ -329,11 +333,9 @@ def _json_option(what: str) -> Callable[[Callable[..., None]], Callable[..., Non
     )
 
 
-# The payload sketch every mutation verb's `--json` help shows — one constant
-# so the sketch can't drift from `_mutation_envelope` site by site.
-_MUTATION_ENVELOPE_HELP = (
-    "a `{target, applied, dry_run, detail}` mutation envelope — branch on `applied`"
-)
+# The payload sketch every mutation verb's `--json` help shows (pinned to
+# `_mutation_envelope`'s keys by a test).
+_MUTATION_ENVELOPE_HELP = "a `{target, applied, dry_run, detail}` mutation envelope"
 
 
 @click.group("ctl")
@@ -345,7 +347,8 @@ def ctl_command() -> None:
     All commands accept `--json`; a failed `--json` invocation emits an
     `{"error": {kind, exception, message, status}}` envelope on stdout
     (exit code stays non-zero; click usage errors — unknown option,
-    missing argument — still exit 2 without one).
+    missing argument — still exit 2 without one). With no running evals,
+    task- and sample-targeted commands (and `config`) print `null`.
 
     A process exits when its eval finishes; launch with `inspect eval
     --ctl-server=keep` to keep it inspectable here until you run
@@ -2734,8 +2737,6 @@ def _mutation_envelope(
 ) -> dict[str, Any]:
     """The uniform ``--json`` mutation result envelope for the cancel verbs.
 
-    Its top-level keys are sketched in every mutation verb's ``--help`` via
-    ``_MUTATION_ENVELOPE_HELP`` — keep the two in sync.
     ``applied`` reports whether the mutation actually landed — false on a
     dry run and on the idempotent already-in-that-state no-op (the server's
     ``changed: false``) — so an agent branches on one field. The server's

--- a/src/inspect_ai/_cli/ctl.py
+++ b/src/inspect_ai/_cli/ctl.py
@@ -348,9 +348,10 @@ def ctl_command() -> None:
     `{"error": {kind, exception, message, status}}` envelope on stdout
     (exit code stays non-zero; click usage errors — unknown option,
     missing argument — still exit 2 without one). With no running evals,
-    task- and sample-targeted commands (and `config`) print `null`,
-    except the paged reads (`sample events` / `sample messages`), which
-    print an empty page (identifier echo with `task_id` null).
+    commands that resolve a single task or sample target (and `config`)
+    print `null`, except the paged reads (`sample events` / `sample
+    messages`), which print an empty page (identifier echo with `task_id`
+    null); list verbs print their usual envelope with empty rows.
 
     A process exits when its eval finishes; launch with `inspect eval
     --ctl-server=keep` to keep it inspectable here until you run
@@ -718,7 +719,7 @@ def sample_errors_command(task: str | None, as_json: bool) -> None:
 )
 @_json_option(
     "the sample's summary + error detail — a flat `{task_id, task, sample_id, "
-    "epoch, status, ..., error, error_retries}` object"
+    "epoch, status, ..., error, error_retries, scores}` object"
 )
 def sample_show_command(
     task: str, sample_id: str, epoch: int, show_traceback: bool, as_json: bool

--- a/src/inspect_ai/_cli/ctl.py
+++ b/src/inspect_ai/_cli/ctl.py
@@ -1133,8 +1133,8 @@ def sample_requeue_command(
     help="Report what would change without applying it (with a set option).",
 )
 @_json_option(
-    "a `{target, knobs, warnings, notes, applied, dry_run, ...}` view, "
-    "every knob labeled with its scope"
+    "a `{target, knobs, warnings, notes, applied, dry_run, persisted, "
+    "requested}` view, every knob labeled with its scope"
 )
 def config_command(
     task: str | None,

--- a/src/inspect_ai/_cli/ctl.py
+++ b/src/inspect_ai/_cli/ctl.py
@@ -348,7 +348,9 @@ def ctl_command() -> None:
     `{"error": {kind, exception, message, status}}` envelope on stdout
     (exit code stays non-zero; click usage errors — unknown option,
     missing argument — still exit 2 without one). With no running evals,
-    task- and sample-targeted commands (and `config`) print `null`.
+    task- and sample-targeted commands (and `config`) print `null`,
+    except the paged reads (`sample events` / `sample messages`), which
+    print an empty page (identifier echo with `task_id` null).
 
     A process exits when its eval finishes; launch with `inspect eval
     --ctl-server=keep` to keep it inspectable here until you run

--- a/src/inspect_ai/_cli/ctl.py
+++ b/src/inspect_ai/_cli/ctl.py
@@ -314,7 +314,12 @@ def _mirror_list_options(group: click.Group, list_command: click.Command) -> Non
 
 
 def _json_option(what: str) -> Callable[[Callable[..., None]], Callable[..., None]]:
-    """The ``--json`` flag every command carries, with per-command envelope help."""
+    """The ``--json`` flag every command carries, with per-command envelope help.
+
+    ``what`` sketches the payload's top-level keys so a scripted consumer can
+    orient the first parse from ``--help`` alone, without a discovery
+    round-trip through the command itself.
+    """
     return click.option(
         "--json",
         "as_json",
@@ -322,6 +327,13 @@ def _json_option(what: str) -> Callable[[Callable[..., None]], Callable[..., Non
         default=False,
         help=f"Output as JSON ({what}).",
     )
+
+
+# The payload sketch every mutation verb's `--json` help shows — one constant
+# so the sketch can't drift from `_mutation_envelope` site by site.
+_MUTATION_ENVELOPE_HELP = (
+    "a `{target, applied, dry_run, detail}` mutation envelope — branch on `applied`"
+)
 
 
 @click.group("ctl")
@@ -467,7 +479,7 @@ _mirror_list_options(task_group, task_list_command)
 
 @task_group.command("log-flush")
 @click.argument("task", required=False)
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def task_log_flush_command(task: str | None, as_json: bool) -> None:
     """Flush a running task's buffered samples to its log now.
 
@@ -500,13 +512,7 @@ def task_log_flush_command(task: str | None, as_json: bool) -> None:
     default=False,
     help="Report what would be cancelled without doing it.",
 )
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Output as JSON (the mutation result envelope).",
-)
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def task_cancel_command(task: str, action: str, dry_run: bool, as_json: bool) -> None:
     """Cancel a running task.
 
@@ -536,7 +542,7 @@ def task_cancel_command(task: str, action: str, dry_run: bool, as_json: bool) ->
     default=False,
     help="Report what would be paused without doing it.",
 )
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def task_pause_command(task: str | None, dry_run: bool, as_json: bool) -> None:
     """Pause a running task (stop dispatching new work; in-flight finishes).
 
@@ -559,7 +565,7 @@ def task_pause_command(task: str | None, dry_run: bool, as_json: bool) -> None:
     default=False,
     help="Report what would be resumed without doing it.",
 )
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def task_resume_command(task: str | None, dry_run: bool, as_json: bool) -> None:
     """Resume a paused task (the inverse of `inspect ctl task pause`).
 
@@ -705,7 +711,10 @@ def sample_errors_command(task: str | None, as_json: bool) -> None:
     default=False,
     help="Show the full traceback for each error (default: message only).",
 )
-@_json_option("the sample's summary + error detail")
+@_json_option(
+    "the sample's summary + error detail — a flat `{task_id, task, sample_id, "
+    "epoch, status, ..., error, error_retries}` object"
+)
 def sample_show_command(
     task: str, sample_id: str, epoch: int, show_traceback: bool, as_json: bool
 ) -> None:
@@ -796,7 +805,7 @@ def sample_show_command(
     default=None,
     help="Only events at/before this unix timestamp.",
 )
-@_json_option("the `{events, next, done}` envelope")
+@_json_option("the `{task_id, sample_id, epoch, events, next, done}` envelope")
 def sample_events_command(
     task: str,
     sample_id: str,
@@ -866,12 +875,8 @@ def sample_events_command(
     default=False,
     help="Return raw ChatMessage JSON instead of the compact summary.",
 )
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Output as JSON (the `{as_of, status, count, messages}` envelope).",
+@_json_option(
+    "the `{task_id, sample_id, epoch, as_of, status, count, messages}` envelope"
 )
 def sample_messages_command(
     task: str,
@@ -924,13 +929,7 @@ def sample_messages_command(
     default=False,
     help="Report what would be cancelled without doing it.",
 )
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Output as JSON (the mutation result envelope).",
-)
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def sample_cancel_command(
     task: str,
     sample_id: str,
@@ -967,13 +966,7 @@ def sample_cancel_command(
     default=False,
     help="Report what would be re-run without doing it.",
 )
-@click.option(
-    "--json",
-    "as_json",
-    is_flag=True,
-    default=False,
-    help="Output as JSON (the mutation result envelope).",
-)
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def sample_requeue_command(
     task: str,
     sample_id: str,
@@ -1136,7 +1129,10 @@ def sample_requeue_command(
     default=False,
     help="Report what would change without applying it (with a set option).",
 )
-@_json_option("the config view, every knob labeled with its scope")
+@_json_option(
+    "a `{target, knobs, warnings, notes, applied, dry_run, ...}` view, "
+    "every knob labeled with its scope"
+)
 def config_command(
     task: str | None,
     max_samples: int | None,
@@ -1250,7 +1246,7 @@ _mirror_list_options(process_group, process_list_command)
 
 @process_group.command("keep")
 @click.argument("pid", required=False, type=int)
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def process_keep_command(pid: int | None, as_json: bool) -> None:
     """Keep a running inspect process alive after its eval finishes.
 
@@ -1264,7 +1260,7 @@ def process_keep_command(pid: int | None, as_json: bool) -> None:
 
 @process_group.command("release")
 @click.argument("pid", required=False, type=int)
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def process_release_command(pid: int | None, as_json: bool) -> None:
     """Release a lingering --ctl-server=keep process so it can exit.
 
@@ -1283,7 +1279,7 @@ def process_release_command(pid: int | None, as_json: bool) -> None:
     default=False,
     help="Report what would be paused without doing it.",
 )
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def process_pause_command(pid: int | None, dry_run: bool, as_json: bool) -> None:
     """Pause a whole running eval or eval-set (stop dispatching new work; in-flight finishes).
 
@@ -1306,7 +1302,7 @@ def process_pause_command(pid: int | None, dry_run: bool, as_json: bool) -> None
     default=False,
     help="Report what would be resumed without doing it.",
 )
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def process_resume_command(pid: int | None, dry_run: bool, as_json: bool) -> None:
     """Resume a paused eval or eval-set (the inverse of `process pause`).
 
@@ -1383,7 +1379,7 @@ model_group.hint = lambda token: (
     default=False,
     help="Report what would be paused without doing it.",
 )
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def model_pause_command(
     model: str, pid: int | None, dry_run: bool, as_json: bool
 ) -> None:
@@ -1410,7 +1406,7 @@ def model_pause_command(
     default=False,
     help="Report what would be resumed without doing it.",
 )
-@_json_option("the mutation result envelope")
+@_json_option(_MUTATION_ENVELOPE_HELP)
 def model_resume_command(
     model: str, pid: int | None, dry_run: bool, as_json: bool
 ) -> None:
@@ -2738,6 +2734,8 @@ def _mutation_envelope(
 ) -> dict[str, Any]:
     """The uniform ``--json`` mutation result envelope for the cancel verbs.
 
+    Its top-level keys are sketched in every mutation verb's ``--help`` via
+    ``_MUTATION_ENVELOPE_HELP`` — keep the two in sync.
     ``applied`` reports whether the mutation actually landed — false on a
     dry run and on the idempotent already-in-that-state no-op (the server's
     ``changed: false``) — so an agent branches on one field. The server's

--- a/tests/_control/test_ctl.py
+++ b/tests/_control/test_ctl.py
@@ -3030,6 +3030,22 @@ def test_mutation_envelope_help_sketches_actual_keys() -> None:
     assert "{" + ", ".join(envelope.keys()) + "}" in _MUTATION_ENVELOPE_HELP
 
 
+def test_config_help_sketches_compose_config_keys() -> None:
+    """`config --help`'s --json sketch names exactly `_compose_config`'s keys."""
+    from inspect_ai._cli.ctl import _compose_config, _DirectiveScope, config_command
+
+    scope = _DirectiveScope(
+        socket_path="sock", pid=1, task_id=None, task=None, header="", siblings=0
+    )
+    view = _compose_config(scope, {}, dry_run=False, set_values=False, notes=[])
+    option = next(
+        p
+        for p in config_command.params
+        if isinstance(p, click.Option) and p.name == "as_json"
+    )
+    assert "{" + ", ".join(view.keys()) + "}" in (option.help or "")
+
+
 def test_every_json_option_help_sketches_payload_keys() -> None:
     """Every visible ctl command's --json help sketches the payload shape.
 

--- a/tests/_control/test_ctl.py
+++ b/tests/_control/test_ctl.py
@@ -8,6 +8,7 @@ cursor validation), and rendering helpers.
 
 import json
 import os
+from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
 
@@ -3026,10 +3027,7 @@ def test_mutation_envelope_help_sketches_actual_keys() -> None:
     envelope = _mutation_envelope(
         {"task_id": "aaa111"}, {"ok": True, "changed": True}, dry_run=False
     )
-    sketch = _MUTATION_ENVELOPE_HELP[
-        _MUTATION_ENVELOPE_HELP.index("{") + 1 : _MUTATION_ENVELOPE_HELP.index("}")
-    ]
-    assert [key.strip() for key in sketch.split(",")] == list(envelope.keys())
+    assert "{" + ", ".join(envelope.keys()) + "}" in _MUTATION_ENVELOPE_HELP
 
 
 def test_every_json_option_help_sketches_payload_keys() -> None:
@@ -3040,20 +3038,26 @@ def test_every_json_option_help_sketches_payload_keys() -> None:
     and failing. A brace in the help is the sketch's marker.
     """
 
-    def visible_commands(group: click.Group, prefix: str = "") -> Any:
+    def visible_commands(
+        group: click.Group, prefix: str = ""
+    ) -> Iterator[tuple[str, click.Command]]:
         for name, cmd in group.commands.items():
             if cmd.hidden:
                 continue
+            yield f"{prefix}{name}", cmd
             if isinstance(cmd, click.Group):
                 yield from visible_commands(cmd, f"{prefix}{name} ")
-            else:
-                yield f"{prefix}{name}", cmd
 
-    assert isinstance(ctl_command, click.Group)
     for path, cmd in visible_commands(ctl_command):
-        json_params = [p for p in cmd.params if p.name == "as_json"]
-        assert json_params, f"`{path}` has no --json option"
-        help_text = getattr(json_params[0], "help", None) or ""
+        json_options = [
+            p for p in cmd.params if isinstance(p, click.Option) and p.name == "as_json"
+        ]
+        if isinstance(cmd, click.Group) and not json_options:
+            # a group without a bare-noun list default (e.g. `model`) carries
+            # no mirrored --json of its own
+            continue
+        assert json_options, f"`{path}` has no --json option"
+        help_text = json_options[0].help or ""
         assert help_text.startswith("Output as JSON ("), path
         assert "{" in help_text, f"`{path}` --json help has no payload sketch"
 

--- a/tests/_control/test_ctl.py
+++ b/tests/_control/test_ctl.py
@@ -3014,6 +3014,50 @@ def test_knob_since_table_is_consistent() -> None:
     assert _PROVENANCE_SINCE <= CONTROL_API_VERSION
 
 
+def test_mutation_envelope_help_sketches_actual_keys() -> None:
+    """The shared --help sketch names exactly `_mutation_envelope`'s keys.
+
+    Every mutation verb's --json help shows `_MUTATION_ENVELOPE_HELP` so a
+    scripted consumer can orient the first parse from --help alone; this
+    pins the sketch to the envelope builder so the two can't drift.
+    """
+    from inspect_ai._cli.ctl import _MUTATION_ENVELOPE_HELP, _mutation_envelope
+
+    envelope = _mutation_envelope(
+        {"task_id": "aaa111"}, {"ok": True, "changed": True}, dry_run=False
+    )
+    sketch = _MUTATION_ENVELOPE_HELP[
+        _MUTATION_ENVELOPE_HELP.index("{") + 1 : _MUTATION_ENVELOPE_HELP.index("}")
+    ]
+    assert [key.strip() for key in sketch.split(",")] == list(envelope.keys())
+
+
+def test_every_json_option_help_sketches_payload_keys() -> None:
+    """Every visible ctl command's --json help sketches the payload shape.
+
+    The agent output contract: a scripted consumer should learn each
+    command's --json top-level keys from --help, not by parsing a payload
+    and failing. A brace in the help is the sketch's marker.
+    """
+
+    def visible_commands(group: click.Group, prefix: str = "") -> Any:
+        for name, cmd in group.commands.items():
+            if cmd.hidden:
+                continue
+            if isinstance(cmd, click.Group):
+                yield from visible_commands(cmd, f"{prefix}{name} ")
+            else:
+                yield f"{prefix}{name}", cmd
+
+    assert isinstance(ctl_command, click.Group)
+    for path, cmd in visible_commands(ctl_command):
+        json_params = [p for p in cmd.params if p.name == "as_json"]
+        assert json_params, f"`{path}` has no --json option"
+        help_text = getattr(json_params[0], "help", None) or ""
+        assert help_text.startswith("Output as JSON ("), path
+        assert "{" in help_text, f"`{path}` --json help has no payload sketch"
+
+
 def test_config_provenance_sent_with_mutations_on_current_server(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/_control/test_ctl.py
+++ b/tests/_control/test_ctl.py
@@ -8,6 +8,7 @@ cursor validation), and rendering helpers.
 
 import json
 import os
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from typing import Any
@@ -3078,6 +3079,159 @@ def test_every_json_option_help_sketches_payload_keys() -> None:
         assert "{" in help_text, f"`{path}` --json help has no payload sketch"
 
 
+def _json_help_sketch_keys(*path: str) -> list[str]:
+    """The key list inside a command's --json help `{...}` payload sketch."""
+    cmd: click.Command = ctl_command
+    for name in path:
+        assert isinstance(cmd, click.Group)
+        cmd = cmd.commands[name]
+    option = next(
+        p for p in cmd.params if isinstance(p, click.Option) and p.name == "as_json"
+    )
+    match = re.search(r"\{([^}]*)\}", option.help or "")
+    assert match is not None, f"`{' '.join(path)}` --json help has no payload sketch"
+    return [key.strip() for key in match.group(1).split(",")]
+
+
+def _assert_payload_matches_sketch(payload: dict[str, Any], *path: str) -> None:
+    """Assert a --json payload's top-level keys match the command's help sketch.
+
+    An exact ordered match, except when the sketch elides keys with `...` (a
+    flat object whose middle rides on the server response): there the keys
+    before the `...` must lead the payload in order, and every other sketched
+    key must be present (their order isn't guaranteed — a key the server's
+    row already carries keeps the row's position on dict merge).
+    """
+    sketch = _json_help_sketch_keys(*path)
+    actual = list(payload.keys())
+    label = " ".join(path)
+    if "..." in sketch:
+        cut = sketch.index("...")
+        assert actual[:cut] == sketch[:cut], (
+            f"`{label}` payload does not lead with the sketched keys: "
+            f"{actual} vs sketch {sketch}"
+        )
+        missing = set(sketch[cut + 1 :]) - set(actual)
+        assert not missing, f"`{label}` payload is missing sketched keys {missing}"
+    else:
+        assert actual == sketch, (
+            f"`{label}` payload keys {actual} != help sketch {sketch}"
+        )
+
+
+def test_task_list_json_payload_matches_help_sketch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_surface(monkeypatch, [_full_summary("aaa111", "t1")])
+    result = cli_runner().invoke(ctl_command, ["task", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    _assert_payload_matches_sketch(json.loads(result.stdout), "task", "list")
+
+
+def test_sample_listing_json_payload_matches_help_sketch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """`sample list` and `sample errors` share the listing envelope sketch."""
+    _patch_surface(
+        monkeypatch,
+        [_full_summary("aaa111", "t1")],
+        samples_by_eval={
+            "eval_aaa111": [_sample_row("s1"), _sample_row("bad", error="boom")]
+        },
+    )
+    runner = cli_runner()
+    for verb in ("list", "errors"):
+        result = runner.invoke(ctl_command, ["sample", verb, "--json"])
+        assert result.exit_code == 0, result.output
+        _assert_payload_matches_sketch(json.loads(result.stdout), "sample", verb)
+
+
+def test_sample_show_json_payload_matches_help_sketch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The flat show object leads with the sketch's identity keys.
+
+    The payload's middle is the server's detail response (elided as `...` in
+    the sketch); the stubbed detail mirrors the terminal-path response shape
+    (``message_count`` included, so no fallback listing fetch fires — the
+    detail's own keys are pinned by the server-side tests).
+    """
+    _patch_surface(monkeypatch, [_full_summary("aaa111", "t1")])
+    detail = {
+        "sample_id": "s1",
+        "epoch": 1,
+        "status": "completed",
+        "total_time": 1.0,
+        "total_tokens": 5,
+        "message_count": 1,
+        "retries": 0,
+        "error": None,
+        "error_retries": [],
+        "scores": {},
+    }
+    monkeypatch.setattr(
+        "inspect_ai._cli.ctl._fetch_sample_detail", lambda *a, **k: dict(detail)
+    )
+    result = cli_runner().invoke(
+        ctl_command, ["sample", "show", "aaa111", "s1", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    _assert_payload_matches_sketch(json.loads(result.stdout), "sample", "show")
+
+
+def test_sample_events_json_payload_matches_help_sketch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both the served page and the no-evals empty page keep the sketched shape."""
+    _patch_surface(monkeypatch, [_full_summary("aaa111", "t1")])
+    monkeypatch.setattr(
+        "inspect_ai._cli.ctl._fetch_sample_events",
+        lambda *a, **k: {"events": [], "next": None, "done": True},
+    )
+    runner = cli_runner()
+    result = runner.invoke(ctl_command, ["sample", "events", "aaa111", "s1", "--json"])
+    assert result.exit_code == 0, result.output
+    _assert_payload_matches_sketch(json.loads(result.stdout), "sample", "events")
+
+    _patch_surface(monkeypatch, [])
+    result = runner.invoke(ctl_command, ["sample", "events", "aaa111", "s1", "--json"])
+    assert result.exit_code == 0, result.output
+    _assert_payload_matches_sketch(json.loads(result.stdout), "sample", "events")
+
+
+def test_sample_messages_json_payload_matches_help_sketch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both the served page and the no-evals empty page keep the sketched shape."""
+    _patch_surface(monkeypatch, [_full_summary("aaa111", "t1")])
+    monkeypatch.setattr(
+        "inspect_ai._cli.ctl._fetch_sample_messages",
+        lambda *a, **k: {"as_of": 1.0, "status": "running", "count": 0, "messages": []},
+    )
+    runner = cli_runner()
+    result = runner.invoke(
+        ctl_command, ["sample", "messages", "aaa111", "s1", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    _assert_payload_matches_sketch(json.loads(result.stdout), "sample", "messages")
+
+    _patch_surface(monkeypatch, [])
+    result = runner.invoke(
+        ctl_command, ["sample", "messages", "aaa111", "s1", "--json"]
+    )
+    assert result.exit_code == 0, result.output
+    _assert_payload_matches_sketch(json.loads(result.stdout), "sample", "messages")
+
+
+def test_process_list_json_payload_matches_help_sketch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_surface(monkeypatch, [_full_summary("aaa111", "t1")])
+    result = cli_runner().invoke(ctl_command, ["process", "list", "--json"])
+    assert result.exit_code == 0, result.output
+    _assert_payload_matches_sketch(json.loads(result.stdout), "process", "list")
+
+
 def test_config_provenance_sent_with_mutations_on_current_server(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -5431,6 +5585,13 @@ def test_process_anomalies_explicit_pid_json(trace_dir: Path) -> None:
     assert [row["action"] for row in section["cancelled"]] == ["Subprocess"]
     assert [row["action"] for row in section["errors"]] == ["Sandbox"]
     assert section["timeouts"] == []
+
+
+def test_process_anomalies_json_payload_matches_help_sketch(trace_dir: Path) -> None:
+    write_trace_log(trace_dir / "trace-123.log", _anomalous_records())
+    result = cli_runner().invoke(ctl_command, ["process", "anomalies", "123", "--json"])
+    assert result.exit_code == 0
+    _assert_payload_matches_sketch(json.loads(result.stdout), "process", "anomalies")
 
 
 def test_process_anomalies_dead_pid_reads_gz(

--- a/tests/_control/test_ctl.py
+++ b/tests/_control/test_ctl.py
@@ -3068,9 +3068,9 @@ def test_every_json_option_help_sketches_payload_keys() -> None:
         json_options = [
             p for p in cmd.params if isinstance(p, click.Option) and p.name == "as_json"
         ]
-        if isinstance(cmd, click.Group) and not json_options:
+        if isinstance(cmd, click.Group) and "list" not in cmd.commands:
             # a group without a bare-noun list default (e.g. `model`) carries
-            # no mirrored --json of its own
+            # no mirrored --json of its own; groups with one must mirror it
             continue
         assert json_options, f"`{path}` has no --json option"
         help_text = json_options[0].help or ""


### PR DESCRIPTION
## This PR contains:
- [x] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [ ] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

Fixes meridianlabs-ai/inspect_ai#161

The `--json` payload shapes of `inspect ctl` commands weren't fully discoverable from `--help`. The list/read verbs already carried a top-level-keys sketch (e.g. `sample errors` → "an `{as_of, counts, samples, truncated}` envelope"), but several surfaces did not:

- all 12 mutation verbs said only "the mutation result envelope" — the envelope's keys (`target` / `applied` / `dry_run` / `detail`) were never sketched anywhere in `--help`
- `sample show` said "the sample's summary + error detail" and `config` said "the config view" — no keys
- `sample events` / `sample messages` sketches omitted the `task_id` / `sample_id` / `epoch` identifier echo the CLI prepends to every page
- the bare-noun spellings (`inspect ctl task --help`, `sample`, `process`) showed `--json  Mirrored from `list` for the bare-noun default.` — the sketch was overwritten by the mirroring machinery
- the `null` payload that targeted commands print when no evals are running was undocumented

So a scripted consumer (LLM agent or human) still paid a discovery round-trip per command — the exact cost described in the issue.

### What is the new behavior?

Every visible `inspect ctl` command's `--json` help sketches its payload's top-level keys:

- the mutation verbs share one constant, `_MUTATION_ENVELOPE_HELP` ("a `` `{target, applied, dry_run, detail}` `` mutation envelope"), and the four inline hand-rolled `--json` options were converted to the existing `_json_option` helper
- `sample show`, `config`, `sample events`, and `sample messages` sketches were made concrete/complete
- mirrored bare-noun options keep the verb's own help and append the mirror note
- the `ctl` group help documents that task-/sample-targeted commands (and `config`) print `null` when no evals are running

Three new tests pin the contract: one asserts `_MUTATION_ENVELOPE_HELP` names exactly `_mutation_envelope()`'s keys, one pins the `config` sketch to `_compose_config()`'s keys, and one walks the visible command tree asserting every `--json` help carries a payload sketch.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Help text and tests only; no payload or behavior changes.

### Other information:

Verification: `pytest tests/_control/test_ctl.py` → 262 passed (plus the 4 trio variants under `--runtrio`). `ruff check` / `ruff format --check` clean on changed files. `mypy` on the changed files reports only two pre-existing errors on untouched lines (`ctl.py:167` and `tests/_control/conftest.py:65`), both artifacts of the older click resolved on the runner because the `[dev]` extra currently fails dependency resolution there (`inspect-scout` / `huggingface_hub` conflict) — the project was installed via `pip install -e .` plus test deps instead.

### Agent review

- Reviewer: Claude Fable 5 via /code-review (fresh-context finder agents, same model family as author), 1 pass of 8 parallel review angles (correctness, reuse, simplification, efficiency, conventions, altitude, cross-file, removed-behavior)
- Findings: 12 distinct — 8 fixed, 4 dismissed:
  - Fixed: help constant's "branch on `applied`" clause over-promised (`process keep/release` and `task log-flush` hardcode `applied: true` — clause dropped, keys kept); bare-noun `--json` lost its sketch to the mirror machinery; `null` no-evals payload undocumented; `config` sketch elided `persisted`/`requested` behind `...` (now names all eight keys, pinned by test); brittle brace-slicing + order-sensitive assertion in the pinning test; `-> Any` on a typed generator; redundant docstring/comment restatements; a `getattr` and `isinstance` scaffold in the test; CHANGELOG rationale clause trimmed.
  - Dismissed: route `keep`/`log-flush` payloads through `_mutation_envelope` (a runtime behavior change — `applied` semantics — out of scope for a help-text fix; worth a follow-up issue); pin every read payload's keys to its builder (payloads are partly server-composed; existing per-command payload tests cover them); hidden deprecated aliases keep bare `--json` (deliberate — deprecation shims slated for removal); test pins the "Output as JSON (" prefix across the `trace.py` module boundary (intentional, pins the shared convention).

Agent involvement: implemented by Claude (Claude Code) from issue #161 (fork), triggered by the `auto` label.

🤖 Generated with [Claude Code](https://claude.com/claude-code)