### PR TITLE
Fix mypy failures when openai 3.x is installed (httpx vs httpx2 types)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,6 +146,13 @@ disallow_untyped_decorators = true
 extra_checks = true
 disable_error_code = "unused-ignore"
 
+[[tool.mypy.overrides]]
+# httpx2 is installed only alongside openai >= 3; when an openai 2.x
+# environment is type-checked it doesn't exist, so resolve it as Any there
+# (see inspect_ai/model/_openai_httpx.py)
+module = ["httpx2"]
+ignore_missing_imports = true
+
 [tool.check-wheel-contents]
 ignore = ["W002", "W009"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,13 +146,6 @@ disallow_untyped_decorators = true
 extra_checks = true
 disable_error_code = "unused-ignore"
 
-[[tool.mypy.overrides]]
-# httpx2 is installed only alongside openai >= 3; when an openai 2.x
-# environment is type-checked it doesn't exist, so resolve it as Any there
-# (see inspect_ai/model/_openai_httpx.py)
-module = ["httpx2"]
-ignore_missing_imports = true
-
 [tool.check-wheel-contents]
 ignore = ["W002", "W009"]
 

--- a/src/inspect_ai/agent/_bridge/bridge.py
+++ b/src/inspect_ai/agent/_bridge/bridge.py
@@ -29,6 +29,7 @@ from inspect_ai.model._openai_convert import (
     messages_from_openai,
     messages_to_openai,
 )
+from inspect_ai.model._openai_httpx import openai_httpx
 from inspect_ai.model._providers.providers import (
     validate_anthropic_client,
     validate_openai_client,
@@ -294,7 +295,7 @@ def init_openai_request_patch() -> None:
         if not raw_response:
             return result
 
-        response = httpx.Response(
+        response = openai_httpx.Response(
             status_code=200,
             headers={"content-type": "application/json"},
             content=result.model_dump_json().encode(),

--- a/src/inspect_ai/model/_openai.py
+++ b/src/inspect_ai/model/_openai.py
@@ -9,11 +9,11 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, TypeAlias, cast
 if TYPE_CHECKING:
     from inspect_ai.model._model import RetryDecision
 
-import httpx
 from openai import (
     APIConnectionError,
     APIStatusError,
     APITimeoutError,
+    DefaultAsyncHttpxClient,
     OpenAIError,
     RateLimitError,
 )
@@ -1222,30 +1222,11 @@ def openai_media_filter(key: JsonValue | None, value: JsonValue) -> JsonValue:
     return value
 
 
-# httpx-native equivalents of openai's DEFAULT_TIMEOUT / DEFAULT_CONNECTION_LIMITS
-# (same values). Do NOT import those from `openai`: openai >= 3.0 is built on
-# httpx2, and its httpx2-typed constants silently corrupt the timeout config of
-# our legacy `httpx.AsyncClient`, failing every request with APIConnectionError.
-DEFAULT_TIMEOUT = httpx.Timeout(timeout=600, connect=5.0)
-DEFAULT_CONNECTION_LIMITS = httpx.Limits(
-    max_connections=1000, max_keepalive_connections=100
-)
+class OpenAIAsyncHttpxClient(DefaultAsyncHttpxClient):
+    """Async http client with the openai SDK's default settings.
 
-
-class OpenAIAsyncHttpxClient(httpx.AsyncClient):
-    """Custom async client that uses OpenAI's default settings.
-
-    This ensures proper proxy support and follows OpenAI's recommended configuration.
-    OpenAI has already incorporated timeout improvements for reasoning models in their
-    default transport, so we don't need custom socket options.
-
+    `DefaultAsyncHttpxClient` applies OpenAI's recommended configuration
+    (timeout, connection limits, redirect and proxy handling) and — unlike a
+    plain httpx client — is always the httpx flavor the installed SDK is
+    built on: legacy `httpx` for openai 2.x, `httpx2` for openai 3.x.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        # Use OpenAI's default settings which handle proxies correctly
-        # https://github.com/openai/openai-python/commit/347363ed67a6a1611346427bb9ebe4becce53f7e
-        kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-        kwargs.setdefault("limits", DEFAULT_CONNECTION_LIMITS)
-        kwargs.setdefault("follow_redirects", True)
-
-        super().__init__(**kwargs)

--- a/src/inspect_ai/model/_openai_httpx.py
+++ b/src/inspect_ai/model/_openai_httpx.py
@@ -1,0 +1,21 @@
+"""The httpx flavor matching the installed openai SDK.
+
+openai < 3 is built on ``httpx``; openai >= 3 is built on ``httpx2`` (a
+separate package installed only alongside openai 3). Objects handed to the
+SDK (Response/Request/Timeout) must be built with the same flavor the SDK
+was built against — the wrong flavor either fails mypy or, worse, is
+silently misinterpreted at runtime (e.g. a legacy ``httpx.Timeout`` passed
+to an ``httpx2`` client is treated as a scalar). Use ``openai_httpx`` for
+any such object instead of importing ``httpx`` directly.
+
+mypy note: when openai 2.x is installed, ``httpx2`` doesn't exist, so a
+pyproject override resolves it as ``Any`` there (making the ignore below
+unused — harmless, as unused-ignore is disabled for inspect_ai modules).
+"""
+
+try:
+    import httpx2 as openai_httpx
+except ModuleNotFoundError:
+    import httpx as openai_httpx  # type: ignore[no-redef]
+
+__all__ = ["openai_httpx"]

--- a/src/inspect_ai/model/_openai_httpx.py
+++ b/src/inspect_ai/model/_openai_httpx.py
@@ -8,14 +8,29 @@ silently misinterpreted at runtime (e.g. a legacy ``httpx.Timeout`` passed
 to an ``httpx2`` client is treated as a scalar). Use ``openai_httpx`` for
 any such object instead of importing ``httpx`` directly.
 
-mypy note: when openai 2.x is installed, ``httpx2`` doesn't exist, so a
-pyproject override resolves it as ``Any`` there (making the ignore below
-unused — harmless, as unused-ignore is disabled for inspect_ai modules).
+The runtime import is keyed on the installed openai version — not on
+whether ``httpx2`` is importable, since an environment can have httpx2
+installed alongside openai 2.x (e.g. leftovers from a package downgrade)
+and the SDK's version is the only signal that matters.
+
+The static type is keyed on the installed openai's *own* httpx import
+(``openai._base_client.httpx2``), which exists exactly when the SDK types
+against httpx2: mypy checks shim uses strictly against ``httpx2`` in
+openai 3.x environments and falls back to ``Any`` in openai 2.x ones
+(where ``httpx2`` types wouldn't exist to check against anyway).
 """
 
-try:
+from typing import TYPE_CHECKING
+
+import openai
+
+if TYPE_CHECKING:
+    from openai import _base_client as _openai_base_client
+
+    openai_httpx = _openai_base_client.httpx2  # type: ignore[attr-defined]
+elif int(openai.__version__.partition(".")[0]) >= 3:
     import httpx2 as openai_httpx
-except ModuleNotFoundError:
-    import httpx as openai_httpx  # type: ignore[no-redef]
+else:
+    import httpx as openai_httpx
 
 __all__ = ["openai_httpx"]

--- a/src/inspect_ai/model/_providers/_openai_batch.py
+++ b/src/inspect_ai/model/_providers/_openai_batch.py
@@ -1,6 +1,5 @@
 from typing import IO, Any, Generic, Literal, TypeVar
 
-import httpx
 import pydantic
 from openai import AsyncOpenAI
 from openai._types import NOT_GIVEN
@@ -11,6 +10,7 @@ from pydantic import BaseModel
 from typing_extensions import TypedDict, override
 
 from inspect_ai.model._generate_config import BatchConfig
+from inspect_ai.model._openai_httpx import openai_httpx
 from inspect_ai.model._retry import ModelRetryConfig
 
 from .util.batch import (
@@ -150,7 +150,9 @@ class OpenAIBatcher(FileBatcher[ResponseT, CompletedBatchInfo], Generic[Response
         else:
             return request_id, (
                 self._openai_client._make_status_error_from_response(  # pyright: ignore[reportPrivateUsage]
-                    httpx.Response(status_code=error["code"], text=error["message"])
+                    openai_httpx.Response(
+                        status_code=error["code"], text=error["message"]
+                    )
                 )
             )
 

--- a/src/inspect_ai/model/_providers/openai_compatible.py
+++ b/src/inspect_ai/model/_providers/openai_compatible.py
@@ -2,7 +2,6 @@ import os
 from logging import getLogger
 from typing import Any, cast
 
-import httpx
 from openai import (
     APIStatusError,
     AsyncOpenAI,
@@ -22,6 +21,7 @@ from typing_extensions import override
 from inspect_ai._util.logger import warn_once
 from inspect_ai.log._samples import set_active_model_event_call
 from inspect_ai.model._openai import chat_choices_from_openai, openai_classify_retry
+from inspect_ai.model._openai_httpx import openai_httpx
 from inspect_ai.model._openai_responses import ResponsesModelInfo
 from inspect_ai.model._providers.openai_responses import generate_responses
 from inspect_ai.model._providers.util.chatapi import (
@@ -150,7 +150,7 @@ class OpenAICompatibleAPI(ModelAPI):
     def _create_http_client(self) -> OpenAIAsyncHttpxClient:
         if self.client_timeout is not None:
             return OpenAIAsyncHttpxClient(
-                timeout=httpx.Timeout(timeout=self.client_timeout, connect=5.0)
+                timeout=openai_httpx.Timeout(timeout=self.client_timeout, connect=5.0)
             )
         return OpenAIAsyncHttpxClient()
 

--- a/src/inspect_ai/model/_providers/util/hooks.py
+++ b/src/inspect_ai/model/_providers/util/hooks.py
@@ -1,9 +1,8 @@
 import re
 import time
 from logging import getLogger
-from typing import Any, Literal, Mapping, NamedTuple, cast
+from typing import Any, Callable, Literal, Mapping, NamedTuple, Protocol, cast
 
-import httpx
 from shortuuid import uuid
 
 from inspect_ai._util.constants import HTTP
@@ -278,21 +277,52 @@ class ConverseHooks(HttpHooks):
     USER_AGENT_PREFIX = "ins/rid#"
 
 
+# Structural stand-ins for httpx types, covering only what the hooks touch.
+# The openai SDK is built on legacy `httpx` (openai 2.x) or `httpx2`
+# (openai 3.x); both flavors (and the real httpx types other SDKs hand us)
+# satisfy these protocols.
+class HttpxRequestLike(Protocol):
+    @property
+    def method(self) -> str: ...
+    @property
+    def url(self) -> object: ...
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+
+class HttpxResponseLike(Protocol):
+    @property
+    def request(self) -> HttpxRequestLike: ...
+    @property
+    def status_code(self) -> int: ...
+    @property
+    def http_version(self) -> str: ...
+    @property
+    def reason_phrase(self) -> str: ...
+    @property
+    def headers(self) -> Mapping[str, str]: ...
+
+
+class HttpxClientLike(Protocol):
+    @property
+    def event_hooks(self) -> dict[str, list[Callable[..., Any]]]: ...
+
+
 class HttpxHooks(HttpHooks):
-    def __init__(self, client: httpx.AsyncClient):
+    def __init__(self, client: HttpxClientLike):
         super().__init__()
 
         # install hooks
         client.event_hooks["request"].append(self.request_hook)
         client.event_hooks["response"].append(self.response_hook)
 
-    async def request_hook(self, request: httpx.Request) -> None:
+    async def request_hook(self, request: HttpxRequestLike) -> None:
         # update the last request time for this request id (as there could be retries)
         request_id = request.headers.get(self.REQUEST_ID_HEADER, None)
         if request_id:
             self.update_request_time(request_id)
 
-    async def response_hook(self, response: httpx.Response) -> None:
+    async def response_hook(self, response: HttpxResponseLike) -> None:
         message = f'{response.request.method} {response.request.url} "{response.http_version} {response.status_code} {response.reason_phrase}" '
         logger.log(HTTP, message)
         # record status + Retry-After / x-ratelimit-reset-* for next retry classification

--- a/tests/model/providers/test_cloudflare.py
+++ b/tests/model/providers/test_cloudflare.py
@@ -33,10 +33,10 @@ async def test_cloudflare_empty_assistant_message() -> None:
 @skip_if_no_openai_package
 def test_cloudflare_retries_503_as_rate_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     """503 must be retried as a rate limit (scales down adaptive concurrency)."""
-    import httpx
     from openai import InternalServerError
 
     from inspect_ai.model._model import RetryDecision
+    from inspect_ai.model._openai_httpx import openai_httpx
     from inspect_ai.model._providers.cloudflare import CloudFlareAPI
 
     monkeypatch.setenv("CLOUDFLARE_API_KEY", "test-key")
@@ -44,10 +44,10 @@ def test_cloudflare_retries_503_as_rate_limit(monkeypatch: pytest.MonkeyPatch) -
     api = CloudFlareAPI(model_name="moonshotai/kimi-k3")
 
     def sdk_error(status_code: int, headers: dict[str, str] | None = None):
-        response = httpx.Response(
+        response = openai_httpx.Response(
             status_code=status_code,
             headers=headers,
-            request=httpx.Request("POST", "https://example/v1/chat/completions"),
+            request=openai_httpx.Request("POST", "https://example/v1/chat/completions"),
         )
         return InternalServerError("Server Error", response=response, body=None)
 

--- a/tests/model/providers/test_moonshot.py
+++ b/tests/model/providers/test_moonshot.py
@@ -173,16 +173,18 @@ def test_moonshot_legacy_model_preserves_sampling_params(mock_moonshot_env):
 
 def test_moonshot_context_overflow_maps_to_model_length(mock_moonshot_env):
     """Moonshot's token-limit 400 (no error code) must map to stop_reason model_length."""
-    import httpx
     from openai import APIStatusError
 
     from inspect_ai.model._model_output import ModelOutput
+    from inspect_ai.model._openai_httpx import openai_httpx
     from inspect_ai.model._providers.moonshot import MoonshotAPI
 
     api = MoonshotAPI(model_name="kimi-k3")
-    response = httpx.Response(
+    response = openai_httpx.Response(
         status_code=400,
-        request=httpx.Request("POST", "https://api.moonshot.ai/v1/chat/completions"),
+        request=openai_httpx.Request(
+            "POST", "https://api.moonshot.ai/v1/chat/completions"
+        ),
     )
     message = (
         "Invalid request: Your request exceeded model token limit: "
@@ -215,19 +217,19 @@ def test_moonshot_base_url_default(mock_moonshot_env):
 
 def test_moonshot_retries_503_as_rate_limit(mock_moonshot_env) -> None:
     """503 must be retried as a rate limit (scales down adaptive concurrency)."""
-    import httpx
     from openai import InternalServerError
 
     from inspect_ai.model._model import RetryDecision
+    from inspect_ai.model._openai_httpx import openai_httpx
     from inspect_ai.model._providers.moonshot import MoonshotAPI
 
     api = MoonshotAPI(model_name="kimi-k3")
 
     def sdk_error(status_code: int, headers: dict[str, str] | None = None):
-        response = httpx.Response(
+        response = openai_httpx.Response(
             status_code=status_code,
             headers=headers,
-            request=httpx.Request(
+            request=openai_httpx.Request(
                 "POST", "https://api.moonshot.ai/v1/chat/completions"
             ),
         )

--- a/tests/model/providers/test_openai_compatible.py
+++ b/tests/model/providers/test_openai_compatible.py
@@ -19,6 +19,7 @@ from inspect_ai.model import (
     get_model,
 )
 from inspect_ai.model._openai import chat_choices_from_openai
+from inspect_ai.model._openai_httpx import openai_httpx
 from inspect_ai.model._providers.openai_compatible import OpenAICompatibleAPI
 from inspect_ai.model._providers.together import TogetherAIAPI
 from inspect_ai.tool import ToolInfo
@@ -137,8 +138,8 @@ def test_handle_bad_request(
     )
     error = APIStatusError(
         message=message,
-        response=httpx.Response(
-            request=httpx.Request(method="POST", url="https://example.com"),
+        response=openai_httpx.Response(
+            request=openai_httpx.Request(method="POST", url="https://example.com"),
             status_code=status_code,
             json={"message": message},
         ),
@@ -222,8 +223,8 @@ def test_handle_bad_request_content_filter(
     )
     error = APIStatusError(
         message=body["message"],
-        response=httpx.Response(
-            request=httpx.Request(method="POST", url="https://example.com"),
+        response=openai_httpx.Response(
+            request=openai_httpx.Request(method="POST", url="https://example.com"),
             status_code=400,
             json=body,
         ),

--- a/tests/model/providers/test_openai_proxy.py
+++ b/tests/model/providers/test_openai_proxy.py
@@ -2,10 +2,10 @@ import threading
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
-import httpx
 import pytest
 
 from inspect_ai.model._openai import OpenAIAsyncHttpxClient
+from inspect_ai.model._openai_httpx import openai_httpx
 
 
 class _EchoHandler(BaseHTTPRequestHandler):
@@ -42,5 +42,5 @@ async def test_openai_async_client_respects_http_proxy(monkeypatch: pytest.Monke
 
     with _http_server() as port:
         async with OpenAIAsyncHttpxClient() as client:
-            with pytest.raises(httpx.TransportError):
+            with pytest.raises(openai_httpx.TransportError):
                 await client.get(f"http://127.0.0.1:{port}/")

--- a/tests/model/providers/test_openai_reasoning_summaries.py
+++ b/tests/model/providers/test_openai_reasoning_summaries.py
@@ -7,10 +7,10 @@ the OpenAI SDK would produce.
 
 from __future__ import annotations
 
-import httpx
 import pytest
 from openai import APITimeoutError, BadRequestError
 
+from inspect_ai.model._openai_httpx import openai_httpx
 from inspect_ai.model._providers.openai import OpenAIAPI
 
 
@@ -20,8 +20,8 @@ def _make_api() -> OpenAIAPI:
     return OpenAIAPI(model_name="gpt-5", api_key="test-key", responses_api=True)
 
 
-def _request() -> httpx.Request:
-    return httpx.Request("POST", "https://api.openai.com/v1/responses")
+def _request() -> openai_httpx.Request:
+    return openai_httpx.Request("POST", "https://api.openai.com/v1/responses")
 
 
 @pytest.mark.anyio
@@ -58,7 +58,7 @@ async def test_reasoning_summaries_unsupported_error_cached(
     api = _make_api()
     try:
         calls = {"n": 0}
-        response = httpx.Response(status_code=400, request=_request())
+        response = openai_httpx.Response(status_code=400, request=_request())
 
         async def unsupported(**kwargs: object) -> object:
             calls["n"] += 1

--- a/tests/model/providers/test_openai_reasoning_summaries.py
+++ b/tests/model/providers/test_openai_reasoning_summaries.py
@@ -7,6 +7,8 @@ the OpenAI SDK would produce.
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 from openai import APITimeoutError, BadRequestError
 
@@ -20,7 +22,9 @@ def _make_api() -> OpenAIAPI:
     return OpenAIAPI(model_name="gpt-5", api_key="test-key", responses_api=True)
 
 
-def _request() -> openai_httpx.Request:
+def _request() -> Any:
+    # Any: `openai_httpx` is a runtime-selected module, so its types can't
+    # appear in annotations.
     return openai_httpx.Request("POST", "https://api.openai.com/v1/responses")
 
 

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -8,6 +8,8 @@ shapes, not just our naive default that assumes `.status_code` is universal.
 
 from __future__ import annotations
 
+from typing import Any
+
 import httpx
 import pytest
 
@@ -27,10 +29,12 @@ def _http_response(
     )
 
 
-def _openai_http_response(
-    status: int, headers: dict[str, str] | None = None
-) -> openai_httpx.Response:
-    """Like _http_response, but in the httpx flavor of the installed openai SDK."""
+def _openai_http_response(status: int, headers: dict[str, str] | None = None) -> Any:
+    """Like _http_response, but in the httpx flavor of the installed openai SDK.
+
+    Returns Any: `openai_httpx` is a runtime-selected module, so its types
+    can't appear in annotations.
+    """
     request = openai_httpx.Request("POST", "https://example.com/v1/chat/completions")
     return openai_httpx.Response(
         status_code=status,

--- a/tests/model/test_should_retry_classification.py
+++ b/tests/model/test_should_retry_classification.py
@@ -12,6 +12,7 @@ import httpx
 import pytest
 
 from inspect_ai.model import RetryDecision, get_model
+from inspect_ai.model._openai_httpx import openai_httpx
 
 
 def _http_response(
@@ -20,6 +21,18 @@ def _http_response(
     """Build a stand-in httpx.Response for SDK exception constructors."""
     request = httpx.Request("POST", "https://example.com/v1/chat/completions")
     return httpx.Response(
+        status_code=status,
+        headers=headers or {},
+        request=request,
+    )
+
+
+def _openai_http_response(
+    status: int, headers: dict[str, str] | None = None
+) -> openai_httpx.Response:
+    """Like _http_response, but in the httpx flavor of the installed openai SDK."""
+    request = openai_httpx.Request("POST", "https://example.com/v1/chat/completions")
+    return openai_httpx.Response(
         status_code=status,
         headers=headers or {},
         request=request,
@@ -104,7 +117,7 @@ def test_openai_classify_rate_limit_429() -> None:
 
     from inspect_ai.model._openai import openai_classify_retry
 
-    response = _http_response(429, {"retry-after": "30"})
+    response = _openai_http_response(429, {"retry-after": "30"})
     ex = APIStatusError(message="rate limited", response=response, body=None)
     decision = openai_classify_retry(ex)
     assert decision is not None
@@ -120,7 +133,7 @@ def test_openai_classify_transient_5xx() -> None:
 
     ex = APIStatusError(
         message="internal error",
-        response=_http_response(503),
+        response=_openai_http_response(503),
         body=None,
     )
     decision = openai_classify_retry(ex)
@@ -136,7 +149,7 @@ def test_openai_classify_non_retryable_4xx_returns_none() -> None:
 
     ex = APIStatusError(
         message="bad request",
-        response=_http_response(400),
+        response=_openai_http_response(400),
         body=None,
     )
     assert openai_classify_retry(ex) is None
@@ -147,7 +160,7 @@ def test_openai_classify_rate_limit_error_subclass() -> None:
 
     from inspect_ai.model._openai import openai_classify_retry
 
-    response = _http_response(429, {"retry-after": "5"})
+    response = _openai_http_response(429, {"retry-after": "5"})
     ex = RateLimitError(message="too many", response=response, body=None)
     decision = openai_classify_retry(ex)
     assert decision is not None
@@ -164,7 +177,7 @@ def test_openai_provider_quota_exceeded_does_not_retry() -> None:
     api = OpenAIAPI.__new__(OpenAIAPI)  # avoid full init
     ex = RateLimitError(
         message="You exceeded your current quota, please check your plan.",
-        response=_http_response(429),
+        response=_openai_http_response(429),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -180,7 +193,7 @@ def test_openai_provider_429_classifies_as_rate_limit() -> None:
     api = OpenAIAPI.__new__(OpenAIAPI)
     ex = RateLimitError(
         message="rate limited",
-        response=_http_response(429, {"retry-after": "10"}),
+        response=_openai_http_response(429, {"retry-after": "10"}),
         body=None,
     )
     decision = api.should_retry(ex)
@@ -682,7 +695,7 @@ def test_together_openai_compatible_429_classifies_as_rate_limit() -> None:
     api = TogetherAIAPI.__new__(TogetherAIAPI)
     ex = APIStatusError(
         message="rate limited",
-        response=_http_response(429, {"retry-after": "15"}),
+        response=_openai_http_response(429, {"retry-after": "15"}),
         body=None,
     )
     decision = api.should_retry(ex)


### PR DESCRIPTION
Fixes #4871

openai 3.x is built on `httpx2` instead of `httpx`, so its APIs now type against `httpx2` objects while our code constructs and passes legacy `httpx` ones — 22 mypy errors when openai 3.x is installed. The fix makes the httpx flavor follow the installed SDK: `OpenAIAsyncHttpxClient` now subclasses `openai.DefaultAsyncHttpxClient` (right flavor in both versions, same defaults), `HttpxHooks` accepts structural protocols satisfied by both flavors, and the few places that construct `Response`/`Timeout` objects handed to the SDK use a new `openai_httpx` shim that resolves to the flavor matching the installed openai version.

## This PR contains:
- [ ] New features
- [ ] Changes to dev-tools e.g. CI config / github tooling
- [ ] Docs
- [x] Bug fixes
- [ ] Code refactor

### What is the current behavior? (You can also link to an open issue here)

With openai 3.x installed, `mypy` reports 22 errors (#4871). CI mypy is green only because it runs against `uv.lock` (openai 2.45.0); a fresh `pip install` env — what users and the planned floating nightly checks get — fails type checking. There is also a latent runtime bug: `openai_compatible.py` passed a legacy `httpx.Timeout` for `client_timeout`, which an openai 3.x client (httpx2-based) misreads as a scalar — the mirror image of the bug fixed in #4837.

### What is the new behavior?

`mypy` passes and the openai provider tests pass with both openai 2.45.0 (declared minimum) and openai 3.0.0 installed. Objects handed to the openai SDK are always the httpx flavor the installed SDK is built on. The declared minimum stays `openai>=2.45.0`.

Notes on the mechanism:

- `_openai_httpx.py` selects the runtime import by openai major version — deliberately not by whether `httpx2` is importable, because an env can have httpx2 installed alongside openai 2.x. CI's mypy/test jobs are exactly such an env: `uv pip install .[dev]` floats in openai 3 + httpx2, then `uv run` syncs openai back to the lock but strands httpx2 (inexact sync doesn't remove extraneous packages). The first draft of this PR keyed on httpx2 presence and failed CI there.
- The shim's static type derives from the installed openai's own httpx import (`openai._base_client.httpx2`), which tracks the SDK exactly: strict `httpx2` type checking in openai 3.x envs, `Any` in 2.x envs (where httpx2 types wouldn't exist to check against anyway). No mypy config changes needed.
- The Anthropic path in `bridge.py` deliberately stays on legacy `httpx` (the anthropic SDK is still httpx-based).
- `test_openai_proxy.py` now catches the flavor-matched `TransportError`; under 3.x the client raises `httpx2.ConnectError`, which the legacy `httpx.TransportError` assertion missed.

### Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No. Under openai 2.x, behavior is byte-for-byte equivalent (same client defaults, now inherited from the SDK). Under openai 3.x, the http client becomes a native `httpx2.AsyncClient` rather than a legacy client passed through the SDK's compat layer.

### Other information:

Verified in all three env shapes (same code; `mypy --exclude tests/test_package src tests` plus the openai/hooks/bridge test files):

- openai 3.0.0: mypy clean; 187 passed
- openai 2.45.0, no httpx2 (the lock env): mypy clean; 101 passed
- openai 2.45.0 with httpx2 stranded (CI's mixed env, see above): mypy clean; 101 passed

`ruff check` and `ruff format --check` clean.

Maintainer note: the mixed CI env may deserve its own follow-up — jobs that `uv pip install .[dev]` and then `uv run` end up testing the lock plus floating strays, which quietly weakens the "what's in the lock is what's tested" guarantee. Not addressed here (this PR makes the code correct in that env too), happy to file an issue.

### Agent review

- Reviewer: Claude Fable 5 via /code-review (fresh context), 1 pass — in progress; this section will be updated with findings before the PR leaves draft.
